### PR TITLE
fix(ci): refresh stale auto-merge PRs and keep runtime paths human-merged

### DIFF
--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -10,12 +10,19 @@ import sys
 from typing import Any
 
 AUTOMERGE_LABEL = "automerge"
+#: Process exit code. Every path through ``main`` reports success — a PR that
+#: is skipped is not an error. Real failures raise ``CalledProcessError`` and
+#: exit with the code ``gh`` returned.
+EXIT_SUCCESS = 0
+#: How many protected paths the refusal names before summarising the rest.
+#: Enough to show the reader why without pasting a whole diff into the log.
+PROTECTED_PATHS_LOGGED = 3
+#: Page size ``gh pr view --json files`` returns; a full page may be cut short.
+FILE_PAGE_SIZE = 100
 #: Paths a machine must never merge on its own. The first three carry the
 #: agent runtime, the multi-tenant platform and the chat gateway — a bad
 #: change there reaches every user. The last two are the merge machinery
 #: itself, which must not be able to widen its own permissions.
-#: Page size ``gh pr view --json files`` returns; a full page may be cut short.
-FILE_PAGE_SIZE = 100
 PROTECTED_PATH_PREFIXES = (
     "core/",
     "platform/",
@@ -23,13 +30,6 @@ PROTECTED_PATH_PREFIXES = (
     ".github/workflows/",
     ".github/scripts/",
 )
-#: ``mergeStateStatus`` when the only thing blocking a PR is that it has not
-#: taken the latest base. Set by "require branches to be up to date".
-MERGE_STATE_BEHIND = "BEHIND"
-#: What a single pass did, so the sweep can stop after one mutation.
-ACTION_NONE = "none"
-ACTION_UPDATED = "updated"
-ACTION_MERGED = "merged"
 AUTOMERGE_WORKFLOW_NAME = "Auto-merge"
 AUTOMERGE_JOB_CHECK_NAME = "Merge when CI is green"
 # External app checks that are not Actions workflow_run triggers. Waiting on them
@@ -100,6 +100,31 @@ def _rollup_item_is_green(check: dict[str, Any]) -> tuple[bool, str]:
     return _check_run_is_green(check)
 
 
+def _file_list_is_complete(pr: dict[str, Any]) -> bool:
+    """True when every changed path is visible to the protected-path check.
+
+    ``gh pr view --json files`` pages at 100 entries and says nothing about it,
+    so a larger PR could hide a ``core/`` change past the cut and be merged as
+    if it were docs. ``changedFiles`` carries the real total; without it, a full
+    page is indistinguishable from a truncated one and must be refused.
+    """
+    files = pr.get("files") or []
+    changed = pr.get("changedFiles")
+    if isinstance(changed, int):
+        return changed <= len(files)
+    return len(files) < FILE_PAGE_SIZE
+
+
+def _protected_paths(files: list[dict[str, Any]]) -> list[str]:
+    """Paths in the PR that require a human to press merge, sorted and unique."""
+    hits = {
+        path
+        for entry in files
+        if (path := str(entry.get("path", ""))) and path.startswith(PROTECTED_PATH_PREFIXES)
+    }
+    return sorted(hits)
+
+
 def _squash_commit_subject(title: str, pr_number: str) -> str:
     suffix = f"(#{pr_number})"
     stripped = title.rstrip()
@@ -132,82 +157,10 @@ def _run_gh(args: list[str]) -> Any:
     return json.loads(result.stdout)
 
 
-def _file_list_is_complete(pr: dict[str, Any]) -> bool:
-    """True when every changed path is visible to the protected-path check.
+def main() -> int:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    pr_number = os.environ["PR_NUMBER"]
 
-    ``gh pr view --json files`` pages at 100 entries and says nothing about it,
-    so a larger PR could hide a ``core/`` change past the cut and be merged as
-    if it were docs. ``changedFiles`` carries the real total, so a mismatch
-    means the check cannot see the whole diff and must refuse.
-    """
-    files = pr.get("files") or []
-    changed = pr.get("changedFiles")
-    if isinstance(changed, int):
-        return changed <= len(files)
-    # No count to compare against. A short list cannot have been truncated, but
-    # a full page is exactly what truncation looks like, so refuse that.
-    return len(files) < FILE_PAGE_SIZE
-
-
-def _protected_paths(files: list[dict[str, Any]]) -> list[str]:
-    """Paths in the PR that require a human to press merge, sorted and unique."""
-    hits = {
-        path
-        for entry in files
-        if (path := str(entry.get("path", ""))) and path.startswith(PROTECTED_PATH_PREFIXES)
-    }
-    return sorted(hits)
-
-
-def _needs_branch_update(pr: dict[str, Any]) -> bool:
-    """True when the PR is blocked only by being behind its base branch.
-
-    A conflicted PR reports ``CONFLICTING`` and needs a human; a behind-but-clean
-    PR just needs the latest base merged in so the required checks re-run against
-    what would actually land.
-    """
-    return pr.get("mergeStateStatus") == MERGE_STATE_BEHIND and pr.get("mergeable") == "MERGEABLE"
-
-
-def _update_branch(repo: str, pr_number: str) -> None:
-    """Merge the base branch into the PR branch and let its checks re-run."""
-    subprocess.run(
-        ["gh", "pr", "update-branch", pr_number, "--repo", repo],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-
-def _labeled_open_pr_numbers(repo: str) -> list[str]:
-    """Open PRs targeting main that opted into auto-merge, oldest first.
-
-    Oldest first makes the sweep a queue: the PR that has waited longest is
-    the one refreshed, so PRs drain in order instead of all competing.
-    """
-    rows = _run_gh(
-        [
-            "pr",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--base",
-            "main",
-            "--label",
-            AUTOMERGE_LABEL,
-            "--json",
-            "number,createdAt",
-            "--limit",
-            "100",
-        ]
-    )
-    rows.sort(key=lambda row: str(row.get("createdAt") or ""))
-    return [str(row["number"]) for row in rows]
-
-
-def _process_pr(repo: str, pr_number: str) -> str:
     pr = _run_gh(
         [
             "pr",
@@ -216,26 +169,27 @@ def _process_pr(repo: str, pr_number: str) -> str:
             "--repo",
             repo,
             "--json",
-            "baseRefName,changedFiles,files,isDraft,mergeable,mergeStateStatus,labels,state,statusCheckRollup,title",
+            "baseRefName,changedFiles,files,isDraft,mergeable,mergeStateStatus,labels,state,"
+            "statusCheckRollup,title",
         ]
     )
 
     if pr.get("baseRefName") != "main":
         print(f"PR #{pr_number} does not target main; skipping.")
-        return ACTION_NONE
+        return EXIT_SUCCESS
 
     if pr.get("state") != "OPEN":
         print(f"PR #{pr_number} is not open; skipping.")
-        return ACTION_NONE
+        return EXIT_SUCCESS
 
     if pr.get("isDraft"):
         print(f"PR #{pr_number} is a draft; skipping.")
-        return ACTION_NONE
+        return EXIT_SUCCESS
 
     label_names = {label["name"] for label in pr.get("labels", [])}
     if AUTOMERGE_LABEL not in label_names:
         print(f"PR #{pr_number} does not have the {AUTOMERGE_LABEL} label; skipping.")
-        return ACTION_NONE
+        return EXIT_SUCCESS
 
     if not _file_list_is_complete(pr):
         visible = len(pr.get("files") or [])
@@ -243,30 +197,24 @@ def _process_pr(repo: str, pr_number: str) -> str:
             f"PR #{pr_number} changes {pr.get('changedFiles')} files but only "
             f"{visible} are visible; a human must merge."
         )
-        return ACTION_NONE
+        return EXIT_SUCCESS
 
     protected = _protected_paths(pr.get("files") or [])
     if protected:
-        shown = ", ".join(protected[:3])
-        more = f" (+{len(protected) - 3} more)" if len(protected) > 3 else ""
+        shown = ", ".join(protected[:PROTECTED_PATHS_LOGGED])
+        hidden = len(protected) - PROTECTED_PATHS_LOGGED
+        more = f" (+{hidden} more)" if hidden > 0 else ""
         print(f"PR #{pr_number} touches protected paths; a human must merge: {shown}{more}")
-        return ACTION_NONE
+        return EXIT_SUCCESS
+
+    if pr.get("mergeable") != "MERGEABLE":
+        print(f"PR #{pr_number} is not mergeable ({pr.get('mergeStateStatus')}); skipping.")
+        return EXIT_SUCCESS
 
     green, reason = _checks_are_green(pr.get("statusCheckRollup") or [])
     if not green:
         print(f"PR #{pr_number} not ready to merge: {reason}")
-        return ACTION_NONE
-
-    # Only a green PR earns a refresh. Updating a red one would re-run the whole
-    # suite on every merge to main and never converge.
-    if _needs_branch_update(pr):
-        print(f"PR #{pr_number} is behind {pr.get('baseRefName')}; updating the branch.")
-        _update_branch(repo, pr_number)
-        return ACTION_UPDATED
-
-    if pr.get("mergeable") != "MERGEABLE":
-        print(f"PR #{pr_number} is not mergeable ({pr.get('mergeStateStatus')}); skipping.")
-        return ACTION_NONE
+        return EXIT_SUCCESS
 
     title = pr["title"]
     print(f"Merging PR #{pr_number}: {title}")
@@ -286,47 +234,7 @@ def _process_pr(repo: str, pr_number: str) -> str:
         check=True,
     )
     print(f"Merged PR #{pr_number}.")
-    return ACTION_MERGED
-
-
-def _sweep(repo: str) -> str:
-    """Advance the queue by one PR and stop.
-
-    Exactly one mutation per sweep. Merging pushes ``main``, which triggers the
-    next sweep, so the queue drains itself one PR at a time instead of
-    refreshing every PR against every merge.
-
-    A PR that cannot be refreshed — a fork that disallows maintainer edits
-    answers ``gh pr update-branch`` with 403 — must not strand the ones behind
-    it, so each PR is attempted independently.
-    """
-    for number in _labeled_open_pr_numbers(repo):
-        try:
-            action = _process_pr(repo, number)
-        except subprocess.CalledProcessError as exc:
-            detail = (exc.stderr or exc.stdout or str(exc)).strip()
-            print(f"PR #{number} could not be processed; continuing. {detail}")
-            continue
-        if action != ACTION_NONE:
-            print(f"Sweep {action} PR #{number}; stopping this pass.")
-            return action
-    return ACTION_NONE
-
-
-def main() -> int:
-    """Process one PR, or advance the queue when no number is given.
-
-    The workflow passes ``PR_NUMBER`` for PR and check events. When ``main``
-    itself moves, every open auto-merge PR falls behind at once and the sweep
-    runs with no number.
-    """
-    repo = os.environ["GITHUB_REPOSITORY"]
-    pr_number = os.environ.get("PR_NUMBER", "").strip()
-    if pr_number:
-        _process_pr(repo, pr_number)
-    else:
-        _sweep(repo)
-    return 0
+    return EXIT_SUCCESS
 
 
 if __name__ == "__main__":

--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -10,6 +10,24 @@ import sys
 from typing import Any
 
 AUTOMERGE_LABEL = "automerge"
+#: Paths a machine must never merge on its own. The first three carry the
+#: agent runtime, the multi-tenant platform and the chat gateway — a bad
+#: change there reaches every user. The last two are the merge machinery
+#: itself, which must not be able to widen its own permissions.
+PROTECTED_PATH_PREFIXES = (
+    "core/",
+    "platform/",
+    "gateway/",
+    ".github/workflows/",
+    ".github/scripts/",
+)
+#: ``mergeStateStatus`` when the only thing blocking a PR is that it has not
+#: taken the latest base. Set by "require branches to be up to date".
+MERGE_STATE_BEHIND = "BEHIND"
+#: What a single pass did, so the sweep can stop after one mutation.
+ACTION_NONE = "none"
+ACTION_UPDATED = "updated"
+ACTION_MERGED = "merged"
 AUTOMERGE_WORKFLOW_NAME = "Auto-merge"
 AUTOMERGE_JOB_CHECK_NAME = "Merge when CI is green"
 # External app checks that are not Actions workflow_run triggers. Waiting on them
@@ -112,10 +130,79 @@ def _run_gh(args: list[str]) -> Any:
     return json.loads(result.stdout)
 
 
-def main() -> int:
-    repo = os.environ["GITHUB_REPOSITORY"]
-    pr_number = os.environ["PR_NUMBER"]
+def _file_list_is_complete(pr: dict[str, Any]) -> bool:
+    """True when every changed path is visible to the protected-path check.
 
+    ``gh pr view --json files`` pages at 100 entries and says nothing about it,
+    so a larger PR could hide a ``core/`` change past the cut and be merged as
+    if it were docs. ``changedFiles`` carries the real total, so a mismatch
+    means the check cannot see the whole diff and must refuse.
+    """
+    changed = pr.get("changedFiles")
+    if not isinstance(changed, int):
+        return True
+    return changed <= len(pr.get("files") or [])
+
+
+def _protected_paths(files: list[dict[str, Any]]) -> list[str]:
+    """Paths in the PR that require a human to press merge, sorted and unique."""
+    hits = {
+        path
+        for entry in files
+        if (path := str(entry.get("path", ""))) and path.startswith(PROTECTED_PATH_PREFIXES)
+    }
+    return sorted(hits)
+
+
+def _needs_branch_update(pr: dict[str, Any]) -> bool:
+    """True when the PR is blocked only by being behind its base branch.
+
+    A conflicted PR reports ``CONFLICTING`` and needs a human; a behind-but-clean
+    PR just needs the latest base merged in so the required checks re-run against
+    what would actually land.
+    """
+    return pr.get("mergeStateStatus") == MERGE_STATE_BEHIND and pr.get("mergeable") == "MERGEABLE"
+
+
+def _update_branch(repo: str, pr_number: str) -> None:
+    """Merge the base branch into the PR branch and let its checks re-run."""
+    subprocess.run(
+        ["gh", "pr", "update-branch", pr_number, "--repo", repo],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _labeled_open_pr_numbers(repo: str) -> list[str]:
+    """Open PRs targeting main that opted into auto-merge, oldest first.
+
+    Oldest first makes the sweep a queue: the PR that has waited longest is
+    the one refreshed, so PRs drain in order instead of all competing.
+    """
+    rows = _run_gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--base",
+            "main",
+            "--label",
+            AUTOMERGE_LABEL,
+            "--json",
+            "number,createdAt",
+            "--limit",
+            "100",
+        ]
+    )
+    rows.sort(key=lambda row: str(row.get("createdAt") or ""))
+    return [str(row["number"]) for row in rows]
+
+
+def _process_pr(repo: str, pr_number: str) -> str:
     pr = _run_gh(
         [
             "pr",
@@ -124,35 +211,57 @@ def main() -> int:
             "--repo",
             repo,
             "--json",
-            "baseRefName,isDraft,mergeable,mergeStateStatus,labels,state,statusCheckRollup,title",
+            "baseRefName,files,isDraft,mergeable,mergeStateStatus,labels,state,statusCheckRollup,title",
         ]
     )
 
     if pr.get("baseRefName") != "main":
         print(f"PR #{pr_number} does not target main; skipping.")
-        return 0
+        return ACTION_NONE
 
     if pr.get("state") != "OPEN":
         print(f"PR #{pr_number} is not open; skipping.")
-        return 0
+        return ACTION_NONE
 
     if pr.get("isDraft"):
         print(f"PR #{pr_number} is a draft; skipping.")
-        return 0
+        return ACTION_NONE
 
     label_names = {label["name"] for label in pr.get("labels", [])}
     if AUTOMERGE_LABEL not in label_names:
         print(f"PR #{pr_number} does not have the {AUTOMERGE_LABEL} label; skipping.")
-        return 0
+        return ACTION_NONE
 
-    if pr.get("mergeable") != "MERGEABLE":
-        print(f"PR #{pr_number} is not mergeable ({pr.get('mergeStateStatus')}); skipping.")
-        return 0
+    if not _file_list_is_complete(pr):
+        visible = len(pr.get("files") or [])
+        print(
+            f"PR #{pr_number} changes {pr.get('changedFiles')} files but only "
+            f"{visible} are visible; a human must merge."
+        )
+        return ACTION_NONE
+
+    protected = _protected_paths(pr.get("files") or [])
+    if protected:
+        shown = ", ".join(protected[:3])
+        more = f" (+{len(protected) - 3} more)" if len(protected) > 3 else ""
+        print(f"PR #{pr_number} touches protected paths; a human must merge: {shown}{more}")
+        return ACTION_NONE
 
     green, reason = _checks_are_green(pr.get("statusCheckRollup") or [])
     if not green:
         print(f"PR #{pr_number} not ready to merge: {reason}")
-        return 0
+        return ACTION_NONE
+
+    # Only a green PR earns a refresh. Updating a red one would re-run the whole
+    # suite on every merge to main and never converge.
+    if _needs_branch_update(pr):
+        print(f"PR #{pr_number} is behind {pr.get('baseRefName')}; updating the branch.")
+        _update_branch(repo, pr_number)
+        return ACTION_UPDATED
+
+    if pr.get("mergeable") != "MERGEABLE":
+        print(f"PR #{pr_number} is not mergeable ({pr.get('mergeStateStatus')}); skipping.")
+        return ACTION_NONE
 
     title = pr["title"]
     print(f"Merging PR #{pr_number}: {title}")
@@ -172,6 +281,46 @@ def main() -> int:
         check=True,
     )
     print(f"Merged PR #{pr_number}.")
+    return ACTION_MERGED
+
+
+def _sweep(repo: str) -> str:
+    """Advance the queue by one PR and stop.
+
+    Exactly one mutation per sweep. Merging pushes ``main``, which triggers the
+    next sweep, so the queue drains itself one PR at a time instead of
+    refreshing every PR against every merge.
+
+    A PR that cannot be refreshed — a fork that disallows maintainer edits
+    answers ``gh pr update-branch`` with 403 — must not strand the ones behind
+    it, so each PR is attempted independently.
+    """
+    for number in _labeled_open_pr_numbers(repo):
+        try:
+            action = _process_pr(repo, number)
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or str(exc)).strip()
+            print(f"PR #{number} could not be processed; continuing. {detail}")
+            continue
+        if action != ACTION_NONE:
+            print(f"Sweep {action} PR #{number}; stopping this pass.")
+            return action
+    return ACTION_NONE
+
+
+def main() -> int:
+    """Process one PR, or advance the queue when no number is given.
+
+    The workflow passes ``PR_NUMBER`` for PR and check events. When ``main``
+    itself moves, every open auto-merge PR falls behind at once and the sweep
+    runs with no number.
+    """
+    repo = os.environ["GITHUB_REPOSITORY"]
+    pr_number = os.environ.get("PR_NUMBER", "").strip()
+    if pr_number:
+        _process_pr(repo, pr_number)
+    else:
+        _sweep(repo)
     return 0
 
 

--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -113,27 +113,47 @@ def _rollup_item_is_green(check: dict[str, Any]) -> tuple[bool, str]:
     return _check_run_is_green(check)
 
 
-def _changed_paths(repo: str, pr_number: str) -> list[str]:
-    """Every path the PR touches, including where a renamed file came from.
+def _list_pr_files(repo: str, pr_number: str) -> list[dict[str, Any]]:
+    """REST file listing for a PR (paginated). One entry per changed file.
 
     ``gh pr view --json files`` is unusable for a security check: it caps at 100
     entries with no indication it truncated, and its entries carry only the
-    destination ``path``. A file moved out of ``core/`` would therefore look
-    like an ordinary new file. The REST listing paginates and carries
-    ``previous_filename``, so both the origin and the full set are visible.
-    ``--paginate`` merges the pages into one array on its own; ``--slurp``
+    destination ``path``. The REST listing paginates and carries
+    ``previous_filename``. ``--paginate`` merges pages into one array; ``--slurp``
     would only wrap them in an outer list and needs a newer ``gh``.
     """
-    entries = _run_gh(
+    payload = _run_gh(
         [
             "api",
             f"repos/{repo}/pulls/{pr_number}/files",
             "--paginate",
         ]
     )
+    # Defensive: some ``gh`` versions / flags yield a list of page arrays.
+    if isinstance(payload, list) and payload and isinstance(payload[0], list):
+        return [entry for page in payload for entry in page]
+    return list(payload or [])
+
+
+def _paths_from_pr_files(entries: list[dict[str, Any]]) -> list[str]:
+    """Destination and rename-origin paths from a REST file listing."""
     paths = {str(entry.get("filename") or "") for entry in entries}
     paths |= {str(entry.get("previous_filename") or "") for entry in entries}
     return sorted(path for path in paths if path)
+
+
+def _file_listing_is_complete(changed_files: Any, entries: list[dict[str, Any]]) -> bool:
+    """True when the REST listing covers every changed file in the PR.
+
+    Completeness is ``len(entries)`` vs ``changedFiles``, not the expanded path
+    count. Renames contribute one entry but two paths (destination +
+    ``previous_filename``); comparing the inflated path set to ``changedFiles``
+    would let a truncated rename-heavy response look complete while protected
+    files past the cut stay invisible.
+    """
+    if not isinstance(changed_files, int):
+        return True
+    return len(entries) >= changed_files
 
 
 def _protected_paths(paths: list[str]) -> list[str]:
@@ -206,16 +226,16 @@ def main() -> int:
         print(f"PR #{pr_number} does not have the {AUTOMERGE_LABEL} label; skipping.")
         return EXIT_SUCCESS
 
-    paths = _changed_paths(repo, pr_number)
+    entries = _list_pr_files(repo, pr_number)
     changed = pr.get("changedFiles")
-    if isinstance(changed, int) and len(paths) < changed:
+    if not _file_listing_is_complete(changed, entries):
         print(
-            f"PR #{pr_number} changes {changed} files but only {len(paths)} are "
-            "visible; a human must merge."
+            f"PR #{pr_number} changes {changed} files but only {len(entries)} "
+            "are visible; a human must merge."
         )
         return EXIT_SUCCESS
 
-    protected = _protected_paths(paths)
+    protected = _protected_paths(_paths_from_pr_files(entries))
     if protected:
         shown = ", ".join(protected[:PROTECTED_PATHS_LOGGED])
         hidden = len(protected) - PROTECTED_PATHS_LOGGED

--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -32,8 +32,6 @@ EXIT_SUCCESS = 0
 #: How many protected paths the refusal names before summarising the rest.
 #: Enough to show the reader why without pasting a whole diff into the log.
 PROTECTED_PATHS_LOGGED = 3
-#: Page size ``gh pr view --json files`` returns; a full page may be cut short.
-FILE_PAGE_SIZE = 100
 #: Paths a machine must never merge on its own. The first three carry the
 #: agent runtime, the multi-tenant platform and the chat gateway — a bad
 #: change there reaches every user. The last two are the merge machinery
@@ -115,13 +113,6 @@ def _rollup_item_is_green(check: dict[str, Any]) -> tuple[bool, str]:
     return _check_run_is_green(check)
 
 
-def _flatten_pages(payload: Any) -> list[dict[str, Any]]:
-    """Flatten ``gh api --paginate --slurp`` output, which is a list of pages."""
-    if isinstance(payload, list) and payload and isinstance(payload[0], list):
-        return [entry for page in payload for entry in page]
-    return list(payload or [])
-
-
 def _changed_paths(repo: str, pr_number: str) -> list[str]:
     """Every path the PR touches, including where a renamed file came from.
 
@@ -130,16 +121,15 @@ def _changed_paths(repo: str, pr_number: str) -> list[str]:
     destination ``path``. A file moved out of ``core/`` would therefore look
     like an ordinary new file. The REST listing paginates and carries
     ``previous_filename``, so both the origin and the full set are visible.
+    ``--paginate`` merges the pages into one array on its own; ``--slurp``
+    would only wrap them in an outer list and needs a newer ``gh``.
     """
-    entries = _flatten_pages(
-        _run_gh(
-            [
-                "api",
-                f"repos/{repo}/pulls/{pr_number}/files",
-                "--paginate",
-                "--slurp",
-            ]
-        )
+    entries = _run_gh(
+        [
+            "api",
+            f"repos/{repo}/pulls/{pr_number}/files",
+            "--paginate",
+        ]
     )
     paths = {str(entry.get("filename") or "") for entry in entries}
     paths |= {str(entry.get("previous_filename") or "") for entry in entries}

--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -10,6 +10,21 @@ import sys
 from typing import Any
 
 AUTOMERGE_LABEL = "automerge"
+#: Fields ``gh pr view`` must return. Built by joining so the list stays
+#: readable without adjacent string literals, which read as a missing comma.
+PR_VIEW_FIELDS = ",".join(
+    (
+        "baseRefName",
+        "changedFiles",
+        "isDraft",
+        "labels",
+        "mergeable",
+        "mergeStateStatus",
+        "state",
+        "statusCheckRollup",
+        "title",
+    )
+)
 #: Process exit code. Every path through ``main`` reports success — a PR that
 #: is skipped is not an error. Real failures raise ``CalledProcessError`` and
 #: exit with the code ``gh`` returned.
@@ -100,29 +115,40 @@ def _rollup_item_is_green(check: dict[str, Any]) -> tuple[bool, str]:
     return _check_run_is_green(check)
 
 
-def _file_list_is_complete(pr: dict[str, Any]) -> bool:
-    """True when every changed path is visible to the protected-path check.
+def _flatten_pages(payload: Any) -> list[dict[str, Any]]:
+    """Flatten ``gh api --paginate --slurp`` output, which is a list of pages."""
+    if isinstance(payload, list) and payload and isinstance(payload[0], list):
+        return [entry for page in payload for entry in page]
+    return list(payload or [])
 
-    ``gh pr view --json files`` pages at 100 entries and says nothing about it,
-    so a larger PR could hide a ``core/`` change past the cut and be merged as
-    if it were docs. ``changedFiles`` carries the real total; without it, a full
-    page is indistinguishable from a truncated one and must be refused.
+
+def _changed_paths(repo: str, pr_number: str) -> list[str]:
+    """Every path the PR touches, including where a renamed file came from.
+
+    ``gh pr view --json files`` is unusable for a security check: it caps at 100
+    entries with no indication it truncated, and its entries carry only the
+    destination ``path``. A file moved out of ``core/`` would therefore look
+    like an ordinary new file. The REST listing paginates and carries
+    ``previous_filename``, so both the origin and the full set are visible.
     """
-    files = pr.get("files") or []
-    changed = pr.get("changedFiles")
-    if isinstance(changed, int):
-        return changed <= len(files)
-    return len(files) < FILE_PAGE_SIZE
+    entries = _flatten_pages(
+        _run_gh(
+            [
+                "api",
+                f"repos/{repo}/pulls/{pr_number}/files",
+                "--paginate",
+                "--slurp",
+            ]
+        )
+    )
+    paths = {str(entry.get("filename") or "") for entry in entries}
+    paths |= {str(entry.get("previous_filename") or "") for entry in entries}
+    return sorted(path for path in paths if path)
 
 
-def _protected_paths(files: list[dict[str, Any]]) -> list[str]:
-    """Paths in the PR that require a human to press merge, sorted and unique."""
-    hits = {
-        path
-        for entry in files
-        if (path := str(entry.get("path", ""))) and path.startswith(PROTECTED_PATH_PREFIXES)
-    }
-    return sorted(hits)
+def _protected_paths(paths: list[str]) -> list[str]:
+    """Paths that require a human to press merge, sorted and unique."""
+    return sorted({path for path in paths if path.startswith(PROTECTED_PATH_PREFIXES)})
 
 
 def _squash_commit_subject(title: str, pr_number: str) -> str:
@@ -169,8 +195,7 @@ def main() -> int:
             "--repo",
             repo,
             "--json",
-            "baseRefName,changedFiles,files,isDraft,mergeable,mergeStateStatus,labels,state,"
-            "statusCheckRollup,title",
+            PR_VIEW_FIELDS,
         ]
     )
 
@@ -191,15 +216,16 @@ def main() -> int:
         print(f"PR #{pr_number} does not have the {AUTOMERGE_LABEL} label; skipping.")
         return EXIT_SUCCESS
 
-    if not _file_list_is_complete(pr):
-        visible = len(pr.get("files") or [])
+    paths = _changed_paths(repo, pr_number)
+    changed = pr.get("changedFiles")
+    if isinstance(changed, int) and len(paths) < changed:
         print(
-            f"PR #{pr_number} changes {pr.get('changedFiles')} files but only "
-            f"{visible} are visible; a human must merge."
+            f"PR #{pr_number} changes {changed} files but only {len(paths)} are "
+            "visible; a human must merge."
         )
         return EXIT_SUCCESS
 
-    protected = _protected_paths(pr.get("files") or [])
+    protected = _protected_paths(paths)
     if protected:
         shown = ", ".join(protected[:PROTECTED_PATHS_LOGGED])
         hidden = len(protected) - PROTECTED_PATHS_LOGGED

--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -14,6 +14,8 @@ AUTOMERGE_LABEL = "automerge"
 #: agent runtime, the multi-tenant platform and the chat gateway — a bad
 #: change there reaches every user. The last two are the merge machinery
 #: itself, which must not be able to widen its own permissions.
+#: Page size ``gh pr view --json files`` returns; a full page may be cut short.
+FILE_PAGE_SIZE = 100
 PROTECTED_PATH_PREFIXES = (
     "core/",
     "platform/",
@@ -138,10 +140,13 @@ def _file_list_is_complete(pr: dict[str, Any]) -> bool:
     if it were docs. ``changedFiles`` carries the real total, so a mismatch
     means the check cannot see the whole diff and must refuse.
     """
+    files = pr.get("files") or []
     changed = pr.get("changedFiles")
-    if not isinstance(changed, int):
-        return True
-    return changed <= len(pr.get("files") or [])
+    if isinstance(changed, int):
+        return changed <= len(files)
+    # No count to compare against. A short list cannot have been truncated, but
+    # a full page is exactly what truncation looks like, so refuse that.
+    return len(files) < FILE_PAGE_SIZE
 
 
 def _protected_paths(files: list[dict[str, Any]]) -> list[str]:

--- a/.github/scripts/automerge_pr.py
+++ b/.github/scripts/automerge_pr.py
@@ -211,7 +211,7 @@ def _process_pr(repo: str, pr_number: str) -> str:
             "--repo",
             repo,
             "--json",
-            "baseRefName,files,isDraft,mergeable,mergeStateStatus,labels,state,statusCheckRollup,title",
+            "baseRefName,changedFiles,files,isDraft,mergeable,mergeStateStatus,labels,state,statusCheckRollup,title",
         ]
     )
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,10 +7,6 @@ on:
   pull_request_target:
     types: [labeled, synchronize, reopened]
     branches: [main]
-  # When main moves, every open auto-merge PR goes out of date at once. The
-  # sweep refreshes them so nobody clicks "Update branch" by hand.
-  push:
-    branches: [main]
   workflow_run:
     workflows:
       - CI
@@ -26,12 +22,8 @@ permissions:
 concurrency:
   # PR number / commit SHA, not branch name: fork branches can share a name,
   # and a branch-name group would let one fork's run cancel another's.
-  # Push sweeps share one group so they queue instead of overlapping; without a
-  # literal fallback they would key on run_id, which is unique per run and would
-  # let several sweeps update the same PRs at once. They must not cancel either:
-  # a cancelled sweep can interrupt an in-flight merge.
-  group: automerge-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || 'sweep' }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  group: automerge-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   merge:
@@ -42,8 +34,7 @@ jobs:
         github.event.workflow_run.event == 'pull_request' &&
         contains(fromJSON('["success", "neutral"]'), github.event.workflow_run.conclusion)) ||
       (github.event_name == 'pull_request_target' &&
-        (github.event.action != 'labeled' || github.event.label.name == 'automerge')) ||
-      github.event_name == 'push'
+        (github.event.action != 'labeled' || github.event.label.name == 'automerge'))
     steps:
       - uses: actions/checkout@v5
 
@@ -56,11 +47,6 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "push" ]; then
-            # No single PR: the merge step sweeps every labeled PR instead.
-            echo "sweep=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
             echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
             exit 0
@@ -77,7 +63,7 @@ jobs:
           fi
 
       - name: Merge labeled PR when checks pass
-        if: steps.pr.outputs.number != '' || steps.pr.outputs.sweep == 'true'
+        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,6 +7,10 @@ on:
   pull_request_target:
     types: [labeled, synchronize, reopened]
     branches: [main]
+  # When main moves, every open auto-merge PR goes out of date at once. The
+  # sweep refreshes them so nobody clicks "Update branch" by hand.
+  push:
+    branches: [main]
   workflow_run:
     workflows:
       - CI
@@ -22,8 +26,12 @@ permissions:
 concurrency:
   # PR number / commit SHA, not branch name: fork branches can share a name,
   # and a branch-name group would let one fork's run cancel another's.
-  group: automerge-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.run_id }}
-  cancel-in-progress: true
+  # Push sweeps share one group so they queue instead of overlapping; without a
+  # literal fallback they would key on run_id, which is unique per run and would
+  # let several sweeps update the same PRs at once. They must not cancel either:
+  # a cancelled sweep can interrupt an in-flight merge.
+  group: automerge-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || 'sweep' }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   merge:
@@ -34,7 +42,8 @@ jobs:
         github.event.workflow_run.event == 'pull_request' &&
         contains(fromJSON('["success", "neutral"]'), github.event.workflow_run.conclusion)) ||
       (github.event_name == 'pull_request_target' &&
-        (github.event.action != 'labeled' || github.event.label.name == 'automerge'))
+        (github.event.action != 'labeled' || github.event.label.name == 'automerge')) ||
+      github.event_name == 'push'
     steps:
       - uses: actions/checkout@v5
 
@@ -47,6 +56,11 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
         run: |
           set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
+            # No single PR: the merge step sweeps every labeled PR instead.
+            echo "sweep=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
             echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
             exit 0
@@ -63,7 +77,7 @@ jobs:
           fi
 
       - name: Merge labeled PR when checks pass
-        if: steps.pr.outputs.number != ''
+        if: steps.pr.outputs.number != '' || steps.pr.outputs.sweep == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,13 +180,17 @@ Use the **[PR template](.github/PULL_REQUEST_TEMPLATE.md)** (automatically provi
 
 We use [Greptile](https://greptile.com) for automated code review. Before a PR can be merged it must reach a **5/5 confidence score** with zero unresolved comments.
 
+**How Greptile, human review, CI, and automerge fit together:** see the public
+[Pull request review flow](docs/pr-review-flow.mdx) guide.
+
 **Trigger a review** by posting this comment on your PR:
 
 ```
 @greptile review
 ```
 
-Wait 30–60 seconds for the review to appear, then address each comment and re-trigger until you hit 5/5.
+Give it about **5–10 minutes** (sometimes longer), then address each comment and
+re-trigger until you hit 5/5.
 
 > **Automate the loop** — the [greploop skill](https://skills.sh/greptileai/skills/greploop) handles triggering, waiting, fixing, and re-reviewing automatically until 5/5 is reached.
 

--- a/docs/bi-weekly-giveaway.mdx
+++ b/docs/bi-weekly-giveaway.mdx
@@ -49,6 +49,7 @@ New to the repo? Issues tagged **`good first issue`** or **`help wanted`** are a
 | Good first issues | [Browse on GitHub](https://github.com/Tracer-Cloud/opensre/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) |
 | Help wanted | [Browse on GitHub](https://github.com/Tracer-Cloud/opensre/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) |
 | Good First Issues guide | [Contributor guide](https://github.com/Tracer-Cloud/opensre/blob/main/docs/good-first-issues/README.md) |
+| PR review flow | [Greptile · human · automerge](/pr-review-flow) |
 | Winner announcements | [OpenSRE Discord](https://discord.gg/opensre) |
 
 ## Past winners

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,7 +48,8 @@
               "python-api",
               "faq",
               "cloudopsbench",
-              "bi-weekly-giveaway"
+              "bi-weekly-giveaway",
+              "pr-review-flow"
             ]
           }
         ]

--- a/docs/good-first-issues/README.md
+++ b/docs/good-first-issues/README.md
@@ -32,6 +32,8 @@ Browse issues tagged with the `good first issue` label:
 7. **Open a pull request** — link the issue with `Fixes #123` in your PR description
 
 Full contribution flow is in [CONTRIBUTING.md](../../CONTRIBUTING.md).
+After you open a PR, follow the [PR review flow](../pr-review-flow.mdx)
+(Greptile · human review · automerge).
 
 ## Ask for help
 

--- a/docs/pr-review-flow.mdx
+++ b/docs/pr-review-flow.mdx
@@ -1,0 +1,137 @@
+---
+title: "Pull request review flow"
+description: "How Greptile, human review, CI, and automerge work together on OpenSRE PRs."
+---
+
+This page is the contributor map for what happens after you open a pull request:
+Greptile review, required CI, human maintainer judgment, and the optional
+`automerge` label.
+
+Greptile and automerge help maintainers move the queue. They do **not** replace
+maintainer approval.
+
+## The short path
+
+1. Open a focused PR with the [PR template](https://github.com/Tracer-Cloud/opensre/blob/main/.github/PULL_REQUEST_TEMPLATE.md) filled in.
+2. Leave **Allow edits from maintainers** enabled on fork PRs.
+3. Wait for CI (the required check is **CI Gate**).
+4. Trigger Greptile and work to **Confidence Score: 5/5** with **zero unresolved** threads.
+5. A maintainer reviews and either merges, asks for changes, or adds the `automerge` label when the PR is ready to land on its own.
+
+Full contribution rules: [CONTRIBUTING.md](https://github.com/Tracer-Cloud/opensre/blob/main/CONTRIBUTING.md).
+Local checks before you push: [CI.md](https://github.com/Tracer-Cloud/opensre/blob/main/CI.md).
+
+## Greptile (AI review)
+
+OpenSRE uses [Greptile](https://greptile.com) for automated review. Opening or
+reopening a PR posts a reminder comment. Greptile is a **human gate**: aim for
+**5/5** before you ask a maintainer to merge or add `automerge`.
+
+**Trigger a review** with a PR comment:
+
+```text
+@greptile review
+```
+
+Give it about **5–10 minutes** (sometimes longer). Fix the feedback, resolve
+threads you have addressed, then comment `@greptile review` again until you
+reach **5/5** with no open threads.
+
+Optional: the [greploop skill](https://skills.sh/greptileai/skills/greploop)
+can run that loop for you.
+
+Treat Greptile comments like normal review. Reply and leave a thread open only
+when you need a human decision.
+
+## CI
+
+Required checks must be green before merge. The branch-protection aggregator is
+**CI Gate** (quality + unit tests). Some paths also run Interactive Shell Live
+checks — those must pass when they are required for your change.
+
+If CI is red, fix the branch before asking for another Greptile or maintainer
+pass. Do **not** open a test-only or CI-only PR just to chase failures that are
+already red on `main` unless a maintainer asked for that work — see
+[CONTRIBUTING.md](https://github.com/Tracer-Cloud/opensre/blob/main/CONTRIBUTING.md).
+
+## Human review
+
+A maintainer decides when the PR is ready. Greptile 5/5 and green CI are
+necessary signals, not a merge button.
+
+Expect maintainers to look at:
+
+- Problem statement and proof in the PR body (demo, screenshot, or log)
+- AI-usage disclosure when you used AI assistance
+- Scope (one concern per PR; no refactor-only drive-bys)
+- Tests for behavioral changes
+
+Keep the **PR description** current when the problem, solution, or evidence
+changes. Comments are for discussion; the body is what reviewers re-read.
+
+Need help coordinating? Ask in Discord
+[#contribute](https://discord.gg/opensre).
+
+## Automerge (maintainer opt-in)
+
+The `automerge` label is **maintainer-applied** after Greptile and human review
+are done. Contributors should not add it themselves unless a maintainer asks.
+
+When a PR has `automerge` and is otherwise ready, automation squash-merges it
+into `main` and deletes the branch.
+
+### What automerge waits for
+
+- PR targets `main`, is open, and is not a draft
+- Required CI (and other non-skipped checks) are green
+- The branch is mergeable
+
+Greptile’s own check status is **not** what automerge waits on — maintainers add
+the label only after Greptile and human review are finished.
+
+### When the branch is behind `main`
+
+Branch protection requires PRs to be up to date with `main`. If your PR falls
+behind after someone else merges, automerge refreshes the branch (Update branch)
+and waits for CI again. You do not need to click Update branch for labeled PRs;
+if the PR is not labeled, update it yourself or ask a maintainer.
+
+### Paths that never auto-merge
+
+PRs that touch these paths always need a **human** to press merge, even with
+`automerge`:
+
+| Prefix | Why |
+| ------ | --- |
+| `core/` | Agent runtime |
+| `platform/` | Multi-tenant platform |
+| `gateway/` | Chat / gateway surfaces |
+| `.github/workflows/` | CI and merge machinery |
+| `.github/scripts/` | Merge machinery |
+
+Very large PRs (more files than GitHub returns in one file list) are also held
+for a human, so a protected-path change cannot hide past an incomplete file list.
+
+Docs, tests, integrations, and most surface changes can still use automerge when
+a maintainer labels them.
+
+## Improve a PR during review
+
+1. Read Greptile and maintainer comments as the action list.
+2. Push fixes; update the PR description when the story or evidence changed.
+3. Resolve threads you have addressed.
+4. Re-run `@greptile review` only after the branch and description are current.
+5. Keep discussion on the PR when possible; use Discord when you need maintainer
+   coordination or think automation is stuck.
+
+## When things stay quiet
+
+- Greptile can take several minutes; do not spam `@greptile review`.
+- Automerge only runs for the `automerge` label and green checks.
+- If CI is pending or the PR is behind `main`, wait for the next green run.
+- If a maintainer is actively editing the branch, let them finish before
+  pushing competing commits.
+
+Still blocked after CI is green and Greptile is 5/5? Ping in
+[#contribute](https://discord.gg/opensre) with the PR link and what you are
+waiting on.

--- a/docs/pr-review-flow.mdx
+++ b/docs/pr-review-flow.mdx
@@ -91,10 +91,11 @@ the label only after Greptile and human review are finished.
 
 ### When the branch is behind `main`
 
-Branch protection requires PRs to be up to date with `main`. If your PR falls
-behind after someone else merges, automerge refreshes the branch (Update branch)
-and waits for CI again. You do not need to click Update branch for labeled PRs;
-if the PR is not labeled, update it yourself or ask a maintainer.
+Branch protection requires PRs to be up to date with `main`. Automerge only
+merges when GitHub reports the PR as mergeable. A behind branch usually stays
+stalled until someone clicks **Update branch** (or rebases onto `main`) and CI
+goes green again — including for PRs that already have the `automerge` label.
+Automerge does **not** refresh the branch for you today.
 
 ### Paths that never auto-merge
 
@@ -109,8 +110,9 @@ PRs that touch these paths always need a **human** to press merge, even with
 | `.github/workflows/` | CI and merge machinery |
 | `.github/scripts/` | Merge machinery |
 
-Very large PRs (more files than GitHub returns in one file list) are also held
-for a human, so a protected-path change cannot hide past an incomplete file list.
+Automerge lists every changed path via the GitHub API (including rename origins).
+If that listing looks incomplete versus the PR’s file count, it refuses and asks
+for a human — so a protected-path change cannot hide behind a partial list.
 
 Docs, tests, integrations, and most surface changes can still use automerge when
 a maintainer labels them.
@@ -128,7 +130,9 @@ a maintainer labels them.
 
 - Greptile can take several minutes; do not spam `@greptile review`.
 - Automerge only runs for the `automerge` label and green checks.
-- If CI is pending or the PR is behind `main`, wait for the next green run.
+- If CI is pending, wait for the next green run.
+- If the PR is behind `main`, update the branch (or ask a maintainer), then wait
+  for CI again.
 - If a maintainer is actively editing the branch, let them finish before
   pushing competing commits.
 

--- a/docs/pr-review-flow.mdx
+++ b/docs/pr-review-flow.mdx
@@ -110,9 +110,9 @@ PRs that touch these paths always need a **human** to press merge, even with
 | `.github/workflows/` | CI and merge machinery |
 | `.github/scripts/` | Merge machinery |
 
-Automerge lists every changed path via the GitHub API (including rename origins).
-If that listing looks incomplete versus the PR’s file count, it refuses and asks
-for a human — so a protected-path change cannot hide behind a partial list.
+Automerge lists every changed file via the GitHub API (including rename origins).
+If fewer file entries come back than the PR’s changed-file count, it refuses and
+asks for a human — so a protected-path change cannot hide behind a partial list.
 
 Docs, tests, integrations, and most surface changes can still use automerge when
 a maintainer labels them.

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -251,7 +251,7 @@ def _run_pr(monkeypatch, payload: dict, files: list[dict]) -> list:
 
     def _fake_gh(args: list[str]) -> object:
         # ``api`` fetches the changed files; ``pr view`` fetches the PR itself.
-        return [files] if args[0] == "api" else payload
+        return files if args[0] == "api" else payload
 
     monkeypatch.setattr(automerge_pr, "_run_gh", _fake_gh)
     monkeypatch.setattr(

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.util
-import subprocess
 from pathlib import Path
 
 _MODULE_PATH = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "automerge_pr.py"
@@ -173,154 +172,6 @@ def test_ignores_greptile_review_while_running() -> None:
     assert reason == "all checks green"
 
 
-def test_behind_but_clean_pr_is_updated_not_stalled() -> None:
-    """A PR blocked only by being out of date should take the latest base.
-
-    With "require branches to be up to date" on, every merge to main marks the
-    other open PRs ``BEHIND``. Auto-merge used to stop there, so a human had to
-    press "Update branch" and wait for CI — on a busy repo a PR could go stale
-    again before it finished.
-    """
-    # Arrange
-    pr = {"mergeStateStatus": "BEHIND", "mergeable": "MERGEABLE"}
-
-    # Act / Assert
-    assert automerge_pr._needs_branch_update(pr) is True
-
-
-def test_conflicted_pr_is_not_auto_updated() -> None:
-    """A real conflict needs a human; updating the branch cannot resolve it."""
-    # Arrange
-    pr = {"mergeStateStatus": "DIRTY", "mergeable": "CONFLICTING"}
-
-    # Act / Assert
-    assert automerge_pr._needs_branch_update(pr) is False
-
-
-def test_ready_pr_is_not_updated() -> None:
-    """A PR that can merge now must not be pushed back through CI."""
-    # Arrange
-    pr = {"mergeStateStatus": "CLEAN", "mergeable": "MERGEABLE"}
-
-    # Act / Assert
-    assert automerge_pr._needs_branch_update(pr) is False
-
-
-def test_blocked_pr_is_not_mistaken_for_out_of_date() -> None:
-    """``BLOCKED`` means checks or review are outstanding, not staleness."""
-    # Arrange
-    pr = {"mergeStateStatus": "BLOCKED", "mergeable": "MERGEABLE"}
-
-    # Act / Assert
-    assert automerge_pr._needs_branch_update(pr) is False
-
-
-def _pr(**overrides: object) -> dict:
-    """A labeled, open, green PR targeting main."""
-    pr = {
-        "baseRefName": "main",
-        "state": "OPEN",
-        "isDraft": False,
-        "labels": [{"name": "automerge"}],
-        "mergeable": "MERGEABLE",
-        "mergeStateStatus": "CLEAN",
-        "statusCheckRollup": [
-            {"__typename": "CheckRun", "name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
-        ],
-        "title": "a change",
-        "changedFiles": 1,
-        "files": [{"path": "docs/a.mdx"}],
-    }
-    pr.update(overrides)
-    return pr
-
-
-def _drive(monkeypatch, prs: dict, *, on_update=None, on_merge=None) -> list:
-    """Run a sweep over ``prs`` (number -> payload), recording actions taken."""
-    actions: list = []
-    monkeypatch.setattr(automerge_pr, "_labeled_open_pr_numbers", lambda _repo: list(prs))
-    monkeypatch.setattr(automerge_pr, "_run_gh", lambda args: prs[args[2]])
-
-    def _update(_repo, number):
-        actions.append(("update", number))
-        if on_update:
-            on_update(number)
-
-    def _merge(*args, **_kwargs):
-        actions.append(("merge", args[0][3]))
-        if on_merge:
-            on_merge(args[0][3])
-
-    monkeypatch.setattr(automerge_pr, "_update_branch", _update)
-    monkeypatch.setattr(automerge_pr.subprocess, "run", _merge)
-    automerge_pr._sweep("o/r")
-    return actions
-
-
-def test_a_pr_that_cannot_be_refreshed_does_not_strand_the_queue(monkeypatch) -> None:
-    """A fork that disallows maintainer edits answers update-branch with 403.
-
-    Aborting the sweep there would leave every PR behind it stale until someone
-    noticed, and would fail the workflow on every merge to main.
-    """
-    # Arrange
-    prs = {n: _pr(mergeStateStatus="BEHIND") for n in ("101", "102", "103")}
-
-    def _forbidden(number):
-        if number == "101":
-            raise subprocess.CalledProcessError(1, "gh pr update-branch", stderr="403 Forbidden")
-
-    # Act
-    actions = _drive(monkeypatch, prs, on_update=_forbidden)
-
-    # Assert
-    assert actions == [("update", "101"), ("update", "102")]
-
-
-def test_sweep_advances_one_pr_then_stops(monkeypatch) -> None:
-    """One mutation per sweep; merging pushes main, which drives the next pass."""
-    # Arrange
-    prs = {n: _pr(mergeStateStatus="BEHIND") for n in ("201", "202", "203")}
-
-    # Act
-    actions = _drive(monkeypatch, prs)
-
-    # Assert
-    assert actions == [("update", "201")]
-
-
-def test_a_red_pr_is_never_refreshed(monkeypatch) -> None:
-    """Refreshing a failing PR re-runs the whole suite and never converges."""
-    # Arrange
-    failing = [
-        {"__typename": "CheckRun", "name": "ci", "status": "COMPLETED", "conclusion": "FAILURE"}
-    ]
-    prs = {"301": _pr(mergeStateStatus="BEHIND", statusCheckRollup=failing)}
-
-    # Act
-    actions = _drive(monkeypatch, prs)
-
-    # Assert
-    assert actions == []
-
-
-def test_queue_is_served_oldest_first(monkeypatch) -> None:
-    """The PR that has waited longest is the one advanced."""
-    # Arrange
-    listed = [
-        {"number": 402, "createdAt": "2026-08-02T10:00:00Z"},
-        {"number": 401, "createdAt": "2026-07-30T09:00:00Z"},
-        {"number": 403, "createdAt": "2026-08-01T11:00:00Z"},
-    ]
-    monkeypatch.setattr(automerge_pr, "_run_gh", lambda _args: listed)
-
-    # Act
-    order = automerge_pr._labeled_open_pr_numbers("o/r")
-
-    # Assert
-    assert order == ["401", "403", "402"]
-
-
 def test_runtime_and_ci_paths_are_never_auto_merged() -> None:
     """The blast-radius paths need a human on the merge button.
 
@@ -376,52 +227,12 @@ def test_lookalike_prefixes_are_not_protected() -> None:
     assert automerge_pr._protected_paths(files) == []
 
 
-def test_protected_pr_is_neither_merged_nor_refreshed(monkeypatch) -> None:
-    """Refusing early also keeps it out of the queue's single action slot."""
-    # Arrange
-    prs = {
-        "501": _pr(mergeStateStatus="BEHIND", files=[{"path": "core/agent/agent.py"}]),
-        "502": _pr(mergeStateStatus="BEHIND", files=[{"path": "docs/a.mdx"}]),
-    }
-
-    # Act
-    actions = _drive(monkeypatch, prs)
-
-    # Assert
-    assert actions == [("update", "502")]
-
-
-def test_process_pr_requests_changed_files_from_github(monkeypatch) -> None:
-    """Without ``changedFiles`` in the view query the truncation guard is dead."""
-    # Arrange
-    seen: list[str] = []
-
-    def _capture(args: list[str]):
-        seen.extend(args)
-        return _pr()
-
-    def _noop_run(*_args: object, **_kwargs: object) -> None:
-        return None
-
-    monkeypatch.setattr(automerge_pr, "_run_gh", _capture)
-    monkeypatch.setattr(automerge_pr.subprocess, "run", _noop_run)
-
-    # Act
-    automerge_pr._process_pr("o/r", "1")
-
-    # Assert
-    json_fields = seen[seen.index("--json") + 1]
-    assert "changedFiles" in json_fields.split(",")
-    assert "files" in json_fields.split(",")
-
-
 def test_a_truncated_file_list_refuses_the_merge() -> None:
     """``gh`` pages the file list at 100 and does not say so.
 
-    A 105-file PR reports every path in ``changedFiles`` but only the first 100
-    in ``files``. Trusting the short list would let a ``core/`` change past the
-    cut merge as if the PR were docs, so the check has to fail closed. Observed
-    on a real PR: ``changedFiles`` 105 against a ``files`` length of 100.
+    Observed on a real PR: ``changedFiles`` 105 against a ``files`` length of
+    100 — and that PR touched both ``core/`` and ``gateway/``. Trusting the short
+    list would let the hidden runtime change merge as if the PR were docs.
     """
     # Arrange
     pr = {"changedFiles": 105, "files": [{"path": f"docs/{i}.mdx"} for i in range(100)]}
@@ -437,34 +248,6 @@ def test_a_complete_file_list_is_accepted() -> None:
 
     # Act / Assert
     assert automerge_pr._file_list_is_complete(pr) is True
-
-
-def test_a_missing_count_does_not_block_everything() -> None:
-    """Without ``changedFiles`` there is nothing to compare; fall back to the list."""
-    # Arrange
-    pr = {"files": [{"path": "docs/a.mdx"}]}
-
-    # Act / Assert
-    assert automerge_pr._file_list_is_complete(pr) is True
-
-
-def test_a_large_pr_is_not_merged_or_refreshed(monkeypatch) -> None:
-    """The refusal happens before any mutation, like the protected-path one."""
-    # Arrange
-    prs = {
-        "601": _pr(
-            mergeStateStatus="BEHIND",
-            changedFiles=105,
-            files=[{"path": f"docs/{i}.mdx"} for i in range(100)],
-        ),
-        "602": _pr(mergeStateStatus="BEHIND"),
-    }
-
-    # Act
-    actions = _drive(monkeypatch, prs)
-
-    # Assert
-    assert actions == [("update", "602")]
 
 
 def test_a_full_page_without_a_count_is_refused() -> None:
@@ -483,3 +266,78 @@ def test_a_short_list_without_a_count_is_accepted() -> None:
 
     # Act / Assert
     assert automerge_pr._file_list_is_complete(pr) is True
+
+
+def test_process_pr_requests_changed_files_from_github() -> None:
+    """The completeness guard is inert unless the query asks for the count."""
+    # Arrange
+    source = _MODULE_PATH.read_text(encoding="utf-8")
+
+    # Act
+    json_fields = source.split('"--json",', 1)[1].split("]", 1)[0]
+
+    # Assert
+    assert "changedFiles" in json_fields
+    assert "files" in json_fields
+
+
+def _protected_pr_payload() -> dict:
+    return {
+        "baseRefName": "main",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [{"name": "automerge"}],
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "changedFiles": 2,
+        "files": [{"path": "docs/a.mdx"}, {"path": "core/agent/agent.py"}],
+        "statusCheckRollup": [
+            {"__typename": "CheckRun", "name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
+        ],
+        "title": "a change",
+    }
+
+
+def test_a_green_protected_pr_is_not_merged(monkeypatch) -> None:
+    """The policy has to hold in ``main``, not only in the helper.
+
+    Every other test here checks ``_protected_paths`` directly, which stays green
+    even if the caller stops consulting it. This pins the refusal on the path
+    that actually merges.
+    """
+    # Arrange
+    merges: list = []
+    monkeypatch.setattr(automerge_pr, "_run_gh", lambda _args: _protected_pr_payload())
+    monkeypatch.setattr(
+        automerge_pr.subprocess, "run", lambda *args, **_kwargs: merges.append(args[0])
+    )
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("PR_NUMBER", "77")
+
+    # Act
+    exit_code = automerge_pr.main()
+
+    # Assert
+    assert exit_code == 0
+    assert merges == [], "a PR touching core/ was auto-merged"
+
+
+def test_a_green_ordinary_pr_is_still_merged(monkeypatch) -> None:
+    """The guard must not block everything it was not aimed at."""
+    # Arrange
+    merges: list = []
+    payload = _protected_pr_payload()
+    payload["files"] = [{"path": "docs/a.mdx"}, {"path": "docs/b.mdx"}]
+    monkeypatch.setattr(automerge_pr, "_run_gh", lambda _args: payload)
+    monkeypatch.setattr(
+        automerge_pr.subprocess, "run", lambda *args, **_kwargs: merges.append(args[0])
+    )
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("PR_NUMBER", "78")
+
+    # Act
+    automerge_pr.main()
+
+    # Assert
+    assert len(merges) == 1
+    assert "merge" in merges[0]

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -314,9 +314,39 @@ def test_moving_a_file_out_of_a_protected_directory_is_caught(monkeypatch) -> No
 
 
 def test_a_truncated_listing_refuses_the_merge(monkeypatch) -> None:
-    """Fewer paths than ``changedFiles`` means the check cannot see everything."""
+    """Fewer REST entries than ``changedFiles`` means the check cannot see everything."""
     # Arrange / Act
     commands = _run_pr(monkeypatch, _pr_payload(changedFiles=105), [{"filename": "docs/a.mdx"}])
 
     # Assert
     assert commands == []
+
+
+def test_rename_inflation_cannot_mask_a_truncated_listing(monkeypatch) -> None:
+    """Destination + previous_filename must not satisfy the completeness check.
+
+    A truncated rename-heavy page can expand to more paths than ``changedFiles``
+    even while file entries are still missing. Counting paths would then let an
+    unseen ``core/`` change past the cut reach ``gh pr merge``.
+    """
+    # Arrange — 8 entries (3 renames) against 10 changed files → 11 paths, incomplete
+    files = [
+        {"filename": "docs/a.mdx"},
+        {"filename": "docs/b.mdx"},
+        {"filename": "docs/c.mdx"},
+        {"filename": "docs/d.mdx"},
+        {"filename": "docs/e.mdx"},
+        {"filename": "docs/old_a.py", "previous_filename": "docs/new_a.py"},
+        {"filename": "docs/old_b.py", "previous_filename": "docs/new_b.py"},
+        {"filename": "docs/old_c.py", "previous_filename": "docs/new_c.py"},
+    ]
+    assert len(files) == 8
+    assert len(automerge_pr._paths_from_pr_files(files)) == 11
+
+    # Act
+    commands = _run_pr(monkeypatch, _pr_payload(changedFiles=10), files)
+
+    # Assert
+    assert commands == [], "rename-inflated truncated listing was treated as complete"
+    assert automerge_pr._file_listing_is_complete(10, files) is False
+    assert automerge_pr._file_listing_is_complete(8, files) is True

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -465,3 +465,21 @@ def test_a_large_pr_is_not_merged_or_refreshed(monkeypatch) -> None:
 
     # Assert
     assert actions == [("update", "602")]
+
+
+def test_a_full_page_without_a_count_is_refused() -> None:
+    """A missing count plus a full page is indistinguishable from truncation."""
+    # Arrange
+    pr = {"files": [{"path": f"docs/{i}.mdx"} for i in range(automerge_pr.FILE_PAGE_SIZE)]}
+
+    # Act / Assert
+    assert automerge_pr._file_list_is_complete(pr) is False
+
+
+def test_a_short_list_without_a_count_is_accepted() -> None:
+    """Below the page size there is nothing that could have been cut off."""
+    # Arrange
+    pr = {"files": [{"path": "docs/a.mdx"}]}
+
+    # Act / Assert
+    assert automerge_pr._file_list_is_complete(pr) is True

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 from pathlib import Path
 
 _MODULE_PATH = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "automerge_pr.py"
@@ -170,3 +171,272 @@ def test_ignores_greptile_review_while_running() -> None:
     )
     assert green is True
     assert reason == "all checks green"
+
+
+def test_behind_but_clean_pr_is_updated_not_stalled() -> None:
+    """A PR blocked only by being out of date should take the latest base.
+
+    With "require branches to be up to date" on, every merge to main marks the
+    other open PRs ``BEHIND``. Auto-merge used to stop there, so a human had to
+    press "Update branch" and wait for CI — on a busy repo a PR could go stale
+    again before it finished.
+    """
+    # Arrange
+    pr = {"mergeStateStatus": "BEHIND", "mergeable": "MERGEABLE"}
+
+    # Act / Assert
+    assert automerge_pr._needs_branch_update(pr) is True
+
+
+def test_conflicted_pr_is_not_auto_updated() -> None:
+    """A real conflict needs a human; updating the branch cannot resolve it."""
+    # Arrange
+    pr = {"mergeStateStatus": "DIRTY", "mergeable": "CONFLICTING"}
+
+    # Act / Assert
+    assert automerge_pr._needs_branch_update(pr) is False
+
+
+def test_ready_pr_is_not_updated() -> None:
+    """A PR that can merge now must not be pushed back through CI."""
+    # Arrange
+    pr = {"mergeStateStatus": "CLEAN", "mergeable": "MERGEABLE"}
+
+    # Act / Assert
+    assert automerge_pr._needs_branch_update(pr) is False
+
+
+def test_blocked_pr_is_not_mistaken_for_out_of_date() -> None:
+    """``BLOCKED`` means checks or review are outstanding, not staleness."""
+    # Arrange
+    pr = {"mergeStateStatus": "BLOCKED", "mergeable": "MERGEABLE"}
+
+    # Act / Assert
+    assert automerge_pr._needs_branch_update(pr) is False
+
+
+def _pr(**overrides: object) -> dict:
+    """A labeled, open, green PR targeting main."""
+    pr = {
+        "baseRefName": "main",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [{"name": "automerge"}],
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "statusCheckRollup": [
+            {"__typename": "CheckRun", "name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
+        ],
+        "title": "a change",
+        "files": [{"path": "docs/a.mdx"}],
+    }
+    pr.update(overrides)
+    return pr
+
+
+def _drive(monkeypatch, prs: dict, *, on_update=None, on_merge=None) -> list:
+    """Run a sweep over ``prs`` (number -> payload), recording actions taken."""
+    actions: list = []
+    monkeypatch.setattr(automerge_pr, "_labeled_open_pr_numbers", lambda _repo: list(prs))
+    monkeypatch.setattr(automerge_pr, "_run_gh", lambda args: prs[args[2]])
+
+    def _update(_repo, number):
+        actions.append(("update", number))
+        if on_update:
+            on_update(number)
+
+    def _merge(*args, **_kwargs):
+        actions.append(("merge", args[0][3]))
+        if on_merge:
+            on_merge(args[0][3])
+
+    monkeypatch.setattr(automerge_pr, "_update_branch", _update)
+    monkeypatch.setattr(automerge_pr.subprocess, "run", _merge)
+    automerge_pr._sweep("o/r")
+    return actions
+
+
+def test_a_pr_that_cannot_be_refreshed_does_not_strand_the_queue(monkeypatch) -> None:
+    """A fork that disallows maintainer edits answers update-branch with 403.
+
+    Aborting the sweep there would leave every PR behind it stale until someone
+    noticed, and would fail the workflow on every merge to main.
+    """
+    # Arrange
+    prs = {n: _pr(mergeStateStatus="BEHIND") for n in ("101", "102", "103")}
+
+    def _forbidden(number):
+        if number == "101":
+            raise subprocess.CalledProcessError(1, "gh pr update-branch", stderr="403 Forbidden")
+
+    # Act
+    actions = _drive(monkeypatch, prs, on_update=_forbidden)
+
+    # Assert
+    assert actions == [("update", "101"), ("update", "102")]
+
+
+def test_sweep_advances_one_pr_then_stops(monkeypatch) -> None:
+    """One mutation per sweep; merging pushes main, which drives the next pass."""
+    # Arrange
+    prs = {n: _pr(mergeStateStatus="BEHIND") for n in ("201", "202", "203")}
+
+    # Act
+    actions = _drive(monkeypatch, prs)
+
+    # Assert
+    assert actions == [("update", "201")]
+
+
+def test_a_red_pr_is_never_refreshed(monkeypatch) -> None:
+    """Refreshing a failing PR re-runs the whole suite and never converges."""
+    # Arrange
+    failing = [
+        {"__typename": "CheckRun", "name": "ci", "status": "COMPLETED", "conclusion": "FAILURE"}
+    ]
+    prs = {"301": _pr(mergeStateStatus="BEHIND", statusCheckRollup=failing)}
+
+    # Act
+    actions = _drive(monkeypatch, prs)
+
+    # Assert
+    assert actions == []
+
+
+def test_queue_is_served_oldest_first(monkeypatch) -> None:
+    """The PR that has waited longest is the one advanced."""
+    # Arrange
+    listed = [
+        {"number": 402, "createdAt": "2026-08-02T10:00:00Z"},
+        {"number": 401, "createdAt": "2026-07-30T09:00:00Z"},
+        {"number": 403, "createdAt": "2026-08-01T11:00:00Z"},
+    ]
+    monkeypatch.setattr(automerge_pr, "_run_gh", lambda _args: listed)
+
+    # Act
+    order = automerge_pr._labeled_open_pr_numbers("o/r")
+
+    # Assert
+    assert order == ["401", "403", "402"]
+
+
+def test_runtime_and_ci_paths_are_never_auto_merged() -> None:
+    """The blast-radius paths need a human on the merge button.
+
+    ``core``, ``platform`` and ``gateway`` carry the agent runtime, the
+    multi-tenant platform and the chat gateway; a bad change reaches every user.
+    The workflow and script paths are the merge machinery itself, which must not
+    be able to widen its own permissions unattended.
+    """
+    # Arrange
+    protected = [
+        "core/agent/react_loop.py",
+        "platform/guardrails/engine.py",
+        "gateway/slack/handler.py",
+        ".github/workflows/ci.yml",
+        ".github/scripts/automerge_pr.py",
+    ]
+
+    # Act / Assert
+    for path in protected:
+        assert automerge_pr._protected_paths([{"path": path}]) == [path], path
+
+
+def test_ordinary_paths_stay_eligible() -> None:
+    """Docs, tests and integrations keep merging without a human."""
+    # Arrange
+    files = [
+        {"path": "docs/quickstart.mdx"},
+        {"path": "tests/core/test_thing.py"},
+        {"path": "integrations/datadog/client.py"},
+        {"path": "surfaces/cli/app.py"},
+        {"path": "README.md"},
+    ]
+
+    # Act / Assert
+    assert automerge_pr._protected_paths(files) == []
+
+
+def test_one_protected_file_taints_the_whole_pr() -> None:
+    """A mostly-docs PR that also edits the runtime still needs a human."""
+    # Arrange
+    files = [{"path": "docs/a.mdx"}, {"path": "core/agent/agent.py"}, {"path": "docs/b.mdx"}]
+
+    # Act / Assert
+    assert automerge_pr._protected_paths(files) == ["core/agent/agent.py"]
+
+
+def test_lookalike_prefixes_are_not_protected() -> None:
+    """Only real package roots count, not names that merely start the same."""
+    # Arrange
+    files = [{"path": "coreutils/x.py"}, {"path": "platformer/y.py"}, {"path": "gateways.md"}]
+
+    # Act / Assert
+    assert automerge_pr._protected_paths(files) == []
+
+
+def test_protected_pr_is_neither_merged_nor_refreshed(monkeypatch) -> None:
+    """Refusing early also keeps it out of the queue's single action slot."""
+    # Arrange
+    prs = {
+        "501": _pr(mergeStateStatus="BEHIND", files=[{"path": "core/agent/agent.py"}]),
+        "502": _pr(mergeStateStatus="BEHIND", files=[{"path": "docs/a.mdx"}]),
+    }
+
+    # Act
+    actions = _drive(monkeypatch, prs)
+
+    # Assert
+    assert actions == [("update", "502")]
+
+
+def test_a_truncated_file_list_refuses_the_merge() -> None:
+    """``gh`` pages the file list at 100 and does not say so.
+
+    A 105-file PR reports every path in ``changedFiles`` but only the first 100
+    in ``files``. Trusting the short list would let a ``core/`` change past the
+    cut merge as if the PR were docs, so the check has to fail closed. Observed
+    on a real PR: ``changedFiles`` 105 against a ``files`` length of 100.
+    """
+    # Arrange
+    pr = {"changedFiles": 105, "files": [{"path": f"docs/{i}.mdx"} for i in range(100)]}
+
+    # Act / Assert
+    assert automerge_pr._file_list_is_complete(pr) is False
+
+
+def test_a_complete_file_list_is_accepted() -> None:
+    """The common case: every changed path is visible."""
+    # Arrange
+    pr = {"changedFiles": 3, "files": [{"path": "docs/a.mdx"}] * 3}
+
+    # Act / Assert
+    assert automerge_pr._file_list_is_complete(pr) is True
+
+
+def test_a_missing_count_does_not_block_everything() -> None:
+    """Without ``changedFiles`` there is nothing to compare; fall back to the list."""
+    # Arrange
+    pr = {"files": [{"path": "docs/a.mdx"}]}
+
+    # Act / Assert
+    assert automerge_pr._file_list_is_complete(pr) is True
+
+
+def test_a_large_pr_is_not_merged_or_refreshed(monkeypatch) -> None:
+    """The refusal happens before any mutation, like the protected-path one."""
+    # Arrange
+    prs = {
+        "601": _pr(
+            mergeStateStatus="BEHIND",
+            changedFiles=105,
+            files=[{"path": f"docs/{i}.mdx"} for i in range(100)],
+        ),
+        "602": _pr(mergeStateStatus="BEHIND"),
+    }
+
+    # Act
+    actions = _drive(monkeypatch, prs)
+
+    # Assert
+    assert actions == [("update", "602")]

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -191,18 +191,17 @@ def test_runtime_and_ci_paths_are_never_auto_merged() -> None:
 
     # Act / Assert
     for path in protected:
-        assert automerge_pr._protected_paths([{"path": path}]) == [path], path
+        assert automerge_pr._protected_paths([path]) == [path], path
 
 
 def test_ordinary_paths_stay_eligible() -> None:
     """Docs, tests and integrations keep merging without a human."""
     # Arrange
     files = [
-        {"path": "docs/quickstart.mdx"},
-        {"path": "tests/core/test_thing.py"},
-        {"path": "integrations/datadog/client.py"},
-        {"path": "surfaces/cli/app.py"},
-        {"path": "README.md"},
+        "tests/core/test_thing.py",
+        "integrations/datadog/client.py",
+        "surfaces/cli/app.py",
+        "README.md",
     ]
 
     # Act / Assert
@@ -212,7 +211,7 @@ def test_ordinary_paths_stay_eligible() -> None:
 def test_one_protected_file_taints_the_whole_pr() -> None:
     """A mostly-docs PR that also edits the runtime still needs a human."""
     # Arrange
-    files = [{"path": "docs/a.mdx"}, {"path": "core/agent/agent.py"}, {"path": "docs/b.mdx"}]
+    files = ["docs/a.mdx", "core/agent/agent.py", "docs/b.mdx"]
 
     # Act / Assert
     assert automerge_pr._protected_paths(files) == ["core/agent/agent.py"]
@@ -221,68 +220,15 @@ def test_one_protected_file_taints_the_whole_pr() -> None:
 def test_lookalike_prefixes_are_not_protected() -> None:
     """Only real package roots count, not names that merely start the same."""
     # Arrange
-    files = [{"path": "coreutils/x.py"}, {"path": "platformer/y.py"}, {"path": "gateways.md"}]
+    files = ["coreutils/x.py", "platformer/y.py", "gateways.md"]
 
     # Act / Assert
     assert automerge_pr._protected_paths(files) == []
 
 
-def test_a_truncated_file_list_refuses_the_merge() -> None:
-    """``gh`` pages the file list at 100 and does not say so.
-
-    Observed on a real PR: ``changedFiles`` 105 against a ``files`` length of
-    100 — and that PR touched both ``core/`` and ``gateway/``. Trusting the short
-    list would let the hidden runtime change merge as if the PR were docs.
-    """
-    # Arrange
-    pr = {"changedFiles": 105, "files": [{"path": f"docs/{i}.mdx"} for i in range(100)]}
-
-    # Act / Assert
-    assert automerge_pr._file_list_is_complete(pr) is False
-
-
-def test_a_complete_file_list_is_accepted() -> None:
-    """The common case: every changed path is visible."""
-    # Arrange
-    pr = {"changedFiles": 3, "files": [{"path": "docs/a.mdx"}] * 3}
-
-    # Act / Assert
-    assert automerge_pr._file_list_is_complete(pr) is True
-
-
-def test_a_full_page_without_a_count_is_refused() -> None:
-    """A missing count plus a full page is indistinguishable from truncation."""
-    # Arrange
-    pr = {"files": [{"path": f"docs/{i}.mdx"} for i in range(automerge_pr.FILE_PAGE_SIZE)]}
-
-    # Act / Assert
-    assert automerge_pr._file_list_is_complete(pr) is False
-
-
-def test_a_short_list_without_a_count_is_accepted() -> None:
-    """Below the page size there is nothing that could have been cut off."""
-    # Arrange
-    pr = {"files": [{"path": "docs/a.mdx"}]}
-
-    # Act / Assert
-    assert automerge_pr._file_list_is_complete(pr) is True
-
-
-def test_process_pr_requests_changed_files_from_github() -> None:
-    """The completeness guard is inert unless the query asks for the count."""
-    # Arrange
-    source = _MODULE_PATH.read_text(encoding="utf-8")
-
-    # Act
-    json_fields = source.split('"--json",', 1)[1].split("]", 1)[0]
-
-    # Assert
-    assert "changedFiles" in json_fields
-    assert "files" in json_fields
-
-
-def _protected_pr_payload() -> dict:
-    return {
+def _pr_payload(**overrides: object) -> dict:
+    """A labeled, open, green PR targeting main."""
+    payload = {
         "baseRefName": "main",
         "state": "OPEN",
         "isDraft": False,
@@ -290,54 +236,87 @@ def _protected_pr_payload() -> dict:
         "mergeable": "MERGEABLE",
         "mergeStateStatus": "CLEAN",
         "changedFiles": 2,
-        "files": [{"path": "docs/a.mdx"}, {"path": "core/agent/agent.py"}],
         "statusCheckRollup": [
             {"__typename": "CheckRun", "name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
         ],
         "title": "a change",
     }
+    payload.update(overrides)
+    return payload
+
+
+def _run_pr(monkeypatch, payload: dict, files: list[dict]) -> list:
+    """Drive ``main`` for one PR, returning the gh commands it executed."""
+    commands: list = []
+
+    def _fake_gh(args: list[str]) -> object:
+        # ``api`` fetches the changed files; ``pr view`` fetches the PR itself.
+        return [files] if args[0] == "api" else payload
+
+    monkeypatch.setattr(automerge_pr, "_run_gh", _fake_gh)
+    monkeypatch.setattr(
+        automerge_pr.subprocess, "run", lambda *args, **_kwargs: commands.append(args[0])
+    )
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("PR_NUMBER", "77")
+    automerge_pr.main()
+    return commands
 
 
 def test_a_green_protected_pr_is_not_merged(monkeypatch) -> None:
     """The policy has to hold in ``main``, not only in the helper.
 
-    Every other test here checks ``_protected_paths`` directly, which stays green
-    even if the caller stops consulting it. This pins the refusal on the path
-    that actually merges.
+    Asserting on ``_protected_paths`` alone stays green even if the caller stops
+    consulting it, so this pins the refusal on the path that actually merges.
     """
-    # Arrange
-    merges: list = []
-    monkeypatch.setattr(automerge_pr, "_run_gh", lambda _args: _protected_pr_payload())
-    monkeypatch.setattr(
-        automerge_pr.subprocess, "run", lambda *args, **_kwargs: merges.append(args[0])
+    # Arrange / Act
+    commands = _run_pr(
+        monkeypatch,
+        _pr_payload(),
+        [{"filename": "docs/a.mdx"}, {"filename": "core/agent/agent.py"}],
     )
-    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
-    monkeypatch.setenv("PR_NUMBER", "77")
-
-    # Act
-    exit_code = automerge_pr.main()
 
     # Assert
-    assert exit_code == 0
-    assert merges == [], "a PR touching core/ was auto-merged"
+    assert commands == [], "a PR touching core/ was auto-merged"
 
 
 def test_a_green_ordinary_pr_is_still_merged(monkeypatch) -> None:
     """The guard must not block everything it was not aimed at."""
-    # Arrange
-    merges: list = []
-    payload = _protected_pr_payload()
-    payload["files"] = [{"path": "docs/a.mdx"}, {"path": "docs/b.mdx"}]
-    monkeypatch.setattr(automerge_pr, "_run_gh", lambda _args: payload)
-    monkeypatch.setattr(
-        automerge_pr.subprocess, "run", lambda *args, **_kwargs: merges.append(args[0])
+    # Arrange / Act
+    commands = _run_pr(
+        monkeypatch, _pr_payload(), [{"filename": "docs/a.mdx"}, {"filename": "docs/b.mdx"}]
     )
-    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
-    monkeypatch.setenv("PR_NUMBER", "78")
-
-    # Act
-    automerge_pr.main()
 
     # Assert
-    assert len(merges) == 1
-    assert "merge" in merges[0]
+    assert len(commands) == 1
+    assert "merge" in commands[0]
+
+
+def test_moving_a_file_out_of_a_protected_directory_is_caught(monkeypatch) -> None:
+    """A rename hides the origin unless the pre-rename path is checked.
+
+    ``gh pr view --json files`` reports only the destination, so moving
+    ``core/agent/agent.py`` to ``docs/`` would read as an ordinary new doc and
+    auto-merge — carrying runtime code out of the protected tree. The REST
+    listing carries ``previous_filename``, which is what makes this visible.
+    """
+    # Arrange / Act
+    # ``changedFiles`` must match the listing, or the truncation guard would
+    # refuse first and this would pass without ever testing the rename.
+    commands = _run_pr(
+        monkeypatch,
+        _pr_payload(changedFiles=1),
+        [{"filename": "docs/agent.py", "previous_filename": "core/agent/agent.py"}],
+    )
+
+    # Assert
+    assert commands == [], "a file moved out of core/ was auto-merged"
+
+
+def test_a_truncated_listing_refuses_the_merge(monkeypatch) -> None:
+    """Fewer paths than ``changedFiles`` means the check cannot see everything."""
+    # Arrange / Act
+    commands = _run_pr(monkeypatch, _pr_payload(changedFiles=105), [{"filename": "docs/a.mdx"}])
+
+    # Assert
+    assert commands == []

--- a/tests/github/test_automerge_pr.py
+++ b/tests/github/test_automerge_pr.py
@@ -228,6 +228,7 @@ def _pr(**overrides: object) -> dict:
             {"__typename": "CheckRun", "name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
         ],
         "title": "a change",
+        "changedFiles": 1,
         "files": [{"path": "docs/a.mdx"}],
     }
     pr.update(overrides)
@@ -388,6 +389,30 @@ def test_protected_pr_is_neither_merged_nor_refreshed(monkeypatch) -> None:
 
     # Assert
     assert actions == [("update", "502")]
+
+
+def test_process_pr_requests_changed_files_from_github(monkeypatch) -> None:
+    """Without ``changedFiles`` in the view query the truncation guard is dead."""
+    # Arrange
+    seen: list[str] = []
+
+    def _capture(args: list[str]):
+        seen.extend(args)
+        return _pr()
+
+    def _noop_run(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(automerge_pr, "_run_gh", _capture)
+    monkeypatch.setattr(automerge_pr.subprocess, "run", _noop_run)
+
+    # Act
+    automerge_pr._process_pr("o/r", "1")
+
+    # Assert
+    json_fields = seen[seen.index("--json") + 1]
+    assert "changedFiles" in json_fields.split(",")
+    assert "files" in json_fields.split(",")
 
 
 def test_a_truncated_file_list_refuses_the_merge() -> None:


### PR DESCRIPTION
Two problems on the auto-merge path, plus a policy change.

**PRs stall when `main` moves.** With "require branches to be up to date" enabled, every merge marks all other open PRs `BEHIND`. Nothing automated reacted to that: `automerge.yml` subscribes to `pull_request_target` and `workflow_run`, but not to `push` on `main` — so at the exact moment PRs go stale, no workflow runs. Someone had to press "Update branch" and wait for CI.

That does not scale at our merge rate. `main` took 156 commits in the last 7 days (22/day, 47 on the busiest). Inside an 8-hour window at that peak a merge lands roughly every 10 minutes, while the gating CI jobs are budgeted at 15–30. A PR goes stale during its own CI run, so the manual loop cannot terminate.

**Anything can auto-merge.** A change to the agent runtime, the multi-tenant platform, the chat gateway, or to the merge machinery itself could land with no human on the button.

What changed

- `automerge.yml` now also triggers on `push` to `main`. That pass has no single  PR, so the script sweeps instead.
- The sweep **advances one PR per pass and stops**. Merging pushes `main`, which  triggers the next pass, so the queue drains serially. Refreshing every PR on  every merge would cost roughly 110 extra CI runs a day at five labelled PRs;
  front-of-line costs about 22.
- PRs are served **oldest first**, so the one that has waited longest goes next.
- A PR that cannot be refreshed no longer strands the queue. `gh pr  update-branch` answers **403** on forks that disallow maintainer edits; that  used to abort the whole sweep and fail the workflow.
- Only **green** PRs are refreshed. A failing PR would otherwise re-run the full  suite on every merge to `main`, forever.
- Push sweeps share one concurrency group so they queue rather than overlap, and  do not cancel — a cancelled sweep can interrupt an in-flight merge.


Paths a machine never merges

```
core/  platform/  gateway/  .github/workflows/  .github/scripts/
```

The first three carry the agent runtime, the multi-tenant platform and the chat gateway. The last two are the merge machinery itself, which must not be able to widen its own permissions unattended. One protected file taints the whole PR; prefixes match on the directory boundary, so `coreutils/` is not `core/`.