### PR TITLE
test(vercel): add unit tests for extract helpers

### DIFF
--- a/tests/integrations/vercel/test_extract_helpers.py
+++ b/tests/integrations/vercel/test_extract_helpers.py
@@ -25,6 +25,11 @@ def test_extract_event_text_returns_empty_string_for_missing_text() -> None:
     assert _extract_event_text({"payload": "abc"}) == ""
 
 
+def test_extract_event_text_returns_empty_string_for_empty_text_values() -> None:
+    assert _extract_event_text({"text": ""}) == ""
+    assert _extract_event_text({"payload": {"text": ""}}) == ""
+
+
 def test_extract_runtime_log_message_prefers_message_field() -> None:
     log = {"message": "runtime error", "payload": {"text": "ignored"}}
 
@@ -48,6 +53,13 @@ def test_extract_runtime_log_message_returns_empty_string_for_missing_message() 
     assert _extract_runtime_log_message({}) == ""
     assert _extract_runtime_log_message({"payload": {}}) == ""
     assert _extract_runtime_log_message({"message": None, "payload": {}}) == ""
+
+
+def test_extract_runtime_log_message_returns_empty_string_for_empty_message_values() -> None:
+    assert _extract_runtime_log_message({"message": ""}) == ""
+    assert _extract_runtime_log_message({"payload": {"text": ""}}) == ""
+    assert _extract_runtime_log_message({"payload": {"message": ""}}) == ""
+    assert _extract_runtime_log_message({"payload": {"body": ""}}) == ""
 
 
 def test_extract_runtime_log_message_prefers_payload_text_over_other_payload_fields() -> None:

--- a/tests/integrations/vercel/test_extract_helpers.py
+++ b/tests/integrations/vercel/test_extract_helpers.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from integrations.vercel.client import (
+    _extract_event_text,
+    _extract_runtime_log_message,
+)
+
+
+def test_extract_event_text_prefers_text_field() -> None:
+    event = {"text": "build started", "payload": {"text": "ignored"}}
+
+    assert _extract_event_text(event) == "build started"
+
+
+def test_extract_event_text_uses_payload_text_when_text_missing() -> None:
+    event = {"payload": {"text": "payload text available"}}
+
+    assert _extract_event_text(event) == "payload text available"
+
+
+def test_extract_event_text_returns_empty_string_for_missing_text() -> None:
+    assert _extract_event_text({}) == ""
+    assert _extract_event_text({"payload": {}}) == ""
+    assert _extract_event_text({"payload": None}) == ""
+    assert _extract_event_text({"payload": "abc"}) == ""
+
+
+def test_extract_runtime_log_message_prefers_message_field() -> None:
+    log = {"message": "runtime error", "payload": {"text": "ignored"}}
+
+    assert _extract_runtime_log_message(log) == "runtime error"
+
+
+def test_extract_runtime_log_message_falls_back_to_nested_payload_text_message_or_body() -> None:
+    assert _extract_runtime_log_message({"payload": {"text": "payload text"}}) == "payload text"
+    assert (
+        _extract_runtime_log_message({"payload": {"message": "payload message"}})
+        == "payload message"
+    )
+    assert _extract_runtime_log_message({"payload": {"body": "payload body"}}) == "payload body"
+
+
+def test_extract_runtime_log_message_returns_payload_string_when_payload_is_not_dict() -> None:
+    assert _extract_runtime_log_message({"payload": "unexpected payload"}) == "unexpected payload"
+
+
+def test_extract_runtime_log_message_returns_empty_string_for_missing_message() -> None:
+    assert _extract_runtime_log_message({}) == ""
+    assert _extract_runtime_log_message({"payload": {}}) == ""
+    assert _extract_runtime_log_message({"message": None, "payload": {}}) == ""
+
+
+def test_extract_runtime_log_message_prefers_payload_text_over_other_payload_fields() -> None:
+    log = {
+        "payload": {
+            "text": "A",
+            "message": "B",
+            "body": "C",
+        }
+    }
+    assert _extract_runtime_log_message(log) == "A"


### PR DESCRIPTION
Fixes #4653

## Describe the changes you have made in this PR

Added unit tests for the following helper functions in `integrations/vercel/client.py`:

- `_extract_event_text`
- `_extract_runtime_log_message`

The tests cover:

- Top-level `text` extraction
- Nested `payload.text` extraction
- Missing and empty payloads
- Top-level `message` extraction
- Fallback to `payload.text`, `payload.message`, and `payload.body`
- Non-dictionary payload handling
- Payload field precedence

No production code was modified.

## Demo/Screenshot for feature changes and bug fixes

Not applicable. This PR only adds unit tests.

---

## Code Understanding and AI Usage

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

### If you used AI assistance

- [x] I have reviewed every single line of the AI-generated code.
- [x] I can explain the purpose and logic of each function/component I added.
- [x] I have tested edge cases and understand how the code handles them.
- [x] I have modified the AI output to follow this project's coding standards and conventions.

### Explain your implementation approach

I first reviewed the implementations of `_extract_event_text` and `_extract_runtime_log_message` to understand their behavior and fallback logic.

Based on the implementation and the issue requirements, I identified the expected behaviors and wrote unit tests covering normal inputs, fallback paths, and missing/empty payload cases. I verified the tests locally using `pytest` and ensured the test file passes formatting and linting checks with Ruff.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue.
- [x] I have performed a self-review of my code.
- [x] I can explain the purpose of every function, class, and logic block I added.
- [x] I understand why my changes work and have tested them thoroughly.
- [x] I have considered potential edge cases and how my code handles them.
- [x] If it is a core feature, I have added thorough tests.
- [x] My code follows the project's style guidelines and conventions.