### PR TITLE
refactor: replace Protocol method stubs with ellipsis

### DIFF
--- a/platform/harness_ports.py
+++ b/platform/harness_ports.py
@@ -475,11 +475,11 @@ class VcsRepoScopeProvider(Protocol):
         cached: tuple[str, ...] | None,
     ) -> tuple[str, ...] | None:
         """Resolve this vendor's repo scope from message/history/env/git/cache."""
-        raise NotImplementedError
+        ...
 
     def apply(self, resolved: dict[str, Any], scope: tuple[str, ...]) -> dict[str, Any]:
         """Return a copy of *resolved* enriched with this vendor's scope."""
-        raise NotImplementedError
+        ...
 
 
 _vcs_repo_scope_providers: list[VcsRepoScopeProvider] = []


### PR DESCRIPTION
Fixes #4647

#### Describe the changes you have made in this PR -

This PR replaces `raise NotImplementedError` with `...` in the `VcsRepoScopeProvider` protocol methods.

Changes made:
- Replaced `raise NotImplementedError` with `...` in `VcsRepoScopeProvider.infer`
- Replaced `raise NotImplementedError` with `...` in `VcsRepoScopeProvider.apply`

This is a non-functional refactoring that aligns the protocol definition with standard Python typing conventions. Since these methods belong to a `typing.Protocol`, an ellipsis is the appropriate placeholder for protocol method stubs.

### Demo/Screenshot for feature changes and bug fixes -

Validation performed:

- `make format-check` ✓
- `make lint` ✓
- `make typecheck` ✓

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue requested replacing `raise NotImplementedError` in a `typing.Protocol` with `...`.

I verified that the affected methods in `VcsRepoScopeProvider` are part of a `typing.Protocol`, where method bodies serve only as interface definitions rather than executable implementations. I replaced the `NotImplementedError` stubs with `...`, which is the standard convention for protocol method stubs and preserves the existing behavior while improving clarity.

Finally, I ran the project's formatting, linting, and type-checking commands to ensure the change introduced no issues.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests (not applicable for this refactoring)
- [x] My code follows the project's style guidelines and conventions

---