### PR TITLE
refactor(secrets): promote KeyringUnavailableReason to StrEnum

### DIFF
--- a/config/secrets/backend.py
+++ b/config/secrets/backend.py
@@ -8,7 +8,7 @@ acyclic.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 # Where a resolved secret came from. ``fallback`` is the owner-only local file
@@ -16,7 +16,7 @@ from typing import Literal
 SecretTier = Literal["env", "keyring", "fallback", "none"]
 
 
-class KeyringUnavailableReason(Enum):
+class KeyringUnavailableReason(StrEnum):
     """Why the OS keyring could not serve a request.
 
     The distinction drives policy: with ``NO_BACKEND`` there is no secure store

--- a/config/secrets/store.py
+++ b/config/secrets/store.py
@@ -134,7 +134,7 @@ def save_secret(env_var: str, value: str) -> SecretSaveResult:
     except KeyringUnavailableError as exc:
         # A machine that was told not to use its keychain is not asking for a
         # weaker store; it is asking for none.
-        if exc.reason is KeyringUnavailableReason.DISABLED:
+        if exc.reason == KeyringUnavailableReason.DISABLED:
             raise
         try:
             local_file.set(env_var, normalized)
@@ -153,7 +153,7 @@ def save_secret(env_var: str, value: str) -> SecretSaveResult:
 
 def _fallback_detail(exc: KeyringUnavailableError) -> str:
     path = local_file.store_path()
-    if exc.reason is KeyringUnavailableReason.NO_BACKEND:
+    if exc.reason == KeyringUnavailableReason.NO_BACKEND:
         return (
             f"No system keychain is available on this machine, so the credential was "
             f"saved to {path} with owner-only permissions."

--- a/tests/config/test_secret_store.py
+++ b/tests/config/test_secret_store.py
@@ -33,6 +33,20 @@ from tests.shared.keyring_backend import MemoryKeyring
 _ENV_VAR = "OPENSRE_TEST_FALLBACK_TOKEN"
 
 
+def test_keyring_unavailable_reason_values_round_trip() -> None:
+    expected = {
+        "disabled": KeyringUnavailableReason.DISABLED,
+        "no_backend": KeyringUnavailableReason.NO_BACKEND,
+        "backend_error": KeyringUnavailableReason.BACKEND_ERROR,
+    }
+
+    assert {reason.value: reason for reason in KeyringUnavailableReason} == expected
+    for value, reason in expected.items():
+        assert KeyringUnavailableReason(value) == reason
+        assert isinstance(reason, str)
+        assert str(reason) == value
+
+
 class _NoBackendKeyring(MemoryKeyring):
     """Stands in for ``keyring.backends.fail.Keyring`` on a headless box."""
 
@@ -238,7 +252,7 @@ def test_disabling_the_keyring_stays_fail_closed(monkeypatch) -> None:
     with pytest.raises(KeyringUnavailableError) as excinfo:
         save_secret(_ENV_VAR, "sk-disabled")
 
-    assert excinfo.value.reason is KeyringUnavailableReason.DISABLED
+    assert excinfo.value.reason == KeyringUnavailableReason.DISABLED
     assert not Path(local_file.store_path()).exists()
 
 


### PR DESCRIPTION
Fixes #4527

#### Describe the changes you have made in this PR -

Promoted `KeyringUnavailableReason` in `config/secrets/backend.py` from `Enum` to `StrEnum`, matching the style already used elsewhere in `config/` (`Environment`, `ReasoningEffort`, `PrincipalKind`). Values are unchanged. Updated the two policy comparisons in `config/secrets/store.py` and the one in `tests/config/test_secret_store.py` from identity (`is`) to equality (`==`), matching StrEnum idiom (identity comparisons still held correctly, since enum members remain singletons, but equality is the conventional form for a str-valued enum).

No behavior change — secret fallback logic and user-facing guidance are unchanged.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run python -m pytest -q tests/config/test_secret_store.py
15 passed, 1 skipped

uv run python -m ruff check config core gateway integrations platform surfaces tools tests/
All checks passed!

uv run python -m ruff format --check config core gateway integrations platform surfaces tools tests/
3092 files already formatted

uv run python -m mypy config core gateway integrations platform surfaces tools
Success: no issues found in 1554 source files
```

The skipped test checks POSIX owner-only file permissions and is not applicable on Windows.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`KeyringUnavailableReason` is a closed string vocabulary distinguishing a disabled keyring, a missing backend, and a backend failure. `StrEnum` keeps those values identical while letting members behave naturally as strings, consistent with sibling enums already in `config/`.

Added a characterization test (`test_keyring_unavailable_reason_values_round_trip`) pinning member values and string round-tripping before the refactor, confirmed it isolated exactly the intended new behavior (`isinstance(reason, str)` / `str(reason)`) against the pre-refactor plain `Enum`, then made the `StrEnum` swap and updated the three comparisons from `is` to `==`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (not applicable; focused regression coverage was added for this refactor)
- [x] My code follows the project's style guidelines and conventions

---

Allow edits from maintainers is enabled.