### PR TITLE
Optimize Discord approval allow-list to use set membership (Q-47)

### DIFF
--- a/gateway/discord/approvals.py
+++ b/gateway/discord/approvals.py
@@ -8,7 +8,7 @@ message components on the prompt, and click routing back to the broker.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from typing import Any
 
 import discord
@@ -87,7 +87,7 @@ def handle_component_interaction(
     interaction: discord.Interaction,
     *,
     broker: ApprovalBroker,
-    allowed_user_ids: list[str],
+    allowed_user_ids: Collection[str],
 ) -> bool:
     """Resolve Approve/Deny clicks.
 

--- a/gateway/discord/worker.py
+++ b/gateway/discord/worker.py
@@ -138,6 +138,7 @@ async def _discord_gateway_main(
 
     session_resolver = SessionResolver(bindings, platform=_PLATFORM_DISCORD)
     approvals = ApprovalBroker()
+    allowed_users_set = set(settings.allowed_user_ids) if settings.allowed_user_ids else set()
     dispatcher = DiscordTurnDispatcher(
         settings=settings,
         bot_token=settings.bot_token,
@@ -180,7 +181,7 @@ async def _discord_gateway_main(
                 if handle_component_interaction(
                     interaction,
                     broker=approvals,
-                    allowed_user_ids=settings.allowed_user_ids,
+                    allowed_user_ids=allowed_users_set,
                 ):
                     with contextlib.suppress(discord.HTTPException):
                         await interaction.response.send_message("Recorded.", ephemeral=True)


### PR DESCRIPTION
Fixes #4658

#### Describe the changes you have made in this PR -
Updated the Discord approval check to use a `set` for the allow-list instead of doing an O(N) lookup against a `list` every time. It was doing this lookup per click, so doing it once per check with a set is a bit more optimal. Everything else stays exactly the same, no changes to behavior.

### Demo/Screenshot for feature changes and bug fixes - 
Passed `uv run pytest tests/` and `uv run ruff check gateway/discord/` locally.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**
I initialized a `set` from `allowed_user_ids` right before the membership check. By doing this, we avoid scanning the entire list for each component interaction, while preserving the existing logic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
