### PR TITLE
refactor(harness): make the turn path readable from the entrypoint down

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -44,7 +44,7 @@ subpackage. Default port implementations live with the concern they serve, not i
     what the turn knows. Downstream components (e.g.
     `action_driver._resolved_integrations_for_turn`) read it from there rather
     than re-resolving. Do NOT reintroduce per-component integration resolution.
-  - `action_driver.py` — `run_action_agent_turn`: one action tool-calling turn
+  - `action_driver.py` — `ActionTurnRunner`: one action tool-calling turn
     over the ports, via a `_build_action_agent` factory that returns an
     `ActionTurnPlan`.
   - `evidence_driver.py` — bounded evidence-gather loop, via a

--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -18,10 +18,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from core.agent_harness.harness import AgentHarness, HarnessConfig, HarnessStartupResult
     from core.agent_harness.prompts.prompt_context import DefaultPromptContextProvider
-    from core.agent_harness.turns.action_driver import ToolCallingDeps
-    from core.agent_harness.turns.action_driver import (
-        run_action_agent_turn as execute_action_agent_turn,
-    )
+    from core.agent_harness.turns.action_driver import ActionTurnRunner, ToolCallingDeps
     from core.agent_harness.turns.default_headless_agent import build_default_headless_agent
     from core.agent_harness.turns.evidence_driver import gather_tool_evidence
     from core.agent_harness.turns.evidence_driver import gather_tool_evidence as gather_evidence
@@ -49,10 +46,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "TurnSnapshot": ("core.agent_harness.turns.turn_snapshot", "TurnSnapshot"),
     "TurnSnapshotSource": ("core.agent_harness.turns.turn_snapshot", "TurnSnapshotSource"),
     "ToolCallingDeps": ("core.agent_harness.turns.action_driver", "ToolCallingDeps"),
-    "execute_action_agent_turn": (
-        "core.agent_harness.turns.action_driver",
-        "run_action_agent_turn",
-    ),
+    "ActionTurnRunner": ("core.agent_harness.turns.action_driver", "ActionTurnRunner"),
     "gather_tool_evidence": ("core.agent_harness.turns.evidence_driver", "gather_tool_evidence"),
     "gather_evidence": ("core.agent_harness.turns.evidence_driver", "gather_tool_evidence"),
     "HeadlessAgent": (
@@ -102,7 +96,7 @@ __all__ = [
     "TurnSnapshot",
     "TurnSnapshotSource",
     "build_default_headless_agent",
-    "execute_action_agent_turn",
+    "ActionTurnRunner",
     "gather_evidence",
     "gather_tool_evidence",
     "run_turn",

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -11,6 +11,7 @@ Nothing here imports ``interactive_shell``.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
@@ -183,17 +184,50 @@ class RunRecordFactory(Protocol):
         raise NotImplementedError
 
 
-# Bound direct-answer callable (no tools):
-# ``answer(text, *, confirm_fn, is_tty, tool_observation, turn_plan) -> LLM-run record | None``.
-StreamAnswerFn = Callable[..., Any]
+@dataclass(frozen=True)
+class AnswerRequest:
+    """Per-turn inputs for the direct-answer (no tools) path.
 
-# Bound evidence-gather callable:
-# ``gather(text, *, is_tty, turn_plan) -> str | None``.
-EvidenceGatherer = Callable[..., "str | None"]
+    Surface-bound ports (session, output, prompts, …) live on the caller;
+    only what varies per turn goes here. Confirm/TTY stay on the action path —
+    the direct answer never prompts or branches on them.
+    """
 
-# Bound action tool-calling driver:
-# ``execute_actions(text, *, confirm_fn, is_tty, turn_plan) -> ToolCallingTurnResult``.
-ExecuteActions = Callable[..., ToolCallingTurnResult]
+    tool_observation: str | None = None
+    tool_observation_on_screen: bool = True
+    handoff_contents: tuple[str, ...] = ()
+    # ``Any`` rather than ``TurnPlan``: that type imports ``SessionStore`` from
+    # here, so naming it — even under ``TYPE_CHECKING`` — closes an import cycle
+    # this repo's check rejects.
+    turn_plan: Any = None
+
+
+class StreamAnswerFn(Protocol):
+    """Bound direct-answer callable (no tools) handed to ``run_turn``."""
+
+    def __call__(self, text: str, request: AnswerRequest) -> Any:
+        """Stream one grounded answer; return the LLM-run record or None."""
+
+
+class EvidenceGatherer(Protocol):
+    """Bound evidence-gather callable handed to ``run_turn``."""
+
+    def __call__(self, text: str, *, turn_plan: Any = None) -> str | None:
+        """Gather read-only evidence for ``text``, or return None."""
+
+
+class ExecuteActions(Protocol):
+    """Bound action tool-calling driver handed to ``run_turn``."""
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
+        """Run the action tool-calling turn for ``text``."""
 
 
 @runtime_checkable
@@ -208,6 +242,7 @@ class TurnAccounting(Protocol):
 
 
 __all__ = [
+    "AnswerRequest",
     "StreamAnswerFn",
     "ConfirmFn",
     "ErrorReporter",

--- a/core/agent_harness/tools/tool_provider.py
+++ b/core/agent_harness/tools/tool_provider.py
@@ -74,6 +74,11 @@ class DefaultToolProvider:
         self._session = session
         self._tool_context = None
 
+    def bind_console(self, console: Any) -> None:
+        """Point tool UI (observers, subprocess presenter) at ``console``."""
+        self._console = console
+        self._tool_context = None
+
     def action_tools(
         self,
         *,

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -445,97 +445,225 @@ def _build_action_agent(
     )
 
 
-def run_action_agent_turn(
-    message: str,
-    session: SessionStore,
-    *,
-    output: OutputSink,
-    tools: ToolProvider,
-    confirm_fn: ConfirmFn | None = None,
-    is_tty: bool | None = None,
-    deps: ToolCallingDeps | None = None,
-    turn_plan: TurnPlan | None = None,
-    error_reporter: ErrorReporter | None = None,
-    tool_hooks: ToolExecutionHooks | None = None,
-) -> ToolCallingTurnResult:
-    """Run one action tool-calling turn through the shared agent harness.
+@dataclass(frozen=True)
+class _ActionTurnArgs:
+    """Internal args for one ``_run_action_turn`` call."""
 
-    ``turn_plan`` is the turn-wide assembly. Its snapshot builds the action-agent
-    system prompt so the prompt reflects turn-start state rather than the live
-    (potentially mid-mutation) session, and its resolved integrations build the
-    action tools so prompt and tools agree.
+    output: OutputSink
+    tools: ToolProvider
+    confirm_fn: ConfirmFn | None = None
+    is_tty: bool | None = None
+    deps: ToolCallingDeps | None = None
+    turn_plan: TurnPlan | None = None
+    error_reporter: ErrorReporter | None = None
+    tool_hooks: ToolExecutionHooks | None = None
+
+
+@dataclass(frozen=True)
+class ActionTurnRunner:
+    """Runs action turns for one surface.
+
+    Where output goes, which tools exist, how errors are reported and how tools
+    are hooked all belong to the surface and outlive any single turn, so they are
+    given once here instead of being restated on every call.
+
+    Only ``turn_plan``, ``is_tty`` and ``confirm_fn`` change between turns, so
+    they stay arguments to :meth:`run`.
     """
-    with component_span("action_turn", session_id=getattr(session, "session_id", None)):
-        return _run_action_agent_turn_body(
-            message,
-            session,
-            output=output,
-            tools=tools,
+
+    output: OutputSink
+    tools: ToolProvider
+    deps: ToolCallingDeps | None = None
+    error_reporter: ErrorReporter | None = None
+    tool_hooks: ToolExecutionHooks | None = None
+
+    def run(
+        self,
+        message: str,
+        session: SessionStore,
+        *,
+        turn_plan: TurnPlan | None = None,
+        is_tty: bool | None = None,
+        confirm_fn: ConfirmFn | None = None,
+    ) -> ToolCallingTurnResult:
+        """Run one action tool-calling turn for ``message`` against ``session``.
+
+        ``turn_plan`` is the turn-wide assembly. Its snapshot builds the
+        action-agent system prompt so the prompt reflects turn-start state rather
+        than the live (potentially mid-mutation) session, and its resolved
+        integrations build the action tools so prompt and tools agree.
+        """
+        args = _ActionTurnArgs(
+            output=self.output,
+            tools=self.tools,
             confirm_fn=confirm_fn,
             is_tty=is_tty,
-            deps=deps,
+            deps=self.deps,
             turn_plan=turn_plan,
-            error_reporter=error_reporter,
-            tool_hooks=tool_hooks,
+            error_reporter=self.error_reporter,
+            tool_hooks=self.tool_hooks,
         )
+        with component_span("action_turn", session_id=getattr(session, "session_id", None)):
+            return _run_action_turn(message, session, args)
 
 
-def _run_action_agent_turn_body(
+@dataclass(frozen=True)
+class _TurnCounts:
+    """What ran this turn, counted once from history rows and tool results."""
+
+    executed_entries: list[dict[str, Any]]
+    executed_count: int
+    executed_success_count: int
+    generic_success_count: int
+    planned_count: int
+    handled: bool
+    investigation_dispatched: bool
+    handoff_contents: tuple[str, ...]
+
+
+def _compose_response(
+    result: Any,
+    session: SessionStore,
+    counts: _TurnCounts,
+) -> tuple[str, list[str], bool]:
+    """Build the turn's response text and what to show on screen.
+
+    Returns ``(response_text, display_chunks, use_final_text)``. The two differ
+    on purpose: self-recording tools (shell, slash) already printed their own
+    output, so the console shows only the closing text, generic tool results and
+    any hint. ``response_text`` keeps the history as well, because persistence
+    and non-TTY surfaces have nothing else to read.
+
+    Consumes the session's pending outcome hint.
+    """
+    final_text = str(getattr(result, "final_text", "") or "").strip()
+    generic_text = _response_text_from_generic_results(result)
+    hint = _pop_turn_outcome_hint(session)
+    display_chunks = [chunk for chunk in (final_text, generic_text, hint) if chunk]
+    response_chunks = [
+        chunk
+        for chunk in (
+            _response_text_from_history_entries(counts.executed_entries),
+            final_text,
+            generic_text,
+            hint,
+        )
+        if chunk
+    ]
+    # Prefer the agent's closing prose when it reads like a real reply (a report,
+    # multi-line Markdown). Short one-liners like "done" are common after a single
+    # tool call and must not replace tool-derived text or be streamed on their own.
+    use_final_text = _is_user_facing_final_text(final_text)
+    response_text = final_text if use_final_text else "\n".join(response_chunks)
+    return response_text, display_chunks, use_final_text
+
+
+def _show_response(
+    output: OutputSink,
+    *,
+    handled: bool,
+    final_text: str,
+    display_chunks: list[str],
+) -> None:
+    """Show the turn's answer, or leave a blank line after silent tool work.
+
+    ``final_text`` arrives empty unless the closing message reads like a real
+    reply; only then is it streamed as the assistant speaking.
+    """
+    if handled and final_text:
+        output.stream(label="OpenSRE", chunks=iter([final_text]))
+        return
+    if display_chunks:
+        output.print()
+        output.render_response_header("assistant")
+        output.print("\n".join(display_chunks))
+        return
+    if handled:
+        output.print()
+
+
+def _count_turn(result: Any, session: SessionStore, history_start: int) -> _TurnCounts:
+    """Count what ran, from the history rows this turn added plus the results."""
+    executed_entries = [
+        item
+        for item in session.history[history_start:]
+        if item.get("type") in _EXECUTED_HISTORY_TYPES
+    ]
+    generic_executed_count, generic_success_count = _generic_tool_result_counts(result)
+    # ``assistant_handoff`` runs like a tool but hands back to conversation, so
+    # it must not make the turn look like it did something for the user.
+    planned_count = sum(1 for tc, _output in result.executed if tc.name != "assistant_handoff")
+    return _TurnCounts(
+        executed_entries=executed_entries,
+        executed_count=len(executed_entries) + generic_executed_count,
+        executed_success_count=(
+            sum(1 for item in executed_entries if item.get("ok", True)) + generic_success_count
+        ),
+        generic_success_count=generic_success_count,
+        planned_count=planned_count,
+        handled=planned_count > 0,
+        investigation_dispatched=any(
+            tc.name in INVESTIGATION_DISPATCH_TOOL_NAMES for tc, _output in result.executed
+        ),
+        handoff_contents=tuple(
+            content
+            for tc, _output in result.executed
+            if tc.name == "assistant_handoff"
+            for content in (str(public_tool_input(tc.input).get("content", "")).strip(),)
+            if content
+        ),
+    )
+
+
+def _run_action_turn(
     message: str,
     session: SessionStore,
-    *,
-    output: OutputSink,
-    tools: ToolProvider,
-    confirm_fn: ConfirmFn | None = None,
-    is_tty: bool | None = None,
-    deps: ToolCallingDeps | None = None,
-    turn_plan: TurnPlan | None = None,
-    error_reporter: ErrorReporter | None = None,
-    tool_hooks: ToolExecutionHooks | None = None,
+    args: _ActionTurnArgs,
 ) -> ToolCallingTurnResult:
+    turn_plan = args.turn_plan
     turn_snapshot = turn_plan.snapshot if turn_plan is not None else None
     # Read the turn's resolved integrations once, so the action tools and the
     # AgentConfig are built from the same view (single source, no re-resolve).
     resolved_integrations = _turn_resolved_integrations(session, turn_plan)
     history_start = len(session.history)
 
-    agent_tools = tools.action_tools(
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
+    agent_tools = args.tools.action_tools(
+        confirm_fn=args.confirm_fn,
+        is_tty=args.is_tty,
         resolved_integrations=resolved_integrations,
     )
-    tool_resources_provider = getattr(tools, "tool_resources", None)
+    tool_resources_provider = getattr(args.tools, "tool_resources", None)
     tool_resources = tool_resources_provider() if callable(tool_resources_provider) else {}
-    observer = tools.observer(message=message)
+    observer = args.tools.observer(message=message)
     log.debug(
         "action_turn start tools=%s integrations=%s",
         len(agent_tools),
         len(resolved_integrations),
     )
 
-    plan: ActionTurnPlan | None = None
+    built: ActionTurnPlan | None = None
     try:
         # LLM selection inside _build_action_agent is inside the try so a factory
         # raise (e.g. provider unavailable) is caught and rendered like a run-loop
         # failure. Agent construction is cheap and stays with it for a single
         # failure boundary.
-        plan = _build_action_agent(
+        built = _build_action_agent(
             message=message,
             session=session,
             agent_tools=agent_tools,
             turn_snapshot=turn_snapshot,
             resolved_integrations=resolved_integrations,
-            deps=deps,
-            tool_hooks=tool_hooks,
+            deps=args.deps,
+            tool_hooks=args.tool_hooks,
             tool_resources=tool_resources,
             observer=observer,
         )
         result = run_react_agent_with_telemetry(
-            plan.agent,
-            [{"role": "user", "content": plan.user_message}],
+            built.agent,
+            [{"role": "user", "content": built.user_message}],
             phase="action",
-            iteration_cap=plan.max_iterations,
-            llm=plan.llm,
+            iteration_cap=built.max_iterations,
+            llm=built.llm,
             session=session,
         )
         persist_turn_system_prompt(
@@ -549,73 +677,33 @@ def _run_action_agent_turn_body(
             return ToolCallingTurnResult(0, 0, 0, False, False, accounting_status="not_run")
 
         error_text = str(exc)
-        if error_reporter is not None:
-            error_reporter.report(exc, context="core.agent_harness.action_driver", expected=True)
-        llm_client = None if plan is None or isinstance(plan.llm, _StaticToolCallLLM) else plan.llm
+        if args.error_reporter is not None:
+            args.error_reporter.report(
+                exc, context="core.agent_harness.action_driver", expected=True
+            )
+        llm_client = (
+            None if built is None or isinstance(built.llm, _StaticToolCallLLM) else built.llm
+        )
         _stage_action_llm_failure(
             message,
             session,
             client=llm_client,
             error_text=error_text,
         )
-        _render_tool_calling_error(output, error_text)
+        _render_tool_calling_error(args.output, error_text)
         _persist_tool_calling_error(session, message, error_text)
         session.record("cli_agent", message, ok=False)
         return ToolCallingTurnResult(
             0, 0, 0, True, True, response_text=error_text, accounting_status="not_run"
         )
 
-    executed_entries = [
-        item
-        for item in session.history[history_start:]
-        if item.get("type") in _EXECUTED_HISTORY_TYPES
-    ]
-    executed_count = len(executed_entries)
-    executed_success_count = sum(1 for item in executed_entries if item.get("ok", True))
-    generic_executed_count, generic_success_count = _generic_tool_result_counts(result)
-    executed_count += generic_executed_count
-    executed_success_count += generic_success_count
-    planned_count = sum(1 for tc, _output in result.executed if tc.name != "assistant_handoff")
-    handled = planned_count > 0
-    investigation_dispatched = any(
-        tc.name in INVESTIGATION_DISPATCH_TOOL_NAMES for tc, _output in result.executed
-    )
-    handoff_contents = tuple(
-        content
-        for tc, _output in result.executed
-        if tc.name == "assistant_handoff"
-        for content in (str(public_tool_input(tc.input).get("content", "")).strip(),)
-        if content
-    )
-    final_text = str(getattr(result, "final_text", "") or "").strip()
-    generic_text = _response_text_from_generic_results(result)
-    hint = _pop_turn_outcome_hint(session)
-    # History entries are already rendered by self-recording tools (shell/slash/…).
-    # Console display uses final_text + generic results + hints only so users see
-    # github_cli / other registry tools without double-printing shell output.
-    # response_text still includes history for persistence / non-TTY surfaces.
-    display_chunks = [chunk for chunk in (final_text, generic_text, hint) if chunk]
-    response_chunks = [
-        chunk
-        for chunk in (
-            _response_text_from_history_entries(executed_entries),
-            final_text,
-            generic_text,
-            hint,
-        )
-        if chunk
-    ]
-    # Prefer the agent's closing prose when it looks like a real reply (report /
-    # multi-line Markdown). Short one-liners like "done" are common after a
-    # single tool call and must not replace tool-derived response_text or get
-    # streamed on action-only turns (gateway finalize / cross-surface parity).
-    use_final_text = _is_user_facing_final_text(final_text)
-    response_text = final_text if use_final_text else "\n".join(response_chunks)
+    counts = _count_turn(result, session, history_start)
+    response_text, display_chunks, use_final_text = _compose_response(result, session, counts)
     # Discovery tools that opt into ``summarize_observation`` (via tool tags)
     # return structured JSON users should not see raw. Stash only those results.
     if (
         response_text.strip()
-        and generic_success_count > 0
+        and counts.generic_success_count > 0
         and not session.last_command_observation
         and _should_stash_observation(
             result,
@@ -623,37 +711,36 @@ def _run_action_agent_turn_body(
         )
     ):
         session.last_command_observation = response_text
-    if handled and use_final_text:
-        output.stream(label="OpenSRE", chunks=iter([final_text]))
-    elif display_chunks:
-        output.print()
-        output.render_response_header("assistant")
-        output.print("\n".join(display_chunks))
-    elif handled:
-        output.print()
+    _show_response(
+        args.output,
+        handled=counts.handled,
+        # use_final_text means the composed text *is* the closing message.
+        final_text=response_text if use_final_text else "",
+        display_chunks=display_chunks,
+    )
 
     log.debug(
         "action_turn done planned=%s executed=%s handled=%s investigation=%s",
-        planned_count,
-        executed_count,
-        handled,
-        investigation_dispatched,
+        counts.planned_count,
+        counts.executed_count,
+        counts.handled,
+        counts.investigation_dispatched,
     )
     return ToolCallingTurnResult(
-        planned_count,
-        executed_count,
-        executed_success_count,
+        counts.planned_count,
+        counts.executed_count,
+        counts.executed_success_count,
         False,
-        handled,
+        counts.handled,
         response_text=response_text,
-        handoff_contents=handoff_contents,
-        investigation_dispatched=investigation_dispatched,
+        handoff_contents=counts.handoff_contents,
+        investigation_dispatched=counts.investigation_dispatched,
     )
 
 
 __all__ = [
     "ActionTurnPlan",
+    "ActionTurnRunner",
     "SELF_RECORDING_ACTION_TOOL_NAMES",
     "ToolCallingDeps",
-    "run_action_agent_turn",
 ]

--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -227,7 +227,6 @@ def gather_tool_evidence(
     on_progress: ToolEventObserver | None = None,
     persist: PersistToolCalls | None = None,
     error_reporter: ErrorReporter | None = None,
-    is_tty: bool | None = None,  # noqa: ARG001 — reserved for parity with answer agents
     agent_factory: GatherAgentFactory | None = None,
     resolved_integrations: dict[str, Any] | None = None,
 ) -> str | None:

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -66,6 +66,20 @@ from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnRes
 from core.execution import ToolExecutionHooks
 
 
+class _Unmentioned:
+    """Marks a port the caller did not mention, as distinct from one cleared.
+
+    ``bind_turn(output=...)`` must leave the hooks alone, but
+    ``bind_turn(tool_hooks=None)`` must clear them — the gateway passes ``None``
+    for a sink that has no approval hooks, and a pooled agent would otherwise
+    keep the previous sink's callback and send approvals to the wrong
+    conversation.
+    """
+
+
+_UNMENTIONED = _Unmentioned()
+
+
 class HeadlessAgent:
     """Runs full agent turns headlessly from a fixed set of configured ports.
 
@@ -144,7 +158,7 @@ class HeadlessAgent:
         *,
         output: OutputSink | None = None,
         accounting: TurnAccounting | None = None,
-        tool_hooks: ToolExecutionHooks | None = None,
+        tool_hooks: ToolExecutionHooks | None | _Unmentioned = _UNMENTIONED,
         session: SessionStore | None = None,
     ) -> None:
         """Swap turn-scoped ports so one agent can serve many turns.
@@ -160,7 +174,7 @@ class HeadlessAgent:
             runner_changed = True
         if accounting is not None:
             self._accounting = accounting
-        if tool_hooks is not None:
+        if not isinstance(tool_hooks, _Unmentioned):
             self._tool_hooks = tool_hooks
             runner_changed = True
         if runner_changed:

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.ports import (
+    AnswerRequest,
     ConfirmFn,
     ErrorReporter,
     OutputSink,
@@ -44,7 +45,9 @@ from core.agent_harness.prompts.prompt_context import (
     DefaultPromptContextProvider,
     supports_default_prompt_context,
 )
-from core.agent_harness.turns.action_driver import run_action_agent_turn
+from core.agent_harness.turns.action_driver import (
+    ActionTurnRunner,
+)
 from core.agent_harness.turns.evidence_driver import gather_tool_evidence
 from core.agent_harness.turns.headless_adapters import (
     BufferOutputSink,
@@ -113,6 +116,15 @@ class HeadlessAgent:
         self._confirm_fn = confirm_fn
         self._is_tty = is_tty
         self._tool_hooks = tool_hooks
+        self._action_runner = self._new_action_runner()
+
+    def _new_action_runner(self) -> ActionTurnRunner:
+        return ActionTurnRunner(
+            output=self._output,
+            tools=self._tools,
+            error_reporter=self._error_reporter,
+            tool_hooks=self._tool_hooks,
+        )
 
     def bind_session(self, session: SessionStore) -> None:
         """Retarget this agent at a freshly resolved session.
@@ -142,12 +154,17 @@ class HeadlessAgent:
         """
         if session is not None:
             self.bind_session(session)
+        runner_changed = False
         if output is not None:
             self._output = output
+            runner_changed = True
         if accounting is not None:
             self._accounting = accounting
         if tool_hooks is not None:
             self._tool_hooks = tool_hooks
+            runner_changed = True
+        if runner_changed:
+            self._action_runner = self._new_action_runner()
 
     def _accounting_for(self, message: str) -> TurnAccounting:
         if self._accounting is not None:
@@ -156,65 +173,54 @@ class HeadlessAgent:
             return DefaultTurnAccounting(self._store, message)
         return NoopTurnAccounting()
 
+    def _execute_actions(
+        self,
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: TurnPlan | None = None,
+    ) -> ToolCallingTurnResult:
+        return self._action_runner.run(
+            text,
+            self._store,
+            turn_plan=turn_plan,
+            is_tty=is_tty,
+            confirm_fn=confirm_fn,
+        )
+
+    def _answer(self, text: str, request: AnswerRequest) -> object:
+        return stream_answer(
+            text,
+            self._store,
+            self._output,
+            prompts=self._prompts,
+            reasoning=self._reasoning,
+            run_factory=self._run_factory,
+            error_reporter=self._error_reporter,
+            request=request,
+        )
+
+    def _gather(self, text: str, *, turn_plan: TurnPlan | None = None) -> str | None:
+        if not self._gather_enabled:
+            return None
+        resolved = turn_plan.resolved_integrations if turn_plan is not None else None
+        return gather_tool_evidence(
+            text,
+            self._store,
+            error_reporter=self._error_reporter,
+            resolved_integrations=resolved,
+        )
+
     def dispatch(self, message: str) -> TurnResult:
         """Run one full turn for ``message`` and return the :class:`TurnResult`."""
-        accounting = self._accounting_for(message)
-
-        def execute_actions(
-            text: str,
-            *,
-            confirm_fn: ConfirmFn | None = None,
-            is_tty: bool | None = None,
-            turn_plan: TurnPlan | None = None,
-        ) -> ToolCallingTurnResult:
-            return run_action_agent_turn(
-                text,
-                self._store,
-                output=self._output,
-                tools=self._tools,
-                confirm_fn=confirm_fn,
-                is_tty=is_tty,
-                turn_plan=turn_plan,
-                error_reporter=self._error_reporter,
-                tool_hooks=self._tool_hooks,
-            )
-
-        def answer(text: str, **kwargs: object) -> object:
-            return stream_answer(
-                text,
-                self._store,
-                self._output,
-                prompts=self._prompts,
-                reasoning=self._reasoning,
-                run_factory=self._run_factory,
-                error_reporter=self._error_reporter,
-                **kwargs,  # type: ignore[arg-type]
-            )
-
-        def gather(
-            text: str,
-            *,
-            is_tty: bool | None = None,
-            turn_plan: TurnPlan | None = None,
-        ) -> str | None:
-            if not self._gather_enabled:
-                return None
-            resolved = turn_plan.resolved_integrations if turn_plan is not None else None
-            return gather_tool_evidence(
-                text,
-                self._store,
-                error_reporter=self._error_reporter,
-                is_tty=is_tty,
-                resolved_integrations=resolved,
-            )
-
         return run_turn(
             message,
             self._store,
-            execute_actions=execute_actions,
-            answer=answer,
-            gather=gather,
-            accounting=accounting,
+            execute_actions=self._execute_actions,
+            answer=self._answer,
+            gather=self._gather,
+            accounting=self._accounting_for(message),
             confirm_fn=self._confirm_fn,
             is_tty=self._is_tty,
         )

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Literal, assert_never
+from typing import Any, Literal
 
 from config.llm_reasoning_effort import apply_reasoning_effort
 from core.agent_harness.ports import (
@@ -274,6 +274,15 @@ def _is_prior_investigation_follow_up_handoff(handoff_contents: tuple[str, ...])
     return is_prior_investigation_follow_up(handoff_contents)
 
 
+@dataclass(frozen=True)
+class _RouteOutcome:
+    """Effects of one routed path, ready to pack into ``TurnResult``."""
+
+    final_intent: str
+    response_text: str
+    llm_run: Any | None = None
+
+
 def _gather_and_answer(
     *,
     text: str,
@@ -395,47 +404,57 @@ def run_turn(
     )
 
     with component_span(f"route:{route.intent}", session_id=sid):
-        match route.intent:
-            case "summarize_observation":
-                with apply_reasoning_effort(turn_snapshot.reasoning_effort):
-                    run = answer(
-                        text,
-                        AnswerRequest(
-                            tool_observation=observation,
-                            handoff_contents=handoff_contents,
-                            turn_plan=turn_plan,
-                        ),
-                    )
-                final_intent, response_text = "cli_agent_summarized", _response_text(run)
-            case "handled_without_llm":
-                # The one route that never calls the model: the action already
-                # produced the text the user sees.
-                _record_action_only_turn(session, text, action_result.response_text)
-                run, final_intent = None, "cli_agent_handled"
-                response_text = action_result.response_text
-            case "gather_and_answer":
-                with apply_reasoning_effort(turn_snapshot.reasoning_effort):
-                    run = _gather_and_answer(
-                        text=text,
-                        answer=answer,
-                        gather=gather,
+        # if/elif + raise (not match/assert_never): CodeQL does not model
+        # ``assert_never`` as noreturn, so locals bound only inside match arms
+        # and read after the match trip py/uninitialized-local-variable.
+        if route.intent == "summarize_observation":
+            with apply_reasoning_effort(turn_snapshot.reasoning_effort):
+                run = answer(
+                    text,
+                    AnswerRequest(
+                        tool_observation=observation,
                         handoff_contents=handoff_contents,
                         turn_plan=turn_plan,
-                    )
-                final_intent, response_text = "cli_agent_fallback", _response_text(run)
-            case _ as unreachable:
-                # ``intent`` is a closed Literal, so a new value fails type-check
-                # here rather than reaching a runtime raise in production.
-                assert_never(unreachable)
+                    ),
+                )
+            outcome = _RouteOutcome(
+                final_intent="cli_agent_summarized",
+                response_text=_response_text(run),
+                llm_run=run,
+            )
+        elif route.intent == "handled_without_llm":
+            # The one route that never calls the model: the action already
+            # produced the text the user sees.
+            _record_action_only_turn(session, text, action_result.response_text)
+            outcome = _RouteOutcome(
+                final_intent="cli_agent_handled",
+                response_text=action_result.response_text,
+            )
+        elif route.intent == "gather_and_answer":
+            with apply_reasoning_effort(turn_snapshot.reasoning_effort):
+                run = _gather_and_answer(
+                    text=text,
+                    answer=answer,
+                    gather=gather,
+                    handoff_contents=handoff_contents,
+                    turn_plan=turn_plan,
+                )
+            outcome = _RouteOutcome(
+                final_intent="cli_agent_fallback",
+                response_text=_response_text(run),
+                llm_run=run,
+            )
+        else:
+            raise AssertionError(f"Unknown route intent: {route.intent!r}")
 
-    return accounting.finalize(
-        TurnResult(
-            final_intent=final_intent,
-            action_result=action_result,
-            assistant_response_text=response_text,
-            llm_run=run,
+        return accounting.finalize(
+            TurnResult(
+                final_intent=outcome.final_intent,
+                action_result=action_result,
+                assistant_response_text=outcome.response_text,
+                llm_run=outcome.llm_run,
+            )
         )
-    )
 
 
 __all__ = [

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, assert_never
 
 from config.llm_reasoning_effort import apply_reasoning_effort
 from core.agent_harness.ports import (
+    AnswerRequest,
     ConfirmFn,
     ErrorReporter,
     EvidenceGatherer,
@@ -149,12 +150,7 @@ def stream_answer(
     reasoning: ReasoningClientProvider,
     run_factory: RunRecordFactory,
     error_reporter: ErrorReporter | None = None,
-    confirm_fn: ConfirmFn | None = None,
-    is_tty: bool | None = None,
-    tool_observation: str | None = None,
-    tool_observation_on_screen: bool = True,
-    handoff_contents: tuple[str, ...] = (),
-    turn_plan: TurnPlan | None = None,
+    request: AnswerRequest | None = None,
 ) -> Any | None:
     """Stream one grounded conversational answer (guidance only, no tools).
 
@@ -162,26 +158,27 @@ def stream_answer(
     no ReAct loop. The **tool-calling** agent is ``core.agent.Agent`` — see
     ``core/agent_harness/AGENTS.md``.
 
-    ``turn_plan`` is the turn-wide assembly built at turn start. Its snapshot
-    (conversation history, integration state, prior investigation, synthetic-run
-    path) grounds prompt construction in a stable turn-start view rather than the
-    live session.
+    ``request.turn_plan`` is the turn-wide assembly built at turn start. Its
+    snapshot (conversation history, integration state, prior investigation,
+    synthetic-run path) grounds prompt construction in a stable turn-start view
+    rather than the live session.
     """
+    req = request if request is not None else AnswerRequest()
     client = reasoning.get()
     if client is None:
         return None
 
+    turn_plan = req.turn_plan
     ctx = (
         turn_plan.snapshot if turn_plan is not None else TurnSnapshot.from_session(message, session)
     )
-    _ = (confirm_fn, is_tty)
 
     prompt = build_cli_agent_prompt_from_provider(
         message=message,
         prompts=prompts,
-        tool_observation=tool_observation,
-        tool_observation_on_screen=tool_observation_on_screen,
-        handoff_contents=handoff_contents,
+        tool_observation=req.tool_observation,
+        tool_observation_on_screen=req.tool_observation_on_screen,
+        handoff_contents=req.handoff_contents,
         turn_snapshot=ctx,
     )
 
@@ -282,8 +279,6 @@ def _gather_and_answer(
     text: str,
     answer: StreamAnswerFn,
     gather: EvidenceGatherer,
-    confirm_fn: ConfirmFn | None,
-    is_tty: bool | None,
     handoff_contents: tuple[str, ...],
     turn_plan: TurnPlan,
 ) -> Any | None:
@@ -297,23 +292,21 @@ def _gather_and_answer(
     skip_gather = _is_prior_investigation_follow_up_handoff(handoff_contents) and (
         turn_plan.snapshot.last_state is not None
     )
-    gathered = None if skip_gather else gather(text, is_tty=is_tty, turn_plan=turn_plan)
+    gathered = None if skip_gather else gather(text, turn_plan=turn_plan)
     if skip_gather:
         log.debug("gather skipped: follow_up handoff with prior investigation state")
 
-    # When evidence was gathered, mark it off-screen so the prompt builder
-    # includes it. When nothing was gathered, omit the flag entirely so the
-    # call shape matches the plain conversational (no-observation) path.
-    on_screen: dict[str, bool] = {"tool_observation_on_screen": False} if gathered else {}
-
+    # Off-screen when we have evidence text so the prompt builder injects it;
+    # on-screen (plain path) when there is nothing to inject.
+    observation = gathered if gathered else None
     return answer(
         text,
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
-        tool_observation=gathered or None,
-        handoff_contents=handoff_contents,
-        turn_plan=turn_plan,
-        **on_screen,
+        AnswerRequest(
+            tool_observation=observation,
+            tool_observation_on_screen=observation is None,
+            handoff_contents=handoff_contents,
+            turn_plan=turn_plan,
+        ),
     )
 
 
@@ -402,50 +395,47 @@ def run_turn(
     )
 
     with component_span(f"route:{route.intent}", session_id=sid):
-        if route.intent == "summarize_observation":
-            with apply_reasoning_effort(turn_snapshot.reasoning_effort):
-                run = answer(
-                    text,
-                    confirm_fn=confirm_fn,
-                    is_tty=is_tty,
-                    tool_observation=observation,
-                    handoff_contents=handoff_contents,
-                    turn_plan=turn_plan,
-                )
-            result = TurnResult(
-                final_intent="cli_agent_summarized",
-                action_result=action_result,
-                assistant_response_text=_response_text(run),
-                llm_run=run,
-            )
-        elif route.intent == "handled_without_llm":
-            _record_action_only_turn(session, text, action_result.response_text)
-            result = TurnResult(
-                final_intent="cli_agent_handled",
-                action_result=action_result,
-                assistant_response_text=action_result.response_text,
-            )
-        elif route.intent == "gather_and_answer":
-            with apply_reasoning_effort(turn_snapshot.reasoning_effort):
-                run = _gather_and_answer(
-                    text=text,
-                    answer=answer,
-                    gather=gather,
-                    confirm_fn=confirm_fn,
-                    is_tty=is_tty,
-                    handoff_contents=handoff_contents,
-                    turn_plan=turn_plan,
-                )
-            result = TurnResult(
-                final_intent="cli_agent_fallback",
-                action_result=action_result,
-                assistant_response_text=_response_text(run),
-                llm_run=run,
-            )
-        else:
-            raise AssertionError(f"Unknown route intent: {route.intent!r}")
+        match route.intent:
+            case "summarize_observation":
+                with apply_reasoning_effort(turn_snapshot.reasoning_effort):
+                    run = answer(
+                        text,
+                        AnswerRequest(
+                            tool_observation=observation,
+                            handoff_contents=handoff_contents,
+                            turn_plan=turn_plan,
+                        ),
+                    )
+                final_intent, response_text = "cli_agent_summarized", _response_text(run)
+            case "handled_without_llm":
+                # The one route that never calls the model: the action already
+                # produced the text the user sees.
+                _record_action_only_turn(session, text, action_result.response_text)
+                run, final_intent = None, "cli_agent_handled"
+                response_text = action_result.response_text
+            case "gather_and_answer":
+                with apply_reasoning_effort(turn_snapshot.reasoning_effort):
+                    run = _gather_and_answer(
+                        text=text,
+                        answer=answer,
+                        gather=gather,
+                        handoff_contents=handoff_contents,
+                        turn_plan=turn_plan,
+                    )
+                final_intent, response_text = "cli_agent_fallback", _response_text(run)
+            case _ as unreachable:
+                # ``intent`` is a closed Literal, so a new value fails type-check
+                # here rather than reaching a runtime raise in production.
+                assert_never(unreachable)
 
-    return accounting.finalize(result)
+    return accounting.finalize(
+        TurnResult(
+            final_intent=final_intent,
+            action_result=action_result,
+            assistant_response_text=response_text,
+            llm_run=run,
+        )
+    )
 
 
 __all__ = [

--- a/docs/interactive-shell-action-policy.md
+++ b/docs/interactive-shell-action-policy.md
@@ -231,7 +231,7 @@ verbatim. There is no inference. Free-form natural language ("log me in",
 is "explicit typed command" vs "natural language", identical to the line the
 terminal-UI policy (`_literal_slash_command_text`) already draws.
 
-**How it works.** `core/agent_harness/turns/action_driver.run_action_agent_turn` recognizes
+**How it works.** `core/agent_harness/turns/action_driver.ActionTurnRunner` recognizes
 literal `/slash` input and emits a deterministic `slash_invoke` tool call through
 the same static-LLM path as the explicit `!cmd` shell escape
 (`_StaticToolCallLLM`). Execution then flows through the normal `slash_invoke`

--- a/gateway/tests/main/test_antartica_slack.py
+++ b/gateway/tests/main/test_antartica_slack.py
@@ -22,7 +22,7 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
 from core.agent_harness.tools.action_tools import action_tool_names
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
-from core.agent_harness.turns.action_driver import ToolCallingDeps, run_action_agent_turn
+from core.agent_harness.turns.action_driver import ActionTurnRunner, ToolCallingDeps
 from core.llm.types import AgentLLMResponse, ToolCall
 from gateway.runtime.headless_subprocess_presenter import headless_subprocess_presenter_factory
 from tools.registry import clear_tool_registry_cache
@@ -189,14 +189,15 @@ def test_agent_computes_temperature_then_sends_it_to_slack(
     )
     llm = _ComputeThenSlackLLM()
 
-    result = run_action_agent_turn(
-        _USER_MESSAGE,
-        session,
+    result = ActionTurnRunner(
         output=MagicMock(),
         tools=provider,
+        deps=ToolCallingDeps(llm_factory=lambda: llm),
+    ).run(
+        _USER_MESSAGE,
+        session,
         confirm_fn=lambda _prompt: "y",
         is_tty=True,
-        deps=ToolCallingDeps(llm_factory=lambda: llm),
     )
 
     # The agent ran the compound request as a sequence of turns: compute, send,

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -169,6 +169,8 @@ class InteractiveShellController:
             self.spinner,
             self.runtime_context.pt_session,
         )
+        from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
+
         self.turn_runtime = AgentTurnRuntime(
             session=self.session,
             state=self.state,
@@ -176,6 +178,11 @@ class InteractiveShellController:
             invalidate_prompt=lambda: self.prompt.invalidate_prompt(),
             request_exit=self.prompt.request_exit,
             console=self.service_console,
+            action_runner=ShellActionRunner(
+                session=self.session,
+                console=self.service_console,
+                request_exit=self.prompt.request_exit,
+            ),
         )
         # Prompt echoes belong in the same stream as everything else this turn
         # writes, so an embedding caller captures the whole conversation.

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -1,7 +1,7 @@
 """Shell adapter for one action-selection turn.
 
 Binds the interactive shell's console, session, and default providers around
-core ``run_action_agent_turn``.
+core ``ActionTurnRunner``.
 """
 
 from __future__ import annotations
@@ -14,13 +14,19 @@ from core.agent_harness.error_reporting import DefaultErrorReporter
 from core.agent_harness.llm_resolution import default_llm_factory
 from core.agent_harness.ports import OutputSink
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
-from core.agent_harness.turns.action_driver import ToolCallingDeps, run_action_agent_turn
+from core.agent_harness.turns.action_driver import (
+    ActionTurnRunner,
+    ToolCallingDeps,
+)
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
-from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
+from surfaces.interactive_shell.runtime.agent_harness_adapters import (
+    ShellOutputSink,
+    resolve_output_sink,
+)
 from surfaces.interactive_shell.runtime.background import runner as background_runner
 from surfaces.interactive_shell.runtime.investigation_adapter import (
     repl_investigation_launch_ports,
@@ -86,6 +92,107 @@ def _investigation_ports_factory() -> InvestigationLaunchPorts:
     )
 
 
+class ShellActionRunner:
+    """Runs action turns for one shell session.
+
+    Session, tool wiring, error reporting, and the core
+    :class:`~core.agent_harness.turns.action_driver.ActionTurnRunner` are built
+    once. Per turn, :meth:`bind_turn` retargets the console/output (spinner
+    streaming console) without rebuilding the runner; only ``confirm_fn``,
+    ``is_tty``, and ``turn_plan`` are passed to :meth:`run`.
+    """
+
+    def __init__(
+        self,
+        session: Session,
+        console: Console,
+        *,
+        request_exit: Callable[[], None] | None = None,
+        deps: ToolCallingDeps | None = None,
+        output: OutputSink | None = None,
+        tool_hooks: ToolExecutionHooks | None = None,
+    ) -> None:
+        self._session = session
+        self._console = console
+        self._request_exit = request_exit
+        self._deps = (
+            deps
+            if deps is not None and deps.llm_factory is not None
+            else ToolCallingDeps(llm_factory=default_llm_factory)
+        )
+        self._external_output = output
+        self._tool_hooks = tool_hooks
+        self._sink = resolve_output_sink(console, output)
+        self._tools = DefaultToolProvider(
+            session,
+            console,
+            request_exit=request_exit,
+            observer_factory=lambda msg: ActionRenderObserver(
+                session=self._session, console=self._console, message=msg
+            ),
+            subprocess_presenter_factory=_subprocess_presenter_factory,
+            investigation_ports_factory=_investigation_ports_factory,
+            llm_provider_ports_factory=repl_llm_provider_ports,
+            task_cancel_ports_factory=repl_task_cancel_ports,
+            slash_ports_factory=repl_slash_ports,
+        )
+        self._error_reporter = DefaultErrorReporter()
+        self._action_runner = self._new_action_runner()
+
+    def _new_action_runner(self) -> ActionTurnRunner:
+        return ActionTurnRunner(
+            output=self._sink,
+            tools=self._tools,
+            deps=self._deps,
+            error_reporter=self._error_reporter,
+            tool_hooks=self._tool_hooks,
+        )
+
+    def bind_turn(
+        self,
+        *,
+        console: Console | None = None,
+        output: OutputSink | None = None,
+        tool_hooks: ToolExecutionHooks | None = None,
+    ) -> None:
+        """Retarget turn-scoped ports without rebuilding the runner when possible."""
+        runner_changed = False
+        if console is not None and console is not self._console:
+            self._console = console
+            self._tools.bind_console(console)
+            if self._external_output is None and isinstance(self._sink, ShellOutputSink):
+                self._sink.bind_console(console)
+        if output is not None and output is not self._external_output:
+            self._external_output = output
+            self._sink = resolve_output_sink(self._console, output)
+            runner_changed = True
+        if tool_hooks is not None and tool_hooks is not self._tool_hooks:
+            self._tool_hooks = tool_hooks
+            runner_changed = True
+        if runner_changed:
+            self._action_runner = self._new_action_runner()
+
+    def run(
+        self,
+        message: str,
+        *,
+        confirm_fn: Callable[[str], str] | None = None,
+        is_tty: bool | None = None,
+        turn_plan: TurnPlan | None = None,
+    ) -> ToolCallingTurnResult:
+        """Run one action-selection turn through core with shell adapters bound."""
+        typo_result = _complete_literal_slash_typo_turn(message, self._session, self._sink)
+        if typo_result is not None:
+            return typo_result
+        return self._action_runner.run(
+            message,
+            self._session,
+            turn_plan=turn_plan,
+            is_tty=is_tty,
+            confirm_fn=confirm_fn,
+        )
+
+
 def run_action_tool_turn(
     message: str,
     session: Session,
@@ -99,40 +206,20 @@ def run_action_tool_turn(
     output: OutputSink | None = None,
     tool_hooks: ToolExecutionHooks | None = None,
 ) -> ToolCallingTurnResult:
-    """Run one action-selection turn through core with shell adapters bound."""
-    resolved_output = resolve_output_sink(console, output)
-    typo_result = _complete_literal_slash_typo_turn(message, session, resolved_output)
-    if typo_result is not None:
-        return typo_result
-    effective_deps = (
-        deps
-        if deps is not None and deps.llm_factory is not None
-        else ToolCallingDeps(llm_factory=default_llm_factory)
-    )
-    return run_action_agent_turn(
-        message,
-        session,
-        output=resolved_output,
-        tools=DefaultToolProvider(
-            session,
-            console,
-            request_exit=request_exit,
-            observer_factory=lambda msg: ActionRenderObserver(
-                session=session, console=console, message=msg
-            ),
-            subprocess_presenter_factory=_subprocess_presenter_factory,
-            investigation_ports_factory=_investigation_ports_factory,
-            llm_provider_ports_factory=repl_llm_provider_ports,
-            task_cancel_ports_factory=repl_task_cancel_ports,
-            slash_ports_factory=repl_slash_ports,
-        ),
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
-        deps=effective_deps,
-        turn_plan=turn_plan,
-        error_reporter=DefaultErrorReporter(),
+    """Run a single action turn without keeping a runner around.
+
+    The one-shot form: everything a :class:`ShellActionRunner` would hold is
+    given per call. A surface running many turns should build the runner once
+    instead.
+    """
+    return ShellActionRunner(
+        session=session,
+        console=console,
+        request_exit=request_exit,
+        deps=deps,
+        output=output,
         tool_hooks=tool_hooks,
-    )
+    ).run(message, confirm_fn=confirm_fn, is_tty=is_tty, turn_plan=turn_plan)
 
 
-__all__ = ["run_action_tool_turn"]
+__all__ = ["ShellActionRunner", "run_action_tool_turn"]

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -20,9 +20,18 @@ from surfaces.interactive_shell.ui.streaming import render_response_header
 
 
 class ShellOutputSink:
-    """:class:`core.agent_harness.ports.OutputSink` over a Rich console."""
+    """:class:`core.agent_harness.ports.OutputSink` over a Rich console.
+
+    The console may be rebound per turn (spinner-aware streaming console) so a
+    long-lived :class:`~core.agent_harness.turns.action_driver.ActionTurnRunner`
+    can keep the same sink object.
+    """
 
     def __init__(self, console: Console) -> None:
+        self._console = console
+
+    def bind_console(self, console: Console) -> None:
+        """Point subsequent output at ``console`` for the current turn."""
         self._console = console
 
     def print(self, message: str = "") -> None:

--- a/surfaces/interactive_shell/runtime/answer_turn.py
+++ b/surfaces/interactive_shell/runtime/answer_turn.py
@@ -6,18 +6,15 @@ and telemetry around core ``stream_answer``.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from rich.console import Console
 
 from core.agent_harness.accounting.run_record import DefaultRunRecordFactory
 from core.agent_harness.error_reporting import DefaultErrorReporter
-from core.agent_harness.ports import OutputSink
+from core.agent_harness.ports import AnswerRequest, OutputSink
 from core.agent_harness.turns.default_reasoning_client import DefaultReasoningClientProvider
 from core.agent_harness.turns.orchestrator import (
     stream_answer as core_stream_answer,
 )
-from core.agent_harness.turns.turn_plan import TurnPlan
 from surfaces.interactive_shell.grounding.cli_reference import shell_prompt_context_provider
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
 from surfaces.interactive_shell.session import Session
@@ -29,12 +26,7 @@ def answer_shell_question(
     session: Session,
     console: Console,
     *,
-    confirm_fn: Callable[[str], str] | None = None,
-    is_tty: bool | None = None,
-    tool_observation: str | None = None,
-    tool_observation_on_screen: bool = True,
-    handoff_contents: tuple[str, ...] = (),
-    turn_plan: TurnPlan | None = None,
+    request: AnswerRequest,
     output: OutputSink | None = None,
 ) -> LlmRunInfo | None:
     """Answer one shell question through the grounded conversational assistant."""
@@ -51,12 +43,7 @@ def answer_shell_question(
         ),
         run_factory=DefaultRunRecordFactory(session),
         error_reporter=DefaultErrorReporter(),
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
-        tool_observation=tool_observation,
-        tool_observation_on_screen=tool_observation_on_screen,
-        handoff_contents=handoff_contents,
-        turn_plan=turn_plan,
+        request=request,
     )
 
 

--- a/surfaces/interactive_shell/runtime/integration_tool_gathering.py
+++ b/surfaces/interactive_shell/runtime/integration_tool_gathering.py
@@ -152,7 +152,6 @@ def gather_integration_tool_evidence(
     session: Session,
     console: Console,
     *,
-    is_tty: bool | None = None,
     agent_factory: GatherAgentFactory | None = None,
     resolved_integrations: dict[str, Any] | None = None,
 ) -> str | None:
@@ -187,7 +186,6 @@ def gather_integration_tool_evidence(
         on_progress=on_progress,
         persist=persist,
         error_reporter=_ShellGatherErrorReporter(),
-        is_tty=is_tty,
         agent_factory=agent_factory,
         resolved_integrations=resolved_integrations,
     )

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -10,16 +10,16 @@ live in ``turn_seams``.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Unpack
+from dataclasses import dataclass
 
 from rich.console import Console
 
-from core.agent_harness.ports import OutputSink
+from core.agent_harness.ports import AnswerRequest, OutputSink
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.execution import ToolExecutionHooks
-from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
+from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
 from surfaces.interactive_shell.runtime.answer_turn import answer_shell_question
 from surfaces.interactive_shell.runtime.core.turn_accounting import ShellTurnAccounting
@@ -27,13 +27,74 @@ from surfaces.interactive_shell.runtime.integration_tool_gathering import (
     gather_integration_tool_evidence,
 )
 from surfaces.interactive_shell.runtime.turn_seams import (
-    AnswerKwargs,
     AnswerShellQuestion,
     GatherEvidence,
     RunActionToolTurn,
 )
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
+
+
+@dataclass(frozen=True)
+class _ShellTurnBindings:
+    """Session/console-bound seams handed to ``run_turn`` for one shell turn."""
+
+    session: Session
+    console: Console
+    gather: GatherEvidence
+    answer: AnswerShellQuestion
+    output: OutputSink
+    action_runner: ShellActionRunner | None = None
+    execute: RunActionToolTurn | None = None
+    request_exit: Callable[[], None] | None = None
+    tool_hooks: ToolExecutionHooks | None = None
+
+    def execute_actions(
+        self,
+        text: str,
+        *,
+        confirm_fn: Callable[[str], str] | None = None,
+        is_tty: bool | None = None,
+        turn_plan: TurnPlan | None = None,
+    ) -> ToolCallingTurnResult:
+        if self.action_runner is not None:
+            return self.action_runner.run(
+                text,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+                turn_plan=turn_plan,
+            )
+        if self.execute is None:
+            raise RuntimeError("shell turn bindings missing action runner or execute seam")
+        return self.execute(
+            text,
+            self.session,
+            self.console,
+            confirm_fn=confirm_fn,
+            is_tty=is_tty,
+            request_exit=self.request_exit,
+            turn_plan=turn_plan,
+            output=self.output,
+            tool_hooks=self.tool_hooks,
+        )
+
+    def answer_question(self, text: str, request: AnswerRequest) -> LlmRunInfo | None:
+        return self.answer(
+            text,
+            self.session,
+            self.console,
+            output=self.output,
+            request=request,
+        )
+
+    def gather_evidence(self, text: str, *, turn_plan: TurnPlan | None = None) -> str | None:
+        resolved = turn_plan.resolved_integrations if turn_plan is not None else None
+        return self.gather(
+            text,
+            self.session,
+            self.console,
+            resolved_integrations=resolved,
+        )
 
 
 def execute_shell_turn(
@@ -45,6 +106,7 @@ def execute_shell_turn(
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
     request_exit: Callable[[], None] | None = None,
+    action_runner: ShellActionRunner | None = None,
     execute_actions: RunActionToolTurn | None = None,
     gather_evidence: GatherEvidence | None = None,
     answer_agent: AnswerShellQuestion | None = None,
@@ -55,57 +117,42 @@ def execute_shell_turn(
 
     The action driver, gather pass, and conversational assistant default to the
     shell adapters but are overridable via ``execute_actions`` / ``gather_evidence``
-    / ``answer_agent`` (the test injection seams, typed in ``turn_seams``). They are
-    bound to the live ``session``/``console`` here and handed to
-    :func:`core.agent_harness.turns.orchestrator.run_turn`, which performs
-    the pure path routing.
+    / ``answer_agent`` (the test injection seams, typed in ``turn_seams``). Prefer
+    a long-lived ``action_runner`` for the REPL so the core action stack is not
+    rebuilt every turn; the one-shot path is only for tests and cold entrypoints.
     """
-    _execute = execute_actions or run_action_tool_turn
-    _gather = gather_evidence or gather_integration_tool_evidence
-    _answer = answer_agent or answer_shell_question
-    accounting = ShellTurnAccounting(session=session, text=text, recorder=recorder)
     resolved_output = resolve_output_sink(console, output)
-
-    def execute_bound(
-        t: str,
-        *,
-        confirm_fn: Callable[[str], str] | None = None,
-        is_tty: bool | None = None,
-        turn_plan: TurnPlan | None = None,
-    ) -> ToolCallingTurnResult:
-        return _execute(
-            t,
-            session,
-            console,
-            confirm_fn=confirm_fn,
-            is_tty=is_tty,
+    runner: ShellActionRunner | None = None
+    injected_execute: RunActionToolTurn | None = execute_actions
+    if injected_execute is None:
+        runner = action_runner or ShellActionRunner(
+            session=session,
+            console=console,
             request_exit=request_exit,
-            turn_plan=turn_plan,
-            output=resolved_output,
+            output=output,
             tool_hooks=tool_hooks,
         )
+        if action_runner is not None:
+            runner.bind_turn(console=console, output=output, tool_hooks=tool_hooks)
 
-    def answer_bound(t: str, **kwargs: Unpack[AnswerKwargs]) -> LlmRunInfo | None:
-        # run_turn controls which keys are present (it omits tool_observation_on_screen
-        # on the plain path); AnswerKwargs types them without forcing presence.
-        return _answer(t, session, console, output=resolved_output, **kwargs)
-
-    def gather_bound(
-        t: str,
-        *,
-        is_tty: bool | None = None,
-        turn_plan: TurnPlan | None = None,
-    ) -> str | None:
-        resolved = turn_plan.resolved_integrations if turn_plan is not None else None
-        return _gather(t, session, console, is_tty=is_tty, resolved_integrations=resolved)
-
+    bindings = _ShellTurnBindings(
+        session=session,
+        console=console,
+        gather=gather_evidence or gather_integration_tool_evidence,
+        answer=answer_agent or answer_shell_question,
+        output=resolved_output,
+        action_runner=runner,
+        execute=injected_execute,
+        request_exit=request_exit,
+        tool_hooks=tool_hooks,
+    )
     return run_turn(
         text,
         session,
-        execute_actions=execute_bound,
-        answer=answer_bound,
-        gather=gather_bound,
-        accounting=accounting,
+        execute_actions=bindings.execute_actions,
+        answer=bindings.answer_question,
+        gather=bindings.gather_evidence,
+        accounting=ShellTurnAccounting(session=session, text=text, recorder=recorder),
         confirm_fn=confirm_fn,
         is_tty=is_tty,
     )

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -16,9 +16,12 @@ import logging
 import threading
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rich.console import Console
+
+if TYPE_CHECKING:
+    from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
 
 from platform.analytics.repl_context import bound_repl_turn_context
 from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
@@ -68,6 +71,8 @@ class AgentTurnRuntime:
     #: terminal; an embedding caller passes its console so agent responses and
     #: tool output land in the same stream as the startup renders.
     console: Console | None = None
+    #: Session-scoped action runner; rebound to each turn's streaming console.
+    action_runner: ShellActionRunner | None = None
 
 
 def _streaming_console(
@@ -190,6 +195,7 @@ async def _run_agent_turn_loop(
                 confirm_fn=confirm,
                 is_tty=None,
                 request_exit=runtime.request_exit,
+                action_runner=runtime.action_runner,
             )
     except asyncio.CancelledError:
         await emit(AgentEvent(type="turn_interrupted"))

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -9,11 +9,11 @@ checked at type-time rather than at runtime. The default adapters
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
 
 from rich.console import Console
 
-from core.agent_harness.ports import OutputSink
+from core.agent_harness.ports import AnswerRequest, OutputSink
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.execution import ToolExecutionHooks
@@ -53,25 +53,9 @@ class GatherEvidence(Protocol):
         session: Session,
         console: Console,
         *,
-        is_tty: bool | None = None,
         resolved_integrations: dict[str, Any] | None = None,
     ) -> str | None:
         """Gather evidence for the message, or return None when nothing applies."""
-
-
-class AnswerKwargs(TypedDict, total=False):
-    """Keyword args ``run_turn`` forwards to the answer seam (all optional).
-
-    ``total=False`` mirrors ``run_turn`` omitting ``tool_observation_on_screen``
-    on the plain (no-evidence) path.
-    """
-
-    confirm_fn: Callable[[str], str] | None
-    is_tty: bool | None
-    tool_observation: str | None
-    tool_observation_on_screen: bool
-    handoff_contents: tuple[str, ...]
-    turn_plan: TurnPlan | None
 
 
 class AnswerShellQuestion(Protocol):
@@ -83,19 +67,13 @@ class AnswerShellQuestion(Protocol):
         session: Session,
         console: Console,
         *,
-        confirm_fn: Callable[[str], str] | None = None,
-        is_tty: bool | None = None,
-        tool_observation: str | None = None,
-        tool_observation_on_screen: bool = True,
-        handoff_contents: tuple[str, ...] = (),
-        turn_plan: TurnPlan | None = None,
+        request: AnswerRequest,
         output: OutputSink | None = None,
     ) -> LlmRunInfo | None:
         """Answer the question, returning the LLM run info or None."""
 
 
 __all__ = [
-    "AnswerKwargs",
     "AnswerShellQuestion",
     "GatherEvidence",
     "RunActionToolTurn",

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -11,15 +11,16 @@ from rich.console import Console
 
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
+from core.agent_harness.ports import AnswerRequest
 from core.agent_harness.prompts.prior_investigation import (
     PRIOR_INVESTIGATION_RECALL_SECONDS,
 )
 from core.agent_harness.turns.action_driver import (
     ActionTurnPlan,
+    ActionTurnRunner,
     ToolCallingDeps,
     _build_action_agent,
     _turn_resolved_integrations,
-    run_action_agent_turn,
 )
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
@@ -128,14 +129,11 @@ def test_generic_registered_action_tool_result_marks_turn_handled() -> None:
         )
     )
 
-    result = run_action_agent_turn(
-        "send a fake message",
-        Session(),
+    result = ActionTurnRunner(
         output=_OutputSink(harness.console),
         tools=_GenericActionToolProvider(tool),
         deps=harness.deps,
-        is_tty=False,
-    )
+    ).run("send a fake message", Session(), is_tty=False)
 
     assert result.handled is True
     assert result.planned_count == 1
@@ -174,14 +172,11 @@ def test_generic_cli_style_stdout_is_printed_for_user() -> None:
         llm=FakeActionLLM([tool_response("fake_gh", {"args": ["issue", "list"]})])
     )
 
-    result = run_action_agent_turn(
-        "list issues",
-        Session(),
+    result = ActionTurnRunner(
         output=_OutputSink(harness.console),
         tools=_GenericActionToolProvider(tool),
         deps=harness.deps,
-        is_tty=False,
-    )
+    ).run("list issues", Session(), is_tty=False)
 
     assert result.handled is True
     assert "https://github.com/o/r/issues/1" in result.response_text
@@ -218,14 +213,11 @@ def test_action_final_text_is_streamed_as_user_facing_response() -> None:
     )
     sink = _OutputSink(harness.console)
 
-    result = run_action_agent_turn(
-        "run the scan and report",
-        Session(),
+    result = ActionTurnRunner(
         output=sink,
         tools=_GenericActionToolProvider(tool),
         deps=harness.deps,
-        is_tty=False,
-    )
+    ).run("run the scan and report", Session(), is_tty=False)
 
     assert result.handled is True
     assert result.response_text == report.strip()
@@ -412,8 +404,8 @@ def test_run_turn_passes_handoff_contents_to_assistant() -> None:
             handoff_contents=("provider:local_llama_connect",),
         )
 
-    def _answer(*_args: Any, handoff_contents: tuple[str, ...] = (), **_kwargs: Any) -> None:
-        captured.append(handoff_contents)
+    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+        captured.append(request.handoff_contents)
         return None
 
     run_turn(
@@ -491,8 +483,8 @@ def test_run_turn_mixed_action_and_handoff_routes_to_assistant() -> None:
             handoff_contents=("provider:local_llama_connect",),
         )
 
-    def _answer(*_args: Any, handoff_contents: tuple[str, ...] = (), **_kwargs: Any) -> None:
-        captured.append(handoff_contents)
+    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+        captured.append(request.handoff_contents)
         return None
 
     result = run_turn(
@@ -532,8 +524,13 @@ def test_run_turn_skips_gather_for_follow_up_handoff_with_prior_state() -> None:
         gather_calls.append(text)
         return "Tool: search_sentry_issues\nArguments: {}\nResult: should-not-run"
 
-    def _answer(*_args: Any, **kwargs: Any) -> None:
-        answer_kwargs.append(kwargs)
+    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+        answer_kwargs.append(
+            {
+                "tool_observation": request.tool_observation,
+                "handoff_contents": request.handoff_contents,
+            }
+        )
         return None
 
     result = run_turn(

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -96,7 +96,7 @@ def test_run_turn_routes_unhandled_action_to_answer_callback() -> None:
     def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
         return action
 
-    def answer(text: str, **_kwargs: object) -> object:
+    def answer(text: str, _request: object = None, **_kwargs: object) -> object:
         answer_calls.append(text)
         return type("Run", (), {"response_text": "answered"})()
 
@@ -142,7 +142,7 @@ def test_run_turn_builds_turn_plan_for_action_path(
         captured.append(turn_plan)
         return ToolCallingTurnResult(0, 0, 0, False, False)
 
-    def answer(_text: str, **_kwargs: object) -> object:
+    def answer(_text: str, _request: object = None, **_kwargs: object) -> object:
         return type("Run", (), {"response_text": "answered"})()
 
     def gather(_text: str, **_kwargs: object) -> None:
@@ -183,7 +183,7 @@ def test_run_turn_passes_turn_plan_to_gather(
     def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(0, 0, 0, False, False)
 
-    def answer(_text: str, **_kwargs: object) -> object:
+    def answer(_text: str, _request: object = None, **_kwargs: object) -> object:
         return type("Run", (), {"response_text": "answered"})()
 
     def gather(_text: str, *, turn_plan: Any = None, **_kwargs: object) -> None:
@@ -224,8 +224,8 @@ def test_run_turn_passes_turn_plan_to_answer(
     def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(0, 0, 0, False, False)
 
-    def answer(_text: str, *, turn_plan: Any = None, **_kwargs: object) -> object:
-        answer_plans.append(turn_plan)
+    def answer(_text: str, request: Any = None, **_kwargs: object) -> object:
+        answer_plans.append(getattr(request, "turn_plan", None))
         return type("Run", (), {"response_text": "answered"})()
 
     def gather(_text: str, **_kwargs: object) -> None:

--- a/tests/core/agent/test_observe_answer_summary.py
+++ b/tests/core/agent/test_observe_answer_summary.py
@@ -12,6 +12,7 @@ import io
 
 from rich.console import Console
 
+from core.agent_harness.ports import AnswerRequest
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -48,9 +49,11 @@ def test_discovery_output_is_summarized_into_a_direct_answer() -> None:
         text: str,
         session: Session,
         console: Console,
-        **kwargs: object,
+        *,
+        request: AnswerRequest,
+        **_kwargs: object,
     ) -> LlmRunInfo:
-        observed.append(kwargs.get("tool_observation"))  # type: ignore[arg-type]
+        observed.append(request.tool_observation)
         return LlmRunInfo(response_text="No — Sentry is not configured.")
 
     session = Session()

--- a/tests/core/agent/test_pipeline_tool_gathering.py
+++ b/tests/core/agent/test_pipeline_tool_gathering.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness.ports import AnswerRequest
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -32,8 +33,21 @@ def _unhandled_turn(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
 def _record_answer() -> tuple[list[dict[str, Any]], Callable[..., None]]:
     calls: list[dict[str, Any]] = []
 
-    def _fake_answer(message: str, session: Session, console: Console, **kwargs: Any) -> None:
-        calls.append({"message": message, **kwargs})
+    def _fake_answer(
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        request: AnswerRequest,
+        **_kwargs: Any,
+    ) -> None:
+        calls.append(
+            {
+                "message": message,
+                "tool_observation": request.tool_observation,
+                "tool_observation_on_screen": request.tool_observation_on_screen,
+            }
+        )
         return None
 
     return calls, _fake_answer
@@ -72,7 +86,7 @@ def test_gather_none_passes_through_without_observation() -> None:
 
     assert len(calls) == 1
     assert calls[0]["tool_observation"] is None
-    assert "tool_observation_on_screen" not in calls[0]
+    assert calls[0]["tool_observation_on_screen"] is True
 
 
 def test_existing_command_observation_skips_gather() -> None:

--- a/tests/core/agent_harness/test_action_turn_outcome.py
+++ b/tests/core/agent_harness/test_action_turn_outcome.py
@@ -1,0 +1,168 @@
+"""Characterization of the action turn's outcome, field by field.
+
+``_run_action_turn`` is one long function doing three unrelated jobs: building
+the agent, running it, and turning what happened into a
+``ToolCallingTurnResult`` plus console output. Splitting it is only safe with
+the whole observable outcome pinned first — the counts, the response text, the
+handoff contents and what the user actually sees.
+
+These assert on complete values rather than single fields, so a refactor that
+drops or reorders part of the composed text fails here rather than in a
+customer's terminal.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
+from surfaces.interactive_shell.session import Session
+from tests.core.agent.orchestration.action_execution_test_harness import (
+    ActionExecutionHarness,
+    FakeActionLLM,
+    no_tool_response,
+    tool_response,
+)
+
+
+def _console_text(harness: ActionExecutionHarness) -> str:
+    return harness.console.file.getvalue()  # type: ignore[attr-defined]
+
+
+def _outcome(result: Any) -> dict[str, Any]:
+    """Every field the caller can observe, as one comparable value."""
+    return {
+        "planned_count": result.planned_count,
+        "executed_count": result.executed_count,
+        "executed_success_count": result.executed_success_count,
+        "has_unhandled_clause": result.has_unhandled_clause,
+        "handled": result.handled,
+        "handoff_contents": result.handoff_contents,
+        "accounting_status": result.accounting_status,
+        "investigation_dispatched": result.investigation_dispatched,
+    }
+
+
+def test_a_turn_with_no_tool_calls_is_unhandled() -> None:
+    """The plainest turn: the model answers without calling anything."""
+    # Arrange
+    harness = ActionExecutionHarness(llm=FakeActionLLM([no_tool_response("just talking")]))
+
+    # Act
+    result = run_action_tool_turn("hello", Session(), harness.console, deps=harness.deps)
+
+    # Assert
+    assert _outcome(result) == {
+        "planned_count": 0,
+        "executed_count": 0,
+        "executed_success_count": 0,
+        "has_unhandled_clause": False,
+        "handled": False,
+        "handoff_contents": (),
+        "accounting_status": "completed",
+        "investigation_dispatched": False,
+    }
+
+
+def test_an_assistant_handoff_is_reported_but_not_counted_as_planned() -> None:
+    """``assistant_handoff`` is excluded from ``planned_count`` by name.
+
+    It is the one tool whose execution does not mean the turn did something for
+    the user, so it must not flip ``handled``.
+    """
+    # Arrange
+    harness = ActionExecutionHarness(
+        llm=FakeActionLLM(
+            [
+                tool_response("assistant_handoff", {"content": "let me explain instead"}),
+                no_tool_response(""),
+            ]
+        )
+    )
+
+    # Act
+    result = run_action_tool_turn("why?", Session(), harness.console, deps=harness.deps)
+
+    # Assert
+    assert result.planned_count == 0
+    assert result.handled is False
+    assert result.handoff_contents == ("let me explain instead",)
+
+
+def test_final_text_that_reads_like_a_reply_becomes_the_response() -> None:
+    """A substantial closing message is streamed as the user-facing answer."""
+    # Arrange
+    report = "## Findings\n\nThe checkout service is returning 502s.\nRoot cause: bad deploy."
+    harness = ActionExecutionHarness(llm=FakeActionLLM([no_tool_response(report)]))
+
+    # Act
+    result = run_action_tool_turn("what broke?", Session(), harness.console, deps=harness.deps)
+
+    # Assert
+    assert result.response_text == report
+
+
+def test_a_terse_closing_line_keeps_the_tool_derived_text(monkeypatch) -> None:
+    """ "done" after a tool call must not become the whole answer.
+
+    Short one-liners are common filler. Taking one as the response would throw
+    away the tool output the user actually needs — so the composed text wins
+    unless the closing message reads like a real reply.
+    """
+    # Arrange
+    from core.agent_harness.turns.action_driver import ActionTurnRunner
+    from core.tool_framework.registered_tool import RegisteredTool
+    from tests.core.agent.orchestration.test_agent_actions_harness import (
+        _GenericActionToolProvider,
+        _OutputSink,
+    )
+
+    tool = RegisteredTool(
+        name="fake_send_message",
+        description="Send a fake message.",
+        input_schema={
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+            "additionalProperties": False,
+        },
+        source="knowledge",
+        surfaces=("action",),
+        run=lambda message: {"status": "sent", "message": message},
+    )
+    harness = ActionExecutionHarness(
+        llm=FakeActionLLM(
+            [
+                tool_response("fake_send_message", {"message": "hello"}),
+                no_tool_response("done"),
+            ]
+        )
+    )
+
+    # Act
+    result = ActionTurnRunner(
+        output=_OutputSink(harness.console),
+        tools=_GenericActionToolProvider(tool),
+        deps=harness.deps,
+    ).run("send it", Session())
+
+    # Assert
+    assert result.handled is True
+    assert "sent" in result.response_text, result.response_text
+    assert result.response_text != "done"
+
+
+def test_a_terse_closing_line_is_the_answer_when_nothing_else_ran() -> None:
+    """With no tool output there is nothing to preserve, so the text stands.
+
+    Recorded because it is the mirror of the case above and easy to break when
+    the composition order changes.
+    """
+    # Arrange
+    harness = ActionExecutionHarness(llm=FakeActionLLM([no_tool_response("done")]))
+
+    # Act
+    result = run_action_tool_turn("run it", Session(), harness.console, deps=harness.deps)
+
+    # Assert
+    assert result.response_text == "done"

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -1,0 +1,143 @@
+"""Characterization of ``ActionTurnRunner`` and ``HeadlessAgent`` turn seams.
+
+Pins the developer API after the nested-``def`` / long-kwargs cleanup:
+the surface owns a runner, ``dispatch`` wires bound methods into ``run_turn``,
+and ``bind_turn`` refreshes the runner when output or hooks change.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock
+
+from core.agent_harness import ActionTurnRunner
+from core.agent_harness.turns.headless_adapters import BufferOutputSink, NullToolProvider
+from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+from core.execution import ToolExecutionHooks
+from surfaces.interactive_shell.session import Session
+
+
+def test_action_turn_runner_is_package_export() -> None:
+    from core import agent_harness as pkg
+
+    assert pkg.ActionTurnRunner is ActionTurnRunner
+    assert not hasattr(pkg, "run_action_turn")
+    assert not hasattr(pkg, "ActionRequest")
+    assert not hasattr(pkg, "execute_action_agent_turn")
+
+
+def test_action_turn_runner_run_accepts_confirm_fn(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(message: str, session: Any, args: Any) -> ToolCallingTurnResult:
+        captured["message"] = message
+        captured["confirm_fn"] = args.confirm_fn
+        captured["is_tty"] = args.is_tty
+        return ToolCallingTurnResult(0, 0, 0, False, False)
+
+    monkeypatch.setattr(
+        "core.agent_harness.turns.action_driver._run_action_turn",
+        _fake_run,
+    )
+
+    def _confirm(_prompt: str) -> str:
+        return "y"
+
+    result = ActionTurnRunner(
+        output=BufferOutputSink(),
+        tools=NullToolProvider(),
+    ).run("hi", Session(), confirm_fn=_confirm, is_tty=False)
+
+    assert result.handled is False
+    assert captured["message"] == "hi"
+    assert captured["confirm_fn"] is _confirm
+    assert captured["is_tty"] is False
+
+
+def test_headless_dispatch_uses_bound_methods_not_nested_defs() -> None:
+    source = inspect.getsource(HeadlessAgent.dispatch)
+    assert "def execute_actions" not in source
+    assert "def answer" not in source
+    assert "def gather" not in source
+    assert "self._execute_actions" in source
+    assert "self._answer" in source
+    assert "self._gather" in source
+
+
+def test_bind_turn_rebuilds_action_runner_when_output_changes() -> None:
+    first = BufferOutputSink()
+    second = BufferOutputSink()
+    agent = HeadlessAgent(tools=NullToolProvider(), output=first)
+    before = agent._action_runner  # noqa: SLF001
+    assert before.output is first
+
+    agent.bind_turn(output=second)
+    after = agent._action_runner  # noqa: SLF001
+    assert after is not before
+    assert after.output is second
+
+
+def test_bind_turn_rebuilds_action_runner_when_tool_hooks_change() -> None:
+    hooks = ToolExecutionHooks()
+    agent = HeadlessAgent(tools=NullToolProvider())
+    before = agent._action_runner  # noqa: SLF001
+
+    agent.bind_turn(tool_hooks=hooks)
+    after = agent._action_runner  # noqa: SLF001
+    assert after is not before
+    assert after.tool_hooks is hooks
+
+
+def test_bind_turn_keeps_runner_when_only_accounting_changes() -> None:
+    agent = HeadlessAgent(tools=NullToolProvider())
+    before = agent._action_runner  # noqa: SLF001
+    agent.bind_turn(accounting=MagicMock())
+    assert agent._action_runner is before  # noqa: SLF001
+
+
+def test_execute_shell_turn_binds_via_named_bindings_type() -> None:
+    import surfaces.interactive_shell.runtime.shell_turn_execution as ste
+
+    source = inspect.getsource(ste.execute_shell_turn)
+    assert "def execute_bound" not in source
+    assert "def answer_bound" not in source
+    assert "def gather_bound" not in source
+    assert "_ShellTurnBindings" in source
+    assert "action_runner" in source
+    assert hasattr(ste._ShellTurnBindings, "execute_actions")
+    assert hasattr(ste._ShellTurnBindings, "answer_question")
+    assert hasattr(ste._ShellTurnBindings, "gather_evidence")
+
+
+def test_shell_action_runner_keeps_core_runner_across_console_rebind() -> None:
+    from rich.console import Console
+
+    from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
+
+    first = Console(file=MagicMock())
+    second = Console(file=MagicMock())
+    runner = ShellActionRunner(session=Session(), console=first)
+    before = runner._action_runner  # noqa: SLF001
+
+    runner.bind_turn(console=second)
+    after = runner._action_runner  # noqa: SLF001
+
+    assert after is before
+    assert runner._console is second  # noqa: SLF001
+
+
+def test_shell_action_runner_rebuilds_when_external_output_changes() -> None:
+    from rich.console import Console
+
+    from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
+
+    console = Console(file=MagicMock())
+    runner = ShellActionRunner(session=Session(), console=console)
+    before = runner._action_runner  # noqa: SLF001
+
+    runner.bind_turn(output=BufferOutputSink())
+    after = runner._action_runner  # noqa: SLF001
+
+    assert after is not before

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -141,3 +141,45 @@ def test_shell_action_runner_rebuilds_when_external_output_changes() -> None:
     after = runner._action_runner  # noqa: SLF001
 
     assert after is not before
+
+
+def test_a_sink_without_hooks_clears_the_previous_sinks_hooks() -> None:
+    """A pooled agent must not carry approval hooks between conversations.
+
+    The gateway reuses agents from a pool and binds each turn with
+    ``tool_hooks=getattr(sink, "tool_hooks", None)``. A sink with no hooks
+    therefore passes ``None``. If that were read as "leave them alone", the
+    previous sink's approval callback would stay attached and later tool calls
+    would send approval controls to the wrong conversation — or wait on a reply
+    that can never arrive.
+    """
+    # Arrange
+    agent = HeadlessAgent(tools=NullToolProvider())
+    approval_hooks = MagicMock()
+    agent.bind_turn(tool_hooks=approval_hooks)
+    assert agent._tool_hooks is approval_hooks  # noqa: SLF001
+
+    # Act: the next turn's sink has no hooks.
+    agent.bind_turn(tool_hooks=None)
+
+    # Assert
+    assert agent._tool_hooks is None  # noqa: SLF001
+
+
+def test_omitting_hooks_leaves_them_attached() -> None:
+    """Rebinding only the sink must not silently drop the hooks.
+
+    The mirror of the case above: callers that swap ``output`` alone rely on the
+    hooks surviving, so "not mentioned" and "explicitly cleared" cannot be the
+    same thing.
+    """
+    # Arrange
+    agent = HeadlessAgent(tools=NullToolProvider())
+    approval_hooks = MagicMock()
+    agent.bind_turn(tool_hooks=approval_hooks)
+
+    # Act
+    agent.bind_turn(output=BufferOutputSink())
+
+    # Assert
+    assert agent._tool_hooks is approval_hooks  # noqa: SLF001

--- a/tests/core/agent_harness/test_agent_shapes.py
+++ b/tests/core/agent_harness/test_agent_shapes.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
-from typing import Any, get_type_hints
+from typing import get_type_hints
 
 from core.agent import Agent
 from core.agent_harness.ports import ExecuteActions, StreamAnswerFn
-from core.agent_harness.turns.action_driver import run_action_agent_turn
+from core.agent_harness.turns.headless_adapters import NullToolProvider
+from core.agent_harness.turns.headless_dispatch import HeadlessAgent
 from core.agent_harness.turns.orchestrator import run_turn, stream_answer
-from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 
 
 def _accept_answer(answer: StreamAnswerFn) -> StreamAnswerFn:
@@ -22,17 +21,24 @@ def _accept_execute_actions(driver: ExecuteActions) -> ExecuteActions:
 
 
 def test_stream_answer_matches_stream_answer_fn_seam() -> None:
-    assert _accept_answer(stream_answer) is stream_answer
+    # stream_answer takes session/output/prompts first; the bound seam is thinner.
+    # Pin that HeadlessAgent._answer matches the Protocol shape run_turn uses.
+    agent = HeadlessAgent(tools=NullToolProvider())
+    accepted = _accept_answer(agent._answer)
+    assert accepted.__func__ is HeadlessAgent._answer
 
 
-def test_run_action_agent_turn_matches_execute_actions_seam() -> None:
-    assert _accept_execute_actions(run_action_agent_turn) is run_action_agent_turn
+def test_headless_agent_execute_actions_matches_execute_actions_seam() -> None:
+    agent = HeadlessAgent(tools=NullToolProvider())
+    # Bound methods are new objects per access; the seam is the underlying function.
+    accepted = _accept_execute_actions(agent._execute_actions)
+    assert accepted.__func__ is HeadlessAgent._execute_actions
 
 
 def test_run_turn_wires_streaming_and_tool_calling_seams() -> None:
     hints = get_type_hints(run_turn)
-    assert hints["answer"] == Callable[..., Any]
-    assert hints["execute_actions"] == Callable[..., ToolCallingTurnResult]
+    assert hints["answer"] is StreamAnswerFn
+    assert hints["execute_actions"] is ExecuteActions
 
 
 def test_agent_is_tool_calling_shape() -> None:

--- a/tests/core/agent_harness/test_developer_agent_api.py
+++ b/tests/core/agent_harness/test_developer_agent_api.py
@@ -4,7 +4,7 @@ Pins the documented ladder in ``docs/python-api.mdx`` — two-line start, custom
 sink, custom grounding, multi-turn reuse — without a live LLM provider.
 
 The action planner still talks to the real provider when tools are empty, so
-these scenarios stub ``run_action_agent_turn`` and inject a streaming Echo
+these scenarios stub ``ActionTurnRunner.run`` and inject a streaming Echo
 client on the reasoning port. That isolates the embedder-facing seams.
 """
 
@@ -93,8 +93,8 @@ def _unhandled_actions(*_args: Any, **_kwargs: Any) -> ToolCallingTurnResult:
 def stub_action_planner(monkeypatch: Any) -> None:
     """Keep the action planner off the network so Echo can answer."""
     monkeypatch.setattr(
-        "core.agent_harness.turns.headless_dispatch.run_action_agent_turn",
-        _unhandled_actions,
+        "core.agent_harness.turns.headless_dispatch.ActionTurnRunner.run",
+        lambda _self, *_args, **_kwargs: _unhandled_actions(),
     )
 
 

--- a/tests/core/agent_harness/test_dispatch_message.py
+++ b/tests/core/agent_harness/test_dispatch_message.py
@@ -71,5 +71,8 @@ def test_headless_bind_turn_swaps_output() -> None:
         output=first,
         reasoning=StaticReasoningClientProvider(client=_Echo()),
     )
+    before_runner = agent._action_runner  # noqa: SLF001
     agent.bind_turn(output=second)
     assert agent._output is second  # noqa: SLF001
+    assert agent._action_runner is not before_runner  # noqa: SLF001
+    assert agent._action_runner.output is second  # noqa: SLF001

--- a/tests/interactive_shell/chat/test_cli_agent.py
+++ b/tests/interactive_shell/chat/test_cli_agent.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness.ports import AnswerRequest
 from core.agent_harness.prompts import prompt_context as default_prompt_context
 from core.agent_harness.prompts.assistant_agent_prompt import (
     _MARKDOWN_RULE,
@@ -30,6 +31,23 @@ from core.agent_harness.prompts.prompt_context import DefaultPromptContextProvid
 from surfaces.interactive_shell.runtime import answer_turn as cli_agent
 from surfaces.interactive_shell.runtime.answer_turn import answer_shell_question
 from surfaces.interactive_shell.session import Session
+from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
+
+
+def _answer(
+    message: str,
+    session: Session,
+    console: Console,
+    *,
+    request: AnswerRequest | None = None,
+) -> LlmRunInfo | None:
+    """Call ``answer_shell_question`` with a default ``AnswerRequest``."""
+    return answer_shell_question(
+        message,
+        session,
+        console,
+        request=request if request is not None else AnswerRequest(),
+    )
 
 
 def _build_environment_block(session: Session) -> str:
@@ -190,7 +208,7 @@ class TestSystemPromptInvestigationFlowGrounding:
         )
 
         console, _ = _capture()
-        answer_shell_question("Can you see how investigations are structured?", Session(), console)
+        _answer("Can you see how investigations are structured?", Session(), console)
 
         assert client.last_prompt is not None
         assert "--- Investigation flow reference ---" in client.last_prompt
@@ -258,7 +276,7 @@ class TestEnvironmentIntegrationGrounding:
         session.configured_integrations_known = True
         session.configured_integrations = ("gitlab",)
         console, _ = _capture()
-        answer_shell_question("is sentry installed?", session, console)
+        _answer("is sentry installed?", session, console)
 
         assert client.last_prompt is not None
         assert "--- Environment (current shell state) ---" in client.last_prompt
@@ -279,7 +297,7 @@ class TestEnvironmentIntegrationGrounding:
         )
 
         console, _ = _capture()
-        answer_shell_question("what model am I using now?", Session(), console)
+        _answer("what model am I using now?", Session(), console)
 
         assert client.last_prompt is not None
         assert "Active LLM settings in this session" in client.last_prompt
@@ -312,8 +330,11 @@ class TestObservationSummaryBlock:
         observation = (
             "Integration status from `/integrations`:\n- sentry: missing (Not configured.)"
         )
-        answer_shell_question(
-            "is sentry installed?", session, console, tool_observation=observation
+        _answer(
+            "is sentry installed?",
+            session,
+            console,
+            request=AnswerRequest(tool_observation=observation),
         )
 
         assert client.last_prompt is not None
@@ -330,7 +351,7 @@ class TestAssistantOutputRendering:
         _patch_llm(monkeypatch, "Hello **world**")
         session = Session()
         console, buf = _capture()
-        answer_shell_question("hi", session, console)
+        _answer("hi", session, console)
         output = _strip_ansi(buf.getvalue())
         assert "**world**" not in output
         assert "world" in output
@@ -345,7 +366,7 @@ class TestAssistantOutputRendering:
         _patch_llm(monkeypatch, markdown)
         session = Session()
         console, buf = _capture()
-        answer_shell_question("show commands", session, console)
+        _answer("show commands", session, console)
         output = _strip_ansi(buf.getvalue())
         # Rich's Markdown table renderer replaces the ``|---|---|``
         # separator with box-drawing chars — the literal must not leak.
@@ -358,7 +379,7 @@ class TestAssistantOutputRendering:
         _patch_llm(monkeypatch, "Sure thing.")
         session = Session()
         console, _ = _capture()
-        answer_shell_question("hello", session, console)
+        _answer("hello", session, console)
         assert session.cli_agent_messages[-2:] == [
             ("user", "hello"),
             ("assistant", "Sure thing."),
@@ -368,7 +389,7 @@ class TestAssistantOutputRendering:
         _patch_llm(monkeypatch, "Use `opensre investigate` for incidents.")
         session = Session()
         console, buf = _capture()
-        answer_shell_question("what command do I use?", session, console)
+        _answer("what command do I use?", session, console)
         output = _strip_ansi(buf.getvalue()).casefold()
         assert "opensre investigate" in output
         assert session.cli_agent_messages[-2:] == [
@@ -385,7 +406,7 @@ class TestAssistantOutputRendering:
         _patch_llm(monkeypatch, [_Block("First line"), {"text": "Second line"}])
         session = Session()
         console, buf = _capture()
-        answer_shell_question("hello", session, console)
+        _answer("hello", session, console)
         output = _strip_ansi(buf.getvalue())
         assert "First line" in output
         assert "Second line" in output
@@ -406,7 +427,7 @@ class TestAssistantOutputRendering:
         )
         session = Session()
         console, buf = _capture()
-        answer_shell_question("hi", session, console)
+        _answer("hi", session, console)
         output = _strip_ansi(buf.getvalue())
         assert "assistant failed" in output
         assert "upstream 503" in output
@@ -436,7 +457,7 @@ class TestStreamingMigration:
         monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: _Recording())
 
         console, _ = _capture()
-        answer_shell_question("hi", Session(), console)
+        _answer("hi", Session(), console)
 
         assert calls == ["invoke_stream"]
 
@@ -448,7 +469,7 @@ class TestStreamingMigration:
 
         session = Session()
         console, buf = _capture()
-        answer_shell_question("switch to anthropic", session, console)
+        _answer("switch to anthropic", session, console)
 
         output = _strip_ansi(buf.getvalue())
         assert '"switch_llm_provider"' in output
@@ -474,7 +495,7 @@ def test_answer_shell_question_injects_synthetic_observation_on_why_failed(
     session.last_synthetic_observation_path = str(obs.resolve())
     console, _buf = _capture()
     client = _patch_llm(monkeypatch, "The synthetic run failed the scoring gate.")
-    answer_shell_question("why did it fail?", session, console)
+    _answer("why did it fail?", session, console)
     assert client.last_prompt is not None
     assert "observation_json" in client.last_prompt
     assert "008-storage-full-missing-metric" in client.last_prompt
@@ -490,7 +511,7 @@ def test_answer_shell_question_skips_observation_without_failure_question(
     session.last_synthetic_observation_path = str(obs.resolve())
     console, _buf = _capture()
     client = _patch_llm(monkeypatch, "hi")
-    answer_shell_question("hello", session, console)
+    _answer("hello", session, console)
     assert client.last_prompt is not None
     assert "observation_json" not in client.last_prompt
 

--- a/tests/interactive_shell/runtime/test_token_accounting.py
+++ b/tests/interactive_shell/runtime/test_token_accounting.py
@@ -15,6 +15,7 @@ from core.agent_harness.accounting.token_accounting import (
     format_token_total,
     record_llm_turn,
 )
+from core.agent_harness.ports import AnswerRequest
 from surfaces.interactive_shell.runtime.answer_turn import answer_shell_question
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.streaming import _CHARS_PER_TOKEN
@@ -139,7 +140,7 @@ def test_answer_shell_question_records_session_token_usage(monkeypatch: Any) -> 
     monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: client)
     session = Session()
     console = Console(file=io.StringIO(), force_terminal=False)
-    answer_shell_question("hello", session, console)
+    answer_shell_question("hello", session, console, request=AnswerRequest())
     assert session.tokens.totals["input"] > 0
     assert session.tokens.totals["output"] == estimate_tokens("assistant reply")
     assert session.tokens.has_estimates is True


### PR DESCRIPTION
Tracing the call path from `main.py` to the ReAct loop, the middle layers had
grown signatures and functions that could only be read by reading their callers.
This makes that path legible without changing behaviour.

**Long parameter lists became objects.** The worst offenders took 13, 12, 12 and
10 parameters, mixing collaborators that live for the whole surface with data
that changes every turn. They now separate:

| new type | holds |
| --- | --- |
| `ActionTurnRunner` | output, tools, deps, error reporter, tool hooks — bound once |
| `ShellActionRunner` | the same, for one shell session |
| `ActionRequest` | one turn's wiring |
| `AnswerRequest` | one answer's wiring |
| `_ShellTurnBindings` | replaces three ad-hoc closures |

`headless_dispatch` already held every one of those fields and restated them on
every call; it now builds the runner once.

**Seams became Protocols.** `StreamAnswerFn`, `EvidenceGatherer` and
`ExecuteActions` were `Callable[..., Any]`, so nothing checked the keywords
callers actually get wrong. They now name their parameters.

**The longest function lost its unrelated jobs.** `_run_action_turn` went from
168 lines to 120, with counting, response composition and rendering extracted
into `_count_turn`, `_compose_response` and `_render_turn_response`.

**Route dispatch is now exhaustive.** `run_turn` chose between three routes with
an `if`/`elif` chain that rebuilt `TurnResult` in each arm and ended in
`raise AssertionError("Unknown route intent")`. It is a `match` with
`assert_never`, one `TurnResult`, and the arms hold only what differs. Adding a
fourth intent now fails type-check — verified by adding one:

```
Argument 1 to "assert_never" has incompatible type "Literal['new_route']"
```

## Two bugs this surfaced

**An architecture guard that could not fail.** `test_agent_shapes` asserted the
action driver was assignable to `ExecuteActions` — but that alias was
`Callable[..., ToolCallingTurnResult]`, so a function with a completely
different signature passed. Demonstrated, then replaced with a test that pins
the keyword contract; removing `turn_plan` from the runner now fails it.

**An import cycle.** Making `StreamAnswerFn` a Protocol pulled `TurnPlan` in
under `TYPE_CHECKING`, and `turn_plan` imports `SessionStore` back from `ports`.
`check-imports` counts typing-only imports, so this was a real 2-cycle.