### PR TITLE
fix(filestorage): validate remote_sync settings on read

### DIFF
--- a/platform/filestorage/config.py
+++ b/platform/filestorage/config.py
@@ -80,16 +80,35 @@ def _truthy(value: object) -> bool:
     return False
 
 
+def _validated_scalar(value: Any, key: str) -> Any:
+    """Reject a stored ``remote_sync`` value that cannot be a single setting.
+
+    A YAML sequence or mapping under a scalar key (``bucket: [my-bucket]``)
+    would otherwise stringify to something like ``"['my-bucket']"`` and fail
+    much later against the storage backend. Caught here, at read time, so the
+    error names the key that is actually wrong.
+    """
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    raise RemoteSyncConfigError(
+        f"remote_sync.{key} must be a single value, not a {type(value).__name__}"
+    )
+
+
 def _env_or_stored(
     env_name: str,
     stored_key: str,
     stored: Callable[[], dict[str, Any]],
 ) -> str:
-    """Environment value, else the stored one. The file is read only if needed."""
+    """Environment value, else the stored one. The file is read only if needed.
+
+    Validated only on the fallback path: a malformed stored value must not
+    break a field that the environment already overrides.
+    """
     env = os.getenv(env_name, "").strip()
     if env:
         return env
-    value = stored().get(stored_key)
+    value = _validated_scalar(stored().get(stored_key), stored_key)
     if value is None:
         return ""
     return str(value).strip()
@@ -116,14 +135,6 @@ def _exclusions(stored: Callable[[], dict[str, Any]]) -> ExclusionRules:
     return parse_exclusions(stored().get("exclude"))
 
 
-def remote_sync_enabled() -> bool:
-    """Whether sync is on in the environment or the stored settings file."""
-    env = os.getenv(REMOTE_SYNC_ENV)
-    if env is not None and env.strip() != "":
-        return env.strip().lower() in _TRUTHY
-    return _truthy(_stored_section().get("enabled"))
-
-
 def _lazy_stored() -> Callable[[], dict[str, Any]]:
     """Read the settings file at most once, and only if something needs it.
 
@@ -140,15 +151,27 @@ def _lazy_stored() -> Callable[[], dict[str, Any]]:
     return read
 
 
+def _enabled(stored: Callable[[], dict[str, Any]]) -> bool:
+    env = os.getenv(REMOTE_SYNC_ENV)
+    if env is not None and env.strip() != "":
+        return env.strip().lower() in _TRUTHY
+    return _truthy(_validated_scalar(stored().get("enabled"), "enabled"))
+
+
+def remote_sync_enabled() -> bool:
+    """Whether sync is on in the environment or the stored settings file."""
+    return _enabled(_lazy_stored())
+
+
 def load_remote_sync_config() -> RemoteSyncConfig | None:
     """Settings when sync is on, otherwise ``None``.
 
     Naming a bucket is not enough — the switch has to be on too, so an
     exported bucket left over from another tool never starts uploading.
     """
-    if not remote_sync_enabled():
-        return None
     stored = _lazy_stored()
+    if not _enabled(stored):
+        return None
     bucket = _env_or_stored(REMOTE_SYNC_BUCKET_ENV, "bucket", stored)
     if not bucket:
         raise RemoteSyncConfigError(

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -807,6 +807,81 @@ def test_environment_overrides_the_stored_bucket(
     assert config.bucket == "env-bucket"
 
 
+def test_a_malformed_stored_bucket_fails_early_naming_the_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A YAML list under ``bucket`` must not stringify into a bogus bucket name."""
+    # Arrange: `bucket: [my-bucket]` instead of a string.
+    from config.constants import paths
+    from config.local_settings import update_section
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.delenv(REMOTE_SYNC_BUCKET_ENV, raising=False)
+    update_section("remote_sync", {"enabled": True, "bucket": ["my-bucket"]})
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+
+    # Act / Assert: fails closed, naming the offending key.
+    with pytest.raises(RemoteSyncConfigError, match="remote_sync.bucket"):
+        load_remote_sync_config()
+
+
+def test_env_bucket_overrides_a_malformed_stored_bucket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Env precedence must hold even when the stored value it shadows is bad."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import update_section
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    update_section("remote_sync", {"enabled": True, "bucket": ["my-bucket"]})
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+    monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "env-bucket")
+
+    # Act
+    config = load_remote_sync_config()
+
+    # Assert: the malformed stored bucket is never read, let alone validated.
+    assert config is not None
+    assert config.bucket == "env-bucket"
+
+
+def test_a_malformed_stored_enabled_fails_early_instead_of_silently_disabling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bad ``enabled`` value must be reported, not read as falsy and ignored."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import update_section
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.delenv(REMOTE_SYNC_ENV, raising=False)
+    update_section("remote_sync", {"enabled": ["true"], "bucket": "stored-bucket"})
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncConfigError, match="remote_sync.enabled"):
+        remote_sync_enabled()
+    with pytest.raises(RemoteSyncConfigError, match="remote_sync.enabled"):
+        load_remote_sync_config()
+
+
+def test_env_enabled_overrides_a_malformed_stored_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``OPENSRE_REMOTE_SYNC`` must still switch sync off without reading the file."""
+    # Arrange
+    from config.constants import paths
+    from config.local_settings import update_section
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    update_section("remote_sync", {"enabled": ["true"], "bucket": "stored-bucket"})
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "0")
+
+    # Act / Assert
+    assert remote_sync_enabled() is False
+    assert load_remote_sync_config() is None
+
+
 # ── Org-scoped turns must not sync (keys carry no principal or actor) ────────
 
 


### PR DESCRIPTION
Fixes #4559

#### Describe the changes you have made in this PR -

`config/local_settings.read_section` silently returns `{}` for a malformed top-level section, but a typo *inside* the section (e.g. `bucket: [my-bucket]`) previously passed straight through `_env_or_stored`, got stringified to `"['my-bucket']"`, and only failed once it reached the storage backend.

`platform/filestorage/config.py` now validates each stored `remote_sync` field (`bucket`, `prefix`, `region`, `profile`, `provider`, `enabled`) at read time via a small `_validated_scalar` helper: non-scalar values (lists, dicts) raise `RemoteSyncConfigError` naming the offending key (e.g. `remote_sync.bucket must be a single value, not a list`).

Two earlier attempts at this issue (#4582, #4601) were closed because whole-section validation broke env-only configs, and because `enabled` bypassed validation and was silently coerced to `False`. This PR fixes both:

- Validation happens only on the fallback path inside `_env_or_stored` (i.e. only when the environment variable for that field is unset), so a bad stored value never blocks a field the environment already overrides.
- `remote_sync_enabled()` / `load_remote_sync_config()` now share one `_enabled()` helper that validates the stored `enabled` value the same way, instead of silently reading a malformed value as falsy.
- `load_remote_sync_config()` now builds a single `_lazy_stored()` snapshot up front and reuses it for the enabled check and every field, so there's one settings-file read per call instead of two.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/filestorage/test_remote_sync.py -q
48 passed in 1.36s
```

New regression tests added:
- `test_a_malformed_stored_bucket_fails_early_naming_the_key`
- `test_env_bucket_overrides_a_malformed_stored_bucket`
- `test_a_malformed_stored_enabled_fails_early_instead_of_silently_disabling`
- `test_env_enabled_overrides_a_malformed_stored_enabled`

Also ran `make lint`, `make format-check`, `make typecheck`, `make test-scope`, and `make verify-integrations-smoke` — all pass.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is that `config.yml`'s `remote_sync` section is read with `yaml.safe_load` and used with no type checking, so a typo (a list instead of a string) turns into a wrong-but-truthy value that only fails deep inside the S3 client. I read the two prior closed PRs for this issue to see what tripped them up: whole-section validation broke env-only setups, and the `enabled` field wasn't covered at all. My fix adds a single `_validated_scalar(value, key)` helper that rejects non-scalar (list/dict) values, and calls it only from the code paths that already fall back to the stored file (`_env_or_stored`'s fallback branch, and a new shared `_enabled()` helper). This preserves the existing env-precedence contract (env is checked first and, if set, the stored value for that field is never even read) while still failing closed and naming the bad key when the file itself is what's read. I also collapsed `remote_sync_enabled()`'s and `load_remote_sync_config()`'s separate file reads into one shared lazy snapshot per `load_remote_sync_config()` call.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
