### PR TITLE
feat(remote-sync): add --dry-run preview to sync

### DIFF
--- a/platform/filestorage/engine.py
+++ b/platform/filestorage/engine.py
@@ -128,8 +128,16 @@ def push(
     report: SyncReport | None = None,
     remote: list[RemoteObject] | None = None,
     exclusions: ExclusionRules = NO_EXCLUSIONS,
+    dry_run: bool = False,
 ) -> SyncReport:
-    """Upload local files whose contents differ from the bucket."""
+    """Upload local files whose contents differ from the bucket.
+
+    Under ``dry_run`` nothing is sent, and a key ``pull`` already previewed as
+    a download (``result.downloaded``, when both share one report) is trusted
+    rather than re-compared against the still-unwritten local file — a real
+    full sync would have overwritten it first, so re-reading stale bytes here
+    would report it as both downloaded and kept back.
+    """
     roots = roots if roots is not None else syncable_roots()
     result = report if report is not None else SyncReport()
     listing = remote if remote is not None else store.list_objects("")
@@ -137,6 +145,8 @@ def push(
     # Resolve each root once rather than per file: this loop touches every
     # session and memory file on the machine.
     allowed = resolved_roots(roots)
+    # Built once, not per file: membership in a loop needs a set, not a list.
+    previewed_pulls = set(result.downloaded) if dry_run else frozenset[str]()
 
     # Check every candidate before uploading any of them. A denied file found
     # halfway through must not leave earlier files already in the store.
@@ -156,6 +166,9 @@ def push(
             planned.append((key, path))
 
     for key, path in planned:
+        if key in previewed_pulls:
+            result.skipped += 1
+            continue
         data = path.read_bytes()
         existing = by_key.get(key)
         if existing is not None:
@@ -167,7 +180,8 @@ def push(
                 # destroy it. Same rule pull applies in the other direction.
                 result.kept_remote.append(key)
                 continue
-        store.put_object(key, data)
+        if not dry_run:
+            store.put_object(key, data)
         result.uploaded.append(key)
         result.uploaded_bytes += len(data)
     return result
@@ -180,8 +194,14 @@ def pull(
     report: SyncReport | None = None,
     remote: list[RemoteObject] | None = None,
     exclusions: ExclusionRules = NO_EXCLUSIONS,
+    dry_run: bool = False,
 ) -> SyncReport:
-    """Download bucket objects missing locally, or newer than the local copy."""
+    """Download bucket objects missing locally, or newer than the local copy.
+
+    Under ``dry_run`` nothing is fetched or written: the listing already has
+    the size needed to report what would move, so previewing costs no request
+    beyond the one listing call.
+    """
     roots = roots if roots is not None else syncable_roots()
     result = report if report is not None else SyncReport()
     by_name = {root.name: root for root in roots}
@@ -198,6 +218,10 @@ def pull(
             continue
         if not _should_download(obj, target):
             result.skipped += 1
+            continue
+        if dry_run:
+            result.downloaded_bytes += obj.size
+            result.downloaded.append(obj.key)
             continue
         data = store.get_object(obj.key)
         result.downloaded_bytes += len(data)
@@ -237,18 +261,34 @@ def run_sync(
     direction: SyncDirection = SyncDirection.BOTH,
     roots: tuple[SyncRoot, ...] | None = None,
     exclusions: ExclusionRules = NO_EXCLUSIONS,
+    dry_run: bool = False,
 ) -> SyncReport:
     """Move files in ``direction``. Both ways pulls first, so an offline edit wins.
 
     The listing is fetched once and shared: a pull changes local files, never
-    the bucket, so the push half can reuse it.
+    the bucket, so the push half can reuse it. ``dry_run`` previews the same
+    plan without writing anywhere, local or remote.
     """
     report = SyncReport()
     listing = store.list_objects("")
     if direction is not SyncDirection.PUSH:
-        pull(store, roots=roots, report=report, remote=listing, exclusions=exclusions)
+        pull(
+            store,
+            roots=roots,
+            report=report,
+            remote=listing,
+            exclusions=exclusions,
+            dry_run=dry_run,
+        )
     if direction is not SyncDirection.PULL:
-        push(store, roots=roots, report=report, remote=listing, exclusions=exclusions)
+        push(
+            store,
+            roots=roots,
+            report=report,
+            remote=listing,
+            exclusions=exclusions,
+            dry_run=dry_run,
+        )
     return report
 
 

--- a/platform/filestorage/engine.py
+++ b/platform/filestorage/engine.py
@@ -136,7 +136,10 @@ def push(
     a download (``result.downloaded``, when both share one report) is trusted
     rather than re-compared against the still-unwritten local file — a real
     full sync would have overwritten it first, so re-reading stale bytes here
-    would report it as both downloaded and kept back.
+    would report it as both downloaded and kept back. A previewed key with no
+    local file at all (nothing pulled it before) never reaches the scan below,
+    so it is counted as skipped separately — a real sync would have written it
+    and then found this same scan matching it.
     """
     roots = roots if roots is not None else syncable_roots()
     result = report if report is not None else SyncReport()
@@ -184,6 +187,12 @@ def push(
             store.put_object(key, data)
         result.uploaded.append(key)
         result.uploaded_bytes += len(data)
+
+    if previewed_pulls:
+        # Keys pull previewed but that never had a local file to begin with
+        # (a brand-new remote object) never entered the scan above at all.
+        planned_keys = {key for key, _ in planned}
+        result.skipped += len(previewed_pulls - planned_keys)
     return result
 
 

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -98,8 +98,12 @@ def format_status_lines(status: SyncStatus) -> tuple[str, ...]:
     return tuple(lines)
 
 
-def format_report_lines(report: SyncReport) -> tuple[str, ...]:
-    """Plain-text result lines after a successful run (pure; snapshots lists)."""
+def format_report_lines(report: SyncReport, *, dry_run: bool = False) -> tuple[str, ...]:
+    """Plain-text result lines after a run (pure; snapshots lists).
+
+    ``dry_run`` only changes the wording — the report already reflects a
+    preview when the caller ran the sync that way.
+    """
     downloaded = list(report.downloaded)
     uploaded = list(report.uploaded)
     kept_remote = list(report.kept_remote)
@@ -108,9 +112,11 @@ def format_report_lines(report: SyncReport) -> tuple[str, ...]:
     up_size = f" ({_human_size(report.uploaded_bytes)})" if report.uploaded_bytes else ""
     total_size = f" ({_human_size(report.total_bytes)} total)" if report.total_bytes else ""
     excluded = len(report.excluded)
+    heading = "Dry run" if dry_run else "Sync complete"
+    would = " would be" if dry_run else ""
     lines: list[str] = [
-        f"Sync complete — {len(downloaded)} downloaded{down_size}, "
-        f"{len(uploaded)} uploaded{up_size}, {skipped} already current{total_size}."
+        f"{heading} — {len(downloaded)}{would} downloaded{down_size}, "
+        f"{len(uploaded)}{would} uploaded{up_size}, {skipped} already current{total_size}."
     ]
     if excluded:
         # Its own line rather than a fourth clause in the summary: a run with no

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -130,12 +130,14 @@ def run_remote_sync(
     pull_only: bool = False,
     push_only: bool = False,
     direction: SyncDirection | None = None,
+    dry_run: bool = False,
 ) -> SyncReport | None:
     """Pull/push for the current scope. ``None`` when sync is disabled.
 
     Builds a new ObjectStore per call. Returns a caller-owned report snapshot.
     Prefer ``direction=`` when the caller already has a :class:`SyncDirection`;
-    the boolean flags remain for CLI/slash adapters.
+    the boolean flags remain for CLI/slash adapters. ``dry_run`` previews the
+    plan without uploading, downloading, or writing anything locally.
     """
     _refuse_org_scoped_turn()
     resolved = (
@@ -149,7 +151,7 @@ def run_remote_sync(
     roots = syncable_roots()
     store = build_object_store(config)
     return _owned_report(
-        run_sync(store, direction=resolved, roots=roots, exclusions=config.exclude)
+        run_sync(store, direction=resolved, roots=roots, exclusions=config.exclude, dry_run=dry_run)
     )
 
 

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -51,17 +51,18 @@ def status_command() -> None:
 @remote_sync_command.command(name=RemoteSyncSubcommand.SYNC.value)
 @click.option("--pull-only", is_flag=True, help="Download only; send nothing.")
 @click.option("--push-only", is_flag=True, help="Upload only; fetch nothing.")
-def sync_now_command(pull_only: bool, push_only: bool) -> None:
+@click.option("--dry-run", is_flag=True, help="Preview transfers without changing anything.")
+def sync_now_command(pull_only: bool, push_only: bool, dry_run: bool) -> None:
     """Sync now: pull remote changes, then push local ones."""
     try:
-        report = run_remote_sync(pull_only=pull_only, push_only=push_only)
+        report = run_remote_sync(pull_only=pull_only, push_only=push_only, dry_run=dry_run)
     except RemoteSyncError as exc:
         click.echo(f"Sync failed: {exc}", err=True)
         raise SystemExit(ERROR) from exc
     if report is None:
         click.echo(DISABLED_HELP)
         raise SystemExit(SUCCESS)
-    for line in format_report_lines(report):
+    for line in format_report_lines(report, dry_run=dry_run):
         click.echo(line)
     raise SystemExit(SUCCESS)
 

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 _USAGE = (
     f"/remote-sync [{RemoteSyncSubcommand.STATUS}|{RemoteSyncSubcommand.SYNC}|"
-    f"{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only] "
+    f"{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only|--dry-run] "
     f"[--provider … --bucket …]"
 )
 
@@ -68,15 +68,17 @@ def _print_status(console: Console) -> bool:
 
 def _run_sync(console: Console, args: list[str]) -> bool:
     flags = {a.lower() for a in args}
+    dry_run = "--dry-run" in flags
     with console.status("syncing…", spinner="dots"):
         report = run_remote_sync(
             pull_only="--pull-only" in flags,
             push_only="--push-only" in flags,
+            dry_run=dry_run,
         )
     if report is None:
         console.print(f"[{DIM}]{DISABLED_HELP}[/]")
         return True
-    lines = format_report_lines(report)
+    lines = format_report_lines(report, dry_run=dry_run)
     _print_lines(console, lines, dim_last=bool(report.kept_remote))
     return True
 

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -97,9 +97,12 @@ def test_gateway_dispatch_status_on(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_gateway_dispatch_sync_with_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, bool] = {}
 
-    def _run(*, pull_only: bool = False, push_only: bool = False) -> SyncReport:
+    def _run(
+        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+    ) -> SyncReport:
         seen["pull_only"] = pull_only
         seen["push_only"] = push_only
+        seen["dry_run"] = dry_run
         return SyncReport(
             uploaded=["sessions/a.jsonl"],
             downloaded=["memory/b.md"],
@@ -123,7 +126,7 @@ def test_gateway_dispatch_sync_with_flags(monkeypatch: pytest.MonkeyPatch) -> No
         )
         is True
     )
-    assert seen == {"pull_only": True, "push_only": False}
+    assert seen == {"pull_only": True, "push_only": False, "dry_run": False}
     out = buf.getvalue()
     assert "1 downloaded" in out
     assert "1 uploaded" in out

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -95,9 +95,12 @@ def test_sync_prints_report(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) 
 def test_sync_passes_direction_flags(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, bool] = {}
 
-    def _capture(*, pull_only: bool = False, push_only: bool = False) -> SyncReport:
+    def _capture(
+        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+    ) -> SyncReport:
         seen["pull_only"] = pull_only
         seen["push_only"] = push_only
+        seen["dry_run"] = dry_run
         return SyncReport()
 
     monkeypatch.setattr(
@@ -106,7 +109,29 @@ def test_sync_passes_direction_flags(runner: CliRunner, monkeypatch: pytest.Monk
     )
     result = runner.invoke(remote_sync_command, ["sync", "--pull-only"])
     assert result.exit_code == 0
-    assert seen == {"pull_only": True, "push_only": False}
+    assert seen == {"pull_only": True, "push_only": False, "dry_run": False}
+
+
+def test_sync_passes_dry_run_and_labels_the_report(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: dict[str, bool] = {}
+
+    def _capture(
+        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+    ) -> SyncReport:
+        seen["dry_run"] = dry_run
+        return SyncReport(uploaded=["sessions/a.jsonl"])
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.run_remote_sync",
+        _capture,
+    )
+    result = runner.invoke(remote_sync_command, ["sync", "--dry-run"])
+    assert result.exit_code == 0
+    assert seen == {"dry_run": True}
+    assert "Dry run" in result.output
+    assert "would be uploaded" in result.output
 
 
 def test_sync_failure_exits_nonzero(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -185,6 +210,7 @@ def test_sync_help_documents_direction_flags(runner: CliRunner) -> None:
     assert result.exit_code == 0
     assert "--pull-only" in result.output
     assert "--push-only" in result.output
+    assert "--dry-run" in result.output
 
 
 def test_setup_rejects_flag_provider_does_not_support(runner: CliRunner) -> None:

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -237,6 +237,63 @@ def test_older_remote_does_not_clobber_a_newer_local_edit(
     assert (home / "sessions" / "abc.jsonl").read_bytes() == b'{"turn": 1}\n'
 
 
+def test_dry_run_preview_matches_what_a_real_full_sync_would_settle_on(
+    home: Path, roots: tuple[SyncRoot, ...]
+) -> None:
+    """A full sync pulls the newer remote copy, then push sees it already matches.
+
+    A dry run must land on the same final classification — downloaded, and
+    neither uploaded nor kept back — without ever writing the file, so push
+    cannot be misled by comparing against the still-stale bytes on disk.
+    """
+    # Arrange: remote holds a newer edit of a file that also exists locally.
+    store = FakeObjectStore()
+    newer = b'{"turn": 2}\n'
+    store.put_object("sessions/abc.jsonl", newer)
+    store.modified["sessions/abc.jsonl"] = datetime.now(tz=UTC) + timedelta(hours=1)
+
+    # Act
+    report = run_sync(store, roots=roots, dry_run=True)
+
+    # Assert
+    assert report.downloaded == ["sessions/abc.jsonl"]
+    assert "sessions/abc.jsonl" not in report.uploaded
+    assert "sessions/abc.jsonl" not in report.kept_remote
+    assert (home / "sessions" / "abc.jsonl").read_bytes() == b'{"turn": 1}\n'
+    assert store.objects["sessions/abc.jsonl"] == newer
+
+
+def test_dry_run_writes_nothing_locally_or_remotely(
+    home: Path, roots: tuple[SyncRoot, ...]
+) -> None:
+    # Arrange: one file only the bucket knows about, one only the laptop knows about.
+    store = FakeObjectStore()
+    store.put_object("memory/from-remote.md", b"hello\n")
+    objects_before = dict(store.objects)
+
+    # Act
+    report = run_sync(store, roots=roots, dry_run=True)
+
+    # Assert: reported as it would happen, but nothing actually moved.
+    assert report.downloaded == ["memory/from-remote.md"]
+    assert sorted(report.uploaded) == ["memory/a-fact.md", "sessions/abc.jsonl"]
+    assert report.downloaded_bytes == len(b"hello\n")
+    assert store.objects == objects_before
+    assert not (home / "memory" / "from-remote.md").exists()
+
+
+def test_push_only_dry_run_does_not_upload(home: Path, roots: tuple[SyncRoot, ...]) -> None:
+    # Arrange
+    store = FakeObjectStore()
+
+    # Act
+    report = push(store, roots=roots, dry_run=True)
+
+    # Assert: reported as it would upload, but the store stays empty.
+    assert sorted(report.uploaded) == ["memory/a-fact.md", "sessions/abc.jsonl"]
+    assert store.objects == {}
+
+
 def test_sync_never_deletes(home: Path, roots: tuple[SyncRoot, ...]) -> None:
     """A file only one side knows about survives on both."""
     # Arrange

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -279,6 +279,37 @@ def test_dry_run_writes_nothing_locally_or_remotely(
     assert sorted(report.uploaded) == ["memory/a-fact.md", "sessions/abc.jsonl"]
     assert report.downloaded_bytes == len(b"hello\n")
     assert store.objects == objects_before
+    # A real full sync would write this file, then have push's local-file scan
+    # find it and count it skipped — the preview must match that tally even
+    # though the brand-new file was never written and so never entered the scan.
+    assert report.skipped == 1
+
+
+def test_dry_runs_skipped_tally_matches_a_real_sync_for_a_brand_new_remote_file(
+    home: Path, roots: tuple[SyncRoot, ...], tmp_path: Path
+) -> None:
+    """The preview's counts must agree with what running for real would produce."""
+    # Arrange: two identical starting points, one bucket shared between them.
+    store = FakeObjectStore()
+    store.put_object("memory/from-remote.md", b"hello\n")
+    real_home = tmp_path / "real"
+    (real_home / "sessions").mkdir(parents=True)
+    (real_home / "memory").mkdir(parents=True)
+    (real_home / "sessions" / "abc.jsonl").write_text('{"turn": 1}\n', encoding="utf-8")
+    (real_home / "memory" / "a-fact.md").write_text("remembered\n", encoding="utf-8")
+    real_roots = (
+        SyncRoot(name=SyncRootName.SESSIONS, path=real_home / "sessions"),
+        SyncRoot(name=SyncRootName.MEMORY, path=real_home / "memory"),
+    )
+
+    # Act
+    dry = run_sync(store, roots=roots, dry_run=True)
+    real = run_sync(store, roots=real_roots)
+
+    # Assert
+    assert dry.skipped == real.skipped
+    assert sorted(dry.uploaded) == sorted(real.uploaded)
+    assert dry.downloaded == real.downloaded
     assert not (home / "memory" / "from-remote.md").exists()
 
 

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -90,6 +90,12 @@ def test_formatters_return_immutable_tuples() -> None:
     assert "2 uploaded" in format_report_lines(report)[0]
 
 
+def test_format_report_lines_marks_a_dry_run_as_a_preview() -> None:
+    report = SyncReport(uploaded=["a"], downloaded=["b"], skipped=2)
+    lines = format_report_lines(report, dry_run=True)
+    assert lines[0] == "Dry run — 1 would be downloaded, 1 would be uploaded, 2 already current."
+
+
 def test_format_report_lines_shows_nonzero_byte_sizes() -> None:
     report = SyncReport(
         uploaded=["a"],

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -65,9 +65,12 @@ def test_status_enabled_shows_roots(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_sync_subcommand_calls_service(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, bool] = {}
 
-    def _run(*, pull_only: bool = False, push_only: bool = False) -> SyncReport:
+    def _run(
+        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+    ) -> SyncReport:
         seen["pull_only"] = pull_only
         seen["push_only"] = push_only
+        seen["dry_run"] = dry_run
         return SyncReport(uploaded=["memory/a.md"], skipped=0)
 
     monkeypatch.setattr(
@@ -77,8 +80,29 @@ def test_sync_subcommand_calls_service(monkeypatch: pytest.MonkeyPatch) -> None:
     # console.status context manager — Rich Console.status works without a real TTY
     console, buf = _capture()
     assert dispatch_slash("/remote-sync sync --push-only", Session(), console) is True
-    assert seen == {"pull_only": False, "push_only": True}
+    assert seen == {"pull_only": False, "push_only": True, "dry_run": False}
     assert "1 uploaded" in buf.getvalue()
+
+
+def test_sync_dry_run_forwards_flag_and_labels_the_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, bool] = {}
+
+    def _run(
+        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+    ) -> SyncReport:
+        seen["dry_run"] = dry_run
+        return SyncReport(uploaded=["sessions/a.jsonl"], skipped=0)
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.run_remote_sync",
+        _run,
+    )
+    console, buf = _capture()
+    assert dispatch_slash("/remote-sync sync --dry-run", Session(), console) is True
+    assert seen == {"dry_run": True}
+    out = buf.getvalue()
+    assert "Dry run" in out
+    assert "would be uploaded" in out
 
 
 def test_sync_disabled_prints_help(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #4549

#### Describe the changes you have made in this PR -

`opensre remote-sync sync --dry-run` and `/remote-sync sync --dry-run` now preview what would upload, download, skip, and be kept back — without calling `store.put_object`, `store.get_object`, or writing anything to disk.

**Why this needed care:** `run_sync` does pull-then-push sharing one `SyncReport`. In a real full sync, if the remote has a newer copy of a file that also exists locally, `pull` overwrites the local file, so `push` re-reads it afterward and finds it already matches the remote (`skipped`). A dry run that just skips the writes but lets `push` read the file naively re-derives the wrong answer from the still-stale local bytes, reporting the same key as both `downloaded` *and* `kept_remote` — a self-contradictory preview. This is exactly the P1 Greptile caught on the first attempt at this issue (#4598, closed after CI also failed).

**Fix:** `pull` and `push` already share one `SyncReport` instance when `run_sync` runs both directions. Under `dry_run`, `push` builds `previewed_pulls = set(result.downloaded)` once and, for any key pull already claimed, trusts that decision (`skipped`) instead of re-comparing against on-disk bytes it never wrote. `pull` itself just appends to `result.downloaded`/`downloaded_bytes` (using the listing's `size`, no `get_object` call) and returns — no network read, no disk write, beyond the one `list_objects` call a normal sync already makes.

This is a smaller footprint than the closed attempt, which fetched the actual bytes during a dry-run pull (an extra `store.get_object()` per previewed file) purely to feed push's content-hash comparison — unnecessary in a mode whose whole point is "touch nothing," and it also had a latent gap on multipart ETags (`comparable_etag` returns `""`, so push falls back to an mtime comparison that could disagree with a real sync's outcome). Trusting pull's decision outright sidesteps that instead of half-fixing it.

`--push-only --dry-run` (no pull ever runs) is unaffected — `previewed_pulls` is empty, push just compares against real on-disk content as it does today, with `put_object` suppressed.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/filestorage/test_remote_sync.py tests/filestorage/test_service_and_registry.py \
    tests/cli/test_remote_sync_command.py tests/cli/test_gateway_remote_sync.py \
    tests/interactive_shell/test_remote_sync_cmds.py -q
219 passed
```

Full `make test-scope` (escalated to cover `tests/cli/` + `tests/interactive_shell/` since this touches the shared engine plus both surfaces): `2436 passed, 4 skipped`. Also ran `make lint`, `make format-check`, `make typecheck`, `make verify-integrations-smoke` — all clean.

New/changed coverage:
- `test_dry_run_preview_matches_what_a_real_full_sync_would_settle_on` — the exact contradictory-preview scenario, asserting the key lands only in `downloaded`, never `uploaded`/`kept_remote`, and nothing on disk or in the store changes.
- `test_dry_run_writes_nothing_locally_or_remotely` — full two-way sync (one remote-only, one local-only file), store and disk untouched.
- `test_push_only_dry_run_does_not_upload`
- `format_report_lines(..., dry_run=True)` wording test.
- CLI (`--dry-run` flag forwarding, `--help` documents it) and slash-command (`/remote-sync sync --dry-run` forwarding + gateway dispatch) coverage.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read the issue and the previously closed attempt (#4598) to understand what tripped it up: CI failed outright, and separately Greptile flagged a real bug — the dry-run preview could report a file as both downloaded and kept-back for the same key, because push re-derived its decision from a local file that a dry run correctly declines to write. Rather than reuse #4598's fix (fetch the real bytes during dry-run pull and feed them into push's normal content-hash comparison), I used the fact that `pull` and `push` already share one `SyncReport` object when `run_sync` calls both directions — so push can just check "did pull already resolve this key" and, if so, defer to that instead of re-evaluating. This needed no new fields on `SyncReport`, no extra parameter threaded through `push`, and no extra `store.get_object()` calls during a dry-run pull (a real sync's pull already does that GET; the dry-run path deliberately skips it and uses the object size from the listing instead). I verified the fix against the specific "newer remote, existing local file" scenario that broke the previous attempt, then threaded `dry_run` through `operations.run_remote_sync`, `messages.format_report_lines` (wording only), the CLI command, and the slash command — plus found and fixed a test at `tests/cli/test_gateway_remote_sync.py` whose fake `run_remote_sync` needed the new keyword, which `make test-scope`'s escalated run caught.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
