### PR TITLE
feat(llm): isolate Bedrock AWS session from investigation tools (#4482)

### DIFF
--- a/config/constants/aws.py
+++ b/config/constants/aws.py
@@ -9,6 +9,19 @@ AWS_ACCESS_KEY_ID_ENV = "AWS_ACCESS_KEY_ID"
 AWS_SECRET_ACCESS_KEY_ENV = "AWS_SECRET_ACCESS_KEY"
 AWS_SESSION_TOKEN_ENV = "AWS_SESSION_TOKEN"
 
+# Bedrock-only identity override, isolated from the vars above. Investigation
+# tools (EC2, CloudWatch, ...) already read the ambient AWS_PROFILE directly,
+# so a laptop configured for one AWS account already investigates that
+# account correctly. Bedrock had no equivalent override, so a cross-account
+# setup (Bedrock reachable only via an AssumeRole profile in a different
+# account than the infra being investigated) could not give Bedrock a
+# different identity than whatever profile was active for everything else.
+# See #4482.
+BEDROCK_AWS_PROFILE_ENV = "BEDROCK_AWS_PROFILE"
+BEDROCK_AWS_ROLE_ARN_ENV = "BEDROCK_AWS_ROLE_ARN"
+BEDROCK_AWS_EXTERNAL_ID_ENV = "BEDROCK_AWS_EXTERNAL_ID"
+BEDROCK_AWS_REGION_ENV = "BEDROCK_AWS_REGION"
+
 __all__ = [
     "AWS_ACCESS_KEY_ID_ENV",
     "AWS_EXTERNAL_ID_ENV",
@@ -16,4 +29,8 @@ __all__ = [
     "AWS_ROLE_ARN_ENV",
     "AWS_SECRET_ACCESS_KEY_ENV",
     "AWS_SESSION_TOKEN_ENV",
+    "BEDROCK_AWS_EXTERNAL_ID_ENV",
+    "BEDROCK_AWS_PROFILE_ENV",
+    "BEDROCK_AWS_REGION_ENV",
+    "BEDROCK_AWS_ROLE_ARN_ENV",
 ]

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -344,27 +344,16 @@ class BedrockAgentClient(AnthropicAgentClient):
         from anthropic import AnthropicBedrock
 
         from core.llm.transports.sdk.bedrock_converse import (
-            frozen_bedrock_credentials,
             require_aws_region,
-            resolve_bedrock_aws_session,
+            resolve_bedrock_anthropic_kwargs,
         )
 
         region = require_aws_region()
-        session = resolve_bedrock_aws_session()
-        if session is not None:
-            frozen = frozen_bedrock_credentials(session)
-            bedrock_client = AnthropicBedrock(
-                aws_access_key=frozen.access_key,
-                aws_secret_key=frozen.secret_key,
-                aws_session_token=frozen.token,
-                aws_region=region,
-                timeout=AGENT_CLIENT_TIMEOUT_SEC,
-            )
-        else:
-            bedrock_client = AnthropicBedrock(
-                aws_region=region,
-                timeout=AGENT_CLIENT_TIMEOUT_SEC,
-            )
+        bedrock_client = AnthropicBedrock(
+            aws_region=region,
+            timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            **resolve_bedrock_anthropic_kwargs(region),
+        )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 
     def _permission_denied_error_message(self) -> str:
@@ -402,7 +391,7 @@ class BedrockConverseAgentClient:
         self._model = model
         self._max_tokens = max_tokens
         region = require_aws_region()
-        session = resolve_bedrock_aws_session()
+        session = resolve_bedrock_aws_session(region)
         if session is not None:
             self._boto3_client = session.client("bedrock-runtime", region_name=region)
         else:

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import time
 from collections.abc import Callable
@@ -336,20 +335,36 @@ class BedrockAgentClient(AnthropicAgentClient):
     provider_name = "Bedrock"
     auth_error_hint = (
         "Check AWS credentials (for example AWS_PROFILE, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, "
-        "or instance role) and AWS_REGION/AWS_DEFAULT_REGION."
+        "or instance role) and AWS_REGION/AWS_DEFAULT_REGION. For a Bedrock account different "
+        "from the one used for infrastructure investigation, set BEDROCK_AWS_PROFILE or "
+        "BEDROCK_AWS_ROLE_ARN."
     )
 
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
         from anthropic import AnthropicBedrock
 
-        region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
-        if not region:
-            raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
-
-        bedrock_client = AnthropicBedrock(
-            aws_region=region,
-            timeout=AGENT_CLIENT_TIMEOUT_SEC,
+        from core.llm.transports.sdk.bedrock_converse import (
+            frozen_bedrock_credentials,
+            require_aws_region,
+            resolve_bedrock_aws_session,
         )
+
+        region = require_aws_region()
+        session = resolve_bedrock_aws_session()
+        if session is not None:
+            frozen = frozen_bedrock_credentials(session)
+            bedrock_client = AnthropicBedrock(
+                aws_access_key=frozen.access_key,
+                aws_secret_key=frozen.secret_key,
+                aws_session_token=frozen.token,
+                aws_region=region,
+                timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            )
+        else:
+            bedrock_client = AnthropicBedrock(
+                aws_region=region,
+                timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 
     def _permission_denied_error_message(self) -> str:
@@ -379,12 +394,19 @@ class BedrockConverseAgentClient:
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
         import boto3
 
-        from core.llm.transports.sdk.bedrock_converse import require_aws_region
+        from core.llm.transports.sdk.bedrock_converse import (
+            require_aws_region,
+            resolve_bedrock_aws_session,
+        )
 
         self._model = model
         self._max_tokens = max_tokens
         region = require_aws_region()
-        self._boto3_client = boto3.client("bedrock-runtime", region_name=region)
+        session = resolve_bedrock_aws_session()
+        if session is not None:
+            self._boto3_client = session.client("bedrock-runtime", region_name=region)
+        else:
+            self._boto3_client = boto3.client("bedrock-runtime", region_name=region)
 
     @property
     def model_id(self) -> str | None:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -46,7 +46,38 @@ def require_aws_region() -> str:
     return region
 
 
-def resolve_bedrock_aws_session() -> boto3.Session | None:
+def _assumed_bedrock_role_credentials(region: str) -> dict[str, str] | None:
+    """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
+
+    A single ``sts:AssumeRole`` snapshot, same shape as
+    ``integrations/aws/verifier.py::_build_sts_client``. The returned
+    credentials are valid for the assumed role's session duration (its
+    ``MaxSessionDuration``, often 1 hour unless the role is configured
+    longer) and do not refresh themselves — a cached client that outlives
+    that window needs to be recreated. Prefer ``BEDROCK_AWS_PROFILE`` with a
+    role_arn + source_profile pair in ``~/.aws/config`` when a process runs
+    longer than that: :func:`resolve_bedrock_aws_session` builds a
+    self-refreshing session for a named profile.
+    """
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if not role_arn:
+        return None
+
+    import boto3
+
+    external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+    sts = boto3.client("sts", region_name=region)
+    assume_role_kwargs: dict[str, str] = {
+        "RoleArn": role_arn,
+        "RoleSessionName": "OpenSREBedrockInvoke",
+    }
+    if external_id:
+        assume_role_kwargs["ExternalId"] = external_id
+    credentials: dict[str, str] = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    return credentials
+
+
+def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
     """Isolate Bedrock's AWS identity from the ambient default credential chain.
 
     Investigation tools (EC2, CloudWatch, ...) already work correctly across
@@ -57,28 +88,26 @@ def resolve_bedrock_aws_session() -> boto3.Session | None:
     investigated had no way to give Bedrock a *different* identity than
     whatever profile was active for everything else (#4482).
 
+    ``region`` is the caller's own already-resolved region (each of the three
+    Bedrock clients has a different region-resolution policy — two raise when
+    unset, one defaults to ``us-east-1``); this function does not re-derive
+    or require it, so it can't reject a config a caller would otherwise
+    accept.
+
     ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
     deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
     ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
-    AssumeRole + source_profile pair — the shape the issue's own setup used.
-    Returns ``None`` when neither is set, so callers fall through to today's
-    exact ambient-chain behavior; this function never changes behavior for a
-    caller who hasn't opted in.
+    AssumeRole + source_profile pair — the shape the issue's own setup used;
+    boto3 refreshes that automatically, since the profile is passed straight
+    through rather than resolved once and frozen. Returns ``None`` when
+    neither is set, so callers fall through to today's exact ambient-chain
+    behavior; this function never changes behavior for a caller who hasn't
+    opted in.
     """
     import boto3
 
-    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
-    if role_arn:
-        region = require_aws_region()
-        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
-        sts = boto3.client("sts", region_name=region)
-        assume_role_kwargs: dict[str, str] = {
-            "RoleArn": role_arn,
-            "RoleSessionName": "OpenSREBedrockInvoke",
-        }
-        if external_id:
-            assume_role_kwargs["ExternalId"] = external_id
-        credentials = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    credentials = _assumed_bedrock_role_credentials(region)
+    if credentials is not None:
         return boto3.Session(
             aws_access_key_id=credentials["AccessKeyId"],
             aws_secret_access_key=credentials["SecretAccessKey"],
@@ -93,21 +122,38 @@ def resolve_bedrock_aws_session() -> boto3.Session | None:
     return None
 
 
-def frozen_bedrock_credentials(session: boto3.Session) -> Any:
-    """Resolved static credentials ``AnthropicBedrock`` needs as explicit kwargs.
+def resolve_bedrock_anthropic_kwargs(region: str) -> dict[str, Any]:
+    """``AnthropicBedrock`` auth kwargs for a cross-account Bedrock override.
 
-    Raises a clear error if the session (from :func:`resolve_bedrock_aws_session`)
-    cannot resolve credentials at all, e.g. ``BEDROCK_AWS_PROFILE`` names a
-    profile with no credentials configured.
+    ``AnthropicBedrock`` only accepts a profile name (which it resolves, and
+    refreshes, itself) or fully static access/secret/session-token strings —
+    unlike ``boto3.Session``, there is no hook for a refreshable credentials
+    provider, so the two overrides are necessarily handled differently:
+
+    - ``BEDROCK_AWS_PROFILE`` is passed straight through as ``aws_profile``,
+      so whatever refresh the named profile supports keeps working (a
+      role_arn + source_profile pair in ``~/.aws/config`` auto-refreshes).
+    - ``BEDROCK_AWS_ROLE_ARN`` has no such hook: the returned credentials are
+      a one-time snapshot (see :func:`_assumed_bedrock_role_credentials`),
+      valid only for the assumed role's session duration.
+
+    Returns an empty dict when neither override is set, so callers fall
+    through to today's exact ambient-chain behavior (``AnthropicBedrock``
+    with no explicit credentials).
     """
-    credentials = session.get_credentials()
-    if credentials is None:
-        raise RuntimeError(
-            "Could not resolve AWS credentials for the Bedrock session. "
-            "Check BEDROCK_AWS_PROFILE (does the named profile have credentials?) "
-            "or BEDROCK_AWS_ROLE_ARN."
-        )
-    return credentials.get_frozen_credentials()
+    credentials = _assumed_bedrock_role_credentials(region)
+    if credentials is not None:
+        return {
+            "aws_access_key": credentials["AccessKeyId"],
+            "aws_secret_key": credentials["SecretAccessKey"],
+            "aws_session_token": credentials["SessionToken"],
+        }
+
+    profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
+    if profile:
+        return {"aws_profile": profile}
+
+    return {}
 
 
 def new_tool_use_id() -> str:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -6,23 +6,108 @@ import json
 import logging
 import os
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from config.constants.aws import (
+    BEDROCK_AWS_EXTERNAL_ID_ENV,
+    BEDROCK_AWS_PROFILE_ENV,
+    BEDROCK_AWS_REGION_ENV,
+    BEDROCK_AWS_ROLE_ARN_ENV,
+)
 from core.llm.shared.tool_schema_normalize import (
     BEDROCK_UNSUPPORTED_SCHEMA_KEYS,
     normalize_object_tool_input_schema,
     sanitize_strict_tool_schema,
 )
 
+if TYPE_CHECKING:
+    import boto3
+
 logger = logging.getLogger(__name__)
 
 
 def require_aws_region() -> str:
-    """Return configured AWS region or raise with a clear configuration error."""
-    region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
+    """Return configured AWS region or raise with a clear configuration error.
+
+    ``BEDROCK_AWS_REGION`` takes precedence so a cross-account Bedrock setup
+    (see :func:`resolve_bedrock_aws_session`) can target a region independent
+    of the region investigation tools use.
+    """
+    region = (
+        os.getenv(BEDROCK_AWS_REGION_ENV)
+        or os.getenv("AWS_REGION")
+        or os.getenv("AWS_DEFAULT_REGION")
+        or ""
+    ).strip()
     if not region:
-        raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
+        raise RuntimeError(
+            "Bedrock requires AWS_REGION, AWS_DEFAULT_REGION, or BEDROCK_AWS_REGION to be set."
+        )
     return region
+
+
+def resolve_bedrock_aws_session() -> boto3.Session | None:
+    """Isolate Bedrock's AWS identity from the ambient default credential chain.
+
+    Investigation tools (EC2, CloudWatch, ...) already work correctly across
+    accounts because they read the process's single ambient ``AWS_PROFILE``
+    directly. Bedrock had no equivalent: every Bedrock client reached for the
+    same ambient chain, so a laptop configured for a Bedrock account reachable
+    only via an AssumeRole profile in a different account than the infra being
+    investigated had no way to give Bedrock a *different* identity than
+    whatever profile was active for everything else (#4482).
+
+    ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
+    deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
+    ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
+    AssumeRole + source_profile pair — the shape the issue's own setup used.
+    Returns ``None`` when neither is set, so callers fall through to today's
+    exact ambient-chain behavior; this function never changes behavior for a
+    caller who hasn't opted in.
+    """
+    import boto3
+
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if role_arn:
+        region = require_aws_region()
+        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+        sts = boto3.client("sts", region_name=region)
+        assume_role_kwargs: dict[str, str] = {
+            "RoleArn": role_arn,
+            "RoleSessionName": "OpenSREBedrockInvoke",
+        }
+        if external_id:
+            assume_role_kwargs["ExternalId"] = external_id
+        credentials = sts.assume_role(**assume_role_kwargs)["Credentials"]
+        return boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            region_name=region,
+        )
+
+    profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
+    if profile:
+        return boto3.Session(profile_name=profile)
+
+    return None
+
+
+def frozen_bedrock_credentials(session: boto3.Session) -> Any:
+    """Resolved static credentials ``AnthropicBedrock`` needs as explicit kwargs.
+
+    Raises a clear error if the session (from :func:`resolve_bedrock_aws_session`)
+    cannot resolve credentials at all, e.g. ``BEDROCK_AWS_PROFILE`` names a
+    profile with no credentials configured.
+    """
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise RuntimeError(
+            "Could not resolve AWS credentials for the Bedrock session. "
+            "Check BEDROCK_AWS_PROFILE (does the named profile have credentials?) "
+            "or BEDROCK_AWS_ROLE_ARN."
+        )
+    return credentials.get_frozen_credentials()
 
 
 def new_tool_use_id() -> str:

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -30,6 +30,7 @@ from openai import OpenAI
 from openai import RateLimitError as OpenAIRateLimitError
 from pydantic import BaseModel
 
+from config.constants.aws import BEDROCK_AWS_REGION_ENV
 from core.llm.providers import provider_credentials
 from core.llm.providers.bedrock_model_ids import is_anthropic_bedrock_model
 from core.llm.shared.llm_retry import extract_retry_after_seconds
@@ -405,20 +406,43 @@ class BedrockLLMClient:
     def __init__(
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
+        from core.llm.transports.sdk.bedrock_converse import (
+            frozen_bedrock_credentials,
+            resolve_bedrock_aws_session,
+        )
+
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._use_anthropic = is_anthropic_bedrock_model(model)
-        self._aws_region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1"))
+        # BEDROCK_AWS_REGION overrides for a cross-account setup; falls back to
+        # the same permissive AWS_REGION/AWS_DEFAULT_REGION/us-east-1 chain
+        # this class has always used (unlike the agent-loop Bedrock clients,
+        # this one does not require a region to be configured explicitly).
+        self._aws_region = os.getenv(
+            BEDROCK_AWS_REGION_ENV,
+            os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+        )
+        session = resolve_bedrock_aws_session()
 
         if self._use_anthropic:
-            self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
-                aws_region=self._aws_region
-            )
+            if session is not None:
+                frozen = frozen_bedrock_credentials(session)
+                self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
+                    aws_access_key=frozen.access_key,
+                    aws_secret_key=frozen.secret_key,
+                    aws_session_token=frozen.token,
+                    aws_region=self._aws_region,
+                )
+            else:
+                self._anthropic_client = AnthropicBedrock(aws_region=self._aws_region)
             self._boto3_client: Any = None
         else:
             self._anthropic_client = None
-            self._boto3_client = boto3.client("bedrock-runtime", region_name=self._aws_region)
+            if session is not None:
+                self._boto3_client = session.client("bedrock-runtime", region_name=self._aws_region)
+            else:
+                self._boto3_client = boto3.client("bedrock-runtime", region_name=self._aws_region)
 
     def with_config(self, **_kwargs: Any) -> BedrockLLMClient:
         return self

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -407,7 +407,7 @@ class BedrockLLMClient:
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
         from core.llm.transports.sdk.bedrock_converse import (
-            frozen_bedrock_credentials,
+            resolve_bedrock_anthropic_kwargs,
             resolve_bedrock_aws_session,
         )
 
@@ -419,26 +419,25 @@ class BedrockLLMClient:
         # the same permissive AWS_REGION/AWS_DEFAULT_REGION/us-east-1 chain
         # this class has always used (unlike the agent-loop Bedrock clients,
         # this one does not require a region to be configured explicitly).
-        self._aws_region = os.getenv(
-            BEDROCK_AWS_REGION_ENV,
-            os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+        # The `or` chain (not nested os.getenv defaults) matters: a variable
+        # present but set to "" must fall through too, not short-circuit on
+        # an empty string.
+        self._aws_region = (
+            os.getenv(BEDROCK_AWS_REGION_ENV)
+            or os.getenv("AWS_REGION")
+            or os.getenv("AWS_DEFAULT_REGION")
+            or "us-east-1"
         )
-        session = resolve_bedrock_aws_session()
 
         if self._use_anthropic:
-            if session is not None:
-                frozen = frozen_bedrock_credentials(session)
-                self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
-                    aws_access_key=frozen.access_key,
-                    aws_secret_key=frozen.secret_key,
-                    aws_session_token=frozen.token,
-                    aws_region=self._aws_region,
-                )
-            else:
-                self._anthropic_client = AnthropicBedrock(aws_region=self._aws_region)
+            self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
+                aws_region=self._aws_region,
+                **resolve_bedrock_anthropic_kwargs(self._aws_region),
+            )
             self._boto3_client: Any = None
         else:
             self._anthropic_client = None
+            session = resolve_bedrock_aws_session(self._aws_region)
             if session is not None:
                 self._boto3_client = session.client("bedrock-runtime", region_name=self._aws_region)
             else:

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -91,6 +91,10 @@ All configuration options for OpenSRE can be set via environment variables. This
 |----------|---------|-------------|--------|
 | `BEDROCK_REASONING_MODEL` | | Model for reasoning tasks | `config` |
 | `BEDROCK_TOOLCALL_MODEL` | | Model for tool calling | `config` |
+| `BEDROCK_AWS_PROFILE` | | Named AWS profile for Bedrock only, isolated from `AWS_PROFILE` used by infrastructure investigation | `config/constants/aws` |
+| `BEDROCK_AWS_ROLE_ARN` | | AWS role to assume for Bedrock only (cross-account setup); takes precedence over `BEDROCK_AWS_PROFILE` | `config/constants/aws` |
+| `BEDROCK_AWS_EXTERNAL_ID` | | External ID for the `BEDROCK_AWS_ROLE_ARN` assume-role call | `config/constants/aws` |
+| `BEDROCK_AWS_REGION` | | Region override for Bedrock only, when it differs from `AWS_REGION` | `config/constants/aws` |
 
 ### Ollama (Local)
 | Variable | Default | Description | Module |

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -327,6 +327,22 @@ No API key — auth uses the AWS credential chain (environment variables, shared
 
 Defaults in `config/config.py` are US cross-region inference profile IDs for Anthropic Claude; override with IDs or ARNs that are **inference-access enabled** in your account and region.
 
+**Cross-account setup** (Bedrock reachable only via an AssumeRole profile in a different AWS account than the one you investigate): infrastructure tools (EC2, CloudWatch, ...) already follow the process's ambient `AWS_PROFILE`, so nothing about your usual credential setup needs to change for them. Bedrock alone can be pointed at a different identity with:
+
+```bash
+# A named profile (may itself be an AssumeRole + source_profile pair):
+export BEDROCK_AWS_PROFILE=bedrock-account
+
+# Or an explicit assume-role, for deployments with no ~/.aws/config file (e.g. Fargate):
+export BEDROCK_AWS_ROLE_ARN=arn:aws:iam::<account-id>:role/BedrockInvoke
+export BEDROCK_AWS_EXTERNAL_ID=your-external-id     # optional
+
+# Optional: only needed if Bedrock's region differs from AWS_REGION
+export BEDROCK_AWS_REGION=us-east-1
+```
+
+`BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
+
 ### Google Vertex AI
 
 ```bash

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -343,6 +343,8 @@ export BEDROCK_AWS_REGION=us-east-1
 
 `BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
 
+`BEDROCK_AWS_PROFILE` refreshes automatically for as long as the process runs, the same as any other AssumeRole profile. `BEDROCK_AWS_ROLE_ARN` is a one-time credential snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process that outlives that window needs its LLM clients recreated (e.g. via `/model` in the interactive shell). Prefer `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` if the process runs longer than that.
+
 ### Google Vertex AI
 
 ```bash

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -64,9 +64,77 @@ def test_bedrock_client_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> 
     _install_fake_anthropic(monkeypatch)
     monkeypatch.delenv("AWS_REGION", raising=False)
     monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
 
-    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION"):
         BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+
+def _record_anthropic_bedrock_init_kwargs(
+    fake_anthropic: types.SimpleNamespace,
+) -> list[dict[str, object]]:
+    """Wrap the fake AnthropicBedrock's __init__ to record every kwarg it receives."""
+    calls: list[dict[str, object]] = []
+    original_init = fake_anthropic.AnthropicBedrock.__init__
+
+    def _recording_init(self: object, **kwargs: object) -> None:
+        calls.append(kwargs)
+        original_init(self, **kwargs)
+
+    fake_anthropic.AnthropicBedrock.__init__ = _recording_init
+    return calls
+
+
+def test_bedrock_client_uses_ambient_chain_when_no_override_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No BEDROCK_AWS_* override: today's exact behavior, no explicit creds passed."""
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: None,
+    )
+    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
+
+    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    assert "aws_access_key" not in calls[0]
+    assert calls[0]["aws_region"] == "us-west-2"
+
+
+def test_bedrock_client_uses_resolved_session_credentials_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must pass explicit static creds,
+    isolated from whatever ambient AWS_PROFILE investigation tools use (#4482)."""
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+    class _FakeFrozenCredentials:
+        access_key = "AKIA-BEDROCK"
+        secret_key = "secret-bedrock"
+        token = "token-bedrock"
+
+    class _FakeSession:
+        pass
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
+        lambda _session: _FakeFrozenCredentials(),
+    )
+    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
+
+    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
+    assert calls[0]["aws_secret_key"] == "secret-bedrock"
+    assert calls[0]["aws_session_token"] == "token-bedrock"
+    assert calls[0]["aws_region"] == "us-west-2"
 
 
 def test_bedrock_auth_error_message_references_aws_credentials(
@@ -1604,12 +1672,46 @@ def _stub_boto3_converse(
 def test_bedrock_converse_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AWS_REGION", raising=False)
     monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
     _stub_boto3_converse(monkeypatch)
 
     from core.llm.transports.sdk.agent_clients import BedrockConverseAgentClient
 
-    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION"):
         BedrockConverseAgentClient(model=_MISTRAL_MODEL)
+
+
+def test_bedrock_converse_uses_resolved_session_client_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must build the runtime client
+    from the resolved session, not the ambient default boto3.client (#4482)."""
+    from core.llm.transports.sdk.agent_clients import BedrockConverseAgentClient
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    _stub_boto3_converse(monkeypatch)
+
+    session_client_calls: list[tuple[str, dict[str, object]]] = []
+    default_client_calls: list[tuple[str, dict[str, object]]] = []
+
+    class _FakeSession:
+        def client(self, service: str, **kwargs: object) -> object:
+            session_client_calls.append((service, kwargs))
+            return object()
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "boto3.client",
+        lambda *args, **kwargs: default_client_calls.append((args, kwargs)),
+    )
+
+    BedrockConverseAgentClient(model=_MISTRAL_MODEL)
+
+    assert session_client_calls == [("bedrock-runtime", {"region_name": "us-east-1"})]
+    assert default_client_calls == []
 
 
 def test_bedrock_converse_invoke_parses_tool_use(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -92,8 +92,8 @@ def test_bedrock_client_uses_ambient_chain_when_no_override_configured(
     fake_anthropic = _install_fake_anthropic(monkeypatch)
     monkeypatch.setenv("AWS_REGION", "us-west-2")
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: None,
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {},
     )
     calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
 
@@ -111,21 +111,13 @@ def test_bedrock_client_uses_resolved_session_credentials_when_configured(
     fake_anthropic = _install_fake_anthropic(monkeypatch)
     monkeypatch.setenv("AWS_REGION", "us-west-2")
 
-    class _FakeFrozenCredentials:
-        access_key = "AKIA-BEDROCK"
-        secret_key = "secret-bedrock"
-        token = "token-bedrock"
-
-    class _FakeSession:
-        pass
-
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
-    )
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
-        lambda _session: _FakeFrozenCredentials(),
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {
+            "aws_access_key": "AKIA-BEDROCK",
+            "aws_secret_key": "secret-bedrock",
+            "aws_session_token": "token-bedrock",
+        },
     )
     calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
 
@@ -1701,7 +1693,7 @@ def test_bedrock_converse_uses_resolved_session_client_when_configured(
 
     monkeypatch.setattr(
         "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
+        lambda _region: _FakeSession(),
     )
     monkeypatch.setattr(
         "boto3.client",

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -16,8 +16,8 @@ from typing import Any
 import pytest
 
 from core.llm.transports.sdk.bedrock_converse import (
-    frozen_bedrock_credentials,
     require_aws_region,
+    resolve_bedrock_anthropic_kwargs,
     resolve_bedrock_aws_session,
 )
 
@@ -55,7 +55,7 @@ def test_require_aws_region_falls_back_to_aws_region(monkeypatch: pytest.MonkeyP
 
 
 # --------------------------------------------------------------------------- #
-# resolve_bedrock_aws_session                                                 #
+# resolve_bedrock_aws_session (boto3.client consumers)                        #
 # --------------------------------------------------------------------------- #
 
 
@@ -65,7 +65,7 @@ def test_resolve_bedrock_aws_session_returns_none_when_unset(
     """No override set: callers must fall through to today's ambient-chain behavior."""
     _clear_bedrock_env(monkeypatch)
 
-    assert resolve_bedrock_aws_session() is None
+    assert resolve_bedrock_aws_session("us-east-1") is None
 
 
 def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,7 +79,7 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    session = resolve_bedrock_aws_session()
+    session = resolve_bedrock_aws_session("us-east-1")
 
     assert isinstance(session, _FakeSession)
     assert calls == [{"profile_name": "bedrock-account"}]
@@ -87,7 +87,6 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
 
 def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
 
@@ -116,7 +115,7 @@ def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr("boto3.client", _fake_boto3_client)
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    session = resolve_bedrock_aws_session()
+    session = resolve_bedrock_aws_session("us-east-1")
 
     assert isinstance(session, _FakeSession)
     assert assume_role_calls == [
@@ -141,7 +140,6 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
 ) -> None:
     """Both set: the explicit assume-role wins, the profile is never touched."""
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
 
@@ -164,7 +162,7 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
     monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    resolve_bedrock_aws_session()
+    resolve_bedrock_aws_session("us-east-1")
 
     assert len(session_calls) == 1
     assert "profile_name" not in session_calls[0]
@@ -175,7 +173,6 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
 ) -> None:
     """ExternalId is optional; omit it entirely rather than sending an empty string."""
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
 
     assume_role_calls: list[dict[str, Any]] = []
@@ -194,36 +191,89 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
     monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
     monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
 
-    resolve_bedrock_aws_session()
+    resolve_bedrock_aws_session("us-east-1")
 
     assert "ExternalId" not in assume_role_calls[0]
 
 
+def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The caller's region is a parameter, not re-derived (regression: a
+    BEDROCK_AWS_ROLE_ARN-only config must not reject a caller's own
+    permissive us-east-1 default just because AWS_REGION is unset)."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", lambda **kwargs: kwargs)
+
+    # No AWS_REGION/AWS_DEFAULT_REGION/BEDROCK_AWS_REGION set anywhere: this
+    # must not raise, since the caller decided "us-east-1" is an acceptable
+    # default and passed it in directly.
+    session = resolve_bedrock_aws_session("us-east-1")
+
+    assert session == {
+        "aws_access_key_id": "AKIA-TEMP",
+        "aws_secret_access_key": "secret-temp",
+        "aws_session_token": "token-temp",
+        "region_name": "us-east-1",
+    }
+
+
 # --------------------------------------------------------------------------- #
-# frozen_bedrock_credentials                                                  #
+# resolve_bedrock_anthropic_kwargs (AnthropicBedrock consumers)                #
 # --------------------------------------------------------------------------- #
 
 
-def test_frozen_bedrock_credentials_returns_frozen_credentials() -> None:
-    sentinel = object()
+def test_resolve_bedrock_anthropic_kwargs_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_bedrock_env(monkeypatch)
 
-    class _FakeCredentials:
-        def get_frozen_credentials(self) -> object:
-            return sentinel
-
-    class _FakeSession:
-        def get_credentials(self) -> _FakeCredentials:
-            return _FakeCredentials()
-
-    assert frozen_bedrock_credentials(_FakeSession()) is sentinel
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {}
 
 
-def test_frozen_bedrock_credentials_raises_a_clear_error_when_unresolved() -> None:
-    """A profile with no configured credentials must not crash with an AttributeError."""
+def test_resolve_bedrock_anthropic_kwargs_passes_profile_through_unresolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named profile must reach AnthropicBedrock as aws_profile=, not be
+    resolved-and-frozen into static keys — freezing would silently drop the
+    refresh a role_arn + source_profile pair in ~/.aws/config provides."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
 
-    class _FakeSession:
-        def get_credentials(self) -> None:
-            return None
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {"aws_profile": "bedrock-account"}
 
-    with pytest.raises(RuntimeError, match="BEDROCK_AWS_PROFILE"):
-        frozen_bedrock_credentials(_FakeSession())
+
+def test_resolve_bedrock_anthropic_kwargs_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {
+        "aws_access_key": "AKIA-TEMP",
+        "aws_secret_key": "secret-temp",
+        "aws_session_token": "token-temp",
+    }

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -1,0 +1,229 @@
+"""Tests for isolating Bedrock's AWS identity from investigation tools' (#4482).
+
+Investigation tools already read the ambient ``AWS_PROFILE`` directly, so a
+laptop configured for one AWS account already investigates that account
+correctly. Bedrock had no equivalent override: every Bedrock client reached
+for the same ambient default credential chain, so a cross-account setup
+(Bedrock reachable only via an AssumeRole profile in a different account
+than the infra being investigated) had no way to give Bedrock a different
+identity than whatever profile was active for everything else.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.llm.transports.sdk.bedrock_converse import (
+    frozen_bedrock_credentials,
+    require_aws_region,
+    resolve_bedrock_aws_session,
+)
+
+
+def _clear_bedrock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "BEDROCK_AWS_REGION",
+        "BEDROCK_AWS_PROFILE",
+        "BEDROCK_AWS_ROLE_ARN",
+        "BEDROCK_AWS_EXTERNAL_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# require_aws_region — BEDROCK_AWS_REGION precedence                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_require_aws_region_prefers_bedrock_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_REGION", "eu-west-1")
+
+    assert require_aws_region() == "eu-west-1"
+
+
+def test_require_aws_region_falls_back_to_aws_region(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    assert require_aws_region() == "us-east-1"
+
+
+# --------------------------------------------------------------------------- #
+# resolve_bedrock_aws_session                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_bedrock_aws_session_returns_none_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No override set: callers must fall through to today's ambient-chain behavior."""
+    _clear_bedrock_env(monkeypatch)
+
+    assert resolve_bedrock_aws_session() is None
+
+
+def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
+    calls: list[dict[str, Any]] = []
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    session = resolve_bedrock_aws_session()
+
+    assert isinstance(session, _FakeSession)
+    assert calls == [{"profile_name": "bedrock-account"}]
+
+
+def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
+
+    assume_role_calls: list[dict[str, Any]] = []
+    session_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            assume_role_calls.append(kwargs)
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            session_calls.append(kwargs)
+
+    def _fake_boto3_client(service: str, **_kwargs: Any) -> _FakeStsClient:
+        assert service == "sts"
+        return _FakeStsClient()
+
+    monkeypatch.setattr("boto3.client", _fake_boto3_client)
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    session = resolve_bedrock_aws_session()
+
+    assert isinstance(session, _FakeSession)
+    assert assume_role_calls == [
+        {
+            "RoleArn": "arn:aws:iam::999:role/BedrockInvoke",
+            "RoleSessionName": "OpenSREBedrockInvoke",
+            "ExternalId": "shared-secret",
+        }
+    ]
+    assert session_calls == [
+        {
+            "aws_access_key_id": "AKIA-TEMP",
+            "aws_secret_access_key": "secret-temp",
+            "aws_session_token": "token-temp",
+            "region_name": "us-east-1",
+        }
+    ]
+
+
+def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both set: the explicit assume-role wins, the profile is never touched."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
+
+    session_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            session_calls.append(kwargs)
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    resolve_bedrock_aws_session()
+
+    assert len(session_calls) == 1
+    assert "profile_name" not in session_calls[0]
+
+
+def test_resolve_bedrock_aws_session_role_arn_without_external_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ExternalId is optional; omit it entirely rather than sending an empty string."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    assume_role_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            assume_role_calls.append(kwargs)
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
+
+    resolve_bedrock_aws_session()
+
+    assert "ExternalId" not in assume_role_calls[0]
+
+
+# --------------------------------------------------------------------------- #
+# frozen_bedrock_credentials                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_frozen_bedrock_credentials_returns_frozen_credentials() -> None:
+    sentinel = object()
+
+    class _FakeCredentials:
+        def get_frozen_credentials(self) -> object:
+            return sentinel
+
+    class _FakeSession:
+        def get_credentials(self) -> _FakeCredentials:
+            return _FakeCredentials()
+
+    assert frozen_bedrock_credentials(_FakeSession()) is sentinel
+
+
+def test_frozen_bedrock_credentials_raises_a_clear_error_when_unresolved() -> None:
+    """A profile with no configured credentials must not crash with an AttributeError."""
+
+    class _FakeSession:
+        def get_credentials(self) -> None:
+            return None
+
+    with pytest.raises(RuntimeError, match="BEDROCK_AWS_PROFILE"):
+        frozen_bedrock_credentials(_FakeSession())

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -240,6 +240,79 @@ def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     assert "system" not in call
 
 
+def test_bedrock_llm_client_converse_uses_resolved_session_when_configured(
+    monkeypatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must build the runtime client
+    from the resolved session, not the ambient default boto3.client (#4482)."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
+    monkeypatch.setattr(
+        "platform.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+    session_client_calls: list[tuple[str, dict]] = []
+    default_client_calls: list[tuple[str, dict]] = []
+
+    class _FakeSession:
+        def client(self, service: str, **kwargs) -> object:
+            session_client_calls.append((service, kwargs))
+            return _RecordingBedrockRuntime({"output": {"message": {"content": []}}})
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        sdk_llm.boto3,
+        "client",
+        lambda *a, **k: default_client_calls.append((a, k)),
+    )
+
+    sdk_llm.BedrockLLMClient(model="mistral.mistral-large-2402-v1:0")
+
+    assert session_client_calls == [("bedrock-runtime", {"region_name": "us-east-1"})]
+    assert default_client_calls == []
+
+
+def test_bedrock_llm_client_anthropic_uses_resolved_session_credentials(monkeypatch) -> None:
+    """Same override, Anthropic-on-Bedrock path: explicit static creds, not ambient."""
+    monkeypatch.setattr(
+        "platform.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+
+    class _FakeFrozenCredentials:
+        access_key = "AKIA-BEDROCK"
+        secret_key = "secret-bedrock"
+        token = "token-bedrock"
+
+    class _FakeSession:
+        pass
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
+        lambda _session: _FakeFrozenCredentials(),
+    )
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        sdk_llm,
+        "AnthropicBedrock",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
+    assert calls[0]["aws_secret_key"] == "secret-bedrock"
+    assert calls[0]["aws_session_token"] == "token-bedrock"
+
+
 def test_invoke_converse_includes_optional_system_temperature(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -217,6 +217,52 @@ def test_is_anthropic_bedrock_model_application_inference_profile_arn() -> None:
     assert not sdk_llm.is_anthropic_bedrock_model(profile_arn)
 
 
+def test_bedrock_llm_client_role_arn_without_any_region_uses_permissive_default(
+    monkeypatch,
+) -> None:
+    """BEDROCK_AWS_ROLE_ARN set with no region env var anywhere must not reject
+    a config that would otherwise default to us-east-1 (#4482 round 2): the
+    session resolver must use the caller's own already-resolved region
+    instead of independently re-requiring one."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs) -> dict:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def client(self, _service: str, **_kwargs) -> object:
+            return _RecordingBedrockRuntime({"output": {"message": {"content": []}}})
+
+    monkeypatch.setattr(sdk_llm.boto3, "client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr(sdk_llm.boto3, "Session", lambda **_kwargs: _FakeSession())
+
+    client = sdk_llm.BedrockLLMClient(model="mistral.mistral-large-2402-v1:0")
+
+    assert client._aws_region == "us-east-1"
+
+
+def test_bedrock_llm_client_treats_empty_bedrock_region_as_unset(monkeypatch) -> None:
+    """BEDROCK_AWS_REGION="" must fall through to AWS_REGION, not become the
+    literal empty string (a plain os.getenv(name, default) does not treat a
+    present-but-empty value as unset)."""
+    monkeypatch.setenv("BEDROCK_AWS_REGION", "")
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+    client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert client._aws_region == "us-west-2"
+
+
 def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",
@@ -262,7 +308,7 @@ def test_bedrock_llm_client_converse_uses_resolved_session_when_configured(
 
     monkeypatch.setattr(
         "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
+        lambda _region: _FakeSession(),
     )
     monkeypatch.setattr(
         sdk_llm.boto3,
@@ -283,21 +329,13 @@ def test_bedrock_llm_client_anthropic_uses_resolved_session_credentials(monkeypa
         _InactiveGuardrailEngine,
     )
 
-    class _FakeFrozenCredentials:
-        access_key = "AKIA-BEDROCK"
-        secret_key = "secret-bedrock"
-        token = "token-bedrock"
-
-    class _FakeSession:
-        pass
-
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
-    )
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
-        lambda _session: _FakeFrozenCredentials(),
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {
+            "aws_access_key": "AKIA-BEDROCK",
+            "aws_secret_key": "secret-bedrock",
+            "aws_session_token": "token-bedrock",
+        },
     )
     calls: list[dict] = []
     monkeypatch.setattr(


### PR DESCRIPTION
Fixes #4482

Bedrock and infrastructure investigation (EC2, CloudWatch, ...) both resolved AWS identity from the same ambient default credential chain, with no way to give them different identities. Investigation tools already work correctly cross-account because they read the process's single ambient `AWS_PROFILE` directly. Bedrock had no equivalent override, so a laptop configured for a Bedrock account reachable only via an AssumeRole profile in a different account than the infra being investigated had no way to give Bedrock a different identity than whatever profile was active for everything else, exactly the symptom in the issue's repro.

Adds a Bedrock-only identity override, isolated from investigation's ambient chain: `BEDROCK_AWS_PROFILE` (named profile), `BEDROCK_AWS_ROLE_ARN` + `BEDROCK_AWS_EXTERNAL_ID` (explicit assume-role, for deployments with no `~/.aws/config` file), and `BEDROCK_AWS_REGION`. Naming mirrors the existing `AWS_ROLE_ARN`/`AWS_EXTERNAL_ID` convention in `config/constants/aws.py`.

A new `resolve_bedrock_aws_session()` in `core/llm/transports/sdk/bedrock_converse.py` builds a `boto3.Session` from the override (role-arn takes precedence) or returns `None` when neither is set, so callers fall through to today's exact ambient-chain behavior. `frozen_bedrock_credentials()` extracts concrete key material for `AnthropicBedrock`'s constructor kwargs (confirmed it accepts `aws_access_key`/`aws_secret_key`/`aws_session_token` directly), raising a clear error instead of an `AttributeError` if a session can't resolve credentials.

Wired into all three Bedrock client construction sites: `BedrockAgentClient` and `BedrockConverseAgentClient` in `agent_clients.py`, and `BedrockLLMClient` in `llm_clients.py`. `BedrockLLMClient`'s existing permissive region default (falls back to `us-east-1` rather than raising) was deliberately preserved.

Out of scope: the `OPENSRE_LLM_TRANSPORT=litellm` Bedrock path, and investigation-tool credential resolution (already correctly isolated via ambient `AWS_PROFILE`).

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/core/runtime/llm/ -q
355 passed

$ uv run python -m ruff check config/ core/ docs/ tests/core/runtime/llm/ && uv run python -m ruff format --check config/ core/ tests/core/runtime/llm/
All checks passed! / 313 files already formatted

$ make typecheck && make check-imports
Success: no issues found in 1555 source files / All 3 import checks passed.

$ uv run pytest tests/core/ -q
1588 passed, 29 skipped
```

14 new tests: 9 unit tests on the new session/credential-resolution helpers (profile path, assume-role path, role-arn-over-profile precedence, missing-ExternalId, unresolved-credentials error), and 5 wiring tests proving each of the three Bedrock client constructors actually uses the resolved session over the ambient default.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Traced every AWS/boto3 client construction site in the repo before writing anything, to confirm the root cause: both Bedrock and investigation tools call plain `boto3.client(...)`/`AnthropicBedrock(...)` against the single ambient default credential chain, with investigation's cross-account support coming entirely from the OS-level `AWS_PROFILE` env var rather than any application code. That meant the fix only needed to touch Bedrock's side. Checked `AnthropicBedrock`'s actual constructor signature before assuming it could accept explicit credentials. Found `integrations/aws/verifier.py::_build_sts_client` already implements the identical assume-role pattern for the AWS integration's verify probe, so the new assume-role branch mirrors its exact shape instead of inventing new semantics. Unified `AnthropicBedrock` (discrete key kwargs) and the raw `boto3.client("bedrock-runtime", ...)` Converse path (wants a Session) behind one `boto3.Session`-returning function. While touching `BedrockLLMClient`, noticed it silently defaults to `us-east-1` unlike the other two Bedrock clients, which raise; deliberately preserved that existing asymmetry instead of unifying it as a side effect of an unrelated credential fix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
