### PR TITLE
feat(llm): isolate Bedrock AWS session from investigation tools (#4482)

### DIFF
--- a/config/constants/aws.py
+++ b/config/constants/aws.py
@@ -9,6 +9,19 @@ AWS_ACCESS_KEY_ID_ENV = "AWS_ACCESS_KEY_ID"
 AWS_SECRET_ACCESS_KEY_ENV = "AWS_SECRET_ACCESS_KEY"
 AWS_SESSION_TOKEN_ENV = "AWS_SESSION_TOKEN"
 
+# Bedrock-only identity override, isolated from the vars above. Investigation
+# tools (EC2, CloudWatch, ...) already read the ambient AWS_PROFILE directly,
+# so a laptop configured for one AWS account already investigates that
+# account correctly. Bedrock had no equivalent override, so a cross-account
+# setup (Bedrock reachable only via an AssumeRole profile in a different
+# account than the infra being investigated) could not give Bedrock a
+# different identity than whatever profile was active for everything else.
+# See #4482.
+BEDROCK_AWS_PROFILE_ENV = "BEDROCK_AWS_PROFILE"
+BEDROCK_AWS_ROLE_ARN_ENV = "BEDROCK_AWS_ROLE_ARN"
+BEDROCK_AWS_EXTERNAL_ID_ENV = "BEDROCK_AWS_EXTERNAL_ID"
+BEDROCK_AWS_REGION_ENV = "BEDROCK_AWS_REGION"
+
 __all__ = [
     "AWS_ACCESS_KEY_ID_ENV",
     "AWS_EXTERNAL_ID_ENV",
@@ -16,4 +29,8 @@ __all__ = [
     "AWS_ROLE_ARN_ENV",
     "AWS_SECRET_ACCESS_KEY_ENV",
     "AWS_SESSION_TOKEN_ENV",
+    "BEDROCK_AWS_EXTERNAL_ID_ENV",
+    "BEDROCK_AWS_PROFILE_ENV",
+    "BEDROCK_AWS_REGION_ENV",
+    "BEDROCK_AWS_ROLE_ARN_ENV",
 ]

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -344,27 +344,16 @@ class BedrockAgentClient(AnthropicAgentClient):
         from anthropic import AnthropicBedrock
 
         from core.llm.transports.sdk.bedrock_converse import (
-            frozen_bedrock_credentials,
             require_aws_region,
-            resolve_bedrock_aws_session,
+            resolve_bedrock_anthropic_kwargs,
         )
 
         region = require_aws_region()
-        session = resolve_bedrock_aws_session()
-        if session is not None:
-            frozen = frozen_bedrock_credentials(session)
-            bedrock_client = AnthropicBedrock(
-                aws_access_key=frozen.access_key,
-                aws_secret_key=frozen.secret_key,
-                aws_session_token=frozen.token,
-                aws_region=region,
-                timeout=AGENT_CLIENT_TIMEOUT_SEC,
-            )
-        else:
-            bedrock_client = AnthropicBedrock(
-                aws_region=region,
-                timeout=AGENT_CLIENT_TIMEOUT_SEC,
-            )
+        bedrock_client = AnthropicBedrock(
+            aws_region=region,
+            timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            **resolve_bedrock_anthropic_kwargs(region),
+        )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 
     def _permission_denied_error_message(self) -> str:
@@ -402,7 +391,7 @@ class BedrockConverseAgentClient:
         self._model = model
         self._max_tokens = max_tokens
         region = require_aws_region()
-        session = resolve_bedrock_aws_session()
+        session = resolve_bedrock_aws_session(region)
         if session is not None:
             self._boto3_client = session.client("bedrock-runtime", region_name=region)
         else:

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import time
 from collections.abc import Callable
@@ -336,20 +335,36 @@ class BedrockAgentClient(AnthropicAgentClient):
     provider_name = "Bedrock"
     auth_error_hint = (
         "Check AWS credentials (for example AWS_PROFILE, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, "
-        "or instance role) and AWS_REGION/AWS_DEFAULT_REGION."
+        "or instance role) and AWS_REGION/AWS_DEFAULT_REGION. For a Bedrock account different "
+        "from the one used for infrastructure investigation, set BEDROCK_AWS_PROFILE or "
+        "BEDROCK_AWS_ROLE_ARN."
     )
 
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
         from anthropic import AnthropicBedrock
 
-        region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
-        if not region:
-            raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
-
-        bedrock_client = AnthropicBedrock(
-            aws_region=region,
-            timeout=AGENT_CLIENT_TIMEOUT_SEC,
+        from core.llm.transports.sdk.bedrock_converse import (
+            frozen_bedrock_credentials,
+            require_aws_region,
+            resolve_bedrock_aws_session,
         )
+
+        region = require_aws_region()
+        session = resolve_bedrock_aws_session()
+        if session is not None:
+            frozen = frozen_bedrock_credentials(session)
+            bedrock_client = AnthropicBedrock(
+                aws_access_key=frozen.access_key,
+                aws_secret_key=frozen.secret_key,
+                aws_session_token=frozen.token,
+                aws_region=region,
+                timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            )
+        else:
+            bedrock_client = AnthropicBedrock(
+                aws_region=region,
+                timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 
     def _permission_denied_error_message(self) -> str:
@@ -379,12 +394,19 @@ class BedrockConverseAgentClient:
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
         import boto3
 
-        from core.llm.transports.sdk.bedrock_converse import require_aws_region
+        from core.llm.transports.sdk.bedrock_converse import (
+            require_aws_region,
+            resolve_bedrock_aws_session,
+        )
 
         self._model = model
         self._max_tokens = max_tokens
         region = require_aws_region()
-        self._boto3_client = boto3.client("bedrock-runtime", region_name=region)
+        session = resolve_bedrock_aws_session()
+        if session is not None:
+            self._boto3_client = session.client("bedrock-runtime", region_name=region)
+        else:
+            self._boto3_client = boto3.client("bedrock-runtime", region_name=region)
 
     @property
     def model_id(self) -> str | None:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -46,7 +46,38 @@ def require_aws_region() -> str:
     return region
 
 
-def resolve_bedrock_aws_session() -> boto3.Session | None:
+def _assumed_bedrock_role_credentials(region: str) -> dict[str, str] | None:
+    """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
+
+    A single ``sts:AssumeRole`` snapshot, same shape as
+    ``integrations/aws/verifier.py::_build_sts_client``. The returned
+    credentials are valid for the assumed role's session duration (its
+    ``MaxSessionDuration``, often 1 hour unless the role is configured
+    longer) and do not refresh themselves — a cached client that outlives
+    that window needs to be recreated. Prefer ``BEDROCK_AWS_PROFILE`` with a
+    role_arn + source_profile pair in ``~/.aws/config`` when a process runs
+    longer than that: :func:`resolve_bedrock_aws_session` builds a
+    self-refreshing session for a named profile.
+    """
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if not role_arn:
+        return None
+
+    import boto3
+
+    external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+    sts = boto3.client("sts", region_name=region)
+    assume_role_kwargs: dict[str, str] = {
+        "RoleArn": role_arn,
+        "RoleSessionName": "OpenSREBedrockInvoke",
+    }
+    if external_id:
+        assume_role_kwargs["ExternalId"] = external_id
+    credentials: dict[str, str] = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    return credentials
+
+
+def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
     """Isolate Bedrock's AWS identity from the ambient default credential chain.
 
     Investigation tools (EC2, CloudWatch, ...) already work correctly across
@@ -57,28 +88,26 @@ def resolve_bedrock_aws_session() -> boto3.Session | None:
     investigated had no way to give Bedrock a *different* identity than
     whatever profile was active for everything else (#4482).
 
+    ``region`` is the caller's own already-resolved region (each of the three
+    Bedrock clients has a different region-resolution policy — two raise when
+    unset, one defaults to ``us-east-1``); this function does not re-derive
+    or require it, so it can't reject a config a caller would otherwise
+    accept.
+
     ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
     deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
     ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
-    AssumeRole + source_profile pair — the shape the issue's own setup used.
-    Returns ``None`` when neither is set, so callers fall through to today's
-    exact ambient-chain behavior; this function never changes behavior for a
-    caller who hasn't opted in.
+    AssumeRole + source_profile pair — the shape the issue's own setup used;
+    boto3 refreshes that automatically, since the profile is passed straight
+    through rather than resolved once and frozen. Returns ``None`` when
+    neither is set, so callers fall through to today's exact ambient-chain
+    behavior; this function never changes behavior for a caller who hasn't
+    opted in.
     """
     import boto3
 
-    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
-    if role_arn:
-        region = require_aws_region()
-        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
-        sts = boto3.client("sts", region_name=region)
-        assume_role_kwargs: dict[str, str] = {
-            "RoleArn": role_arn,
-            "RoleSessionName": "OpenSREBedrockInvoke",
-        }
-        if external_id:
-            assume_role_kwargs["ExternalId"] = external_id
-        credentials = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    credentials = _assumed_bedrock_role_credentials(region)
+    if credentials is not None:
         return boto3.Session(
             aws_access_key_id=credentials["AccessKeyId"],
             aws_secret_access_key=credentials["SecretAccessKey"],
@@ -93,21 +122,38 @@ def resolve_bedrock_aws_session() -> boto3.Session | None:
     return None
 
 
-def frozen_bedrock_credentials(session: boto3.Session) -> Any:
-    """Resolved static credentials ``AnthropicBedrock`` needs as explicit kwargs.
+def resolve_bedrock_anthropic_kwargs(region: str) -> dict[str, Any]:
+    """``AnthropicBedrock`` auth kwargs for a cross-account Bedrock override.
 
-    Raises a clear error if the session (from :func:`resolve_bedrock_aws_session`)
-    cannot resolve credentials at all, e.g. ``BEDROCK_AWS_PROFILE`` names a
-    profile with no credentials configured.
+    ``AnthropicBedrock`` only accepts a profile name (which it resolves, and
+    refreshes, itself) or fully static access/secret/session-token strings —
+    unlike ``boto3.Session``, there is no hook for a refreshable credentials
+    provider, so the two overrides are necessarily handled differently:
+
+    - ``BEDROCK_AWS_PROFILE`` is passed straight through as ``aws_profile``,
+      so whatever refresh the named profile supports keeps working (a
+      role_arn + source_profile pair in ``~/.aws/config`` auto-refreshes).
+    - ``BEDROCK_AWS_ROLE_ARN`` has no such hook: the returned credentials are
+      a one-time snapshot (see :func:`_assumed_bedrock_role_credentials`),
+      valid only for the assumed role's session duration.
+
+    Returns an empty dict when neither override is set, so callers fall
+    through to today's exact ambient-chain behavior (``AnthropicBedrock``
+    with no explicit credentials).
     """
-    credentials = session.get_credentials()
-    if credentials is None:
-        raise RuntimeError(
-            "Could not resolve AWS credentials for the Bedrock session. "
-            "Check BEDROCK_AWS_PROFILE (does the named profile have credentials?) "
-            "or BEDROCK_AWS_ROLE_ARN."
-        )
-    return credentials.get_frozen_credentials()
+    credentials = _assumed_bedrock_role_credentials(region)
+    if credentials is not None:
+        return {
+            "aws_access_key": credentials["AccessKeyId"],
+            "aws_secret_key": credentials["SecretAccessKey"],
+            "aws_session_token": credentials["SessionToken"],
+        }
+
+    profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
+    if profile:
+        return {"aws_profile": profile}
+
+    return {}
 
 
 def new_tool_use_id() -> str:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -46,7 +46,7 @@ def require_aws_region() -> str:
     return region
 
 
-def _assumed_bedrock_role_credentials(region: str) -> dict[str, str] | None:
+def _assumed_bedrock_role_credentials(region: str) -> dict[str, Any] | None:
     """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
 
     A single ``sts:AssumeRole`` snapshot, same shape as
@@ -73,7 +73,7 @@ def _assumed_bedrock_role_credentials(region: str) -> dict[str, str] | None:
     }
     if external_id:
         assume_role_kwargs["ExternalId"] = external_id
-    credentials: dict[str, str] = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    credentials: dict[str, Any] = sts.assume_role(**assume_role_kwargs)["Credentials"]
     return credentials
 
 

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -6,23 +6,108 @@ import json
 import logging
 import os
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from config.constants.aws import (
+    BEDROCK_AWS_EXTERNAL_ID_ENV,
+    BEDROCK_AWS_PROFILE_ENV,
+    BEDROCK_AWS_REGION_ENV,
+    BEDROCK_AWS_ROLE_ARN_ENV,
+)
 from core.llm.shared.tool_schema_normalize import (
     BEDROCK_UNSUPPORTED_SCHEMA_KEYS,
     normalize_object_tool_input_schema,
     sanitize_strict_tool_schema,
 )
 
+if TYPE_CHECKING:
+    import boto3
+
 logger = logging.getLogger(__name__)
 
 
 def require_aws_region() -> str:
-    """Return configured AWS region or raise with a clear configuration error."""
-    region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
+    """Return configured AWS region or raise with a clear configuration error.
+
+    ``BEDROCK_AWS_REGION`` takes precedence so a cross-account Bedrock setup
+    (see :func:`resolve_bedrock_aws_session`) can target a region independent
+    of the region investigation tools use.
+    """
+    region = (
+        os.getenv(BEDROCK_AWS_REGION_ENV)
+        or os.getenv("AWS_REGION")
+        or os.getenv("AWS_DEFAULT_REGION")
+        or ""
+    ).strip()
     if not region:
-        raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
+        raise RuntimeError(
+            "Bedrock requires AWS_REGION, AWS_DEFAULT_REGION, or BEDROCK_AWS_REGION to be set."
+        )
     return region
+
+
+def resolve_bedrock_aws_session() -> boto3.Session | None:
+    """Isolate Bedrock's AWS identity from the ambient default credential chain.
+
+    Investigation tools (EC2, CloudWatch, ...) already work correctly across
+    accounts because they read the process's single ambient ``AWS_PROFILE``
+    directly. Bedrock had no equivalent: every Bedrock client reached for the
+    same ambient chain, so a laptop configured for a Bedrock account reachable
+    only via an AssumeRole profile in a different account than the infra being
+    investigated had no way to give Bedrock a *different* identity than
+    whatever profile was active for everything else (#4482).
+
+    ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
+    deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
+    ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
+    AssumeRole + source_profile pair — the shape the issue's own setup used.
+    Returns ``None`` when neither is set, so callers fall through to today's
+    exact ambient-chain behavior; this function never changes behavior for a
+    caller who hasn't opted in.
+    """
+    import boto3
+
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if role_arn:
+        region = require_aws_region()
+        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+        sts = boto3.client("sts", region_name=region)
+        assume_role_kwargs: dict[str, str] = {
+            "RoleArn": role_arn,
+            "RoleSessionName": "OpenSREBedrockInvoke",
+        }
+        if external_id:
+            assume_role_kwargs["ExternalId"] = external_id
+        credentials = sts.assume_role(**assume_role_kwargs)["Credentials"]
+        return boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            region_name=region,
+        )
+
+    profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
+    if profile:
+        return boto3.Session(profile_name=profile)
+
+    return None
+
+
+def frozen_bedrock_credentials(session: boto3.Session) -> Any:
+    """Resolved static credentials ``AnthropicBedrock`` needs as explicit kwargs.
+
+    Raises a clear error if the session (from :func:`resolve_bedrock_aws_session`)
+    cannot resolve credentials at all, e.g. ``BEDROCK_AWS_PROFILE`` names a
+    profile with no credentials configured.
+    """
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise RuntimeError(
+            "Could not resolve AWS credentials for the Bedrock session. "
+            "Check BEDROCK_AWS_PROFILE (does the named profile have credentials?) "
+            "or BEDROCK_AWS_ROLE_ARN."
+        )
+    return credentials.get_frozen_credentials()
 
 
 def new_tool_use_id() -> str:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -50,14 +50,17 @@ def _assumed_bedrock_role_credentials(region: str) -> dict[str, Any] | None:
     """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
 
     A single ``sts:AssumeRole`` snapshot, same shape as
-    ``integrations/aws/verifier.py::_build_sts_client``. The returned
-    credentials are valid for the assumed role's session duration (its
-    ``MaxSessionDuration``, often 1 hour unless the role is configured
-    longer) and do not refresh themselves — a cached client that outlives
-    that window needs to be recreated. Prefer ``BEDROCK_AWS_PROFILE`` with a
-    role_arn + source_profile pair in ``~/.aws/config`` when a process runs
-    longer than that: :func:`resolve_bedrock_aws_session` builds a
-    self-refreshing session for a named profile.
+    ``integrations/aws/verifier.py::_build_sts_client``. Used only by
+    :func:`resolve_bedrock_anthropic_kwargs`: ``AnthropicBedrock`` has no
+    hook for a refreshable credentials provider, so its credentials are
+    necessarily a one-time snapshot, valid for the assumed role's session
+    duration (its ``MaxSessionDuration``, often 1 hour unless the role is
+    configured longer) — a cached ``AnthropicBedrock`` client that outlives
+    that window needs to be recreated. The ``boto3``-backed Bedrock clients
+    do not have this limitation: :func:`resolve_bedrock_aws_session` builds
+    a self-refreshing session for ``BEDROCK_AWS_ROLE_ARN`` via
+    :func:`_refreshable_role_session`, and for ``BEDROCK_AWS_PROFILE`` boto3
+    refreshes a role_arn-backed profile automatically.
     """
     role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
     if not role_arn:
@@ -75,6 +78,46 @@ def _assumed_bedrock_role_credentials(region: str) -> dict[str, Any] | None:
         assume_role_kwargs["ExternalId"] = external_id
     credentials: dict[str, Any] = sts.assume_role(**assume_role_kwargs)["Credentials"]
     return credentials
+
+
+def _refreshable_role_session(*, role_arn: str, external_id: str, region: str) -> boto3.Session:
+    """A ``boto3.Session`` that re-assumes ``role_arn`` itself as credentials near expiry.
+
+    Unlike a one-time ``sts:AssumeRole`` snapshot, this never goes stale for a
+    long-lived cached client: ``DeferredRefreshableCredentials`` calls
+    ``fetcher.fetch_credentials`` (issuing a fresh ``AssumeRole``) whenever
+    boto3 asks for credentials and the cached ones are near or past their
+    expiry, the same mechanism boto3 uses internally for a profile configured
+    with ``role_arn`` + ``source_profile``. Requires some base ambient
+    identity to perform the ``AssumeRole`` call itself (the same requirement
+    the one-time snapshot already had); if there is none, the first refresh
+    raises ``NoCredentialsError`` when a Bedrock call is actually made.
+    """
+    import boto3
+    import botocore.session
+    from botocore.credentials import AssumeRoleCredentialFetcher, DeferredRefreshableCredentials
+
+    extra_args: dict[str, str] = {"RoleSessionName": "OpenSREBedrockInvoke"}
+    if external_id:
+        extra_args["ExternalId"] = external_id
+
+    botocore_session = botocore.session.Session()
+    fetcher = AssumeRoleCredentialFetcher(
+        client_creator=botocore_session.create_client,  # type: ignore[arg-type]
+        source_credentials=botocore_session.get_credentials(),
+        role_arn=role_arn,
+        extra_args=extra_args,
+    )
+    # Pre-seed the lazy credential slot get_credentials() checks before
+    # resolving from scratch — the same mechanism botocore itself uses
+    # internally for a profile configured with role_arn + source_profile.
+    # Not part of the public stub surface, but a real, stable botocore
+    # mechanism (see botocore.session.Session.get_credentials).
+    botocore_session._credentials = DeferredRefreshableCredentials(  # type: ignore[attr-defined]
+        method="assume-role",
+        refresh_using=fetcher.fetch_credentials,
+    )
+    return boto3.Session(botocore_session=botocore_session, region_name=region)
 
 
 def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
@@ -95,25 +138,23 @@ def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
     accept.
 
     ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
-    deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
+    deployments with no ``~/.aws/config`` profile file (e.g. Fargate). The
+    returned session self-refreshes (see :func:`_refreshable_role_session`),
+    so a long-lived cached client using the ``boto3``-backed Converse clients
+    (:func:`resolve_bedrock_anthropic_kwargs` covers ``AnthropicBedrock``,
+    which cannot use a refreshable session) never goes stale.
     ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
     AssumeRole + source_profile pair — the shape the issue's own setup used;
-    boto3 refreshes that automatically, since the profile is passed straight
-    through rather than resolved once and frozen. Returns ``None`` when
-    neither is set, so callers fall through to today's exact ambient-chain
-    behavior; this function never changes behavior for a caller who hasn't
-    opted in.
+    boto3 refreshes that automatically too. Returns ``None`` when neither is
+    set, so callers fall through to today's exact ambient-chain behavior;
+    this function never changes behavior for a caller who hasn't opted in.
     """
     import boto3
 
-    credentials = _assumed_bedrock_role_credentials(region)
-    if credentials is not None:
-        return boto3.Session(
-            aws_access_key_id=credentials["AccessKeyId"],
-            aws_secret_access_key=credentials["SecretAccessKey"],
-            aws_session_token=credentials["SessionToken"],
-            region_name=region,
-        )
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if role_arn:
+        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+        return _refreshable_role_session(role_arn=role_arn, external_id=external_id, region=region)
 
     profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
     if profile:

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -421,13 +421,15 @@ class BedrockLLMClient:
         # this one does not require a region to be configured explicitly).
         # The `or` chain (not nested os.getenv defaults) matters: a variable
         # present but set to "" must fall through too, not short-circuit on
-        # an empty string.
+        # an empty string. The trailing .strip() matches require_aws_region():
+        # a shell-provided " us-east-1" must be normalized, not forwarded
+        # verbatim to the SDK, which rejects a region string with whitespace.
         self._aws_region = (
             os.getenv(BEDROCK_AWS_REGION_ENV)
             or os.getenv("AWS_REGION")
             or os.getenv("AWS_DEFAULT_REGION")
             or "us-east-1"
-        )
+        ).strip()
 
         if self._use_anthropic:
             self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -30,6 +30,7 @@ from openai import OpenAI
 from openai import RateLimitError as OpenAIRateLimitError
 from pydantic import BaseModel
 
+from config.constants.aws import BEDROCK_AWS_REGION_ENV
 from core.llm.providers import provider_credentials
 from core.llm.providers.bedrock_model_ids import is_anthropic_bedrock_model
 from core.llm.shared.llm_retry import extract_retry_after_seconds
@@ -405,20 +406,43 @@ class BedrockLLMClient:
     def __init__(
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
+        from core.llm.transports.sdk.bedrock_converse import (
+            frozen_bedrock_credentials,
+            resolve_bedrock_aws_session,
+        )
+
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._use_anthropic = is_anthropic_bedrock_model(model)
-        self._aws_region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1"))
+        # BEDROCK_AWS_REGION overrides for a cross-account setup; falls back to
+        # the same permissive AWS_REGION/AWS_DEFAULT_REGION/us-east-1 chain
+        # this class has always used (unlike the agent-loop Bedrock clients,
+        # this one does not require a region to be configured explicitly).
+        self._aws_region = os.getenv(
+            BEDROCK_AWS_REGION_ENV,
+            os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+        )
+        session = resolve_bedrock_aws_session()
 
         if self._use_anthropic:
-            self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
-                aws_region=self._aws_region
-            )
+            if session is not None:
+                frozen = frozen_bedrock_credentials(session)
+                self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
+                    aws_access_key=frozen.access_key,
+                    aws_secret_key=frozen.secret_key,
+                    aws_session_token=frozen.token,
+                    aws_region=self._aws_region,
+                )
+            else:
+                self._anthropic_client = AnthropicBedrock(aws_region=self._aws_region)
             self._boto3_client: Any = None
         else:
             self._anthropic_client = None
-            self._boto3_client = boto3.client("bedrock-runtime", region_name=self._aws_region)
+            if session is not None:
+                self._boto3_client = session.client("bedrock-runtime", region_name=self._aws_region)
+            else:
+                self._boto3_client = boto3.client("bedrock-runtime", region_name=self._aws_region)
 
     def with_config(self, **_kwargs: Any) -> BedrockLLMClient:
         return self

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -407,7 +407,7 @@ class BedrockLLMClient:
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
         from core.llm.transports.sdk.bedrock_converse import (
-            frozen_bedrock_credentials,
+            resolve_bedrock_anthropic_kwargs,
             resolve_bedrock_aws_session,
         )
 
@@ -419,26 +419,25 @@ class BedrockLLMClient:
         # the same permissive AWS_REGION/AWS_DEFAULT_REGION/us-east-1 chain
         # this class has always used (unlike the agent-loop Bedrock clients,
         # this one does not require a region to be configured explicitly).
-        self._aws_region = os.getenv(
-            BEDROCK_AWS_REGION_ENV,
-            os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+        # The `or` chain (not nested os.getenv defaults) matters: a variable
+        # present but set to "" must fall through too, not short-circuit on
+        # an empty string.
+        self._aws_region = (
+            os.getenv(BEDROCK_AWS_REGION_ENV)
+            or os.getenv("AWS_REGION")
+            or os.getenv("AWS_DEFAULT_REGION")
+            or "us-east-1"
         )
-        session = resolve_bedrock_aws_session()
 
         if self._use_anthropic:
-            if session is not None:
-                frozen = frozen_bedrock_credentials(session)
-                self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
-                    aws_access_key=frozen.access_key,
-                    aws_secret_key=frozen.secret_key,
-                    aws_session_token=frozen.token,
-                    aws_region=self._aws_region,
-                )
-            else:
-                self._anthropic_client = AnthropicBedrock(aws_region=self._aws_region)
+            self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
+                aws_region=self._aws_region,
+                **resolve_bedrock_anthropic_kwargs(self._aws_region),
+            )
             self._boto3_client: Any = None
         else:
             self._anthropic_client = None
+            session = resolve_bedrock_aws_session(self._aws_region)
             if session is not None:
                 self._boto3_client = session.client("bedrock-runtime", region_name=self._aws_region)
             else:

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -91,6 +91,10 @@ All configuration options for OpenSRE can be set via environment variables. This
 |----------|---------|-------------|--------|
 | `BEDROCK_REASONING_MODEL` | | Model for reasoning tasks | `config` |
 | `BEDROCK_TOOLCALL_MODEL` | | Model for tool calling | `config` |
+| `BEDROCK_AWS_PROFILE` | | Named AWS profile for Bedrock only, isolated from `AWS_PROFILE` used by infrastructure investigation | `config/constants/aws` |
+| `BEDROCK_AWS_ROLE_ARN` | | AWS role to assume for Bedrock only (cross-account setup); takes precedence over `BEDROCK_AWS_PROFILE` | `config/constants/aws` |
+| `BEDROCK_AWS_EXTERNAL_ID` | | External ID for the `BEDROCK_AWS_ROLE_ARN` assume-role call | `config/constants/aws` |
+| `BEDROCK_AWS_REGION` | | Region override for Bedrock only, when it differs from `AWS_REGION` | `config/constants/aws` |
 
 ### Ollama (Local)
 | Variable | Default | Description | Module |

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -327,6 +327,22 @@ No API key — auth uses the AWS credential chain (environment variables, shared
 
 Defaults in `config/config.py` are US cross-region inference profile IDs for Anthropic Claude; override with IDs or ARNs that are **inference-access enabled** in your account and region.
 
+**Cross-account setup** (Bedrock reachable only via an AssumeRole profile in a different AWS account than the one you investigate): infrastructure tools (EC2, CloudWatch, ...) already follow the process's ambient `AWS_PROFILE`, so nothing about your usual credential setup needs to change for them. Bedrock alone can be pointed at a different identity with:
+
+```bash
+# A named profile (may itself be an AssumeRole + source_profile pair):
+export BEDROCK_AWS_PROFILE=bedrock-account
+
+# Or an explicit assume-role, for deployments with no ~/.aws/config file (e.g. Fargate):
+export BEDROCK_AWS_ROLE_ARN=arn:aws:iam::<account-id>:role/BedrockInvoke
+export BEDROCK_AWS_EXTERNAL_ID=your-external-id     # optional
+
+# Optional: only needed if Bedrock's region differs from AWS_REGION
+export BEDROCK_AWS_REGION=us-east-1
+```
+
+`BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
+
 ### Google Vertex AI
 
 ```bash

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -343,7 +343,7 @@ export BEDROCK_AWS_REGION=us-east-1
 
 `BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
 
-`BEDROCK_AWS_PROFILE` refreshes automatically for as long as the process runs, the same as any other AssumeRole profile. `BEDROCK_AWS_ROLE_ARN` is a one-time credential snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process that outlives that window needs its LLM clients recreated (e.g. via `/model` in the interactive shell). Prefer `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` if the process runs longer than that.
+Both variables keep refreshing for as long as the process runs, for non-Claude models (Mistral, Llama, ...) and for Claude models when using `BEDROCK_AWS_PROFILE`. Claude models on Bedrock via `BEDROCK_AWS_ROLE_ARN` are the one exception: the Anthropic Bedrock SDK has no hook for a refreshable credential provider, so those credentials are a one-time snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process using a Claude model this way needs its LLM clients recreated once that expires (e.g. via `/model` in the interactive shell). Use `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` instead if that matters for your setup.
 
 ### Google Vertex AI
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -343,6 +343,8 @@ export BEDROCK_AWS_REGION=us-east-1
 
 `BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
 
+`BEDROCK_AWS_PROFILE` refreshes automatically for as long as the process runs, the same as any other AssumeRole profile. `BEDROCK_AWS_ROLE_ARN` is a one-time credential snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process that outlives that window needs its LLM clients recreated (e.g. via `/model` in the interactive shell). Prefer `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` if the process runs longer than that.
+
 ### Google Vertex AI
 
 ```bash

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -64,9 +64,77 @@ def test_bedrock_client_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> 
     _install_fake_anthropic(monkeypatch)
     monkeypatch.delenv("AWS_REGION", raising=False)
     monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
 
-    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION"):
         BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+
+def _record_anthropic_bedrock_init_kwargs(
+    fake_anthropic: types.SimpleNamespace,
+) -> list[dict[str, object]]:
+    """Wrap the fake AnthropicBedrock's __init__ to record every kwarg it receives."""
+    calls: list[dict[str, object]] = []
+    original_init = fake_anthropic.AnthropicBedrock.__init__
+
+    def _recording_init(self: object, **kwargs: object) -> None:
+        calls.append(kwargs)
+        original_init(self, **kwargs)
+
+    fake_anthropic.AnthropicBedrock.__init__ = _recording_init
+    return calls
+
+
+def test_bedrock_client_uses_ambient_chain_when_no_override_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No BEDROCK_AWS_* override: today's exact behavior, no explicit creds passed."""
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: None,
+    )
+    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
+
+    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    assert "aws_access_key" not in calls[0]
+    assert calls[0]["aws_region"] == "us-west-2"
+
+
+def test_bedrock_client_uses_resolved_session_credentials_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must pass explicit static creds,
+    isolated from whatever ambient AWS_PROFILE investigation tools use (#4482)."""
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+    class _FakeFrozenCredentials:
+        access_key = "AKIA-BEDROCK"
+        secret_key = "secret-bedrock"
+        token = "token-bedrock"
+
+    class _FakeSession:
+        pass
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
+        lambda _session: _FakeFrozenCredentials(),
+    )
+    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
+
+    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
+    assert calls[0]["aws_secret_key"] == "secret-bedrock"
+    assert calls[0]["aws_session_token"] == "token-bedrock"
+    assert calls[0]["aws_region"] == "us-west-2"
 
 
 def test_bedrock_auth_error_message_references_aws_credentials(
@@ -1604,12 +1672,46 @@ def _stub_boto3_converse(
 def test_bedrock_converse_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AWS_REGION", raising=False)
     monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
     _stub_boto3_converse(monkeypatch)
 
     from core.llm.transports.sdk.agent_clients import BedrockConverseAgentClient
 
-    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION"):
         BedrockConverseAgentClient(model=_MISTRAL_MODEL)
+
+
+def test_bedrock_converse_uses_resolved_session_client_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must build the runtime client
+    from the resolved session, not the ambient default boto3.client (#4482)."""
+    from core.llm.transports.sdk.agent_clients import BedrockConverseAgentClient
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    _stub_boto3_converse(monkeypatch)
+
+    session_client_calls: list[tuple[str, dict[str, object]]] = []
+    default_client_calls: list[tuple[str, dict[str, object]]] = []
+
+    class _FakeSession:
+        def client(self, service: str, **kwargs: object) -> object:
+            session_client_calls.append((service, kwargs))
+            return object()
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "boto3.client",
+        lambda *args, **kwargs: default_client_calls.append((args, kwargs)),
+    )
+
+    BedrockConverseAgentClient(model=_MISTRAL_MODEL)
+
+    assert session_client_calls == [("bedrock-runtime", {"region_name": "us-east-1"})]
+    assert default_client_calls == []
 
 
 def test_bedrock_converse_invoke_parses_tool_use(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -92,8 +92,8 @@ def test_bedrock_client_uses_ambient_chain_when_no_override_configured(
     fake_anthropic = _install_fake_anthropic(monkeypatch)
     monkeypatch.setenv("AWS_REGION", "us-west-2")
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: None,
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {},
     )
     calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
 
@@ -111,21 +111,13 @@ def test_bedrock_client_uses_resolved_session_credentials_when_configured(
     fake_anthropic = _install_fake_anthropic(monkeypatch)
     monkeypatch.setenv("AWS_REGION", "us-west-2")
 
-    class _FakeFrozenCredentials:
-        access_key = "AKIA-BEDROCK"
-        secret_key = "secret-bedrock"
-        token = "token-bedrock"
-
-    class _FakeSession:
-        pass
-
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
-    )
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
-        lambda _session: _FakeFrozenCredentials(),
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {
+            "aws_access_key": "AKIA-BEDROCK",
+            "aws_secret_key": "secret-bedrock",
+            "aws_session_token": "token-bedrock",
+        },
     )
     calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
 
@@ -1701,7 +1693,7 @@ def test_bedrock_converse_uses_resolved_session_client_when_configured(
 
     monkeypatch.setattr(
         "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
+        lambda _region: _FakeSession(),
     )
     monkeypatch.setattr(
         "boto3.client",

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -16,8 +16,8 @@ from typing import Any
 import pytest
 
 from core.llm.transports.sdk.bedrock_converse import (
-    frozen_bedrock_credentials,
     require_aws_region,
+    resolve_bedrock_anthropic_kwargs,
     resolve_bedrock_aws_session,
 )
 
@@ -55,7 +55,7 @@ def test_require_aws_region_falls_back_to_aws_region(monkeypatch: pytest.MonkeyP
 
 
 # --------------------------------------------------------------------------- #
-# resolve_bedrock_aws_session                                                 #
+# resolve_bedrock_aws_session (boto3.client consumers)                        #
 # --------------------------------------------------------------------------- #
 
 
@@ -65,7 +65,7 @@ def test_resolve_bedrock_aws_session_returns_none_when_unset(
     """No override set: callers must fall through to today's ambient-chain behavior."""
     _clear_bedrock_env(monkeypatch)
 
-    assert resolve_bedrock_aws_session() is None
+    assert resolve_bedrock_aws_session("us-east-1") is None
 
 
 def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,7 +79,7 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    session = resolve_bedrock_aws_session()
+    session = resolve_bedrock_aws_session("us-east-1")
 
     assert isinstance(session, _FakeSession)
     assert calls == [{"profile_name": "bedrock-account"}]
@@ -87,7 +87,6 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
 
 def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
 
@@ -116,7 +115,7 @@ def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr("boto3.client", _fake_boto3_client)
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    session = resolve_bedrock_aws_session()
+    session = resolve_bedrock_aws_session("us-east-1")
 
     assert isinstance(session, _FakeSession)
     assert assume_role_calls == [
@@ -141,7 +140,6 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
 ) -> None:
     """Both set: the explicit assume-role wins, the profile is never touched."""
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
 
@@ -164,7 +162,7 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
     monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    resolve_bedrock_aws_session()
+    resolve_bedrock_aws_session("us-east-1")
 
     assert len(session_calls) == 1
     assert "profile_name" not in session_calls[0]
@@ -175,7 +173,6 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
 ) -> None:
     """ExternalId is optional; omit it entirely rather than sending an empty string."""
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
 
     assume_role_calls: list[dict[str, Any]] = []
@@ -194,36 +191,89 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
     monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
     monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
 
-    resolve_bedrock_aws_session()
+    resolve_bedrock_aws_session("us-east-1")
 
     assert "ExternalId" not in assume_role_calls[0]
 
 
+def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The caller's region is a parameter, not re-derived (regression: a
+    BEDROCK_AWS_ROLE_ARN-only config must not reject a caller's own
+    permissive us-east-1 default just because AWS_REGION is unset)."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", lambda **kwargs: kwargs)
+
+    # No AWS_REGION/AWS_DEFAULT_REGION/BEDROCK_AWS_REGION set anywhere: this
+    # must not raise, since the caller decided "us-east-1" is an acceptable
+    # default and passed it in directly.
+    session = resolve_bedrock_aws_session("us-east-1")
+
+    assert session == {
+        "aws_access_key_id": "AKIA-TEMP",
+        "aws_secret_access_key": "secret-temp",
+        "aws_session_token": "token-temp",
+        "region_name": "us-east-1",
+    }
+
+
 # --------------------------------------------------------------------------- #
-# frozen_bedrock_credentials                                                  #
+# resolve_bedrock_anthropic_kwargs (AnthropicBedrock consumers)                #
 # --------------------------------------------------------------------------- #
 
 
-def test_frozen_bedrock_credentials_returns_frozen_credentials() -> None:
-    sentinel = object()
+def test_resolve_bedrock_anthropic_kwargs_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_bedrock_env(monkeypatch)
 
-    class _FakeCredentials:
-        def get_frozen_credentials(self) -> object:
-            return sentinel
-
-    class _FakeSession:
-        def get_credentials(self) -> _FakeCredentials:
-            return _FakeCredentials()
-
-    assert frozen_bedrock_credentials(_FakeSession()) is sentinel
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {}
 
 
-def test_frozen_bedrock_credentials_raises_a_clear_error_when_unresolved() -> None:
-    """A profile with no configured credentials must not crash with an AttributeError."""
+def test_resolve_bedrock_anthropic_kwargs_passes_profile_through_unresolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named profile must reach AnthropicBedrock as aws_profile=, not be
+    resolved-and-frozen into static keys — freezing would silently drop the
+    refresh a role_arn + source_profile pair in ~/.aws/config provides."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
 
-    class _FakeSession:
-        def get_credentials(self) -> None:
-            return None
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {"aws_profile": "bedrock-account"}
 
-    with pytest.raises(RuntimeError, match="BEDROCK_AWS_PROFILE"):
-        frozen_bedrock_credentials(_FakeSession())
+
+def test_resolve_bedrock_anthropic_kwargs_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {
+        "aws_access_key": "AKIA-TEMP",
+        "aws_secret_key": "secret-temp",
+        "aws_session_token": "token-temp",
+    }

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -85,54 +85,84 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
     assert calls == [{"profile_name": "bedrock-account"}]
 
 
+def _install_fake_assume_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    """Patch the real STS network call inside AssumeRoleCredentialFetcher.
+
+    Returns the list of ``assume_role``-shaped kwargs the fetcher was called
+    with (RoleArn/RoleSessionName/ExternalId), one entry per real fetch.
+    Leaves the real ``DeferredRefreshableCredentials``/``AssumeRoleCredentialFetcher``
+    wiring un-mocked, so a test can call ``get_frozen_credentials()`` and get
+    values produced by a genuine (if network-stubbed) assume-role flow.
+    """
+    from botocore.credentials import AssumeRoleCredentialFetcher
+
+    calls: list[dict[str, Any]] = []
+    counter = iter(range(1, 1000))
+
+    def _fake_get_credentials(self: Any) -> dict[str, Any]:
+        n = next(counter)
+        calls.append(dict(self._assume_kwargs))
+        return {
+            "Credentials": {
+                "AccessKeyId": f"AKIA-TEMP-{n}",
+                "SecretAccessKey": f"secret-temp-{n}",
+                "SessionToken": f"token-temp-{n}",
+                # Far enough out that a single get_frozen_credentials() call
+                # doesn't itself trigger a second fetch via botocore's own
+                # advisory-refresh window.
+                "Expiration": "2999-01-01T00:00:00+00:00",
+            }
+        }
+
+    monkeypatch.setattr(AssumeRoleCredentialFetcher, "_get_credentials", _fake_get_credentials)
+    return calls
+
+
 def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
-
-    assume_role_calls: list[dict[str, Any]] = []
-    session_calls: list[dict[str, Any]] = []
-
-    class _FakeStsClient:
-        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
-            assume_role_calls.append(kwargs)
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    class _FakeSession:
-        def __init__(self, **kwargs: Any) -> None:
-            session_calls.append(kwargs)
-
-    def _fake_boto3_client(service: str, **_kwargs: Any) -> _FakeStsClient:
-        assert service == "sts"
-        return _FakeStsClient()
-
-    monkeypatch.setattr("boto3.client", _fake_boto3_client)
-    monkeypatch.setattr("boto3.Session", _FakeSession)
+    calls = _install_fake_assume_role(monkeypatch)
 
     session = resolve_bedrock_aws_session("us-east-1")
 
-    assert isinstance(session, _FakeSession)
-    assert assume_role_calls == [
+    assert session is not None
+    frozen = session.get_credentials().get_frozen_credentials()
+    assert frozen.access_key == "AKIA-TEMP-1"
+    assert frozen.secret_key == "secret-temp-1"
+    assert frozen.token == "token-temp-1"
+    assert calls == [
         {
             "RoleArn": "arn:aws:iam::999:role/BedrockInvoke",
             "RoleSessionName": "OpenSREBedrockInvoke",
             "ExternalId": "shared-secret",
         }
     ]
-    assert session_calls == [
-        {
-            "aws_access_key_id": "AKIA-TEMP",
-            "aws_secret_access_key": "secret-temp",
-            "aws_session_token": "token-temp",
-            "region_name": "us-east-1",
-        }
-    ]
+
+
+def test_resolve_bedrock_aws_session_role_arn_credentials_are_refreshable_not_frozen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defining fix for #4482's repeated P1: BEDROCK_AWS_ROLE_ARN must
+    produce a self-refreshing credentials object, not a static one-time
+    snapshot (the round-1/round-2 bug). ``DeferredRefreshableCredentials``
+    is real, heavily-used botocore/boto3 machinery (the same mechanism
+    boto3 uses internally for a role_arn + source_profile profile) -- its
+    own time-based refresh-on-expiry behavior is botocore's tested concern,
+    not ours; what this asserts is that OpenSRE's wiring actually produces
+    that type instead of a plain, permanently-static Credentials object."""
+    from botocore.credentials import DeferredRefreshableCredentials
+
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    _install_fake_assume_role(monkeypatch)
+
+    session = resolve_bedrock_aws_session("us-east-1")
+
+    assert session is not None
+    assert isinstance(session.get_credentials(), DeferredRefreshableCredentials)
 
 
 def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
@@ -142,25 +172,9 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
-
+    _install_fake_assume_role(monkeypatch)
     session_calls: list[dict[str, Any]] = []
-
-    class _FakeStsClient:
-        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    class _FakeSession:
-        def __init__(self, **kwargs: Any) -> None:
-            session_calls.append(kwargs)
-
-    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
-    monkeypatch.setattr("boto3.Session", _FakeSession)
+    monkeypatch.setattr("boto3.Session", lambda **kwargs: session_calls.append(kwargs) or object())
 
     resolve_bedrock_aws_session("us-east-1")
 
@@ -174,26 +188,13 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
     """ExternalId is optional; omit it entirely rather than sending an empty string."""
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    calls = _install_fake_assume_role(monkeypatch)
 
-    assume_role_calls: list[dict[str, Any]] = []
+    session = resolve_bedrock_aws_session("us-east-1")
+    assert session is not None
+    session.get_credentials().get_frozen_credentials()
 
-    class _FakeStsClient:
-        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
-            assume_role_calls.append(kwargs)
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
-    monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
-
-    resolve_bedrock_aws_session("us-east-1")
-
-    assert "ExternalId" not in assume_role_calls[0]
+    assert "ExternalId" not in calls[0]
 
 
 def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
@@ -204,31 +205,15 @@ def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
     permissive us-east-1 default just because AWS_REGION is unset)."""
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
-
-    class _FakeStsClient:
-        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
-    monkeypatch.setattr("boto3.Session", lambda **kwargs: kwargs)
+    _install_fake_assume_role(monkeypatch)
 
     # No AWS_REGION/AWS_DEFAULT_REGION/BEDROCK_AWS_REGION set anywhere: this
     # must not raise, since the caller decided "us-east-1" is an acceptable
     # default and passed it in directly.
     session = resolve_bedrock_aws_session("us-east-1")
 
-    assert session == {
-        "aws_access_key_id": "AKIA-TEMP",
-        "aws_secret_access_key": "secret-temp",
-        "aws_session_token": "token-temp",
-        "region_name": "us-east-1",
-    }
+    assert session is not None
+    assert session.region_name == "us-east-1"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -1,0 +1,229 @@
+"""Tests for isolating Bedrock's AWS identity from investigation tools' (#4482).
+
+Investigation tools already read the ambient ``AWS_PROFILE`` directly, so a
+laptop configured for one AWS account already investigates that account
+correctly. Bedrock had no equivalent override: every Bedrock client reached
+for the same ambient default credential chain, so a cross-account setup
+(Bedrock reachable only via an AssumeRole profile in a different account
+than the infra being investigated) had no way to give Bedrock a different
+identity than whatever profile was active for everything else.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.llm.transports.sdk.bedrock_converse import (
+    frozen_bedrock_credentials,
+    require_aws_region,
+    resolve_bedrock_aws_session,
+)
+
+
+def _clear_bedrock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "BEDROCK_AWS_REGION",
+        "BEDROCK_AWS_PROFILE",
+        "BEDROCK_AWS_ROLE_ARN",
+        "BEDROCK_AWS_EXTERNAL_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# require_aws_region — BEDROCK_AWS_REGION precedence                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_require_aws_region_prefers_bedrock_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_REGION", "eu-west-1")
+
+    assert require_aws_region() == "eu-west-1"
+
+
+def test_require_aws_region_falls_back_to_aws_region(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    assert require_aws_region() == "us-east-1"
+
+
+# --------------------------------------------------------------------------- #
+# resolve_bedrock_aws_session                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_bedrock_aws_session_returns_none_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No override set: callers must fall through to today's ambient-chain behavior."""
+    _clear_bedrock_env(monkeypatch)
+
+    assert resolve_bedrock_aws_session() is None
+
+
+def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
+    calls: list[dict[str, Any]] = []
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    session = resolve_bedrock_aws_session()
+
+    assert isinstance(session, _FakeSession)
+    assert calls == [{"profile_name": "bedrock-account"}]
+
+
+def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
+
+    assume_role_calls: list[dict[str, Any]] = []
+    session_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            assume_role_calls.append(kwargs)
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            session_calls.append(kwargs)
+
+    def _fake_boto3_client(service: str, **_kwargs: Any) -> _FakeStsClient:
+        assert service == "sts"
+        return _FakeStsClient()
+
+    monkeypatch.setattr("boto3.client", _fake_boto3_client)
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    session = resolve_bedrock_aws_session()
+
+    assert isinstance(session, _FakeSession)
+    assert assume_role_calls == [
+        {
+            "RoleArn": "arn:aws:iam::999:role/BedrockInvoke",
+            "RoleSessionName": "OpenSREBedrockInvoke",
+            "ExternalId": "shared-secret",
+        }
+    ]
+    assert session_calls == [
+        {
+            "aws_access_key_id": "AKIA-TEMP",
+            "aws_secret_access_key": "secret-temp",
+            "aws_session_token": "token-temp",
+            "region_name": "us-east-1",
+        }
+    ]
+
+
+def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both set: the explicit assume-role wins, the profile is never touched."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
+
+    session_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            session_calls.append(kwargs)
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    resolve_bedrock_aws_session()
+
+    assert len(session_calls) == 1
+    assert "profile_name" not in session_calls[0]
+
+
+def test_resolve_bedrock_aws_session_role_arn_without_external_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ExternalId is optional; omit it entirely rather than sending an empty string."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    assume_role_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            assume_role_calls.append(kwargs)
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
+
+    resolve_bedrock_aws_session()
+
+    assert "ExternalId" not in assume_role_calls[0]
+
+
+# --------------------------------------------------------------------------- #
+# frozen_bedrock_credentials                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_frozen_bedrock_credentials_returns_frozen_credentials() -> None:
+    sentinel = object()
+
+    class _FakeCredentials:
+        def get_frozen_credentials(self) -> object:
+            return sentinel
+
+    class _FakeSession:
+        def get_credentials(self) -> _FakeCredentials:
+            return _FakeCredentials()
+
+    assert frozen_bedrock_credentials(_FakeSession()) is sentinel
+
+
+def test_frozen_bedrock_credentials_raises_a_clear_error_when_unresolved() -> None:
+    """A profile with no configured credentials must not crash with an AttributeError."""
+
+    class _FakeSession:
+        def get_credentials(self) -> None:
+            return None
+
+    with pytest.raises(RuntimeError, match="BEDROCK_AWS_PROFILE"):
+        frozen_bedrock_credentials(_FakeSession())

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -263,6 +263,16 @@ def test_bedrock_llm_client_treats_empty_bedrock_region_as_unset(monkeypatch) ->
     assert client._aws_region == "us-west-2"
 
 
+def test_bedrock_llm_client_strips_whitespace_from_region(monkeypatch) -> None:
+    """A shell-provided ' us-east-1' must be normalized before reaching the
+    SDK, which rejects a region string containing whitespace."""
+    monkeypatch.setenv("BEDROCK_AWS_REGION", " us-east-1 ")
+
+    client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert client._aws_region == "us-east-1"
+
+
 def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -240,6 +240,79 @@ def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     assert "system" not in call
 
 
+def test_bedrock_llm_client_converse_uses_resolved_session_when_configured(
+    monkeypatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must build the runtime client
+    from the resolved session, not the ambient default boto3.client (#4482)."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
+    monkeypatch.setattr(
+        "platform.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+    session_client_calls: list[tuple[str, dict]] = []
+    default_client_calls: list[tuple[str, dict]] = []
+
+    class _FakeSession:
+        def client(self, service: str, **kwargs) -> object:
+            session_client_calls.append((service, kwargs))
+            return _RecordingBedrockRuntime({"output": {"message": {"content": []}}})
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        sdk_llm.boto3,
+        "client",
+        lambda *a, **k: default_client_calls.append((a, k)),
+    )
+
+    sdk_llm.BedrockLLMClient(model="mistral.mistral-large-2402-v1:0")
+
+    assert session_client_calls == [("bedrock-runtime", {"region_name": "us-east-1"})]
+    assert default_client_calls == []
+
+
+def test_bedrock_llm_client_anthropic_uses_resolved_session_credentials(monkeypatch) -> None:
+    """Same override, Anthropic-on-Bedrock path: explicit static creds, not ambient."""
+    monkeypatch.setattr(
+        "platform.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+
+    class _FakeFrozenCredentials:
+        access_key = "AKIA-BEDROCK"
+        secret_key = "secret-bedrock"
+        token = "token-bedrock"
+
+    class _FakeSession:
+        pass
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
+        lambda _session: _FakeFrozenCredentials(),
+    )
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        sdk_llm,
+        "AnthropicBedrock",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
+    assert calls[0]["aws_secret_key"] == "secret-bedrock"
+    assert calls[0]["aws_session_token"] == "token-bedrock"
+
+
 def test_invoke_converse_includes_optional_system_temperature(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -217,6 +217,52 @@ def test_is_anthropic_bedrock_model_application_inference_profile_arn() -> None:
     assert not sdk_llm.is_anthropic_bedrock_model(profile_arn)
 
 
+def test_bedrock_llm_client_role_arn_without_any_region_uses_permissive_default(
+    monkeypatch,
+) -> None:
+    """BEDROCK_AWS_ROLE_ARN set with no region env var anywhere must not reject
+    a config that would otherwise default to us-east-1 (#4482 round 2): the
+    session resolver must use the caller's own already-resolved region
+    instead of independently re-requiring one."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs) -> dict:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def client(self, _service: str, **_kwargs) -> object:
+            return _RecordingBedrockRuntime({"output": {"message": {"content": []}}})
+
+    monkeypatch.setattr(sdk_llm.boto3, "client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr(sdk_llm.boto3, "Session", lambda **_kwargs: _FakeSession())
+
+    client = sdk_llm.BedrockLLMClient(model="mistral.mistral-large-2402-v1:0")
+
+    assert client._aws_region == "us-east-1"
+
+
+def test_bedrock_llm_client_treats_empty_bedrock_region_as_unset(monkeypatch) -> None:
+    """BEDROCK_AWS_REGION="" must fall through to AWS_REGION, not become the
+    literal empty string (a plain os.getenv(name, default) does not treat a
+    present-but-empty value as unset)."""
+    monkeypatch.setenv("BEDROCK_AWS_REGION", "")
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+    client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert client._aws_region == "us-west-2"
+
+
 def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",
@@ -262,7 +308,7 @@ def test_bedrock_llm_client_converse_uses_resolved_session_when_configured(
 
     monkeypatch.setattr(
         "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
+        lambda _region: _FakeSession(),
     )
     monkeypatch.setattr(
         sdk_llm.boto3,
@@ -283,21 +329,13 @@ def test_bedrock_llm_client_anthropic_uses_resolved_session_credentials(monkeypa
         _InactiveGuardrailEngine,
     )
 
-    class _FakeFrozenCredentials:
-        access_key = "AKIA-BEDROCK"
-        secret_key = "secret-bedrock"
-        token = "token-bedrock"
-
-    class _FakeSession:
-        pass
-
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
-    )
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
-        lambda _session: _FakeFrozenCredentials(),
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {
+            "aws_access_key": "AKIA-BEDROCK",
+            "aws_secret_key": "secret-bedrock",
+            "aws_session_token": "token-bedrock",
+        },
     )
     calls: list[dict] = []
     monkeypatch.setattr(


### PR DESCRIPTION
Fixes #4482

Bedrock and infrastructure investigation (EC2, CloudWatch, ...) both resolved AWS identity from the same ambient default credential chain, with no way to give them different identities. Investigation tools already work correctly cross-account because they read the process's single ambient `AWS_PROFILE` directly. Bedrock had no equivalent override, so a laptop configured for a Bedrock account reachable only via an AssumeRole profile in a different account than the infra being investigated had no way to give Bedrock a different identity than whatever profile was active for everything else, exactly the symptom in the issue's repro.

Adds a Bedrock-only identity override, isolated from investigation's ambient chain: `BEDROCK_AWS_PROFILE` (named profile), `BEDROCK_AWS_ROLE_ARN` + `BEDROCK_AWS_EXTERNAL_ID` (explicit assume-role, for deployments with no `~/.aws/config` file), and `BEDROCK_AWS_REGION`. Naming mirrors the existing `AWS_ROLE_ARN`/`AWS_EXTERNAL_ID` convention in `config/constants/aws.py`. Wired into all three Bedrock client construction sites in `core/llm/transports/sdk/`.

**Update 1:** closed after Greptile found three issues: (1) freezing a `BEDROCK_AWS_PROFILE` session's credentials at construction time discarded whatever refresh the underlying profile supported, so a long-lived cached `AnthropicBedrock` client would fail once the snapshot expired, fixed by passing the profile straight through as `aws_profile=` instead (`AnthropicBedrock` resolves and refreshes it internally); `BEDROCK_AWS_ROLE_ARN` stays a documented one-time snapshot since `AnthropicBedrock` has no hook for a refreshable provider at all; (2) the session resolver called a strict region-requiring helper internally, so `BEDROCK_AWS_ROLE_ARN` with no region env var would reject a config `BedrockLLMClient`'s own permissive `us-east-1` default should have accepted, fixed by making region a parameter each caller resolves itself; (3) `BedrockLLMClient`'s region resolution used nested `os.getenv(name, default)`, so `BEDROCK_AWS_REGION=""` would short-circuit instead of falling through, fixed with the same `or`-chain `require_aws_region()` already used.

I also did an independent deeper self-review afterward, including verifying against the actual installed `anthropic` SDK source that `aws_profile=` genuinely re-resolves credentials on every request, not just at construction. That pass found one minor issue: the STS credentials helper was typed `dict[str, str]`, but the real response also includes a non-string `Expiration` field; harmless today since only the three string fields are read, but corrected to `dict[str, Any]`.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/core/runtime/llm/ -q
359 passed

$ uv run python -m ruff check core/llm/ docs/ tests/core/runtime/llm/ && uv run python -m ruff format --check core/llm/ tests/core/runtime/llm/
All checks passed! / 63 files already formatted

$ make typecheck && make check-imports
Success: no issues found in 1555 source files / All 3 import checks passed.

$ uv run pytest tests/core/ -q
1592 passed, 29 skipped
```

Confirmed the two new regression tests (region-conflict, empty-string region) fail against the pre-fix code and pass after.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Checked `AnthropicBedrock`'s actual constructor signature: it accepts `aws_profile` directly, so passing a named profile straight through uses the SDK's own supported refresh mechanism instead of resolving a `boto3.Session` and freezing static credentials out of it. Split credential resolution into two functions: `resolve_bedrock_aws_session()` for `boto3.client()` consumers, `resolve_bedrock_anthropic_kwargs()` for `AnthropicBedrock` consumers, since only the former can accept a refreshable session. For `BEDROCK_AWS_ROLE_ARN`, considered building a self-refreshing session via botocore's `AssumeRoleCredentialFetcher`, but this codebase has no precedent for that pattern and `AnthropicBedrock` can't use a refreshable provider regardless, so documented the one-time-snapshot limitation instead of adding new refresh infrastructure. For the region-conflict finding, moved region resolution to a parameter each caller passes in, removing the second, conflicting policy that lived inside the shared helper. For the empty-string finding, reused the `or`-chain pattern `require_aws_region()` already used correctly, instead of writing new logic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
