### PR TITLE
feat(llm): isolate Bedrock AWS session from investigation tools (#4482)

### DIFF
--- a/config/constants/aws.py
+++ b/config/constants/aws.py
@@ -9,6 +9,19 @@ AWS_ACCESS_KEY_ID_ENV = "AWS_ACCESS_KEY_ID"
 AWS_SECRET_ACCESS_KEY_ENV = "AWS_SECRET_ACCESS_KEY"
 AWS_SESSION_TOKEN_ENV = "AWS_SESSION_TOKEN"
 
+# Bedrock-only identity override, isolated from the vars above. Investigation
+# tools (EC2, CloudWatch, ...) already read the ambient AWS_PROFILE directly,
+# so a laptop configured for one AWS account already investigates that
+# account correctly. Bedrock had no equivalent override, so a cross-account
+# setup (Bedrock reachable only via an AssumeRole profile in a different
+# account than the infra being investigated) could not give Bedrock a
+# different identity than whatever profile was active for everything else.
+# See #4482.
+BEDROCK_AWS_PROFILE_ENV = "BEDROCK_AWS_PROFILE"
+BEDROCK_AWS_ROLE_ARN_ENV = "BEDROCK_AWS_ROLE_ARN"
+BEDROCK_AWS_EXTERNAL_ID_ENV = "BEDROCK_AWS_EXTERNAL_ID"
+BEDROCK_AWS_REGION_ENV = "BEDROCK_AWS_REGION"
+
 __all__ = [
     "AWS_ACCESS_KEY_ID_ENV",
     "AWS_EXTERNAL_ID_ENV",
@@ -16,4 +29,8 @@ __all__ = [
     "AWS_ROLE_ARN_ENV",
     "AWS_SECRET_ACCESS_KEY_ENV",
     "AWS_SESSION_TOKEN_ENV",
+    "BEDROCK_AWS_EXTERNAL_ID_ENV",
+    "BEDROCK_AWS_PROFILE_ENV",
+    "BEDROCK_AWS_REGION_ENV",
+    "BEDROCK_AWS_ROLE_ARN_ENV",
 ]

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -341,18 +341,14 @@ class BedrockAgentClient(AnthropicAgentClient):
     )
 
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
-        from anthropic import AnthropicBedrock
-
         from core.llm.transports.sdk.bedrock_converse import (
+            build_bedrock_anthropic_client,
             require_aws_region,
-            resolve_bedrock_anthropic_kwargs,
         )
 
         region = require_aws_region()
-        bedrock_client = AnthropicBedrock(
-            aws_region=region,
-            timeout=AGENT_CLIENT_TIMEOUT_SEC,
-            **resolve_bedrock_anthropic_kwargs(region),
+        bedrock_client = build_bedrock_anthropic_client(
+            region=region, timeout=AGENT_CLIENT_TIMEOUT_SEC
         )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -344,27 +344,16 @@ class BedrockAgentClient(AnthropicAgentClient):
         from anthropic import AnthropicBedrock
 
         from core.llm.transports.sdk.bedrock_converse import (
-            frozen_bedrock_credentials,
             require_aws_region,
-            resolve_bedrock_aws_session,
+            resolve_bedrock_anthropic_kwargs,
         )
 
         region = require_aws_region()
-        session = resolve_bedrock_aws_session()
-        if session is not None:
-            frozen = frozen_bedrock_credentials(session)
-            bedrock_client = AnthropicBedrock(
-                aws_access_key=frozen.access_key,
-                aws_secret_key=frozen.secret_key,
-                aws_session_token=frozen.token,
-                aws_region=region,
-                timeout=AGENT_CLIENT_TIMEOUT_SEC,
-            )
-        else:
-            bedrock_client = AnthropicBedrock(
-                aws_region=region,
-                timeout=AGENT_CLIENT_TIMEOUT_SEC,
-            )
+        bedrock_client = AnthropicBedrock(
+            aws_region=region,
+            timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            **resolve_bedrock_anthropic_kwargs(region),
+        )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 
     def _permission_denied_error_message(self) -> str:
@@ -402,7 +391,7 @@ class BedrockConverseAgentClient:
         self._model = model
         self._max_tokens = max_tokens
         region = require_aws_region()
-        session = resolve_bedrock_aws_session()
+        session = resolve_bedrock_aws_session(region)
         if session is not None:
             self._boto3_client = session.client("bedrock-runtime", region_name=region)
         else:

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import time
 from collections.abc import Callable
@@ -336,20 +335,36 @@ class BedrockAgentClient(AnthropicAgentClient):
     provider_name = "Bedrock"
     auth_error_hint = (
         "Check AWS credentials (for example AWS_PROFILE, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, "
-        "or instance role) and AWS_REGION/AWS_DEFAULT_REGION."
+        "or instance role) and AWS_REGION/AWS_DEFAULT_REGION. For a Bedrock account different "
+        "from the one used for infrastructure investigation, set BEDROCK_AWS_PROFILE or "
+        "BEDROCK_AWS_ROLE_ARN."
     )
 
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
         from anthropic import AnthropicBedrock
 
-        region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
-        if not region:
-            raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
-
-        bedrock_client = AnthropicBedrock(
-            aws_region=region,
-            timeout=AGENT_CLIENT_TIMEOUT_SEC,
+        from core.llm.transports.sdk.bedrock_converse import (
+            frozen_bedrock_credentials,
+            require_aws_region,
+            resolve_bedrock_aws_session,
         )
+
+        region = require_aws_region()
+        session = resolve_bedrock_aws_session()
+        if session is not None:
+            frozen = frozen_bedrock_credentials(session)
+            bedrock_client = AnthropicBedrock(
+                aws_access_key=frozen.access_key,
+                aws_secret_key=frozen.secret_key,
+                aws_session_token=frozen.token,
+                aws_region=region,
+                timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            )
+        else:
+            bedrock_client = AnthropicBedrock(
+                aws_region=region,
+                timeout=AGENT_CLIENT_TIMEOUT_SEC,
+            )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 
     def _permission_denied_error_message(self) -> str:
@@ -379,12 +394,19 @@ class BedrockConverseAgentClient:
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
         import boto3
 
-        from core.llm.transports.sdk.bedrock_converse import require_aws_region
+        from core.llm.transports.sdk.bedrock_converse import (
+            require_aws_region,
+            resolve_bedrock_aws_session,
+        )
 
         self._model = model
         self._max_tokens = max_tokens
         region = require_aws_region()
-        self._boto3_client = boto3.client("bedrock-runtime", region_name=region)
+        session = resolve_bedrock_aws_session()
+        if session is not None:
+            self._boto3_client = session.client("bedrock-runtime", region_name=region)
+        else:
+            self._boto3_client = boto3.client("bedrock-runtime", region_name=region)
 
     @property
     def model_id(self) -> str | None:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -46,7 +46,38 @@ def require_aws_region() -> str:
     return region
 
 
-def resolve_bedrock_aws_session() -> boto3.Session | None:
+def _assumed_bedrock_role_credentials(region: str) -> dict[str, str] | None:
+    """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
+
+    A single ``sts:AssumeRole`` snapshot, same shape as
+    ``integrations/aws/verifier.py::_build_sts_client``. The returned
+    credentials are valid for the assumed role's session duration (its
+    ``MaxSessionDuration``, often 1 hour unless the role is configured
+    longer) and do not refresh themselves — a cached client that outlives
+    that window needs to be recreated. Prefer ``BEDROCK_AWS_PROFILE`` with a
+    role_arn + source_profile pair in ``~/.aws/config`` when a process runs
+    longer than that: :func:`resolve_bedrock_aws_session` builds a
+    self-refreshing session for a named profile.
+    """
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if not role_arn:
+        return None
+
+    import boto3
+
+    external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+    sts = boto3.client("sts", region_name=region)
+    assume_role_kwargs: dict[str, str] = {
+        "RoleArn": role_arn,
+        "RoleSessionName": "OpenSREBedrockInvoke",
+    }
+    if external_id:
+        assume_role_kwargs["ExternalId"] = external_id
+    credentials: dict[str, str] = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    return credentials
+
+
+def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
     """Isolate Bedrock's AWS identity from the ambient default credential chain.
 
     Investigation tools (EC2, CloudWatch, ...) already work correctly across
@@ -57,28 +88,26 @@ def resolve_bedrock_aws_session() -> boto3.Session | None:
     investigated had no way to give Bedrock a *different* identity than
     whatever profile was active for everything else (#4482).
 
+    ``region`` is the caller's own already-resolved region (each of the three
+    Bedrock clients has a different region-resolution policy — two raise when
+    unset, one defaults to ``us-east-1``); this function does not re-derive
+    or require it, so it can't reject a config a caller would otherwise
+    accept.
+
     ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
     deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
     ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
-    AssumeRole + source_profile pair — the shape the issue's own setup used.
-    Returns ``None`` when neither is set, so callers fall through to today's
-    exact ambient-chain behavior; this function never changes behavior for a
-    caller who hasn't opted in.
+    AssumeRole + source_profile pair — the shape the issue's own setup used;
+    boto3 refreshes that automatically, since the profile is passed straight
+    through rather than resolved once and frozen. Returns ``None`` when
+    neither is set, so callers fall through to today's exact ambient-chain
+    behavior; this function never changes behavior for a caller who hasn't
+    opted in.
     """
     import boto3
 
-    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
-    if role_arn:
-        region = require_aws_region()
-        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
-        sts = boto3.client("sts", region_name=region)
-        assume_role_kwargs: dict[str, str] = {
-            "RoleArn": role_arn,
-            "RoleSessionName": "OpenSREBedrockInvoke",
-        }
-        if external_id:
-            assume_role_kwargs["ExternalId"] = external_id
-        credentials = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    credentials = _assumed_bedrock_role_credentials(region)
+    if credentials is not None:
         return boto3.Session(
             aws_access_key_id=credentials["AccessKeyId"],
             aws_secret_access_key=credentials["SecretAccessKey"],
@@ -93,21 +122,38 @@ def resolve_bedrock_aws_session() -> boto3.Session | None:
     return None
 
 
-def frozen_bedrock_credentials(session: boto3.Session) -> Any:
-    """Resolved static credentials ``AnthropicBedrock`` needs as explicit kwargs.
+def resolve_bedrock_anthropic_kwargs(region: str) -> dict[str, Any]:
+    """``AnthropicBedrock`` auth kwargs for a cross-account Bedrock override.
 
-    Raises a clear error if the session (from :func:`resolve_bedrock_aws_session`)
-    cannot resolve credentials at all, e.g. ``BEDROCK_AWS_PROFILE`` names a
-    profile with no credentials configured.
+    ``AnthropicBedrock`` only accepts a profile name (which it resolves, and
+    refreshes, itself) or fully static access/secret/session-token strings —
+    unlike ``boto3.Session``, there is no hook for a refreshable credentials
+    provider, so the two overrides are necessarily handled differently:
+
+    - ``BEDROCK_AWS_PROFILE`` is passed straight through as ``aws_profile``,
+      so whatever refresh the named profile supports keeps working (a
+      role_arn + source_profile pair in ``~/.aws/config`` auto-refreshes).
+    - ``BEDROCK_AWS_ROLE_ARN`` has no such hook: the returned credentials are
+      a one-time snapshot (see :func:`_assumed_bedrock_role_credentials`),
+      valid only for the assumed role's session duration.
+
+    Returns an empty dict when neither override is set, so callers fall
+    through to today's exact ambient-chain behavior (``AnthropicBedrock``
+    with no explicit credentials).
     """
-    credentials = session.get_credentials()
-    if credentials is None:
-        raise RuntimeError(
-            "Could not resolve AWS credentials for the Bedrock session. "
-            "Check BEDROCK_AWS_PROFILE (does the named profile have credentials?) "
-            "or BEDROCK_AWS_ROLE_ARN."
-        )
-    return credentials.get_frozen_credentials()
+    credentials = _assumed_bedrock_role_credentials(region)
+    if credentials is not None:
+        return {
+            "aws_access_key": credentials["AccessKeyId"],
+            "aws_secret_key": credentials["SecretAccessKey"],
+            "aws_session_token": credentials["SessionToken"],
+        }
+
+    profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
+    if profile:
+        return {"aws_profile": profile}
+
+    return {}
 
 
 def new_tool_use_id() -> str:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -46,7 +46,7 @@ def require_aws_region() -> str:
     return region
 
 
-def _assumed_bedrock_role_credentials(region: str) -> dict[str, str] | None:
+def _assumed_bedrock_role_credentials(region: str) -> dict[str, Any] | None:
     """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
 
     A single ``sts:AssumeRole`` snapshot, same shape as
@@ -73,7 +73,7 @@ def _assumed_bedrock_role_credentials(region: str) -> dict[str, str] | None:
     }
     if external_id:
         assume_role_kwargs["ExternalId"] = external_id
-    credentials: dict[str, str] = sts.assume_role(**assume_role_kwargs)["Credentials"]
+    credentials: dict[str, Any] = sts.assume_role(**assume_role_kwargs)["Credentials"]
     return credentials
 
 

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -6,7 +6,11 @@ import json
 import logging
 import os
 import secrets
+import threading
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
+
+from anthropic import AnthropicBedrock
 
 from config.constants.aws import (
     BEDROCK_AWS_EXTERNAL_ID_ENV,
@@ -22,6 +26,7 @@ from core.llm.shared.tool_schema_normalize import (
 
 if TYPE_CHECKING:
     import boto3
+    import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -49,18 +54,13 @@ def require_aws_region() -> str:
 def _assumed_bedrock_role_credentials(region: str) -> dict[str, Any] | None:
     """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
 
-    A single ``sts:AssumeRole`` snapshot, same shape as
-    ``integrations/aws/verifier.py::_build_sts_client``. Used only by
-    :func:`resolve_bedrock_anthropic_kwargs`: ``AnthropicBedrock`` has no
-    hook for a refreshable credentials provider, so its credentials are
-    necessarily a one-time snapshot, valid for the assumed role's session
-    duration (its ``MaxSessionDuration``, often 1 hour unless the role is
-    configured longer) — a cached ``AnthropicBedrock`` client that outlives
-    that window needs to be recreated. The ``boto3``-backed Bedrock clients
-    do not have this limitation: :func:`resolve_bedrock_aws_session` builds
-    a self-refreshing session for ``BEDROCK_AWS_ROLE_ARN`` via
-    :func:`_refreshable_role_session`, and for ``BEDROCK_AWS_PROFILE`` boto3
-    refreshes a role_arn-backed profile automatically.
+    A single ``sts:AssumeRole`` call, same shape as
+    ``integrations/aws/verifier.py::_build_sts_client``. Used by
+    :class:`_RefreshingBedrockAnthropicClient` to (re-)assume the role on
+    construction and again whenever its credentials are near expiry. The
+    ``boto3``-backed Bedrock clients (:func:`resolve_bedrock_aws_session`) use
+    a separate mechanism, :func:`_refreshable_role_session`, that refreshes
+    via botocore's own ``AssumeRoleCredentialFetcher`` instead.
     """
     role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
     if not role_arn:
@@ -140,9 +140,9 @@ def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
     ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
     deployments with no ``~/.aws/config`` profile file (e.g. Fargate). The
     returned session self-refreshes (see :func:`_refreshable_role_session`),
-    so a long-lived cached client using the ``boto3``-backed Converse clients
-    (:func:`resolve_bedrock_anthropic_kwargs` covers ``AnthropicBedrock``,
-    which cannot use a refreshable session) never goes stale.
+    so a long-lived cached client built from it never goes stale. This is for
+    the ``boto3``-backed Converse clients only; :func:`build_bedrock_anthropic_client`
+    covers ``AnthropicBedrock``, which cannot accept a ``boto3.Session`` at all.
     ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
     AssumeRole + source_profile pair — the shape the issue's own setup used;
     boto3 refreshes that automatically too. Returns ``None`` when neither is
@@ -163,38 +163,108 @@ def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
     return None
 
 
-def resolve_bedrock_anthropic_kwargs(region: str) -> dict[str, Any]:
-    """``AnthropicBedrock`` auth kwargs for a cross-account Bedrock override.
+def _parse_expiration(expiration: Any) -> datetime:
+    """Normalize an STS ``Expiration`` value to a timezone-aware ``datetime``.
 
-    ``AnthropicBedrock`` only accepts a profile name (which it resolves, and
-    refreshes, itself) or fully static access/secret/session-token strings —
-    unlike ``boto3.Session``, there is no hook for a refreshable credentials
-    provider, so the two overrides are necessarily handled differently:
-
-    - ``BEDROCK_AWS_PROFILE`` is passed straight through as ``aws_profile``,
-      so whatever refresh the named profile supports keeps working (a
-      role_arn + source_profile pair in ``~/.aws/config`` auto-refreshes).
-    - ``BEDROCK_AWS_ROLE_ARN`` has no such hook: the returned credentials are
-      a one-time snapshot (see :func:`_assumed_bedrock_role_credentials`),
-      valid only for the assumed role's session duration.
-
-    Returns an empty dict when neither override is set, so callers fall
-    through to today's exact ambient-chain behavior (``AnthropicBedrock``
-    with no explicit credentials).
+    The real ``boto3`` client always returns a ``datetime`` already (botocore
+    parses the API's timestamp shape automatically); a plain ``isoformat()``
+    string is accepted too, so a hand-built fake in a test doesn't need a
+    real ``datetime`` object.
     """
-    credentials = _assumed_bedrock_role_credentials(region)
-    if credentials is not None:
-        return {
+    if isinstance(expiration, datetime):
+        return expiration
+    return datetime.fromisoformat(str(expiration))
+
+
+class _RefreshingBedrockAnthropicClient(AnthropicBedrock):
+    """``AnthropicBedrock`` whose ``BEDROCK_AWS_ROLE_ARN`` credentials
+    re-assume the role in place once they're near expiry.
+
+    ``AnthropicBedrock`` has no hook for a refreshable credentials provider:
+    ``aws_access_key``/``aws_secret_key``/``aws_session_token`` are plain
+    instance attributes read fresh from ``self`` by ``_prepare_request``
+    (called once per outgoing request, before every ``sts:AssumeRole``-signed
+    call), never re-resolved after construction. Overriding
+    ``_prepare_request`` to refresh those attributes in place first, before
+    delegating to the real implementation, reaches the same effect as a
+    refreshable provider would without needing one — the SDK re-reads
+    ``self.aws_access_key`` etc. on every call regardless.
+    """
+
+    _REFRESH_BUFFER = timedelta(minutes=5)
+
+    def __init__(self, *, region: str, timeout: float | None = None) -> None:
+        self._region = region
+        self._expiry: datetime | None = None
+        self._refresh_lock = threading.Lock()
+        credentials = self._assume_and_track_expiry()
+        init_kwargs: dict[str, Any] = {
             "aws_access_key": credentials["AccessKeyId"],
             "aws_secret_key": credentials["SecretAccessKey"],
             "aws_session_token": credentials["SessionToken"],
+            "aws_region": region,
         }
+        if timeout is not None:
+            init_kwargs["timeout"] = timeout
+        super().__init__(**init_kwargs)
+
+    def _assume_and_track_expiry(self) -> dict[str, Any]:
+        credentials = _assumed_bedrock_role_credentials(self._region)
+        assert credentials is not None, "BEDROCK_AWS_ROLE_ARN must be set to construct this client"
+        expiration = credentials.get("Expiration")
+        self._expiry = _parse_expiration(expiration) if expiration is not None else None
+        return credentials
+
+    def _refresh_if_needed(self) -> None:
+        if self._expiry is None:
+            return
+        if datetime.now(UTC) < self._expiry - self._REFRESH_BUFFER:
+            return
+        with self._refresh_lock:
+            if self._expiry is not None and datetime.now(UTC) < (
+                self._expiry - self._REFRESH_BUFFER
+            ):
+                return
+            credentials = self._assume_and_track_expiry()
+            self.aws_access_key = credentials["AccessKeyId"]
+            self.aws_secret_key = credentials["SecretAccessKey"]
+            self.aws_session_token = credentials["SessionToken"]
+
+    def _prepare_request(self, request: httpx.Request) -> None:
+        self._refresh_if_needed()
+        super()._prepare_request(request)
+
+
+def build_bedrock_anthropic_client(
+    *, region: str, timeout: float | None = None
+) -> AnthropicBedrock:
+    """The ``AnthropicBedrock`` client for the resolved Bedrock identity.
+
+    - No override: today's exact ambient-chain client.
+    - ``BEDROCK_AWS_PROFILE``: passed straight through as ``aws_profile``, so
+      whatever refresh the named profile supports keeps working (a role_arn +
+      source_profile pair in ``~/.aws/config`` auto-refreshes; ``AnthropicBedrock``
+      resolves and refreshes a profile itself, unlike static credentials).
+    - ``BEDROCK_AWS_ROLE_ARN``: a :class:`_RefreshingBedrockAnthropicClient`,
+      since ``AnthropicBedrock`` has no other hook for a refreshable provider.
+
+    ``timeout`` is forwarded only when given, so a caller that omits it (as
+    ``BedrockLLMClient`` always has) gets the SDK's own default rather than a
+    literal ``None`` overriding it to no-timeout.
+    """
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if role_arn:
+        return _RefreshingBedrockAnthropicClient(region=region, timeout=timeout)
+
+    init_kwargs: dict[str, Any] = {"aws_region": region}
+    if timeout is not None:
+        init_kwargs["timeout"] = timeout
 
     profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
     if profile:
-        return {"aws_profile": profile}
+        init_kwargs["aws_profile"] = profile
 
-    return {}
+    return AnthropicBedrock(**init_kwargs)
 
 
 def new_tool_use_id() -> str:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -6,23 +6,108 @@ import json
 import logging
 import os
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from config.constants.aws import (
+    BEDROCK_AWS_EXTERNAL_ID_ENV,
+    BEDROCK_AWS_PROFILE_ENV,
+    BEDROCK_AWS_REGION_ENV,
+    BEDROCK_AWS_ROLE_ARN_ENV,
+)
 from core.llm.shared.tool_schema_normalize import (
     BEDROCK_UNSUPPORTED_SCHEMA_KEYS,
     normalize_object_tool_input_schema,
     sanitize_strict_tool_schema,
 )
 
+if TYPE_CHECKING:
+    import boto3
+
 logger = logging.getLogger(__name__)
 
 
 def require_aws_region() -> str:
-    """Return configured AWS region or raise with a clear configuration error."""
-    region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
+    """Return configured AWS region or raise with a clear configuration error.
+
+    ``BEDROCK_AWS_REGION`` takes precedence so a cross-account Bedrock setup
+    (see :func:`resolve_bedrock_aws_session`) can target a region independent
+    of the region investigation tools use.
+    """
+    region = (
+        os.getenv(BEDROCK_AWS_REGION_ENV)
+        or os.getenv("AWS_REGION")
+        or os.getenv("AWS_DEFAULT_REGION")
+        or ""
+    ).strip()
     if not region:
-        raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
+        raise RuntimeError(
+            "Bedrock requires AWS_REGION, AWS_DEFAULT_REGION, or BEDROCK_AWS_REGION to be set."
+        )
     return region
+
+
+def resolve_bedrock_aws_session() -> boto3.Session | None:
+    """Isolate Bedrock's AWS identity from the ambient default credential chain.
+
+    Investigation tools (EC2, CloudWatch, ...) already work correctly across
+    accounts because they read the process's single ambient ``AWS_PROFILE``
+    directly. Bedrock had no equivalent: every Bedrock client reached for the
+    same ambient chain, so a laptop configured for a Bedrock account reachable
+    only via an AssumeRole profile in a different account than the infra being
+    investigated had no way to give Bedrock a *different* identity than
+    whatever profile was active for everything else (#4482).
+
+    ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
+    deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
+    ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
+    AssumeRole + source_profile pair — the shape the issue's own setup used.
+    Returns ``None`` when neither is set, so callers fall through to today's
+    exact ambient-chain behavior; this function never changes behavior for a
+    caller who hasn't opted in.
+    """
+    import boto3
+
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if role_arn:
+        region = require_aws_region()
+        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+        sts = boto3.client("sts", region_name=region)
+        assume_role_kwargs: dict[str, str] = {
+            "RoleArn": role_arn,
+            "RoleSessionName": "OpenSREBedrockInvoke",
+        }
+        if external_id:
+            assume_role_kwargs["ExternalId"] = external_id
+        credentials = sts.assume_role(**assume_role_kwargs)["Credentials"]
+        return boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            region_name=region,
+        )
+
+    profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
+    if profile:
+        return boto3.Session(profile_name=profile)
+
+    return None
+
+
+def frozen_bedrock_credentials(session: boto3.Session) -> Any:
+    """Resolved static credentials ``AnthropicBedrock`` needs as explicit kwargs.
+
+    Raises a clear error if the session (from :func:`resolve_bedrock_aws_session`)
+    cannot resolve credentials at all, e.g. ``BEDROCK_AWS_PROFILE`` names a
+    profile with no credentials configured.
+    """
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise RuntimeError(
+            "Could not resolve AWS credentials for the Bedrock session. "
+            "Check BEDROCK_AWS_PROFILE (does the named profile have credentials?) "
+            "or BEDROCK_AWS_ROLE_ARN."
+        )
+    return credentials.get_frozen_credentials()
 
 
 def new_tool_use_id() -> str:

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -50,14 +50,17 @@ def _assumed_bedrock_role_credentials(region: str) -> dict[str, Any] | None:
     """Raw STS credentials from ``BEDROCK_AWS_ROLE_ARN``, or ``None`` if unset.
 
     A single ``sts:AssumeRole`` snapshot, same shape as
-    ``integrations/aws/verifier.py::_build_sts_client``. The returned
-    credentials are valid for the assumed role's session duration (its
-    ``MaxSessionDuration``, often 1 hour unless the role is configured
-    longer) and do not refresh themselves — a cached client that outlives
-    that window needs to be recreated. Prefer ``BEDROCK_AWS_PROFILE`` with a
-    role_arn + source_profile pair in ``~/.aws/config`` when a process runs
-    longer than that: :func:`resolve_bedrock_aws_session` builds a
-    self-refreshing session for a named profile.
+    ``integrations/aws/verifier.py::_build_sts_client``. Used only by
+    :func:`resolve_bedrock_anthropic_kwargs`: ``AnthropicBedrock`` has no
+    hook for a refreshable credentials provider, so its credentials are
+    necessarily a one-time snapshot, valid for the assumed role's session
+    duration (its ``MaxSessionDuration``, often 1 hour unless the role is
+    configured longer) — a cached ``AnthropicBedrock`` client that outlives
+    that window needs to be recreated. The ``boto3``-backed Bedrock clients
+    do not have this limitation: :func:`resolve_bedrock_aws_session` builds
+    a self-refreshing session for ``BEDROCK_AWS_ROLE_ARN`` via
+    :func:`_refreshable_role_session`, and for ``BEDROCK_AWS_PROFILE`` boto3
+    refreshes a role_arn-backed profile automatically.
     """
     role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
     if not role_arn:
@@ -75,6 +78,46 @@ def _assumed_bedrock_role_credentials(region: str) -> dict[str, Any] | None:
         assume_role_kwargs["ExternalId"] = external_id
     credentials: dict[str, Any] = sts.assume_role(**assume_role_kwargs)["Credentials"]
     return credentials
+
+
+def _refreshable_role_session(*, role_arn: str, external_id: str, region: str) -> boto3.Session:
+    """A ``boto3.Session`` that re-assumes ``role_arn`` itself as credentials near expiry.
+
+    Unlike a one-time ``sts:AssumeRole`` snapshot, this never goes stale for a
+    long-lived cached client: ``DeferredRefreshableCredentials`` calls
+    ``fetcher.fetch_credentials`` (issuing a fresh ``AssumeRole``) whenever
+    boto3 asks for credentials and the cached ones are near or past their
+    expiry, the same mechanism boto3 uses internally for a profile configured
+    with ``role_arn`` + ``source_profile``. Requires some base ambient
+    identity to perform the ``AssumeRole`` call itself (the same requirement
+    the one-time snapshot already had); if there is none, the first refresh
+    raises ``NoCredentialsError`` when a Bedrock call is actually made.
+    """
+    import boto3
+    import botocore.session
+    from botocore.credentials import AssumeRoleCredentialFetcher, DeferredRefreshableCredentials
+
+    extra_args: dict[str, str] = {"RoleSessionName": "OpenSREBedrockInvoke"}
+    if external_id:
+        extra_args["ExternalId"] = external_id
+
+    botocore_session = botocore.session.Session()
+    fetcher = AssumeRoleCredentialFetcher(
+        client_creator=botocore_session.create_client,  # type: ignore[arg-type]
+        source_credentials=botocore_session.get_credentials(),
+        role_arn=role_arn,
+        extra_args=extra_args,
+    )
+    # Pre-seed the lazy credential slot get_credentials() checks before
+    # resolving from scratch — the same mechanism botocore itself uses
+    # internally for a profile configured with role_arn + source_profile.
+    # Not part of the public stub surface, but a real, stable botocore
+    # mechanism (see botocore.session.Session.get_credentials).
+    botocore_session._credentials = DeferredRefreshableCredentials(  # type: ignore[attr-defined]
+        method="assume-role",
+        refresh_using=fetcher.fetch_credentials,
+    )
+    return boto3.Session(botocore_session=botocore_session, region_name=region)
 
 
 def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
@@ -95,25 +138,23 @@ def resolve_bedrock_aws_session(region: str) -> boto3.Session | None:
     accept.
 
     ``BEDROCK_AWS_ROLE_ARN`` takes precedence — an explicit assume-role, for
-    deployments with no ``~/.aws/config`` profile file (e.g. Fargate).
+    deployments with no ``~/.aws/config`` profile file (e.g. Fargate). The
+    returned session self-refreshes (see :func:`_refreshable_role_session`),
+    so a long-lived cached client using the ``boto3``-backed Converse clients
+    (:func:`resolve_bedrock_anthropic_kwargs` covers ``AnthropicBedrock``,
+    which cannot use a refreshable session) never goes stale.
     ``BEDROCK_AWS_PROFILE`` is a named profile, which may itself be an
     AssumeRole + source_profile pair — the shape the issue's own setup used;
-    boto3 refreshes that automatically, since the profile is passed straight
-    through rather than resolved once and frozen. Returns ``None`` when
-    neither is set, so callers fall through to today's exact ambient-chain
-    behavior; this function never changes behavior for a caller who hasn't
-    opted in.
+    boto3 refreshes that automatically too. Returns ``None`` when neither is
+    set, so callers fall through to today's exact ambient-chain behavior;
+    this function never changes behavior for a caller who hasn't opted in.
     """
     import boto3
 
-    credentials = _assumed_bedrock_role_credentials(region)
-    if credentials is not None:
-        return boto3.Session(
-            aws_access_key_id=credentials["AccessKeyId"],
-            aws_secret_access_key=credentials["SecretAccessKey"],
-            aws_session_token=credentials["SessionToken"],
-            region_name=region,
-        )
+    role_arn = os.getenv(BEDROCK_AWS_ROLE_ARN_ENV, "").strip()
+    if role_arn:
+        external_id = os.getenv(BEDROCK_AWS_EXTERNAL_ID_ENV, "").strip()
+        return _refreshable_role_session(role_arn=role_arn, external_id=external_id, region=region)
 
     profile = os.getenv(BEDROCK_AWS_PROFILE_ENV, "").strip()
     if profile:

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -421,13 +421,15 @@ class BedrockLLMClient:
         # this one does not require a region to be configured explicitly).
         # The `or` chain (not nested os.getenv defaults) matters: a variable
         # present but set to "" must fall through too, not short-circuit on
-        # an empty string.
+        # an empty string. The trailing .strip() matches require_aws_region():
+        # a shell-provided " us-east-1" must be normalized, not forwarded
+        # verbatim to the SDK, which rejects a region string with whitespace.
         self._aws_region = (
             os.getenv(BEDROCK_AWS_REGION_ENV)
             or os.getenv("AWS_REGION")
             or os.getenv("AWS_DEFAULT_REGION")
             or "us-east-1"
-        )
+        ).strip()
 
         if self._use_anthropic:
             self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -30,6 +30,7 @@ from openai import OpenAI
 from openai import RateLimitError as OpenAIRateLimitError
 from pydantic import BaseModel
 
+from config.constants.aws import BEDROCK_AWS_REGION_ENV
 from core.llm.providers import provider_credentials
 from core.llm.providers.bedrock_model_ids import is_anthropic_bedrock_model
 from core.llm.shared.llm_retry import extract_retry_after_seconds
@@ -405,20 +406,43 @@ class BedrockLLMClient:
     def __init__(
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
+        from core.llm.transports.sdk.bedrock_converse import (
+            frozen_bedrock_credentials,
+            resolve_bedrock_aws_session,
+        )
+
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._use_anthropic = is_anthropic_bedrock_model(model)
-        self._aws_region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1"))
+        # BEDROCK_AWS_REGION overrides for a cross-account setup; falls back to
+        # the same permissive AWS_REGION/AWS_DEFAULT_REGION/us-east-1 chain
+        # this class has always used (unlike the agent-loop Bedrock clients,
+        # this one does not require a region to be configured explicitly).
+        self._aws_region = os.getenv(
+            BEDROCK_AWS_REGION_ENV,
+            os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+        )
+        session = resolve_bedrock_aws_session()
 
         if self._use_anthropic:
-            self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
-                aws_region=self._aws_region
-            )
+            if session is not None:
+                frozen = frozen_bedrock_credentials(session)
+                self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
+                    aws_access_key=frozen.access_key,
+                    aws_secret_key=frozen.secret_key,
+                    aws_session_token=frozen.token,
+                    aws_region=self._aws_region,
+                )
+            else:
+                self._anthropic_client = AnthropicBedrock(aws_region=self._aws_region)
             self._boto3_client: Any = None
         else:
             self._anthropic_client = None
-            self._boto3_client = boto3.client("bedrock-runtime", region_name=self._aws_region)
+            if session is not None:
+                self._boto3_client = session.client("bedrock-runtime", region_name=self._aws_region)
+            else:
+                self._boto3_client = boto3.client("bedrock-runtime", region_name=self._aws_region)
 
     def with_config(self, **_kwargs: Any) -> BedrockLLMClient:
         return self

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -407,7 +407,7 @@ class BedrockLLMClient:
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
         from core.llm.transports.sdk.bedrock_converse import (
-            resolve_bedrock_anthropic_kwargs,
+            build_bedrock_anthropic_client,
             resolve_bedrock_aws_session,
         )
 
@@ -432,9 +432,8 @@ class BedrockLLMClient:
         ).strip()
 
         if self._use_anthropic:
-            self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
-                aws_region=self._aws_region,
-                **resolve_bedrock_anthropic_kwargs(self._aws_region),
+            self._anthropic_client: AnthropicBedrock | None = build_bedrock_anthropic_client(
+                region=self._aws_region
             )
             self._boto3_client: Any = None
         else:

--- a/core/llm/transports/sdk/llm_clients.py
+++ b/core/llm/transports/sdk/llm_clients.py
@@ -407,7 +407,7 @@ class BedrockLLMClient:
         self, *, model: str, max_tokens: int = 1024, temperature: float | None = None
     ) -> None:
         from core.llm.transports.sdk.bedrock_converse import (
-            frozen_bedrock_credentials,
+            resolve_bedrock_anthropic_kwargs,
             resolve_bedrock_aws_session,
         )
 
@@ -419,26 +419,25 @@ class BedrockLLMClient:
         # the same permissive AWS_REGION/AWS_DEFAULT_REGION/us-east-1 chain
         # this class has always used (unlike the agent-loop Bedrock clients,
         # this one does not require a region to be configured explicitly).
-        self._aws_region = os.getenv(
-            BEDROCK_AWS_REGION_ENV,
-            os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+        # The `or` chain (not nested os.getenv defaults) matters: a variable
+        # present but set to "" must fall through too, not short-circuit on
+        # an empty string.
+        self._aws_region = (
+            os.getenv(BEDROCK_AWS_REGION_ENV)
+            or os.getenv("AWS_REGION")
+            or os.getenv("AWS_DEFAULT_REGION")
+            or "us-east-1"
         )
-        session = resolve_bedrock_aws_session()
 
         if self._use_anthropic:
-            if session is not None:
-                frozen = frozen_bedrock_credentials(session)
-                self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
-                    aws_access_key=frozen.access_key,
-                    aws_secret_key=frozen.secret_key,
-                    aws_session_token=frozen.token,
-                    aws_region=self._aws_region,
-                )
-            else:
-                self._anthropic_client = AnthropicBedrock(aws_region=self._aws_region)
+            self._anthropic_client: AnthropicBedrock | None = AnthropicBedrock(
+                aws_region=self._aws_region,
+                **resolve_bedrock_anthropic_kwargs(self._aws_region),
+            )
             self._boto3_client: Any = None
         else:
             self._anthropic_client = None
+            session = resolve_bedrock_aws_session(self._aws_region)
             if session is not None:
                 self._boto3_client = session.client("bedrock-runtime", region_name=self._aws_region)
             else:

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -91,6 +91,10 @@ All configuration options for OpenSRE can be set via environment variables. This
 |----------|---------|-------------|--------|
 | `BEDROCK_REASONING_MODEL` | | Model for reasoning tasks | `config` |
 | `BEDROCK_TOOLCALL_MODEL` | | Model for tool calling | `config` |
+| `BEDROCK_AWS_PROFILE` | | Named AWS profile for Bedrock only, isolated from `AWS_PROFILE` used by infrastructure investigation | `config/constants/aws` |
+| `BEDROCK_AWS_ROLE_ARN` | | AWS role to assume for Bedrock only (cross-account setup); takes precedence over `BEDROCK_AWS_PROFILE` | `config/constants/aws` |
+| `BEDROCK_AWS_EXTERNAL_ID` | | External ID for the `BEDROCK_AWS_ROLE_ARN` assume-role call | `config/constants/aws` |
+| `BEDROCK_AWS_REGION` | | Region override for Bedrock only, when it differs from `AWS_REGION` | `config/constants/aws` |
 
 ### Ollama (Local)
 | Variable | Default | Description | Module |

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -327,6 +327,22 @@ No API key — auth uses the AWS credential chain (environment variables, shared
 
 Defaults in `config/config.py` are US cross-region inference profile IDs for Anthropic Claude; override with IDs or ARNs that are **inference-access enabled** in your account and region.
 
+**Cross-account setup** (Bedrock reachable only via an AssumeRole profile in a different AWS account than the one you investigate): infrastructure tools (EC2, CloudWatch, ...) already follow the process's ambient `AWS_PROFILE`, so nothing about your usual credential setup needs to change for them. Bedrock alone can be pointed at a different identity with:
+
+```bash
+# A named profile (may itself be an AssumeRole + source_profile pair):
+export BEDROCK_AWS_PROFILE=bedrock-account
+
+# Or an explicit assume-role, for deployments with no ~/.aws/config file (e.g. Fargate):
+export BEDROCK_AWS_ROLE_ARN=arn:aws:iam::<account-id>:role/BedrockInvoke
+export BEDROCK_AWS_EXTERNAL_ID=your-external-id     # optional
+
+# Optional: only needed if Bedrock's region differs from AWS_REGION
+export BEDROCK_AWS_REGION=us-east-1
+```
+
+`BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
+
 ### Google Vertex AI
 
 ```bash

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -343,7 +343,7 @@ export BEDROCK_AWS_REGION=us-east-1
 
 `BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
 
-`BEDROCK_AWS_PROFILE` refreshes automatically for as long as the process runs, the same as any other AssumeRole profile. `BEDROCK_AWS_ROLE_ARN` is a one-time credential snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process that outlives that window needs its LLM clients recreated (e.g. via `/model` in the interactive shell). Prefer `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` if the process runs longer than that.
+Both variables keep refreshing for as long as the process runs, for non-Claude models (Mistral, Llama, ...) and for Claude models when using `BEDROCK_AWS_PROFILE`. Claude models on Bedrock via `BEDROCK_AWS_ROLE_ARN` are the one exception: the Anthropic Bedrock SDK has no hook for a refreshable credential provider, so those credentials are a one-time snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process using a Claude model this way needs its LLM clients recreated once that expires (e.g. via `/model` in the interactive shell). Use `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` instead if that matters for your setup.
 
 ### Google Vertex AI
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -343,7 +343,7 @@ export BEDROCK_AWS_REGION=us-east-1
 
 `BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
 
-Both variables keep refreshing for as long as the process runs, for non-Claude models (Mistral, Llama, ...) and for Claude models when using `BEDROCK_AWS_PROFILE`. Claude models on Bedrock via `BEDROCK_AWS_ROLE_ARN` are the one exception: the Anthropic Bedrock SDK has no hook for a refreshable credential provider, so those credentials are a one-time snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process using a Claude model this way needs its LLM clients recreated once that expires (e.g. via `/model` in the interactive shell). Use `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` instead if that matters for your setup.
+Both variables keep refreshing for as long as the process runs, for every model, including Claude via `BEDROCK_AWS_ROLE_ARN`. The Anthropic Bedrock SDK itself has no hook for a refreshable credential provider, so OpenSRE re-assumes the role in place shortly before the assumed session's credentials expire, keeping a long-running process's LLM client usable indefinitely without needing to be recreated.
 
 ### Google Vertex AI
 

--- a/docs/llm-providers.mdx
+++ b/docs/llm-providers.mdx
@@ -343,6 +343,8 @@ export BEDROCK_AWS_REGION=us-east-1
 
 `BEDROCK_AWS_ROLE_ARN` takes precedence when both are set. Neither variable changes behavior when unset — Bedrock keeps using the same ambient credential chain as everything else.
 
+`BEDROCK_AWS_PROFILE` refreshes automatically for as long as the process runs, the same as any other AssumeRole profile. `BEDROCK_AWS_ROLE_ARN` is a one-time credential snapshot valid for the assumed role's session duration (its `MaxSessionDuration`, often 1 hour unless the role is configured longer) — a long-running process that outlives that window needs its LLM clients recreated (e.g. via `/model` in the interactive shell). Prefer `BEDROCK_AWS_PROFILE` with a role_arn + source_profile pair in `~/.aws/config` if the process runs longer than that.
+
 ### Google Vertex AI
 
 ```bash

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from core.llm.factory import LLMRole, get_llm, reset_llm_clients
+from core.llm.shared.openai_chat_completions import AGENT_CLIENT_TIMEOUT_SEC
 from core.llm.transports.sdk.agent_clients import (
     AnthropicAgentClient,
     BedrockAgentClient,
@@ -70,63 +71,30 @@ def test_bedrock_client_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> 
         BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
 
 
-def _record_anthropic_bedrock_init_kwargs(
-    fake_anthropic: types.SimpleNamespace,
-) -> list[dict[str, object]]:
-    """Wrap the fake AnthropicBedrock's __init__ to record every kwarg it receives."""
+def test_bedrock_client_uses_build_bedrock_anthropic_client_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BedrockAgentClient must delegate client construction (ambient chain,
+    BEDROCK_AWS_PROFILE, or BEDROCK_AWS_ROLE_ARN selection) entirely to
+    build_bedrock_anthropic_client -- see test_bedrock_aws_session.py for
+    coverage of that selection logic itself -- and use its exact result."""
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    sentinel_client = object()
     calls: list[dict[str, object]] = []
-    original_init = fake_anthropic.AnthropicBedrock.__init__
 
-    def _recording_init(self: object, **kwargs: object) -> None:
-        calls.append(kwargs)
-        original_init(self, **kwargs)
-
-    fake_anthropic.AnthropicBedrock.__init__ = _recording_init
-    return calls
-
-
-def test_bedrock_client_uses_ambient_chain_when_no_override_configured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No BEDROCK_AWS_* override: today's exact behavior, no explicit creds passed."""
-    fake_anthropic = _install_fake_anthropic(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-west-2")
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
-        lambda _region: {},
-    )
-    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
-
-    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
-
-    assert "aws_access_key" not in calls[0]
-    assert calls[0]["aws_region"] == "us-west-2"
-
-
-def test_bedrock_client_uses_resolved_session_credentials_when_configured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must pass explicit static creds,
-    isolated from whatever ambient AWS_PROFILE investigation tools use (#4482)."""
-    fake_anthropic = _install_fake_anthropic(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    def _fake_build(*, region: str, timeout: float | None = None) -> object:
+        calls.append({"region": region, "timeout": timeout})
+        return sentinel_client
 
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
-        lambda _region: {
-            "aws_access_key": "AKIA-BEDROCK",
-            "aws_secret_key": "secret-bedrock",
-            "aws_session_token": "token-bedrock",
-        },
+        "core.llm.transports.sdk.bedrock_converse.build_bedrock_anthropic_client",
+        _fake_build,
     )
-    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
 
-    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+    client = BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
 
-    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
-    assert calls[0]["aws_secret_key"] == "secret-bedrock"
-    assert calls[0]["aws_session_token"] == "token-bedrock"
-    assert calls[0]["aws_region"] == "us-west-2"
+    assert client._client is sentinel_client
+    assert calls == [{"region": "us-west-2", "timeout": AGENT_CLIENT_TIMEOUT_SEC}]
 
 
 def test_bedrock_auth_error_message_references_aws_credentials(

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -64,9 +64,77 @@ def test_bedrock_client_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> 
     _install_fake_anthropic(monkeypatch)
     monkeypatch.delenv("AWS_REGION", raising=False)
     monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
 
-    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION"):
         BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+
+def _record_anthropic_bedrock_init_kwargs(
+    fake_anthropic: types.SimpleNamespace,
+) -> list[dict[str, object]]:
+    """Wrap the fake AnthropicBedrock's __init__ to record every kwarg it receives."""
+    calls: list[dict[str, object]] = []
+    original_init = fake_anthropic.AnthropicBedrock.__init__
+
+    def _recording_init(self: object, **kwargs: object) -> None:
+        calls.append(kwargs)
+        original_init(self, **kwargs)
+
+    fake_anthropic.AnthropicBedrock.__init__ = _recording_init
+    return calls
+
+
+def test_bedrock_client_uses_ambient_chain_when_no_override_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No BEDROCK_AWS_* override: today's exact behavior, no explicit creds passed."""
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: None,
+    )
+    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
+
+    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    assert "aws_access_key" not in calls[0]
+    assert calls[0]["aws_region"] == "us-west-2"
+
+
+def test_bedrock_client_uses_resolved_session_credentials_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must pass explicit static creds,
+    isolated from whatever ambient AWS_PROFILE investigation tools use (#4482)."""
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+    class _FakeFrozenCredentials:
+        access_key = "AKIA-BEDROCK"
+        secret_key = "secret-bedrock"
+        token = "token-bedrock"
+
+    class _FakeSession:
+        pass
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
+        lambda _session: _FakeFrozenCredentials(),
+    )
+    calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
+
+    BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
+    assert calls[0]["aws_secret_key"] == "secret-bedrock"
+    assert calls[0]["aws_session_token"] == "token-bedrock"
+    assert calls[0]["aws_region"] == "us-west-2"
 
 
 def test_bedrock_auth_error_message_references_aws_credentials(
@@ -1604,12 +1672,46 @@ def _stub_boto3_converse(
 def test_bedrock_converse_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AWS_REGION", raising=False)
     monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
     _stub_boto3_converse(monkeypatch)
 
     from core.llm.transports.sdk.agent_clients import BedrockConverseAgentClient
 
-    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION"):
         BedrockConverseAgentClient(model=_MISTRAL_MODEL)
+
+
+def test_bedrock_converse_uses_resolved_session_client_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must build the runtime client
+    from the resolved session, not the ambient default boto3.client (#4482)."""
+    from core.llm.transports.sdk.agent_clients import BedrockConverseAgentClient
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    _stub_boto3_converse(monkeypatch)
+
+    session_client_calls: list[tuple[str, dict[str, object]]] = []
+    default_client_calls: list[tuple[str, dict[str, object]]] = []
+
+    class _FakeSession:
+        def client(self, service: str, **kwargs: object) -> object:
+            session_client_calls.append((service, kwargs))
+            return object()
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "boto3.client",
+        lambda *args, **kwargs: default_client_calls.append((args, kwargs)),
+    )
+
+    BedrockConverseAgentClient(model=_MISTRAL_MODEL)
+
+    assert session_client_calls == [("bedrock-runtime", {"region_name": "us-east-1"})]
+    assert default_client_calls == []
 
 
 def test_bedrock_converse_invoke_parses_tool_use(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -92,8 +92,8 @@ def test_bedrock_client_uses_ambient_chain_when_no_override_configured(
     fake_anthropic = _install_fake_anthropic(monkeypatch)
     monkeypatch.setenv("AWS_REGION", "us-west-2")
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: None,
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {},
     )
     calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
 
@@ -111,21 +111,13 @@ def test_bedrock_client_uses_resolved_session_credentials_when_configured(
     fake_anthropic = _install_fake_anthropic(monkeypatch)
     monkeypatch.setenv("AWS_REGION", "us-west-2")
 
-    class _FakeFrozenCredentials:
-        access_key = "AKIA-BEDROCK"
-        secret_key = "secret-bedrock"
-        token = "token-bedrock"
-
-    class _FakeSession:
-        pass
-
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
-    )
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
-        lambda _session: _FakeFrozenCredentials(),
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {
+            "aws_access_key": "AKIA-BEDROCK",
+            "aws_secret_key": "secret-bedrock",
+            "aws_session_token": "token-bedrock",
+        },
     )
     calls = _record_anthropic_bedrock_init_kwargs(fake_anthropic)
 
@@ -1701,7 +1693,7 @@ def test_bedrock_converse_uses_resolved_session_client_when_configured(
 
     monkeypatch.setattr(
         "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
+        lambda _region: _FakeSession(),
     )
     monkeypatch.setattr(
         "boto3.client",

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -16,8 +16,8 @@ from typing import Any
 import pytest
 
 from core.llm.transports.sdk.bedrock_converse import (
-    frozen_bedrock_credentials,
     require_aws_region,
+    resolve_bedrock_anthropic_kwargs,
     resolve_bedrock_aws_session,
 )
 
@@ -55,7 +55,7 @@ def test_require_aws_region_falls_back_to_aws_region(monkeypatch: pytest.MonkeyP
 
 
 # --------------------------------------------------------------------------- #
-# resolve_bedrock_aws_session                                                 #
+# resolve_bedrock_aws_session (boto3.client consumers)                        #
 # --------------------------------------------------------------------------- #
 
 
@@ -65,7 +65,7 @@ def test_resolve_bedrock_aws_session_returns_none_when_unset(
     """No override set: callers must fall through to today's ambient-chain behavior."""
     _clear_bedrock_env(monkeypatch)
 
-    assert resolve_bedrock_aws_session() is None
+    assert resolve_bedrock_aws_session("us-east-1") is None
 
 
 def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,7 +79,7 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    session = resolve_bedrock_aws_session()
+    session = resolve_bedrock_aws_session("us-east-1")
 
     assert isinstance(session, _FakeSession)
     assert calls == [{"profile_name": "bedrock-account"}]
@@ -87,7 +87,6 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
 
 def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
 
@@ -116,7 +115,7 @@ def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr("boto3.client", _fake_boto3_client)
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    session = resolve_bedrock_aws_session()
+    session = resolve_bedrock_aws_session("us-east-1")
 
     assert isinstance(session, _FakeSession)
     assert assume_role_calls == [
@@ -141,7 +140,6 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
 ) -> None:
     """Both set: the explicit assume-role wins, the profile is never touched."""
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
 
@@ -164,7 +162,7 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
     monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
     monkeypatch.setattr("boto3.Session", _FakeSession)
 
-    resolve_bedrock_aws_session()
+    resolve_bedrock_aws_session("us-east-1")
 
     assert len(session_calls) == 1
     assert "profile_name" not in session_calls[0]
@@ -175,7 +173,6 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
 ) -> None:
     """ExternalId is optional; omit it entirely rather than sending an empty string."""
     _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
 
     assume_role_calls: list[dict[str, Any]] = []
@@ -194,36 +191,89 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
     monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
     monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
 
-    resolve_bedrock_aws_session()
+    resolve_bedrock_aws_session("us-east-1")
 
     assert "ExternalId" not in assume_role_calls[0]
 
 
+def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The caller's region is a parameter, not re-derived (regression: a
+    BEDROCK_AWS_ROLE_ARN-only config must not reject a caller's own
+    permissive us-east-1 default just because AWS_REGION is unset)."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", lambda **kwargs: kwargs)
+
+    # No AWS_REGION/AWS_DEFAULT_REGION/BEDROCK_AWS_REGION set anywhere: this
+    # must not raise, since the caller decided "us-east-1" is an acceptable
+    # default and passed it in directly.
+    session = resolve_bedrock_aws_session("us-east-1")
+
+    assert session == {
+        "aws_access_key_id": "AKIA-TEMP",
+        "aws_secret_access_key": "secret-temp",
+        "aws_session_token": "token-temp",
+        "region_name": "us-east-1",
+    }
+
+
 # --------------------------------------------------------------------------- #
-# frozen_bedrock_credentials                                                  #
+# resolve_bedrock_anthropic_kwargs (AnthropicBedrock consumers)                #
 # --------------------------------------------------------------------------- #
 
 
-def test_frozen_bedrock_credentials_returns_frozen_credentials() -> None:
-    sentinel = object()
+def test_resolve_bedrock_anthropic_kwargs_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_bedrock_env(monkeypatch)
 
-    class _FakeCredentials:
-        def get_frozen_credentials(self) -> object:
-            return sentinel
-
-    class _FakeSession:
-        def get_credentials(self) -> _FakeCredentials:
-            return _FakeCredentials()
-
-    assert frozen_bedrock_credentials(_FakeSession()) is sentinel
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {}
 
 
-def test_frozen_bedrock_credentials_raises_a_clear_error_when_unresolved() -> None:
-    """A profile with no configured credentials must not crash with an AttributeError."""
+def test_resolve_bedrock_anthropic_kwargs_passes_profile_through_unresolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named profile must reach AnthropicBedrock as aws_profile=, not be
+    resolved-and-frozen into static keys — freezing would silently drop the
+    refresh a role_arn + source_profile pair in ~/.aws/config provides."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
 
-    class _FakeSession:
-        def get_credentials(self) -> None:
-            return None
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {"aws_profile": "bedrock-account"}
 
-    with pytest.raises(RuntimeError, match="BEDROCK_AWS_PROFILE"):
-        frozen_bedrock_credentials(_FakeSession())
+
+def test_resolve_bedrock_anthropic_kwargs_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+
+    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {
+        "aws_access_key": "AKIA-TEMP",
+        "aws_secret_key": "secret-temp",
+        "aws_session_token": "token-temp",
+    }

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -85,54 +85,84 @@ def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatc
     assert calls == [{"profile_name": "bedrock-account"}]
 
 
+def _install_fake_assume_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    """Patch the real STS network call inside AssumeRoleCredentialFetcher.
+
+    Returns the list of ``assume_role``-shaped kwargs the fetcher was called
+    with (RoleArn/RoleSessionName/ExternalId), one entry per real fetch.
+    Leaves the real ``DeferredRefreshableCredentials``/``AssumeRoleCredentialFetcher``
+    wiring un-mocked, so a test can call ``get_frozen_credentials()`` and get
+    values produced by a genuine (if network-stubbed) assume-role flow.
+    """
+    from botocore.credentials import AssumeRoleCredentialFetcher
+
+    calls: list[dict[str, Any]] = []
+    counter = iter(range(1, 1000))
+
+    def _fake_get_credentials(self: Any) -> dict[str, Any]:
+        n = next(counter)
+        calls.append(dict(self._assume_kwargs))
+        return {
+            "Credentials": {
+                "AccessKeyId": f"AKIA-TEMP-{n}",
+                "SecretAccessKey": f"secret-temp-{n}",
+                "SessionToken": f"token-temp-{n}",
+                # Far enough out that a single get_frozen_credentials() call
+                # doesn't itself trigger a second fetch via botocore's own
+                # advisory-refresh window.
+                "Expiration": "2999-01-01T00:00:00+00:00",
+            }
+        }
+
+    monkeypatch.setattr(AssumeRoleCredentialFetcher, "_get_credentials", _fake_get_credentials)
+    return calls
+
+
 def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
-
-    assume_role_calls: list[dict[str, Any]] = []
-    session_calls: list[dict[str, Any]] = []
-
-    class _FakeStsClient:
-        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
-            assume_role_calls.append(kwargs)
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    class _FakeSession:
-        def __init__(self, **kwargs: Any) -> None:
-            session_calls.append(kwargs)
-
-    def _fake_boto3_client(service: str, **_kwargs: Any) -> _FakeStsClient:
-        assert service == "sts"
-        return _FakeStsClient()
-
-    monkeypatch.setattr("boto3.client", _fake_boto3_client)
-    monkeypatch.setattr("boto3.Session", _FakeSession)
+    calls = _install_fake_assume_role(monkeypatch)
 
     session = resolve_bedrock_aws_session("us-east-1")
 
-    assert isinstance(session, _FakeSession)
-    assert assume_role_calls == [
+    assert session is not None
+    frozen = session.get_credentials().get_frozen_credentials()
+    assert frozen.access_key == "AKIA-TEMP-1"
+    assert frozen.secret_key == "secret-temp-1"
+    assert frozen.token == "token-temp-1"
+    assert calls == [
         {
             "RoleArn": "arn:aws:iam::999:role/BedrockInvoke",
             "RoleSessionName": "OpenSREBedrockInvoke",
             "ExternalId": "shared-secret",
         }
     ]
-    assert session_calls == [
-        {
-            "aws_access_key_id": "AKIA-TEMP",
-            "aws_secret_access_key": "secret-temp",
-            "aws_session_token": "token-temp",
-            "region_name": "us-east-1",
-        }
-    ]
+
+
+def test_resolve_bedrock_aws_session_role_arn_credentials_are_refreshable_not_frozen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defining fix for #4482's repeated P1: BEDROCK_AWS_ROLE_ARN must
+    produce a self-refreshing credentials object, not a static one-time
+    snapshot (the round-1/round-2 bug). ``DeferredRefreshableCredentials``
+    is real, heavily-used botocore/boto3 machinery (the same mechanism
+    boto3 uses internally for a role_arn + source_profile profile) -- its
+    own time-based refresh-on-expiry behavior is botocore's tested concern,
+    not ours; what this asserts is that OpenSRE's wiring actually produces
+    that type instead of a plain, permanently-static Credentials object."""
+    from botocore.credentials import DeferredRefreshableCredentials
+
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    _install_fake_assume_role(monkeypatch)
+
+    session = resolve_bedrock_aws_session("us-east-1")
+
+    assert session is not None
+    assert isinstance(session.get_credentials(), DeferredRefreshableCredentials)
 
 
 def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
@@ -142,25 +172,9 @@ def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
     monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
-
+    _install_fake_assume_role(monkeypatch)
     session_calls: list[dict[str, Any]] = []
-
-    class _FakeStsClient:
-        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    class _FakeSession:
-        def __init__(self, **kwargs: Any) -> None:
-            session_calls.append(kwargs)
-
-    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
-    monkeypatch.setattr("boto3.Session", _FakeSession)
+    monkeypatch.setattr("boto3.Session", lambda **kwargs: session_calls.append(kwargs) or object())
 
     resolve_bedrock_aws_session("us-east-1")
 
@@ -174,26 +188,13 @@ def test_resolve_bedrock_aws_session_role_arn_without_external_id(
     """ExternalId is optional; omit it entirely rather than sending an empty string."""
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    calls = _install_fake_assume_role(monkeypatch)
 
-    assume_role_calls: list[dict[str, Any]] = []
+    session = resolve_bedrock_aws_session("us-east-1")
+    assert session is not None
+    session.get_credentials().get_frozen_credentials()
 
-    class _FakeStsClient:
-        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
-            assume_role_calls.append(kwargs)
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
-    monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
-
-    resolve_bedrock_aws_session("us-east-1")
-
-    assert "ExternalId" not in assume_role_calls[0]
+    assert "ExternalId" not in calls[0]
 
 
 def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
@@ -204,31 +205,15 @@ def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
     permissive us-east-1 default just because AWS_REGION is unset)."""
     _clear_bedrock_env(monkeypatch)
     monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
-
-    class _FakeStsClient:
-        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
-            return {
-                "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
-                }
-            }
-
-    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
-    monkeypatch.setattr("boto3.Session", lambda **kwargs: kwargs)
+    _install_fake_assume_role(monkeypatch)
 
     # No AWS_REGION/AWS_DEFAULT_REGION/BEDROCK_AWS_REGION set anywhere: this
     # must not raise, since the caller decided "us-east-1" is an acceptable
     # default and passed it in directly.
     session = resolve_bedrock_aws_session("us-east-1")
 
-    assert session == {
-        "aws_access_key_id": "AKIA-TEMP",
-        "aws_secret_access_key": "secret-temp",
-        "aws_session_token": "token-temp",
-        "region_name": "us-east-1",
-    }
+    assert session is not None
+    assert session.region_name == "us-east-1"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -1,0 +1,229 @@
+"""Tests for isolating Bedrock's AWS identity from investigation tools' (#4482).
+
+Investigation tools already read the ambient ``AWS_PROFILE`` directly, so a
+laptop configured for one AWS account already investigates that account
+correctly. Bedrock had no equivalent override: every Bedrock client reached
+for the same ambient default credential chain, so a cross-account setup
+(Bedrock reachable only via an AssumeRole profile in a different account
+than the infra being investigated) had no way to give Bedrock a different
+identity than whatever profile was active for everything else.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.llm.transports.sdk.bedrock_converse import (
+    frozen_bedrock_credentials,
+    require_aws_region,
+    resolve_bedrock_aws_session,
+)
+
+
+def _clear_bedrock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "BEDROCK_AWS_REGION",
+        "BEDROCK_AWS_PROFILE",
+        "BEDROCK_AWS_ROLE_ARN",
+        "BEDROCK_AWS_EXTERNAL_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# require_aws_region — BEDROCK_AWS_REGION precedence                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_require_aws_region_prefers_bedrock_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_REGION", "eu-west-1")
+
+    assert require_aws_region() == "eu-west-1"
+
+
+def test_require_aws_region_falls_back_to_aws_region(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    assert require_aws_region() == "us-east-1"
+
+
+# --------------------------------------------------------------------------- #
+# resolve_bedrock_aws_session                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_bedrock_aws_session_returns_none_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No override set: callers must fall through to today's ambient-chain behavior."""
+    _clear_bedrock_env(monkeypatch)
+
+    assert resolve_bedrock_aws_session() is None
+
+
+def test_resolve_bedrock_aws_session_uses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
+    calls: list[dict[str, Any]] = []
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    session = resolve_bedrock_aws_session()
+
+    assert isinstance(session, _FakeSession)
+    assert calls == [{"profile_name": "bedrock-account"}]
+
+
+def test_resolve_bedrock_aws_session_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    monkeypatch.setenv("BEDROCK_AWS_EXTERNAL_ID", "shared-secret")
+
+    assume_role_calls: list[dict[str, Any]] = []
+    session_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            assume_role_calls.append(kwargs)
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            session_calls.append(kwargs)
+
+    def _fake_boto3_client(service: str, **_kwargs: Any) -> _FakeStsClient:
+        assert service == "sts"
+        return _FakeStsClient()
+
+    monkeypatch.setattr("boto3.client", _fake_boto3_client)
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    session = resolve_bedrock_aws_session()
+
+    assert isinstance(session, _FakeSession)
+    assert assume_role_calls == [
+        {
+            "RoleArn": "arn:aws:iam::999:role/BedrockInvoke",
+            "RoleSessionName": "OpenSREBedrockInvoke",
+            "ExternalId": "shared-secret",
+        }
+    ]
+    assert session_calls == [
+        {
+            "aws_access_key_id": "AKIA-TEMP",
+            "aws_secret_access_key": "secret-temp",
+            "aws_session_token": "token-temp",
+            "region_name": "us-east-1",
+        }
+    ]
+
+
+def test_resolve_bedrock_aws_session_role_arn_takes_precedence_over_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both set: the explicit assume-role wins, the profile is never touched."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "should-be-ignored")
+
+    session_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def __init__(self, **kwargs: Any) -> None:
+            session_calls.append(kwargs)
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", _FakeSession)
+
+    resolve_bedrock_aws_session()
+
+    assert len(session_calls) == 1
+    assert "profile_name" not in session_calls[0]
+
+
+def test_resolve_bedrock_aws_session_role_arn_without_external_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ExternalId is optional; omit it entirely rather than sending an empty string."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    assume_role_calls: list[dict[str, Any]] = []
+
+    class _FakeStsClient:
+        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            assume_role_calls.append(kwargs)
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr("boto3.Session", lambda **_kwargs: object())
+
+    resolve_bedrock_aws_session()
+
+    assert "ExternalId" not in assume_role_calls[0]
+
+
+# --------------------------------------------------------------------------- #
+# frozen_bedrock_credentials                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_frozen_bedrock_credentials_returns_frozen_credentials() -> None:
+    sentinel = object()
+
+    class _FakeCredentials:
+        def get_frozen_credentials(self) -> object:
+            return sentinel
+
+    class _FakeSession:
+        def get_credentials(self) -> _FakeCredentials:
+            return _FakeCredentials()
+
+    assert frozen_bedrock_credentials(_FakeSession()) is sentinel
+
+
+def test_frozen_bedrock_credentials_raises_a_clear_error_when_unresolved() -> None:
+    """A profile with no configured credentials must not crash with an AttributeError."""
+
+    class _FakeSession:
+        def get_credentials(self) -> None:
+            return None
+
+    with pytest.raises(RuntimeError, match="BEDROCK_AWS_PROFILE"):
+        frozen_bedrock_credentials(_FakeSession())

--- a/tests/core/runtime/llm/test_bedrock_aws_session.py
+++ b/tests/core/runtime/llm/test_bedrock_aws_session.py
@@ -16,8 +16,9 @@ from typing import Any
 import pytest
 
 from core.llm.transports.sdk.bedrock_converse import (
+    _RefreshingBedrockAnthropicClient,
+    build_bedrock_anthropic_client,
     require_aws_region,
-    resolve_bedrock_anthropic_kwargs,
     resolve_bedrock_aws_session,
 )
 
@@ -217,48 +218,172 @@ def test_resolve_bedrock_aws_session_never_requires_a_region_itself(
 
 
 # --------------------------------------------------------------------------- #
-# resolve_bedrock_anthropic_kwargs (AnthropicBedrock consumers)                #
+# build_bedrock_anthropic_client (AnthropicBedrock consumers)                  #
 # --------------------------------------------------------------------------- #
 
 
-def test_resolve_bedrock_anthropic_kwargs_empty_when_unset(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _clear_bedrock_env(monkeypatch)
-
-    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {}
-
-
-def test_resolve_bedrock_anthropic_kwargs_passes_profile_through_unresolved(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A named profile must reach AnthropicBedrock as aws_profile=, not be
-    resolved-and-frozen into static keys — freezing would silently drop the
-    refresh a role_arn + source_profile pair in ~/.aws/config provides."""
-    _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
-
-    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {"aws_profile": "bedrock-account"}
-
-
-def test_resolve_bedrock_anthropic_kwargs_assumes_role(monkeypatch: pytest.MonkeyPatch) -> None:
-    _clear_bedrock_env(monkeypatch)
-    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+def _install_fake_sts_assume_role(
+    monkeypatch: pytest.MonkeyPatch, *, expiration: str = "2999-01-01T00:00:00+00:00"
+) -> list[dict[str, Any]]:
+    """Patch the plain boto3.client("sts").assume_role() call
+    _assumed_bedrock_role_credentials makes directly (not the
+    AssumeRoleCredentialFetcher-based path _refreshable_role_session uses)."""
+    calls: list[dict[str, Any]] = []
+    counter = iter(range(1, 1000))
 
     class _FakeStsClient:
-        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+        def assume_role(self, **kwargs: Any) -> dict[str, Any]:
+            n = next(counter)
+            calls.append(kwargs)
             return {
                 "Credentials": {
-                    "AccessKeyId": "AKIA-TEMP",
-                    "SecretAccessKey": "secret-temp",
-                    "SessionToken": "token-temp",
+                    "AccessKeyId": f"AKIA-TEMP-{n}",
+                    "SecretAccessKey": f"secret-temp-{n}",
+                    "SessionToken": f"token-temp-{n}",
+                    "Expiration": expiration,
                 }
             }
 
     monkeypatch.setattr("boto3.client", lambda *_a, **_k: _FakeStsClient())
+    return calls
 
-    assert resolve_bedrock_anthropic_kwargs("us-east-1") == {
-        "aws_access_key": "AKIA-TEMP",
-        "aws_secret_key": "secret-temp",
-        "aws_session_token": "token-temp",
-    }
+
+def test_build_bedrock_anthropic_client_ambient_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No override: today's exact ambient-chain client, not the refreshing subclass."""
+    _clear_bedrock_env(monkeypatch)
+
+    client = build_bedrock_anthropic_client(region="us-east-1")
+
+    assert type(client) is not _RefreshingBedrockAnthropicClient
+    assert client.aws_access_key is None
+    assert client.aws_profile is None
+    assert client.aws_region == "us-east-1"
+
+
+def test_build_bedrock_anthropic_client_uses_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A named profile must reach AnthropicBedrock as aws_profile=, not be
+    resolved-and-frozen into static keys -- freezing would silently drop the
+    refresh a role_arn + source_profile pair in ~/.aws/config provides."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_PROFILE", "bedrock-account")
+
+    client = build_bedrock_anthropic_client(region="us-east-1")
+
+    assert type(client) is not _RefreshingBedrockAnthropicClient
+    assert client.aws_profile == "bedrock-account"
+    assert client.aws_access_key is None
+
+
+def test_build_bedrock_anthropic_client_role_arn_uses_refreshing_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defining fix, round 3: BEDROCK_AWS_ROLE_ARN must build a client
+    that re-assumes the role near expiry, not a client with credentials
+    frozen forever at construction (the round 1/2 bug, repeatedly flagged)."""
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    calls = _install_fake_sts_assume_role(monkeypatch)
+
+    client = build_bedrock_anthropic_client(region="us-east-1", timeout=7.0)
+
+    assert isinstance(client, _RefreshingBedrockAnthropicClient)
+    assert client.aws_access_key == "AKIA-TEMP-1"
+    assert client.aws_secret_key == "secret-temp-1"
+    assert client.aws_session_token == "token-temp-1"
+    assert client.aws_region == "us-east-1"
+    assert client.timeout == 7.0
+    assert len(calls) == 1
+
+
+def test_build_bedrock_anthropic_client_omits_timeout_when_not_given(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BedrockLLMClient never passes timeout; it must get the SDK's own
+    default (a real Timeout object) rather than a literal None, which
+    AnthropicBedrock treats as no-timeout-at-all."""
+    _clear_bedrock_env(monkeypatch)
+
+    client = build_bedrock_anthropic_client(region="us-east-1")
+
+    assert client.timeout is not None
+
+
+# --------------------------------------------------------------------------- #
+# _RefreshingBedrockAnthropicClient                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_refreshing_client_does_not_refetch_when_not_near_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    calls = _install_fake_sts_assume_role(monkeypatch)
+
+    client = build_bedrock_anthropic_client(region="us-east-1")
+    assert isinstance(client, _RefreshingBedrockAnthropicClient)
+    client._refresh_if_needed()
+    client._refresh_if_needed()
+
+    assert len(calls) == 1
+    assert client.aws_access_key == "AKIA-TEMP-1"
+
+
+def test_refreshing_client_refetches_when_near_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The property under test: a client that outlives the buffer window
+    re-assumes the role in place instead of staying frozen on stale creds."""
+    from datetime import UTC, datetime, timedelta
+
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    near_expiry = (datetime.now(UTC) + timedelta(minutes=1)).isoformat()
+    calls = _install_fake_sts_assume_role(monkeypatch, expiration=near_expiry)
+
+    client = build_bedrock_anthropic_client(region="us-east-1")
+    assert isinstance(client, _RefreshingBedrockAnthropicClient)
+    first_access_key = client.aws_access_key
+
+    client._refresh_if_needed()
+
+    assert len(calls) == 2
+    assert client.aws_access_key != first_access_key
+    assert client.aws_access_key == "AKIA-TEMP-2"
+
+
+def test_refreshing_client_prepare_request_refreshes_before_delegating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_prepare_request is the one hook AnthropicBedrock calls before every
+    signed request; the refresh check must run there, not only at construction."""
+    from anthropic import AnthropicBedrock
+
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    _install_fake_sts_assume_role(monkeypatch)
+
+    client = build_bedrock_anthropic_client(region="us-east-1")
+    assert isinstance(client, _RefreshingBedrockAnthropicClient)
+
+    call_order: list[str] = []
+    monkeypatch.setattr(client, "_refresh_if_needed", lambda: call_order.append("refresh"))
+    monkeypatch.setattr(
+        AnthropicBedrock, "_prepare_request", lambda _self, _request: call_order.append("prepare")
+    )
+
+    client._prepare_request(object())
+
+    assert call_order == ["refresh", "prepare"]
+
+
+def test_refreshing_client_refresh_omits_external_id_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_bedrock_env(monkeypatch)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+    calls = _install_fake_sts_assume_role(monkeypatch)
+
+    build_bedrock_anthropic_client(region="us-east-1")
+
+    assert "ExternalId" not in calls[0]

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -263,6 +263,16 @@ def test_bedrock_llm_client_treats_empty_bedrock_region_as_unset(monkeypatch) ->
     assert client._aws_region == "us-west-2"
 
 
+def test_bedrock_llm_client_strips_whitespace_from_region(monkeypatch) -> None:
+    """A shell-provided ' us-east-1' must be normalized before reaching the
+    SDK, which rejects a region string containing whitespace."""
+    monkeypatch.setenv("BEDROCK_AWS_REGION", " us-east-1 ")
+
+    client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert client._aws_region == "us-east-1"
+
+
 def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -332,33 +332,34 @@ def test_bedrock_llm_client_converse_uses_resolved_session_when_configured(
     assert default_client_calls == []
 
 
-def test_bedrock_llm_client_anthropic_uses_resolved_session_credentials(monkeypatch) -> None:
-    """Same override, Anthropic-on-Bedrock path: explicit static creds, not ambient."""
+def test_bedrock_llm_client_anthropic_uses_build_bedrock_anthropic_client_result(
+    monkeypatch,
+) -> None:
+    """BedrockLLMClient's Anthropic-on-Bedrock branch must delegate client
+    construction entirely to build_bedrock_anthropic_client (see
+    test_bedrock_aws_session.py for coverage of ambient/profile/role-arn
+    selection) and use its exact result, passing no timeout (unlike the
+    agent-loop Bedrock client, this class has never set one explicitly)."""
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",
         _InactiveGuardrailEngine,
     )
-
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
-        lambda _region: {
-            "aws_access_key": "AKIA-BEDROCK",
-            "aws_secret_key": "secret-bedrock",
-            "aws_session_token": "token-bedrock",
-        },
-    )
+    sentinel_client = object()
     calls: list[dict] = []
+
+    def _fake_build(*, region: str, timeout: float | None = None) -> object:
+        calls.append({"region": region, "timeout": timeout})
+        return sentinel_client
+
     monkeypatch.setattr(
-        sdk_llm,
-        "AnthropicBedrock",
-        lambda **kwargs: calls.append(kwargs),
+        "core.llm.transports.sdk.bedrock_converse.build_bedrock_anthropic_client",
+        _fake_build,
     )
 
-    sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+    client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
 
-    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
-    assert calls[0]["aws_secret_key"] == "secret-bedrock"
-    assert calls[0]["aws_session_token"] == "token-bedrock"
+    assert client._anthropic_client is sentinel_client
+    assert calls == [{"region": client._aws_region, "timeout": None}]
 
 
 def test_invoke_converse_includes_optional_system_temperature(monkeypatch) -> None:
@@ -436,7 +437,9 @@ def test_bedrock_anthropic_bad_request_does_not_retry(monkeypatch) -> None:
         def __init__(self, **_kwargs) -> None:
             self.messages = _Messages()
 
-    monkeypatch.setattr(sdk_llm, "AnthropicBedrock", _AnthropicBedrock)
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.AnthropicBedrock", _AnthropicBedrock
+    )
     monkeypatch.setattr(sdk_llm.time, "sleep", lambda s: sleeps.append(s))
 
     client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
@@ -464,7 +467,9 @@ def test_bedrock_anthropic_stream_bad_request_does_not_retry(monkeypatch) -> Non
         def __init__(self, **_kwargs) -> None:
             self.messages = _Messages()
 
-    monkeypatch.setattr(sdk_llm, "AnthropicBedrock", _AnthropicBedrock)
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.AnthropicBedrock", _AnthropicBedrock
+    )
     monkeypatch.setattr(sdk_llm.time, "sleep", lambda s: sleeps.append(s))
 
     client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
@@ -2071,7 +2076,8 @@ def test_bedrock_invoke_anthropic_not_found_raises_immediately(monkeypatch) -> N
     )
     err = NotFoundError(message="not found", response=resp, body={})  # type: ignore[arg-type]
     monkeypatch.setattr(
-        sdk_llm, "AnthropicBedrock", lambda **_: _make_bedrock_anthropic_client(err)
+        "core.llm.transports.sdk.bedrock_converse.AnthropicBedrock",
+        lambda **_: _make_bedrock_anthropic_client(err),
     )
 
     client = sdk_llm.BedrockLLMClient(model="anthropic.claude-old-v1:0")
@@ -2096,7 +2102,8 @@ def test_bedrock_invoke_anthropic_authentication_raises_immediately(monkeypatch)
     )
     err = AuthenticationError(message="bad credentials", response=resp, body={})  # type: ignore[arg-type]
     monkeypatch.setattr(
-        sdk_llm, "AnthropicBedrock", lambda **_: _make_bedrock_anthropic_client(err)
+        "core.llm.transports.sdk.bedrock_converse.AnthropicBedrock",
+        lambda **_: _make_bedrock_anthropic_client(err),
     )
 
     client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
@@ -2128,7 +2135,8 @@ def test_bedrock_invoke_anthropic_bad_request_inference_profile(monkeypatch) -> 
         message="on-demand throughput isn't supported", response=resp, body={}
     )  # type: ignore[arg-type]
     monkeypatch.setattr(
-        sdk_llm, "AnthropicBedrock", lambda **_: _make_bedrock_anthropic_client(err)
+        "core.llm.transports.sdk.bedrock_converse.AnthropicBedrock",
+        lambda **_: _make_bedrock_anthropic_client(err),
     )
 
     client = sdk_llm.BedrockLLMClient(model="anthropic.claude-opus-4-1-20250805-v1:0")
@@ -2153,7 +2161,8 @@ def test_bedrock_invoke_anthropic_permission_denied_raises_immediately(monkeypat
     )
     err = PermissionDeniedError(message="not available for this account", response=resp, body={})  # type: ignore[arg-type]
     monkeypatch.setattr(
-        sdk_llm, "AnthropicBedrock", lambda **_: _make_bedrock_anthropic_client(err)
+        "core.llm.transports.sdk.bedrock_converse.AnthropicBedrock",
+        lambda **_: _make_bedrock_anthropic_client(err),
     )
 
     client = sdk_llm.BedrockLLMClient(model="anthropic.claude-opus-4-7")

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -240,6 +240,79 @@ def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     assert "system" not in call
 
 
+def test_bedrock_llm_client_converse_uses_resolved_session_when_configured(
+    monkeypatch,
+) -> None:
+    """A BEDROCK_AWS_PROFILE/ROLE_ARN override must build the runtime client
+    from the resolved session, not the ambient default boto3.client (#4482)."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
+    monkeypatch.setattr(
+        "platform.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+    session_client_calls: list[tuple[str, dict]] = []
+    default_client_calls: list[tuple[str, dict]] = []
+
+    class _FakeSession:
+        def client(self, service: str, **kwargs) -> object:
+            session_client_calls.append((service, kwargs))
+            return _RecordingBedrockRuntime({"output": {"message": {"content": []}}})
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        sdk_llm.boto3,
+        "client",
+        lambda *a, **k: default_client_calls.append((a, k)),
+    )
+
+    sdk_llm.BedrockLLMClient(model="mistral.mistral-large-2402-v1:0")
+
+    assert session_client_calls == [("bedrock-runtime", {"region_name": "us-east-1"})]
+    assert default_client_calls == []
+
+
+def test_bedrock_llm_client_anthropic_uses_resolved_session_credentials(monkeypatch) -> None:
+    """Same override, Anthropic-on-Bedrock path: explicit static creds, not ambient."""
+    monkeypatch.setattr(
+        "platform.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+
+    class _FakeFrozenCredentials:
+        access_key = "AKIA-BEDROCK"
+        secret_key = "secret-bedrock"
+        token = "token-bedrock"
+
+    class _FakeSession:
+        pass
+
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
+        lambda: _FakeSession(),
+    )
+    monkeypatch.setattr(
+        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
+        lambda _session: _FakeFrozenCredentials(),
+    )
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        sdk_llm,
+        "AnthropicBedrock",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert calls[0]["aws_access_key"] == "AKIA-BEDROCK"
+    assert calls[0]["aws_secret_key"] == "secret-bedrock"
+    assert calls[0]["aws_session_token"] == "token-bedrock"
+
+
 def test_invoke_converse_includes_optional_system_temperature(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",

--- a/tests/core/runtime/llm/test_llm_client.py
+++ b/tests/core/runtime/llm/test_llm_client.py
@@ -217,6 +217,52 @@ def test_is_anthropic_bedrock_model_application_inference_profile_arn() -> None:
     assert not sdk_llm.is_anthropic_bedrock_model(profile_arn)
 
 
+def test_bedrock_llm_client_role_arn_without_any_region_uses_permissive_default(
+    monkeypatch,
+) -> None:
+    """BEDROCK_AWS_ROLE_ARN set with no region env var anywhere must not reject
+    a config that would otherwise default to us-east-1 (#4482 round 2): the
+    session resolver must use the caller's own already-resolved region
+    instead of independently re-requiring one."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("BEDROCK_AWS_REGION", raising=False)
+    monkeypatch.setenv("BEDROCK_AWS_ROLE_ARN", "arn:aws:iam::999:role/BedrockInvoke")
+
+    class _FakeStsClient:
+        def assume_role(self, **_kwargs) -> dict:
+            return {
+                "Credentials": {
+                    "AccessKeyId": "AKIA-TEMP",
+                    "SecretAccessKey": "secret-temp",
+                    "SessionToken": "token-temp",
+                }
+            }
+
+    class _FakeSession:
+        def client(self, _service: str, **_kwargs) -> object:
+            return _RecordingBedrockRuntime({"output": {"message": {"content": []}}})
+
+    monkeypatch.setattr(sdk_llm.boto3, "client", lambda *_a, **_k: _FakeStsClient())
+    monkeypatch.setattr(sdk_llm.boto3, "Session", lambda **_kwargs: _FakeSession())
+
+    client = sdk_llm.BedrockLLMClient(model="mistral.mistral-large-2402-v1:0")
+
+    assert client._aws_region == "us-east-1"
+
+
+def test_bedrock_llm_client_treats_empty_bedrock_region_as_unset(monkeypatch) -> None:
+    """BEDROCK_AWS_REGION="" must fall through to AWS_REGION, not become the
+    literal empty string (a plain os.getenv(name, default) does not treat a
+    present-but-empty value as unset)."""
+    monkeypatch.setenv("BEDROCK_AWS_REGION", "")
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+    client = sdk_llm.BedrockLLMClient(model="anthropic.claude-test")
+
+    assert client._aws_region == "us-west-2"
+
+
 def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
     monkeypatch.setattr(
         "platform.guardrails.engine.get_guardrail_engine",
@@ -262,7 +308,7 @@ def test_bedrock_llm_client_converse_uses_resolved_session_when_configured(
 
     monkeypatch.setattr(
         "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
+        lambda _region: _FakeSession(),
     )
     monkeypatch.setattr(
         sdk_llm.boto3,
@@ -283,21 +329,13 @@ def test_bedrock_llm_client_anthropic_uses_resolved_session_credentials(monkeypa
         _InactiveGuardrailEngine,
     )
 
-    class _FakeFrozenCredentials:
-        access_key = "AKIA-BEDROCK"
-        secret_key = "secret-bedrock"
-        token = "token-bedrock"
-
-    class _FakeSession:
-        pass
-
     monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_aws_session",
-        lambda: _FakeSession(),
-    )
-    monkeypatch.setattr(
-        "core.llm.transports.sdk.bedrock_converse.frozen_bedrock_credentials",
-        lambda _session: _FakeFrozenCredentials(),
+        "core.llm.transports.sdk.bedrock_converse.resolve_bedrock_anthropic_kwargs",
+        lambda _region: {
+            "aws_access_key": "AKIA-BEDROCK",
+            "aws_secret_key": "secret-bedrock",
+            "aws_session_token": "token-bedrock",
+        },
     )
     calls: list[dict] = []
     monkeypatch.setattr(


### PR DESCRIPTION
Fixes #4482

Bedrock and infrastructure investigation (EC2, CloudWatch, ...) both resolved AWS identity from the same ambient default credential chain, with no way to give them different identities. Investigation tools already follow the process's ambient `AWS_PROFILE` correctly cross-account; Bedrock had no equivalent, so a Bedrock account reachable only via a different AssumeRole profile than the infra account had no way to be isolated.

Adds a Bedrock-only identity override: `BEDROCK_AWS_PROFILE`, `BEDROCK_AWS_ROLE_ARN` + `BEDROCK_AWS_EXTERNAL_ID` (assume-role, for deployments with no `~/.aws/config`), and `BEDROCK_AWS_REGION`. Naming mirrors the existing `AWS_ROLE_ARN`/`AWS_EXTERNAL_ID` convention in `config/constants/aws.py`. Wired into all three Bedrock client construction sites in `core/llm/transports/sdk/`.

**Two rounds of Greptile fixes since opening:** (1) a `BEDROCK_AWS_PROFILE` session's credentials were frozen at construction instead of passed through as `aws_profile=`, discarding the profile's own refresh; (2) the session resolver required a region internally, rejecting configs `BedrockLLMClient`'s permissive `us-east-1` default should accept, fixed by making region a caller-supplied parameter; (3) `BedrockLLMClient`'s `os.getenv(name, default)` didn't treat `BEDROCK_AWS_REGION=""` as unset; (4) `BEDROCK_AWS_ROLE_ARN` credentials for the `boto3`-backed clients (Converse/non-Anthropic models) were a one-time snapshot that went stale on a long-lived cached client, fixed using botocore's public `AssumeRoleCredentialFetcher`/`DeferredRefreshableCredentials` (the same mechanism boto3 uses for a `role_arn` + `source_profile` profile) so that path now self-refreshes; `AnthropicBedrock` (Claude models) still has no hook for a refreshable provider at all, so it remains a documented one-time snapshot with `BEDROCK_AWS_PROFILE` recommended instead; (5) region resolution wasn't stripping whitespace.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/core/runtime/llm/ -q
361 passed

$ make typecheck && make check-imports
Success: no issues found in 1555 source files / All 3 import checks passed.

$ uv run pytest tests/core/ -q
1594 passed, 29 skipped
```

Every regression test confirmed failing against the pre-fix code and passing after. The self-refresh fix is proven by asserting the role-arn session's credentials are a `DeferredRefreshableCredentials` instance rather than a static snapshot.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Checked `AnthropicBedrock`'s actual constructor signature before assuming it could refresh a profile: it accepts `aws_profile` directly, using the SDK's own mechanism rather than freezing static credentials out of a resolved session. Split credential resolution into two functions since only `boto3.client()` consumers can accept a refreshable session. For the `BEDROCK_AWS_ROLE_ARN` refresh finding, verified via `inspect.signature`/botocore's source that `AssumeRoleCredentialFetcher`/`DeferredRefreshableCredentials` are real, public classes before wiring them up, and tested by asserting the resulting object's type rather than reproducing botocore's own expiry-timing logic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
