### PR TITLE
fix: remediate GitHub code quality finding #13

### DIFF
--- a/tests/e2e/upstream_lambda/pipeline_code/api_ingester/requests/auth.py
+++ b/tests/e2e/upstream_lambda/pipeline_code/api_ingester/requests/auth.py
@@ -178,8 +178,6 @@ class HTTPDigestAuth(AuthBase):
         if hash_utf8 is None:
             return None
 
-        # XXX not implemented yet
-        entdig = None
         p_parsed = urlparse(url)
         #: path is request-uri defined in RFC 2616 which should not be empty
         path = p_parsed.path or "/"
@@ -226,8 +224,6 @@ class HTTPDigestAuth(AuthBase):
             base += f', opaque="{opaque}"'
         if algorithm:
             base += f', algorithm="{algorithm}"'
-        if entdig:
-            base += f', digest="{entdig}"'
         if qop:
             base += f', qop="auth", nc={ncvalue}, cnonce="{cnonce}"'
 


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code quality finding #13](https://github.com/Tracer-Cloud/opensre/security/quality/findings/13).

**Alert summary**
Unreachable code

**Fix summary**
Confirmed: the same 6 ruff findings exist on HEAD, so my change introduces no new lint issues, and the edit is restored in the working tree.

## Summary

**Finding:** CodeQL `py/unreachable-statement` at `tests/e2e/upstream_lambda/pipeline_code/api_ingester/requests/auth.py:230` — `base += f', digest="{entdig}"'` could never run because `entdig` was unconditionally set to `None` at line 182 (an old `# XXX not implemented yet` placeholder for RFC 2617 `auth-int` entity digests, inherited from the vendored `requests` digest-auth code; the `auth-int` qop path already returns `None` earlier).

**Change** (4 deleted lines, one file):
- Removed the dead `if entdig: base += f', digest="{entdig}"'` branch.
- Removed the now-unused `entdig = None` assignment and its `XXX` comment, so the fix doesn't trade an unreachable-statement alert for an unused-variable one.

Behavior is unchanged — the branch was provably never taken, so the built `Digest` header is byte-identical before and after. Maintainability improves because readers no longer have to trace `entdig` through 50 lines to discover it's always `None`.

**Verification:** `py_compile` passes; `ruff check` output is identical on HEAD and after the edit (6 pre-existing findings in this vendored file, none on the changed lines); no remaining `entdig` references anywhere under `tests/e2e/upstream_lambda`. No tests exercise this vendored digest-auth path directly, and as a maintainability finding no new test is warranted.

**Files changed**
- `tests/e2e/upstream_lambda/pipeline_code/api_ingester/requests/auth.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.