### PR TITLE
refactor: use HTTPStatus in Telegram poller client (#4282)

### DIFF
--- a/gateway/telegram/poller/client.py
+++ b/gateway/telegram/poller/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from http import HTTPStatus
 from typing import Any
 
 from platform.notifications.delivery_transport import post_json
@@ -26,7 +27,7 @@ class TelegramBotClient:
         )
         if not response.ok:
             return False, {}, response.error
-        if response.status_code != 200 or not isinstance(response.data, Mapping):
+        if response.status_code != HTTPStatus.OK or not isinstance(response.data, Mapping):
             return False, {}, response.text or f"HTTP {response.status_code}"
         if not response.data.get("ok"):
             description = str(response.data.get("description", "unknown"))


### PR DESCRIPTION
Fixes #4282

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Replaces the bare numeric literal `200` in `gateway/telegram/poller/client.py` with the named `HTTPStatus.OK` member, per the project rule to use `http.HTTPStatus` instead of raw numeric status codes. Behavior is unchanged.

### Demo/Screenshot for feature changes and bug fixes -
No user-visible change; verified with `make lint`, `make format-check`, `make typecheck`, and `gateway/tests/telegram` (54 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The change adds `from http import HTTPStatus` to the imports and replaces the single status comparison in `TelegramBotClient._call` (`response.status_code != 200`) with `response.status_code != HTTPStatus.OK`. This is the only bare status code in the file. `HTTPStatus.OK` compares equal to the integer 200, so the runtime behavior is identical; no alternatives were needed since the enum member is the canonical named form. The surrounding f-string `HTTP {response.status_code}` is diagnostic text, not a comparison, and was left untouched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
