### PR TITLE
feat(filestorage): show progress during remote sync

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -130,10 +130,10 @@ opensre remote-sync sync --pull-only    # new machine, fetch only
 opensre remote-sync sync --push-only    # back up without pulling
 ```
 
-On a terminal, each file prints as it moves (`↑`/`↓` and its path) so a large
-`sessions/` tree doesn't look hung; piped or scripted output stays to the final
-summary line only. The interactive shell shows the same thing as a live-updating
-spinner.
+On a terminal, a progress bar (`Pulling`/`Pushing`, a count of how many files
+are done, and the current file) shows a large `sessions/` tree moving instead
+of looking hung; piped or scripted output stays to the final summary line
+only. The interactive shell shows the same thing as a live-updating bar.
 
 ## Exclude paths
 

--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -130,6 +130,11 @@ opensre remote-sync sync --pull-only    # new machine, fetch only
 opensre remote-sync sync --push-only    # back up without pulling
 ```
 
+On a terminal, each file prints as it moves (`↑`/`↓` and its path) so a large
+`sessions/` tree doesn't look hung; piped or scripted output stays to the final
+summary line only. The interactive shell shows the same thing as a live-updating
+spinner.
+
 ## Exclude paths
 
 By default every session and every memory file mirrors. Patterns hold some of

--- a/platform/filestorage/engine.py
+++ b/platform/filestorage/engine.py
@@ -31,10 +31,29 @@ from platform.filestorage.syncable import SyncRoot, resolved_roots, syncable_roo
 
 logger = logging.getLogger(__name__)
 
-#: Called once per key as it moves (or, under ``dry_run``, as it is previewed),
-#: with the direction it moved in. A callback raising propagates to the caller —
-#: same as any other unexpected error during a sync.
-ProgressCallback = Callable[[str, SyncDirection], None]
+
+@dataclass(frozen=True)
+class SyncProgress:
+    """One evaluated candidate, for a live "how much is left" display.
+
+    Fired for every candidate a direction's pass looks at — transferred,
+    skipped as unchanged, or held back for a newer remote copy — not only the
+    ones that move. A tree that is mostly already in sync would otherwise
+    barely advance a caller's progress bar even though the whole tree is
+    being scanned, which is the exact "looks hung" symptom this exists to fix.
+    ``completed`` is 1-based and counts up to ``total`` within one direction;
+    a full sync's pull pass and push pass each start their own count at 1.
+    """
+
+    direction: SyncDirection
+    key: str
+    completed: int
+    total: int
+
+
+#: A callback raising propagates to the caller, same as any other unexpected
+#: error during a sync.
+ProgressCallback = Callable[[SyncProgress], None]
 
 
 @dataclass
@@ -175,27 +194,35 @@ def push(
                 continue
             planned.append((key, path))
 
-    for key, path in planned:
+    total = len(planned)
+
+    def _report(key: str, completed: int) -> None:
+        if on_progress is not None:
+            on_progress(SyncProgress(SyncDirection.PUSH, key, completed, total))
+
+    for completed, (key, path) in enumerate(planned, start=1):
         if key in previewed_pulls:
             result.skipped += 1
+            _report(key, completed)
             continue
         data = path.read_bytes()
         existing = by_key.get(key)
         if existing is not None:
             if comparable_etag(existing) == content_tag(data):
                 result.skipped += 1
+                _report(key, completed)
                 continue
             if existing.last_modified > _modified_at(path):
                 # The store holds the more recent write, so uploading would
                 # destroy it. Same rule pull applies in the other direction.
                 result.kept_remote.append(key)
+                _report(key, completed)
                 continue
         if not dry_run:
             store.put_object(key, data)
         result.uploaded.append(key)
         result.uploaded_bytes += len(data)
-        if on_progress is not None:
-            on_progress(key, SyncDirection.PUSH)
+        _report(key, completed)
 
     if previewed_pulls:
         # Keys pull previewed but that never had a local file to begin with
@@ -224,32 +251,39 @@ def pull(
     roots = roots if roots is not None else syncable_roots()
     result = report if report is not None else SyncReport()
     by_name = {root.name: root for root in roots}
+    listing = remote if remote is not None else store.list_objects("")
+    total = len(listing)
 
-    for obj in remote if remote is not None else store.list_objects(""):
+    def _report(key: str, completed: int) -> None:
+        if on_progress is not None:
+            on_progress(SyncProgress(SyncDirection.PULL, key, completed, total))
+
+    for completed, obj in enumerate(listing, start=1):
         target = _local_path_for(obj, by_name)
         if target is None:
+            _report(obj.key, completed)
             continue
         # Excluding a path means it does not belong on this machine, so the
         # pattern holds in both directions: a file another machine still
         # uploads is not pulled back down here.
         if exclusions.excludes(obj.key):
             result.excluded.add(obj.key)
+            _report(obj.key, completed)
             continue
         if not _should_download(obj, target):
             result.skipped += 1
+            _report(obj.key, completed)
             continue
         if dry_run:
             result.downloaded_bytes += obj.size
             result.downloaded.append(obj.key)
-            if on_progress is not None:
-                on_progress(obj.key, SyncDirection.PULL)
+            _report(obj.key, completed)
             continue
         data = store.get_object(obj.key)
         result.downloaded_bytes += len(data)
         _write_atomically(target, data)
         result.downloaded.append(obj.key)
-        if on_progress is not None:
-            on_progress(obj.key, SyncDirection.PULL)
+        _report(obj.key, completed)
     return result
 
 
@@ -292,8 +326,8 @@ def run_sync(
     The listing is fetched once and shared: a pull changes local files, never
     the bucket, so the push half can reuse it. ``dry_run`` previews the same
     plan without writing anywhere, local or remote. ``on_progress``, when
-    given, is called once per key as pull and then push move it — see
-    :data:`ProgressCallback`.
+    given, is called once per key evaluated in the pull pass and then again
+    for the push pass — see :data:`ProgressCallback`.
     """
     report = SyncReport()
     listing = store.list_objects("")
@@ -323,6 +357,7 @@ def run_sync(
 __all__ = [
     "ProgressCallback",
     "SyncDirection",
+    "SyncProgress",
     "SyncReport",
     "comparable_etag",
     "content_tag",

--- a/platform/filestorage/engine.py
+++ b/platform/filestorage/engine.py
@@ -18,6 +18,7 @@ import hashlib
 import logging
 import os
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -29,6 +30,11 @@ from platform.filestorage.ports import ObjectStore, RemoteObject
 from platform.filestorage.syncable import SyncRoot, resolved_roots, syncable_roots
 
 logger = logging.getLogger(__name__)
+
+#: Called once per key as it moves (or, under ``dry_run``, as it is previewed),
+#: with the direction it moved in. A callback raising propagates to the caller —
+#: same as any other unexpected error during a sync.
+ProgressCallback = Callable[[str, SyncDirection], None]
 
 
 @dataclass
@@ -129,6 +135,7 @@ def push(
     remote: list[RemoteObject] | None = None,
     exclusions: ExclusionRules = NO_EXCLUSIONS,
     dry_run: bool = False,
+    on_progress: ProgressCallback | None = None,
 ) -> SyncReport:
     """Upload local files whose contents differ from the bucket.
 
@@ -187,6 +194,8 @@ def push(
             store.put_object(key, data)
         result.uploaded.append(key)
         result.uploaded_bytes += len(data)
+        if on_progress is not None:
+            on_progress(key, SyncDirection.PUSH)
 
     if previewed_pulls:
         # Keys pull previewed but that never had a local file to begin with
@@ -204,6 +213,7 @@ def pull(
     remote: list[RemoteObject] | None = None,
     exclusions: ExclusionRules = NO_EXCLUSIONS,
     dry_run: bool = False,
+    on_progress: ProgressCallback | None = None,
 ) -> SyncReport:
     """Download bucket objects missing locally, or newer than the local copy.
 
@@ -231,11 +241,15 @@ def pull(
         if dry_run:
             result.downloaded_bytes += obj.size
             result.downloaded.append(obj.key)
+            if on_progress is not None:
+                on_progress(obj.key, SyncDirection.PULL)
             continue
         data = store.get_object(obj.key)
         result.downloaded_bytes += len(data)
         _write_atomically(target, data)
         result.downloaded.append(obj.key)
+        if on_progress is not None:
+            on_progress(obj.key, SyncDirection.PULL)
     return result
 
 
@@ -271,12 +285,15 @@ def run_sync(
     roots: tuple[SyncRoot, ...] | None = None,
     exclusions: ExclusionRules = NO_EXCLUSIONS,
     dry_run: bool = False,
+    on_progress: ProgressCallback | None = None,
 ) -> SyncReport:
     """Move files in ``direction``. Both ways pulls first, so an offline edit wins.
 
     The listing is fetched once and shared: a pull changes local files, never
     the bucket, so the push half can reuse it. ``dry_run`` previews the same
-    plan without writing anywhere, local or remote.
+    plan without writing anywhere, local or remote. ``on_progress``, when
+    given, is called once per key as pull and then push move it — see
+    :data:`ProgressCallback`.
     """
     report = SyncReport()
     listing = store.list_objects("")
@@ -288,6 +305,7 @@ def run_sync(
             remote=listing,
             exclusions=exclusions,
             dry_run=dry_run,
+            on_progress=on_progress,
         )
     if direction is not SyncDirection.PULL:
         push(
@@ -297,11 +315,13 @@ def run_sync(
             remote=listing,
             exclusions=exclusions,
             dry_run=dry_run,
+            on_progress=on_progress,
         )
     return report
 
 
 __all__ = [
+    "ProgressCallback",
     "SyncDirection",
     "SyncReport",
     "comparable_etag",

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -19,6 +19,7 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
+from platform.filestorage.enums import SyncDirection
 from platform.filestorage.exclusions import ExclusionRules
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from platform.filestorage.providers import credential_hint_for_provider
@@ -28,6 +29,13 @@ from platform.filestorage.providers.registry import builtin_providers
 #: live. Built once, not per key: a dict is checked by ``str.translate``, not
 #: scanned as a list.
 _CONTROL_CHAR_TABLE = dict.fromkeys((*range(0, 32), 127, *range(128, 160)), "�")
+
+_DIRECTION_LABEL = {SyncDirection.PULL: "Pulling", SyncDirection.PUSH: "Pushing"}
+
+
+def direction_label(direction: SyncDirection) -> str:
+    """Human label for a sync direction, shared so surfaces can't drift apart."""
+    return _DIRECTION_LABEL[direction]
 
 
 def sanitize_terminal_text(text: str) -> str:
@@ -171,6 +179,7 @@ __all__ = [
     "DISABLED_HELP",
     "NO_EXCLUSIONS_HELP",
     "SETUP_DISABLED_CONFIRM",
+    "direction_label",
     "format_exclusion_lines",
     "format_report_lines",
     "format_setup_lines",

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -19,6 +19,7 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
+from platform.filestorage.enums import SyncDirection
 from platform.filestorage.exclusions import ExclusionRules
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from platform.filestorage.providers import credential_hint_for_provider
@@ -98,6 +99,16 @@ def format_status_lines(status: SyncStatus) -> tuple[str, ...]:
     return tuple(lines)
 
 
+def format_progress_line(key: str, direction: SyncDirection) -> str:
+    """One line for a single file as it moves, shared by CLI and the shell.
+
+    A TTY-only surface: the caller decides whether to print it at all, so
+    piped output never sees a line per file.
+    """
+    symbol = "↑" if direction is SyncDirection.PUSH else "↓"
+    return f"  {symbol} {key}"
+
+
 def format_report_lines(report: SyncReport, *, dry_run: bool = False) -> tuple[str, ...]:
     """Plain-text result lines after a run (pure; snapshots lists).
 
@@ -154,6 +165,7 @@ __all__ = [
     "NO_EXCLUSIONS_HELP",
     "SETUP_DISABLED_CONFIRM",
     "format_exclusion_lines",
+    "format_progress_line",
     "format_report_lines",
     "format_setup_lines",
     "format_status_lines",

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -19,11 +19,28 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
-from platform.filestorage.enums import SyncDirection
 from platform.filestorage.exclusions import ExclusionRules
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from platform.filestorage.providers import credential_hint_for_provider
 from platform.filestorage.providers.registry import builtin_providers
+
+#: ASCII C0/DEL and Latin-1 C1 control ranges — where CSI/OSC escape sequences
+#: live. Built once, not per key: a dict is checked by ``str.translate``, not
+#: scanned as a list.
+_CONTROL_CHAR_TABLE = dict.fromkeys((*range(0, 32), 127, *range(128, 160)), "�")
+
+
+def sanitize_terminal_text(text: str) -> str:
+    """Replace control/escape characters so an untrusted key cannot spoof the terminal.
+
+    Object keys come from the local filesystem or a remote listing — either
+    can be attacker-influenced (a crafted local filename, or a compromised or
+    misconfigured remote store) — and are shown directly in a live progress
+    display or a report line. Control and escape characters (CSI, OSC, ...)
+    are replaced with U+FFFD so a key cannot move the cursor, hide text, or
+    fake other terminal output.
+    """
+    return text.translate(_CONTROL_CHAR_TABLE)
 
 
 def _human_size(n: int) -> str:
@@ -99,16 +116,6 @@ def format_status_lines(status: SyncStatus) -> tuple[str, ...]:
     return tuple(lines)
 
 
-def format_progress_line(key: str, direction: SyncDirection) -> str:
-    """One line for a single file as it moves, shared by CLI and the shell.
-
-    A TTY-only surface: the caller decides whether to print it at all, so
-    piped output never sees a line per file.
-    """
-    symbol = "↑" if direction is SyncDirection.PUSH else "↓"
-    return f"  {symbol} {key}"
-
-
 def format_report_lines(report: SyncReport, *, dry_run: bool = False) -> tuple[str, ...]:
     """Plain-text result lines after a run (pure; snapshots lists).
 
@@ -135,7 +142,7 @@ def format_report_lines(report: SyncReport, *, dry_run: bool = False) -> tuple[s
         lines.append(f"{excluded} held back by your exclude settings.")
     if kept_remote:
         lines.append(f"{len(kept_remote)} kept the store's newer copy:")
-        lines.extend(f"  {key}" for key in kept_remote)
+        lines.extend(f"  {sanitize_terminal_text(key)}" for key in kept_remote)
         lines.append(_KEPT_REMOTE_HINT)
     return tuple(lines)
 
@@ -165,9 +172,9 @@ __all__ = [
     "NO_EXCLUSIONS_HELP",
     "SETUP_DISABLED_CONFIRM",
     "format_exclusion_lines",
-    "format_progress_line",
     "format_report_lines",
     "format_setup_lines",
     "format_status_lines",
     "root_state",
+    "sanitize_terminal_text",
 ]

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -140,9 +140,9 @@ def run_remote_sync(
     Prefer ``direction=`` when the caller already has a :class:`SyncDirection`;
     the boolean flags remain for CLI/slash adapters. ``dry_run`` previews the
     plan without uploading, downloading, or writing anything locally.
-    ``on_progress``, when given, is called once per key as it moves — the
+    ``on_progress``, when given, is called once per key evaluated — the
     single place CLI and slash both get live progress from, so neither
-    re-derives it. See :data:`platform.filestorage.engine.ProgressCallback`.
+    re-derives it. See :class:`platform.filestorage.engine.SyncProgress`.
     """
     _refuse_org_scoped_turn()
     resolved = (

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from config.scope_context import current_scope
 from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_config
 from platform.filestorage.engine import (
+    ProgressCallback,
     SyncReport,
     local_files,
     relative_key,
@@ -131,6 +132,7 @@ def run_remote_sync(
     push_only: bool = False,
     direction: SyncDirection | None = None,
     dry_run: bool = False,
+    on_progress: ProgressCallback | None = None,
 ) -> SyncReport | None:
     """Pull/push for the current scope. ``None`` when sync is disabled.
 
@@ -138,6 +140,9 @@ def run_remote_sync(
     Prefer ``direction=`` when the caller already has a :class:`SyncDirection`;
     the boolean flags remain for CLI/slash adapters. ``dry_run`` previews the
     plan without uploading, downloading, or writing anything locally.
+    ``on_progress``, when given, is called once per key as it moves — the
+    single place CLI and slash both get live progress from, so neither
+    re-derives it. See :data:`platform.filestorage.engine.ProgressCallback`.
     """
     _refuse_org_scoped_turn()
     resolved = (
@@ -151,7 +156,14 @@ def run_remote_sync(
     roots = syncable_roots()
     store = build_object_store(config)
     return _owned_report(
-        run_sync(store, direction=resolved, roots=roots, exclusions=config.exclude, dry_run=dry_run)
+        run_sync(
+            store,
+            direction=resolved,
+            roots=roots,
+            exclusions=config.exclude,
+            dry_run=dry_run,
+            on_progress=on_progress,
+        )
     )
 
 

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import click
 
 from config.constants.filestorage import (
@@ -10,14 +12,15 @@ from config.constants.filestorage import (
 )
 from platform.common.exit_codes import ERROR, SUCCESS
 from platform.filestorage import RemoteSyncConfigError, RemoteSyncError
+from platform.filestorage.engine import SyncProgress
 from platform.filestorage.enums import RemoteSyncField, RemoteSyncSubcommand, SyncDirection
 from platform.filestorage.messages import (
     DISABLED_HELP,
     SETUP_DISABLED_CONFIRM,
-    format_progress_line,
     format_report_lines,
     format_setup_lines,
     format_status_lines,
+    sanitize_terminal_text,
 )
 from platform.filestorage.operations import get_sync_status, run_remote_sync
 from platform.filestorage.providers.registry import builtin_providers, provider_extra_fields
@@ -27,9 +30,39 @@ from platform.filestorage.setup import (
     save_remote_sync_settings,
 )
 
+_DIRECTION_LABEL = {SyncDirection.PULL: "Pulling", SyncDirection.PUSH: "Pushing"}
 
-def _print_progress(key: str, direction: SyncDirection) -> None:
-    click.echo(format_progress_line(key, direction))
+
+class _CliProgress:
+    """Renders each direction's :class:`SyncProgress` events as a Click bar.
+
+    ``run_sync`` always finishes pull before starting push, so at most one
+    bar is open at a time; a direction change closes the previous bar (if
+    any) and opens the next with its own known length.
+    """
+
+    def __init__(self) -> None:
+        self._bar: Any = None
+        self._direction: SyncDirection | None = None
+
+    def __call__(self, progress: SyncProgress) -> None:
+        if progress.direction is not self._direction:
+            self.close()
+            self._bar = click.progressbar(
+                length=progress.total,
+                label=_DIRECTION_LABEL[progress.direction],
+                item_show_func=lambda item: item,
+            )
+            self._bar.__enter__()
+            self._direction = progress.direction
+        self._bar.current_item = sanitize_terminal_text(progress.key)
+        self._bar.update(1)
+
+    def close(self) -> None:
+        if self._bar is not None:
+            self._bar.__exit__(None, None, None)
+            self._bar = None
+            self._direction = None
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -59,14 +92,19 @@ def status_command() -> None:
 @click.option("--dry-run", is_flag=True, help="Preview transfers without changing anything.")
 def sync_now_command(pull_only: bool, push_only: bool, dry_run: bool) -> None:
     """Sync now: pull remote changes, then push local ones."""
-    on_progress = _print_progress if click.get_text_stream("stdout").isatty() else None
+    progress = _CliProgress() if click.get_text_stream("stdout").isatty() else None
     try:
         report = run_remote_sync(
-            pull_only=pull_only, push_only=push_only, dry_run=dry_run, on_progress=on_progress
+            pull_only=pull_only, push_only=push_only, dry_run=dry_run, on_progress=progress
         )
     except RemoteSyncError as exc:
+        if progress is not None:
+            progress.close()
         click.echo(f"Sync failed: {exc}", err=True)
         raise SystemExit(ERROR) from exc
+    finally:
+        if progress is not None:
+            progress.close()
     if report is None:
         click.echo(DISABLED_HELP)
         raise SystemExit(SUCCESS)

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import click
 
 from config.constants.filestorage import (
@@ -12,15 +10,13 @@ from config.constants.filestorage import (
 )
 from platform.common.exit_codes import ERROR, SUCCESS
 from platform.filestorage import RemoteSyncConfigError, RemoteSyncError
-from platform.filestorage.engine import SyncProgress
-from platform.filestorage.enums import RemoteSyncField, RemoteSyncSubcommand, SyncDirection
+from platform.filestorage.enums import RemoteSyncField, RemoteSyncSubcommand
 from platform.filestorage.messages import (
     DISABLED_HELP,
     SETUP_DISABLED_CONFIRM,
     format_report_lines,
     format_setup_lines,
     format_status_lines,
-    sanitize_terminal_text,
 )
 from platform.filestorage.operations import get_sync_status, run_remote_sync
 from platform.filestorage.providers.registry import builtin_providers, provider_extra_fields
@@ -29,40 +25,7 @@ from platform.filestorage.setup import (
     disable_remote_sync,
     save_remote_sync_settings,
 )
-
-_DIRECTION_LABEL = {SyncDirection.PULL: "Pulling", SyncDirection.PUSH: "Pushing"}
-
-
-class _CliProgress:
-    """Renders each direction's :class:`SyncProgress` events as a Click bar.
-
-    ``run_sync`` always finishes pull before starting push, so at most one
-    bar is open at a time; a direction change closes the previous bar (if
-    any) and opens the next with its own known length.
-    """
-
-    def __init__(self) -> None:
-        self._bar: Any = None
-        self._direction: SyncDirection | None = None
-
-    def __call__(self, progress: SyncProgress) -> None:
-        if progress.direction is not self._direction:
-            self.close()
-            self._bar = click.progressbar(
-                length=progress.total,
-                label=_DIRECTION_LABEL[progress.direction],
-                item_show_func=lambda item: item,
-            )
-            self._bar.__enter__()
-            self._direction = progress.direction
-        self._bar.current_item = sanitize_terminal_text(progress.key)
-        self._bar.update(1)
-
-    def close(self) -> None:
-        if self._bar is not None:
-            self._bar.__exit__(None, None, None)
-            self._bar = None
-            self._direction = None
+from surfaces.cli.commands.remote_sync_progress import CliProgress
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -92,7 +55,7 @@ def status_command() -> None:
 @click.option("--dry-run", is_flag=True, help="Preview transfers without changing anything.")
 def sync_now_command(pull_only: bool, push_only: bool, dry_run: bool) -> None:
     """Sync now: pull remote changes, then push local ones."""
-    progress = _CliProgress() if click.get_text_stream("stdout").isatty() else None
+    progress = CliProgress() if click.get_text_stream("stdout").isatty() else None
     try:
         report = run_remote_sync(
             pull_only=pull_only, push_only=push_only, dry_run=dry_run, on_progress=progress

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -10,10 +10,11 @@ from config.constants.filestorage import (
 )
 from platform.common.exit_codes import ERROR, SUCCESS
 from platform.filestorage import RemoteSyncConfigError, RemoteSyncError
-from platform.filestorage.enums import RemoteSyncField, RemoteSyncSubcommand
+from platform.filestorage.enums import RemoteSyncField, RemoteSyncSubcommand, SyncDirection
 from platform.filestorage.messages import (
     DISABLED_HELP,
     SETUP_DISABLED_CONFIRM,
+    format_progress_line,
     format_report_lines,
     format_setup_lines,
     format_status_lines,
@@ -25,6 +26,10 @@ from platform.filestorage.setup import (
     disable_remote_sync,
     save_remote_sync_settings,
 )
+
+
+def _print_progress(key: str, direction: SyncDirection) -> None:
+    click.echo(format_progress_line(key, direction))
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -54,8 +59,11 @@ def status_command() -> None:
 @click.option("--dry-run", is_flag=True, help="Preview transfers without changing anything.")
 def sync_now_command(pull_only: bool, push_only: bool, dry_run: bool) -> None:
     """Sync now: pull remote changes, then push local ones."""
+    on_progress = _print_progress if click.get_text_stream("stdout").isatty() else None
     try:
-        report = run_remote_sync(pull_only=pull_only, push_only=push_only, dry_run=dry_run)
+        report = run_remote_sync(
+            pull_only=pull_only, push_only=push_only, dry_run=dry_run, on_progress=on_progress
+        )
     except RemoteSyncError as exc:
         click.echo(f"Sync failed: {exc}", err=True)
         raise SystemExit(ERROR) from exc

--- a/surfaces/cli/commands/remote_sync_progress.py
+++ b/surfaces/cli/commands/remote_sync_progress.py
@@ -1,0 +1,46 @@
+"""Click progress-bar rendering for ``opensre remote-sync sync``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from platform.filestorage.engine import SyncProgress
+from platform.filestorage.enums import SyncDirection
+from platform.filestorage.messages import direction_label, sanitize_terminal_text
+
+
+class CliProgress:
+    """Renders each direction's :class:`SyncProgress` events as a Click bar.
+
+    ``run_sync`` always finishes pull before starting push, so at most one
+    bar is open at a time; a direction change closes the previous bar (if
+    any) and opens the next with its own known length.
+    """
+
+    def __init__(self) -> None:
+        self._bar: Any = None
+        self._direction: SyncDirection | None = None
+
+    def __call__(self, progress: SyncProgress) -> None:
+        if progress.direction is not self._direction:
+            self.close()
+            self._bar = click.progressbar(
+                length=progress.total,
+                label=direction_label(progress.direction),
+                item_show_func=lambda item: item,
+            )
+            self._bar.__enter__()
+            self._direction = progress.direction
+        self._bar.current_item = sanitize_terminal_text(progress.key)
+        self._bar.update(1)
+
+    def close(self) -> None:
+        if self._bar is not None:
+            self._bar.__exit__(None, None, None)
+            self._bar = None
+            self._direction = None
+
+
+__all__ = ["CliProgress"]

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -12,10 +12,11 @@ from config.constants.filestorage import (
     DEFAULT_REMOTE_SYNC_PROVIDER,
 )
 from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError
-from platform.filestorage.enums import RemoteSyncSubcommand
+from platform.filestorage.enums import RemoteSyncSubcommand, SyncDirection
 from platform.filestorage.messages import (
     DISABLED_HELP,
     format_exclusion_lines,
+    format_progress_line,
     format_report_lines,
     format_setup_lines,
     root_state,
@@ -69,11 +70,24 @@ def _print_status(console: Console) -> bool:
 def _run_sync(console: Console, args: list[str]) -> bool:
     flags = {a.lower() for a in args}
     dry_run = "--dry-run" in flags
-    with console.status("syncing…", spinner="dots"):
+    # Running tally rather than an index/total: the engine streams keys as it
+    # finds them, with no upfront count cheap enough to pull ahead of time.
+    counts = {SyncDirection.PUSH: 0, SyncDirection.PULL: 0}
+
+    def _on_progress(key: str, direction: SyncDirection) -> None:
+        counts[direction] += 1
+        tally = f"↑{counts[SyncDirection.PUSH]} ↓{counts[SyncDirection.PULL]}"
+        # Rich renders status text as markup; a session/memory filename is
+        # attacker-shaped the same way an exclude pattern is, so it gets the
+        # same treatment as _print_status's escape(line) below.
+        status.update(f"{tally}  {escape(format_progress_line(key, direction).lstrip())}")
+
+    with console.status("syncing…", spinner="dots") as status:
         report = run_remote_sync(
             pull_only="--pull-only" in flags,
             push_only="--push-only" in flags,
             dry_run=dry_run,
+            on_progress=_on_progress,
         )
     if report is None:
         console.print(f"[{DIM}]{DISABLED_HELP}[/]")

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -6,20 +6,22 @@ import logging
 
 from rich.console import Console
 from rich.markup import escape
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, TaskID, TextColumn
 
 from config.constants.filestorage import (
     DEFAULT_REMOTE_SYNC_PREFIX,
     DEFAULT_REMOTE_SYNC_PROVIDER,
 )
 from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError
+from platform.filestorage.engine import SyncProgress
 from platform.filestorage.enums import RemoteSyncSubcommand, SyncDirection
 from platform.filestorage.messages import (
     DISABLED_HELP,
     format_exclusion_lines,
-    format_progress_line,
     format_report_lines,
     format_setup_lines,
     root_state,
+    sanitize_terminal_text,
 )
 from platform.filestorage.operations import get_sync_status, run_remote_sync
 from platform.filestorage.providers.registry import builtin_providers
@@ -35,6 +37,8 @@ _USAGE = (
     f"{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only|--dry-run] "
     f"[--provider … --bucket …]"
 )
+
+_DIRECTION_LABEL = {SyncDirection.PULL: "Pulling", SyncDirection.PUSH: "Pushing"}
 
 
 def _print_lines(
@@ -70,19 +74,34 @@ def _print_status(console: Console) -> bool:
 def _run_sync(console: Console, args: list[str]) -> bool:
     flags = {a.lower() for a in args}
     dry_run = "--dry-run" in flags
-    # Running tally rather than an index/total: the engine streams keys as it
-    # finds them, with no upfront count cheap enough to pull ahead of time.
-    counts = {SyncDirection.PUSH: 0, SyncDirection.PULL: 0}
+    bar = Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("{task.fields[current]}"),
+        console=console,
+        transient=True,
+    )
+    task_id: TaskID | None = None
+    current_direction: SyncDirection | None = None
 
-    def _on_progress(key: str, direction: SyncDirection) -> None:
-        counts[direction] += 1
-        tally = f"↑{counts[SyncDirection.PUSH]} ↓{counts[SyncDirection.PULL]}"
-        # Rich renders status text as markup; a session/memory filename is
+    def _on_progress(progress: SyncProgress) -> None:
+        nonlocal task_id, current_direction
+        # Rich renders task fields as markup; a session/memory filename is
         # attacker-shaped the same way an exclude pattern is, so it gets the
         # same treatment as _print_status's escape(line) below.
-        status.update(f"{tally}  {escape(format_progress_line(key, direction).lstrip())}")
+        key_text = escape(sanitize_terminal_text(progress.key))
+        if progress.direction is not current_direction:
+            current_direction = progress.direction
+            label = _DIRECTION_LABEL[progress.direction]
+            if task_id is None:
+                task_id = bar.add_task(label, total=progress.total, current=key_text)
+            else:
+                bar.reset(task_id, total=progress.total, description=label, current=key_text)
+        assert task_id is not None
+        bar.update(task_id, completed=progress.completed, current=key_text)
 
-    with console.status("syncing…", spinner="dots") as status:
+    with bar:
         report = run_remote_sync(
             pull_only="--pull-only" in flags,
             push_only="--push-only" in flags,

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -17,6 +17,7 @@ from platform.filestorage.engine import SyncProgress
 from platform.filestorage.enums import RemoteSyncSubcommand, SyncDirection
 from platform.filestorage.messages import (
     DISABLED_HELP,
+    direction_label,
     format_exclusion_lines,
     format_report_lines,
     format_setup_lines,
@@ -37,8 +38,6 @@ _USAGE = (
     f"{RemoteSyncSubcommand.SETUP}] [--pull-only|--push-only|--dry-run] "
     f"[--provider … --bucket …]"
 )
-
-_DIRECTION_LABEL = {SyncDirection.PULL: "Pulling", SyncDirection.PUSH: "Pushing"}
 
 
 def _print_lines(
@@ -93,7 +92,7 @@ def _run_sync(console: Console, args: list[str]) -> bool:
         key_text = escape(sanitize_terminal_text(progress.key))
         if progress.direction is not current_direction:
             current_direction = progress.direction
-            label = _DIRECTION_LABEL[progress.direction]
+            label = direction_label(progress.direction)
             if task_id is None:
                 task_id = bar.add_task(label, total=progress.total, current=key_text)
             else:

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -11,8 +11,8 @@ import pytest
 from rich.console import Console
 
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.engine import SyncReport
-from platform.filestorage.enums import SyncDirection, SyncRootName
+from platform.filestorage.engine import SyncProgress, SyncReport
+from platform.filestorage.enums import SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from surfaces.cli.gateway_entry import gateway_slash_ports_factory, start_gateway
@@ -103,7 +103,7 @@ def test_gateway_dispatch_sync_with_flags(monkeypatch: pytest.MonkeyPatch) -> No
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, SyncDirection], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         del on_progress
         seen["pull_only"] = pull_only

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -11,7 +12,7 @@ from rich.console import Console
 
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
-from platform.filestorage.enums import SyncRootName
+from platform.filestorage.enums import SyncDirection, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from surfaces.cli.gateway_entry import gateway_slash_ports_factory, start_gateway
@@ -98,8 +99,13 @@ def test_gateway_dispatch_sync_with_flags(monkeypatch: pytest.MonkeyPatch) -> No
     seen: dict[str, bool] = {}
 
     def _run(
-        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, SyncDirection], None] | None = None,
     ) -> SyncReport:
+        del on_progress
         seen["pull_only"] = pull_only
         seen["push_only"] = push_only
         seen["dry_run"] = dry_run

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -92,12 +92,66 @@ def test_sync_prints_report(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) 
     assert "already current" in result.output
 
 
+def test_sync_prints_progress_lines_on_a_tty(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from platform.filestorage.enums import SyncDirection
+
+    _set_interactive(monkeypatch)
+
+    def _fake_run_remote_sync(
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, SyncDirection], None] | None = None,
+    ) -> SyncReport:
+        assert on_progress is not None
+        on_progress("sessions/a.jsonl", SyncDirection.PUSH)
+        return SyncReport(uploaded=["sessions/a.jsonl"])
+
+    monkeypatch.setattr("surfaces.cli.commands.remote_sync.run_remote_sync", _fake_run_remote_sync)
+    result = runner.invoke(remote_sync_command, ["sync"])
+    assert result.exit_code == 0
+    assert "sessions/a.jsonl" in result.output
+    assert "↑" in result.output
+
+
+def test_sync_stays_script_clean_off_a_tty(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CliRunner's stdout is not a TTY by default: on_progress must stay None."""
+    from platform.filestorage.enums import SyncDirection
+
+    seen: dict[str, object] = {}
+
+    def _capture(
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, SyncDirection], None] | None = None,
+    ) -> SyncReport:
+        seen["on_progress"] = on_progress
+        return SyncReport(uploaded=["sessions/a.jsonl"])
+
+    monkeypatch.setattr("surfaces.cli.commands.remote_sync.run_remote_sync", _capture)
+    result = runner.invoke(remote_sync_command, ["sync"])
+    assert result.exit_code == 0
+    assert seen["on_progress"] is None
+
+
 def test_sync_passes_direction_flags(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, bool] = {}
 
     def _capture(
-        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, str], None] | None = None,
     ) -> SyncReport:
+        del on_progress
         seen["pull_only"] = pull_only
         seen["push_only"] = push_only
         seen["dry_run"] = dry_run
@@ -118,8 +172,13 @@ def test_sync_passes_dry_run_and_labels_the_report(
     seen: dict[str, bool] = {}
 
     def _capture(
-        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, str], None] | None = None,
     ) -> SyncReport:
+        del on_progress
         seen["dry_run"] = dry_run
         return SyncReport(uploaded=["sessions/a.jsonl"])
 

--- a/tests/cli/test_remote_sync_command.py
+++ b/tests/cli/test_remote_sync_command.py
@@ -13,8 +13,13 @@ from click.testing import CliRunner
 
 from config.constants.filestorage import REMOTE_SYNC_BUCKET_ENV, REMOTE_SYNC_ENV
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.engine import SyncReport
-from platform.filestorage.enums import BuiltInProvider, RemoteSyncSubcommand, SyncRootName
+from platform.filestorage.engine import SyncProgress, SyncReport
+from platform.filestorage.enums import (
+    BuiltInProvider,
+    RemoteSyncSubcommand,
+    SyncDirection,
+    SyncRootName,
+)
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from platform.filestorage.setup import RemoteSyncSetupRequest
@@ -92,11 +97,17 @@ def test_sync_prints_report(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) 
     assert "already current" in result.output
 
 
-def test_sync_prints_progress_lines_on_a_tty(
+def test_sync_creates_progress_bars_on_a_tty(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from platform.filestorage.enums import SyncDirection
+    """A TTY gets a real bar per direction, driven end-to-end without crashing.
 
+    Click hides bar frames (percent, current item) when the underlying
+    stream isn't a real TTY — true for CliRunner's captured output even
+    after faking ``isatty()`` for our own gate — falling back to printing
+    each bar's label once. That fallback is what this asserts: the wiring
+    reaches Click's ProgressBar and survives a direction change intact.
+    """
     _set_interactive(monkeypatch)
 
     def _fake_run_remote_sync(
@@ -104,25 +115,29 @@ def test_sync_prints_progress_lines_on_a_tty(
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, SyncDirection], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         assert on_progress is not None
-        on_progress("sessions/a.jsonl", SyncDirection.PUSH)
-        return SyncReport(uploaded=["sessions/a.jsonl"])
+        on_progress(SyncProgress(SyncDirection.PULL, "memory/a.md", 1, 1))
+        on_progress(SyncProgress(SyncDirection.PUSH, "sessions/a.jsonl", 1, 2))
+        on_progress(SyncProgress(SyncDirection.PUSH, "sessions/b.jsonl", 2, 2))
+        return SyncReport(
+            downloaded=["memory/a.md"], uploaded=["sessions/a.jsonl", "sessions/b.jsonl"]
+        )
 
     monkeypatch.setattr("surfaces.cli.commands.remote_sync.run_remote_sync", _fake_run_remote_sync)
     result = runner.invoke(remote_sync_command, ["sync"])
-    assert result.exit_code == 0
-    assert "sessions/a.jsonl" in result.output
-    assert "↑" in result.output
+    assert result.exit_code == 0, result.output
+    assert "Pulling" in result.output
+    assert "Pushing" in result.output
+    assert "1 downloaded" in result.output
+    assert "2 uploaded" in result.output
 
 
 def test_sync_stays_script_clean_off_a_tty(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """CliRunner's stdout is not a TTY by default: on_progress must stay None."""
-    from platform.filestorage.enums import SyncDirection
-
     seen: dict[str, object] = {}
 
     def _capture(
@@ -130,7 +145,7 @@ def test_sync_stays_script_clean_off_a_tty(
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, SyncDirection], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         seen["on_progress"] = on_progress
         return SyncReport(uploaded=["sessions/a.jsonl"])
@@ -149,7 +164,7 @@ def test_sync_passes_direction_flags(runner: CliRunner, monkeypatch: pytest.Monk
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, str], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         del on_progress
         seen["pull_only"] = pull_only
@@ -176,7 +191,7 @@ def test_sync_passes_dry_run_and_labels_the_report(
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, str], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         del on_progress
         seen["dry_run"] = dry_run

--- a/tests/cli/test_remote_sync_progress.py
+++ b/tests/cli/test_remote_sync_progress.py
@@ -1,0 +1,63 @@
+"""``CliProgress`` — Click progress-bar rendering for ``opensre remote-sync sync``."""
+
+from __future__ import annotations
+
+from platform.filestorage.engine import SyncProgress
+from platform.filestorage.enums import SyncDirection
+from surfaces.cli.commands.remote_sync_progress import CliProgress
+
+
+def test_first_event_opens_a_bar_with_the_right_length_and_label() -> None:
+    progress = CliProgress()
+
+    progress(SyncProgress(SyncDirection.PULL, "sessions/a.jsonl", 1, 3))
+
+    assert progress._bar is not None
+    assert progress._bar.length == 3
+    assert progress._bar.label == "Pulling"
+    assert progress._bar.pos == 1
+    progress.close()
+
+
+def test_a_direction_change_closes_the_old_bar_and_opens_a_new_one() -> None:
+    progress = CliProgress()
+    progress(SyncProgress(SyncDirection.PULL, "sessions/a.jsonl", 1, 1))
+    first_bar = progress._bar
+
+    progress(SyncProgress(SyncDirection.PUSH, "sessions/b.jsonl", 1, 2))
+
+    assert progress._bar is not first_bar
+    assert progress._bar.length == 2
+    assert progress._bar.label == "Pushing"
+    progress.close()
+
+
+def test_same_direction_reuses_the_bar_and_advances_it() -> None:
+    progress = CliProgress()
+    progress(SyncProgress(SyncDirection.PUSH, "sessions/a.jsonl", 1, 2))
+    first_bar = progress._bar
+
+    progress(SyncProgress(SyncDirection.PUSH, "sessions/b.jsonl", 2, 2))
+
+    assert progress._bar is first_bar
+    assert progress._bar.pos == 2
+    progress.close()
+
+
+def test_close_is_idempotent() -> None:
+    progress = CliProgress()
+    progress(SyncProgress(SyncDirection.PULL, "sessions/a.jsonl", 1, 1))
+
+    progress.close()
+    progress.close()  # must not raise
+
+    assert progress._bar is None
+
+
+def test_current_item_is_sanitized_before_reaching_the_bar() -> None:
+    progress = CliProgress()
+
+    progress(SyncProgress(SyncDirection.PULL, "sessions/\x1b[2Kpwned.jsonl", 1, 1))
+
+    assert "\x1b" not in progress._bar.current_item
+    progress.close()

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -21,6 +21,7 @@ from platform.filestorage import engine as sync_module
 from platform.filestorage.config import load_remote_sync_config, remote_sync_enabled
 from platform.filestorage.engine import (
     ProgressCallback,
+    SyncProgress,
     content_tag,
     pull,
     push,
@@ -335,16 +336,12 @@ def test_push_only_dry_run_does_not_upload(home: Path, roots: tuple[SyncRoot, ..
 # ── Progress ─────────────────────────────────────────────────────────────
 
 
-def _progress_recorder() -> tuple[list[tuple[str, SyncDirection]], ProgressCallback]:
-    events: list[tuple[str, SyncDirection]] = []
-
-    def _record(key: str, direction: SyncDirection) -> None:
-        events.append((key, direction))
-
-    return events, _record
+def _progress_recorder() -> tuple[list[SyncProgress], ProgressCallback]:
+    events: list[SyncProgress] = []
+    return events, events.append
 
 
-def test_push_reports_progress_once_per_uploaded_key(
+def test_push_reports_progress_for_every_candidate_with_a_known_total(
     home: Path, roots: tuple[SyncRoot, ...]
 ) -> None:
     store = FakeObjectStore()
@@ -352,13 +349,16 @@ def test_push_reports_progress_once_per_uploaded_key(
 
     push(store, roots=roots, on_progress=on_progress)
 
-    assert sorted(events) == [
+    assert sorted((e.key, e.direction) for e in events) == [
         ("memory/a-fact.md", SyncDirection.PUSH),
         ("sessions/abc.jsonl", SyncDirection.PUSH),
     ]
+    # Both candidates share one total, and completed counts up to it.
+    assert {e.total for e in events} == {2}
+    assert sorted(e.completed for e in events) == [1, 2]
 
 
-def test_pull_reports_progress_once_per_downloaded_key(
+def test_pull_reports_progress_for_every_candidate_with_a_known_total(
     home: Path, roots: tuple[SyncRoot, ...], tmp_path: Path
 ) -> None:
     store = FakeObjectStore()
@@ -371,23 +371,31 @@ def test_pull_reports_progress_once_per_downloaded_key(
 
     pull(store, roots=second_roots, on_progress=on_progress)
 
-    assert sorted(events) == [
+    assert sorted((e.key, e.direction) for e in events) == [
         ("memory/a-fact.md", SyncDirection.PULL),
         ("sessions/abc.jsonl", SyncDirection.PULL),
     ]
+    assert {e.total for e in events} == {2}
+    assert sorted(e.completed for e in events) == [1, 2]
 
 
-def test_progress_is_silent_for_files_already_in_sync(
+def test_progress_still_fires_for_files_already_in_sync(
     home: Path, roots: tuple[SyncRoot, ...]
 ) -> None:
-    """A second push with nothing changed must not replay progress events."""
+    """A second push with nothing changed still reports — the tree was still scanned.
+
+    Reporting only actual transfers would make a bar barely move on a tree
+    that is mostly already in sync, which is the exact "looks hung" symptom
+    progress reporting exists to fix.
+    """
     store = FakeObjectStore()
     push(store, roots=roots)
     events, on_progress = _progress_recorder()
 
-    push(store, roots=roots, on_progress=on_progress)
+    report = push(store, roots=roots, on_progress=on_progress)
 
-    assert events == []
+    assert report.uploaded == []
+    assert sorted(e.key for e in events) == ["memory/a-fact.md", "sessions/abc.jsonl"]
 
 
 def test_dry_run_still_reports_progress_for_the_preview(
@@ -399,7 +407,7 @@ def test_dry_run_still_reports_progress_for_the_preview(
 
     push(store, roots=roots, dry_run=True, on_progress=on_progress)
 
-    assert sorted(events) == [
+    assert sorted((e.key, e.direction) for e in events) == [
         ("memory/a-fact.md", SyncDirection.PUSH),
         ("sessions/abc.jsonl", SyncDirection.PUSH),
     ]
@@ -415,10 +423,31 @@ def test_run_sync_progress_covers_pull_then_push(home: Path, roots: tuple[SyncRo
 
     run_sync(store, roots=roots, on_progress=on_progress)
 
-    directions_in_order = [direction for _key, direction in events]
+    directions_in_order = [e.direction for e in events]
     assert directions_in_order[0] is SyncDirection.PULL
     assert SyncDirection.PUSH in directions_in_order
-    assert ("memory/from-remote.md", SyncDirection.PULL) in events
+    assert any(
+        e.key == "memory/from-remote.md" and e.direction is SyncDirection.PULL for e in events
+    )
+    # Each direction's own pass starts its own count at 1, restarting after
+    # the pull pass hands off to the push pass.
+    pull_completed = [e.completed for e in events if e.direction is SyncDirection.PULL]
+    push_completed = [e.completed for e in events if e.direction is SyncDirection.PUSH]
+    assert pull_completed[0] == 1
+    assert push_completed[0] == 1
+
+
+def test_progress_reports_a_key_pull_skips_as_outside_any_root(
+    home: Path, roots: tuple[SyncRoot, ...]
+) -> None:
+    """An unrecognised remote key is still one of the candidates pull looked at."""
+    store = FakeObjectStore()
+    store.put_object("not-a-known-root/whatever.txt", b"data")
+    events, on_progress = _progress_recorder()
+
+    pull(store, roots=roots, on_progress=on_progress)
+
+    assert "not-a-known-root/whatever.txt" in {e.key for e in events}
 
 
 def test_sync_never_deletes(home: Path, roots: tuple[SyncRoot, ...]) -> None:

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -19,8 +19,15 @@ from config.constants.filestorage import (
 )
 from platform.filestorage import engine as sync_module
 from platform.filestorage.config import load_remote_sync_config, remote_sync_enabled
-from platform.filestorage.engine import content_tag, pull, push, resolve_direction, run_sync
-from platform.filestorage.enums import SyncRootName
+from platform.filestorage.engine import (
+    ProgressCallback,
+    content_tag,
+    pull,
+    push,
+    resolve_direction,
+    run_sync,
+)
+from platform.filestorage.enums import SyncDirection, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError, UnsyncablePathError
 from platform.filestorage.ports import RemoteObject
 from platform.filestorage.syncable import SyncRoot, is_syncable
@@ -323,6 +330,95 @@ def test_push_only_dry_run_does_not_upload(home: Path, roots: tuple[SyncRoot, ..
     # Assert: reported as it would upload, but the store stays empty.
     assert sorted(report.uploaded) == ["memory/a-fact.md", "sessions/abc.jsonl"]
     assert store.objects == {}
+
+
+# ── Progress ─────────────────────────────────────────────────────────────
+
+
+def _progress_recorder() -> tuple[list[tuple[str, SyncDirection]], ProgressCallback]:
+    events: list[tuple[str, SyncDirection]] = []
+
+    def _record(key: str, direction: SyncDirection) -> None:
+        events.append((key, direction))
+
+    return events, _record
+
+
+def test_push_reports_progress_once_per_uploaded_key(
+    home: Path, roots: tuple[SyncRoot, ...]
+) -> None:
+    store = FakeObjectStore()
+    events, on_progress = _progress_recorder()
+
+    push(store, roots=roots, on_progress=on_progress)
+
+    assert sorted(events) == [
+        ("memory/a-fact.md", SyncDirection.PUSH),
+        ("sessions/abc.jsonl", SyncDirection.PUSH),
+    ]
+
+
+def test_pull_reports_progress_once_per_downloaded_key(
+    home: Path, roots: tuple[SyncRoot, ...], tmp_path: Path
+) -> None:
+    store = FakeObjectStore()
+    push(store, roots=roots)
+    second_roots = (
+        SyncRoot(name=SyncRootName.SESSIONS, path=tmp_path / "two" / "sessions"),
+        SyncRoot(name=SyncRootName.MEMORY, path=tmp_path / "two" / "memory"),
+    )
+    events, on_progress = _progress_recorder()
+
+    pull(store, roots=second_roots, on_progress=on_progress)
+
+    assert sorted(events) == [
+        ("memory/a-fact.md", SyncDirection.PULL),
+        ("sessions/abc.jsonl", SyncDirection.PULL),
+    ]
+
+
+def test_progress_is_silent_for_files_already_in_sync(
+    home: Path, roots: tuple[SyncRoot, ...]
+) -> None:
+    """A second push with nothing changed must not replay progress events."""
+    store = FakeObjectStore()
+    push(store, roots=roots)
+    events, on_progress = _progress_recorder()
+
+    push(store, roots=roots, on_progress=on_progress)
+
+    assert events == []
+
+
+def test_dry_run_still_reports_progress_for_the_preview(
+    home: Path, roots: tuple[SyncRoot, ...]
+) -> None:
+    """A dry run previews what would move, so progress fires the same as a real run."""
+    store = FakeObjectStore()
+    events, on_progress = _progress_recorder()
+
+    push(store, roots=roots, dry_run=True, on_progress=on_progress)
+
+    assert sorted(events) == [
+        ("memory/a-fact.md", SyncDirection.PUSH),
+        ("sessions/abc.jsonl", SyncDirection.PUSH),
+    ]
+    # Preview only: nothing actually reached the store.
+    assert store.objects == {}
+
+
+def test_run_sync_progress_covers_pull_then_push(home: Path, roots: tuple[SyncRoot, ...]) -> None:
+    """A full sync reports the pull half before the push half, matching run order."""
+    store = FakeObjectStore()
+    store.put_object("memory/from-remote.md", b"hello\n")
+    events, on_progress = _progress_recorder()
+
+    run_sync(store, roots=roots, on_progress=on_progress)
+
+    directions_in_order = [direction for _key, direction in events]
+    assert directions_in_order[0] is SyncDirection.PULL
+    assert SyncDirection.PUSH in directions_in_order
+    assert ("memory/from-remote.md", SyncDirection.PULL) in events
 
 
 def test_sync_never_deletes(home: Path, roots: tuple[SyncRoot, ...]) -> None:

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -14,10 +14,11 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport, content_tag
-from platform.filestorage.enums import RemoteSyncField, SyncRootName
+from platform.filestorage.enums import RemoteSyncField, SyncDirection, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.messages import (
     DISABLED_HELP,
+    direction_label,
     format_report_lines,
     format_status_lines,
     sanitize_terminal_text,
@@ -144,6 +145,13 @@ def test_format_report_lines_handles_megabyte_boundary() -> None:
     lines = format_report_lines(report)
     assert "2.4 MiB" in lines[0]
     assert "2.4 MiB total" in lines[0]
+
+
+def test_direction_label_is_distinct_and_shared_by_both_surfaces() -> None:
+    """One source of truth for the label, so CLI and REPL cannot drift apart."""
+    assert direction_label(SyncDirection.PULL) == "Pulling"
+    assert direction_label(SyncDirection.PUSH) == "Pushing"
+    assert direction_label(SyncDirection.PULL) != direction_label(SyncDirection.PUSH)
 
 
 def test_sanitize_terminal_text_leaves_ordinary_paths_untouched() -> None:

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -14,13 +14,13 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport, content_tag
-from platform.filestorage.enums import RemoteSyncField, SyncDirection, SyncRootName
+from platform.filestorage.enums import RemoteSyncField, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.messages import (
     DISABLED_HELP,
-    format_progress_line,
     format_report_lines,
     format_status_lines,
+    sanitize_terminal_text,
 )
 from platform.filestorage.operations import get_sync_status, run_remote_sync
 from platform.filestorage.ports import RemoteObject
@@ -146,12 +146,26 @@ def test_format_report_lines_handles_megabyte_boundary() -> None:
     assert "2.4 MiB total" in lines[0]
 
 
-def test_format_progress_line_marks_direction_with_a_distinct_symbol() -> None:
-    up = format_progress_line("sessions/a.jsonl", SyncDirection.PUSH)
-    down = format_progress_line("sessions/a.jsonl", SyncDirection.PULL)
-    assert up != down
-    assert "sessions/a.jsonl" in up
-    assert "sessions/a.jsonl" in down
+def test_sanitize_terminal_text_leaves_ordinary_paths_untouched() -> None:
+    assert sanitize_terminal_text("sessions/a.jsonl") == "sessions/a.jsonl"
+    assert sanitize_terminal_text("sessions/日本語.jsonl") == "sessions/日本語.jsonl"
+
+
+def test_sanitize_terminal_text_replaces_escape_and_control_characters() -> None:
+    # ESC (CSI/OSC lead-in), a C0 control char, and a C1 control char.
+    crafted = "sessions/\x1b[2K\x1b]0;pwned\x07\x07\x9bwhoami.jsonl"
+    cleaned = sanitize_terminal_text(crafted)
+    assert "\x1b" not in cleaned
+    assert "\x07" not in cleaned
+    assert "\x9b" not in cleaned
+    assert "sessions/" in cleaned
+    assert "whoami.jsonl" in cleaned
+
+
+def test_format_report_lines_sanitizes_kept_remote_keys() -> None:
+    report = SyncReport(kept_remote=["sessions/\x1b[2Kspoofed.jsonl"])
+    lines = format_report_lines(report)
+    assert not any("\x1b" in line for line in lines)
 
 
 def test_factory_delegates_to_registry() -> None:

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -14,10 +14,11 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport, content_tag
-from platform.filestorage.enums import RemoteSyncField, SyncRootName
+from platform.filestorage.enums import RemoteSyncField, SyncDirection, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.messages import (
     DISABLED_HELP,
+    format_progress_line,
     format_report_lines,
     format_status_lines,
 )
@@ -143,6 +144,14 @@ def test_format_report_lines_handles_megabyte_boundary() -> None:
     lines = format_report_lines(report)
     assert "2.4 MiB" in lines[0]
     assert "2.4 MiB total" in lines[0]
+
+
+def test_format_progress_line_marks_direction_with_a_distinct_symbol() -> None:
+    up = format_progress_line("sessions/a.jsonl", SyncDirection.PUSH)
+    down = format_progress_line("sessions/a.jsonl", SyncDirection.PULL)
+    assert up != down
+    assert "sessions/a.jsonl" in up
+    assert "sessions/a.jsonl" in down
 
 
 def test_factory_delegates_to_registry() -> None:

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,7 @@ from rich.console import Console
 
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
-from platform.filestorage.enums import SyncRootName
+from platform.filestorage.enums import SyncDirection, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS, dispatch_slash
@@ -66,8 +67,13 @@ def test_sync_subcommand_calls_service(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, bool] = {}
 
     def _run(
-        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, SyncDirection], None] | None = None,
     ) -> SyncReport:
+        del on_progress
         seen["pull_only"] = pull_only
         seen["push_only"] = push_only
         seen["dry_run"] = dry_run
@@ -88,8 +94,13 @@ def test_sync_dry_run_forwards_flag_and_labels_the_report(monkeypatch: pytest.Mo
     seen: dict[str, bool] = {}
 
     def _run(
-        *, pull_only: bool = False, push_only: bool = False, dry_run: bool = False
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, SyncDirection], None] | None = None,
     ) -> SyncReport:
+        del on_progress
         seen["dry_run"] = dry_run
         return SyncReport(uploaded=["sessions/a.jsonl"], skipped=0)
 
@@ -103,6 +114,36 @@ def test_sync_dry_run_forwards_flag_and_labels_the_report(monkeypatch: pytest.Mo
     out = buf.getvalue()
     assert "Dry run" in out
     assert "would be uploaded" in out
+
+
+def test_sync_progress_callback_is_wired_and_tallies_by_direction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The service-supplied on_progress must work through a real console.status()."""
+
+    def _run(
+        *,
+        pull_only: bool = False,
+        push_only: bool = False,
+        dry_run: bool = False,
+        on_progress: Callable[[str, SyncDirection], None] | None = None,
+    ) -> SyncReport:
+        assert on_progress is not None
+        on_progress("memory/a.md", SyncDirection.PULL)
+        on_progress("sessions/b.jsonl", SyncDirection.PUSH)
+        return SyncReport(downloaded=["memory/a.md"], uploaded=["sessions/b.jsonl"])
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.remote_sync_cmds.run_remote_sync",
+        _run,
+    )
+    console, buf = _capture()
+    assert dispatch_slash("/remote-sync sync", Session(), console) is True
+    # A non-terminal console (as used here and by the gateway) renders no live
+    # status output — only the final report reaches buf. Wiring correctness is
+    # verified above by on_progress firing without raising.
+    assert "1 downloaded" in buf.getvalue()
+    assert "1 uploaded" in buf.getvalue()
 
 
 def test_sync_disabled_prints_help(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -10,7 +10,7 @@ import pytest
 from rich.console import Console
 
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.engine import SyncReport
+from platform.filestorage.engine import SyncProgress, SyncReport
 from platform.filestorage.enums import SyncDirection, SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
@@ -71,7 +71,7 @@ def test_sync_subcommand_calls_service(monkeypatch: pytest.MonkeyPatch) -> None:
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, SyncDirection], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         del on_progress
         seen["pull_only"] = pull_only
@@ -98,7 +98,7 @@ def test_sync_dry_run_forwards_flag_and_labels_the_report(monkeypatch: pytest.Mo
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, SyncDirection], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         del on_progress
         seen["dry_run"] = dry_run
@@ -116,21 +116,26 @@ def test_sync_dry_run_forwards_flag_and_labels_the_report(monkeypatch: pytest.Mo
     assert "would be uploaded" in out
 
 
-def test_sync_progress_callback_is_wired_and_tallies_by_direction(
+def test_sync_progress_callback_is_wired_through_a_direction_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The service-supplied on_progress must work through a real console.status()."""
+    """The service-supplied on_progress must work through a real Progress bar.
+
+    Exercises both add_task (first PULL event) and reset (the PULL→PUSH
+    direction change) without raising, against a non-terminal console —
+    the same rendering path the gateway uses.
+    """
 
     def _run(
         *,
         pull_only: bool = False,
         push_only: bool = False,
         dry_run: bool = False,
-        on_progress: Callable[[str, SyncDirection], None] | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
     ) -> SyncReport:
         assert on_progress is not None
-        on_progress("memory/a.md", SyncDirection.PULL)
-        on_progress("sessions/b.jsonl", SyncDirection.PUSH)
+        on_progress(SyncProgress(SyncDirection.PULL, "memory/a.md", 1, 1))
+        on_progress(SyncProgress(SyncDirection.PUSH, "sessions/b.jsonl", 1, 1))
         return SyncReport(downloaded=["memory/a.md"], uploaded=["sessions/b.jsonl"])
 
     monkeypatch.setattr(
@@ -140,8 +145,9 @@ def test_sync_progress_callback_is_wired_and_tallies_by_direction(
     console, buf = _capture()
     assert dispatch_slash("/remote-sync sync", Session(), console) is True
     # A non-terminal console (as used here and by the gateway) renders no live
-    # status output — only the final report reaches buf. Wiring correctness is
-    # verified above by on_progress firing without raising.
+    # progress output — only the final report reaches buf. Wiring correctness
+    # is verified above by on_progress firing through both branches without
+    # raising.
     assert "1 downloaded" in buf.getvalue()
     assert "1 uploaded" in buf.getvalue()
 


### PR DESCRIPTION
Fixes #4550

#### Describe the changes you have made in this PR -

`remote_sync.py` printed nothing until an entire run finished, which looked hung on a large `sessions/` tree. This adds a real progress bar (percent, ETA, `M/N` count, current file) for push and pull, driven from the shared service rather than duplicated per surface:

- `platform/filestorage/engine.py` — `push()`, `pull()`, `run_sync()` take an `on_progress: ProgressCallback | None` callback, fired once per candidate with a `SyncProgress(direction, key, completed, total)` event. `total` is known upfront for both directions with no extra I/O: push already builds its full candidate list before the upload loop, and pull already has the full remote listing before the download loop. Progress fires for **every** candidate evaluated — transferred, skipped as unchanged, or held back for a newer remote copy — not only the ones that move, so the bar keeps advancing even when most of a tree is already in sync (the exact "looks hung" symptom this exists to fix). Fires under `dry_run` too, so a preview reports the same events a real run would.
- `platform/filestorage/operations.py` — `run_remote_sync()` threads `on_progress` straight through to `run_sync()`. Still stateless/thread-safe; no new caching.
- `platform/filestorage/messages.py` — new `sanitize_terminal_text(text)`, replacing ASCII/Latin-1 control and escape characters (CSI, OSC, ...) with U+FFFD before an untrusted key — a local filename or a remote listing, either attacker-influenceable — reaches a terminal. Applied to the new progress display *and* the pre-existing `kept_remote` report line, which had the same unsanitized-key gap.
- `surfaces/cli/commands/remote_sync.py` — a real `click.progressbar` per direction (`Pulling`/`Pushing`), swapped when the direction changes; still gated on `stdout` being a TTY, so piped output is unchanged (final summary only).
- `surfaces/interactive_shell/command_registry/remote_sync_cmds.py` — `rich.progress.Progress` (bar + `M/N` + current file) replacing the old spinner. Confirmed Rich's `Live.refresh()` is a no-op when `console.is_terminal` is `False` (gateway uses `Console(force_terminal=False)`), so chat/gateway output stays script-clean with no extra branching needed.
- `tests/filestorage/test_remote_sync.py` — fake-store tests: progress fires for every candidate (transferred *and* skipped) with a correct running `completed`/`total`, still fires under `dry_run`, `run_sync` reports the pull pass before the push pass with each direction restarting its own count at 1, and an unrecognised remote key still counts as an evaluated candidate.
- `tests/filestorage/test_service_and_registry.py` — `sanitize_terminal_text` unit tests (ordinary/unicode paths untouched, control/escape chars replaced) and a `format_report_lines` test confirming `kept_remote` keys are sanitized.
- `tests/cli/test_remote_sync_command.py`, `tests/cli/test_gateway_remote_sync.py`, `tests/interactive_shell/test_remote_sync_cmds.py` — TTY vs non-TTY wiring tests for the new bar-based callback, plus fixed existing fakes whose `run_remote_sync` signatures didn't yet accept `on_progress`.
- `docs/configuration/remote-sync.mdx` — updated to describe the bar instead of the earlier per-line design.

### Demo/Screenshot for feature changes and bug fixes -

Live push then pull against a real private Vercel Blob store (throwaway store, deleted after), captured via `script -qec "uv run opensre remote-sync sync" ...` to force a pty so the real (non-hidden) bar renders — 15 files (12 sessions + 3 memory):

**Push** (frames as the bar advances):
```
Pushing  [------------------------------------]    0%
Pushing  [##----------------------------------]    6%  sessions/session-1.jsonl
Pushing  [####--------------------------------]   13%  sessions/session-10.jsonl
Pushing  [#######-----------------------------]   20%  00:00:04  sessions/session-11.jsonl
...
Pushing  [####################################]  100%  memory/fact-3.md
Sync complete — 0 downloaded, 15 uploaded (504 B), 0 already current (504 B total).
```

**Pull** (fresh machine, `--pull-only`):
```
Pulling  [------------------------------------]    0%
Pulling  [##----------------------------------]    6%  memory/fact-1.md
Pulling  [####--------------------------------]   13%  memory/fact-2.md
...
Pulling  [####################################]  100%  sessions/session-9.jsonl
Sync complete — 15 downloaded (504 B), 0 uploaded, 0 already current (504 B total).
```

15/15 files landed correctly on the second machine. Piped (`| cat`) stays to the summary line only, no bar frames — confirmed separately.

Local: `uv run pytest tests/filestorage/ tests/cli/test_remote_sync_command.py tests/cli/test_gateway_remote_sync.py tests/interactive_shell/test_remote_sync_cmds.py tests/surfaces/test_remote_sync_surface_contract.py -q` → 244 passed. `make lint` / `make format-check` / `make typecheck` clean.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The engine already threads a `SyncReport` by reference through `push`/`pull`/`run_sync`, so a callback fired at the same points was the smallest change that keeps a single source of truth: no second bookkeeping structure, no polling. `on_progress` lives in `engine.py` (the "narrow" layer per `ports.py`'s own doc comment) rather than on `ObjectStore`, since progress is a property of the sync loop, not the backend — every provider gets it for free with no provider-side changes.

An earlier version of this PR only reported actual transfers with a running tally and no total. Review feedback (and a direct ask) was that "how much is left" needs a real total and a real bar, not just a counter. Revisiting the engine showed both directions already have their full candidate count available before their respective transfer loop starts — push's `planned` list and pull's remote listing — so no second pass or extra request was needed to get an accurate `total` up front. That also surfaced a design gap: reporting only transfers means a bar barely moves on a tree that's mostly already in sync, so progress now fires for every evaluated candidate (skipped or kept-back included), which is what the issue's "looks hung" complaint is actually about.

Review also flagged that object keys — sourced from the local filesystem or a remote listing, either attacker-influenceable — were printed to the terminal unsanitized, a terminal-escape-injection gap (CSI/OSC sequences could move the cursor or spoof output). Fixed once in `messages.py` (`sanitize_terminal_text`) and reused by both the new progress path and the pre-existing `kept_remote` line, which had the identical gap.

Alternatives considered: (1) keep the plain-text `format_progress_line` approach and just add sanitization — rejected once a real bar was the goal, since `click.progressbar`/`rich.progress.Progress` render their own label/bar/percent and only need the current item's text, not a fully formatted line. (2) A single shared bar object across both surfaces — rejected; CLI (Click) and REPL (Rich) have no shared bar primitive, so each surface owns its own thin renderer over the same `SyncProgress` events, matching how `format_report_lines` already keeps wording shared while surfaces own rendering.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
