### PR TITLE
refactor(analytics): replace SURFACE_* constants with UsageSurface StrEnum

### DIFF
--- a/core/domain/memory/settings.py
+++ b/core/domain/memory/settings.py
@@ -9,10 +9,10 @@ from config.constants import (
     OPENSRE_MEMORY_DISABLED_ENV,
     OPENSRE_MEMORY_GATEWAY_ENABLED_ENV,
 )
-from platform.analytics.usage_context import SURFACE_SLACK, SURFACE_TELEGRAM, get_surface
+from platform.analytics.usage_context import UsageSurface, get_surface
 
 _TRUTHY = frozenset({"1", "true", "yes"})
-_GATEWAY_ANALYTICS_SURFACES = frozenset({SURFACE_SLACK, SURFACE_TELEGRAM})
+_GATEWAY_ANALYTICS_SURFACES = frozenset({UsageSurface.SLACK, UsageSurface.TELEGRAM})
 
 
 def _flag_set(name: str) -> bool:

--- a/gateway/discord/dispatcher.py
+++ b/gateway/discord/dispatcher.py
@@ -33,7 +33,7 @@ from gateway.runtime.approvals import ApprovalBroker, approval_tool_hooks
 from gateway.runtime.attention import GateDecision, ThreadAttentionGate
 from gateway.runtime.sink_protocol import GatewayAgentCallback
 from gateway.storage import SessionResolver
-from platform.analytics.usage_context import SURFACE_DISCORD, bound_usage_context
+from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
 _MAX_CONVERSATION_LOCKS = 1024
 _DENIAL_REPLY = "You're not authorized to use this bot. Ask an admin to add you."
@@ -309,7 +309,7 @@ class DiscordTurnDispatcher:
                     if ctx:
                         agent_text = f"{agent_text}\n\n{ctx}"
                 with bound_usage_context(
-                    surface=SURFACE_DISCORD,
+                    surface=UsageSurface.DISCORD,
                     session_id=session.session_id,
                     user_id=inbound.user_id or None,
                 ):

--- a/gateway/slack/dispatcher.py
+++ b/gateway/slack/dispatcher.py
@@ -37,7 +37,7 @@ from gateway.slack.thread_history import (
     session_needs_thread_seed,
 )
 from gateway.storage import SessionResolver
-from platform.analytics.usage_context import SURFACE_SLACK, bound_usage_context
+from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
 _ROTATE_SESSION = "__ROTATE_SESSION__"
 
@@ -376,7 +376,7 @@ class _SlackTurnDispatcher:
                 ):
                     agent_text = f"{agent_text}\n\n{files_context}"
                 with bound_usage_context(
-                    surface=SURFACE_SLACK,
+                    surface=UsageSurface.SLACK,
                     session_id=session.session_id,
                     user_id=inbound.user_id or None,
                 ):

--- a/gateway/telegram/inbound_handler.py
+++ b/gateway/telegram/inbound_handler.py
@@ -15,7 +15,7 @@ from gateway.telegram.output_sink import GatewayOutputSink
 from gateway.telegram.poller.client import TelegramBotClient
 from gateway.telegram.session_rotation import resolve_or_rotate_session
 from gateway.telegram.settings import GatewaySettings, TelegramInboundMessage
-from platform.analytics.usage_context import SURFACE_TELEGRAM, bound_usage_context
+from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ async def handle_polled_inbound_telegram_message(
 
         def _run_turn() -> None:
             with bound_usage_context(
-                surface=SURFACE_TELEGRAM,
+                surface=UsageSurface.TELEGRAM,
                 session_id=session.session_id,
                 user_id=event.user_id or None,
             ):

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -250,16 +250,16 @@ def test_turn_handler_emits_gateway_turn_analytics(monkeypatch: Any) -> None:
     )
     _patch_headless_agent(monkeypatch, _empty_turn_result())
 
-    from platform.analytics.usage_context import SURFACE_SLACK, bound_usage_context
+    from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
     session = SessionCore(storage=InMemorySessionStorage())
     handler = GatewayTurnHandler(console=Console(force_terminal=False))
-    with bound_usage_context(surface=SURFACE_SLACK, user_id="U1"):
+    with bound_usage_context(surface=UsageSurface.SLACK, user_id="U1"):
         handler("hi", session, MagicMock(), logging.getLogger("test"))
 
-    assert started == [{"surface": SURFACE_SLACK}]
+    assert started == [{"surface": UsageSurface.SLACK}]
     assert len(completed) == 1
-    assert completed[0]["surface"] == SURFACE_SLACK
+    assert completed[0]["surface"] == UsageSurface.SLACK
     assert completed[0]["answered"] is False
 
 

--- a/integrations/hermes/investigation.py
+++ b/integrations/hermes/investigation.py
@@ -75,7 +75,7 @@ def run_incident_investigation(
     from platform.analytics.cli import track_investigation
     from platform.analytics.source import EntrypointSource, TriggerMode
     from platform.analytics.usage_context import (
-        SURFACE_CLI,
+        UsageSurface,
         bound_usage_context,
         ensure_process_session_id,
         get_surface,
@@ -86,7 +86,7 @@ def run_incident_investigation(
     # for standalone Hermes watch processes.
     with (
         bound_usage_context(
-            surface=None if get_surface() else SURFACE_CLI,
+            surface=None if get_surface() else UsageSurface.CLI,
             session_id=ensure_process_session_id(),
         ),
         track_investigation(

--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -28,7 +28,7 @@ from platform.analytics.source import (
     TriggerMode,
     build_source_properties,
 )
-from platform.analytics.usage_context import SURFACE_CLI
+from platform.analytics.usage_context import UsageSurface
 from platform.observability.errors.sentry import capture_exception
 
 if TYPE_CHECKING:
@@ -473,7 +473,7 @@ def capture_cli_invoked(properties: Properties | None = None) -> None:
         from platform.analytics.usage_context import ensure_process_session_id
 
         analytics = get_analytics()
-        analytics.set_persistent_property("surface", SURFACE_CLI)
+        analytics.set_persistent_property("surface", UsageSurface.CLI)
         ensure_process_session_id()
         analytics.capture(Event.CLI_INVOKED, properties)
     except Exception as exc:

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -17,6 +17,7 @@ import contextlib
 import threading
 from collections.abc import Iterator
 from contextvars import ContextVar, Token
+from enum import StrEnum
 from typing import Final
 from uuid import uuid4
 
@@ -27,13 +28,17 @@ type JsonScalar = str | bool | int | float
 type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 type Properties = dict[str, JsonValue]
 
-SURFACE_CLI: Final[str] = "cli"
-SURFACE_SLACK: Final[str] = "slack"
-SURFACE_TELEGRAM: Final[str] = "telegram"
-SURFACE_DISCORD: Final[str] = "discord"
-CANONICAL_SURFACES: Final[frozenset[str]] = frozenset(
-    {SURFACE_CLI, SURFACE_SLACK, SURFACE_TELEGRAM, SURFACE_DISCORD}
-)
+
+class UsageSurface(StrEnum):
+    """Canonical usage channel stamped onto analytics events."""
+
+    CLI = "cli"
+    SLACK = "slack"
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+
+
+CANONICAL_SURFACES: Final[frozenset[UsageSurface]] = frozenset(UsageSurface)
 ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
 
 _SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -117,10 +117,10 @@ def _start_background_investigation(
     session.terminal.background_investigations[task.task_id] = record
 
     def _worker() -> None:
-        from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
+        from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
         with bound_usage_context(
-            surface=SURFACE_CLI,
+            surface=UsageSurface.CLI,
             session_id=session.session_id,
         ):
             try:

--- a/surfaces/interactive_shell/runtime/startup/initial_input.py
+++ b/surfaces/interactive_shell/runtime/startup/initial_input.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 
 from platform.analytics.repl_context import bound_repl_turn_context
-from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
+from platform.analytics.usage_context import UsageSurface, bound_usage_context
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.banner import render_ready_box, render_splash
 from surfaces.interactive_shell.ui.input_prompt.rendering import render_submitted_prompt
@@ -40,7 +40,7 @@ def run_initial_input(
         recorder = PromptRecorder.start(session=session, text=stripped, turn_kind=_TURN_KIND)
         with (
             bound_usage_context(
-                surface=SURFACE_CLI,
+                surface=UsageSurface.CLI,
                 session_id=session.session_id,
             ),
             bound_repl_turn_context(

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
 
 from platform.analytics.repl_context import bound_repl_turn_context
-from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
+from platform.analytics.usage_context import UsageSurface, bound_usage_context
 from platform.observability.trace.spans import bind_session_trace, emit_thread_boundary
 from surfaces.interactive_shell.runtime.agent_presentation import (
     AgentEvent,
@@ -177,7 +177,7 @@ async def _run_agent_turn_loop(
 
         with (
             bound_usage_context(
-                surface=SURFACE_CLI,
+                surface=UsageSurface.CLI,
                 session_id=runtime.session.session_id,
             ),
             bound_repl_turn_context(

--- a/tests/analytics/test_usage_context.py
+++ b/tests/analytics/test_usage_context.py
@@ -12,8 +12,7 @@ from platform.analytics.events import Event
 from platform.analytics.repl_context import bound_repl_turn_context
 from platform.analytics.usage_context import (
     ORGANIZATION_GROUP_TYPE,
-    SURFACE_CLI,
-    SURFACE_SLACK,
+    UsageSurface,
     bound_usage_context,
     build_usage_enrichment,
     merge_usage_enrichment,
@@ -69,17 +68,31 @@ def _stub_httpx_client(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object
     return posted_payloads
 
 
+def test_usage_surface_members_and_string_round_trip() -> None:
+    from platform.analytics.usage_context import CANONICAL_SURFACES, UsageSurface
+
+    assert set(UsageSurface) == {
+        UsageSurface.CLI,
+        UsageSurface.SLACK,
+        UsageSurface.TELEGRAM,
+        UsageSurface.DISCORD,
+    }
+    assert frozenset(UsageSurface) == CANONICAL_SURFACES
+    assert UsageSurface("slack") is UsageSurface.SLACK
+    assert UsageSurface.SLACK == "slack"
+
+
 def test_build_usage_enrichment_from_context_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_abc")
     with bound_usage_context(
-        surface=SURFACE_SLACK,
+        surface=UsageSurface.SLACK,
         session_id="sess-1",
         user_id="U123",
     ):
         props = build_usage_enrichment()
     assert props["organization_id"] == "org_abc"
     assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_abc"}
-    assert props["surface"] == SURFACE_SLACK
+    assert props["surface"] == UsageSurface.SLACK
     assert props["session_id"] == "sess-1"
     assert props["user_id"] == "U123"
 
@@ -92,7 +105,7 @@ def test_session_id_falls_back_to_cli_session() -> None:
 
 def test_merge_usage_enrichment_caller_wins(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_env")
-    with bound_usage_context(surface=SURFACE_CLI, organization_id="org_ctx"):
+    with bound_usage_context(surface=UsageSurface.CLI, organization_id="org_ctx"):
         merged = merge_usage_enrichment({"organization_id": "org_caller", "surface": "cli"})
     assert merged["organization_id"] == "org_caller"
     assert merged["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_caller"}
@@ -106,7 +119,7 @@ def test_capture_stamps_org_groups_and_emits_groupidentify(
     monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_prod")
 
     analytics = provider.Analytics()
-    with bound_usage_context(surface=SURFACE_CLI, session_id="s1"):
+    with bound_usage_context(surface=UsageSurface.CLI, session_id="s1"):
         analytics.capture(Event.CLI_INVOKED, {"entrypoint": "opensre"})
     analytics.shutdown(flush=True)
 
@@ -125,7 +138,7 @@ def test_capture_stamps_org_groups_and_emits_groupidentify(
     props = capture_payload["properties"]
     assert props["organization_id"] == "org_prod"
     assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_prod"}
-    assert props["surface"] == SURFACE_CLI
+    assert props["surface"] == UsageSurface.CLI
     assert props["session_id"] == "s1"
 
 
@@ -183,7 +196,7 @@ def test_process_session_id_stamps_cli_investigate_without_repl(
     props = started["properties"]
     assert props["organization_id"] == "org_cli"
     assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_cli"}
-    assert props["surface"] == SURFACE_CLI
+    assert props["surface"] == UsageSurface.CLI
     assert props["session_id"] == process_session
 
 
@@ -198,7 +211,7 @@ def test_track_investigation_binds_session_from_session_object(
     analytics = provider.Analytics()
     monkeypatch.setattr(provider, "_instance", analytics)
     monkeypatch.setattr(analytics_cli, "get_analytics", lambda: analytics)
-    analytics.set_persistent_property("surface", SURFACE_CLI)
+    analytics.set_persistent_property("surface", UsageSurface.CLI)
 
     class _Session:
         session_id = "repl-session-123"
@@ -216,5 +229,5 @@ def test_track_investigation_binds_session_from_session_object(
         p["json"] for p in posted if p["json"]["event"] == Event.INVESTIGATION_STARTED.value
     )
     assert started["properties"]["session_id"] == "repl-session-123"
-    assert started["properties"]["surface"] == SURFACE_CLI
+    assert started["properties"]["surface"] == UsageSurface.CLI
     assert started["properties"]["organization_id"] == "org_repl"

--- a/tests/core/domain/memory/test_memory_store.py
+++ b/tests/core/domain/memory/test_memory_store.py
@@ -226,9 +226,9 @@ class TestSettings:
     def test_gateway_surfaces_require_opt_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from config.constants import OPENSRE_MEMORY_GATEWAY_ENABLED_ENV
         from core.domain.memory import gateway_memory_enabled, memory_available_here
-        from platform.analytics.usage_context import SURFACE_SLACK, bound_usage_context
+        from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
-        with bound_usage_context(surface=SURFACE_SLACK):
+        with bound_usage_context(surface=UsageSurface.SLACK):
             assert memory_enabled() is True
             assert gateway_memory_enabled() is False
             assert memory_available_here() is False


### PR DESCRIPTION
Fixes #4521

## Summary
- Introduce `UsageSurface` StrEnum in `platform/analytics/usage_context.py` with the same string values as today (`cli`, `slack`, `telegram`, `discord`).
- Derive `CANONICAL_SURFACES` from the enum and migrate all consumers from `SURFACE_*` constants to `UsageSurface` members.
- Add a unit test pinning enum members and string round-trip compatibility.

## Test plan
- [x] `uv run python -m pytest tests/analytics/test_usage_context.py gateway/tests/runtime/test_turn_handler.py tests/core/domain/memory/test_memory_store.py -q`
- [x] `make lint`
- [x] `make typecheck`

## Code Understanding and AI Usage
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project coding standards and conventions

**Explain your implementation approach:**
The analytics package already uses StrEnums for related vocabularies (`EntrypointSource`, `TriggerMode`). This change moves surface stamps onto the same pattern: one enum owns the canonical values, `CANONICAL_SURFACES` is derived from it, and call sites bind `UsageSurface` members instead of hand-maintained `Final[str]` constants. StrEnum keeps persisted/stamped values as plain strings, so existing equality checks and gateway validation continue to work.
