### PR TITLE
docs(ci): stop directing agents to run make test-scope

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -70,24 +70,18 @@ Run all of these first:
 
 ## 2) Mandatory test harness (scope by touched modules)
 
-**Recommended — run this instead of manually looking up the table below:**
+Pick a focused test command for the modules you changed — do **not** default to
+the full unit suite.
 
-```bash
-make test-scope
-```
+Map changed paths to targets using the `PathRule` entries in
+[`.github/ci/test_scope_rules.py`](.github/ci/test_scope_rules.py):
 
-`make test-scope` reads `git diff` against `main`, maps each changed path to
-its test target(s) using [`.github/ci/test_scope_rules.py`](.github/ci/test_scope_rules.py),
-and runs the minimal `pytest` invocation. It escalates automatically to
-`make test-cov` when shared/core code is touched or 3+ app areas change.
-Pass `ARGS=--dry-run` to preview without running.
+- Rules with `always_escalate=True` map to `make test-cov`
+- All other rules list a `test_targets` tuple — run those with
+  `uv run python -m pytest <targets>`
+- Changed files under `tests/` with no app rule run as-is
 
-### Manual lookup (reference only)
-
-If you prefer to pick the command yourself, or need a focused `-k` filter,
-see the `PathRule` entries in [`.github/ci/test_scope_rules.py`](.github/ci/test_scope_rules.py).
-Rules with `always_escalate=True` map to `make test-cov`; all others list their
-`test_targets` tuple. Changed files under `tests/` with no app rule run as-is.
+Use a focused `-k` filter when you only need a subset of a package.
 
 ## 3) Escalation rules (must run full unit CI suite)
 


### PR DESCRIPTION
Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Stop telling agents (via `CI.md` §2) to run `make test-scope` as the default pre-push test harness.

- Agents now map changed paths with `.github/ci/test_scope_rules.py` and run focused `pytest` targets
- Escalation to `make test-cov` remains explicit in §3 (shared/core, 3+ areas, unclear blast radius, etc.)
- `make test-scope` is unchanged and still available as a local convenience wrapper

Docs/process-only change — no runtime code.

### Demo/Screenshot for feature changes and bug fixes - 

N/A — documentation-only change to agent pre-push guidance in `CI.md`. No UI or runtime behavior.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`make test-scope` auto-escalates to the full unit suite (`make test-cov`) when shared paths or 3+ app areas change. That is fine as a human convenience, but as the default agent instruction it often burned a full suite run when a focused pytest was enough.

Approach:
1. Keep `test_scope_rules.py` as the source of truth for path → test targets
2. Instruct agents to look up rules and run `uv run python -m pytest <targets>`
3. Keep §3 escalation rules for when full `make test-cov` is still required
4. Do not remove or change the Make target / runner scripts

Alternatives considered:
- Leave `make test-scope` as recommended — rejected; agents over-ran full suite
- Delete `make test-scope` entirely — out of scope; humans may still want the wrapper

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
