### PR TITLE
feat(filestorage): warn when the target bucket is publicly readable

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -232,7 +232,9 @@ Minimum permissions on the prefix you use:
 s3:ListBucket, s3:GetObject, s3:PutObject
 ```
 
-`s3:DeleteObject` is not needed — sync never deletes anything.
+`s3:DeleteObject` is not needed — sync never deletes anything. Add
+`s3:GetBucketPolicyStatus` (bucket-level, not prefix-scoped) so `status` can
+warn you if the bucket is publicly readable — see [The store](#the-store).
 
 ### Google Cloud Storage
 
@@ -255,6 +257,10 @@ opensre never deletes anything, but GCS still requires `storage.objects.delete`
 to **replace** an existing object — without it the first changed session or
 memory file fails with a 403. Objects are encrypted at rest by default; there
 is nothing to configure.
+
+Add `storage.buckets.getIamPolicy` (bucket-level) so `status` can warn you if
+the bucket is publicly readable — see [The store](#the-store). Without it,
+`status` shows "could not confirm it is private" instead of failing.
 
 ### Vercel Blob
 
@@ -287,6 +293,14 @@ Keep the store private. It holds your incident conversations and everything
 opensre has remembered about your systems. Prefer a private S3 bucket or a
 private Vercel Blob store — never a public one.
 </Warning>
+
+On AWS and GCS, `status` checks this for you: if the bucket policy (S3) or
+bucket IAM policy (GCS) makes the bucket publicly readable, `opensre
+remote-sync status` / `/remote-sync status` opens with a warning instead of
+silently mirroring your history into it. Without the permission the check
+needs — or on Vercel, which has no bucket-level public/private setting to
+check — `status` shows "could not confirm it is private" instead of failing;
+it never blocks the rest of the command.
 
 ## How conflicts resolve
 

--- a/platform/filestorage/__init__.py
+++ b/platform/filestorage/__init__.py
@@ -33,6 +33,7 @@ from platform.filestorage.engine import (
     run_sync,
 )
 from platform.filestorage.enums import (
+    BucketExposure,
     BuiltInProvider,
     RemoteSyncSubcommand,
     SyncDirection,
@@ -50,10 +51,12 @@ from platform.filestorage.exclusions import (
     ExclusionRules,
     parse_exclusions,
 )
+from platform.filestorage.exposure import PublicAccessStatus
 from platform.filestorage.messages import (
     DISABLED_HELP,
     NO_EXCLUSIONS_HELP,
     format_exclusion_lines,
+    format_exposure_line,
     format_report_lines,
     format_status_lines,
     root_state,
@@ -65,15 +68,18 @@ from platform.filestorage.operations import (
     run_remote_sync,
 )
 from platform.filestorage.ports import ObjectStore, RemoteObject
-from platform.filestorage.providers import build_object_store
+from platform.filestorage.providers import build_object_store, check_bucket_exposure
 from platform.filestorage.syncable import SyncRoot, is_syncable, resolved_roots, syncable_roots
 
 __all__ = [
     "NO_EXCLUSIONS",
     "NO_EXCLUSIONS_HELP",
+    "BucketExposure",
     "ExclusionRules",
     "OrgScopeNotSupportedError",
+    "PublicAccessStatus",
     "format_exclusion_lines",
+    "format_exposure_line",
     "format_status_lines",
     "format_report_lines",
     "DISABLED_HELP",
@@ -93,6 +99,7 @@ __all__ = [
     "SyncStatus",
     "UnsyncablePathError",
     "build_object_store",
+    "check_bucket_exposure",
     "get_sync_status",
     "is_syncable",
     "load_remote_sync_config",

--- a/platform/filestorage/enums.py
+++ b/platform/filestorage/enums.py
@@ -59,7 +59,22 @@ class RemoteSyncField(StrEnum):
     PROFILE = "profile"
 
 
+class BucketExposure(StrEnum):
+    """Whether a store is readable by anyone on the internet.
+
+    ``UNKNOWN`` covers every reason the question could not be answered — no
+    checker registered for the provider, a missing permission, or an
+    unreachable store — so a caller never has to distinguish those from a
+    definitive answer (see :mod:`platform.filestorage.exposure`).
+    """
+
+    PRIVATE = "private"
+    PUBLIC = "public"
+    UNKNOWN = "unknown"
+
+
 __all__ = [
+    "BucketExposure",
     "BuiltInProvider",
     "RemoteSyncField",
     "RemoteSyncSubcommand",

--- a/platform/filestorage/exposure.py
+++ b/platform/filestorage/exposure.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.enums import BucketExposure
 
 
@@ -36,7 +37,13 @@ class PublicAccessStatus:
     detail: str = ""
 
 
-PublicAccessChecker = Callable[["RemoteSyncConfig"], PublicAccessStatus]
+# A plain (non-``TYPE_CHECKING``, unquoted) import: ``RemoteSyncConfig`` is only
+# ever referenced here, inside a runtime expression, not an annotation position
+# — a quoted forward reference under ``TYPE_CHECKING`` type-checks fine but
+# reads as an unused import to a linter that doesn't parse type strings inside
+# a bare ``Callable[[...]]`` subscript. ``config.py`` doesn't import this
+# module, so there is no cycle to guard against.
+PublicAccessChecker = Callable[[RemoteSyncConfig], PublicAccessStatus]
 
 
 def not_checked(provider: str) -> PublicAccessStatus:

--- a/platform/filestorage/exposure.py
+++ b/platform/filestorage/exposure.py
@@ -1,0 +1,53 @@
+"""Whether the configured store is publicly readable — an optional provider capability.
+
+Kept apart from :mod:`platform.filestorage.ports` on purpose: the engine's
+``ObjectStore`` protocol stays at its four operations for every backend.
+Answering "can anyone on the internet read this?" needs vendor-specific APIs
+(S3's ``GetBucketPolicyStatus`` today) that most providers, and every
+community backend, will never implement — so a provider opts in by
+registering a checker (see
+:func:`platform.filestorage.providers.registry.register_object_store`)
+instead of the protocol growing a fifth method every backend must satisfy.
+
+A checker is never load-bearing: it degrades to
+:class:`~platform.filestorage.enums.BucketExposure.UNKNOWN` rather than
+raising, so a stalled or denied exposure check never blocks ``status`` or
+``setup`` — only ``PUBLIC`` is worth interrupting anyone's day for.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from platform.filestorage.enums import BucketExposure
+
+if TYPE_CHECKING:
+    from platform.filestorage.config import RemoteSyncConfig
+
+
+@dataclass(frozen=True)
+class PublicAccessStatus:
+    """Best-effort answer to "is this store publicly readable?"
+
+    ``detail`` is empty for a definitive ``PRIVATE``/``PUBLIC`` result and
+    carries a short, operator-facing reason whenever ``exposure`` is
+    ``UNKNOWN``.
+    """
+
+    exposure: BucketExposure
+    detail: str = ""
+
+
+PublicAccessChecker = Callable[["RemoteSyncConfig"], PublicAccessStatus]
+
+
+def not_checked(provider: str) -> PublicAccessStatus:
+    """Result for a provider that has not registered an exposure checker."""
+    return PublicAccessStatus(
+        BucketExposure.UNKNOWN, f"public-access check not implemented for provider {provider!r}"
+    )
+
+
+__all__ = ["PublicAccessChecker", "PublicAccessStatus", "not_checked"]

--- a/platform/filestorage/exposure.py
+++ b/platform/filestorage/exposure.py
@@ -19,12 +19,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from platform.filestorage.enums import BucketExposure
-
-if TYPE_CHECKING:
-    from platform.filestorage.config import RemoteSyncConfig
 
 
 @dataclass(frozen=True)

--- a/platform/filestorage/messages.py
+++ b/platform/filestorage/messages.py
@@ -19,8 +19,9 @@ from config.constants.filestorage import (
 )
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.engine import SyncReport
-from platform.filestorage.enums import SyncDirection
+from platform.filestorage.enums import BucketExposure, SyncDirection
 from platform.filestorage.exclusions import ExclusionRules
+from platform.filestorage.exposure import PublicAccessStatus
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
 from platform.filestorage.providers import credential_hint_for_provider
 from platform.filestorage.providers.registry import builtin_providers
@@ -108,6 +109,24 @@ def format_exclusion_lines(exclusions: ExclusionRules) -> tuple[str, ...]:
     return ("Excluded by your settings:", *(f"  {pattern}" for pattern in exclusions.patterns))
 
 
+def format_exposure_line(exposure: PublicAccessStatus) -> str:
+    """One line on whether the store is publicly readable.
+
+    Kept a single loud sentence for ``PUBLIC`` — the one exposure state
+    worth an operator stopping to read — and a short, easy-to-skim line
+    otherwise.
+    """
+    if exposure.exposure is BucketExposure.PUBLIC:
+        return (
+            "WARNING: this store is publicly readable. Anyone on the internet can read "
+            "your synced sessions and memory — restrict its access now."
+        )
+    if exposure.exposure is BucketExposure.PRIVATE:
+        return "Bucket access: private."
+    detail = f" ({exposure.detail})" if exposure.detail else ""
+    return f"Bucket access: could not confirm it is private{detail}."
+
+
 def format_status_lines(status: SyncStatus) -> tuple[str, ...]:
     """Plain-text status lines for CLI, REPL, or gateway sinks (pure)."""
     if not status.enabled or status.config is None:
@@ -115,8 +134,10 @@ def format_status_lines(status: SyncStatus) -> tuple[str, ...]:
     cfg = status.config
     lines: list[str] = [
         f"Remote sync is on ({cfg.provider}) → {cfg.bucket}/{cfg.prefix}",
-        "Mirrored:",
     ]
+    if status.exposure is not None:
+        lines.append(format_exposure_line(status.exposure))
+    lines.append("Mirrored:")
     for root in status.roots:
         lines.append(f"  {root.name:<10} {root.path} ({root_state(root)})")
     lines.extend(format_exclusion_lines(status.exclusions))
@@ -181,6 +202,7 @@ __all__ = [
     "SETUP_DISABLED_CONFIRM",
     "direction_label",
     "format_exclusion_lines",
+    "format_exposure_line",
     "format_report_lines",
     "format_setup_lines",
     "format_status_lines",

--- a/platform/filestorage/operations.py
+++ b/platform/filestorage/operations.py
@@ -34,7 +34,8 @@ from platform.filestorage.engine import (
 from platform.filestorage.enums import SyncDirection, SyncRootName
 from platform.filestorage.errors import OrgScopeNotSupportedError
 from platform.filestorage.exclusions import NO_EXCLUSIONS, ExclusionRules
-from platform.filestorage.providers import build_object_store
+from platform.filestorage.exposure import PublicAccessStatus
+from platform.filestorage.providers import build_object_store, check_bucket_exposure
 from platform.filestorage.syncable import SyncRoot, syncable_roots
 
 
@@ -55,10 +56,17 @@ class SyncRootStatus:
 
 @dataclass(frozen=True)
 class SyncStatus:
-    """Whether sync is on and what would move — shared across all surfaces."""
+    """Whether sync is on and what would move — shared across all surfaces.
+
+    ``exposure`` is ``None`` when sync is off (nothing to check) and a
+    :class:`~platform.filestorage.exposure.PublicAccessStatus` otherwise —
+    always present, since :func:`~platform.filestorage.providers.check_bucket_exposure`
+    itself degrades to ``UNKNOWN`` instead of raising.
+    """
 
     config: RemoteSyncConfig | None
     roots: tuple[SyncRootStatus, ...]
+    exposure: PublicAccessStatus | None = None
 
     @property
     def enabled(self) -> bool:
@@ -118,12 +126,18 @@ def _root_status(root: SyncRoot, exclusions: ExclusionRules) -> SyncRootStatus:
 
 
 def get_sync_status() -> SyncStatus:
-    """Load config and resolve scoped roots (no network, no cached state)."""
+    """Load config, resolve scoped roots, and check whether the store is public.
+
+    The exposure check is the one network call this makes — only when sync
+    is on, and only if the provider registered a checker; see
+    :func:`~platform.filestorage.providers.check_bucket_exposure`.
+    """
     _refuse_org_scoped_turn()
     config = load_remote_sync_config()
     exclusions = config.exclude if config is not None else NO_EXCLUSIONS
     roots = tuple(_root_status(root, exclusions) for root in syncable_roots())
-    return SyncStatus(config=config, roots=roots)
+    exposure = check_bucket_exposure(config) if config is not None else None
+    return SyncStatus(config=config, roots=roots, exposure=exposure)
 
 
 def run_remote_sync(

--- a/platform/filestorage/providers/__init__.py
+++ b/platform/filestorage/providers/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from platform.filestorage.providers.registry import (
     SetupExtraField,
     build_object_store,
+    check_bucket_exposure,
     credential_hint_for_provider,
     provider_extra_fields,
     register_object_store,
@@ -20,6 +21,7 @@ from platform.filestorage.providers.registry import (
 __all__ = [
     "SetupExtraField",
     "build_object_store",
+    "check_bucket_exposure",
     "credential_hint_for_provider",
     "provider_extra_fields",
     "register_object_store",

--- a/platform/filestorage/providers/aws.py
+++ b/platform/filestorage/providers/aws.py
@@ -8,8 +8,9 @@ import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.enums import BuiltInProvider, RemoteSyncField
+from platform.filestorage.enums import BucketExposure, BuiltInProvider, RemoteSyncField
 from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.exposure import PublicAccessStatus
 from platform.filestorage.ports import RemoteObject
 from platform.filestorage.providers.registry import SetupExtraField, register_object_store
 
@@ -112,8 +113,55 @@ def _factory(config: RemoteSyncConfig) -> S3ObjectStore:
     return S3ObjectStore(config)
 
 
+def check_public_access(
+    config: RemoteSyncConfig, *, client: Any | None = None
+) -> PublicAccessStatus:
+    """Ask S3 whether ``config.bucket`` is publicly readable.
+
+    Uses ``s3:GetBucketPolicyStatus``, so the result reflects only the bucket
+    policy (plus account/bucket Block Public Access settings, which factor
+    into ``IsPublic``), not object or bucket ACLs.
+
+    Degrades to :class:`~platform.filestorage.enums.BucketExposure.UNKNOWN`
+    rather than raising: the permission can be missing on an otherwise
+    perfectly usable bucket, and this check must never stand in the way of
+    ``status`` or ``setup`` reporting the rest of what they know. ``detail``
+    never carries the raw exception text for any failure but the permission
+    gap — this result can be echoed straight into a gateway chat surface (see
+    ``format_status_lines``), and an S3 error message is not vetted for that
+    (CWE-209).
+    """
+    try:
+        s3 = client if client is not None else _build_client(config)
+        response = s3.get_bucket_policy_status(Bucket=config.bucket)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "AccessDenied":
+            return PublicAccessStatus(
+                BucketExposure.UNKNOWN, "missing the s3:GetBucketPolicyStatus permission"
+            )
+        if code == "NoSuchBucketPolicy":
+            # No policy means nothing grants public access through one.
+            return PublicAccessStatus(BucketExposure.PRIVATE)
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    except (BotoCoreError, ValueError, RemoteSyncUnavailableError) as exc:
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    is_public = bool(response.get("PolicyStatus", {}).get("IsPublic", False))
+    return PublicAccessStatus(BucketExposure.PUBLIC if is_public else BucketExposure.PRIVATE)
+
+
 register_object_store(
-    PROVIDER_NAME, _factory, credential_hint=CREDENTIAL_HINT, extra_fields=EXTRA_FIELDS
+    PROVIDER_NAME,
+    _factory,
+    credential_hint=CREDENTIAL_HINT,
+    extra_fields=EXTRA_FIELDS,
+    public_access_checker=check_public_access,
 )
 
-__all__ = ["CREDENTIAL_HINT", "EXTRA_FIELDS", "PROVIDER_NAME", "S3ObjectStore"]
+__all__ = [
+    "CREDENTIAL_HINT",
+    "EXTRA_FIELDS",
+    "PROVIDER_NAME",
+    "S3ObjectStore",
+    "check_public_access",
+]

--- a/platform/filestorage/providers/gcs.py
+++ b/platform/filestorage/providers/gcs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import binascii
 from datetime import datetime
+from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -19,8 +20,9 @@ from google.auth.exceptions import GoogleAuthError
 from google.auth.transport.requests import AuthorizedSession
 
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.enums import BuiltInProvider
+from platform.filestorage.enums import BucketExposure, BuiltInProvider
 from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.exposure import PublicAccessStatus
 from platform.filestorage.ports import RemoteObject
 from platform.filestorage.providers.registry import register_object_store
 
@@ -36,6 +38,25 @@ _UPLOAD_BASE = "https://storage.googleapis.com/upload/storage/v1"
 _SCOPE = "https://www.googleapis.com/auth/devstorage.read_write"
 _LIST_FIELDS = "items(name,size,updated,md5Hash),nextPageToken"
 _TIMEOUT = 30.0
+
+#: Anyone (``allUsers``) or anyone with a Google account (``allAuthenticatedUsers``)
+#: — GCS's two "not actually scoped to you" bucket-IAM members. Mirrors treating an
+#: S3 bucket policy grant to any AWS principal as public, not just literally anyone.
+_PUBLIC_MEMBERS = frozenset({"allUsers", "allAuthenticatedUsers"})
+#: Bucket-IAM roles that can read object contents; a grant of one of these to a
+#: member in ``_PUBLIC_MEMBERS`` is what "publicly readable" means here. Roles
+#: that only grant write (``objectCreator``) or delete are not exposure for a
+#: read warning.
+_READ_CAPABLE_ROLES = frozenset(
+    {
+        "roles/storage.objectViewer",
+        "roles/storage.legacyObjectReader",
+        "roles/storage.legacyBucketReader",
+        "roles/viewer",
+        "roles/editor",
+        "roles/owner",
+    }
+)
 
 
 class GCSObjectStore:
@@ -194,6 +215,63 @@ def _factory(config: RemoteSyncConfig) -> GCSObjectStore:
     return GCSObjectStore(config)
 
 
-register_object_store(PROVIDER_NAME, _factory, credential_hint=CREDENTIAL_HINT)
+def check_public_access(
+    config: RemoteSyncConfig, *, session: Any | None = None
+) -> PublicAccessStatus:
+    """Ask GCS whether ``config.bucket`` is publicly readable.
 
-__all__ = ["CREDENTIAL_HINT", "PROVIDER_NAME", "GCSObjectStore"]
+    Uses ``storage.buckets.getIamPolicy`` to look for a read-capable role
+    (``_READ_CAPABLE_ROLES``) granted to ``allUsers`` or
+    ``allAuthenticatedUsers`` — GCS's bucket-level equivalent of an S3 bucket
+    policy. Object-level ACLs on individual objects are not inspected, the
+    same scope limitation :func:`platform.filestorage.providers.aws.check_public_access`
+    documents for S3 bucket policies.
+
+    Degrades to :class:`~platform.filestorage.enums.BucketExposure.UNKNOWN`
+    rather than raising: a missing permission (or an OAuth scope narrower
+    than IAM policy reads require) must never stand in the way of ``status``
+    or ``setup`` reporting the rest of what they know. ``detail`` never
+    carries the raw GCS error body — this result can be echoed straight into
+    a gateway chat surface (see ``format_status_lines``), and that text is
+    not vetted for that (CWE-209).
+    """
+    try:
+        sess = session if session is not None else _build_session()
+        response = sess.get(f"{_API_BASE}/b/{config.bucket}/iam", timeout=_TIMEOUT)
+        response.raise_for_status()
+        payload = response.json()
+    except requests.HTTPError as exc:
+        code = exc.response.status_code if exc.response is not None else None
+        if code == HTTPStatus.FORBIDDEN:
+            return PublicAccessStatus(
+                BucketExposure.UNKNOWN, "missing permission to read the bucket's IAM policy"
+            )
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    except (
+        requests.RequestException,
+        GoogleAuthError,
+        RemoteSyncUnavailableError,
+        ValueError,
+    ) as exc:
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    if not isinstance(payload, dict):
+        return PublicAccessStatus(BucketExposure.UNKNOWN, "malformed IAM policy response")
+    bindings = payload.get("bindings", [])
+    is_public = isinstance(bindings, list) and any(
+        isinstance(binding, dict)
+        and binding.get("role") in _READ_CAPABLE_ROLES
+        and isinstance(binding.get("members"), list)
+        and not _PUBLIC_MEMBERS.isdisjoint(binding["members"])
+        for binding in bindings
+    )
+    return PublicAccessStatus(BucketExposure.PUBLIC if is_public else BucketExposure.PRIVATE)
+
+
+register_object_store(
+    PROVIDER_NAME,
+    _factory,
+    credential_hint=CREDENTIAL_HINT,
+    public_access_checker=check_public_access,
+)
+
+__all__ = ["CREDENTIAL_HINT", "PROVIDER_NAME", "GCSObjectStore", "check_public_access"]

--- a/platform/filestorage/providers/registry.py
+++ b/platform/filestorage/providers/registry.py
@@ -20,8 +20,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from platform.filestorage.enums import BuiltInProvider, RemoteSyncField
+from platform.filestorage.enums import BucketExposure, BuiltInProvider, RemoteSyncField
 from platform.filestorage.errors import RemoteSyncConfigError
+from platform.filestorage.exposure import PublicAccessChecker, PublicAccessStatus, not_checked
 
 if TYPE_CHECKING:
     from platform.filestorage.config import RemoteSyncConfig
@@ -55,6 +56,7 @@ class SetupExtraField:
 _REGISTRY: dict[str, ObjectStoreFactory] = {}
 _CREDENTIAL_HINTS: dict[str, str] = {}
 _EXTRA_FIELDS: dict[str, tuple[SetupExtraField, ...]] = {}
+_PUBLIC_ACCESS_CHECKERS: dict[str, PublicAccessChecker] = {}
 _REGISTRY_LOCK = threading.RLock()
 
 # Built-in backends, imported on first use so this package never imports itself.
@@ -80,6 +82,7 @@ def register_object_store(
     *,
     credential_hint: str | None = None,
     extra_fields: tuple[SetupExtraField, ...] = (),
+    public_access_checker: PublicAccessChecker | None = None,
 ) -> None:
     """Bind ``name`` (the value of ``OPENSRE_REMOTE_SYNC_PROVIDER``) to a factory.
 
@@ -91,6 +94,11 @@ def register_object_store(
     ``extra_fields`` declares which of ``RemoteSyncConfig``'s ``region``/
     ``profile`` slots this provider consumes (see :func:`provider_extra_fields`).
     Omit it — as most providers do — when the provider needs neither.
+
+    ``public_access_checker`` answers whether the store is publicly readable
+    (see :func:`check_bucket_exposure`). Omit it when the provider has no way
+    to ask — ``status`` then reports the exposure as unchecked rather than
+    guessing.
     """
     key = name.strip().lower()
     if not key:
@@ -100,6 +108,8 @@ def register_object_store(
         if credential_hint is not None:
             _CREDENTIAL_HINTS[key] = credential_hint
         _EXTRA_FIELDS[key] = extra_fields
+        if public_access_checker is not None:
+            _PUBLIC_ACCESS_CHECKERS[key] = public_access_checker
 
 
 def unregister_object_store(name: str) -> None:
@@ -109,6 +119,7 @@ def unregister_object_store(name: str) -> None:
         _REGISTRY.pop(key, None)
         _CREDENTIAL_HINTS.pop(key, None)
         _EXTRA_FIELDS.pop(key, None)
+        _PUBLIC_ACCESS_CHECKERS.pop(key, None)
 
 
 def registered_providers() -> tuple[str, ...]:
@@ -156,6 +167,35 @@ def credential_hint_for_provider(provider: str) -> str:
     return hint if hint is not None else _DEFAULT_CREDENTIAL_HINT
 
 
+def check_bucket_exposure(config: RemoteSyncConfig) -> PublicAccessStatus:
+    """Ask ``config.provider`` whether ``config.bucket`` is publicly readable.
+
+    Loads a not-yet-imported built-in module first, same as
+    :func:`credential_hint_for_provider`. A provider with no registered
+    checker resolves to :func:`~platform.filestorage.exposure.not_checked`.
+
+    Never raises: a checker is community-authored code as far as this
+    registry is concerned, and an exposure check is a best-effort courtesy on
+    top of ``status``/``setup``, not something either command should fail
+    for. An unexpected exception degrades to ``UNKNOWN`` with only the
+    exception's type named — not its message, which could carry provider
+    internals — matching the same failure the checker itself is asked to
+    report for a merely unreachable store.
+    """
+    key = config.provider.strip().lower()
+    with _REGISTRY_LOCK:
+        _load_builtin(key)
+        checker = _PUBLIC_ACCESS_CHECKERS.get(key)
+    if checker is None:
+        return not_checked(config.provider)
+    try:
+        return checker(config)
+    except Exception as exc:  # noqa: BLE001 - see docstring: a checker must never fail status/setup
+        return PublicAccessStatus(
+            BucketExposure.UNKNOWN, f"exposure check raised {type(exc).__name__}"
+        )
+
+
 def provider_extra_fields(provider: str) -> tuple[SetupExtraField, ...]:
     """``region``/``profile`` fields ``provider`` declared, or ``()`` for neither.
 
@@ -176,6 +216,7 @@ __all__ = [
     "SetupExtraField",
     "build_object_store",
     "builtin_providers",
+    "check_bucket_exposure",
     "credential_hint_for_provider",
     "provider_extra_fields",
     "register_object_store",

--- a/platform/filestorage/providers/registry.py
+++ b/platform/filestorage/providers/registry.py
@@ -108,7 +108,9 @@ def register_object_store(
         if credential_hint is not None:
             _CREDENTIAL_HINTS[key] = credential_hint
         _EXTRA_FIELDS[key] = extra_fields
-        if public_access_checker is not None:
+        if public_access_checker is None:
+            _PUBLIC_ACCESS_CHECKERS.pop(key, None)
+        else:
             _PUBLIC_ACCESS_CHECKERS[key] = public_access_checker
 
 

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -14,11 +14,12 @@ from config.constants.filestorage import (
 )
 from platform.filestorage import OrgScopeNotSupportedError, RemoteSyncError
 from platform.filestorage.engine import SyncProgress
-from platform.filestorage.enums import RemoteSyncSubcommand, SyncDirection
+from platform.filestorage.enums import BucketExposure, RemoteSyncSubcommand, SyncDirection
 from platform.filestorage.messages import (
     DISABLED_HELP,
     direction_label,
     format_exclusion_lines,
+    format_exposure_line,
     format_report_lines,
     format_setup_lines,
     root_state,
@@ -57,6 +58,9 @@ def _print_status(console: Console) -> bool:
         return True
     cfg = status.config
     console.print(f"Remote sync is on ({cfg.provider}) → [{HIGHLIGHT}]{cfg.bucket}/{cfg.prefix}[/]")
+    if status.exposure is not None:
+        style = ERROR if status.exposure.exposure is BucketExposure.PUBLIC else DIM
+        console.print(f"[{style}]{escape(format_exposure_line(status.exposure))}[/]")
     for root in status.roots:
         console.print(f"  {root.name:<10} {root.path} [{DIM}]({root_state(root)})[/]")
     for line in format_exclusion_lines(status.exclusions):

--- a/tests/filestorage/test_bucket_exposure.py
+++ b/tests/filestorage/test_bucket_exposure.py
@@ -91,12 +91,12 @@ def test_transport_failure_degrades_to_unknown() -> None:
 
 def test_client_build_failure_degrades_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     """Even a totally unreachable AWS session must not raise out of the checker."""
-    import platform.filestorage.providers.aws as aws_module
+    from platform.filestorage.providers.aws import RemoteSyncUnavailableError
 
     def _raise_client(_config: RemoteSyncConfig) -> object:
-        raise aws_module.RemoteSyncUnavailableError("cannot build an S3 client — boom")
+        raise RemoteSyncUnavailableError("cannot build an S3 client — boom")
 
-    monkeypatch.setattr(aws_module, "_build_client", _raise_client)
+    monkeypatch.setattr("platform.filestorage.providers.aws._build_client", _raise_client)
     result = aws_check_public_access(RemoteSyncConfig(bucket="b"))
     assert result.exposure is BucketExposure.UNKNOWN
 
@@ -253,6 +253,30 @@ def test_unregister_drops_the_checker_too() -> None:
     unregister_object_store("exposure-toggle")
     result = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="exposure-toggle"))
     assert result.exposure is BucketExposure.UNKNOWN
+
+
+def test_replacing_a_provider_without_a_checker_clears_the_old_one() -> None:
+    """A stale checker must never survive a factory swap under the same name.
+
+    If it did, ``status`` would query a completely unrelated cloud API (the
+    old provider's) and label the *new* backend with the old one's answer.
+    """
+
+    def _public(_config: RemoteSyncConfig) -> PublicAccessStatus:
+        return PublicAccessStatus(BucketExposure.PUBLIC)
+
+    register_object_store("exposure-swap", lambda _cfg: object(), public_access_checker=_public)
+    try:
+        before = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="exposure-swap"))
+        assert before.exposure is BucketExposure.PUBLIC
+
+        # Re-register the same name with a different factory and no checker.
+        register_object_store("exposure-swap", lambda _cfg: object())
+        after = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="exposure-swap"))
+        assert after.exposure is BucketExposure.UNKNOWN
+        assert "exposure-swap" in after.detail
+    finally:
+        unregister_object_store("exposure-swap")
 
 
 # ── operations.get_sync_status ──────────────────────────────────────────────

--- a/tests/filestorage/test_bucket_exposure.py
+++ b/tests/filestorage/test_bucket_exposure.py
@@ -1,0 +1,323 @@
+"""Public-bucket warning: the AWS checker, the registry seam, and the surfaces.
+
+The security property under test is that a public store is loud (``status``
+warns) and everything short of that is quiet but truthful — a missing
+permission or an unreachable store never fails ``status``, and never echoes
+raw exception text into output that a gateway chat surface could relay.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import requests
+from botocore.exceptions import ClientError, EndpointConnectionError
+
+from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.enums import BucketExposure, SyncRootName
+from platform.filestorage.exposure import PublicAccessStatus
+from platform.filestorage.messages import format_exposure_line, format_status_lines
+from platform.filestorage.operations import SyncRootStatus, SyncStatus, get_sync_status
+from platform.filestorage.providers.aws import check_public_access as aws_check_public_access
+from platform.filestorage.providers.gcs import check_public_access as gcs_check_public_access
+from platform.filestorage.providers.registry import (
+    check_bucket_exposure,
+    register_object_store,
+    unregister_object_store,
+)
+
+
+class _S3Client:
+    """Fake boto3 S3 client exposing only ``get_bucket_policy_status``."""
+
+    def __init__(self, *, response: dict | None = None, error: Exception | None = None) -> None:
+        self._response = response
+        self._error = error
+
+    def get_bucket_policy_status(self, Bucket: str) -> dict:  # noqa: N803, ARG002 - boto3 kwarg casing
+        if self._error is not None:
+            raise self._error
+        assert self._response is not None
+        return self._response
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": "irrelevant"}}, "GetBucketPolicyStatus")
+
+
+# ── aws.check_public_access ─────────────────────────────────────────────────
+
+
+def test_public_policy_status_is_reported_public() -> None:
+    client = _S3Client(response={"PolicyStatus": {"IsPublic": True}})
+    result = aws_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result == PublicAccessStatus(BucketExposure.PUBLIC)
+
+
+def test_private_policy_status_is_reported_private() -> None:
+    client = _S3Client(response={"PolicyStatus": {"IsPublic": False}})
+    result = aws_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+
+
+def test_no_bucket_policy_is_reported_private() -> None:
+    client = _S3Client(error=_client_error("NoSuchBucketPolicy"))
+    result = aws_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+
+
+def test_missing_permission_degrades_to_a_note_not_an_error() -> None:
+    client = _S3Client(error=_client_error("AccessDenied"))
+    result = aws_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "s3:GetBucketPolicyStatus" in result.detail
+
+
+def test_other_client_error_degrades_without_leaking_its_message() -> None:
+    """A gateway chat surface can echo ``detail`` verbatim — it must not carry AWS-side text."""
+    client = _S3Client(error=_client_error("InternalError"))
+    result = aws_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "irrelevant" not in result.detail
+    assert "ClientError" in result.detail
+
+
+def test_transport_failure_degrades_to_unknown() -> None:
+    client = _S3Client(error=EndpointConnectionError(endpoint_url="https://s3.example"))
+    result = aws_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+def test_client_build_failure_degrades_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Even a totally unreachable AWS session must not raise out of the checker."""
+    import platform.filestorage.providers.aws as aws_module
+
+    def _raise_client(_config: RemoteSyncConfig) -> object:
+        raise aws_module.RemoteSyncUnavailableError("cannot build an S3 client — boom")
+
+    monkeypatch.setattr(aws_module, "_build_client", _raise_client)
+    result = aws_check_public_access(RemoteSyncConfig(bucket="b"))
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+# ── gcs.check_public_access ─────────────────────────────────────────────────
+
+
+class _GCSResponse:
+    """Fake ``requests.Response`` exposing only what the checker touches."""
+
+    def __init__(self, *, body: object = None, status_code: int = 200) -> None:
+        self._body = body
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:  # noqa: PLR2004 - mirrors requests' own threshold
+            raise requests.HTTPError(f"HTTP {self.status_code}", response=self)
+
+    def json(self) -> object:
+        return self._body
+
+
+class _GCSSession:
+    """Fake ``AuthorizedSession`` exposing only ``get``."""
+
+    def __init__(
+        self, response: _GCSResponse | None = None, *, error: Exception | None = None
+    ) -> None:
+        self._response = response
+        self._error = error
+
+    def get(self, _url: str, timeout: float | None = None) -> _GCSResponse:  # noqa: ARG002
+        if self._error is not None:
+            raise self._error
+        assert self._response is not None
+        return self._response
+
+
+def _iam_policy(*bindings: dict) -> dict:
+    return {"bindings": list(bindings)}
+
+
+def test_public_iam_binding_is_reported_public() -> None:
+    body = _iam_policy({"role": "roles/storage.objectViewer", "members": ["allUsers"]})
+    session = _GCSSession(_GCSResponse(body=body))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result == PublicAccessStatus(BucketExposure.PUBLIC)
+
+
+def test_authenticated_users_binding_is_also_reported_public() -> None:
+    """Any Google account is not "your bucket owner" — same posture as AWS's AuthenticatedUsers."""
+    body = _iam_policy(
+        {"role": "roles/storage.legacyBucketReader", "members": ["allAuthenticatedUsers"]}
+    )
+    session = _GCSSession(_GCSResponse(body=body))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result == PublicAccessStatus(BucketExposure.PUBLIC)
+
+
+def test_write_only_public_binding_is_not_reported_public() -> None:
+    """A public objectCreator grant is a write exposure, not the read exposure this checks."""
+    body = _iam_policy({"role": "roles/storage.objectCreator", "members": ["allUsers"]})
+    session = _GCSSession(_GCSResponse(body=body))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+
+
+def test_scoped_binding_is_reported_private() -> None:
+    body = _iam_policy(
+        {"role": "roles/storage.objectViewer", "members": ["serviceAccount:ci@example.iam"]}
+    )
+    session = _GCSSession(_GCSResponse(body=body))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+
+
+def test_no_bindings_is_reported_private() -> None:
+    session = _GCSSession(_GCSResponse(body=_iam_policy()))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+
+
+def test_forbidden_degrades_to_a_note_not_an_error() -> None:
+    session = _GCSSession(_GCSResponse(status_code=403))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "IAM policy" in result.detail
+
+
+def test_gcs_other_http_error_degrades_without_leaking_body() -> None:
+    session = _GCSSession(_GCSResponse(status_code=500))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "HTTPError" in result.detail
+
+
+def test_gcs_transport_failure_degrades_to_unknown() -> None:
+    session = _GCSSession(error=requests.ConnectionError("boom"))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+def test_gcs_malformed_response_degrades_to_unknown() -> None:
+    session = _GCSSession(_GCSResponse(body=["not", "an", "object"]))
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"), session=session)
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+def test_gcs_session_build_failure_degrades_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    import platform.filestorage.providers.gcs as gcs_module
+
+    def _raise_session() -> object:
+        raise gcs_module.RemoteSyncUnavailableError("cannot build GCS credentials — boom")
+
+    monkeypatch.setattr(gcs_module, "_build_session", _raise_session)
+    result = gcs_check_public_access(RemoteSyncConfig(bucket="b"))
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+# ── providers.registry.check_bucket_exposure ────────────────────────────────
+
+
+def test_provider_without_a_checker_is_reported_unchecked() -> None:
+    """Vercel Blob has no bucket-level public/private setting to check."""
+    result = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="vercel"))
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "vercel" in result.detail
+
+
+def _raising_checker(_config: RemoteSyncConfig) -> PublicAccessStatus:
+    raise ValueError("a community checker's own secret-shaped failure")
+
+
+def test_a_checker_that_raises_degrades_without_leaking_its_message() -> None:
+    register_object_store(
+        "exposure-raises", lambda _cfg: object(), public_access_checker=_raising_checker
+    )
+    try:
+        result = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="exposure-raises"))
+    finally:
+        unregister_object_store("exposure-raises")
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "secret-shaped" not in result.detail
+    assert "ValueError" in result.detail
+
+
+def test_unregister_drops_the_checker_too() -> None:
+    def _ok(_config: RemoteSyncConfig) -> PublicAccessStatus:
+        return PublicAccessStatus(BucketExposure.PUBLIC)
+
+    register_object_store("exposure-toggle", lambda _cfg: object(), public_access_checker=_ok)
+    before = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="exposure-toggle"))
+    assert before.exposure is BucketExposure.PUBLIC
+    unregister_object_store("exposure-toggle")
+    result = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="exposure-toggle"))
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+# ── operations.get_sync_status ──────────────────────────────────────────────
+
+
+def test_status_exposure_is_none_when_sync_is_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    from config.constants.filestorage import REMOTE_SYNC_ENV
+
+    monkeypatch.delenv(REMOTE_SYNC_ENV, raising=False)
+    status = get_sync_status()
+    assert status.exposure is None
+
+
+def test_status_calls_the_registered_checker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from config.constants import paths
+    from config.constants.filestorage import REMOTE_SYNC_BUCKET_ENV, REMOTE_SYNC_ENV
+    from platform.filestorage import operations as sync_service
+
+    def _public(_config: RemoteSyncConfig) -> PublicAccessStatus:
+        return PublicAccessStatus(BucketExposure.PUBLIC)
+
+    register_object_store("exposure-status", lambda _cfg: object(), public_access_checker=_public)
+    try:
+        monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+        monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+        monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "b")
+        monkeypatch.setenv("OPENSRE_REMOTE_SYNC_PROVIDER", "exposure-status")
+        monkeypatch.setattr(sync_service, "syncable_roots", lambda: ())
+        status = get_sync_status()
+    finally:
+        unregister_object_store("exposure-status")
+    assert status.exposure == PublicAccessStatus(BucketExposure.PUBLIC)
+
+
+# ── messages.format_status_lines / format_exposure_line ────────────────────
+
+
+def _status(exposure: PublicAccessStatus | None) -> SyncStatus:
+    return SyncStatus(
+        config=RemoteSyncConfig(bucket="b", provider="aws", prefix="p"),
+        roots=(SyncRootStatus(name=SyncRootName.SESSIONS, path=Path("/s"), exists=True),),
+        exposure=exposure,
+    )
+
+
+def test_format_status_lines_warns_loudly_on_a_public_bucket() -> None:
+    lines = format_status_lines(_status(PublicAccessStatus(BucketExposure.PUBLIC)))
+    assert any("WARNING" in line and "publicly readable" in line for line in lines)
+
+
+def test_format_status_lines_is_quiet_for_a_private_bucket() -> None:
+    lines = format_status_lines(_status(PublicAccessStatus(BucketExposure.PRIVATE)))
+    assert not any("WARNING" in line for line in lines)
+    assert any("private" in line for line in lines)
+
+
+def test_format_status_lines_omits_the_line_when_exposure_was_never_computed() -> None:
+    """Backward compatible: callers that build a bare ``SyncStatus`` see no new line."""
+    lines = format_status_lines(_status(None))
+    assert not any("Bucket access" in line or "WARNING" in line for line in lines)
+
+
+def test_format_exposure_line_unknown_includes_the_detail() -> None:
+    line = format_exposure_line(PublicAccessStatus(BucketExposure.UNKNOWN, "missing permission"))
+    assert "missing permission" in line
+    assert "could not confirm" in line

--- a/tests/filestorage/test_bucket_exposure.py
+++ b/tests/filestorage/test_bucket_exposure.py
@@ -206,12 +206,12 @@ def test_gcs_malformed_response_degrades_to_unknown() -> None:
 
 
 def test_gcs_session_build_failure_degrades_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
-    import platform.filestorage.providers.gcs as gcs_module
+    from platform.filestorage.providers.gcs import RemoteSyncUnavailableError
 
     def _raise_session() -> object:
-        raise gcs_module.RemoteSyncUnavailableError("cannot build GCS credentials — boom")
+        raise RemoteSyncUnavailableError("cannot build GCS credentials — boom")
 
-    monkeypatch.setattr(gcs_module, "_build_session", _raise_session)
+    monkeypatch.setattr("platform.filestorage.providers.gcs._build_session", _raise_session)
     result = gcs_check_public_access(RemoteSyncConfig(bucket="b"))
     assert result.exposure is BucketExposure.UNKNOWN
 


### PR DESCRIPTION
Fixes #4556

#### Describe the changes you have made in this PR -

`opensre remote-sync status` (CLI, `/remote-sync status`, and the same slash command on gateway surfaces) now checks whether the configured bucket is publicly readable and opens with a loud warning if so — the store holds incident conversations and everything opensre remembers, so a public bucket is worth interrupting the operator for.

- **AWS**: uses `s3:GetBucketPolicyStatus`. A bucket policy that grants read access to a public principal reports `PUBLIC`; no policy reports `PRIVATE`.
- **GCS**: uses `storage.buckets.getIamPolicy`, checking for a read-capable role (`objectViewer`, `legacyObjectReader`, `legacyBucketReader`, `viewer`, `editor`, `owner`) granted to `allUsers` or `allAuthenticatedUsers`.
- **Vercel Blob**: not checked — Blob access is set per-object at upload time (this provider always writes `private`), so there is no bucket-level public/private setting to query the way S3/GCS have one. `status` reports it as unchecked rather than faking an answer.

A missing permission, an unreachable bucket, or (for community providers) a checker that raises all degrade to a short note — never an error, and `status`/`setup` still report everything else they know. Exception detail is never embedded in the note text, since it can be echoed straight into a Slack/Telegram gateway chat surface (CWE-209 boundary).

**Design**: added `public_access_checker` as an optional per-provider registration on `register_object_store`, alongside the existing `credential_hint`/`extra_fields` pattern — so the core `ObjectStore` protocol stays at its four operations (list/get/put/describe) instead of growing a fifth method every backend, including community ones, would have to implement.

### Demo/Screenshot for feature changes and bug fixes -

```
>>> from platform.filestorage.messages import format_status_lines
>>> for line in format_status_lines(status_with_public_bucket): print(line)
Remote sync is on (aws) → b/p
WARNING: this store is publicly readable. Anyone on the internet can read your synced sessions and memory — restrict its access now.
Mirrored:
  sessions   /s (exists)
...

>>> for line in format_status_lines(status_with_missing_permission): print(line)
Remote sync is on (aws) → b/p
Bucket access: could not confirm it is private (missing the s3:GetBucketPolicyStatus permission).
...
```

Local verification (see `CI.md`):
```
make lint            # All checks passed!
make format-check    # already formatted
make typecheck        # Success: no issues found in 1575 source files
uv run python -m pytest tests/filestorage/ tests/cli/test_remote_sync_command.py \
  tests/cli/test_gateway_remote_sync.py tests/interactive_shell/test_remote_sync_cmds.py \
  tests/surfaces/test_remote_sync_surface_contract.py -q
# 271 passed
```

No live AWS/GCS bucket was used — every checker is exercised with fakes/mocks (26 new tests in `tests/filestorage/test_bucket_exposure.py`), matching the issue's own "mockable without a real public bucket" requirement.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue asked for a warning when the target bucket is publicly readable, with a missing `s3:GetBucketPolicyStatus` permission degrading to a note rather than an error, and behavior mockable without a real public bucket. A prior attempt (#4603) added a standalone `describe_bucket_public_access` helper in `aws.py` that was never wired into `status`/`setup` and was closed after CI failures on unrelated config changes.

I considered adding the check directly to the `ObjectStore` protocol, but that would force every provider — including community ones — to implement a check that doesn't make sense for all of them (Vercel Blob has no bucket-level access setting). Instead I extended the existing per-provider registration pattern (`credential_hint`, `extra_fields`) with an optional `public_access_checker`, so a provider opts in only when it has something meaningful to say. `status` calls a single vendor-agnostic `check_bucket_exposure(config)` that always degrades to `UNKNOWN` with a note instead of raising — whether because no checker is registered, a permission is missing, the bucket is unreachable, or (for a community-registered checker) the checker itself raises.

Key pieces:
- `platform/filestorage/enums.py` — `BucketExposure` (`PRIVATE`/`PUBLIC`/`UNKNOWN`).
- `platform/filestorage/exposure.py` — `PublicAccessStatus` dataclass, `PublicAccessChecker` type, `not_checked()`.
- `platform/filestorage/providers/registry.py` — `public_access_checker` on `register_object_store`, and `check_bucket_exposure()`, which never raises.
- `platform/filestorage/providers/aws.py` / `gcs.py` — the two vendor-specific checks.
- `platform/filestorage/operations.py` — `SyncStatus.exposure`, populated by `get_sync_status()`.
- `platform/filestorage/messages.py` — `format_exposure_line()`, shared by the CLI and REPL/gateway renderers.

I tested the degrade paths explicitly (missing permission, other AWS/GCS API errors, transport failures, a raising community checker, an unregistered provider) and asserted that none of them leak the underlying exception's message into `detail`, since that field is rendered verbatim on gateway chat surfaces.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
