### PR TITLE
feat(filestorage): warn when a Vercel Blob store's access mode is public

### DIFF
--- a/config/constants/vercel.py
+++ b/config/constants/vercel.py
@@ -1,11 +1,21 @@
-"""Vercel environment variable names."""
+"""Vercel environment variable names and shared static constants.
+
+``VERCEL_API_BASE_URL`` is the account/team management API — projects,
+deployments, logs, and (for ``platform.filestorage.providers.vercel``) Blob
+store metadata. It is a *different* host and audience than the Blob
+data-plane API (``https://vercel.com/api/blob``, authenticated with
+``BLOB_READ_WRITE_TOKEN``), which stays local to
+``platform.filestorage.providers.vercel`` since nothing else calls it.
+"""
 
 from __future__ import annotations
 
 VERCEL_API_TOKEN_ENV = "VERCEL_API_TOKEN"
 VERCEL_TEAM_ID_ENV = "VERCEL_TEAM_ID"
+VERCEL_API_BASE_URL = "https://api.vercel.com"
 
 __all__ = [
+    "VERCEL_API_BASE_URL",
     "VERCEL_API_TOKEN_ENV",
     "VERCEL_TEAM_ID_ENV",
 ]

--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -286,6 +286,23 @@ share history at the same token (or an equivalent token for that store), plus
 the same prefix.
 </Note>
 
+Access mode (private or public) is set once, for the whole store, when you
+create it — Vercel does not let you change it afterward. `status` can check
+this and warn you if the store came out public, but it needs a **different,
+broader** credential than `BLOB_READ_WRITE_TOKEN`: a Vercel account/team API
+token, since the store-management API does not accept a Blob read-write
+token at all. If you already use the `vercel` integration for observability,
+this is the same `VERCEL_API_TOKEN` (and optional `VERCEL_TEAM_ID` for a
+token spanning several teams) — nothing new to set up. Entirely optional:
+without it, `status` shows "could not confirm it is private" instead of
+failing.
+
+```bash
+# Optional — enables the public-store warning on status
+export VERCEL_API_TOKEN=...
+# export VERCEL_TEAM_ID=...   # only if the token spans multiple teams
+```
+
 ## The store
 
 <Warning>
@@ -294,13 +311,13 @@ opensre has remembered about your systems. Prefer a private S3 bucket or a
 private Vercel Blob store — never a public one.
 </Warning>
 
-On AWS and GCS, `status` checks this for you: if the bucket policy (S3) or
-bucket IAM policy (GCS) makes the bucket publicly readable, `opensre
-remote-sync status` / `/remote-sync status` opens with a warning instead of
-silently mirroring your history into it. Without the permission the check
-needs — or on Vercel, which has no bucket-level public/private setting to
-check — `status` shows "could not confirm it is private" instead of failing;
-it never blocks the rest of the command.
+`status` checks this for you on every built-in provider: the bucket policy
+(S3), the bucket IAM policy (GCS), or the store's access mode (Vercel Blob,
+via the optional `VERCEL_API_TOKEN` above) — if any of them say public,
+`opensre remote-sync status` / `/remote-sync status` opens with a warning
+instead of silently mirroring your history into it. Without the permission
+or credential the check needs, `status` shows "could not confirm it is
+private" instead of failing; it never blocks the rest of the command.
 
 ## How conflicts resolve
 

--- a/integrations/vercel/client.py
+++ b/integrations/vercel/client.py
@@ -17,6 +17,7 @@ from urllib.parse import quote
 
 import httpx
 
+from config.constants.vercel import VERCEL_API_BASE_URL
 from integrations.config_models import VercelIntegrationConfig
 from integrations.probes import ProbeResult
 from platform.observability.errors.service import capture_service_error
@@ -24,7 +25,7 @@ from platform.observability.streaming import StreamingParseStats
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "https://api.vercel.com"
+_BASE_URL = VERCEL_API_BASE_URL
 _MAX_VERCEL_PATH_SEGMENT_LEN = 256
 # Vercel project and deployment IDs are opaque tokens (no slashes or traversal).
 _VERCEL_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")

--- a/platform/filestorage/providers/vercel.py
+++ b/platform/filestorage/providers/vercel.py
@@ -11,7 +11,7 @@ from urllib.parse import urlencode
 import httpx
 
 from config.constants.filestorage import BLOB_READ_WRITE_TOKEN_ENV
-from config.constants.vercel import VERCEL_API_TOKEN_ENV, VERCEL_TEAM_ID_ENV
+from config.constants.vercel import VERCEL_API_BASE_URL, VERCEL_API_TOKEN_ENV, VERCEL_TEAM_ID_ENV
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.enums import BucketExposure, BuiltInProvider
 from platform.filestorage.errors import RemoteSyncUnavailableError
@@ -35,14 +35,15 @@ _TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 # Store-management API — a *different* host and a *different* token type than
 # _API_BASE: it does not accept BLOB_READ_WRITE_TOKEN at all (confirmed live:
 # that token shape gets a 403 with "invalidToken": true), only a Vercel
-# account/team API token. Reuses VERCEL_API_TOKEN_ENV / VERCEL_TEAM_ID_ENV —
-# the same credential the (unrelated) integrations/vercel/ SRE integration
-# already asks for — rather than inventing a second Vercel token convention;
-# platform/ cannot import integrations/vercel/client.py directly (see
-# docs/ARCHITECTURE.md's tier table: platform must never import integrations),
-# so this call is hand-rolled instead of shared. Used solely by
-# check_public_access — sync itself never calls this host.
-_ACCOUNT_API_BASE = "https://api.vercel.com"
+# account/team API token. Reuses VERCEL_API_BASE_URL / VERCEL_API_TOKEN_ENV /
+# VERCEL_TEAM_ID_ENV — the same host and credential the (unrelated)
+# integrations/vercel/ SRE integration already talks to and asks for — rather
+# than inventing a second Vercel token convention; platform/ cannot import
+# integrations/vercel/client.py directly (see docs/ARCHITECTURE.md's tier
+# table: platform must never import integrations), so this call is
+# hand-rolled instead of shared. Used solely by check_public_access — sync
+# itself never calls this host.
+_ACCOUNT_API_BASE = VERCEL_API_BASE_URL
 
 
 class VercelBlobObjectStore:

--- a/platform/filestorage/providers/vercel.py
+++ b/platform/filestorage/providers/vercel.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
 import httpx
 
 from config.constants.filestorage import BLOB_READ_WRITE_TOKEN_ENV
+from config.constants.vercel import VERCEL_API_TOKEN_ENV, VERCEL_TEAM_ID_ENV
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.enums import BuiltInProvider
+from platform.filestorage.enums import BucketExposure, BuiltInProvider
 from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.exposure import PublicAccessStatus
 from platform.filestorage.ports import RemoteObject
 from platform.filestorage.providers.registry import register_object_store
 
@@ -28,6 +31,18 @@ _API_VERSION = "12"
 _ACCESS = "private"
 _LIST_LIMIT = 1000
 _TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+# Store-management API — a *different* host and a *different* token type than
+# _API_BASE: it does not accept BLOB_READ_WRITE_TOKEN at all (confirmed live:
+# that token shape gets a 403 with "invalidToken": true), only a Vercel
+# account/team API token. Reuses VERCEL_API_TOKEN_ENV / VERCEL_TEAM_ID_ENV —
+# the same credential the (unrelated) integrations/vercel/ SRE integration
+# already asks for — rather than inventing a second Vercel token convention;
+# platform/ cannot import integrations/vercel/client.py directly (see
+# docs/ARCHITECTURE.md's tier table: platform must never import integrations),
+# so this call is hand-rolled instead of shared. Used solely by
+# check_public_access — sync itself never calls this host.
+_ACCOUNT_API_BASE = "https://api.vercel.com"
 
 
 class VercelBlobObjectStore:
@@ -256,6 +271,94 @@ def _factory(config: RemoteSyncConfig) -> VercelBlobObjectStore:
     return VercelBlobObjectStore(config)
 
 
-register_object_store(PROVIDER_NAME, _factory, credential_hint=CREDENTIAL_HINT)
+def check_public_access(
+    _config: RemoteSyncConfig, *, client: httpx.Client | None = None
+) -> PublicAccessStatus:
+    """Ask Vercel whether the configured Blob store's access mode is public.
 
-__all__ = ["CREDENTIAL_HINT", "PROVIDER_NAME", "VercelBlobObjectStore"]
+    ``_config`` is unused: unlike AWS/GCS, the store id here comes from
+    ``BLOB_READ_WRITE_TOKEN`` (see below), not ``config.bucket`` — the
+    parameter stays only to satisfy the shared ``PublicAccessChecker`` shape
+    every provider's checker is called through.
+
+    Unlike S3/GCS, Vercel Blob access is a **store-level, immutable**
+    property — set at store creation and the same for every object in it
+    (see Vercel's docs: "you cannot change it after the creation of a blob
+    store"). ``GET /v1/storage/stores/{id}`` on ``_ACCOUNT_API_BASE`` answers
+    it in one call, the same shape as the AWS/GCS checks, but needs two
+    ambient values this provider does not otherwise require:
+
+    - ``VERCEL_API_TOKEN_ENV`` (``VERCEL_API_TOKEN``), plus an optional
+      ``VERCEL_TEAM_ID_ENV`` (``VERCEL_TEAM_ID``) for a token that spans
+      several teams — the same credential the ``integrations/vercel/`` SRE
+      integration already asks for, reused here rather than inventing a
+      second Vercel token convention. ``BLOB_READ_WRITE_TOKEN`` cannot
+      authenticate this endpoint at all (confirmed live: it is rejected with
+      ``invalidToken: true``), so this is a genuinely different,
+      broader-scoped credential, not an extra permission on the same one.
+      Entirely optional: unset, the check degrades to unchecked, same as no
+      permission on AWS/GCS.
+    - The store id, parsed from ``BLOB_READ_WRITE_TOKEN`` the same way
+      :class:`VercelBlobObjectStore` does — ``config.bucket`` is a
+      human-facing label, not guaranteed to be the API store id.
+
+    Degrades to :class:`~platform.filestorage.enums.BucketExposure.UNKNOWN`
+    rather than raising, and never carries the raw Vercel response body in
+    ``detail`` — this result can be echoed straight into a gateway chat
+    surface (see ``format_status_lines``), and that text is not vetted for
+    that (CWE-209).
+    """
+    api_token = os.getenv(VERCEL_API_TOKEN_ENV, "").strip()
+    if not api_token:
+        return PublicAccessStatus(
+            BucketExposure.UNKNOWN, f"set {VERCEL_API_TOKEN_ENV} to check this"
+        )
+    store_id = _store_id_from_token(_token_from_env().strip())
+    if not store_id:
+        return PublicAccessStatus(
+            BucketExposure.UNKNOWN,
+            f"cannot determine the store id — set {BLOB_READ_WRITE_TOKEN_ENV}",
+        )
+    team_id = os.getenv(VERCEL_TEAM_ID_ENV, "").strip()
+    owns_client = client is None
+    cl = client if client is not None else httpx.Client(timeout=_TIMEOUT)
+    try:
+        response = cl.get(
+            f"{_ACCOUNT_API_BASE}/v1/storage/stores/{store_id}",
+            headers={"authorization": f"Bearer {api_token}"},
+            params={"teamId": team_id} if team_id else {},
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+            return PublicAccessStatus(
+                BucketExposure.UNKNOWN, f"{VERCEL_API_TOKEN_ENV} cannot read this store"
+            )
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    except (httpx.HTTPError, ValueError) as exc:
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    finally:
+        if owns_client:
+            cl.close()
+    if not isinstance(payload, dict):
+        return PublicAccessStatus(BucketExposure.UNKNOWN, "malformed store response")
+    store = payload.get("store")
+    access = store.get("access") if isinstance(store, dict) else None
+    if access == "public":
+        return PublicAccessStatus(BucketExposure.PUBLIC)
+    if access == "private":
+        return PublicAccessStatus(BucketExposure.PRIVATE)
+    return PublicAccessStatus(
+        BucketExposure.UNKNOWN, "store response did not include an access mode"
+    )
+
+
+register_object_store(
+    PROVIDER_NAME,
+    _factory,
+    credential_hint=CREDENTIAL_HINT,
+    public_access_checker=check_public_access,
+)
+
+__all__ = ["CREDENTIAL_HINT", "PROVIDER_NAME", "VercelBlobObjectStore", "check_public_access"]

--- a/tests/filestorage/test_bucket_exposure.py
+++ b/tests/filestorage/test_bucket_exposure.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import httpx
 import pytest
 import requests
 from botocore.exceptions import ClientError, EndpointConnectionError
 
+from config.constants.vercel import VERCEL_API_TOKEN_ENV
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.enums import BucketExposure, SyncRootName
 from platform.filestorage.exposure import PublicAccessStatus
@@ -26,6 +28,7 @@ from platform.filestorage.providers.registry import (
     register_object_store,
     unregister_object_store,
 )
+from platform.filestorage.providers.vercel import check_public_access as vercel_check_public_access
 
 
 class _S3Client:
@@ -216,14 +219,166 @@ def test_gcs_session_build_failure_degrades_to_unknown(monkeypatch: pytest.Monke
     assert result.exposure is BucketExposure.UNKNOWN
 
 
+# ── vercel.check_public_access ──────────────────────────────────────────────
+
+_BLOB_TOKEN = "vercel_blob_rw_TestStoreId_deadbeefsecret"
+
+
+class _VercelResponse:
+    """Fake ``httpx.Response`` exposing only what the checker touches."""
+
+    def __init__(self, *, body: object = None, status_code: int = 200) -> None:
+        self._body = body
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:  # noqa: PLR2004 - mirrors httpx's own threshold
+            request = httpx.Request("GET", "https://api.vercel.com/v1/storage/stores/x")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}", request=request, response=response
+            )
+
+    def json(self) -> object:
+        return self._body
+
+
+class _VercelClient:
+    """Fake ``httpx.Client`` exposing only ``get``."""
+
+    def __init__(
+        self, response: _VercelResponse | None = None, *, error: Exception | None = None
+    ) -> None:
+        self._response = response
+        self._error = error
+
+    def get(
+        self,
+        _url: str,
+        headers: dict[str, str] | None = None,  # noqa: ARG002
+        params: dict[str, str] | None = None,  # noqa: ARG002
+    ) -> _VercelResponse:
+        if self._error is not None:
+            raise self._error
+        assert self._response is not None
+        return self._response
+
+    def close(self) -> None:
+        pass
+
+
+def test_missing_vercel_api_token_degrades_to_a_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    """VERCEL_API_TOKEN is optional — BLOB_READ_WRITE_TOKEN cannot authenticate this endpoint at all."""
+    monkeypatch.delenv(VERCEL_API_TOKEN_ENV, raising=False)
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"))
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert VERCEL_API_TOKEN_ENV in result.detail
+
+
+def test_missing_blob_token_degrades_to_a_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The store id comes from BLOB_READ_WRITE_TOKEN — config.bucket is only a label."""
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "a-real-looking-account-token")
+    monkeypatch.delenv("BLOB_READ_WRITE_TOKEN", raising=False)
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"))
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "BLOB_READ_WRITE_TOKEN" in result.detail
+
+
+def test_public_store_is_reported_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "account-token")
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    client = _VercelClient(_VercelResponse(body={"store": {"access": "public"}}))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result == PublicAccessStatus(BucketExposure.PUBLIC)
+
+
+def test_team_id_is_forwarded_as_a_query_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token spanning several teams needs teamId to resolve the right one."""
+    from config.constants.vercel import VERCEL_TEAM_ID_ENV
+
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "account-token")
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    monkeypatch.setenv(VERCEL_TEAM_ID_ENV, "team_abc123")
+    seen_params: list[dict[str, str] | None] = []
+
+    class _RecordingClient(_VercelClient):
+        def get(
+            self,
+            _url: str,
+            headers: dict[str, str] | None = None,
+            params: dict[str, str] | None = None,
+        ) -> _VercelResponse:
+            seen_params.append(params)
+            return super().get(_url, headers=headers, params=params)
+
+    client = _RecordingClient(_VercelResponse(body={"store": {"access": "private"}}))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+    assert seen_params == [{"teamId": "team_abc123"}]
+
+
+def test_private_store_is_reported_private(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "account-token")
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    client = _VercelClient(_VercelResponse(body={"store": {"access": "private"}}))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+
+
+def test_blob_token_cannot_authenticate_this_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Confirmed live: this endpoint rejects a Blob read-write token outright (403, invalidToken)."""
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, _BLOB_TOKEN)  # the wrong token type, on purpose
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    client = _VercelClient(_VercelResponse(status_code=403))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert VERCEL_API_TOKEN_ENV in result.detail
+
+
+def test_vercel_other_http_error_degrades_without_leaking_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "account-token")
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    client = _VercelClient(_VercelResponse(status_code=500))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "HTTPStatusError" in result.detail
+
+
+def test_vercel_transport_failure_degrades_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "account-token")
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    client = _VercelClient(error=httpx.ConnectError("boom"))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+def test_vercel_malformed_response_degrades_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "account-token")
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    client = _VercelClient(_VercelResponse(body=["not", "an", "object"]))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+def test_vercel_response_missing_access_field_degrades_to_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(VERCEL_API_TOKEN_ENV, "account-token")
+    monkeypatch.setenv("BLOB_READ_WRITE_TOKEN", _BLOB_TOKEN)
+    client = _VercelClient(_VercelResponse(body={"store": {"status": "available"}}))
+    result = vercel_check_public_access(RemoteSyncConfig(bucket="b"), client=client)
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
 # ── providers.registry.check_bucket_exposure ────────────────────────────────
 
 
 def test_provider_without_a_checker_is_reported_unchecked() -> None:
-    """Vercel Blob has no bucket-level public/private setting to check."""
-    result = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="vercel"))
+    result = check_bucket_exposure(RemoteSyncConfig(bucket="b", provider="not-a-real-provider"))
     assert result.exposure is BucketExposure.UNKNOWN
-    assert "vercel" in result.detail
+    assert "not-a-real-provider" in result.detail
 
 
 def _raising_checker(_config: RemoteSyncConfig) -> PublicAccessStatus:


### PR DESCRIPTION
Fixes #4720

#### Describe the changes you have made in this PR -

Follow-up to #4719: extends the public-store warning on `opensre remote-sync status` (and `/remote-sync status`) to Vercel Blob.

**What changed since #4720 was filed**: that issue assumed Vercel Blob access was set per-object, making a store-wide check an expensive O(n) full-store scan. That assumption was wrong — I verified against Vercel's own docs and live against a throwaway test store (created and deleted during this work) that **access mode is a store-level, immutable property**, set once at store creation ("you cannot change it after the creation of a blob store"). That means it's checkable in a single call, the same shape as the AWS/GCS checks:

- `GET https://api.vercel.com/v1/storage/stores/{id}` returns the store's `access: "private"|"public"` directly. Confirmed live with `vercel blob get-store --debug` (`Access: Private` in the output, endpoint traced via `--debug`).
- That endpoint does **not** accept `BLOB_READ_WRITE_TOKEN` — confirmed live via `curl` with a correctly-shaped-but-fake Blob token: `403 {"error":{"code":"forbidden","message":"Not authorized","invalidToken":true}}`. It needs a genuinely different, broader-scoped Vercel account/team API token.
- Rather than invent a new env var for that token, this reuses `VERCEL_API_TOKEN` / `VERCEL_TEAM_ID` from `config.constants.vercel` — the same credential the existing `integrations/vercel/` SRE integration already asks for. Anyone with that integration configured gets this check for free.
- `platform/` cannot import `integrations/vercel/client.py` (`docs/ARCHITECTURE.md`'s tier table: `platform` must never import `integrations`), so the request is hand-rolled in `providers/vercel.py` rather than sharing `VercelClient` — small, intentional duplication across a real architectural boundary.
- The store id comes from parsing `BLOB_READ_WRITE_TOKEN` (same as `VercelBlobObjectStore` already does) — `config.bucket` is only a human-facing label, not guaranteed to be the API store id.

Entirely optional and additive: no `VERCEL_API_TOKEN` set → `status` shows "could not confirm it is private", same degrade-to-a-note behavior as a missing AWS/GCS permission, never an error.

### Demo/Screenshot for feature changes and bug fixes -

Live verification against a throwaway private store (`opensre-exposure-check-test`, created and deleted during this work):

```
$ vercel blob get-store store_Ei5dOoMYgXLgFyQH --debug
...
> [debug] #1 → GET https://api.vercel.com/v1/storage/stores/store_Ei5dOoMYgXLgFyQH
> [debug] #1 ← 200 OK
Blob Store: opensre-exposure-check-test (store_Ei5dOoMYgXLgFyQH)
Access: Private
...

$ curl -s -w "\nHTTP:%{http_code}\n" \
    -H "Authorization: Bearer <redacted>" \
    https://api.vercel.com/v1/storage/stores/store_Ei5dOoMYgXLgFyQH
{"error":{"code":"forbidden","message":"Not authorized","invalidToken":true}}
HTTP:403
```

Local verification (see `CI.md`):
```
make lint            # All checks passed!
make format-check    # already formatted
make typecheck        # Success: no issues found in 1575 source files
uv run python -m pytest tests/filestorage/ tests/cli/test_remote_sync_command.py \
  tests/cli/test_gateway_remote_sync.py tests/interactive_shell/test_remote_sync_cmds.py \
  tests/surfaces/test_remote_sync_surface_contract.py tests/integrations/vercel/ -q
# 361 passed
```

10 new tests in `tests/filestorage/test_bucket_exposure.py` cover: public/private store, missing `VERCEL_API_TOKEN`, missing `BLOB_READ_WRITE_TOKEN` (no store id to check), the 401/403 auth-failure path (documented as the confirmed-live "wrong token type" case), other HTTP errors (asserting the raw response body never leaks into `detail`), transport failures, malformed responses, a response missing the `access` field, and `teamId` being forwarded as a query param when `VERCEL_TEAM_ID` is set.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

#4720 (which I filed after #4719) assumed Vercel Blob's access model was per-object and that a bucket-wide check would need an expensive full-store listing scan. Before implementing anything I asked for clarity from Vercel's own docs, since training-data knowledge of a fast-moving platform API is unreliable — that surfaced the actual model (store-level, immutable access) and, live-testing against a real throwaway store, the exact endpoint and its auth requirements, which turned out to need a different credential than assumed.

Given that, I designed this the same way as the AWS/GCS checkers in #4719: an opt-in `public_access_checker` registered via `register_object_store`, degrading to `UNKNOWN` with a short note (never raising, never leaking raw response text) whenever the new credential is absent or the API call fails for any reason. The one Vercel-specific decision was credential reuse: rather than add a third Vercel token name to the codebase, I checked whether an existing convention already covered "Vercel account API token" — it did (`config.constants.vercel`, used by `integrations/vercel/`) — and reused it, respecting the layer boundary that keeps `platform/` from importing `integrations/` directly.

Key pieces:
- `platform/filestorage/providers/vercel.py` — `check_public_access()`, registered as this provider's `public_access_checker`.
- `docs/configuration/remote-sync.mdx` — documents the optional `VERCEL_API_TOKEN`/`VERCEL_TEAM_ID` and updates "The store" section to cover all three providers uniformly.
- `tests/filestorage/test_bucket_exposure.py` — the new Vercel test section, plus a fix to `test_provider_without_a_checker_is_reported_unchecked` (it previously asserted `vercel` had no checker, which is no longer true).

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
