### PR TITLE
fix(pagerduty): log swallowed exception in client factory soft-fail path

### DIFF
--- a/integrations/pagerduty/client.py
+++ b/integrations/pagerduty/client.py
@@ -464,5 +464,6 @@ def make_pagerduty_client(
         if base_url:
             config_kwargs["base_url"] = base_url
         return PagerDutyClient(PagerDutyConfig(**config_kwargs))
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to create PagerDuty client: %s", exc, exc_info=True)
         return None

--- a/tests/integrations/pagerduty/test_client.py
+++ b/tests/integrations/pagerduty/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -474,3 +475,23 @@ def test_make_client_uses_default_base_url_when_none() -> None:
     client = make_pagerduty_client("test-key", None)
     assert client is not None
     assert client.config.base_url == "https://api.pagerduty.com"
+
+
+def _raise_runtime_error(**_kwargs: Any) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Force client construction inside the factory to raise, exercising the
+    # soft-fail `except Exception` path (SM-115). The factory must still return
+    # None, but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.pagerduty.client.PagerDutyConfig", _raise_runtime_error)
+    with caplog.at_level(logging.WARNING, logger="integrations.pagerduty.client"):
+        result = make_pagerduty_client("test-key")
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    )


### PR DESCRIPTION
Fixes #4649

#### Describe the changes you have made in this PR -

`make_pagerduty_client` in `integrations/pagerduty/client.py` wrapped client
construction in `try/except Exception` and returned `None` on any failure — but
swallowed the exception silently. A misconfigured PagerDuty integration would
then fail to build with **no diagnostic signal** anywhere.

This adds a `logger.warning(..., exc_info=True)` in the soft-fail path while
keeping the `None` return unchanged, so the failure is diagnosable without
changing behavior. It follows the same pattern requested by the SM-11x series
and already merged for the GitHub identity lookup (SM-114, #4669) and the
Discord verifier (#4718).

Scope: one issue, one production file (plus its companion test).

#### Demo/Screenshot for feature changes and bug fixes -

Characterization test proves the behavior (RED → GREEN):

```text
# BEFORE the fix (silent swallow) — new test fails:
tests/integrations/pagerduty/test_client.py::test_make_client_logs_soft_fail_on_construction_error FAILED
E   assert False   # no WARNING record captured

# AFTER the fix — full file green:
tests/integrations/pagerduty/test_client.py .................................  [100%]
============================== 33 passed in 0.90s ==============================
```

`make lint`, `make format-check`, `make typecheck`, and
`make verify-integrations-smoke` all pass.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The factory's `except Exception` branch returned `None` with no logging, so an
operator got zero signal when PagerDuty client construction failed. I bind the
exception (`as exc`, matching the identifier used everywhere else in this
module) and log it at WARNING with `exc_info=True` for the traceback, then keep
the existing `return None` so the soft-fail contract is untouched. I chose
`warning` over `debug` because the issue anchors on SM-114 (#4669), which logs
at `warning`. The test monkeypatches `PagerDutyConfig` to raise, then asserts
both that the factory still returns `None` and that a WARNING record carrying
`exc_info` was captured — which fails against the old silent code and passes
with the fix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
