### PR TITLE
test(pagerduty): unit-test _extract_ref and _extract_priority helpers

### DIFF
--- a/tests/integrations/pagerduty/test_extract_helpers.py
+++ b/tests/integrations/pagerduty/test_extract_helpers.py
@@ -1,0 +1,74 @@
+"""Unit tests for the PagerDuty payload extract helpers (C-44).
+
+`_extract_ref` and `_extract_priority` normalise raw PagerDuty API objects into
+compact dicts used across the incident/service/on-call parsers. They must be
+null-safe and default missing fields to empty strings — these tests pin that
+contract for present, missing, and edge-case inputs (no live API calls).
+"""
+
+from __future__ import annotations
+
+from integrations.pagerduty.client import _extract_priority, _extract_ref
+
+# --- _extract_ref ---
+
+
+def test_extract_ref_full_object() -> None:
+    ref = {"id": "PABC123", "summary": "Payments API", "type": "service_reference"}
+    assert _extract_ref(ref) == {
+        "id": "PABC123",
+        "summary": "Payments API",
+        "type": "service_reference",
+    }
+
+
+def test_extract_ref_none_returns_empty() -> None:
+    assert _extract_ref(None) == {}
+
+
+def test_extract_ref_empty_dict_returns_empty() -> None:
+    # Falsy dict short-circuits before field extraction.
+    assert _extract_ref({}) == {}
+
+
+def test_extract_ref_missing_fields_default_to_empty_string() -> None:
+    # A truthy-but-partial ref keeps every key, defaulting absent ones to "".
+    assert _extract_ref({"id": "P1"}) == {"id": "P1", "summary": "", "type": ""}
+
+
+def test_extract_ref_ignores_unknown_keys() -> None:
+    ref = {"id": "P1", "summary": "s", "type": "t", "html_url": "http://x", "self": "y"}
+    assert _extract_ref(ref) == {"id": "P1", "summary": "s", "type": "t"}
+
+
+# --- _extract_priority ---
+
+
+def test_extract_priority_present() -> None:
+    incident = {"priority": {"id": "PRI1", "name": "P1", "summary": "Critical"}}
+    assert _extract_priority(incident) == {
+        "id": "PRI1",
+        "name": "P1",
+        "summary": "Critical",
+    }
+
+
+def test_extract_priority_null_priority_returns_empty() -> None:
+    # PagerDuty sends priority: null for unprioritised incidents.
+    assert _extract_priority({"priority": None}) == {}
+
+
+def test_extract_priority_absent_key_returns_empty() -> None:
+    assert _extract_priority({}) == {}
+
+
+def test_extract_priority_empty_dict_returns_empty() -> None:
+    assert _extract_priority({"priority": {}}) == {}
+
+
+def test_extract_priority_missing_fields_default_to_empty_string() -> None:
+    assert _extract_priority({"priority": {"id": "PRI1"}}) == {
+        "id": "PRI1",
+        "name": "",
+        "summary": "",
+    }


### PR DESCRIPTION
Fixes #4654

#### Describe the changes you have made in this PR -

C-44 (sibling of C-43 for the Vercel extractors): the PagerDuty payload helpers
`_extract_ref` and `_extract_priority` in `integrations/pagerduty/client.py` are
used across the incident / service / on-call / log-entry parsers, but had **no
direct unit coverage**. This adds a focused test module,
`tests/integrations/pagerduty/test_extract_helpers.py`, pinning their contract:

- `_extract_ref`: full object round-trips `{id, summary, type}`; `None` and an
  empty dict yield `{}`; a partial ref defaults missing fields to `""`; unknown
  keys (`html_url`, `self`, …) are dropped.
- `_extract_priority`: a present priority yields `{id, name, summary}`; the
  PagerDuty `priority: null` case, an absent key, and an empty dict all yield
  `{}`; a partial priority defaults missing fields to `""`.

Inline fixtures only — no live API calls, no network.

### Demo/Screenshot for feature changes and bug fixes -

```
tests/integrations/pagerduty/test_extract_helpers.py ..........
10 passed in 0.80s
```

These tests have teeth: mutating `_extract_ref`'s `summary` default from `""`
to a sentinel makes `test_extract_ref_missing_fields_default_to_empty_string`
fail, confirming the assertions exercise the real helper logic rather than
passing vacuously.

Local CI (`make lint`, `make format-check`, `make typecheck`,
`make verify-integrations-smoke`) is green on both the upstream `main` baseline
and this branch.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The helpers are small, null-safe normalisers, so the risk they guard against is
regression: a future refactor silently dropping the `""` defaults or the
`None`-priority short-circuit would corrupt every downstream incident payload
with no test to catch it. I enumerated the three input classes the issue calls
out — present, missing, edge — for each helper: a full object, `None`, an empty
dict, a partial object, and (for priority) the real PagerDuty `priority: null`
shape. I kept it as a new focused module rather than growing the large
`test_client.py`, matching the C-43 issue's "small unit test file" instruction.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
