### PR TITLE
refactor(analytics): ReactPhase and ReactStopReason as StrEnums

### DIFF
--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -43,7 +43,7 @@ from core.execution import ToolExecutionHooks, public_tool_input
 from core.llm.failure_classification import is_context_length_overflow
 from core.llm.types import AgentLLMResponse, ToolCall
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
-from platform.analytics.react_turn import run_react_agent_with_telemetry
+from platform.analytics.react_turn import ReactPhase, run_react_agent_with_telemetry
 from platform.observability.trace.prompts import persist_turn_system_prompt
 from platform.observability.trace.spans import component_span
 
@@ -752,7 +752,7 @@ def _run_action_turn(
         result = run_react_agent_with_telemetry(
             built.agent,
             [{"role": "user", "content": built.user_message}],
-            phase="action",
+            phase=ReactPhase.ACTION,
             iteration_cap=built.max_iterations,
             llm=built.llm,
             session=session,

--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -32,7 +32,7 @@ from core.agent_harness.session.integration_resolution import resolve_and_cache_
 from core.domain.alerts.alert_source import secondary_tool_sources
 from core.events import runtime_event_callback_from_observer
 from core.state import MAX_CONVERSATION_MESSAGES
-from platform.analytics.react_turn import run_react_agent_with_telemetry
+from platform.analytics.react_turn import ReactPhase, run_react_agent_with_telemetry
 from platform.harness_ports import enrich_resolved_with_repo_scopes
 from platform.observability.trace.prompts import persist_turn_system_prompt
 from platform.observability.trace.spans import component_span
@@ -270,7 +270,7 @@ def gather_tool_evidence(
         result = run_react_agent_with_telemetry(
             agent,
             [{"role": "user", "content": _build_gather_user_message(session, message)}],
-            phase="gather",
+            phase=ReactPhase.GATHER,
             iteration_cap=_MAX_GATHER_ITERATIONS,
             llm=llm,
             session=session,

--- a/platform/analytics/react_turn.py
+++ b/platform/analytics/react_turn.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Any
 
 from core.agent import Agent
 from core.agent.run_io import AgentRunResult
@@ -28,8 +29,25 @@ from platform.analytics.repl_context import (
     get_prompt_turn_id,
 )
 
-ReactPhase = Literal["action", "gather"]
-ReactStopReason = Literal["completed", "iteration_cap", "error", "cancelled", "no_tools_needed"]
+
+class ReactPhase(StrEnum):
+    """Which bounded ReAct phase a turn ran in."""
+
+    ACTION = "action"
+    GATHER = "gather"
+
+
+class ReactStopReason(StrEnum):
+    """Public ``stop_reason`` vocabulary keyed by PostHog dashboards.
+
+    String values must stay identical — analytics dashboards depend on them.
+    """
+
+    COMPLETED = "completed"
+    ITERATION_CAP = "iteration_cap"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+    NO_TOOLS_NEEDED = "no_tools_needed"
 
 
 def resolve_react_stop_reason(
@@ -41,14 +59,14 @@ def resolve_react_stop_reason(
 ) -> ReactStopReason:
     """Map a finished or failed Agent.run to the public stop-reason enum."""
     if cancelled:
-        return "cancelled"
+        return ReactStopReason.CANCELLED
     if error is not None:
-        return "error"
+        return ReactStopReason.ERROR
     if hit_iteration_cap:
-        return "iteration_cap"
+        return ReactStopReason.ITERATION_CAP
     if tool_calls_executed == 0:
-        return "no_tools_needed"
-    return "completed"
+        return ReactStopReason.NO_TOOLS_NEEDED
+    return ReactStopReason.COMPLETED
 
 
 def _session_investigation_id(session: SessionStore | None) -> str | None:
@@ -120,7 +138,7 @@ def emit_react_turn_completed(
         error=error,
         cancelled=cancelled,
     )
-    hit_iteration_cap = stop_reason == "iteration_cap"
+    hit_iteration_cap = stop_reason == ReactStopReason.ITERATION_CAP
 
     cli_turn_kind = get_cli_turn_kind() or "agent"
     investigation_id = _session_investigation_id(session)

--- a/tests/analytics/test_react_turn.py
+++ b/tests/analytics/test_react_turn.py
@@ -5,7 +5,12 @@ import pytest
 from core.agent.run_io import AgentRunResult
 from platform.analytics import cli
 from platform.analytics.events import Event
-from platform.analytics.react_turn import emit_react_turn_completed, resolve_react_stop_reason
+from platform.analytics.react_turn import (
+    ReactPhase,
+    ReactStopReason,
+    emit_react_turn_completed,
+    resolve_react_stop_reason,
+)
 
 
 class _StubLLM:
@@ -32,7 +37,25 @@ class _StubAnalytics:
     ],
 )
 def test_resolve_react_stop_reason(kwargs: dict[str, object], expected: str) -> None:
-    assert resolve_react_stop_reason(**kwargs) == expected  # type: ignore[arg-type]
+    result = resolve_react_stop_reason(**kwargs)  # type: ignore[arg-type]
+    assert result == expected
+    # The resolver returns enum members, not bare strings, on every branch.
+    assert isinstance(result, ReactStopReason)
+
+
+def test_react_enums_pin_public_string_values() -> None:
+    # Dashboards key on these exact strings — pin them so a rename is caught.
+    assert [p.value for p in ReactPhase] == ["action", "gather"]
+    assert [r.value for r in ReactStopReason] == [
+        "completed",
+        "iteration_cap",
+        "error",
+        "cancelled",
+        "no_tools_needed",
+    ]
+    # StrEnum members round-trip from their wire strings and compare as str.
+    assert ReactStopReason("iteration_cap") is ReactStopReason.ITERATION_CAP
+    assert ReactPhase("gather") == "gather"
 
 
 def test_capture_react_turn_completed_emits_required_properties(


### PR DESCRIPTION
Fixes #4520

#### Describe the changes you have made in this PR -

ReAct turn telemetry (`platform/analytics/react_turn.py`) documents `phase` and
`stop_reason` as **public PostHog vocabularies**, but they were bare `Literal`
string aliases — the contract was not enforceable in code and
`resolve_react_stop_reason` returned raw strings. This converts both to
`enum.StrEnum` with **identical** string values:

```python
class ReactPhase(StrEnum):
    ACTION = "action"
    GATHER = "gather"

class ReactStopReason(StrEnum):
    COMPLETED = "completed"
    ITERATION_CAP = "iteration_cap"
    ERROR = "error"
    CANCELLED = "cancelled"
    NO_TOOLS_NEEDED = "no_tools_needed"
```

`resolve_react_stop_reason` now returns members, and the two
`run_react_agent_with_telemetry` call sites (action + evidence drivers) pass
`ReactPhase.ACTION` / `ReactPhase.GATHER`. Because `StrEnum` members are `str`
subclasses that compare and serialise as their value, the emitted analytics
payload is byte-identical — **no dashboard property value changes**. A pinning
test guards the exact strings against future renames.

### Demo/Screenshot for feature changes and bug fixes -

**RED — the new tests against the pre-refactor `Literal` module:**

```
tests/analytics/test_react_turn.py::test_resolve_react_stop_reason[kwargs0-completed] FAILED
tests/analytics/test_react_turn.py::test_react_enums_pin_public_string_values FAILED
6 failed, 2 passed
```
(the resolver returned bare strings, and `ReactStopReason` / `ReactPhase` were
not iterable enums)

**GREEN — after the StrEnum conversion:**

```
tests/analytics/test_react_turn.py ........
8 passed in 0.77s
```

Local CI green on both the upstream `main` baseline and this branch:
`make lint`, `make format-check`, `make typecheck` (full, 1581 files — the
call-site updates satisfy it), `make verify-integrations-smoke`. Turn-driver
suite (`tests/core/agent_harness/turns/`) stays green.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The goal is compile-time exhaustiveness without changing any persisted/analytics
string. `StrEnum` is the right tool because members *are* strings — so the
PostHog `properties` dict, `json` serialisation, and the existing `== "completed"`
comparisons keep working untouched. I returned members from the resolver (the
issue's explicit ask) and only had to update the two real telemetry call sites;
the `"action_agent"` / `"gather_agent"` strings elsewhere go to a different
function (`persist_turn_system_prompt`) and are intentionally left alone. I
considered leaving the call sites as bare strings, but mypy correctly rejects a
plain `str` for a `StrEnum` parameter, and passing members is clearer. The
pinning test enumerates every member value so a future rename that would break a
dashboard fails loudly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
