### PR TITLE
refactor(masking): IdentifierKind StrEnum for masking policy

### DIFF
--- a/platform/masking/detectors.py
+++ b/platform/masking/detectors.py
@@ -61,14 +61,14 @@ _EMAIL_RE = re.compile(r"\b([\w.+-]+@[\w-]+\.[\w.-]+)\b")
 
 
 _BUILTIN_DETECTORS: dict[IdentifierKind, re.Pattern[str]] = {
-    "pod": _POD_RE,
-    "namespace": _NAMESPACE_RE,
-    "cluster": _CLUSTER_RE,
-    "service_name": _SERVICE_NAME_RE,
-    "hostname": _HOSTNAME_RE,
-    "account_id": _ACCOUNT_RE,
-    "ip_address": _IP_RE,
-    "email": _EMAIL_RE,
+    IdentifierKind.POD: _POD_RE,
+    IdentifierKind.NAMESPACE: _NAMESPACE_RE,
+    IdentifierKind.CLUSTER: _CLUSTER_RE,
+    IdentifierKind.SERVICE_NAME: _SERVICE_NAME_RE,
+    IdentifierKind.HOSTNAME: _HOSTNAME_RE,
+    IdentifierKind.ACCOUNT_ID: _ACCOUNT_RE,
+    IdentifierKind.IP_ADDRESS: _IP_RE,
+    IdentifierKind.EMAIL: _EMAIL_RE,
 }
 
 

--- a/platform/masking/policy.py
+++ b/platform/masking/policy.py
@@ -12,7 +12,8 @@ import json
 import logging
 import os
 import re
-from typing import ClassVar, Literal
+from enum import StrEnum
+from typing import ClassVar
 
 from pydantic import Field, field_validator
 
@@ -20,27 +21,25 @@ from config.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
 
-IdentifierKind = Literal[
-    "pod",
-    "namespace",
-    "cluster",
-    "hostname",
-    "account_id",
-    "ip_address",
-    "email",
-    "service_name",
-]
 
-ALL_KINDS: tuple[IdentifierKind, ...] = (
-    "pod",
-    "namespace",
-    "cluster",
-    "hostname",
-    "account_id",
-    "ip_address",
-    "email",
-    "service_name",
-)
+class IdentifierKind(StrEnum):
+    """A kind of sensitive infrastructure identifier the masker can redact.
+
+    String values are the wire format used by ``OPENSRE_MASK_KINDS`` and
+    persisted config, so they must stay identical.
+    """
+
+    POD = "pod"
+    NAMESPACE = "namespace"
+    CLUSTER = "cluster"
+    HOSTNAME = "hostname"
+    ACCOUNT_ID = "account_id"
+    IP_ADDRESS = "ip_address"
+    EMAIL = "email"
+    SERVICE_NAME = "service_name"
+
+
+ALL_KINDS: tuple[IdentifierKind, ...] = tuple(IdentifierKind)
 
 
 class MaskingPolicy(StrictConfigModel):
@@ -72,7 +71,7 @@ class MaskingPolicy(StrictConfigModel):
         valid: list[IdentifierKind] = []
         for p in parts:
             if p in ALL_KINDS:
-                valid.append(p)  # type: ignore[arg-type]
+                valid.append(IdentifierKind(p))
             else:
                 logger.warning("[masking] ignoring unknown identifier kind: %r", p)
         return tuple(valid) if valid else ALL_KINDS

--- a/tests/masking/test_policy.py
+++ b/tests/masking/test_policy.py
@@ -4,7 +4,32 @@ from __future__ import annotations
 
 import pytest
 
-from platform.masking.policy import ALL_KINDS, MaskingPolicy
+from platform.masking.policy import ALL_KINDS, IdentifierKind, MaskingPolicy
+
+
+def test_identifier_kind_is_strenum_and_pins_wire_values() -> None:
+    assert issubclass(IdentifierKind, str)
+    assert [k.value for k in IdentifierKind] == [
+        "pod",
+        "namespace",
+        "cluster",
+        "hostname",
+        "account_id",
+        "ip_address",
+        "email",
+        "service_name",
+    ]
+    # ALL_KINDS is derived from the enum — no drift between the two.
+    assert tuple(IdentifierKind) == ALL_KINDS
+    # Membership works against both wire strings and members (round-trip).
+    assert "email" in ALL_KINDS
+    assert IdentifierKind("email") is IdentifierKind.EMAIL
+
+
+def test_policy_coerces_kind_strings_to_members() -> None:
+    policy = MaskingPolicy.model_validate({"enabled": True, "kinds": ("pod", "email")})
+    assert policy.kinds == (IdentifierKind.POD, IdentifierKind.EMAIL)
+    assert all(isinstance(k, IdentifierKind) for k in policy.kinds)
 
 
 def test_default_policy_is_disabled() -> None:


### PR DESCRIPTION
Fixes #4524

#### Describe the changes you have made in this PR -

`IdentifierKind` in `platform/masking/policy.py` was a `Literal` paired with an
`ALL_KINDS` tuple that re-listed the same eight values — the two could drift.
This converts `IdentifierKind` to `enum.StrEnum` with **identical** string
values and derives the tuple:

```python
class IdentifierKind(StrEnum):
    POD = "pod"
    ...
    SERVICE_NAME = "service_name"

ALL_KINDS: tuple[IdentifierKind, ...] = tuple(IdentifierKind)
```

- The `kinds` before-validator now coerces accepted strings to members
  (`IdentifierKind(p)`), dropping a `# type: ignore`.
- `_BUILTIN_DETECTORS` in `detectors.py` is keyed by members.
- Env/JSON kind lists (`OPENSRE_MASK_KINDS`) still parse the same strings, and
  because `StrEnum` members compare and format as their value, no persisted
  shape, placeholder text, or `is_kind_enabled` behaviour changes.

### Demo/Screenshot for feature changes and bug fixes -

**RED — the new tests against the pre-refactor `Literal` module:**

```
tests/masking/test_policy.py::test_identifier_kind_is_strenum_and_pins_wire_values FAILED
tests/masking/test_policy.py::test_policy_coerces_kind_strings_to_members FAILED
2 failed, 19 passed
```

**GREEN — after the StrEnum conversion (whole masking suite):**

```
tests/masking/ .......................................................................
74 passed in 0.83s
```

Local CI green on the upstream `main` baseline and this branch: `make lint`,
`make format-check`, `make typecheck` (full), `make verify-integrations-smoke`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The value here is a single source of truth for the kind vocabulary:
`ALL_KINDS` now cannot fall out of sync with the type. `StrEnum` is the right
tool because the values are configured by string (env var, JSON) and the
Pydantic `kinds` field must round-trip them — members are `str`, so validation,
`in` membership, and the masker's placeholder text keep working unchanged. I
kept the before-validator's `p in ALL_KINDS` guard (now matching members via
`==`) and coerce accepted strings to members so `policy.kinds` is uniformly
typed. I verified the full masking suite (policy, detectors, context,
integration fixtures) stays green, since detector keys and placeholder rendering
both flow through the kind value.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
