### PR TITLE
refactor(interactive-shell): make ExecutionVerdict a StrEnum

### DIFF
--- a/tests/interactive_shell/tools/shared/test_execution_policy.py
+++ b/tests/interactive_shell/tools/shared/test_execution_policy.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from tools.interactive_shell.shared import (
     ConfirmationOutcome,
     ExecutionPolicyResult,
+    ExecutionVerdict,
     ToolExecutionMode,
     ToolExecutionPlan,
     allow_tool,
@@ -33,6 +34,29 @@ def _ask_result() -> ExecutionPolicyResult:
         tool_type="slash",
         reason="this command may change configuration or run heavy work",
     )
+
+
+# --- ExecutionVerdict enum contract -----------------------------------------
+
+
+def test_execution_verdict_wire_values_are_stable() -> None:
+    assert [v.value for v in ExecutionVerdict] == ["allow", "ask", "deny"]
+
+
+def test_execution_verdict_is_str_subclass() -> None:
+    assert issubclass(ExecutionVerdict, str)
+
+
+def test_execution_verdict_round_trips_from_wire_value() -> None:
+    assert ExecutionVerdict("allow") is ExecutionVerdict.ALLOW
+    assert ExecutionVerdict("ask") is ExecutionVerdict.ASK
+    assert ExecutionVerdict("deny") is ExecutionVerdict.DENY
+
+
+def test_execution_verdict_compares_equal_to_wire_string() -> None:
+    assert ExecutionVerdict.ALLOW == "allow"
+    assert ExecutionVerdict.ASK == "ask"
+    assert ExecutionVerdict.DENY == "deny"
 
 
 # --- Default-allow policy decisions -----------------------------------------

--- a/tools/interactive_shell/cli.py
+++ b/tools/interactive_shell/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from platform.common.task_types import TaskKind
 from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
+    ExecutionVerdict,
     ToolExecutionMode,
     ToolExecutionPlan,
 )
@@ -199,7 +200,7 @@ def to_tool_execution_plan(plan: OpensreExecutionPlan) -> ToolExecutionPlan:
         mode = ToolExecutionMode.FOREGROUND_STREAMING
     if not plan.requires_confirmation:
         policy = ExecutionPolicyResult(
-            verdict="allow",
+            verdict=ExecutionVerdict.ALLOW,
             tool_type="cli_command",
             reason=None,
             hint=None,
@@ -207,7 +208,7 @@ def to_tool_execution_plan(plan: OpensreExecutionPlan) -> ToolExecutionPlan:
         )
     else:
         policy = ExecutionPolicyResult(
-            verdict="ask",
+            verdict=ExecutionVerdict.ASK,
             tool_type="cli_command",
             reason=plan.confirmation_reason,
             hint="Use a read-only subcommand (health, version, list, status, show)",

--- a/tools/interactive_shell/shared/execution_policy.py
+++ b/tools/interactive_shell/shared/execution_policy.py
@@ -37,9 +37,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal
 
-ExecutionVerdict = Literal["allow", "ask", "deny"]
+
+class ExecutionVerdict(StrEnum):
+    """Execution policy verdict for a tool launch (wire values are stable)."""
+
+    ALLOW = "allow"
+    ASK = "ask"
+    DENY = "deny"
 
 
 class ToolExecutionMode(StrEnum):
@@ -106,7 +111,7 @@ def resolve_confirmation(
     (``interactive_shell.ui.execution_confirm``) renders the decision and emits
     analytics.
     """
-    if result.verdict == "deny":
+    if result.verdict == ExecutionVerdict.DENY:
         return ConfirmationPlan(
             outcome=ConfirmationOutcome.DENY,
             result=result,
@@ -114,7 +119,7 @@ def resolve_confirmation(
             analytics_reason=result.reason,
         )
 
-    if result.verdict == "allow":
+    if result.verdict == ExecutionVerdict.ALLOW:
         return ConfirmationPlan(
             outcome=ConfirmationOutcome.ALLOW,
             result=result,
@@ -153,7 +158,7 @@ def allow_tool(tool_type: str) -> ExecutionPolicyResult:
     so every caller resolves to ``allow``. ``tool_type`` is carried through for
     analytics and confirmation UX.
     """
-    return ExecutionPolicyResult(verdict="allow", tool_type=tool_type, reason=None)
+    return ExecutionPolicyResult(verdict=ExecutionVerdict.ALLOW, tool_type=tool_type, reason=None)
 
 
 def plan_foreground_tool(

--- a/tools/interactive_shell/shell/policy.py
+++ b/tools/interactive_shell/shell/policy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import config.constants.platform as _platform
 from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
+    ExecutionVerdict,
     ToolExecutionMode,
     ToolExecutionPlan,
 )
@@ -32,7 +33,7 @@ def evaluate_shell_from_parsed(parsed: ParsedShellCommand) -> ExecutionPolicyRes
     """
     if parsed.parse_error is not None:
         return ExecutionPolicyResult(
-            verdict="deny",
+            verdict=ExecutionVerdict.DENY,
             tool_type="shell",
             reason=parsed.parse_error,
             hint="Enter a command to run.",
@@ -40,7 +41,7 @@ def evaluate_shell_from_parsed(parsed: ParsedShellCommand) -> ExecutionPolicyRes
         )
 
     return ExecutionPolicyResult(
-        verdict="allow",
+        verdict=ExecutionVerdict.ALLOW,
         tool_type="shell",
         reason=None,
         shell_classification="unrestricted",

--- a/tools/interactive_shell/shell/runner.py
+++ b/tools/interactive_shell/shell/runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import config.constants.platform as _platform
+from tools.interactive_shell.shared import ExecutionVerdict
 from tools.interactive_shell.shell import execution as shell_execution
 from tools.interactive_shell.shell.display import format_shell_command_for_display
 from tools.interactive_shell.shell.parsing import (
@@ -75,7 +76,7 @@ def run_shell_command(
             command=command,
             ok=False,
             response_text=plan.policy.reason or "shell command blocked",
-            cancelled=plan.policy.verdict != "deny",
+            cancelled=plan.policy.verdict != ExecutionVerdict.DENY,
         )
 
     if not quiet:


### PR DESCRIPTION
Fixes #4537

#### Describe the changes you have made in this PR -

Converts `ExecutionVerdict` in `tools/interactive_shell/shared/execution_policy.py` from a bare `Literal["allow", "ask", "deny"]` type alias into a `StrEnum`:

```python
class ExecutionVerdict(StrEnum):
    """Execution policy verdict for a tool launch (wire values are stable)."""
    ALLOW = "allow"
    ASK = "ask"
    DENY = "deny"
```

This matches the two sibling enums already defined in the same module (`ConfirmationOutcome` and `ToolExecutionMode`), which are already `StrEnum`s. The wire values are byte-for-byte identical, so serialized analytics props and any `== "allow"`-style comparisons keep working.

All call sites that constructed or compared the literal strings now use the members:

- `shared/execution_policy.py` — `allow_tool` returns `ExecutionVerdict.ALLOW`; `resolve_confirmation` branches on `ExecutionVerdict.DENY`/`ALLOW`.
- `tools/interactive_shell/cli.py` — `ExecutionVerdict.ALLOW` / `ExecutionVerdict.ASK`.
- `tools/interactive_shell/shell/policy.py` — `ExecutionVerdict.DENY` / `ALLOW`.
- `tools/interactive_shell/shell/runner.py` — `plan.policy.verdict != ExecutionVerdict.DENY`.

The unused `Literal` import is removed. **No behavior change**: the alpha policy still resolves every tool launch to `allow`.

### Demo/Screenshot for feature changes and bug fixes -

Added enum-contract tests to the existing `tests/interactive_shell/tools/shared/test_execution_policy.py`. They fail on the current `Literal` (can't iterate/subclass it) and pass after the refactor.

RED (new tests run against the unmodified `Literal` source):

```
FAILED tests/interactive_shell/tools/shared/test_execution_policy.py::test_execution_verdict_wire_values_are_stable
FAILED tests/interactive_shell/tools/shared/test_execution_policy.py::test_execution_verdict_is_str_subclass
FAILED tests/interactive_shell/tools/shared/test_execution_policy.py::test_execution_verdict_round_trips_from_wire_value
FAILED tests/interactive_shell/tools/shared/test_execution_policy.py::test_execution_verdict_compares_equal_to_wire_string
========================= 4 failed, 9 passed in 0.91s ==========================
```

GREEN (with the StrEnum refactor):

```
============================== 13 passed in 0.77s ==============================
```

Local CI replay (`run-ci.sh`: lint, format-check, typecheck, verify-integrations-smoke + the affected pytest target) exits 0 / ALL GREEN.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a type-consistency gap: `ExecutionVerdict` was the only verdict/mode type in `execution_policy.py` still expressed as a raw `Literal`, while its two siblings (`ConfirmationOutcome`, `ToolExecutionMode`) are `StrEnum`s. A `StrEnum` gives named members, iteration, and `ExecutionVerdict("allow")` parsing while remaining a `str`, so it is a strict superset of what the `Literal` offered. I considered leaving the `Literal` (rejected: the issue asks for the enum and the inconsistency is the point) and a plain `Enum` (rejected: it would break the `str` identity the analytics layer and existing string comparisons rely on — `StrEnum` preserves that). I kept the three wire values identical so nothing serialized or compared changes, then swapped every construction/comparison site to the members so mypy stays green. The key symbols: the `ExecutionVerdict` enum itself (the three verdicts) and the resolver `resolve_confirmation`, which branches on `DENY`/`ALLOW` and otherwise treats the verdict as `ask`. Tests pin the wire values `["allow","ask","deny"]`, assert `issubclass(ExecutionVerdict, str)`, round-trip `ExecutionVerdict("allow") is ExecutionVerdict.ALLOW`, and the pre-existing tests already cover every resolver branch.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
