### PR TITLE
feat(filestorage): retry transient S3 object-store failures

### DIFF
--- a/platform/filestorage/providers/aws.py
+++ b/platform/filestorage/providers/aws.py
@@ -151,16 +151,19 @@ class S3ObjectStore:
         full_prefix = (
             self._config.key_for(prefix) if prefix else f"{self._config.prefix.rstrip('/')}/"
         )
-        out: list[RemoteObject] = []
-        try:
-            # list() so pagination runs *inside* _with_retry: a transient blip
-            # partway through a multi-page listing is then retried. Returning
-            # the bare generator would defer pagination to the loop below,
-            # outside the retry wrapper, and lose that coverage.
-            for page in _with_retry(lambda: list(self._pages(full_prefix))):
+
+        def _collect() -> list[RemoteObject]:
+            # Consume pages one at a time and keep only the parsed objects, so a
+            # prefix spanning many S3 pages never retains every raw page at once
+            # (peak memory stays O(objects), not O(objects + raw pages)). Runs
+            # *inside* _with_retry, so a transient blip partway through a
+            # multi-page listing retries the whole listing rather than escaping
+            # the retry wrapper.
+            objects: list[RemoteObject] = []
+            for page in self._pages(full_prefix):
                 for item in page.get("Contents", []):
                     key = str(item["Key"])
-                    out.append(
+                    objects.append(
                         RemoteObject(
                             key=self._strip_prefix(key),
                             size=int(item.get("Size", 0)),
@@ -170,11 +173,14 @@ class S3ObjectStore:
                             etag=str(item.get("ETag", "")).strip('"'),
                         )
                     )
+            return objects
+
+        try:
+            return _with_retry(_collect)
         except (BotoCoreError, ClientError) as exc:
             raise RemoteSyncUnavailableError(
                 f"cannot list {self.describe()} — {_reason(exc)}"
             ) from exc
-        return out
 
     def get_object(self, key: str) -> bytes:
         def _read() -> bytes:

--- a/platform/filestorage/providers/aws.py
+++ b/platform/filestorage/providers/aws.py
@@ -8,7 +8,12 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 import boto3
-from botocore.exceptions import BotoCoreError, ClientError
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    NoCredentialsError,
+    PartialCredentialsError,
+)
 
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.enums import BucketExposure, BuiltInProvider, RemoteSyncField
@@ -49,6 +54,13 @@ PERMANENT_ERROR_CODES = frozenset(
         "SignatureDoesNotMatch",
     }
 )
+# BotoCoreError subclasses that are a misconfiguration, not a blip: missing or
+# incomplete credentials never resolve by retrying, so they surface at once
+# rather than after four futile attempts and 3.5s of backoff.
+PERMANENT_BOTOCORE_ERRORS: tuple[type[BotoCoreError], ...] = (
+    NoCredentialsError,
+    PartialCredentialsError,
+)
 # Codes that mean "the store was busy or briefly unhealthy" — safe to retry.
 TRANSIENT_ERROR_CODES = frozenset(
     {
@@ -67,11 +79,15 @@ TRANSIENT_ERROR_CODES = frozenset(
 def _is_transient(exc: BotoCoreError | ClientError) -> bool:
     """Whether ``exc`` is a blip worth retrying rather than a permanent fault.
 
-    A :class:`BotoCoreError` is a client-side network/connection failure (no
-    HTTP response reached us), which is always transient. A
-    :class:`ClientError` is a real S3 response: retry only throttling codes and
-    5xx statuses, and never the permanent set (bad bucket, denied, missing key).
+    A :class:`BotoCoreError` is usually a client-side network/connection
+    failure (no HTTP response reached us), which is transient — except the
+    credential-configuration subclasses in :data:`PERMANENT_BOTOCORE_ERRORS`,
+    which never resolve by retrying. A :class:`ClientError` is a real S3
+    response: retry only throttling codes and 5xx statuses, and never the
+    permanent set (bad bucket, denied, missing key).
     """
+    if isinstance(exc, PERMANENT_BOTOCORE_ERRORS):
+        return False
     if isinstance(exc, ClientError):
         error = exc.response.get("Error", {})
         code = str(error.get("Code", ""))
@@ -137,6 +153,10 @@ class S3ObjectStore:
         )
         out: list[RemoteObject] = []
         try:
+            # list() so pagination runs *inside* _with_retry: a transient blip
+            # partway through a multi-page listing is then retried. Returning
+            # the bare generator would defer pagination to the loop below,
+            # outside the retry wrapper, and lose that coverage.
             for page in _with_retry(lambda: list(self._pages(full_prefix))):
                 for item in page.get("Contents", []):
                     key = str(item["Key"])

--- a/platform/filestorage/providers/aws.py
+++ b/platform/filestorage/providers/aws.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+import time
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 import boto3
@@ -15,7 +18,9 @@ from platform.filestorage.ports import RemoteObject
 from platform.filestorage.providers.registry import SetupExtraField, register_object_store
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
+
+logger = logging.getLogger(__name__)
 
 _SERVER_SIDE_ENCRYPTION = "AES256"
 PROVIDER_NAME = BuiltInProvider.AWS
@@ -24,6 +29,95 @@ EXTRA_FIELDS = (
     SetupExtraField(RemoteSyncField.PROFILE, "Credentials profile (blank if unused)"),
     SetupExtraField(RemoteSyncField.REGION, "Region (blank if unused)"),
 )
+
+# Transient-failure retry policy for S3 calls. A dropped connection or a
+# throttling response should not fail the whole run, so retryable errors back
+# off and retry; permanent errors (see PERMANENT_ERROR_CODES) never do.
+RETRY_MAX_ATTEMPTS = 4
+RETRY_BASE_DELAY_SECONDS = 0.5
+RETRY_BACKOFF_FACTOR = 2.0
+
+# Error codes S3 returns that are the caller's fault, not a blip: retrying only
+# burns time and quota, so these surface immediately.
+PERMANENT_ERROR_CODES = frozenset(
+    {
+        "NoSuchBucket",
+        "AccessDenied",
+        "NoSuchKey",
+        "NoSuchBucketPolicy",
+        "InvalidAccessKeyId",
+        "SignatureDoesNotMatch",
+    }
+)
+# Codes that mean "the store was busy or briefly unhealthy" — safe to retry.
+TRANSIENT_ERROR_CODES = frozenset(
+    {
+        "SlowDown",
+        "RequestTimeout",
+        "RequestTimeoutException",
+        "Throttling",
+        "ThrottlingException",
+        "RequestLimitExceeded",
+        "ServiceUnavailable",
+        "InternalError",
+    }
+)
+
+
+def _is_transient(exc: BotoCoreError | ClientError) -> bool:
+    """Whether ``exc`` is a blip worth retrying rather than a permanent fault.
+
+    A :class:`BotoCoreError` is a client-side network/connection failure (no
+    HTTP response reached us), which is always transient. A
+    :class:`ClientError` is a real S3 response: retry only throttling codes and
+    5xx statuses, and never the permanent set (bad bucket, denied, missing key).
+    """
+    if isinstance(exc, ClientError):
+        error = exc.response.get("Error", {})
+        code = str(error.get("Code", ""))
+        if code in PERMANENT_ERROR_CODES:
+            return False
+        if code in TRANSIENT_ERROR_CODES:
+            return True
+        status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+        return int(status or 0) >= HTTPStatus.INTERNAL_SERVER_ERROR
+    # BotoCoreError: a connection dropped, timed out, or never resolved.
+    return True
+
+
+def _with_retry[T](call: Callable[[], T], *, sleep: Callable[[float], None] | None = None) -> T:
+    """Run ``call``, retrying transient S3 failures with exponential backoff.
+
+    Permanent failures (and any non-boto exception) propagate on the first hit.
+    Transient failures back off up to ``RETRY_MAX_ATTEMPTS`` times; the last
+    failure is re-raised so the caller can wrap it in
+    :class:`RemoteSyncUnavailableError`. ``sleep`` defaults to
+    :func:`time.sleep`, resolved lazily so a test patching ``aws.time.sleep``
+    takes effect without threading an argument through every call site.
+    """
+    if sleep is None:
+        sleep = time.sleep
+    delay = RETRY_BASE_DELAY_SECONDS
+    for attempt in range(1, RETRY_MAX_ATTEMPTS + 1):
+        try:
+            return call()
+        except (BotoCoreError, ClientError) as exc:
+            if not _is_transient(exc) or attempt == RETRY_MAX_ATTEMPTS:
+                raise
+            # Detail stays server-side only (CWE-209): callers map the final
+            # raise to a generic RemoteSyncUnavailableError.
+            logger.warning(
+                "[remote-sync] transient S3 failure (attempt %d/%d), retrying in %.1fs: %s",
+                attempt,
+                RETRY_MAX_ATTEMPTS,
+                delay,
+                _reason(exc),
+            )
+            sleep(delay)
+            delay *= RETRY_BACKOFF_FACTOR
+    # Unreachable: the loop either returns or raises on every path, but a bare
+    # fall-through would silently return None, so fail loudly instead.
+    raise AssertionError("retry loop exited without returning or raising")
 
 
 class S3ObjectStore:
@@ -43,7 +137,7 @@ class S3ObjectStore:
         )
         out: list[RemoteObject] = []
         try:
-            for page in self._pages(full_prefix):
+            for page in _with_retry(lambda: list(self._pages(full_prefix))):
                 for item in page.get("Contents", []):
                     key = str(item["Key"])
                     out.append(
@@ -63,23 +157,29 @@ class S3ObjectStore:
         return out
 
     def get_object(self, key: str) -> bytes:
-        try:
+        def _read() -> bytes:
             response = self._client.get_object(
                 Bucket=self._config.bucket, Key=self._config.key_for(key)
             )
             body: bytes = response["Body"].read()
             return body
+
+        try:
+            return _with_retry(_read)
         except (BotoCoreError, ClientError) as exc:
             raise RemoteSyncUnavailableError(f"cannot read {key} — {_reason(exc)}") from exc
 
     def put_object(self, key: str, data: bytes) -> None:
-        try:
+        def _write() -> None:
             self._client.put_object(
                 Bucket=self._config.bucket,
                 Key=self._config.key_for(key),
                 Body=data,
                 ServerSideEncryption=_SERVER_SIDE_ENCRYPTION,
             )
+
+        try:
+            _with_retry(_write)
         except (BotoCoreError, ClientError) as exc:
             raise RemoteSyncUnavailableError(f"cannot write {key} — {_reason(exc)}") from exc
 

--- a/tests/filestorage/test_s3_retry.py
+++ b/tests/filestorage/test_s3_retry.py
@@ -1,0 +1,186 @@
+"""Transient S3 failures retry with backoff; permanent ones surface immediately.
+
+These exercise :class:`~platform.filestorage.providers.aws.S3ObjectStore`
+against fake clients only — no cloud. The sleep is patched so the backoff does
+not actually wait.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from botocore.exceptions import ClientError, EndpointConnectionError
+
+from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.providers.aws import S3ObjectStore
+
+_BUCKET = "test-bucket"
+_KEY = "sessions/abc.jsonl"
+_BODY = b'{"turn": 1}\n'
+
+
+def _client_error(code: str, http_status: int | None = None) -> ClientError:
+    """A botocore ClientError with ``code`` (and optional HTTP status)."""
+    error: dict[str, object] = {"Error": {"Code": code, "Message": code}}
+    if http_status is not None:
+        error["ResponseMetadata"] = {"HTTPStatusCode": http_status}
+    return ClientError(error, "GetObject")
+
+
+class _Body:
+    """The streaming-body shape ``get_object`` reads from."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _TransientThenOk:
+    """Fails ``failures`` times with a transient error, then returns the body."""
+
+    def __init__(self, exc: Exception, failures: int) -> None:
+        self._exc = exc
+        self._remaining = failures
+        self.calls = 0
+
+    def get_object(self, **_kwargs: object) -> dict[str, object]:
+        self.calls += 1
+        if self._remaining > 0:
+            self._remaining -= 1
+            raise self._exc
+        return {"Body": _Body(_BODY)}
+
+
+class _AlwaysRaises:
+    """Every ``get_object`` raises the same error; counts the calls."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    def get_object(self, **_kwargs: object) -> dict[str, object]:
+        self.calls += 1
+        raise self._exc
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backoff must not actually pause the test suite.
+
+    Patches the shared ``time.sleep`` the provider resolves lazily, so the
+    fixture works whether or not the retry helper exists yet (it is a no-op on a
+    build with no backoff to skip).
+    """
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+
+def _store(client: object) -> S3ObjectStore:
+    return S3ObjectStore(RemoteSyncConfig(bucket=_BUCKET), client=client)
+
+
+def test_a_transient_throttle_is_retried_then_succeeds() -> None:
+    """A SlowDown blip does not fail the run — the next attempt returns data."""
+    # Arrange: one throttling failure, then success.
+    client = _TransientThenOk(_client_error("SlowDown"), failures=1)
+    store = _store(client)
+
+    # Act
+    body = store.get_object(_KEY)
+
+    # Assert: the second attempt won, and it really did retry.
+    assert body == _BODY
+    assert client.calls == 2
+
+
+def test_a_dropped_connection_is_retried_then_succeeds() -> None:
+    """A BotoCoreError (no HTTP response) is a network blip and retries."""
+    # Arrange
+    dropped = EndpointConnectionError(endpoint_url="https://s3")
+    client = _TransientThenOk(dropped, failures=1)
+    store = _store(client)
+
+    # Act
+    body = store.get_object(_KEY)
+
+    # Assert
+    assert body == _BODY
+    assert client.calls == 2
+
+
+def test_a_5xx_status_is_treated_as_transient_and_retried() -> None:
+    """An unlisted code with a 5xx HTTP status is still a server blip."""
+    # Arrange: code botocore does not special-case, but a 503 status.
+    server_blip = _client_error("SomethingUpstream", http_status=503)
+    client = _TransientThenOk(server_blip, failures=1)
+    store = _store(client)
+
+    # Act
+    body = store.get_object(_KEY)
+
+    # Assert
+    assert body == _BODY
+    assert client.calls == 2
+
+
+def test_a_permanent_error_is_surfaced_immediately_and_not_retried() -> None:
+    """AccessDenied is the caller's fault — fail fast, exactly one call."""
+    # Arrange
+    client = _AlwaysRaises(_client_error("AccessDenied"))
+    store = _store(client)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncUnavailableError):
+        store.get_object(_KEY)
+    assert client.calls == 1
+
+
+def test_a_missing_bucket_is_not_retried() -> None:
+    """NoSuchBucket is permanent — retrying only burns time and quota."""
+    # Arrange
+    client = _AlwaysRaises(_client_error("NoSuchBucket"))
+    store = _store(client)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncUnavailableError):
+        store.get_object(_KEY)
+    assert client.calls == 1
+
+
+def test_a_persistent_transient_error_exhausts_attempts_then_raises() -> None:
+    """Backoff is bounded: after RETRY_MAX_ATTEMPTS tries it gives up cleanly."""
+    from platform.filestorage.providers.aws import RETRY_MAX_ATTEMPTS
+
+    # Arrange: throttling that never clears.
+    client = _AlwaysRaises(_client_error("SlowDown"))
+    store = _store(client)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncUnavailableError):
+        store.get_object(_KEY)
+    assert client.calls == RETRY_MAX_ATTEMPTS
+
+
+def test_the_user_facing_message_never_leaks_boto_internals() -> None:
+    """CWE-209: the surfaced error names the key, not the raw boto payload.
+
+    Detail is logged server-side; the message a user could see on a chat surface
+    stays generic. The wrapper carries a stable ``cannot read`` phrase and the
+    key, but not the AccessDenied credentials-shaped internals of the response.
+    """
+    # Arrange: an error whose raw text carries something secret-looking.
+    secret_shaped = _client_error("SlowDown")
+    client = _AlwaysRaises(secret_shaped)
+    store = _store(client)
+
+    # Act
+    with pytest.raises(RemoteSyncUnavailableError) as caught:
+        store.get_object(_KEY)
+
+    # Assert: the message identifies the failed operation and key only.
+    message = str(caught.value)
+    assert _KEY in message
+    assert "cannot read" in message

--- a/tests/filestorage/test_s3_retry.py
+++ b/tests/filestorage/test_s3_retry.py
@@ -8,6 +8,8 @@ not actually wait.
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 import pytest
 from botocore.exceptions import (
@@ -21,9 +23,15 @@ from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.errors import RemoteSyncUnavailableError
 from platform.filestorage.providers.aws import S3ObjectStore
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 _BUCKET = "test-bucket"
 _KEY = "sessions/abc.jsonl"
 _BODY = b'{"turn": 1}\n'
+# RemoteSyncConfig's default prefix; a listing returns keys under "<prefix>/".
+_PREFIX = "opensre"
+_LISTED_AT = datetime(2026, 1, 1, tzinfo=UTC)
 
 
 def _client_error(code: str, http_status: int | None = None) -> ClientError:
@@ -70,6 +78,46 @@ class _AlwaysRaises:
     def get_object(self, **_kwargs: object) -> dict[str, object]:
         self.calls += 1
         raise self._exc
+
+
+def _page(*keys: str) -> dict[str, object]:
+    """One ``list_objects_v2`` page carrying ``keys`` under the default prefix."""
+    return {
+        "Contents": [
+            {
+                "Key": f"{_PREFIX}/{k}",
+                "Size": len(k),
+                "LastModified": _LISTED_AT,
+                "ETag": f'"{k}"',
+            }
+            for k in keys
+        ]
+    }
+
+
+class _ListingClient:
+    """A fake S3 client that serves ``list_objects_v2`` pagination.
+
+    Acts as its own paginator. A transient ``blip`` raised on the first pass
+    (after the first page) forces the retry wrapper to re-run pagination from
+    the top, since the real S3 paginator cannot resume mid-listing.
+    """
+
+    def __init__(self, pages: list[dict[str, object]], *, blip: Exception | None = None) -> None:
+        self._pages = pages
+        self._blip = blip
+        self.passes = 0
+
+    def get_paginator(self, _name: str) -> _ListingClient:
+        return self
+
+    def paginate(self, **_kwargs: object) -> Iterator[dict[str, object]]:
+        self.passes += 1
+        first_pass = self.passes == 1
+        for index, page in enumerate(self._pages):
+            if first_pass and self._blip is not None and index == 1:
+                raise self._blip
+            yield page
 
 
 @pytest.fixture(autouse=True)
@@ -220,3 +268,63 @@ def test_the_user_facing_message_names_the_key_and_operation() -> None:
     message = str(caught.value)
     assert _KEY in message
     assert "cannot read" in message
+
+
+def test_the_surfaced_message_excludes_the_raw_response_payload() -> None:
+    """The local message carries the curated boto reason, not the raw payload.
+
+    ``_reason`` renders only the ClientError Code and Message. Secret-shaped
+    values a real S3 response can carry elsewhere (request ids, response
+    headers) must never be spilled into the surfaced message by a future change
+    that interpolates ``exc.response`` wholesale — defence in depth for CWE-209
+    even though the local surface is allowed the curated reason.
+    """
+    # Arrange: a permanent secret marker planted in the response metadata.
+    secret = "AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI-should-not-leak"
+    error: dict[str, object] = {
+        "Error": {"Code": "AccessDenied", "Message": "AccessDenied"},
+        "ResponseMetadata": {"RequestId": secret, "HTTPHeaders": {"x-amz-id-2": secret}},
+    }
+    client = _AlwaysRaises(ClientError(error, "GetObject"))
+    store = _store(client)
+
+    # Act
+    with pytest.raises(RemoteSyncUnavailableError) as caught:
+        store.get_object(_KEY)
+
+    # Assert: curated detail is present, the raw response payload is not.
+    message = str(caught.value)
+    assert _KEY in message
+    assert "AccessDenied" in message
+    assert secret not in message
+
+
+def test_list_objects_aggregates_keys_across_pages() -> None:
+    """A multi-page listing returns every object with the prefix stripped."""
+    # Arrange: two pages of keys under the default prefix.
+    client = _ListingClient([_page("a.jsonl", "b.jsonl"), _page("c.jsonl")])
+    store = _store(client)
+
+    # Act
+    objects = store.list_objects("")
+
+    # Assert: all keys aggregated in order, listed exactly once.
+    assert [o.key for o in objects] == ["a.jsonl", "b.jsonl", "c.jsonl"]
+    assert client.passes == 1
+
+
+def test_a_transient_blip_during_listing_retries_the_whole_listing() -> None:
+    """A throttle partway through pagination retries from the top, not partial."""
+    # Arrange: the first pass throttles after page one; the retry pass is clean.
+    client = _ListingClient(
+        [_page("a.jsonl", "b.jsonl"), _page("c.jsonl")],
+        blip=_client_error("SlowDown"),
+    )
+    store = _store(client)
+
+    # Act
+    objects = store.list_objects("")
+
+    # Assert: the retry returned the complete listing — nothing dropped or doubled.
+    assert [o.key for o in objects] == ["a.jsonl", "b.jsonl", "c.jsonl"]
+    assert client.passes == 2

--- a/tests/filestorage/test_s3_retry.py
+++ b/tests/filestorage/test_s3_retry.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 import time
 
 import pytest
-from botocore.exceptions import ClientError, EndpointConnectionError
+from botocore.exceptions import (
+    ClientError,
+    EndpointConnectionError,
+    NoCredentialsError,
+    PartialCredentialsError,
+)
 
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.errors import RemoteSyncUnavailableError
@@ -150,6 +155,36 @@ def test_a_missing_bucket_is_not_retried() -> None:
     assert client.calls == 1
 
 
+def test_missing_credentials_are_not_retried() -> None:
+    """NoCredentialsError is a misconfiguration — fail fast, exactly one call.
+
+    It subclasses BotoCoreError, which is otherwise treated as a transient
+    network blip; without the permanent-botocore guard it would be retried
+    four times with backoff before surfacing the same error.
+    """
+    # Arrange
+    client = _AlwaysRaises(NoCredentialsError())
+    store = _store(client)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncUnavailableError):
+        store.get_object(_KEY)
+    assert client.calls == 1
+
+
+def test_partial_credentials_are_not_retried() -> None:
+    """PartialCredentialsError (e.g. key id but no secret) is also permanent."""
+    # Arrange
+    incomplete = PartialCredentialsError(provider="env", cred_var="aws_secret_access_key")
+    client = _AlwaysRaises(incomplete)
+    store = _store(client)
+
+    # Act / Assert
+    with pytest.raises(RemoteSyncUnavailableError):
+        store.get_object(_KEY)
+    assert client.calls == 1
+
+
 def test_a_persistent_transient_error_exhausts_attempts_then_raises() -> None:
     """Backoff is bounded: after RETRY_MAX_ATTEMPTS tries it gives up cleanly."""
     from platform.filestorage.providers.aws import RETRY_MAX_ATTEMPTS
@@ -164,23 +199,24 @@ def test_a_persistent_transient_error_exhausts_attempts_then_raises() -> None:
     assert client.calls == RETRY_MAX_ATTEMPTS
 
 
-def test_the_user_facing_message_never_leaks_boto_internals() -> None:
-    """CWE-209: the surfaced error names the key, not the raw boto payload.
+def test_the_user_facing_message_names_the_key_and_operation() -> None:
+    """The surfaced error identifies the failed operation and key.
 
-    Detail is logged server-side; the message a user could see on a chat surface
-    stays generic. The wrapper carries a stable ``cannot read`` phrase and the
-    key, but not the AccessDenied credentials-shaped internals of the response.
+    Sync runs on local surfaces, so :class:`RemoteSyncUnavailableError`
+    intentionally carries the AWS cause for the operator (pinned by
+    ``test_aws_failures_name_their_cause``). CWE-209 redaction of that detail
+    happens at the *external* gateway sink boundary, not in this exception, so
+    the local message legitimately includes the boto reason.
     """
-    # Arrange: an error whose raw text carries something secret-looking.
-    secret_shaped = _client_error("SlowDown")
-    client = _AlwaysRaises(secret_shaped)
+    # Arrange
+    client = _AlwaysRaises(_client_error("SlowDown"))
     store = _store(client)
 
     # Act
     with pytest.raises(RemoteSyncUnavailableError) as caught:
         store.get_object(_KEY)
 
-    # Assert: the message identifies the failed operation and key only.
+    # Assert: the message identifies the failed operation and key.
     message = str(caught.value)
     assert _KEY in message
     assert "cannot read" in message


### PR DESCRIPTION
Fixes #4555

#### Describe the changes you have made in this PR -

`platform/filestorage/providers/aws.py` (`S3ObjectStore`) had **no retry**, so a single dropped connection or a brief throttling response failed the whole remote-sync run. This PR wraps the three transient S3 calls (`get_object`, `put_object`, and the `list_objects` page fetch) in a small bounded exponential-backoff helper and classifies the error before deciding to retry:

- **Transient → retry with backoff.** `BotoCoreError` (a client-side connection drop/timeout — no HTTP response reached us), throttling codes (`SlowDown`, `RequestTimeout`, `Throttling`, `ThrottlingException`, `RequestLimitExceeded`, `ServiceUnavailable`, `InternalError`), and any response with an HTTP status `>= 500`.
- **Permanent → fail fast, no retry.** `NoSuchBucket`, `AccessDenied`, `NoSuchKey`, `NoSuchBucketPolicy`, `InvalidAccessKeyId`, `SignatureDoesNotMatch` — retrying these only burns time and quota, so they surface immediately.
- Attempts are bounded (`RETRY_MAX_ATTEMPTS`), delays grow geometrically (`RETRY_BASE_DELAY_SECONDS` × `RETRY_BACKOFF_FACTOR`), and after exhausting attempts the last failure is re-raised. All three are named module constants — no hardcoded literals.
- **CWE-209 boundary preserved.** The existing `RemoteSyncUnavailableError` + `_reason(exc)` wrapping is unchanged, so gateway/slash replies still carry no raw provider payload; full boto detail is only `logger.warning`'d server-side on each retry. The sleep is resolved lazily so tests patch `time.sleep` and never actually wait.

The credential deny-list and what `push()` walks are untouched — the planted-secret canary tests in `tests/filestorage/test_remote_sync.py` stay green (236/236 filestorage tests pass).

### Demo/Screenshot for feature changes and bug fixes -

## Test verification (RED → GREEN)

New `tests/filestorage/test_s3_retry.py` drives a fake S3 client (no cloud). On the **unmodified upstream** `aws.py` (no retry exists), the transient-retry tests fail because a transient error is raised on the first call:

```
FAILED tests/filestorage/test_s3_retry.py::test_a_transient_throttle_is_retried_then_succeeds
FAILED tests/filestorage/test_s3_retry.py::test_a_dropped_connection_is_retried_then_succeeds
FAILED tests/filestorage/test_s3_retry.py::test_a_5xx_status_is_treated_as_transient_and_retried
FAILED tests/filestorage/test_s3_retry.py::test_a_persistent_transient_error_exhausts_attempts_then_raises
```

With the fix applied, all pass — transient errors are retried then succeed, permanent errors are surfaced after exactly one call, and a persistent transient error gives up cleanly after `RETRY_MAX_ATTEMPTS`:

```
tests/filestorage/test_s3_retry.py .......                               [100%]
============================== 7 passed in 0.82s ==============================
```

Full local CI (lint, format-check, typecheck, verify-integrations-smoke, `tests/filestorage/`) is green — 236 passed, including the planted-secret canary.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: remote sync issued raw one-shot S3 calls, so a transient blip (a dropped TCP connection, an S3 `SlowDown`/503) aborted an entire push/pull instead of being retried. But blanket "retry every exception" is wrong — a `NoSuchBucket` or `AccessDenied` will never succeed on retry and would just delay the real failure while consuming quota, so error classification has to come first.

I considered leaning on botocore's built-in `max_attempts`/`adaptive` retry mode via the client config, but that lives at client construction and would retry indiscriminately across every code path, is harder to unit-test deterministically without a live client, and wouldn't give the explicit permanent-vs-transient split the issue asks for. So I kept it a small, testable helper local to the S3 provider: `_is_transient(exc)` decides retryability (permanent code set → False; throttling code set or `ResponseMetadata` HTTP status `>= 500` → True; any `BotoCoreError` → True as a network blip), and `_with_retry(call, *, sleep=None)` runs the callable with bounded exponential backoff, re-raising the last boto exception so the existing `except (BotoCoreError, ClientError)` blocks in each method still wrap it into `RemoteSyncUnavailableError` exactly as before — which is what keeps provider detail off external surfaces (CWE-209). `list_objects` retries by materializing the paginator inside the retried callable, so a mid-stream page failure restarts cleanly and never half-fills the output. The sleep is injected lazily (default `time.sleep`, resolved at call time) purely so the tests patch it and run instantly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
