### PR TITLE
fix(interactive_shell): make _PromptSpinner.stop docstring-only (SM-110)

### DIFF
--- a/surfaces/interactive_shell/ui/streaming/console.py
+++ b/surfaces/interactive_shell/ui/streaming/console.py
@@ -16,7 +16,7 @@ class _PromptSpinner(Protocol):
     streaming: bool
 
     def stop(self) -> None:
-        raise NotImplementedError
+        """Stop the prompt spinner."""
 
 
 class StreamingConsole(Console):


### PR DESCRIPTION
Fixes #4645

    #### Describe the changes you have made in this PR -

    Converted `_PromptSpinner.stop` in `surfaces/interactive_shell/ui/streaming/console.py`
    from a `raise NotImplementedError` stub to a docstring-only body, per the
    AGENTS.md rule: Protocol methods we touch use a docstring-only body — no
    `...`, `pass`, or `raise NotImplementedError`.

    ```python
    class _PromptSpinner(Protocol):
        bytes_in: int
        streaming: bool

        def stop(self) -> None:
            """Stop the prompt spinner."""

  This matches the precedent in platform/filestorage/ports.py. No other
  Protocol files were touched (per the issue's scope: one Protocol, one PR).

  Demo/Screenshot for feature changes and bug fixes -

  N/A — docstring-only change, no behavioral difference. Verified with:

  - ruff check config core gateway integrations platform surfaces tools tests/ — passed
  - ruff format --check — passed
  - pytest tests/interactive_shell/ui/test_streaming_console_output.py -q --tb=line — 3 passed
  - pytest tests/integrations/test_verification_registry.py tests/integrations/test_registry.py — 31 passed

  ───

  Code Understanding and AI Usage

  Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?

  - [ ]  No, I wrote all the code myself
  - [X]  Yes, I used AI assistance (continue below)

  If you used AI assistance:

  - [X]  I have reviewed every single line of the AI-generated code
  - [X]  I can explain the purpose and logic of each function/component I added
  - [X]  I have tested edge cases and understand how the code handles them
  - [X]  I have modified the AI output to follow this project's coding standards and conventions

  Explain your implementation approach:
  The issue (SM-110) requires that Protocol methods we touch use a docstring-only
  body, per AGENTS.md, instead of raise NotImplementedError. The fix replaces
  the raise stub on _PromptSpinner.stop with a one-line docstring, exactly as
  done in the cited precedent platform/filestorage/ports.py. The change is
  purely stylistic — the Protocol method signature is unchanged, so callers and
  the StreamingConsole class that consumes the protocol are unaffected.

  ───

  Checklist before requesting a review

  - [X]  I have added proper PR title and linked to the issue
  - [X]  I have performed a self-review of my code
  - [X]  I can explain the purpose of every function, class, and logic block I added
  - [X]  I understand why my changes work and have tested them thoroughly
  - [X]  I have considered potential edge cases and how my code handles them
  - [X]  If it is a core feature, I have added thorough tests
  - [X]  My code follows the project's style guidelines and conventions