### PR TITLE
refactor: use docstring-only protocol bodies for BindingStore

### DIFF
--- a/gateway/storage/session/binding_store.py
+++ b/gateway/storage/session/binding_store.py
@@ -32,7 +32,7 @@ class BindingStore(Protocol):
         principal: Principal | None = None,
         actor: Actor | str | None = None,
     ) -> str | None:
-        raise NotImplementedError
+        """Return the session id for the binding, if present."""
 
     def bind(
         self,
@@ -43,7 +43,7 @@ class BindingStore(Protocol):
         principal: Principal | None = None,
         actor: Actor | str | None = None,
     ) -> None:
-        raise NotImplementedError
+        """Bind the chat to the provided session id."""
 
     def rotate(
         self,
@@ -53,7 +53,7 @@ class BindingStore(Protocol):
         principal: Principal | None = None,
         actor: Actor | str | None = None,
     ) -> str:
-        raise NotImplementedError
+        """Create and return a replacement session id for the chat."""
 
     def has_any_actor_binding(
         self,
@@ -62,10 +62,10 @@ class BindingStore(Protocol):
         chat_id: str,
         principal: Principal | None = None,
     ) -> bool:
-        raise NotImplementedError
+        """Return whether the chat has any actor-specific binding."""
 
     def close(self) -> None:
-        raise NotImplementedError
+        """Release any resources held by the binding store."""
 
 
 def legacy_bindings_for(path: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
Replaced `raise NotImplementedError` with docstring-only method bodies for all methods in the `BindingStore` protocol.

This follows the project's Protocol conventions described in `AGENTS.md` and keeps the change limited to the protocol interface without modifying any concrete implementations.

<img width="1446" height="141" alt="image" src="https://github.com/user-attachments/assets/dfa0ac43-8c45-4f10-a694-7c1f9dec9ac9" />
<img width="1222" height="94" alt="image" src="https://github.com/user-attachments/assets/63020d4f-5614-4259-a43c-c436ff47d237" />
