### PR TITLE
fix: soft-fail corrupt config when remote sync is fully env-driven

### DIFF
--- a/platform/filestorage/config.py
+++ b/platform/filestorage/config.py
@@ -135,17 +135,27 @@ def _exclusions(stored: Callable[[], dict[str, Any]]) -> ExclusionRules:
     return parse_exclusions(stored().get("exclude"))
 
 
-def _lazy_stored() -> Callable[[], dict[str, Any]]:
+def _lazy_stored(*, soft: bool = False) -> Callable[[], dict[str, Any]]:
     """Read the settings file at most once, and only if something needs it.
 
     A run configured entirely through the environment must not fail because an
     unrelated section of ``config.yml`` is damaged.
+
+    When ``soft`` is true (docs happy path: switch + bucket already in env), a
+    corrupt stored section falls back to ``{}`` so optional fields use defaults
+    instead of blocking sync.
     """
     cache: dict[str, dict[str, Any]] = {}
 
     def read() -> dict[str, Any]:
         if "section" not in cache:
-            cache["section"] = _stored_section()
+            try:
+                cache["section"] = _stored_section()
+            except RemoteSyncConfigError:
+                if soft:
+                    cache["section"] = {}
+                else:
+                    raise
         return cache["section"]
 
     return read
@@ -169,7 +179,17 @@ def load_remote_sync_config() -> RemoteSyncConfig | None:
     Naming a bucket is not enough — the switch has to be on too, so an
     exported bucket left over from another tool never starts uploading.
     """
-    stored = _lazy_stored()
+    env_switch = os.getenv(REMOTE_SYNC_ENV)
+    env_bucket = os.getenv(REMOTE_SYNC_BUCKET_ENV, "").strip()
+    # Docs path: only OPENSRE_REMOTE_SYNC + OPENSRE_REMOTE_SYNC_BUCKET.
+    # Optionals may still consult the file — soft-fail corrupt YAML there.
+    soft = (
+        env_switch is not None
+        and env_switch.strip() != ""
+        and env_switch.strip().lower() in _TRUTHY
+        and bool(env_bucket)
+    )
+    stored = _lazy_stored(soft=soft)
     if not _enabled(stored):
         return None
     bucket = _env_or_stored(REMOTE_SYNC_BUCKET_ENV, "bucket", stored)

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from config.constants.filestorage import (
+    DEFAULT_REMOTE_SYNC_PREFIX,
     REMOTE_SYNC_BUCKET_ENV,
     REMOTE_SYNC_ENV,
     REMOTE_SYNC_PREFIX_ENV,
@@ -1201,6 +1202,36 @@ def test_env_only_config_ignores_a_corrupt_settings_file(
     assert config.bucket == "env-bucket"
     assert config.prefix == "env-prefix"
     assert config.exclude.patterns == ("*.tmp",)
+
+
+def test_docs_two_env_vars_soft_fail_corrupt_optional_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Docs happy path: only switch + bucket in env; corrupt config must not block."""
+    from config.constants import paths
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    (tmp_path / "config.yml").write_text("not a mapping", encoding="utf-8")
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+    monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "docs-bucket")
+    # Intentionally leave prefix/provider/region/profile/exclude unset so they
+    # would have fallen through to the corrupt file before the soft-fail fix.
+    for name in (
+        REMOTE_SYNC_PREFIX_ENV,
+        "OPENSRE_REMOTE_SYNC_REGION",
+        "OPENSRE_REMOTE_SYNC_PROFILE",
+        "OPENSRE_REMOTE_SYNC_PROVIDER",
+        "OPENSRE_REMOTE_SYNC_EXCLUDE",
+        "OPENSRE_REMOTE_SYNC_EXCLUDE_OFF",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    config = load_remote_sync_config()
+
+    assert config is not None
+    assert config.bucket == "docs-bucket"
+    # Defaults for optionals when stored section is unreadable
+    assert config.prefix == DEFAULT_REMOTE_SYNC_PREFIX
 
 
 def test_list_prefix_is_delimited_so_a_sibling_bucket_path_cannot_match() -> None:


### PR DESCRIPTION
## Summary
Docs teach enabling remote sync with only `OPENSRE_REMOTE_SYNC` + `OPENSRE_REMOTE_SYNC_BUCKET`. Optional fields still fell through to `config.yml`, so a corrupt YAML blocked that documented happy path.

## Changes
- When switch + bucket are already set in the environment, soft-fail a corrupt stored `remote_sync` section to `{}` so optionals use defaults.
- Keep hard `RemoteSyncConfigError` when the stored section is actually required (env switch unset / bucket only in file).
- Unit test for the two-variable docs path with a damaged `config.yml`.

Closes #4552