### PR TITLE
fix(gateway): ruff format gateway/discord/client.py

### DIFF
--- a/gateway/discord/client.py
+++ b/gateway/discord/client.py
@@ -1,4 +1,5 @@
 """Discord REST helpers for the gateway output sink."""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- Adds the missing blank line after the module docstring in `gateway/discord/client.py`, which was failing `ruff format --check` on `main` CI (ubuntu quality job).

## Test plan
- [x] `uv run python -m ruff format --check config core gateway integrations platform surfaces tools tests/` passes locally