### PR TITLE
docs(ci): add post-push CI/Greptile follow-up checklist to CI.md

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -195,9 +195,11 @@ regression, or a Greptile finding can still block merge. After every push:
 
 3. **Fix, don't rubber-stamp.** Verify a flagged issue is real before patching
    — read the affected code path, don't just apply the suggested diff blind.
-   Add or extend a test that would have caught it. Re-run the relevant checks
-   from §1–3 locally, push, and repeat from step 1 until CI is green and
-   Greptile is 5/5 with no unresolved threads.
+   Where a test can capture the defect, add or extend one — this doesn't apply
+   to docs/process-only changes (§0) or config-only fixes with no unit-testable
+   behavior (e.g. an `.importlinter.strict` allowlist entry). Re-run the
+   relevant checks from §1–3 locally, push, and repeat from step 1 until CI is
+   green and Greptile is 5/5 with no unresolved threads.
 
 ## Precedence
 

--- a/CI.md
+++ b/CI.md
@@ -151,6 +151,54 @@ Some paths require live infrastructure and are excluded from `make test-cov`:
 
 Mark CI-only tests with the appropriate pytest marker or place them in the correct folder so they do not run locally by default.
 
+## 8) After pushing / opening a PR
+
+Passing local checks is necessary, not sufficient — a stale branch, a main-side
+regression, or a Greptile finding can still block merge. After every push:
+
+1. **Check CI status.**
+
+   ```bash
+   gh pr checks <PR#> --repo Tracer-Cloud/opensre
+   ```
+
+   For a failing job, pull its log before touching code:
+
+   ```bash
+   gh run view <run-id> --repo Tracer-Cloud/opensre --job <job-id> --log-failed
+   ```
+
+   Attribute root cause before fixing anything — **PR-caused** (your diff broke
+   it: fix it) vs **pre-existing/main-side** (fails identically on a clean
+   `upstream/main` checkout of the same file: do not "fix" it in your PR).
+   Check `gh pr view <PR#> --json mergeStateStatus` first: `BEHIND` means your
+   branch is stale, and GitHub Actions checks out the *synthetic merge* of
+   your branch with current `main` (`refs/pull/<PR#>/merge`), not your raw
+   branch head — a stale branch can produce a failure that reproduces on
+   neither side alone. Merge (or rebase) the current base branch into yours
+   and re-push before investigating further; that alone resolves most of
+   these.
+
+2. **Check for review feedback.** Greptile posts automatically; trigger or
+   re-trigger it with a PR comment:
+
+   ```
+   @greptile review
+   ```
+
+   Read findings via `gh pr view <PR#> --json comments,reviews`, or the
+   Greptile summary comment on the PR. See
+   [CONTRIBUTING.md § Greptile Code Review](CONTRIBUTING.md#greptile-code-review)
+   for the confidence-score bar (5/5, zero unresolved) and the
+   [greploop skill](https://skills.sh/greptileai/skills/greploop) that
+   automates the trigger/wait/fix/re-review loop.
+
+3. **Fix, don't rubber-stamp.** Verify a flagged issue is real before patching
+   — read the affected code path, don't just apply the suggested diff blind.
+   Add or extend a test that would have caught it. Re-run the relevant checks
+   from §1–3 locally, push, and repeat from step 1 until CI is green and
+   Greptile is 5/5 with no unresolved threads.
+
 ## Precedence
 
 If readiness instructions conflict across docs, **this file wins** for push/PR checks.


### PR DESCRIPTION
No tracking issue — process improvement identified while working #4756.

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Adds a new `## 8) After pushing / opening a PR` section to `CI.md`. The file was scoped to pre-push readiness (lint/format/typecheck/tests) and stopped at the push itself, with no guidance on what to do once CI actually runs and Greptile/human review lands. This adds a short checklist:

1. Check `gh pr checks`, and — before touching code — attribute a failing job's root cause as PR-caused vs. pre-existing/main-side (reproduce on a clean `upstream/main` checkout of the same file before assuming your diff is at fault).
2. Specifically calls out the `mergeStateStatus: BEHIND` trap: GitHub Actions checks out the *synthetic PR merge ref* (`refs/pull/<PR#>/merge`), not your raw branch head, so a stale branch can fail on a file neither your branch nor `main` fails on individually. Fix: merge/rebase base into your branch, not the flagged file.
3. Check and address Greptile + human review comments, linking to the existing `CONTRIBUTING.md` § Greptile Code Review section and the `greploop` skill rather than duplicating that guidance.

This is docs-only (`CI.md` is on the §0 shortcut exemption list), so per its own rule the only required local check is `git status --short`.

**Why this is worth writing down**: hit this exact case live on #4756 — `quality (ubuntu-latest)` failed on `gateway/discord/client.py`, a file that PR never touched. Confirmed it wasn't PR-caused (identical content passed `ruff format --check` on the branch head and on a clean `main` checkout), then found the actual cause by fetching `refs/pull/4756/merge` directly: the synthetic merge (branch was 2 commits behind) lost a blank line neither parent was missing. Merging `main` into the branch fixed it — no code change needed. `main` also got an independent same-day fix for the same root formatting issue (#4757), confirming it really was pre-existing. Without this written down, the natural reaction is to "fix" the flagged file directly, which is wrong when the branch is stale.

### Demo/Screenshot for feature changes and bug fixes -

Documentation-only change — no runtime behavior to demo. Diff is the new `CI.md` section itself; see the file for the added text.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Requested after live-debugging a real CI failure on PR #4756 that turned out to be a stale-branch/synthetic-merge-ref artifact rather than a code defect. Rather than write generic "check CI" advice, the new section documents the exact diagnostic sequence that found the real cause (`gh pr checks` → pull the failing job's log → check `mergeStateStatus` → fetch `refs/pull/<PR#>/merge` directly when in doubt → merge base into branch) so the next person (human or agent) hitting this doesn't waste time editing a file that isn't actually broken. Kept it short and pointed at `CONTRIBUTING.md`'s existing Greptile section instead of re-explaining the trigger/loop mechanics, since CI.md's job is the checklist, not the tutorial.

---

## Checklist before requesting a review
- [x] I have added a proper PR title (no tracking issue to link — see note above)
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
