### PR TITLE
SM-50: Use HTTPStatus in delivery_transport

### DIFF
--- a/platform/notifications/delivery_transport.py
+++ b/platform/notifications/delivery_transport.py
@@ -15,14 +15,15 @@ The helper deliberately does **not** decide whether the call succeeded
 at the provider level. It returns ``ok=True`` whenever the request
 completed without raising; callers then inspect ``status_code`` and
 ``data``/``text`` to apply provider semantics (e.g. ``data["ok"]`` for
-Slack, ``status_code in (200, 201)`` for Discord, ``status_code == 200``
-for Telegram).
+Slack, ``status_code in (HTTPStatus.OK, HTTPStatus.CREATED)`` for Discord,
+``status_code == HTTPStatus.OK`` for Telegram).
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from http import HTTPStatus
 from types import MappingProxyType
 from typing import Any
 
@@ -121,9 +122,15 @@ def post_form(
         # non-JSON body is permitted; fall through with empty data
         pass
 
+    status_code_val = (
+        HTTPStatus(response.status_code)
+        if response.status_code in HTTPStatus._value2member_map_
+        else response.status_code
+    )
+
     return DeliveryResponse(
         ok=True,
-        status_code=response.status_code,
+        status_code=status_code_val,
         data=parsed_data,
         text=text,
     )
@@ -183,9 +190,15 @@ def post_json(
         # non-JSON body is permitted; fall through with empty data
         pass
 
+    status_code_val = (
+        HTTPStatus(response.status_code)
+        if response.status_code in HTTPStatus._value2member_map_
+        else response.status_code
+    )
+
     return DeliveryResponse(
         ok=True,
-        status_code=response.status_code,
+        status_code=status_code_val,
         data=data,
         text=text,
     )


### PR DESCRIPTION
Fixes #4308

Replaced bare numeric HTTP status examples in the module docstring with HTTPStatus members and map response status codes to HTTPStatus when they are known enum members. This keeps behavior identical (HTTPStatus is IntEnum so comparisons with ints remain true) while following the project rule to use http.HTTPStatus.

Validation performed locally:
- ruff lint + format
- mypy typecheck

No behavior changes beyond using HTTPStatus typed values for known codes; exception flows still set status_code to 0 when no response was received.