### PR TITLE
feat: added azure blob storage exposure check with warning if public

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -321,6 +321,8 @@ Authentication relies entirely on Azure's ambient credentials (`DefaultAzureCred
 
 The authenticated principal must have the **Storage Blob Data Contributor** role assignment on the storage account. The generic "Contributor" role is insufficient as it only grants control-plane access, not data-plane access.
 
+Add `Microsoft.Storage/storageAccounts/blobServices/containers/read` (included in the Storage Blob Data Reader role) so `status` can warn you if the container is publicly readable — see [The store](#the-store). Without it, `status` shows "could not confirm it is private" instead of failing.
+
 ## The store
 
 <Warning>

--- a/platform/filestorage/providers/azure.py
+++ b/platform/filestorage/providers/azure.py
@@ -9,10 +9,10 @@ from urllib.parse import quote
 
 import httpx
 
-from platform.filestorage import BucketExposure, PublicAccessStatus
 from platform.filestorage.config import RemoteSyncConfig
-from platform.filestorage.enums import BuiltInProvider, RemoteSyncField
+from platform.filestorage.enums import BucketExposure, BuiltInProvider, RemoteSyncField
 from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.exposure import PublicAccessStatus
 from platform.filestorage.ports import RemoteObject
 from platform.filestorage.providers.registry import SetupExtraField, register_object_store
 
@@ -23,6 +23,11 @@ CREDENTIAL_HINT = (
 EXTRA_FIELDS = (
     SetupExtraField(RemoteSyncField.PROFILE, "Azure Storage Account Name (e.g., opensre)"),
 )
+_API_VERSION = "2026-04-06"
+
+
+def _get_account_name(config: RemoteSyncConfig) -> str:
+    return config.profile or os.getenv("AZURE_STORAGE_ACCOUNT_NAME", "")
 
 
 class AzureBlobObjectStore:
@@ -36,13 +41,11 @@ class AzureBlobObjectStore:
         client: httpx.Client | None = None,
     ) -> None:
         self._config = config
-        self._account_name = config.profile or os.getenv("AZURE_STORAGE_ACCOUNT_NAME", "")
-
+        self._account_name = _get_account_name(config)
         if not self._account_name:
             raise RemoteSyncUnavailableError(
                 "Azure storage account name is missing. Set it during setup or via AZURE_STORAGE_ACCOUNT_NAME."
             )
-
         self._token = token if token is not None else _get_azure_access_token()
         self._client = client if client is not None else httpx.Client(timeout=30.0)
 
@@ -129,7 +132,7 @@ class AzureBlobObjectStore:
         return quote(self._config.key_for(key), safe="/")
 
     def _auth_headers(self) -> dict[str, str]:
-        return {"Authorization": f"Bearer {self._token}", "x-ms-version": "2026-04-06"}
+        return {"Authorization": f"Bearer {self._token}", "x-ms-version": _API_VERSION}
 
     def _strip_prefix(self, full_key: str) -> str:
         prefix = f"{self._config.prefix.rstrip('/')}/"
@@ -218,7 +221,7 @@ def _factory(config: RemoteSyncConfig) -> AzureBlobObjectStore:
 def check_public_access(
     config: RemoteSyncConfig, *, client: httpx.Client | None = None
 ) -> PublicAccessStatus:
-    account_name = config.profile or os.getenv("AZURE_STORAGE_ACCOUNT_NAME", "")
+    account_name = _get_account_name(config)
     if not account_name:
         return PublicAccessStatus(BucketExposure.UNKNOWN, "AZURE_STORAGE_ACCOUNT_NAME is missing")
 
@@ -235,7 +238,7 @@ def check_public_access(
         response = cl.get(
             url,
             params={"restype": "container"},
-            headers={"Authorization": f"Bearer {token}", "x-ms-version": "2026-04-06"},
+            headers={"Authorization": f"Bearer {token}", "x-ms-version": _API_VERSION},
         )
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
@@ -265,4 +268,10 @@ register_object_store(
     public_access_checker=check_public_access,
 )
 
-__all__ = ["CREDENTIAL_HINT", "EXTRA_FIELDS", "PROVIDER_NAME", "AzureBlobObjectStore"]
+__all__ = [
+    "CREDENTIAL_HINT",
+    "EXTRA_FIELDS",
+    "PROVIDER_NAME",
+    "AzureBlobObjectStore",
+    "check_public_access",
+]

--- a/platform/filestorage/providers/azure.py
+++ b/platform/filestorage/providers/azure.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 
 import httpx
 
+from platform.filestorage import BucketExposure, PublicAccessStatus
 from platform.filestorage.config import RemoteSyncConfig
 from platform.filestorage.enums import BuiltInProvider, RemoteSyncField
 from platform.filestorage.errors import RemoteSyncUnavailableError
@@ -214,8 +215,54 @@ def _factory(config: RemoteSyncConfig) -> AzureBlobObjectStore:
     return AzureBlobObjectStore(config)
 
 
+def check_public_access(
+    config: RemoteSyncConfig, *, client: httpx.Client | None = None
+) -> PublicAccessStatus:
+    account_name = config.profile or os.getenv("AZURE_STORAGE_ACCOUNT_NAME", "")
+    if not account_name:
+        return PublicAccessStatus(BucketExposure.UNKNOWN, "AZURE_STORAGE_ACCOUNT_NAME is missing")
+
+    try:
+        token = _get_azure_access_token()
+    except Exception as exc:
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+
+    url = f"https://{account_name}.blob.core.windows.net/{config.bucket}"
+    owns_client = client is None
+    cl = client if client is not None else httpx.Client(timeout=30.0)
+
+    try:
+        response = cl.get(
+            url,
+            params={"restype": "container"},
+            headers={"Authorization": f"Bearer {token}", "x-ms-version": "2026-04-06"},
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            return PublicAccessStatus(
+                BucketExposure.UNKNOWN, "missing permission to read container properties"
+            )
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    except httpx.HTTPError as exc:
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    finally:
+        if owns_client:
+            cl.close()
+
+    access = response.headers.get("x-ms-blob-public-access")
+    if access in ("blob", "container"):
+        return PublicAccessStatus(BucketExposure.PUBLIC)
+
+    return PublicAccessStatus(BucketExposure.PRIVATE)
+
+
 register_object_store(
-    PROVIDER_NAME, _factory, credential_hint=CREDENTIAL_HINT, extra_fields=EXTRA_FIELDS
+    PROVIDER_NAME,
+    _factory,
+    credential_hint=CREDENTIAL_HINT,
+    extra_fields=EXTRA_FIELDS,
+    public_access_checker=check_public_access,
 )
 
 __all__ = ["CREDENTIAL_HINT", "EXTRA_FIELDS", "PROVIDER_NAME", "AzureBlobObjectStore"]

--- a/tests/filestorage/test_bucket_exposure.py
+++ b/tests/filestorage/test_bucket_exposure.py
@@ -22,6 +22,7 @@ from platform.filestorage.exposure import PublicAccessStatus
 from platform.filestorage.messages import format_exposure_line, format_status_lines
 from platform.filestorage.operations import SyncRootStatus, SyncStatus, get_sync_status
 from platform.filestorage.providers.aws import check_public_access as aws_check_public_access
+from platform.filestorage.providers.azure import check_public_access as azure_check_public_access
 from platform.filestorage.providers.gcs import check_public_access as gcs_check_public_access
 from platform.filestorage.providers.registry import (
     check_bucket_exposure,
@@ -101,6 +102,135 @@ def test_client_build_failure_degrades_to_unknown(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr("platform.filestorage.providers.aws._build_client", _raise_client)
     result = aws_check_public_access(RemoteSyncConfig(bucket="b"))
+    assert result.exposure is BucketExposure.UNKNOWN
+
+
+# ── azure.check_public_access ───────────────────────────────────────────────
+
+
+class _AzureResponse:
+    """Fake ``httpx.Response`` exposing only what the Azure checker touches."""
+
+    def __init__(self, *, headers: dict[str, str] | None = None, status_code: int = 200) -> None:
+        self.headers = headers or {}
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            request = httpx.Request("GET", "https://fake.blob.core.windows.net/")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}", request=request, response=response
+            )
+
+
+class _AzureClient:
+    """Fake ``httpx.Client`` exposing only ``get``."""
+
+    def __init__(
+        self, response: _AzureResponse | None = None, *, error: Exception | None = None
+    ) -> None:
+        self._response = response
+        self._error = error
+
+    def get(
+        self,
+        _url: str,
+        headers: dict[str, str] | None = None,  # noqa: ARG002
+        params: dict[str, str] | None = None,  # noqa: ARG002
+    ) -> _AzureResponse:
+        if self._error is not None:
+            raise self._error
+        assert self._response is not None
+        return self._response
+
+    def close(self) -> None:
+        pass
+
+
+def test_azure_missing_account_name_degrades_to_a_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unconfigured account name must degrade gracefully without attempting auth."""
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_NAME", raising=False)
+    result = azure_check_public_access(RemoteSyncConfig(bucket="b", provider="azure"))
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "AZURE_STORAGE_ACCOUNT_NAME" in result.detail
+
+
+def test_azure_public_blob_access_is_reported_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "testaccount")
+    monkeypatch.setattr(
+        "platform.filestorage.providers.azure._get_azure_access_token", lambda: "token"
+    )
+    client = _AzureClient(_AzureResponse(headers={"x-ms-blob-public-access": "blob"}))
+    result = azure_check_public_access(
+        RemoteSyncConfig(bucket="b", provider="azure"), client=client
+    )
+    assert result == PublicAccessStatus(BucketExposure.PUBLIC)
+
+
+def test_azure_public_container_access_is_reported_public(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "testaccount")
+    monkeypatch.setattr(
+        "platform.filestorage.providers.azure._get_azure_access_token", lambda: "token"
+    )
+    client = _AzureClient(_AzureResponse(headers={"x-ms-blob-public-access": "container"}))
+    result = azure_check_public_access(
+        RemoteSyncConfig(bucket="b", provider="azure"), client=client
+    )
+    assert result == PublicAccessStatus(BucketExposure.PUBLIC)
+
+
+def test_azure_private_access_is_reported_private(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Absence of the x-ms-blob-public-access header dictates a private container."""
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "testaccount")
+    monkeypatch.setattr(
+        "platform.filestorage.providers.azure._get_azure_access_token", lambda: "token"
+    )
+    client = _AzureClient(_AzureResponse(headers={}))
+    result = azure_check_public_access(
+        RemoteSyncConfig(bucket="b", provider="azure"), client=client
+    )
+    assert result == PublicAccessStatus(BucketExposure.PRIVATE)
+
+
+def test_azure_forbidden_degrades_to_a_note_not_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing RBAC permissions must fail closed to UNKNOWN without crashing."""
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "testaccount")
+    monkeypatch.setattr(
+        "platform.filestorage.providers.azure._get_azure_access_token", lambda: "token"
+    )
+    client = _AzureClient(_AzureResponse(status_code=403))
+    result = azure_check_public_access(
+        RemoteSyncConfig(bucket="b", provider="azure"), client=client
+    )
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "permission" in result.detail
+
+
+def test_azure_other_http_error_degrades_without_leaking_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "testaccount")
+    monkeypatch.setattr(
+        "platform.filestorage.providers.azure._get_azure_access_token", lambda: "token"
+    )
+    client = _AzureClient(_AzureResponse(status_code=500))
+    result = azure_check_public_access(
+        RemoteSyncConfig(bucket="b", provider="azure"), client=client
+    )
+    assert result.exposure is BucketExposure.UNKNOWN
+    assert "HTTPStatusError" in result.detail
+
+
+def test_azure_transport_failure_degrades_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "testaccount")
+    monkeypatch.setattr(
+        "platform.filestorage.providers.azure._get_azure_access_token", lambda: "token"
+    )
+    client = _AzureClient(error=httpx.ConnectError("boom"))
+    result = azure_check_public_access(
+        RemoteSyncConfig(bucket="b", provider="azure"), client=client
+    )
     assert result.exposure is BucketExposure.UNKNOWN
 
 


### PR DESCRIPTION
Fixes #4726 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

I have made the following changes in the PR:
- Added code for checking blob access
- Added tests and docs

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

https://github.com/user-attachments/assets/f9b63cfd-435d-49b4-860f-c15deaa4d36b

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [X] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [X] I have reviewed every single line of the AI-generated code
- [X] I can explain the purpose and logic of each function/component I added
- [X] I have tested edge cases and understand how the code handles them
- [X] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

The code addressed the missing Azure blob storage access check. It first gets the Azure storage container/blob data, checks the header value of `x-ms-blob-public-access` and gives a warning if that header field exists and has a value either `blob` or `container`. The complete procedure happens via a single Azure's REST API call.

---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [X] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
