### PR TITLE
fix(gateway): avoid logging raw credits client exceptions

### DIFF
--- a/gateway/core/billing/credits_client.py
+++ b/gateway/core/billing/credits_client.py
@@ -110,10 +110,9 @@ def consume_credits(
         )
     except Exception as exc:
         logger.warning(
-            "[credits] webapp unreachable for reason=%s (%s: %s)",
+            "[credits] webapp unreachable for reason=%s (%s)",
             reason,
             type(exc).__name__,
-            exc,
         )
         return CreditsOutcome.UNAVAILABLE
 

--- a/gateway/tests/billing/test_credits_client.py
+++ b/gateway/tests/billing/test_credits_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from http import HTTPStatus
 from typing import Any
 
@@ -94,6 +95,35 @@ def test_transport_error_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None
 
     # Assert: UNAVAILABLE so the gateway can fail open instead of blocking the user.
     assert outcome is CreditsOutcome.UNAVAILABLE
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_transport_error_log_omits_exception_detail(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: the exception message contains a URL that must never reach the log.
+    sensitive_url = "https://app.opensre.internal/api/credits/consume"
+
+    def unreachable(*_a: object, **_k: object) -> httpx.Response:
+        raise httpx.ConnectError(f"[Errno -2] Name or service not known: {sensitive_url}")
+
+    monkeypatch.setattr("gateway.core.billing.credits_client.httpx.post", unreachable)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.core.billing.credits_client"):
+        consume_credits(organization_id="org_x", reason="slack_turn")
+
+    # Assert: the log record was emitted but contains no part of the exception message.
+    assert any("[credits] webapp unreachable" in r.message for r in caplog.records)
+    for record in caplog.records:
+        if "[credits] webapp unreachable" in record.message:
+            assert sensitive_url not in record.message, (
+                "Log must not expose the exception message (may contain the webapp URL)"
+            )
+            assert "Name or service not known" not in record.message, (
+                "Log must not expose raw exception text"
+            )
+            # Only the exception type name is permitted.
+            assert "ConnectError" in record.message
 
 
 @pytest.mark.usefixtures("metering_on")


### PR DESCRIPTION
When the credits webapp is unreachable, the previous warning logged the raw exception object via the third format argument (`exc`). Depending on the exception type (for example, `httpx.ConnectError`), this could expose endpoint details in application logs.

This change updates the warning to log only the exception type, matching the existing logging pattern already used across the project.

The implementation:
- Removes the raw exception text from the unreachable-path warning.
- Logs only `type(exc).__name__`.
- Preserves the existing timeout, return value, and error-handling behavior.
- Adds a regression test to ensure sensitive exception details are never written to logs.

Fixes #4773

---

#### Describe the changes you have made in this PR

- Removed raw exception text from the credits client warning log.
- Updated the logger to record only the exception type.
- Added a regression test to verify that sensitive exception details are not emitted to logs.
- Preserved the existing timeout, return value, and billing behavior.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I reviewed the existing logging patterns used in the repository and kept the implementation consistent with them. The fix was intentionally minimal, removing only the raw exception text from the warning log while preserving the existing timeout, return value, and error-handling behavior. I also added a regression test to ensure sensitive exception details are never logged in the future.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

**Note:** I have enabled **Allow edits from maintainers**.
