### PR TITLE
feat(interactive-shell): toggle tool details with Tab

### DIFF
--- a/surfaces/cli/ui/renderer/renderer.py
+++ b/surfaces/cli/ui/renderer/renderer.py
@@ -123,7 +123,7 @@ class StreamRenderer:
     def _start_toggle_watcher(self) -> None:
         if get_output_format() != "rich" or _repl_progress_active():
             return
-        # ProgressTracker already owns the single Ctrl+O stdin watcher.
+        # ProgressTracker already owns the single Tab stdin watcher.
         # Register our handler so toggle_active_tool_details() routes here.
         self._toggle_unregister = register_tool_detail_toggle(self._toggle_tool_details)
 
@@ -138,7 +138,7 @@ class StreamRenderer:
             self._sync_tool_detail_view(clear=True)
             return
         label = "shown" if self._tool_details_visible else "hidden"
-        self._print_above_renderable(Text(f"  Tool details {label} (ctrl+o)", style="dim"))
+        self._print_above_renderable(Text(f"  Tool details {label} (tab)", style="dim"))
         if self._tool_details_visible:
             self._flush_tool_details()
 

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -213,7 +213,7 @@ class SpinnerState:
 
     def idle_hint_ansi(self) -> str:
         """Dim hint line shown above the rule when no dispatch is running."""
-        hint = "/ for commands  ·  ↑↓ history"
+        hint = "/ for commands  ·  tab tool details  ·  ↑↓ history"
         app = get_app_or_none()
         if app is not None and app.current_buffer.text:
             hint += "  ·  esc to clear"

--- a/surfaces/interactive_shell/ui/components/key_reader.py
+++ b/surfaces/interactive_shell/ui/components/key_reader.py
@@ -27,7 +27,7 @@ def flush_stdin_unix() -> None:
 def restore_stdin_terminal() -> None:
     """Return stdin to canonical echo mode after Live/raw investigation UI.
 
-    Investigation progress uses a background Ctrl+O watcher that puts stdin in
+    Investigation progress uses a background Tab watcher that puts stdin in
     non-canonical mode without echo. If nested watchers restore the wrong
     snapshot, the shell prompt appears to accept input but characters are not
     echoed. Call this after investigation UI teardown and before line prompts.

--- a/surfaces/interactive_shell/ui/feedback/__init__.py
+++ b/surfaces/interactive_shell/ui/feedback/__init__.py
@@ -11,7 +11,7 @@ Why a custom select menu instead of repl_choose_one() on the CLI path:
 
   The local :func:`_run_select` erases line-by-line with ``\\x1b[2K`` and is
   robust to any cursor state.  Call :func:`restore_stdin_terminal` before
-  entering the menu so investigation progress UI (Ctrl+O watcher) does not
+  entering the menu so investigation progress UI (Tab watcher) does not
   leave stdin in no-echo mode.  The REPL path keeps :func:`repl_choose_one`
   inside prompt_toolkit's stdout patch context.
 """

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -82,7 +82,7 @@ def resolve_prompt_prefix_ansi(*, inline_spinner: str, idle_hint: str) -> str:
 
 def resolve_idle_hint_ansi(session: Session) -> str:
     """Dim hint line above the prompt rule: shortcuts plus connected integrations."""
-    parts = ["/ for commands", "↑↓ history"]
+    parts = ["/ for commands", "tab tool details", "↑↓ history"]
     if session.configured_integrations_known and session.configured_integrations:
         max_shown = 4
         names = [integration_display_name(name) for name in sorted(session.configured_integrations)]

--- a/surfaces/interactive_shell/ui/output/__init__.py
+++ b/surfaces/interactive_shell/ui/output/__init__.py
@@ -21,7 +21,7 @@ from surfaces.interactive_shell.ui.output.renderers import (
     render_investigation_header,
 )
 from surfaces.interactive_shell.ui.output.toggles import (
-    CtrlOToggleWatcher,
+    ToolDetailToggleWatcher,
     register_tool_detail_toggle,
     suppress_stdin_watchers,
     toggle_active_tool_details,
@@ -53,7 +53,7 @@ __all__ = [
     "stop_display",
     "unregister_live_console",
     # Tool-detail toggle
-    "CtrlOToggleWatcher",
+    "ToolDetailToggleWatcher",
     "register_tool_detail_toggle",
     "suppress_stdin_watchers",
     "toggle_active_tool_details",

--- a/surfaces/interactive_shell/ui/output/live_display.py
+++ b/surfaces/interactive_shell/ui/output/live_display.py
@@ -74,7 +74,7 @@ def _render_active_steps(
 
     yield Text("")
     yield Text("┄" * (options.max_width - 1), style=DIM)
-    yield _footer(display, now - display._t0, "ctrl+o tool details  ")
+    yield _footer(display, now - display._t0, "tab tool details  ")
 
 
 def _render_tool_detail_view(
@@ -100,7 +100,7 @@ def _render_tool_detail_view(
         yield from _tool_record_rows(record)
 
     yield Text("┄" * (options.max_width - 1), style=DIM)
-    yield _footer(display, elapsed_total, "ctrl+o compact view  ", phase="TOOL DETAILS")
+    yield _footer(display, elapsed_total, "tab compact view  ", phase="TOOL DETAILS")
 
 
 def _tool_record_rows(record: dict[str, Any]) -> RenderResult:

--- a/surfaces/interactive_shell/ui/output/toggles.py
+++ b/surfaces/interactive_shell/ui/output/toggles.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover - Windows fallback
 _stdin_watcher_suppression_depth = 0
 _stdin_watcher_lock = threading.Lock()
 _tool_detail_toggle_callbacks: list[Callable[[], None]] = []
-_TOOL_DETAIL_TOGGLE_BYTES = {b"\x0f", b"\x00"}  # ctrl+o; ctrl+0/space on some terminals
+_TOOL_DETAIL_TOGGLE_BYTES = {b"\t"}  # Tab toggles tool-detail view during progress
 
 
 @contextlib.contextmanager
@@ -39,7 +39,7 @@ def _stdin_watchers_suppressed() -> bool:
 
 
 def register_tool_detail_toggle(callback: Callable[[], None]) -> Callable[[], None]:
-    """Register a process-local Ctrl+O handler for the active progress view."""
+    """Register a process-local Tab handler for the active progress view."""
     with _stdin_watcher_lock:
         _tool_detail_toggle_callbacks.append(callback)
 
@@ -79,8 +79,8 @@ def _disable_control_char(fd: int, existing: Any) -> Any:
     return _control_char(disabled, existing)
 
 
-class CtrlOToggleWatcher:
-    """Background stdin watcher for Ctrl+O without triggering terminal discard."""
+class ToolDetailToggleWatcher:
+    """Background stdin watcher for Tab without triggering terminal discard."""
 
     def __init__(self, callback: Callable[[], None]) -> None:
         self._callback = callback

--- a/surfaces/interactive_shell/ui/output/tool_tracking.py
+++ b/surfaces/interactive_shell/ui/output/tool_tracking.py
@@ -119,7 +119,7 @@ class ToolTrackingMixin:
             self._sync_tool_detail_view(clear=True)
             return
         label = "shown" if self._tool_details_visible else "hidden"
-        _safe_print(f"  Tool details {label} (ctrl+o)")
+        _safe_print(f"  Tool details {label} (tab)")
         if self._tool_details_visible:
             self._flush_tool_details()
 

--- a/surfaces/interactive_shell/ui/output/tracker.py
+++ b/surfaces/interactive_shell/ui/output/tracker.py
@@ -16,7 +16,7 @@ from surfaces.interactive_shell.ui.output.environment import (
 from surfaces.interactive_shell.ui.output.events import DisplayProtocol, ProgressEvent
 from surfaces.interactive_shell.ui.output.labels import _humanise_message, _node_label
 from surfaces.interactive_shell.ui.output.toggles import (
-    CtrlOToggleWatcher,
+    ToolDetailToggleWatcher,
     register_tool_detail_toggle,
     toggle_active_tool_details,
 )
@@ -67,13 +67,15 @@ class ProgressTracker(ToolTrackingMixin):
         self._printed_tool_detail_ids: set[int] = set()
         self._tool_summary_counts: dict[str, dict[str, int]] = {}
         self._tool_summary_order: list[tuple[str, str]] = []
-        self._toggle_watcher: CtrlOToggleWatcher | None = None
+        self._toggle_watcher: ToolDetailToggleWatcher | None = None
         self._toggle_unregister: Callable[[], None] | None = None
         if self._rich and not self._silent:
             self._display = _make_event_log_display(t0=self._t0, console=self._output_console)
             self._toggle_unregister = register_tool_detail_toggle(self.toggle_tool_details)
             if not self._repl_append_only:
-                self._toggle_watcher = CtrlOToggleWatcher(_invoke_registered_tool_detail_toggle)
+                self._toggle_watcher = ToolDetailToggleWatcher(
+                    _invoke_registered_tool_detail_toggle
+                )
                 self._toggle_watcher.start()
 
     @property

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -436,7 +436,7 @@ def test_rich_tracker_tool_details_toggle_replaces_live_view(
     assert hidden["clear"] is True
 
 
-def test_ctrl_o_watcher_disables_terminal_output_discard(
+def test_tool_detail_watcher_disables_terminal_output_discard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _TTY:
@@ -475,7 +475,7 @@ def test_ctrl_o_watcher_disables_terminal_output_discard(
     monkeypatch.setattr(output_toggles, "termios", _Termios)
     monkeypatch.setattr(output_toggles.os, "fpathconf", lambda _fd, _name: 0)
 
-    watcher = output.CtrlOToggleWatcher(lambda: None)
+    watcher = output.ToolDetailToggleWatcher(lambda: None)
     watcher.start()
     watcher.stop()
 
@@ -486,7 +486,7 @@ def test_ctrl_o_watcher_disables_terminal_output_discard(
     assert attrs[6][_Termios.VDISCARD] == b"\x00"
 
 
-def test_ctrl_o_watcher_stop_restores_canonical_echo(
+def test_tool_detail_watcher_stop_restores_canonical_echo(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _TTY:
@@ -537,7 +537,7 @@ def test_ctrl_o_watcher_stop_restores_canonical_echo(
     monkeypatch.setattr(key_reader, "termios", _Termios, raising=False)
     monkeypatch.setattr(key_reader.sys, "stdin", _TTY())
 
-    watcher = output.CtrlOToggleWatcher(lambda: None)
+    watcher = output.ToolDetailToggleWatcher(lambda: None)
     watcher.start()
     watcher.stop()
 
@@ -565,7 +565,7 @@ def test_suppressed_stdin_watchers_do_not_touch_terminal_mode(
     monkeypatch.setattr(output_toggles.sys, "stdout", _TTY())
     monkeypatch.setattr(output_toggles, "termios", _Termios)
 
-    watcher = output.CtrlOToggleWatcher(lambda: None)
+    watcher = output.ToolDetailToggleWatcher(lambda: None)
     with suppress_stdin_watchers():
         watcher.start()
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -844,6 +844,7 @@ class TestSpinnerState:
         spinner = loop_state.SpinnerState()
         rendered = _strip_ansi(spinner.idle_hint_ansi())
         assert "/ for commands" in rendered
+        assert "tab tool details" in rendered
         assert "history" in rendered
         # Hidden — buffer is empty, Esc would be a no-op, so the hint
         # would mislead the user.

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -99,6 +99,7 @@ class TestResolveIdleHint:
         session.configured_integrations = ("datadog", "github", "grafana")
         rendered = _strip_ansi(resolve_idle_hint_ansi(session))
         assert "/ for commands" in rendered
+        assert "tab tool details" in rendered
         assert "Datadog" in rendered
         assert "GitHub" in rendered
         assert "Grafana" in rendered
@@ -110,6 +111,7 @@ class TestResolveIdleHint:
         rendered = _strip_ansi(resolve_idle_hint_ansi(session))
         assert "Datadog" not in rendered
         assert "/ for commands" in rendered
+        assert "tab tool details" in rendered
 
 
 class TestResolvePromptPlaceholder:


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
- Switch the investigation tool-detail toggle from **Ctrl+O** to **Tab**
- Show `tab tool details` in the idle hint next to `/ for commands`
- Update live progress footer hints and related watcher naming/docs

### Demo/Screenshot for feature changes and bug fixes -
Idle hint now reads: `/ for commands · tab tool details · ↑↓ history`
During an investigation: press Tab to show/hide tool query input/output details.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Ctrl+O was hard to discover for the tool-detail view. Tab is a clearer shortcut during live investigation progress (when the prompt is inactive). The stdin watcher now listens for `\t`, footer/idle hints advertise it, and the watcher class was renamed from `CtrlOToggleWatcher` to `ToolDetailToggleWatcher`. At the idle prompt Tab still completes slash commands; during investigation progress it toggles details.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.