### PR TITLE
refactor(masking): replace IdentifierKind Literal with StrEnum for improved type safety and consistency

### DIFF
--- a/platform/masking/detectors.py
+++ b/platform/masking/detectors.py
@@ -61,14 +61,14 @@ _EMAIL_RE = re.compile(r"\b([\w.+-]+@[\w-]+\.[\w.-]+)\b")
 
 
 _BUILTIN_DETECTORS: dict[IdentifierKind, re.Pattern[str]] = {
-    "pod": _POD_RE,
-    "namespace": _NAMESPACE_RE,
-    "cluster": _CLUSTER_RE,
-    "service_name": _SERVICE_NAME_RE,
-    "hostname": _HOSTNAME_RE,
-    "account_id": _ACCOUNT_RE,
-    "ip_address": _IP_RE,
-    "email": _EMAIL_RE,
+    IdentifierKind.POD: _POD_RE,
+    IdentifierKind.NAMESPACE: _NAMESPACE_RE,
+    IdentifierKind.CLUSTER: _CLUSTER_RE,
+    IdentifierKind.SERVICE_NAME: _SERVICE_NAME_RE,
+    IdentifierKind.HOSTNAME: _HOSTNAME_RE,
+    IdentifierKind.ACCOUNT_ID: _ACCOUNT_RE,
+    IdentifierKind.IP_ADDRESS: _IP_RE,
+    IdentifierKind.EMAIL: _EMAIL_RE,
 }
 
 

--- a/platform/masking/policy.py
+++ b/platform/masking/policy.py
@@ -12,7 +12,8 @@ import json
 import logging
 import os
 import re
-from typing import ClassVar, Literal
+from enum import StrEnum
+from typing import ClassVar
 
 from pydantic import Field, field_validator
 
@@ -20,27 +21,19 @@ from config.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
 
-IdentifierKind = Literal[
-    "pod",
-    "namespace",
-    "cluster",
-    "hostname",
-    "account_id",
-    "ip_address",
-    "email",
-    "service_name",
-]
 
-ALL_KINDS: tuple[IdentifierKind, ...] = (
-    "pod",
-    "namespace",
-    "cluster",
-    "hostname",
-    "account_id",
-    "ip_address",
-    "email",
-    "service_name",
-)
+class IdentifierKind(StrEnum):
+    POD = "pod"
+    NAMESPACE = "namespace"
+    CLUSTER = "cluster"
+    HOSTNAME = "hostname"
+    ACCOUNT_ID = "account_id"
+    IP_ADDRESS = "ip_address"
+    EMAIL = "email"
+    SERVICE_NAME = "service_name"
+
+
+ALL_KINDS: tuple[IdentifierKind, ...] = tuple(IdentifierKind)
 
 
 class MaskingPolicy(StrictConfigModel):
@@ -72,7 +65,7 @@ class MaskingPolicy(StrictConfigModel):
         valid: list[IdentifierKind] = []
         for p in parts:
             if p in ALL_KINDS:
-                valid.append(p)  # type: ignore[arg-type]
+                valid.append(IdentifierKind(p))
             else:
                 logger.warning("[masking] ignoring unknown identifier kind: %r", p)
         return tuple(valid) if valid else ALL_KINDS

--- a/tests/masking/test_policy.py
+++ b/tests/masking/test_policy.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from platform.masking.policy import ALL_KINDS, MaskingPolicy
+from platform.masking.policy import ALL_KINDS, IdentifierKind, MaskingPolicy
+
+
+def test_identifier_kind_strenum_membership() -> None:
+    assert "pod" in ALL_KINDS
+    assert IdentifierKind.POD == "pod"
+    assert "not_a_real_kind" not in ALL_KINDS
 
 
 def test_default_policy_is_disabled() -> None:
@@ -86,10 +92,10 @@ def test_invalid_regex_in_extra_patterns_raises() -> None:
 
 def test_is_kind_enabled_respects_enabled_flag() -> None:
     policy = MaskingPolicy.model_validate({"enabled": False, "kinds": ("pod",)})
-    assert policy.is_kind_enabled("pod") is False
+    assert policy.is_kind_enabled(IdentifierKind.POD) is False
 
 
 def test_is_kind_enabled_filters_by_selected_kinds() -> None:
     policy = MaskingPolicy.model_validate({"enabled": True, "kinds": ("pod", "namespace")})
-    assert policy.is_kind_enabled("pod") is True
-    assert policy.is_kind_enabled("email") is False
+    assert policy.is_kind_enabled(IdentifierKind.POD) is True
+    assert policy.is_kind_enabled(IdentifierKind.EMAIL) is False


### PR DESCRIPTION
Fixes #4524

#### Describe the changes you have made in this PR -
- Refactored `IdentifierKind` in `platform/masking/policy.py` from a `Literal` type alias into a native `enum.StrEnum` class.
- Derived the `ALL_KINDS` tuple directly from the new `StrEnum`, removing the duplicated hardcoded strings to prevent future drift.
- Updated the Pydantic `_filter_valid_kinds` validator to instantiate the `IdentifierKind` enum (e.g. `IdentifierKind(p)`), removing the need for `type: ignore` pragmas.
- Updated `_BUILTIN_DETECTORS` map in `platform/masking/detectors.py` to use strict `IdentifierKind` enum keys rather than raw strings, satisfying strict `mypy` checks.
- Updated existing unit tests to pass `IdentifierKind` instead of raw strings to `is_kind_enabled`.
- Added a specific unit test (`test_identifier_kind_strenum_membership`) to verify `StrEnum` equivalence behavior against strings.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

.venv/bin/python -m ruff check config core gateway integrations platform surfaces tools tests/
All checks passed!
.venv/bin/python -m mypy config core gateway integrations platform surfaces tools
Success: no issues found in 1581 source files


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The primary problem was that `IdentifierKind` was previously defined as a `Literal` alongside a separate hardcoded `ALL_KINDS` tuple. This opened the door to drift between the runtime tuple and static types, and forced us to use raw strings in dictionaries (like `_BUILTIN_DETECTORS`), weakening `mypy`'s ability to verify type boundaries.

By switching to `enum.StrEnum` (available natively in Python 3.11+), we solve this cleanly. `StrEnum` acts identically to strings at runtime (so existing Pydantic validation and Env/JSON parsing still work flawlessly via string equivalence), while acting as a strict distinct class for static type checkers. I updated the dictionary keys and `is_kind_enabled` calls to use the strongly-typed Enum properties (e.g., `IdentifierKind.POD`). This also allowed me to clean up a stale `# type: ignore` in the policy validator.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

