### PR TITLE
test(pagerduty): add unit tests for extract helpers

### DIFF
--- a/tests/integrations/pagerduty/test_client_helpers.py
+++ b/tests/integrations/pagerduty/test_client_helpers.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from integrations.pagerduty.client import _extract_priority, _extract_ref
+
+
+def test_extract_ref_prefers_id_summary_type() -> None:
+    obj = {
+        "id": "PXXXXX",
+        "summary": "Service A",
+        "type": "service_reference",
+        "self": "https://api.pagerduty.com/services/PXXXXX",
+    }
+    assert _extract_ref(obj) == {
+        "id": "PXXXXX",
+        "summary": "Service A",
+        "type": "service_reference",
+    }
+
+
+def test_extract_ref_handles_missing_fields_with_empty_strings() -> None:
+    obj = {"id": "PYYYYY"}
+    assert _extract_ref(obj) == {
+        "id": "PYYYYY",
+        "summary": "",
+        "type": "",
+    }
+
+
+def test_extract_ref_returns_empty_dict_for_missing_or_empty_object() -> None:
+    assert _extract_ref(None) == {}
+    assert _extract_ref({}) == {}
+
+
+def test_extract_priority_prefers_id_name_summary() -> None:
+    incident = {
+        "priority": {
+            "id": "P123",
+            "name": "P1",
+            "summary": "P1",
+            "type": "priority",
+        }
+    }
+    assert _extract_priority(incident) == {
+        "id": "P123",
+        "name": "P1",
+        "summary": "P1",
+    }
+
+
+def test_extract_priority_handles_missing_fields_with_empty_strings() -> None:
+    incident = {
+        "priority": {
+            "id": "P123",
+        }
+    }
+    assert _extract_priority(incident) == {
+        "id": "P123",
+        "name": "",
+        "summary": "",
+    }
+
+
+def test_extract_priority_returns_empty_dict_for_missing_or_empty_priority() -> None:
+    assert _extract_priority({"priority": None}) == {}
+    assert _extract_priority({}) == {}


### PR DESCRIPTION
 Fixes #4654
**Title:**

    test(pagerduty): add unit tests for extract helpers

**Description:**



 **Describe the changes you have made in this PR -**

Added unit tests for `_extract_ref` and `_extract_priority` in `integrations/pagerduty/client.py`. The tests verify proper handling of present, missing, and empty inputs using inline fixtures, with no live API calls. The test file perfectly aligns with the style/structure from C-43 (Vercel).

### Code Understanding and AI Usage
Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

If you used AI assistance:
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Leveraged simple, explicit `pytest` functions with inline dictionary fixtures simulating standard and edge-case
payload responses from the PagerDuty API. Tested each helper to ensure they correctly fallback to empty strings or
dicts when expected data is missing or empty, isolating the logic away from HTTP constraints.

### Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions