### PR TITLE
refactor(config): extract LLM model defaults into a catalog

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -25,29 +25,162 @@ from config.llm_auth.auth_method import (
 from config.llm_auth.credentials import status as credential_status
 from config.llm_auth.provider_catalog import (
     API_KEY_PROVIDER_ENVS,
+    PROVIDER_BY_VALUE,
     SUPPORTED_PROVIDER_VALUES,
+)
+from config.llm_models import (
+    ANTHROPIC_CLASSIFICATION_MODEL,
+    ANTHROPIC_LLM_CONFIG,
+    ANTHROPIC_REASONING_MODEL,
+    ANTHROPIC_TOOLCALL_MODEL,
+    AZURE_OPENAI_CLASSIFICATION_MODEL,
+    AZURE_OPENAI_LLM_CONFIG,
+    AZURE_OPENAI_REASONING_MODEL,
+    AZURE_OPENAI_TOOLCALL_MODEL,
+    BEDROCK_CLASSIFICATION_MODEL,
+    BEDROCK_LLM_CONFIG,
+    BEDROCK_REASONING_MODEL,
+    BEDROCK_TOOLCALL_MODEL,
+    DEEPSEEK_BASE_URL,
+    DEEPSEEK_CLASSIFICATION_MODEL,
+    DEEPSEEK_LLM_CONFIG,
+    DEEPSEEK_REASONING_MODEL,
+    DEEPSEEK_TOOLCALL_MODEL,
+    DEFAULT_AZURE_OPENAI_API_VERSION,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_OLLAMA_HOST,
+    DEFAULT_OLLAMA_MODEL,
+    DEFAULT_VERTEX_AI_LOCATION,
+    GEMINI_BASE_URL,
+    GEMINI_CLASSIFICATION_MODEL,
+    GEMINI_LLM_CONFIG,
+    GEMINI_REASONING_MODEL,
+    GEMINI_TOOLCALL_MODEL,
+    GROQ_BASE_URL,
+    GROQ_CLASSIFICATION_MODEL,
+    GROQ_LLM_CONFIG,
+    GROQ_REASONING_MODEL,
+    GROQ_TOOLCALL_MODEL,
+    MINIMAX_BASE_URL,
+    MINIMAX_CLASSIFICATION_MODEL,
+    MINIMAX_LLM_CONFIG,
+    MINIMAX_REASONING_MODEL,
+    MINIMAX_TOOLCALL_MODEL,
+    NVIDIA_BASE_URL,
+    NVIDIA_CLASSIFICATION_MODEL,
+    NVIDIA_LLM_CONFIG,
+    NVIDIA_REASONING_MODEL,
+    NVIDIA_TOOLCALL_MODEL,
+    OLLAMA_LLM_CONFIG,
+    OPENAI_CLASSIFICATION_MODEL,
+    OPENAI_LLM_CONFIG,
+    OPENAI_REASONING_MODEL,
+    OPENAI_TOOLCALL_MODEL,
+    OPENROUTER_BASE_URL,
+    OPENROUTER_CLASSIFICATION_MODEL,
+    OPENROUTER_LLM_CONFIG,
+    OPENROUTER_REASONING_MODEL,
+    OPENROUTER_TOOLCALL_MODEL,
+    PROVIDER_MODEL_DEFAULTS,
+    VERTEX_AI_CLASSIFICATION_MODEL,
+    VERTEX_AI_LLM_CONFIG,
+    VERTEX_AI_REASONING_MODEL,
+    VERTEX_AI_TOOLCALL_MODEL,
+    LLMModelConfig,
 )
 from config.local_env import bootstrap_opensre_env
 from config.strict_config import StrictConfigModel
 
-
-class LLMModelConfig(StrictConfigModel):
-    """Configuration for an LLM provider's model variants.
-
-    Three tiers, ordered by capability/cost:
-    - ``reasoning_model`` — highest-capability model used for root-cause
-      diagnosis and other deep-reasoning steps (e.g. Claude Opus, GPT-5).
-    - ``classification_model`` — mid-tier model for tasks that need more
-      reasoning than a fast toolcall model but don't justify reasoning cost
-      (e.g. interactive-shell intent classification). Sonnet for Anthropic.
-    - ``toolcall_model`` — lightweight, low-latency model for simple tool
-      selection / action planning (e.g. Claude Haiku, GPT-5 mini).
-    """
-
-    reasoning_model: str
-    classification_model: str
-    toolcall_model: str
-    max_tokens: int
+__all__ = (
+    "ANTHROPIC_CLASSIFICATION_MODEL",
+    "ANTHROPIC_LLM_CONFIG",
+    "ANTHROPIC_REASONING_MODEL",
+    "ANTHROPIC_TOOLCALL_MODEL",
+    "AZURE_OPENAI_CLASSIFICATION_MODEL",
+    "AZURE_OPENAI_LLM_CONFIG",
+    "AZURE_OPENAI_REASONING_MODEL",
+    "AZURE_OPENAI_TOOLCALL_MODEL",
+    "BEDROCK_CLASSIFICATION_MODEL",
+    "BEDROCK_LLM_CONFIG",
+    "BEDROCK_REASONING_MODEL",
+    "BEDROCK_TOOLCALL_MODEL",
+    "CLERK_CONFIG_DEV",
+    "CLERK_CONFIG_PROD",
+    "CLERK_ISSUER_ENV",
+    "CLERK_JWKS_URL_ENV",
+    "ClerkConfig",
+    "DEEPSEEK_BASE_URL",
+    "DEEPSEEK_CLASSIFICATION_MODEL",
+    "DEEPSEEK_LLM_CONFIG",
+    "DEEPSEEK_REASONING_MODEL",
+    "DEEPSEEK_TOOLCALL_MODEL",
+    "DEFAULT_AZURE_OPENAI_API_VERSION",
+    "DEFAULT_MAX_TOKENS",
+    "DEFAULT_OLLAMA_HOST",
+    "DEFAULT_OLLAMA_MODEL",
+    "DEFAULT_VERTEX_AI_LOCATION",
+    "Environment",
+    "GEMINI_BASE_URL",
+    "GEMINI_CLASSIFICATION_MODEL",
+    "GEMINI_LLM_CONFIG",
+    "GEMINI_REASONING_MODEL",
+    "GEMINI_TOOLCALL_MODEL",
+    "GROQ_BASE_URL",
+    "GROQ_CLASSIFICATION_MODEL",
+    "GROQ_LLM_CONFIG",
+    "GROQ_REASONING_MODEL",
+    "GROQ_TOOLCALL_MODEL",
+    "JWT_ALGORITHM",
+    "JWKS_CACHE_TTL_SECONDS",
+    "LLMModelConfig",
+    "LLMProvider",
+    "LLMResolution",
+    "LLMSettings",
+    "LLM_PROVIDER_API_KEY_ENVS",
+    "MINIMAX_BASE_URL",
+    "MINIMAX_CLASSIFICATION_MODEL",
+    "MINIMAX_LLM_CONFIG",
+    "MINIMAX_REASONING_MODEL",
+    "MINIMAX_TOOLCALL_MODEL",
+    "NVIDIA_BASE_URL",
+    "NVIDIA_CLASSIFICATION_MODEL",
+    "NVIDIA_LLM_CONFIG",
+    "NVIDIA_REASONING_MODEL",
+    "NVIDIA_TOOLCALL_MODEL",
+    "OLLAMA_LLM_CONFIG",
+    "OPENAI_CLASSIFICATION_MODEL",
+    "OPENAI_LLM_CONFIG",
+    "OPENAI_REASONING_MODEL",
+    "OPENAI_TOOLCALL_MODEL",
+    "OPENROUTER_BASE_URL",
+    "OPENROUTER_CLASSIFICATION_MODEL",
+    "OPENROUTER_LLM_CONFIG",
+    "OPENROUTER_REASONING_MODEL",
+    "OPENROUTER_TOOLCALL_MODEL",
+    "PROVIDER_ANTHROPIC",
+    "PROVIDER_BEDROCK",
+    "PROVIDER_MODEL_DEFAULTS",
+    "PROVIDER_OLLAMA",
+    "PROVIDER_OPENAI",
+    "PROVIDER_VERTEX_AI",
+    "SLACK_CHANNEL",
+    "TRACER_BASE_URL_DEV",
+    "TRACER_BASE_URL_PROD",
+    "VERTEX_AI_CLASSIFICATION_MODEL",
+    "VERTEX_AI_LLM_CONFIG",
+    "VERTEX_AI_REASONING_MODEL",
+    "VERTEX_AI_TOOLCALL_MODEL",
+    "describe_llm_resolution",
+    "get_clerk_config_override",
+    "get_configured_llm_provider",
+    "get_environment",
+    "get_llm_provider_api_key_env",
+    "get_tracer_base_url",
+    "has_credentials_for_active_llm_provider",
+    "llm_provider_error_context",
+    "resolve_llm_settings",
+    "resolve_llm_settings_verbose",
+)
 
 
 class Environment(StrEnum):
@@ -114,87 +247,6 @@ def get_environment() -> Environment:
 JWT_ALGORITHM = "RS256"
 JWKS_CACHE_TTL_SECONDS = 3600
 
-# LLM Model Constants
-DEFAULT_MAX_TOKENS = 4096
-
-# Anthropic model constants
-ANTHROPIC_REASONING_MODEL = "claude-opus-4-7"
-ANTHROPIC_CLASSIFICATION_MODEL = "claude-sonnet-4-6"
-ANTHROPIC_TOOLCALL_MODEL = "claude-haiku-4-5-20251001"
-
-# OpenAI model constants
-# Default to GPT-5.4 mini for both reasoning and toolcall paths; override via
-# OPENAI_REASONING_MODEL / OPENAI_TOOLCALL_MODEL when needed.
-OPENAI_REASONING_MODEL = "gpt-5.4-mini"
-# Mid-tier mirrors the toolcall (mini) model by default — OpenAI's mini sits
-# between full and nano, which matches the "Sonnet-equivalent" classification
-# tier well enough; override via OPENAI_CLASSIFICATION_MODEL when needed.
-OPENAI_CLASSIFICATION_MODEL = "gpt-5.4-mini"
-OPENAI_TOOLCALL_MODEL = "gpt-5.4-mini"
-
-# OpenRouter model constants
-OPENROUTER_REASONING_MODEL = "openrouter/auto"
-OPENROUTER_CLASSIFICATION_MODEL = "openrouter/auto"
-OPENROUTER_TOOLCALL_MODEL = "openrouter/auto"
-
-# DeepSeek model constants
-DEEPSEEK_REASONING_MODEL = "deepseek-v4-pro"
-DEEPSEEK_CLASSIFICATION_MODEL = "deepseek-v4-flash"
-DEEPSEEK_TOOLCALL_MODEL = "deepseek-v4-flash"
-
-# Gemini model constants (Google AI preview IDs; OpenAI-compatible endpoint)
-# UNVERIFIED PLACEHOLDER — gemini-3.1-pro-preview / gemini-3.1-flash-lite-preview are
-# forward-looking IDs that may not yet exist. Override via GEMINI_REASONING_MODEL env var.
-GEMINI_REASONING_MODEL = "gemini-3.1-pro-preview"
-GEMINI_CLASSIFICATION_MODEL = "gemini-3-flash-preview"
-GEMINI_TOOLCALL_MODEL = "gemini-3.1-flash-lite-preview"
-
-# NVIDIA NIM model constants
-# Verified safe defaults from the NVIDIA API Catalog (build.nvidia.com).
-# Override via NVIDIA_REASONING_MODEL, NVIDIA_TOOLCALL_MODEL, or NVIDIA_MODEL env vars.
-NVIDIA_REASONING_MODEL = "meta/llama-3.1-405b-instruct"
-NVIDIA_CLASSIFICATION_MODEL = "meta/llama-3.1-70b-instruct"
-NVIDIA_TOOLCALL_MODEL = "meta/llama-3.1-8b-instruct"
-
-# MiniMax model constants
-MINIMAX_REASONING_MODEL = "MiniMax-M3"
-MINIMAX_CLASSIFICATION_MODEL = "MiniMax-M2.7-highspeed"
-MINIMAX_TOOLCALL_MODEL = "MiniMax-M2.7-highspeed"
-
-# Groq model constants
-GROQ_REASONING_MODEL = "llama-3.3-70b-versatile"
-GROQ_CLASSIFICATION_MODEL = "llama-3.3-70b-versatile"
-GROQ_TOOLCALL_MODEL = "llama-3.1-8b-instant"
-
-# Azure OpenAI deployment-name defaults (must match your Azure deployment names).
-AZURE_OPENAI_REASONING_MODEL = "gpt-5.4-mini"
-AZURE_OPENAI_CLASSIFICATION_MODEL = "gpt-5.4-mini"
-AZURE_OPENAI_TOOLCALL_MODEL = "gpt-5.4-mini"
-DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
-
-# Base URLs for OpenAI-compatible providers
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-DEEPSEEK_BASE_URL = "https://api.deepseek.com"  # no /v1 — DeepSeek serves the OpenAI-compatible API at the root path
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
-NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
-MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-GROQ_BASE_URL = "https://api.groq.com/openai/v1"
-
-# Amazon Bedrock model constants (US cross-region inference profile IDs)
-BEDROCK_REASONING_MODEL = "us.anthropic.claude-sonnet-4-6"
-BEDROCK_CLASSIFICATION_MODEL = "us.anthropic.claude-sonnet-4-6"
-BEDROCK_TOOLCALL_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
-
-# Google Vertex AI model constants (Gemini models served via Vertex; ADC auth)
-VERTEX_AI_REASONING_MODEL = "gemini-2.5-pro"
-VERTEX_AI_CLASSIFICATION_MODEL = "gemini-2.5-flash"
-VERTEX_AI_TOOLCALL_MODEL = "gemini-2.5-flash-lite"
-DEFAULT_VERTEX_AI_LOCATION = "us-central1"
-
-# Ollama local model constants
-DEFAULT_OLLAMA_MODEL = "llama3.2"
-DEFAULT_OLLAMA_HOST = "http://localhost:11434"
-
 LLMProvider = Literal[
     "anthropic",
     "openai",
@@ -252,173 +304,52 @@ def _llm_api_key_payload(provider: str) -> dict[str, str]:
     return {}
 
 
+def _resolve_model_env(primary: str, default: str, legacy: str | None = None) -> str:
+    """Resolve a model id from primary env, optional legacy env, then *default*."""
+    if legacy:
+        raw = os.getenv(primary, os.getenv(legacy, default))
+    else:
+        raw = os.getenv(primary, default)
+    return (raw or "").strip() or default
+
+
+def _tiered_model_env_payload() -> dict[str, str]:
+    """Build ``{settings_key}_*_model`` keys from the model catalog + ProviderSpec envs."""
+    payload: dict[str, str] = {}
+    for defaults in PROVIDER_MODEL_DEFAULTS.values():
+        if defaults.single_model_settings:
+            continue
+        spec = PROVIDER_BY_VALUE[defaults.provider]
+        key = defaults.settings_key
+        reasoning_env = spec.model_env or f"{key.upper()}_REASONING_MODEL"
+        payload[f"{key}_reasoning_model"] = _resolve_model_env(
+            reasoning_env, defaults.reasoning, spec.legacy_model_env
+        )
+        classification_env = spec.classification_model_env or f"{key.upper()}_CLASSIFICATION_MODEL"
+        payload[f"{key}_classification_model"] = _resolve_model_env(
+            classification_env, defaults.classification, spec.legacy_model_env
+        )
+        toolcall_env = spec.toolcall_model_env or f"{key.upper()}_TOOLCALL_MODEL"
+        payload[f"{key}_toolcall_model"] = _resolve_model_env(
+            toolcall_env, defaults.toolcall, spec.legacy_model_env
+        )
+    return payload
+
+
 def _llm_settings_env_payload(provider: str) -> dict[str, object]:
     """Build the raw env-backed payload used to validate LLM settings."""
     return {
         "provider": provider,
         **_llm_api_key_payload(provider),
-        "anthropic_reasoning_model": os.getenv(
-            "ANTHROPIC_REASONING_MODEL", ANTHROPIC_REASONING_MODEL
-        ).strip()
-        or ANTHROPIC_REASONING_MODEL,
-        "anthropic_classification_model": os.getenv(
-            "ANTHROPIC_CLASSIFICATION_MODEL", ANTHROPIC_CLASSIFICATION_MODEL
-        ).strip()
-        or ANTHROPIC_CLASSIFICATION_MODEL,
-        "anthropic_toolcall_model": os.getenv(
-            "ANTHROPIC_TOOLCALL_MODEL", ANTHROPIC_TOOLCALL_MODEL
-        ).strip()
-        or ANTHROPIC_TOOLCALL_MODEL,
-        "openai_reasoning_model": os.getenv(
-            "OPENAI_REASONING_MODEL", OPENAI_REASONING_MODEL
-        ).strip()
-        or OPENAI_REASONING_MODEL,
-        "openai_classification_model": os.getenv(
-            "OPENAI_CLASSIFICATION_MODEL", OPENAI_CLASSIFICATION_MODEL
-        ).strip()
-        or OPENAI_CLASSIFICATION_MODEL,
-        "openai_toolcall_model": os.getenv("OPENAI_TOOLCALL_MODEL", OPENAI_TOOLCALL_MODEL).strip()
-        or OPENAI_TOOLCALL_MODEL,
-        "openrouter_reasoning_model": os.getenv(
-            "OPENROUTER_REASONING_MODEL",
-            os.getenv("OPENROUTER_MODEL", OPENROUTER_REASONING_MODEL),
-        ).strip()
-        or OPENROUTER_REASONING_MODEL,
-        "openrouter_classification_model": os.getenv(
-            "OPENROUTER_CLASSIFICATION_MODEL",
-            os.getenv("OPENROUTER_MODEL", OPENROUTER_CLASSIFICATION_MODEL),
-        ).strip()
-        or OPENROUTER_CLASSIFICATION_MODEL,
-        "openrouter_toolcall_model": os.getenv(
-            "OPENROUTER_TOOLCALL_MODEL",
-            os.getenv("OPENROUTER_MODEL", OPENROUTER_TOOLCALL_MODEL),
-        ).strip()
-        or OPENROUTER_TOOLCALL_MODEL,
-        "deepseek_reasoning_model": os.getenv(
-            "DEEPSEEK_REASONING_MODEL",
-            os.getenv("DEEPSEEK_MODEL", DEEPSEEK_REASONING_MODEL),
-        ).strip()
-        or DEEPSEEK_REASONING_MODEL,
-        "deepseek_classification_model": os.getenv(
-            "DEEPSEEK_CLASSIFICATION_MODEL",
-            os.getenv("DEEPSEEK_MODEL", DEEPSEEK_CLASSIFICATION_MODEL),
-        ).strip()
-        or DEEPSEEK_CLASSIFICATION_MODEL,
-        "deepseek_toolcall_model": os.getenv(
-            "DEEPSEEK_TOOLCALL_MODEL",
-            os.getenv("DEEPSEEK_MODEL", DEEPSEEK_TOOLCALL_MODEL),
-        ).strip()
-        or DEEPSEEK_TOOLCALL_MODEL,
-        "gemini_reasoning_model": os.getenv(
-            "GEMINI_REASONING_MODEL",
-            os.getenv("GEMINI_MODEL", GEMINI_REASONING_MODEL),
-        ).strip()
-        or GEMINI_REASONING_MODEL,
-        "gemini_classification_model": os.getenv(
-            "GEMINI_CLASSIFICATION_MODEL",
-            os.getenv("GEMINI_MODEL", GEMINI_CLASSIFICATION_MODEL),
-        ).strip()
-        or GEMINI_CLASSIFICATION_MODEL,
-        "gemini_toolcall_model": os.getenv(
-            "GEMINI_TOOLCALL_MODEL",
-            os.getenv("GEMINI_MODEL", GEMINI_TOOLCALL_MODEL),
-        ).strip()
-        or GEMINI_TOOLCALL_MODEL,
-        "nvidia_reasoning_model": os.getenv(
-            "NVIDIA_REASONING_MODEL",
-            os.getenv("NVIDIA_MODEL", NVIDIA_REASONING_MODEL),
-        ).strip()
-        or NVIDIA_REASONING_MODEL,
-        "nvidia_classification_model": os.getenv(
-            "NVIDIA_CLASSIFICATION_MODEL",
-            os.getenv("NVIDIA_MODEL", NVIDIA_CLASSIFICATION_MODEL),
-        ).strip()
-        or NVIDIA_CLASSIFICATION_MODEL,
-        "nvidia_toolcall_model": os.getenv(
-            "NVIDIA_TOOLCALL_MODEL",
-            os.getenv("NVIDIA_MODEL", NVIDIA_TOOLCALL_MODEL),
-        ).strip()
-        or NVIDIA_TOOLCALL_MODEL,
-        "minimax_reasoning_model": os.getenv(
-            "MINIMAX_REASONING_MODEL",
-            os.getenv("MINIMAX_MODEL", MINIMAX_REASONING_MODEL),
-        ).strip()
-        or MINIMAX_REASONING_MODEL,
-        "minimax_classification_model": os.getenv(
-            "MINIMAX_CLASSIFICATION_MODEL",
-            os.getenv("MINIMAX_MODEL", MINIMAX_CLASSIFICATION_MODEL),
-        ).strip()
-        or MINIMAX_CLASSIFICATION_MODEL,
-        "minimax_toolcall_model": os.getenv(
-            "MINIMAX_TOOLCALL_MODEL",
-            os.getenv("MINIMAX_MODEL", MINIMAX_TOOLCALL_MODEL),
-        ).strip()
-        or MINIMAX_TOOLCALL_MODEL,
-        "groq_reasoning_model": os.getenv(
-            "GROQ_REASONING_MODEL",
-            os.getenv("GROQ_MODEL", GROQ_REASONING_MODEL),
-        ).strip()
-        or GROQ_REASONING_MODEL,
-        "groq_classification_model": os.getenv(
-            "GROQ_CLASSIFICATION_MODEL",
-            os.getenv("GROQ_MODEL", GROQ_CLASSIFICATION_MODEL),
-        ).strip()
-        or GROQ_CLASSIFICATION_MODEL,
-        "groq_toolcall_model": os.getenv(
-            "GROQ_TOOLCALL_MODEL",
-            os.getenv("GROQ_MODEL", GROQ_TOOLCALL_MODEL),
-        ).strip()
-        or GROQ_TOOLCALL_MODEL,
+        **_tiered_model_env_payload(),
         "azure_openai_base_url": os.getenv(AZURE_OPENAI_BASE_URL_ENV, "").strip(),
         "azure_openai_api_version": os.getenv(
             AZURE_OPENAI_API_VERSION_ENV, DEFAULT_AZURE_OPENAI_API_VERSION
         ).strip()
         or DEFAULT_AZURE_OPENAI_API_VERSION,
-        "azure_openai_reasoning_model": os.getenv(
-            "AZURE_OPENAI_REASONING_MODEL",
-            os.getenv("AZURE_OPENAI_MODEL", AZURE_OPENAI_REASONING_MODEL),
-        ).strip()
-        or AZURE_OPENAI_REASONING_MODEL,
-        "azure_openai_classification_model": os.getenv(
-            "AZURE_OPENAI_CLASSIFICATION_MODEL",
-            os.getenv("AZURE_OPENAI_MODEL", AZURE_OPENAI_CLASSIFICATION_MODEL),
-        ).strip()
-        or AZURE_OPENAI_CLASSIFICATION_MODEL,
-        "azure_openai_toolcall_model": os.getenv(
-            "AZURE_OPENAI_TOOLCALL_MODEL",
-            os.getenv("AZURE_OPENAI_MODEL", AZURE_OPENAI_TOOLCALL_MODEL),
-        ).strip()
-        or AZURE_OPENAI_TOOLCALL_MODEL,
-        "bedrock_reasoning_model": os.getenv(
-            "BEDROCK_REASONING_MODEL", BEDROCK_REASONING_MODEL
-        ).strip()
-        or BEDROCK_REASONING_MODEL,
-        "bedrock_classification_model": os.getenv(
-            "BEDROCK_CLASSIFICATION_MODEL", BEDROCK_CLASSIFICATION_MODEL
-        ).strip()
-        or BEDROCK_CLASSIFICATION_MODEL,
-        "bedrock_toolcall_model": os.getenv(
-            "BEDROCK_TOOLCALL_MODEL", BEDROCK_TOOLCALL_MODEL
-        ).strip()
-        or BEDROCK_TOOLCALL_MODEL,
         "vertex_ai_project": os.getenv("VERTEX_AI_PROJECT", "").strip(),
         "vertex_ai_location": os.getenv("VERTEX_AI_LOCATION", DEFAULT_VERTEX_AI_LOCATION).strip()
         or DEFAULT_VERTEX_AI_LOCATION,
-        "vertex_ai_reasoning_model": os.getenv(
-            "VERTEX_AI_REASONING_MODEL",
-            os.getenv("VERTEX_AI_MODEL", VERTEX_AI_REASONING_MODEL),
-        ).strip()
-        or VERTEX_AI_REASONING_MODEL,
-        "vertex_ai_classification_model": os.getenv(
-            "VERTEX_AI_CLASSIFICATION_MODEL",
-            os.getenv("VERTEX_AI_MODEL", VERTEX_AI_CLASSIFICATION_MODEL),
-        ).strip()
-        or VERTEX_AI_CLASSIFICATION_MODEL,
-        "vertex_ai_toolcall_model": os.getenv(
-            "VERTEX_AI_TOOLCALL_MODEL",
-            os.getenv("VERTEX_AI_MODEL", VERTEX_AI_TOOLCALL_MODEL),
-        ).strip()
-        or VERTEX_AI_TOOLCALL_MODEL,
         "ollama_model": os.getenv("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL).strip()
         or DEFAULT_OLLAMA_MODEL,
         "ollama_host": os.getenv("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).strip() or DEFAULT_OLLAMA_HOST,
@@ -635,91 +566,6 @@ def has_credentials_for_active_llm_provider() -> bool:
     )
     return auth_status.configured and not auth_status.stale
 
-
-# LLM Provider Configs
-ANTHROPIC_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=ANTHROPIC_REASONING_MODEL,
-    classification_model=ANTHROPIC_CLASSIFICATION_MODEL,
-    toolcall_model=ANTHROPIC_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-OPENAI_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=OPENAI_REASONING_MODEL,
-    classification_model=OPENAI_CLASSIFICATION_MODEL,
-    toolcall_model=OPENAI_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-OPENROUTER_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=OPENROUTER_REASONING_MODEL,
-    classification_model=OPENROUTER_CLASSIFICATION_MODEL,
-    toolcall_model=OPENROUTER_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-DEEPSEEK_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=DEEPSEEK_REASONING_MODEL,
-    classification_model=DEEPSEEK_CLASSIFICATION_MODEL,
-    toolcall_model=DEEPSEEK_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-GROQ_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=GROQ_REASONING_MODEL,
-    classification_model=GROQ_CLASSIFICATION_MODEL,
-    toolcall_model=GROQ_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-AZURE_OPENAI_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=AZURE_OPENAI_REASONING_MODEL,
-    classification_model=AZURE_OPENAI_CLASSIFICATION_MODEL,
-    toolcall_model=AZURE_OPENAI_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-GEMINI_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=GEMINI_REASONING_MODEL,
-    classification_model=GEMINI_CLASSIFICATION_MODEL,
-    toolcall_model=GEMINI_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-NVIDIA_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=NVIDIA_REASONING_MODEL,
-    classification_model=NVIDIA_CLASSIFICATION_MODEL,
-    toolcall_model=NVIDIA_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-MINIMAX_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=MINIMAX_REASONING_MODEL,
-    classification_model=MINIMAX_CLASSIFICATION_MODEL,
-    toolcall_model=MINIMAX_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-BEDROCK_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=BEDROCK_REASONING_MODEL,
-    classification_model=BEDROCK_CLASSIFICATION_MODEL,
-    toolcall_model=BEDROCK_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-VERTEX_AI_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=VERTEX_AI_REASONING_MODEL,
-    classification_model=VERTEX_AI_CLASSIFICATION_MODEL,
-    toolcall_model=VERTEX_AI_TOOLCALL_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
-
-OLLAMA_LLM_CONFIG = LLMModelConfig(
-    reasoning_model=DEFAULT_OLLAMA_MODEL,
-    classification_model=DEFAULT_OLLAMA_MODEL,
-    toolcall_model=DEFAULT_OLLAMA_MODEL,
-    max_tokens=DEFAULT_MAX_TOKENS,
-)
 
 # Tracer API Configuration
 TRACER_BASE_URL_DEV = "https://staging.tracer.cloud"

--- a/config/llm_models.py
+++ b/config/llm_models.py
@@ -1,0 +1,284 @@
+"""Canonical LLM model defaults and base URLs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from config.strict_config import StrictConfigModel
+
+
+class LLMModelConfig(StrictConfigModel):
+    """Configuration for an LLM provider's model variants.
+
+    Three tiers, ordered by capability/cost:
+    - ``reasoning_model`` — highest-capability model used for root-cause
+      diagnosis and other deep-reasoning steps (e.g. Claude Opus, GPT-5).
+    - ``classification_model`` — mid-tier model for tasks that need more
+      reasoning than a fast toolcall model but don't justify reasoning cost
+      (e.g. interactive-shell intent classification). Sonnet for Anthropic.
+    - ``toolcall_model`` — lightweight, low-latency model for simple tool
+      selection / action planning (e.g. Claude Haiku, GPT-5 mini).
+    """
+
+    reasoning_model: str
+    classification_model: str
+    toolcall_model: str
+    max_tokens: int
+
+
+@dataclass(frozen=True)
+class ProviderModelDefaults:
+    """Static model-tier defaults for one hosted LLM provider."""
+
+    provider: str
+    settings_key: str
+    reasoning: str
+    classification: str
+    toolcall: str
+    base_url: str | None = None
+    single_model_settings: bool = False
+
+
+DEFAULT_MAX_TOKENS = 4096
+DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
+DEFAULT_VERTEX_AI_LOCATION = "us-central1"
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+GROQ_BASE_URL = "https://api.groq.com/openai/v1"
+
+PROVIDER_MODEL_DEFAULTS: dict[str, ProviderModelDefaults] = {
+    "anthropic": ProviderModelDefaults(
+        provider="anthropic",
+        settings_key="anthropic",
+        reasoning="claude-opus-4-7",
+        classification="claude-sonnet-4-6",
+        toolcall="claude-haiku-4-5-20251001",
+    ),
+    "openai": ProviderModelDefaults(
+        provider="openai",
+        settings_key="openai",
+        reasoning="gpt-5.4-mini",
+        classification="gpt-5.4-mini",
+        toolcall="gpt-5.4-mini",
+    ),
+    "openrouter": ProviderModelDefaults(
+        provider="openrouter",
+        settings_key="openrouter",
+        reasoning="openrouter/auto",
+        classification="openrouter/auto",
+        toolcall="openrouter/auto",
+        base_url=OPENROUTER_BASE_URL,
+    ),
+    "deepseek": ProviderModelDefaults(
+        provider="deepseek",
+        settings_key="deepseek",
+        reasoning="deepseek-v4-pro",
+        classification="deepseek-v4-flash",
+        toolcall="deepseek-v4-flash",
+        base_url=DEEPSEEK_BASE_URL,
+    ),
+    "gemini": ProviderModelDefaults(
+        provider="gemini",
+        settings_key="gemini",
+        reasoning="gemini-3.1-pro-preview",
+        classification="gemini-3-flash-preview",
+        toolcall="gemini-3.1-flash-lite-preview",
+        base_url=GEMINI_BASE_URL,
+    ),
+    "nvidia": ProviderModelDefaults(
+        provider="nvidia",
+        settings_key="nvidia",
+        reasoning="meta/llama-3.1-405b-instruct",
+        classification="meta/llama-3.1-70b-instruct",
+        toolcall="meta/llama-3.1-8b-instruct",
+        base_url=NVIDIA_BASE_URL,
+    ),
+    "minimax": ProviderModelDefaults(
+        provider="minimax",
+        settings_key="minimax",
+        reasoning="MiniMax-M3",
+        classification="MiniMax-M2.7-highspeed",
+        toolcall="MiniMax-M2.7-highspeed",
+        base_url=MINIMAX_BASE_URL,
+    ),
+    "groq": ProviderModelDefaults(
+        provider="groq",
+        settings_key="groq",
+        reasoning="llama-3.3-70b-versatile",
+        classification="llama-3.3-70b-versatile",
+        toolcall="llama-3.1-8b-instant",
+        base_url=GROQ_BASE_URL,
+    ),
+    "azure-openai": ProviderModelDefaults(
+        provider="azure-openai",
+        settings_key="azure_openai",
+        reasoning="gpt-5.4-mini",
+        classification="gpt-5.4-mini",
+        toolcall="gpt-5.4-mini",
+    ),
+    "bedrock": ProviderModelDefaults(
+        provider="bedrock",
+        settings_key="bedrock",
+        reasoning="us.anthropic.claude-sonnet-4-6",
+        classification="us.anthropic.claude-sonnet-4-6",
+        toolcall="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    ),
+    "vertex-ai": ProviderModelDefaults(
+        provider="vertex-ai",
+        settings_key="vertex_ai",
+        reasoning="gemini-2.5-pro",
+        classification="gemini-2.5-flash",
+        toolcall="gemini-2.5-flash-lite",
+    ),
+    "ollama": ProviderModelDefaults(
+        provider="ollama",
+        settings_key="ollama",
+        reasoning="llama3.2",
+        classification="llama3.2",
+        toolcall="llama3.2",
+        single_model_settings=True,
+    ),
+}
+
+
+def model_config_for(provider: str, *, max_tokens: int = DEFAULT_MAX_TOKENS) -> LLMModelConfig:
+    """Return an ``LLMModelConfig`` built from the catalog row for *provider*."""
+    defaults = PROVIDER_MODEL_DEFAULTS[provider]
+    return LLMModelConfig(
+        reasoning_model=defaults.reasoning,
+        classification_model=defaults.classification,
+        toolcall_model=defaults.toolcall,
+        max_tokens=max_tokens,
+    )
+
+
+def _defaults(provider: str) -> ProviderModelDefaults:
+    return PROVIDER_MODEL_DEFAULTS[provider]
+
+
+ANTHROPIC_REASONING_MODEL = _defaults("anthropic").reasoning
+ANTHROPIC_CLASSIFICATION_MODEL = _defaults("anthropic").classification
+ANTHROPIC_TOOLCALL_MODEL = _defaults("anthropic").toolcall
+
+OPENAI_REASONING_MODEL = _defaults("openai").reasoning
+OPENAI_CLASSIFICATION_MODEL = _defaults("openai").classification
+OPENAI_TOOLCALL_MODEL = _defaults("openai").toolcall
+
+OPENROUTER_REASONING_MODEL = _defaults("openrouter").reasoning
+OPENROUTER_CLASSIFICATION_MODEL = _defaults("openrouter").classification
+OPENROUTER_TOOLCALL_MODEL = _defaults("openrouter").toolcall
+
+DEEPSEEK_REASONING_MODEL = _defaults("deepseek").reasoning
+DEEPSEEK_CLASSIFICATION_MODEL = _defaults("deepseek").classification
+DEEPSEEK_TOOLCALL_MODEL = _defaults("deepseek").toolcall
+
+GEMINI_REASONING_MODEL = _defaults("gemini").reasoning
+GEMINI_CLASSIFICATION_MODEL = _defaults("gemini").classification
+GEMINI_TOOLCALL_MODEL = _defaults("gemini").toolcall
+
+NVIDIA_REASONING_MODEL = _defaults("nvidia").reasoning
+NVIDIA_CLASSIFICATION_MODEL = _defaults("nvidia").classification
+NVIDIA_TOOLCALL_MODEL = _defaults("nvidia").toolcall
+
+MINIMAX_REASONING_MODEL = _defaults("minimax").reasoning
+MINIMAX_CLASSIFICATION_MODEL = _defaults("minimax").classification
+MINIMAX_TOOLCALL_MODEL = _defaults("minimax").toolcall
+
+GROQ_REASONING_MODEL = _defaults("groq").reasoning
+GROQ_CLASSIFICATION_MODEL = _defaults("groq").classification
+GROQ_TOOLCALL_MODEL = _defaults("groq").toolcall
+
+AZURE_OPENAI_REASONING_MODEL = _defaults("azure-openai").reasoning
+AZURE_OPENAI_CLASSIFICATION_MODEL = _defaults("azure-openai").classification
+AZURE_OPENAI_TOOLCALL_MODEL = _defaults("azure-openai").toolcall
+
+BEDROCK_REASONING_MODEL = _defaults("bedrock").reasoning
+BEDROCK_CLASSIFICATION_MODEL = _defaults("bedrock").classification
+BEDROCK_TOOLCALL_MODEL = _defaults("bedrock").toolcall
+
+VERTEX_AI_REASONING_MODEL = _defaults("vertex-ai").reasoning
+VERTEX_AI_CLASSIFICATION_MODEL = _defaults("vertex-ai").classification
+VERTEX_AI_TOOLCALL_MODEL = _defaults("vertex-ai").toolcall
+
+DEFAULT_OLLAMA_MODEL = _defaults("ollama").reasoning
+
+ANTHROPIC_LLM_CONFIG = model_config_for("anthropic")
+OPENAI_LLM_CONFIG = model_config_for("openai")
+OPENROUTER_LLM_CONFIG = model_config_for("openrouter")
+DEEPSEEK_LLM_CONFIG = model_config_for("deepseek")
+GROQ_LLM_CONFIG = model_config_for("groq")
+AZURE_OPENAI_LLM_CONFIG = model_config_for("azure-openai")
+GEMINI_LLM_CONFIG = model_config_for("gemini")
+NVIDIA_LLM_CONFIG = model_config_for("nvidia")
+MINIMAX_LLM_CONFIG = model_config_for("minimax")
+BEDROCK_LLM_CONFIG = model_config_for("bedrock")
+VERTEX_AI_LLM_CONFIG = model_config_for("vertex-ai")
+OLLAMA_LLM_CONFIG = model_config_for("ollama")
+
+__all__ = [
+    "ANTHROPIC_CLASSIFICATION_MODEL",
+    "ANTHROPIC_LLM_CONFIG",
+    "ANTHROPIC_REASONING_MODEL",
+    "ANTHROPIC_TOOLCALL_MODEL",
+    "AZURE_OPENAI_CLASSIFICATION_MODEL",
+    "AZURE_OPENAI_LLM_CONFIG",
+    "AZURE_OPENAI_REASONING_MODEL",
+    "AZURE_OPENAI_TOOLCALL_MODEL",
+    "BEDROCK_CLASSIFICATION_MODEL",
+    "BEDROCK_LLM_CONFIG",
+    "BEDROCK_REASONING_MODEL",
+    "BEDROCK_TOOLCALL_MODEL",
+    "DEEPSEEK_BASE_URL",
+    "DEEPSEEK_CLASSIFICATION_MODEL",
+    "DEEPSEEK_LLM_CONFIG",
+    "DEEPSEEK_REASONING_MODEL",
+    "DEEPSEEK_TOOLCALL_MODEL",
+    "DEFAULT_AZURE_OPENAI_API_VERSION",
+    "DEFAULT_MAX_TOKENS",
+    "DEFAULT_OLLAMA_HOST",
+    "DEFAULT_OLLAMA_MODEL",
+    "DEFAULT_VERTEX_AI_LOCATION",
+    "GEMINI_BASE_URL",
+    "GEMINI_CLASSIFICATION_MODEL",
+    "GEMINI_LLM_CONFIG",
+    "GEMINI_REASONING_MODEL",
+    "GEMINI_TOOLCALL_MODEL",
+    "GROQ_BASE_URL",
+    "GROQ_CLASSIFICATION_MODEL",
+    "GROQ_LLM_CONFIG",
+    "GROQ_REASONING_MODEL",
+    "GROQ_TOOLCALL_MODEL",
+    "LLMModelConfig",
+    "MINIMAX_BASE_URL",
+    "MINIMAX_CLASSIFICATION_MODEL",
+    "MINIMAX_LLM_CONFIG",
+    "MINIMAX_REASONING_MODEL",
+    "MINIMAX_TOOLCALL_MODEL",
+    "NVIDIA_BASE_URL",
+    "NVIDIA_CLASSIFICATION_MODEL",
+    "NVIDIA_LLM_CONFIG",
+    "NVIDIA_REASONING_MODEL",
+    "NVIDIA_TOOLCALL_MODEL",
+    "OLLAMA_LLM_CONFIG",
+    "OPENAI_CLASSIFICATION_MODEL",
+    "OPENAI_LLM_CONFIG",
+    "OPENAI_REASONING_MODEL",
+    "OPENAI_TOOLCALL_MODEL",
+    "OPENROUTER_BASE_URL",
+    "OPENROUTER_CLASSIFICATION_MODEL",
+    "OPENROUTER_LLM_CONFIG",
+    "OPENROUTER_REASONING_MODEL",
+    "OPENROUTER_TOOLCALL_MODEL",
+    "PROVIDER_MODEL_DEFAULTS",
+    "ProviderModelDefaults",
+    "VERTEX_AI_CLASSIFICATION_MODEL",
+    "VERTEX_AI_LLM_CONFIG",
+    "VERTEX_AI_REASONING_MODEL",
+    "VERTEX_AI_TOOLCALL_MODEL",
+    "model_config_for",
+]

--- a/core/llm/AGENTS.md
+++ b/core/llm/AGENTS.md
@@ -7,7 +7,8 @@ agent loop. Subprocess-backed LLM CLIs live under `integrations/llm_cli/`.
 
 | File | Role |
 | --- | --- |
-| `config/config.py` | Declares `LLMProvider`, provider env vars, defaults, and validation requirements. |
+| `config/llm_models.py` | Canonical per-provider model-tier defaults, base URLs, and `*_LLM_CONFIG` shapes. |
+| `config/config.py` | Declares `LLMProvider`, `LLMSettings` validation, and env-backed resolution. |
 | `config/llm_auth/provider_catalog.py` | Canonical `ProviderSpec` metadata shared by wizard, auth, and runtime checks. |
 | `core/llm/factory.py` | Single routing entrypoint: `resolve_llm_route()`, `get_llm(role)`, `reset_llm_clients()`. |
 | `core/llm/client_builders.py` | Construct the client for a resolved route: `build_agent_client()`, `build_reasoning_client()`. |
@@ -61,7 +62,8 @@ and wizard env sync call `reset_llm_clients()` directly.
 ## Adding a Hosted API Provider
 
 1. Add the provider literal to `LLMProvider` and normalization/validation paths in `config/config.py`.
-2. Add `ProviderSpec` in `config/llm_auth/provider_catalog.py` and matching `ProviderOption` in
+2. Add a `ProviderModelDefaults` row in `config/llm_models.py` (model-tier defaults / base URL).
+3. Add `ProviderSpec` in `config/llm_auth/provider_catalog.py` and matching `ProviderOption` in
    `surfaces/cli/wizard/config.py` (model env vars, defaults, `endpoint_env` if needed).
 3. Add runtime construction (routing itself stays in `core/llm/factory.py`; clients are built in `core/llm/client_builders.py`):
    - **First-party provider** (its own SDK models + a LiteLLM prefix): add **one row** to

--- a/core/llm/providers/openai_compat_providers.py
+++ b/core/llm/providers/openai_compat_providers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Final
 
-from config.config import (
+from config.llm_models import (
     DEEPSEEK_BASE_URL,
     DEEPSEEK_LLM_CONFIG,
     GEMINI_BASE_URL,

--- a/core/llm/providers/provider_registry.py
+++ b/core/llm/providers/provider_registry.py
@@ -9,14 +9,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from config.config import (
-    ANTHROPIC_LLM_CONFIG,
-    BEDROCK_LLM_CONFIG,
-    OPENAI_LLM_CONFIG,
-    PROVIDER_ANTHROPIC,
-    PROVIDER_BEDROCK,
-    PROVIDER_OPENAI,
-)
+from config.config import PROVIDER_ANTHROPIC, PROVIDER_BEDROCK, PROVIDER_OPENAI
+from config.llm_models import ANTHROPIC_LLM_CONFIG, BEDROCK_LLM_CONFIG, OPENAI_LLM_CONFIG
 
 
 @dataclass(frozen=True)

--- a/tests/config/test_llm_models.py
+++ b/tests/config/test_llm_models.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from config.config import LLMSettings
+from config.llm_auth.provider_catalog import PROVIDER_SPECS
+from config.llm_models import PROVIDER_MODEL_DEFAULTS, model_config_for
+
+
+def test_provider_model_defaults_cover_tiered_provider_specs() -> None:
+    for spec in PROVIDER_SPECS:
+        if not spec.toolcall_model_env:
+            continue
+        assert spec.value in PROVIDER_MODEL_DEFAULTS, (
+            f"ProviderSpec '{spec.value}' has tiered model envs but no PROVIDER_MODEL_DEFAULTS row"
+        )
+        defaults = PROVIDER_MODEL_DEFAULTS[spec.value]
+        assert defaults.provider == spec.value
+        assert defaults.settings_key
+        assert defaults.reasoning
+        assert defaults.classification
+        assert defaults.toolcall
+
+
+def test_provider_model_defaults_settings_keys_match_llm_settings() -> None:
+    fields = LLMSettings.model_fields
+    for defaults in PROVIDER_MODEL_DEFAULTS.values():
+        if defaults.single_model_settings:
+            assert f"{defaults.settings_key}_model" in fields
+            continue
+        for tier in ("reasoning", "classification", "toolcall"):
+            attr = f"{defaults.settings_key}_{tier}_model"
+            assert attr in fields, f"missing LLMSettings field {attr}"
+
+
+def test_model_config_for_matches_catalog_row() -> None:
+    config = model_config_for("deepseek")
+    defaults = PROVIDER_MODEL_DEFAULTS["deepseek"]
+    assert config.reasoning_model == defaults.reasoning
+    assert config.classification_model == defaults.classification
+    assert config.toolcall_model == defaults.toolcall
+
+
+def test_llm_settings_from_env_honors_primary_model_override(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+    monkeypatch.setenv("DEEPSEEK_REASONING_MODEL", "deepseek-custom-reasoning")
+    monkeypatch.setenv("DEEPSEEK_CLASSIFICATION_MODEL", "deepseek-custom-class")
+    monkeypatch.setenv("DEEPSEEK_TOOLCALL_MODEL", "deepseek-custom-tool")
+    monkeypatch.delenv("DEEPSEEK_MODEL", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    settings = LLMSettings.from_env()
+
+    assert settings.deepseek_reasoning_model == "deepseek-custom-reasoning"
+    assert settings.deepseek_classification_model == "deepseek-custom-class"
+    assert settings.deepseek_toolcall_model == "deepseek-custom-tool"
+
+
+def test_llm_settings_from_env_honors_legacy_model_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openrouter")
+    monkeypatch.delenv("OPENROUTER_REASONING_MODEL", raising=False)
+    monkeypatch.delenv("OPENROUTER_CLASSIFICATION_MODEL", raising=False)
+    monkeypatch.delenv("OPENROUTER_TOOLCALL_MODEL", raising=False)
+    monkeypatch.setenv("OPENROUTER_MODEL", "openrouter/legacy-shared")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    settings = LLMSettings.from_env()
+
+    assert settings.openrouter_reasoning_model == "openrouter/legacy-shared"
+    assert settings.openrouter_classification_model == "openrouter/legacy-shared"
+    assert settings.openrouter_toolcall_model == "openrouter/legacy-shared"


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Extract duplicated LLM model defaults out of `config/config.py` into a leaf catalog (`config/llm_models.py`). Env payload construction now loops over `PROVIDER_MODEL_DEFAULTS` + `ProviderSpec` env names instead of copy-pasting per provider. `LLMSettings` stays flat; historical `config.config` names are re-exported.

### Demo/Screenshot for feature changes and bug fixes -
N/A — internal config refactor. Covered by `tests/config/test_llm_models.py` + existing `tests/config/test_config.py`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
`config/config.py` defined the same model info three ways (flat constants, `LLMSettings` defaults, `*_LLM_CONFIG`). Auth env *names* already lived in `ProviderSpec`. This change adds `ProviderModelDefaults` as the single source of default *values*, derives the old aliases/`*_LLM_CONFIG` from it, and builds `_llm_settings_env_payload` from the catalog loop. Kept settings flat because call sites use `getattr(settings, f"{provider}_{tier}_model")`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.