### PR TITLE
Fix/4774 gateway security robustness hardening

### DIFF
--- a/gateway/core/billing/credits_client.py
+++ b/gateway/core/billing/credits_client.py
@@ -110,10 +110,9 @@ def consume_credits(
         )
     except Exception as exc:
         logger.warning(
-            "[credits] webapp unreachable for reason=%s (%s: %s)",
+            "[credits] webapp unreachable for reason=%s (%s)",
             reason,
             type(exc).__name__,
-            exc,
         )
         return CreditsOutcome.UNAVAILABLE
 

--- a/gateway/core/storage/investigations/postgres.py
+++ b/gateway/core/storage/investigations/postgres.py
@@ -84,7 +84,11 @@ class PostgresInvestigationStore:
                 from psycopg2.pool import ThreadedConnectionPool
 
                 self._pool = ThreadedConnectionPool(
-                    _POOL_MIN_CONNECTIONS, _POOL_MAX_CONNECTIONS, self._dsn
+                    _POOL_MIN_CONNECTIONS,
+                    _POOL_MAX_CONNECTIONS,
+                    self._dsn,
+                    connect_timeout=5,
+                    options="-c statement_timeout=10000",
                 )
             return self._pool
 

--- a/gateway/tests/billing/test_credits_client.py
+++ b/gateway/tests/billing/test_credits_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from http import HTTPStatus
 from typing import Any
 
@@ -94,6 +95,35 @@ def test_transport_error_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None
 
     # Assert: UNAVAILABLE so the gateway can fail open instead of blocking the user.
     assert outcome is CreditsOutcome.UNAVAILABLE
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_transport_error_log_omits_exception_detail(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: the exception message contains a URL that must never reach the log.
+    sensitive_url = "https://app.opensre.internal/api/credits/consume"
+
+    def unreachable(*_a: object, **_k: object) -> httpx.Response:
+        raise httpx.ConnectError(f"[Errno -2] Name or service not known: {sensitive_url}")
+
+    monkeypatch.setattr("gateway.core.billing.credits_client.httpx.post", unreachable)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.core.billing.credits_client"):
+        consume_credits(organization_id="org_x", reason="slack_turn")
+
+    # Assert: the log record was emitted but contains no part of the exception message.
+    assert any("[credits] webapp unreachable" in r.message for r in caplog.records)
+    for record in caplog.records:
+        if "[credits] webapp unreachable" in record.message:
+            assert sensitive_url not in record.message, (
+                "Log must not expose the exception message (may contain the webapp URL)"
+            )
+            assert "Name or service not known" not in record.message, (
+                "Log must not expose raw exception text"
+            )
+            # Only the exception type name is permitted.
+            assert "ConnectError" in record.message
 
 
 @pytest.mark.usefixtures("metering_on")

--- a/gateway/tests/slack/test_attachments.py
+++ b/gateway/tests/slack/test_attachments.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from gateway.transports.slack.attachments import (
     build_files_context,
     extract_text,
@@ -107,3 +109,33 @@ def test_build_files_context_reports_failed_download() -> None:
 
 def test_build_files_context_empty_when_no_files() -> None:
     assert build_files_context((), token="test-bot-token") == ""
+
+
+def test_download_file_rejects_non_allowlisted_host() -> None:
+    from gateway.transports.slack.attachments import download_file
+    file = SlackInboundFile(
+        id="F1", name="log.txt", mimetype="text/plain", size=10, url_private="https://evil.com/file"
+    )
+    assert download_file(file, "token") is None
+
+
+def test_download_file_rejects_redirect_to_non_allowlisted_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    from contextlib import contextmanager
+    from collections.abc import Iterator
+    import httpx
+    from gateway.transports.slack.attachments import download_file
+
+    @contextmanager
+    def mock_stream(self: object, method: str, url: str, **kwargs: object) -> Iterator[httpx.Response]:
+        if "files.slack.com" in url:
+            yield httpx.Response(302, headers={"Location": "https://malicious.com/file"})
+        else:
+            yield httpx.Response(200, content=b"stolen")
+
+    monkeypatch.setattr("httpx.Client.stream", mock_stream)
+
+    file = SlackInboundFile(
+        id="F1", name="log.txt", mimetype="text/plain", size=10, url_private="https://files.slack.com/file"
+    )
+    assert download_file(file, "token") is None
+

--- a/gateway/tests/storage/investigations/test_postgres.py
+++ b/gateway/tests/storage/investigations/test_postgres.py
@@ -42,10 +42,11 @@ def _install_fake_psycopg2(monkeypatch: pytest.MonkeyPatch) -> type:
     class _FakePool:
         instances: list[_FakePool] = []
 
-        def __init__(self, minconn: int, maxconn: int, dsn: str) -> None:
+        def __init__(self, minconn: int, maxconn: int, dsn: str, **kwargs: Any) -> None:
             self.minconn = minconn
             self.maxconn = maxconn
             self.dsn = dsn
+            self.kwargs = kwargs
             self.connection = _FakeConnection()
             self.gets = 0
             self.puts = 0
@@ -82,6 +83,17 @@ def test_one_pool_and_every_connection_returned(monkeypatch: pytest.MonkeyPatch)
     # Three operations (schema, get, claim): each borrowed and returned once.
     assert pool.gets == 3
     assert pool.puts == 3
+
+
+def test_pool_timeout_options_passed_to_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_pool_cls, _ = _install_fake_psycopg2(monkeypatch)
+
+    _ = PostgresInvestigationStore("postgresql://example/db")
+
+    assert len(fake_pool_cls.instances) == 1
+    pool = fake_pool_cls.instances[0]
+    assert pool.kwargs.get("connect_timeout") == 5
+    assert "statement_timeout=10000" in pool.kwargs.get("options", "")
 
 
 def _raise_query_error() -> None:

--- a/gateway/tests/telegram/test_telegram_poller.py
+++ b/gateway/tests/telegram/test_telegram_poller.py
@@ -91,3 +91,26 @@ def test_poll_once_parses_inbound_message(mock_get: MagicMock, mock_sleep: Magic
     assert events[0].text == "hello"
     assert events[0].chat_id == "99"
     mock_sleep.assert_not_called()
+
+
+@patch("gateway.transports.telegram.poller.poller.time.sleep")
+@patch("gateway.transports.telegram.poller.poller.httpx.get")
+def test_poll_once_exception_omits_bot_token_detail(
+    mock_get: MagicMock,
+    _mock_sleep: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    bot_token = "secret_bot_token_12345"
+    mock_get.side_effect = httpx.ConnectError(
+        f"failed to connect to https://api.telegram.org/bot{bot_token}/getUpdates"
+    )
+    poller = TelegramPoller(bot_token)
+    with caplog.at_level(logging.WARNING, logger="gateway.transports.telegram.poller.poller"):
+        assert poller.poll_once() == []
+
+    assert any("[telegram-gateway] getUpdates failed: ConnectError" in r.message for r in caplog.records)
+    for record in caplog.records:
+        assert bot_token not in record.message
+

--- a/gateway/tests/web/test_artifacts.py
+++ b/gateway/tests/web/test_artifacts.py
@@ -57,3 +57,32 @@ def test_upload_uses_no_org_prefix_when_org_empty(
 
     assert key == "no-org/inv-1/report.json"
     fake.upload_file.assert_called_once()
+
+
+def test_upload_passes_timeout_config_to_boto3(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from typing import Any
+
+    calls = []
+
+    def mock_client(service_name: str, config: Any = None) -> Any:
+        calls.append((service_name, config))
+        fake = MagicMock()
+        return fake
+
+    import boto3
+
+    monkeypatch.setenv(ARTIFACTS_BUCKET_ENV, "bucket")
+    monkeypatch.setattr(boto3, "client", mock_client)
+    local = write_local_report("inv-1", {}, base_dir=tmp_path)
+
+    key = upload_report_to_s3(local, org_id="org", investigation_id="inv-1")
+
+    assert key == "org/inv-1/report.json"
+    assert len(calls) == 1
+    service, config = calls[0]
+    assert service == "s3"
+    assert config is not None
+    assert config.connect_timeout == 5.0
+    assert config.read_timeout == 10.0

--- a/gateway/tests/web/test_webapp_alerts.py
+++ b/gateway/tests/web/test_webapp_alerts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from http import HTTPStatus
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -84,14 +86,27 @@ def test_rejected_alert_does_not_leak_exception_detail(client: TestClient) -> No
 
 def test_oversized_body_returns_413(client: TestClient, inbox: AlertInbox) -> None:
     resp = client.post("/alerts", json={"text": "x" * (webapp.MAX_ALERT_BODY_BYTES + 1)})
-    assert resp.status_code == 413
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": "payload too large"}
+    assert inbox.pop_nowait() is None
+
+
+def test_oversized_body_chunked_returns_413(client: TestClient, inbox: AlertInbox) -> None:
+    def chunked_payload() -> Iterator[bytes]:
+        yield b'{"text":"'
+        yield b"x" * (webapp.MAX_ALERT_BODY_BYTES // 2)
+        yield b"x" * (webapp.MAX_ALERT_BODY_BYTES // 2 + 10)
+        yield b'"}'
+        
+    resp = client.post("/alerts", content=chunked_payload())
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert resp.json() == {"error": "payload too large"}
     assert inbox.pop_nowait() is None
 
 
 def test_investigate_oversized_body_returns_413(client: TestClient) -> None:
     resp = client.post("/investigate", json={"alert_name": "x" * (webapp.MAX_BODY_BYTES + 1)})
-    assert resp.status_code == 413
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert resp.json() == {"error": "payload too large"}
 
 
@@ -107,7 +122,7 @@ def test_api_investigations_oversized_body_returns_413(client: TestClient, monke
         json={"alert_name": "x" * (webapp.MAX_BODY_BYTES + 1)},
         headers={"Authorization": "Bearer token"},
     )
-    assert resp.status_code == 413
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert resp.json() == {"error": "payload too large"}
 
 

--- a/gateway/tests/web/test_webapp_alerts.py
+++ b/gateway/tests/web/test_webapp_alerts.py
@@ -89,6 +89,29 @@ def test_oversized_body_returns_413(client: TestClient, inbox: AlertInbox) -> No
     assert inbox.pop_nowait() is None
 
 
+def test_investigate_oversized_body_returns_413(client: TestClient) -> None:
+    resp = client.post("/investigate", json={"alert_name": "x" * (webapp.MAX_BODY_BYTES + 1)})
+    assert resp.status_code == 413
+    assert resp.json() == {"error": "payload too large"}
+
+
+def test_api_investigations_oversized_body_returns_413(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from unittest.mock import AsyncMock
+    from platform.auth.jwt_auth import JWTClaims
+    monkeypatch.setattr(
+        "gateway.web.clerk_deps.verify_jwt_async",
+        AsyncMock(return_value=JWTClaims(sub="user_1", organization="org_1", organization_slug="test", email="u@example.com", full_name="Test User", issuer="https://test", exp=9999999999, iat=1)),
+    )
+    resp = client.post(
+        "/api/investigations",
+        json={"alert_name": "x" * (webapp.MAX_BODY_BYTES + 1)},
+        headers={"Authorization": "Bearer token"},
+    )
+    assert resp.status_code == 413
+    assert resp.json() == {"error": "payload too large"}
+
+
+
 def test_non_loopback_without_token_returns_403(inbox: AlertInbox) -> None:
     remote = TestClient(webapp.app, client=_REMOTE)
     resp = remote.post("/alerts", json={"text": "x"})

--- a/gateway/transports/slack/attachments.py
+++ b/gateway/transports/slack/attachments.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -96,38 +97,90 @@ def extract_text(file: SlackInboundFile, data: bytes) -> str | None:
         text = data.decode("latin-1", errors="replace")
     return _truncate(text)
 
+_ALLOWED_SLACK_HOST_SUFFIXES = (".slack.com", ".slack-edge.com")
+_ALLOWED_SLACK_HOSTS = frozenset(
+    {"files.slack.com", "slack-files.com", "downloads.slack-edge.com", "slack-edge.com"}
+)
+_MAX_REDIRECTS = 5
+
+
+def _is_allowed_slack_host(host: str) -> bool:
+    host = host.lower()
+    return host in _ALLOWED_SLACK_HOSTS or any(
+        host.endswith(suffix) for suffix in _ALLOWED_SLACK_HOST_SUFFIXES
+    )
+
 
 def download_file(file: SlackInboundFile, token: str) -> bytes | None:
     """GET a Slack ``url_private`` with the bot token; None on any failure.
 
     Slack redirects file downloads (307/308) and requires the bot token as a
-    bearer header. The response is size-capped so a huge upload cannot exhaust
-    memory (the file is dropped, not truncated, past the cap).
+    bearer header. Redirect target hosts are validated against the Slack host
+    allowlist, and the Authorization header is never forwarded across different
+    hosts. The response is size-capped so a huge upload cannot exhaust memory.
     """
     if not (file.url_private and token):
         return None
+
+    current_url = file.url_private
+    initial_parsed = urlparse(current_url)
+    initial_host = (initial_parsed.hostname or "").lower()
+
+    if not _is_allowed_slack_host(initial_host):
+        logger.warning("[slack-files] initial host %s not on allowlist; rejected", initial_host)
+        return None
+
     try:
-        with httpx.stream(
-            "GET",
-            file.url_private,
-            headers={"Authorization": f"Bearer {token}"},
-            follow_redirects=True,
-            timeout=_DOWNLOAD_TIMEOUT_SECONDS,
-        ) as response:
-            if response.status_code != httpx.codes.OK:
-                logger.warning("[slack-files] %s download HTTP %s", file.name, response.status_code)
-                return None
-            chunks: list[bytes] = []
-            total = 0
-            for chunk in response.iter_bytes():
-                total += len(chunk)
-                if total > _MAX_FILE_BYTES:
-                    logger.info(
-                        "[slack-files] %s exceeds %d bytes; skipped", file.name, _MAX_FILE_BYTES
+        with httpx.Client(timeout=_DOWNLOAD_TIMEOUT_SECONDS, follow_redirects=False) as client:
+            for _ in range(_MAX_REDIRECTS):
+                parsed = urlparse(current_url)
+                host = (parsed.hostname or "").lower()
+
+                if not _is_allowed_slack_host(host):
+                    logger.warning(
+                        "[slack-files] redirect target host %s not on allowlist; rejected", host
                     )
                     return None
-                chunks.append(chunk)
-            return b"".join(chunks)
+
+                headers: dict[str, str] = {}
+                if host == initial_host or host == "files.slack.com":
+                    headers["Authorization"] = f"Bearer {token}"
+
+                with client.stream("GET", current_url, headers=headers) as response:
+                    if response.status_code in (
+                        httpx.codes.MOVED_PERMANENTLY,
+                        httpx.codes.FOUND,
+                        httpx.codes.SEE_OTHER,
+                        httpx.codes.TEMPORARY_REDIRECT,
+                        httpx.codes.PERMANENT_REDIRECT,
+                    ):
+                        location = response.headers.get("location")
+                        if not location:
+                            return None
+                        current_url = urljoin(current_url, location)
+                        continue
+
+                    if response.status_code != httpx.codes.OK:
+                        logger.warning(
+                            "[slack-files] %s download HTTP %s", file.name, response.status_code
+                        )
+                        return None
+
+                    chunks: list[bytes] = []
+                    total = 0
+                    for chunk in response.iter_bytes():
+                        total += len(chunk)
+                        if total > _MAX_FILE_BYTES:
+                            logger.info(
+                                "[slack-files] %s exceeds %d bytes; skipped",
+                                file.name,
+                                _MAX_FILE_BYTES,
+                            )
+                            return None
+                        chunks.append(chunk)
+                    return b"".join(chunks)
+            logger.warning("[slack-files] too many redirects downloading %s", file.name)
+            return None
     except httpx.HTTPError as exc:
         logger.warning("[slack-files] %s download failed: %s", file.name, type(exc).__name__)
         return None

--- a/gateway/transports/telegram/poller/poller.py
+++ b/gateway/transports/telegram/poller/poller.py
@@ -50,7 +50,7 @@ class TelegramPoller:
         try:
             response = httpx.get(url, params=params, timeout=float(self._timeout + 5))
         except Exception as exc:
-            self._log_transient("[telegram-gateway] getUpdates failed: %s", exc)
+            self._log_transient("[telegram-gateway] getUpdates failed: %s", type(exc).__name__)
             time.sleep(_DEFAULT_RETRY_SECONDS)
             return []
 
@@ -85,6 +85,8 @@ class TelegramPoller:
         description = str(
             data.get("description") or response.text.strip() or f"HTTP {response.status_code}"
         )
+        if self._token:
+            description = description.replace(self._token, "[REDACTED]")
         if error_code == _CONFLICT_ERROR_CODE:
             logger.debug(
                 "[telegram-gateway] getUpdates conflict (retry in %.0fs): %s",

--- a/gateway/web/artifacts.py
+++ b/gateway/web/artifacts.py
@@ -42,8 +42,10 @@ def upload_report_to_s3(
     key = f"{org_id or 'no-org'}/{investigation_id}/report.json"
     try:
         import boto3
+        from botocore.config import Config
 
-        boto3.client("s3").upload_file(str(local_path), bucket, key)
+        config = Config(connect_timeout=5.0, read_timeout=10.0)
+        boto3.client("s3", config=config).upload_file(str(local_path), bucket, key)
     except Exception:
         logger.warning("[investigations] S3 upload failed for %s", investigation_id, exc_info=True)
         return None

--- a/gateway/web/body_cap.py
+++ b/gateway/web/body_cap.py
@@ -1,0 +1,31 @@
+"""Body size cap utilities for gateway HTTP routes."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+MAX_BODY_BYTES = 1 * 1024 * 1024
+MAX_ALERT_BODY_BYTES = MAX_BODY_BYTES
+
+
+async def validate_body_size(request: Request, max_bytes: int = MAX_BODY_BYTES) -> JSONResponse | None:
+    try:
+        declared_length = int(request.headers.get("content-length", 0))
+    except ValueError:
+        return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
+    if declared_length < 0:
+        return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
+    if declared_length > max_bytes:
+        return JSONResponse(
+            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+        )
+
+    body = await request.body()
+    if len(body) > max_bytes:
+        return JSONResponse(
+            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+        )
+    return None

--- a/gateway/web/body_cap.py
+++ b/gateway/web/body_cap.py
@@ -23,9 +23,15 @@ async def validate_body_size(request: Request, max_bytes: int = MAX_BODY_BYTES) 
             {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
         )
 
-    body = await request.body()
-    if len(body) > max_bytes:
-        return JSONResponse(
-            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-        )
+    total = 0
+    chunks = []
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            return JSONResponse(
+                {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+            )
+        chunks.append(chunk)
+    
+    request._body = b"".join(chunks)
     return None

--- a/gateway/web/webapp.py
+++ b/gateway/web/webapp.py
@@ -55,9 +55,11 @@ init_sentry(entrypoint="webapp")
 
 logger = logging.getLogger(__name__)
 
-# Cap on POST body size accepted from any caller (authed or not). Realistic
-# alert payloads top out around 50 KB, so 1 MiB is ~20× headroom.
-MAX_ALERT_BODY_BYTES = 1 * 1024 * 1024
+from gateway.web.body_cap import (  # noqa: E402
+    MAX_ALERT_BODY_BYTES,
+    MAX_BODY_BYTES,
+    validate_body_size,
+)
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
@@ -71,6 +73,14 @@ class HealthResponse(BaseModel):
 
 app = FastAPI()
 app.include_router(investigations_router)
+
+
+@app.middleware("http")
+async def limit_body_size(request: Request, call_next: Any) -> Response:
+    if request.method == "POST":
+        if (size_error := await validate_body_size(request)) is not None:
+            return size_error
+    return await call_next(request)
 
 
 def get_health_response() -> HealthResponse:
@@ -145,23 +155,7 @@ async def receive_alert(request: Request) -> JSONResponse:
     if (auth_error := _gateway_auth_error(request)) is not None:
         return auth_error
 
-    try:
-        declared_length = int(request.headers.get("content-length", 0))
-    except ValueError:
-        return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
-    if declared_length < 0:
-        return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
-    if declared_length > MAX_ALERT_BODY_BYTES:
-        return JSONResponse(
-            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-        )
-
     body = await request.body()
-    if len(body) > MAX_ALERT_BODY_BYTES:
-        return JSONResponse(
-            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-        )
-
     try:
         data = json.loads(body)
     except ValueError:

--- a/gateway/web/webapp.py
+++ b/gateway/web/webapp.py
@@ -16,7 +16,7 @@ import logging
 import os
 from datetime import UTC, datetime
 from http import HTTPStatus
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
@@ -76,7 +76,10 @@ app.include_router(investigations_router)
 
 
 @app.middleware("http")
-async def limit_body_size(request: Request, call_next: Any) -> Response:
+async def limit_body_size(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
     if request.method == "POST":
         if (size_error := await validate_body_size(request)) is not None:
             return size_error


### PR DESCRIPTION
Fixes #4769
Fixes #4770
Fixes #4771
Fixes #4772

#### Describe the changes you have made in this PR -

This PR addresses multiple security and robustness gaps across the `gateway` 
module: enforcing payload size limits, restricting redirect-following on 
external downloads, sanitizing sensitive data out of logs, and adding 
bounded timeouts on external dependency calls. It also fixes a strict 
type-checking issue introduced in the gateway middleware.

### 1. Timeout Bounds for External Dependencies (#4772)
**Files:** `gateway/web/artifacts.py`, `gateway/core/storage/investigations/postgres.py`, `gateway/tests/web/test_artifacts.py`, `gateway/tests/storage/test_postgres.py`

- **Problem:** S3 artifact uploads and Postgres connection attempts had no 
  bounded timeout, so the gateway could hang indefinitely if either 
  dependency became slow or unreachable.
- **Fix:** Added explicit connect/read timeouts to the S3 client config and 
  the Postgres connection setup, so a stalled external dependency can no 
  longer block a gateway thread indefinitely.

### 2. Secure Slack Attachment Downloads (#4771)
**Files:** `gateway/transports/slack/attachments.py`, `gateway/tests/slack/test_attachments.py`

- **Problem:** The Slack attachment downloader followed redirects while 
  still forwarding the bot's `Authorization` header, with no allowlist on 
  the redirect target host — allowing the bot token to be sent to an 
  untrusted domain.
- **Fix:** The downloader now strips the `Authorization` header before 
  following any redirect to a domain outside the trusted Slack host 
  allowlist, so the token is never forwarded off-domain.

### 3. Body-Size Cap Enforcement (#4770)
**Files:** `gateway/web/webapp.py`, `gateway/web/body_cap.py`, `gateway/tests/web/test_webapp_alerts.py`

- **Problem:** The request body-size cap was only enforced on `/alerts`. 
  `/investigate` and `/api/investigations` had no limit and could buffer 
  unbounded JSON payloads.
- **Fix:** Extended the same body-size limit middleware to `/investigate` 
  and `/api/investigations`, reusing the existing cap logic instead of 
  duplicating it.
- Also fixed a `mypy` strict-mode `no-any-return` error by correctly 
  typing the `call_next` parameter of the `limit_body_size` middleware as 
  `Callable[[Request], Awaitable[Response]]`.

### 4. Log Masking for Telegram Poller (#4769)
**Files:** `gateway/transports/telegram/poller/poller.py`, `gateway/tests/telegram/test_telegram_poller.py`

- **Problem:** On transient failures, the Telegram poller could log or 
  return the raw exception/response, which may contain the live bot token 
  in the request URL.
- **Fix:** Applied the same `type(exc).__name__`-only logging pattern used 
  in #4773, and ensured the bot token is never present in any logged 
  string or returned error detail.

## Testing & Verification

Unit and integration tests were added/updated for each change:
- `test_telegram_poller.py`
- `test_webapp_alerts.py`
- `test_attachments.py`
- `test_artifacts.py` / `test_postgres.py`

- `mypy --strict` passes locally with no errors.
- `ruff` format and lint pass locally with no warnings.
- Full test suite passes locally.

---

## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Each fix follows the same principle: never let sensitive data (tokens, 
internal URLs, unbounded payloads) leave the intended boundary. For 
logging, only the exception *type* is recorded, never its string form. For 
the Slack downloader, the auth header is dropped the moment a redirect 
crosses a host boundary not on the allowlist. For body-size limits, the 
existing `/alerts` cap logic was reused rather than reimplemented, to keep 
the limit consistent across all routes. For S3/Postgres, standard 
connect/read timeout parameters were added at the client-construction 
level so no code path can bypass them.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
