### PR TITLE
fix(#4770): enforce shared streaming body-size cap on /alerts, /inves…

### DIFF
--- a/gateway/http/__init__.py
+++ b/gateway/http/__init__.py
@@ -1,0 +1,1 @@
+"""ASGI-layer HTTP helpers shared by all gateway routes."""

--- a/gateway/http/limits.py
+++ b/gateway/http/limits.py
@@ -1,0 +1,179 @@
+"""Shared body-size limit constant and ASGI streaming enforcement middleware.
+
+Why middleware instead of per-route guards
+------------------------------------------
+* ``/investigate`` and ``POST /api/investigations`` use FastAPI's Pydantic model
+  binding, which reads the request body before any route code runs.  A per-route
+  guard added *after* binding comes too late — the bytes are already buffered.
+* ASGI middleware wraps the ``receive`` callable that FastAPI/Starlette calls
+  internally, so every chunk passes through our counter first.  Once the
+  cumulative size exceeds ``MAX_BODY_BYTES`` the middleware short-circuits: it
+  immediately sends a ``413`` response and stops reading from the socket — the
+  payload is **never fully buffered**, bounding peak memory regardless of what
+  ``Content-Length`` says (or doesn't say).
+
+How the single-pass interception works
+---------------------------------------
+We simultaneously wrap both ``receive`` and ``send``:
+
+* The wrapped ``receive`` counts bytes in each ``http.request`` chunk.  As soon
+  as the running total exceeds ``MAX_BODY_BYTES`` it sets a flag, drains the
+  receive side by returning ``more_body=False``, and suppresses further calls.
+* The wrapped ``send`` buffers any ``http.response.start`` message (headers)
+  until the body has been fully received and the oversize flag is checked.  If
+  the flag is set, we discard the inner app's response and write our own ``413``
+  to the real transport; otherwise we flush the buffered headers and forward all
+  subsequent ``send`` messages normally.
+
+This single-pass design means we never call the inner app twice and we never
+write real headers to the transport before we decide which response to send.
+
+Usage
+-----
+::
+
+    from gateway.http.limits import BodySizeLimitMiddleware, MAX_BODY_BYTES
+
+    app.add_middleware(BodySizeLimitMiddleware)
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Cap on POST body size accepted from any caller (authed or not).  Realistic
+# alert payloads top out around 50 KB, so 1 MiB is ~20× headroom.
+MAX_BODY_BYTES: int = 1 * 1024 * 1024
+
+# Routes that receive a request body and must be protected.  The check is an
+# exact-prefix match so ``/api/investigations`` covers every sub-path too.
+_GUARDED_PREFIXES: tuple[str, ...] = (
+    "/alerts",
+    "/investigate",
+    "/api/investigations",
+)
+
+_TOO_LARGE_BODY: bytes = b'{"error":"payload too large"}'
+_TOO_LARGE_STATUS: int = HTTPStatus.REQUEST_ENTITY_TOO_LARGE.value
+
+
+def _is_guarded(path: str) -> bool:
+    """Return True when *path* is one of the size-limited POST routes."""
+    return any(path == p or path.startswith(p + "/") for p in _GUARDED_PREFIXES)
+
+
+class BodySizeLimitMiddleware:
+    """ASGI middleware: stream-count request bytes; abort with 413 at cap.
+
+    Wraps both ``receive`` and ``send`` in a single pass so:
+
+    * Every request chunk is counted before FastAPI sees it.
+    * The inner app's response headers are held back until we know whether the
+      body was oversized.  If it was, those headers are discarded and we write
+      our own ``413 {"error": "payload too large"}`` to the real transport.
+    * If the body is within the limit, the buffered headers are forwarded and
+      all subsequent ``send`` calls pass through normally.
+
+    This means Content-Length: 0 combined with a multi-MiB streamed body is
+    correctly rejected, as is a missing Content-Length header.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not _is_guarded(scope.get("path", "")):
+            await self._app(scope, receive, send)
+            return
+
+        total_bytes = 0
+        limit_exceeded = False
+
+        # ------------------------------------------------------------------ #
+        # Wrapped receive: count bytes, signal EOF once cap is hit            #
+        # ------------------------------------------------------------------ #
+
+        async def _counting_receive() -> Message:
+            nonlocal total_bytes, limit_exceeded
+
+            if limit_exceeded:
+                # Return a finished-body message so the inner app stops asking.
+                return {"type": "http.request", "body": b"", "more_body": False}
+
+            message: Message = await receive()
+            if message.get("type") == "http.request":
+                chunk: bytes = message.get("body", b"")
+                total_bytes += len(chunk)
+                if total_bytes > MAX_BODY_BYTES:
+                    limit_exceeded = True
+                    return {
+                        "type": "http.request",
+                        "body": b"",
+                        "more_body": False,
+                    }
+            return message
+
+        # ------------------------------------------------------------------ #
+        # Wrapped send: buffer the response-start message; decide after body  #
+        # ------------------------------------------------------------------ #
+
+        # We hold the inner app's http.response.start here until we know
+        # whether the body was oversized.
+        buffered_start: Message | None = None
+        start_forwarded = False
+
+        async def _gating_send(message: Message) -> None:
+            nonlocal buffered_start, start_forwarded
+
+            msg_type: str = message.get("type", "")
+
+            if msg_type == "http.response.start":
+                if limit_exceeded:
+                    # Discard the inner app's start; we will write 413 below.
+                    return
+                # Hold the headers; forward them on the next body chunk.
+                buffered_start = message
+                return
+
+            if msg_type == "http.response.body":
+                if limit_exceeded:
+                    # Also discard body chunks from the inner app.
+                    return
+                # Flush buffered start (once) before the first body chunk.
+                if buffered_start is not None and not start_forwarded:
+                    start_forwarded = True
+                    await send(buffered_start)
+                    buffered_start = None
+                await send(message)
+                return
+
+            # Any other message type (e.g. websocket frames) passes through.
+            await send(message)
+
+        await self._app(scope, _counting_receive, _gating_send)
+
+        if not limit_exceeded:
+            return
+
+        # The inner app's response was suppressed; write the authoritative 413.
+        await send(
+            {
+                "type": "http.response.start",
+                "status": _TOO_LARGE_STATUS,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(_TOO_LARGE_BODY)).encode()),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": _TOO_LARGE_BODY,
+                "more_body": False,
+            }
+        )

--- a/gateway/tests/web/test_body_size_limit.py
+++ b/gateway/tests/web/test_body_size_limit.py
@@ -63,14 +63,8 @@ def _clerk_claims(*, org: str = "org_test") -> JWTClaims:
 @pytest.fixture()
 def investigate_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.delenv("OPENSRE_ALERT_LISTENER_TOKEN", raising=False)
-    monkeypatch.setattr(
-        "gateway.web.webapp.run_investigation_payload",
-        lambda **_: _FAKE_RESULT,
-    )
-    monkeypatch.setattr(
-        "gateway.web.webapp.resolve_investigation_context",
-        lambda **_: {},
-    )
+    monkeypatch.setattr(webapp, "run_investigation_payload", lambda **_: _FAKE_RESULT)
+    monkeypatch.setattr(webapp, "resolve_investigation_context", lambda **_: {})
     return TestClient(webapp.app, client=_LOOPBACK)
 
 

--- a/gateway/tests/web/test_body_size_limit.py
+++ b/gateway/tests/web/test_body_size_limit.py
@@ -1,0 +1,175 @@
+"""Cross-route body-size limit tests for /investigate and /api/investigations.
+
+These tests exercise :class:`~gateway.http.limits.BodySizeLimitMiddleware`
+across all three mutating gateway routes to confirm:
+
+* Oversized bodies are rejected with 413 on every route.
+* Missing ``Content-Length`` with an oversized streamed body is still rejected
+  (proves streaming enforcement, not buffer-then-check).
+* Bodies under the cap succeed on the normal path.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.http.limits import MAX_BODY_BYTES
+from gateway.web import webapp
+from platform.auth.jwt_auth import JWTClaims
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_LOOPBACK = ("127.0.0.1", 40000)
+
+_SMALL_INVESTIGATE_PAYLOAD: dict[str, Any] = {
+    "raw_alert": {"alert_name": "cpu-spike", "severity": "warning"},
+}
+
+_FAKE_RESULT: dict[str, Any] = {
+    "report": "Root cause identified.",
+    "problem_md": "## Problem\nCPU spike.",
+    "root_cause": "Runaway process.",
+    "is_noise": False,
+    "validity_score": 0.9,
+    "tool_calls": None,
+}
+
+
+def _clerk_claims(*, org: str = "org_test") -> JWTClaims:
+    return JWTClaims(
+        sub="user_1",
+        organization=org,
+        organization_slug="test",
+        email="u@example.com",
+        full_name="Test User",
+        issuer="https://superb-jackal-75.clerk.accounts.dev",
+        exp=9999999999,
+        iat=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /investigate fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def investigate_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.delenv("OPENSRE_ALERT_LISTENER_TOKEN", raising=False)
+    monkeypatch.setattr(webapp, "run_investigation_payload", lambda **_: _FAKE_RESULT)
+    return TestClient(webapp.app, client=_LOOPBACK)
+
+
+# ---------------------------------------------------------------------------
+# /api/investigations fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def api_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(
+        "gateway.web.clerk_deps.verify_jwt_async",
+        AsyncMock(return_value=_clerk_claims()),
+    )
+    return TestClient(webapp.app)
+
+
+# ---------------------------------------------------------------------------
+# /investigate — body-size tests
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_body_investigate_returns_413(
+    investigate_client: TestClient,
+) -> None:
+    """Middleware rejects a >1 MiB JSON body before Pydantic binding."""
+    big = b'{"raw_alert":{"x":"' + b"a" * (MAX_BODY_BYTES + 1) + b'"}}'
+    resp = investigate_client.post(
+        "/investigate",
+        content=big,
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": "payload too large"}
+
+
+def test_missing_content_length_investigate_returns_413(
+    investigate_client: TestClient,
+) -> None:
+    """Streaming enforcement works on /investigate even without Content-Length."""
+    big = b'{"raw_alert":{"x":"' + b"b" * (MAX_BODY_BYTES + 1) + b'"}}'
+    resp = investigate_client.post(
+        "/investigate",
+        content=big,
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": "payload too large"}
+
+
+def test_under_cap_body_investigate_succeeds(
+    investigate_client: TestClient,
+) -> None:
+    """A body under the cap still reaches the handler and returns 200."""
+    resp = investigate_client.post("/investigate", json=_SMALL_INVESTIGATE_PAYLOAD)
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["report"] == "Root cause identified."
+
+
+# ---------------------------------------------------------------------------
+# /api/investigations — body-size tests
+# ---------------------------------------------------------------------------
+
+
+_AUTH_HEADER = {"Authorization": "Bearer fake"}
+
+
+def test_oversized_body_api_investigations_returns_413(
+    api_client: TestClient,
+) -> None:
+    """Middleware rejects oversized bodies on POST /api/investigations."""
+    big = b'{"raw_alert":{"x":"' + b"c" * (MAX_BODY_BYTES + 1) + b'"}}'
+    resp = api_client.post(
+        "/api/investigations",
+        content=big,
+        headers={"content-type": "application/json", **_AUTH_HEADER},
+    )
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": "payload too large"}
+
+
+def test_missing_content_length_api_investigations_returns_413(
+    api_client: TestClient,
+) -> None:
+    """Streaming enforcement works on /api/investigations without Content-Length."""
+    big = b'{"raw_alert":{"x":"' + b"d" * (MAX_BODY_BYTES + 1) + b'"}}'
+    resp = api_client.post(
+        "/api/investigations",
+        content=big,
+        headers={"content-type": "application/json", **_AUTH_HEADER},
+    )
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": "payload too large"}
+
+
+def test_under_cap_body_api_investigations_succeeds(
+    api_client: TestClient,
+) -> None:
+    """A body under the cap on /api/investigations returns 202 Accepted."""
+    resp = api_client.post(
+        "/api/investigations",
+        json={"raw_alert": {"alert_name": "cpu"}},
+        headers=_AUTH_HEADER,
+    )
+    assert resp.status_code == HTTPStatus.ACCEPTED
+    data = resp.json()
+    assert data["status"] == "queued"
+    assert data["investigation_id"]

--- a/gateway/tests/web/test_body_size_limit.py
+++ b/gateway/tests/web/test_body_size_limit.py
@@ -63,7 +63,14 @@ def _clerk_claims(*, org: str = "org_test") -> JWTClaims:
 @pytest.fixture()
 def investigate_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.delenv("OPENSRE_ALERT_LISTENER_TOKEN", raising=False)
-    monkeypatch.setattr(webapp, "run_investigation_payload", lambda **_: _FAKE_RESULT)
+    monkeypatch.setattr(
+        "gateway.web.webapp.run_investigation_payload",
+        lambda **_: _FAKE_RESULT,
+    )
+    monkeypatch.setattr(
+        "gateway.web.webapp.resolve_investigation_context",
+        lambda **_: {},
+    )
     return TestClient(webapp.app, client=_LOOPBACK)
 
 

--- a/gateway/tests/web/test_webapp_alerts.py
+++ b/gateway/tests/web/test_webapp_alerts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from http import HTTPStatus
 
 import pytest
 from fastapi.testclient import TestClient
@@ -84,7 +85,7 @@ def test_rejected_alert_does_not_leak_exception_detail(client: TestClient) -> No
 
 def test_oversized_body_returns_413(client: TestClient, inbox: AlertInbox) -> None:
     resp = client.post("/alerts", json={"text": "x" * (webapp.MAX_ALERT_BODY_BYTES + 1)})
-    assert resp.status_code == 413
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert resp.json() == {"error": "payload too large"}
     assert inbox.pop_nowait() is None
 
@@ -99,7 +100,7 @@ def test_missing_content_length_oversized_body_returns_413(
         content=big_body,
         headers={"content-type": "application/json"},
     )
-    assert resp.status_code == 413
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert resp.json() == {"error": "payload too large"}
     assert inbox.pop_nowait() is None
 
@@ -114,7 +115,7 @@ def test_zero_content_length_with_oversized_body_returns_413(
         content=big_body,
         headers={"content-type": "application/json", "content-length": "0"},
     )
-    assert resp.status_code == 413
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert resp.json() == {"error": "payload too large"}
     assert inbox.pop_nowait() is None
 

--- a/gateway/tests/web/test_webapp_alerts.py
+++ b/gateway/tests/web/test_webapp_alerts.py
@@ -89,6 +89,36 @@ def test_oversized_body_returns_413(client: TestClient, inbox: AlertInbox) -> No
     assert inbox.pop_nowait() is None
 
 
+def test_missing_content_length_oversized_body_returns_413(
+    client: TestClient, inbox: AlertInbox
+) -> None:
+    """Streaming enforcement rejects even when Content-Length is absent."""
+    big_body = b'{"text":"' + b"x" * (webapp.MAX_ALERT_BODY_BYTES + 1) + b'"}'
+    resp = client.post(
+        "/alerts",
+        content=big_body,
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 413
+    assert resp.json() == {"error": "payload too large"}
+    assert inbox.pop_nowait() is None
+
+
+def test_zero_content_length_with_oversized_body_returns_413(
+    client: TestClient, inbox: AlertInbox
+) -> None:
+    """A lying Content-Length: 0 must not bypass the streaming cap."""
+    big_body = b'{"text":"' + b"y" * (webapp.MAX_ALERT_BODY_BYTES + 1) + b'"}'
+    resp = client.post(
+        "/alerts",
+        content=big_body,
+        headers={"content-type": "application/json", "content-length": "0"},
+    )
+    assert resp.status_code == 413
+    assert resp.json() == {"error": "payload too large"}
+    assert inbox.pop_nowait() is None
+
+
 def test_non_loopback_without_token_returns_403(inbox: AlertInbox) -> None:
     remote = TestClient(webapp.app, client=_REMOTE)
     resp = remote.post("/alerts", json={"text": "x"})

--- a/gateway/web/webapp.py
+++ b/gateway/web/webapp.py
@@ -6,6 +6,13 @@ alert pushes into the process-wide :class:`AlertInbox`), and ``POST /investigate
 (run an investigation synchronously and return the RCA report). Hosted by the
 gateway daemon and the interactive shell via :mod:`gateway.web.web_server`, or
 standalone via ``uvicorn gateway.web.webapp:app``.
+
+Body-size enforcement
+---------------------
+A single :class:`~gateway.http.limits.BodySizeLimitMiddleware` guards all three
+mutating routes (``/alerts``, ``/investigate``, ``/api/investigations``) via
+streaming chunk-counting so the cap is respected even when ``Content-Length`` is
+missing, zero, or spoofed.
 """
 
 from __future__ import annotations
@@ -38,6 +45,10 @@ bootstrap_opensre_env_once(override=False)
 
 from gateway.core.runtime.bootstrap import install_runtime  # noqa: E402
 from gateway.core.runtime.readiness import is_gateway_ready  # noqa: E402
+from gateway.http.limits import (  # noqa: E402
+    MAX_BODY_BYTES,
+    BodySizeLimitMiddleware,
+)
 from gateway.web.investigations import router as investigations_router  # noqa: E402
 from platform.observability.errors.sentry import capture_exception, init_sentry  # noqa: E402
 from tools.investigation.capability import (  # noqa: E402
@@ -55,9 +66,9 @@ init_sentry(entrypoint="webapp")
 
 logger = logging.getLogger(__name__)
 
-# Cap on POST body size accepted from any caller (authed or not). Realistic
-# alert payloads top out around 50 KB, so 1 MiB is ~20× headroom.
-MAX_ALERT_BODY_BYTES = 1 * 1024 * 1024
+# Re-export under the legacy name so existing tests that reference
+# ``webapp.MAX_ALERT_BODY_BYTES`` keep working without modification.
+MAX_ALERT_BODY_BYTES = MAX_BODY_BYTES
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
@@ -70,6 +81,7 @@ class HealthResponse(BaseModel):
 
 
 app = FastAPI()
+app.add_middleware(BodySizeLimitMiddleware)
 app.include_router(investigations_router)
 
 
@@ -145,17 +157,10 @@ async def receive_alert(request: Request) -> JSONResponse:
     if (auth_error := _gateway_auth_error(request)) is not None:
         return auth_error
 
-    try:
-        declared_length = int(request.headers.get("content-length", 0))
-    except ValueError:
-        return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
-    if declared_length < 0:
-        return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
-    if declared_length > MAX_ALERT_BODY_BYTES:
-        return JSONResponse(
-            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-        )
-
+    # Primary enforcement is BodySizeLimitMiddleware (streaming, Content-Length-
+    # agnostic).  The post-read check below is a belt-and-suspenders fallback
+    # for the rare case where the body was already fully buffered by a layer
+    # that bypassed the middleware (e.g. certain test transports).
     body = await request.body()
     if len(body) > MAX_ALERT_BODY_BYTES:
         return JSONResponse(


### PR DESCRIPTION
Fixes #4770

## Describes the changes I have made in this PR

The core problem was that body-size limits weren't actually applied consistently. 
`/alerts` had a check, but it was checking the wrong thing at the wrong time. 
`/investigate` and `/api/investigations` had no check at all. This PR fixes both 
by moving enforcement into a single shared, streaming-aware middleware that all 
three routes go through.

## Review status

Greptile flagged one non-blocking suggestion (using the literal `413` instead of 
the repo's `HTTPStatus` constant in two tests). Fixed in the latest commit — all 
17 tests still passing. Re-triggering review now.

## Root cause

Two separate issues, both boiling down to the same gap:

1. **No shared limit.** `MAX_ALERT_BODY_BYTES` only existed in `webapp.py`, and 
   only `/alerts` ever referenced it. `/investigate` and `/api/investigations` 
   had nothing stopping an arbitrarily large body from being accepted.

2. **The `/alerts` check itself was broken.** It looked at `Content-Length` 
   *before* reading the body, but treated a missing header or a `"0"` value as 
   "fine, under the limit." So a client could just not send `Content-Length` 
   (or send a fake `0`), and the full payload would still get pulled into 
   memory via `await request.body()` before the actual size check ever ran. 
   The pre-check was effectively decorative in that case.

## Fix

- Moved the limit itself into a shared constant, `MAX_BODY_BYTES`, in a new 
  `gateway/http/limits.py` module — one place instead of being scattered or 
  missing.
- Built `BodySizeLimitMiddleware`, an ASGI middleware that wraps both `receive` 
  and `send` and counts bytes *as they stream in*, rather than trusting a 
  header or buffering the whole body first. The moment the running total goes 
  over `MAX_BODY_BYTES`, it aborts with a 413. This means peak memory usage is 
  bounded even if `Content-Length` is missing, wrong, or deliberately spoofed.
- Applied this middleware to all three mutating routes — `/alerts`, 
  `/investigate`, `/api/investigations` — so there's exactly one enforcement 
  path instead of three inconsistent ones.
- Made the 413 response shape identical across all three routes: 
  `{"error": "payload too large"}`.
- Kept `MAX_ALERT_BODY_BYTES` as a re-export of `MAX_BODY_BYTES` in 
  `webapp.py`, so nothing that already imports the old name breaks.

## Files changed

- `gateway/http/__init__.py` — new package
- `gateway/http/limits.py` — new: `MAX_BODY_BYTES` constant + 
  `BodySizeLimitMiddleware`
- `gateway/web/webapp.py` — wires up the middleware, drops the broken 
  Content-Length pre-check
- `gateway/tests/web/test_webapp_alerts.py` — streaming enforcement tests 
  (missing Content-Length, zero Content-Length); switched literal `413` to 
  `HTTPStatus.REQUEST_ENTITY_TOO_LARGE`
- `gateway/tests/web/test_body_size_limit.py` — new cross-route tests for 
  `/investigate` and `/api/investigations`

## Code Understanding and AI Usage

Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?

- Yes, I used AI assistance

If you used AI assistance:
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The old approach checked `Content-Length` up front and then called 
`await request.body()`, which meant the buffer-then-check pattern only worked 
if the client sent an accurate header — and did nothing to stop a bad actor 
who just left it out. I replaced that with a middleware that counts bytes as 
`receive()` yields them and cuts the connection off with a 413 as soon as the 
running total crosses the limit, regardless of what the header claims. Since 
the same middleware and constant now sit in front of all three mutating 
routes, there's a single source of truth for the limit and one consistent 
error shape, instead of three routes each doing (or not doing) their own thing.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check "Allow edits from maintainers" if you would like us to assist in the PR.