### PR TITLE
fix(hermes): spell out join timeout constant

### DIFF
--- a/integrations/hermes/agent.py
+++ b/integrations/hermes/agent.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 IncidentSink = Callable[[HermesIncident], None]
 
 DEFAULT_LOG_PATH: Final[Path] = Path.home() / ".hermes" / "logs" / "errors.log"
-_THREAD_JOIN_TIMEOUT_S: Final[float] = 2.0
+_THREAD_JOIN_TIMEOUT_SECONDS: Final[float] = 2.0
 
 
 class HermesAgent:
@@ -102,7 +102,7 @@ class HermesAgent:
         )
         self._thread.start()
 
-    def stop(self, *, timeout: float = _THREAD_JOIN_TIMEOUT_S) -> None:
+    def stop(self, *, timeout: float = _THREAD_JOIN_TIMEOUT_SECONDS) -> None:
         """Signal the polling thread and wait until it has exited.
 
         The poller is joined for up to ``timeout`` seconds first so slow


### PR DESCRIPTION
Fixes #4327

 #### Describe the changes you have made in this PR -

  - Renamed `_THREAD_JOIN_TIMEOUT_S` to
  `_THREAD_JOIN_TIMEOUT_SECONDS` in `integrations/hermes/
  agent.py`.
  - Updated `HermesAgent.stop()` to use the renamed
  constant.
  - Preserved the existing timeout value and runtime
  behavior.
  - Limited the change to the file requested in issue #4327.

  ### Demo/Screenshot for feature changes and bug fixes -

  Terminal validation was completed successfully:

  ```text
  uv run ruff check config core gateway integrations
  platform surfaces tools tests/
  PASS

  uv run ruff format --check config core gateway
  integrations platform surfaces tools tests/
  PASS

  uv run mypy config core gateway integrations platform
  surfaces tools
  PASS

  uv run python -m pytest tests/hermes/test_agent.py
  23 passed

  The change is a naming-only cleanup and does not alter
  application behavior.
```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [X] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [X] I have reviewed every single line of the AI-generated code
- [X] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
