### PR TITLE
docs(CI.md): drop mandatory local make test-cov escalation

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -76,28 +76,15 @@ the full unit suite.
 Map changed paths to targets using the `PathRule` entries in
 [`.github/ci/test_scope_rules.py`](.github/ci/test_scope_rules.py):
 
-- Rules with `always_escalate=True` map to `make test-cov`
+- Rules with `always_escalate=True` have no scoped local target — the full
+  suite runs in CI; no local run is required
 - All other rules list a `test_targets` tuple — run those with
   `uv run python -m pytest <targets>`
 - Changed files under `tests/` with no app rule run as-is
 
 Use a focused `-k` filter when you only need a subset of a package.
 
-## 3) Escalation rules (must run full unit CI suite)
-
-Run `make test-cov` (instead of only targeted tests) when any of these are true:
-
-- Shared/core code changed (`core/state/`, `core/domain/types/`, `tools/investigation/`, `tools/investigation/stages/`)
-- 3+ app areas changed in one diff
-- New files with unclear blast radius
-- Cross-cutting refactor
-- You are unsure test scope is sufficient
-
-```bash
-make test-cov
-```
-
-## 4) Conditional checks
+## 3) Conditional checks
 
 CI runs the fast registry smoke gate on every code change:
 
@@ -114,11 +101,11 @@ make verify-integrations
 If Fargate CDK code, its deployment commands, or infrastructure tests changed,
 also run:
 
-## 5) Optional extra confidence
+## 4) Optional extra confidence
 
 You may run `make check` as a final pass, but it is heavier (`test-full`) than the required harness.
 
-## 6) Interactive-shell turn tests
+## 5) Interactive-shell turn tests
 
 Interactive-shell live turn tests always run with live coverage enabled. Do not use deselection filters like `-k "not live_llm"`. Fix failures by improving planner/tool correctness or updating fixtures only when behavior changes are explicitly approved.
 
@@ -141,7 +128,7 @@ In CI, [`.github/workflows/interactive-shell-live.yml`](.github/workflows/intera
 
 `@live` gather scenarios **fail** (not skip) in GitHub Actions when integration credentials are missing; locally they may still skip. Natural-language investigation dispatch is **enabled** by default (`INTERACTIVE_SHELL_INVESTIGATION_ENABLED = True`). Investigation dispatch scenarios run in `turn-live`; if the flag is set to `False` for emergency rollback, those scenarios **skip** in live shards and `turn-checks` stays green. Require all `turn-checks` and `turn-live shard *` checks on `main` branch protection.
 
-## 7) CI-only tests
+## 6) CI-only tests
 
 Some paths require live infrastructure and are excluded from `make test-cov`:
 


### PR DESCRIPTION
<!-- No issue number: process/docs-only change to CI.md, not tied to a tracked issue. -->

#### Describe the changes you have made in this PR -

CI.md §3 required a local `make test-cov` run before push whenever an
escalation trigger fired (core/domain changes, cross-cutting refactors, 3+
areas touched in one diff, etc.). That full-suite run is slow locally and CI
already runs `make test-cov` on every push, so this removes the local
requirement: escalation-triggered changes now push and rely on CI's
`test-cov` job, fixing failures from the CI log instead of a mandatory local
pass first. Sections renumbered accordingly; scoped per-module local test
runs (§2) are unaffected.

A separate follow-up doc on watching/monitoring CI for these pushes is
planned separately.

### Demo/Screenshot for feature changes and bug fixes -
Docs-only change (CI.md process document) — no runtime behavior to
demo. Diff: `CI.md | 25 +++++-------------------`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
This is a policy change to CI.md, drafted with Claude Code based on my
direction: drop the mandatory local `make test-cov` run for escalation
triggers since it's redundant with CI's own `test-cov` job and slow to run
locally. I reviewed the resulting section renumbering and wording.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.