### PR TITLE
fix(release): avoid nm|grep pipefail false negative on OpenSSL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,13 +261,16 @@ jobs:
             echo "PKG_CONFIG_PATH=${OPENSSL_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
             echo "LDFLAGS=-L${OPENSSL_PREFIX}/lib ${LDFLAGS:-}"
             echo "CFLAGS=-I${OPENSSL_PREFIX}/include ${CFLAGS:-}"
-            echo "DYLD_FALLBACK_LIBRARY_PATH=${OPENSSL_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
           } >> "$GITHUB_ENV"
-          if ! nm -gU "${OPENSSL_PREFIX}/lib/libssl.3.dylib" | grep -q 'SSL_get0_group_name'; then
-            echo "::error::Homebrew openssl@3 at ${OPENSSL_PREFIX} lacks SSL_get0_group_name (need OpenSSL >= 3.2)" >&2
+          # Prefer `openssl version` over `nm | grep -q`: under pipefail, grep -q
+          # closes the pipe early → nm SIGPIPE ("Broken pipe") → false negative
+          # even when OpenSSL 3.6.x is fine.
+          OPENSSL_VER="$("${OPENSSL_PREFIX}/bin/openssl" version | awk '{print $2}')"
+          if [[ "$(printf '%s\n' "${OPENSSL_VER}" '3.2.0' | sort -V | head -n1)" != '3.2.0' ]]; then
+            echo "::error::Homebrew openssl@3 at ${OPENSSL_PREFIX} is ${OPENSSL_VER} (need >= 3.2)" >&2
             exit 1
           fi
-          echo "Using OpenSSL from ${OPENSSL_PREFIX}"
+          echo "Using OpenSSL ${OPENSSL_VER} from ${OPENSSL_PREFIX}"
 
       - name: Sync binary version
         shell: bash
@@ -314,23 +317,49 @@ jobs:
         run: |
           set -euo pipefail
           # PyInstaller's binary dependency scan can still collect a stale
-          # libssl.3.dylib. Force the OpenSSL cryptography was built against.
+          # libssl.3.dylib. If the bundled lib lacks SSL_get0_group_name
+          # (OpenSSL < 3.2), replace from the Homebrew OpenSSL we built against
+          # and rewrite install names so smoke is not masked by brew on the runner.
           INTERNAL="./dist/opensre/_internal"
           OPENSSL_PREFIX="${OPENSSL_DIR:-$(brew --prefix openssl@3)}"
           if [ ! -d "$INTERNAL" ]; then
             echo "No onedir _internal; skipping libssl alignment"
             exit 0
           fi
+          BUNDLED_SSL="${INTERNAL}/libssl.3.dylib"
+          BUNDLED_CRYPTO="${INTERNAL}/libcrypto.3.dylib"
+          needs_align=0
+          if [ -f "$BUNDLED_SSL" ]; then
+            # Buffer nm output — do not use `nm | grep -q` under pipefail.
+            ssl_syms="$(nm -gU "$BUNDLED_SSL" 2>/dev/null || true)"
+            if ! grep -Fq 'SSL_get0_group_name' <<<"$ssl_syms"; then
+              needs_align=1
+            fi
+          fi
+          if [ "$needs_align" -eq 0 ]; then
+            echo "Bundled libssl already exports SSL_get0_group_name; leaving as-is"
+            exit 0
+          fi
           for lib in libssl.3.dylib libcrypto.3.dylib; do
             src="${OPENSSL_PREFIX}/lib/${lib}"
-            if [ -f "$src" ]; then
-              cp -f "$src" "${INTERNAL}/${lib}"
-              echo "Installed ${lib} from ${src}"
+            if [ ! -f "$src" ]; then
+              echo "::error::Missing ${src} (needed to replace stale bundled OpenSSL)" >&2
+              exit 1
             fi
+            cp -f "$src" "${INTERNAL}/${lib}"
+            echo "Installed ${lib} from ${src}"
           done
-          if [ -f "${INTERNAL}/libssl.3.dylib" ] \
-            && ! nm -gU "${INTERNAL}/libssl.3.dylib" | grep -q 'SSL_get0_group_name'; then
-            echo "::error::Bundled libssl.3.dylib still lacks SSL_get0_group_name" >&2
+          # Homebrew dylibs keep absolute install names; rewrite for onedir rpath.
+          install_name_tool -id '@rpath/libcrypto.3.dylib' "$BUNDLED_CRYPTO"
+          install_name_tool -id '@rpath/libssl.3.dylib' "$BUNDLED_SSL"
+          # libssl → libcrypto (whatever absolute path brew baked in)
+          while read -r old; do
+            [ -n "$old" ] || continue
+            install_name_tool -change "$old" '@rpath/libcrypto.3.dylib' "$BUNDLED_SSL" || true
+          done < <(otool -L "$BUNDLED_SSL" | awk '/libcrypto\.3\.dylib/{print $1}' | grep -v '@rpath' || true)
+          ssl_syms="$(nm -gU "$BUNDLED_SSL" 2>/dev/null || true)"
+          if ! grep -Fq 'SSL_get0_group_name' <<<"$ssl_syms"; then
+            echo "::error::Bundled libssl.3.dylib still lacks SSL_get0_group_name after align" >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,8 +265,30 @@ jobs:
           # Prefer `openssl version` over `nm | grep -q`: under pipefail, grep -q
           # closes the pipe early → nm SIGPIPE ("Broken pipe") → false negative
           # even when OpenSSL 3.6.x is fine.
+          # Compare with a portable major.minor.patch check — do not use
+          # `sort -V` (GNU); macOS /usr/bin/sort is BSD and may reject -V.
           OPENSSL_VER="$("${OPENSSL_PREFIX}/bin/openssl" version | awk '{print $2}')"
-          if [[ "$(printf '%s\n' "${OPENSSL_VER}" '3.2.0' | sort -V | head -n1)" != '3.2.0' ]]; then
+          openssl_version_ge() {
+            local ver="$1" min="$2" i
+            local -a va vb
+            IFS='.' read -r -a va <<<"${ver}"
+            IFS='.' read -r -a vb <<<"${min}"
+            for i in 0 1 2; do
+              local ai="${va[i]:-0}" bi="${vb[i]:-0}"
+              ai="${ai%%[!0-9]*}"
+              bi="${bi%%[!0-9]*}"
+              ai="${ai:-0}"
+              bi="${bi:-0}"
+              if ((10#${ai} > 10#${bi})); then
+                return 0
+              fi
+              if ((10#${ai} < 10#${bi})); then
+                return 1
+              fi
+            done
+            return 0
+          }
+          if ! openssl_version_ge "${OPENSSL_VER}" '3.2.0'; then
             echo "::error::Homebrew openssl@3 at ${OPENSSL_PREFIX} is ${OPENSSL_VER} (need >= 3.2)" >&2
             exit 1
           fi


### PR DESCRIPTION
Fix: #4812 

- Replace `nm | grep -q` OpenSSL gate (false negative under `pipefail` / Broken pipe) with `openssl version` ≥ 3.2.
- Align bundled libssl only when `SSL_get0_group_name` is missing; rewrite `@rpath` install names; drop `DYLD_FALLBACK_LIBRARY_PATH`.