### PR TITLE
refactor(gateway): extract channels from the manager and cut the gateway→surfaces cycle

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -24,9 +24,10 @@ forbidden_modules =
     gateway.transports
     gateway.web
 ignore_imports =
-    # Composition root: wires transports and the web surface together.
-    gateway.core.runtime.manager -> gateway.transports.**
-    gateway.core.runtime.manager -> gateway.web.web_server
+    # Composition root: the one edge into the channels composer, which owns all
+    # transport and web wiring. Pinned by gateway/tests/test_package_borders.py
+    # (test_only_manager_imports_channels_module).
+    gateway.core.runtime.manager -> gateway.channels
 
 [importlinter:contract:gateway-web-no-transports]
 name = Gateway web surface never imports chat transports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,11 @@ Steps:
 
 ## 3. Footguns (common mistakes to avoid)
 
+- Constant-condition toggles: never disable product logic with
+  `if False and …`, `if True or …`, or `if False:` to silence a failing test.
+  That hides real behavior (e.g. cancel short-circuit after action) and ships
+  as dead code. Keep the real condition and fix the test, or delete the branch.
+  Enforced by `tests/quality/test_no_constant_condition_toggles.py`.
 - No planning-stage fail-closed safeguard (v0.1): the interactive-shell action planner never denies a turn — do **not** reintroduce a planner denial, `mark_unhandled`, or the `UNHANDLED:` convention. Full rationale: [docs/interactive-shell-action-policy.md](docs/interactive-shell-action-policy.md); package rule: `surfaces/interactive_shell/AGENTS.md` ("Action Selection And Execution").
 - Docs navigation: Adding an `.mdx` file under `docs/` is not enough — Mintlify only shows pages listed in `docs/docs.json`. Forgetting the `pages` entry leaves the doc unreachable from the site sidebar.
 - Investigation tool schemas: draft-07 JSON Schema (e.g. `"type": ["object", "null"]`) can pass loose checks but fail the LLM API on first invoke because **all** available investigation tools are sent together. Normalize in the provider adapter and extend registry contract tests; see [docs/investigation-tool-calling.md](docs/investigation-tool-calling.md).

--- a/config/constants/paths.py
+++ b/config/constants/paths.py
@@ -93,8 +93,9 @@ def opensre_home() -> Path:
 
     The mount named by ``OPENSRE_CONTEXT_ROOT`` belongs to one organization, so
     it is used only for a turn that names that organization. Anything unbound —
-    Telegram, boot-time integration reads, the CLI — stays on the host root
-    rather than writing into a customer's volume.
+    boot-time integration reads, the CLI — stays on the host root rather than
+    writing into a customer's volume. Chat transports bind an org scope and
+    therefore use the mount (or ``orgs/<id>/`` nest) when configured.
 
     Without the mount, a bound org principal nests under
     ``~/.opensre/orgs/<org_id>/`` so several organizations can be exercised on

--- a/core/agent/cancel.py
+++ b/core/agent/cancel.py
@@ -1,0 +1,30 @@
+"""Cooperative cancel detection for the ReAct loop (host-agnostic).
+
+Hosts put a console with ``cancel_requested`` on an object in
+``tool_resources``:
+
+* shell — ``StreamingConsole``
+* gateway — ``CancelConsole`` (wraps ``sink.turn_cancel``)
+* gather — cancel probe from ``host_cancel.cancel_tool_resources``
+
+Tools already short-circuit on the same flag; the loop uses this helper so the
+next LLM iteration does not start after cancel is set.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def tool_resources_cancel_requested(tool_resources: Any) -> bool:
+    """True when any tool-resource console reports ``cancel_requested``."""
+    if not isinstance(tool_resources, dict):
+        return False
+    for value in tool_resources.values():
+        console = getattr(value, "console", None)
+        if console is not None and bool(getattr(console, "cancel_requested", False)):
+            return True
+    return False
+
+
+__all__ = ["tool_resources_cancel_requested"]

--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from core.agent.cancel import tool_resources_cancel_requested
 from core.agent.handle_conclusion import ConclusionHandler
 from core.agent.loop_host import LoopHost
 from core.agent.run_io import AgentRunInput, AgentRunResult
@@ -115,25 +116,9 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                     hit_iteration_cap=self._hit_cap,
                 )
 
-    def _cancel_requested(self) -> bool:
-        """True when a host console (shell / gateway) asked to stop this run.
-
-        Duck-types ``console.cancel_requested`` off tool resources so the loop
-        stays free of ``agent_harness`` imports. Tools already short-circuit the
-        same flag; this stops the next LLM iteration after cancel is set.
-        """
-        resources = self._tool_resources
-        if not isinstance(resources, dict):
-            return False
-        for value in resources.values():
-            console = getattr(value, "console", None)
-            if console is not None and bool(getattr(console, "cancel_requested", False)):
-                return True
-        return False
-
     def _run_iteration(self, iteration: int) -> bool:
         """Run one think -> observe step. Return True when the loop should stop."""
-        if self._cancel_requested():
+        if tool_resources_cancel_requested(self._tool_resources):
             self._hit_cap = False
             self._cancelled = True
             return True

--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -85,6 +85,7 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         self._final_system_prompt = self._system
         self._hit_cap = True
         self._terminated_by_tool = False
+        self._cancelled = False
         self._iterations_used = 0
         self._conclusion = ConclusionHandler(host, self._messages, self._runtime_tools)
 
@@ -134,7 +135,7 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         """Run one think -> observe step. Return True when the loop should stop."""
         if self._cancel_requested():
             self._hit_cap = False
-            self._terminated_by_tool = True
+            self._cancelled = True
             return True
         self._host._drain_steering_messages(self._messages)
         self._host._emit_runtime(
@@ -315,6 +316,7 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             executed=self._executed,
             tool_results=self._tool_results,
             terminated_by_tool=self._terminated_by_tool,
+            cancelled=self._cancelled,
             hit_iteration_cap=self._hit_cap,
             llm_iterations_used=self._iterations_used,
             final_system_prompt=self._final_system_prompt,
@@ -326,6 +328,7 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                     "final_text": self._final_text,
                     "hit_iteration_cap": self._hit_cap,
                     "terminated_by_tool": self._terminated_by_tool,
+                    "cancelled": self._cancelled,
                     "message_count": len(self._messages),
                     "executed_count": len(self._executed),
                 },

--- a/core/agent/run_io.py
+++ b/core/agent/run_io.py
@@ -30,6 +30,8 @@ class AgentRunResult:
     executed: list[tuple[ToolCall, Any]] = field(default_factory=list)
     tool_results: list[tuple[ToolCall, ToolExecutionResult]] = field(default_factory=list)
     terminated_by_tool: bool = False
+    #: Host cooperative cancel (``console.cancel_requested``), not a tool terminate.
+    cancelled: bool = False
     hit_iteration_cap: bool = False
     llm_iterations_used: int = 0
     final_system_prompt: str = ""

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -1060,11 +1060,10 @@ def _run_action_turn(
 
     counts = _count_turn(result, session, history_start)
     response_text, display_chunks, use_final_text = _compose_response(result, session, counts)
-    cancelled = _cancel_requested(tool_resources)
+    cancelled = _cancel_requested(tool_resources) or bool(getattr(result, "cancelled", False))
     # Cancelled turns must not fall through to gather/answer: the host already
-    # owns the terminal UX (timeout message / stop). Force handled and drop
-    # handoffs so routing cannot start another LLM phase.
-    handled = True if cancelled else counts.handled
+    # owns the terminal UX (timeout message / stop). Drop handoffs; the
+    # orchestrator short-circuits on ``cancelled`` before routing.
     handoff_contents = () if cancelled else counts.handoff_contents
     # Discovery tools that opt into ``summarize_observation`` (via tool tags)
     # return structured JSON users should not see raw. Stash only those results.
@@ -1082,7 +1081,7 @@ def _run_action_turn(
     if not cancelled:
         _show_response(
             args.output,
-            handled=handled,
+            handled=counts.handled,
             # use_final_text means the composed text *is* the closing message.
             final_text=response_text if use_final_text else "",
             display_chunks=display_chunks,
@@ -1092,7 +1091,7 @@ def _run_action_turn(
         "action_turn done planned=%s executed=%s handled=%s cancelled=%s investigation=%s",
         counts.planned_count,
         counts.executed_count,
-        handled,
+        counts.handled,
         cancelled,
         counts.investigation_dispatched,
     )
@@ -1101,11 +1100,12 @@ def _run_action_turn(
         counts.executed_count,
         counts.executed_success_count,
         False,
-        handled,
+        False if cancelled else counts.handled,
         response_text="" if cancelled else response_text,
         handoff_contents=handoff_contents,
         handoff_requires_gather=(False if cancelled else counts.handoff_requires_gather),
         investigation_dispatched=(False if cancelled else counts.investigation_dispatched),
+        cancelled=cancelled,
     )
 
 

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from core.agent import Agent
+from core.agent.cancel import tool_resources_cancel_requested
 from core.agent.goals import Goal
 from core.agent_harness.agent_builder import AgentConfig, build_agent
 from core.agent_harness.llm_resolution import default_llm_factory
@@ -965,17 +966,6 @@ def _count_turn(result: Any, session: SessionStore, history_start: int) -> _Turn
     )
 
 
-def _cancel_requested(tool_resources: Any) -> bool:
-    """True when the turn console asked to stop (shell / gateway cancel Event)."""
-    if not isinstance(tool_resources, dict):
-        return False
-    for value in tool_resources.values():
-        console = getattr(value, "console", None)
-        if console is not None and bool(getattr(console, "cancel_requested", False)):
-            return True
-    return False
-
-
 def _run_action_turn(
     message: str,
     session: SessionStore,
@@ -1060,7 +1050,9 @@ def _run_action_turn(
 
     counts = _count_turn(result, session, history_start)
     response_text, display_chunks, use_final_text = _compose_response(result, session, counts)
-    cancelled = _cancel_requested(tool_resources) or bool(getattr(result, "cancelled", False))
+    cancelled = tool_resources_cancel_requested(tool_resources) or bool(
+        getattr(result, "cancelled", False)
+    )
     # Cancelled turns must not fall through to gather/answer: the host already
     # owns the terminal UX (timeout message / stop). Drop handoffs; the
     # orchestrator short-circuits on ``cancelled`` before routing.

--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -218,6 +218,7 @@ def _build_evidence_agent(
     on_progress: ToolEventObserver | None,
     message: str,
     max_iterations: int = _MAX_GATHER_ITERATIONS,
+    tool_resources: dict[str, Any] | None = None,
 ) -> Agent[Any]:
     """Build the Agent for one evidence-gather turn.
 
@@ -238,6 +239,7 @@ def _build_evidence_agent(
         tool_hooks=SourceCircuitBreaker().hooks(),
         on_runtime_event=runtime_event_callback_from_observer(on_progress),
         goal=build_gather_goal_reviewer(llm, message),
+        tool_resources=dict(tool_resources or {}),
     )
     return build_agent(config)
 
@@ -252,6 +254,7 @@ def gather_tool_evidence(
     agent_factory: GatherAgentFactory | None = None,
     resolved_integrations: dict[str, Any] | None = None,
     max_iterations: int | None = None,
+    is_cancelled: Callable[[], bool] | None = None,
 ) -> str | None:
     """Run a bounded tool-calling loop and return collected evidence, or None.
 
@@ -264,8 +267,12 @@ def gather_tool_evidence(
     def _run_gather_turn() -> Any | None:
         # Tool discovery, integration resolution, and LLM load run inside this
         # helper, within the ``_safe_execute`` fallback boundary.
+        from core.agent_harness.turns.host_cancel import cancel_tool_resources
         from platform.harness_ports import get_investigation_tools
 
+        if is_cancelled is not None and is_cancelled():
+            log.debug("gather_evidence skip: host cancelled")
+            return None
         resolved = _resolve_gather_integrations(
             session, message, resolved_integrations=resolved_integrations
         )
@@ -286,16 +293,30 @@ def gather_tool_evidence(
             len(resolved),
             iteration_cap,
         )
-        build_agent_for_turn = agent_factory or _build_evidence_agent
-        agent = build_agent_for_turn(
-            llm=llm,
-            session=session,
-            gather_tools=gather_tools,
-            resolved=resolved,
-            on_progress=on_progress,
-            message=message,
-            max_iterations=iteration_cap,
-        )
+        tool_resources = cancel_tool_resources(is_cancelled)
+        if agent_factory is None:
+            agent = _build_evidence_agent(
+                llm=llm,
+                session=session,
+                gather_tools=gather_tools,
+                resolved=resolved,
+                on_progress=on_progress,
+                message=message,
+                max_iterations=iteration_cap,
+                tool_resources=tool_resources,
+            )
+        else:
+            # Test/custom factories keep the historical signature; cancel probe
+            # still short-circuits before this path via ``is_cancelled`` above.
+            agent = agent_factory(
+                llm=llm,
+                session=session,
+                gather_tools=gather_tools,
+                resolved=resolved,
+                on_progress=on_progress,
+                message=message,
+                max_iterations=iteration_cap,
+            )
         result = run_react_agent_with_telemetry(
             agent,
             [{"role": "user", "content": _build_gather_user_message(session, message)}],

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -233,6 +233,10 @@ class HeadlessAgent:
     def _gather(self, text: str, *, turn_plan: TurnPlan | None = None) -> str | None:
         if not self._gather_ports.enabled:
             return None
+        from core.agent_harness.turns.host_cancel import host_cancel_requested
+
+        if host_cancel_requested(self._output):
+            return None
         resolved = turn_plan.resolved_integrations if turn_plan is not None else None
         return gather_tool_evidence(
             text,
@@ -242,6 +246,7 @@ class HeadlessAgent:
             max_iterations=self._gather_ports.max_iterations,
             on_progress=self._gather_ports.on_progress,
             persist=self._gather_ports.persist,
+            is_cancelled=lambda: host_cancel_requested(self._output),
         )
 
     def dispatch(self, message: str) -> TurnResult:

--- a/core/agent_harness/turns/host_cancel.py
+++ b/core/agent_harness/turns/host_cancel.py
@@ -1,15 +1,26 @@
-"""Detect cooperative host cancel (gateway ``sink.turn_cancel`` Event).
+"""Host cancel signal for chat turns (gateway ``sink.turn_cancel``).
 
-Shell cancel still flows through ``console.cancel_requested`` on the action /
-gather tool context. Chat hosts attach a ``threading.Event`` on the turn sink;
-``LiveOutputSink`` forwards it so the orchestrator can skip gather/answer.
+Mental model (one Event, three readers)::
+
+    transport timeout / ``/stop``
+            │
+            ▼
+    sink.turn_cancel  ──►  CancelConsole.cancel_requested  ──►  ReAct + tools
+            │
+            ├──────────►  host_cancel_requested(output)   ──►  orchestrator
+            └──────────►  LiveOutputSink stream guard
+
+Shell cancel stays on ``StreamingConsole``; it never needs ``turn_cancel``.
 """
 
 from __future__ import annotations
 
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
+
+from core.agent_harness.tools.tool_context import ACTION_TOOL_CONTEXT_RESOURCE_KEY
 
 
 def host_cancel_requested(output: Any | None) -> bool:
@@ -20,39 +31,41 @@ def host_cancel_requested(output: Any | None) -> bool:
     return isinstance(cancel, threading.Event) and cancel.is_set()
 
 
-def cancel_probe_console(is_cancelled: Callable[[], bool]) -> Any:
-    """Minimal console stand-in for gather ReAct ``cancel_requested`` checks."""
+@dataclass(frozen=True, slots=True)
+class CancelProbeConsole:
+    """Minimal console so gather ReAct sees the same ``cancel_requested`` flag."""
 
-    class _ProbeConsole:
-        @property
-        def cancel_requested(self) -> bool:
-            return bool(is_cancelled())
+    is_cancelled: Callable[[], bool]
 
-        def print(self, *args: Any, **kwargs: Any) -> None:
-            _ = (args, kwargs)
+    @property
+    def cancel_requested(self) -> bool:
+        return bool(self.is_cancelled())
 
-    return _ProbeConsole()
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        _ = (args, kwargs)
+
+
+@dataclass(frozen=True, slots=True)
+class CancelProbeContext:
+    """Stand-in ``ActionToolContext`` carrying only the cancel console."""
+
+    console: CancelProbeConsole
 
 
 def cancel_tool_resources(is_cancelled: Callable[[], bool] | None) -> dict[str, Any]:
     """``tool_resources`` so :class:`~core.agent.react_loop.ReactLoop` sees cancel."""
     if is_cancelled is None:
         return {}
-    from core.agent_harness.tools.tool_context import ACTION_TOOL_CONTEXT_RESOURCE_KEY
-
-    # Bind the narrowed callable: inside the nested class body the parameter
-    # widens back to ``| None``.
-    probe = is_cancelled
-
-    class _ProbeContext:
-        def __init__(self) -> None:
-            self.console = cancel_probe_console(probe)
-
-    return {ACTION_TOOL_CONTEXT_RESOURCE_KEY: _ProbeContext()}
+    return {
+        ACTION_TOOL_CONTEXT_RESOURCE_KEY: CancelProbeContext(
+            console=CancelProbeConsole(is_cancelled=is_cancelled)
+        )
+    }
 
 
 __all__ = [
-    "cancel_probe_console",
+    "CancelProbeConsole",
+    "CancelProbeContext",
     "cancel_tool_resources",
     "host_cancel_requested",
 ]

--- a/core/agent_harness/turns/host_cancel.py
+++ b/core/agent_harness/turns/host_cancel.py
@@ -1,0 +1,54 @@
+"""Detect cooperative host cancel (gateway ``sink.turn_cancel`` Event).
+
+Shell cancel still flows through ``console.cancel_requested`` on the action /
+gather tool context. Chat hosts attach a ``threading.Event`` on the turn sink;
+``LiveOutputSink`` forwards it so the orchestrator can skip gather/answer.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+
+def host_cancel_requested(output: Any | None) -> bool:
+    """True when the bound sink's ``turn_cancel`` Event is set."""
+    if output is None:
+        return False
+    cancel = getattr(output, "turn_cancel", None)
+    return isinstance(cancel, threading.Event) and cancel.is_set()
+
+
+def cancel_probe_console(is_cancelled: Callable[[], bool]) -> Any:
+    """Minimal console stand-in for gather ReAct ``cancel_requested`` checks."""
+
+    class _ProbeConsole:
+        @property
+        def cancel_requested(self) -> bool:
+            return bool(is_cancelled())
+
+        def print(self, *args: Any, **kwargs: Any) -> None:
+            _ = (args, kwargs)
+
+    return _ProbeConsole()
+
+
+def cancel_tool_resources(is_cancelled: Callable[[], bool] | None) -> dict[str, Any]:
+    """``tool_resources`` so :class:`~core.agent.react_loop.ReactLoop` sees cancel."""
+    if is_cancelled is None:
+        return {}
+    from core.agent_harness.tools.tool_context import ACTION_TOOL_CONTEXT_RESOURCE_KEY
+
+    class _ProbeContext:
+        def __init__(self) -> None:
+            self.console = cancel_probe_console(is_cancelled)
+
+    return {ACTION_TOOL_CONTEXT_RESOURCE_KEY: _ProbeContext()}
+
+
+__all__ = [
+    "cancel_probe_console",
+    "cancel_tool_resources",
+    "host_cancel_requested",
+]

--- a/core/agent_harness/turns/host_cancel.py
+++ b/core/agent_harness/turns/host_cancel.py
@@ -40,9 +40,13 @@ def cancel_tool_resources(is_cancelled: Callable[[], bool] | None) -> dict[str, 
         return {}
     from core.agent_harness.tools.tool_context import ACTION_TOOL_CONTEXT_RESOURCE_KEY
 
+    # Bind the narrowed callable: inside the nested class body the parameter
+    # widens back to ``| None``.
+    probe = is_cancelled
+
     class _ProbeContext:
         def __init__(self) -> None:
-            self.console = cancel_probe_console(is_cancelled)
+            self.console = cancel_probe_console(probe)
 
     return {ACTION_TOOL_CONTEXT_RESOURCE_KEY: _ProbeContext()}
 

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -51,6 +51,7 @@ from core.agent_harness.session.pending_offer import (
 )
 from core.agent_harness.tools.tool_context import capability_not_explicitly_disabled
 from core.agent_harness.turns.conversation_recording import record_conversation_turn
+from core.agent_harness.turns.host_cancel import host_cancel_requested
 from core.agent_harness.turns.transcript_compaction import auto_compact_if_needed
 from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
@@ -319,6 +320,26 @@ class _RouteOutcome:
     evidence_for_offer: str | None = None
 
 
+def _cancelled_turn_result(
+    accounting: TurnAccounting,
+    action_result: ToolCallingTurnResult,
+) -> TurnResult:
+    """Finalize a host-cancelled turn without gather/answer side effects."""
+    cancelled_action = (
+        action_result
+        if action_result.cancelled
+        else replace(action_result, cancelled=True, handoff_contents=())
+    )
+    return accounting.finalize(
+        TurnResult(
+            final_intent="cli_agent_cancelled",
+            action_result=cancelled_action,
+            assistant_response_text="",
+            llm_run=None,
+        )
+    )
+
+
 def _gather_and_answer(
     *,
     text: str,
@@ -327,7 +348,9 @@ def _gather_and_answer(
     handoff_contents: tuple[str, ...],
     turn_plan: TurnPlan,
     handoff_requires_gather: bool = True,
-) -> tuple[Any | None, str | None]:
+    output: OutputSink | None = None,
+) -> tuple[Any | None, str | None] | None:
+    """Run gather+answer, or ``None`` when the host cancelled mid-path."""
     # Two cases skip the live gather loop:
     # 1. Answer-only handoffs (``requires_gather=false``): the action turn's
     #    own tool work already produced what the reply needs, and a fresh sweep
@@ -341,11 +364,15 @@ def _gather_and_answer(
     #    emitting the tag *is* the judgement that the user means that incident,
     #    so a clock must not override it and answer with current conditions
     #    instead of what happened.
+    if host_cancel_requested(output):
+        return None
     skip_gather = not handoff_requires_gather or (
         _is_prior_investigation_follow_up_handoff(handoff_contents)
         and turn_plan.snapshot.last_state is not None
     )
     gathered = None if skip_gather else gather(text, turn_plan=turn_plan)
+    if host_cancel_requested(output):
+        return None
     if skip_gather:
         log.debug(
             "gather skipped: %s",
@@ -370,6 +397,8 @@ def _gather_and_answer(
             defer_want_me_to_closer=not skip_gather,
         ),
     )
+    if host_cancel_requested(output):
+        return None
     return run, observation
 
 
@@ -463,6 +492,10 @@ def run_turn(
         consume_confirmed_pending_offer(session, expanded)
     accounting.record_action_result(action_result)
 
+    if action_result.cancelled or host_cancel_requested(output):
+        log.debug("turn cancelled after action; skipping gather/answer")
+        return _cancelled_turn_result(accounting, action_result)
+
     handoff_contents = action_result.handoff_contents
     observation = session.last_command_observation
     route = _route_turn(
@@ -494,6 +527,8 @@ def run_turn(
         # if/elif + raise (not match/assert_never): CodeQL does not model
         # ``assert_never`` as noreturn, so locals bound only inside match arms
         # and read after the match trip py/uninitialized-local-variable.
+        if host_cancel_requested(output):
+            return _cancelled_turn_result(accounting, action_result)
         if route.intent == "summarize_observation":
             with apply_reasoning_effort(turn_snapshot.reasoning_effort):
                 run = answer(
@@ -504,6 +539,8 @@ def run_turn(
                         turn_plan=turn_plan,
                     ),
                 )
+            if host_cancel_requested(output):
+                return _cancelled_turn_result(accounting, action_result)
             outcome = _RouteOutcome(
                 final_intent="cli_agent_summarized",
                 response_text=_response_text(run),
@@ -520,14 +557,18 @@ def run_turn(
             )
         elif route.intent == "gather_and_answer":
             with apply_reasoning_effort(turn_snapshot.reasoning_effort):
-                run, gathered = _gather_and_answer(
+                gathered_outcome = _gather_and_answer(
                     text=text,
                     answer=answer,
                     gather=gather,
                     handoff_contents=handoff_contents,
                     turn_plan=turn_plan,
                     handoff_requires_gather=action_result.handoff_requires_gather,
+                    output=output,
                 )
+            if gathered_outcome is None:
+                return _cancelled_turn_result(accounting, action_result)
+            run, gathered = gathered_outcome
             outcome = _RouteOutcome(
                 final_intent="cli_agent_fallback",
                 response_text=_response_text(run),

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -54,7 +54,11 @@ from core.agent_harness.turns.conversation_recording import record_conversation_
 from core.agent_harness.turns.host_cancel import host_cancel_requested
 from core.agent_harness.turns.transcript_compaction import auto_compact_if_needed
 from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
-from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from core.agent_harness.turns.turn_results import (
+    FINAL_INTENT_CANCELLED,
+    ToolCallingTurnResult,
+    TurnResult,
+)
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.llm_invoke_errors import is_cli_timeout_error
 from platform.observability.trace.spans import component_span, emit_route
@@ -332,12 +336,23 @@ def _cancelled_turn_result(
     )
     return accounting.finalize(
         TurnResult(
-            final_intent="cli_agent_cancelled",
+            final_intent=FINAL_INTENT_CANCELLED,
             action_result=cancelled_action,
             assistant_response_text="",
             llm_run=None,
         )
     )
+
+
+def _abort_if_cancelled(
+    accounting: TurnAccounting,
+    action_result: ToolCallingTurnResult,
+    output: OutputSink | None,
+) -> TurnResult | None:
+    """Return a cancelled :class:`TurnResult` when the host asked to stop."""
+    if action_result.cancelled or host_cancel_requested(output):
+        return _cancelled_turn_result(accounting, action_result)
+    return None
 
 
 def _gather_and_answer(
@@ -492,9 +507,10 @@ def run_turn(
         consume_confirmed_pending_offer(session, expanded)
     accounting.record_action_result(action_result)
 
-    if action_result.cancelled or host_cancel_requested(output):
+    aborted = _abort_if_cancelled(accounting, action_result, output)
+    if aborted is not None:
         log.debug("turn cancelled after action; skipping gather/answer")
-        return _cancelled_turn_result(accounting, action_result)
+        return aborted
 
     handoff_contents = action_result.handoff_contents
     observation = session.last_command_observation
@@ -527,8 +543,9 @@ def run_turn(
         # if/elif + raise (not match/assert_never): CodeQL does not model
         # ``assert_never`` as noreturn, so locals bound only inside match arms
         # and read after the match trip py/uninitialized-local-variable.
-        if host_cancel_requested(output):
-            return _cancelled_turn_result(accounting, action_result)
+        aborted = _abort_if_cancelled(accounting, action_result, output)
+        if aborted is not None:
+            return aborted
         if route.intent == "summarize_observation":
             with apply_reasoning_effort(turn_snapshot.reasoning_effort):
                 run = answer(
@@ -539,8 +556,9 @@ def run_turn(
                         turn_plan=turn_plan,
                     ),
                 )
-            if host_cancel_requested(output):
-                return _cancelled_turn_result(accounting, action_result)
+            aborted = _abort_if_cancelled(accounting, action_result, output)
+            if aborted is not None:
+                return aborted
             outcome = _RouteOutcome(
                 final_intent="cli_agent_summarized",
                 response_text=_response_text(run),

--- a/core/agent_harness/turns/turn_results.py
+++ b/core/agent_harness/turns/turn_results.py
@@ -34,6 +34,8 @@ class ToolCallingTurnResult:
     handoff_requires_gather: bool = True
     accounting_status: ToolCallingAccountingStatus = "completed"
     investigation_dispatched: bool = False
+    #: Host soft-timeout / stop asked the action phase to halt (shell/gateway).
+    cancelled: bool = False
 
 
 @dataclass(frozen=True)
@@ -52,6 +54,11 @@ class TurnResult:
     def answered(self) -> bool:
         """A turn is "answered" exactly when the conversational LLM produced a run."""
         return self.llm_run is not None
+
+    @property
+    def cancelled(self) -> bool:
+        """True when the host cancelled mid-turn (timeout / stop)."""
+        return self.final_intent == "cli_agent_cancelled" or self.action_result.cancelled
 
     @property
     def primary_response_text(self) -> str:

--- a/core/agent_harness/turns/turn_results.py
+++ b/core/agent_harness/turns/turn_results.py
@@ -16,6 +16,9 @@ from typing import Any, Literal
 # versus a run that never produced actions because it failed/overflowed ("not_run").
 ToolCallingAccountingStatus = Literal["completed", "not_run"]
 
+# Host soft-timeout / ``/stop`` — orchestrator skips gather/answer on this intent.
+FINAL_INTENT_CANCELLED = "cli_agent_cancelled"
+
 
 @dataclass(frozen=True)
 class ToolCallingTurnResult:
@@ -58,7 +61,7 @@ class TurnResult:
     @property
     def cancelled(self) -> bool:
         """True when the host cancelled mid-turn (timeout / stop)."""
-        return self.final_intent == "cli_agent_cancelled" or self.action_result.cancelled
+        return self.final_intent == FINAL_INTENT_CANCELLED or self.action_result.cancelled
 
     @property
     def primary_response_text(self) -> str:
@@ -67,6 +70,7 @@ class TurnResult:
 
 
 __all__ = [
+    "FINAL_INTENT_CANCELLED",
     "ToolCallingAccountingStatus",
     "ToolCallingTurnResult",
     "TurnResult",

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -9,48 +9,78 @@ changes.
 
 | Role | Path |
 |------|------|
-| Package main | `main.py` (`python -m gateway.main`) |
-| Production entry (slash ports) | `surfaces.cli.gateway_entry` (`python -m surfaces.cli.gateway_entry`) |
-| Composition root / process | `core/runtime/manager.py` |
+| Production entry (slash ports) | CLI: `opensre gateway start` / `--foreground` (composition root outside this package) |
+| Package main | `main.py` — **fails closed** (no slash-port glue; not a production entry) |
+| Composition root / process | `core/runtime/manager.py` (`GatewayManager`; inject `slash_ports_factory`) |
+| Channels (web + chat composer) | `channels/` (`start_channels` / `ChannelsHandle`) |
 | Daemon pidfile / status | `core/runtime/daemon.py` |
 | Turn callback | `core/runtime/turn_handler.py` |
 | Sink + callback contracts | `core/runtime/sink_protocol.py` |
-| Config error type | `core/runtime/errors.py` (`GatewayConfigurationError`) |
+| Config / transport errors | `core/runtime/errors.py` (`GatewayConfigurationError`, `GatewayTransportFailedError`) |
 | Web surface (FastAPI) | `web/webapp.py` (`app`) |
-| Telegram start | `transports/telegram/wiring.py` (`start_telegram_worker`) |
-| Slack start | `transports/slack/wiring.py` (`start_slack_worker`) |
-| Discord start | `transports/discord/wiring.py` (`start_discord_worker`) |
+| Chat registry (inside channels) | `channels/chat.py` (`start_transports` / `stop_transports`) |
+| Telegram start | `transports/telegram/startup.py` (`start_telegram_worker`) |
+| Slack start | `transports/slack/startup.py` (`start_slack_worker`) |
+| Discord start | `transports/discord/startup.py` (`start_discord_worker`) |
+
+Bare `python -m gateway.main` and `manager.main()` / `start_gateway()` without
+`slash_ports_factory` exit with a clear error. Unit tests may construct
+`GatewayManager(...)` directly (factory optional there).
+
+## Lifecycle (`GatewayManager`)
+
+```
+start_gateway()
+  → configure_process(GATEWAY_PROFILE)
+  → compose turn handler
+  → start_channels()   # delegates to gateway.channels (web + chat)
+  → start_scheduler()  # peer of channels — not a "channel"
+  → ready
+```
+
+- **Channels** live in `gateway/channels/` — sole composer of web + Telegram /
+  Slack / Discord. Manager keeps only `ChannelsHandle`.
+- Missing chat credentials → `not configured`; readiness/runtime failures →
+  `failed`. The rest still start.
+- **Scheduler** starts after channels and is a peer (cron / loops), not a
+  transport. Daemon pidfile/status stays in `core/runtime/daemon.py` — do not
+  fold the process daemon into a "scheduler" package.
+- `gateway.core` must not import `gateway.transports` / `gateway.web`; only
+  `manager.py` imports `gateway.channels`.
+- Peer transports and `web` must not import `gateway.channels`.
 
 ## Layout
 
 Packages are split like `core/agent_harness/prompts/`: **core infra** vs
-**peer surfaces**. See `gateway/core/AGENTS.md` and
-`gateway/transports/AGENTS.md`.
+**peer surfaces** vs **composer**. See `gateway/core/AGENTS.md`,
+`gateway/channels/AGENTS.md`, and `gateway/transports/AGENTS.md`.
 
 - `core/` — process and leaf infrastructure (`runtime`, `storage`,
   `billing`, `attachments`, `session`, `config`). No imports from transports
-  or `web`, except the composition root `core/runtime/manager.py`, which
-  wires them together.
+  or `web`. Only `core/runtime/manager.py` imports `gateway.channels`.
+- `channels/` — starts/stops web + chat transports as one consumer set.
+  Imports `web/` and each peer's `startup` only. See `channels/AGENTS.md`.
 - `transports/` — chat peers (`slack`, `discord`, `telegram`). Each owns
-  settings, inbound worker, security, output sink, and `wiring.py`. Peers
-  never import each other; anything two need belongs in `core/` (usually
-  `gateway.core.runtime`). See `transports/AGENTS.md`.
+  settings, inbound worker, security, output sink, and `startup.py`. Peers
+  never import each other or `channels`/`web`; anything two need belongs in
+  `core/` (usually `gateway.core.runtime`). See `transports/AGENTS.md`.
 - `web/` — web surface (FastAPI app, investigations API, worker/artifacts).
-  May import `core/`; must not import chat transports. See `web/AGENTS.md`.
+  May import `core/`; must not import chat transports or `channels`. See
+  `web/AGENTS.md`.
 - `core/storage/session/resolver.py` — per-conversation session binding
   keyed by platform; delegates create / resolve / rotate to `SessionManager`.
 
 ### Dependency rule (acyclic)
 
 ```
-core  ←  transports.{slack,discord,telegram} · web
-         (peer surfaces — never import each other)
+core.manager  →  channels  →  transports.{telegram,slack,discord}.startup
+                           →  web
+peer transports · web  →  core leaves
+(peers never import each other, channels, or each other's packages)
 ```
 
-Sole exception: `core/runtime/manager.py` (composition root) imports the
-transports and `web`. Package DAG pinned by
-`tests/test_package_borders.py` (plus discord↔slack isolation in
-`tests/discord/test_transport_borders.py`).
+Package DAG pinned by `tests/test_package_borders.py` (plus discord↔slack
+isolation in `tests/discord/test_transport_borders.py`).
 
 Tests stay flat under `gateway/tests/{runtime,web,slack,discord,telegram,…}/`
 (nesting `tests/transports/discord` collides with the `discord` PyPI package
@@ -58,6 +88,12 @@ name during collection).
 
 ## Gateway turn dispatch
 
+- **One turn handler:** `GatewayTurnHandler` (optional `gate=` for capacity).
+  Transport Slack/Discord/Telegram *dispatchers* are ingress only — authorize,
+  resolve session, build sink, then call the shared callback. Do not add a
+  second production turn-handler class next to `GatewayTurnHandler`.
+- **Logging** is configured once at the gateway process level
+  (`configure_logging` in `GatewayManager.start_gateway`) — that is intentional.
 - **No persistent gateway `Agent` instance.** Each inbound message gets a
   per-chat `Session` from `SessionResolver` and is handled by the shared
   headless dispatch path (`core.agent_harness.turns.headless_dispatch`).
@@ -70,6 +106,45 @@ name during collection).
   integration context after `SessionResolver.resolve`.
 - Per-chat session lifecycle (create / resolve / rotate / restore) is owned by
   `SessionResolver` → `SessionManager`, not by `GatewayManager`.
+
+## Tenancy (principal / actor)
+
+Slack, Discord, and Telegram each resolve a `StorageScope` in their own
+`transports/<peer>/principal.py` (peer isolation — no cross-imports):
+
+- **Principal** = silo `ORGANIZATION_ID` (fail closed if missing)
+- **Actor** = platform user id
+- Turn runs under `bound_storage_scope` so bindings/sessions/integrations land
+  on the org mount or `~/.opensre/orgs/<id>/`
+
+CLI / interactive shell stay unbound (legacy empty principal/actor ids).
+`SessionResolver` may adopt a same-document legacy empty-id Telegram row into
+the scoped key on first scoped resolve.
+
+## Capacity (process gate vs transport pools)
+
+Two different limits — do not conflate them:
+
+| Layer | Mechanism | Behavior when full |
+|-------|-----------|-------------------|
+| **Process** | `TurnConcurrencyGate` from `OPENSRE_SIZE_PROFILE` (SMALL=1, MEDIUM=2, LARGE=4) | Chat turns: non-blocking `try_acquire` on `GatewayTurnHandler`; reply with busy message and drop the turn. Scheduler runners: **blocking** `acquire` (already-claimed work waits for a slot). |
+| **Per-transport** | `max_concurrent_turns` (defaults to the same profile limit via `turn_limit_for_profile`; override with `*_GATEWAY_MAX_CONCURRENT`) | Caps how many inbound messages that transport may process in parallel *before* they hit the shared turn handler. Does not replace the process gate. |
+
+```text
+Telegram/Slack/Discord ──► GatewayTurnHandler.try_acquire ──► TurnConcurrencyGate
+Scheduler (agent + investigate runners) ──► blocking acquire ──► same gate
+POST /investigate + InvestigationWorker ──► AgentSession.investigate (Path-2) ──► ungated today
+```
+
+- Production chat capacity is on `GatewayTurnHandler(gate=manager.turn_gate)`.
+- `ConcurrencyLimitedTurnHandler` is for tests / arbitrary callbacks only — not a
+  second production turn-handler class.
+- **Chat vs investigate:** the process gate covers gateway **chat** and
+  **scheduler** runners. Path-2 HTTP investigate (`POST /investigate`,
+  `InvestigationWorker`) does **not** take the gate today — do not assume web
+  investigations are capped by `OPENSRE_SIZE_PROFILE`. Analytics: chat uses
+  `gateway_turn_*` with `surface` ∈ {slack,telegram,discord}; investigate uses
+  separate `investigation_*` events (no capacity-reject event yet).
 
 ## Testing
 

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -148,6 +148,45 @@ POST /investigate + InvestigationWorker ──► AgentSession.investigate (Path
   `gateway_turn_*` with `surface` ∈ {slack,telegram,discord}; investigate uses
   separate `investigation_*` events (no capacity-reject event yet).
 
+## Host parity (channels)
+
+Same turn engine for Slack / Telegram / Discord: ingress → `GatewayTurnHandler`
+→ `SessionAgentPool` → `AgentSession.chat`. Web investigate is Path-2 (separate
+verb) — see Capacity above. Values: **yes** / **partial** / **no** / **n/a**.
+
+| Concern | Slack | Telegram | Discord | Web |
+|---------|-------|----------|---------|-----|
+| Cancel / stop mid-turn | **partial** — soft timeout UX; handler not cancelled | **no** — no turn timeout / user-stop | **partial** — same as Slack | **partial** — queued investigate cancel only |
+| Approvals / `before_tool_call` | **yes** — Block Kit + `approval_tool_hooks` | **yes** — inline keyboard + `approval_tool_hooks` | **yes** — components + `approval_tool_hooks` | **n/a** — Path-2 |
+| Tool resolution | **yes** — live `DefaultToolProvider(session)` | **yes** — same | **yes** — same | **n/a** — investigate runner |
+| Sink redaction | **yes** — `user_facing_error_message` | **yes** — same | **yes** — same | **yes** — `type(exc).__name__` only |
+| Principal / actor | **yes** — `slack/principal.py` | **yes** — `telegram/principal.py` | **yes** — `discord/principal.py` | **partial** — Clerk org audit; no `StorageScope` |
+| Capacity gate | **yes** — process gate + transport pool | **yes** — same + TG semaphore | **yes** — same + executor | **no** — Path-2 ungated |
+
+**Documented exceptions (do not “fix” by forking a second loop):**
+
+- Gateway chat disables `task_cancel` / investigation / llm_provider
+  (`GatewayTurnHandler._UNSUPPORTED_GATEWAY_CAPABILITIES`).
+- Path-2 web investigate is ungated and has no chat approval prompter.
+- True mid-turn cancel is still missing on all chat hosts (soft timeout ≠ cancel).
+- Telegram write-tool approvals require a non-empty `allowed_user_ids` allowlist
+  (same fail-closed posture as Discord).
+
+**Characterization:** live-session tools —
+`tests/runtime/test_turn_handler.py` +
+`test_gateway_chat_never_builds_core_agent_or_precomputed_tools`;
+redaction — Slack/Telegram/Discord sink tests + `tests/runtime/test_status_messages.py`;
+Telegram approvals — `tests/telegram/test_approvals.py`.
+
+**Dogfood + smoke (turn-engine regressions):**
+
+| Check | How |
+|-------|-----|
+| Borders + capacity | `pytest gateway/tests/test_package_borders.py gateway/tests/runtime/test_concurrency_gate.py -q` |
+| Smoke gateway wiring | `./trace smoke --suite gateway` (or tags covering `cli.gateway_*`) |
+| Dogfood (dev silo only) | `@mention` on **dev** Slack — thread continuity, Digging in…, `Want me to:` → `yes`; one Socket Mode consumer. See notes `ops-dogfood.html#glossary`. |
+| Not a substitute | Laptop `opensre gateway` + smoke ≠ dogfood |
+
 ## Testing
 
 Gateway E2E regression tests should drive a normalized polled Telegram message

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -137,8 +137,10 @@ POST /investigate + InvestigationWorker ──► AgentSession.investigate (Path
 ```
 
 - Production chat capacity is on `GatewayTurnHandler(gate=manager.turn_gate)`.
-- `ConcurrencyLimitedTurnHandler` is for tests / arbitrary callbacks only — not a
-  second production turn-handler class.
+- `ConcurrencyLimitedTurnHandler` is **quarantined under**
+  `gateway/tests/runtime/concurrency_limited_handler.py` (tests only). Do not
+  reintroduce it under `gateway/core/` — production uses `gate=` on
+  `GatewayTurnHandler` only.
 - **Chat vs investigate:** the process gate covers gateway **chat** and
   **scheduler** runners. Path-2 HTTP investigate (`POST /investigate`,
   `InvestigationWorker`) does **not** take the gate today — do not assume web

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -118,8 +118,9 @@ Slack, Discord, and Telegram each resolve a `StorageScope` in their own
   on the org mount or `~/.opensre/orgs/<id>/`
 
 CLI / interactive shell stay unbound (legacy empty principal/actor ids).
-`SessionResolver` may adopt a same-document legacy empty-id Telegram row into
-the scoped key on first scoped resolve.
+`SessionResolver` may adopt a same-document legacy empty-id row into the scoped
+key once (`adopt_unscoped_binding` removes the unscoped row) so a second actor
+cannot inherit that session.
 
 ## Capacity (process gate vs transport pools)
 
@@ -156,7 +157,7 @@ verb) — see Capacity above. Values: **yes** / **partial** / **no** / **n/a**.
 
 | Concern | Slack | Telegram | Discord | Web |
 |---------|-------|----------|---------|-----|
-| Cancel / stop mid-turn | **partial** — soft timeout sets `sink.turn_cancel` (ReAct/tools stop); no user `/stop` yet | **partial** — same (`turn_timeout_seconds`) | **partial** — same as Slack | **partial** — queued investigate cancel only |
+| Cancel / stop mid-turn | **yes** — soft timeout + user `/stop` via `ActiveTurnCancels` → `sink.turn_cancel` | **yes** — same | **yes** — same | **partial** — queued investigate cancel only |
 | Approvals / `before_tool_call` | **yes** — Block Kit + `approval_tool_hooks` | **yes** — inline keyboard + `approval_tool_hooks` | **yes** — components + `approval_tool_hooks` | **n/a** — Path-2 |
 | Tool resolution | **yes** — live `DefaultToolProvider(session)` | **yes** — same | **yes** — same | **n/a** — investigate runner |
 | Sink redaction | **yes** — `user_facing_error_message` | **yes** — same | **yes** — same | **yes** — `type(exc).__name__` only |
@@ -168,11 +169,14 @@ verb) — see Capacity above. Values: **yes** / **partial** / **no** / **n/a**.
 - Gateway chat disables `task_cancel` / investigation / llm_provider
   (`GatewayTurnHandler._UNSUPPORTED_GATEWAY_CAPABILITIES`).
 - Path-2 web investigate is ungated and has no chat approval prompter.
-- Soft turn timeout (Slack/Discord/Telegram) finalizes UX copy **and** sets
+- Soft turn timeout **and** user `/stop` / `stop` / `/cancel` set
   `sink.turn_cancel` so the ReAct loop / remaining tools stop cooperatively
-  (shell `cancel_requested` parity via `CancelConsole`). The executor thread
-  is not killed; in-flight LLM/provider calls still finish the current request.
-  True mid-turn **user** cancel (`/stop`) is still missing.
+  (shell `cancel_requested` parity via `CancelConsole` + `ActiveTurnCancels`).
+  Orchestrator skips gather/answer and reports `final_intent=cli_agent_cancelled`;
+  the live sink stops draining stream chunks when the Event fires. `/stop` is
+  handled **outside** the per-conversation turn lock so it can interrupt an
+  in-flight turn. The executor thread is not killed; in-flight LLM/provider
+  calls still finish the current request.
 - Telegram write-tool approvals require a non-empty `allowed_user_ids` allowlist
   (same fail-closed posture as Discord).
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -11,15 +11,17 @@ transport-specific code.
 
 | What you want | File / symbol | How it is started |
 |---------------|---------------|-------------------|
-| **Package main** | `gateway/main.py` → `main()` | `python -m gateway.main` (manager only) |
-| **Production entry** | `surfaces/cli/gateway_entry.py` → `main()` | Daemon / `opensre gateway start` (wires slash ports) |
-| **Composition root (impl)** | `gateway/core/runtime/manager.py` → `GatewayManager` / `main()` | Called by the entry modules |
+| **Production entry** | CLI composition root (outside `gateway/`) | `opensre gateway start` / `--foreground` (wires slash ports) |
+| **Package main** | `gateway/main.py` → `main()` | Fails closed — no slash-port glue |
+| **Composition root (impl)** | `gateway/core/runtime/manager.py` → `GatewayManager` | Injected `slash_ports_factory` from CLI; bare `manager.main` fails closed |
 | **Background daemon helpers** | `gateway/core/runtime/daemon.py` | Used by CLI `gateway start/stop/status` (pidfile + `components.json`) |
 | **Web surface (web-only task)** | `gateway/web/webapp.py` → `app` | `uvicorn gateway.web.webapp:app` (`MODE=web` in Docker) |
-| **Telegram transport** | `gateway/transports/telegram/wiring.py` → `start_telegram_worker` | Started by `GatewayManager._start_telegram` |
-| **Slack transport** | `gateway/transports/slack/wiring.py` → `start_slack_worker` | Started by `GatewayManager._start_slack` |
-| **Discord transport** | `gateway/transports/discord/wiring.py` → `start_discord_worker` | Started by `GatewayManager._start_discord` |
-| **Per-message turn** | `gateway/core/runtime/turn_handler.py` → `GatewayTurnHandler` | Injected into both transports as the agent callback |
+| **Channels** | `gateway/channels/` → `start_channels` / `ChannelsHandle` | Called by `GatewayManager.start_channels` |
+| **Chat transport registry** | `gateway/channels/chat.py` → `start_transports` | Used by `gateway.channels.compose` |
+| **Telegram transport** | `gateway/transports/telegram/startup.py` → `start_telegram_worker` | Via channels chat registry |
+| **Slack transport** | `gateway/transports/slack/startup.py` → `start_slack_worker` | Via channels chat registry |
+| **Discord transport** | `gateway/transports/discord/startup.py` → `start_discord_worker` | Via channels (includes readiness wait) |
+| **Per-message turn** | `gateway/core/runtime/turn_handler.py` → `GatewayTurnHandler` | Injected into chat transports as the agent callback |
 
 ```text
 opensre gateway start
@@ -32,15 +34,16 @@ surfaces/cli/gateway_entry.py
         │  wires headless slash ports
         ▼
 gateway.core.runtime.manager.GatewayManager.start_gateway
-        ├── web/web_server  →  web/webapp:app
-        ├── transports/telegram/wiring.start_telegram_worker
-        ├── transports/slack/wiring.start_slack_worker
-        ├── transports/discord/wiring.start_discord_worker
-        └── scheduler
+        ├── start_channels()  →  gateway.channels.start_channels
+        │     ├── web/web_server  →  web/webapp:app
+        │     └── channels/chat.start_transports
+        │           (telegram / slack / discord startup)
+        └── start_scheduler()   # peer of channels, not a transport
 ```
 
-Layout: `core/` (runtime, storage, …), `transports/` (slack, discord,
-telegram), and `web/` (web surface). See `AGENTS.md`.
+Layout: `core/` (runtime, storage, …), `channels/` (consumer composer),
+`transports/` (slack, discord, telegram peers), and `web/` (web surface). See
+`AGENTS.md`.
 
 ## How the pieces fit (surfaces, gateway, integrations)
 
@@ -125,7 +128,7 @@ with the same five pieces `gateway/transports/telegram/` and `gateway/transports
 
 1. **Settings** (`settings.py`): env-backed config, raising
    `GatewayConfigurationError` (from `gateway/core/runtime/errors.py`) when missing.
-2. **A listener** (`wiring.py` + the transport worker): receives inbound
+2. **A listener** (`startup.py` + the transport worker): receives inbound
    messages and calls the shared handler with `(text, session, sink, logger)`.
 3. **Inbound security**: authorize each message and audit-log it
    (`integrations/messaging_security`).

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -28,9 +28,11 @@ opensre gateway start
         │
         ▼
 gateway.core.runtime.daemon.start_gateway_daemon
-        │  spawns: python -m surfaces.cli.gateway_entry
+        │  spawns surface-owned argv (see surfaces.shared.gateway_entrypoint):
+        │    venv:   python -m surfaces.cli.gateway_entry
+        │    frozen: opensre gateway start --foreground
         ▼
-surfaces/cli/gateway_entry.py
+surfaces/cli/gateway_entry.py  (or Click foreground → same composition root)
         │  wires headless slash ports
         ▼
 gateway.core.runtime.manager.GatewayManager.start_gateway

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -9,13 +9,14 @@ Subpackages (see ``gateway/AGENTS.md``):
 
 Entry points:
 
-* Package main — :mod:`gateway.main` (``python -m gateway.main``)
+* Production — ``opensre gateway start`` (CLI wires slash ports into ``GatewayManager``)
+* Package main — :mod:`gateway.main` (fails closed; not a production entry)
 * Composition root — :mod:`gateway.core.runtime.manager`
 * Daemon helpers — :mod:`gateway.core.runtime.daemon`
 * HTTP app (``MODE=web``) — :mod:`gateway.web.webapp` (``app``)
-* Telegram — :mod:`gateway.transports.telegram.wiring`
-* Slack — :mod:`gateway.transports.slack.wiring`
-* Discord — :mod:`gateway.transports.discord.wiring`
+* Telegram — :mod:`gateway.transports.telegram.startup`
+* Slack — :mod:`gateway.transports.slack.startup`
+* Discord — :mod:`gateway.transports.discord.startup`
 
 See ``gateway/README.md`` § Entry points.
 """

--- a/gateway/channels/AGENTS.md
+++ b/gateway/channels/AGENTS.md
@@ -1,0 +1,20 @@
+# gateway/channels/ — consumer composition
+
+Sole module that starts/stops the gateway's consumer surfaces together.
+
+| May import | Must not |
+|------------|----------|
+| `gateway.core.*` | be imported by `transports.*` or `web` |
+| `gateway.web.*` | |
+| `gateway.transports.*.startup` | peer transport internals beyond wiring |
+
+| File | Role |
+|------|------|
+| `__init__.py` | Public API: `start_channels`, `ChannelsHandle`, `ChannelName` |
+| `compose.py` | Web + chat as one unit |
+| `chat.py` | Chat transport registry (`start_transports` / `stop_transports`) |
+
+Scheduler is **not** a channel — `GatewayManager.start_scheduler` starts it as a
+peer after `start_channels` returns.
+
+Pinned by `gateway/tests/test_package_borders.py`.

--- a/gateway/channels/__init__.py
+++ b/gateway/channels/__init__.py
@@ -1,0 +1,24 @@
+"""Consumer channels the gateway process serves: web + chat transports.
+
+Sole composer of peer surfaces (``gateway.web`` and
+``gateway.transports.{telegram,slack,discord}``). The process composition root
+(:mod:`gateway.core.runtime.manager`) calls :func:`start_channels` and holds
+:class:`ChannelsHandle` — it does not import transports or web.
+"""
+
+from __future__ import annotations
+
+from gateway.channels.chat import (
+    DEFAULT_STOP_TIMEOUT_SECONDS,
+    TransportHandle,
+    TransportName,
+)
+from gateway.channels.compose import ChannelsHandle, start_channels
+
+__all__ = [
+    "DEFAULT_STOP_TIMEOUT_SECONDS",
+    "ChannelsHandle",
+    "TransportHandle",
+    "TransportName",
+    "start_channels",
+]

--- a/gateway/channels/chat.py
+++ b/gateway/channels/chat.py
@@ -1,0 +1,152 @@
+"""Uniform start/stop contract for chat transports.
+
+Owned by :mod:`gateway.channels` (the consumer composer). Peer packages under
+``gateway.transports`` expose ``startup.start_*_worker`` only — they do not
+compose each other. Anything specific to one transport (readiness waits,
+settings shapes) stays in that transport's ``startup`` module.
+
+A transport that is not configured is not an error: the gateway runs with
+whichever transports have credentials.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+from gateway.core.runtime.errors import (
+    GatewayConfigurationError,
+    GatewayTransportFailedError,
+)
+from gateway.core.runtime.sink_protocol import GatewayAgentCallback
+from gateway.transports.discord.startup import start_discord_worker
+from gateway.transports.slack.startup import start_slack_worker
+from gateway.transports.telegram.startup import start_telegram_worker
+
+# How long a shutdown waits on each worker before giving up on it.
+DEFAULT_STOP_TIMEOUT_SECONDS = 8.0
+
+
+class TransportName(StrEnum):
+    """Chat transports the gateway can serve.
+
+    Doubles as the key in :attr:`gateway.channels.ChannelsHandle.transports`
+    and in the component status map, so status keys and lookups cannot drift.
+    Web is not a member: it is a channel but not a chat transport.
+    """
+
+    TELEGRAM = "telegram"
+    SLACK = "slack"
+    DISCORD = "discord"
+
+
+class TransportWorker(Protocol):
+    """Background worker owning one transport's connection."""
+
+    def stop(self, *, timeout: float = ...) -> bool:
+        """Stop the worker and return whether it shut down within ``timeout``."""
+
+
+# Each transport's startup returns its worker plus its own settings object.
+TransportStarter = Callable[..., tuple[TransportWorker, Any]]
+
+
+@dataclass(frozen=True)
+class TransportSpec:
+    """How to start one transport and what to report once it is running."""
+
+    name: TransportName
+    start: TransportStarter
+    running_status: str
+
+
+@dataclass(frozen=True)
+class TransportHandle:
+    """A started transport: the worker to stop, and how to describe it."""
+
+    name: TransportName
+    worker: TransportWorker
+    status: str
+
+
+@dataclass(frozen=True)
+class ChatStartup:
+    """Started chat transports plus the status of every transport that was tried.
+
+    ``statuses`` covers transports that did not start, so the caller can report
+    "not configured" without the callee reaching into its status map.
+    """
+
+    handles: list[TransportHandle]
+    statuses: dict[TransportName, str]
+
+
+TRANSPORTS: tuple[TransportSpec, ...] = (
+    TransportSpec(TransportName.TELEGRAM, start_telegram_worker, "polling for messages"),
+    TransportSpec(TransportName.SLACK, start_slack_worker, "connected via socket mode"),
+    TransportSpec(TransportName.DISCORD, start_discord_worker, "connected via gateway"),
+)
+
+
+def start_transports(
+    *,
+    logger: logging.Logger,
+    handler: GatewayAgentCallback,
+) -> ChatStartup:
+    """Start every configured transport and report what each one did.
+
+    * :class:`GatewayConfigurationError` → ``not configured (…)`` (skipped).
+    * :class:`GatewayTransportFailedError` → ``failed (…)`` (skipped).
+
+    The gateway still serves whichever transports started successfully.
+    """
+    handles: list[TransportHandle] = []
+    statuses: dict[TransportName, str] = {}
+    for spec in TRANSPORTS:
+        try:
+            worker, _settings = spec.start(logger=logger, handler=handler)
+        except GatewayConfigurationError as exc:
+            logger.warning("%s chat disabled: %s", spec.name.capitalize(), exc)
+            statuses[spec.name] = f"not configured ({exc})"
+            continue
+        except GatewayTransportFailedError as exc:
+            logger.warning("%s chat failed: %s", spec.name.capitalize(), exc)
+            statuses[spec.name] = f"failed ({exc})"
+            continue
+        handles.append(
+            TransportHandle(name=spec.name, worker=worker, status=spec.running_status)
+        )
+        statuses[spec.name] = spec.running_status
+    return ChatStartup(handles=handles, statuses=statuses)
+
+
+def stop_transports(
+    *,
+    handles: Sequence[TransportHandle],
+    timeout: float = DEFAULT_STOP_TIMEOUT_SECONDS,
+) -> bool:
+    """Stop every started transport and return whether all of them stopped.
+
+    Every worker is asked to stop even after one fails, so a single stuck
+    transport cannot leave the others running.
+    """
+    stopped = True
+    for handle in handles:
+        stopped = handle.worker.stop(timeout=timeout) and stopped
+    return stopped
+
+
+__all__ = [
+    "DEFAULT_STOP_TIMEOUT_SECONDS",
+    "TRANSPORTS",
+    "ChatStartup",
+    "TransportHandle",
+    "TransportName",
+    "TransportSpec",
+    "TransportWorker",
+    "start_transports",
+    "stop_transports",
+]

--- a/gateway/channels/chat.py
+++ b/gateway/channels/chat.py
@@ -116,9 +116,7 @@ def start_transports(
             logger.warning("%s chat failed: %s", spec.name.capitalize(), exc)
             statuses[spec.name] = f"failed ({exc})"
             continue
-        handles.append(
-            TransportHandle(name=spec.name, worker=worker, status=spec.running_status)
-        )
+        handles.append(TransportHandle(name=spec.name, worker=worker, status=spec.running_status))
         statuses[spec.name] = spec.running_status
     return ChatStartup(handles=handles, statuses=statuses)
 

--- a/gateway/channels/compose.py
+++ b/gateway/channels/compose.py
@@ -1,0 +1,72 @@
+"""Start and stop the full consumer channel set: web + chat transports.
+
+The composition root (:class:`~gateway.core.runtime.manager.GatewayManager`)
+calls :func:`start_channels` and keeps only the returned handle. The scheduler
+is not a channel; the manager starts it as a peer after this module returns.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from gateway.channels.chat import (
+    DEFAULT_STOP_TIMEOUT_SECONDS,
+    TransportHandle,
+    TransportName,
+    start_transports,
+    stop_transports,
+)
+from gateway.core.runtime.sink_protocol import GatewayAgentCallback
+from gateway.web.startup import start_web_server
+from gateway.web.web_server import WebAppServerHandle
+
+# The web app is a thread join, not a network drain, so it gets a smaller slice
+# of the shutdown budget and leaves the rest for in-flight chat turns.
+WEB_STOP_TIMEOUT_SECONDS = 5.0
+
+_WEB_COMPONENT = "web"
+
+
+@dataclass
+class ChannelsHandle:
+    """Running consumer channels: optional web server, chat transports, statuses."""
+
+    web_server: WebAppServerHandle | None = None
+    transports: dict[TransportName, TransportHandle] = field(default_factory=dict)
+    statuses: dict[str, str] = field(default_factory=dict)
+
+    def stop(self, *, timeout: float = DEFAULT_STOP_TIMEOUT_SECONDS) -> bool:
+        """Stop web and every chat transport; return whether all chat workers stopped."""
+        if self.web_server is not None:
+            self.web_server.stop(timeout=min(timeout, WEB_STOP_TIMEOUT_SECONDS))
+            self.web_server = None
+        stopped = stop_transports(handles=list(self.transports.values()), timeout=timeout)
+        self.transports = {}
+        return stopped
+
+
+def start_channels(
+    *,
+    logger: logging.Logger,
+    handler: GatewayAgentCallback,
+) -> ChannelsHandle:
+    """Start web and every chat transport together.
+
+    Missing chat credentials skip that transport (``not configured``); readiness
+    or runtime failures record ``failed``. The rest still start.
+    """
+    web = start_web_server(logger=logger)
+    chat = start_transports(logger=logger, handler=handler)
+    return ChannelsHandle(
+        web_server=web.server,
+        transports={handle.name: handle for handle in chat.handles},
+        statuses={_WEB_COMPONENT: web.status, **chat.statuses},
+    )
+
+
+__all__ = [
+    "WEB_STOP_TIMEOUT_SECONDS",
+    "ChannelsHandle",
+    "start_channels",
+]

--- a/gateway/channels/compose.py
+++ b/gateway/channels/compose.py
@@ -58,10 +58,13 @@ def start_channels(
     """
     web = start_web_server(logger=logger)
     chat = start_transports(logger=logger, handler=handler)
+    statuses: dict[str, str] = {_WEB_COMPONENT: web.status}
+    for name, status in chat.statuses.items():
+        statuses[name] = status
     return ChannelsHandle(
         web_server=web.server,
         transports={handle.name: handle for handle in chat.handles},
-        statuses={_WEB_COMPONENT: web.status, **chat.statuses},
+        statuses=statuses,
     )
 
 

--- a/gateway/core/AGENTS.md
+++ b/gateway/core/AGENTS.md
@@ -1,9 +1,9 @@
 # gateway/core/ — process and leaf infrastructure
 
 Gateway core machinery used by every surface. **Must not** import
-`gateway.transports.*` or `gateway.web` (surfaces). Sole exception:
-`runtime/manager.py`, the composition root, which wires the transports and
-the web surface together. Pinned by `gateway/tests/test_package_borders.py`.
+`gateway.transports.*` or `gateway.web` (surfaces). Channel composition lives
+in `gateway.channels`; only `runtime/manager.py` imports that module.
+Pinned by `gateway/tests/test_package_borders.py`.
 
 | Package | Role |
 |---------|------|
@@ -23,9 +23,11 @@ Shared process setup (env → Sentry → harness adapters → capability warning
 LLM preload) lives in
 :func:`bootstrap.process.configure_process` with ``GATEWAY_PROFILE``.
 `GatewayManager.start_gateway` is lifecycle-only after logging + credential
-hydrate: configure process, compose `GatewayTurnHandler`, start web / telegram /
-slack / discord / scheduler. Do not reintroduce a bootstrap essay in the
-manager. Scheduler runners register when the scheduler stage starts
+hydrate: configure process, compose **one** `GatewayTurnHandler(gate=…)`, then
+`start_channels()` (delegates to :func:`gateway.channels.start_channels`) and
+`start_scheduler()` (peer of the channels). Do not wrap the turn handler in a
+second handler class. Do not reintroduce a bootstrap essay in the manager.
+Scheduler runners register when the scheduler stage starts
 (:func:`bootstrap.adapters.install_scheduler_runners`).
 
 Process boot has one entrypoint: :func:`bootstrap.process.configure_process`

--- a/gateway/core/runtime/__init__.py
+++ b/gateway/core/runtime/__init__.py
@@ -1,8 +1,8 @@
 """Gateway process and turn machinery: lifecycle, dispatch, sink contracts.
 
 Composition root: :mod:`gateway.core.runtime.manager` (``GatewayManager``).
-Package entry: ``python -m gateway.main`` → :mod:`gateway.main` → ``manager.main``.
-Production entry with slash ports: ``python -m surfaces.cli.gateway_entry``.
+Production boot: ``opensre gateway start`` (CLI injects slash ports).
+Package ``python -m gateway.main`` and bare ``manager.main`` fail closed.
 Shared contracts: :mod:`gateway.core.runtime.sink_protocol`, :mod:`gateway.core.runtime.errors`.
 """
 

--- a/gateway/core/runtime/active_turns.py
+++ b/gateway/core/runtime/active_turns.py
@@ -1,0 +1,82 @@
+"""In-flight turn cancel registry for gateway chat hosts.
+
+Transports serialize turns per conversation, so a ``/stop`` message cannot
+wait behind the same lock as the running turn. Instead each turn registers its
+``turn_cancel`` Event here under a conversation key; ``/stop`` looks up the
+key **outside** the turn lock, sets the Event, and optionally runs a
+transport-supplied finalize callback (claim outcome + ``Stopped.`` copy).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+_STOP_TOKENS = frozenset({"/stop", "stop", "/cancel", "cancel"})
+
+USER_STOP_MESSAGE = "Stopped."
+
+
+@dataclass(slots=True)
+class _TrackedTurn:
+    event: threading.Event
+    on_user_stop: Callable[[], None] | None = None
+
+
+class ActiveTurnCancels:
+    """Thread-safe map of conversation key → in-flight cancel Event."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._turns: dict[str, _TrackedTurn] = {}
+
+    @contextmanager
+    def track(
+        self,
+        key: str,
+        event: threading.Event,
+        *,
+        on_user_stop: Callable[[], None] | None = None,
+    ) -> Iterator[None]:
+        """Publish ``event`` for ``key`` for the duration of one turn."""
+        with self._lock:
+            self._turns[key] = _TrackedTurn(event=event, on_user_stop=on_user_stop)
+        try:
+            yield
+        finally:
+            with self._lock:
+                current = self._turns.get(key)
+                if current is not None and current.event is event:
+                    del self._turns[key]
+
+    def request_stop(self, key: str) -> bool:
+        """Set the cancel Event for ``key``. Return whether a turn was active."""
+        with self._lock:
+            tracked = self._turns.get(key)
+        if tracked is None:
+            return False
+        tracked.event.set()
+        if tracked.on_user_stop is not None:
+            tracked.on_user_stop()
+        return True
+
+
+def is_stop_command(text: str) -> bool:
+    """True when the message is a user stop/cancel command (first token)."""
+    stripped = text.strip()
+    if not stripped:
+        return False
+    token = stripped.split(maxsplit=1)[0].lower()
+    # Telegram: ``/stop@MyBot`` → ``/stop``
+    if "@" in token:
+        token = token.split("@", 1)[0]
+    return token in _STOP_TOKENS
+
+
+__all__ = [
+    "USER_STOP_MESSAGE",
+    "ActiveTurnCancels",
+    "is_stop_command",
+]

--- a/gateway/core/runtime/approvals.py
+++ b/gateway/core/runtime/approvals.py
@@ -9,7 +9,8 @@ This module holds the parts that do not depend on a chat transport: the broker
 that connects a click to the waiting tool call, the button identifiers, and the
 harness hooks. Each transport supplies its own :class:`ApprovalPrompter` — Block
 Kit in ``gateway.transports.slack.approvals``, message components in
-``gateway.transports.discord.approvals``.
+``gateway.transports.discord.approvals``, inline keyboard in
+``gateway.transports.telegram.approvals``. See ``gateway/AGENTS.md`` → Host parity.
 """
 
 from __future__ import annotations

--- a/gateway/core/runtime/cancel_console.py
+++ b/gateway/core/runtime/cancel_console.py
@@ -1,9 +1,12 @@
-"""Cooperative turn cancel for gateway hosts (shell ``StreamingConsole`` parity).
+"""Gateway console wrapper: Rich console + ``cancel_requested`` (shell parity).
 
-Transports attach a ``threading.Event`` as ``sink.turn_cancel`` and set it on
-soft timeout (or later user stop). The turn handler wraps the pool console in
-:class:`CancelConsole` so action tools and the ReAct loop see
-``cancel_requested`` the same way the interactive shell does.
+One Event per turn (``sink.turn_cancel``). Soft timeout and ``/stop``
+(:class:`~gateway.core.runtime.active_turns.ActiveTurnCancels`) both ``set()``
+it. :class:`GatewayTurnHandler` binds this wrapper so tools and ReAct see
+``cancel_requested`` like the interactive shell's ``StreamingConsole``.
+
+See also ``core.agent_harness.turns.host_cancel`` for the orchestrator /
+gather side of the same Event.
 """
 
 from __future__ import annotations

--- a/gateway/core/runtime/cancel_console.py
+++ b/gateway/core/runtime/cancel_console.py
@@ -14,12 +14,20 @@ from typing import Any
 
 from rich.console import Console
 
+# Set on the wrapper itself; everything else is proxied to the wrapped console.
+_OWN_ATTRIBUTES = frozenset({"_output", "_cancel_event"})
+
 
 class CancelConsole:
     """Console stand-in that exposes ``cancel_requested`` from a shared Event.
 
     Delegates rendering to the gateway pool's Rich console so tool observers and
     subprocess presenters keep working; only cancellation is added.
+
+    Reads *and writes* are proxied. Slash capture turns recording on
+    (``console.record = True``) and then calls ``export_text`` on the same
+    object: if the write stopped at the wrapper, recording would stay off on
+    the wrapped console and every slash command on a chat transport would fail.
     """
 
     def __init__(self, output: Console, cancel_event: threading.Event) -> None:
@@ -35,6 +43,12 @@ class CancelConsole:
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._output, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in _OWN_ATTRIBUTES:
+            super().__setattr__(name, value)
+            return
+        setattr(self._output, name, value)
 
 
 def ensure_turn_cancel(sink: Any) -> threading.Event:

--- a/gateway/core/runtime/concurrency.py
+++ b/gateway/core/runtime/concurrency.py
@@ -1,4 +1,9 @@
-"""Process-wide turn concurrency shared by every Gateway ingress."""
+"""Process-wide turn concurrency shared by every Gateway ingress.
+
+Production chat turns take the gate via :class:`GatewayTurnHandler` (``gate=``).
+:class:`ConcurrencyLimitedTurnHandler` wraps *arbitrary* callbacks (tests,
+scheduler helpers) — it is not a second production turn handler.
+"""
 
 from __future__ import annotations
 
@@ -16,6 +21,19 @@ _PROFILE_LIMITS = {
 }
 
 
+def turn_limit_for_profile(profile: SizeProfile | str | None = None) -> int:
+    """Process-gate / transport-pool default for ``OPENSRE_SIZE_PROFILE``.
+
+    When ``profile`` is omitted, reads the env (default SMALL). Used by
+    :class:`TurnConcurrencyGate` and as the default for per-transport
+    ``max_concurrent_turns`` when the transport-specific env is unset.
+    """
+    import os
+
+    raw = profile if profile is not None else os.getenv("OPENSRE_SIZE_PROFILE", "SMALL")
+    return _PROFILE_LIMITS[SizeProfile(str(raw).strip().upper())]
+
+
 class TurnConcurrencyGate:
     """A non-blocking process-wide capacity gate for agent turns."""
 
@@ -28,7 +46,7 @@ class TurnConcurrencyGate:
     @classmethod
     def for_profile(cls, profile: SizeProfile | str) -> TurnConcurrencyGate:
         """Build the documented concurrency limit for a Fargate size profile."""
-        return cls(_PROFILE_LIMITS[SizeProfile(profile)])
+        return cls(turn_limit_for_profile(profile))
 
     def try_acquire(self) -> bool:
         """Take one slot without waiting, leaving durable excess work queued."""
@@ -46,7 +64,11 @@ class TurnConcurrencyGate:
 
 
 class ConcurrencyLimitedTurnHandler:
-    """Apply a shared capacity gate without changing ``GatewayTurnHandler``."""
+    """Capacity wrapper for arbitrary :data:`GatewayAgentCallback` callables.
+
+    Prefer ``GatewayTurnHandler(gate=…)`` for production chat. Keep this for
+    tests and non-handler callbacks that share the same gate.
+    """
 
     def __init__(
         self,
@@ -79,7 +101,7 @@ def gated_callback(
     handler: GatewayAgentCallback,
     gate: TurnConcurrencyGate,
 ) -> GatewayAgentCallback:
-    """Return the callback form expected by Telegram and Slack wiring."""
+    """Wrap an arbitrary callback with the shared capacity gate."""
     return ConcurrencyLimitedTurnHandler(handler=handler, gate=gate)
 
 
@@ -87,4 +109,5 @@ __all__ = [
     "ConcurrencyLimitedTurnHandler",
     "TurnConcurrencyGate",
     "gated_callback",
+    "turn_limit_for_profile",
 ]

--- a/gateway/core/runtime/concurrency.py
+++ b/gateway/core/runtime/concurrency.py
@@ -1,17 +1,14 @@
 """Process-wide turn concurrency shared by every Gateway ingress.
 
 Production chat turns take the gate via :class:`GatewayTurnHandler` (``gate=``).
-:class:`ConcurrencyLimitedTurnHandler` wraps *arbitrary* callbacks (tests,
-scheduler helpers) — it is not a second production turn handler.
+A callback wrapper for arbitrary handlers lives under ``gateway/tests/`` only —
+see ``gateway/tests/runtime/concurrency_limited_handler.py``.
 """
 
 from __future__ import annotations
 
-import logging
 import threading
 
-from core.agent_harness.session import SessionCore
-from gateway.core.runtime.sink_protocol import GatewayAgentCallback, GatewaySink
 from platform.deployment_contracts.models import SizeProfile
 
 _PROFILE_LIMITS = {
@@ -63,51 +60,7 @@ class TurnConcurrencyGate:
         self._semaphore.release()
 
 
-class ConcurrencyLimitedTurnHandler:
-    """Capacity wrapper for arbitrary :data:`GatewayAgentCallback` callables.
-
-    Prefer ``GatewayTurnHandler(gate=…)`` for production chat. Keep this for
-    tests and non-handler callbacks that share the same gate.
-    """
-
-    def __init__(
-        self,
-        *,
-        handler: GatewayAgentCallback,
-        gate: TurnConcurrencyGate,
-        busy_message: str = "OpenSRE is at capacity. Please try again shortly.",
-    ) -> None:
-        self._handler = handler
-        self._gate = gate
-        self._busy_message = busy_message
-
-    def __call__(
-        self,
-        text: str,
-        session: SessionCore,
-        sink: GatewaySink,
-        logger: logging.Logger,
-    ) -> None:
-        if not self._gate.try_acquire():
-            sink.finalize(self._busy_message)
-            return
-        try:
-            self._handler(text, session, sink, logger)
-        finally:
-            self._gate.release()
-
-
-def gated_callback(
-    handler: GatewayAgentCallback,
-    gate: TurnConcurrencyGate,
-) -> GatewayAgentCallback:
-    """Wrap an arbitrary callback with the shared capacity gate."""
-    return ConcurrencyLimitedTurnHandler(handler=handler, gate=gate)
-
-
 __all__ = [
-    "ConcurrencyLimitedTurnHandler",
     "TurnConcurrencyGate",
-    "gated_callback",
     "turn_limit_for_profile",
 ]

--- a/gateway/core/runtime/daemon.py
+++ b/gateway/core/runtime/daemon.py
@@ -1,10 +1,13 @@
 """Background (daemon) lifecycle for the OpenSRE gateway process.
 
-The CLI and the interactive shell both drive the daemon through these helpers:
-a detached ``python -m surfaces.cli.gateway_entry`` child whose output is captured in
+Supervises a detached child process whose output is captured in
 ``~/.opensre/gateway/gateway.log`` and whose PID is tracked in ``gateway.pid``.
-The running process reports per-component state (web app, Telegram chat, task
+The running process reports per-component state (web app, chat transports, task
 scheduler) through ``components.json``.
+
+The caller supplies the child's ``argv``: each surface owns its own composition
+root, so this module names no entrypoint and stays free of any ``surfaces``
+dependency.
 """
 
 from __future__ import annotations
@@ -14,7 +17,6 @@ import json
 import os
 import signal
 import subprocess
-import sys
 import time
 from collections import deque
 from collections.abc import Sequence
@@ -39,10 +41,11 @@ def gateway_daemon_pid() -> int | None:
     return None
 
 
-def start_gateway_daemon(
-    *, startup_wait: float = 2.0, argv: Sequence[str] | None = None
-) -> tuple[bool, str]:
-    """Spawn the gateway as a detached background process.
+def start_gateway_daemon(*, argv: Sequence[str], startup_wait: float = 2.0) -> tuple[bool, str]:
+    """Spawn ``argv`` as a detached background gateway process.
+
+    ``argv`` is required: the surface starting the gateway owns which
+    composition root runs, so this module never names one.
 
     Returns ``(ok, message)``. Starting an already-running gateway is a no-op
     success; a child that dies during ``startup_wait`` is a failure and the
@@ -54,7 +57,7 @@ def start_gateway_daemon(
     GATEWAY_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     with GATEWAY_LOG_FILE.open("ab") as log:
         process = subprocess.Popen(
-            argv or (sys.executable, "-m", "surfaces.cli.gateway_entry"),
+            argv,
             stdin=subprocess.DEVNULL,
             stdout=log,
             stderr=subprocess.STDOUT,

--- a/gateway/core/runtime/errors.py
+++ b/gateway/core/runtime/errors.py
@@ -7,4 +7,8 @@ class GatewayConfigurationError(RuntimeError):
     """Raised when a gateway transport's configuration is missing or invalid."""
 
 
-__all__ = ["GatewayConfigurationError"]
+class GatewayTransportFailedError(RuntimeError):
+    """Raised when a transport starts but fails readiness or a runtime check."""
+
+
+__all__ = ["GatewayConfigurationError", "GatewayTransportFailedError"]

--- a/gateway/core/runtime/live_sink.py
+++ b/gateway/core/runtime/live_sink.py
@@ -7,7 +7,8 @@ Transport sinks are per-turn, so this holder stays on the agent and
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import threading
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from gateway.core.runtime.sink_protocol import GatewaySink
@@ -61,10 +62,18 @@ class LiveOutputSink:
     ) -> str:
         return self._require().stream(
             label=label,
-            chunks=chunks,
+            chunks=self._stop_chunks_on_cancel(chunks),
             suppress_if_starts_with=suppress_if_starts_with,
             defer_want_me_to_closer=defer_want_me_to_closer,
         )
+
+    def _stop_chunks_on_cancel(self, chunks: Iterable[str]) -> Iterator[str]:
+        """Stop draining the LLM stream when the host soft-timeout Event fires."""
+        cancel = getattr(self._inner, "turn_cancel", None) if self._inner is not None else None
+        for chunk in chunks:
+            if isinstance(cancel, threading.Event) and cancel.is_set():
+                return
+            yield chunk
 
     def finalize(self, text: str) -> None:
         self._require().finalize(text)

--- a/gateway/core/runtime/manager.py
+++ b/gateway/core/runtime/manager.py
@@ -39,6 +39,7 @@ from gateway.core.runtime.daemon import (
 )
 from gateway.core.runtime.errors import GatewayConfigurationError
 from gateway.core.runtime.readiness import set_ready
+from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.runtime.turn_handler import GatewayTurnHandler
 
 # The reload watcher only polls a flag, so it should never need the full
@@ -254,9 +255,7 @@ def start_gateway(
     """
     if slash_ports_factory is None:
         raise SystemExit(_BARE_MANAGER_EXIT)
-    return GatewayManager(slash_ports_factory=slash_ports_factory).start_gateway(
-        wait=wait
-    )
+    return GatewayManager(slash_ports_factory=slash_ports_factory).start_gateway(wait=wait)
 
 
 def main() -> None:

--- a/gateway/core/runtime/manager.py
+++ b/gateway/core/runtime/manager.py
@@ -3,12 +3,15 @@
 ``GatewayManager`` is the composition root for the OpenSRE background agent:
 logging + credential hydrate, then
 :func:`bootstrap.process.configure_process` (``GATEWAY_PROFILE``), then
-assemble the turn handler and start daemon components — web, Telegram / Slack /
-Discord (when configured), and the scheduled-task runner. Owns signals and
-``stop``/``wait``. Component states go through
-:func:`gateway.core.runtime.daemon.write_component_status`. Transport and turn
-dispatch live in :mod:`gateway.core.runtime.turn_handler` and the transport
-wiring packages — not here.
+assemble the turn handler and start components —
+
+* :meth:`start_channels` — web + chat transports via :mod:`gateway.channels`
+* :meth:`start_scheduler` — peer of the consumer surfaces (cron / loops)
+
+Owns signals and ``stop``/``wait``. Component states go through
+:func:`gateway.core.runtime.daemon.write_component_status`. Channel start/stop
+lives in :mod:`gateway.channels`; turn dispatch lives in
+:mod:`gateway.core.runtime.turn_handler` — not here.
 """
 
 from __future__ import annotations
@@ -22,11 +25,9 @@ from typing import Any
 
 from rich.console import Console
 
+from gateway import channels as gateway_channels
 from gateway.core.config.logging_config import configure_logging
-from gateway.core.runtime.concurrency import (
-    ConcurrencyLimitedTurnHandler,
-    TurnConcurrencyGate,
-)
+from gateway.core.runtime.concurrency import TurnConcurrencyGate
 from gateway.core.runtime.credential_hydration import (
     GatewayBootstrap,
     GatewayCredentialHydrator,
@@ -39,13 +40,10 @@ from gateway.core.runtime.daemon import (
 from gateway.core.runtime.errors import GatewayConfigurationError
 from gateway.core.runtime.readiness import set_ready
 from gateway.core.runtime.turn_handler import GatewayTurnHandler
-from gateway.transports.discord.background import DiscordGatewayBackground
-from gateway.transports.discord.wiring import start_discord_worker
-from gateway.transports.slack.socket_mode_worker import SlackGatewayBackground
-from gateway.transports.slack.wiring import start_slack_worker
-from gateway.transports.telegram.background import TelegramGatewayBackground
-from gateway.transports.telegram.settings import GatewaySettings
-from gateway.transports.telegram.wiring import start_telegram_worker
+
+# The reload watcher only polls a flag, so it should never need the full
+# shutdown budget; cap it so chat workers keep the rest.
+SCHEDULER_RELOAD_JOIN_TIMEOUT_SECONDS = 2.0
 
 SlashPortsFactory = Callable[[], Any]
 CredentialHydratorFactory = Callable[[], GatewayCredentialHydrator | None]
@@ -61,12 +59,8 @@ class GatewayManager:
         credential_hydrator_factory: CredentialHydratorFactory | None = None,
         turn_gate: TurnConcurrencyGate | None = None,
     ) -> None:
-        self.settings: GatewaySettings | None = None
         self.logger: logging.Logger | None = None
-        self.telegram_background_worker: TelegramGatewayBackground | None = None
-        self.slack_background_worker: SlackGatewayBackground | None = None
-        self.discord_background_worker: DiscordGatewayBackground | None = None
-        self.web_server: Any = None
+        self.channels: gateway_channels.ChannelsHandle | None = None
         self.scheduler: Any = None
         self._scheduler_reload_thread: threading.Thread | None = None
         self.components: dict[str, str] = {}
@@ -79,7 +73,7 @@ class GatewayManager:
         self._stopped = threading.Event()
 
     def start_gateway(self, *, wait: bool = True) -> GatewayManager:
-        """Credential hydrate, shared process boot, then start daemon components."""
+        """Credential hydrate, shared process boot, then channels + scheduler."""
         from bootstrap.process import GATEWAY_PROFILE, configure_process
 
         logger = self.logger = configure_logging()
@@ -87,23 +81,18 @@ class GatewayManager:
         self._load_credentials(logger)
         configure_process(GATEWAY_PROFILE, logger=logger)
 
-        # Compose the transport-agnostic turn handler. Action tools are resolved
-        # per turn from each chat's live session inside the handler (not here).
+        # One turn handler for every chat transport. Capacity gate lives on the
+        # same object — do not wrap it in a second "turn handler". Action tools
+        # resolve per turn from each chat's live session inside the handler.
         console = Console(force_terminal=False)
         handler = GatewayTurnHandler(
             console=console,
             slash_ports_factory=self._slash_ports_factory,
-        )
-        chat_handler = ConcurrencyLimitedTurnHandler(
-            handler=handler,
             gate=self.turn_gate,
         )
 
-        self._start_web(logger)
-        self._start_telegram(logger, chat_handler)
-        self._start_slack(logger, chat_handler)
-        self._start_discord(logger, chat_handler)
-        self._start_scheduler(logger)
+        self.start_channels(logger=logger, handler=handler)
+        self.start_scheduler(logger=logger)
         self._publish_status(logger)
         # Deploy health waits (EC2 Docker + AMI) match this line for Telegram
         # and/or Slack — do not rely on transport-specific log strings alone.
@@ -117,26 +106,54 @@ class GatewayManager:
             self.wait()
         return self
 
-    def stop(self, *, timeout: float = 8.0) -> bool:
-        """Shut down all components and return whether the chat worker stopped."""
+    def start_channels(
+        self,
+        *,
+        logger: logging.Logger,
+        handler: GatewayAgentCallback,
+    ) -> None:
+        """Start web + every chat transport together (via :mod:`gateway.channels`)."""
+        self.channels = gateway_channels.start_channels(logger=logger, handler=handler)
+        self.components.update(self.channels.statuses)
+
+    def start_scheduler(self, *, logger: logging.Logger) -> None:
+        """Host the platform scheduler as a peer of the consumer channels."""
+        from bootstrap.adapters import install_scheduler_runners
+        from platform.scheduler.reload_signal import consume_scheduler_reload_request
+        from platform.scheduler.runner import start_background_scheduler
+
+        # Investigation + multiplexed scheduled-agent runners (Sentry digest, etc.).
+        # Adapters already registered at process boot; runners attach with the scheduler.
+        install_scheduler_runners()
+        from gateway.core.runtime.scheduler_concurrency import gate_registered_scheduler_runners
+
+        gate_registered_scheduler_runners(self.turn_gate)
+        # Drop any reload request queued before this process owned the scheduler.
+        consume_scheduler_reload_request()
+        scheduler, task_count = start_background_scheduler()
+        if scheduler is None:
+            self.components["scheduler"] = "idle (no scheduled tasks)"
+        else:
+            self.scheduler = scheduler
+            self.components["scheduler"] = f"running {task_count} scheduled task(s)"
+        self._start_scheduler_reload_watcher(logger)
+
+    def stop(self, *, timeout: float = gateway_channels.DEFAULT_STOP_TIMEOUT_SECONDS) -> bool:
+        """Shut down all components and return whether the chat workers stopped."""
         set_ready(False)
         self._stopped.set()
         stopped = True
         if self._scheduler_reload_thread is not None:
-            self._scheduler_reload_thread.join(timeout=min(timeout, 2.0))
+            self._scheduler_reload_thread.join(
+                timeout=min(timeout, SCHEDULER_RELOAD_JOIN_TIMEOUT_SECONDS)
+            )
             self._scheduler_reload_thread = None
         if self.scheduler is not None:
             self.scheduler.shutdown(wait=False)
             self.scheduler = None
-        if self.web_server is not None:
-            self.web_server.stop()
-            self.web_server = None
-        if self.telegram_background_worker is not None:
-            stopped = self.telegram_background_worker.stop(timeout=timeout) and stopped
-        if self.slack_background_worker is not None:
-            stopped = self.slack_background_worker.stop(timeout=timeout) and stopped
-        if self.discord_background_worker is not None:
-            stopped = self.discord_background_worker.stop(timeout=timeout) and stopped
+        if self.channels is not None:
+            stopped = self.channels.stop(timeout=timeout) and stopped
+            self.channels = None
         clear_component_status()
         return stopped
 
@@ -160,87 +177,6 @@ class GatewayManager:
     def wait(self, *, timeout: float | None = None) -> bool:
         """Wait until shutdown is requested and return whether the gateway has stopped."""
         return self._stopped.wait(timeout)
-
-    def _start_web(self, logger: logging.Logger) -> None:
-        """Serve the shared web app (health probes + alert intake) in a daemon thread."""
-        from core.domain.alerts.inbox import AlertInbox, set_current_inbox
-        from gateway.web.web_server import serve_webapp_in_thread
-
-        set_current_inbox(AlertInbox())
-        port = int(os.environ.get("PORT", "8000"))
-        try:
-            handle = serve_webapp_in_thread(host="0.0.0.0", port=port)
-        except RuntimeError as exc:
-            logger.warning("web app disabled: %s", exc)
-            self.components["web"] = f"failed ({exc})"
-            return
-        self.web_server = handle
-        self.components["web"] = f"serving http://{handle.bound_address} (health, alerts)"
-        logger.info("web app serving on http://%s", handle.bound_address)
-
-    def _start_telegram(self, logger: logging.Logger, handler: Any) -> None:
-        """Start the Telegram chat worker; run without it when not configured."""
-        try:
-            worker, settings = start_telegram_worker(logger=logger, handler=handler)
-        except GatewayConfigurationError as exc:
-            logger.warning("Telegram chat disabled: %s", exc)
-            self.components["telegram"] = f"not configured ({exc})"
-            return
-        self.settings = settings
-        self.telegram_background_worker = worker
-        self.components["telegram"] = "polling for messages"
-
-    def _start_slack(self, logger: logging.Logger, handler: Any) -> None:
-        """Start the Slack chat worker; run without it when not configured."""
-        try:
-            worker, _settings = start_slack_worker(logger=logger, handler=handler)
-        except GatewayConfigurationError as exc:
-            logger.warning("Slack chat disabled: %s", exc)
-            self.components["slack"] = f"not configured ({exc})"
-            return
-        self.slack_background_worker = worker
-        self.components["slack"] = "connected via socket mode"
-
-    def _start_discord(self, logger: logging.Logger, handler: Any) -> None:
-        """Start the Discord chat worker; run without it when not configured."""
-        try:
-            worker, settings = start_discord_worker(logger=logger, handler=handler)
-        except GatewayConfigurationError as exc:
-            logger.warning("Discord chat disabled: %s", exc)
-            self.components["discord"] = f"not configured ({exc})"
-            return
-        if not worker.wait_until_ready(timeout=settings.startup_timeout_seconds):
-            logger.warning(
-                "Discord gateway did not become ready within %.0fs",
-                settings.startup_timeout_seconds,
-            )
-            worker.stop()
-            self.components["discord"] = "failed (startup timeout)"
-            return
-        self.discord_background_worker = worker
-        self.components["discord"] = "connected via gateway"
-
-    def _start_scheduler(self, _logger: logging.Logger) -> None:
-        """Run cron-scheduled tasks inside the daemon (no separate process needed)."""
-        from bootstrap.adapters import install_scheduler_runners
-        from platform.scheduler.reload_signal import consume_scheduler_reload_request
-        from platform.scheduler.runner import start_background_scheduler
-
-        # Investigation + multiplexed scheduled-agent runners (Sentry digest, etc.).
-        # Adapters already registered at process boot; runners attach with the scheduler.
-        install_scheduler_runners()
-        from gateway.core.runtime.scheduler_concurrency import gate_registered_scheduler_runners
-
-        gate_registered_scheduler_runners(self.turn_gate)
-        # Drop any reload request queued before this process owned the scheduler.
-        consume_scheduler_reload_request()
-        scheduler, task_count = start_background_scheduler()
-        if scheduler is None:
-            self.components["scheduler"] = "idle (no scheduled tasks)"
-        else:
-            self.scheduler = scheduler
-            self.components["scheduler"] = f"running {task_count} scheduled task(s)"
-        self._start_scheduler_reload_watcher(_logger)
 
     def _start_scheduler_reload_watcher(self, logger: logging.Logger) -> None:
         """Poll for cross-process reload requests from `/loops` and cron mutations."""
@@ -296,18 +232,36 @@ class GatewayManager:
         self.stop()
 
 
-def start_gateway(*, wait: bool = True) -> GatewayManager:
-    """Compatibility wrapper for existing CLI/import callers.
+_BARE_MANAGER_EXIT = (
+    "GatewayManager requires slash_ports_factory for production chat.\n"
+    "Start with: opensre gateway start\n"
+    "        or: opensre gateway start --foreground\n"
+    "Unit tests may construct GatewayManager(...) directly.\n"
+)
 
-    Production boot with slash ports goes through
-    :mod:`surfaces.cli.gateway_entry` (surfaces may import gateway; the reverse
-    is forbidden).
+
+def start_gateway(
+    *,
+    wait: bool = True,
+    slash_ports_factory: SlashPortsFactory | None = None,
+) -> GatewayManager:
+    """Compatibility wrapper — requires ``slash_ports_factory`` (fail closed).
+
+    Production boot goes through the CLI composition root
+    (``opensre gateway start``), which injects headless slash ports. The
+    gateway package must not import the surfaces layer, so bare
+    ``GatewayManager()`` here cannot wire them.
     """
-    return GatewayManager().start_gateway(wait=wait)
+    if slash_ports_factory is None:
+        raise SystemExit(_BARE_MANAGER_EXIT)
+    return GatewayManager(slash_ports_factory=slash_ports_factory).start_gateway(
+        wait=wait
+    )
 
 
 def main() -> None:
-    GatewayManager().start_gateway()
+    """Refuse bare manager main — same policy as :mod:`gateway.main`."""
+    raise SystemExit(_BARE_MANAGER_EXIT)
 
 
 if __name__ == "__main__":

--- a/gateway/core/runtime/turn_handler.py
+++ b/gateway/core/runtime/turn_handler.py
@@ -1,5 +1,10 @@
 """Dispatch one inbound gateway message through the shared headless agent.
 
+This is the **only** gateway turn handler. Transport dispatchers
+(Slack/Discord/Telegram) are ingress adapters: they authorize, resolve a
+session, build a sink, then call this callback. Process-wide capacity is an
+optional gate on the same object — not a second handler.
+
 Transport-agnostic: takes ``(text, session, sink, logger)``, runs the turn, and
 finalizes outbound text on the sink. Agent reuse is handled by
 :class:`SessionAgentPool`.
@@ -17,6 +22,7 @@ from rich.console import Console
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.harness import AgentSession, SessionConfig
 from core.agent_harness.session import SessionCore
+from gateway.core.runtime.concurrency import TurnConcurrencyGate
 from gateway.core.runtime.session_agents import SessionAgentPool
 from gateway.core.runtime.sink_protocol import GatewaySink
 from gateway.core.runtime.status_messages import EMPTY_RESPONSE_MESSAGE
@@ -40,6 +46,8 @@ _UNSUPPORTED_GATEWAY_CAPABILITIES = (
     "task_cancel",
 )
 
+_DEFAULT_BUSY_MESSAGE = "OpenSRE is at capacity. Please try again shortly."
+
 
 class GatewayTurnHandler:
     """Services one inbound gateway message per call (a :data:`GatewayAgentCallback`).
@@ -48,6 +56,9 @@ class GatewayTurnHandler:
     turns; per-turn sinks, accounting, and tool hooks are rebound via
     :meth:`HeadlessAgent.bind_turn`. Concurrent turns for different sessions
     stay isolated. Chat goes through :meth:`AgentSession.chat`.
+
+    When ``gate`` is set, capacity is checked here before the turn runs — the
+    manager must not wrap this class in a second "turn handler".
     """
 
     def __init__(
@@ -55,6 +66,8 @@ class GatewayTurnHandler:
         *,
         console: Console,
         slash_ports_factory: SlashPortsFactory | None = None,
+        gate: TurnConcurrencyGate | None = None,
+        busy_message: str = _DEFAULT_BUSY_MESSAGE,
     ) -> None:
         self._pool = SessionAgentPool(
             console=console,
@@ -62,8 +75,26 @@ class GatewayTurnHandler:
         )
         # Gateway already bootstrapped env at process start; turns must not reload.
         self._session_api = AgentSession(SessionConfig(load_env=False))
+        self._gate = gate
+        self._busy_message = busy_message
 
     def __call__(
+        self,
+        text: str,
+        session: SessionCore,
+        sink: GatewaySink,
+        logger: logging.Logger,
+    ) -> None:
+        if self._gate is not None and not self._gate.try_acquire():
+            sink.finalize(self._busy_message)
+            return
+        try:
+            self._run_turn(text, session, sink, logger)
+        finally:
+            if self._gate is not None:
+                self._gate.release()
+
+    def _run_turn(
         self,
         text: str,
         session: SessionCore,

--- a/gateway/core/storage/session/binding_store.py
+++ b/gateway/core/storage/session/binding_store.py
@@ -45,6 +45,21 @@ class BindingStore(Protocol):
     ) -> None:
         """Bind the chat to the provided session id."""
 
+    def adopt_unscoped_binding(
+        self,
+        *,
+        platform: str,
+        chat_id: str,
+        principal: Principal,
+        actor: Actor | str,
+    ) -> str | None:
+        """Move a legacy empty-id row onto ``principal``/``actor`` once.
+
+        Atomic and single-use: the unscoped row is removed so a second actor in
+        the same conversation cannot inherit the same session. Idempotent when
+        the scoped binding already exists.
+        """
+
     def rotate(
         self,
         *,

--- a/gateway/core/storage/session/file_bindings.py
+++ b/gateway/core/storage/session/file_bindings.py
@@ -218,6 +218,48 @@ class FileBindingStore:
             )
             self._write(path, {"version": _VERSION, "bindings": rows})
 
+    def adopt_unscoped_binding(
+        self,
+        *,
+        platform: str,
+        chat_id: str,
+        principal: Principal,
+        actor: Actor | str,
+    ) -> str | None:
+        """Move a legacy empty-id row onto ``principal``/``actor`` under one lock."""
+        scoped = BindingKey.build(
+            platform=platform, chat_id=chat_id, principal=principal, actor=actor
+        )
+        legacy = BindingKey.build(platform=platform, chat_id=chat_id, principal=None, actor=None)
+        path = self.path
+        with self._locked(path):
+            data = self._load(path)
+            rows = [r for r in data.get("bindings", []) if isinstance(r, dict)]
+            for row in rows:
+                if self._matches(row, scoped):
+                    return str(row.get("session_id", "")) or None
+            session_id: str | None = None
+            kept: list[dict[str, Any]] = []
+            for row in rows:
+                if self._matches(row, legacy):
+                    session_id = str(row.get("session_id", "")) or None
+                    continue
+                kept.append(row)
+            if not session_id:
+                return None
+            kept.append(
+                {
+                    "platform": scoped.platform,
+                    "chat_id": scoped.chat_id,
+                    "principal_id": scoped.principal_id,
+                    "actor_id": scoped.actor_id,
+                    "session_id": session_id,
+                    "updated_at": time.time(),
+                }
+            )
+            self._write(path, {"version": _VERSION, "bindings": kept})
+            return session_id
+
     def rotate(
         self,
         *,

--- a/gateway/core/storage/session/records.py
+++ b/gateway/core/storage/session/records.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 
 from config.principal import Actor, Principal
 
-# The id a turn gets when it names no organization or no member: Telegram, the
-# local CLI, and every row written before scoping existed. Empty string rather
-# than None so it is a real key a lookup can match, and so a pre-scoping row
-# adopted from the old index still resolves for the surface that wrote it.
+# The id a turn gets when it names no organization or no member: the local CLI,
+# and every row written before scoping existed. Empty string rather than None so
+# it is a real key a lookup can match, and so a pre-scoping row adopted from the
+# old index still resolves for the surface that wrote it.
 #
 # It is deliberately not a valid organization or Slack user id, so an unscoped
 # lookup can never collide with a real one.

--- a/gateway/core/storage/session/resolver.py
+++ b/gateway/core/storage/session/resolver.py
@@ -68,7 +68,11 @@ class SessionResolver:
         principal: Principal | None,
         actor: Actor | str | None,
     ) -> str | None:
-        """Scoped binding, or adopt a same-document legacy empty-id row once."""
+        """Scoped binding, or adopt a same-document legacy empty-id row once.
+
+        Adoption is single-use (legacy row removed) so a second actor in the
+        same conversation cannot inherit the same persisted session.
+        """
         existing = self._bindings.get_session_id(
             platform=self._platform,
             chat_id=user_id,
@@ -77,30 +81,22 @@ class SessionResolver:
         )
         if existing:
             return existing
-        if principal is None and actor is None:
+        if principal is None or actor is None:
             return None
-        legacy = self._bindings.get_session_id(
+        legacy = self._bindings.adopt_unscoped_binding(
             platform=self._platform,
             chat_id=user_id,
-            principal=None,
-            actor=None,
-        )
-        if not legacy:
-            return None
-        self._bindings.bind(
-            platform=self._platform,
-            chat_id=user_id,
-            session_id=legacy,
             principal=principal,
             actor=actor,
         )
-        logger.info(
-            "[gateway] adopted legacy %s binding conversation=%s → principal=%s actor=%s",
-            self._platform,
-            user_id,
-            principal.id if principal is not None else "",
-            actor.id if actor is not None and hasattr(actor, "id") else (actor or ""),
-        )
+        if legacy:
+            logger.info(
+                "[gateway] adopted legacy %s binding conversation=%s → principal=%s actor=%s",
+                self._platform,
+                user_id,
+                principal.id,
+                actor.id if hasattr(actor, "id") else actor,
+            )
         return legacy
 
     def resolve(

--- a/gateway/core/storage/session/resolver.py
+++ b/gateway/core/storage/session/resolver.py
@@ -61,6 +61,48 @@ class SessionResolver:
         self._manager = manager or SessionManager()
         self._platform = platform
 
+    def _lookup_or_adopt_session_id(
+        self,
+        *,
+        user_id: str,
+        principal: Principal | None,
+        actor: Actor | str | None,
+    ) -> str | None:
+        """Scoped binding, or adopt a same-document legacy empty-id row once."""
+        existing = self._bindings.get_session_id(
+            platform=self._platform,
+            chat_id=user_id,
+            principal=principal,
+            actor=actor,
+        )
+        if existing:
+            return existing
+        if principal is None and actor is None:
+            return None
+        legacy = self._bindings.get_session_id(
+            platform=self._platform,
+            chat_id=user_id,
+            principal=None,
+            actor=None,
+        )
+        if not legacy:
+            return None
+        self._bindings.bind(
+            platform=self._platform,
+            chat_id=user_id,
+            session_id=legacy,
+            principal=principal,
+            actor=actor,
+        )
+        logger.info(
+            "[gateway] adopted legacy %s binding conversation=%s → principal=%s actor=%s",
+            self._platform,
+            user_id,
+            principal.id if principal is not None else "",
+            actor.id if actor is not None and hasattr(actor, "id") else (actor or ""),
+        )
+        return legacy
+
     def resolve(
         self,
         *,
@@ -71,13 +113,11 @@ class SessionResolver:
     ) -> SessionCore:
         """Return a hydrated session for the platform conversation key ``user_id``.
 
-        Slack team turns pass an org ``principal`` and Slack ``actor``. Other
-        surfaces omit them and keep main-branch binding behavior (legacy empty
-        principal/actor ids).
+        Chat transports pass an org ``principal`` and platform ``actor``. Omitting
+        them keeps legacy empty principal/actor binding keys (CLI / pre-scope rows).
         """
-        existing = self._bindings.get_session_id(
-            platform=self._platform,
-            chat_id=user_id,
+        existing = self._lookup_or_adopt_session_id(
+            user_id=user_id,
             principal=principal,
             actor=actor,
         )
@@ -125,9 +165,8 @@ class SessionResolver:
         """Flush the current session file and start a new binding."""
         from core.domain.memory import gateway_memory_enabled
 
-        existing = self._bindings.get_session_id(
-            platform=self._platform,
-            chat_id=user_id,
+        existing = self._lookup_or_adopt_session_id(
+            user_id=user_id,
             principal=principal,
             actor=actor,
         )

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,14 +1,25 @@
-"""Process entry for the OpenSRE messaging gateway.
+"""Package entry for the OpenSRE messaging gateway.
 
-Prefer ``python -m surfaces.cli.gateway_entry`` (what the daemon spawns): that
-composition root wires headless slash ports. This module keeps
-``python -m gateway.main`` working for callers that only need the manager
-boot path without the surfaces glue.
+This module is intentionally **not** a production composition root: slash-command
+ports are wired by the CLI composition root outside this package. Starting here
+would boot chat without ``slash_invoke``.
+
+Production: ``opensre gateway start`` / ``opensre gateway start --foreground``.
 """
 
 from __future__ import annotations
 
-from gateway.core.runtime.manager import main
+_BARE_MAIN_EXIT = (
+    "python -m gateway.main has no slash-port glue and is not a production entry.\n"
+    "Start the gateway with: opensre gateway start\n"
+    "                  or: opensre gateway start --foreground\n"
+)
+
+
+def main() -> None:
+    """Refuse bare package main — production must use the CLI composition root."""
+    raise SystemExit(_BARE_MAIN_EXIT)
+
 
 __all__ = ["main"]
 

--- a/gateway/tests/discord/test_output_sink.py
+++ b/gateway/tests/discord/test_output_sink.py
@@ -1,0 +1,126 @@
+"""Discord output sink — redaction and finalize characterization."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.transports.discord.output_sink import DiscordOutputSink
+
+
+@pytest.fixture
+def _patch_discord_client(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub Discord HTTP helpers so sink construction does not leave the process."""
+    state: dict[str, Any] = {"edits": [], "posts": []}
+
+    def _send_message(*, channel_id: str, content: str, bot_token: str) -> str:
+        _ = (channel_id, bot_token)
+        state["posts"].append(content)
+        return "msg-1"
+
+    def _edit_message(
+        *,
+        channel_id: str,
+        message_id: str,
+        content: str,
+        bot_token: str,
+    ) -> bool:
+        _ = (channel_id, message_id, bot_token)
+        state["edits"].append(content)
+        return True
+
+    def _edit_with_components(
+        *,
+        channel_id: str,
+        message_id: str,
+        content: str,
+        components: Any,
+        bot_token: str,
+    ) -> bool:
+        _ = (channel_id, message_id, components, bot_token)
+        state["edits"].append(content)
+        return True
+
+    def _send_with_components(
+        *,
+        channel_id: str,
+        content: str,
+        components: Any,
+        bot_token: str,
+    ) -> str:
+        _ = (channel_id, components, bot_token)
+        state["posts"].append(content)
+        return "msg-extra"
+
+    monkeypatch.setattr(
+        "gateway.transports.discord.output_sink.send_message",
+        _send_message,
+    )
+    monkeypatch.setattr(
+        "gateway.transports.discord.output_sink.edit_message",
+        _edit_message,
+    )
+    monkeypatch.setattr(
+        "gateway.transports.discord.output_sink.edit_message_with_components",
+        _edit_with_components,
+    )
+    monkeypatch.setattr(
+        "gateway.transports.discord.output_sink.send_message_with_components",
+        _send_with_components,
+    )
+    monkeypatch.setattr(
+        "gateway.transports.discord.output_sink.feedback_components",
+        lambda: [],
+    )
+    return state
+
+
+def test_render_error_hides_raw_detail_behind_generic_copy(
+    _patch_discord_client: dict[str, Any],
+) -> None:
+    # Arrange
+    sink = DiscordOutputSink(
+        bot_token="tok",
+        channel_id="chan-1",
+        edit_interval_seconds=0.0,
+    )
+
+    # Act: hand render_error a raw exception string with sensitive detail.
+    sink.render_error("RuntimeError: token sk-DO-NOT-LEAK rejected by db-host:5432")
+
+    # Assert: the channel shows generic copy, none of the raw detail.
+    finalized = _patch_discord_client["edits"][-1]
+    assert finalized == "Something went wrong handling that request. Please try again."
+    assert "sk-DO-NOT-LEAK" not in finalized
+    assert "db-host" not in finalized
+
+
+def test_render_error_keeps_credit_exhaustion_guidance(
+    _patch_discord_client: dict[str, Any],
+) -> None:
+    from core.llm.shared.llm_retry import CREDIT_EXHAUSTED_MARKER
+
+    sink = DiscordOutputSink(
+        bot_token="tok",
+        channel_id="chan-1",
+        edit_interval_seconds=0.0,
+    )
+    sink.render_error(f"Anthropic {CREDIT_EXHAUSTED_MARKER}. Original error: 400")
+    finalized = _patch_discord_client["edits"][-1]
+    assert "opensre auth login" in finalized
+    assert "400" not in finalized
+
+
+def test_sink_accepts_tool_hooks_attribute(
+    _patch_discord_client: dict[str, Any],
+) -> None:
+    hooks = MagicMock(name="approval_hooks")
+    sink = DiscordOutputSink(
+        bot_token="tok",
+        channel_id="chan-1",
+        edit_interval_seconds=0.0,
+        tool_hooks=hooks,
+    )
+    assert sink.tool_hooks is hooks

--- a/gateway/tests/discord/test_output_sink_redaction.py
+++ b/gateway/tests/discord/test_output_sink_redaction.py
@@ -1,0 +1,31 @@
+"""Discord sink must not leak exception detail to users (Wave D3)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gateway.transports.discord.output_sink import DiscordOutputSink
+
+
+def test_render_error_hides_raw_detail_behind_generic_copy() -> None:
+    with (
+        patch(
+            "gateway.transports.discord.output_sink.send_message",
+            return_value="msg-1",
+        ),
+        patch(
+            "gateway.transports.discord.output_sink.edit_message_with_components"
+        ) as edit_components,
+    ):
+        sink = DiscordOutputSink(
+            bot_token="tok",
+            channel_id="ch-1",
+            edit_interval_seconds=0.0,
+        )
+        sink.render_error("RuntimeError: token sk-DO-NOT-LEAK rejected by db-host:5432")
+
+    assert edit_components.call_count == 1
+    finalized = edit_components.call_args.kwargs["content"]
+    assert "sk-DO-NOT-LEAK" not in finalized
+    assert "db-host" not in finalized
+    assert "Something went wrong" in finalized

--- a/gateway/tests/discord/test_startup_readiness.py
+++ b/gateway/tests/discord/test_startup_readiness.py
@@ -1,0 +1,66 @@
+"""Discord startup owns the readiness wait before returning a live worker."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.core.runtime.errors import GatewayTransportFailedError
+from gateway.transports.discord import startup
+from gateway.transports.discord.settings import DiscordGatewaySettings
+
+
+def _settings() -> DiscordGatewaySettings:
+    return DiscordGatewaySettings(
+        bot_token="discord-test-token",
+        allowed_user_ids=["u1"],
+        startup_timeout_seconds=0.1,
+    )
+
+
+def test_start_discord_worker_waits_until_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    worker = MagicMock()
+    worker.wait_until_ready.return_value = True
+    settings = _settings()
+
+    monkeypatch.setattr(startup, "load_discord_gateway_settings", lambda: settings)
+    monkeypatch.setattr(
+        startup,
+        "start_discord_gateway_background",
+        lambda **_kwargs: worker,
+    )
+
+    started, resolved = startup.start_discord_worker(
+        logger=logging.getLogger("test.discord.startup"),
+        handler=MagicMock(),
+    )
+
+    assert started is worker
+    assert resolved is settings
+    worker.wait_until_ready.assert_called_once_with(timeout=0.1)
+    worker.stop.assert_not_called()
+
+
+def test_start_discord_worker_fails_closed_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = MagicMock()
+    worker.wait_until_ready.return_value = False
+    settings = _settings()
+
+    monkeypatch.setattr(startup, "load_discord_gateway_settings", lambda: settings)
+    monkeypatch.setattr(
+        startup,
+        "start_discord_gateway_background",
+        lambda **_kwargs: worker,
+    )
+
+    with pytest.raises(GatewayTransportFailedError, match="startup timeout"):
+        startup.start_discord_worker(
+            logger=logging.getLogger("test.discord.startup"),
+            handler=MagicMock(),
+        )
+
+    worker.stop.assert_called_once()

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -26,23 +26,40 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from gateway.channels import TransportName
+from gateway.core.runtime.errors import GatewayConfigurationError
 from gateway.core.runtime.manager import GatewayManager, start_gateway
 from gateway.transports.telegram.inbound_handler import (
     handle_polled_inbound_telegram_message,
 )
 from gateway.transports.telegram.inbound_security import InboundDecision
 from gateway.transports.telegram.settings import (
-    GatewayConfigurationError,
     GatewaySettings,
     TelegramInboundMessage,
 )
+from gateway.web.startup import WebStartup
 
 
 def _patch_non_telegram_components(monkeypatch) -> None:
     """Keep lifecycle tests focused on the Telegram worker: skip web/scheduler/pidfile."""
-    monkeypatch.setattr(GatewayManager, "_start_web", lambda *_args: None)
-    monkeypatch.setattr(GatewayManager, "_start_scheduler", lambda *_args: None)
+    monkeypatch.setattr(
+        "gateway.channels.compose.start_web_server",
+        lambda **_kwargs: WebStartup(server=None, status="skipped in lifecycle test"),
+    )
+    monkeypatch.setattr(GatewayManager, "start_scheduler", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(GatewayManager, "_publish_status", lambda *_args: None)
+
+    def _skip_transport(**_kwargs: Any) -> None:
+        raise GatewayConfigurationError("skipped in lifecycle test")
+
+    monkeypatch.setattr(
+        "gateway.channels.chat.start_slack_worker",
+        _skip_transport,
+    )
+    monkeypatch.setattr(
+        "gateway.channels.chat.start_discord_worker",
+        _skip_transport,
+    )
 
 
 def _patch_process_boot(monkeypatch) -> None:
@@ -79,7 +96,7 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
     monkeypatch.setattr("gateway.core.runtime.manager.configure_logging", lambda: logger)
     _patch_non_telegram_components(monkeypatch)
     monkeypatch.setattr(
-        "gateway.transports.telegram.wiring.load_gateway_settings", lambda: settings
+        "gateway.transports.telegram.startup.load_gateway_settings", lambda: settings
     )
     monkeypatch.setattr(
         "gateway.core.runtime.manager.signal.signal",
@@ -96,16 +113,18 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
         return handle
 
     monkeypatch.setattr(
-        "gateway.transports.telegram.wiring.start_telegram_gateway_background",
+        "gateway.transports.telegram.startup.start_telegram_gateway_background",
         _start_telegram_gateway_background,
     )
 
     gateway = GatewayManager().start_gateway(wait=False)
 
     assert isinstance(gateway, GatewayManager)
-    assert gateway.settings is settings
     assert gateway.logger is logger
-    assert gateway.telegram_background_worker is handle
+    assert gateway.channels is not None
+    telegram = gateway.channels.transports.get(TransportName.TELEGRAM)
+    assert telegram is not None
+    assert telegram.worker is handle
     assert background_kwargs["settings"] is settings
     assert background_kwargs["logger"] is logger
     assert background_kwargs["handle_callback_to_gateway_agent"] is not None
@@ -184,21 +203,24 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
         def __init__(self, session: SessionCore) -> None:
             self._session = session
 
-        def resolve(self, *, user_id: str, chat_id: str) -> SessionCore:
+        def resolve(self, *, user_id: str, chat_id: str, **kwargs: object) -> SessionCore:
+            assert user_id == "user-1"
+            assert chat_id == "chat-1"
+            assert kwargs.get("principal") is not None
+            assert kwargs.get("actor") is not None
+            return self._session
+
+        def rotate(self, *, user_id: str, chat_id: str, **kwargs: object) -> SessionCore:
             assert user_id == "user-1"
             assert chat_id == "chat-1"
             return self._session
 
-        def rotate(self, *, user_id: str, chat_id: str) -> SessionCore:
-            assert user_id == "user-1"
-            assert chat_id == "chat-1"
-            return self._session
-
+    monkeypatch.setenv("ORGANIZATION_ID", "org_lifecycle_e2e")
     _patch_process_boot(monkeypatch)
     monkeypatch.setattr("gateway.core.runtime.manager.configure_logging", lambda: logger)
     _patch_non_telegram_components(monkeypatch)
     monkeypatch.setattr(
-        "gateway.transports.telegram.wiring.load_gateway_settings", lambda: settings
+        "gateway.transports.telegram.startup.load_gateway_settings", lambda: settings
     )
     monkeypatch.setattr("gateway.core.runtime.manager.signal.signal", lambda *_args: None)
 
@@ -207,7 +229,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
         return handle
 
     monkeypatch.setattr(
-        "gateway.transports.telegram.wiring.start_telegram_gateway_background",
+        "gateway.transports.telegram.startup.start_telegram_gateway_background",
         _start_telegram_gateway_background,
     )
     monkeypatch.setattr(
@@ -261,18 +283,21 @@ def test_gateway_start_continues_without_telegram_configuration(monkeypatch) -> 
     def _unconfigured() -> GatewaySettings:
         raise GatewayConfigurationError("TELEGRAM_BOT_TOKEN is not set")
 
-    monkeypatch.setattr("gateway.transports.telegram.wiring.load_gateway_settings", _unconfigured)
+    monkeypatch.setattr("gateway.transports.telegram.startup.load_gateway_settings", _unconfigured)
 
     gateway = GatewayManager().start_gateway(wait=False)
 
-    assert gateway.telegram_background_worker is None
+    assert gateway.channels is not None
+    assert TransportName.TELEGRAM not in gateway.channels.transports
     assert gateway.components["telegram"].startswith("not configured")
     assert gateway.stop() is True
+    assert gateway.channels is None
 
 
 def test_start_gateway_wrapper_delegates_to_gateway_instance(monkeypatch) -> None:
     expected = MagicMock(spec=GatewayManager)
     calls: list[bool] = []
+    factory = object()
 
     def _start_gateway(
         self: GatewayManager,
@@ -280,10 +305,11 @@ def test_start_gateway_wrapper_delegates_to_gateway_instance(monkeypatch) -> Non
         wait: bool = True,
     ) -> GatewayManager:
         assert isinstance(self, GatewayManager)
+        assert self._slash_ports_factory is factory
         calls.append(wait)
         return expected
 
     monkeypatch.setattr(GatewayManager, "start_gateway", _start_gateway)
 
-    assert start_gateway(wait=False) is expected
+    assert start_gateway(wait=False, slash_ports_factory=factory) is expected  # type: ignore[arg-type]
     assert calls == [False]

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -247,6 +247,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
     async def _run_message() -> None:
         executor = ThreadPoolExecutor(max_workers=1)
         try:
+            from gateway.core.runtime.active_turns import ActiveTurnCancels
             from gateway.core.runtime.approvals import ApprovalBroker
 
             await handle_polled_inbound_telegram_message(
@@ -264,6 +265,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
                 chat_locks={},
                 turn_semaphore=asyncio.Semaphore(1),
                 approvals=ApprovalBroker(),
+                active_cancels=ActiveTurnCancels(),
                 handle_callback_to_gateway_agent=callback,
             )
         finally:

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -247,6 +247,8 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
     async def _run_message() -> None:
         executor = ThreadPoolExecutor(max_workers=1)
         try:
+            from gateway.core.runtime.approvals import ApprovalBroker
+
             await handle_polled_inbound_telegram_message(
                 TelegramInboundMessage(
                     update_id=1,
@@ -261,6 +263,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
                 executor=executor,
                 chat_locks={},
                 turn_semaphore=asyncio.Semaphore(1),
+                approvals=ApprovalBroker(),
                 handle_callback_to_gateway_agent=callback,
             )
         finally:

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -210,7 +210,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
             assert kwargs.get("actor") is not None
             return self._session
 
-        def rotate(self, *, user_id: str, chat_id: str, **kwargs: object) -> SessionCore:
+        def rotate(self, *, user_id: str, chat_id: str, **_kwargs: object) -> SessionCore:
             assert user_id == "user-1"
             assert chat_id == "chat-1"
             return self._session

--- a/gateway/tests/runtime/concurrency_limited_handler.py
+++ b/gateway/tests/runtime/concurrency_limited_handler.py
@@ -1,0 +1,52 @@
+"""Test-only capacity wrapper for arbitrary gateway callbacks.
+
+Production chat uses :class:`~gateway.core.runtime.turn_handler.GatewayTurnHandler`
+with ``gate=``. This helper stays under ``gateway/tests/`` so it cannot be
+mistaken for a second production turn-handler class (Wave C4 quarantine).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.agent_harness.session import SessionCore
+from gateway.core.runtime.concurrency import TurnConcurrencyGate
+from gateway.core.runtime.sink_protocol import GatewayAgentCallback, GatewaySink
+
+
+class ConcurrencyLimitedTurnHandler:
+    """Capacity wrapper for arbitrary :data:`GatewayAgentCallback` callables."""
+
+    def __init__(
+        self,
+        *,
+        handler: GatewayAgentCallback,
+        gate: TurnConcurrencyGate,
+        busy_message: str = "OpenSRE is at capacity. Please try again shortly.",
+    ) -> None:
+        self._handler = handler
+        self._gate = gate
+        self._busy_message = busy_message
+
+    def __call__(
+        self,
+        text: str,
+        session: SessionCore,
+        sink: GatewaySink,
+        logger: logging.Logger,
+    ) -> None:
+        if not self._gate.try_acquire():
+            sink.finalize(self._busy_message)
+            return
+        try:
+            self._handler(text, session, sink, logger)
+        finally:
+            self._gate.release()
+
+
+def gated_callback(
+    handler: GatewayAgentCallback,
+    gate: TurnConcurrencyGate,
+) -> GatewayAgentCallback:
+    """Wrap an arbitrary callback with the shared capacity gate (tests only)."""
+    return ConcurrencyLimitedTurnHandler(handler=handler, gate=gate)

--- a/gateway/tests/runtime/test_active_turns.py
+++ b/gateway/tests/runtime/test_active_turns.py
@@ -1,0 +1,54 @@
+"""Active-turn cancel registry and /stop command parsing."""
+
+from __future__ import annotations
+
+import threading
+
+from gateway.core.runtime.active_turns import (
+    ActiveTurnCancels,
+    is_stop_command,
+)
+
+
+def test_is_stop_command_accepts_common_forms() -> None:
+    assert is_stop_command("/stop")
+    assert is_stop_command("stop")
+    assert is_stop_command("/cancel")
+    assert is_stop_command("  /stop@OpenSREBot please ")
+    assert not is_stop_command("/status")
+    assert not is_stop_command("please stop later")
+    assert not is_stop_command("")
+
+
+def test_request_stop_sets_event_and_runs_callback() -> None:
+    registry = ActiveTurnCancels()
+    event = threading.Event()
+    seen: list[str] = []
+
+    with registry.track("chat-1", event, on_user_stop=lambda: seen.append("stop")):
+        assert registry.request_stop("chat-1") is True
+        assert event.is_set()
+        assert seen == ["stop"]
+
+    assert registry.request_stop("chat-1") is False
+
+
+def test_track_unregisters_even_when_turn_raises() -> None:
+    registry = ActiveTurnCancels()
+    event = threading.Event()
+    try:
+        with registry.track("chat-1", event):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert registry.request_stop("chat-1") is False
+
+
+def test_newer_track_replaces_key() -> None:
+    registry = ActiveTurnCancels()
+    first = threading.Event()
+    second = threading.Event()
+    with registry.track("chat-1", first), registry.track("chat-1", second):
+        assert registry.request_stop("chat-1") is True
+        assert second.is_set()
+        assert not first.is_set()

--- a/gateway/tests/runtime/test_cancel_console.py
+++ b/gateway/tests/runtime/test_cancel_console.py
@@ -1,0 +1,45 @@
+"""CancelConsole must behave like the console it wraps, including writes."""
+
+from __future__ import annotations
+
+import io
+import threading
+
+from rich.console import Console
+
+from gateway.core.runtime.cancel_console import CancelConsole
+
+
+def _console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=False, width=100)
+
+
+def test_enabling_recording_through_the_wrapper_reaches_the_wrapped_console() -> None:
+    """Slash capture sets ``record`` then calls ``export_text`` on the same object.
+
+    ``__getattr__`` only proxies reads, so an unproxied write would leave
+    recording off on the wrapped console and make ``export_text`` raise —
+    which surfaces as every slash command failing on a chat transport.
+    """
+    # Arrange.
+    wrapped = _console()
+    console = CancelConsole(wrapped, threading.Event())
+
+    # Act.
+    console.record = True
+    console.print("hello from the gateway")
+
+    # Assert: the write landed on the wrapped console, so export works.
+    assert wrapped.record is True
+    assert "hello from the gateway" in console.export_text()
+
+
+def test_cancel_requested_tracks_the_shared_event() -> None:
+    # Arrange.
+    cancel = threading.Event()
+    console = CancelConsole(_console(), cancel)
+
+    # Act / Assert.
+    assert console.cancel_requested is False
+    cancel.set()
+    assert console.cancel_requested is True

--- a/gateway/tests/runtime/test_channels.py
+++ b/gateway/tests/runtime/test_channels.py
@@ -1,0 +1,78 @@
+"""Characterization for :mod:`gateway.channels` — web + chat as one unit."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.channels import ChannelsHandle, TransportHandle, TransportName, start_channels
+from gateway.channels.chat import ChatStartup
+from gateway.web.startup import WebStartup
+
+
+def test_start_channels_boots_web_and_transports(monkeypatch: pytest.MonkeyPatch) -> None:
+    web_server = MagicMock(name="web")
+    telegram_worker = MagicMock(name="telegram")
+    handles = [
+        TransportHandle(
+            TransportName.TELEGRAM,
+            telegram_worker,
+            "polling for messages",
+        ),
+    ]
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "gateway.channels.compose.start_web_server",
+        lambda **kwargs: captured.update(kwargs)
+        or WebStartup(server=web_server, status="serving"),
+    )
+
+    def _start_transports(*, logger, handler):
+        captured["logger"] = logger
+        captured["handler"] = handler
+        return ChatStartup(
+            handles=handles,
+            statuses={TransportName.TELEGRAM: "polling for messages"},
+        )
+
+    monkeypatch.setattr("gateway.channels.compose.start_transports", _start_transports)
+
+    logger = logging.getLogger("test.channels")
+    handler = MagicMock(name="chat-handler")
+    channels = start_channels(logger=logger, handler=handler)
+
+    assert channels.web_server is web_server
+    assert channels.transports[TransportName.TELEGRAM] is handles[0]
+    assert channels.transports[TransportName.TELEGRAM].worker is telegram_worker
+    assert TransportName.SLACK not in channels.transports
+    assert channels.statuses["web"] == "serving"
+    assert channels.statuses[TransportName.TELEGRAM] == "polling for messages"
+    assert captured["logger"] is logger
+    assert captured["handler"] is handler
+
+
+def test_channels_handle_stop_stops_web_and_transports() -> None:
+    web = MagicMock()
+    w1 = MagicMock()
+    w1.stop.return_value = True
+    w2 = MagicMock()
+    w2.stop.return_value = False
+    handle = ChannelsHandle(
+        web_server=web,
+        transports={
+            TransportName.TELEGRAM: TransportHandle(
+                TransportName.TELEGRAM, w1, "polling"
+            ),
+            TransportName.SLACK: TransportHandle(TransportName.SLACK, w2, "connected"),
+        },
+    )
+
+    assert handle.stop(timeout=1.5) is False
+    web.stop.assert_called_once()
+    w1.stop.assert_called_once_with(timeout=1.5)
+    w2.stop.assert_called_once_with(timeout=1.5)
+    assert handle.web_server is None
+    assert handle.transports == {}

--- a/gateway/tests/runtime/test_channels.py
+++ b/gateway/tests/runtime/test_channels.py
@@ -26,8 +26,7 @@ def test_start_channels_boots_web_and_transports(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(
         "gateway.channels.compose.start_web_server",
-        lambda **kwargs: captured.update(kwargs)
-        or WebStartup(server=web_server, status="serving"),
+        lambda **kwargs: captured.update(kwargs) or WebStartup(server=web_server, status="serving"),
     )
 
     def _start_transports(*, logger, handler):
@@ -63,9 +62,7 @@ def test_channels_handle_stop_stops_web_and_transports() -> None:
     handle = ChannelsHandle(
         web_server=web,
         transports={
-            TransportName.TELEGRAM: TransportHandle(
-                TransportName.TELEGRAM, w1, "polling"
-            ),
+            TransportName.TELEGRAM: TransportHandle(TransportName.TELEGRAM, w1, "polling"),
             TransportName.SLACK: TransportHandle(TransportName.SLACK, w2, "connected"),
         },
     )

--- a/gateway/tests/runtime/test_chat_registry.py
+++ b/gateway/tests/runtime/test_chat_registry.py
@@ -1,0 +1,72 @@
+"""Characterization for the chat-transport registry in gateway.channels.chat."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+from gateway.channels import chat
+from gateway.channels.chat import TransportName
+
+
+def test_start_transports_skips_not_configured_and_failed(
+    monkeypatch,
+) -> None:
+    """Not configured vs failed are distinct component statuses; others still start."""
+    from gateway.core.runtime.errors import (
+        GatewayConfigurationError,
+        GatewayTransportFailedError,
+    )
+
+    workers = {
+        TransportName.TELEGRAM: MagicMock(name="telegram-worker"),
+        TransportName.SLACK: MagicMock(name="slack-worker"),
+        TransportName.DISCORD: MagicMock(name="discord-worker"),
+    }
+
+    def _telegram(**_kwargs):
+        raise GatewayConfigurationError("TELEGRAM_BOT_TOKEN is not set")
+
+    def _slack(**_kwargs):
+        return workers[TransportName.SLACK], MagicMock(name="slack-settings")
+
+    def _discord(**_kwargs):
+        raise GatewayTransportFailedError("startup timeout")
+
+    monkeypatch.setattr(
+        chat,
+        "TRANSPORTS",
+        (
+            chat.TransportSpec(TransportName.TELEGRAM, _telegram, "polling for messages"),
+            chat.TransportSpec(TransportName.SLACK, _slack, "connected via socket mode"),
+            chat.TransportSpec(TransportName.DISCORD, _discord, "connected via gateway"),
+        ),
+    )
+
+    components: dict[str, str] = {}
+    handles = chat.start_transports(
+        logger=logging.getLogger("test.chat"),
+        handler=MagicMock(),
+        components=components,
+    )
+
+    assert [h.name for h in handles] == [TransportName.SLACK]
+    assert handles[0].worker is workers[TransportName.SLACK]
+    assert components[TransportName.TELEGRAM].startswith("not configured")
+    assert components[TransportName.SLACK] == "connected via socket mode"
+    assert components[TransportName.DISCORD].startswith("failed")
+
+
+def test_stop_transports_stops_every_handle() -> None:
+    w1 = MagicMock()
+    w1.stop.return_value = True
+    w2 = MagicMock()
+    w2.stop.return_value = False
+    handles = [
+        chat.TransportHandle(TransportName.TELEGRAM, w1, MagicMock(), "polling"),
+        chat.TransportHandle(TransportName.SLACK, w2, MagicMock(), "connected"),
+    ]
+
+    assert chat.stop_transports(handles, timeout=1.5) is False
+    w1.stop.assert_called_once_with(timeout=1.5)
+    w2.stop.assert_called_once_with(timeout=1.5)

--- a/gateway/tests/runtime/test_chat_registry.py
+++ b/gateway/tests/runtime/test_chat_registry.py
@@ -43,18 +43,16 @@ def test_start_transports_skips_not_configured_and_failed(
         ),
     )
 
-    components: dict[str, str] = {}
-    handles = chat.start_transports(
+    started = chat.start_transports(
         logger=logging.getLogger("test.chat"),
         handler=MagicMock(),
-        components=components,
     )
 
-    assert [h.name for h in handles] == [TransportName.SLACK]
-    assert handles[0].worker is workers[TransportName.SLACK]
-    assert components[TransportName.TELEGRAM].startswith("not configured")
-    assert components[TransportName.SLACK] == "connected via socket mode"
-    assert components[TransportName.DISCORD].startswith("failed")
+    assert [h.name for h in started.handles] == [TransportName.SLACK]
+    assert started.handles[0].worker is workers[TransportName.SLACK]
+    assert started.statuses[TransportName.TELEGRAM].startswith("not configured")
+    assert started.statuses[TransportName.SLACK] == "connected via socket mode"
+    assert started.statuses[TransportName.DISCORD].startswith("failed")
 
 
 def test_stop_transports_stops_every_handle() -> None:
@@ -63,10 +61,10 @@ def test_stop_transports_stops_every_handle() -> None:
     w2 = MagicMock()
     w2.stop.return_value = False
     handles = [
-        chat.TransportHandle(TransportName.TELEGRAM, w1, MagicMock(), "polling"),
-        chat.TransportHandle(TransportName.SLACK, w2, MagicMock(), "connected"),
+        chat.TransportHandle(TransportName.TELEGRAM, w1, "polling"),
+        chat.TransportHandle(TransportName.SLACK, w2, "connected"),
     ]
 
-    assert chat.stop_transports(handles, timeout=1.5) is False
+    assert chat.stop_transports(handles=handles, timeout=1.5) is False
     w1.stop.assert_called_once_with(timeout=1.5)
     w2.stop.assert_called_once_with(timeout=1.5)

--- a/gateway/tests/runtime/test_concurrency_gate.py
+++ b/gateway/tests/runtime/test_concurrency_gate.py
@@ -78,6 +78,49 @@ def test_chat_handler_refuses_excess_turn_without_calling_handler() -> None:
     assert finalized == ["OpenSRE is at capacity. Please try again shortly."]
 
 
+def test_gateway_turn_handler_gate_refuses_excess_without_second_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production path: capacity lives on GatewayTurnHandler itself."""
+    from rich.console import Console
+
+    from gateway.core.runtime.turn_handler import GatewayTurnHandler
+
+    gate = TurnConcurrencyGate(1)
+    entered = threading.Event()
+    release = threading.Event()
+    finalized: list[str] = []
+    ran: list[str] = []
+
+    class Sink:
+        def finalize(self, text: str) -> None:
+            finalized.append(text)
+
+    handler = GatewayTurnHandler(console=Console(force_terminal=False), gate=gate)
+
+    def _fake_run(self, text, session, sink, logger):  # noqa: ANN001
+        _ = (self, session, sink, logger)
+        ran.append(text)
+        entered.set()
+        release.wait(1)
+
+    monkeypatch.setattr(GatewayTurnHandler, "_run_turn", _fake_run)
+
+    first = threading.Thread(
+        target=handler,
+        args=("one", object(), Sink(), logging.getLogger("test")),
+    )
+    first.start()
+    assert entered.wait(1)
+
+    handler("two", object(), Sink(), logging.getLogger("test"))  # type: ignore[arg-type]
+    release.set()
+    first.join(1)
+
+    assert ran == ["one"]
+    assert finalized == ["OpenSRE is at capacity. Please try again shortly."]
+
+
 def test_scheduler_runner_waits_for_the_same_chat_capacity() -> None:
     gate = TurnConcurrencyGate(1)
     assert gate.try_acquire() is True  # active chat turn

--- a/gateway/tests/runtime/test_concurrency_gate.py
+++ b/gateway/tests/runtime/test_concurrency_gate.py
@@ -7,11 +7,11 @@ import threading
 
 import pytest
 
-from gateway.core.runtime.concurrency import (
-    ConcurrencyLimitedTurnHandler,
-    TurnConcurrencyGate,
-)
+from gateway.core.runtime.concurrency import TurnConcurrencyGate
 from gateway.core.runtime.scheduler_concurrency import gate_registered_scheduler_runners
+from gateway.tests.runtime.concurrency_limited_handler import (
+    ConcurrencyLimitedTurnHandler,
+)
 from platform.deployment_contracts.models import SizeProfile
 from platform.scheduler.agent_runner import (
     invoke_agent_runner,

--- a/gateway/tests/runtime/test_manager.py
+++ b/gateway/tests/runtime/test_manager.py
@@ -2,34 +2,82 @@
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+from gateway.channels import ChannelsHandle, TransportHandle, TransportName
 from gateway.core.runtime.manager import GatewayManager
 
 
-def test_wait_blocks_until_stop_not_telegram_thread_exit() -> None:
-    """The unified daemon should not exit when the Telegram worker thread ends."""
-    manager = GatewayManager()
-    telegram_wait = MagicMock(return_value=True)
+def test_start_channels_delegates_to_channels_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manager stores an opaque ChannelsHandle; no per-transport fields."""
+    telegram = TransportHandle(
+        TransportName.TELEGRAM,
+        MagicMock(name="telegram"),
+        "polling for messages",
+    )
+    expected = ChannelsHandle(
+        web_server=MagicMock(name="web"),
+        transports={TransportName.TELEGRAM: telegram},
+        statuses={"web": "serving", TransportName.TELEGRAM: "polling for messages"},
+    )
+    captured: dict[str, object] = {}
 
-    class FakeTelegramWorker:
+    def _boot(*, logger, handler):
+        captured["logger"] = logger
+        captured["handler"] = handler
+        return expected
+
+    monkeypatch.setattr("gateway.core.runtime.manager.gateway_channels.start_channels", _boot)
+    manager = GatewayManager()
+    handler = MagicMock(name="chat-handler")
+    logger = logging.getLogger("test.manager.channels")
+
+    manager.start_channels(logger=logger, handler=handler)
+
+    assert manager.channels is expected
+    assert captured["logger"] is logger
+    assert captured["handler"] is handler
+    assert manager.components[TransportName.TELEGRAM] == "polling for messages"
+    assert not hasattr(manager, "telegram_background_worker")
+    assert not hasattr(manager, "web_server")
+
+
+def test_wait_blocks_until_stop_not_channel_worker_exit() -> None:
+    """The unified daemon should not exit when a chat worker thread ends."""
+    manager = GatewayManager()
+    worker_wait = MagicMock(return_value=True)
+
+    class FakeWorker:
         def wait(self, *, timeout: float | None = None) -> bool:
-            return telegram_wait(timeout=timeout)
+            return worker_wait(timeout=timeout)
 
         def stop(self, *, timeout: float = 8.0) -> bool:
             _ = timeout
             return True
 
-    manager.telegram_background_worker = FakeTelegramWorker()
+    manager.channels = ChannelsHandle(
+        transports={
+            TransportName.TELEGRAM: TransportHandle(
+                TransportName.TELEGRAM,
+                FakeWorker(),
+                "polling",
+            )
+        }
+    )
     manager._stopped.clear()
 
     assert manager.wait(timeout=0.01) is False
-    telegram_wait.assert_not_called()
+    worker_wait.assert_not_called()
 
     manager.stop()
     assert manager.wait(timeout=0.01) is True
+    assert manager.channels is None
 
 
 def test_manager_stop_never_touches_the_real_gateway_directory() -> None:
@@ -40,17 +88,12 @@ def test_manager_stop_never_touches_the_real_gateway_directory() -> None:
     ``gateway/tests/conftest.py`` this test deleted
     ``~/.opensre/gateway/components.json`` on the developer's machine.
     """
-    # Arrange
-    from pathlib import Path
-
     from gateway.core.runtime import daemon
 
     real_gateway_dir = Path.home() / ".opensre" / "gateway"
 
-    # Act
     GatewayManager().stop()
 
-    # Assert
     assert real_gateway_dir not in daemon.GATEWAY_COMPONENTS_FILE.parents
     assert real_gateway_dir not in daemon.GATEWAY_PID_FILE.parents
 
@@ -59,8 +102,6 @@ def test_manager_reload_scheduler_refreshes_component_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Loop/cron mutations must resync the long-lived gateway scheduler."""
-    from logging import getLogger
-
     publishes: list[dict[str, str]] = []
 
     def _refresh(scheduler: object | None, *, task_filter=None):
@@ -79,7 +120,7 @@ def test_manager_reload_scheduler_refreshes_component_status(
         lambda _logger: publishes.append(dict(manager.components)),
     )
 
-    manager._reload_scheduler(getLogger("test"))
+    manager._reload_scheduler(logging.getLogger("test"))
 
     assert manager.components["scheduler"] == "running 3 scheduled task(s)"
     assert publishes == [{"scheduler": "running 3 scheduled task(s)"}]

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import io
 import logging
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 from rich.console import Console
@@ -190,17 +189,15 @@ def test_gateway_manager_registers_harness_adapters(monkeypatch: pytest.MonkeyPa
         "platform.sandbox.capabilities.boot_capability_warnings",
         lambda: [],
     )
+    from gateway.channels import ChannelsHandle
+
     monkeypatch.setattr(
-        "gateway.core.runtime.manager.start_telegram_worker",
-        lambda **_kwargs: (MagicMock(), MagicMock()),
+        "gateway.core.runtime.manager.boot_channels",
+        lambda **_kwargs: ChannelsHandle(),
     )
     # Keep this test focused on adapter registration (life-cycle tests cover scheduler).
     monkeypatch.setattr(
-        "gateway.core.runtime.manager.GatewayManager._start_scheduler",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "gateway.core.runtime.manager.GatewayManager._start_web",
+        "gateway.core.runtime.manager.GatewayManager.start_scheduler",
         lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -192,7 +192,7 @@ def test_gateway_manager_registers_harness_adapters(monkeypatch: pytest.MonkeyPa
     from gateway.channels import ChannelsHandle
 
     monkeypatch.setattr(
-        "gateway.core.runtime.manager.boot_channels",
+        "gateway.core.runtime.manager.gateway_channels.start_channels",
         lambda **_kwargs: ChannelsHandle(),
     )
     # Keep this test focused on adapter registration (life-cycle tests cover scheduler).

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -161,7 +161,7 @@ def test_turn_handler_forwards_sink_tool_hooks_to_agent(monkeypatch: Any) -> Non
 
 
 def test_turn_handler_tolerates_sinks_without_tool_hooks(monkeypatch: Any) -> None:
-    """Sinks without the attribute (Telegram) run unhooked, as before."""
+    """Sinks without tool_hooks (Telegram today) run unhooked — documented host gap."""
 
     class _BareSink:
         def finalize(self, text: str) -> None:

--- a/gateway/tests/slack/test_dispatcher.py
+++ b/gateway/tests/slack/test_dispatcher.py
@@ -147,14 +147,14 @@ def _settings(
     )
 
 
-def _inbound() -> SlackInboundMessage:
+def _inbound(*, text: str = "check the api", ts: str = "100.1") -> SlackInboundMessage:
     return SlackInboundMessage(
         team_id="T1",
         user_id="U1",
         channel_id="C1",
-        ts="100.1",
+        ts=ts,
         thread_ts="100.1",
-        text="check the api",
+        text=text,
     )
 
 
@@ -374,6 +374,59 @@ def test_agent_context_attributes_the_speaker() -> None:
 
     # Single metadata line: prefix stays one line, text follows on the next.
     assert text == "[Slack channel_id=C1 user=<@U1>]\ncheck the api"
+
+
+def test_stop_with_nothing_running_posts_idle_reply() -> None:
+    messaging = _FakeMessagingClient()
+    turns: list[str] = []
+
+    def handler(text: str, _session: Any, sink: Any, _logger: logging.Logger) -> None:
+        turns.append(text)
+        sink.finalize("done")
+
+    _dispatcher(
+        settings=_settings(["U1"]), messaging=messaging, resolver=_FakeSessionResolver(), handler=handler
+    ).dispatch(_inbound(text="/stop"))
+
+    assert turns == []
+    assert any("Nothing running to stop" in p["text"] for p in messaging.posts)
+
+
+def test_stop_cancels_in_flight_turn() -> None:
+    messaging = _FakeMessagingClient()
+    started = threading.Event()
+    release = threading.Event()
+    seen_cancel: list[threading.Event] = []
+
+    def hanging_handler(_text: str, _session: Any, sink: Any, _logger: logging.Logger) -> None:
+        cancel = getattr(sink, "turn_cancel", None)
+        assert isinstance(cancel, threading.Event)
+        seen_cancel.append(cancel)
+        started.set()
+        release.wait(5.0)
+
+    dispatcher = _dispatcher(
+        settings=_settings(["U1"], turn_timeout_seconds=30.0),
+        messaging=messaging,
+        resolver=_FakeSessionResolver(),
+        handler=hanging_handler,
+    )
+    worker = threading.Thread(target=lambda: dispatcher._run_turn(_inbound(), _test_scope()))
+    worker.start()
+    assert started.wait(3.0), "turn did not start"
+    dispatcher.dispatch(_inbound(text="/stop", ts="100.2"))
+    try:
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not any(
+            update["text"] == "Stopped." for update in messaging.updates
+        ):
+            time.sleep(0.02)
+    finally:
+        release.set()
+        worker.join(5.0)
+
+    assert seen_cancel and seen_cancel[0].is_set()
+    assert any(update["text"] == "Stopped." for update in messaging.updates)
 
 
 def test_turn_timeout_finalizes_placeholder_when_handler_hangs() -> None:

--- a/gateway/tests/slack/test_dispatcher.py
+++ b/gateway/tests/slack/test_dispatcher.py
@@ -385,7 +385,10 @@ def test_stop_with_nothing_running_posts_idle_reply() -> None:
         sink.finalize("done")
 
     _dispatcher(
-        settings=_settings(["U1"]), messaging=messaging, resolver=_FakeSessionResolver(), handler=handler
+        settings=_settings(["U1"]),
+        messaging=messaging,
+        resolver=_FakeSessionResolver(),
+        handler=handler,
     ).dispatch(_inbound(text="/stop"))
 
     assert turns == []

--- a/gateway/tests/slack/test_slack_settings.py
+++ b/gateway/tests/slack/test_slack_settings.py
@@ -50,6 +50,7 @@ def _store_record(credentials: dict[str, Any]) -> dict[str, Any]:
 def test_loads_tokens_with_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_tokens(monkeypatch)
     monkeypatch.setenv("SLACK_ALLOWED_USERS", "U111")
+    monkeypatch.delenv("OPENSRE_SIZE_PROFILE", raising=False)
 
     settings = load_slack_gateway_settings()
 
@@ -57,7 +58,8 @@ def test_loads_tokens_with_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.app_token == "xapp-test"
     assert settings.allowed_user_ids == ["U111"]
     assert settings.allow_open_workspace is False
-    assert settings.max_concurrent_turns == 4
+    # Default pool tracks OPENSRE_SIZE_PROFILE (SMALL → 1) unless env overrides.
+    assert settings.max_concurrent_turns == 1
 
 
 def test_parses_allowed_users_csv(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/gateway/tests/telegram/test_approvals.py
+++ b/gateway/tests/telegram/test_approvals.py
@@ -200,3 +200,11 @@ def test_tools_without_requires_approval_skip_prompt() -> None:
     result = hooks.before_tool_call(_request(_FakeTool(requires_approval=False)))
     assert result is None
     assert client.posts == []
+
+
+def test_approval_callback_data_fits_telegram_limit() -> None:
+    from gateway.transports.telegram.approvals import _approval_keyboard
+
+    markup = _approval_keyboard("a" * 32)  # uuid.hex length
+    for button in markup["inline_keyboard"][0]:
+        assert len(button["callback_data"].encode("utf-8")) <= 64

--- a/gateway/tests/telegram/test_approvals.py
+++ b/gateway/tests/telegram/test_approvals.py
@@ -1,0 +1,201 @@
+"""Telegram inline-keyboard approval gate: prompter, hooks, callback routing."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+from core.execution import ToolExecutionRequest
+from core.llm.types import ToolCall
+from gateway.core.runtime.approvals import (
+    APPROVE_ACTION_ID,
+    DENY_ACTION_ID,
+    ApprovalBroker,
+    approval_tool_hooks,
+)
+from gateway.transports.telegram.approvals import (
+    TelegramApprovalPrompter,
+    handle_callback_query,
+)
+from gateway.transports.telegram.settings import TelegramCallbackQuery
+
+
+class _FakeClient:
+    def __init__(self, *, post_ok: bool = True) -> None:
+        self.post_ok = post_ok
+        self.posts: list[dict[str, Any]] = []
+        self.edits: list[dict[str, Any]] = []
+        self.answers: list[dict[str, Any]] = []
+
+    def send_message(
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        parse_mode: str = "",
+        reply_markup: dict[str, Any] | None = None,
+    ) -> tuple[bool, str, str]:
+        self.posts.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "parse_mode": parse_mode,
+                "reply_markup": reply_markup,
+            }
+        )
+        if not self.post_ok:
+            return False, "fail", ""
+        return True, "", f"msg-{len(self.posts)}"
+
+    def edit_message_text(
+        self,
+        chat_id: str,
+        message_id: str,
+        text: str,
+        *,
+        parse_mode: str = "",
+        reply_markup: dict[str, Any] | None = None,
+    ) -> tuple[bool, str]:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "text": text,
+                "reply_markup": reply_markup,
+            }
+        )
+        return True, ""
+
+    def answer_callback_query(self, callback_query_id: str, *, text: str = "") -> None:
+        self.answers.append({"id": callback_query_id, "text": text})
+
+
+class _FakeTool:
+    def __init__(self, *, requires_approval: bool = True) -> None:
+        self.requires_approval = requires_approval
+        self.approval_reason = "Sends a Telegram message."
+        self.approval_expiry_seconds = 60
+
+
+def _request(tool: _FakeTool, name: str = "telegram_send_message") -> ToolExecutionRequest:
+    return ToolExecutionRequest(
+        tool_call=ToolCall(id="tc-1", name=name, input={"message": "hi"}),
+        tool=tool,  # type: ignore[arg-type]
+        arguments={"message": "hi"},
+        source="telegram",
+        resolved_integrations={},
+    )
+
+
+def _approval_id_from_markup(markup: dict[str, Any]) -> str:
+    data = markup["inline_keyboard"][0][0]["callback_data"]
+    return str(data).split(":", 1)[1]
+
+
+def _prompter(client: _FakeClient, broker: ApprovalBroker) -> TelegramApprovalPrompter:
+    return TelegramApprovalPrompter(client=client, broker=broker, chat_id="42")
+
+
+def _click_later(
+    broker: ApprovalBroker,
+    client: _FakeClient,
+    *,
+    action_id: str,
+    user_id: str = "42",
+) -> None:
+    def _click() -> None:
+        approval_id = _approval_id_from_markup(client.posts[-1]["reply_markup"])
+        handle_callback_query(
+            TelegramCallbackQuery(
+                update_id=1,
+                user_id=user_id,
+                chat_id="42",
+                callback_query_id="cq-1",
+                data=f"{action_id}:{approval_id}",
+            ),
+            broker=broker,
+            client=client,  # type: ignore[arg-type]
+            allowed_user_ids=["42"],
+        )
+
+    threading.Timer(0.05, _click).start()
+
+
+def test_approved_click_lets_the_tool_run() -> None:
+    broker = ApprovalBroker()
+    client = _FakeClient()
+    hooks = approval_tool_hooks(_prompter(client, broker))
+    _click_later(broker, client, action_id=APPROVE_ACTION_ID)
+
+    result = hooks.before_tool_call(_request(_FakeTool()))
+    assert result is not None
+    assert result.approved is True
+    assert client.edits  # outcome message cleared buttons
+
+
+def test_denied_click_blocks_the_tool() -> None:
+    broker = ApprovalBroker()
+    client = _FakeClient()
+    hooks = approval_tool_hooks(_prompter(client, broker))
+    _click_later(broker, client, action_id=DENY_ACTION_ID)
+
+    result = hooks.before_tool_call(_request(_FakeTool()))
+    assert result is not None
+    assert result.blocked is True
+
+
+def test_failed_prompt_post_fails_closed() -> None:
+    broker = ApprovalBroker()
+    client = _FakeClient(post_ok=False)
+    hooks = approval_tool_hooks(_prompter(client, broker))
+    result = hooks.before_tool_call(_request(_FakeTool()))
+    assert result is not None
+    assert result.blocked is True
+
+
+def test_empty_allowlist_rejects_click() -> None:
+    broker = MagicMock()
+    client = _FakeClient()
+    ok = handle_callback_query(
+        TelegramCallbackQuery(
+            update_id=1,
+            user_id="42",
+            chat_id="42",
+            callback_query_id="cq",
+            data=f"{APPROVE_ACTION_ID}:appr-1",
+        ),
+        broker=broker,
+        client=client,  # type: ignore[arg-type]
+        allowed_user_ids=[],
+    )
+    assert ok is False
+    broker.resolve.assert_not_called()
+
+
+def test_unlisted_user_rejected() -> None:
+    broker = MagicMock()
+    client = _FakeClient()
+    ok = handle_callback_query(
+        TelegramCallbackQuery(
+            update_id=1,
+            user_id="999",
+            chat_id="42",
+            callback_query_id="cq",
+            data=f"{APPROVE_ACTION_ID}:appr-1",
+        ),
+        broker=broker,
+        client=client,  # type: ignore[arg-type]
+        allowed_user_ids=["42"],
+    )
+    assert ok is False
+    broker.resolve.assert_not_called()
+
+
+def test_tools_without_requires_approval_skip_prompt() -> None:
+    broker = ApprovalBroker()
+    client = _FakeClient()
+    hooks = approval_tool_hooks(_prompter(client, broker))
+    result = hooks.before_tool_call(_request(_FakeTool(requires_approval=False)))
+    assert result is None
+    assert client.posts == []

--- a/gateway/tests/telegram/test_background.py
+++ b/gateway/tests/telegram/test_background.py
@@ -13,7 +13,9 @@ from gateway.transports.telegram.settings import GatewaySettings
 
 @patch("gateway.transports.telegram.background.TelegramPoller")
 def test_start_starts_poll_thread(mock_poller_cls: MagicMock) -> None:
-    mock_poller_cls.return_value.poll_once.return_value = []
+    from gateway.transports.telegram.poller.poller import TelegramPollResult
+
+    mock_poller_cls.return_value.poll_once.return_value = TelegramPollResult()
     logger = logging.getLogger("gateway.test")
     handle = start_telegram_gateway_background(
         settings=GatewaySettings(bot_token="tok"),

--- a/gateway/tests/telegram/test_get_gateway_settings.py
+++ b/gateway/tests/telegram/test_get_gateway_settings.py
@@ -41,11 +41,14 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 # ---------------------------------------------------------------------------
 
 
-def test_gateway_env_defaults() -> None:
+def test_gateway_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENSRE_SIZE_PROFILE", raising=False)
+    monkeypatch.delenv("TELEGRAM_GATEWAY_MAX_CONCURRENT", raising=False)
     env = GatewayEnv()
     assert env.bot_token == ""
     assert env.allowed_users == []
-    assert env.gateway_max_concurrent == 4
+    # Default pool tracks OPENSRE_SIZE_PROFILE (SMALL → 1).
+    assert env.gateway_max_concurrent == 1
     assert env.gateway_auto_start is True
 
 

--- a/gateway/tests/telegram/test_parse_telegram_update.py
+++ b/gateway/tests/telegram/test_parse_telegram_update.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from gateway.transports.telegram.poller.parse_telegram_update import parse_update
+from gateway.transports.telegram.poller.parse_telegram_update import (
+    parse_callback_query,
+    parse_update,
+)
 
 
 def test_parse_private_text_message() -> None:
@@ -20,19 +23,37 @@ def test_parse_private_text_message() -> None:
     assert event.text == "hello"
 
 
-def test_parse_callback_query_is_ignored() -> None:
+def test_parse_update_ignores_callback_query() -> None:
     event = parse_update(
         {
             "update_id": 2,
             "callback_query": {
                 "id": "cq1",
                 "from": {"id": 42},
-                "data": "approve:abc",
+                "data": "opensre_approval_approve:abc",
                 "message": {"message_id": 3, "chat": {"id": 42, "type": "private"}},
             },
         }
     )
     assert event is None
+
+
+def test_parse_callback_query_private() -> None:
+    event = parse_callback_query(
+        {
+            "update_id": 2,
+            "callback_query": {
+                "id": "cq1",
+                "from": {"id": 42},
+                "data": "opensre_approval_approve:abc",
+                "message": {"message_id": 3, "chat": {"id": 42, "type": "private"}},
+            },
+        }
+    )
+    assert event is not None
+    assert event.user_id == "42"
+    assert event.data == "opensre_approval_approve:abc"
+    assert event.callback_query_id == "cq1"
 
 
 def test_ignores_group_messages() -> None:

--- a/gateway/tests/telegram/test_principal.py
+++ b/gateway/tests/telegram/test_principal.py
@@ -1,0 +1,41 @@
+"""Telegram principal resolution — silo org + per-user actor."""
+
+from __future__ import annotations
+
+import pytest
+
+from config.constants.billing import ORGANIZATION_ID_ENV
+from config.principal import Principal
+from gateway.transports.telegram.principal import (
+    PrincipalResolutionError,
+    resolve_telegram_principal,
+    resolve_telegram_scope,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ORGANIZATION_ID_ENV, raising=False)
+
+
+def test_configured_organization_owns_the_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_tg")
+    assert resolve_telegram_principal() == Principal.org("org_tg")
+
+
+def test_turn_is_refused_when_no_organization_is_configured() -> None:
+    with pytest.raises(PrincipalResolutionError, match="no organization"):
+        resolve_telegram_principal()
+
+
+def test_scope_pairs_org_with_telegram_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_tg")
+    scope = resolve_telegram_scope(user_id="tg-42")
+    assert scope.principal == Principal.org("org_tg")
+    assert scope.actor.id == "tg-42"
+
+
+def test_empty_user_id_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_tg")
+    with pytest.raises(PrincipalResolutionError, match="no user id"):
+        resolve_telegram_scope(user_id="  ")

--- a/gateway/tests/telegram/test_telegram_poller.py
+++ b/gateway/tests/telegram/test_telegram_poller.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 
-from gateway.transports.telegram.poller.poller import TelegramPoller, _decode_telegram_response
+from gateway.transports.telegram.poller.poller import (
+    TelegramPollResult,
+    TelegramPoller,
+    _decode_telegram_response,
+)
 
 
 def test_decode_telegram_response_parses_non_200_json() -> None:
@@ -40,7 +44,7 @@ def test_poll_once_conflict_is_debug_not_warning(
         },
     )
     poller = TelegramPoller("tok")
-    assert poller.poll_once() == []
+    assert poller.poll_once() == TelegramPollResult()
     mock_sleep.assert_called_once_with(2.0)
     assert not any(
         "[telegram-gateway] getUpdates not ok" in record.message for record in caplog.records
@@ -61,8 +65,8 @@ def test_poll_once_success_resets_conflict_backoff(
     ]
     poller = TelegramPoller("tok")
     poller._conflict_backoff_seconds = 8.0
-    assert poller.poll_once() == []
-    assert poller.poll_once() == []
+    assert poller.poll_once() == TelegramPollResult()
+    assert poller.poll_once() == TelegramPollResult()
     assert poller._conflict_backoff_seconds == 2.0
 
 
@@ -86,8 +90,42 @@ def test_poll_once_parses_inbound_message(mock_get: MagicMock, mock_sleep: Magic
             ],
         },
     )
-    events = TelegramPoller("tok").poll_once()
-    assert len(events) == 1
-    assert events[0].text == "hello"
-    assert events[0].chat_id == "99"
+    batch = TelegramPoller("tok").poll_once()
+    assert len(batch.messages) == 1
+    assert batch.messages[0].text == "hello"
+    assert batch.messages[0].chat_id == "99"
+    assert batch.callbacks == []
+    mock_sleep.assert_not_called()
+
+
+@patch("gateway.transports.telegram.poller.poller.time.sleep")
+@patch("gateway.transports.telegram.poller.poller.httpx.get")
+def test_poll_once_parses_callback_query(mock_get: MagicMock, mock_sleep: MagicMock) -> None:
+    mock_get.return_value = httpx.Response(
+        200,
+        json={
+            "ok": True,
+            "result": [
+                {
+                    "update_id": 8,
+                    "callback_query": {
+                        "id": "cq-9",
+                        "from": {"id": 42},
+                        "data": "opensre_approval_approve:abc",
+                        "message": {
+                            "message_id": 3,
+                            "chat": {"id": 99, "type": "private"},
+                        },
+                    },
+                }
+            ],
+        },
+    )
+    batch = TelegramPoller("tok").poll_once()
+    assert batch.messages == []
+    assert len(batch.callbacks) == 1
+    assert batch.callbacks[0].data == "opensre_approval_approve:abc"
+    assert batch.callbacks[0].chat_id == "99"
+    # Ensure getUpdates asked for callback_query updates.
+    assert "callback_query" in mock_get.call_args.kwargs["params"]["allowed_updates"]
     mock_sleep.assert_not_called()

--- a/gateway/tests/telegram/test_turn_timeout.py
+++ b/gateway/tests/telegram/test_turn_timeout.py
@@ -14,6 +14,7 @@ import pytest
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
 from gateway.core.runtime.approvals import ApprovalBroker
+from gateway.core.runtime.active_turns import ActiveTurnCancels
 from gateway.transports.telegram.inbound_handler import handle_polled_inbound_telegram_message
 from gateway.transports.telegram.inbound_security import InboundDecision
 from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
@@ -118,6 +119,7 @@ def test_turn_timeout_finalizes_placeholder_when_handler_hangs() -> None:
                 chat_locks={},
                 turn_semaphore=asyncio.Semaphore(1),
                 approvals=ApprovalBroker(),
+                active_cancels=ActiveTurnCancels(),
                 handle_callback_to_gateway_agent=hanging_handler,
             )
         finally:
@@ -127,12 +129,12 @@ def test_turn_timeout_finalizes_placeholder_when_handler_hangs() -> None:
     # Drive the async path from a thread so the hang cannot block pytest forever
     # if the soft timeout fails to fire.
     done = threading.Event()
-    error: list[BaseException] = []
+    error: list[Exception] = []
 
     def _thread() -> None:
         try:
             asyncio.run(_run())
-        except BaseException as exc:  # noqa: BLE001 — surface in main thread
+        except Exception as exc:
             error.append(exc)
         finally:
             done.set()

--- a/gateway/tests/telegram/test_turn_timeout.py
+++ b/gateway/tests/telegram/test_turn_timeout.py
@@ -13,8 +13,8 @@ import pytest
 
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
-from gateway.core.runtime.approvals import ApprovalBroker
 from gateway.core.runtime.active_turns import ActiveTurnCancels
+from gateway.core.runtime.approvals import ApprovalBroker
 from gateway.transports.telegram.inbound_handler import handle_polled_inbound_telegram_message
 from gateway.transports.telegram.inbound_security import InboundDecision
 from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage

--- a/gateway/tests/telegram/test_unbound_storage_borders.py
+++ b/gateway/tests/telegram/test_unbound_storage_borders.py
@@ -1,4 +1,4 @@
-"""Telegram gateway stays unbound — Slack org scoping must not touch it."""
+"""Telegram binds org scope + actor; must not import Slack principal modules."""
 
 from __future__ import annotations
 
@@ -7,10 +7,12 @@ from pathlib import Path
 import pytest
 
 from config.constants import paths
+from config.constants.billing import ORGANIZATION_ID_ENV
 from config.principal import Actor, Principal
-from config.scope_context import current_scope
+from config.scope_context import bound_storage_scope, current_scope
 from gateway.core.storage import FileBindingStore
 from gateway.transports.telegram.inbound_security import InboundDecision
+from gateway.transports.telegram.principal import resolve_telegram_scope
 from gateway.transports.telegram.session_rotation import resolve_or_rotate_session
 
 
@@ -18,6 +20,7 @@ from gateway.transports.telegram.session_rotation import resolve_or_rotate_sessi
 def _host(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
     monkeypatch.delenv(paths.CONTEXT_ROOT_ENV, raising=False)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_tg")
     return tmp_path
 
 
@@ -35,8 +38,9 @@ class _Client:
         self.sent.append((chat_id, text))
 
 
-def test_telegram_resolve_never_passes_principal_or_actor() -> None:
+def test_telegram_resolve_passes_principal_and_actor() -> None:
     calls: list[dict[str, object]] = []
+    scope = resolve_telegram_scope(user_id="tg-7")
 
     class _Resolver:
         def resolve(self, *, user_id: str, chat_id: str, **kwargs: object) -> object:
@@ -52,12 +56,19 @@ def test_telegram_resolve_never_passes_principal_or_actor() -> None:
         InboundDecision(allowed=True),
         session_resolver=_Resolver(),  # type: ignore[arg-type]
         client=_Client(),  # type: ignore[arg-type]
+        scope=scope,
     )
     assert session is not None
-    assert calls == [{"user_id": "tg-7", "chat_id": "chat-7", "kwargs": {}}]
+    assert calls == [
+        {
+            "user_id": "tg-7",
+            "chat_id": "chat-7",
+            "kwargs": {"principal": scope.principal, "actor": scope.actor},
+        }
+    ]
 
 
-def test_telegram_legacy_binding_unaffected_by_slack_org_rows(tmp_path: Path) -> None:
+def test_telegram_scoped_binding_isolated_from_slack_org_rows(tmp_path: Path) -> None:
     store = FileBindingStore(tmp_path / "bindings.json")
     org = Principal.org("org_acme")
     store.bind(
@@ -67,32 +78,43 @@ def test_telegram_legacy_binding_unaffected_by_slack_org_rows(tmp_path: Path) ->
         principal=org,
         actor=Actor(id="U_ALICE"),
     )
-    store.bind(platform="telegram", chat_id="chat-7", session_id="tg-sess")
+    store.bind(
+        platform="telegram",
+        chat_id="chat-7",
+        session_id="tg-sess",
+        principal=org,
+        actor=Actor(id="tg-7"),
+    )
 
-    assert store.get_session_id(platform="telegram", chat_id="chat-7") == "tg-sess"
     assert (
         store.get_session_id(
             platform="telegram",
             chat_id="chat-7",
             principal=org,
+            actor="tg-7",
+        )
+        == "tg-sess"
+    )
+    assert store.get_session_id(platform="telegram", chat_id="chat-7") is None
+    assert (
+        store.get_session_id(
+            platform="slack",
+            chat_id="T:C:1",
+            principal=org,
             actor="U_ALICE",
         )
-        is None
+        == "slack-sess"
     )
-    assert store.get_session_id(platform="slack", chat_id="T:C:1") is None
     store.close()
 
 
-def test_telegram_paths_stay_flat_when_slack_mount_is_configured(
+def test_telegram_bound_scope_uses_org_nest(
     _host: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Same ECS task may have OPENSRE_CONTEXT_ROOT; Telegram must ignore it."""
-    mount = _host / "workspace" / "memories"
-    mount.mkdir(parents=True)
-    monkeypatch.setenv(paths.CONTEXT_ROOT_ENV, str(mount))
-
-    assert current_scope() is None
-    assert paths.opensre_home() == _host
-    assert paths.session_home() == _host
-    assert paths.integrations_store_path() == _host / "integrations.json"
-    assert mount not in paths.session_home().parents
+    """With ORGANIZATION_ID and no mount, Telegram turns nest under orgs/<id>/."""
+    scope = resolve_telegram_scope(user_id="tg-7")
+    with bound_storage_scope(scope):
+        assert current_scope() is scope
+        home = paths.opensre_home()
+        assert home == _host / "orgs" / "org_tg"
+        assert paths.integrations_store_path() == home / "integrations.json"

--- a/gateway/tests/telegram/test_unbound_storage_borders.py
+++ b/gateway/tests/telegram/test_unbound_storage_borders.py
@@ -108,9 +108,7 @@ def test_telegram_scoped_binding_isolated_from_slack_org_rows(tmp_path: Path) ->
     store.close()
 
 
-def test_telegram_bound_scope_uses_org_nest(
-    _host: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_telegram_bound_scope_uses_org_nest(_host: Path) -> None:
     """With ORGANIZATION_ID and no mount, Telegram turns nest under orgs/<id>/."""
     scope = resolve_telegram_scope(user_id="tg-7")
     with bound_storage_scope(scope):

--- a/gateway/tests/test_main.py
+++ b/gateway/tests/test_main.py
@@ -2,22 +2,33 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import pytest
 
 
-def test_gateway_main_delegates_to_manager() -> None:
-    """``python -m gateway.main`` must boot ``GatewayManager.start_gateway``."""
-    mock_manager = MagicMock()
-    with patch("gateway.core.runtime.manager.GatewayManager", return_value=mock_manager):
-        from gateway.core.runtime.manager import main as runtime_main
+def test_gateway_main_fails_closed_without_slash_ports() -> None:
+    """Bare ``python -m gateway.main`` must not boot a slash-less gateway."""
+    import gateway.main as entry
 
-        runtime_main()
+    with pytest.raises(SystemExit, match="slash-port glue"):
+        entry.main()
 
-    mock_manager.start_gateway.assert_called_once_with()
+
+def test_manager_main_fails_closed_without_slash_ports() -> None:
+    from gateway.core.runtime import manager as manager_module
+
+    with pytest.raises(SystemExit, match="slash_ports_factory"):
+        manager_module.main()
+
+
+def test_manager_start_gateway_wrapper_requires_slash_ports() -> None:
+    from gateway.core.runtime.manager import start_gateway
+
+    with pytest.raises(SystemExit, match="slash_ports_factory"):
+        start_gateway(wait=False)
 
 
 def test_gateway_main_module_exports_main() -> None:
     import gateway.main as entry
 
     assert callable(entry.main)
-    assert entry.main.__module__ == "gateway.core.runtime.manager"
+    assert entry.main.__module__ == "gateway.main"

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -213,3 +213,85 @@ def test_concurrency_limited_handler_stays_out_of_production_gateway() -> None:
     assert offenders == [], (
         "quarantined ConcurrencyLimitedTurnHandler leaked into production:\n" + "\n".join(offenders)
     )
+
+
+def test_production_gateway_never_subclasses_core_agent() -> None:
+    """Wave D4: gateway hosts HeadlessAgent; it must not own a core.agent.Agent subclass.
+
+    Chat turns reuse SessionAgentPool → build_default_headless_agent. A production
+    ``class …(Agent)`` under gateway/ would be a second brain beside the harness.
+    """
+    offenders: list[str] = []
+    for path in _python_files("gateway"):
+        if "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        agent_aliases: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in {
+                "core.agent",
+                "core.agent.agent",
+            }:
+                for alias in node.names:
+                    if alias.name == "Agent":
+                        agent_aliases.add(alias.asname or "Agent")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in {"core.agent", "core.agent.agent"}:
+                        # ``import core.agent`` — subclass would be Attribute on that name.
+                        agent_aliases.add(f"{alias.asname or alias.name}.Agent")
+        if not agent_aliases:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for base in node.bases:
+                base_name = _ast_name(base)
+                if base_name in agent_aliases or base_name == "Agent":
+                    offenders.append(
+                        f"{path.relative_to(REPO_ROOT)} → class {node.name}({base_name})"
+                    )
+    assert offenders == [], "production gateway subclasses core.agent.Agent:\n" + "\n".join(
+        offenders
+    )
+
+
+def _ast_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        left = _ast_name(node.value)
+        return f"{left}.{node.attr}" if left else node.attr
+    return ""
+
+
+def test_gateway_chat_never_builds_core_agent_or_precomputed_tools() -> None:
+    """Wave D4: chat uses SessionAgentPool → HeadlessAgent; no gateway-owned Agent."""
+    offenders: list[str] = []
+    for path in _python_files("gateway"):
+        if "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                mod = node.module
+                if mod == "core.agent" or (
+                    mod.startswith("core.agent.") and not mod.startswith("core.agent_harness")
+                ):
+                    offenders.append(f"{path.relative_to(REPO_ROOT)} → import {mod}")
+                for alias in node.names:
+                    if alias.name == "build_agent":
+                        offenders.append(
+                            f"{path.relative_to(REPO_ROOT)} → from {mod} import build_agent"
+                        )
+            elif isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "build_agent":
+                    offenders.append(f"{path.relative_to(REPO_ROOT)} → build_agent(...)")
+                if isinstance(func, ast.Attribute) and func.attr == "build_agent":
+                    offenders.append(f"{path.relative_to(REPO_ROOT)} → *.build_agent(...)")
+            elif isinstance(node, ast.keyword) and node.arg == "precomputed_action_tools":
+                offenders.append(f"{path.relative_to(REPO_ROOT)} → precomputed_action_tools=")
+    assert offenders == [], (
+        "gateway must not own a ReAct Agent or precomputed tools:\n" + "\n".join(offenders)
+    )

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -1,11 +1,14 @@
-"""AST borders for gateway/core · transports · web package DAG.
+"""AST borders for gateway/core · channels · transports · web package DAG.
 
 Pinned rules (see ``gateway/AGENTS.md``):
 
 * Chat transports are peers — none imports another.
-* ``gateway.web`` never imports ``gateway.transports``.
-* ``gateway.core`` never imports surfaces, except the composition root
-  ``gateway.core.runtime.manager``.
+* ``gateway.web`` never imports ``gateway.transports`` or ``gateway.channels``.
+* ``gateway.core`` never imports chat transports or ``gateway.web``.
+* Only ``gateway.core.runtime.manager`` may import ``gateway.channels``.
+* ``gateway.transports.*`` never imports ``gateway.channels`` or ``gateway.web``.
+* ``gateway.channels`` may import peer ``*.startup`` (and ``gateway.web``); peers
+  must not import channels.
 """
 
 from __future__ import annotations
@@ -21,16 +24,23 @@ _TRANSPORTS = (
     "gateway.transports.telegram",
 )
 
-_CORE_SURFACE_ALLOWLIST = frozenset(
+_CHANNELS_COMPOSER = "gateway/core/runtime/manager.py"
+
+_TRANSPORT_STARTUP_MODULES = frozenset(
     {
-        # Composition root — wires chat workers + web server.
-        "gateway/core/runtime/manager.py",
+        "gateway.transports.slack.startup",
+        "gateway.transports.discord.startup",
+        "gateway.transports.telegram.startup",
     }
 )
 
 
 def _python_files(package: str) -> list[Path]:
     root = REPO_ROOT / Path(*package.split("."))
+    if root.is_file() and root.suffix == ".py":
+        return [root]
+    if not root.is_dir():
+        return []
     return sorted(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
 
 
@@ -71,22 +81,54 @@ def test_chat_transport_peers_never_import_each_other() -> None:
     assert offenders == [], "Chat transport peer import:\n" + "\n".join(offenders)
 
 
-def test_web_surface_never_imports_chat_transports() -> None:
-    offenders = _offenders("gateway.web", _TRANSPORTS)
-    assert offenders == [], "Web surface reached into a chat transport:\n" + "\n".join(offenders)
+def test_web_surface_never_imports_chat_transports_or_channels() -> None:
+    offenders = _offenders("gateway.web", (*_TRANSPORTS, "gateway.channels"))
+    assert offenders == [], "Web surface reached into transports/channels:\n" + "\n".join(offenders)
 
 
-def test_core_leaves_never_import_surfaces_except_manager() -> None:
-    banned = (*_TRANSPORTS, "gateway.web")
+def test_core_never_imports_chat_transports_or_web() -> None:
+    """Surfaces are composed via ``gateway.channels``, not from core leaves."""
+    banned = (*_TRANSPORTS, "gateway.web", "gateway.transports")
+    offenders = _offenders("gateway.core", banned)
+    assert offenders == [], "Core imported a surface directly:\n" + "\n".join(offenders)
+
+
+def test_only_manager_imports_channels_module() -> None:
     offenders: list[str] = []
     for path in _python_files("gateway.core"):
         rel = str(path.relative_to(REPO_ROOT))
-        if rel in _CORE_SURFACE_ALLOWLIST:
-            continue
         for name in _imported_modules(path):
-            if any(name == p or name.startswith(f"{p}.") for p in banned):
+            names_channels = name == "gateway.channels" or name.startswith("gateway.channels.")
+            if names_channels and rel != _CHANNELS_COMPOSER:
                 offenders.append(f"{rel} → {name}")
-    assert offenders == [], "Core leaf imported a surface:\n" + "\n".join(offenders)
+    assert offenders == [], "Non-manager core imported gateway.channels:\n" + "\n".join(offenders)
+
+
+def test_transports_never_import_channels_or_web() -> None:
+    offenders: list[str] = []
+    for package in _TRANSPORTS:
+        offenders.extend(_offenders(package, ("gateway.channels", "gateway.web")))
+    # Also scan transports package root (no registry composer left there).
+    offenders.extend(_offenders("gateway.transports", ("gateway.channels", "gateway.web")))
+    # Deduplicate paths that appear both as package and via rglob of parent.
+    offenders = sorted(set(offenders))
+    assert offenders == [], "Transport peer imported channels/web:\n" + "\n".join(offenders)
+
+
+def test_channels_only_imports_peer_startup_not_transport_internals() -> None:
+    """Channels may compose via ``*.startup``; deeper peer modules stay private."""
+    offenders: list[str] = []
+    for path in _python_files("gateway.channels"):
+        rel = str(path.relative_to(REPO_ROOT))
+        for name in _imported_modules(path):
+            if not any(name == p or name.startswith(f"{p}.") for p in _TRANSPORTS):
+                continue
+            if name in _TRANSPORT_STARTUP_MODULES:
+                continue
+            offenders.append(f"{rel} → {name}")
+    assert offenders == [], "channels imported non-startup transport modules:\n" + "\n".join(
+        offenders
+    )
 
 
 def test_approvals_module_imports_no_transport() -> None:
@@ -94,3 +136,51 @@ def test_approvals_module_imports_no_transport() -> None:
     imported = _imported_modules(path)
     leaked = [n for n in imported if any(n == p or n.startswith(f"{p}.") for p in _TRANSPORTS)]
     assert leaked == [], f"approvals.py imports transports: {leaked}"
+
+
+def _executable_surface_references(path: Path) -> list[str]:
+    """Return imports and runtime string literals naming a ``surfaces`` module.
+
+    Docstrings are excluded: prose describing the boundary is documentation,
+    not a dependency.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    docstrings = {
+        node.body[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        and node.body
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    }
+    found: list[str] = []
+    for name in _imported_modules(path):
+        if name == "surfaces" or name.startswith("surfaces."):
+            found.append(f"import {name}")
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or node in docstrings:
+            continue
+        if isinstance(node.value, str) and node.value.startswith("surfaces."):
+            found.append(f"line {node.lineno}: {node.value!r}")
+    return found
+
+
+def test_gateway_never_names_a_surfaces_module_in_executable_code() -> None:
+    """``surfaces`` is a peer package, and a spawned module path is still a dependency.
+
+    The daemon used to hardcode ``python -m surfaces.cli.gateway_entry`` in its
+    subprocess argv. Import-linter cannot see a dependency spelled as a string
+    literal, so the cycle stayed invisible: a surface starts the daemon, and the
+    daemon starts a surface back. Each surface now passes its own argv.
+    """
+    # Arrange / Act: scan every non-test gateway module.
+    offenders: list[str] = []
+    for path in _python_files("gateway"):
+        if "tests" in path.parts:
+            continue
+        for reference in _executable_surface_references(path):
+            offenders.append(f"{path.relative_to(REPO_ROOT)}: {reference}")
+
+    # Assert.
+    assert offenders == [], "gateway depends on a surfaces module:\n" + "\n".join(offenders)

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -18,21 +18,26 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-_TRANSPORTS = (
-    "gateway.transports.slack",
-    "gateway.transports.discord",
-    "gateway.transports.telegram",
-)
+
+def _discover_transport_packages() -> tuple[str, ...]:
+    """Every chat transport package on disk.
+
+    Discovered rather than listed: a hand-maintained list silently exempts a
+    newly added transport from every border rule below.
+    """
+    root = REPO_ROOT / "gateway" / "transports"
+    return tuple(
+        f"gateway.transports.{child.name}"
+        for child in sorted(root.iterdir())
+        if child.is_dir() and (child / "__init__.py").is_file()
+    )
+
+
+_TRANSPORTS = _discover_transport_packages()
 
 _CHANNELS_COMPOSER = "gateway/core/runtime/manager.py"
 
-_TRANSPORT_STARTUP_MODULES = frozenset(
-    {
-        "gateway.transports.slack.startup",
-        "gateway.transports.discord.startup",
-        "gateway.transports.telegram.startup",
-    }
-)
+_TRANSPORT_STARTUP_MODULES = frozenset(f"{package}.startup" for package in _TRANSPORTS)
 
 
 def _python_files(package: str) -> list[Path]:
@@ -294,4 +299,25 @@ def test_gateway_chat_never_builds_core_agent_or_precomputed_tools() -> None:
                 offenders.append(f"{path.relative_to(REPO_ROOT)} → precomputed_action_tools=")
     assert offenders == [], (
         "gateway must not own a ReAct Agent or precomputed tools:\n" + "\n".join(offenders)
+    )
+
+
+def test_every_transport_package_is_registered_in_the_chat_table() -> None:
+    """A transport package on disk must appear in the registry, and vice versa.
+
+    Adding a transport used to mean editing the manager; now it means adding a
+    ``TransportSpec`` row. This fails if someone ships the package without the
+    row (the transport never starts) or the row without the package.
+    """
+    # Arrange / Act.
+    from gateway.channels.chat import TRANSPORTS
+
+    on_disk = {package.rsplit(".", 1)[-1] for package in _TRANSPORTS}
+    registered = {spec.name.value for spec in TRANSPORTS}
+
+    # Assert.
+    assert on_disk == registered, (
+        f"transport packages and registry rows disagree: "
+        f"only on disk={sorted(on_disk - registered)}, "
+        f"only registered={sorted(registered - on_disk)}"
     )

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -184,3 +184,32 @@ def test_gateway_never_names_a_surfaces_module_in_executable_code() -> None:
 
     # Assert.
     assert offenders == [], "gateway depends on a surfaces module:\n" + "\n".join(offenders)
+
+
+_QUARANTINED_HANDLER_NAMES = frozenset(
+    {
+        "ConcurrencyLimitedTurnHandler",
+        "gated_callback",
+    }
+)
+
+
+def test_concurrency_limited_handler_stays_out_of_production_gateway() -> None:
+    """Wave C4: capacity wrapper is tests-only; production uses GatewayTurnHandler(gate=)."""
+    offenders: list[str] = []
+    for path in _python_files("gateway"):
+        if "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.name in _QUARANTINED_HANDLER_NAMES:
+                        offenders.append(
+                            f"{path.relative_to(REPO_ROOT)} → from {node.module} import {alias.name}"
+                        )
+            elif isinstance(node, ast.Name) and node.id in _QUARANTINED_HANDLER_NAMES:
+                offenders.append(f"{path.relative_to(REPO_ROOT)} → name {node.id}")
+    assert offenders == [], (
+        "quarantined ConcurrencyLimitedTurnHandler leaked into production:\n" + "\n".join(offenders)
+    )

--- a/gateway/tests/test_session_resolver.py
+++ b/gateway/tests/test_session_resolver.py
@@ -145,6 +145,32 @@ def test_rotate_flushes_old_and_binds_new(resolver: SessionResolver) -> None:
     )
 
 
+def test_resolve_adopts_legacy_empty_binding_into_scoped_key(
+    resolver: SessionResolver,
+) -> None:
+    """Same-document legacy Telegram rows are re-keyed on first scoped resolve."""
+    org = Principal.org("org_acme")
+    resolver._bindings.bind(
+        platform="telegram",
+        chat_id="42",
+        session_id="legacy-session",
+    )
+    resolver._fake_repo.load_session = lambda session_id: {
+        "session_id": session_id,
+        "cli_agent_messages": [],
+    }
+
+    resolved = resolver.resolve(user_id="42", chat_id="99", principal=org, actor="tg-42")
+
+    assert resolved.session_id == "legacy-session"
+    assert (
+        resolver._bindings.get_session_id(
+            platform="telegram", chat_id="42", principal=org, actor="tg-42"
+        )
+        == "legacy-session"
+    )
+
+
 def test_slack_actors_get_distinct_sessions(resolver: SessionResolver) -> None:
     org = Principal.org("org_acme")
     alice = resolver.resolve(user_id="T:C:1", chat_id="C1", principal=org, actor="U_ALICE")

--- a/gateway/tests/test_session_resolver.py
+++ b/gateway/tests/test_session_resolver.py
@@ -169,6 +169,29 @@ def test_resolve_adopts_legacy_empty_binding_into_scoped_key(
         )
         == "legacy-session"
     )
+    # Single-use: legacy empty-id row must be gone after adoption.
+    assert resolver._bindings.get_session_id(platform="telegram", chat_id="42") is None
+
+
+def test_legacy_adoption_is_single_use_across_actors(resolver: SessionResolver) -> None:
+    """Second actor must not inherit the session the first actor adopted."""
+    org = Principal.org("org_acme")
+    resolver._bindings.bind(
+        platform="telegram",
+        chat_id="T:C:1",
+        session_id="legacy-shared",
+    )
+    resolver._fake_repo.load_session = lambda session_id: {
+        "session_id": session_id,
+        "cli_agent_messages": [],
+    }
+
+    alice = resolver.resolve(user_id="T:C:1", chat_id="C1", principal=org, actor="U_ALICE")
+    bob = resolver.resolve(user_id="T:C:1", chat_id="C1", principal=org, actor="U_BOB")
+
+    assert alice.session_id == "legacy-shared"
+    assert bob.session_id != alice.session_id
+    assert resolver._bindings.get_session_id(platform="telegram", chat_id="T:C:1") is None
 
 
 def test_slack_actors_get_distinct_sessions(resolver: SessionResolver) -> None:

--- a/gateway/tests/test_storage_surface_borders.py
+++ b/gateway/tests/test_storage_surface_borders.py
@@ -1,11 +1,11 @@
-"""Regression: Slack org scoping must not leak into other surfaces.
+"""Regression: Slack org scoping must not leak into peer surfaces.
 
 Borders under test
 ------------------
-* Slack team turn — only place that binds ``StorageScope`` and resolves a
-  principal from the install catalog.
-* Telegram / CLI / interactive shell — stay unbound; host ``~/.opensre``;
-  bindings omit principal/actor (legacy empty ids).
+* Slack / Discord / Telegram — each binds ``StorageScope`` via its own
+  ``*.principal`` module (peer isolation; no cross-imports).
+* CLI / interactive shell — stay unbound; host ``~/.opensre``; bindings omit
+  principal/actor (legacy empty ids).
 * Shared ``gateway.core.storage`` — transport-neutral; no Slack resolve exports.
 * Actors in one org — private sessions; shared integrations; no cross-user
   corruption.
@@ -60,11 +60,12 @@ def _imported_modules(path: Path) -> set[str]:
     return names
 
 
-def test_telegram_package_never_imports_slack_principal_or_scope() -> None:
-    """Telegram must not resolve Slack installs or bind org scope."""
+def test_telegram_package_never_imports_slack_or_discord_principal() -> None:
+    """Telegram uses its own principal module — never Slack/Discord peers."""
     banned = (
         "gateway.transports.slack.principal",
         "gateway.transports.slack.installs",
+        "gateway.transports.discord.principal",
         "gateway.core.storage.principal_resolve",
         "gateway.core.storage.slack_installs",
     )
@@ -74,11 +75,7 @@ def test_telegram_package_never_imports_slack_principal_or_scope() -> None:
         for name in banned:
             if name in imported or any(n.startswith(name + ".") for n in imported):
                 offenders.append(f"{path.relative_to(REPO_ROOT)} → {name}")
-        # bound_storage_scope is allowed only via gateway.core.storage re-export in
-        # theory — Telegram must not use it at all.
-        if "config.scope_context" in imported:
-            offenders.append(f"{path.relative_to(REPO_ROOT)} → config.scope_context")
-    assert offenders == [], "Telegram crossed the Slack storage border:\n" + "\n".join(offenders)
+    assert offenders == [], "Telegram crossed a peer principal border:\n" + "\n".join(offenders)
 
 
 def test_surfaces_never_import_slack_principal_resolve() -> None:
@@ -166,7 +163,7 @@ def test_two_orgs_do_not_share_integrations_or_sessions(_host: Path) -> None:
     assert globex_integ.read_text(encoding="utf-8") == '{"globex": true}'
 
 
-def test_slack_bindings_isolate_actors_and_keep_legacy_telegram_untouched(
+def test_slack_and_telegram_scoped_bindings_stay_isolated(
     tmp_path: Path,
 ) -> None:
     store = FileBindingStore(tmp_path / "bindings.json")
@@ -185,8 +182,13 @@ def test_slack_bindings_isolate_actors_and_keep_legacy_telegram_untouched(
         principal=org,
         actor="U_BOB",
     )
-    # Telegram production shape: omit principal + actor → legacy empty ids.
-    store.bind(platform="telegram", chat_id="42", session_id="tg-legacy")
+    store.bind(
+        platform="telegram",
+        chat_id="42",
+        session_id="tg-alice",
+        principal=org,
+        actor="tg-42",
+    )
 
     assert (
         store.get_session_id(platform="slack", chat_id="T:C:1", principal=org, actor="U_ALICE")
@@ -196,10 +198,14 @@ def test_slack_bindings_isolate_actors_and_keep_legacy_telegram_untouched(
         store.get_session_id(platform="slack", chat_id="T:C:1", principal=org, actor="U_BOB")
         == "slack-bob"
     )
-    assert store.get_session_id(platform="telegram", chat_id="42") == "tg-legacy"
-    # Slack actor rows must never answer a Telegram omit-scope lookup.
+    assert (
+        store.get_session_id(platform="telegram", chat_id="42", principal=org, actor="tg-42")
+        == "tg-alice"
+    )
+    # Unscoped lookups must not answer scoped rows.
     assert store.get_session_id(platform="slack", chat_id="T:C:1") is None
-    # Telegram legacy must never answer a Slack scoped lookup.
+    assert store.get_session_id(platform="telegram", chat_id="42") is None
+    # Cross-platform scoped lookup must miss.
     assert (
         store.get_session_id(platform="telegram", chat_id="42", principal=org, actor="U_ALICE")
         is None
@@ -207,7 +213,7 @@ def test_slack_bindings_isolate_actors_and_keep_legacy_telegram_untouched(
     store.close()
 
 
-# ── Non-Slack surfaces: unbound / mount ignored ─────────────────────────────
+# ── Unbound CLI surfaces: mount ignored ─────────────────────────────────────
 
 
 def test_unbound_surfaces_ignore_context_root_mount(

--- a/gateway/tests/test_surface_borders.py
+++ b/gateway/tests/test_surface_borders.py
@@ -1,12 +1,11 @@
-"""Regression borders: only Slack org turns may change, and only their own data.
+"""Regression borders: scoped chat turns stay on their own org data.
 
-Three surfaces share one process and one filesystem: the local CLI, Telegram,
-and Slack. Scoping was introduced for Slack alone, so each test here fixes one
-edge of that boundary — either "this surface is untouched" or "this Slack turn
-cannot reach anything but its own".
+Chat transports (Slack / Discord / Telegram) bind ``StorageScope``; the local
+CLI stays unbound. Each test fixes one edge — either "unbound surfaces ignore
+the mount" or "an org turn cannot reach another org's data".
 
-The deployed Slack task always has ``OPENSRE_CONTEXT_ROOT`` set, so most tests
-configure the mount and then assert what *does not* reach it.
+Deployed silos set ``OPENSRE_CONTEXT_ROOT``; most tests configure the mount and
+assert what *does not* cross organizations.
 """
 
 from __future__ import annotations
@@ -107,49 +106,56 @@ def test_cli_is_unaffected_by_a_configured_mount(mounted: Path) -> None:
         assert path != mounted
 
 
-# ── Border 2: Telegram is untouched ─────────────────────────────────────────
+# ── Border 2: Telegram is scoped like Slack; platforms stay separate ─────────
 
 
-def test_telegram_bindings_keep_the_unscoped_key(host: Path) -> None:
-    """Telegram passes no principal or actor, exactly as before scoping."""
-    # Arrange
+def test_telegram_bindings_use_scoped_keys(host: Path) -> None:
+    """Telegram production shape: org principal + Telegram user actor."""
     store = FileBindingStore(host / "bindings.json")
-
-    # Act: bind the way gateway/telegram does, then read it back the same way.
-    store.bind(platform=_TELEGRAM, chat_id="42", session_id="tg-1")
-    resolved = store.get_session_id(platform=_TELEGRAM, chat_id="42")
+    store.bind(
+        platform=_TELEGRAM,
+        chat_id="42",
+        session_id="tg-1",
+        principal=ACME,
+        actor="tg-42",
+    )
+    assert (
+        store.get_session_id(platform=_TELEGRAM, chat_id="42", principal=ACME, actor="tg-42")
+        == "tg-1"
+    )
+    assert store.get_session_id(platform=_TELEGRAM, chat_id="42") is None
     store.close()
 
-    # Assert
-    assert resolved == "tg-1"
 
-
-def test_telegram_writes_nothing_to_a_customer_volume(host: Path, mounted: Path) -> None:
-    """Telegram shares the Slack task but names no organization."""
-    # Act: a Telegram turn binds no scope.
+def test_unbound_boot_writes_nothing_to_a_customer_volume(host: Path, mounted: Path) -> None:
+    """With no bound scope (CLI / process boot), paths stay on host storage."""
     sessions = session_paths.sessions_dir()
     bindings = bindings_file_path()
     memory = paths.get_memory_dir()
 
-    # Assert: all of it stays on ephemeral host storage, not the customer's disk.
     for path in (sessions, bindings, memory):
         assert mounted not in path.parents
     assert sessions == host / "sessions"
 
 
 def test_a_slack_org_cannot_hijack_a_telegram_binding(host: Path) -> None:
-    """Same chat id on two platforms and two scopes must stay separate rows."""
-    # Arrange: Telegram binds chat "42" unscoped.
+    """Same chat id on two platforms must stay separate rows."""
     store = FileBindingStore(host / "bindings.json")
-    store.bind(platform=_TELEGRAM, chat_id="42", session_id="tg-session")
-
-    # Act: a Slack org binds the same chat id under its own principal and actor.
+    store.bind(
+        platform=_TELEGRAM,
+        chat_id="42",
+        session_id="tg-session",
+        principal=ACME,
+        actor="tg-42",
+    )
     store.bind(
         platform=_SLACK, chat_id="42", session_id="slack-session", principal=ACME, actor=ALICE
     )
 
-    # Assert: neither read sees the other's session.
-    assert store.get_session_id(platform=_TELEGRAM, chat_id="42") == "tg-session"
+    assert (
+        store.get_session_id(platform=_TELEGRAM, chat_id="42", principal=ACME, actor="tg-42")
+        == "tg-session"
+    )
     assert (
         store.get_session_id(platform=_SLACK, chat_id="42", principal=ACME, actor=ALICE)
         == "slack-session"

--- a/gateway/transports/AGENTS.md
+++ b/gateway/transports/AGENTS.md
@@ -4,13 +4,20 @@ One package per inbound chat platform. Peers: **none imports another**.
 
 | Package | Start |
 |---------|--------|
-| `slack/` | `wiring.start_slack_worker` |
-| `discord/` | `wiring.start_discord_worker` |
-| `telegram/` | `wiring.start_telegram_worker` |
+| `slack/` | `startup.start_slack_worker` |
+| `discord/` | `startup.start_discord_worker` |
+| `telegram/` | `startup.start_telegram_worker` |
 
-Each owns settings, inbound worker, security, output sink, and wiring.
+Composition of peers lives in `gateway.channels` (`chat.py` + `compose.py`),
+not here. `GatewayManager` only holds the opaque `ChannelsHandle`.
+Transport-specific work (settings load, Discord readiness wait) stays in each
+package's `startup.py`.
+
+Each owns settings, inbound worker, security, output sink, and `startup.py`.
 Anything two transports need belongs in `gateway.core` (usually
 `gateway.core.runtime`).
+
+Peers must not import `gateway.channels` or `gateway.web`.
 
 Peer import DAG pinned by `gateway/tests/test_package_borders.py`.
 Discord↔Slack isolation extras:

--- a/gateway/transports/__init__.py
+++ b/gateway/transports/__init__.py
@@ -1,8 +1,9 @@
 """Chat transport peers — Slack, Discord, Telegram.
 
 Each transport owns settings, inbound worker, security, output sink, and
-``wiring.py``. Transports are peers: none imports another. Shared machinery
-lives under ``gateway.core``.
+``startup.py``. Transports are peers: none imports another. Shared machinery
+lives under ``gateway.core``. Consumer composition (starting peers together)
+lives in ``gateway.channels``.
 """
 
 from __future__ import annotations

--- a/gateway/transports/discord/__init__.py
+++ b/gateway/transports/discord/__init__.py
@@ -1,8 +1,8 @@
 """Discord Gateway WebSocket transport for two-way agent chat.
 
-Transport entry: :mod:`gateway.transports.discord.wiring` (``start_discord_worker``).
+Transport entry: :mod:`gateway.transports.discord.startup` (``start_discord_worker``).
 """
 
-from gateway.transports.discord.wiring import start_discord_worker
+from gateway.transports.discord.startup import start_discord_worker
 
 __all__ = ["start_discord_worker"]

--- a/gateway/transports/discord/dispatcher.py
+++ b/gateway/transports/discord/dispatcher.py
@@ -13,12 +13,17 @@ from config.principal import StorageScope
 from config.scope_context import bound_storage_scope
 from core.agent_harness.session import SessionCore
 from gateway.core.billing.credits_client import CreditsOutcome, consume_credits
+from gateway.core.runtime.active_turns import (
+    USER_STOP_MESSAGE,
+    ActiveTurnCancels,
+    is_stop_command,
+)
 from gateway.core.runtime.approvals import ApprovalBroker, approval_tool_hooks
 from gateway.core.runtime.attention import GateDecision, ThreadAttentionGate
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.storage import SessionResolver
 from gateway.transports.discord.approvals import DiscordApprovalPrompter
-from gateway.transports.discord.client import add_reaction, remove_reaction
+from gateway.transports.discord.client import add_reaction, remove_reaction, send_message
 from gateway.transports.discord.events import DiscordInboundMessage
 from gateway.transports.discord.output_sink import DiscordOutputSink
 from gateway.transports.discord.principal import PrincipalResolutionError, resolve_discord_scope
@@ -73,6 +78,7 @@ class DiscordTurnDispatcher:
         self._logger = logger
         self._bot_user_id = bot_user_id
         self._approvals = approvals or ApprovalBroker()
+        self._active_cancels = ActiveTurnCancels()
         self._attention = ThreadAttentionGate()
         self._conversation_locks: dict[str, _ConversationLock] = {}
         self._locks_guard = threading.Lock()
@@ -86,6 +92,15 @@ class DiscordTurnDispatcher:
         self._bot_user_id = bot_user_id
 
     def dispatch(self, inbound: DiscordInboundMessage) -> None:
+        # /stop must not wait on the per-conversation turn lock.
+        if is_stop_command(inbound.text):
+            if not self._active_cancels.request_stop(inbound.conversation_key):
+                send_message(
+                    channel_id=inbound.channel_id,
+                    content="Nothing running to stop.",
+                    bot_token=self._bot_token,
+                )
+            return
         try:
             scope = resolve_discord_scope(guild_id=inbound.guild_id, user_id=inbound.user_id)
         except PrincipalResolutionError:
@@ -293,6 +308,26 @@ class DiscordTurnDispatcher:
                     bot_token=self._bot_token,
                 )
 
+            def _on_user_stop() -> None:
+                if not _claim_terminal_outcome():
+                    return
+                try:
+                    sink.finalize(USER_STOP_MESSAGE)
+                except Exception:
+                    self._logger.debug("[discord-gateway] user-stop finalize failed", exc_info=True)
+                remove_reaction(
+                    channel_id=inbound.channel_id,
+                    message_id=inbound.message_id,
+                    emoji=_WORKING_EMOJI,
+                    bot_token=self._bot_token,
+                )
+                add_reaction(
+                    channel_id=inbound.channel_id,
+                    message_id=inbound.message_id,
+                    emoji=_FAILED_EMOJI,
+                    bot_token=self._bot_token,
+                )
+
             timer = threading.Timer(self._settings.turn_timeout_seconds, _on_turn_timeout)
             timer.start()
             turn_started = time.monotonic()
@@ -314,10 +349,17 @@ class DiscordTurnDispatcher:
                     )
                     if ctx:
                         agent_text = f"{agent_text}\n\n{ctx}"
-                with bound_usage_context(
-                    surface=SURFACE_DISCORD,
-                    session_id=session.session_id,
-                    user_id=inbound.user_id or None,
+                with (
+                    self._active_cancels.track(
+                        inbound.conversation_key,
+                        turn_cancel,
+                        on_user_stop=_on_user_stop,
+                    ),
+                    bound_usage_context(
+                        surface=SURFACE_DISCORD,
+                        session_id=session.session_id,
+                        user_id=inbound.user_id or None,
+                    ),
                 ):
                     self._handler(agent_text, session, sink, self._logger)
             except Exception:

--- a/gateway/transports/discord/output_sink.py
+++ b/gateway/transports/discord/output_sink.py
@@ -38,6 +38,9 @@ class DiscordOutputSink:
         tool_hooks: object | None = None,
     ) -> None:
         self.tool_hooks = tool_hooks
+        # Set per turn by this transport's dispatcher; the turn handler reads it
+        # to give tools a cooperative cancel signal on soft timeout or stop.
+        self.turn_cancel: threading.Event | None = None
         self._bot_token = bot_token
         self._channel_id = channel_id
         self._edit_interval = edit_interval_seconds

--- a/gateway/transports/discord/principal.py
+++ b/gateway/transports/discord/principal.py
@@ -2,8 +2,8 @@
 
 Discord guild/DM turns attribute data to the silo organization
 (``ORGANIZATION_ID``) and key per-actor sessions by Discord user id —
-same border as Slack org + actor. Telegram/CLI stay unbound and must not import
-this module.
+same border as Slack/Telegram org + actor. CLI stays unbound and must not
+import this module; Telegram uses ``telegram.principal``.
 """
 
 from __future__ import annotations

--- a/gateway/transports/discord/settings.py
+++ b/gateway/transports/discord/settings.py
@@ -11,6 +11,7 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from config.constants.discord import DISCORD_ALLOW_OPEN_GUILD_ENV, DISCORD_ALLOWED_USERS_ENV
 from config.strict_config import StrictConfigModel
+from gateway.core.runtime.concurrency import turn_limit_for_profile
 from gateway.core.runtime.errors import GatewayConfigurationError
 from integrations.messaging_security import MessagingIdentityPolicy, MessagingPlatform
 from integrations.store import get_integration
@@ -24,7 +25,7 @@ class DiscordGatewaySettings(StrictConfigModel):
     bot_token: str
     allowed_user_ids: list[str] = Field(default_factory=list)
     allow_open_guild: bool = False
-    max_concurrent_turns: int = Field(default=4, ge=1)
+    max_concurrent_turns: int = Field(default_factory=turn_limit_for_profile, ge=1)
     status_update_interval_seconds: float = Field(default=2.0, gt=0)
     turn_timeout_seconds: float = Field(default=240.0, gt=0)
     startup_timeout_seconds: float = Field(default=30.0, gt=0)
@@ -38,7 +39,7 @@ class DiscordGatewayEnv(BaseSettings):
     bot_token: str = ""
     allowed_users: Annotated[list[str], NoDecode] = Field(default_factory=list)
     allow_open_guild: bool = False
-    gateway_max_concurrent: int = Field(default=4, ge=1)
+    gateway_max_concurrent: int = Field(default_factory=turn_limit_for_profile, ge=1)
     gateway_status_update_interval_seconds: float = Field(default=2.0, gt=0)
     gateway_turn_timeout_seconds: float = Field(default=240.0, gt=0)
     gateway_startup_timeout_seconds: float = Field(default=30.0, gt=0)

--- a/gateway/transports/discord/startup.py
+++ b/gateway/transports/discord/startup.py
@@ -1,9 +1,10 @@
-"""Discord-specific gateway wiring."""
+"""Start the Discord chat worker for the gateway."""
 
 from __future__ import annotations
 
 import logging
 
+from gateway.core.runtime.errors import GatewayTransportFailedError
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.transports.discord.background import (
     DiscordGatewayBackground,
@@ -20,13 +21,24 @@ def start_discord_worker(
     logger: logging.Logger,
     handler: GatewayAgentCallback,
 ) -> tuple[DiscordGatewayBackground, DiscordGatewaySettings]:
-    """Load Discord settings and start the Gateway WebSocket background worker."""
+    """Load Discord settings and start the Gateway WebSocket background worker.
+
+    Waits until the gateway is ready so the uniform transport registry can treat
+    Discord like Telegram/Slack (start returns only a live worker).
+    """
     settings = load_discord_gateway_settings()
     worker = start_discord_gateway_background(
         settings=settings,
         logger=logger,
         handler=handler,
     )
+    if not worker.wait_until_ready(timeout=settings.startup_timeout_seconds):
+        logger.warning(
+            "Discord gateway did not become ready within %.0fs",
+            settings.startup_timeout_seconds,
+        )
+        worker.stop()
+        raise GatewayTransportFailedError("startup timeout")
     return worker, settings
 
 

--- a/gateway/transports/slack/__init__.py
+++ b/gateway/transports/slack/__init__.py
@@ -6,7 +6,7 @@ per-message handler it drives is transport-agnostic and injected by the
 composition root (:mod:`gateway.core.runtime.manager`). Outbound-only Slack delivery
 (webhooks, RCA reports) lives in :mod:`integrations.slack`.
 
-Transport entry: :mod:`gateway.transports.slack.wiring` (``start_slack_worker``).
+Transport entry: :mod:`gateway.transports.slack.startup` (``start_slack_worker``).
 """
 
 from __future__ import annotations

--- a/gateway/transports/slack/dispatcher.py
+++ b/gateway/transports/slack/dispatcher.py
@@ -13,6 +13,11 @@ from config.principal import StorageScope
 from config.scope_context import bound_storage_scope
 from core.agent_harness.session import SessionCore
 from gateway.core.billing.credits_client import CreditsOutcome, consume_credits
+from gateway.core.runtime.active_turns import (
+    USER_STOP_MESSAGE,
+    ActiveTurnCancels,
+    is_stop_command,
+)
 from gateway.core.runtime.approvals import ApprovalBroker, approval_tool_hooks
 from gateway.core.runtime.attention import GateDecision, ThreadAttentionGate
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
@@ -83,12 +88,18 @@ class _SlackTurnDispatcher:
         self._logger = logger
         self._bot_user_id = bot_user_id
         self._approvals = approvals if approvals is not None else ApprovalBroker()
+        self._active_cancels = ActiveTurnCancels()
         self._attention = ThreadAttentionGate()
         self._conversation_locks: dict[str, _ConversationLock] = {}
         self._locks_guard = threading.Lock()
         self._resolver_lock = threading.Lock()
 
     def dispatch(self, inbound: SlackInboundMessage) -> None:
+        # /stop must not wait on the per-conversation turn lock.
+        if is_stop_command(inbound.text):
+            if not self._active_cancels.request_stop(inbound.conversation_key):
+                self._post(inbound, "Nothing running to stop.")
+            return
         try:
             scope = resolve_slack_scope(team_id=inbound.team_id, user_id=inbound.user_id)
         except PrincipalResolutionError:
@@ -355,6 +366,19 @@ class _SlackTurnDispatcher:
                     timestamp=inbound.ts,
                 )
 
+            def _on_user_stop() -> None:
+                if not _claim_terminal_outcome():
+                    return
+                try:
+                    sink.finalize(USER_STOP_MESSAGE)
+                except Exception:
+                    self._logger.debug("[slack-gateway] user-stop finalize failed", exc_info=True)
+                mark_turn_failed(
+                    self._messaging,
+                    channel=inbound.channel_id,
+                    timestamp=inbound.ts,
+                )
+
             timer = threading.Timer(self._settings.turn_timeout_seconds, _on_turn_timeout)
             timer.start()
             try:
@@ -378,10 +402,17 @@ class _SlackTurnDispatcher:
                     files_context := _slack_files_context(inbound.files, self._logger)
                 ):
                     agent_text = f"{agent_text}\n\n{files_context}"
-                with bound_usage_context(
-                    surface=SURFACE_SLACK,
-                    session_id=session.session_id,
-                    user_id=inbound.user_id or None,
+                with (
+                    self._active_cancels.track(
+                        inbound.conversation_key,
+                        turn_cancel,
+                        on_user_stop=_on_user_stop,
+                    ),
+                    bound_usage_context(
+                        surface=SURFACE_SLACK,
+                        session_id=session.session_id,
+                        user_id=inbound.user_id or None,
+                    ),
                 ):
                     self._handler(agent_text, session, sink, self._logger)
             except Exception:

--- a/gateway/transports/slack/output_sink.py
+++ b/gateway/transports/slack/output_sink.py
@@ -53,6 +53,9 @@ class SlackOutputSink:
         # Per-turn tool-execution hooks (e.g. the Block Kit approval gate),
         # read duck-typed by GatewayTurnHandler when building the agent.
         self.tool_hooks = tool_hooks
+        # Set per turn by this transport's dispatcher; the turn handler reads it
+        # to give tools a cooperative cancel signal on soft timeout or stop.
+        self.turn_cancel: threading.Event | None = None
         self._client = client
         self._channel_id = channel_id
         self._thread_ts = thread_ts

--- a/gateway/transports/slack/principal.py
+++ b/gateway/transports/slack/principal.py
@@ -1,8 +1,8 @@
 """Resolve the owning principal for a Slack team-install turn.
 
-Slack-only. Telegram, CLI, and interactive shell must not import this module —
-they stay unbound on the host home. Border regressions live in
-``gateway/tests/test_storage_surface_borders.py``.
+Slack-only. Telegram has its own ``telegram.principal``; CLI and interactive
+shell must not import this module — they stay unbound on the host home. Border
+regressions live in ``gateway/tests/test_storage_surface_borders.py``.
 """
 
 from __future__ import annotations

--- a/gateway/transports/slack/settings.py
+++ b/gateway/transports/slack/settings.py
@@ -10,6 +10,7 @@ from pydantic import Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from config.strict_config import StrictConfigModel
+from gateway.core.runtime.concurrency import turn_limit_for_profile
 from gateway.core.runtime.errors import GatewayConfigurationError
 from integrations.messaging_security import MessagingIdentityPolicy, MessagingPlatform
 from integrations.store import get_integration
@@ -24,7 +25,7 @@ class SlackGatewaySettings(StrictConfigModel):
     app_token: str
     allowed_user_ids: list[str] = Field(default_factory=list)
     allow_open_workspace: bool = False
-    max_concurrent_turns: int = Field(default=4, ge=1)
+    max_concurrent_turns: int = Field(default_factory=turn_limit_for_profile, ge=1)
     # Slack's AI-app guidance: call chat.update at most once every 3 seconds.
     status_update_interval_seconds: float = Field(default=3.0, gt=0)
     turn_timeout_seconds: float = Field(default=240.0, gt=0)
@@ -47,7 +48,7 @@ class SlackGatewayEnv(BaseSettings):
     allowed_users: Annotated[list[str], NoDecode] = Field(default_factory=list)
     # Explicit escape hatch only — empty allowlist alone must not open the bot.
     allow_open_workspace: bool = False
-    gateway_max_concurrent: int = Field(default=4, ge=1)
+    gateway_max_concurrent: int = Field(default_factory=turn_limit_for_profile, ge=1)
     gateway_status_update_interval_seconds: float = Field(default=3.0, gt=0)
     gateway_turn_timeout_seconds: float = Field(default=240.0, gt=0)
     gateway_heartbeat_path: str = ""

--- a/gateway/transports/slack/startup.py
+++ b/gateway/transports/slack/startup.py
@@ -1,4 +1,4 @@
-"""Slack-specific gateway wiring.
+"""Start the Slack chat worker for the gateway.
 
 Owns everything that is particular to the Slack Socket Mode transport: loading
 Slack settings and starting the background Socket Mode worker. The message

--- a/gateway/transports/telegram/__init__.py
+++ b/gateway/transports/telegram/__init__.py
@@ -5,7 +5,7 @@ edit-in-place output sink, and the background worker. The per-message handler
 it drives is transport-agnostic and injected by the composition root
 (:mod:`gateway.core.runtime.manager`). Mirrors :mod:`gateway.transports.slack`.
 
-Transport entry: :mod:`gateway.transports.telegram.wiring` (``start_telegram_worker``).
+Transport entry: :mod:`gateway.transports.telegram.startup` (``start_telegram_worker``).
 """
 
 from __future__ import annotations

--- a/gateway/transports/telegram/approvals.py
+++ b/gateway/transports/telegram/approvals.py
@@ -1,0 +1,160 @@
+"""Inline-keyboard approval prompt for write tools on Telegram.
+
+The transport-neutral half — broker, button identifiers, harness hooks — lives
+in :mod:`gateway.core.runtime.approvals`. This module renders the Telegram side:
+an Approve / Deny inline keyboard, and callback_query routing back to the broker.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from gateway.core.runtime.approvals import (
+    APPROVE_ACTION_ID,
+    DENY_ACTION_ID,
+    MAX_APPROVAL_WAIT_SECONDS,
+    ApprovalBroker,
+    arguments_preview,
+)
+from gateway.transports.telegram.poller.client import TelegramBotClient
+from gateway.transports.telegram.settings import TelegramCallbackQuery
+
+logger = logging.getLogger("gateway")
+
+
+class TelegramApprovalPrompter:
+    """Posts Approve/Deny buttons in-chat and waits for an authorized click."""
+
+    def __init__(
+        self,
+        *,
+        client: TelegramBotClient,
+        broker: ApprovalBroker,
+        chat_id: str,
+    ) -> None:
+        self._client = client
+        self._broker = broker
+        self._chat_id = chat_id
+
+    def request(
+        self,
+        *,
+        tool_name: str,
+        reason: str,
+        arguments: Mapping[str, Any],
+        expiry_seconds: float,
+    ) -> tuple[bool, str]:
+        approval_id = self._broker.create(
+            platform="telegram",
+            chat_id=self._chat_id,
+        )
+        body = f"🔒 Approval needed — `{tool_name}`"
+        if reason.strip():
+            body += f"\n{reason.strip()}"
+        preview = arguments_preview(arguments)
+        if preview:
+            body += f"\n```\n{preview}\n```"
+        ok, error, message_id = self._client.send_message(
+            self._chat_id,
+            body,
+            reply_markup=_approval_keyboard(approval_id),
+        )
+        if not ok or not message_id:
+            logger.warning(
+                "[telegram-gateway] approval prompt post failed tool=%s chat=%s err=%s",
+                tool_name,
+                self._chat_id,
+                error,
+            )
+            return (False, "")
+        timeout = min(float(expiry_seconds), MAX_APPROVAL_WAIT_SECONDS)
+        approved, decided_by = self._broker.wait(approval_id, timeout=timeout)
+        outcome = _outcome_text(tool_name, approved=approved, decided_by=decided_by)
+        # Clear buttons so a late click cannot re-fire.
+        self._client.edit_message_text(
+            self._chat_id,
+            message_id,
+            outcome,
+            reply_markup={"inline_keyboard": []},
+        )
+        logger.info(
+            "[telegram-gateway] approval tool=%s approved=%s decided_by=%s",
+            tool_name,
+            approved,
+            decided_by or "(expired)",
+        )
+        return (approved, decided_by)
+
+
+def handle_callback_query(
+    event: TelegramCallbackQuery,
+    *,
+    broker: ApprovalBroker,
+    client: TelegramBotClient,
+    allowed_user_ids: Sequence[str],
+) -> bool:
+    """Resolve Approve/Deny callback clicks.
+
+    Write-tool approvals always require an explicit allowlist — open chat trust
+    must not extend to approving side-effecting tools.
+    """
+    data = event.data
+    if data.startswith(f"{APPROVE_ACTION_ID}:"):
+        approval_id = data[len(APPROVE_ACTION_ID) + 1 :]
+        approved = True
+    elif data.startswith(f"{DENY_ACTION_ID}:"):
+        approval_id = data[len(DENY_ACTION_ID) + 1 :]
+        approved = False
+    else:
+        return False
+
+    allowed = set(allowed_user_ids)
+    if not allowed or event.user_id not in allowed:
+        logger.info(
+            "[telegram-gateway] approval click from unauthorized user=%s ignored",
+            event.user_id,
+        )
+        client.answer_callback_query(event.callback_query_id, text="Not authorized")
+        return False
+
+    resolved = broker.resolve(
+        approval_id,
+        approved=approved,
+        decided_by=event.user_id,
+    )
+    client.answer_callback_query(
+        event.callback_query_id,
+        text="Approved" if approved else "Denied",
+    )
+    return resolved
+
+
+def _approval_keyboard(approval_id: str) -> dict[str, Any]:
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "Approve",
+                    "callback_data": f"{APPROVE_ACTION_ID}:{approval_id}",
+                },
+                {
+                    "text": "Deny",
+                    "callback_data": f"{DENY_ACTION_ID}:{approval_id}",
+                },
+            ]
+        ]
+    }
+
+
+def _outcome_text(tool_name: str, *, approved: bool, decided_by: str) -> str:
+    who = f"by user {decided_by}" if decided_by else "(expired — no click)"
+    verb = "approved" if approved else "denied"
+    return f"🔒 `{tool_name}` {verb} {who}."
+
+
+__all__ = [
+    "TelegramApprovalPrompter",
+    "handle_callback_query",
+]

--- a/gateway/transports/telegram/approvals.py
+++ b/gateway/transports/telegram/approvals.py
@@ -131,18 +131,26 @@ def handle_callback_query(
     return resolved
 
 
+_TELEGRAM_CALLBACK_DATA_LIMIT = 64
+
+
 def _approval_keyboard(approval_id: str) -> dict[str, Any]:
+    approve = f"{APPROVE_ACTION_ID}:{approval_id}"
+    deny = f"{DENY_ACTION_ID}:{approval_id}"
+    # Telegram Bot API rejects callback_data longer than 64 bytes.
+    if (
+        len(approve.encode("utf-8")) > _TELEGRAM_CALLBACK_DATA_LIMIT
+        or len(deny.encode("utf-8")) > _TELEGRAM_CALLBACK_DATA_LIMIT
+    ):
+        raise ValueError(
+            f"Telegram callback_data exceeds {_TELEGRAM_CALLBACK_DATA_LIMIT} bytes "
+            f"(approve={len(approve.encode('utf-8'))}, deny={len(deny.encode('utf-8'))})"
+        )
     return {
         "inline_keyboard": [
             [
-                {
-                    "text": "Approve",
-                    "callback_data": f"{APPROVE_ACTION_ID}:{approval_id}",
-                },
-                {
-                    "text": "Deny",
-                    "callback_data": f"{DENY_ACTION_ID}:{approval_id}",
-                },
+                {"text": "Approve", "callback_data": approve},
+                {"text": "Deny", "callback_data": deny},
             ]
         ]
     }

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -7,6 +7,7 @@ import logging
 import threading
 
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
+from gateway.transports.telegram.approvals import handle_callback_query
 from gateway.transports.telegram.inbound_handler import (
     handle_polled_inbound_telegram_message,
 )
@@ -118,10 +119,18 @@ async def _poll_telegram_until_stopped(
 
     while not stop_event.is_set():
         try:
-            events = await asyncio.to_thread(poller.poll_once)
+            batch = await asyncio.to_thread(poller.poll_once)
             loop = asyncio.get_running_loop()
 
-            for event in events:
+            for callback in batch.callbacks:
+                handle_callback_query(
+                    callback,
+                    broker=resources.approvals,
+                    client=resources.client,
+                    allowed_user_ids=settings.allowed_user_ids,
+                )
+
+            for event in batch.messages:
                 await handle_polled_inbound_telegram_message(
                     event,
                     client=resources.client,
@@ -130,6 +139,7 @@ async def _poll_telegram_until_stopped(
                     executor=resources.executor,
                     chat_locks=resources.chat_locks,
                     turn_semaphore=turn_semaphore,
+                    approvals=resources.approvals,
                     loop=loop,
                     handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
                 )

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import threading
 
+from gateway.core.runtime.active_turns import is_stop_command
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.transports.telegram.approvals import handle_callback_query
 from gateway.transports.telegram.inbound_handler import (
@@ -131,6 +132,12 @@ async def _poll_telegram_until_stopped(
                 )
 
             for event in batch.messages:
+                # /stop must not wait on the per-user turn lock — resolve via
+                # the active-turn registry before dispatching a new turn.
+                if is_stop_command(event.text):
+                    if not resources.active_cancels.request_stop(event.chat_id):
+                        resources.client.send_message(event.chat_id, "Nothing running to stop.")
+                    continue
                 await handle_polled_inbound_telegram_message(
                     event,
                     client=resources.client,
@@ -140,6 +147,7 @@ async def _poll_telegram_until_stopped(
                     chat_locks=resources.chat_locks,
                     turn_semaphore=turn_semaphore,
                     approvals=resources.approvals,
+                    active_cancels=resources.active_cancels,
                     loop=loop,
                     handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
                 )

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
+from config.scope_context import bound_storage_scope
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.storage import SessionResolver
 from gateway.transports.telegram.inbound_security import (
@@ -13,6 +14,10 @@ from gateway.transports.telegram.inbound_security import (
 )
 from gateway.transports.telegram.output_sink import GatewayOutputSink
 from gateway.transports.telegram.poller.client import TelegramBotClient
+from gateway.transports.telegram.principal import (
+    PrincipalResolutionError,
+    resolve_telegram_scope,
+)
 from gateway.transports.telegram.session_rotation import resolve_or_rotate_session
 from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
 from platform.analytics.usage_context import SURFACE_TELEGRAM, bound_usage_context
@@ -40,46 +45,61 @@ async def handle_polled_inbound_telegram_message(
         text=event.text,
         env_allowed_user_ids=settings.allowed_user_ids,
     )
-    async with user_lock, turn_semaphore:
-        session = resolve_or_rotate_session(
-            event,
-            decision,
-            session_resolver=session_resolver,
-            client=client,
-        )
-        if session is None:
-            return
-
-        preview = event.text.replace("\n", " ").strip()
-        if len(preview) > 80:
-            preview = f"{preview[:77]}..."
-        logger.info(
-            "inbound user=%s chat=%s session=%s text=%r",
+    try:
+        scope = resolve_telegram_scope(user_id=event.user_id)
+    except PrincipalResolutionError:
+        logger.error(
+            "[telegram-gateway] turn refused: unresolved principal user=%s chat=%s",
             event.user_id,
             event.chat_id,
-            session.session_id[:8],
-            preview,
+            exc_info=True,
         )
+        return
 
-        sink = GatewayOutputSink(
-            client=client,
-            chat_id=event.chat_id,
-            edit_interval_seconds=settings.stream_edit_interval_seconds,
-        )
+    async with user_lock, turn_semaphore:
+        with bound_storage_scope(scope):
+            session = resolve_or_rotate_session(
+                event,
+                decision,
+                session_resolver=session_resolver,
+                client=client,
+                scope=scope,
+            )
+            if session is None:
+                return
 
-        event_loop = loop or asyncio.get_running_loop()
+            preview = event.text.replace("\n", " ").strip()
+            if len(preview) > 80:
+                preview = f"{preview[:77]}..."
+            logger.info(
+                "inbound user=%s chat=%s session=%s principal=%s text=%r",
+                event.user_id,
+                event.chat_id,
+                session.session_id[:8],
+                scope.principal.id,
+                preview,
+            )
 
-        def _run_turn() -> None:
-            with bound_usage_context(
-                surface=SURFACE_TELEGRAM,
-                session_id=session.session_id,
-                user_id=event.user_id or None,
-            ):
-                handle_callback_to_gateway_agent(
-                    event.text,
-                    session,
-                    sink,
-                    logger,
-                )
+            sink = GatewayOutputSink(
+                client=client,
+                chat_id=event.chat_id,
+                edit_interval_seconds=settings.stream_edit_interval_seconds,
+            )
 
-        await event_loop.run_in_executor(executor, _run_turn)
+            event_loop = loop or asyncio.get_running_loop()
+
+            def _run_turn() -> None:
+                with bound_storage_scope(scope):
+                    with bound_usage_context(
+                        surface=SURFACE_TELEGRAM,
+                        session_id=session.session_id,
+                        user_id=event.user_id or None,
+                    ):
+                        handle_callback_to_gateway_agent(
+                            event.text,
+                            session,
+                            sink,
+                            logger,
+                        )
+
+            await event_loop.run_in_executor(executor, _run_turn)

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -7,8 +7,10 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 
 from config.scope_context import bound_storage_scope
+from gateway.core.runtime.approvals import ApprovalBroker, approval_tool_hooks
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.storage import SessionResolver
+from gateway.transports.telegram.approvals import TelegramApprovalPrompter
 from gateway.transports.telegram.inbound_security import (
     enforce_inbound_telegram_message_security,
 )
@@ -34,6 +36,7 @@ async def handle_polled_inbound_telegram_message(
     executor: ThreadPoolExecutor,
     chat_locks: dict[str, asyncio.Lock],
     turn_semaphore: asyncio.Semaphore,
+    approvals: ApprovalBroker,
     loop: asyncio.AbstractEventLoop | None = None,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
 ) -> None:
@@ -84,6 +87,13 @@ async def handle_polled_inbound_telegram_message(
                 client=client,
                 chat_id=event.chat_id,
                 edit_interval_seconds=settings.stream_edit_interval_seconds,
+                tool_hooks=approval_tool_hooks(
+                    TelegramApprovalPrompter(
+                        client=client,
+                        broker=approvals,
+                        chat_id=event.chat_id,
+                    )
+                ),
             )
 
             event_loop = loop or asyncio.get_running_loop()

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -89,17 +89,19 @@ async def handle_polled_inbound_telegram_message(
             event_loop = loop or asyncio.get_running_loop()
 
             def _run_turn() -> None:
-                with bound_storage_scope(scope):
-                    with bound_usage_context(
+                with (
+                    bound_storage_scope(scope),
+                    bound_usage_context(
                         surface=SURFACE_TELEGRAM,
                         session_id=session.session_id,
                         user_id=event.user_id or None,
-                    ):
-                        handle_callback_to_gateway_agent(
-                            event.text,
-                            session,
-                            sink,
-                            logger,
-                        )
+                    ),
+                ):
+                    handle_callback_to_gateway_agent(
+                        event.text,
+                        session,
+                        sink,
+                        logger,
+                    )
 
             await event_loop.run_in_executor(executor, _run_turn)

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -8,6 +8,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 
 from config.scope_context import bound_storage_scope
+from gateway.core.runtime.active_turns import USER_STOP_MESSAGE, ActiveTurnCancels
 from gateway.core.runtime.approvals import ApprovalBroker, approval_tool_hooks
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.storage import SessionResolver
@@ -40,6 +41,7 @@ async def handle_polled_inbound_telegram_message(
     chat_locks: dict[str, asyncio.Lock],
     turn_semaphore: asyncio.Semaphore,
     approvals: ApprovalBroker,
+    active_cancels: ActiveTurnCancels,
     loop: asyncio.AbstractEventLoop | None = None,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
 ) -> None:
@@ -137,6 +139,14 @@ async def handle_polled_inbound_telegram_message(
                         exc_info=True,
                     )
 
+            def _on_user_stop() -> None:
+                if not _claim_terminal_outcome():
+                    return
+                try:
+                    sink.finalize(USER_STOP_MESSAGE)
+                except Exception:
+                    logger.debug("[telegram-gateway] user-stop finalize failed", exc_info=True)
+
             def _run_turn() -> None:
                 with (
                     bound_storage_scope(scope),
@@ -156,7 +166,8 @@ async def handle_polled_inbound_telegram_message(
             timer = threading.Timer(settings.turn_timeout_seconds, _on_turn_timeout)
             timer.start()
             try:
-                await event_loop.run_in_executor(executor, _run_turn)
+                with active_cancels.track(event.chat_id, turn_cancel, on_user_stop=_on_user_stop):
+                    await event_loop.run_in_executor(executor, _run_turn)
             except Exception:
                 logger.exception(
                     "[telegram-gateway] turn ERRORED chat=%s session=%s",

--- a/gateway/transports/telegram/output_sink.py
+++ b/gateway/transports/telegram/output_sink.py
@@ -42,6 +42,9 @@ class GatewayOutputSink:
         tool_hooks: object | None = None,
     ) -> None:
         self.tool_hooks = tool_hooks
+        # Set per turn by this transport's dispatcher; the turn handler reads it
+        # to give tools a cooperative cancel signal on soft timeout or stop.
+        self.turn_cancel: threading.Event | None = None
         self._client = client
         self._chat_id = chat_id
         self._edit_interval = edit_interval_seconds

--- a/gateway/transports/telegram/output_sink.py
+++ b/gateway/transports/telegram/output_sink.py
@@ -39,7 +39,9 @@ class GatewayOutputSink:
         client: TelegramBotClient,
         chat_id: str,
         edit_interval_seconds: float = 1.5,
+        tool_hooks: object | None = None,
     ) -> None:
+        self.tool_hooks = tool_hooks
         self._client = client
         self._chat_id = chat_id
         self._edit_interval = edit_interval_seconds

--- a/gateway/transports/telegram/poller/client.py
+++ b/gateway/transports/telegram/poller/client.py
@@ -35,11 +35,18 @@ class TelegramBotClient:
         return True, dict(result) if isinstance(result, Mapping) else {}, ""
 
     def send_message(
-        self, chat_id: str, text: str, *, parse_mode: str = ""
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        parse_mode: str = "",
+        reply_markup: Mapping[str, Any] | None = None,
     ) -> tuple[bool, str, str]:
         payload: dict[str, Any] = {"chat_id": chat_id, "text": text}
         if parse_mode:
             payload["parse_mode"] = parse_mode
+        if reply_markup is not None:
+            payload["reply_markup"] = dict(reply_markup)
         ok, result, error = self._call("sendMessage", payload)
         if not ok:
             logger.warning("[telegram-gateway] sendMessage failed: %s", error)
@@ -53,6 +60,7 @@ class TelegramBotClient:
         text: str,
         *,
         parse_mode: str = "",
+        reply_markup: Mapping[str, Any] | None = None,
     ) -> tuple[bool, str]:
         payload: dict[str, Any] = {
             "chat_id": chat_id,
@@ -61,10 +69,20 @@ class TelegramBotClient:
         }
         if parse_mode:
             payload["parse_mode"] = parse_mode
+        if reply_markup is not None:
+            payload["reply_markup"] = dict(reply_markup)
         ok, _, error = self._call("editMessageText", payload)
         if not ok:
             logger.debug("[telegram-gateway] editMessageText failed: %s", error)
         return ok, error
+
+    def answer_callback_query(self, callback_query_id: str, *, text: str = "") -> None:
+        payload: dict[str, Any] = {"callback_query_id": callback_query_id}
+        if text:
+            payload["text"] = text
+        ok, _, error = self._call("answerCallbackQuery", payload)
+        if not ok:
+            logger.debug("[telegram-gateway] answerCallbackQuery failed: %s", error)
 
     def send_chat_action(self, chat_id: str, action: str = "typing") -> None:
         self._call("sendChatAction", {"chat_id": chat_id, "action": action})

--- a/gateway/transports/telegram/poller/parse_telegram_update.py
+++ b/gateway/transports/telegram/poller/parse_telegram_update.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from gateway.transports.telegram.settings import TelegramInboundMessage
+from gateway.transports.telegram.settings import (
+    TelegramCallbackQuery,
+    TelegramInboundMessage,
+)
 
 
 def parse_update(update: dict[str, Any]) -> TelegramInboundMessage | None:
-    """Extract a normalized inbound event from a Telegram update object."""
-    if update.get("callback_query"):
-        return None
-
+    """Extract a normalized inbound DM event from a Telegram update object."""
     message = update.get("message") or update.get("edited_message")
     if not isinstance(message, dict):
         return None
@@ -30,4 +30,28 @@ def parse_update(update: dict[str, Any]) -> TelegramInboundMessage | None:
         chat_id=chat_id,
         message_id=str(message.get("message_id") or ""),
         text=text.strip(),
+    )
+
+
+def parse_callback_query(update: dict[str, Any]) -> TelegramCallbackQuery | None:
+    """Extract an inline-keyboard callback (private chats only)."""
+    query = update.get("callback_query")
+    if not isinstance(query, dict):
+        return None
+    from_user = query.get("from") or {}
+    message = query.get("message") or {}
+    chat = message.get("chat") or {}
+    if chat and chat.get("type") not in (None, "private"):
+        return None
+    data = query.get("data")
+    if not isinstance(data, str) or not data.strip():
+        return None
+    user_id = str(from_user.get("id") or "")
+    chat_id = str(chat.get("id") or user_id)
+    return TelegramCallbackQuery(
+        update_id=int(update.get("update_id") or 0),
+        user_id=user_id,
+        chat_id=chat_id,
+        callback_query_id=str(query.get("id") or ""),
+        data=data.strip(),
     )

--- a/gateway/transports/telegram/poller/poller.py
+++ b/gateway/transports/telegram/poller/poller.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import json
 import logging
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
 
-from gateway.transports.telegram.poller.parse_telegram_update import parse_update
-from gateway.transports.telegram.settings import TelegramInboundMessage
+from gateway.transports.telegram.poller.parse_telegram_update import (
+    parse_callback_query,
+    parse_update,
+)
+from gateway.transports.telegram.settings import (
+    TelegramCallbackQuery,
+    TelegramInboundMessage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +26,14 @@ _CONFLICT_ERROR_CODE = 409
 _DEFAULT_RETRY_SECONDS = 2.0
 _MAX_CONFLICT_BACKOFF_SECONDS = 30.0
 _WARNING_COOLDOWN_SECONDS = 60.0
+
+
+@dataclass(slots=True)
+class TelegramPollResult:
+    """One getUpdates batch split into DM messages and callback clicks."""
+
+    messages: list[TelegramInboundMessage] = field(default_factory=list)
+    callbacks: list[TelegramCallbackQuery] = field(default_factory=list)
 
 
 def _decode_telegram_response(response: httpx.Response) -> dict[str, Any]:
@@ -31,7 +46,7 @@ def _decode_telegram_response(response: httpx.Response) -> dict[str, Any]:
 
 
 class TelegramPoller:
-    """Poll Telegram getUpdates and yield normalized inbound messages."""
+    """Poll Telegram getUpdates and yield normalized inbound events."""
 
     def __init__(self, bot_token: str, *, timeout: int = 30) -> None:
         self._token = bot_token
@@ -40,31 +55,32 @@ class TelegramPoller:
         self._conflict_backoff_seconds = _DEFAULT_RETRY_SECONDS
         self._last_warning_monotonic = 0.0
 
-    def poll_once(self) -> list[TelegramInboundMessage]:
+    def poll_once(self) -> TelegramPollResult:
         url = _API.format(token=self._token)
         params: dict[str, str | int | list[str]] = {
             "timeout": self._timeout,
             "offset": self._offset + 1,
-            "allowed_updates": ["message"],
+            "allowed_updates": ["message", "callback_query"],
         }
         try:
             response = httpx.get(url, params=params, timeout=float(self._timeout + 5))
         except Exception as exc:
             self._log_transient("[telegram-gateway] getUpdates failed: %s", exc)
             time.sleep(_DEFAULT_RETRY_SECONDS)
-            return []
+            return TelegramPollResult()
 
         data = _decode_telegram_response(response)
         if not data.get("ok"):
             self._handle_poll_error(data=data, response=response)
-            return []
+            return TelegramPollResult()
 
         self._conflict_backoff_seconds = _DEFAULT_RETRY_SECONDS
         result = data.get("result")
         if not isinstance(result, list):
-            return []
+            return TelegramPollResult()
 
-        events: list[TelegramInboundMessage] = []
+        messages: list[TelegramInboundMessage] = []
+        callbacks: list[TelegramCallbackQuery] = []
         for raw in result:
             if not isinstance(raw, dict):
                 continue
@@ -72,8 +88,12 @@ class TelegramPoller:
             self._offset = max(self._offset, update_id)
             parsed = parse_update(raw)
             if parsed is not None:
-                events.append(parsed)
-        return events
+                messages.append(parsed)
+                continue
+            callback = parse_callback_query(raw)
+            if callback is not None:
+                callbacks.append(callback)
+        return TelegramPollResult(messages=messages, callbacks=callbacks)
 
     def _handle_poll_error(
         self,

--- a/gateway/transports/telegram/principal.py
+++ b/gateway/transports/telegram/principal.py
@@ -1,0 +1,47 @@
+"""Resolve the owning principal for a Telegram gateway turn.
+
+Telegram DMs attribute data to the silo organization (``ORGANIZATION_ID``) and
+key per-actor sessions by Telegram user id — same border as Slack/Discord org +
+actor. Must not import Slack/Discord principal modules (peer isolation).
+"""
+
+from __future__ import annotations
+
+from config.principal import Actor, Principal, StorageScope
+from gateway.core.billing.credits_client import organization_id_for_silo
+
+
+class PrincipalResolutionError(RuntimeError):
+    """Raised when the owner of a Telegram turn's data cannot be established."""
+
+
+def resolve_telegram_principal() -> Principal:
+    """Principal for a Telegram turn: the organization this deployment serves."""
+    silo_org = organization_id_for_silo()
+    if not silo_org:
+        raise PrincipalResolutionError(
+            "Telegram turn cannot be resolved: no organization is configured "
+            "for this deployment"
+        )
+    return Principal.org(silo_org)
+
+
+def telegram_scope(principal: Principal, user_id: str) -> StorageScope:
+    """Pair an organization with the Telegram user acting in it."""
+    return StorageScope(principal=principal, actor=Actor(id=user_id))
+
+
+def resolve_telegram_scope(*, user_id: str) -> StorageScope:
+    """Owning principal and acting member for one Telegram turn."""
+    user = (user_id or "").strip()
+    if not user:
+        raise PrincipalResolutionError("Telegram turn carried no user id")
+    return telegram_scope(resolve_telegram_principal(), user)
+
+
+__all__ = [
+    "PrincipalResolutionError",
+    "resolve_telegram_principal",
+    "resolve_telegram_scope",
+    "telegram_scope",
+]

--- a/gateway/transports/telegram/principal.py
+++ b/gateway/transports/telegram/principal.py
@@ -20,8 +20,7 @@ def resolve_telegram_principal() -> Principal:
     silo_org = organization_id_for_silo()
     if not silo_org:
         raise PrincipalResolutionError(
-            "Telegram turn cannot be resolved: no organization is configured "
-            "for this deployment"
+            "Telegram turn cannot be resolved: no organization is configured for this deployment"
         )
     return Principal.org(silo_org)
 

--- a/gateway/transports/telegram/runtime.py
+++ b/gateway/transports/telegram/runtime.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
+from gateway.core.runtime.approvals import ApprovalBroker
 from gateway.core.storage import SessionResolver
 from gateway.core.storage.session.binding_store import BindingStore, open_binding_store
 from gateway.transports.telegram.poller.client import TelegramBotClient
@@ -25,6 +26,7 @@ class TelegramPollingRuntime:
     session_resolver: SessionResolver
     chat_locks: dict[str, asyncio.Lock]
     executor: ThreadPoolExecutor
+    approvals: ApprovalBroker
 
 
 InitializeTelegramPollingRuntime = Callable[[GatewaySettings], TelegramPollingRuntime]
@@ -48,6 +50,7 @@ def initialize_telegram_polling_runtime(settings: GatewaySettings) -> TelegramPo
             max_workers=settings.max_concurrent_turns,
             thread_name_prefix="GatewayTurn",
         ),
+        approvals=ApprovalBroker(),
     )
 
 

--- a/gateway/transports/telegram/runtime.py
+++ b/gateway/transports/telegram/runtime.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
+from gateway.core.runtime.active_turns import ActiveTurnCancels
 from gateway.core.runtime.approvals import ApprovalBroker
 from gateway.core.storage import SessionResolver
 from gateway.core.storage.session.binding_store import BindingStore, open_binding_store
@@ -27,6 +28,7 @@ class TelegramPollingRuntime:
     chat_locks: dict[str, asyncio.Lock]
     executor: ThreadPoolExecutor
     approvals: ApprovalBroker
+    active_cancels: ActiveTurnCancels
 
 
 InitializeTelegramPollingRuntime = Callable[[GatewaySettings], TelegramPollingRuntime]
@@ -51,6 +53,7 @@ def initialize_telegram_polling_runtime(settings: GatewaySettings) -> TelegramPo
             thread_name_prefix="GatewayTurn",
         ),
         approvals=ApprovalBroker(),
+        active_cancels=ActiveTurnCancels(),
     )
 
 

--- a/gateway/transports/telegram/session_rotation.py
+++ b/gateway/transports/telegram/session_rotation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from config.principal import StorageScope
 from core.agent_harness.session import SessionCore
 from gateway.core.storage import SessionResolver
 from gateway.transports.telegram.inbound_security import (
@@ -18,6 +19,7 @@ def resolve_or_rotate_session(
     *,
     session_resolver: SessionResolver,
     client: TelegramBotClient,
+    scope: StorageScope,
 ) -> SessionCore | None:
     """Apply inbound decision side effects, then resolve or rotate the REPL session."""
     persist_policy_if_needed(decision)
@@ -31,10 +33,20 @@ def resolve_or_rotate_session(
         return None
 
     if decision.reply_text == "__ROTATE_SESSION__":
-        session = session_resolver.rotate(user_id=event.user_id, chat_id=event.chat_id)
+        session = session_resolver.rotate(
+            user_id=event.user_id,
+            chat_id=event.chat_id,
+            principal=scope.principal,
+            actor=scope.actor,
+        )
         client.send_message(event.chat_id, "Started a new session.")
         if event.text.strip().lower() == "/new":
             return None
         return session
 
-    return session_resolver.resolve(user_id=event.user_id, chat_id=event.chat_id)
+    return session_resolver.resolve(
+        user_id=event.user_id,
+        chat_id=event.chat_id,
+        principal=scope.principal,
+        actor=scope.actor,
+    )

--- a/gateway/transports/telegram/settings.py
+++ b/gateway/transports/telegram/settings.py
@@ -61,13 +61,24 @@ class GatewayEnv(BaseSettings):
 
 @dataclass(frozen=True)
 class TelegramInboundMessage:
-    """Normalized inbound Telegram DM text or callback."""
+    """Normalized inbound Telegram DM text."""
 
     update_id: int
     user_id: str
     chat_id: str
     message_id: str
     text: str
+
+
+@dataclass(frozen=True)
+class TelegramCallbackQuery:
+    """Normalized Approve/Deny (or other) inline-keyboard callback."""
+
+    update_id: int
+    user_id: str
+    chat_id: str
+    callback_query_id: str
+    data: str
 
 
 def load_telegram_credentials() -> Mapping[str, Any]:

--- a/gateway/transports/telegram/settings.py
+++ b/gateway/transports/telegram/settings.py
@@ -11,6 +11,7 @@ from pydantic import Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from config.strict_config import StrictConfigModel
+from gateway.core.runtime.concurrency import turn_limit_for_profile
 from gateway.core.runtime.errors import GatewayConfigurationError
 from integrations.messaging_security import MessagingIdentityPolicy, MessagingPlatform
 from integrations.store import get_integration
@@ -23,7 +24,7 @@ class GatewaySettings(StrictConfigModel):
 
     bot_token: str
     allowed_user_ids: list[str] = Field(default_factory=list)
-    max_concurrent_turns: int = Field(default=4, ge=1)
+    max_concurrent_turns: int = Field(default_factory=turn_limit_for_profile, ge=1)
     stream_edit_interval_seconds: float = Field(default=1.5, gt=0)
     auto_start_enabled: bool = True
 
@@ -37,7 +38,7 @@ class GatewayEnv(BaseSettings):
     # NoDecode keeps pydantic-settings from JSON-decoding the env value so the
     # CSV validator below can parse "42,99" instead of raising a SettingsError.
     allowed_users: Annotated[list[str], NoDecode] = Field(default_factory=list)
-    gateway_max_concurrent: int = Field(default=4, ge=1)
+    gateway_max_concurrent: int = Field(default_factory=turn_limit_for_profile, ge=1)
     gateway_stream_edit_interval_seconds: float = Field(default=1.5, gt=0)
     gateway_auto_start: bool = True
 

--- a/gateway/transports/telegram/startup.py
+++ b/gateway/transports/telegram/startup.py
@@ -1,4 +1,4 @@
-"""Telegram-specific gateway wiring.
+"""Start the Telegram chat worker for the gateway.
 
 Owns everything that is particular to the Telegram long-poll transport: loading
 Telegram settings and starting the background poller with the Telegram polling

--- a/gateway/web/AGENTS.md
+++ b/gateway/web/AGENTS.md
@@ -5,9 +5,20 @@ Not a chat transport — no turn-handler / sink wiring.
 
 | May import | Must not |
 |------------|----------|
-| `gateway.core.*` | `gateway.transports.*` |
+| `gateway.core.*` | `gateway.transports.*`, `gateway.channels` |
 
 Entry: `webapp.py` (`app`) — `uvicorn gateway.web.webapp:app` when `MODE=web`,
 or daemon / shell via `web_server.serve_webapp_in_thread`.
 
 Pinned by `gateway/tests/test_package_borders.py`.
+
+## Process boot (`WEB_PROFILE`)
+
+Importing `gateway.web.webapp` (uvicorn or in-process via
+`serve_webapp_in_thread`) runs `configure_process(WEB_PROFILE)` — env, Sentry
+(`webapp`), and harness adapters. That is intentional so `MODE=web` and
+embedded web both get Path-2 investigate wiring without a CLI/manager boot. Do
+**not** add a second harness-registration site in `web/`; adapters stay in
+`bootstrap.adapters` only. In a full gateway process, `GATEWAY_PROFILE` already
+ran; `WEB_PROFILE` may still run (separate idempotency key) — steps must stay
+safe to re-enter, not invent a divergent registry.

--- a/gateway/web/startup.py
+++ b/gateway/web/startup.py
@@ -1,0 +1,46 @@
+"""Bring up the gateway web app, mirroring each chat transport's ``startup``.
+
+Returns the running handle plus the status line to report, so the caller owns
+the component-status map rather than having it written behind its back.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from core.domain.alerts.inbox import AlertInbox, set_current_inbox
+from gateway.web.web_server import WebAppServerHandle, serve_webapp_in_thread
+
+DEFAULT_WEB_PORT = 8000
+
+
+@dataclass(frozen=True)
+class WebStartup:
+    """A started (or skipped) web app and the status line describing it."""
+
+    server: WebAppServerHandle | None
+    status: str
+
+
+def start_web_server(*, logger: logging.Logger) -> WebStartup:
+    """Serve the shared web app (health probes + alert intake) in a daemon thread.
+
+    A web app that cannot bind is not fatal: the gateway still serves chat.
+    """
+    set_current_inbox(AlertInbox())
+    port = int(os.environ.get("PORT", str(DEFAULT_WEB_PORT)))
+    try:
+        server = serve_webapp_in_thread(host="0.0.0.0", port=port)
+    except RuntimeError as exc:
+        logger.warning("web app disabled: %s", exc)
+        return WebStartup(server=None, status=f"failed ({exc})")
+    logger.info("web app serving on http://%s", server.bound_address)
+    return WebStartup(
+        server=server,
+        status=f"serving http://{server.bound_address} (health, alerts)",
+    )
+
+
+__all__ = ["DEFAULT_WEB_PORT", "WebStartup", "start_web_server"]

--- a/main.py
+++ b/main.py
@@ -5,9 +5,10 @@ Prefer the ``opensre`` console script in normal use. This module exists so
 ``surfaces.cli.app:main``.
 
 This covers the interactive shell, the landing page, and every one-shot
-subcommand. The gateway daemon is a separate process entry —
-``python -m gateway.main``, managed via ``opensre gateway start`` — because
-``gateway`` and ``surfaces`` are peer packages that must not import each other.
+subcommand. The gateway daemon is a separate process entry managed via
+``opensre gateway start`` (CLI wires slash ports). Bare ``python -m gateway.main``
+fails closed — ``gateway`` and ``surfaces`` are peer packages that must not
+import each other.
 
 Shared process setup — environment, error reporting, adapter registration —
 lives in ``bootstrap.process``. Each host picks a profile rather than repeating

--- a/surfaces/cli/commands/gateway.py
+++ b/surfaces/cli/commands/gateway.py
@@ -14,6 +14,7 @@ from gateway.core.runtime.daemon import (
     start_gateway_daemon,
     stop_gateway_daemon,
 )
+from surfaces.shared.gateway_entrypoint import GATEWAY_ENTRY_ARGV
 
 
 def _echo_components() -> None:
@@ -42,7 +43,7 @@ def gateway_start_command(foreground: bool) -> None:
         start_gateway()
         return
 
-    ok, message = start_gateway_daemon()
+    ok, message = start_gateway_daemon(argv=GATEWAY_ENTRY_ARGV)
     click.echo(message)
     click.echo(f"Logs: {GATEWAY_LOG_FILE}")
     if not ok:

--- a/surfaces/cli/commands/gateway.py
+++ b/surfaces/cli/commands/gateway.py
@@ -14,7 +14,7 @@ from gateway.core.runtime.daemon import (
     start_gateway_daemon,
     stop_gateway_daemon,
 )
-from surfaces.shared.gateway_entrypoint import GATEWAY_ENTRY_ARGV
+from surfaces.shared.gateway_entrypoint import gateway_entry_argv
 
 
 def _echo_components() -> None:
@@ -43,7 +43,7 @@ def gateway_start_command(foreground: bool) -> None:
         start_gateway()
         return
 
-    ok, message = start_gateway_daemon(argv=GATEWAY_ENTRY_ARGV)
+    ok, message = start_gateway_daemon(argv=gateway_entry_argv())
     click.echo(message)
     click.echo(f"Logs: {GATEWAY_LOG_FILE}")
     if not ok:

--- a/surfaces/cli/gateway_entry.py
+++ b/surfaces/cli/gateway_entry.py
@@ -41,7 +41,11 @@ def main() -> None:
     start_gateway()
 
 
-__all__ = ["gateway_slash_ports_factory", "main", "start_gateway"]
+__all__ = [
+    "gateway_slash_ports_factory",
+    "main",
+    "start_gateway",
+]
 
 
 if __name__ == "__main__":

--- a/surfaces/interactive_shell/command_registry/gateway_cmds.py
+++ b/surfaces/interactive_shell/command_registry/gateway_cmds.py
@@ -16,6 +16,7 @@ from gateway.core.runtime.daemon import (
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
+from surfaces.shared.gateway_entrypoint import GATEWAY_ENTRY_ARGV
 
 _USAGE = "/gateway [start|stop|status|logs [lines]]"
 
@@ -28,7 +29,7 @@ def _cmd_gateway(_session: Session, console: Console, args: list[str]) -> bool:
     sub = args[0].lower() if args else "status"
 
     if sub == "start":
-        _print_outcome(console, *start_gateway_daemon())
+        _print_outcome(console, *start_gateway_daemon(argv=GATEWAY_ENTRY_ARGV))
         console.print(f"[{DIM}]logs: {GATEWAY_LOG_FILE} — /gateway logs to tail[/]")
     elif sub == "stop":
         _print_outcome(console, *stop_gateway_daemon())

--- a/surfaces/interactive_shell/command_registry/gateway_cmds.py
+++ b/surfaces/interactive_shell/command_registry/gateway_cmds.py
@@ -16,7 +16,7 @@ from gateway.core.runtime.daemon import (
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
-from surfaces.shared.gateway_entrypoint import GATEWAY_ENTRY_ARGV
+from surfaces.shared.gateway_entrypoint import gateway_entry_argv
 
 _USAGE = "/gateway [start|stop|status|logs [lines]]"
 
@@ -29,7 +29,7 @@ def _cmd_gateway(_session: Session, console: Console, args: list[str]) -> bool:
     sub = args[0].lower() if args else "status"
 
     if sub == "start":
-        _print_outcome(console, *start_gateway_daemon(argv=GATEWAY_ENTRY_ARGV))
+        _print_outcome(console, *start_gateway_daemon(argv=gateway_entry_argv()))
         console.print(f"[{DIM}]logs: {GATEWAY_LOG_FILE} — /gateway logs to tail[/]")
     elif sub == "stop":
         _print_outcome(console, *stop_gateway_daemon())

--- a/surfaces/shared/gateway_entrypoint.py
+++ b/surfaces/shared/gateway_entrypoint.py
@@ -1,0 +1,19 @@
+"""The child process the gateway daemon spawns.
+
+A leaf: it imports only ``sys``, so the CLI command and the interactive shell's
+``/gateway`` command can both read it without either pulling in the other's
+package. Naming it inside ``surfaces.cli.gateway_entry`` instead would make the
+shell import the CLI entrypoint, which re-enters the shell's own command
+registry mid-import.
+
+It lives under ``surfaces`` rather than ``gateway`` because the surface owns its
+composition root; the gateway supervises whatever child it is handed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+GATEWAY_ENTRY_ARGV: tuple[str, ...] = (sys.executable, "-m", "surfaces.cli.gateway_entry")
+
+__all__ = ["GATEWAY_ENTRY_ARGV"]

--- a/surfaces/shared/gateway_entrypoint.py
+++ b/surfaces/shared/gateway_entrypoint.py
@@ -1,19 +1,54 @@
 """The child process the gateway daemon spawns.
 
-A leaf: it imports only ``sys``, so the CLI command and the interactive shell's
-``/gateway`` command can both read it without either pulling in the other's
-package. Naming it inside ``surfaces.cli.gateway_entry`` instead would make the
-shell import the CLI entrypoint, which re-enters the shell's own command
-registry mid-import.
+A leaf: it imports only ``sys`` / ``pathlib``, so the CLI command and the
+interactive shell's ``/gateway`` command can both read it without either
+pulling in the other's package. Naming it inside ``surfaces.cli.gateway_entry``
+instead would make the shell import the CLI entrypoint, which re-enters the
+shell's own command registry mid-import.
 
-It lives under ``surfaces`` rather than ``gateway`` because the surface owns its
-composition root; the gateway supervises whatever child it is handed.
+It lives under ``surfaces`` rather than ``gateway`` because the surface owns
+its composition root; the gateway supervises whatever child it is handed.
+
+Frozen / ``opensre`` binaries cannot take ``python -m …`` — that sends ``-m``
+to Click. Those builds re-enter via ``gateway start --foreground`` so the
+child runs the composition root attached (no second daemon spawn).
 """
 
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
-GATEWAY_ENTRY_ARGV: tuple[str, ...] = (sys.executable, "-m", "surfaces.cli.gateway_entry")
+_PYTHON_EXECUTABLE_PREFIXES: tuple[str, ...] = ("python", "pypy")
+_FOREGROUND_GATEWAY: tuple[str, ...] = ("gateway", "start", "--foreground")
+_MODULE_GATEWAY_ENTRY: tuple[str, ...] = ("-m", "surfaces.cli.gateway_entry")
 
-__all__ = ["GATEWAY_ENTRY_ARGV"]
+
+def _sys_executable_is_python() -> bool:
+    return Path(sys.executable).name.lower().startswith(_PYTHON_EXECUTABLE_PREFIXES)
+
+
+def _current_opensre_entrypoint() -> str | None:
+    """Return the current ``opensre`` launcher when this process was started by one."""
+    argv0 = sys.argv[0].strip() if sys.argv else ""
+    if not argv0:
+        return None
+    if Path(argv0).name.lower() not in ("opensre", "opensre.exe"):
+        return None
+    return argv0
+
+
+def gateway_entry_argv() -> tuple[str, ...]:
+    """Argv for the background daemon's child process.
+
+    Call at spawn time (not import time) so frozen / launcher detection can be
+    tested and so ``sys.executable`` reflects the current process.
+    """
+    if entrypoint := _current_opensre_entrypoint():
+        return (entrypoint, *_FOREGROUND_GATEWAY)
+    if getattr(sys, "frozen", False) or not _sys_executable_is_python():
+        return (sys.executable, *_FOREGROUND_GATEWAY)
+    return (sys.executable, *_MODULE_GATEWAY_ENTRY)
+
+
+__all__ = ["gateway_entry_argv"]

--- a/tests/cli/test_gateway_command.py
+++ b/tests/cli/test_gateway_command.py
@@ -45,6 +45,8 @@ def test_gateway_entry_wires_slash_ports() -> None:
 
 
 def test_gateway_start_spawns_daemon(runner: CliRunner) -> None:
+    from surfaces.shared.gateway_entrypoint import gateway_entry_argv
+
     with patch(
         "surfaces.cli.commands.gateway.start_gateway_daemon",
         return_value=(True, "Telegram gateway started (pid 4242)."),
@@ -52,7 +54,7 @@ def test_gateway_start_spawns_daemon(runner: CliRunner) -> None:
         result = runner.invoke(cli, ["gateway", "start"])
 
     assert result.exit_code == 0
-    mock_start.assert_called_once()
+    mock_start.assert_called_once_with(argv=gateway_entry_argv())
     assert "pid 4242" in result.output
     assert "Logs:" in result.output
 

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -366,7 +366,11 @@ def test_execute_cli_actions_skips_remaining_actions_when_cancelled(
         console,  # type: ignore[arg-type]
     )
 
-    assert handled.handled is True
+    # A cancelled turn reports ``cancelled``; the orchestrator short-circuits on
+    # that flag to skip gather/answer, which is what forcing ``handled=True``
+    # used to accomplish. ``handled`` now reflects the work that actually ran.
+    assert handled.cancelled is True
+    assert handled.handled is False
     # Only the first action ran; the second was skipped because the
     # cancel event was set between iterations.
     assert dispatched == ["/health"], (

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -2320,3 +2320,52 @@ def test_action_turn_suppresses_partial_replay_of_a_succeeded_batch() -> None:
 
     assert result.handled is True
     assert runs == ["/health", "/integrations list"]
+
+
+def test_run_turn_skips_gather_and_answer_when_the_action_turn_was_cancelled() -> None:
+    """A cancelled action turn must not fall through to gather or answer.
+
+    The host already owns the terminal message (soft-timeout notice, or the
+    user's stop), so sweeping integrations and composing an answer would both
+    cost time nobody is waiting for and overwrite that message. This used to be
+    enforced by forcing ``handled=True`` on cancel; the turn result now carries
+    ``cancelled`` explicitly and the router short-circuits on it.
+    """
+    # Arrange: an action turn that ran one action, then was cancelled.
+    session = Session()
+    gather_calls: list[str] = []
+    answer_calls: list[str] = []
+
+    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(
+            planned_count=2,
+            executed_count=1,
+            executed_success_count=1,
+            has_unhandled_clause=False,
+            handled=False,
+            cancelled=True,
+        )
+
+    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+        gather_calls.append(text)
+        return "Tool: kubernetes_list_pods\nResult: should-not-run"
+
+    def _answer(text: str, _request: AnswerRequest, **_kwargs: Any) -> None:
+        answer_calls.append(text)
+        return None
+
+    # Act.
+    result = run_turn(
+        "check health and then list integrations",
+        session,
+        execute_actions=_execute,
+        gather=_gather,
+        answer=_answer,
+        accounting=DefaultTurnAccounting(session, "check health and then list integrations"),
+    )
+
+    # Assert: neither stage ran, and the turn reports the cancel.
+    assert gather_calls == [], "swept integrations after the user cancelled"
+    assert answer_calls == [], "composed an answer after the user cancelled"
+    assert result.action_result is not None
+    assert result.action_result.cancelled is True

--- a/tests/core/agent/test_react_loop_cancel.py
+++ b/tests/core/agent/test_react_loop_cancel.py
@@ -53,7 +53,81 @@ def test_react_loop_stops_before_llm_when_cancel_requested() -> None:
         max_iterations=3,
     )
     result = agent.run([{"role": "user", "content": "hello"}])
-    assert result.terminated_by_tool is True
+    assert result.cancelled is True
+    assert result.terminated_by_tool is False
     assert result.hit_iteration_cap is False
     assert result.llm_iterations_used == 1
     assert result.final_text == ""
+
+
+def test_react_loop_stops_after_iteration_when_cancel_flips() -> None:
+    """Cancel between iterations must not start another LLM call."""
+    import threading
+
+    from core.llm.types import ToolCall
+
+    cancel = threading.Event()
+
+    class _FlipConsole:
+        @property
+        def cancel_requested(self) -> bool:
+            return cancel.is_set()
+
+    class _NoopTool:
+        name = "noop"
+        description = "noop"
+        parameters: dict[str, Any] = {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        }
+
+        def execute(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"ok": True}
+
+    class _CountingLLM(_BoomLLM):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+            return [
+                {
+                    "name": getattr(t, "name", "noop"),
+                    "description": "",
+                    "parameters": getattr(t, "parameters", {}),
+                }
+                for t in tools
+            ]
+
+        def invoke(
+            self,
+            _messages: list[dict[str, Any]],
+            *,
+            system: str | None = None,
+            tools: list[dict[str, Any]] | None = None,
+        ) -> AgentLLMResponse:
+            _ = (system, tools)
+            self.calls += 1
+            if self.calls == 1:
+                # After tools run, cancel is set so iteration 2 must not call us.
+                cancel.set()
+                return AgentLLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(id="c1", name="noop", input={})],
+                    raw_content=None,
+                )
+            raise AssertionError("second LLM iteration must not run after cancel")
+
+    llm = _CountingLLM()
+    agent = Agent(
+        llm=llm,
+        system="sys",
+        tools=[_NoopTool()],
+        resolved_integrations={},
+        tool_resources={"action_tool_context": type("Ctx", (), {"console": _FlipConsole()})()},
+        max_iterations=5,
+    )
+    result = agent.run([{"role": "user", "content": "hello"}])
+    assert llm.calls == 1
+    assert result.cancelled is True
+    assert result.terminated_by_tool is False

--- a/tests/core/agent_harness/test_host_cancel_turn.py
+++ b/tests/core/agent_harness/test_host_cancel_turn.py
@@ -1,0 +1,159 @@
+"""Host cooperative cancel short-circuits gather/answer and labels the turn."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from core.agent_harness.session import SessionCore
+from core.agent_harness.session.persistence.memory import InMemorySessionStorage
+from core.agent_harness.turns.host_cancel import host_cancel_requested
+from core.agent_harness.turns.orchestrator import run_turn
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+
+
+class _Accounting:
+    def record_action_result(self, _result: ToolCallingTurnResult) -> None:
+        return None
+
+    def finalize(self, result: TurnResult) -> TurnResult:
+        return result
+
+
+class _CancelSink:
+    def __init__(self) -> None:
+        self.turn_cancel = threading.Event()
+        self.streamed: list[str] = []
+
+    def print(self, message: str = "") -> None:
+        _ = message
+
+    def render_response_header(self, label: str) -> None:
+        _ = label
+
+    def render_error(self, message: str) -> None:
+        _ = message
+
+    def stream(self, *, label: str, chunks: Any, **_kwargs: Any) -> str:
+        _ = label
+        parts = list(chunks)
+        text = "".join(str(p) for p in parts)
+        self.streamed.append(text)
+        return text
+
+    def finalize(self, text: str) -> None:
+        _ = text
+
+
+def test_host_cancel_requested_reads_sink_event() -> None:
+    sink = _CancelSink()
+    assert host_cancel_requested(sink) is False
+    sink.turn_cancel.set()
+    assert host_cancel_requested(sink) is True
+    assert host_cancel_requested(None) is False
+
+
+def test_run_turn_cancelled_action_skips_gather_and_answer() -> None:
+    answer_calls: list[str] = []
+    gather_calls: list[str] = []
+
+    def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(
+            0,
+            0,
+            0,
+            False,
+            False,
+            cancelled=True,
+        )
+
+    def answer(text: str, _request: object = None, **_kwargs: object) -> object:
+        answer_calls.append(text)
+        return type("Run", (), {"response_text": "should-not-run"})()
+
+    def gather(text: str, **_kwargs: object) -> None:
+        gather_calls.append(text)
+        return None
+
+    result = run_turn(
+        "question?",
+        SessionCore(storage=InMemorySessionStorage()),
+        execute_actions=execute_actions,
+        answer=answer,
+        gather=gather,
+        accounting=_Accounting(),
+        output=_CancelSink(),
+    )
+    assert result.final_intent == "cli_agent_cancelled"
+    assert result.cancelled is True
+    assert result.answered is False
+    assert answer_calls == []
+    assert gather_calls == []
+
+
+def test_run_turn_cancel_during_gather_skips_answer() -> None:
+    sink = _CancelSink()
+    answer_calls: list[str] = []
+
+    def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(0, 0, 0, False, False)
+
+    def gather(_text: str, **_kwargs: object) -> str:
+        sink.turn_cancel.set()
+        return "evidence"
+
+    def answer(text: str, _request: object = None, **_kwargs: object) -> object:
+        answer_calls.append(text)
+        return type("Run", (), {"response_text": "should-not-run"})()
+
+    result = run_turn(
+        "question?",
+        SessionCore(storage=InMemorySessionStorage()),
+        execute_actions=execute_actions,
+        answer=answer,
+        gather=gather,
+        accounting=_Accounting(),
+        output=sink,
+    )
+    assert result.final_intent == "cli_agent_cancelled"
+    assert answer_calls == []
+
+
+def test_live_sink_stream_stops_when_turn_cancel_set() -> None:
+    from gateway.core.runtime.live_sink import LiveOutputSink
+
+    class _Inner:
+        def __init__(self) -> None:
+            self.turn_cancel = threading.Event()
+            self.seen: list[str] = []
+
+        def stream(self, *, label: str, chunks: Any, **_kwargs: Any) -> str:
+            _ = label
+            parts: list[str] = []
+            for chunk in chunks:
+                self.seen.append(str(chunk))
+                parts.append(str(chunk))
+            return "".join(parts)
+
+        def finalize(self, text: str) -> None:
+            _ = text
+
+        def render_error(self, message: str) -> None:
+            _ = message
+
+        def set_tool_status(self, text: str) -> None:
+            _ = text
+
+    inner = _Inner()
+    live = LiveOutputSink()
+    live.bind(inner)  # type: ignore[arg-type]
+
+    def _chunks() -> Any:
+        yield "a"
+        inner.turn_cancel.set()
+        yield "b"
+        yield "c"
+
+    text = live.stream(label="assistant", chunks=_chunks())
+    assert text == "a"
+    assert inner.seen == ["a"]

--- a/tests/core/agent_harness/test_host_cancel_turn.py
+++ b/tests/core/agent_harness/test_host_cancel_turn.py
@@ -9,7 +9,11 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStorage
 from core.agent_harness.turns.host_cancel import host_cancel_requested
 from core.agent_harness.turns.orchestrator import run_turn
-from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from core.agent_harness.turns.turn_results import (
+    FINAL_INTENT_CANCELLED,
+    ToolCallingTurnResult,
+    TurnResult,
+)
 
 
 class _Accounting:
@@ -84,7 +88,7 @@ def test_run_turn_cancelled_action_skips_gather_and_answer() -> None:
         accounting=_Accounting(),
         output=_CancelSink(),
     )
-    assert result.final_intent == "cli_agent_cancelled"
+    assert result.final_intent == FINAL_INTENT_CANCELLED
     assert result.cancelled is True
     assert result.answered is False
     assert answer_calls == []
@@ -115,7 +119,7 @@ def test_run_turn_cancel_during_gather_skips_answer() -> None:
         accounting=_Accounting(),
         output=sink,
     )
-    assert result.final_intent == "cli_agent_cancelled"
+    assert result.final_intent == FINAL_INTENT_CANCELLED
     assert answer_calls == []
 
 

--- a/tests/interactive_shell/test_gateway_cmds.py
+++ b/tests/interactive_shell/test_gateway_cmds.py
@@ -8,7 +8,7 @@ import pytest
 from rich.console import Console
 
 from surfaces.interactive_shell.command_registry.gateway_cmds import _cmd_gateway
-from surfaces.shared.gateway_entrypoint import GATEWAY_ENTRY_ARGV
+from surfaces.shared.gateway_entrypoint import gateway_entry_argv
 
 _MODULE = "surfaces.interactive_shell.command_registry.gateway_cmds"
 
@@ -64,7 +64,7 @@ def test_start_reports_outcome_and_log_path(
     assert "started (pid 7)" in out
     assert "gateway.log" in out
     # The shell supplies the entrypoint; the daemon never picks one itself.
-    assert spawned["argv"] == GATEWAY_ENTRY_ARGV
+    assert spawned["argv"] == gateway_entry_argv()
 
 
 def test_logs_prints_tail(monkeypatch: pytest.MonkeyPatch, console: Console) -> None:

--- a/tests/interactive_shell/test_gateway_cmds.py
+++ b/tests/interactive_shell/test_gateway_cmds.py
@@ -8,6 +8,7 @@ import pytest
 from rich.console import Console
 
 from surfaces.interactive_shell.command_registry.gateway_cmds import _cmd_gateway
+from surfaces.shared.gateway_entrypoint import GATEWAY_ENTRY_ARGV
 
 _MODULE = "surfaces.interactive_shell.command_registry.gateway_cmds"
 
@@ -49,16 +50,21 @@ def test_bare_gateway_defaults_to_status(monkeypatch: pytest.MonkeyPatch, consol
 def test_start_reports_outcome_and_log_path(
     monkeypatch: pytest.MonkeyPatch, console: Console
 ) -> None:
-    monkeypatch.setattr(
-        f"{_MODULE}.start_gateway_daemon",
-        lambda: (True, "OpenSRE gateway started (pid 7)."),
-    )
+    spawned: dict[str, object] = {}
+
+    def _start(*, argv):
+        spawned["argv"] = argv
+        return True, "OpenSRE gateway started (pid 7)."
+
+    monkeypatch.setattr(f"{_MODULE}.start_gateway_daemon", _start)
 
     assert _cmd_gateway(MagicMock(), console, ["start"]) is True
 
     out = _output(console)
     assert "started (pid 7)" in out
     assert "gateway.log" in out
+    # The shell supplies the entrypoint; the daemon never picks one itself.
+    assert spawned["argv"] == GATEWAY_ENTRY_ARGV
 
 
 def test_logs_prints_tail(monkeypatch: pytest.MonkeyPatch, console: Console) -> None:

--- a/tests/quality/test_no_constant_condition_toggles.py
+++ b/tests/quality/test_no_constant_condition_toggles.py
@@ -1,0 +1,88 @@
+"""Ban constant-condition toggles that disable real product logic.
+
+Never ship ``if False and …`` / ``if True or …`` / ``if False:`` to mute a
+branch while “fixing tests”. Delete the code, gate on a real named flag, or
+fix the underlying failure — do not leave dead boolean toggles in product
+packages.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PRODUCT_ROOTS = (
+    "bootstrap",
+    "config",
+    "core",
+    "gateway",
+    "integrations",
+    "platform",
+    "surfaces",
+    "tools",
+)
+
+
+def _is_test_path(path: Path) -> bool:
+    return "tests" in path.parts or path.name.startswith("test_")
+
+
+def _bool_const(node: ast.AST) -> bool | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+        return node.value
+    return None
+
+
+def _toggle_offenses(tree: ast.AST) -> list[tuple[int, str]]:
+    hits: list[tuple[int, str]] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_If(self, node: ast.If) -> None:
+            self._check_test(node.test, node.lineno)
+            self.generic_visit(node)
+
+        def _check_test(self, test: ast.AST, lineno: int) -> None:
+            alone = _bool_const(test)
+            if alone is not None:
+                hits.append((lineno, f"if {alone}"))
+                return
+            if not isinstance(test, ast.BoolOp):
+                return
+            op = "and" if isinstance(test.op, ast.And) else "or"
+            for value in test.values:
+                flag = _bool_const(value)
+                if flag is False and op == "and":
+                    hits.append((lineno, "… and False"))
+                elif flag is True and op == "or":
+                    hits.append((lineno, "… or True"))
+
+    _Visitor().visit(tree)
+    return hits
+
+
+@pytest.mark.parametrize("package", _PRODUCT_ROOTS)
+def test_product_packages_have_no_constant_condition_toggles(package: str) -> None:
+    root = _REPO_ROOT / package
+    if not root.is_dir():
+        pytest.skip(f"{package}/ missing")
+
+    offenders: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        if _is_test_path(path):
+            continue
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            offenders.append(f"{path.relative_to(_REPO_ROOT)}: syntax error: {exc}")
+            continue
+        for lineno, kind in _toggle_offenses(tree):
+            offenders.append(f"{path.relative_to(_REPO_ROOT)}:{lineno}: {kind}")
+
+    assert offenders == [], (
+        "Constant-condition toggles disable real logic (e.g. cancel short-circuit). "
+        "Remove the toggle; keep or delete the branch for real:\n" + "\n".join(offenders)
+    )

--- a/tests/surfaces/test_gateway_entrypoint.py
+++ b/tests/surfaces/test_gateway_entrypoint.py
@@ -1,0 +1,69 @@
+"""Frozen-safe argv for the gateway daemon child (Wave C2)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from surfaces.shared import gateway_entrypoint as ge
+
+
+def test_python_executable_uses_module_gateway_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ge.sys, "executable", sys.executable)
+    monkeypatch.setattr(ge.sys, "argv", ["pytest"])
+    monkeypatch.delattr(ge.sys, "frozen", raising=False)
+
+    assert ge.gateway_entry_argv() == (
+        sys.executable,
+        "-m",
+        "surfaces.cli.gateway_entry",
+    )
+
+
+def test_frozen_binary_uses_foreground_click_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ge.sys, "executable", "/tmp/opensre")
+    monkeypatch.setattr(ge.sys, "argv", ["/tmp/opensre"])
+    monkeypatch.setattr(ge.sys, "frozen", True, raising=False)
+
+    assert ge.gateway_entry_argv() == (
+        "/tmp/opensre",
+        "gateway",
+        "start",
+        "--foreground",
+    )
+
+
+def test_opensre_console_script_reuses_argv0_without_module_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Installed launchers may look like Python but still choke on ``-m``."""
+    monkeypatch.setattr(ge.sys, "executable", "/usr/bin/python3.14")
+    monkeypatch.setattr(ge.sys, "argv", ["/usr/local/bin/opensre"])
+    monkeypatch.delattr(ge.sys, "frozen", raising=False)
+
+    assert ge.gateway_entry_argv() == (
+        "/usr/local/bin/opensre",
+        "gateway",
+        "start",
+        "--foreground",
+    )
+
+
+def test_non_python_executable_uses_foreground_click_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ge.sys, "executable", "/opt/opensre/bin/opensre")
+    monkeypatch.setattr(ge.sys, "argv", ["something-else"])
+    monkeypatch.delattr(ge.sys, "frozen", raising=False)
+
+    assert ge.gateway_entry_argv() == (
+        "/opt/opensre/bin/opensre",
+        "gateway",
+        "start",
+        "--foreground",
+    )


### PR DESCRIPTION
Implements the "Improvements To Gateway Structure" note. Three things, plus a naming pass.

**Channels are no longer wired inside the manager.** `GatewayManager` had a worker field, a `_start_*` method, and a stop branch per transport. It now calls `start_channels()` and holds one `ChannelsHandle`. The new `gateway/channels/`
package is the sole composer of web + Telegram/Slack/Discord; `chat.py` drives every transport through one table (`TRANSPORTS`) keyed by a `TransportName` StrEnum. Adding a transport is now one row plus a `startup.py`, and the manager imports no transport class at all.

Startup outcomes are uniform: missing credentials report `not configured`, a transport that starts but never becomes usable reports `failed` (a new `GatewayTransportFailedError`), and the rest still start. Discord's readiness wait moved out of the manager and into `transports/discord/startup.py`, where the other transport-specific detail already lives.

**The daemon no longer names a surface.** `gateway/core/runtime/daemon.py` hardcoded `python -m surfaces.cli.gateway_entry` in its subprocess argv, so a surface started the daemon and the daemon started a surface back. Import-linter cannot see a dependency spelled as a string literal, so this passed every boundary check in CI. `start_gateway_daemon(argv=...)` is now required and each surface supplies its own entrypoint via `surfaces/shared/gateway_entrypoint.py`. `gateway_entry_argv()` resolves at spawn time and falls back to `gateway start --foreground` for frozen builds, where `python -m` would hand `-m` to Click.

**`wiring.py` → `startup.py`.** Each of those modules contained exactly one function, `start_<name>_worker`; the name described nothing. `startup.py` matches the existing `surfaces/cli/startup.py` precedent, and the surrounding vocabulary
moved with it.

Also on this branch: Telegram inline-keyboard approvals (`transports/telegram/approvals.py`, with the transport-neutral broker staying in `core/runtime/approvals.py`), a Telegram `principal.py` matching the Slack/Discord org+actor border, and `concurrency.py` reduced to the process gate with the test-only callback wrapper moved under `gateway/tests/`.