### PR TITLE
refactor(harness): AgentSession narrative, shared process gate, scheduler worker profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ opensre hermes watch
 **From Python** — drive the agent in-process from your own code (source checkout required):
 
 ```python
-from core.agent_harness import AgentHarness
+from core.agent_harness import AgentSession
 
-harness = AgentHarness.start()
-result = harness.dispatch_message("why is checkout-api slow?")
+session = AgentSession.start()
+result = session.chat("why is checkout-api slow?")
 if result.answered:
     print(result.primary_response_text)
 ```

--- a/bootstrap/process.py
+++ b/bootstrap/process.py
@@ -10,8 +10,7 @@ composition root (``GatewayManager.configure_logging``, CLI stderr).
 Does **not** construct :class:`~core.agent_harness.turns.headless_dispatch.HeadlessAgent`
 or run turns — that is ``build_default_headless_agent`` /
 :class:`~core.agent_harness.harness.AgentSession` after boot. Bootstrap and
-headless construction are two layers of one narrative, not duplicated stacks
-(see ``opensre-notes/agent-session-api-scaling-aug2026.md``).
+headless construction are separate layers, not duplicated stacks.
 """
 
 from __future__ import annotations
@@ -98,6 +97,10 @@ WEB_PROFILE: Final = ProcessProfile(
 )
 SCHEDULER_WORKER_PROFILE: Final = ProcessProfile(
     name=ProcessName.SCHEDULER_WORKER,
+    # Dedicated blocking scheduler process (`opensre cron start`). Owns its
+    # Sentry entrypoint and installs runners at boot. Gateway co-hosts the
+    # scheduler differently: GATEWAY_PROFILE + late install_scheduler_runners
+    # in GatewayManager.start_scheduler — do not confuse the two.
     steps=frozenset(
         {
             BootStep.ENV,
@@ -110,9 +113,10 @@ SCHEDULER_WORKER_PROFILE: Final = ProcessProfile(
 )
 SCHEDULED_COMMAND_PROFILE: Final = ProcessProfile(
     name=ProcessName.SCHEDULED_COMMAND,
-    # A CLI command that creates or dispatches scheduled work (cron, digests,
+    # A CLI command that creates or dispatches scheduled work (cron add, digests,
     # metric reports). It runs inside an already-booted CLI process, so Sentry
     # stays with the CLI; it needs the runners scheduled tasks dispatch through.
+    # Not the long-running daemon — that is SCHEDULER_WORKER_PROFILE.
     steps=frozenset({BootStep.ENV, BootStep.HARNESS_ADAPTERS, BootStep.SCHEDULER_RUNNERS}),
 )
 EMBEDDED_PROFILE: Final = ProcessProfile(

--- a/bootstrap/process.py
+++ b/bootstrap/process.py
@@ -6,6 +6,12 @@ and a profile cannot invent a different sequence.
 
 Does **not** configure gateway or CLI logging — that stays with the surface
 composition root (``GatewayManager.configure_logging``, CLI stderr).
+
+Does **not** construct :class:`~core.agent_harness.turns.headless_dispatch.HeadlessAgent`
+or run turns — that is ``build_default_headless_agent`` /
+:class:`~core.agent_harness.harness.AgentSession` after boot. Bootstrap and
+headless construction are two layers of one narrative, not duplicated stacks
+(see ``opensre-notes/agent-session-api-scaling-aug2026.md``).
 """
 
 from __future__ import annotations

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -7,15 +7,13 @@ It was extracted out of `interactive_shell` so the same harness can run the
 interactive terminal and be invoked headlessly via
 `agent_harness.turns.headless_dispatch`.
 
-## Canonical narrative (teach this)
+## Host API (teach this)
 
 Prefer `AgentSession.start()` → `.chat` / `.investigate` — not free-function
-turn dumps. **Goal B:** construct one agent per logical session (or scheduled
-loop), then many turns — do not rebuild every message. Full Goal A/B + scaling +
-**bootstrap vs headless layers:**
-`opensre-notes/agent-session-api-scaling-aug2026.md`
-([#layers](../../opensre-notes/agent-session-api-scaling-aug2026.html#layers)).
-Also: `opensre-notes/agent-harness-guide.md`.
+turn dumps. Construct one agent per logical session (or scheduled loop), then
+many turns — do not rebuild every message. Process boot
+(`configure_process`) and headless construction (`build_default_headless_agent`)
+are separate layers.
 
 | Path | Call |
 |------|------|
@@ -30,7 +28,7 @@ Shell uses a TTY `ChatDispatcher` (same `AgentSession.chat` / `run_turn`) —
 intentional, not a second headless factory. Do not reintroduce peer
 `bootstrap.adapters` copies under surfaces or gateway.
 
-**Goal B bind ports:** session-aware defaults implement
+**Bind ports:** session-aware defaults implement
 `SessionBindable` / `ConsoleBindable` / `OutputBindable` (`ports.py`).
 `HeadlessAgent.bind_session` / `bind_turn(console=…, output=…)` only call ports
 that match those Protocols. Gateway usually keeps a stable `LiveOutputSink` and
@@ -41,19 +39,17 @@ rebinds the transport via `LiveOutputSink.bind` (no `output=` each turn).
 tools (console `cancel_requested`), orchestrator/gather, and stream guards all
 read that same Event. Do not invent a second cancel channel.
 
-**Cloud “infinite” scale:** more Fargate tasks (fleet), not unbound in-process
-concurrency or a new `chat` API — see notes `#fargate`.
+**Cloud scale-out:** more Fargate tasks (fleet), not unbound in-process
+concurrency or a new `chat` API.
 
-## Hard boundary (enforced by tests)
+## Hard boundary
 
-- **No `import interactive_shell` anywhere under `agent_harness/`.** This is the whole
-  point of the package and is checked by
-  `tests/core/agent/test_import_boundaries.py`. The dependency direction is strictly
-  one-way: `interactive_shell -> agent_harness -> core`.
+- **No `import interactive_shell` anywhere under `agent_harness/`.** The dependency
+  direction is strictly one-way: `interactive_shell -> agent_harness -> core`.
 - `agent_harness/` may depend on `core/`, `config/`, and `platform/`. It must not
   import `integrations/`, `tools/`, `surfaces/`, or `gateway/`. Integration and tool
   behavior reaches the harness through ports in `platform/harness_ports.py`, wired at
-  startup via `install_harness_ports()` in `surfaces/interactive_shell/ui/output/boundary.py`.
+  startup via `install_harness_ports()` in the interactive-shell output boundary.
   It must not depend on terminal UI concerns (Rich rendering, prompt-toolkit
   mutable UI state, slash dispatch, the shell `REGISTRY`).
 
@@ -103,7 +99,7 @@ subpackage. Default port implementations live with the concern they serve, not i
   default `TurnAccounting` (`turn_accounting.py`) and `RunRecordFactory`
   (`run_record.py`).
 - `prompts/` — prompt builders by agent path (pure string assembly; grounding
-  via `PromptContextProvider`). See `prompts/AGENTS.md`. Layout: `kernel/`
+  via `PromptContextProvider`). Layout: `kernel/`
   (envelope + surface Strategy), `assistant/` / `action/` / `gather/` (peer
   assemblers), `grounding/` (prompt providers), plus leaves `memory/` /
   `runtime_facts/` / `skills/`.
@@ -217,13 +213,11 @@ shape; if it answers directly without tools it is the direct-answer shape.
 2. Update this file when harness rules change.
 3. Inject through `ports.py` callables (`StreamAnswerFn`, `ExecuteActions`,
    `EvidenceGatherer`); do not import surface code into `agent_harness/`.
-4. Add or extend guards in `tests/core/agent_harness/test_agent_shapes.py` when
-   you introduce a new entrypoint or rename a shape seam.
-5. Public host API is `AgentSession.chat` / `AgentSession.investigate`
-   (`tests/core/agent_harness/test_agent_session_api.py`). Adapters build
-   `ChatTurnBindings` and call `dispatch_chat_turn` internally — never add a
-   new top-level binder that calls `run_turn` directly
-   (`tests/core/agent_harness/test_chat_api.py`).
+4. Add or extend shape-guard tests when you introduce a new entrypoint or
+   rename a shape seam.
+5. Public host API is `AgentSession.chat` / `AgentSession.investigate`.
+   Adapters build `ChatTurnBindings` and call `dispatch_chat_turn` internally —
+   never add a new top-level binder that calls `run_turn` directly.
 
 **Read order for new code:** this file → `harness.py` (`AgentSession`) →
 `turns/orchestrator.py` (`run_turn`) → `core/agent/agent.py` (facade + wiring)
@@ -237,14 +231,13 @@ composes the shared `EventEmitterMixin` and `ToolFilterMixin` mixins
 `run()` (seed calls, evidence collection, duplicate detection, stagnation
 handling). It is still the tool-calling shape — composition, not a forked loop.
 
-## Canonical narrative (construct once → many turns)
+## Construct once → many turns
 
-The technology is already object-shaped. Prefer this story in docs, samples,
-and new call sites — do **not** invent a second top-level free function that
-dumps the turn stack, and do **not** rebuild a headless agent on every message
-for the same logical session.
+Prefer this shape in docs, samples, and new call sites — do **not** invent a
+second top-level free function that dumps the turn stack, and do **not** rebuild
+a headless agent on every message for the same logical session.
 
-**Goal A — host API shape**
+**Host API shape**
 
 ```python
 from bootstrap.process import EMBEDDED_PROFILE, configure_process
@@ -257,7 +250,7 @@ result = session.chat("…")            # turn 2 — same attached agent
 report = session.investigate({…})     # Path-2 verb (separate stage machine)
 ```
 
-**Goal B — one agent per logical session (or scheduled loop)**
+**One agent per logical session (or scheduled loop)**
 
 | Lifetime | Construct | Then |
 |----------|-----------|------|
@@ -281,20 +274,19 @@ per-session lock). Different sessions stay concurrent under the capacity gate.
 There is no `dispatch_message_to_headless_agent` — that free-function dump was
 replaced by `HeadlessAgent.dispatch` / `AgentSession.chat`.
 
-**Scaling is a separate track** from this narrative: local concurrency
+**Scaling** is separate from the host API: local concurrency
 (`TurnConcurrencyGate` / transport pools / `OPENSRE_SIZE_PROFILE`) and cloud
 Fargate scale-out (spin more tasks; same API per task) sit *around*
 `chat`/`investigate`. Construct-once-per-session is the reuse story;
 process/task scale-out is deploy. Do not redesign the host API to “enable
-scaling.” See `opensre-notes/agent-session-api-scaling-aug2026.md` (#fargate).
+scaling.”
 
 ## Four hosts, one AgentSession API
 
 **Public host contract:** :class:`~core.agent_harness.harness.AgentSession`
 with ``chat`` and ``investigate``. One name per concept — the former
 ``AgentHarness`` / ``HarnessConfig`` / ``HarnessStartupResult`` /
-``dispatch_message`` aliases are deleted, pinned by
-``tests/core/agent_harness/test_agent_session_api.py``.
+``dispatch_message`` aliases are deleted.
 
 **Internal chat seam:** adapters build
 :class:`~core.agent_harness.turns.chat_api.ChatTurnBindings`, then call
@@ -324,8 +316,7 @@ it does not re-implement it. Do not fork the loop here.
 
 ## core/agent package (Agent is a facade, not the algorithm owner)
 
-`core/agent/` is a package with one file per responsibility (see
-[docs/NAMING.md](../../docs/NAMING.md) for the naming convention). `Agent`
+`core/agent/` is a package with one file per responsibility. `Agent`
 (in `agent.py`) is a thin facade: `__init__` stores construction-time config
 and `run()` resolves per-run context (from `runtime_request=` or
 `initial_messages=`) and hands it to `core.agent.react_loop.run_react_loop`,

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -7,6 +7,43 @@ It was extracted out of `interactive_shell` so the same harness can run the
 interactive terminal and be invoked headlessly via
 `agent_harness.turns.headless_dispatch`.
 
+## Canonical narrative (teach this)
+
+Prefer `AgentSession.start()` → `.chat` / `.investigate` — not free-function
+turn dumps. **Goal B:** construct one agent per logical session (or scheduled
+loop), then many turns — do not rebuild every message. Full Goal A/B + scaling +
+**bootstrap vs headless layers:**
+`opensre-notes/agent-session-api-scaling-aug2026.md`
+([#layers](../../opensre-notes/agent-session-api-scaling-aug2026.html#layers)).
+Also: `opensre-notes/agent-harness-guide.md`.
+
+| Path | Call |
+|------|------|
+| Process boot (once) | `configure_process(PROFILE)` — adapters only; not agent construction |
+| Happy path | `AgentSession.start()` → repeated `.chat` / `.investigate` |
+| Custom host | **`build_default_headless_agent(...)`** (only factory) → `attach_agent` once → many `.chat` |
+| Gateway | `SessionAgentPool` → factory once / session → `bind_turn` → `.chat` |
+| Scheduled one-shot | `AgentSession.run_headless_turn(...)` (not the multi-turn pattern) |
+
+Do **not** duplicate the default port stack outside `build_default_headless_agent`.
+Shell uses a TTY `ChatDispatcher` (same `AgentSession.chat` / `run_turn`) —
+intentional, not a second headless factory. Do not reintroduce peer
+`bootstrap.adapters` copies under surfaces or gateway.
+
+**Goal B bind ports:** session-aware defaults implement
+`SessionBindable` / `ConsoleBindable` / `OutputBindable` (`ports.py`).
+`HeadlessAgent.bind_session` / `bind_turn(console=…, output=…)` only call ports
+that match those Protocols. Gateway usually keeps a stable `LiveOutputSink` and
+rebinds the transport via `LiveOutputSink.bind` (no `output=` each turn).
+
+**Host cancel:** one `threading.Event` on the output sink
+(`ensure_turn_cancel` / `host_cancel_requested` in `turns/host_cancel.py`) —
+tools (console `cancel_requested`), orchestrator/gather, and stream guards all
+read that same Event. Do not invent a second cancel channel.
+
+**Cloud “infinite” scale:** more Fargate tasks (fleet), not unbound in-process
+concurrency or a new `chat` API — see notes `#fargate`.
+
 ## Hard boundary (enforced by tests)
 
 - **No `import interactive_shell` anywhere under `agent_harness/`.** This is the whole
@@ -144,9 +181,10 @@ agent = build_agent(config)
 Action (`turns/action_driver.py::_build_action_agent`) and evidence
 (`turns/evidence_driver.py::_build_evidence_agent`) assemble an
 ``AgentConfig`` and call ``build_agent``. The gateway turn path does not
-construct a persistent ``Agent`` — it builds a fresh ``HeadlessAgent`` per turn with
-:class:`~core.agent_harness.tools.tool_provider.DefaultToolProvider`
-from the live chat session. When ``Agent.__init__``'s signature changes,
+construct a persistent ``core.agent.Agent`` — gateway chat reuses one
+``HeadlessAgent`` per logical session via ``SessionAgentPool`` (each turn
+``bind_turn`` + live ``DefaultToolProvider`` from the chat session). When
+``Agent.__init__``'s signature changes,
 ``agent_builder.py`` is the single edit site for harness surfaces that call
 ``build_agent``.
 
@@ -199,11 +237,64 @@ composes the shared `EventEmitterMixin` and `ToolFilterMixin` mixins
 `run()` (seed calls, evidence collection, duplicate detection, stagnation
 handling). It is still the tool-calling shape — composition, not a forked loop.
 
+## Canonical narrative (construct once → many turns)
+
+The technology is already object-shaped. Prefer this story in docs, samples,
+and new call sites — do **not** invent a second top-level free function that
+dumps the turn stack, and do **not** rebuild a headless agent on every message
+for the same logical session.
+
+**Goal A — host API shape**
+
+```python
+from bootstrap.process import EMBEDDED_PROFILE, configure_process
+from core.agent_harness import AgentSession
+
+configure_process(EMBEDDED_PROFILE)   # adapters / investigation runner
+session = AgentSession.start()        # construct once (session + default agent)
+result = session.chat("…")            # turn 1
+result = session.chat("…")            # turn 2 — same attached agent
+report = session.investigate({…})     # Path-2 verb (separate stage machine)
+```
+
+**Goal B — one agent per logical session (or scheduled loop)**
+
+| Lifetime | Construct | Then |
+|----------|-----------|------|
+| Chat session (gateway) | `SessionAgentPool` keeps one `HeadlessAgent` per session id; each turn rebinds outer sink via `LiveOutputSink.bind`, then `bind_turn` (session / accounting / console / tool_hooks) | `AgentSession.chat` / `agent.dispatch` |
+| Embedder / script | `AgentSession.start()` or `attach_agent(HeadlessAgent…)` once | repeated `chat` / `dispatch` |
+| Scheduled loop | Prefer one agent for the loop’s lifetime when multi-turn; `run_headless_turn` is OK for true one-shot digests | do not treat one-shot as the multi-turn pattern |
+| Interactive shell | TTY `ChatDispatcher` bound for the REPL lifetime (not `HeadlessAgent`) | `AgentSession.chat` per submission |
+
+Same-session turns must not overlap on one pooled agent (gateway holds a
+per-session lock). Different sessions stay concurrent under the capacity gate.
+
+| Name | Use |
+|------|-----|
+| **`AgentSession`** + **`chat` / `investigate`** | **Public host API** — prefer in all new code |
+| **`HeadlessAgent`** + **`dispatch`** | Non-TTY `ChatDispatcher` (ports object); gateway / embedders / tests |
+| **`SessionAgentPool`** | Gateway: one headless agent per logical session across turns |
+| **`build_default_headless_agent`** | Factory for the standard port stack when a surface supplies its own sink |
+| **`run_headless_turn`** | One-shot convenience for scheduler digests — not the multi-turn pattern |
+| **`dispatch_chat_turn`** | **Internal** seam over `run_turn` — adapters only |
+
+There is no `dispatch_message_to_headless_agent` — that free-function dump was
+replaced by `HeadlessAgent.dispatch` / `AgentSession.chat`.
+
+**Scaling is a separate track** from this narrative: local concurrency
+(`TurnConcurrencyGate` / transport pools / `OPENSRE_SIZE_PROFILE`) and cloud
+Fargate scale-out (spin more tasks; same API per task) sit *around*
+`chat`/`investigate`. Construct-once-per-session is the reuse story;
+process/task scale-out is deploy. Do not redesign the host API to “enable
+scaling.” See `opensre-notes/agent-session-api-scaling-aug2026.md` (#fargate).
+
 ## Four hosts, one AgentSession API
 
 **Public host contract:** :class:`~core.agent_harness.harness.AgentSession`
-with ``chat`` and ``investigate``. Compatibility aliases:
-``AgentHarness`` / ``dispatch_message`` / ``HarnessConfig``.
+with ``chat`` and ``investigate``. One name per concept — the former
+``AgentHarness`` / ``HarnessConfig`` / ``HarnessStartupResult`` /
+``dispatch_message`` aliases are deleted, pinned by
+``tests/core/agent_harness/test_agent_session_api.py``.
 
 **Internal chat seam:** adapters build
 :class:`~core.agent_harness.turns.chat_api.ChatTurnBindings`, then call

--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -7,8 +7,7 @@ terminal, gateway, and embedders share one entry.
 
 Hard boundary: nothing under ``agent_harness/`` may import from
 ``interactive_shell``, ``tools``, or ``integrations``. The dependency direction
-is one-way: ``interactive_shell -> agent_harness -> core``. See
-``agent_harness/AGENTS.md``.
+is one-way: ``interactive_shell -> agent_harness -> core``.
 """
 
 from __future__ import annotations

--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -18,11 +18,8 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from core.agent_harness.harness import (
-        AgentHarness,
         AgentSession,
         ChatDispatcher,
-        HarnessConfig,
-        HarnessStartupResult,
         SessionConfig,
         SessionStartupResult,
     )
@@ -49,11 +46,8 @@ if TYPE_CHECKING:
 # import graph. This keeps interactive-shell boot cheap.
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "AgentSession": ("core.agent_harness.harness", "AgentSession"),
-    "AgentHarness": ("core.agent_harness.harness", "AgentHarness"),
     "SessionConfig": ("core.agent_harness.harness", "SessionConfig"),
-    "HarnessConfig": ("core.agent_harness.harness", "HarnessConfig"),
     "SessionStartupResult": ("core.agent_harness.harness", "SessionStartupResult"),
-    "HarnessStartupResult": ("core.agent_harness.harness", "HarnessStartupResult"),
     "ChatDispatcher": ("core.agent_harness.harness", "ChatDispatcher"),
     "InvestigationResult": ("core.agent_harness.investigation_api", "InvestigationResult"),
     "TurnResult": ("core.agent_harness.turns.turn_results", "TurnResult"),
@@ -102,15 +96,12 @@ def __dir__() -> list[str]:
 
 __all__ = [
     "ActionTurnRunner",
-    "AgentHarness",
     "AgentRuntimeRequest",
     "AgentSession",
     "BufferOutputSink",
     "ChatDispatcher",
     "ChatTurnBindings",
     "DefaultPromptContextProvider",
-    "HarnessConfig",
-    "HarnessStartupResult",
     "HeadlessAgent",
     "InvestigationResult",
     "SessionConfig",

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -7,15 +7,24 @@ the installed payload runner (wired at process boot). Session lifecycle
 :class:`~core.agent_harness.session.lifecycle.SessionManager`; the session API
 sits one layer above and adds env resolution and prompt context.
 
-::
+Narrative — construct **one** agent per logical session, then many turns::
 
-    session = AgentSession.start()
-    result = session.chat("why is checkout-api slow?")
-    report = session.investigate({"alert_name": "HighLatency"})
+    session = AgentSession.start()       # or attach_agent(custom_headless)
+    result = session.chat("…")           # turn 1
+    follow = session.chat("…")           # turn 2 — same attached agent
+    report = session.investigate({…})    # Path-2 (no attached chat agent required)
 
-Compatibility aliases: :class:`AgentHarness` (= ``AgentSession``),
-:class:`HarnessConfig` (= ``SessionConfig``),
-:meth:`AgentSession.dispatch_message` (= ``chat``).
+Custom ports (live gateway sink, REPL)::
+
+    session = AgentSession(SessionConfig(load_env=False))
+    session.startup()
+    session.attach_agent(build_default_headless_agent(session=…, output=sink, …))
+    session.chat(text)                   # reuse the same agent across messages
+
+Gateway chat reuses one ``HeadlessAgent`` per session via ``SessionAgentPool``
+(``bind_turn`` each message). Scheduled **one-shots** may use
+:meth:`run_headless_turn`; multi-turn loops should keep one agent for the loop.
+There is no ``dispatch_message_to_headless_agent`` free function.
 
 Must not import ``surfaces.interactive_shell`` (enforced by
 ``tests/core/agent/test_import_boundaries.py``). Surfaces inject prompt
@@ -34,7 +43,6 @@ if TYPE_CHECKING:
     from core.agent_harness.investigation_api import AlertInput, InvestigationResult
     from core.agent_harness.ports import OutputSink, PromptContextProvider
     from core.agent_harness.session.session_core import SessionCore
-    from core.agent_harness.turns.headless_dispatch import HeadlessAgent
     from core.agent_harness.turns.turn_results import TurnResult
 
 
@@ -67,8 +75,15 @@ class SessionConfig:
     session_manager: SessionManager | None = None
 
 
-# Compatibility alias — prefer SessionConfig.
-HarnessConfig = SessionConfig
+# Scheduled/one-shot runs: a fresh warm session that leaves no persisted task
+# registry or open storage behind.
+SCHEDULED_RUN_CONFIG = SessionConfig(
+    load_env=True,
+    hydrate_integrations=True,
+    warm_integrations=True,
+    persistent_tasks=False,
+    open_storage=False,
+)
 
 
 @dataclass(frozen=True)
@@ -77,10 +92,6 @@ class SessionStartupResult:
 
     session: SessionCore
     prompts: PromptContextProvider | None
-
-
-# Compatibility alias — prefer SessionStartupResult.
-HarnessStartupResult = SessionStartupResult
 
 
 class AgentSession:
@@ -148,44 +159,78 @@ class AgentSession:
         """Return the surface's grounding-context provider, if any."""
         return self._config.prompts
 
-    @classmethod
-    def start(
-        cls,
-        config: SessionConfig | None = None,
+    def _attach_default_headless(
+        self,
+        *,
+        session: SessionCore,
+        output: OutputSink,
+        prompts: PromptContextProvider | None,
+        message: str | None = None,
         **agent_kwargs: Any,
-    ) -> AgentSession:
-        """Return a session that is ready to :meth:`chat`.
+    ) -> None:
+        """Attach the shared default headless port stack (one construction recipe).
 
-        Runs startup and attaches a default agent, so the common case is two
-        lines rather than assembling a console, logger, sink and factory call::
-
-            session = AgentSession.start()
-            result = session.chat("why is checkout-api slow?")
-
-        Extra ``agent_kwargs`` are forwarded to
-        :func:`~core.agent_harness.turns.default_headless_agent.build_default_headless_agent`
-        (e.g. ``logger=``, ``gather_max_iterations=``). Surfaces that need their
-        own ports (a live gateway sink, a REPL console) still build the agent
-        themselves and call :meth:`attach_agent`.
+        Used by :meth:`start` and :meth:`run_headless_turn`. Custom hosts
+        (gateway pool, REPL) still call :func:`build_default_headless_agent` or
+        assemble :class:`HeadlessAgent` and :meth:`attach_agent` themselves —
+        they must not re-copy this wiring ad hoc.
         """
         from core.agent_harness.turns.default_headless_agent import (
             build_default_headless_agent,
         )
+
+        agent_kwargs.pop("message", None)
+        self.attach_agent(
+            build_default_headless_agent(
+                session=session,
+                output=output,
+                prompts=prompts,
+                message=message,
+                **agent_kwargs,
+            )
+        )
+
+    @classmethod
+    def start(
+        cls,
+        config: SessionConfig | None = None,
+        *,
+        output: OutputSink | None = None,
+        prompts: PromptContextProvider | None = None,
+        prepare_session: Callable[[SessionCore], None] | None = None,
+        message: str | None = None,
+        **agent_kwargs: Any,
+    ) -> AgentSession:
+        """Return a session that is ready to :meth:`chat`.
+
+        The single headless bootstrap: create the session, run ``prepare_session``,
+        resolve the sink and prompt context, and attach the default agent. Build
+        it once and dispatch as many turns as the caller needs::
+
+            session = AgentSession.start()
+            for prompt in prompts:
+                result = session.chat(prompt)
+
+        ``prepare_session`` runs after session create (e.g. pin a project scope)
+        and before the agent is built. ``message`` is the first turn's text when
+        it is already known, for ports that size themselves to it. Remaining
+        keyword arguments reach
+        :func:`~core.agent_harness.turns.default_headless_agent.build_default_headless_agent`.
+        Surfaces that need their own ports (a live gateway sink, a REPL console)
+        build the agent themselves and call :meth:`attach_agent`.
+        """
         from core.agent_harness.turns.headless_adapters import BufferOutputSink
 
         agent_session = cls(config)
         startup = agent_session.startup()
-        output = agent_kwargs.pop("output", None)
-        if output is None:
-            output = BufferOutputSink()
-        prompts = agent_kwargs.pop("prompts", startup.prompts)
-        agent_session.attach_agent(
-            build_default_headless_agent(
-                session=startup.session,
-                output=output,
-                prompts=prompts,
-                **agent_kwargs,
-            )
+        if prepare_session is not None:
+            prepare_session(startup.session)
+        agent_session._attach_default_headless(
+            session=startup.session,
+            output=output if output is not None else BufferOutputSink(),
+            prompts=prompts if prompts is not None else startup.prompts,
+            message=message,
+            **agent_kwargs,
         )
         return agent_session
 
@@ -199,43 +244,20 @@ class AgentSession:
         prepare_session: Callable[[SessionCore], None] | None = None,
         **agent_kwargs: Any,
     ) -> TurnResult:
-        """Boot a default headless agent and run one turn for ``message``.
+        """Run exactly one turn for ``message`` on a throwaway session.
 
-        Collapses the session + BufferOutputSink + ``build_default_headless_agent``
-        stack shared by scheduled digests and report runners. Optional
-        ``prepare_session`` runs after session create (e.g. pin a project scope)
-        and before the agent is built. Extra kwargs forward to
-        :func:`~core.agent_harness.turns.default_headless_agent.build_default_headless_agent`.
+        Convenience for scheduled digests and report runners that fire once. A
+        loop that runs several turns must call :meth:`start` once and
+        :meth:`chat` per turn instead — this rebuilds the session, re-hydrates
+        integrations, and discards every warm cache on each call.
         """
-        from core.agent_harness.turns.default_headless_agent import (
-            build_default_headless_agent,
-        )
-        from core.agent_harness.turns.headless_adapters import BufferOutputSink
-
-        session_config = config or SessionConfig(
-            load_env=True,
-            hydrate_integrations=True,
-            warm_integrations=True,
-            persistent_tasks=False,
-            open_storage=False,
-        )
-        agent_session = cls(session_config)
-        startup = agent_session.startup()
-        session = startup.session
-        if prepare_session is not None:
-            prepare_session(session)
-        sink = output if output is not None else BufferOutputSink()
-        prompts = agent_kwargs.pop("prompts", startup.prompts)
-        agent_kwargs.pop("message", None)
-        agent = build_default_headless_agent(
-            session=session,
-            output=sink,
-            prompts=prompts,
+        return cls.start(
+            config or SCHEDULED_RUN_CONFIG,
+            output=output,
+            prepare_session=prepare_session,
             message=message,
             **agent_kwargs,
-        )
-        agent_session.attach_agent(agent)
-        return agent_session.chat(message)
+        ).chat(message)
 
     @property
     def agent(self) -> ChatDispatcher | None:
@@ -274,15 +296,6 @@ class AgentSession:
             )
         return target.dispatch(message)
 
-    def dispatch_message(
-        self,
-        message: str,
-        *,
-        agent: ChatDispatcher | HeadlessAgent | None = None,
-    ) -> TurnResult:
-        """Compatibility alias for :meth:`chat`."""
-        return self.chat(message, agent=agent)
-
     def investigate(
         self,
         alert: AlertInput,
@@ -305,16 +318,10 @@ class AgentSession:
         )
 
 
-# Compatibility alias — prefer AgentSession.
-AgentHarness = AgentSession
-
-
 __all__ = [
-    "AgentHarness",
+    "SCHEDULED_RUN_CONFIG",
     "AgentSession",
     "ChatDispatcher",
-    "HarnessConfig",
-    "HarnessStartupResult",
     "SessionConfig",
     "SessionStartupResult",
 ]

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -7,7 +7,7 @@ the installed payload runner (wired at process boot). Session lifecycle
 :class:`~core.agent_harness.session.lifecycle.SessionManager`; the session API
 sits one layer above and adds env resolution and prompt context.
 
-Narrative — construct **one** agent per logical session, then many turns::
+Construct **one** agent per logical session, then many turns::
 
     session = AgentSession.start()       # or attach_agent(custom_headless)
     result = session.chat("…")           # turn 1
@@ -26,8 +26,7 @@ Gateway chat reuses one ``HeadlessAgent`` per session via ``SessionAgentPool``
 :meth:`run_headless_turn`; multi-turn loops should keep one agent for the loop.
 There is no ``dispatch_message_to_headless_agent`` free function.
 
-Must not import ``surfaces.interactive_shell`` (enforced by
-``tests/core/agent/test_import_boundaries.py``). Surfaces inject prompt
+Must not import ``surfaces.interactive_shell``. Surfaces inject prompt
 context through :class:`SessionConfig`.
 """
 

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -88,6 +88,48 @@ class SessionStore(Protocol):
 
 
 @runtime_checkable
+class SessionBindable(Protocol):
+    """Port that can retarget a session for Goal B agent reuse.
+
+    Pooled / multi-turn hosts call :meth:`bind_session` when
+    ``SessionManager.resolve`` returns a fresh session object for the same id.
+    Ports that ignore session identity need not implement this; ``HeadlessAgent``
+    only invokes it when the port structurally matches.
+    """
+
+    def bind_session(self, session: SessionStore) -> None:
+        """Point this port at ``session`` (same logical session, new object)."""
+
+
+@runtime_checkable
+class ConsoleBindable(Protocol):
+    """Tool port that can retarget the turn console (cancel / TTY observers).
+
+    Gateway binds a per-turn ``CancelConsole`` so ``cancel_requested`` tracks
+    the shared ``sink.turn_cancel`` Event for that message.
+    """
+
+    def bind_console(self, console: Any) -> None:
+        """Point tool UI / cancel probes at ``console`` for this turn."""
+
+
+@runtime_checkable
+class OutputBindable(Protocol):
+    """Port that holds an :class:`OutputSink` and can retarget it for Goal B reuse.
+
+    ``HeadlessAgent.bind_turn(output=…)`` updates the agent's sink and must
+    retarget every port that cached the previous sink (e.g. reasoning error
+    rendering). Gateway usually keeps a stable ``LiveOutputSink`` and rebinds
+    the outer transport sink via ``LiveOutputSink.bind`` — that path does not
+    need ``bind_turn(output=)``. Hosts that swap the ``OutputSink`` object
+    itself must pass ``output=`` so :class:`OutputBindable` ports follow.
+    """
+
+    def bind_output(self, output: OutputSink) -> None:
+        """Point this port at ``output`` for the current turn."""
+
+
+@runtime_checkable
 class ToolProvider(Protocol):
     """Supplies the action-agent tools and the per-turn tool-event observer."""
 
@@ -257,6 +299,7 @@ __all__ = [
     "AnswerRequest",
     "StreamAnswerFn",
     "ConfirmFn",
+    "ConsoleBindable",
     "ErrorReporter",
     "EvidenceGatherer",
     "ExecuteActions",
@@ -264,6 +307,7 @@ __all__ = [
     "PromptContextProvider",
     "ReasoningClientProvider",
     "RunRecordFactory",
+    "SessionBindable",
     "SessionStore",
     "ToolEventObserver",
     "ToolProvider",

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -60,7 +60,7 @@ class SessionStore(Protocol):
     action driver, the three-path engine, and the gather loop touch.
     """
 
-    # --- turn-context snapshot fields (see core.agent_harness.turns.turn_snapshot.TurnSnapshotSource) ---
+    # --- turn-context snapshot fields ---
     cli_agent_messages: list[tuple[str, str]]
     configured_integrations_known: bool
 
@@ -89,7 +89,7 @@ class SessionStore(Protocol):
 
 @runtime_checkable
 class SessionBindable(Protocol):
-    """Port that can retarget a session for Goal B agent reuse.
+    """Port that can retarget a session when the agent is reused across turns.
 
     Pooled / multi-turn hosts call :meth:`bind_session` when
     ``SessionManager.resolve`` returns a fresh session object for the same id.
@@ -115,7 +115,7 @@ class ConsoleBindable(Protocol):
 
 @runtime_checkable
 class OutputBindable(Protocol):
-    """Port that holds an :class:`OutputSink` and can retarget it for Goal B reuse.
+    """Port that holds an :class:`OutputSink` and can retarget it across turns.
 
     ``HeadlessAgent.bind_turn(output=…)`` updates the agent's sink and must
     retarget every port that cached the previous sink (e.g. reasoning error

--- a/core/agent_harness/prompts/__init__.py
+++ b/core/agent_harness/prompts/__init__.py
@@ -1,6 +1,6 @@
 """Prompt builders for the decoupled agentic turn engine.
 
-Subpackages (by agent path — see ``prompts/AGENTS.md``):
+Subpackages (by agent path):
 
 * ``kernel/`` — shared types: ``PromptEnvelope``, tiers, ``SurfaceProfile``
   (no agent-path knowledge)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -64,7 +64,7 @@ log = logging.getLogger(__name__)
 # 203): slash_invoke, shell_run, cli_exec. One rule — no per-tool carve-outs.
 _DEDUPE_ACTION_TOOL_NAMES: frozenset[str] = frozenset({"slash_invoke", "shell_run", "cli_exec"})
 
-# Hashable identity for one guarded call (no hot-path json.dumps — AGENTS.md).
+# Hashable identity for one guarded call (no hot-path json.dumps).
 _ActionCallFingerprint = tuple[Any, ...]
 
 
@@ -913,7 +913,7 @@ def _show_response(
         output.print()
         output.render_response_header("assistant")
         # Literal text: the sink decides how to render it safely. The harness
-        # must not reach for terminal-markup helpers (agent_harness/AGENTS.md).
+        # must not reach for terminal-markup helpers.
         output.print("\n".join(display_chunks))
         return
     if handled:

--- a/core/agent_harness/turns/default_headless_agent.py
+++ b/core/agent_harness/turns/default_headless_agent.py
@@ -1,7 +1,15 @@
 """Build a :class:`HeadlessAgent` with the standard default port stack.
 
-Gateway, scheduled digests, and other headless surfaces share this wiring so
-tool/prompt/reasoning defaults stay aligned.
+**This is the single headless construction seam.** Gateway
+``SessionAgentPool``, ``AgentSession.start``, and ``AgentSession.run_headless_turn``
+all call here — they are not parallel stacks. Surfaces pass host-specific kwargs
+(``output``, ``slash_ports_factory``, ``subprocess_presenter_factory``, …);
+they must not re-assemble ``DefaultToolProvider`` / reasoning / accounting by
+hand.
+
+Process boot (``configure_process``) is a **different layer** — adapters and
+env — and does not build agents. Narrative:
+``opensre-notes/agent-session-api-scaling-aug2026.md`` (§ Bootstrap vs HeadlessAgent).
 """
 
 from __future__ import annotations

--- a/core/agent_harness/turns/default_headless_agent.py
+++ b/core/agent_harness/turns/default_headless_agent.py
@@ -8,8 +8,7 @@ they must not re-assemble ``DefaultToolProvider`` / reasoning / accounting by
 hand.
 
 Process boot (``configure_process``) is a **different layer** — adapters and
-env — and does not build agents. Narrative:
-``opensre-notes/agent-session-api-scaling-aug2026.md`` (§ Bootstrap vs HeadlessAgent).
+env — and does not build agents.
 """
 
 from __future__ import annotations

--- a/core/agent_harness/turns/default_reasoning_client.py
+++ b/core/agent_harness/turns/default_reasoning_client.py
@@ -42,6 +42,10 @@ class DefaultReasoningClientProvider:
         """Point error staging at a freshly resolved session (gateway reuse)."""
         self._session = session
 
+    def bind_output(self, output: OutputSink | None) -> None:
+        """Retarget LLM-unavailable error rendering (Goal B ``bind_turn(output=)``)."""
+        self._output = output
+
     def get(self) -> Any | None:
         try:
             from core.llm.factory import LLMRole, get_llm

--- a/core/agent_harness/turns/default_reasoning_client.py
+++ b/core/agent_harness/turns/default_reasoning_client.py
@@ -43,7 +43,7 @@ class DefaultReasoningClientProvider:
         self._session = session
 
     def bind_output(self, output: OutputSink | None) -> None:
-        """Retarget LLM-unavailable error rendering (Goal B ``bind_turn(output=)``)."""
+        """Retarget LLM-unavailable error rendering after ``bind_turn(output=)``."""
         self._output = output
 
     def get(self) -> Any | None:

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -110,7 +110,7 @@ class EmptyPromptContextProvider:
     """Grounding provider that supplies no corpora (headless)."""
 
     def bind_session(self, session: Any) -> None:
-        """No session state — Goal B reuse is a no-op for empty grounding."""
+        """No session state — session retarget is a no-op for empty grounding."""
         _ = session
 
     def surface(self) -> str:

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -109,6 +109,10 @@ class BufferOutputSink:
 class EmptyPromptContextProvider:
     """Grounding provider that supplies no corpora (headless)."""
 
+    def bind_session(self, session: Any) -> None:
+        """No session state — Goal B reuse is a no-op for empty grounding."""
+        _ = session
+
     def surface(self) -> str:
         return "interactive_shell"
 
@@ -148,6 +152,14 @@ class EmptyPromptContextProvider:
 
 class NullToolProvider:
     """Provides no action tools and a no-op tool-event observer."""
+
+    def bind_session(self, session: Any) -> None:
+        """No tools to retarget."""
+        _ = session
+
+    def bind_console(self, console: Any) -> None:
+        """No console-backed tools."""
+        _ = console
 
     def action_tools(
         self,
@@ -200,6 +212,10 @@ class SimpleRunRecord:
 class SimpleRunRecordFactory:
     """Builds :class:`SimpleRunRecord` values."""
 
+    def bind_session(self, session: Any) -> None:
+        """Records are ephemeral — no session handle to update."""
+        _ = session
+
     def build(
         self, *, client: Any, prompt: str, response_text: str, started: float
     ) -> SimpleRunRecord:
@@ -212,6 +228,14 @@ class StaticReasoningClientProvider:
     """Provides a fixed reasoning client (or None to skip the assistant)."""
 
     client: Any | None = None
+
+    def bind_session(self, session: Any) -> None:
+        """Client is fixed at construction — ignore session retargets."""
+        _ = session
+
+    def bind_output(self, output: Any) -> None:
+        """No sink of its own — accept rebind for :class:`OutputBindable` parity."""
+        _ = output
 
     def get(self) -> Any | None:
         return self.client

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -208,9 +208,17 @@ class HeadlessAgent:
         if runner_changed:
             self._action_runner = self._new_action_runner()
 
-    def _accounting_for(self, message: str) -> TurnAccounting:
-        if self._accounting is not None:
-            return self._accounting
+    def _take_accounting(self, message: str) -> TurnAccounting:
+        """Return turn accounting and clear the slot (consume-once).
+
+        A prior turn's ``DefaultTurnAccounting`` (which captures that turn's
+        prompt text) must not leak into the next ``dispatch`` when a host
+        forgets ``bind_turn(accounting=…)``.
+        """
+        accounting = self._accounting
+        self._accounting = None
+        if accounting is not None:
+            return accounting
         if hasattr(self._store, "storage"):
             return DefaultTurnAccounting(self._store, message)
         return NoopTurnAccounting()
@@ -271,7 +279,7 @@ class HeadlessAgent:
                 execute_actions=self._execute_actions,
                 answer=self._answer,
                 gather=self._gather,
-                accounting=self._accounting_for(message),
+                accounting=self._take_accounting(message),
                 confirm_fn=self._confirm_fn,
                 is_tty=self._is_tty,
                 surface=self._prompts.surface(),

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -34,11 +34,14 @@ from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.ports import (
     AnswerRequest,
     ConfirmFn,
+    ConsoleBindable,
     ErrorReporter,
+    OutputBindable,
     OutputSink,
     PromptContextProvider,
     ReasoningClientProvider,
     RunRecordFactory,
+    SessionBindable,
     SessionStore,
     ToolProvider,
     TurnAccounting,
@@ -155,12 +158,15 @@ class HeadlessAgent:
         Gateway ``SessionManager.resolve`` returns a new ``SessionCore`` each
         turn (same id, restored state). Cached agents must follow that object
         so tools/prompts see current integrations and chat metadata.
+
+        Only ports that implement :class:`~core.agent_harness.ports.SessionBindable`
+        are rebound — silent ``getattr`` skips are avoided so a missing binder
+        on a session-aware default port is a type/test gap, not a runtime miss.
         """
         self._store = session
         for port in (self._tools, self._prompts, self._reasoning, self._run_factory):
-            binder = getattr(port, "bind_session", None)
-            if callable(binder):
-                binder(session)
+            if isinstance(port, SessionBindable):
+                port.bind_session(session)
 
     def bind_turn(
         self,
@@ -173,19 +179,26 @@ class HeadlessAgent:
     ) -> None:
         """Swap turn-scoped ports so one agent can serve many turns.
 
-        Gateway sinks, per-message accounting, and (when provided) the current
-        session object are rebound each inbound message. ``console`` rebinds the
-        tool provider so cooperative cancel (``cancel_requested``) is per-turn.
+        Per-message accounting and (when provided) the current session object
+        are rebound each inbound message. ``console`` rebinds a
+        :class:`~core.agent_harness.ports.ConsoleBindable` tool provider so
+        cooperative cancel (``cancel_requested``) is per-turn.
+
+        Gateway keeps a stable ``LiveOutputSink`` on the pooled agent and
+        rebinds the outer transport sink via ``LiveOutputSink.bind`` — it does
+        not pass ``output=`` here. Hosts that replace the ``OutputSink`` object
+        itself must pass ``output=`` so :class:`~core.agent_harness.ports.OutputBindable`
+        ports (reasoning error rendering) follow the new sink.
         """
         if session is not None:
             self.bind_session(session)
-        if console is not None:
-            binder = getattr(self._tools, "bind_console", None)
-            if callable(binder):
-                binder(console)
+        if console is not None and isinstance(self._tools, ConsoleBindable):
+            self._tools.bind_console(console)
         runner_changed = False
         if output is not None:
             self._output = output
+            if isinstance(self._reasoning, OutputBindable):
+                self._reasoning.bind_output(output)
             runner_changed = True
         if accounting is not None:
             self._accounting = accounting

--- a/core/agent_harness/turns/host_cancel.py
+++ b/core/agent_harness/turns/host_cancel.py
@@ -1,26 +1,49 @@
-"""Host cancel signal for chat turns (gateway ``sink.turn_cancel``).
+"""Host cancel signal for chat turns — one Event, many readers.
 
-Mental model (one Event, three readers)::
+Mental model (do not invent a second cancel channel)::
 
-    transport timeout / ``/stop``
+    transport soft-timeout / user ``/stop``
             │
             ▼
-    sink.turn_cancel  ──►  CancelConsole.cancel_requested  ──►  ReAct + tools
+    sink.turn_cancel  (threading.Event)   ← sole write site
             │
-            ├──────────►  host_cancel_requested(output)   ──►  orchestrator
-            └──────────►  LiveOutputSink stream guard
+            ├── console.cancel_requested        → ReAct + tools
+            ├── host_cancel_requested(output)   → orchestrator / gather
+            └── output stream guard             → stop draining LLM chunks
+
+:func:`ensure_turn_cancel` is the create/attach seam. Chat transports set the
+Event on the concrete sink before the turn; retargetable output adapters
+forward ``turn_cancel`` so the harness output port and the transport share
+one signal.
 
 Shell cancel stays on ``StreamingConsole``; it never needs ``turn_cancel``.
 """
 
 from __future__ import annotations
 
+import contextlib
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 from core.agent_harness.tools.tool_context import ACTION_TOOL_CONTEXT_RESOURCE_KEY
+
+
+def ensure_turn_cancel(output: Any) -> threading.Event:
+    """Return the turn's cancel Event on ``output``, creating one when missing.
+
+    Prefer attaching before the turn starts (chat transports). When the sink
+    rejects dynamic attributes, callers still hold the returned Event for a
+    console wrapper that exposes ``cancel_requested``.
+    """
+    existing = getattr(output, "turn_cancel", None)
+    if isinstance(existing, threading.Event):
+        return existing
+    event = threading.Event()
+    with contextlib.suppress(Exception):
+        output.turn_cancel = event
+    return event
 
 
 def host_cancel_requested(output: Any | None) -> bool:
@@ -67,5 +90,6 @@ __all__ = [
     "CancelProbeConsole",
     "CancelProbeContext",
     "cancel_tool_resources",
+    "ensure_turn_cancel",
     "host_cancel_requested",
 ]

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -177,8 +177,7 @@ def stream_answer(
     """Stream one grounded conversational answer (guidance only, no tools).
 
     The **direct answer** path (no tools): a single ``invoke_stream`` call with
-    no ReAct loop. The **tool-calling** agent is ``core.agent.Agent`` — see
-    ``core/agent_harness/AGENTS.md``.
+    no ReAct loop. The **tool-calling** agent is ``core.agent.Agent``.
 
     ``request.turn_plan`` is the turn-wide assembly built at turn start. Its
     snapshot (conversation history, integration state, prior investigation,

--- a/docs/python-api.mdx
+++ b/docs/python-api.mdx
@@ -55,14 +55,6 @@ Always check `result.answered` before trusting chat text: when a turn fails (for
 example the LLM provider is unreachable), the error message itself lands in
 `result.primary_response_text`.
 
-### Compatibility aliases
-
-| Prefer | Alias (still works) |
-| --- | --- |
-| `AgentSession` | `AgentHarness` |
-| `SessionConfig` | `HarnessConfig` |
-| `session.chat(...)` | `session.dispatch_message(...)` |
-
 ### Internal seams (not for hosts)
 
 Chat hosts terminate at `dispatch_chat_turn` → `run_turn`. Investigation

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -124,7 +124,14 @@ cannot inherit that session.
 
 ## Capacity (process gate vs transport pools)
 
-Two different limits — do not conflate them:
+**Cloud scale-out** (“infinite” via new Fargate tasks) is a **third** layer
+above these two: each task is one gateway process with its own gate; raise
+fleet size / workers when saturated — do not unbound the in-process gate or
+redesign `AgentSession.chat`. Narrative:
+`opensre-notes/agent-session-api-scaling-aug2026.md` (#fargate). Infra topology:
+`opensre-notes/silo-aws.html` / scalable-silos notes.
+
+Two different **in-process** limits — do not conflate them:
 
 | Layer | Mechanism | Behavior when full |
 |-------|-----------|-------------------|
@@ -148,6 +155,25 @@ POST /investigate + InvestigationWorker ──► AgentSession.investigate (Path
   investigations are capped by `OPENSRE_SIZE_PROFILE`. Analytics: chat uses
   `gateway_turn_*` with `surface` ∈ {slack,telegram,discord}; investigate uses
   separate `investigation_*` events (no capacity-reject event yet).
+
+## Agent lifetime (Goal B)
+
+Construct **one** `HeadlessAgent` per logical chat session
+(`SessionAgentPool`), then many turns. Each inbound message:
+
+1. `LiveOutputSink.bind(outer_gateway_sink)` — stable live sink on the agent;
+   outer transport sink changes per turn.
+2. `bind_turn(session=…, accounting=…, console=…, tool_hooks=…)` — session /
+   cancel / approvals. Do **not** pass `output=` here unless replacing the
+   `OutputSink` object itself (then `OutputBindable` ports, e.g. reasoning,
+   must follow).
+3. `AgentSession.chat` → `dispatch`.
+
+Do **not** build a fresh headless agent on every message. Same-session turns
+serialize on the pool’s per-session lock; different sessions stay concurrent
+under the capacity gate. Multi-turn scheduled loops should keep one agent for
+the loop; true one-shot digests may use `AgentSession.run_headless_turn`.
+Narrative SoT: `opensre-notes/agent-session-api-scaling-aug2026.md`.
 
 ## Host parity (channels)
 

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -1,9 +1,7 @@
 # Gateway Package Guidance
 
-Gateway tests live in `gateway/tests/`, not the repo-wide `tests/` tree — add
-new gateway unit tests there. `pytest.ini` discovers them and
-`.github/ci/test_scope_rules.py` scopes CI to that path when only `gateway/`
-changes.
+Gateway unit tests live under this package’s `tests/` tree, not the repo-wide
+tests tree.
 
 ## Entry points (open these first)
 
@@ -52,21 +50,19 @@ start_gateway()
 ## Layout
 
 Packages are split like `core/agent_harness/prompts/`: **core infra** vs
-**peer surfaces** vs **composer**. See `gateway/core/AGENTS.md`,
-`gateway/channels/AGENTS.md`, and `gateway/transports/AGENTS.md`.
+**peer surfaces** vs **composer**.
 
 - `core/` — process and leaf infrastructure (`runtime`, `storage`,
   `billing`, `attachments`, `session`, `config`). No imports from transports
   or `web`. Only `core/runtime/manager.py` imports `gateway.channels`.
 - `channels/` — starts/stops web + chat transports as one consumer set.
-  Imports `web/` and each peer's `startup` only. See `channels/AGENTS.md`.
+  Imports `web/` and each peer's `startup` only.
 - `transports/` — chat peers (`slack`, `discord`, `telegram`). Each owns
   settings, inbound worker, security, output sink, and `startup.py`. Peers
   never import each other or `channels`/`web`; anything two need belongs in
-  `core/` (usually `gateway.core.runtime`). See `transports/AGENTS.md`.
+  `core/` (usually `gateway.core.runtime`).
 - `web/` — web surface (FastAPI app, investigations API, worker/artifacts).
-  May import `core/`; must not import chat transports or `channels`. See
-  `web/AGENTS.md`.
+  May import `core/`; must not import chat transports or `channels`.
 - `core/storage/session/resolver.py` — per-conversation session binding
   keyed by platform; delegates create / resolve / rotate to `SessionManager`.
 
@@ -79,12 +75,8 @@ peer transports · web  →  core leaves
 (peers never import each other, channels, or each other's packages)
 ```
 
-Package DAG pinned by `tests/test_package_borders.py` (plus discord↔slack
-isolation in `tests/discord/test_transport_borders.py`).
-
-Tests stay flat under `gateway/tests/{runtime,web,slack,discord,telegram,…}/`
-(nesting `tests/transports/discord` collides with the `discord` PyPI package
-name during collection).
+Package DAG and peer isolation are pinned by border tests. Keep gateway tests
+flat by surface (do not nest a directory named after the Discord PyPI package).
 
 ## Gateway turn dispatch
 
@@ -127,36 +119,32 @@ cannot inherit that session.
 **Cloud scale-out** (“infinite” via new Fargate tasks) is a **third** layer
 above these two: each task is one gateway process with its own gate; raise
 fleet size / workers when saturated — do not unbound the in-process gate or
-redesign `AgentSession.chat`. Narrative:
-`opensre-notes/agent-session-api-scaling-aug2026.md` (#fargate). Infra topology:
-`opensre-notes/silo-aws.html` / scalable-silos notes.
+redesign `AgentSession.chat`.
 
 Two different **in-process** limits — do not conflate them:
 
 | Layer | Mechanism | Behavior when full |
 |-------|-----------|-------------------|
-| **Process** | `TurnConcurrencyGate` from `OPENSRE_SIZE_PROFILE` (SMALL=1, MEDIUM=2, LARGE=4) | Chat turns: non-blocking `try_acquire` on `GatewayTurnHandler`; reply with busy message and drop the turn. Scheduler runners: **blocking** `acquire` (already-claimed work waits for a slot). |
+| **Process** | `TurnConcurrencyGate` / `process_turn_gate()` from `OPENSRE_SIZE_PROFILE` (SMALL=1, MEDIUM=2, LARGE=4) | Chat + sync `/investigate`: non-blocking `try_acquire` (busy drop / 503). Scheduler + `InvestigationWorker`: **blocking** `acquire` (already-claimed work waits). |
 | **Per-transport** | `max_concurrent_turns` (defaults to the same profile limit via `turn_limit_for_profile`; override with `*_GATEWAY_MAX_CONCURRENT`) | Caps how many inbound messages that transport may process in parallel *before* they hit the shared turn handler. Does not replace the process gate. |
 
 ```text
-Telegram/Slack/Discord ──► GatewayTurnHandler.try_acquire ──► TurnConcurrencyGate
+Telegram/Slack/Discord ──► GatewayTurnHandler.try_acquire ──► process_turn_gate()
 Scheduler (agent + investigate runners) ──► blocking acquire ──► same gate
-POST /investigate + InvestigationWorker ──► AgentSession.investigate (Path-2) ──► ungated today
+POST /investigate ──► try_acquire (busy → 503) ──► same gate
+InvestigationWorker ──► blocking acquire (already claimed) ──► same gate
 ```
 
 - Production chat capacity is on `GatewayTurnHandler(gate=manager.turn_gate)`.
-- `ConcurrencyLimitedTurnHandler` is **quarantined under**
-  `gateway/tests/runtime/concurrency_limited_handler.py` (tests only). Do not
-  reintroduce it under `gateway/core/` — production uses `gate=` on
-  `GatewayTurnHandler` only.
-- **Chat vs investigate:** the process gate covers gateway **chat** and
-  **scheduler** runners. Path-2 HTTP investigate (`POST /investigate`,
-  `InvestigationWorker`) does **not** take the gate today — do not assume web
-  investigations are capped by `OPENSRE_SIZE_PROFILE`. Analytics: chat uses
-  `gateway_turn_*` with `surface` ∈ {slack,telegram,discord}; investigate uses
-  separate `investigation_*` events (no capacity-reject event yet).
+- `GatewayManager` and Path-2 share :func:`~gateway.core.runtime.concurrency.process_turn_gate`.
+- `ConcurrencyLimitedTurnHandler` is tests-only. Do not reintroduce it under
+  `gateway/core/` — production uses `gate=` on `GatewayTurnHandler` only.
+- **Chat + Path-2:** HTTP `/investigate` busy-drops like chat; the investigation
+  worker blocks like scheduler runners. Analytics: chat uses `gateway_turn_*`
+  with `surface` ∈ {slack,telegram,discord}; investigate uses separate
+  `investigation_*` events (no dedicated capacity-reject event yet).
 
-## Agent lifetime (Goal B)
+## Agent lifetime
 
 Construct **one** `HeadlessAgent` per logical chat session
 (`SessionAgentPool`), then many turns. Each inbound message:
@@ -173,7 +161,6 @@ Do **not** build a fresh headless agent on every message. Same-session turns
 serialize on the pool’s per-session lock; different sessions stay concurrent
 under the capacity gate. Multi-turn scheduled loops should keep one agent for
 the loop; true one-shot digests may use `AgentSession.run_headless_turn`.
-Narrative SoT: `opensre-notes/agent-session-api-scaling-aug2026.md`.
 
 ## Host parity (channels)
 
@@ -188,13 +175,13 @@ verb) — see Capacity above. Values: **yes** / **partial** / **no** / **n/a**.
 | Tool resolution | **yes** — live `DefaultToolProvider(session)` | **yes** — same | **yes** — same | **n/a** — investigate runner |
 | Sink redaction | **yes** — `user_facing_error_message` | **yes** — same | **yes** — same | **yes** — `type(exc).__name__` only |
 | Principal / actor | **yes** — `slack/principal.py` | **yes** — `telegram/principal.py` | **yes** — `discord/principal.py` | **partial** — Clerk org audit; no `StorageScope` |
-| Capacity gate | **yes** — process gate + transport pool | **yes** — same + TG semaphore | **yes** — same + executor | **no** — Path-2 ungated |
+| Capacity gate | **yes** — process gate + transport pool | **yes** — same + TG semaphore | **yes** — same + executor | **yes** — same `process_turn_gate` (HTTP try_acquire / worker blocking) |
 
 **Documented exceptions (do not “fix” by forking a second loop):**
 
 - Gateway chat disables `task_cancel` / investigation / llm_provider
-  (`GatewayTurnHandler._UNSUPPORTED_GATEWAY_CAPABILITIES`).
-- Path-2 web investigate is ungated and has no chat approval prompter.
+  (`gateway.core.runtime.capability_policy.ensure_gateway_capability_policy`).
+- Path-2 web investigate shares the process gate but has no chat approval prompter.
 - Soft turn timeout **and** user `/stop` / `stop` / `/cancel` set
   `sink.turn_cancel` so the ReAct loop / remaining tools stop cooperatively
   (shell `cancel_requested` parity via `CancelConsole` + `ActiveTurnCancels`).
@@ -206,20 +193,16 @@ verb) — see Capacity above. Values: **yes** / **partial** / **no** / **n/a**.
 - Telegram write-tool approvals require a non-empty `allowed_user_ids` allowlist
   (same fail-closed posture as Discord).
 
-**Characterization:** live-session tools —
-`tests/runtime/test_turn_handler.py` +
-`test_gateway_chat_never_builds_core_agent_or_precomputed_tools`;
-redaction — Slack/Telegram/Discord sink tests + `tests/runtime/test_status_messages.py`;
-Telegram approvals — `tests/telegram/test_approvals.py`;
-Telegram soft timeout — `tests/telegram/test_turn_timeout.py`.
+**Characterization:** cover live-session tools, sink redaction, Telegram
+approvals, and soft timeout in the gateway test suite.
 
 **Dogfood + smoke (turn-engine regressions):**
 
 | Check | How |
 |-------|-----|
-| Borders + capacity | `pytest gateway/tests/test_package_borders.py gateway/tests/runtime/test_concurrency_gate.py -q` |
-| Smoke gateway wiring | `./trace smoke --suite gateway` (or tags covering `cli.gateway_*`) |
-| Dogfood (dev silo only) | `@mention` on **dev** Slack — thread continuity, Digging in…, `Want me to:` → `yes`; one Socket Mode consumer. See notes `ops-dogfood.html#glossary`. |
+| Borders + capacity | Gateway border + concurrency gate tests |
+| Smoke gateway wiring | Local smoke suite for gateway / `cli.gateway_*` tags |
+| Dogfood (dev silo only) | `@mention` on **dev** Slack — thread continuity, Digging in…, `Want me to:` → `yes`; one Socket Mode consumer. |
 | Not a substitute | Laptop `opensre gateway` + smoke ≠ dogfood |
 
 ## Testing

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -1,6 +1,6 @@
 """Standalone messaging gateway for inbound chat platforms.
 
-Subpackages (see ``gateway/AGENTS.md``):
+Subpackages:
 
 * ``core/`` — process + leaf infrastructure (``runtime``, ``storage``,
   ``billing``, ``attachments``, ``session``, ``config``)
@@ -17,8 +17,6 @@ Entry points:
 * Telegram — :mod:`gateway.transports.telegram.startup`
 * Slack — :mod:`gateway.transports.slack.startup`
 * Discord — :mod:`gateway.transports.discord.startup`
-
-See ``gateway/README.md`` § Entry points.
 """
 
 from __future__ import annotations

--- a/gateway/core/runtime/approvals.py
+++ b/gateway/core/runtime/approvals.py
@@ -10,7 +10,7 @@ that connects a click to the waiting tool call, the button identifiers, and the
 harness hooks. Each transport supplies its own :class:`ApprovalPrompter` — Block
 Kit in ``gateway.transports.slack.approvals``, message components in
 ``gateway.transports.discord.approvals``, inline keyboard in
-``gateway.transports.telegram.approvals``. See ``gateway/AGENTS.md`` → Host parity.
+``gateway.transports.telegram.approvals``.
 """
 
 from __future__ import annotations

--- a/gateway/core/runtime/cancel_console.py
+++ b/gateway/core/runtime/cancel_console.py
@@ -5,17 +5,19 @@ One Event per turn (``sink.turn_cancel``). Soft timeout and ``/stop``
 it. :class:`GatewayTurnHandler` binds this wrapper so tools and ReAct see
 ``cancel_requested`` like the interactive shell's ``StreamingConsole``.
 
-See also ``core.agent_harness.turns.host_cancel`` for the orchestrator /
-gather side of the same Event.
+The Event itself is created/attached by
+:func:`core.agent_harness.turns.host_cancel.ensure_turn_cancel` — re-exported
+here so transport call sites keep a stable import path.
 """
 
 from __future__ import annotations
 
-import contextlib
 import threading
 from typing import Any
 
 from rich.console import Console
+
+from core.agent_harness.turns.host_cancel import ensure_turn_cancel
 
 # Set on the wrapper itself; everything else is proxied to the wrapped console.
 _OWN_ATTRIBUTES = frozenset({"_output", "_cancel_event"})
@@ -52,20 +54,6 @@ class CancelConsole:
             super().__setattr__(name, value)
             return
         setattr(self._output, name, value)
-
-
-def ensure_turn_cancel(sink: Any) -> threading.Event:
-    """Return the Event on ``sink.turn_cancel``, creating one when missing."""
-    existing = getattr(sink, "turn_cancel", None)
-    if isinstance(existing, threading.Event):
-        return existing
-    event = threading.Event()
-    # Protocol sinks may reject dynamic attrs; the handler still holds
-    # ``event`` for CancelConsole, and transports that own the concrete
-    # sink set ``turn_cancel`` before calling the handler.
-    with contextlib.suppress(Exception):
-        sink.turn_cancel = event
-    return event
 
 
 __all__ = ["CancelConsole", "ensure_turn_cancel"]

--- a/gateway/core/runtime/capability_policy.py
+++ b/gateway/core/runtime/capability_policy.py
@@ -1,0 +1,32 @@
+"""Host capability policy for gateway chat sessions.
+
+Gateway chat does not expose investigation / llm_provider / task_cancel tool
+surfaces. Apply this when a session is prepared for a chat transport (resolver)
+and again in the turn handler for tests that inject a ``SessionCore`` directly.
+Assignments are idempotent — re-applying the same empty tuples is intentional.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+UNSUPPORTED_GATEWAY_CAPABILITIES = (
+    "investigation",
+    "llm_provider",
+    "task_cancel",
+)
+
+
+def ensure_gateway_capability_policy(session: Any) -> None:
+    """Force unsupported capability keys to empty tool tuples on ``session``."""
+    caps = getattr(session, "available_capabilities", None)
+    if not isinstance(caps, dict):
+        return
+    for name in UNSUPPORTED_GATEWAY_CAPABILITIES:
+        caps[name] = ()
+
+
+__all__ = [
+    "UNSUPPORTED_GATEWAY_CAPABILITIES",
+    "ensure_gateway_capability_policy",
+]

--- a/gateway/core/runtime/concurrency.py
+++ b/gateway/core/runtime/concurrency.py
@@ -1,12 +1,18 @@
 """Process-wide turn concurrency shared by every Gateway ingress.
 
 Production chat turns take the gate via :class:`GatewayTurnHandler` (``gate=``).
-A callback wrapper for arbitrary handlers lives under ``gateway/tests/`` only —
-see ``gateway/tests/runtime/concurrency_limited_handler.py``.
+Path-2 ``POST /investigate`` and :class:`InvestigationWorker` use the same
+process gate (:func:`process_turn_gate`) so HTTP investigate cannot starve
+chat or the reverse. Scheduler runners wrap the same instance via
+``gate_registered_scheduler_runners``.
+
+A callback wrapper for arbitrary handlers lives under tests only — not in
+production ``gateway/core/``.
 """
 
 from __future__ import annotations
 
+import os
 import threading
 
 from platform.deployment_contracts.models import SizeProfile
@@ -17,6 +23,9 @@ _PROFILE_LIMITS = {
     SizeProfile.LARGE: 4,
 }
 
+_process_gate: TurnConcurrencyGate | None = None
+_process_gate_lock = threading.Lock()
+
 
 def turn_limit_for_profile(profile: SizeProfile | str | None = None) -> int:
     """Process-gate / transport-pool default for ``OPENSRE_SIZE_PROFILE``.
@@ -25,14 +34,12 @@ def turn_limit_for_profile(profile: SizeProfile | str | None = None) -> int:
     :class:`TurnConcurrencyGate` and as the default for per-transport
     ``max_concurrent_turns`` when the transport-specific env is unset.
     """
-    import os
-
     raw = profile if profile is not None else os.getenv("OPENSRE_SIZE_PROFILE", "SMALL")
     return _PROFILE_LIMITS[SizeProfile(str(raw).strip().upper())]
 
 
 class TurnConcurrencyGate:
-    """A non-blocking process-wide capacity gate for agent turns."""
+    """A process-wide capacity gate for agent turns (chat + Path-2 + scheduler)."""
 
     def __init__(self, limit: int) -> None:
         if limit < 1:
@@ -46,11 +53,11 @@ class TurnConcurrencyGate:
         return cls(turn_limit_for_profile(profile))
 
     def try_acquire(self) -> bool:
-        """Take one slot without waiting, leaving durable excess work queued."""
+        """Take one slot without waiting (chat / sync HTTP investigate)."""
         return self._semaphore.acquire(blocking=False)
 
     def acquire(self, *, timeout: float | None = None) -> bool:
-        """Wait for capacity, used by already-claimed scheduler executions."""
+        """Wait for capacity (scheduler / InvestigationWorker — already claimed)."""
         if timeout is None:
             return self._semaphore.acquire()
         return self._semaphore.acquire(timeout=timeout)
@@ -60,7 +67,39 @@ class TurnConcurrencyGate:
         self._semaphore.release()
 
 
+def process_turn_gate() -> TurnConcurrencyGate:
+    """Return the process-wide gate (lazy from ``OPENSRE_SIZE_PROFILE``).
+
+    :class:`GatewayManager` installs its gate here so chat and Path-2 share one
+    semaphore in a full gateway process. Standalone ``WEB_PROFILE`` web creates
+    the gate on first investigate/worker use.
+    """
+    global _process_gate
+    with _process_gate_lock:
+        if _process_gate is None:
+            profile = os.getenv("OPENSRE_SIZE_PROFILE", "SMALL").strip().upper()
+            _process_gate = TurnConcurrencyGate.for_profile(profile)
+        return _process_gate
+
+
+def set_process_turn_gate(gate: TurnConcurrencyGate) -> None:
+    """Install ``gate`` as the process-wide instance (manager / tests)."""
+    global _process_gate
+    with _process_gate_lock:
+        _process_gate = gate
+
+
+def reset_process_turn_gate_for_tests() -> None:
+    """Clear the process gate singleton so tests can rebuild from env."""
+    global _process_gate
+    with _process_gate_lock:
+        _process_gate = None
+
+
 __all__ = [
     "TurnConcurrencyGate",
+    "process_turn_gate",
+    "reset_process_turn_gate_for_tests",
+    "set_process_turn_gate",
     "turn_limit_for_profile",
 ]

--- a/gateway/core/runtime/live_sink.py
+++ b/gateway/core/runtime/live_sink.py
@@ -33,6 +33,20 @@ class LiveOutputSink:
         """Currently bound transport sink, if any."""
         return self._inner
 
+    @property
+    def turn_cancel(self) -> threading.Event | None:
+        """Same cancel Event as the bound transport sink (one signal, many readers).
+
+        Explicit (not only ``__getattr__``) so
+        :func:`~core.agent_harness.turns.host_cancel.host_cancel_requested` and
+        the stream guard see cancel without depending on attribute forwarding.
+        """
+        inner = self._inner
+        if inner is None:
+            return None
+        cancel = getattr(inner, "turn_cancel", None)
+        return cancel if isinstance(cancel, threading.Event) else None
+
     def _require(self) -> GatewaySink:
         inner = self._inner
         if inner is None:
@@ -69,8 +83,8 @@ class LiveOutputSink:
 
     def _stop_chunks_on_cancel(self, chunks: Iterable[str]) -> Iterator[str]:
         """Stop draining the LLM stream when the host soft-timeout Event fires."""
-        cancel = getattr(self._inner, "turn_cancel", None) if self._inner is not None else None
         for chunk in chunks:
+            cancel = self.turn_cancel
             if isinstance(cancel, threading.Event) and cancel.is_set():
                 return
             yield chunk

--- a/gateway/core/runtime/manager.py
+++ b/gateway/core/runtime/manager.py
@@ -27,7 +27,11 @@ from rich.console import Console
 
 from gateway import channels as gateway_channels
 from gateway.core.config.logging_config import configure_logging
-from gateway.core.runtime.concurrency import TurnConcurrencyGate
+from gateway.core.runtime.concurrency import (
+    TurnConcurrencyGate,
+    process_turn_gate,
+    set_process_turn_gate,
+)
 from gateway.core.runtime.credential_hydration import (
     GatewayBootstrap,
     GatewayCredentialHydrator,
@@ -69,8 +73,12 @@ class GatewayManager:
         self._credential_hydrator_factory = (
             credential_hydrator_factory or GatewayCredentialHydrator.from_environment
         )
-        profile = os.getenv("OPENSRE_SIZE_PROFILE", "SMALL").strip().upper()
-        self.turn_gate = turn_gate or TurnConcurrencyGate.for_profile(profile)
+        if turn_gate is not None:
+            set_process_turn_gate(turn_gate)
+            self.turn_gate = turn_gate
+        else:
+            # Same instance Path-2 investigate / InvestigationWorker use.
+            self.turn_gate = process_turn_gate()
         self._stopped = threading.Event()
 
     def start_gateway(self, *, wait: bool = True) -> GatewayManager:

--- a/gateway/core/runtime/session_agents.py
+++ b/gateway/core/runtime/session_agents.py
@@ -3,7 +3,7 @@
 Keeps agent construction out of :class:`GatewayTurnHandler` so the handler
 stays a thin dispatch/finalize orchestrator. Construction goes through
 :func:`~core.agent_harness.turns.default_headless_agent.build_default_headless_agent`
-once per session — not a second port-wiring stack (Goal B / narrative layers).
+once per session — not a second port-wiring stack.
 """
 
 from __future__ import annotations

--- a/gateway/core/runtime/session_agents.py
+++ b/gateway/core/runtime/session_agents.py
@@ -1,7 +1,9 @@
 """Session-scoped :class:`HeadlessAgent` pool for the gateway turn handler.
 
 Keeps agent construction out of :class:`GatewayTurnHandler` so the handler
-stays a thin dispatch/finalize orchestrator.
+stays a thin dispatch/finalize orchestrator. Construction goes through
+:func:`~core.agent_harness.turns.default_headless_agent.build_default_headless_agent`
+once per session — not a second port-wiring stack (Goal B / narrative layers).
 """
 
 from __future__ import annotations

--- a/gateway/core/runtime/turn_handler.py
+++ b/gateway/core/runtime/turn_handler.py
@@ -24,6 +24,7 @@ from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.harness import AgentSession, SessionConfig
 from core.agent_harness.session import SessionCore
 from gateway.core.runtime.cancel_console import CancelConsole, ensure_turn_cancel
+from gateway.core.runtime.capability_policy import ensure_gateway_capability_policy
 from gateway.core.runtime.concurrency import TurnConcurrencyGate
 from gateway.core.runtime.session_agents import SessionAgentPool
 from gateway.core.runtime.sink_protocol import GatewaySink
@@ -41,12 +42,6 @@ from platform.analytics.usage_context import (
 from platform.observability.trace.spans import traced_session
 
 SlashPortsFactory = Callable[[], Any]
-
-_UNSUPPORTED_GATEWAY_CAPABILITIES = (
-    "investigation",
-    "llm_provider",
-    "task_cancel",
-)
 
 _DEFAULT_BUSY_MESSAGE = "OpenSRE is at capacity. Please try again shortly."
 
@@ -104,7 +99,8 @@ class GatewayTurnHandler:
         sink: GatewaySink,
         logger: logging.Logger,
     ) -> None:
-        session.available_capabilities.update(dict.fromkeys(_UNSUPPORTED_GATEWAY_CAPABILITIES, ()))
+        # Idempotent host policy (also applied in SessionResolver for production).
+        ensure_gateway_capability_policy(session)
         session_id = getattr(session, "session_id", None)
         surface = get_surface()
         if surface not in CANONICAL_SURFACES:

--- a/gateway/core/storage/session/resolver.py
+++ b/gateway/core/storage/session/resolver.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from core.agent_harness.session import SessionCore, SessionManager
 from core.agent_harness.session.integration_resolution import has_resolved_integrations
+from gateway.core.runtime.capability_policy import ensure_gateway_capability_policy
 from gateway.core.session.gateway_chat_context import inject_gateway_chat_context
 
 if TYPE_CHECKING:
@@ -37,13 +38,14 @@ def _ensure_integrations(session: SessionCore) -> SessionCore:
 
 
 def _inject_chat_context(session: SessionCore, *, chat_id: str, platform: str = "") -> SessionCore:
-    """Attach per-turn gateway chat metadata to the session's integration cache."""
+    """Attach per-turn gateway chat metadata and host capability policy."""
     _ensure_integrations(session)
     session.resolved_integrations_cache = inject_gateway_chat_context(
         dict(session.resolved_integrations_cache or {}),
         chat_id,
         platform,
     )
+    ensure_gateway_capability_policy(session)
     return session
 
 

--- a/gateway/tests/runtime/test_concurrency_gate.py
+++ b/gateway/tests/runtime/test_concurrency_gate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -119,6 +120,89 @@ def test_gateway_turn_handler_gate_refuses_excess_without_second_wrapper(
 
     assert ran == ["one"]
     assert finalized == ["OpenSRE is at capacity. Please try again shortly."]
+
+
+def test_process_turn_gate_is_shared_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gateway.core.runtime.concurrency import (
+        process_turn_gate,
+        reset_process_turn_gate_for_tests,
+        set_process_turn_gate,
+    )
+
+    reset_process_turn_gate_for_tests()
+    monkeypatch.setenv("OPENSRE_SIZE_PROFILE", "SMALL")
+    first = process_turn_gate()
+    second = process_turn_gate()
+    assert first is second
+    custom = TurnConcurrencyGate(2)
+    set_process_turn_gate(custom)
+    assert process_turn_gate() is custom
+    reset_process_turn_gate_for_tests()
+
+
+def test_path2_sync_investigate_busy_drops_when_gate_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /investigate shares process_turn_gate — try_acquire like chat."""
+    from fastapi.testclient import TestClient
+
+    from gateway.core.runtime.concurrency import (
+        TurnConcurrencyGate,
+        reset_process_turn_gate_for_tests,
+        set_process_turn_gate,
+    )
+    from gateway.web import webapp
+
+    reset_process_turn_gate_for_tests()
+    gate = TurnConcurrencyGate(1)
+    assert gate.try_acquire() is True  # simulate active chat turn
+    set_process_turn_gate(gate)
+    monkeypatch.setattr(webapp, "_gateway_auth_error", lambda _req: None)
+
+    client = TestClient(webapp.app)
+    resp = client.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
+    assert resp.status_code == 503
+    assert "capacity" in resp.json()["error"].lower()
+    gate.release()
+    reset_process_turn_gate_for_tests()
+
+
+def test_investigation_worker_waits_for_the_same_chat_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gateway.core.runtime.concurrency import (
+        TurnConcurrencyGate,
+        reset_process_turn_gate_for_tests,
+        set_process_turn_gate,
+    )
+    from gateway.core.storage.investigations.store import InMemoryInvestigationStore
+    from gateway.web.worker import InvestigationWorker
+
+    reset_process_turn_gate_for_tests()
+    gate = TurnConcurrencyGate(1)
+    assert gate.try_acquire() is True
+    set_process_turn_gate(gate)
+    monkeypatch.setenv("OPENSRE_ANALYTICS_DISABLED", "1")
+
+    store = InMemoryInvestigationStore()
+    store.create(clerk_org_id="org_a", trigger={"raw_alert": {"alert_name": "cpu"}})
+    entered = threading.Event()
+    result: list[str] = []
+
+    def runner(_trigger: dict[str, object]) -> dict[str, object]:
+        entered.set()
+        return {"report": "ok"}
+
+    worker = InvestigationWorker(store, runner=runner, artifacts_dir=tmp_path)
+    thread = threading.Thread(target=lambda: result.append(str(worker.run_once())))
+    thread.start()
+    assert not entered.wait(0.05)
+    gate.release()
+    assert entered.wait(1)
+    thread.join(1)
+    assert result == ["True"]
+    reset_process_turn_gate_for_tests()
 
 
 def test_scheduler_runner_waits_for_the_same_chat_capacity() -> None:

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -213,7 +213,8 @@ def test_turn_handler_tolerates_sinks_without_tool_hooks(monkeypatch: Any) -> No
     assert agent.bind_turn.call_args.kwargs["tool_hooks"] is None
 
 
-def test_turn_handler_disables_unsupported_gateway_capabilities() -> None:
+def test_turn_handler_disables_unsupported_gateway_capabilities(monkeypatch: Any) -> None:
+    _patch_headless_agent(monkeypatch, _empty_turn_result())
     session = SessionCore(storage=InMemorySessionStorage())
     handler = GatewayTurnHandler(console=Console(force_terminal=False))
 
@@ -229,7 +230,8 @@ def test_turn_handler_disables_unsupported_gateway_capabilities() -> None:
     assert session.available_capabilities["task_cancel"] == ()
 
 
-def test_turn_handler_preserves_supported_capabilities() -> None:
+def test_turn_handler_preserves_supported_capabilities(monkeypatch: Any) -> None:
+    _patch_headless_agent(monkeypatch, _empty_turn_result())
     session = SessionCore(storage=InMemorySessionStorage())
     session.available_capabilities.update(
         {
@@ -257,7 +259,8 @@ def test_turn_handler_preserves_supported_capabilities() -> None:
     assert session.available_capabilities["custom_gateway_capability"] == ("enabled",)
 
 
-def test_turn_handler_capability_gating_is_stable_across_turns() -> None:
+def test_turn_handler_capability_gating_is_stable_across_turns(monkeypatch: Any) -> None:
+    _patch_headless_agent(monkeypatch, _empty_turn_result())
     session = SessionCore(storage=InMemorySessionStorage())
     session.available_capabilities["shell_commands"] = ("shell",)
 

--- a/gateway/tests/web/test_webapp_investigate.py
+++ b/gateway/tests/web/test_webapp_investigate.py
@@ -162,3 +162,23 @@ def test_investigate_token_auth(monkeypatch: pytest.MonkeyPatch) -> None:
         ).status_code
         == 200
     )
+
+
+def test_investigate_at_capacity_returns_503(client: TestClient) -> None:
+    from gateway.core.runtime.concurrency import (
+        TurnConcurrencyGate,
+        reset_process_turn_gate_for_tests,
+        set_process_turn_gate,
+    )
+
+    install_investigation_payload_runner(lambda **_: _fake_payload())
+    gate = TurnConcurrencyGate(1)
+    assert gate.try_acquire() is True  # occupy the only slot
+    set_process_turn_gate(gate)
+    try:
+        resp = client.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
+        assert resp.status_code == 503
+        assert "at capacity" in resp.json()["error"]
+    finally:
+        gate.release()
+        reset_process_turn_gate_for_tests()

--- a/gateway/web/AGENTS.md
+++ b/gateway/web/AGENTS.md
@@ -22,3 +22,11 @@ embedded web both get Path-2 investigate wiring without a CLI/manager boot. Do
 `bootstrap.adapters` only. In a full gateway process, `GATEWAY_PROFILE` already
 ran; `WEB_PROFILE` may still run (separate idempotency key) — steps must stay
 safe to re-enter, not invent a divergent registry.
+
+## Capacity (Path-2)
+
+`POST /investigate` and `InvestigationWorker` take
+:func:`~gateway.core.runtime.concurrency.process_turn_gate` — the same
+process gate as chat/scheduler (`OPENSRE_SIZE_PROFILE`). Sync HTTP
+`try_acquire` → 503 when full; the worker `acquire`s (blocking) after claim.
+Capacity is process gate + transport pools + Fargate fleet (same rules as the gateway package).

--- a/gateway/web/webapp.py
+++ b/gateway/web/webapp.py
@@ -211,6 +211,16 @@ def investigate(req: InvestigateRequest, request: Request) -> InvestigateRespons
     if (auth_error := _gateway_auth_error(request)) is not None:
         return auth_error
 
+    from gateway.core.runtime.concurrency import process_turn_gate
+
+    gate = process_turn_gate()
+    # Same process gate as chat / scheduler — busy-drop like GatewayTurnHandler.
+    if not gate.try_acquire():
+        return JSONResponse(
+            {"error": "OpenSRE is at capacity. Please try again shortly."},
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+
     investigation_metadata = resolve_investigation_context(
         raw_alert=req.raw_alert,
         alert_name=req.alert_name,
@@ -234,3 +244,5 @@ def investigate(req: InvestigateRequest, request: Request) -> InvestigateRespons
             {"error": f"investigation failed: {type(exc).__name__}"},
             status_code=HTTPStatus.SERVICE_UNAVAILABLE,
         )
+    finally:
+        gate.release()

--- a/gateway/web/worker.py
+++ b/gateway/web/worker.py
@@ -76,6 +76,12 @@ class InvestigationWorker:
                 error="insufficient_credits",
             )
             return True
+        from gateway.core.runtime.concurrency import process_turn_gate
+
+        # Already claimed from the queue — block like scheduler runners so the
+        # work waits for a chat/Path-2 slot instead of racing the process gate.
+        gate = process_turn_gate()
+        gate.acquire()
         try:
             from platform.analytics.cli import track_investigation
             from platform.analytics.source import EntrypointSource, TriggerMode
@@ -119,6 +125,8 @@ class InvestigationWorker:
                 status=InvestigationStatus.FAILED,
                 error=type(exc).__name__,
             )
+        finally:
+            gate.release()
         return True
 
     def start(self) -> threading.Thread:

--- a/main.py
+++ b/main.py
@@ -22,10 +22,11 @@ Driving the agent from Python instead of the CLI::
 
     configure_process(EMBEDDED_PROFILE)
 
-    session = AgentSession.start()
+    session = AgentSession.start()  # one agent for this logical session
     result = session.chat("why is checkout-api slow?")
     if result.answered:
         print(result.primary_response_text)
+    follow = session.chat("what should we check next?")  # same agent, next turn
 
     report = session.investigate({"alert_name": "HighLatency"})
     print(report.report)
@@ -42,9 +43,14 @@ process.
 ``result.answered`` before trusting the text — on a failed turn (e.g. the LLM
 provider is unreachable) the error message itself lands in
 ``primary_response_text``. Surfaces that need their own ports — a live gateway
-sink, a REPL console — build the agent with
-``core.agent_harness.build_default_headless_agent`` and call ``attach_agent``
-instead. ``AgentHarness`` / ``dispatch_message`` remain compatibility aliases.
+sink, a REPL console — build a ``HeadlessAgent`` (or
+``build_default_headless_agent``) and call ``attach_agent``, then ``chat``.
+
+Canonical story (Goal A + B): construct **one** agent per logical session
+(or scheduled loop), then many ``chat`` / ``investigate`` turns — do not
+rebuild every message. Gateway does this via ``SessionAgentPool`` +
+``bind_turn``. There is no ``dispatch_message_to_headless_agent`` free
+function, and no ``AgentHarness`` alias — ``AgentSession`` is the only name.
 """
 
 from __future__ import annotations

--- a/main.py
+++ b/main.py
@@ -46,11 +46,11 @@ provider is unreachable) the error message itself lands in
 sink, a REPL console — build a ``HeadlessAgent`` (or
 ``build_default_headless_agent``) and call ``attach_agent``, then ``chat``.
 
-Canonical story (Goal A + B): construct **one** agent per logical session
-(or scheduled loop), then many ``chat`` / ``investigate`` turns — do not
-rebuild every message. Gateway does this via ``SessionAgentPool`` +
-``bind_turn``. There is no ``dispatch_message_to_headless_agent`` free
-function, and no ``AgentHarness`` alias — ``AgentSession`` is the only name.
+Construct **one** agent per logical session (or scheduled loop), then many
+``chat`` / ``investigate`` turns — do not rebuild every message. Gateway does
+this via ``SessionAgentPool`` + ``bind_turn``. There is no
+``dispatch_message_to_headless_agent`` free function, and no ``AgentHarness``
+alias — ``AgentSession`` is the only name.
 """
 
 from __future__ import annotations

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -254,10 +254,11 @@ def cron_logs(task_id: str, limit: int) -> None:
 @cron_command.command(name="start")
 def cron_start() -> None:
     """Start the scheduler daemon (blocks until interrupted)."""
-    from bootstrap.process import SCHEDULED_COMMAND_PROFILE, configure_process
+    from bootstrap.process import SCHEDULER_WORKER_PROFILE, configure_process
     from platform.scheduler.runner import start_scheduler
 
-    configure_process(SCHEDULED_COMMAND_PROFILE)
+    # Dedicated scheduler process — not SCHEDULED_COMMAND (one-shot CLI helpers).
+    configure_process(SCHEDULER_WORKER_PROFILE)
 
     _console.print("[bold]Starting scheduler daemon...[/bold]")
     _console.print("Press Ctrl+C to stop.")

--- a/tests/bootstrap/test_process.py
+++ b/tests/bootstrap/test_process.py
@@ -191,6 +191,33 @@ def test_gateway_reports_missing_capabilities_at_boot(monkeypatch: pytest.Monkey
     assert warned == ["gateway kubectl missing"]
 
 
+def test_scheduler_worker_profile_boots_runners_with_scheduler_sentry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``opensre cron start`` uses SCHEDULER_WORKER_PROFILE (dedicated daemon)."""
+    from bootstrap import process
+
+    ran: list[str] = []
+
+    def _record(name: str):
+        def _step() -> None:
+            ran.append(name)
+
+        return _step
+
+    monkeypatch.setattr(process, "bootstrap_opensre_env_once", lambda **_kw: ran.append("env"))
+    monkeypatch.setattr(process, "install_harness_adapters", _record("adapters"))
+    monkeypatch.setattr(process, "install_scheduler_runners", _record("runners"))
+    monkeypatch.setattr(
+        "platform.observability.errors.sentry.init_sentry",
+        lambda **_kw: ran.append(f"sentry:{_kw.get('entrypoint')}"),
+    )
+
+    process.configure_process(process.SCHEDULER_WORKER_PROFILE)
+
+    assert ran == ["env", "sentry:scheduler", "adapters", "runners"]
+
+
 def test_scheduled_command_profile_dispatches_without_touching_sentry(monkeypatch) -> None:
     # Arrange: cron / digest / report commands run inside an already-booted CLI
     # process. They need the runners that dispatch scheduled work, but Sentry is

--- a/tests/core/agent_harness/test_accounting_consume_once.py
+++ b/tests/core/agent_harness/test_accounting_consume_once.py
@@ -1,0 +1,90 @@
+"""Turn accounting is consume-once — no stale prompt across dispatches."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.session import SessionCore
+from core.agent_harness.session.persistence.memory import InMemorySessionStorage
+from core.agent_harness.turns.headless_adapters import NullToolProvider
+from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+
+
+class _SpyAccounting:
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.finalized: list[str] = []
+
+    def record_action_result(self, _result: Any) -> None:
+        return None
+
+    def finalize(self, result: TurnResult) -> TurnResult:
+        self.finalized.append(self.label)
+        return result
+
+
+def _empty_result() -> TurnResult:
+    return TurnResult(
+        final_intent="cli_agent_handled",
+        action_result=ToolCallingTurnResult(
+            planned_count=0,
+            executed_count=0,
+            executed_success_count=0,
+            has_unhandled_clause=False,
+            handled=True,
+        ),
+        assistant_response_text="",
+    )
+
+
+def _stub_dispatch(monkeypatch: Any) -> None:
+    """Skip the real turn engine; only exercise accounting take/finalize."""
+
+    def _dispatch(message: str, session: Any, bindings: Any) -> TurnResult:
+        _ = (message, session)
+        bindings.accounting.record_action_result(None)  # type: ignore[arg-type]
+        return bindings.accounting.finalize(_empty_result())
+
+    monkeypatch.setattr(
+        "core.agent_harness.turns.headless_dispatch.dispatch_chat_turn",
+        _dispatch,
+    )
+
+
+def test_dispatch_consumes_bound_accounting(monkeypatch: Any) -> None:
+    _stub_dispatch(monkeypatch)
+    session = SessionCore(storage=InMemorySessionStorage())
+    first = _SpyAccounting("first")
+    agent = HeadlessAgent(tools=NullToolProvider(), session=session, accounting=first)
+    agent.dispatch("one")
+    assert first.finalized == ["first"]
+    agent.dispatch("two")
+    assert first.finalized == ["first"]
+
+
+def test_second_dispatch_without_rebind_does_not_reuse_prior_accounting(
+    monkeypatch: Any,
+) -> None:
+    _stub_dispatch(monkeypatch)
+    session = SessionCore(storage=InMemorySessionStorage())
+    first = _SpyAccounting("first")
+    agent = HeadlessAgent(tools=NullToolProvider(), session=session)
+    agent.bind_turn(accounting=first)
+    agent.dispatch("one")
+    agent.dispatch("two")
+    assert first.finalized == ["first"]
+
+
+def test_bind_turn_supplies_fresh_accounting_each_message(monkeypatch: Any) -> None:
+    _stub_dispatch(monkeypatch)
+    session = SessionCore(storage=InMemorySessionStorage())
+    agent = HeadlessAgent(tools=NullToolProvider(), session=session)
+    a = _SpyAccounting("a")
+    b = _SpyAccounting("b")
+    agent.bind_turn(accounting=a)
+    agent.dispatch("one")
+    agent.bind_turn(accounting=b)
+    agent.dispatch("two")
+    assert a.finalized == ["a"]
+    assert b.finalized == ["b"]

--- a/tests/core/agent_harness/test_agent_session_api.py
+++ b/tests/core/agent_harness/test_agent_session_api.py
@@ -3,26 +3,17 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
-from core.agent_harness.harness import (
-    AgentHarness,
-    AgentSession,
-    HarnessConfig,
-    SessionConfig,
-)
+from core.agent_harness.harness import AgentSession
 from core.agent_harness.investigation_api import (
     InvestigationResult,
     install_investigation_payload_runner,
     reset_investigation_payload_runner_for_tests,
 )
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
-
-
-def test_session_config_aliases_harness_config() -> None:
-    assert SessionConfig is HarnessConfig
-    assert AgentSession is AgentHarness
 
 
 def _stub_turn_result() -> TurnResult:
@@ -55,7 +46,7 @@ def test_chat_is_the_public_verb(monkeypatch: Any) -> None:
     assert captured == ["why is checkout-api slow?"]
     assert result.answered is True
     # Compatibility alias
-    session.dispatch_message("follow-up")
+    session.chat("follow-up")
     assert captured == ["why is checkout-api slow?", "follow-up"]
 
 
@@ -112,3 +103,68 @@ def test_investigation_result_round_trips_optional_fields() -> None:
     }
     result = InvestigationResult.from_payload(payload)
     assert result.as_dict() == payload
+
+
+def test_one_shot_turn_reuses_the_start_bootstrap_instead_of_repeating_it() -> None:
+    """``start`` is the single headless bootstrap; the one-shot delegates to it.
+
+    ``start`` and ``run_headless_turn`` each used to run the same sequence —
+    create session, resolve sink, resolve prompts, build the default agent,
+    attach it — so a change to headless startup had to be made twice. Pinning
+    the delegation keeps one bootstrap and makes the multi-turn shape
+    (``start()`` once, ``chat()`` per turn) the same code path as the one-shot.
+    """
+    # Arrange: record every start() call and hand back a stub session.
+    calls: list[dict[str, Any]] = []
+    turns: list[str] = []
+
+    class _StubSession:
+        def chat(self, message: str, **_kwargs: Any) -> str:
+            turns.append(message)
+            return "answered"
+
+    def _start(config=None, **kwargs: Any) -> Any:
+        calls.append({"config": config, **kwargs})
+        return _StubSession()
+
+    bootstraps: list[str] = []
+
+    def _startup(_self: Any) -> Any:
+        bootstraps.append("startup")
+        raise AssertionError("bootstrap ran outside start()")
+
+    def _start_classmethod(_cls: Any, *args: Any, **kwargs: Any) -> Any:
+        return _start(*args, **kwargs)
+
+    with (
+        patch.object(AgentSession, "start", classmethod(_start_classmethod)),
+        patch.object(AgentSession, "startup", _startup),
+    ):
+        # Act.
+        result = AgentSession.run_headless_turn("summarize open incidents")
+
+    # Assert: exactly one bootstrap, and it happened inside start().
+    assert len(calls) == 1, "run_headless_turn re-implemented the bootstrap"
+    assert bootstraps == [], "run_headless_turn ran its own startup alongside start()"
+    assert turns == ["summarize open incidents"]
+    assert result == "answered"
+
+
+def test_the_harness_exposes_one_name_per_concept() -> None:
+    """No compatibility aliases: a second name for a live concept is drift waiting to happen.
+
+    ``AgentHarness``/``HarnessConfig``/``HarnessStartupResult``/``dispatch_message``
+    were removed once every caller moved. AGENTS.md forbids keeping
+    compatibility-only paths after a refactor, so this fails if one returns.
+    """
+    # Arrange / Act.
+    import core.agent_harness as package
+    from core.agent_harness import harness as harness_module
+
+    retired = ("AgentHarness", "HarnessConfig", "HarnessStartupResult")
+
+    # Assert.
+    for name in retired:
+        assert not hasattr(harness_module, name), f"{name} alias is back in harness.py"
+        assert not hasattr(package, name), f"{name} alias is back in the package API"
+    assert not hasattr(AgentSession, "dispatch_message"), "dispatch_message alias is back"

--- a/tests/core/agent_harness/test_agent_session_api.py
+++ b/tests/core/agent_harness/test_agent_session_api.py
@@ -158,7 +158,7 @@ def test_the_harness_exposes_one_name_per_concept() -> None:
     compatibility-only paths after a refactor, so this fails if one returns.
     """
     # Arrange / Act.
-    import core.agent_harness as package
+    from core import agent_harness as package
     from core.agent_harness import harness as harness_module
 
     retired = ("AgentHarness", "HarnessConfig", "HarnessStartupResult")

--- a/tests/core/agent_harness/test_chat_turns.py
+++ b/tests/core/agent_harness/test_chat_turns.py
@@ -1,10 +1,10 @@
-"""Characterization tests for ``AgentHarness.dispatch_message``."""
+"""Characterization tests for ``AgentSession.chat``."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness.harness import AgentHarness, HarnessConfig
+from core.agent_harness.harness import AgentSession, SessionConfig
 from core.agent_harness.turns.headless_dispatch import (
     HeadlessAgent,
     NullToolProvider,
@@ -28,17 +28,17 @@ def _empty_action() -> ToolCallingTurnResult:
     )
 
 
-def test_dispatch_message_requires_attached_agent() -> None:
-    harness = AgentHarness(HarnessConfig(load_env=False, open_storage=False))
+def test_chat_requires_attached_agent() -> None:
+    harness = AgentSession(SessionConfig(load_env=False, open_storage=False))
     try:
-        harness.dispatch_message("hi")
+        harness.chat("hi")
     except RuntimeError as exc:
         assert "attach_agent" in str(exc)
     else:
         raise AssertionError("expected RuntimeError")
 
 
-def test_dispatch_message_reuses_attached_agent(monkeypatch: Any) -> None:
+def test_chat_reuses_attached_agent(monkeypatch: Any) -> None:
     calls: list[str] = []
 
     class _Agent:
@@ -51,10 +51,10 @@ def test_dispatch_message_reuses_attached_agent(monkeypatch: Any) -> None:
                 llm_run=object(),
             )
 
-    harness = AgentHarness(HarnessConfig(load_env=False))
+    harness = AgentSession(SessionConfig(load_env=False))
     harness.attach_agent(_Agent())  # type: ignore[arg-type]
-    first = harness.dispatch_message("one")
-    second = harness.dispatch_message("two")
+    first = harness.chat("one")
+    second = harness.chat("two")
 
     assert calls == ["one", "two"]
     assert first.assistant_response_text == "ok:one"

--- a/tests/core/agent_harness/test_developer_agent_api.py
+++ b/tests/core/agent_harness/test_developer_agent_api.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import pytest
 
-from core.agent_harness.harness import AgentHarness, HarnessConfig
+from core.agent_harness.harness import AgentSession, SessionConfig
 from core.agent_harness.turns.default_headless_agent import build_default_headless_agent
 from core.agent_harness.turns.gather_ports import GATHER_DISABLED
 from core.agent_harness.turns.headless_adapters import (
@@ -73,9 +73,9 @@ class _RecordingPrompts(EmptyPromptContextProvider):
         return ""
 
 
-def _headless_config(**overrides: Any) -> HarnessConfig:
+def _headless_config(**overrides: Any) -> SessionConfig:
     """No env / storage / integrations — embedder unit-test shape."""
-    return HarnessConfig(
+    return SessionConfig(
         load_env=False,
         hydrate_integrations=False,
         persistent_tasks=False,
@@ -121,14 +121,14 @@ def _controlled_agent(
 
 
 def test_two_line_api_dispatches_an_answer(stub_action_planner: None) -> None:
-    """``AgentHarness`` + ``dispatch_message`` is the documented happy path."""
+    """``AgentSession`` + ``chat`` is the documented happy path."""
     # Arrange
-    harness = AgentHarness(_headless_config())
+    harness = AgentSession(_headless_config())
     agent, _sink = _controlled_agent()
     harness.attach_agent(agent)
 
     # Act
-    result = harness.dispatch_message("why is checkout-api slow?")
+    result = harness.chat("why is checkout-api slow?")
 
     # Assert
     assert isinstance(result, TurnResult)
@@ -137,15 +137,15 @@ def test_two_line_api_dispatches_an_answer(stub_action_planner: None) -> None:
 
 
 def test_follow_up_reuses_the_same_attached_agent(stub_action_planner: None) -> None:
-    """Each ``dispatch_message`` is one turn on the same agent/session."""
+    """Each ``chat`` is one turn on the same agent/session."""
     # Arrange
-    harness = AgentHarness(_headless_config())
+    harness = AgentSession(_headless_config())
     agent, _sink = _controlled_agent()
     harness.attach_agent(agent)
 
     # Act
-    first = harness.dispatch_message("list open incidents")
-    second = harness.dispatch_message("which affect checkout?")
+    first = harness.chat("list open incidents")
+    second = harness.chat("which affect checkout?")
 
     # Assert
     assert harness.agent is agent
@@ -159,7 +159,7 @@ def test_documented_custom_sink_path_captures_streamed_answer(
 ) -> None:
     """``startup`` → ``build_default_headless_agent(output=…)`` → ``attach_agent``."""
     # Arrange
-    harness = AgentHarness(_headless_config())
+    harness = AgentSession(_headless_config())
     startup = harness.startup()
     sink = BufferOutputSink()
     agent = build_default_headless_agent(session=startup.session, output=sink)
@@ -169,7 +169,7 @@ def test_documented_custom_sink_path_captures_streamed_answer(
     harness.attach_agent(agent)
 
     # Act
-    result = harness.dispatch_message("summarize open incidents")
+    result = harness.chat("summarize open incidents")
 
     # Assert
     assert result.answered
@@ -178,17 +178,17 @@ def test_documented_custom_sink_path_captures_streamed_answer(
 
 
 def test_start_honours_caller_grounding_provider(stub_action_planner: None) -> None:
-    """``HarnessConfig.prompts`` must be the provider the answer path uses."""
+    """``SessionConfig.prompts`` must be the provider the answer path uses."""
     # Arrange
     prompts = _RecordingPrompts()
-    harness = AgentHarness.start(_headless_config(prompts=prompts))
+    harness = AgentSession.start(_headless_config(prompts=prompts))
     assert harness.agent is not None
     harness.agent._tools = NullToolProvider()  # noqa: SLF001
     harness.agent._reasoning = StaticReasoningClientProvider(client=_EchoClient())  # noqa: SLF001
     harness.agent._gather_ports = GATHER_DISABLED  # noqa: SLF001
 
     # Act
-    result = harness.dispatch_message("what is our on-call policy?")
+    result = harness.chat("what is our on-call policy?")
 
     # Assert
     assert harness.agent._prompts is prompts  # noqa: SLF001
@@ -200,7 +200,7 @@ def test_start_honours_caller_grounding_provider(stub_action_planner: None) -> N
 def test_builder_accepts_caller_grounding_on_the_second_path() -> None:
     """The explicit ``build_default_headless_agent`` path must take ``prompts=``."""
     # Arrange
-    harness = AgentHarness(_headless_config())
+    harness = AgentSession(_headless_config())
     startup = harness.startup()
     prompts = _RecordingPrompts()
     sink = BufferOutputSink()
@@ -248,12 +248,12 @@ def test_custom_output_sink_protocol_is_enough(stub_action_planner: None) -> Non
 
     # Arrange
     sink = _ListSink()
-    harness = AgentHarness(_headless_config())
+    harness = AgentSession(_headless_config())
     agent, _ = _controlled_agent(output=sink)
     harness.attach_agent(agent)
 
     # Act
-    result = harness.dispatch_message("ping")
+    result = harness.chat("ping")
 
     # Assert
     assert result.answered
@@ -263,7 +263,7 @@ def test_custom_output_sink_protocol_is_enough(stub_action_planner: None) -> Non
 def test_start_without_prompts_keeps_default_grounding() -> None:
     """Omitting ``prompts`` must not leave the agent ungrounded."""
     # Arrange / Act
-    harness = AgentHarness.start(_headless_config())
+    harness = AgentSession.start(_headless_config())
 
     # Assert
     assert harness.agent is not None
@@ -271,7 +271,7 @@ def test_start_without_prompts_keeps_default_grounding() -> None:
 
 
 def test_resume_config_reaches_session_manager() -> None:
-    """``HarnessConfig.session_id`` is how a developer resumes a conversation."""
+    """``SessionConfig.session_id`` is how a developer resumes a conversation."""
     # Arrange
     from surfaces.interactive_shell.session import Session
 
@@ -288,8 +288,8 @@ def test_resume_config_reaches_session_manager() -> None:
             return self.session
 
     manager = _FakeSessionManager()
-    harness = AgentHarness(
-        HarnessConfig(
+    harness = AgentSession(
+        SessionConfig(
             session_id="abc123",
             load_env=False,
             hydrate_integrations=False,

--- a/tests/core/agent_harness/test_harness.py
+++ b/tests/core/agent_harness/test_harness.py
@@ -1,4 +1,4 @@
-"""Tests for :class:`core.agent_harness.harness.AgentHarness`.
+"""Tests for :class:`core.agent_harness.harness.AgentSession`.
 
 Covers the startup responsibilities the harness consolidates: env
 resolution, session bootstrap/resume (delegated to
@@ -43,7 +43,7 @@ def test_resolve_env_variables_calls_bootstrap_once(monkeypatch: Any) -> None:
         "config.local_env.bootstrap_opensre_env_once",
         _bootstrap,
     )
-    harness = harness_module.AgentHarness()
+    harness = harness_module.AgentSession()
 
     harness.resolve_env_variables()
 
@@ -56,7 +56,7 @@ def test_resolve_env_variables_skipped_when_load_env_false(monkeypatch: Any) -> 
         "config.local_env.bootstrap_opensre_env_once",
         lambda **kwargs: calls.append(kwargs),
     )
-    harness = harness_module.AgentHarness(harness_module.HarnessConfig(load_env=False))
+    harness = harness_module.AgentSession(harness_module.SessionConfig(load_env=False))
 
     harness.resolve_env_variables()
 
@@ -65,7 +65,7 @@ def test_resolve_env_variables_skipped_when_load_env_false(monkeypatch: Any) -> 
 
 def test_load_or_create_session_creates_when_no_session_id() -> None:
     manager = _FakeSessionManager(Session())
-    harness = harness_module.AgentHarness(harness_module.HarnessConfig(session_manager=manager))  # type: ignore[arg-type]
+    harness = harness_module.AgentSession(harness_module.SessionConfig(session_manager=manager))  # type: ignore[arg-type]
 
     session = harness.load_or_create_session()
 
@@ -83,8 +83,8 @@ def test_load_or_create_session_creates_when_no_session_id() -> None:
 
 def test_load_or_create_session_resolves_when_session_id_given() -> None:
     manager = _FakeSessionManager(Session())
-    harness = harness_module.AgentHarness(
-        harness_module.HarnessConfig(session_id="abc123", session_manager=manager)  # type: ignore[arg-type]
+    harness = harness_module.AgentSession(
+        harness_module.SessionConfig(session_id="abc123", session_manager=manager)  # type: ignore[arg-type]
     )
 
     session = harness.load_or_create_session()
@@ -103,8 +103,8 @@ def test_load_or_create_session_resolves_when_session_id_given() -> None:
 
 def test_load_or_create_session_forwards_explicit_warm_integrations() -> None:
     manager = _FakeSessionManager(Session())
-    harness = harness_module.AgentHarness(
-        harness_module.HarnessConfig(warm_integrations=True, session_manager=manager)  # type: ignore[arg-type]
+    harness = harness_module.AgentSession(
+        harness_module.SessionConfig(warm_integrations=True, session_manager=manager)  # type: ignore[arg-type]
     )
 
     harness.load_or_create_session()
@@ -122,7 +122,7 @@ def test_load_or_create_session_forwards_explicit_warm_integrations() -> None:
 def test_resolve_integrations_delegates_to_session() -> None:
     session = Session()
     session.resolved_integrations_cache = {"datadog": {"api_key": "x"}}
-    harness = harness_module.AgentHarness()
+    harness = harness_module.AgentSession()
 
     resolved = harness.resolve_integrations(session)
 
@@ -131,13 +131,13 @@ def test_resolve_integrations_delegates_to_session() -> None:
 
 def test_load_context_returns_configured_prompts() -> None:
     sentinel = object()
-    harness = harness_module.AgentHarness(harness_module.HarnessConfig(prompts=sentinel))  # type: ignore[arg-type]
+    harness = harness_module.AgentSession(harness_module.SessionConfig(prompts=sentinel))  # type: ignore[arg-type]
 
     assert harness.load_context() is sentinel
 
 
 def test_load_context_returns_none_by_default() -> None:
-    harness = harness_module.AgentHarness()
+    harness = harness_module.AgentSession()
 
     assert harness.load_context() is None
 
@@ -148,29 +148,29 @@ def test_startup_runs_env_then_session_then_context(monkeypatch: Any) -> None:
     sentinel = object()
     order: list[str] = []
     monkeypatch.setattr(
-        harness_module.AgentHarness,
+        harness_module.AgentSession,
         "resolve_env_variables",
         lambda _self: order.append("env"),
     )
-    original_load_session = harness_module.AgentHarness.load_or_create_session
+    original_load_session = harness_module.AgentSession.load_or_create_session
 
-    def _tracked_load_session(self: harness_module.AgentHarness) -> Session:
+    def _tracked_load_session(self: harness_module.AgentSession) -> Session:
         order.append("session")
         return original_load_session(self)
 
     monkeypatch.setattr(
-        harness_module.AgentHarness, "load_or_create_session", _tracked_load_session
+        harness_module.AgentSession, "load_or_create_session", _tracked_load_session
     )
-    original_context = harness_module.AgentHarness.load_context
+    original_context = harness_module.AgentSession.load_context
 
-    def _tracked_context(self: harness_module.AgentHarness) -> Any:
+    def _tracked_context(self: harness_module.AgentSession) -> Any:
         order.append("context")
         return original_context(self)
 
-    monkeypatch.setattr(harness_module.AgentHarness, "load_context", _tracked_context)
+    monkeypatch.setattr(harness_module.AgentSession, "load_context", _tracked_context)
 
-    harness = harness_module.AgentHarness(
-        harness_module.HarnessConfig(prompts=sentinel, session_manager=manager)  # type: ignore[arg-type]
+    harness = harness_module.AgentSession(
+        harness_module.SessionConfig(prompts=sentinel, session_manager=manager)  # type: ignore[arg-type]
     )
     result = harness.startup()
 

--- a/tests/core/agent_harness/test_harness_start.py
+++ b/tests/core/agent_harness/test_harness_start.py
@@ -14,9 +14,9 @@ from typing import Any
 def test_start_returns_a_ready_harness() -> None:
     """One call: env resolved, session created, default agent attached."""
     # Arrange / Act
-    from core.agent_harness.harness import AgentHarness
+    from core.agent_harness.harness import AgentSession
 
-    harness = AgentHarness.start()
+    harness = AgentSession.start()
 
     # Assert: dispatch works without any further wiring.
     assert harness.agent is not None
@@ -25,10 +25,10 @@ def test_start_returns_a_ready_harness() -> None:
 def test_start_accepts_a_config_for_callers_that_need_one() -> None:
     """Surfaces that resume a session must still be able to pass config."""
     # Arrange
-    from core.agent_harness.harness import AgentHarness, HarnessConfig
+    from core.agent_harness.harness import AgentSession, SessionConfig
 
     # Act
-    harness = AgentHarness.start(HarnessConfig())
+    harness = AgentSession.start(SessionConfig())
 
     # Assert
     assert harness.agent is not None
@@ -37,9 +37,9 @@ def test_start_accepts_a_config_for_callers_that_need_one() -> None:
 def test_started_harness_dispatches_without_extra_wiring(monkeypatch: Any) -> None:
     """The documented two-liner must actually run end to end."""
     # Arrange
-    from core.agent_harness.harness import AgentHarness
+    from core.agent_harness.harness import AgentSession
 
-    harness = AgentHarness.start()
+    harness = AgentSession.start()
     captured: list[str] = []
 
     def _fake_dispatch(message: str) -> Any:
@@ -49,7 +49,7 @@ def test_started_harness_dispatches_without_extra_wiring(monkeypatch: Any) -> No
     monkeypatch.setattr(harness.agent, "dispatch", _fake_dispatch)
 
     # Act
-    harness.dispatch_message("why is checkout-api slow?")
+    harness.chat("why is checkout-api slow?")
 
     # Assert
     assert captured == ["why is checkout-api slow?"]
@@ -57,9 +57,9 @@ def test_started_harness_dispatches_without_extra_wiring(monkeypatch: Any) -> No
 
 def _headless_config(**overrides: Any) -> Any:
     """A config that touches no env, no storage, no integrations."""
-    from core.agent_harness.harness import HarnessConfig
+    from core.agent_harness.harness import SessionConfig
 
-    return HarnessConfig(
+    return SessionConfig(
         load_env=False,
         hydrate_integrations=False,
         persistent_tasks=False,
@@ -77,7 +77,7 @@ def test_configured_prompts_reach_the_agent() -> None:
     ``_prompts`` pins the wiring directly; there is no public accessor yet.
     """
     # Arrange
-    from core.agent_harness.harness import AgentHarness
+    from core.agent_harness.harness import AgentSession
 
     class _CallerPrompts:
         """Stands in for a caller's own grounding-context provider."""
@@ -85,7 +85,7 @@ def test_configured_prompts_reach_the_agent() -> None:
     supplied = _CallerPrompts()
 
     # Act
-    harness = AgentHarness.start(_headless_config(prompts=supplied))
+    harness = AgentSession.start(_headless_config(prompts=supplied))
 
     # Assert
     assert harness.agent is not None
@@ -95,10 +95,10 @@ def test_configured_prompts_reach_the_agent() -> None:
 def test_omitting_prompts_keeps_the_built_in_context() -> None:
     """No provider configured must still ground the agent, not leave it bare."""
     # Arrange
-    from core.agent_harness.harness import AgentHarness
+    from core.agent_harness.harness import AgentSession
 
     # Act
-    harness = AgentHarness.start(_headless_config())
+    harness = AgentSession.start(_headless_config())
 
     # Assert
     assert harness.agent is not None
@@ -137,7 +137,7 @@ def test_a_falsy_prompts_provider_is_still_used() -> None:
     one — the same quiet substitution this seam already suffered once.
     """
     # Arrange
-    from core.agent_harness.harness import AgentHarness
+    from core.agent_harness.harness import AgentSession
 
     class _FalsyPrompts:
         def __bool__(self) -> bool:
@@ -146,7 +146,7 @@ def test_a_falsy_prompts_provider_is_still_used() -> None:
     supplied = _FalsyPrompts()
 
     # Act
-    harness = AgentHarness.start(_headless_config(prompts=supplied))
+    harness = AgentSession.start(_headless_config(prompts=supplied))
 
     # Assert
     assert harness.agent is not None

--- a/tests/core/agent_harness/test_host_cancel_turn.py
+++ b/tests/core/agent_harness/test_host_cancel_turn.py
@@ -50,9 +50,11 @@ class _CancelSink:
 
 
 def test_host_cancel_requested_reads_sink_event() -> None:
+    from core.agent_harness.turns.host_cancel import ensure_turn_cancel
+
     sink = _CancelSink()
     assert host_cancel_requested(sink) is False
-    sink.turn_cancel.set()
+    ensure_turn_cancel(sink).set()
     assert host_cancel_requested(sink) is True
     assert host_cancel_requested(None) is False
 

--- a/tests/core/agent_harness/test_session_bindable_ports.py
+++ b/tests/core/agent_harness/test_session_bindable_ports.py
@@ -1,0 +1,147 @@
+"""Goal B reuse: session/console bind ports are Protocol-visible."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from core.agent_harness.ports import ConsoleBindable, OutputBindable, SessionBindable
+from core.agent_harness.tools.tool_provider import DefaultToolProvider
+from core.agent_harness.turns.default_reasoning_client import DefaultReasoningClientProvider
+from core.agent_harness.turns.headless_adapters import (
+    BufferOutputSink,
+    EmptyPromptContextProvider,
+    InMemorySessionStore,
+    NullToolProvider,
+    SimpleRunRecordFactory,
+    StaticReasoningClientProvider,
+)
+from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.host_cancel import ensure_turn_cancel
+
+
+class _SpyTools:
+    """Minimal SessionBindable + ConsoleBindable + ToolProvider for bind checks."""
+
+    def __init__(self) -> None:
+        self.sessions: list[Any] = []
+        self.consoles: list[Any] = []
+
+    def bind_session(self, session: Any) -> None:
+        self.sessions.append(session)
+
+    def bind_console(self, console: Any) -> None:
+        self.consoles.append(console)
+
+    def action_tools(self, **_kwargs: Any) -> list[Any]:
+        return []
+
+    def tool_resources(self) -> dict[str, Any]:
+        return {}
+
+    def observer(self, *, message: str) -> Any:
+        _ = message
+
+        def _observer(_kind: str, _data: dict[str, Any]) -> None:
+            return None
+
+        return _observer
+
+
+def test_default_and_null_tool_providers_are_session_and_console_bindable() -> None:
+    tools = DefaultToolProvider(InMemorySessionStore(), console=object())
+    assert isinstance(tools, SessionBindable)
+    assert isinstance(tools, ConsoleBindable)
+    null = NullToolProvider()
+    assert isinstance(null, SessionBindable)
+    assert isinstance(null, ConsoleBindable)
+
+
+def test_headless_default_ports_are_session_bindable() -> None:
+    assert isinstance(EmptyPromptContextProvider(), SessionBindable)
+    assert isinstance(StaticReasoningClientProvider(), SessionBindable)
+    assert isinstance(SimpleRunRecordFactory(), SessionBindable)
+
+
+def test_headless_agent_bind_session_invokes_session_bindable() -> None:
+    first = InMemorySessionStore(session_id="a")
+    second = InMemorySessionStore(session_id="b")
+    tools = _SpyTools()
+    agent = HeadlessAgent(tools=tools, session=first)
+    agent.bind_session(second)
+    assert tools.sessions == [second]
+
+
+def test_headless_agent_bind_turn_console_invokes_console_bindable() -> None:
+    tools = _SpyTools()
+    agent = HeadlessAgent(tools=tools, session=InMemorySessionStore())
+    agent.bind_turn(console="second")
+    assert tools.consoles == ["second"]
+
+
+def test_default_reasoning_provider_is_output_bindable() -> None:
+    first = BufferOutputSink()
+    second = BufferOutputSink()
+    reasoning = DefaultReasoningClientProvider(output=first)
+    assert isinstance(reasoning, OutputBindable)
+    assert isinstance(StaticReasoningClientProvider(), OutputBindable)
+    reasoning.bind_output(second)
+    reasoning._handle_unavailable(RuntimeError("boom"), context="test")
+    assert "LLM client unavailable" in second.text
+    assert first.text == ""
+
+
+def test_headless_agent_bind_turn_output_retargets_reasoning() -> None:
+    first = BufferOutputSink()
+    second = BufferOutputSink()
+    reasoning = DefaultReasoningClientProvider(output=first)
+    agent = HeadlessAgent(
+        tools=NullToolProvider(),
+        session=InMemorySessionStore(),
+        output=first,
+        reasoning=reasoning,
+    )
+    agent.bind_turn(output=second)
+    reasoning._handle_unavailable(RuntimeError("boom"), context="test")
+    assert "LLM client unavailable" in second.text
+    assert first.text == ""
+
+
+def test_ensure_turn_cancel_reuses_existing_event() -> None:
+    class _Sink:
+        turn_cancel = threading.Event()
+
+    sink: Any = _Sink()
+    first = ensure_turn_cancel(sink)
+    second = ensure_turn_cancel(sink)
+    assert first is second is sink.turn_cancel
+
+
+def test_live_sink_exposes_turn_cancel_property() -> None:
+    from gateway.core.runtime.live_sink import LiveOutputSink
+
+    class _Inner:
+        def __init__(self) -> None:
+            self.turn_cancel = threading.Event()
+
+        def print(self, message: str = "") -> None:
+            _ = message
+
+        def render_response_header(self, label: str) -> None:
+            _ = label
+
+        def render_error(self, message: str) -> None:
+            _ = message
+
+        def stream(self, *, label: str, chunks: Any, **_kwargs: Any) -> str:
+            _ = (label, chunks)
+            return ""
+
+        def finalize(self, text: str) -> None:
+            _ = text
+
+    inner = _Inner()
+    live = LiveOutputSink()
+    assert live.turn_cancel is None
+    live.bind(inner)  # type: ignore[arg-type]
+    assert live.turn_cancel is inner.turn_cancel

--- a/tests/core/agent_harness/test_session_bindable_ports.py
+++ b/tests/core/agent_harness/test_session_bindable_ports.py
@@ -1,4 +1,4 @@
-"""Goal B reuse: session/console bind ports are Protocol-visible."""
+"""Session/console/output bind ports are Protocol-visible for agent reuse."""
 
 from __future__ import annotations
 

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -183,13 +183,15 @@ def test_one_headless_agent_dispatches_multiple_messages(monkeypatch: pytest.Mon
     assert len(agent._store.cli_agent_messages) == 4
 
 
-def test_provided_accounting_is_reused_across_messages() -> None:
+def test_provided_accounting_is_consumed_once() -> None:
+    """Constructor accounting is take-once — hosts must rebind per message."""
     from core.agent_harness.turns.headless_dispatch import NoopTurnAccounting, NullToolProvider
 
     accounting = NoopTurnAccounting()
     agent = HeadlessAgent(tools=NullToolProvider(), accounting=accounting)
-    assert agent._accounting_for("a") is accounting
-    assert agent._accounting_for("b") is accounting
+    assert agent._take_accounting("a") is accounting
+    # Slot cleared so a forgotten bind_turn cannot leak the prior turn's prompt.
+    assert agent._take_accounting("b") is not accounting
 
 
 def test_default_accounting_is_resolved_fresh_per_message() -> None:
@@ -201,9 +203,10 @@ def test_default_accounting_is_resolved_fresh_per_message() -> None:
 
     agent = HeadlessAgent(tools=NullToolProvider(), session=_PersistentStore())
 
-    first = agent._accounting_for("msg-a")
-    second = agent._accounting_for("msg-b")
+    first = agent._take_accounting("msg-a")
+    second = agent._take_accounting("msg-b")
     assert isinstance(first, DefaultTurnAccounting)
+    assert isinstance(second, DefaultTurnAccounting)
     assert first is not second  # resolved per message, not once at construction
 
 


### PR DESCRIPTION
Summary

- Teach and enforce the host API narrative: `configure_process` → `AgentSession.start()` → repeated `.chat` / `.investigate`; one `build_default_headless_agent` factory; reuse via `SessionAgentPool` / `bind_turn` (compat aliases kept thin).
- Share process capacity across chat, scheduler, and : `process_turn_gate()` — `POST /investigate` busy-drops (503); `InvestigationWorker` blocks after claim.
- Wire `SCHEDULER_WORKER_PROFILE` for `opensre cron start` (dedicated daemon); keep `SCHEDULED_COMMAND_PROFILE` for one-shot CLI helpers.
