### PR TITLE
chore(betterstack): use HTTPStatus enum for status comparisons (SM-35)

### DIFF
--- a/integrations/betterstack/__init__.py
+++ b/integrations/betterstack/__init__.py
@@ -22,6 +22,7 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import datetime
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -233,7 +234,7 @@ def validate_betterstack_config(
     assert response is not None
 
     status = response.status_code
-    if status == 200:
+    if status == HTTPStatus.OK:
         body = response.text.strip()
         if not body:
             return BetterStackValidationResult(
@@ -244,12 +245,12 @@ def validate_betterstack_config(
             ok=True,
             detail=f"Connected to Better Stack SQL API at {config.query_endpoint}.",
         )
-    if status == 401:
+    if status == HTTPStatus.UNAUTHORIZED:
         return BetterStackValidationResult(
             ok=False,
             detail="Better Stack authentication failed (check BETTERSTACK_USERNAME / BETTERSTACK_PASSWORD).",
         )
-    if status == 404:
+    if status == HTTPStatus.NOT_FOUND:
         return BetterStackValidationResult(
             ok=False,
             detail=(
@@ -416,12 +417,12 @@ def query_logs(
             source=safe_source,
         )
 
-    if response.status_code == 401:
+    if response.status_code == HTTPStatus.UNAUTHORIZED:
         return _error_evidence(
             "Better Stack authentication failed (check credentials).",
             source=safe_source,
         )
-    if response.status_code != 200:
+    if response.status_code != HTTPStatus.OK:
         return _error_evidence(
             f"Better Stack query returned HTTP {response.status_code}: {response.text[:200]}",
             source=safe_source,


### PR DESCRIPTION
Fixes #4293

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Replaced 5 raw HTTP status literal comparisons in `integrations/betterstack/__init__.py` with `http.HTTPStatus` named members, per the project rule to never compare against bare numeric status codes:

- `validate_betterstack_config`: `status == 200` → `status == HTTPStatus.OK`, `status == 401` → `status == HTTPStatus.UNAUTHORIZED`, `status == 404` → `status == HTTPStatus.NOT_FOUND`
- `query_logs`: `response.status_code == 401` → `response.status_code == HTTPStatus.UNAUTHORIZED`, `response.status_code != 200` → `response.status_code != HTTPStatus.OK`

`HTTPStatus` is a stdlib `IntEnum`, so every comparison evaluates identically at runtime — zero behavior change. Single file, matches the issue's "one ID = one file = one PR" scope.

### Demo/Screenshot for feature changes and bug fixes -

Before → after (one of five, same pattern for the rest):
```python
# before
if response.status_code == 401:
# after
if response.status_code == HTTPStatus.UNAUTHORIZED:
```

Local checks, run against the changed file:
```
$ uv run ruff check integrations/betterstack/__init__.py
All checks passed!

$ uv run ruff format --check integrations/betterstack/__init__.py
1 file already formatted

$ uv run mypy integrations/betterstack/__init__.py
Success: no issues found in 1 source file

$ uv run pytest tests/integrations/test_betterstack.py tests/tools/test_betterstack_logs_tool.py -v
...
77 passed in 4.33s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**What problem does this solve?** `integrations/betterstack/__init__.py` compared HTTP status codes against bare integers (`200`, `401`, `404`) in two functions (`validate_betterstack_config`, `query_logs`). This repo's coding standard requires `http.HTTPStatus` enum members instead of magic numbers, so a reader doesn't have to memorize what each integer means.

**What alternative did I consider?** Project-defined constants (e.g. `HTTP_OK = 200`) — rejected because `http.HTTPStatus` is already the stdlib idiomatic solution and is the convention used everywhere else in this codebase (e.g. `integrations/webapp_vault.py`).

**Why this implementation?** `HTTPStatus` members are `IntEnum`, so `HTTPStatus.OK == 200` is `True` — the swap is a zero-risk drop-in replacement. No new dependency (stdlib), and `ruff`'s import sorter placed `from http import HTTPStatus` correctly among the existing `from X import Y` block.

**What do the touched functions do?** `validate_betterstack_config` sends a cheap `SELECT 1` probe to the Better Stack SQL endpoint and classifies the response (200 → connected, 401 → bad credentials, 404 → wrong region endpoint, else → generic failure). `query_logs` runs the actual log query and classifies non-2xx responses the same way (401 → auth failure, non-200 → generic error with the response body echoed back for diagnosis).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
