### PR TITLE
fix(telegram): redact bot tokens from poller errors

### DIFF
--- a/gateway/tests/telegram/test_telegram_client.py
+++ b/gateway/tests/telegram/test_telegram_client.py
@@ -33,3 +33,24 @@ def test_send_message_success_with_mapping_proxy_data(mock_post: MagicMock) -> N
     assert ok is True
     assert error == ""
     assert message_id == "42"
+
+
+@patch("gateway.transports.telegram.poller.client.post_json")
+def test_client_redacts_token_from_transport_error(mock_post: MagicMock) -> None:
+    token = "123456:SECRET"
+
+    mock_post.return_value = DeliveryResponse(
+        ok=False,
+        error=(f"ConnectError: https://api.telegram.org/bot{token}/sendMessage"),
+        exc_type="ConnectError",
+    )
+
+    client = TelegramBotClient(token)
+
+    ok, error, message_id = client.send_message("123", "hello")
+
+    assert ok is False
+    assert message_id == ""
+    assert token not in error
+    assert f"/bot{token}/" not in error
+    assert "<redacted>" in error

--- a/gateway/tests/telegram/test_telegram_poller.py
+++ b/gateway/tests/telegram/test_telegram_poller.py
@@ -129,3 +129,61 @@ def test_poll_once_parses_callback_query(mock_get: MagicMock, mock_sleep: MagicM
     # Ensure getUpdates asked for callback_query updates.
     assert "callback_query" in mock_get.call_args.kwargs["params"]["allowed_updates"]
     mock_sleep.assert_not_called()
+
+
+@patch("gateway.transports.telegram.poller.poller.time.sleep")
+@patch("gateway.transports.telegram.poller.poller.httpx.get")
+def test_poll_once_redacts_token_from_transient_exception(
+    mock_get: MagicMock,
+    mock_sleep: MagicMock,
+    caplog: object,
+) -> None:
+    import logging
+
+    token = "123456:SECRET"
+
+    mock_get.side_effect = httpx.ConnectError(
+        f"Connection failed for https://api.telegram.org/bot{token}/getUpdates"
+    )
+
+    caplog.set_level(
+        logging.DEBUG,
+        logger="gateway.transports.telegram.poller.poller",
+    )
+
+    result = TelegramPoller(token).poll_once()
+
+    assert result == TelegramPollResult()
+    assert token not in caplog.text
+    assert f"/bot{token}/" not in caplog.text
+    assert "<redacted>" in caplog.text
+    mock_sleep.assert_called_once_with(2.0)
+
+
+@patch("gateway.transports.telegram.poller.poller.time.sleep")
+@patch("gateway.transports.telegram.poller.poller.httpx.get")
+def test_poll_once_redacts_token_from_error_response(
+    mock_get: MagicMock,
+    mock_sleep: MagicMock,
+    caplog: object,
+) -> None:
+    import logging
+
+    token = "123456:SECRET"
+
+    mock_get.return_value = httpx.Response(
+        500,
+        text=f"request failed: https://api.telegram.org/bot{token}/getUpdates",
+    )
+
+    caplog.set_level(
+        logging.DEBUG,
+        logger="gateway.transports.telegram.poller.poller",
+    )
+
+    TelegramPoller(token).poll_once()
+
+    assert token not in caplog.text
+    assert f"/bot{token}/" not in caplog.text
+    assert "<redacted>" in caplog.text
+    mock_sleep.assert_called_once_with(2.0)

--- a/gateway/transports/telegram/poller/client.py
+++ b/gateway/transports/telegram/poller/client.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from platform.notifications.delivery_transport import post_json
+from platform.notifications.redaction import redact_token
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class TelegramBotClient:
             payload=payload,
         )
         if not response.ok:
-            return False, {}, response.error
+            return False, {}, redact_token(response.error, self._token)
         if response.status_code != 200 or not isinstance(response.data, Mapping):
             return False, {}, response.text or f"HTTP {response.status_code}"
         if not response.data.get("ok"):

--- a/gateway/transports/telegram/poller/poller.py
+++ b/gateway/transports/telegram/poller/poller.py
@@ -18,6 +18,7 @@ from gateway.transports.telegram.settings import (
     TelegramCallbackQuery,
     TelegramInboundMessage,
 )
+from platform.notifications.redaction import redact_token
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,12 @@ class TelegramPoller:
         try:
             response = httpx.get(url, params=params, timeout=float(self._timeout + 5))
         except Exception as exc:
-            self._log_transient("[telegram-gateway] getUpdates failed: %s", exc)
+            safe_error = redact_token(str(exc), self._token)
+            self._log_transient(
+                "[telegram-gateway] getUpdates failed (%s): %s",
+                type(exc).__name__,
+                safe_error,
+            )
             time.sleep(_DEFAULT_RETRY_SECONDS)
             return TelegramPollResult()
 
@@ -102,8 +108,9 @@ class TelegramPoller:
         response: httpx.Response,
     ) -> None:
         error_code = data.get("error_code")
-        description = str(
-            data.get("description") or response.text.strip() or f"HTTP {response.status_code}"
+        description = redact_token(
+            str(data.get("description") or response.text.strip() or f"HTTP {response.status_code}"),
+            self._token,
         )
         if error_code == _CONFLICT_ERROR_CODE:
             logger.debug(


### PR DESCRIPTION
Fixes #4769.

## Summary
Prevent Telegram bot tokens from appearing in gateway logs or caller-visible errors when transient HTTP failures occur.

## Changes
- Redact bot tokens from transient `getUpdates` exceptions before logging.
- Log the exception type separately for debugging.
- Redact bot tokens from Telegram HTTP error descriptions.
- Redact bot tokens from `TelegramBotClient` transport errors.
- Add regression tests covering exception, HTTP response, and client error paths.

## Testing
- `pytest -q gateway/tests/telegram/test_telegram_poller.py gateway/tests/telegram/test_telegram_client.py` - 10 passed
- `ruff check` on changed files - passed
- `git diff --check` - passed