### PR TITLE
refactor(analytics): UsageSurface StrEnum for analytics stamps

### DIFF
--- a/platform/analytics/cli.py
+++ b/platform/analytics/cli.py
@@ -28,7 +28,7 @@ from platform.analytics.source import (
     TriggerMode,
     build_source_properties,
 )
-from platform.analytics.usage_context import SURFACE_CLI
+from platform.analytics.usage_context import UsageSurface
 from platform.observability.errors.sentry import capture_exception
 
 if TYPE_CHECKING:
@@ -392,7 +392,7 @@ def capture_cli_invoked(properties: Properties | None = None) -> None:
         from platform.analytics.usage_context import ensure_process_session_id
 
         analytics = get_analytics()
-        analytics.set_persistent_property("surface", SURFACE_CLI)
+        analytics.set_persistent_property("surface", UsageSurface.CLI)
         ensure_process_session_id()
         analytics.capture(Event.CLI_INVOKED, properties)
     except Exception as exc:

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -17,6 +17,7 @@ import contextlib
 import threading
 from collections.abc import Iterator
 from contextvars import ContextVar, Token
+from enum import StrEnum
 from typing import Final
 from uuid import uuid4
 
@@ -27,14 +28,21 @@ type JsonScalar = str | bool | int | float
 type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 type Properties = dict[str, JsonValue]
 
-SURFACE_CLI: Final[str] = "cli"
-SURFACE_SLACK: Final[str] = "slack"
-SURFACE_TELEGRAM: Final[str] = "telegram"
-SURFACE_DISCORD: Final[str] = "discord"
-SURFACE_BUZZ: Final[str] = "buzz"
-CANONICAL_SURFACES: Final[frozenset[str]] = frozenset(
-    {SURFACE_CLI, SURFACE_SLACK, SURFACE_TELEGRAM, SURFACE_DISCORD, SURFACE_BUZZ}
-)
+class UsageSurface(StrEnum):
+    """Analytics usage surface (closed set — add new surfaces here).
+
+    Members are StrEnum so they compare equal to their string values and
+    serialize cleanly in JSON/PostHog payloads.
+    """
+
+    CLI = "cli"
+    SLACK = "slack"
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+    BUZZ = "buzz"
+
+
+CANONICAL_SURFACES: Final[frozenset[UsageSurface]] = frozenset(UsageSurface)
 ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
 
 _SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -117,10 +117,10 @@ def _start_background_investigation(
     session.terminal.background_investigations[task.task_id] = record
 
     def _worker() -> None:
-        from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
+        from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
         with bound_usage_context(
-            surface=SURFACE_CLI,
+            surface=UsageSurface.CLI,
             session_id=session.session_id,
         ):
             try:

--- a/surfaces/interactive_shell/runtime/startup/initial_input.py
+++ b/surfaces/interactive_shell/runtime/startup/initial_input.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 
 from platform.analytics.repl_context import bound_repl_turn_context
-from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
+from platform.analytics.usage_context import UsageSurface, bound_usage_context
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.input_prompt.rendering import render_submitted_prompt
 from surfaces.interactive_shell.ui.terminal_ui import render_terminal_ui
@@ -39,7 +39,7 @@ def run_initial_input(
         recorder = PromptRecorder.start(session=session, text=stripped, turn_kind=_TURN_KIND)
         with (
             bound_usage_context(
-                surface=SURFACE_CLI,
+                surface=UsageSurface.CLI,
                 session_id=session.session_id,
             ),
             bound_repl_turn_context(

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
 
 from platform.analytics.repl_context import bound_repl_turn_context
-from platform.analytics.usage_context import SURFACE_CLI, bound_usage_context
+from platform.analytics.usage_context import UsageSurface, bound_usage_context
 from platform.observability.trace.spans import bind_session_trace, emit_thread_boundary
 from surfaces.interactive_shell.runtime.agent_presentation import (
     AgentEvent,
@@ -177,7 +177,7 @@ async def _run_agent_turn_loop(
 
         with (
             bound_usage_context(
-                surface=SURFACE_CLI,
+                surface=UsageSurface.CLI,
                 session_id=runtime.session.session_id,
             ),
             bound_repl_turn_context(

--- a/tests/analytics/test_usage_context.py
+++ b/tests/analytics/test_usage_context.py
@@ -11,9 +11,9 @@ from platform.analytics import provider
 from platform.analytics.events import Event
 from platform.analytics.repl_context import bound_repl_turn_context
 from platform.analytics.usage_context import (
+    CANONICAL_SURFACES,
     ORGANIZATION_GROUP_TYPE,
-    SURFACE_CLI,
-    SURFACE_SLACK,
+    UsageSurface,
     bound_usage_context,
     build_usage_enrichment,
     merge_usage_enrichment,
@@ -69,17 +69,31 @@ def _stub_httpx_client(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object
     return posted_payloads
 
 
+def test_usage_surface_members_and_roundtrip() -> None:
+    assert {member.value for member in UsageSurface} == {
+        "cli",
+        "slack",
+        "telegram",
+        "discord",
+        "buzz",
+    }
+    assert UsageSurface("cli") is UsageSurface.CLI
+    assert UsageSurface("buzz") is UsageSurface.BUZZ
+    assert UsageSurface.CLI == "cli"
+    assert CANONICAL_SURFACES == frozenset(UsageSurface)
+
+
 def test_build_usage_enrichment_from_context_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_abc")
     with bound_usage_context(
-        surface=SURFACE_SLACK,
+        surface=UsageSurface.SLACK,
         session_id="sess-1",
         user_id="U123",
     ):
         props = build_usage_enrichment()
     assert props["organization_id"] == "org_abc"
     assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_abc"}
-    assert props["surface"] == SURFACE_SLACK
+    assert props["surface"] == UsageSurface.SLACK
     assert props["session_id"] == "sess-1"
     assert props["user_id"] == "U123"
 
@@ -92,7 +106,7 @@ def test_session_id_falls_back_to_cli_session() -> None:
 
 def test_merge_usage_enrichment_caller_wins(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_env")
-    with bound_usage_context(surface=SURFACE_CLI, organization_id="org_ctx"):
+    with bound_usage_context(surface=UsageSurface.CLI, organization_id="org_ctx"):
         merged = merge_usage_enrichment({"organization_id": "org_caller", "surface": "cli"})
     assert merged["organization_id"] == "org_caller"
     assert merged["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_caller"}
@@ -106,7 +120,7 @@ def test_capture_stamps_org_groups_and_emits_groupidentify(
     monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_prod")
 
     analytics = provider.Analytics()
-    with bound_usage_context(surface=SURFACE_CLI, session_id="s1"):
+    with bound_usage_context(surface=UsageSurface.CLI, session_id="s1"):
         analytics.capture(Event.CLI_INVOKED, {"entrypoint": "opensre"})
     analytics.shutdown(flush=True)
 
@@ -125,7 +139,7 @@ def test_capture_stamps_org_groups_and_emits_groupidentify(
     props = capture_payload["properties"]
     assert props["organization_id"] == "org_prod"
     assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_prod"}
-    assert props["surface"] == SURFACE_CLI
+    assert props["surface"] == UsageSurface.CLI
     assert props["session_id"] == "s1"
 
 
@@ -183,7 +197,7 @@ def test_process_session_id_stamps_cli_investigate_without_repl(
     props = started["properties"]
     assert props["organization_id"] == "org_cli"
     assert props["$groups"] == {ORGANIZATION_GROUP_TYPE: "org_cli"}
-    assert props["surface"] == SURFACE_CLI
+    assert props["surface"] == UsageSurface.CLI
     assert props["session_id"] == process_session
 
 
@@ -198,7 +212,7 @@ def test_track_investigation_binds_session_from_session_object(
     analytics = provider.Analytics()
     monkeypatch.setattr(provider, "_instance", analytics)
     monkeypatch.setattr(analytics_cli, "get_analytics", lambda: analytics)
-    analytics.set_persistent_property("surface", SURFACE_CLI)
+    analytics.set_persistent_property("surface", UsageSurface.CLI)
 
     class _Session:
         session_id = "repl-session-123"
@@ -216,5 +230,5 @@ def test_track_investigation_binds_session_from_session_object(
         p["json"] for p in posted if p["json"]["event"] == Event.INVESTIGATION_STARTED.value
     )
     assert started["properties"]["session_id"] == "repl-session-123"
-    assert started["properties"]["surface"] == SURFACE_CLI
+    assert started["properties"]["surface"] == UsageSurface.CLI
     assert started["properties"]["organization_id"] == "org_repl"

--- a/tests/core/domain/memory/test_memory_store.py
+++ b/tests/core/domain/memory/test_memory_store.py
@@ -226,9 +226,9 @@ class TestSettings:
     def test_gateway_surfaces_require_opt_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from config.constants import OPENSRE_MEMORY_GATEWAY_ENABLED_ENV
         from core.domain.memory import gateway_memory_enabled, memory_available_here
-        from platform.analytics.usage_context import SURFACE_SLACK, bound_usage_context
+        from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
-        with bound_usage_context(surface=SURFACE_SLACK):
+        with bound_usage_context(surface=UsageSurface.SLACK):
             assert memory_enabled() is True
             assert gateway_memory_enabled() is False
             assert memory_available_here() is False


### PR DESCRIPTION
Fixes #4521

#### Describe the changes you have made in this PR -

Replaces the hand-maintained `SURFACE_*` `Final[str]` constants and frozenset in `platform/analytics/usage_context.py` with a `UsageSurface(StrEnum)`, matching the existing `StrEnum` conventions in `platform/filestorage/enums.py`:

- `UsageSurface.CLI/SLACK/TELEGRAM/DISCORD/BUZZ` with values byte-identical to today's strings (`cli`, `slack`, `telegram`, `discord`, `buzz`).
- `CANONICAL_SURFACES` is now derived as `frozenset(UsageSurface)`. Once a surface is a member, it is canonically valid — adding a new surface is an intentional enum change.
- All consumers updated to use `UsageSurface.CLI` / `UsageSurface.SLACK` instead of the removed constants (`platform/analytics/cli.py`, interactive-shell runtime files, and the two test modules).
- Added `test_usage_surface_members_and_roundtrip` pinning members, string round-trip (`UsageSurface("cli") is UsageSurface.CLI`), str equality, and `CANONICAL_SURFACES`.

Duplicate constants were removed rather than kept as aliases (per repo convention, no compatibility-only forwarding).

### Demo/Screenshot for feature changes and bug fixes
N/A — refactor; string values are unchanged (`cli|slack|telegram|discord|buzz`) so persisted/PostHog payload shapes are identical.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The refactor is mechanical: the five `SURFACE_*` `Final[str]` constants become members of one `UsageSurface(StrEnum)` with identical string values, `CANONICAL_SURFACES` is derived from the enum, and every importer was migrated to member access. StrEnum members compare equal to plain strings, so existing "stamp paths" (`set_persistent_property("surface", ...)`, `bound_usage_context(surface=...)`, JSON/PostHog payloads) work unchanged.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Closes #4521
