### PR TITLE
fix(dagster): spell out timeout constant unit suffix

### DIFF
--- a/integrations/dagster/__init__.py
+++ b/integrations/dagster/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_DAGSTER_TIMEOUT_S = 10
+DEFAULT_DAGSTER_TIMEOUT_SECONDS = 10
 DEFAULT_DAGSTER_MAX_RESULTS = 25
 DEFAULT_DAGSTER_RUN_LOG_PAGE_SIZE = 250
 # Sliding window of the most recent non-failure events kept from a run log;
@@ -68,7 +68,7 @@ def validate_dagster_config(config: DagsterConfig) -> DagsterValidationResult:
     with DagsterClient(
         endpoint=config.endpoint,
         api_token=config.api_token,
-        timeout_s=DEFAULT_DAGSTER_TIMEOUT_S,
+        timeout_s=DEFAULT_DAGSTER_TIMEOUT_SECONDS,
     ) as client:
         probe = client.ping()
     if "error" in probe:
@@ -106,7 +106,7 @@ def _client(config: DagsterConfig) -> DagsterClient:
     return DagsterClient(
         endpoint=config.endpoint,
         api_token=config.api_token,
-        timeout_s=DEFAULT_DAGSTER_TIMEOUT_S,
+        timeout_s=DEFAULT_DAGSTER_TIMEOUT_SECONDS,
     )
 
 


### PR DESCRIPTION
## Problem

The Dagster integration constant `DEFAULT_DAGSTER_TIMEOUT_S` uses a short unit suffix (`_S`) instead of spelling out the unit. This makes the constant's purpose less clear at a glance and is inconsistent with the project's preference for explicit naming.

## Fix

Renamed `DEFAULT_DAGSTER_TIMEOUT_S` → `DEFAULT_DAGSTER_TIMEOUT_SECONDS` in `integrations/dagster/__init__.py`. All three occurrences (definition at line 24, usages at lines 71 and 109) were updated. No behavior change — this is a pure rename.

## Test Plan

- [x] Lint passes (`make lint` — verified locally)
- [x] Constant only appears in the listed file (confirmed via grep across the repo)
- [x] No third file breaks (only 3 references, all in the same file)

Closes Tracer-Cloud/opensre#4321