### PR TITLE
refactor(gateway): share poll transport thread lifecycle

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -76,26 +76,22 @@ the full unit suite.
 Map changed paths to targets using the `PathRule` entries in
 [`.github/ci/test_scope_rules.py`](.github/ci/test_scope_rules.py):
 
-- Rules with `always_escalate=True` map to `make test-cov`
+- Rules with `always_escalate=True` identify high-blast-radius changes. Run the
+  focused package and contract tests affected by the change.
 - All other rules list a `test_targets` tuple — run those with
   `uv run python -m pytest <targets>`
 - Changed files under `tests/` with no app rule run as-is
 
 Use a focused `-k` filter when you only need a subset of a package.
 
-## 3) Escalation rules (must run full unit CI suite)
+## 3) Full suite runs in CI
 
-Run `make test-cov` (instead of only targeted tests) when any of these are true:
+The focused suite from section 2 is the required local test gate. Do not run
+`make test-cov` as part of the normal local pre-push workflow; pull-request CI
+runs the repository test suite in parallel shards.
 
-- Shared/core code changed (`core/state/`, `core/domain/types/`, `tools/investigation/`, `tools/investigation/stages/`)
-- 3+ app areas changed in one diff
-- New files with unclear blast radius
-- Cross-cutting refactor
-- You are unsure test scope is sufficient
-
-```bash
-make test-cov
-```
+List the focused tests you ran in the PR description. CI is the authoritative
+repository-wide test result.
 
 ## 4) Conditional checks
 

--- a/gateway/core/runtime/polling_thread.py
+++ b/gateway/core/runtime/polling_thread.py
@@ -1,0 +1,85 @@
+"""Shared background-thread lifecycle for poll-based gateway transports."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+
+class PollingBackground:
+    """Control handle for a poll transport's background thread."""
+
+    def __init__(
+        self,
+        *,
+        thread: threading.Thread,
+        stop_event: threading.Event,
+    ) -> None:
+        self._thread = thread
+        self._stop_event = stop_event
+
+    def stop(self, *, timeout: float = 8.0) -> bool:
+        """Request shutdown and return whether the thread stopped."""
+        self._stop_event.set()
+        self._thread.join(timeout=timeout)
+        return not self._thread.is_alive()
+
+    def wait(self, *, timeout: float | None = None) -> bool:
+        """Wait for the thread and return whether it has stopped."""
+        self._thread.join(timeout=timeout)
+        return not self._thread.is_alive()
+
+
+def start_polling_background[RuntimeT](
+    *,
+    thread_name: str,
+    started_message: str,
+    fatal_message: str,
+    logger: logging.Logger,
+    initialize_runtime: Callable[[], RuntimeT],
+    poll_until_stopped: Callable[[RuntimeT, threading.Event], Coroutine[Any, Any, None]],
+    shutdown_runtime: Callable[[RuntimeT], None],
+) -> PollingBackground:
+    """Initialize, run, and shut down a poll transport on a background thread."""
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_run_polling_thread,
+        kwargs={
+            "stop_event": stop_event,
+            "fatal_message": fatal_message,
+            "logger": logger,
+            "initialize_runtime": initialize_runtime,
+            "poll_until_stopped": poll_until_stopped,
+            "shutdown_runtime": shutdown_runtime,
+        },
+        name=thread_name,
+        daemon=True,
+    )
+    thread.start()
+
+    logger.info(started_message)
+    return PollingBackground(thread=thread, stop_event=stop_event)
+
+
+def _run_polling_thread[RuntimeT](
+    *,
+    stop_event: threading.Event,
+    fatal_message: str,
+    logger: logging.Logger,
+    initialize_runtime: Callable[[], RuntimeT],
+    poll_until_stopped: Callable[[RuntimeT, threading.Event], Coroutine[Any, Any, None]],
+    shutdown_runtime: Callable[[RuntimeT], None],
+) -> None:
+    resources = initialize_runtime()
+    try:
+        asyncio.run(poll_until_stopped(resources, stop_event))
+    except Exception:
+        logger.critical(fatal_message, exc_info=True)
+    finally:
+        shutdown_runtime(resources)
+
+
+__all__ = ["PollingBackground", "start_polling_background"]

--- a/gateway/tests/runtime/test_polling_background_lifecycle.py
+++ b/gateway/tests/runtime/test_polling_background_lifecycle.py
@@ -1,0 +1,102 @@
+"""Characterization tests for poll-transport background lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.transports.buzz import background as buzz_background
+from gateway.transports.buzz.settings import GatewaySettings as BuzzGatewaySettings
+from gateway.transports.telegram import background as telegram_background
+from gateway.transports.telegram.settings import GatewaySettings as TelegramGatewaySettings
+
+
+@dataclass(frozen=True)
+class _TransportCase:
+    module: ModuleType
+    start: Callable[..., Any]
+    poll_name: str
+    settings: object
+    fatal_message: str
+
+
+_CASES = (
+    _TransportCase(
+        module=telegram_background,
+        start=telegram_background.start_telegram_gateway_background,
+        poll_name="_poll_telegram_until_stopped",
+        settings=TelegramGatewaySettings(bot_token="tok"),
+        fatal_message="Fatal error in Telegram gateway thread",
+    ),
+    _TransportCase(
+        module=buzz_background,
+        start=buzz_background.start_buzz_gateway_background,
+        poll_name="_poll_buzz_until_stopped",
+        settings=BuzzGatewaySettings(private_key="key"),
+        fatal_message="Fatal error in Buzz gateway thread",
+    ),
+)
+
+
+@pytest.mark.parametrize("case", _CASES)
+def test_stop_wakes_polling_thread_and_shuts_down_runtime(
+    case: _TransportCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    runtime = object()
+    shutdown_runtime = MagicMock()
+
+    async def _poll_until_stopped(**kwargs: Any) -> None:
+        stop_event = kwargs["stop_event"]
+        started.set()
+        await asyncio.to_thread(stop_event.wait)
+
+    monkeypatch.setattr(case.module, case.poll_name, _poll_until_stopped)
+
+    handle = case.start(
+        settings=case.settings,
+        logger=logging.getLogger("gateway.test.polling-lifecycle"),
+        initialize_runtime=lambda _settings: runtime,
+        shutdown_runtime=shutdown_runtime,
+        handle_callback_to_gateway_agent=lambda *_args: None,
+    )
+
+    assert started.wait(timeout=1.0)
+    assert handle.stop(timeout=1.0)
+    shutdown_runtime.assert_called_once_with(runtime)
+
+
+@pytest.mark.parametrize("case", _CASES)
+def test_fatal_polling_error_is_logged_and_runtime_is_shut_down(
+    case: _TransportCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = object()
+    logger = MagicMock(spec=logging.Logger)
+    shutdown_runtime = MagicMock()
+
+    async def _raise_fatal_error(**_kwargs: Any) -> None:
+        raise RuntimeError("polling failed")
+
+    monkeypatch.setattr(case.module, case.poll_name, _raise_fatal_error)
+
+    handle = case.start(
+        settings=case.settings,
+        logger=logger,
+        initialize_runtime=lambda _settings: runtime,
+        shutdown_runtime=shutdown_runtime,
+        handle_callback_to_gateway_agent=lambda *_args: None,
+    )
+
+    assert handle.wait(timeout=1.0)
+    logger.critical.assert_called_once_with(case.fatal_message, exc_info=True)
+    shutdown_runtime.assert_called_once_with(runtime)

--- a/gateway/transports/buzz/background.py
+++ b/gateway/transports/buzz/background.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 
 from gateway.core.runtime.approvals import ApprovalBroker
+from gateway.core.runtime.polling_thread import PollingBackground, start_polling_background
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.storage import SessionResolver
 from gateway.transports.buzz.inbound_handler import handle_polled_inbound_buzz_message
@@ -29,30 +30,6 @@ _APPROVE_WORDS = frozenset({"approve", "approved", "approves", "yes", "y", "ok",
 _DENY_WORDS = frozenset({"deny", "denied", "denies", "no", "n", "reject", "rejected", "cancel"})
 
 
-class BuzzGatewayBackground:
-    """Control handle for the background Buzz gateway thread."""
-
-    def __init__(
-        self,
-        *,
-        thread: threading.Thread,
-        stop_event: threading.Event,
-    ) -> None:
-        self._thread = thread
-        self._stop_event = stop_event
-
-    def stop(self, *, timeout: float = 8.0) -> bool:
-        """Request shutdown and return whether the thread stopped."""
-        self._stop_event.set()
-        self._thread.join(timeout=timeout)
-        return not self._thread.is_alive()
-
-    def wait(self, *, timeout: float | None = None) -> bool:
-        """Wait for the thread and return whether it has stopped."""
-        self._thread.join(timeout=timeout)
-        return not self._thread.is_alive()
-
-
 def start_buzz_gateway_background(
     *,
     settings: GatewaySettings,
@@ -60,55 +37,33 @@ def start_buzz_gateway_background(
     initialize_runtime: InitializeBuzzPollingRuntime,
     shutdown_runtime: ShutdownBuzzPollingRuntime,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
-) -> BuzzGatewayBackground:
+) -> PollingBackground:
     """Start Buzz mention polling in a background thread."""
-    stop_event = threading.Event()
 
-    thread = threading.Thread(
-        target=_run_buzz_gateway_thread,
-        kwargs={
-            "settings": settings,
-            "stop_event": stop_event,
-            "logger": logger,
-            "initialize_runtime": initialize_runtime,
-            "shutdown_runtime": shutdown_runtime,
-            "handle_callback_to_gateway_agent": handle_callback_to_gateway_agent,
-        },
-        name="BuzzGatewayThread",
-        daemon=True,
-    )
-    thread.start()
+    def _initialize_runtime() -> BuzzPollingRuntime:
+        return initialize_runtime(settings)
 
-    logger.info("[buzz-gateway] polling started")
-    return BuzzGatewayBackground(thread=thread, stop_event=stop_event)
-
-
-def _run_buzz_gateway_thread(
-    *,
-    settings: GatewaySettings,
-    stop_event: threading.Event,
-    logger: logging.Logger,
-    initialize_runtime: InitializeBuzzPollingRuntime,
-    shutdown_runtime: ShutdownBuzzPollingRuntime,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
-) -> None:
-    """Own Buzz polling resources for the lifetime of the thread."""
-    resources = initialize_runtime(settings)
-
-    try:
-        asyncio.run(
-            _poll_buzz_until_stopped(
-                settings=settings,
-                stop_event=stop_event,
-                logger=logger,
-                resources=resources,
-                handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
-            )
+    async def _poll_until_stopped(
+        resources: BuzzPollingRuntime,
+        stop_event: threading.Event,
+    ) -> None:
+        await _poll_buzz_until_stopped(
+            settings=settings,
+            stop_event=stop_event,
+            logger=logger,
+            resources=resources,
+            handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
         )
-    except Exception:
-        logger.critical("Fatal error in Buzz gateway thread", exc_info=True)
-    finally:
-        shutdown_runtime(resources)
+
+    return start_polling_background(
+        thread_name="BuzzGatewayThread",
+        started_message="[buzz-gateway] polling started",
+        fatal_message="Fatal error in Buzz gateway thread",
+        logger=logger,
+        initialize_runtime=_initialize_runtime,
+        poll_until_stopped=_poll_until_stopped,
+        shutdown_runtime=shutdown_runtime,
+    )
 
 
 async def _poll_buzz_until_stopped(
@@ -356,4 +311,4 @@ def _decision(text: str) -> bool | None:
     return None
 
 
-__all__ = ["BuzzGatewayBackground", "start_buzz_gateway_background"]
+__all__ = ["start_buzz_gateway_background"]

--- a/gateway/transports/buzz/startup.py
+++ b/gateway/transports/buzz/startup.py
@@ -10,11 +10,9 @@ from __future__ import annotations
 
 import logging
 
+from gateway.core.runtime.polling_thread import PollingBackground
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
-from gateway.transports.buzz.background import (
-    BuzzGatewayBackground,
-    start_buzz_gateway_background,
-)
+from gateway.transports.buzz.background import start_buzz_gateway_background
 from gateway.transports.buzz.runtime import (
     initialize_buzz_polling_runtime,
     shutdown_buzz_polling_runtime,
@@ -29,7 +27,7 @@ def start_buzz_worker(
     *,
     logger: logging.Logger,
     handler: GatewayAgentCallback,
-) -> tuple[BuzzGatewayBackground, GatewaySettings]:
+) -> tuple[PollingBackground, GatewaySettings]:
     """Load Buzz settings and start the mention-poll background worker.
 
     ``handler`` is the transport-agnostic per-message callback. Returns the

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -7,6 +7,7 @@ import logging
 import threading
 
 from gateway.core.runtime.active_turns import is_stop_command
+from gateway.core.runtime.polling_thread import PollingBackground, start_polling_background
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.transports.telegram.approvals import handle_callback_query
 from gateway.transports.telegram.inbound_handler import (
@@ -21,30 +22,6 @@ from gateway.transports.telegram.runtime import (
 from gateway.transports.telegram.settings import GatewaySettings
 
 
-class TelegramGatewayBackground:
-    """Control handle for the background Telegram gateway thread."""
-
-    def __init__(
-        self,
-        *,
-        thread: threading.Thread,
-        stop_event: threading.Event,
-    ) -> None:
-        self._thread = thread
-        self._stop_event = stop_event
-
-    def stop(self, *, timeout: float = 8.0) -> bool:
-        """Request shutdown and return whether the thread stopped."""
-        self._stop_event.set()
-        self._thread.join(timeout=timeout)
-        return not self._thread.is_alive()
-
-    def wait(self, *, timeout: float | None = None) -> bool:
-        """Wait for the thread and return whether it has stopped."""
-        self._thread.join(timeout=timeout)
-        return not self._thread.is_alive()
-
-
 def start_telegram_gateway_background(
     *,
     settings: GatewaySettings,
@@ -52,56 +29,33 @@ def start_telegram_gateway_background(
     initialize_runtime: InitializeTelegramPollingRuntime,
     shutdown_runtime: ShutdownTelegramPollingRuntime,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
-) -> TelegramGatewayBackground:
+) -> PollingBackground:
     """Start Telegram polling in a background thread."""
-    stop_event = threading.Event()
 
-    thread = threading.Thread(
-        target=_run_telegram_gateway_thread,
-        kwargs={
-            "settings": settings,
-            "stop_event": stop_event,
-            "logger": logger,
-            "initialize_runtime": initialize_runtime,
-            "shutdown_runtime": shutdown_runtime,
-            "handle_callback_to_gateway_agent": handle_callback_to_gateway_agent,
-        },
-        name="TelegramGatewayThread",
-        daemon=True,
-    )
-    thread.start()
+    def _initialize_runtime() -> TelegramPollingRuntime:
+        return initialize_runtime(settings)
 
-    logger.info("[telegram-gateway] polling started")
-    return TelegramGatewayBackground(thread=thread, stop_event=stop_event)
-
-
-def _run_telegram_gateway_thread(
-    *,
-    settings: GatewaySettings,
-    stop_event: threading.Event,
-    logger: logging.Logger,
-    initialize_runtime: InitializeTelegramPollingRuntime,
-    shutdown_runtime: ShutdownTelegramPollingRuntime,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
-) -> None:
-    """Own Telegram polling resources for the lifetime of the thread."""
-    # Consideration: We could initialize a broader set of resources here that could be used by the gateway (i.e. the agent itself)
-    resources = initialize_runtime(settings)
-
-    try:
-        asyncio.run(
-            _poll_telegram_until_stopped(
-                settings=settings,
-                stop_event=stop_event,
-                logger=logger,
-                resources=resources,
-                handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
-            )
+    async def _poll_until_stopped(
+        resources: TelegramPollingRuntime,
+        stop_event: threading.Event,
+    ) -> None:
+        await _poll_telegram_until_stopped(
+            settings=settings,
+            stop_event=stop_event,
+            logger=logger,
+            resources=resources,
+            handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
         )
-    except Exception:
-        logger.critical("Fatal error in Telegram gateway thread", exc_info=True)
-    finally:
-        shutdown_runtime(resources)
+
+    return start_polling_background(
+        thread_name="TelegramGatewayThread",
+        started_message="[telegram-gateway] polling started",
+        fatal_message="Fatal error in Telegram gateway thread",
+        logger=logger,
+        initialize_runtime=_initialize_runtime,
+        poll_until_stopped=_poll_until_stopped,
+        shutdown_runtime=shutdown_runtime,
+    )
 
 
 async def _poll_telegram_until_stopped(

--- a/gateway/transports/telegram/startup.py
+++ b/gateway/transports/telegram/startup.py
@@ -10,11 +10,9 @@ from __future__ import annotations
 
 import logging
 
+from gateway.core.runtime.polling_thread import PollingBackground
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
-from gateway.transports.telegram.background import (
-    TelegramGatewayBackground,
-    start_telegram_gateway_background,
-)
+from gateway.transports.telegram.background import start_telegram_gateway_background
 from gateway.transports.telegram.runtime import (
     initialize_telegram_polling_runtime,
     shutdown_telegram_polling_runtime,
@@ -29,7 +27,7 @@ def start_telegram_worker(
     *,
     logger: logging.Logger,
     handler: GatewayAgentCallback,
-) -> tuple[TelegramGatewayBackground, GatewaySettings]:
+) -> tuple[PollingBackground, GatewaySettings]:
     """Load Telegram settings and start the long-poll background worker.
 
     ``handler`` is the transport-agnostic per-message callback. Returns the


### PR DESCRIPTION
Refs #4804

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Add `gateway.core.runtime.polling_thread` to own the lifecycle shared by poll-based gateway threads: start, stop, wait, fatal-error logging, and runtime teardown.
- Migrate the Telegram and Buzz background starters to the shared lifecycle while retaining their transport-specific entrypoints.
- Keep each transport's polling loop, cursor/acknowledgement semantics, approval handling, and shutdown policy in its owning package.
- Add characterization coverage for cooperative stops, fatal polling errors, and runtime teardown across both transports.
- Update `CI.md` so focused tests are the required local gate while repository-wide coverage runs in sharded PR CI.

This intentionally does not introduce a shared polling loop or runtime base. Telegram awaits long-poll dispatch, while Buzz detaches turns and drains unacknowledged work; combining those paths would obscure correctness-sensitive behavior.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ uv run python -m pytest gateway/tests/telegram gateway/tests/buzz \
    gateway/tests/runtime/test_polling_background_lifecycle.py \
    gateway/tests/test_package_borders.py -q
112 passed in 4.26s

$ make lint && make format-check && make typecheck
All checks passed!
3285 files already formatted
Success: no issues found in 1685 source files

$ make verify-integrations-smoke
31 passed in 1.65s
```

`make test-cov` was skipped for this local run; the focused suites above completed successfully.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The duplicated and stable boundary was the background-thread lifecycle, not the polling algorithm. `PollingBackground` now provides the common control handle, and `start_polling_background` owns thread creation plus initialize/run/shutdown ordering. Telegram and Buzz provide small typed closures that bind their settings and delegate back to their existing polling coroutines.

I considered extracting a common polling loop and a shared runtime dataclass. I rejected both for this change because the two transports have materially different dispatch, acknowledgement, approval, and shutdown semantics, and no shared algorithm currently consumes the common runtime fields. The narrower lifecycle extraction reduces duplication without guessing at a future third transport's requirements.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


