### PR TITLE
refactor(gateway): share conversation lock registry

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -71,6 +71,7 @@ from config.constants.filestorage import (
     REMOTE_SYNC_PROVIDER_ENV,
     REMOTE_SYNC_REGION_ENV,
 )
+from config.constants.gateway import DEFAULT_MAX_CONVERSATION_LOCKS
 from config.constants.git import (
     OPENSRE_COMMIT_COAUTHOR_EMAIL,
     OPENSRE_COMMIT_COAUTHOR_NAME,
@@ -351,6 +352,7 @@ __all__ = [
     "BUZZ_RELAY_URL_ENV",
     "CONTEXT_ROOT_ENV",
     "BLOB_READ_WRITE_TOKEN_ENV",
+    "DEFAULT_MAX_CONVERSATION_LOCKS",
     "DEFAULT_MAX_PARALLEL_UPLOADS",
     "DEFAULT_REMOTE_SYNC_PREFIX",
     "DEFAULT_REMOTE_SYNC_PROVIDER",

--- a/config/constants/gateway.py
+++ b/config/constants/gateway.py
@@ -1,0 +1,5 @@
+"""Gateway runtime constants."""
+
+DEFAULT_MAX_CONVERSATION_LOCKS = 1024
+
+__all__ = ["DEFAULT_MAX_CONVERSATION_LOCKS"]

--- a/gateway/core/runtime/conversation_locks.py
+++ b/gateway/core/runtime/conversation_locks.py
@@ -1,0 +1,53 @@
+"""Bounded per-conversation synchronization for gateway transports."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+from config.constants.gateway import DEFAULT_MAX_CONVERSATION_LOCKS
+
+
+@dataclass(slots=True)
+class _LockEntry:
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    refs: int = 0
+
+
+class ConversationLockRegistry:
+    """Serialize work per conversation while bounding retained idle locks."""
+
+    def __init__(self, *, max_entries: int = DEFAULT_MAX_CONVERSATION_LOCKS) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries must be positive")
+        self._max_entries = max_entries
+        self._entries: dict[str, _LockEntry] = {}
+        self._guard = threading.Lock()
+
+    @contextmanager
+    def hold(self, conversation_key: str) -> Iterator[None]:
+        """Hold the lock for one conversation until the context exits."""
+        with self._guard:
+            entry = self._entries.get(conversation_key)
+            if entry is None:
+                if len(self._entries) >= self._max_entries:
+                    self._entries = {
+                        key: existing
+                        for key, existing in self._entries.items()
+                        if existing.refs > 0
+                    }
+                entry = self._entries[conversation_key] = _LockEntry()
+            entry.refs += 1
+        try:
+            with entry.lock:
+                yield
+        finally:
+            with self._guard:
+                entry.refs -= 1
+
+    def __len__(self) -> int:
+        """Return the number of retained conversation lock entries."""
+        with self._guard:
+            return len(self._entries)

--- a/gateway/tests/runtime/test_conversation_locks.py
+++ b/gateway/tests/runtime/test_conversation_locks.py
@@ -1,0 +1,74 @@
+"""Concurrency contracts for the shared conversation lock registry."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from gateway.core.runtime.conversation_locks import ConversationLockRegistry
+
+_THREAD_TIMEOUT_SECONDS = 1.0
+_BLOCKED_CHECK_SECONDS = 0.05
+
+
+def test_different_conversations_can_run_concurrently() -> None:
+    registry = ConversationLockRegistry()
+    entered = threading.Event()
+
+    def hold_other_conversation() -> None:
+        with registry.hold("other"):
+            entered.set()
+
+    with registry.hold("busy"):
+        worker = threading.Thread(target=hold_other_conversation)
+        worker.start()
+        assert entered.wait(_THREAD_TIMEOUT_SECONDS)
+
+    worker.join(_THREAD_TIMEOUT_SECONDS)
+    assert not worker.is_alive()
+
+
+def test_active_conversation_survives_pruning_and_serializes_waiter() -> None:
+    registry = ConversationLockRegistry(max_entries=1)
+    attempting = threading.Event()
+    entered = threading.Event()
+
+    def wait_for_busy_conversation() -> None:
+        attempting.set()
+        with registry.hold("busy"):
+            entered.set()
+
+    with registry.hold("busy"):
+        # A new conversation at capacity triggers pruning while busy is active.
+        with registry.hold("other"):
+            pass
+
+        worker = threading.Thread(target=wait_for_busy_conversation)
+        worker.start()
+        assert attempting.wait(_THREAD_TIMEOUT_SECONDS)
+        assert not entered.wait(_BLOCKED_CHECK_SECONDS)
+
+    assert entered.wait(_THREAD_TIMEOUT_SECONDS)
+    worker.join(_THREAD_TIMEOUT_SECONDS)
+    assert not worker.is_alive()
+
+
+def test_idle_entries_are_pruned_at_capacity() -> None:
+    registry = ConversationLockRegistry(max_entries=2)
+
+    for index in range(10):
+        with registry.hold(f"conversation-{index}"):
+            pass
+
+    assert len(registry) <= 2
+
+
+def test_exception_releases_conversation_for_next_turn() -> None:
+    registry = ConversationLockRegistry()
+
+    with pytest.raises(RuntimeError, match="turn failed"), registry.hold("conversation"):
+        raise RuntimeError("turn failed")
+
+    with registry.hold("conversation"):
+        pass

--- a/gateway/tests/slack/test_dispatcher.py
+++ b/gateway/tests/slack/test_dispatcher.py
@@ -279,44 +279,6 @@ def test_non_denied_credit_outcomes_run_the_turn(
     assert len(turns) == 1
 
 
-def test_conversation_locks_are_pruned_at_cap(monkeypatch: pytest.MonkeyPatch) -> None:
-    from gateway.transports.slack import dispatcher
-
-    monkeypatch.setattr(dispatcher, "_MAX_CONVERSATION_LOCKS", 4)
-    dispatcher = _dispatcher(
-        settings=_settings(["U1"]),
-        messaging=_FakeMessagingClient(),
-        resolver=_FakeSessionResolver(),
-        handler=lambda *_args: None,
-    )
-
-    for index in range(10):
-        with dispatcher._conversation_turn(f"T1:C1:{index}"):
-            pass
-
-    assert len(dispatcher._conversation_locks) <= 4 + 1
-
-
-def test_in_use_conversation_lock_survives_pruning(monkeypatch: pytest.MonkeyPatch) -> None:
-    from gateway.transports.slack import dispatcher
-
-    monkeypatch.setattr(dispatcher, "_MAX_CONVERSATION_LOCKS", 1)
-    dispatcher = _dispatcher(
-        settings=_settings(["U1"]),
-        messaging=_FakeMessagingClient(),
-        resolver=_FakeSessionResolver(),
-        handler=lambda *_args: None,
-    )
-
-    with dispatcher._conversation_turn("T1:C1:busy"):
-        busy_entry = dispatcher._conversation_locks["T1:C1:busy"]
-        # Another conversation triggers pruning while the first turn is running.
-        with dispatcher._conversation_turn("T1:C1:other"):
-            pass
-        # The in-use entry was never discarded or replaced.
-        assert dispatcher._conversation_locks["T1:C1:busy"] is busy_entry
-
-
 def test_handler_exception_is_contained() -> None:
     messaging = _FakeMessagingClient()
 

--- a/gateway/transports/discord/dispatcher.py
+++ b/gateway/transports/discord/dispatcher.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from collections.abc import Iterator
-from contextlib import contextmanager, suppress
-from dataclasses import dataclass, field
+from contextlib import suppress
 
 from config.principal import StorageScope
 from config.scope_context import bound_storage_scope
@@ -20,6 +18,7 @@ from gateway.core.runtime.active_turns import (
 )
 from gateway.core.runtime.approvals import ApprovalBroker, approval_tool_hooks
 from gateway.core.runtime.attention import GateDecision, ThreadAttentionGate
+from gateway.core.runtime.conversation_locks import ConversationLockRegistry
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.storage import SessionResolver
 from gateway.transports.discord.approvals import DiscordApprovalPrompter
@@ -40,7 +39,6 @@ from gateway.transports.discord.thread_history import (
 )
 from platform.analytics.usage_context import SURFACE_DISCORD, bound_usage_context
 
-_MAX_CONVERSATION_LOCKS = 1024
 _DENIAL_REPLY = "You're not authorized to use this bot. Ask an admin to add you."
 _NEW_SESSION_REPLY = "Started a new session."
 _TURN_TIMEOUT_MESSAGE = "This is taking longer than expected. Please try again."
@@ -49,12 +47,6 @@ _CREDITS_DENIED_MESSAGE = "Out of credits — top up in the OpenSRE console."
 _WORKING_EMOJI = "\N{EYES}"
 _DONE_EMOJI = "\N{WHITE HEAVY CHECK MARK}"
 _FAILED_EMOJI = "\N{CROSS MARK}"
-
-
-@dataclass
-class _ConversationLock:
-    lock: threading.Lock = field(default_factory=threading.Lock)
-    refs: int = 0
 
 
 class DiscordTurnDispatcher:
@@ -80,8 +72,7 @@ class DiscordTurnDispatcher:
         self._approvals = approvals or ApprovalBroker()
         self._active_cancels = ActiveTurnCancels()
         self._attention = ThreadAttentionGate()
-        self._conversation_locks: dict[str, _ConversationLock] = {}
-        self._locks_guard = threading.Lock()
+        self._conversation_locks = ConversationLockRegistry()
         self._resolver_lock = threading.Lock()
 
     @property
@@ -152,26 +143,6 @@ class DiscordTurnDispatcher:
         )
         return True
 
-    @contextmanager
-    def _conversation_turn(self, conversation_key: str) -> Iterator[None]:
-        with self._locks_guard:
-            entry = self._conversation_locks.get(conversation_key)
-            if entry is None:
-                if len(self._conversation_locks) >= _MAX_CONVERSATION_LOCKS:
-                    self._conversation_locks = {
-                        key: existing
-                        for key, existing in self._conversation_locks.items()
-                        if existing.refs > 0
-                    }
-                entry = self._conversation_locks[conversation_key] = _ConversationLock()
-            entry.refs += 1
-        try:
-            with entry.lock:
-                yield
-        finally:
-            with self._locks_guard:
-                entry.refs -= 1
-
     def _post(self, inbound: DiscordInboundMessage, text: str) -> None:
         from gateway.transports.discord.client import send_message
 
@@ -222,7 +193,7 @@ class DiscordTurnDispatcher:
             )
 
     def _run_turn(self, inbound: DiscordInboundMessage, scope: StorageScope) -> None:
-        with self._conversation_turn(inbound.conversation_key):
+        with self._conversation_locks.hold(inbound.conversation_key):
             decision = enforce_inbound_discord_message_security(
                 user_id=inbound.user_id,
                 channel_id=inbound.channel_id,

--- a/gateway/transports/slack/dispatcher.py
+++ b/gateway/transports/slack/dispatcher.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from collections.abc import Iterator
-from contextlib import contextmanager
-from dataclasses import dataclass, field
 
 from config.principal import StorageScope
 from config.scope_context import bound_storage_scope
@@ -20,6 +17,7 @@ from gateway.core.runtime.active_turns import (
 )
 from gateway.core.runtime.approvals import ApprovalBroker, approval_tool_hooks
 from gateway.core.runtime.attention import GateDecision, ThreadAttentionGate
+from gateway.core.runtime.conversation_locks import ConversationLockRegistry
 from gateway.core.runtime.sink_protocol import GatewayAgentCallback
 from gateway.core.storage import SessionResolver
 from gateway.transports.slack.approvals import ThreadApprovalPrompter
@@ -46,10 +44,6 @@ from platform.analytics.usage_context import SURFACE_SLACK, bound_usage_context
 
 _ROTATE_SESSION = "__ROTATE_SESSION__"
 
-# Per-thread locks are pruned once this many conversations have been seen,
-# keeping memory flat in workspaces where every message starts a new thread.
-_MAX_CONVERSATION_LOCKS = 1024
-
 _DENIAL_REPLY = "You're not authorized to use this bot. Ask an admin to add you."
 _NEW_SESSION_REPLY = "Started a new session."
 _TURN_TIMEOUT_MESSAGE = "This is taking longer than expected. Please try again."
@@ -57,14 +51,6 @@ _TURN_TIMEOUT_MESSAGE = "This is taking longer than expected. Please try again."
 # UNAVAILABLE outcomes run the turn instead, so a misconfiguration or webapp
 # outage never masquerades to users as "out of credits".
 _CREDITS_DENIED_MESSAGE = "Out of credits — top up in the OpenSRE console."
-
-
-@dataclass
-class _ConversationLock:
-    """A per-conversation lock with a holder/waiter count for safe pruning."""
-
-    lock: threading.Lock = field(default_factory=threading.Lock)
-    refs: int = 0
 
 
 class _SlackTurnDispatcher:
@@ -90,8 +76,7 @@ class _SlackTurnDispatcher:
         self._approvals = approvals if approvals is not None else ApprovalBroker()
         self._active_cancels = ActiveTurnCancels()
         self._attention = ThreadAttentionGate()
-        self._conversation_locks: dict[str, _ConversationLock] = {}
-        self._locks_guard = threading.Lock()
+        self._conversation_locks = ConversationLockRegistry()
         self._resolver_lock = threading.Lock()
 
     def dispatch(self, inbound: SlackInboundMessage) -> None:
@@ -176,32 +161,6 @@ class _SlackTurnDispatcher:
         )
         return True
 
-    @contextmanager
-    def _conversation_turn(self, conversation_key: str) -> Iterator[None]:
-        """Serialize turns per conversation, pruning idle lock entries at the cap.
-
-        The reference count marks an entry as in use from before this thread
-        leaves the guard until after it releases the lock, so pruning can never
-        discard a lock another thread is about to acquire.
-        """
-        with self._locks_guard:
-            entry = self._conversation_locks.get(conversation_key)
-            if entry is None:
-                if len(self._conversation_locks) >= _MAX_CONVERSATION_LOCKS:
-                    self._conversation_locks = {
-                        key: existing
-                        for key, existing in self._conversation_locks.items()
-                        if existing.refs > 0
-                    }
-                entry = self._conversation_locks[conversation_key] = _ConversationLock()
-            entry.refs += 1
-        try:
-            with entry.lock:
-                yield
-        finally:
-            with self._locks_guard:
-                entry.refs -= 1
-
     def _post(self, inbound: SlackInboundMessage, text: str) -> None:
         self._messaging.post_message(
             channel=inbound.channel_id,
@@ -256,7 +215,7 @@ class _SlackTurnDispatcher:
             )
 
     def _run_turn(self, inbound: SlackInboundMessage, scope: StorageScope) -> None:
-        with self._conversation_turn(inbound.conversation_key):
+        with self._conversation_locks.hold(inbound.conversation_key):
             decision = enforce_inbound_slack_message_security(
                 user_id=inbound.user_id,
                 channel_id=inbound.channel_id,


### PR DESCRIPTION
Follow-up to #4827
Refs #4804

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Add `ConversationLockRegistry` under `gateway.core.runtime` to own bounded per-conversation synchronization.
- Migrate the Slack and Discord dispatchers from duplicate lock maps, guards, reference counting, and pruning logic to the shared registry.
- Move the shared lock-cap default to `config.constants.gateway`.
- Add focused concurrency coverage for cross-conversation parallelism, same-conversation serialization during pruning, bounded idle retention, and exception cleanup.

This extraction deliberately stops at the stable synchronization primitive. Slack and Discord retain their transport-specific admission, security, session resolution, reactions, approvals, and turn execution paths.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ uv run python -m pytest gateway/tests/slack gateway/tests/discord \
    gateway/tests/runtime/test_conversation_locks.py \
    gateway/tests/runtime/test_polling_background_lifecycle.py \
    gateway/tests/test_package_borders.py -q
229 passed in 4.85s

$ make lint && make format-check && make typecheck
All checks passed!
3288 files already formatted
Success: no issues found in 1687 source files

$ make verify-integrations-smoke
31 passed in 1.13s
```

`make test-cov` was not run locally; repository-wide coverage is handled by the sharded PR CI jobs documented in `CI.md`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I first ran the existing Slack pruning and multi-actor characterization tests against the pre-refactor implementation. The extracted registry preserves the existing reference-counting invariant: an entry is marked active before leaving the registry guard and remains active until after its per-conversation lock is released, so capacity pruning cannot replace a lock held or awaited by another turn. Both transports now compose this runtime primitive while keeping all vendor behavior local.

I considered extracting a shared dispatcher base class, but rejected it because the common behavior is limited to lock ownership. A base dispatcher would couple unrelated transport policies and create inheritance without a stable shared lifecycle.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
