### PR TITLE
refactor(grafana): use HTTPStatus.NO_CONTENT in base client

### DIFF
--- a/integrations/grafana/base.py
+++ b/integrations/grafana/base.py
@@ -6,6 +6,7 @@ import base64
 import json
 import logging
 from datetime import UTC, datetime
+from http import HTTPStatus
 from typing import Any, cast
 from urllib.parse import quote
 
@@ -423,7 +424,7 @@ class GrafanaClientBase:
             verify=self._config.ssl_verify,
         )
         response.raise_for_status()
-        if response.status_code == 204 or not response.content.strip():
+        if response.status_code == HTTPStatus.NO_CONTENT or not response.content.strip():
             return {}
         data: dict[str, Any] = response.json()
         return data


### PR DESCRIPTION
Fixes #4299

#### Describe the changes you have made in this PR -
- Added `from http import HTTPStatus` to `integrations/grafana/base.py`
- Replaced the raw integer status code `204` with `HTTPStatus.NO_CONTENT` in `_make_post_request`

### Demo/Screenshot for feature changes and bug fixes - 
N/A - This is a pure refactor that replaces an integer literal with an Enum constant (`HTTPStatus.NO_CONTENT == 204`). Behavior stays identical.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
This PR solves the issue by replacing a bare numeric HTTP status code with its matching standard library enum constant in `base.py`. I audited the file and confirmed this is the only occurrence of a raw status code. No alternative approaches were needed since this is a 1:1 replacement mandated by project rules (as seen in sibling files `loki.py` and `log_sink.py`).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
