### PR TITLE
docs(ci): require post-push PR monitoring

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -110,11 +110,77 @@ make verify-integrations
 If Fargate CDK code, its deployment commands, or infrastructure tests changed,
 also run:
 
-## 5) Optional extra confidence
+## 5) Mandatory post-push PR monitoring
+
+Opening or updating a PR does not finish the task. After every push, continue
+monitoring and fixing the PR without waiting for another prompt until all exit
+conditions below pass or an external dependency is genuinely blocking progress.
+
+1. Verify that the PR is reviewing the commit you just pushed:
+
+   ```bash
+   LOCAL_SHA=$(git rev-parse HEAD)
+   REMOTE_SHA=$(gh pr view --json headRefOid -q .headRefOid)
+   test "$LOCAL_SHA" = "$REMOTE_SHA"
+   ```
+
+   Do not trigger a review or wait on results for a stale remote head.
+
+2. Watch every reported check, including CI shards, CodeQL, synthetic tests,
+   and installed review integrations:
+
+   ```bash
+   gh pr checks --watch --interval 30
+   ```
+
+   A conditionally skipped job is neutral. Pending, queued, failing, cancelled,
+   errored, or timed-out required checks do not satisfy the gate.
+
+3. Inspect all review surfaces, not only Actions checks:
+
+   ```bash
+   gh pr view --json reviewDecision,reviews,statusCheckRollup
+   gh api repos/{owner}/{repo}/pulls/{pr}/comments
+   gh api repos/{owner}/{repo}/issues/{pr}/comments
+   ```
+
+   Also inspect unresolved GitHub review threads. Review apps may publish their
+   score in a PR comment or review instead of an Actions check. When Greptile is
+   installed, require a **5/5 score for the current head commit** and zero
+   unresolved Greptile threads; do not accept a stale score from an older push.
+
+4. For each failure or actionable review comment:
+
+   - Read the full log or thread before changing code. For Actions failures,
+     use `gh run view <run-id> --log-failed` and reproduce the smallest relevant
+     command locally when possible.
+   - Fix the root cause, run the focused checks, commit, and push to the same PR
+     branch.
+   - Resolve a review thread only after its concern is addressed or clearly
+     explained as non-actionable.
+   - Restart this section from the remote-head verification step after every
+     push. Rerun a job without a code change only for a credible flaky or
+     external failure, never to hide a deterministic failure.
+
+The PR monitoring loop is complete only when:
+
+- every required CI and security check is successful or legitimately skipped;
+- there are no unresolved actionable human or bot review threads and no active
+  changes-requested review;
+- Greptile, when configured, reports 5/5 for the current head with zero
+  unresolved comments; and
+- the PR is mergeable.
+
+If credentials, an unavailable external service, or maintainer-only action
+prevents completion, report that concrete blocker instead of claiming the PR is
+ready. `CI.md` defines the agent workflow; it does not authorize a GitHub
+workflow to modify arbitrary contributor branches automatically.
+
+## 6) Optional extra confidence
 
 You may run `make check` as a final pass, but it is heavier (`test-full`) than the required harness.
 
-## 6) Interactive-shell turn tests
+## 7) Interactive-shell turn tests
 
 Interactive-shell live turn tests always run with live coverage enabled. Do not use deselection filters like `-k "not live_llm"`. Fix failures by improving planner/tool correctness or updating fixtures only when behavior changes are explicitly approved.
 
@@ -137,7 +203,7 @@ In CI, [`.github/workflows/interactive-shell-live.yml`](.github/workflows/intera
 
 `@live` gather scenarios **fail** (not skip) in GitHub Actions when integration credentials are missing; locally they may still skip. Natural-language investigation dispatch is **enabled** by default (`INTERACTIVE_SHELL_INVESTIGATION_ENABLED = True`). Investigation dispatch scenarios run in `turn-live`; if the flag is set to `False` for emergency rollback, those scenarios **skip** in live shards and `turn-checks` stays green. Require all `turn-checks` and `turn-live shard *` checks on `main` branch protection.
 
-## 7) CI-only tests
+## 8) CI-only tests
 
 Some paths require live infrastructure and are excluded from `make test-cov`:
 


### PR DESCRIPTION
Refs #4804

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Add a mandatory post-push PR monitoring loop to `CI.md`.
- Require agents to verify that the remote PR head matches the local commit before waiting on results.
- Require monitoring across Actions shards, CodeQL, synthetic checks, human reviews, bot reviews, issue comments, inline comments, and unresolved threads.
- Define completion as green required checks, a mergeable PR, no unresolved actionable feedback, and current-head Greptile 5/5 with zero unresolved comments when Greptile is installed.
- Document the fix/retest/repush cycle and distinguish legitimate flaky reruns from attempts to hide deterministic failures.

The policy requires coding agents to continue the monitoring and remediation loop automatically. It deliberately does not authorize a GitHub Actions workflow to write arbitrary fixes to contributor branches; automated code modification requires a separately designed and secured bot boundary.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ git status --short
# clean
```

This is a contributor-process-only change, so the documentation shortcut in `CI.md` applies.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The new section turns post-push review into an explicit exit-gated loop rather than treating PR creation as completion. It checks the published SHA first, watches all CI/security jobs, then separately inspects human and bot review surfaces because review integrations do not always appear as Actions checks. Every new push invalidates the prior result and restarts the loop.

The guidance distinguishes agent-driven remediation from a self-modifying CI workflow. The former operates with the active contributor's reviewed credentials and context; the latter would require additional permission, trust, fork-safety, and branch-protection design outside this documentation change.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the change handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My change follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
