### PR TITLE
fix(interactive-shell): reserve stdin for the /background status table

### DIFF
--- a/surfaces/interactive_shell/runtime/utils/input_policy.py
+++ b/surfaces/interactive_shell/runtime/utils/input_policy.py
@@ -58,6 +58,7 @@ _EXCLUSIVE_STDIN_MENU_COMMANDS: frozenset[str] = frozenset(
         "/resume",
         "/new",
         "/rca",
+        "/background",
     }
 )
 _EXCLUSIVE_STDIN_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -122,6 +122,24 @@ def test_turn_needs_exclusive_stdin_for_integration_remove(
     )
 
 
+def test_turn_needs_exclusive_stdin_for_background_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare ``/background`` defaults to the status table, so the next prompt must
+    wait for the drain; otherwise the redraw's CPR response lands in the incoming
+    prompt buffer. Arg-bearing forms follow ``/integrations list`` above and stay
+    out of the menu gate."""
+    monkeypatch.setattr(loop_input_policy, "repl_tty_interactive", lambda: True)
+    session = Session()
+
+    assert loop_input_policy.turn_needs_exclusive_stdin("/background", session) is True
+
+    assert loop_input_policy.turn_needs_exclusive_stdin("/background list", session) is False
+    assert loop_input_policy.turn_needs_exclusive_stdin("/background on", session) is False
+    # Bare command words are not recognized under literal-/slash gating.
+    assert loop_input_policy.turn_needs_exclusive_stdin("background", session) is False
+
+
 def test_turn_needs_exclusive_stdin_for_onboard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #4838

#### Describe the changes you have made in this PR -

Bare `/background` falls through to its `status` subcommand, which prints a Rich table via
`print_repl_table`. The command was in neither exclusive-stdin set, so under
`patch_stdout(raw=True)` the REPL ran dispatch concurrently with the next `prompt_async()`.
`surfaces/interactive_shell/AGENTS.md` ("CPR / exclusive-stdin registration") requires any
command calling `print_repl_table` to be listed in `_EXCLUSIVE_STDIN_MENU_COMMANDS`. This
adds it.

Registration also drops the duplicate `$ /background` banner, since `slash.py:220` prints
that banner only when exclusive stdin is inactive.

**Scope.** The menu set is consulted only when the command carries no arguments
(`input_policy.py:121`), so `/background list` and `/background show <id>` are unchanged.
That matches `/integrations list` and `/verify <service>`, which print through the same
helper and are asserted *not* to reserve stdin in
`tests/interactive_shell/test_terminal_runtime_turns.py:42,47`. Extending the rule to
arg-bearing forms would touch five commands and flip two passing assertions, so I would
rather raise that separately than widen this fix.

### Demo/Screenshot for feature changes and bug fixes -

Driving the REPL in a pseudo-TTY that answers `ESC[6n` cursor-position queries the way a
real terminal does. Two runs per branch, identical results:

| | `main` | this branch |
| --- | --- | --- |
| `ESC[6n` queries answered during the turn | 4 | **2** |
| `$ /background` banner occurrences | 1 | **0** |

The halved count is the mechanism the rule targets: with exclusive stdin the next prompt is
not redrawing while the table is written, so it stops asking where the cursor is.

I could not reproduce the visible `^[[<row>;<col>R` garbage in a bare pty on either branch,
so I am not claiming it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I first wrote a wider fix that also registered `status`, `list` and `show` in
`_EXCLUSIVE_STDIN_SUBCOMMANDS`, assuming `/rca` was the precedent for table commands. It is
not. `/rca list|show|history|save` are registered because they open a raw-stdin arrow-key
picker, and all nine members of that set are pickers or wizards rather than tables. Adding
table entries would have given the set a second meaning and contradicted the two passing
assertions cited above, so I narrowed the change to exactly what the documented rule asks
for.

The test asserts both directions, the bare form reserving stdin and the arg-bearing forms
not, so a later change either way trips it deliberately.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
