### PR TITLE
fix(agent-harness): register the subprocess presenter so the default agent can execute

### DIFF
--- a/bootstrap/adapters.py
+++ b/bootstrap/adapters.py
@@ -31,13 +31,18 @@ def install_harness_adapters() -> None:
     nothing until both registries have been installed. Also installs the
     investigation payload runner used by :meth:`AgentSession.investigate`.
     """
+    import platform.harness_ports as harness_ports
     from integrations.harness_adapters import (
         register_harness_adapters as register_integrations,
     )
     from tools.harness_adapters import register_harness_adapters as register_tools
+    from tools.interactive_shell.subprocess_presenter import (
+        headless_subprocess_presenter_factory,
+    )
 
     register_integrations()
     register_tools()
+    harness_ports.set_subprocess_presenter_factory(headless_subprocess_presenter_factory)
     install_investigation_api()
 
 

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -309,6 +309,7 @@ __all__ = [
     "RunRecordFactory",
     "SessionBindable",
     "SessionStore",
+    "SubprocessPresenterFactory",
     "ToolEventObserver",
     "ToolProvider",
     "ToolRegistry",

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -314,3 +314,12 @@ __all__ = [
     "ToolRegistry",
     "TurnAccounting",
 ]
+
+
+# Builds the presenter that streams a subprocess tool's output. The concrete
+# presenter lives in ``tools`` (process helpers), so this seam is how a host
+# hands one to the agent without ``core`` importing ``tools``.
+SubprocessPresenterFactory = Callable[
+    [Any, Any, "ConfirmFn | None", bool | None, bool],
+    Any,
+]

--- a/core/agent_harness/tools/tool_provider.py
+++ b/core/agent_harness/tools/tool_provider.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from core.agent_harness.ports import (
     ConfirmFn,
+    SubprocessPresenterFactory,
     ToolEventObserver,
 )
 from core.agent_harness.tools.action_tools import get_action_tools_from_integrations_context
@@ -18,10 +19,7 @@ from core.agent_harness.tools.tool_context import (
 
 ActionObserverFactory = Callable[[str], ToolEventObserver]
 # Return value is tools.interactive_shell.subprocess.SubprocessPresenter (surface-injected).
-SubprocessPresenterFactory = Callable[
-    [Any, Any, ConfirmFn | None, bool | None, bool],
-    Any,
-]
+
 
 InvestigationPortsFactory = Callable[[], Any]
 LlmProviderPortsFactory = Callable[[], Any]

--- a/core/agent_harness/turns/default_headless_agent.py
+++ b/core/agent_harness/turns/default_headless_agent.py
@@ -22,13 +22,17 @@ from rich.console import Console
 from core.agent_harness.accounting.run_record import DefaultRunRecordFactory
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.error_reporting import DefaultErrorReporter
-from core.agent_harness.ports import OutputSink, PromptContextProvider, TurnAccounting
+from core.agent_harness.ports import (
+    OutputSink,
+    PromptContextProvider,
+    SubprocessPresenterFactory,
+    TurnAccounting,
+)
 from core.agent_harness.prompts.grounding import DefaultPromptContextProvider
 from core.agent_harness.tools.tool_provider import (
     ActionObserverFactory,
     DefaultToolProvider,
     SlashPortsFactory,
-    SubprocessPresenterFactory,
 )
 from core.agent_harness.turns.default_reasoning_client import DefaultReasoningClientProvider
 from core.agent_harness.turns.gather_ports import GATHER_DISABLED, GatherPorts
@@ -58,6 +62,24 @@ def _resolve_gather(
     if not gather_enabled:
         return GATHER_DISABLED
     return GatherPorts(enabled=True, max_iterations=gather_max_iterations)
+
+
+def _resolved_presenter_factory(
+    explicit: SubprocessPresenterFactory | None,
+) -> SubprocessPresenterFactory | None:
+    """Return the caller's presenter, else the one registered at process boot.
+
+    Without this the default port stack has no presenter, so ``shell_run``
+    refuses every call and the agent degrades into describing a plan it cannot
+    run. A host that wants different behavior (a TTY console) still passes its
+    own factory and wins.
+    """
+    if explicit is not None:
+        return explicit
+    import platform.harness_ports as harness_ports
+
+    registered: SubprocessPresenterFactory | None = harness_ports.get_subprocess_presenter_factory()
+    return registered
 
 
 def build_default_headless_agent(
@@ -107,7 +129,7 @@ def build_default_headless_agent(
             console,
             tool_action_logger=tool_action_logger or logger,
             observer_factory=observer_factory,
-            subprocess_presenter_factory=subprocess_presenter_factory,
+            subprocess_presenter_factory=_resolved_presenter_factory(subprocess_presenter_factory),
             slash_ports_factory=slash_ports_factory,
         ),
         # ``is not None``, not ``or``: a provider defining __bool__ would be

--- a/gateway/core/runtime/session_agents.py
+++ b/gateway/core/runtime/session_agents.py
@@ -20,12 +20,12 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.turns.default_headless_agent import build_default_headless_agent
 from core.agent_harness.turns.gather_ports import GatherPorts
 from core.agent_harness.turns.headless_dispatch import HeadlessAgent
-from gateway.core.runtime.headless_subprocess_presenter import (
-    headless_subprocess_presenter_factory,
-)
 from gateway.core.runtime.live_sink import LiveOutputSink
 from gateway.core.runtime.sink_protocol import GatewaySink
 from gateway.core.runtime.status_messages import status_from_tool_start
+from tools.interactive_shell.subprocess_presenter import (
+    headless_subprocess_presenter_factory,
+)
 
 SlashPortsFactory = Callable[[], Any]
 

--- a/gateway/tests/main/test_antartica_slack.py
+++ b/gateway/tests/main/test_antartica_slack.py
@@ -24,7 +24,7 @@ from core.agent_harness.tools.action_tools import action_tool_names
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import ActionTurnRunner, ToolCallingDeps
 from core.llm.types import AgentLLMResponse, ToolCall
-from gateway.core.runtime.headless_subprocess_presenter import (
+from tools.interactive_shell.subprocess_presenter import (
     headless_subprocess_presenter_factory,
 )
 from tools.registry import clear_tool_registry_cache

--- a/platform/harness_ports.py
+++ b/platform/harness_ports.py
@@ -22,6 +22,8 @@ from core.tool_framework.registered_tool import RegisteredTool
 if TYPE_CHECKING:
     from core.agent_harness.ports import ToolRegistry
 
+from core.agent_harness.ports import SubprocessPresenterFactory
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -676,6 +678,7 @@ def reset_harness_ports() -> None:
     clear_assistant_prompt_fragments()
     clear_gateway_persona_fragments()
     clear_message_context_prefix_strippers()
+    set_subprocess_presenter_factory(None)
 
     # Core leaf registries (populated by integrations/harness_adapters).
     from core.domain.alerts.alert_source import (
@@ -695,3 +698,24 @@ def reset_harness_ports() -> None:
     clear_alert_detail_fields()
     clear_taxonomy_profiles()
     clear_anchor_parsers()
+
+
+# --- Subprocess presenter -------------------------------------------------
+#
+# Streaming shell/CLI output needs a presenter that lives in ``tools`` (its
+# process helpers) and is therefore invisible to ``core.agent_harness``.
+# Registering it here lets the default agent execute shell tools instead of
+# refusing them, without core importing tools or gateway.
+
+_subprocess_presenter_factory: SubprocessPresenterFactory | None = None
+
+
+def set_subprocess_presenter_factory(factory: SubprocessPresenterFactory | None) -> None:
+    """Register (or clear) the presenter the default agent gives shell tools."""
+    global _subprocess_presenter_factory
+    _subprocess_presenter_factory = factory
+
+
+def get_subprocess_presenter_factory() -> SubprocessPresenterFactory | None:
+    """Return the registered presenter factory, or ``None`` before boot."""
+    return _subprocess_presenter_factory

--- a/tests/bootstrap/test_subprocess_presenter_port.py
+++ b/tests/bootstrap/test_subprocess_presenter_port.py
@@ -1,0 +1,80 @@
+"""The default agent must be able to run shell tools after process boot.
+
+``AgentSession.start()`` is the documented Python entry point. With no
+subprocess presenter, ``shell_run`` refuses every call ("subprocess presenter
+is required for this action tool") and the agent silently degrades to writing
+a plan it cannot execute — which reads as a reasoning failure but is a wiring
+gap. Observed live: the 5-step goal prompt returned PLANNED=4 / EXECUTED=0.
+
+The presenter cannot be a core default: it lives in ``tools`` (its process
+helpers) and ``core.agent_harness`` may import neither ``tools`` nor
+``gateway``. It is registered on this port at process boot instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+import platform.harness_ports as harness_ports
+
+
+@pytest.fixture(autouse=True)
+def _restore_port() -> Iterator[None]:
+    """Keep this module's writes out of every other test in the process."""
+    previous = harness_ports.get_subprocess_presenter_factory()
+    yield
+    harness_ports.set_subprocess_presenter_factory(previous)
+
+
+def test_process_boot_installs_a_subprocess_presenter_for_the_default_agent() -> None:
+    """Boot leaves a presenter registered so the default port stack can execute."""
+    # Arrange.
+    harness_ports.set_subprocess_presenter_factory(None)
+
+    # Act.
+    from bootstrap.adapters import install_harness_adapters
+
+    install_harness_adapters()
+
+    # Assert.
+    assert harness_ports.get_subprocess_presenter_factory() is not None
+
+
+def test_resetting_the_harness_ports_clears_the_presenter() -> None:
+    """A booted presenter must not leak into tests that reset the ports.
+
+    ``reset_harness_ports`` is the suite's "back to noop defaults" call; a port
+    it forgets stays registered for the rest of the process.
+    """
+
+    # Arrange: something registered, as after boot.
+    def _presenter(*_args: object, **_kwargs: object) -> object:
+        return object()
+
+    harness_ports.set_subprocess_presenter_factory(_presenter)
+
+    # Act.
+    harness_ports.reset_harness_ports()
+
+    # Assert.
+    assert harness_ports.get_subprocess_presenter_factory() is None
+
+
+def test_an_explicit_presenter_wins_over_the_registered_one() -> None:
+    """A host with its own presenter (TTY console) must not get the headless default."""
+    # Arrange.
+    from core.agent_harness.turns.default_headless_agent import _resolved_presenter_factory
+
+    def _registered(*_args: object, **_kwargs: object) -> object:
+        return object()
+
+    def _explicit(*_args: object, **_kwargs: object) -> object:
+        return object()
+
+    harness_ports.set_subprocess_presenter_factory(_registered)
+
+    # Act / Assert.
+    assert _resolved_presenter_factory(_explicit) is _explicit
+    assert _resolved_presenter_factory(None) is _registered

--- a/tools/interactive_shell/subprocess_presenter.py
+++ b/tools/interactive_shell/subprocess_presenter.py
@@ -1,4 +1,10 @@
-"""Headless subprocess presenter for gateway and other non-TTY agent surfaces."""
+"""Subprocess presenter for non-TTY agent surfaces (gateway, scheduled, embedded).
+
+Lives beside its process helpers in ``tools`` rather than in ``gateway``: every
+non-TTY host needs it, and ``core.agent_harness`` may import neither package.
+:func:`bootstrap.adapters.install_harness_adapters` registers it on the
+harness port so the default agent can execute shell tools after process boot.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
The defect: **`AgentSession.start()` produced an agent that could not run
`shell_run`.** `build_default_headless_agent` defaulted
`subprocess_presenter_factory=None`, so the tool refused every call and the
agent degraded into writing a plan and explaining it was blocked. That reads
exactly like a reasoning failure, which is why it was filed as one. It is the
documented Python entry point, so anyone following README or
`docs/python-api.mdx` got a planning-only agent.

Reproduced with the milestone's own test prompt, changing one argument:

| Entry point | Result |
| --- | --- |
| `AgentSession.start()` | PLANNED 4, **EXECUTED 0** |
| Same, plus a subprocess presenter | PLANNED 5, **EXECUTED 5** |

**Why the default was `None`:** a layering trap, not an oversight. The
presenter lived in `gateway/` but imports `tools.interactive_shell.*`, and
`core.agent_harness` may import neither `gateway` nor `tools`. Core could not
default to it, so the shell and gateway each wired their own copy and every
other host silently got nothing.

**The fix** uses the seam this repo already has for exactly this problem, a
harness port registered at process boot:

* `platform/harness_ports.py` gains `set/get_subprocess_presenter_factory`
* `bootstrap/adapters.py::install_harness_adapters()` registers it alongside
  the tool and integration adapters
* `build_default_headless_agent` falls back to the registered port. An explicit
  factory still wins, so the shell's TTY presenter is unchanged
* the presenter moves to `tools/interactive_shell/subprocess_presenter.py`,
  beside its process helpers. Its own docstring already described it as "for
  gateway and other non-TTY agent surfaces"

`SubprocessPresenterFactory` moves from `tools/tool_provider.py` to
`core/agent_harness/ports.py`. Typing the port properly rather than as `Any`
created a circular import, and per AGENTS.md that is fixed structurally by
moving the shared symbol to the leaf seam both sides already import, not by a
lazy import.

`reset_harness_ports()` now clears the new port. Without that, a presenter
registered by one test's boot leaks into every later test in the process.

### Demo/Screenshot for feature changes and bug fixes -

Milestone #4's test prompt, through the plain documented API with nothing extra
passed:

    ANSWERED: False
    PLANNED: 5 | EXECUTED: 5 | SUCCEEDED: 5 | HANDLED: True

    | Step | n  | Running total |
    | 1    | 30 | 30  |
    | 2    | 30 | 60  |
    | 3    | 3  | 63  |
    | 4    | 72 | 135 |
    | 5    | 24 | 159 |

Real side effects on disk, not narration. `/tmp/random_total_state.json`:

    {
      "total": 159,
      "steps": [
        {"step": 1, "n": 30, "status": "committed", "prev_total": 0,  "total_after": 30},
        {"step": 2, "n": 30, "status": "committed", "prev_total": 30, "total_after": 60},
        ...
      ]
    }

The agent ran all five steps in one turn, wrote a started/committed write-ahead
trail with atomic `os.replace`, and never asked "want me to continue?". The
milestone's stated symptom did not appear once execution was possible.

Gates:

    pytest (CI scope)  14,050 passed, 31 skipped, 1 failed (see below)
    mypy               Success: no issues found in 1691 source files
    ruff check/format  All checks passed
    check_imports      All 3 import checks passed

The single failure is
`tests/platform/terminal/test_theme.py::test_rich_renders_each_token_with_its_own_color`.
It passes in isolation and passes under parallel execution within
`tests/platform` (359 passed). It fails only in the whole-suite run and touches
none of the files in this PR. Rich's theme is process-global, so this is
cross-module contention. Pre-existing, though I did not isolate the colliding
module.