### PR TITLE
fix(reporting): render WhatsApp and SMS links as plain text

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -236,6 +236,7 @@ from config.constants.redis import (
     REDIS_SSL_ENV,
     REDIS_USERNAME_ENV,
 )
+from config.constants.reporting import SLACK_LINK_RE
 from config.constants.runtime_metadata import (
     GITHUB_REPO_ENV,
     GITHUB_REPOSITORY_ENV,
@@ -523,6 +524,7 @@ __all__ = [
     "SIGNOZ_URL_ENV",
     "SLACK_APP_TOKEN_ENV",
     "SLACK_BOT_TOKEN_ENV",
+    "SLACK_LINK_RE",
     "SMTP_DEFAULT_TO_ENV",
     "SMTP_FROM_ADDRESS_ENV",
     "SMTP_HOST_ENV",

--- a/config/constants/reporting.py
+++ b/config/constants/reporting.py
@@ -1,0 +1,12 @@
+"""Constants shared across the investigation reporting package."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+# Matches Slack-style links: <url|label> or <url>. Shared between the WhatsApp
+# formatter and the terminal plain-text renderer so both stay in step.
+SLACK_LINK_RE: Final[re.Pattern[str]] = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
+
+__all__ = ["SLACK_LINK_RE"]

--- a/tests/delivery/test_terminal_renderer.py
+++ b/tests/delivery/test_terminal_renderer.py
@@ -5,10 +5,10 @@ from collections.abc import Generator
 import pytest
 
 from platform.terminal.theme import DEFAULT_THEME_NAME, set_active_theme
+from tools.investigation.reporting.formatters.base import slack_links_to_plain_text
 from tools.investigation.reporting.renderers.terminal import (
     _rich_line_with_links,
     _strip_mrkdwn,
-    _strip_slack_links,
     render_report,
 )
 
@@ -125,7 +125,7 @@ def test_strip_mrkdwn(raw: str, expected: str) -> None:
             "A (https://a.test) and B (https://b.test)",
         ),
         # No Slack-style link -> passthrough (including bare URLs, which
-        # _strip_slack_links is not responsible for).
+        # slack_links_to_plain_text is not responsible for).
         ("plain text", "plain text"),
         (
             "https://example.com without angle brackets",
@@ -135,8 +135,8 @@ def test_strip_mrkdwn(raw: str, expected: str) -> None:
         ("", ""),
     ],
 )
-def test_strip_slack_links(raw: str, expected: str) -> None:
-    assert _strip_slack_links(raw) == expected
+def test_slack_links_to_plain_text(raw: str, expected: str) -> None:
+    assert slack_links_to_plain_text(raw) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/delivery/test_whatsapp_plain_text.py
+++ b/tests/delivery/test_whatsapp_plain_text.py
@@ -1,0 +1,68 @@
+"""WhatsApp and SMS are plain-text channels: no Slack link markup may reach them."""
+
+from __future__ import annotations
+
+from tools.investigation.reporting.context import build_report_context
+from tools.investigation.reporting.formatters.messages import build_report_messages
+from tools.investigation.reporting.formatters.report import format_whatsapp_message
+
+
+def _make_state() -> dict:
+    return {
+        "alert_name": "Checkout latency spike",
+        "severity": "critical",
+        "root_cause": "Checkout service was throttled by the upstream API cluster.",
+        "validated_claims": [
+            {
+                "claim": "Grafana logs show repeated 500 responses.",
+                "evidence_sources": ["grafana_logs"],
+            }
+        ],
+        "available_sources": {
+            "grafana": {
+                "grafana_endpoint": "https://myorg.grafana.net",
+                "service_name": "checkout-api",
+            },
+        },
+        "evidence": {
+            "grafana_logs": [{"message": "service unavailable"}],
+            "grafana_logs_query": '{service="checkout-api"}',
+        },
+    }
+
+
+def test_whatsapp_message_renders_evidence_links_as_plain_text() -> None:
+    body = format_whatsapp_message(build_report_context(_make_state()))
+
+    assert "<https://" not in body
+    assert "E1 (https://myorg.grafana.net" in body
+
+
+def test_whatsapp_message_renders_s3_trace_links_as_plain_text() -> None:
+    state = _make_state()
+    state["raw_alert"] = {
+        "annotations": {
+            "landing_bucket": "tracer-landing",
+            "s3_key": "runs/checkout/input.json",
+        },
+    }
+
+    body = format_whatsapp_message(build_report_context(state))
+
+    assert "<https://" not in body
+    assert "S3 object (https://" in body
+
+
+def test_sms_body_carries_no_slack_link_markup() -> None:
+    messages = build_report_messages(build_report_context(_make_state()))
+
+    assert messages.sms_text == messages.whatsapp_text
+    assert "<https://" not in messages.sms_text
+
+
+def test_slack_and_telegram_keep_their_own_link_syntax() -> None:
+    """The plain-text conversion must not bleed into the other channels."""
+    messages = build_report_messages(build_report_context(_make_state()))
+
+    assert "<https://myorg.grafana.net" in messages.slack_text
+    assert '<a href="https://myorg.grafana.net' in messages.telegram_html

--- a/tools/investigation/reporting/formatters/base.py
+++ b/tools/investigation/reporting/formatters/base.py
@@ -1,10 +1,13 @@
 """Base formatting utilities for report generation."""
 
+from __future__ import annotations
+
 import html
 import re
 
-# Matches Slack-style links: <url|label> or <url>
-SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
+from config.constants import SLACK_LINK_RE
+
+__all__ = ["format_html_link", "format_slack_link", "shorten_text", "slack_links_to_plain_text"]
 
 
 def shorten_text(text: str, max_chars: int = 120, suffix: str = "...") -> str:

--- a/tools/investigation/reporting/formatters/base.py
+++ b/tools/investigation/reporting/formatters/base.py
@@ -1,6 +1,10 @@
 """Base formatting utilities for report generation."""
 
 import html
+import re
+
+# Matches Slack-style links: <url|label> or <url>
+SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
 
 
 def shorten_text(text: str, max_chars: int = 120, suffix: str = "...") -> str:
@@ -30,6 +34,22 @@ def format_slack_link(label: str, url: str | None) -> str:
 
     safe_label = label.replace("|", "¦").strip() or url
     return f"<{url}|{safe_label}>"
+
+
+def slack_links_to_plain_text(text: str) -> str:
+    """Convert Slack ``<url|label>`` links to plain ``label (url)``.
+
+    The inverse of :func:`format_slack_link`, for channels that render no markup
+    (WhatsApp, SMS, terminal plain-text mode). The URL is kept because
+    plain-text clients auto-linkify bare URLs.
+    """
+
+    def _repl(match: re.Match[str]) -> str:
+        url = str(match.group(1))
+        label = match.group(2)
+        return f"{label} ({url})" if label else url
+
+    return SLACK_LINK_RE.sub(_repl, text)
 
 
 def format_html_link(label: str, url: str | None) -> str:

--- a/tools/investigation/reporting/formatters/report.py
+++ b/tools/investigation/reporting/formatters/report.py
@@ -7,6 +7,7 @@ from tools.investigation.reporting.context import ReportContext
 from tools.investigation.reporting.formatters.base import (
     format_html_link,
     format_slack_link,
+    slack_links_to_plain_text,
 )
 from tools.investigation.reporting.formatters.evidence import (
     format_cited_evidence_section,
@@ -723,7 +724,9 @@ def format_whatsapp_message(ctx: ReportContext) -> str:
     if meta_bits:
         parts.append(" | ".join(meta_bits))
 
-    return "\n\n".join(p for p in parts if p)
+    # Shared helpers emit Slack <url|label> links; WhatsApp and SMS render no
+    # markup, so convert at this boundary to plain `label (url)` form.
+    return slack_links_to_plain_text("\n\n".join(p for p in parts if p))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/investigation/reporting/renderers/terminal.py
+++ b/tools/investigation/reporting/renderers/terminal.py
@@ -10,14 +10,16 @@ from rich.text import Text
 
 from platform.observability import get_output_format
 from platform.terminal.theme import BRAND, DIM, HIGHLIGHT, WARNING
+from tools.investigation.reporting.formatters.base import (
+    SLACK_LINK_RE,
+    slack_links_to_plain_text,
+)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
 _URL_RE = re.compile(r"https?://\S+")
-# Matches Slack-style links: <url|label> or <url>
-_SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
 
 
 def _rich_line_with_links(text: str) -> Text:
@@ -25,7 +27,7 @@ def _rich_line_with_links(text: str) -> Text:
     result = Text()
     cursor = 0
 
-    for m in _SLACK_LINK_RE.finditer(text):
+    for m in SLACK_LINK_RE.finditer(text):
         # Text before the match
         if m.start() > cursor:
             result.append(text[cursor : m.start()])
@@ -47,17 +49,6 @@ def _rich_line_with_links(text: str) -> Text:
         result.append(remaining[sub_cursor:])
 
     return result
-
-
-def _strip_slack_links(text: str) -> str:
-    """Convert Slack <url|label> to plain 'label (url)' for plain text mode."""
-
-    def _repl(m: re.Match[str]) -> str:
-        url = str(m.group(1))
-        label = m.group(2)
-        return f"{label} ({url})" if label else url
-
-    return _SLACK_LINK_RE.sub(_repl, text)
 
 
 def _strip_mrkdwn(text: str) -> str:
@@ -251,5 +242,5 @@ def _render_rich_report(slack_message: str) -> str:
 
 
 def _render_plain_report(slack_message: str) -> str:
-    clean = _strip_slack_links(_strip_mrkdwn(slack_message))
+    clean = slack_links_to_plain_text(_strip_mrkdwn(slack_message))
     return f"\n{clean}\n"

--- a/tools/investigation/reporting/renderers/terminal.py
+++ b/tools/investigation/reporting/renderers/terminal.py
@@ -8,12 +8,10 @@ import sys
 from rich.console import Console
 from rich.text import Text
 
+from config.constants import SLACK_LINK_RE
 from platform.observability import get_output_format
 from platform.terminal.theme import BRAND, DIM, HIGHLIGHT, WARNING
-from tools.investigation.reporting.formatters.base import (
-    SLACK_LINK_RE,
-    slack_links_to_plain_text,
-)
+from tools.investigation.reporting.formatters.base import slack_links_to_plain_text
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers


### PR DESCRIPTION
Fixes #4695

#### Describe the changes you have made in this PR -

WhatsApp and SMS recipients were shown Slack's link markup verbatim — `[<https://grafana…|E1>]` instead of a readable citation. `format_whatsapp_message` builds its body from Slack-flavoured helpers, and two of them emit `<url|label>` through `format_slack_link`:

| Helper | Line | What leaked |
|---|---|---|
| `_render_claim_lines` | `report.py:114` | evidence citations `[E1]` |
| `build_investigation_trace` | `infrastructure.py:288,294` | "Input data inspected" / "Audit trail found" S3 console links |

Telegram already dodges this with its own `_render_claim_lines_telegram` calling `format_html_link`. WhatsApp was the only channel with no plain-text path, and `ReportMessages.sms_text` returns `whatsapp_text`, so SMS inherited the bug.

The conversion happens at the WhatsApp boundary rather than per-helper. That covers citations, trace links, and any Slack link a future change adds upstream, in one place — the same approach `_render_plain_report` already takes for terminal output (`renderers/terminal.py:242`).

`label (url)` keeps the URL rather than dropping it, because WhatsApp and SMS auto-linkify bare URLs — a bare `E1` would lose the link entirely. That form was already the repo's convention, pinned by the existing terminal-renderer tests.

**On the shared helper.** The `label (url)` conversion already existed as `_strip_slack_links` in `renderers/terminal.py`, byte-identical to what WhatsApp needs. Rather than add a second copy, it moves next to its inverse `format_slack_link` in `formatters/base.py` and both callers use it. `_rich_line_with_links` keeps using the same regex, now imported. The existing parametrized cases in `test_terminal_renderer.py` follow the rename and become coverage for the shared helper.

Not touched: `integrations/telegram/markdown.py:16` holds a third copy of that regex, but it drives an HTML conversion rather than plain text, so folding it in would change Telegram behavior. Left for a separate change.

### Demo/Screenshot for feature changes and bug fixes -

Same `ReportContext` in both runs (the reproduction from #4695, plus a remediation step).

**Before**
```
[CRITICAL] OpenSRE Investigation

Connection pool exhausted on orders-db

*Findings*
• Pool saturation began at 14:02 UTC. [<https://grafana.example.com/d/abc/db?viewPanel=7|E1>]

*Recommended Actions*
• Raise max_connections to 200.
```

**After**
```
[CRITICAL] OpenSRE Investigation

Connection pool exhausted on orders-db

*Findings*
• Pool saturation began at 14:02 UTC. [E1 (https://grafana.example.com/d/abc/db?viewPanel=7)]

*Recommended Actions*
• Raise max_connections to 200.
```

Slack and Telegram are byte-identical before and after — `test_slack_and_telegram_keep_their_own_link_syntax` guards that, and it passed against unpatched `main` as well as after the fix.

Local checks, per `CI.md`. `tools/investigation/` is on the §3 escalation list, so this ran the full suite rather than scoped tests:

```
$ make lint
All checks passed!

$ make format-check
3105 files already formatted

$ make typecheck
Success: no issues found in 1577 source files

$ make test-cov
========== 13134 passed, 63 skipped, 7 warnings in 249.92s (0:04:09) ==========

$ make verify-integrations-smoke
============================== 31 passed in 1.08s ==============================
```

The two `test_runtime_metadata_perf` failures observed under `make test-cov` (5ms wall-clock assertions against `build_runtime_metadata`) pass in isolation AND against baseline `main` via `git stash`. Pre-existing full-suite flake, unrelated to this change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The fix has one decision: where to convert Slack markup to plain text. I considered (a) per-helper rewrites in `_render_claim_lines` and `build_investigation_trace`, and (b) a single boundary conversion at the WhatsApp formatter exit. (a) is brittle — any future Slack-link producer upstream of WhatsApp would silently leak. (b) matches the precedent already set by `_render_plain_report` for the terminal plain-text path, which calls the same `_strip_slack_links` on its output. Reusing that helper was the obvious move, but it lived in `renderers/terminal.py` as a module-private duplicate of the regex and function in `formatters/base.py`. Promoting it to `base.py` as `slack_links_to_plain_text` (the inverse of `format_slack_link`) lets both callers — the WhatsApp formatter and the terminal plain-text renderer — share one regex and one function. The terminal test cases for the renamed helper come along for free and pin the contract.

Key files:
- `tools/investigation/reporting/formatters/base.py` — adds `SLACK_LINK_RE` and `slack_links_to_plain_text`
- `tools/investigation/reporting/formatters/report.py:727` — wraps `format_whatsapp_message` output through the helper
- `tools/investigation/reporting/renderers/terminal.py` — drops `_SLACK_LINK_RE` and `_strip_slack_links`, imports the shared versions
- `tests/delivery/test_terminal_renderer.py` — rename test follows the symbol
- `tests/delivery/test_whatsapp_plain_text.py` — new regression tests covering citations, S3 trace links, SMS parity, and Slack/Telegram non-regression

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
