### PR TITLE
perf(context_budget): cache message token estimates across ReAct thinks

### DIFF
--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
 
@@ -46,17 +47,25 @@ _DUPLICATE_RESULT_KEY = "_opensre_duplicate_result"
 # ``id(content)`` and hold a strong reference — keeping the object alive is what
 # makes its id safe to trust, since a collected object's id can be reused by an
 # unrelated one. ``size`` then catches in-place truncation of that same object.
-_CONTENT_CACHE_MAX = 4_096
+#
+# Bounding by entry count alone is not enough: tool results routinely carry
+# multi-megabyte payloads, so a handful of large entries could still retain
+# gigabytes of memory well under a count cap. The cache is bounded by total
+# retained size instead, evicting the least-recently-used entry first, so
+# large payloads from completed investigations are reclaimed instead of
+# sitting alive in a long-lived worker until thousands of unrelated inserts.
+_CONTENT_CACHE_MAX_CHARS = 8_000_000
 
 
-@dataclass(frozen=True) 
+@dataclass(frozen=True)
 class _ContentEstimate:
     content: Any
     size: tuple[int, int]
     tokens: int
 
 
-_CONTENT_CACHE: dict[int, _ContentEstimate] = {}
+_CONTENT_CACHE: OrderedDict[int, _ContentEstimate] = OrderedDict()
+_CONTENT_CACHE_CHARS = 0
 
 
 def strip_internal_message_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -211,11 +220,30 @@ def _content_size(content: Any) -> tuple[int, int]:
     return (0, 0)
 
 
+def _content_chars(size: tuple[int, int]) -> int:
+    """Approximate retained chars for ``size``, used to bound cache memory."""
+    return size[0] + size[1]
+
+
+def _clear_content_cache() -> None:
+    """Drop every cached estimate and reset the tracked size (tests only)."""
+    global _CONTENT_CACHE_CHARS
+    _CONTENT_CACHE.clear()
+    _CONTENT_CACHE_CHARS = 0
+
+
 def _cache_content_estimate(content: Any, tokens: int) -> int:
     """Cache ``tokens`` against ``content`` identity and return it."""
-    if len(_CONTENT_CACHE) >= _CONTENT_CACHE_MAX:
-        _CONTENT_CACHE.clear()
-    _CONTENT_CACHE[id(content)] = _ContentEstimate(content, _content_size(content), tokens)
+    global _CONTENT_CACHE_CHARS
+    existing = _CONTENT_CACHE.pop(id(content), None)
+    if existing is not None:
+        _CONTENT_CACHE_CHARS -= _content_chars(existing.size)
+    size = _content_size(content)
+    while _CONTENT_CACHE and _CONTENT_CACHE_CHARS + _content_chars(size) > _CONTENT_CACHE_MAX_CHARS:
+        _, evicted = _CONTENT_CACHE.popitem(last=False)
+        _CONTENT_CACHE_CHARS -= _content_chars(evicted.size)
+    _CONTENT_CACHE[id(content)] = _ContentEstimate(content, size, tokens)
+    _CONTENT_CACHE_CHARS += _content_chars(size)
     return tokens
 
 
@@ -243,8 +271,10 @@ def _message_token_estimate(message: dict[str, Any]) -> int:
     identity so shallow provider-payload copies still hit.
     """
     content = message.get("content", "")
-    cached = _CONTENT_CACHE.get(id(content))
+    key = id(content)
+    cached = _CONTENT_CACHE.get(key)
     if cached is not None and cached.content is content and cached.size == _content_size(content):
+        _CONTENT_CACHE.move_to_end(key)
         return cached.tokens
     return _cache_content_estimate(content, _compute_message_token_estimate(message))
 

--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
@@ -46,26 +47,63 @@ _DUPLICATE_RESULT_KEY = "_opensre_duplicate_result"
 # dict is not. Plain lists cannot be weakly referenced, so entries key on
 # ``id(content)`` and hold a strong reference — keeping the object alive is what
 # makes its id safe to trust, since a collected object's id can be reused by an
-# unrelated one. ``size`` then catches in-place truncation of that same object.
+# unrelated one. ``retained_bytes`` then catches in-place size changes to that
+# same object.
 #
 # Bounding by entry count alone is not enough: tool results routinely carry
 # multi-megabyte payloads, so a handful of large entries could still retain
 # gigabytes of memory well under a count cap. The cache is bounded by total
-# retained size instead, evicting the least-recently-used entry first, so
-# large payloads from completed investigations are reclaimed instead of
-# sitting alive in a long-lived worker until thousands of unrelated inserts.
-_CONTENT_CACHE_MAX_CHARS = 8_000_000
+# retained bytes across the entire nested content graph, evicting the least-
+# recently-used entry first. This includes structured provider payloads such as
+# Bedrock Converse ``{"json": ...}`` tool results, not only text fields.
+_CONTENT_CACHE_MAX_BYTES = 8_000_000
 
 
 @dataclass(frozen=True)
 class _ContentEstimate:
     content: Any
-    size: tuple[int, int]
+    retained_bytes: int
     tokens: int
 
 
-_CONTENT_CACHE: OrderedDict[int, _ContentEstimate] = OrderedDict()
-_CONTENT_CACHE_CHARS = 0
+class _ContentEstimateCache:
+    """Size-bounded identity cache for serialized-content token estimates."""
+
+    def __init__(self, max_retained_bytes: int) -> None:
+        self.max_retained_bytes = max_retained_bytes
+        self.entries: OrderedDict[int, _ContentEstimate] = OrderedDict()
+        self.retained_bytes = 0
+
+    def get(self, content: Any, retained_bytes: int) -> _ContentEstimate | None:
+        key = id(content)
+        cached = self.entries.get(key)
+        if (
+            cached is None
+            or cached.content is not content
+            or cached.retained_bytes != retained_bytes
+        ):
+            return None
+        self.entries.move_to_end(key)
+        return cached
+
+    def put(self, content: Any, retained_bytes: int, tokens: int) -> None:
+        existing = self.entries.pop(id(content), None)
+        if existing is not None:
+            self.retained_bytes -= existing.retained_bytes
+        if retained_bytes > self.max_retained_bytes:
+            return
+        while self.entries and self.retained_bytes + retained_bytes > self.max_retained_bytes:
+            _, evicted = self.entries.popitem(last=False)
+            self.retained_bytes -= evicted.retained_bytes
+        self.entries[id(content)] = _ContentEstimate(content, retained_bytes, tokens)
+        self.retained_bytes += retained_bytes
+
+    def clear(self) -> None:
+        self.entries.clear()
+        self.retained_bytes = 0
+
+
+_CONTENT_CACHE = _ContentEstimateCache(_CONTENT_CACHE_MAX_BYTES)
 
 
 def strip_internal_message_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -211,28 +249,43 @@ def context_budget_ceiling_for_model(model: str | None) -> int:
     return max(window - _RESPONSE_HEADROOM_TOKENS, _RESPONSE_HEADROOM_TOKENS)
 
 
-def _content_size(content: Any) -> tuple[int, int]:
-    """Cheap mutation check; changes whenever truncation rewrites ``content``."""
-    if isinstance(content, str):
-        return (len(content), 0)
-    if isinstance(content, list):
-        return (len(content), _sum_text_chars(content))
-    return (0, 0)
+def _content_retained_bytes(content: Any) -> int:
+    """Estimate bytes strongly retained through ``content``.
 
-
-def _content_chars(size: tuple[int, int]) -> int:
-    """Approximate retained chars for ``size``, used to bound cache memory."""
-    return size[0] + size[1]
+    Provider content is JSON-like but can contain shared objects. Walking by
+    identity counts each reachable object once and avoids looping on malformed
+    cyclic input. ``sys.getsizeof`` includes container storage as well as
+    scalar payloads, so nested structured results cannot bypass the cache cap.
+    """
+    retained_bytes = 0
+    seen: set[int] = set()
+    pending = [content]
+    while pending:
+        value = pending.pop()
+        identity = id(value)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        retained_bytes += sys.getsizeof(value)
+        if isinstance(value, dict):
+            pending.extend(value.keys())
+            pending.extend(value.values())
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            pending.extend(value)
+    return retained_bytes
 
 
 def _clear_content_cache() -> None:
     """Drop every cached estimate and reset the tracked size (tests only)."""
-    global _CONTENT_CACHE_CHARS
     _CONTENT_CACHE.clear()
-    _CONTENT_CACHE_CHARS = 0
 
 
-def _cache_content_estimate(content: Any, tokens: int) -> int:
+def _cache_content_estimate(
+    content: Any,
+    tokens: int,
+    *,
+    retained_bytes: int | None = None,
+) -> int:
     """Cache ``tokens`` against ``content`` identity and return it.
 
     An entry bigger than the whole budget is left uncached rather than
@@ -240,19 +293,9 @@ def _cache_content_estimate(content: Any, tokens: int) -> int:
     retain it above the stated bound until some later, unrelated insert
     happened to evict it.
     """
-    global _CONTENT_CACHE_CHARS
-    existing = _CONTENT_CACHE.pop(id(content), None)
-    if existing is not None:
-        _CONTENT_CACHE_CHARS -= _content_chars(existing.size)
-    size = _content_size(content)
-    content_chars = _content_chars(size)
-    if content_chars > _CONTENT_CACHE_MAX_CHARS:
-        return tokens
-    while _CONTENT_CACHE and _CONTENT_CACHE_CHARS + content_chars > _CONTENT_CACHE_MAX_CHARS:
-        _, evicted = _CONTENT_CACHE.popitem(last=False)
-        _CONTENT_CACHE_CHARS -= _content_chars(evicted.size)
-    _CONTENT_CACHE[id(content)] = _ContentEstimate(content, size, tokens)
-    _CONTENT_CACHE_CHARS += content_chars
+    if retained_bytes is None:
+        retained_bytes = _content_retained_bytes(content)
+    _CONTENT_CACHE.put(content, retained_bytes, tokens)
     return tokens
 
 
@@ -280,12 +323,15 @@ def _message_token_estimate(message: dict[str, Any]) -> int:
     identity so shallow provider-payload copies still hit.
     """
     content = message.get("content", "")
-    key = id(content)
-    cached = _CONTENT_CACHE.get(key)
-    if cached is not None and cached.content is content and cached.size == _content_size(content):
-        _CONTENT_CACHE.move_to_end(key)
+    retained_bytes = _content_retained_bytes(content)
+    cached = _CONTENT_CACHE.get(content, retained_bytes)
+    if cached is not None:
         return cached.tokens
-    return _cache_content_estimate(content, _compute_message_token_estimate(message))
+    return _cache_content_estimate(
+        content,
+        _compute_message_token_estimate(message),
+        retained_bytes=retained_bytes,
+    )
 
 
 def _refresh_message_token_estimate(message: dict[str, Any]) -> int:

--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -66,44 +66,13 @@ class _ContentEstimate:
     tokens: int
 
 
-class _ContentEstimateCache:
-    """Size-bounded identity cache for serialized-content token estimates."""
+class _ContentEstimateCache(OrderedDict[int, _ContentEstimate]):
+    """LRU entries plus their total retained size."""
 
-    def __init__(self, max_retained_bytes: int) -> None:
-        self.max_retained_bytes = max_retained_bytes
-        self.entries: OrderedDict[int, _ContentEstimate] = OrderedDict()
-        self.retained_bytes = 0
-
-    def get(self, content: Any, retained_bytes: int) -> _ContentEstimate | None:
-        key = id(content)
-        cached = self.entries.get(key)
-        if (
-            cached is None
-            or cached.content is not content
-            or cached.retained_bytes != retained_bytes
-        ):
-            return None
-        self.entries.move_to_end(key)
-        return cached
-
-    def put(self, content: Any, retained_bytes: int, tokens: int) -> None:
-        existing = self.entries.pop(id(content), None)
-        if existing is not None:
-            self.retained_bytes -= existing.retained_bytes
-        if retained_bytes > self.max_retained_bytes:
-            return
-        while self.entries and self.retained_bytes + retained_bytes > self.max_retained_bytes:
-            _, evicted = self.entries.popitem(last=False)
-            self.retained_bytes -= evicted.retained_bytes
-        self.entries[id(content)] = _ContentEstimate(content, retained_bytes, tokens)
-        self.retained_bytes += retained_bytes
-
-    def clear(self) -> None:
-        self.entries.clear()
-        self.retained_bytes = 0
+    retained_bytes = 0
 
 
-_CONTENT_CACHE = _ContentEstimateCache(_CONTENT_CACHE_MAX_BYTES)
+_CONTENT_CACHE = _ContentEstimateCache()
 
 
 def strip_internal_message_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -250,13 +219,7 @@ def context_budget_ceiling_for_model(model: str | None) -> int:
 
 
 def _content_retained_bytes(content: Any) -> int:
-    """Estimate bytes strongly retained through ``content``.
-
-    Provider content is JSON-like but can contain shared objects. Walking by
-    identity counts each reachable object once and avoids looping on malformed
-    cyclic input. ``sys.getsizeof`` includes container storage as well as
-    scalar payloads, so nested structured results cannot bypass the cache cap.
-    """
+    """Estimate bytes strongly retained through the nested content graph."""
     retained_bytes = 0
     seen: set[int] = set()
     pending = [content]
@@ -278,6 +241,7 @@ def _content_retained_bytes(content: Any) -> int:
 def _clear_content_cache() -> None:
     """Drop every cached estimate and reset the tracked size (tests only)."""
     _CONTENT_CACHE.clear()
+    _CONTENT_CACHE.retained_bytes = 0
 
 
 def _cache_content_estimate(
@@ -295,7 +259,18 @@ def _cache_content_estimate(
     """
     if retained_bytes is None:
         retained_bytes = _content_retained_bytes(content)
-    _CONTENT_CACHE.put(content, retained_bytes, tokens)
+    existing = _CONTENT_CACHE.pop(id(content), None)
+    if existing is not None:
+        _CONTENT_CACHE.retained_bytes -= existing.retained_bytes
+    if retained_bytes > _CONTENT_CACHE_MAX_BYTES:
+        return tokens
+    while (
+        _CONTENT_CACHE and _CONTENT_CACHE.retained_bytes + retained_bytes > _CONTENT_CACHE_MAX_BYTES
+    ):
+        _, evicted = _CONTENT_CACHE.popitem(last=False)
+        _CONTENT_CACHE.retained_bytes -= evicted.retained_bytes
+    _CONTENT_CACHE[id(content)] = _ContentEstimate(content, retained_bytes, tokens)
+    _CONTENT_CACHE.retained_bytes += retained_bytes
     return tokens
 
 
@@ -324,8 +299,10 @@ def _message_token_estimate(message: dict[str, Any]) -> int:
     """
     content = message.get("content", "")
     retained_bytes = _content_retained_bytes(content)
-    cached = _CONTENT_CACHE.get(content, retained_bytes)
-    if cached is not None:
+    key = id(content)
+    cached = _CONTENT_CACHE.get(key)
+    if cached is not None and cached.content is content and cached.retained_bytes == retained_bytes:
+        _CONTENT_CACHE.move_to_end(key)
         return cached.tokens
     return _cache_content_estimate(
         content,

--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -40,6 +40,24 @@ _TRUNCATION_MIN_TOKENS = 1_000
 _PINNED_MESSAGE_KEY = "_opensre_seed"
 _DUPLICATE_RESULT_KEY = "_opensre_duplicate_result"
 
+# Token estimates are cached per ``content`` object: each think shallow-copies
+# the provider message, so the nested ``content`` is shared while the message
+# dict is not. Plain lists cannot be weakly referenced, so entries key on
+# ``id(content)`` and hold a strong reference — keeping the object alive is what
+# makes its id safe to trust, since a collected object's id can be reused by an
+# unrelated one. ``size`` then catches in-place truncation of that same object.
+_CONTENT_CACHE_MAX = 4_096
+
+
+@dataclass(frozen=True) 
+class _ContentEstimate:
+    content: Any
+    size: tuple[int, int]
+    tokens: int
+
+
+_CONTENT_CACHE: dict[int, _ContentEstimate] = {}
+
 
 def strip_internal_message_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return a copy of ``messages`` without internal ``_opensre_*`` keys.
@@ -184,7 +202,25 @@ def context_budget_ceiling_for_model(model: str | None) -> int:
     return max(window - _RESPONSE_HEADROOM_TOKENS, _RESPONSE_HEADROOM_TOKENS)
 
 
-def _message_token_estimate(message: dict[str, Any]) -> int:
+def _content_size(content: Any) -> tuple[int, int]:
+    """Cheap mutation check; changes whenever truncation rewrites ``content``."""
+    if isinstance(content, str):
+        return (len(content), 0)
+    if isinstance(content, list):
+        return (len(content), _sum_text_chars(content))
+    return (0, 0)
+
+
+def _cache_content_estimate(content: Any, tokens: int) -> int:
+    """Cache ``tokens`` against ``content`` identity and return it."""
+    if len(_CONTENT_CACHE) >= _CONTENT_CACHE_MAX:
+        _CONTENT_CACHE.clear()
+    _CONTENT_CACHE[id(content)] = _ContentEstimate(content, _content_size(content), tokens)
+    return tokens
+
+
+def _compute_message_token_estimate(message: dict[str, Any]) -> int:
+    """Serialize content blocks to estimate tokens (no cache read/write)."""
     total = 0
     content = message.get("content", "")
     if isinstance(content, str):
@@ -196,6 +232,27 @@ def _message_token_estimate(message: dict[str, Any]) -> int:
             elif isinstance(block, str):
                 total += int(len(block) * _TOKENS_PER_CHAR)
     return total
+
+
+def _message_token_estimate(message: dict[str, Any]) -> int:
+    """Return a cheap token estimate, reusing prior work for unchanged content.
+
+    Blocks are ``json.dumps``'d only to get a length, and every think re-walks
+    the whole transcript. Tool schemas are already serialized once per run; this
+    gives message bodies the same treatment, keyed on shared ``content``
+    identity so shallow provider-payload copies still hit.
+    """
+    content = message.get("content", "")
+    cached = _CONTENT_CACHE.get(id(content))
+    if cached is not None and cached.content is content and cached.size == _content_size(content):
+        return cached.tokens
+    return _cache_content_estimate(content, _compute_message_token_estimate(message))
+
+
+def _refresh_message_token_estimate(message: dict[str, Any]) -> int:
+    """Recompute and re-cache after truncation mutated ``content`` in place."""
+    content = message.get("content", "")
+    return _cache_content_estimate(content, _compute_message_token_estimate(message))
 
 
 def _message_token_estimates(messages: list[dict[str, Any]]) -> tuple[list[int], int]:
@@ -382,7 +439,8 @@ def _truncate_largest_message(
         new_content, changed = truncate_content(messages[idx].get("content"), max_chars)
         if changed:
             messages[idx]["content"] = new_content
-            updated_tokens = _message_token_estimate(messages[idx])
+            # Content mutated — do not reuse the pre-truncation stamp.
+            updated_tokens = _refresh_message_token_estimate(messages[idx])
             total_message_tokens += updated_tokens - message_tokens[idx]
             message_tokens[idx] = updated_tokens
             return True, total_message_tokens

--- a/core/context_budget.py
+++ b/core/context_budget.py
@@ -233,17 +233,26 @@ def _clear_content_cache() -> None:
 
 
 def _cache_content_estimate(content: Any, tokens: int) -> int:
-    """Cache ``tokens`` against ``content`` identity and return it."""
+    """Cache ``tokens`` against ``content`` identity and return it.
+
+    An entry bigger than the whole budget is left uncached rather than
+    inserted after emptying the cache: inserting it anyway would strongly
+    retain it above the stated bound until some later, unrelated insert
+    happened to evict it.
+    """
     global _CONTENT_CACHE_CHARS
     existing = _CONTENT_CACHE.pop(id(content), None)
     if existing is not None:
         _CONTENT_CACHE_CHARS -= _content_chars(existing.size)
     size = _content_size(content)
-    while _CONTENT_CACHE and _CONTENT_CACHE_CHARS + _content_chars(size) > _CONTENT_CACHE_MAX_CHARS:
+    content_chars = _content_chars(size)
+    if content_chars > _CONTENT_CACHE_MAX_CHARS:
+        return tokens
+    while _CONTENT_CACHE and _CONTENT_CACHE_CHARS + content_chars > _CONTENT_CACHE_MAX_CHARS:
         _, evicted = _CONTENT_CACHE.popitem(last=False)
         _CONTENT_CACHE_CHARS -= _content_chars(evicted.size)
     _CONTENT_CACHE[id(content)] = _ContentEstimate(content, size, tokens)
-    _CONTENT_CACHE_CHARS += _content_chars(size)
+    _CONTENT_CACHE_CHARS += content_chars
     return tokens
 
 

--- a/tests/core/test_context_budget_ledger.py
+++ b/tests/core/test_context_budget_ledger.py
@@ -1,8 +1,10 @@
-"""Context-budget token ledger.
+"""Context-budget token ledger and cross-think content estimate cache.
 
 Each think used to re-``json.dumps`` every content block and, while trimming,
 re-estimate the whole transcript after every eviction. A per-message ledger
-should estimate once, then adjust only touched indices.
+should estimate once within a call, and the content-identity cache should skip
+re-serialization on later thinks (including shallow provider-payload copies)
+until truncation changes the content fingerprint.
 """
 
 from __future__ import annotations
@@ -140,3 +142,116 @@ def test_ledger_slices_match_a_fresh_estimate_after_mixed_trim() -> None:
     assert [(c.start, c.end) for c in with_ledger] == [(c.start, c.end) for c in from_scratch]
     for ledger_candidate, fresh in zip(with_ledger, from_scratch, strict=True):
         assert ledger_candidate.token_estimate == fresh.token_estimate
+
+
+def test_second_enforce_under_ceiling_does_not_redump_cached_content() -> None:
+    """Cross-think reuse: content-identity cache skips json.dumps on later enforces."""
+    budget._CONTENT_CACHE.clear()
+    messages = _over_budget_transcript(exchanges=4, payload=2_000)
+    budget.enforce_context_budget(messages, fixed_overhead_tokens=0, ceiling=100_000)
+
+    dumps_calls = 0
+    original = json.dumps
+
+    def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
+        nonlocal dumps_calls
+        dumps_calls += 1
+        return original(value, *args, **kwargs)
+
+    with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
+        budget.enforce_context_budget(messages, fixed_overhead_tokens=0, ceiling=100_000)
+
+    assert dumps_calls == 0
+
+
+def test_shallow_provider_copy_reuses_content_estimate_cache() -> None:
+    """ReactLoop shallow-copies provider payloads; shared content must cache-hit."""
+    budget._CONTENT_CACHE.clear()
+    original = _tool_result("t0", "payload " * 500)
+    first = budget._message_token_estimate(original)
+    copied = dict(original)
+
+    dumps_calls = 0
+    dumps = json.dumps
+
+    def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
+        nonlocal dumps_calls
+        dumps_calls += 1
+        return dumps(value, *args, **kwargs)
+
+    with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
+        assert budget._message_token_estimate(copied) == first
+
+    assert dumps_calls == 0
+    assert copied == original  # cache must not mutate the provider message
+
+
+def test_content_cache_rejects_stale_entry_at_a_reused_id() -> None:
+    """A cache entry keyed by ``id()`` must never be served for an unrelated
+    object that happens to land at the same address after garbage collection.
+
+    Two different single-block ``tool_use`` contents (or two truncated
+    payloads landing on the same target length) can share a size —
+    ``(block_count, text_char_sum)`` — without being the same object. The
+    identity check (not just the size) must reject a stale hit.
+    """
+    budget._CONTENT_CACHE.clear()
+    real_content = [{"type": "tool_use", "id": "t1", "name": "noop", "input": {}}]
+    real_tokens = budget._compute_message_token_estimate({"content": real_content})
+
+    # Seed a stale entry at this id for a *different* object with a matching
+    # size but a deliberately wrong token count.
+    budget._CONTENT_CACHE[id(real_content)] = budget._ContentEstimate(
+        content=object(),
+        size=budget._content_size(real_content),
+        tokens=real_tokens + 999_999,
+    )
+
+    assert budget._message_token_estimate({"content": real_content}) == real_tokens
+
+
+def test_truncate_invalidates_content_estimate_cache() -> None:
+    """After truncation mutates content, the cache must match a fresh compute."""
+    budget._CONTENT_CACHE.clear()
+    ceiling = 50_000
+    big = "y" * 1_000_000
+    messages = [{"role": "user", "content": [{"type": "text", "text": big}]}]
+    stale = budget._message_token_estimate(messages[0])
+
+    budget.enforce_context_budget(messages, fixed_overhead_tokens=0, ceiling=ceiling)
+
+    cached = budget._message_token_estimate(messages[0])
+    recomputed = budget._compute_message_token_estimate(messages[0])
+    assert cached == recomputed
+    assert cached < stale
+    assert budget.estimate_message_tokens(messages) <= ceiling
+    assert messages[0]["content"][0]["text"].endswith(budget._TRUNCATION_MARKER)
+
+
+def test_multi_think_shallow_copies_bound_json_dumps() -> None:
+    """Growing transcript across thinks should dump new blocks, not the whole history."""
+    budget._CONTENT_CACHE.clear()
+    payload = "x" * 20_000
+    provider_messages: list[dict[str, Any]] = [{"role": "user", "content": "alert"}]
+    dumps_calls = 0
+    original = json.dumps
+
+    def counting_dumps(value: object, *args: object, **kwargs: object) -> str:
+        nonlocal dumps_calls
+        dumps_calls += 1
+        return original(value, *args, **kwargs)
+
+    with patch("core.context_budget.json.dumps", side_effect=counting_dumps):
+        for index in range(20):
+            call_id = f"t{index}"
+            provider_messages.append(_assistant_tool_use(call_id))
+            provider_messages.append(_tool_result(call_id, payload))
+            # ReactLoop: fresh shallow copies each think, shared nested content.
+            think_messages = [dict(message) for message in provider_messages]
+            budget.enforce_context_budget(
+                think_messages, fixed_overhead_tokens=0, ceiling=2_000_000
+            )
+
+    # Without a content cache this is ~420 dumps (2 * sum(1..20)).
+    # With a cache: one dump per new block ≈ 40.
+    assert dumps_calls < 80, f"json.dumps called {dumps_calls} times across 20 thinks"

--- a/tests/core/test_context_budget_ledger.py
+++ b/tests/core/test_context_budget_ledger.py
@@ -200,7 +200,7 @@ def test_content_cache_rejects_stale_entry_at_a_reused_id() -> None:
 
     # Seed a stale entry at this id for a *different* object with a matching
     # size but a deliberately wrong token count.
-    budget._CONTENT_CACHE.entries[id(real_content)] = budget._ContentEstimate(
+    budget._CONTENT_CACHE[id(real_content)] = budget._ContentEstimate(
         content=object(),
         retained_bytes=budget._content_retained_bytes(real_content),
         tokens=real_tokens + 999_999,
@@ -244,10 +244,10 @@ def test_content_cache_evicts_by_size_not_just_entry_count() -> None:
         kept.append(content)
 
     assert budget._CONTENT_CACHE.retained_bytes <= budget._CONTENT_CACHE_MAX_BYTES
-    assert len(budget._CONTENT_CACHE.entries) < len(kept)
+    assert len(budget._CONTENT_CACHE) < len(kept)
     # The earliest (least-recently-used) entries are evicted first.
-    assert id(kept[0]) not in budget._CONTENT_CACHE.entries
-    assert id(kept[-1]) in budget._CONTENT_CACHE.entries
+    assert id(kept[0]) not in budget._CONTENT_CACHE
+    assert id(kept[-1]) in budget._CONTENT_CACHE
 
 
 def test_content_cache_skips_a_single_entry_larger_than_the_cap() -> None:
@@ -262,7 +262,7 @@ def test_content_cache_skips_a_single_entry_larger_than_the_cap() -> None:
     tokens = budget._message_token_estimate({"content": huge_content})
 
     assert tokens == budget._compute_message_token_estimate({"content": huge_content})
-    assert id(huge_content) not in budget._CONTENT_CACHE.entries
+    assert id(huge_content) not in budget._CONTENT_CACHE
     assert budget._CONTENT_CACHE.retained_bytes == 0
 
 
@@ -278,10 +278,10 @@ def test_content_cache_counts_nested_bedrock_json_toward_the_cap() -> None:
         }
     ]
 
-    with patch.object(budget._CONTENT_CACHE, "max_retained_bytes", 1_000):
+    with patch.object(budget, "_CONTENT_CACHE_MAX_BYTES", 1_000):
         budget._message_token_estimate({"content": huge_content})
 
-    assert id(huge_content) not in budget._CONTENT_CACHE.entries
+    assert id(huge_content) not in budget._CONTENT_CACHE
     assert budget._CONTENT_CACHE.retained_bytes == 0
 
 

--- a/tests/core/test_context_budget_ledger.py
+++ b/tests/core/test_context_budget_ledger.py
@@ -254,6 +254,22 @@ def test_content_cache_evicts_by_size_not_just_entry_count() -> None:
     assert id(kept[-1]) in budget._CONTENT_CACHE
 
 
+def test_content_cache_skips_a_single_entry_larger_than_the_cap() -> None:
+    """An entry that alone exceeds the retained-size budget must never be
+    inserted. Evicting everything else and inserting it anyway would still
+    leave the process retaining more than the stated bound until some later,
+    unrelated insert happened to evict it.
+    """
+    budget._clear_content_cache()
+    huge_content = [{"type": "text", "text": "z" * (budget._CONTENT_CACHE_MAX_CHARS + 1)}]
+
+    tokens = budget._message_token_estimate({"content": huge_content})
+
+    assert tokens == budget._compute_message_token_estimate({"content": huge_content})
+    assert id(huge_content) not in budget._CONTENT_CACHE
+    assert budget._CONTENT_CACHE_CHARS == 0
+
+
 def test_multi_think_shallow_copies_bound_json_dumps() -> None:
     """Growing transcript across thinks should dump new blocks, not the whole history."""
     budget._clear_content_cache()

--- a/tests/core/test_context_budget_ledger.py
+++ b/tests/core/test_context_budget_ledger.py
@@ -146,7 +146,7 @@ def test_ledger_slices_match_a_fresh_estimate_after_mixed_trim() -> None:
 
 def test_second_enforce_under_ceiling_does_not_redump_cached_content() -> None:
     """Cross-think reuse: content-identity cache skips json.dumps on later enforces."""
-    budget._CONTENT_CACHE.clear()
+    budget._clear_content_cache()
     messages = _over_budget_transcript(exchanges=4, payload=2_000)
     budget.enforce_context_budget(messages, fixed_overhead_tokens=0, ceiling=100_000)
 
@@ -166,7 +166,7 @@ def test_second_enforce_under_ceiling_does_not_redump_cached_content() -> None:
 
 def test_shallow_provider_copy_reuses_content_estimate_cache() -> None:
     """ReactLoop shallow-copies provider payloads; shared content must cache-hit."""
-    budget._CONTENT_CACHE.clear()
+    budget._clear_content_cache()
     original = _tool_result("t0", "payload " * 500)
     first = budget._message_token_estimate(original)
     copied = dict(original)
@@ -195,7 +195,7 @@ def test_content_cache_rejects_stale_entry_at_a_reused_id() -> None:
     ``(block_count, text_char_sum)`` — without being the same object. The
     identity check (not just the size) must reject a stale hit.
     """
-    budget._CONTENT_CACHE.clear()
+    budget._clear_content_cache()
     real_content = [{"type": "tool_use", "id": "t1", "name": "noop", "input": {}}]
     real_tokens = budget._compute_message_token_estimate({"content": real_content})
 
@@ -212,7 +212,7 @@ def test_content_cache_rejects_stale_entry_at_a_reused_id() -> None:
 
 def test_truncate_invalidates_content_estimate_cache() -> None:
     """After truncation mutates content, the cache must match a fresh compute."""
-    budget._CONTENT_CACHE.clear()
+    budget._clear_content_cache()
     ceiling = 50_000
     big = "y" * 1_000_000
     messages = [{"role": "user", "content": [{"type": "text", "text": big}]}]
@@ -228,9 +228,35 @@ def test_truncate_invalidates_content_estimate_cache() -> None:
     assert messages[0]["content"][0]["text"].endswith(budget._TRUNCATION_MARKER)
 
 
+def test_content_cache_evicts_by_size_not_just_entry_count() -> None:
+    """Large tool-result payloads must be reclaimed once the cache's retained-
+    size budget is exceeded, not merely once an entry-count cap is hit.
+
+    A long-lived worker processes many investigations; content from ones that
+    finished must not sit alive in this cache indefinitely just because fewer
+    than a few thousand *other* entries have been inserted since.
+    """
+    budget._clear_content_cache()
+    chunk_chars = 2_000_000  # 6 chunks (12MB) exceeds the 8MB retained-size cap.
+    kept: list[list[dict[str, Any]]] = []
+    for index in range(6):
+        content = [{"type": "text", "text": f"chunk{index} " + "z" * chunk_chars}]
+        budget._message_token_estimate({"content": content})
+        kept.append(content)
+
+    total_cached_chars = sum(
+        budget._content_chars(entry.size) for entry in budget._CONTENT_CACHE.values()
+    )
+    assert total_cached_chars <= budget._CONTENT_CACHE_MAX_CHARS
+    assert len(budget._CONTENT_CACHE) < len(kept)
+    # The earliest (least-recently-used) entries are evicted first.
+    assert id(kept[0]) not in budget._CONTENT_CACHE
+    assert id(kept[-1]) in budget._CONTENT_CACHE
+
+
 def test_multi_think_shallow_copies_bound_json_dumps() -> None:
     """Growing transcript across thinks should dump new blocks, not the whole history."""
-    budget._CONTENT_CACHE.clear()
+    budget._clear_content_cache()
     payload = "x" * 20_000
     provider_messages: list[dict[str, Any]] = [{"role": "user", "content": "alert"}]
     dumps_calls = 0

--- a/tests/core/test_context_budget_ledger.py
+++ b/tests/core/test_context_budget_ledger.py
@@ -190,10 +190,9 @@ def test_content_cache_rejects_stale_entry_at_a_reused_id() -> None:
     """A cache entry keyed by ``id()`` must never be served for an unrelated
     object that happens to land at the same address after garbage collection.
 
-    Two different single-block ``tool_use`` contents (or two truncated
-    payloads landing on the same target length) can share a size —
-    ``(block_count, text_char_sum)`` — without being the same object. The
-    identity check (not just the size) must reject a stale hit.
+    Two different single-block ``tool_use`` contents can have the same retained
+    byte estimate without being the same object. The identity check (not just
+    the size) must reject a stale hit.
     """
     budget._clear_content_cache()
     real_content = [{"type": "tool_use", "id": "t1", "name": "noop", "input": {}}]
@@ -201,9 +200,9 @@ def test_content_cache_rejects_stale_entry_at_a_reused_id() -> None:
 
     # Seed a stale entry at this id for a *different* object with a matching
     # size but a deliberately wrong token count.
-    budget._CONTENT_CACHE[id(real_content)] = budget._ContentEstimate(
+    budget._CONTENT_CACHE.entries[id(real_content)] = budget._ContentEstimate(
         content=object(),
-        size=budget._content_size(real_content),
+        retained_bytes=budget._content_retained_bytes(real_content),
         tokens=real_tokens + 999_999,
     )
 
@@ -237,21 +236,18 @@ def test_content_cache_evicts_by_size_not_just_entry_count() -> None:
     than a few thousand *other* entries have been inserted since.
     """
     budget._clear_content_cache()
-    chunk_chars = 2_000_000  # 6 chunks (12MB) exceeds the 8MB retained-size cap.
+    chunk_chars = 2_000_000  # Six chunks exceed the 8MB retained-size cap.
     kept: list[list[dict[str, Any]]] = []
     for index in range(6):
         content = [{"type": "text", "text": f"chunk{index} " + "z" * chunk_chars}]
         budget._message_token_estimate({"content": content})
         kept.append(content)
 
-    total_cached_chars = sum(
-        budget._content_chars(entry.size) for entry in budget._CONTENT_CACHE.values()
-    )
-    assert total_cached_chars <= budget._CONTENT_CACHE_MAX_CHARS
-    assert len(budget._CONTENT_CACHE) < len(kept)
+    assert budget._CONTENT_CACHE.retained_bytes <= budget._CONTENT_CACHE_MAX_BYTES
+    assert len(budget._CONTENT_CACHE.entries) < len(kept)
     # The earliest (least-recently-used) entries are evicted first.
-    assert id(kept[0]) not in budget._CONTENT_CACHE
-    assert id(kept[-1]) in budget._CONTENT_CACHE
+    assert id(kept[0]) not in budget._CONTENT_CACHE.entries
+    assert id(kept[-1]) in budget._CONTENT_CACHE.entries
 
 
 def test_content_cache_skips_a_single_entry_larger_than_the_cap() -> None:
@@ -261,13 +257,32 @@ def test_content_cache_skips_a_single_entry_larger_than_the_cap() -> None:
     unrelated insert happened to evict it.
     """
     budget._clear_content_cache()
-    huge_content = [{"type": "text", "text": "z" * (budget._CONTENT_CACHE_MAX_CHARS + 1)}]
+    huge_content = [{"type": "text", "text": "z" * (budget._CONTENT_CACHE_MAX_BYTES + 1)}]
 
     tokens = budget._message_token_estimate({"content": huge_content})
 
     assert tokens == budget._compute_message_token_estimate({"content": huge_content})
-    assert id(huge_content) not in budget._CONTENT_CACHE
-    assert budget._CONTENT_CACHE_CHARS == 0
+    assert id(huge_content) not in budget._CONTENT_CACHE.entries
+    assert budget._CONTENT_CACHE.retained_bytes == 0
+
+
+def test_content_cache_counts_nested_bedrock_json_toward_the_cap() -> None:
+    """Structured Converse tool results must not bypass retention accounting."""
+    budget._clear_content_cache()
+    huge_content = [
+        {
+            "toolResult": {
+                "content": [{"json": {"payload": "z" * 2_000}}],
+                "toolUseId": "call-1",
+            }
+        }
+    ]
+
+    with patch.object(budget._CONTENT_CACHE, "max_retained_bytes", 1_000):
+        budget._message_token_estimate({"content": huge_content})
+
+    assert id(huge_content) not in budget._CONTENT_CACHE.entries
+    assert budget._CONTENT_CACHE.retained_bytes == 0
 
 
 def test_multi_think_shallow_copies_bound_json_dumps() -> None:


### PR DESCRIPTION
This pull request introduces a cross-think content estimate cache to optimize token estimation in the context-budget logic. The main goal is to avoid redundant `json.dumps` serialization of message content blocks across multiple "thinks," especially when provider payloads are shallow-copied and content is unchanged. The cache is keyed on content identity and size, and is carefully invalidated when content is mutated (e.g., by truncation). Several tests are added to verify cache correctness and efficiency.

The most important changes are:

**Caching and Token Estimation Logic:**
* Added a content estimate cache (`_CONTENT_CACHE`) keyed by `id(content)` and content size, with a configurable max size, to store token estimates and avoid redundant serialization. Introduced the `_ContentEstimate` dataclass to track content, size, and token count.
* Refactored token estimation functions: `_message_token_estimate` now checks the cache before estimating, and `_refresh_message_token_estimate` forces a recompute after content mutation. The cache is invalidated on truncation to ensure correctness. [[1]](diffhunk://#diff-6c0b55332f7de2efffe264c5069bb833c6f5de994c153c7aa01a122d18d0c21cL187-R223) [[2]](diffhunk://#diff-6c0b55332f7de2efffe264c5069bb833c6f5de994c153c7aa01a122d18d0c21cR237-R257) [[3]](diffhunk://#diff-6c0b55332f7de2efffe264c5069bb833c6f5de994c153c7aa01a122d18d0c21cL385-R443)

**Testing and Validation:**
* Added comprehensive tests to verify cache behavior, including: skipping redundant `json.dumps` calls on repeated budget enforcement; ensuring shallow-copied provider messages reuse cached estimates; rejecting stale cache entries when object IDs are reused; invalidating cache after truncation; and confirming efficient serialization across multiple "thinks."
* Updated the test module docstring to reflect the new cross-think content estimate cache and its intended behavior.