### PR TITLE
fix(release): update OpenAI API integration in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - ".importlinter.strict"
       - ".github/ci/**"
       - ".github/workflows/ci.yml"
+      - ".github/workflows/release.yml"
 
   # No path filter: a filtered workflow never starts, so its gate never
   # reports and a PR that needs it can wait forever. The `changes` job
@@ -75,6 +76,7 @@ jobs:
               - ".importlinter.strict"
               - ".github/ci/**"
               - ".github/workflows/ci.yml"
+              - ".github/workflows/release.yml"
 
   quality:
     needs: [changes]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ on:
 permissions:
   contents: write
   actions: read
-  models: read
 
 concurrency:
   group: release-${{ github.event_name == 'push' && 'main' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'main' && 'main') || 'stable' }}
@@ -549,7 +548,7 @@ jobs:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           RANGE_SPEC: ${{ steps.release_ctx.outputs.range_spec }}
           PREVIOUS_TAG: ${{ steps.release_ctx.outputs.previous_tag }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -567,10 +566,12 @@ jobs:
             echo
           } > GENERATED_CHANGELOG.md
 
-          # Summarize commits into prose via GitHub Models (gpt-4o-mini).
-          # Falls back to raw changelog if the API is unavailable.
+          # Summarize commits into prose via OpenAI (gpt-4o-mini).
+          # Falls back to raw changelog if the key is unset or the API is unavailable.
           raw_commits="$(git log "$RANGE_SPEC" --no-merges --pretty='%s' | head -40 || true)"
-          if [ -n "$raw_commits" ]; then
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "OPENAI_API_KEY is not set; Discord will use raw changelog."
+          elif [ -n "$raw_commits" ]; then
             api_body="$(jq -n --arg commits "$raw_commits" '{
               model: "gpt-4o-mini",
               messages: [
@@ -584,9 +585,9 @@ jobs:
               temperature: 0.4
             }')"
             curl -sS --max-time 20 \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Authorization: Bearer $OPENAI_API_KEY" \
               -H "Content-Type: application/json" \
-              "https://models.inference.ai.azure.com/chat/completions" \
+              "https://api.openai.com/v1/chat/completions" \
               -d "$api_body" 2>/dev/null \
               | jq -r '.choices[0].message.content // empty' 2>/dev/null \
               | tr -d '\r' > DISCORD_NARRATIVE.md || true


### PR DESCRIPTION
- Removed the models permission and replaced GITHUB_TOKEN with OPENAI_API_KEY for API calls.
- Updated the API endpoint to OpenAI's official URL and adjusted the logic to handle cases where the API key is not set, ensuring a fallback to raw changelog generation.