### PR TITLE
feat(observability): emit loop and iteration spans from the ReAct agent

### DIFF
--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -12,6 +12,7 @@ host can drive it. ``run_react_loop`` is the one-line functional entry.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from core.agent.cancel import tool_resources_cancel_requested
@@ -48,9 +49,25 @@ from core.messages import MessageMapper
 from core.provider import ProviderRequest
 from core.types import RuntimeTool
 from platform.observability.trace.redaction import redact_sensitive
-from platform.observability.trace.spans import llm_span
+from platform.observability.trace.spans import (
+    llm_span,
+    loop_iteration_span,
+    loop_span,
+    mark_span_outcome,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _IterationResult:
+    """Outcome summary for one loop iteration."""
+
+    should_stop: bool
+    outcome: str
+    requested_tool_count: int = 0
+    tool_error_count: int = 0
+    terminated_tool_count: int = 0
 
 
 class ReactLoop[RuntimeToolT: RuntimeTool]:
@@ -88,6 +105,7 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         self._terminated_by_tool = False
         self._cancelled = False
         self._iterations_used = 0
+        self._stop_reason = "iteration_cap"
         self._conclusion = ConclusionHandler(host, self._messages, self._runtime_tools)
 
     def run(self) -> AgentRunResult:
@@ -101,32 +119,89 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                 }
             )
         )
-        try:
-            for iteration in range(self._max_iterations):
-                self._iterations_used = iteration + 1
-                if self._run_iteration(iteration):
-                    break
-            return self._finalize()
-        finally:
-            note_progress = getattr(self._host, "_note_react_run_progress", None)
-            if callable(note_progress):
-                note_progress(
-                    iterations_used=self._iterations_used,
-                    executed=list(self._executed),
-                    hit_iteration_cap=self._hit_cap,
-                )
+        with loop_span(
+            "react_loop",
+            attributes={
+                "max_iterations": self._max_iterations,
+                "initial_message_count": len(self._messages),
+                "tool_count": len(self._runtime_tools),
+                "tool_schema_count": len(self._tool_schemas),
+            },
+        ) as loop_attrs:
+            try:
+                if self._cancel_requested():
+                    self._mark_cancelled()
+                else:
+                    for iteration in range(self._max_iterations):
+                        if self._cancel_requested():
+                            self._mark_cancelled()
+                            break
+                        iteration_result = self._run_iteration(iteration)
+                        if iteration_result.should_stop:
+                            break
+                run_result = self._finalize()
+                self._mark_loop_span(loop_attrs)
+                return run_result
+            except KeyboardInterrupt as exc:
+                self._mark_cancelled()
+                self._mark_loop_error(loop_attrs, exc)
+                raise
+            except BaseException as exc:
+                self._hit_cap = False
+                self._stop_reason = "error"
+                self._mark_loop_error(loop_attrs, exc)
+                raise
+            finally:
+                note_progress = getattr(self._host, "_note_react_run_progress", None)
+                if callable(note_progress):
+                    note_progress(
+                        iterations_used=self._iterations_used,
+                        executed=list(self._executed),
+                        hit_iteration_cap=self._hit_cap,
+                    )
 
-    def _run_iteration(self, iteration: int) -> bool:
-        """Run one think -> observe step. Return True when the loop should stop."""
-        if tool_resources_cancel_requested(self._tool_resources):
-            self._hit_cap = False
-            self._cancelled = True
-            return True
+    def _run_iteration(self, iteration: int) -> _IterationResult:
+        """Run one think -> observe step."""
+        with loop_iteration_span(
+            "react_iteration",
+            iteration=iteration,
+            attributes={
+                "max_iterations": self._max_iterations,
+                "message_count_start": len(self._messages),
+                "executed_count_start": len(self._executed),
+            },
+        ) as span_attrs:
+            try:
+                result = self._run_iteration_body(iteration)
+            except BaseException as exc:
+                mark_span_outcome(
+                    span_attrs,
+                    "error",
+                    error=True,
+                    exception_type=type(exc).__name__,
+                    message_count=len(self._messages),
+                    executed_count=len(self._executed),
+                )
+                raise
+            self._mark_iteration_span(span_attrs, result)
+            return result
+
+    def _run_iteration_body(self, iteration: int) -> _IterationResult:
+        """Run one loop body after the tracing envelope has been opened."""
+        if self._cancel_requested():
+            self._mark_cancelled()
+            return _IterationResult(should_stop=True, outcome="cancelled")
+        self._iterations_used = iteration + 1
         self._host._drain_steering_messages(self._messages)
         self._host._emit_runtime(
             TurnStartEvent(
                 iteration=iteration,
-                data={"message_count": len(self._messages), "tool_count": len(self._runtime_tools)},
+                data={
+                    "message_count": len(self._messages),
+                    "tool_count": len(self._runtime_tools),
+                    "max_iterations": self._max_iterations,
+                    "executed_count": len(self._executed),
+                },
             )
         )
         response = self._think(iteration)
@@ -146,7 +221,8 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             )
         self._messages.append(assistant_message)
 
-        # If the response has no further actions (tool calls), execute the conclusion handler to decide if the agent should continue or stop.
+        # A no-tool response is a candidate conclusion; the conclusion handler
+        # may still append a nudge or queued follow-up and continue the loop.
         if not response.has_tool_calls:
             return self._handle_conclusion(response, assistant_message, iteration)
         return self._observe(response, assistant_message, iteration)
@@ -172,25 +248,45 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             ProviderRequestStartEvent(
                 iteration=iteration,
                 message_count=len(provider_request.messages),
+                data={
+                    "tool_schema_count": len(provider_request.tools or []),
+                    "fixed_overhead_tokens": self._fixed_overhead_tokens,
+                },
             )
         )
         model_name = str(getattr(self._llm, "model_id", None) or "invoke")
-        with llm_span(model_name, iteration=iteration):
+        with llm_span(
+            model_name,
+            iteration=iteration,
+            attributes={
+                "message_count": len(provider_request.messages),
+                "tool_schema_count": len(provider_request.tools or []),
+            },
+        ) as span_attrs:
             response = self._llm.invoke(
                 provider_request.messages,
                 system=provider_request.system,
                 tools=provider_request.tools,
             )
+            span_attrs["has_tool_calls"] = response.has_tool_calls
+            span_attrs["tool_call_count"] = len(response.tool_calls)
+            span_attrs["content_chars"] = len(response.content or "")
         response = self._host._after_response(provider_request, response)
         self._host._emit_runtime(
             ProviderRequestEndEvent(
                 iteration=iteration,
                 has_tool_calls=response.has_tool_calls,
+                data={
+                    "tool_call_count": len(response.tool_calls),
+                    "content_chars": len(response.content or ""),
+                },
             )
         )
         return response
 
-    def _handle_conclusion(self, response: Any, assistant_message: Any, iteration: int) -> bool:
+    def _handle_conclusion(
+        self, response: Any, assistant_message: Any, iteration: int
+    ) -> _IterationResult:
         """No tool calls: accept the answer (maybe after a follow-up) or nudge and continue."""
         accepted = self._conclusion.handle(
             response,
@@ -201,17 +297,24 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         if accepted:
             self._final_text = response.content or ""
             self._hit_cap = False
-        return accepted
+            self._stop_reason = "no_tools_needed" if not self._executed else "completed"
+            return _IterationResult(should_stop=True, outcome=self._stop_reason)
+        return _IterationResult(should_stop=False, outcome="conclusion_deferred")
 
-    def _observe(self, response: Any, assistant_message: Any, iteration: int) -> bool:
-        """Execute the requested tools, record results, emit events. Return True if a tool terminated."""
-        for tc in response.tool_calls:
+    def _observe(self, response: Any, assistant_message: Any, iteration: int) -> _IterationResult:
+        """Execute the requested tools, record results, and emit events."""
+        requested_tool_count = len(response.tool_calls)
+        for index, tc in enumerate(response.tool_calls):
             self._host._emit_runtime(
                 ToolExecutionStartEvent(
                     tool_call_id=tc.id,
                     tool_name=tc.name,
                     args=public_tool_input(tc.input),
                     iteration=iteration,
+                    data={
+                        "tool_call_index": index,
+                        "tool_call_count": requested_tool_count,
+                    },
                 )
             )
 
@@ -242,7 +345,9 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         )
         self._messages.append(tool_result_message)
 
-        for tc, result in zip(response.tool_calls, results):
+        tool_error_count = sum(1 for result in results if result.is_error)
+        terminated_tool_count = sum(1 for result in results if result.terminate)
+        for index, (tc, result) in enumerate(zip(response.tool_calls, results, strict=True)):
             compat_payload = result.compat_payload()
             self._executed.append((tc, compat_payload))
             self._tool_results.append((tc, result))
@@ -254,7 +359,11 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                     result=redact_sensitive(compat_payload),
                     is_error=result.is_error,
                     iteration=iteration,
-                    data={"terminate": result.terminate},
+                    data={
+                        "terminate": result.terminate,
+                        "tool_call_index": index,
+                        "tool_call_count": requested_tool_count,
+                    },
                 )
             )
         self._host._emit_runtime(
@@ -262,14 +371,32 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                 iteration=iteration,
                 message=assistant_message,
                 tool_results=tuple(result.compat_payload() for result in results),
-                data={"accepted": False},
+                data={
+                    "accepted": False,
+                    "tool_call_count": requested_tool_count,
+                    "tool_error_count": tool_error_count,
+                    "terminated_tool_count": terminated_tool_count,
+                },
             )
         )
-        if any(result.terminate for result in results):
+        if terminated_tool_count:
             self._terminated_by_tool = True
             self._hit_cap = False
-            return True
-        return False
+            self._stop_reason = "tool_terminated"
+            return _IterationResult(
+                should_stop=True,
+                outcome="tool_terminated",
+                requested_tool_count=requested_tool_count,
+                tool_error_count=tool_error_count,
+                terminated_tool_count=terminated_tool_count,
+            )
+        return _IterationResult(
+            should_stop=False,
+            outcome="tool_observed",
+            requested_tool_count=requested_tool_count,
+            tool_error_count=tool_error_count,
+            terminated_tool_count=0,
+        )
 
     def _emit_tool_update(
         self, request: ToolExecutionRequest, update: Any, *, event_iteration: int
@@ -311,15 +438,74 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                 messages=tuple(self._messages),
                 data={
                     "final_text": self._final_text,
+                    "stop_reason": self._stop_reason,
                     "hit_iteration_cap": self._hit_cap,
                     "terminated_by_tool": self._terminated_by_tool,
                     "cancelled": self._cancelled,
+                    "llm_iterations_used": self._iterations_used,
+                    "max_iterations": self._max_iterations,
                     "message_count": len(self._messages),
                     "executed_count": len(self._executed),
+                    "tool_result_count": len(self._tool_results),
                 },
             )
         )
         return run_result
+
+    def _cancel_requested(self) -> bool:
+        return bool(tool_resources_cancel_requested(self._tool_resources))
+
+    def _mark_cancelled(self) -> None:
+        self._hit_cap = False
+        self._cancelled = True
+        self._stop_reason = "cancelled"
+
+    def _mark_iteration_span(
+        self,
+        span_attrs: dict[str, Any],
+        result: _IterationResult,
+    ) -> None:
+        mark_span_outcome(
+            span_attrs,
+            result.outcome,
+            should_stop=result.should_stop,
+            stop_reason=self._stop_reason if result.should_stop else None,
+            requested_tool_count=result.requested_tool_count,
+            tool_error_count=result.tool_error_count,
+            terminated_tool_count=result.terminated_tool_count,
+            message_count=len(self._messages),
+            executed_count=len(self._executed),
+        )
+
+    def _mark_loop_span(self, span_attrs: dict[str, Any]) -> None:
+        mark_span_outcome(
+            span_attrs,
+            self._stop_reason,
+            stop_reason=self._stop_reason,
+            hit_iteration_cap=self._hit_cap,
+            terminated_by_tool=self._terminated_by_tool,
+            cancelled=self._cancelled,
+            iterations_used=self._iterations_used,
+            max_iterations=self._max_iterations,
+            message_count=len(self._messages),
+            executed_count=len(self._executed),
+            tool_result_count=len(self._tool_results),
+            final_text_chars=len(self._final_text),
+        )
+
+    def _mark_loop_error(self, span_attrs: dict[str, Any], exc: BaseException) -> None:
+        mark_span_outcome(
+            span_attrs,
+            self._stop_reason,
+            error=True,
+            stop_reason=self._stop_reason,
+            exception_type=type(exc).__name__,
+            iterations_used=self._iterations_used,
+            max_iterations=self._max_iterations,
+            message_count=len(self._messages),
+            executed_count=len(self._executed),
+            tool_result_count=len(self._tool_results),
+        )
 
 
 def run_react_loop[RuntimeToolT: RuntimeTool](

--- a/platform/observability/trace/spans.py
+++ b/platform/observability/trace/spans.py
@@ -250,6 +250,26 @@ def llm_span(
     return timed_span(span_kind="llm", name=name, attributes=attrs)
 
 
+def loop_span(
+    name: str,
+    *,
+    attributes: dict[str, Any] | None = None,
+) -> AbstractContextManager[dict[str, Any]]:
+    """Time one bounded loop such as a ReAct run."""
+    return timed_span(span_kind="loop", name=name, attributes=attributes)
+
+
+def loop_iteration_span(
+    name: str,
+    *,
+    iteration: int,
+    attributes: dict[str, Any] | None = None,
+) -> AbstractContextManager[dict[str, Any]]:
+    """Time one iteration inside a bounded loop."""
+    attrs = {"iteration": iteration, **(attributes or {})}
+    return timed_span(span_kind="loop_iteration", name=name, attributes=attrs)
+
+
 def emit_route(
     name: str,
     *,
@@ -311,6 +331,8 @@ __all__ = [
     "get_session_trace_sink",
     "is_session_trace_active",
     "llm_span",
+    "loop_iteration_span",
+    "loop_span",
     "mark_span_outcome",
     "set_session_trace_sink",
     "stage_span",

--- a/tests/core/agent/test_react_loop_cancel.py
+++ b/tests/core/agent/test_react_loop_cancel.py
@@ -56,7 +56,7 @@ def test_react_loop_stops_before_llm_when_cancel_requested() -> None:
     assert result.cancelled is True
     assert result.terminated_by_tool is False
     assert result.hit_iteration_cap is False
-    assert result.llm_iterations_used == 1
+    assert result.llm_iterations_used == 0
     assert result.final_text == ""
 
 

--- a/tests/core/agent/test_react_loop_spans.py
+++ b/tests/core/agent/test_react_loop_spans.py
@@ -10,7 +10,7 @@ import pytest
 
 from core.agent import Agent
 from core.agent_harness.session.persistence.jsonl_storage import JsonlSessionStorage
-from core.llm.types import AgentLLMResponse
+from core.llm.types import AgentLLMResponse, ToolCall
 from platform.observability.trace.spans import (
     NoopSessionTraceSink,
     bind_session_trace,
@@ -53,21 +53,92 @@ class _NoToolLLM:
         return {"role": "tool", "content": "[]"}
 
 
-def test_agent_run_emits_llm_span_when_sink_active(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+class _ToolThenDoneLLM(_NoToolLLM):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": getattr(tool, "name", "tool"),
+                "description": "",
+                "parameters": getattr(tool, "parameters", {}),
+            }
+            for tool in tools
+        ]
+
+    def invoke(
+        self,
+        _messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        _ = (system, tools)
+        self.calls += 1
+        if self.calls == 1:
+            return AgentLLMResponse(
+                content="",
+                tool_calls=[ToolCall(id="c1", name="echo", input={})],
+                raw_content=None,
+            )
+        return AgentLLMResponse(content="done", tool_calls=[], raw_content=None)
+
+
+class _EchoTool:
+    name = "echo"
+    description = "echo"
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+
+    def validate_public_input(self, value: dict[str, Any]) -> str | None:
+        _ = value
+        return None
+
+    def extract_params(self, resolved: dict[str, Any]) -> dict[str, Any]:
+        _ = resolved
+        return {}
+
+    def run(self, **_kwargs: Any) -> dict[str, bool]:
+        return {"ok": True}
+
+
+def _activate_trace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    session_id: str,
+) -> Path:
     monkeypatch.setattr(
         "core.agent_harness.session.persistence.jsonl_storage.session_path",
-        lambda session_id: tmp_path / f"{session_id}.jsonl",
+        lambda requested_session_id: tmp_path / f"{requested_session_id}.jsonl",
     )
     storage = JsonlSessionStorage()
-    session_id = "sess-llm-span"
     path = tmp_path / f"{session_id}.jsonl"
     path.write_text(
         json.dumps({"type": "session", "version": 2, "id": session_id}) + "\n",
         encoding="utf-8",
     )
     set_session_trace_sink(JsonlSessionTraceSink(storage=storage))
+    return path
+
+
+def _trace_spans(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").strip().splitlines()
+        if json.loads(line).get("type") == "trace_span"
+    ]
+
+
+def test_agent_run_emits_llm_span_when_sink_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "sess-llm-span"
+    path = _activate_trace(tmp_path, monkeypatch, session_id=session_id)
 
     agent = Agent(
         llm=_NoToolLLM(),
@@ -80,17 +151,27 @@ def test_agent_run_emits_llm_span_when_sink_active(
         result = agent.run([{"role": "user", "content": "hello"}])
 
     assert result.final_text == "done"
-    spans = [
-        json.loads(line)
-        for line in path.read_text(encoding="utf-8").strip().splitlines()
-        if json.loads(line).get("type") == "trace_span"
-    ]
+    spans = _trace_spans(path)
     llm_spans = [s for s in spans if s.get("span_kind") == "llm"]
     assert len(llm_spans) == 1
     assert llm_spans[0]["name"] == "test-model"
     assert llm_spans[0]["status"] == "ok"
     assert llm_spans[0]["attributes"]["iteration"] == 0
+    assert llm_spans[0]["attributes"]["has_tool_calls"] is False
+    assert llm_spans[0]["attributes"]["tool_call_count"] == 0
     assert "duration_ms" in llm_spans[0]
+
+    loop_span = next(s for s in spans if s.get("span_kind") == "loop")
+    assert loop_span["name"] == "react_loop"
+    assert loop_span["attributes"]["outcome"] == "no_tools_needed"
+    assert loop_span["attributes"]["iterations_used"] == 1
+    assert loop_span["attributes"]["executed_count"] == 0
+
+    iteration_span = next(s for s in spans if s.get("span_kind") == "loop_iteration")
+    assert iteration_span["name"] == "react_iteration"
+    assert iteration_span["attributes"]["iteration"] == 0
+    assert iteration_span["attributes"]["outcome"] == "no_tools_needed"
+    assert iteration_span["attributes"]["should_stop"] is True
 
 
 def test_agent_run_skips_llm_span_when_noop() -> None:
@@ -103,3 +184,37 @@ def test_agent_run_skips_llm_span_when_noop() -> None:
     )
     result = agent.run([{"role": "user", "content": "hello"}])
     assert result.final_text == "done"
+
+
+def test_agent_run_emits_loop_iteration_outcomes_for_tool_round(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "sess-react-loop-tool-round"
+    path = _activate_trace(tmp_path, monkeypatch, session_id=session_id)
+    agent = Agent(
+        llm=_ToolThenDoneLLM(),
+        system="sys",
+        tools=[_EchoTool()],
+        resolved_integrations={},
+        max_iterations=3,
+    )
+
+    with bind_session_trace(session_id):
+        result = agent.run([{"role": "user", "content": "hello"}])
+
+    assert result.final_text == "done"
+    assert result.llm_iterations_used == 2
+    spans = _trace_spans(path)
+    iteration_spans = [s for s in spans if s.get("span_kind") == "loop_iteration"]
+    assert [span["attributes"]["outcome"] for span in iteration_spans] == [
+        "tool_observed",
+        "completed",
+    ]
+    assert iteration_spans[0]["attributes"]["requested_tool_count"] == 1
+    assert iteration_spans[0]["attributes"]["tool_error_count"] == 0
+    assert iteration_spans[0]["attributes"]["should_stop"] is False
+
+    loop = next(s for s in spans if s.get("span_kind") == "loop")
+    assert loop["attributes"]["outcome"] == "completed"
+    assert loop["attributes"]["iterations_used"] == 2
+    assert loop["attributes"]["executed_count"] == 1

--- a/tests/platform/observability/test_package_layout.py
+++ b/tests/platform/observability/test_package_layout.py
@@ -20,6 +20,8 @@ def test_trace_subpackage_exports_span_helpers() -> None:
         "stage_span",
         "tool_span",
         "llm_span",
+        "loop_span",
+        "loop_iteration_span",
         "emit_route",
         "traced_session",
         "mark_span_outcome",

--- a/tests/platform/observability/test_session_trace.py
+++ b/tests/platform/observability/test_session_trace.py
@@ -344,6 +344,8 @@ def test_mark_span_outcome_sets_status_and_extra_attrs() -> None:
 
 
 def test_semantic_helpers_match_span_kinds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from platform.observability.trace.spans import loop_iteration_span, loop_span
+
     session_id = "sess-helpers"
     path = _activate_jsonl_sink(tmp_path, session_id, monkeypatch)
     with traced_session(session_id, component="gateway_turn") as attrs:
@@ -357,6 +359,10 @@ def test_semantic_helpers_match_span_kinds(tmp_path: Path, monkeypatch: pytest.M
             mark_span_outcome(tool_attrs, "ok", source="agent")
         with llm_span("model-x", iteration=1):
             pass
+        with loop_span("react_loop") as loop_attrs:
+            mark_span_outcome(loop_attrs, "completed")
+        with loop_iteration_span("react_iteration", iteration=2):
+            pass
     spans = _trace_spans(path)
     kinds = {(rec["span_kind"], rec["name"]) for rec in spans}
     assert ("component", "gateway_turn") in kinds
@@ -365,6 +371,8 @@ def test_semantic_helpers_match_span_kinds(tmp_path: Path, monkeypatch: pytest.M
     assert ("stage", "intake") in kinds
     assert ("tool", "echo") in kinds
     assert ("llm", "model-x") in kinds
+    assert ("loop", "react_loop") in kinds
+    assert ("loop_iteration", "react_iteration") in kinds
 
     tool = next(r for r in spans if r["span_kind"] == "tool")
     assert tool["attributes"]["tool_call_id"] == "c1"
@@ -373,6 +381,9 @@ def test_semantic_helpers_match_span_kinds(tmp_path: Path, monkeypatch: pytest.M
 
     llm = next(r for r in spans if r["span_kind"] == "llm")
     assert llm["attributes"]["iteration"] == 1
+
+    loop_iteration = next(r for r in spans if r["span_kind"] == "loop_iteration")
+    assert loop_iteration["attributes"]["iteration"] == 2
 
     gateway = next(r for r in spans if r["name"] == "gateway_turn")
     assert gateway["attributes"]["outcome"] == "ok"


### PR DESCRIPTION
## Summary
- Add `loop_span` / `loop_iteration_span` helpers and wire them through `ReactLoop` so session traces record run and per-iteration outcomes.
- Capture stop reasons, tool counts, cancel/error paths, and richer LLM span attributes instead of inferring them from LLM spans alone.
- Extend react-loop and observability tests to pin the new span kinds and outcomes.

## Test plan
- [x] Pre-commit hooks (ruff + secret scan) passed on commit
- [ ] `uv run pytest tests/core/agent/test_react_loop_spans.py tests/core/agent/test_react_loop_cancel.py tests/platform/observability/test_session_trace.py tests/platform/observability/test_package_layout.py`
- [ ] Confirm a traced agent run emits `loop`, `loop_iteration`, and enriched `llm` spans in the session JSONL