### PR TITLE
feat(integrations): let an out-of-tree package register an integration

### DIFF
--- a/config/strict_config.py
+++ b/config/strict_config.py
@@ -37,6 +37,11 @@ class StrictConfigModel(BaseModel):
     def _reject_unknown_fields(cls, data: Any) -> Any:
         if not isinstance(data, dict):
             return data
+        # A subclass that opts into extras is asking for open-ended keys on
+        # purpose (an out-of-tree integration has no declared field to fill).
+        # Typo protection still applies to every model that stays closed.
+        if cls.model_config.get("extra") == "allow":
+            return data
 
         field_aliases = {
             name: field.alias

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -465,6 +465,28 @@ _CLASSIFIERS: dict[str, _ClassifyFn] = {
     "railway": _classify_railway,
 }
 
+#: Classifiers contributed by out-of-tree integration packages.
+_EXTERNAL_CLASSIFIERS: dict[str, _ClassifyFn] = {}
+
+#: Environment loaders contributed by out-of-tree integration packages. Each
+#: returns an active record, or None when its variables are not set.
+_EXTERNAL_ENV_LOADERS: dict[str, Any] = {}
+
+
+def register_classifier(service: str, classify: _ClassifyFn) -> None:
+    """Register the classifier for an integration shipped outside this repo."""
+    _EXTERNAL_CLASSIFIERS[service] = classify
+
+
+def register_env_loader(service: str, loader: Any) -> None:
+    """Register an environment loader for an out-of-tree integration.
+
+    The loader is called with no arguments during ``load_env_integrations`` and
+    returns a record in the same shape ``_active_env_record`` produces, or None
+    when the integration is not configured in the environment.
+    """
+    _EXTERNAL_ENV_LOADERS[service] = loader
+
 
 def _classify_service_instance(
     key: str, credentials: dict[str, Any], *, record_id: str
@@ -476,7 +498,7 @@ def _classify_service_instance(
     ``key`` itself, but Grafana splits into ``grafana`` or ``grafana_local``
     based on its ``is_local`` property.
     """
-    handler = _CLASSIFIERS.get(key)
+    handler = _CLASSIFIERS.get(key) or _EXTERNAL_CLASSIFIERS.get(key)
     if handler is not None:
         return handler(credentials, record_id)
     # Fallback for unknown services: pass through credentials + record id.
@@ -1822,6 +1844,15 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     temporal_config.model_dump(),
                 )
             )
+
+    for service, loader in _EXTERNAL_ENV_LOADERS.items():
+        try:
+            record = loader()
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration=service)
+        else:
+            if record:
+                integrations.append(record)
 
     return integrations
 

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
@@ -480,12 +481,38 @@ _EXTERNAL_ENV_LOADERS: dict[str, Any] = {}
 _EXTERNAL_ENV_PRESENCE: dict[str, Callable[[], bool]] = {}
 
 
-def _external_hook_key(service: str, *, hook: str) -> str:
+#: Which package registered each hook, keyed by ``(hook, service)``. The hook
+#: maps themselves store only the callable, and the entry has to be attributable
+#: to decide whether a second registration is the same plugin reloading or a
+#: different one taking the key over.
+_EXTERNAL_HOOK_OWNERS: dict[tuple[str, str], str] = {}
+
+
+def _hook_owner(callback: Any) -> str:
+    """Return the top-level package *callback* was defined in, or "" if unknown.
+
+    Owner is inferred rather than passed in so the hook signatures stay as they
+    are. A plugin that reloads produces a new function object from the same
+    package, which has to keep working; a different package must not.
+    """
+    target = callback
+    while isinstance(target, functools.partial):
+        target = target.func
+    module = str(getattr(target, "__module__", "") or "")
+    root = module.split(".", 1)[0]
+    # ``functools`` is what a partial reports through its type, and a builtin
+    # says nothing about who registered it - neither identifies a plugin.
+    return "" if root in {"functools", "builtins"} else root
+
+
+def _claim_external_hook(service: str, callback: Any, *, hook: str) -> str:
     """Return the key *hook* may be stored under, or raise if it is not allowed.
 
-    ``register_integration_spec`` already refuses built-in keys, but each hook
-    below can be called on its own, and a loader registered under ``github``
-    would emit a record that outranks the real one during the merge.
+    ``register_integration_spec`` already refuses built-in keys and keys another
+    plugin holds, but each hook below can be called without ever registering a
+    spec. Two packages registering under the same key would otherwise be settled
+    by import order, with the later one classifying, loading or reporting
+    presence for the earlier one's integration.
 
     Normalized for the same reason the registry normalizes: every lookup here is
     by a stripped, lower-cased key, so storing ``"GitHub"`` verbatim would both
@@ -499,12 +526,24 @@ def _external_hook_key(service: str, *, hook: str) -> str:
             f"Cannot register {hook} for {service!r}: a built-in integration already "
             "answers to that key."
         )
+
+    owner = _hook_owner(callback)
+    previous = _EXTERNAL_HOOK_OWNERS.get((hook, key))
+    if previous is not None and (not owner or previous != owner):
+        held_by = f"{previous!r}" if previous else "another package"
+        raise ValueError(
+            f"Cannot register {hook} for {key!r}: already registered by {held_by}. "
+            "Two packages cannot share one integration's hooks; pick a key unique to "
+            "this integration."
+        )
+
+    _EXTERNAL_HOOK_OWNERS[(hook, key)] = owner
     return key
 
 
 def register_classifier(service: str, classify: _ClassifyFn) -> None:
     """Register the classifier for an integration shipped outside this repo."""
-    _EXTERNAL_CLASSIFIERS[_external_hook_key(service, hook="a classifier")] = classify
+    _EXTERNAL_CLASSIFIERS[_claim_external_hook(service, classify, hook="a classifier")] = classify
 
 
 def register_env_loader(service: str, loader: Any) -> None:
@@ -516,7 +555,8 @@ def register_env_loader(service: str, loader: Any) -> None:
     be for *service*: one naming a different integration is dropped, since the
     merge that follows lets a later record replace an earlier one by service.
     """
-    _EXTERNAL_ENV_LOADERS[_external_hook_key(service, hook="an environment loader")] = loader
+    key = _claim_external_hook(service, loader, hook="an environment loader")
+    _EXTERNAL_ENV_LOADERS[key] = loader
 
 
 def register_env_presence(service: str, is_configured: Callable[[], bool]) -> None:
@@ -528,7 +568,8 @@ def register_env_presence(service: str, is_configured: Callable[[], bool]) -> No
     invisible to the welcome, REPL and health surfaces even though verification
     and tool resolution both see it.
     """
-    _EXTERNAL_ENV_PRESENCE[_external_hook_key(service, hook="a presence check")] = is_configured
+    key = _claim_external_hook(service, is_configured, hook="a presence check")
+    _EXTERNAL_ENV_PRESENCE[key] = is_configured
 
 
 def external_env_presence_services() -> list[str]:

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -6,6 +6,7 @@ import functools
 import json
 import logging
 import os
+import threading
 from collections.abc import Callable
 from typing import Any
 
@@ -487,6 +488,11 @@ _EXTERNAL_ENV_PRESENCE: dict[str, Callable[[], bool]] = {}
 #: different one taking the key over.
 _EXTERNAL_HOOK_OWNERS: dict[tuple[str, str], str] = {}
 
+#: Serialises claiming a key with installing the callback. Reading the current
+#: owner and then writing is a check-then-act: two packages registering the same
+#: key concurrently could both see it free and the later one would win silently.
+_HOOK_REGISTRATION_LOCK = threading.Lock()
+
 
 def _hook_owner(callback: Any) -> str:
     """Return the top-level package *callback* was defined in, or "" if unknown.
@@ -505,8 +511,24 @@ def _hook_owner(callback: Any) -> str:
     return "" if root in {"functools", "builtins"} else root
 
 
+def _install_external_hook(
+    target: dict[str, Any], service: str, callback: Any, *, hook: str
+) -> None:
+    """Claim *service* for *callback* and install it into *target*, as one step.
+
+    Claiming and installing are a single critical section: read the owner, then
+    write, and two packages registering the same key concurrently would both see
+    it free and the later one would take it with nothing reported.
+    """
+    with _HOOK_REGISTRATION_LOCK:
+        target[_claim_external_hook(service, callback, hook=hook)] = callback
+
+
 def _claim_external_hook(service: str, callback: Any, *, hook: str) -> str:
     """Return the key *hook* may be stored under, or raise if it is not allowed.
+
+    Callers reach this through :func:`_install_external_hook`, which holds the
+    registration lock across the check and the write.
 
     ``register_integration_spec`` already refuses built-in keys and keys another
     plugin holds, but each hook below can be called without ever registering a
@@ -543,7 +565,7 @@ def _claim_external_hook(service: str, callback: Any, *, hook: str) -> str:
 
 def register_classifier(service: str, classify: _ClassifyFn) -> None:
     """Register the classifier for an integration shipped outside this repo."""
-    _EXTERNAL_CLASSIFIERS[_claim_external_hook(service, classify, hook="a classifier")] = classify
+    _install_external_hook(_EXTERNAL_CLASSIFIERS, service, classify, hook="a classifier")
 
 
 def register_env_loader(service: str, loader: Any) -> None:
@@ -555,8 +577,7 @@ def register_env_loader(service: str, loader: Any) -> None:
     be for *service*: one naming a different integration is dropped, since the
     merge that follows lets a later record replace an earlier one by service.
     """
-    key = _claim_external_hook(service, loader, hook="an environment loader")
-    _EXTERNAL_ENV_LOADERS[key] = loader
+    _install_external_hook(_EXTERNAL_ENV_LOADERS, service, loader, hook="an environment loader")
 
 
 def register_env_presence(service: str, is_configured: Callable[[], bool]) -> None:
@@ -568,14 +589,15 @@ def register_env_presence(service: str, is_configured: Callable[[], bool]) -> No
     invisible to the welcome, REPL and health surfaces even though verification
     and tool resolution both see it.
     """
-    key = _claim_external_hook(service, is_configured, hook="a presence check")
-    _EXTERNAL_ENV_PRESENCE[key] = is_configured
+    _install_external_hook(_EXTERNAL_ENV_PRESENCE, service, is_configured, hook="a presence check")
 
 
 def external_env_presence_services() -> list[str]:
     """Return the out-of-tree services whose environment variables are set."""
     present: list[str] = []
-    for service, is_configured in _EXTERNAL_ENV_PRESENCE.items():
+    # Snapshot: a plugin registering from another thread would otherwise turn
+    # this into "dictionary changed size during iteration" mid-startup.
+    for service, is_configured in list(_EXTERNAL_ENV_PRESENCE.items()):
         try:
             if is_configured():
                 present.append(service)
@@ -1941,7 +1963,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 )
             )
 
-    for service, loader in _EXTERNAL_ENV_LOADERS.items():
+    for service, loader in list(_EXTERNAL_ENV_LOADERS.items()):
         try:
             record = loader()
         except Exception as exc:

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -260,8 +260,10 @@ from integrations.registry import (
     DIRECT_CLASSIFIED_EFFECTIVE_SERVICES,
     INTEGRATION_SPECS_BY_SERVICE,
     SKIP_CLASSIFIED_SERVICES,
+    builtin_claimed_keys,
     external_integration_services,
     family_key,
+    normalize_service_key,
     service_key,
 )
 from integrations.rocketchat import classify as _classify_rocketchat
@@ -478,9 +480,31 @@ _EXTERNAL_ENV_LOADERS: dict[str, Any] = {}
 _EXTERNAL_ENV_PRESENCE: dict[str, Callable[[], bool]] = {}
 
 
+def _external_hook_key(service: str, *, hook: str) -> str:
+    """Return the key *hook* may be stored under, or raise if it is not allowed.
+
+    ``register_integration_spec`` already refuses built-in keys, but each hook
+    below can be called on its own, and a loader registered under ``github``
+    would emit a record that outranks the real one during the merge.
+
+    Normalized for the same reason the registry normalizes: every lookup here is
+    by a stripped, lower-cased key, so storing ``"GitHub"`` verbatim would both
+    slip past this check and register under a name nothing ever queries.
+    """
+    key = normalize_service_key(service)
+    if not key:
+        raise ValueError(f"Cannot register {hook} without a service name.")
+    if key in builtin_claimed_keys():
+        raise ValueError(
+            f"Cannot register {hook} for {service!r}: a built-in integration already "
+            "answers to that key."
+        )
+    return key
+
+
 def register_classifier(service: str, classify: _ClassifyFn) -> None:
     """Register the classifier for an integration shipped outside this repo."""
-    _EXTERNAL_CLASSIFIERS[service] = classify
+    _EXTERNAL_CLASSIFIERS[_external_hook_key(service, hook="a classifier")] = classify
 
 
 def register_env_loader(service: str, loader: Any) -> None:
@@ -488,9 +512,11 @@ def register_env_loader(service: str, loader: Any) -> None:
 
     The loader is called with no arguments during ``load_env_integrations`` and
     returns a record in the same shape ``_active_env_record`` produces, or None
-    when the integration is not configured in the environment.
+    when the integration is not configured in the environment. The record must
+    be for *service*: one naming a different integration is dropped, since the
+    merge that follows lets a later record replace an earlier one by service.
     """
-    _EXTERNAL_ENV_LOADERS[service] = loader
+    _EXTERNAL_ENV_LOADERS[_external_hook_key(service, hook="an environment loader")] = loader
 
 
 def register_env_presence(service: str, is_configured: Callable[[], bool]) -> None:
@@ -502,7 +528,7 @@ def register_env_presence(service: str, is_configured: Callable[[], bool]) -> No
     invisible to the welcome, REPL and health surfaces even though verification
     and tool resolution both see it.
     """
-    _EXTERNAL_ENV_PRESENCE[service] = is_configured
+    _EXTERNAL_ENV_PRESENCE[_external_hook_key(service, hook="a presence check")] = is_configured
 
 
 def external_env_presence_services() -> list[str]:
@@ -1880,8 +1906,20 @@ def load_env_integrations() -> list[dict[str, Any]]:
         except Exception as exc:
             _report_env_loader_failure(exc, integration=service)
         else:
-            if record:
-                integrations.append(record)
+            if not record:
+                continue
+            emitted = normalize_service_key(str(record.get("service", service)))
+            if emitted != service:
+                # The merge below replaces an earlier record with a later one of
+                # the same service, so an emitted name other than the registered
+                # one would let this loader stand in for another integration.
+                logger.warning(
+                    "load_env_integrations: loader registered for %r emitted %r; dropping it",
+                    service,
+                    emitted,
+                )
+                continue
+            integrations.append(record)
 
     return integrations
 

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -260,6 +260,7 @@ from integrations.registry import (
     DIRECT_CLASSIFIED_EFFECTIVE_SERVICES,
     INTEGRATION_SPECS_BY_SERVICE,
     SKIP_CLASSIFIED_SERVICES,
+    external_integration_services,
     family_key,
     service_key,
 )
@@ -472,6 +473,10 @@ _EXTERNAL_CLASSIFIERS: dict[str, _ClassifyFn] = {}
 #: returns an active record, or None when its variables are not set.
 _EXTERNAL_ENV_LOADERS: dict[str, Any] = {}
 
+#: Cheap "is this configured?" predicates for out-of-tree integrations, used by
+#: the startup-safe presence check that must not touch the keyring.
+_EXTERNAL_ENV_PRESENCE: dict[str, Callable[[], bool]] = {}
+
 
 def register_classifier(service: str, classify: _ClassifyFn) -> None:
     """Register the classifier for an integration shipped outside this repo."""
@@ -486,6 +491,30 @@ def register_env_loader(service: str, loader: Any) -> None:
     when the integration is not configured in the environment.
     """
     _EXTERNAL_ENV_LOADERS[service] = loader
+
+
+def register_env_presence(service: str, is_configured: Callable[[], bool]) -> None:
+    """Register the startup-safe presence check for an out-of-tree integration.
+
+    ``load_env_integration_services`` runs before the first prompt and must not
+    resolve secrets, so it cannot call the full loader registered above. Without
+    a predicate here an integration configured purely from the environment stays
+    invisible to the welcome, REPL and health surfaces even though verification
+    and tool resolution both see it.
+    """
+    _EXTERNAL_ENV_PRESENCE[service] = is_configured
+
+
+def external_env_presence_services() -> list[str]:
+    """Return the out-of-tree services whose environment variables are set."""
+    present: list[str] = []
+    for service, is_configured in _EXTERNAL_ENV_PRESENCE.items():
+        try:
+            if is_configured():
+                present.append(service)
+        except Exception as exc:  # a plugin predicate must not break startup
+            _report_env_loader_failure(exc, integration=service)
+    return present
 
 
 def _classify_service_instance(
@@ -2154,7 +2183,10 @@ def resolve_effective_integrations(
                 },
             )
 
-    known_keys = set(EffectiveIntegrations.model_fields)
+    # Registered plugins have no declared field on the model, so they have to be
+    # named here as well; without this the key is dropped as unrecognised one
+    # line before the model would have accepted it.
+    known_keys = set(EffectiveIntegrations.model_fields) | external_integration_services()
     unknown_keys = set(effective) - known_keys
     if unknown_keys:
         logger.warning(

--- a/integrations/app.py
+++ b/integrations/app.py
@@ -14,12 +14,12 @@ from collections.abc import Callable
 from dotenv import load_dotenv
 
 from integrations.cli import (
-    SUPPORTED,
     cmd_list,
     cmd_remove,
     cmd_setup,
     cmd_show,
     cmd_verify,
+    setup_services,
 )
 from integrations.verify import SUPPORTED_VERIFY_SERVICES
 from platform.analytics.cli import build_cli_invoked_properties, capture_cli_invoked
@@ -73,7 +73,7 @@ _COMMANDS: dict[str, CommandHandler] = {
 
 def _print_help() -> None:
     print(__doc__)
-    print(f"  Supported services: {SUPPORTED}\n")
+    print(f"  Supported services: {', '.join(setup_services())}\n")
     print(f"  Verify services: {', '.join(SUPPORTED_VERIFY_SERVICES)}\n")
 
 

--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -162,6 +162,8 @@ def load_env_integration_services() -> list[str]:
     add("mariadb", _all_env("MARIADB_HOST", "MARIADB_DATABASE"))
     add("opensearch", _env_is_set("OPENSEARCH_URL"))
 
+    services.extend(_catalog_impl.external_env_presence_services())
+
     return list(dict.fromkeys(services))
 
 
@@ -288,6 +290,13 @@ def configured_integration_health() -> list[tuple[str, str]]:
     return health
 
 
+# Re-exported so an out-of-tree integration registers through this facade
+# instead of reaching into the private implementation module.
+register_classifier = _catalog_impl.register_classifier
+register_env_loader = _catalog_impl.register_env_loader
+register_env_presence = _catalog_impl.register_env_presence
+
+
 __all__ = [
     "classify_integrations",
     "configured_integration_health",
@@ -297,5 +306,8 @@ __all__ = [
     "load_integrations",
     "merge_integrations_by_service",
     "merge_local_integrations",
+    "register_classifier",
+    "register_env_loader",
+    "register_env_presence",
     "resolve_effective_integrations",
 ]

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -775,19 +775,25 @@ def _setup_azure_sql() -> None:
 
 _HANDLERS["azure_sql"] = _setup_azure_sql
 
-_SETUP_SERVICES = tuple(service for service in SUPPORTED_SETUP_SERVICES if service in _HANDLERS)
 
+def setup_services() -> tuple[str, ...]:
+    """Return the services that both declare a setup order and have a handler.
 
-SUPPORTED = ", ".join(_SETUP_SERVICES)
-SUPPORTED_VERIFY = ", ".join(SUPPORTED_VERIFY_SERVICES)
+    Computed per call rather than once at import: a plugin registers its spec
+    and adds its ``_HANDLERS`` entry after this module has been imported, and a
+    snapshot taken here would reject it as unsupported for the rest of the
+    process.
+    """
+    return tuple(service for service in SUPPORTED_SETUP_SERVICES if service in _HANDLERS)
 
 
 def cmd_setup(service: str | None) -> str:
+    available = setup_services()
     if not service:
         try:
             service = _select(
                 "Which service would you like to set up?",
-                choices=list(_SETUP_SERVICES),
+                choices=list(available),
                 instruction="(use arrow keys)",
             )
         except (EOFError, KeyboardInterrupt):
@@ -795,8 +801,8 @@ def cmd_setup(service: str | None) -> str:
             sys.exit(1)
     if service:
         service = resolve_management_service(service)
-    if not service or service not in _SETUP_SERVICES:
-        _die(f"Usage: setup <service>. Supported: {SUPPORTED}")
+    if not service or service not in available:
+        _die(f"Usage: setup <service>. Supported: {', '.join(available)}")
     print(f"\n  Setting up {_B}{service}{_R}\n")
     _HANDLERS[service]()
     print(f"\n  ✓ Saved → {STORE_PATH}\n")
@@ -880,7 +886,7 @@ def cmd_verify(service: str | None, *, send_slack_test: bool = False) -> int:
     if service:
         service = resolve_management_service(service)
     if service and service not in SUPPORTED_VERIFY_SERVICES:
-        _die(f"Usage: verify [service]. Supported: {SUPPORTED_VERIFY}")
+        _die(f"Usage: verify [service]. Supported: {', '.join(SUPPORTED_VERIFY_SERVICES)}")
 
     results = verify_integrations(service=service, send_slack_test=send_slack_test)
 

--- a/integrations/effective_models.py
+++ b/integrations/effective_models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ConfigDict
+
 from config.strict_config import StrictConfigModel
 
 
@@ -16,7 +18,15 @@ class EffectiveIntegrationEntry(StrictConfigModel):
 
 
 class EffectiveIntegrations(StrictConfigModel):
-    """Strict container for normalized effective integrations."""
+    """Container for normalized effective integrations.
+
+    Fields are declared per integration so a typo in a shipped name is still
+    caught. Extras are allowed on top of them, because an integration that lives
+    outside this repository has no field here to fill and would otherwise be
+    dropped at validation with nothing but a log line to show for it.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     grafana: EffectiveIntegrationEntry | None = None
     datadog: EffectiveIntegrationEntry | None = None

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -450,41 +450,49 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
 _EXTERNAL_SPECS: list[IntegrationSpec] = []
 
 #: Every spec, built-in first so a plugin cannot shadow a shipped integration.
-INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = ()
+#:
+#: This and the tables below are filled by :func:`_rebuild_registry` and then
+#: updated **in place** on every later registration. That matters: readers use
+#: ``from integrations.registry import SUPPORTED_VERIFY_SERVICES``, which binds
+#: the object, not the name — rebinding here would leave every one of them
+#: holding the pre-registration snapshot. Mutating in place mirrors how
+#: ``tools.registry.register_external_tool_package`` extends its own list.
+INTEGRATION_SPECS: list[IntegrationSpec] = []
 
 INTEGRATION_SPECS_BY_SERVICE: dict[str, IntegrationSpec] = {}
 SERVICE_KEY_MAP: dict[str, str] = {}
-SKIP_CLASSIFIED_SERVICES: frozenset[str] = frozenset()
+SKIP_CLASSIFIED_SERVICES: set[str] = set()
 SERVICE_FAMILY_MAP: dict[str, str] = {}
-DIRECT_CLASSIFIED_EFFECTIVE_SERVICES: tuple[str, ...] = ()
-SUPPORTED_VERIFY_SERVICES: tuple[str, ...] = ()
-SUPPORTED_SETUP_SERVICES: tuple[str, ...] = ()
-CORE_VERIFY_SERVICES: frozenset[str] = frozenset()
+DIRECT_CLASSIFIED_EFFECTIVE_SERVICES: list[str] = []
+SUPPORTED_VERIFY_SERVICES: list[str] = []
+SUPPORTED_SETUP_SERVICES: list[str] = []
+CORE_VERIFY_SERVICES: set[str] = set()
 
 
 def _rebuild_registry() -> None:
     """Recompute every lookup derived from the spec list.
 
     The derived tables used to be computed once at import. A plugin registers
-    after import, so they are rebuilt on each registration instead. The module
-    names stay the same, which keeps every existing reader working unchanged.
+    after import, so they are rebuilt on each registration instead.
+
+    Every table is updated **in place**. Readers import these names directly,
+    which binds the object rather than the name, so replacing a table would
+    leave them on the snapshot taken before the plugin registered.
     """
-    global INTEGRATION_SPECS, INTEGRATION_SPECS_BY_SERVICE, SERVICE_KEY_MAP
-    global SKIP_CLASSIFIED_SERVICES, SERVICE_FAMILY_MAP
-    global DIRECT_CLASSIFIED_EFFECTIVE_SERVICES, SUPPORTED_VERIFY_SERVICES
-    global SUPPORTED_SETUP_SERVICES, CORE_VERIFY_SERVICES
+    INTEGRATION_SPECS[:] = (*_BUILTIN_SPECS, *_EXTERNAL_SPECS)
 
-    INTEGRATION_SPECS = (*_BUILTIN_SPECS, *_EXTERNAL_SPECS)
-
-    INTEGRATION_SPECS_BY_SERVICE = {spec.service: spec for spec in INTEGRATION_SPECS}
+    INTEGRATION_SPECS_BY_SERVICE.clear()
+    INTEGRATION_SPECS_BY_SERVICE.update({spec.service: spec for spec in INTEGRATION_SPECS})
 
     service_keys: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
     for spec in INTEGRATION_SPECS:
         for alias in spec.aliases:
             service_keys[alias] = spec.service
-    SERVICE_KEY_MAP = service_keys
+    SERVICE_KEY_MAP.clear()
+    SERVICE_KEY_MAP.update(service_keys)
 
-    SKIP_CLASSIFIED_SERVICES = frozenset(
+    SKIP_CLASSIFIED_SERVICES.clear()
+    SKIP_CLASSIFIED_SERVICES.update(
         spec.service for spec in INTEGRATION_SPECS if spec.skip_classification
     )
 
@@ -492,13 +500,14 @@ def _rebuild_registry() -> None:
     for spec in INTEGRATION_SPECS:
         for member in spec.family_members:
             families[member] = spec.service
-    SERVICE_FAMILY_MAP = families
+    SERVICE_FAMILY_MAP.clear()
+    SERVICE_FAMILY_MAP.update(families)
 
-    DIRECT_CLASSIFIED_EFFECTIVE_SERVICES = tuple(
+    DIRECT_CLASSIFIED_EFFECTIVE_SERVICES[:] = [
         spec.service for spec in INTEGRATION_SPECS if spec.direct_effective
-    )
+    ]
 
-    SUPPORTED_VERIFY_SERVICES = tuple(
+    SUPPORTED_VERIFY_SERVICES[:] = [
         spec.service
         for spec in sorted(
             (candidate for candidate in INTEGRATION_SPECS if candidate.has_verifier),
@@ -506,9 +515,9 @@ def _rebuild_registry() -> None:
                 candidate.verify_order if candidate.verify_order is not None else 10_000
             ),
         )
-    )
+    ]
 
-    SUPPORTED_SETUP_SERVICES = tuple(
+    SUPPORTED_SETUP_SERVICES[:] = [
         spec.service
         for spec in sorted(
             (candidate for candidate in INTEGRATION_SPECS if candidate.setup_order is not None),
@@ -516,9 +525,10 @@ def _rebuild_registry() -> None:
                 candidate.setup_order if candidate.setup_order is not None else 10_000
             ),
         )
-    )
+    ]
 
-    CORE_VERIFY_SERVICES = frozenset(spec.service for spec in INTEGRATION_SPECS if spec.core_verify)
+    CORE_VERIFY_SERVICES.clear()
+    CORE_VERIFY_SERVICES.update(spec.service for spec in INTEGRATION_SPECS if spec.core_verify)
 
 
 def register_integration_spec(spec: IntegrationSpec) -> None:
@@ -529,11 +539,18 @@ def register_integration_spec(spec: IntegrationSpec) -> None:
     Registering the same service twice replaces the earlier entry, so a reload
     does not accumulate duplicates.
     """
-    global _EXTERNAL_SPECS
-
-    _EXTERNAL_SPECS = [entry for entry in _EXTERNAL_SPECS if entry.service != spec.service]
+    _EXTERNAL_SPECS[:] = [entry for entry in _EXTERNAL_SPECS if entry.service != spec.service]
     _EXTERNAL_SPECS.append(spec)
     _rebuild_registry()
+
+
+def external_integration_services() -> set[str]:
+    """Return the services registered from outside this repository.
+
+    Callers that validate against a fixed set of known integrations need this
+    to avoid discarding a plugin's service as unrecognised.
+    """
+    return {spec.service for spec in _EXTERNAL_SPECS}
 
 
 _rebuild_registry()

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -449,7 +449,25 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
 #: can add itself without the module literal having to know about it.
 _EXTERNAL_SPECS: list[IntegrationSpec] = []
 
-#: Every spec, built-in first so a plugin cannot shadow a shipped integration.
+
+def _builtin_claimed_keys() -> frozenset[str]:
+    """Return every key the built-in specs answer to.
+
+    A spec owns its service name, its aliases and its family members: all three
+    end up as keys in the derived lookups, so all three have to be off limits to
+    a plugin.
+    """
+    claimed: set[str] = set()
+    for spec in _BUILTIN_SPECS:
+        claimed.add(spec.service)
+        claimed.update(spec.aliases)
+        claimed.update(spec.family_members)
+    return frozenset(claimed)
+
+
+_BUILTIN_CLAIMED_KEYS = _builtin_claimed_keys()
+
+#: Every spec, built-in first.
 #:
 #: This and the tables below are filled by :func:`_rebuild_registry` and then
 #: updated **in place** on every later registration. That matters: readers use
@@ -481,13 +499,21 @@ def _rebuild_registry() -> None:
     """
     INTEGRATION_SPECS[:] = (*_BUILTIN_SPECS, *_EXTERNAL_SPECS)
 
-    INTEGRATION_SPECS_BY_SERVICE.clear()
-    INTEGRATION_SPECS_BY_SERVICE.update({spec.service: spec for spec in INTEGRATION_SPECS})
+    # Built-ins are written last so that they win any key collision. Registration
+    # rejects a colliding spec outright, so this only matters if that check is
+    # ever bypassed - but the failure it prevents is a plugin silently taking
+    # over a shipped integration's setup, verification and classification.
+    by_precedence = (*_EXTERNAL_SPECS, *_BUILTIN_SPECS)
 
-    service_keys: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
-    for spec in INTEGRATION_SPECS:
+    INTEGRATION_SPECS_BY_SERVICE.clear()
+    INTEGRATION_SPECS_BY_SERVICE.update({spec.service: spec for spec in by_precedence})
+
+    service_keys: dict[str, str] = {spec.service: spec.service for spec in by_precedence}
+    for spec in by_precedence:
         for alias in spec.aliases:
             service_keys[alias] = spec.service
+    for spec in _BUILTIN_SPECS:
+        service_keys[spec.service] = spec.service
     SERVICE_KEY_MAP.clear()
     SERVICE_KEY_MAP.update(service_keys)
 
@@ -496,10 +522,12 @@ def _rebuild_registry() -> None:
         spec.service for spec in INTEGRATION_SPECS if spec.skip_classification
     )
 
-    families: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
-    for spec in INTEGRATION_SPECS:
+    families: dict[str, str] = {spec.service: spec.service for spec in by_precedence}
+    for spec in by_precedence:
         for member in spec.family_members:
             families[member] = spec.service
+    for spec in _BUILTIN_SPECS:
+        families[spec.service] = spec.service
     SERVICE_FAMILY_MAP.clear()
     SERVICE_FAMILY_MAP.update(families)
 
@@ -538,7 +566,23 @@ def register_integration_spec(spec: IntegrationSpec) -> None:
     of the tree, mirroring ``register_external_tool_package`` for tools.
     Registering the same service twice replaces the earlier entry, so a reload
     does not accumulate duplicates.
+
+    Raises ``ValueError`` when the spec claims a service name, alias or family
+    member that a built-in integration already answers to. Those keys index the
+    derived lookups, so accepting one would quietly point setup, verification,
+    classification or family bucketing at the plugin instead of the shipped
+    integration. Refusing at registration makes it a plugin bug with a clear
+    message rather than a misrouted investigation later.
     """
+    claimed = {spec.service, *spec.aliases, *spec.family_members}
+    conflicts = sorted(claimed & _BUILTIN_CLAIMED_KEYS)
+    if conflicts:
+        raise ValueError(
+            f"Integration {spec.service!r} cannot claim {conflicts}: already used by a "
+            "built-in integration as a service name, alias or family member. Pick keys "
+            "unique to this integration."
+        )
+
     _EXTERNAL_SPECS[:] = [entry for entry in _EXTERNAL_SPECS if entry.service != spec.service]
     _EXTERNAL_SPECS.append(spec)
     _rebuild_registry()

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -24,7 +24,7 @@ class IntegrationSpec:
     verify_order: int | None = None
 
 
-INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
+_BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(
         service="grafana",
         family_members=("grafana_local",),
@@ -444,47 +444,99 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     ),
 )
 
-INTEGRATION_SPECS_BY_SERVICE = {spec.service: spec for spec in INTEGRATION_SPECS}
+#: Specs contributed by out-of-tree packages through
+#: :func:`register_integration_spec`. Kept apart from the built-ins so a plugin
+#: can add itself without the module literal having to know about it.
+_EXTERNAL_SPECS: list[IntegrationSpec] = []
 
-SERVICE_KEY_MAP: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
-for _spec in INTEGRATION_SPECS:
-    for _alias in _spec.aliases:
-        SERVICE_KEY_MAP[_alias] = _spec.service
+#: Every spec, built-in first so a plugin cannot shadow a shipped integration.
+INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = ()
 
-SKIP_CLASSIFIED_SERVICES: frozenset[str] = frozenset(
-    spec.service for spec in INTEGRATION_SPECS if spec.skip_classification
-)
+INTEGRATION_SPECS_BY_SERVICE: dict[str, IntegrationSpec] = {}
+SERVICE_KEY_MAP: dict[str, str] = {}
+SKIP_CLASSIFIED_SERVICES: frozenset[str] = frozenset()
+SERVICE_FAMILY_MAP: dict[str, str] = {}
+DIRECT_CLASSIFIED_EFFECTIVE_SERVICES: tuple[str, ...] = ()
+SUPPORTED_VERIFY_SERVICES: tuple[str, ...] = ()
+SUPPORTED_SETUP_SERVICES: tuple[str, ...] = ()
+CORE_VERIFY_SERVICES: frozenset[str] = frozenset()
 
-SERVICE_FAMILY_MAP: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
-for _spec in INTEGRATION_SPECS:
-    for _member in _spec.family_members:
-        SERVICE_FAMILY_MAP[_member] = _spec.service
 
-DIRECT_CLASSIFIED_EFFECTIVE_SERVICES = tuple(
-    spec.service for spec in INTEGRATION_SPECS if spec.direct_effective
-)
+def _rebuild_registry() -> None:
+    """Recompute every lookup derived from the spec list.
 
-SUPPORTED_VERIFY_SERVICES = tuple(
-    spec.service
-    for spec in sorted(
-        (candidate for candidate in INTEGRATION_SPECS if candidate.has_verifier),
-        key=lambda candidate: (
-            candidate.verify_order if candidate.verify_order is not None else 10_000
-        ),
+    The derived tables used to be computed once at import. A plugin registers
+    after import, so they are rebuilt on each registration instead. The module
+    names stay the same, which keeps every existing reader working unchanged.
+    """
+    global INTEGRATION_SPECS, INTEGRATION_SPECS_BY_SERVICE, SERVICE_KEY_MAP
+    global SKIP_CLASSIFIED_SERVICES, SERVICE_FAMILY_MAP
+    global DIRECT_CLASSIFIED_EFFECTIVE_SERVICES, SUPPORTED_VERIFY_SERVICES
+    global SUPPORTED_SETUP_SERVICES, CORE_VERIFY_SERVICES
+
+    INTEGRATION_SPECS = (*_BUILTIN_SPECS, *_EXTERNAL_SPECS)
+
+    INTEGRATION_SPECS_BY_SERVICE = {spec.service: spec for spec in INTEGRATION_SPECS}
+
+    service_keys: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
+    for spec in INTEGRATION_SPECS:
+        for alias in spec.aliases:
+            service_keys[alias] = spec.service
+    SERVICE_KEY_MAP = service_keys
+
+    SKIP_CLASSIFIED_SERVICES = frozenset(
+        spec.service for spec in INTEGRATION_SPECS if spec.skip_classification
     )
-)
 
-SUPPORTED_SETUP_SERVICES = tuple(
-    spec.service
-    for spec in sorted(
-        (candidate for candidate in INTEGRATION_SPECS if candidate.setup_order is not None),
-        key=lambda candidate: (
-            candidate.setup_order if candidate.setup_order is not None else 10_000
-        ),
+    families: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
+    for spec in INTEGRATION_SPECS:
+        for member in spec.family_members:
+            families[member] = spec.service
+    SERVICE_FAMILY_MAP = families
+
+    DIRECT_CLASSIFIED_EFFECTIVE_SERVICES = tuple(
+        spec.service for spec in INTEGRATION_SPECS if spec.direct_effective
     )
-)
 
-CORE_VERIFY_SERVICES = frozenset(spec.service for spec in INTEGRATION_SPECS if spec.core_verify)
+    SUPPORTED_VERIFY_SERVICES = tuple(
+        spec.service
+        for spec in sorted(
+            (candidate for candidate in INTEGRATION_SPECS if candidate.has_verifier),
+            key=lambda candidate: (
+                candidate.verify_order if candidate.verify_order is not None else 10_000
+            ),
+        )
+    )
+
+    SUPPORTED_SETUP_SERVICES = tuple(
+        spec.service
+        for spec in sorted(
+            (candidate for candidate in INTEGRATION_SPECS if candidate.setup_order is not None),
+            key=lambda candidate: (
+                candidate.setup_order if candidate.setup_order is not None else 10_000
+            ),
+        )
+    )
+
+    CORE_VERIFY_SERVICES = frozenset(spec.service for spec in INTEGRATION_SPECS if spec.core_verify)
+
+
+def register_integration_spec(spec: IntegrationSpec) -> None:
+    """Register an integration shipped outside this repository.
+
+    The extension point for packages that add an integration without being part
+    of the tree, mirroring ``register_external_tool_package`` for tools.
+    Registering the same service twice replaces the earlier entry, so a reload
+    does not accumulate duplicates.
+    """
+    global _EXTERNAL_SPECS
+
+    _EXTERNAL_SPECS = [entry for entry in _EXTERNAL_SPECS if entry.service != spec.service]
+    _EXTERNAL_SPECS.append(spec)
+    _rebuild_registry()
+
+
+_rebuild_registry()
 
 
 def family_key(service_key: str) -> str:

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import threading
+from dataclasses import dataclass, replace
 from typing import Any
 
 
@@ -449,6 +450,22 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
 #: can add itself without the module literal having to know about it.
 _EXTERNAL_SPECS: list[IntegrationSpec] = []
 
+#: Serialises registration so two plugins importing concurrently cannot
+#: interleave the conflict check with the table rebuild. Mirrors the lock
+#: ``tools.registry`` takes around external tool-package registration.
+_REGISTRATION_LOCK = threading.Lock()
+
+
+def normalize_service_key(key: str) -> str:
+    """Return *key* in the form the lookups are read with.
+
+    ``service_key`` and the classification path both lower-case and strip before
+    looking a service up, so a spec registered as ``"GitHub"`` would be stored
+    under a key nothing ever queries - and would slip past a conflict check that
+    compared raw strings.
+    """
+    return key.strip().lower()
+
 
 def _builtin_claimed_keys() -> frozenset[str]:
     """Return every key the built-in specs answer to.
@@ -459,9 +476,9 @@ def _builtin_claimed_keys() -> frozenset[str]:
     """
     claimed: set[str] = set()
     for spec in _BUILTIN_SPECS:
-        claimed.add(spec.service)
-        claimed.update(spec.aliases)
-        claimed.update(spec.family_members)
+        claimed.add(normalize_service_key(spec.service))
+        claimed.update(normalize_service_key(alias) for alias in spec.aliases)
+        claimed.update(normalize_service_key(member) for member in spec.family_members)
     return frozenset(claimed)
 
 
@@ -487,6 +504,27 @@ SUPPORTED_SETUP_SERVICES: list[str] = []
 CORE_VERIFY_SERVICES: set[str] = set()
 
 
+def _refill_mapping(target: dict[Any, Any], source: dict[Any, Any]) -> None:
+    """Make *target* match *source* without it ever going empty.
+
+    Clearing first leaves a window where a concurrent reader sees nothing:
+    ``service_key`` falls back to the identity on a miss, so an alias would
+    quietly resolve to itself and route to the wrong integration. Writing the
+    new entries before dropping the departed ones keeps every surviving key
+    continuously present.
+    """
+    target.update(source)
+    for key in [key for key in target if key not in source]:
+        del target[key]
+
+
+def _refill_set(target: set[Any], source: set[Any]) -> None:
+    """Make *target* match *source* without it ever going empty."""
+    target.update(source)
+    for item in list(target - source):
+        target.discard(item)
+
+
 def _rebuild_registry() -> None:
     """Recompute every lookup derived from the spec list.
 
@@ -505,8 +543,7 @@ def _rebuild_registry() -> None:
     # over a shipped integration's setup, verification and classification.
     by_precedence = (*_EXTERNAL_SPECS, *_BUILTIN_SPECS)
 
-    INTEGRATION_SPECS_BY_SERVICE.clear()
-    INTEGRATION_SPECS_BY_SERVICE.update({spec.service: spec for spec in by_precedence})
+    _refill_mapping(INTEGRATION_SPECS_BY_SERVICE, {spec.service: spec for spec in by_precedence})
 
     service_keys: dict[str, str] = {spec.service: spec.service for spec in by_precedence}
     for spec in by_precedence:
@@ -514,12 +551,11 @@ def _rebuild_registry() -> None:
             service_keys[alias] = spec.service
     for spec in _BUILTIN_SPECS:
         service_keys[spec.service] = spec.service
-    SERVICE_KEY_MAP.clear()
-    SERVICE_KEY_MAP.update(service_keys)
+    _refill_mapping(SERVICE_KEY_MAP, service_keys)
 
-    SKIP_CLASSIFIED_SERVICES.clear()
-    SKIP_CLASSIFIED_SERVICES.update(
-        spec.service for spec in INTEGRATION_SPECS if spec.skip_classification
+    _refill_set(
+        SKIP_CLASSIFIED_SERVICES,
+        {spec.service for spec in INTEGRATION_SPECS if spec.skip_classification},
     )
 
     families: dict[str, str] = {spec.service: spec.service for spec in by_precedence}
@@ -528,8 +564,7 @@ def _rebuild_registry() -> None:
             families[member] = spec.service
     for spec in _BUILTIN_SPECS:
         families[spec.service] = spec.service
-    SERVICE_FAMILY_MAP.clear()
-    SERVICE_FAMILY_MAP.update(families)
+    _refill_mapping(SERVICE_FAMILY_MAP, families)
 
     DIRECT_CLASSIFIED_EFFECTIVE_SERVICES[:] = [
         spec.service for spec in INTEGRATION_SPECS if spec.direct_effective
@@ -555,8 +590,9 @@ def _rebuild_registry() -> None:
         )
     ]
 
-    CORE_VERIFY_SERVICES.clear()
-    CORE_VERIFY_SERVICES.update(spec.service for spec in INTEGRATION_SPECS if spec.core_verify)
+    _refill_set(
+        CORE_VERIFY_SERVICES, {spec.service for spec in INTEGRATION_SPECS if spec.core_verify}
+    )
 
 
 def register_integration_spec(spec: IntegrationSpec) -> None:
@@ -568,24 +604,61 @@ def register_integration_spec(spec: IntegrationSpec) -> None:
     does not accumulate duplicates.
 
     Raises ``ValueError`` when the spec claims a service name, alias or family
-    member that a built-in integration already answers to. Those keys index the
-    derived lookups, so accepting one would quietly point setup, verification,
-    classification or family bucketing at the plugin instead of the shipped
-    integration. Refusing at registration makes it a plugin bug with a clear
-    message rather than a misrouted investigation later.
+    member that another integration already answers to - built-in or a plugin
+    registered earlier. Those keys index the derived lookups, so accepting one
+    would quietly point setup, verification, classification or family bucketing
+    at the wrong integration. Refusing at registration makes it a plugin bug with
+    a clear message rather than a misrouted investigation later.
+
+    Two packages installed together are the case worth naming: whichever
+    imported last would otherwise win every key they share, and nothing would
+    report it.
     """
-    claimed = {spec.service, *spec.aliases, *spec.family_members}
+    service = normalize_service_key(spec.service)
+    if not service:
+        raise ValueError("An integration spec needs a non-empty service name.")
+
+    aliases = tuple(normalize_service_key(alias) for alias in spec.aliases)
+    family_members = tuple(normalize_service_key(member) for member in spec.family_members)
+    if not all(aliases) or not all(family_members):
+        raise ValueError(
+            f"Integration {service!r} has an empty alias or family member. Every key has "
+            "to be a name something can be looked up by."
+        )
+
+    # Stored normalized, so the tables only ever hold keys in the form the
+    # readers query with.
+    normalized = replace(spec, service=service, aliases=aliases, family_members=family_members)
+    claimed = {service, *aliases, *family_members}
+
     conflicts = sorted(claimed & _BUILTIN_CLAIMED_KEYS)
     if conflicts:
         raise ValueError(
-            f"Integration {spec.service!r} cannot claim {conflicts}: already used by a "
+            f"Integration {service!r} cannot claim {conflicts}: already used by a "
             "built-in integration as a service name, alias or family member. Pick keys "
             "unique to this integration."
         )
 
-    _EXTERNAL_SPECS[:] = [entry for entry in _EXTERNAL_SPECS if entry.service != spec.service]
-    _EXTERNAL_SPECS.append(spec)
-    _rebuild_registry()
+    with _REGISTRATION_LOCK:
+        # Re-registering the same service replaces its entry, so its own keys are
+        # not a conflict with itself.
+        others = [entry for entry in _EXTERNAL_SPECS if entry.service != service]
+        owner_by_key: dict[str, str] = {}
+        for entry in others:
+            for key in (entry.service, *entry.aliases, *entry.family_members):
+                owner_by_key.setdefault(key, entry.service)
+
+        taken = sorted(claimed & owner_by_key.keys())
+        if taken:
+            owners = ", ".join(f"{key!r} (registered by {owner_by_key[key]!r})" for key in taken)
+            raise ValueError(
+                f"Integration {service!r} cannot claim {owners}: another registered "
+                "integration already answers to those keys. Pick keys unique to this "
+                "integration."
+            )
+
+        _EXTERNAL_SPECS[:] = [*others, normalized]
+        _rebuild_registry()
 
 
 def external_integration_services() -> set[str]:
@@ -595,6 +668,16 @@ def external_integration_services() -> set[str]:
     to avoid discarding a plugin's service as unrecognised.
     """
     return {spec.service for spec in _EXTERNAL_SPECS}
+
+
+def builtin_claimed_keys() -> frozenset[str]:
+    """Return every key a built-in integration answers to.
+
+    Other registration hooks validate against this so a plugin cannot attach
+    itself to a shipped integration's key by a route that does not go through
+    :func:`register_integration_spec`.
+    """
+    return _BUILTIN_CLAIMED_KEYS
 
 
 _rebuild_registry()

--- a/surfaces/cli/commands/integrations.py
+++ b/surfaces/cli/commands/integrations.py
@@ -11,11 +11,7 @@ from platform.analytics.cli import (
     capture_integration_verified,
     capture_integrations_listed,
 )
-from surfaces.cli.constants import (
-    MANAGED_INTEGRATION_SERVICES,
-    SETUP_SERVICES,
-    VERIFY_SERVICES,
-)
+from surfaces.cli import constants
 
 
 class IntegrationServiceChoice(click.Choice):
@@ -24,7 +20,22 @@ class IntegrationServiceChoice(click.Choice):
     Applies ``resolve_management_service`` before the enum check so management-only
     aliases (when defined) are accepted while keeping Click's friendly
     ``[[a|b|c]]`` usage/error display and shell completion.
+
+    The choices are read from :mod:`surfaces.cli.constants` on each access rather
+    than captured when the decorator runs. A plugin registers its integration
+    after this module is imported, and a list baked into the ``click.Command``
+    would reject it before ``cmd_setup`` ever saw it.
     """
+
+    def __init__(self, source: str) -> None:
+        # ``click.Choice.__init__`` only assigns ``choices`` and ``case_sensitive``;
+        # ``choices`` is a live property here, so set the other one directly.
+        self._source = source
+        self.case_sensitive = True
+
+    @property
+    def choices(self) -> tuple[str, ...]:  # type: ignore[override]
+        return tuple(getattr(constants, self._source))
 
     def convert(
         self,
@@ -46,7 +57,7 @@ def integrations() -> None:
 
 @integrations.command(name="setup")
 @click.argument(
-    "service", required=False, default=None, type=IntegrationServiceChoice(SETUP_SERVICES)
+    "service", required=False, default=None, type=IntegrationServiceChoice("SETUP_SERVICES")
 )
 def setup_integration(service: str | None) -> None:
     """Set up credentials for a service."""
@@ -57,7 +68,7 @@ def setup_integration(service: str | None) -> None:
     resolved_service = cmd_setup(service)
     capture_integration_setup_completed(resolved_service)
 
-    if resolved_service in VERIFY_SERVICES:
+    if resolved_service in constants.VERIFY_SERVICES:
         click.echo(f"  Verifying {resolved_service}...\n")
         exit_code = cmd_verify(resolved_service)
         if exit_code == 0:
@@ -75,7 +86,7 @@ def list_integrations() -> None:
 
 
 @integrations.command(name="show")
-@click.argument("service", type=IntegrationServiceChoice(MANAGED_INTEGRATION_SERVICES))
+@click.argument("service", type=IntegrationServiceChoice("MANAGED_INTEGRATION_SERVICES"))
 def show_integration(service: str) -> None:
     """Show details for a configured integration."""
     from integrations.cli import cmd_show
@@ -84,7 +95,7 @@ def show_integration(service: str) -> None:
 
 
 @integrations.command(name="remove")
-@click.argument("service", type=IntegrationServiceChoice(MANAGED_INTEGRATION_SERVICES))
+@click.argument("service", type=IntegrationServiceChoice("MANAGED_INTEGRATION_SERVICES"))
 def remove_integration(service: str) -> None:
     """Remove a configured integration."""
     from integrations.cli import cmd_remove
@@ -95,7 +106,7 @@ def remove_integration(service: str) -> None:
 
 @integrations.command(name="verify")
 @click.argument(
-    "service", required=False, default=None, type=IntegrationServiceChoice(VERIFY_SERVICES)
+    "service", required=False, default=None, type=IntegrationServiceChoice("VERIFY_SERVICES")
 )
 @click.option(
     "--send-slack-test", is_flag=True, help="Send a test message to the configured Slack webhook."

--- a/surfaces/cli/constants.py
+++ b/surfaces/cli/constants.py
@@ -42,11 +42,11 @@ def __getattr__(name: str) -> tuple[str, ...]:
     if name == "SETUP_SERVICES":
         from integrations.registry import SUPPORTED_SETUP_SERVICES
 
-        return SUPPORTED_SETUP_SERVICES
+        return tuple(SUPPORTED_SETUP_SERVICES)
     if name == "VERIFY_SERVICES":
         from integrations.registry import SUPPORTED_VERIFY_SERVICES
 
-        return SUPPORTED_VERIFY_SERVICES
+        return tuple(SUPPORTED_VERIFY_SERVICES)
     if name == "MANAGED_INTEGRATION_SERVICES":
         from integrations.registry import (
             SUPPORTED_SETUP_SERVICES,

--- a/tests/integrations/test_external_registration.py
+++ b/tests/integrations/test_external_registration.py
@@ -185,3 +185,43 @@ def test_help_text_lists_a_registered_integration(
     import integrations.cli as cli
 
     assert SERVICE in ", ".join(cli.setup_services())
+
+
+@pytest.mark.parametrize(
+    ("label", "spec"),
+    [
+        ("service name", IntegrationSpec(service="github", setup_order=999)),
+        ("alias", IntegrationSpec(service="acme_alias", aliases=("github_mcp",))),
+        (
+            "family member",
+            IntegrationSpec(service="acme_family", family_members=("grafana_local",)),
+        ),
+        ("alias over a service", IntegrationSpec(service="acme_over", aliases=("datadog",))),
+    ],
+)
+def test_a_spec_cannot_claim_a_built_in_key(label: str, spec: IntegrationSpec) -> None:
+    """Service names, aliases and family members all index the derived lookups.
+
+    Letting a plugin claim any of them would point setup, verification,
+    classification or family bucketing at the plugin instead of the built-in.
+    """
+    with pytest.raises(ValueError, match="built-in integration"):
+        register_integration_spec(spec)
+
+
+def test_a_rejected_spec_leaves_the_registry_untouched() -> None:
+    before = dict(registry.INTEGRATION_SPECS_BY_SERVICE)
+
+    with pytest.raises(ValueError):
+        register_integration_spec(IntegrationSpec(service="github", setup_order=999))
+
+    assert before == registry.INTEGRATION_SPECS_BY_SERVICE
+    assert registry.INTEGRATION_SPECS_BY_SERVICE["github"].setup_order != 999
+    assert "github" not in {spec.service for spec in registry._EXTERNAL_SPECS}
+
+
+def test_built_in_lookups_still_resolve_after_a_registration(registered_integration: str) -> None:
+    from integrations.registry import family_key, service_key
+
+    assert service_key("github_mcp") == "github"
+    assert family_key("grafana_local") == "grafana"

--- a/tests/integrations/test_external_registration.py
+++ b/tests/integrations/test_external_registration.py
@@ -142,3 +142,46 @@ def test_built_in_integrations_are_unaffected(registered_integration: str) -> No
 
     assert "github" in verify.SUPPORTED_VERIFY_SERVICES
     assert len(verify.SUPPORTED_VERIFY_SERVICES) > 1
+
+
+@pytest.fixture
+def registered_with_setup_handler(registered_integration: str) -> Iterator[list[str]]:
+    """Add the ``_HANDLERS`` entry a plugin appends, and record invocations."""
+    import integrations.cli as cli
+
+    calls: list[str] = []
+
+    def _handler() -> None:
+        calls.append(registered_integration)
+
+    cli._HANDLERS[registered_integration] = _handler
+
+    yield calls
+
+    cli._HANDLERS.pop(registered_integration, None)
+
+
+def test_setup_offers_a_registered_integration(registered_with_setup_handler: list[str]) -> None:
+    """``setup_services`` was a tuple built at import from the registry and the
+    handler map, so it could not see a plugin that arrives after either."""
+    import integrations.cli as cli
+
+    assert SERVICE in cli.setup_services()
+
+
+def test_setup_dispatches_to_a_registered_integration(
+    registered_with_setup_handler: list[str],
+) -> None:
+    """The gate in ``cmd_setup`` rejected an unknown service with ``_die``."""
+    import integrations.cli as cli
+
+    assert cli.cmd_setup(SERVICE) == SERVICE
+    assert registered_with_setup_handler == [SERVICE]
+
+
+def test_help_text_lists_a_registered_integration(
+    registered_with_setup_handler: list[str],
+) -> None:
+    import integrations.cli as cli
+
+    assert SERVICE in ", ".join(cli.setup_services())

--- a/tests/integrations/test_external_registration.py
+++ b/tests/integrations/test_external_registration.py
@@ -225,3 +225,167 @@ def test_built_in_lookups_still_resolve_after_a_registration(registered_integrat
 
     assert service_key("github_mcp") == "github"
     assert family_key("grafana_local") == "grafana"
+
+
+@pytest.fixture
+def first_plugin() -> Iterator[str]:
+    """Register one external integration so a second one can collide with it."""
+    register_integration_spec(
+        IntegrationSpec(
+            service="plugin_a", aliases=("shared_alias",), family_members=("shared_kid",)
+        )
+    )
+
+    yield "plugin_a"
+
+    registry._EXTERNAL_SPECS[:] = [
+        spec for spec in registry._EXTERNAL_SPECS if spec.service != "plugin_a"
+    ]
+    registry._rebuild_registry()
+
+
+@pytest.mark.parametrize(
+    ("label", "spec"),
+    [
+        ("alias", IntegrationSpec(service="plugin_b", aliases=("shared_alias",))),
+        ("family member", IntegrationSpec(service="plugin_c", family_members=("shared_kid",))),
+        ("alias over their service", IntegrationSpec(service="plugin_d", aliases=("plugin_a",))),
+        ("service over their alias", IntegrationSpec(service="shared_alias")),
+    ],
+)
+def test_a_spec_cannot_claim_another_plugins_key(
+    first_plugin: str, label: str, spec: IntegrationSpec
+) -> None:
+    """Two plugins installed together must not silently fight over a key.
+
+    Whichever imported last would otherwise win, with nothing reporting it.
+    """
+    with pytest.raises(ValueError, match="another registered integration"):
+        register_integration_spec(spec)
+
+
+def test_re_registering_the_same_service_still_replaces_it(first_plugin: str) -> None:
+    """A reload re-registers the same spec; its own keys are not a self-conflict."""
+    from integrations.registry import service_key
+
+    register_integration_spec(
+        IntegrationSpec(service=first_plugin, aliases=("shared_alias",), setup_order=5)
+    )
+
+    assert service_key("shared_alias") == first_plugin
+    assert registry.INTEGRATION_SPECS_BY_SERVICE[first_plugin].setup_order == 5
+    assert [spec.service for spec in registry._EXTERNAL_SPECS].count(first_plugin) == 1
+
+
+@pytest.mark.parametrize(
+    ("hook", "register"),
+    [
+        ("classifier", lambda: register_classifier("github", _classify)),
+        ("env loader", lambda: register_env_loader("github", _env_record)),
+        ("presence check", lambda: register_env_presence("github", _is_configured)),
+    ],
+)
+def test_a_hook_cannot_attach_to_a_built_in_service(hook: str, register: Any) -> None:
+    """Each hook can be called without a spec, so each needs the same gate."""
+    with pytest.raises(ValueError, match="built-in integration"):
+        register()
+
+
+def test_an_env_loader_cannot_emit_another_integrations_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The merge replaces by service, so an impostor record would outrank the real one."""
+    monkeypatch.setenv("GITHUB_MCP_URL", "https://real.example")
+
+    def _impostor() -> dict[str, Any]:
+        return {
+            "service": "github",
+            "status": "active",
+            "source": "local env",
+            "config": {"url": "https://impostor.example"},
+        }
+
+    register_env_loader("acme_impostor", _impostor)
+    try:
+        github = [r for r in _catalog_impl.load_env_integrations() if r.get("service") == "github"]
+    finally:
+        _catalog_impl._EXTERNAL_ENV_LOADERS.pop("acme_impostor", None)
+
+    assert len(github) == 1
+    assert "impostor" not in str(github[0].get("config"))
+
+
+def test_the_cli_command_offers_a_registered_integration(
+    registered_with_setup_handler: list[str],
+) -> None:
+    """``click.Choice`` captured the service list when the decorator ran.
+
+    The command module is imported during CLI startup, before any plugin has
+    registered, so a captured list rejected the plugin with "is not one of"
+    before ``cmd_setup`` was reached.
+    """
+    import surfaces.cli.commands.integrations as integrations_group
+
+    setup_command = integrations_group.get_command(None, "setup")
+    assert setup_command is not None
+    assert SERVICE in list(setup_command.params[0].type.choices)
+
+
+def test_the_cli_command_still_rejects_an_unknown_service() -> None:
+    from click.testing import CliRunner
+
+    import surfaces.cli.commands.integrations as integrations_group
+
+    result = CliRunner().invoke(integrations_group, ["setup", "definitely_not_a_service"])
+
+    assert result.exit_code == 2
+
+
+@pytest.mark.parametrize("name", ["GitHub", " github", "github ", "GITHUB_MCP"])
+def test_a_built_in_key_is_claimed_whatever_the_casing(name: str) -> None:
+    """Readers strip and lower-case, so a raw string comparison would let these through."""
+    with pytest.raises(ValueError, match="built-in integration"):
+        register_integration_spec(IntegrationSpec(service=name, has_verifier=True))
+
+
+@pytest.mark.parametrize("name", ["", "   "])
+def test_a_spec_needs_a_service_name(name: str) -> None:
+    with pytest.raises(ValueError, match="non-empty service name"):
+        register_integration_spec(IntegrationSpec(service=name))
+
+
+def test_keys_are_stored_in_the_form_the_lookups_are_queried_with() -> None:
+    from integrations.registry import service_key
+
+    register_integration_spec(IntegrationSpec(service="  MixedCase  ", aliases=("Some Alias ",)))
+    try:
+        assert service_key("MIXEDCASE") == "mixedcase"
+        assert service_key("some alias") == "mixedcase"
+        assert "mixedcase" in registry.INTEGRATION_SPECS_BY_SERVICE
+    finally:
+        registry._EXTERNAL_SPECS[:] = [
+            spec for spec in registry._EXTERNAL_SPECS if spec.service != "mixedcase"
+        ]
+        registry._rebuild_registry()
+
+
+def test_a_rebuilt_table_never_drops_a_surviving_key() -> None:
+    """A reader must not catch the tables mid-rebuild.
+
+    ``service_key`` falls back to the identity on a miss, so a key that vanished
+    for an instant would resolve an alias to itself and route to the wrong
+    integration.
+    """
+    observed: list[bool] = []
+    table = {"keep": "keep", "drop": "drop"}
+
+    class _Watcher(dict[str, str]):
+        def __delitem__(self, key: str) -> None:
+            observed.append("keep" in self)
+            super().__delitem__(key)
+
+    watched = _Watcher(table)
+    registry._refill_mapping(watched, {"keep": "keep", "added": "added"})
+
+    assert all(observed), "a surviving key disappeared while the table was rebuilt"
+    assert watched == {"keep": "keep", "added": "added"}

--- a/tests/integrations/test_external_registration.py
+++ b/tests/integrations/test_external_registration.py
@@ -74,9 +74,17 @@ def registered_integration(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
         spec for spec in registry._EXTERNAL_SPECS if spec.service != SERVICE
     ]
     registry._rebuild_registry()
-    _catalog_impl._EXTERNAL_CLASSIFIERS.pop(SERVICE, None)
-    _catalog_impl._EXTERNAL_ENV_LOADERS.pop(SERVICE, None)
-    _catalog_impl._EXTERNAL_ENV_PRESENCE.pop(SERVICE, None)
+    _forget_hooks(SERVICE)
+
+
+def _forget_hooks(service: str) -> None:
+    """Drop every hook registered for *service*, ownership record included."""
+    _catalog_impl._EXTERNAL_CLASSIFIERS.pop(service, None)
+    _catalog_impl._EXTERNAL_ENV_LOADERS.pop(service, None)
+    _catalog_impl._EXTERNAL_ENV_PRESENCE.pop(service, None)
+    for hook, key in list(_catalog_impl._EXTERNAL_HOOK_OWNERS):
+        if key == service:
+            del _catalog_impl._EXTERNAL_HOOK_OWNERS[hook, key]
 
 
 def test_registration_reaches_a_module_that_imported_the_tables_earlier(
@@ -309,7 +317,7 @@ def test_an_env_loader_cannot_emit_another_integrations_record(
     try:
         github = [r for r in _catalog_impl.load_env_integrations() if r.get("service") == "github"]
     finally:
-        _catalog_impl._EXTERNAL_ENV_LOADERS.pop("acme_impostor", None)
+        _forget_hooks("acme_impostor")
 
     assert len(github) == 1
     assert "impostor" not in str(github[0].get("config"))
@@ -389,3 +397,85 @@ def test_a_rebuilt_table_never_drops_a_surviving_key() -> None:
 
     assert all(observed), "a surviving key disappeared while the table was rebuilt"
     assert watched == {"keep": "keep", "added": "added"}
+
+
+def _make_plugin_module(name: str) -> Any:
+    """Return a throwaway module standing in for a separately installed plugin.
+
+    Ownership is inferred from where the callback was defined, so two plugins
+    have to come from two modules for the check to mean anything.
+    """
+    import sys
+    import types
+
+    module = types.ModuleType(name)
+    exec(  # noqa: S102 - building a stand-in plugin module is the point
+        "def classify(credentials, record_id):\n"
+        "    return None, None\n"
+        "def load():\n"
+        "    return None\n"
+        "def present():\n"
+        "    return True\n",
+        module.__dict__,
+    )
+    sys.modules[name] = module
+    return module
+
+
+@pytest.fixture
+def two_plugin_modules() -> Iterator[tuple[Any, Any]]:
+    import sys
+
+    alpha = _make_plugin_module("plugin_alpha_stub")
+    beta = _make_plugin_module("plugin_beta_stub")
+
+    yield alpha, beta
+
+    _forget_hooks("shared_hook_key")
+    sys.modules.pop("plugin_alpha_stub", None)
+    sys.modules.pop("plugin_beta_stub", None)
+
+
+@pytest.mark.parametrize(
+    ("hook", "attribute", "register"),
+    [
+        ("classifier", "classify", register_classifier),
+        ("env loader", "load", register_env_loader),
+        ("presence check", "present", register_env_presence),
+    ],
+)
+def test_a_second_plugin_cannot_take_over_a_hook(
+    two_plugin_modules: tuple[Any, Any], hook: str, attribute: str, register: Any
+) -> None:
+    """Assignment into the hook map was last-write-wins, settled by import order."""
+    alpha, beta = two_plugin_modules
+
+    register("shared_hook_key", getattr(alpha, attribute))
+
+    with pytest.raises(ValueError, match="already registered by"):
+        register("shared_hook_key", getattr(beta, attribute))
+
+
+def test_the_owning_plugin_can_re_register_its_own_hook(
+    two_plugin_modules: tuple[Any, Any],
+) -> None:
+    """A reload hands back a new function object from the same package."""
+    alpha, _beta = two_plugin_modules
+
+    register_classifier("shared_hook_key", alpha.classify)
+    exec(  # noqa: S102 - stands in for the module being reloaded
+        "def classify(credentials, record_id):\n    return None, None\n", alpha.__dict__
+    )
+    register_classifier("shared_hook_key", alpha.classify)
+
+    assert _catalog_impl._EXTERNAL_CLASSIFIERS["shared_hook_key"] is alpha.classify
+
+
+def test_an_unattributable_hook_cannot_overwrite_an_existing_one() -> None:
+    """A callable with no package of its own identifies nobody, so it may not replace."""
+    register_env_loader("unattributable_key", dict)
+    try:
+        with pytest.raises(ValueError, match="already registered by"):
+            register_env_loader("unattributable_key", list)
+    finally:
+        _forget_hooks("unattributable_key")

--- a/tests/integrations/test_external_registration.py
+++ b/tests/integrations/test_external_registration.py
@@ -1,0 +1,144 @@
+"""An out-of-tree integration has to survive the paths production actually uses.
+
+Each test here drives a public entry point rather than the structure beneath it.
+Asserting on ``EffectiveIntegrations`` or on ``registry.SUPPORTED_VERIFY_SERVICES``
+directly would pass even when the resolver drops the key and when every importing
+module is left holding a pre-registration snapshot.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from integrations import _catalog_impl, registry
+from integrations.catalog import (
+    load_env_integration_services,
+    register_classifier,
+    register_env_loader,
+    register_env_presence,
+    resolve_effective_integrations,
+)
+from integrations.registry import IntegrationSpec, register_integration_spec
+
+SERVICE = "acme_external"
+ENV_VAR = "ACME_EXTERNAL_API_KEY"
+
+
+def _classify(credentials: dict[str, Any], record_id: str) -> tuple[Any | None, str | None]:
+    return {"configured": True, "source": "local env"}, SERVICE
+
+
+def _env_record() -> dict[str, Any] | None:
+    if not os.getenv(ENV_VAR):
+        return None
+    return {
+        "service": SERVICE,
+        "status": "active",
+        "source": "local env",
+        "config": {"api_key": os.environ[ENV_VAR]},
+    }
+
+
+def _is_configured() -> bool:
+    return bool(os.getenv(ENV_VAR))
+
+
+@pytest.fixture
+def registered_integration(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Register an external integration and remove it again afterwards.
+
+    Registration mutates module-level tables, so leaking one would change the
+    service lists every other test in the suite asserts against.
+    """
+    monkeypatch.setenv(ENV_VAR, "secret-value")
+
+    register_integration_spec(
+        IntegrationSpec(
+            service=SERVICE,
+            has_verifier=True,
+            setup_order=99,
+            direct_effective=True,
+        )
+    )
+    register_classifier(SERVICE, _classify)
+    register_env_loader(SERVICE, _env_record)
+    register_env_presence(SERVICE, _is_configured)
+
+    yield SERVICE
+
+    registry._EXTERNAL_SPECS[:] = [
+        spec for spec in registry._EXTERNAL_SPECS if spec.service != SERVICE
+    ]
+    registry._rebuild_registry()
+    _catalog_impl._EXTERNAL_CLASSIFIERS.pop(SERVICE, None)
+    _catalog_impl._EXTERNAL_ENV_LOADERS.pop(SERVICE, None)
+    _catalog_impl._EXTERNAL_ENV_PRESENCE.pop(SERVICE, None)
+
+
+def test_registration_reaches_a_module_that_imported_the_tables_earlier(
+    registered_integration: str,
+) -> None:
+    """``integrations.verify`` binds the service lists at import time.
+
+    It is imported long before a plugin registers, so a registration that
+    replaced the tables instead of updating them would never be seen here.
+    """
+    import integrations.verify as verify
+
+    assert registered_integration in verify.SUPPORTED_VERIFY_SERVICES
+
+
+def test_registration_reaches_a_second_hand_re_export(registered_integration: str) -> None:
+    """``integrations.app`` re-imports the list from ``integrations.verify``."""
+    import integrations.app as app
+
+    assert registered_integration in app.SUPPORTED_VERIFY_SERVICES
+
+
+def test_external_service_survives_effective_resolution(registered_integration: str) -> None:
+    """The resolver filters unknown keys before validating, so it must know this one."""
+    effective = resolve_effective_integrations(
+        store_integrations=[],
+        env_integrations=[_env_record() or {}],
+    )
+
+    assert registered_integration in effective
+
+
+def test_external_service_is_visible_to_the_startup_presence_check(
+    registered_integration: str,
+) -> None:
+    """The pre-prompt check is a separate list from the full environment loader."""
+    assert registered_integration in load_env_integration_services()
+
+
+def test_presence_check_stays_quiet_when_the_integration_is_unconfigured(
+    registered_integration: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+    assert registered_integration not in load_env_integration_services()
+
+
+def test_a_failing_presence_predicate_does_not_break_startup(
+    registered_integration: str,
+) -> None:
+    """A plugin bug must degrade to "not configured", never to a failed launch."""
+
+    def _explode() -> bool:
+        raise RuntimeError("plugin is broken")
+
+    _catalog_impl._EXTERNAL_ENV_PRESENCE[registered_integration] = _explode
+
+    assert registered_integration not in load_env_integration_services()
+
+
+def test_built_in_integrations_are_unaffected(registered_integration: str) -> None:
+    import integrations.verify as verify
+
+    assert "github" in verify.SUPPORTED_VERIFY_SERVICES
+    assert len(verify.SUPPORTED_VERIFY_SERVICES) > 1

--- a/tests/integrations/test_external_registration.py
+++ b/tests/integrations/test_external_registration.py
@@ -479,3 +479,75 @@ def test_an_unattributable_hook_cannot_overwrite_an_existing_one() -> None:
             register_env_loader("unattributable_key", list)
     finally:
         _forget_hooks("unattributable_key")
+
+
+def test_only_one_package_wins_a_contested_hook_key() -> None:
+    """Claiming and installing must be one step.
+
+    Reading the owner and then writing lets every concurrent caller see the key
+    free, so the last writer takes it and the others never learn they lost.
+    """
+    import threading
+
+    modules = [_make_plugin_module(f"contender_{index}_stub") for index in range(8)]
+    won: list[str] = []
+    refused: list[str] = []
+    barrier = threading.Barrier(len(modules))
+
+    def claim(module: Any) -> None:
+        barrier.wait()
+        try:
+            register_classifier("contested_key", module.classify)
+            won.append(module.__name__)
+        except ValueError:
+            refused.append(module.__name__)
+
+    threads = [threading.Thread(target=claim, args=(module,)) for module in modules]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    try:
+        assert len(won) == 1, f"expected a single winner, got {won}"
+        assert len(refused) == len(modules) - 1
+        owner = _catalog_impl._EXTERNAL_HOOK_OWNERS["a classifier", "contested_key"]
+        assert owner == won[0]
+    finally:
+        import sys
+
+        _forget_hooks("contested_key")
+        for module in modules:
+            sys.modules.pop(module.__name__, None)
+
+
+def test_the_presence_sweep_survives_a_registration_from_another_thread() -> None:
+    """``load_env_integration_services`` iterates the hook map during startup."""
+    import sys
+    import threading
+
+    module = _make_plugin_module("sweeper_stub")
+    crashes: list[str] = []
+    stop = threading.Event()
+
+    def scan() -> None:
+        while not stop.is_set():
+            try:
+                load_env_integration_services()
+            except RuntimeError as exc:  # "dictionary changed size during iteration"
+                crashes.append(str(exc))
+
+    scanner = threading.Thread(target=scan)
+    scanner.start()
+    registered = [f"sweep_target_{index}" for index in range(200)]
+    try:
+        for service in registered:
+            register_env_presence(service, module.present)
+    finally:
+        stop.set()
+        scanner.join()
+        for service in registered:
+            _forget_hooks(service)
+        sys.modules.pop("sweeper_stub", None)
+
+    assert not crashes

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -22,7 +22,9 @@ def test_registry_declares_each_service_once() -> None:
 
 
 def test_registry_supported_lists_are_derived_from_specs() -> None:
-    expected_verify = tuple(
+    # Lists, not tuples: the derived tables are mutated in place on registration
+    # so that readers holding an imported reference keep seeing current data.
+    expected_verify = [
         spec.service
         for spec in sorted(
             (candidate for candidate in INTEGRATION_SPECS if candidate.has_verifier),
@@ -30,8 +32,8 @@ def test_registry_supported_lists_are_derived_from_specs() -> None:
                 candidate.verify_order if candidate.verify_order is not None else 10_000
             ),
         )
-    )
-    expected_setup = tuple(
+    ]
+    expected_setup = [
         spec.service
         for spec in sorted(
             (candidate for candidate in INTEGRATION_SPECS if candidate.setup_order is not None),
@@ -39,7 +41,7 @@ def test_registry_supported_lists_are_derived_from_specs() -> None:
                 candidate.setup_order if candidate.setup_order is not None else 10_000
             ),
         )
-    )
+    ]
 
     assert expected_verify == SUPPORTED_VERIFY_SERVICES
     assert expected_setup == SUPPORTED_SETUP_SERVICES


### PR DESCRIPTION
Part of #4605. It does not close it - see "Scope" at the end.

#### Describe the changes you have made in this PR -

## The problem

OpenSRE ships 65 built-in integrations. Adding a 66th today means changing this
repository.

I wanted to add Yandex Cloud without doing that - as a separate pip package, so
that a vendor's API clients, its 16 tools and its release cycle stay out of your
tree. That is what was suggested on #4605: ship it as a plugin using integrations
and tools, with core adding rather than changing.

It turns out that is *almost* possible today. A plugin can already register:

- its tools, through `register_external_tool_package`
- its alert handling, through `register_alert_source_detector`,
  `register_alert_source_routing`, `register_alert_detail_fields`

What it cannot do is tell OpenSRE that the integration itself exists. There is
no hook for that - `INTEGRATION_SPECS` is a literal in `integrations/registry.py`
and everything else is derived from it at import.

So the plugin can ship the tools, but not the thing that gives those tools their
credentials:

| | today |
|---|---|
| `opensre integrations setup yandex_cloud` | `Error: 'yandex_cloud' is not one of 'alertmanager', 'aws', ...` |
| `opensre integrations verify yandex_cloud` | same |
| credentials | nowhere to live; the plugin has to invent its own config file outside `~/.opensre` and its own `configure` command |
| welcome banner / REPL / `health` | never mentions it, even when it is fully configured |

In our plugin that workaround is currently ~490 lines - a parallel config file, a
parallel CLI, plus a setup flow and a verifier that are written but unreachable
because there is nowhere to register them.

## What this PR adds

Four registration hooks, all in `integrations/`, each mirroring the shape the
tool and alert hooks already use - the built-in list stays as it is, external
entries live beside it, and a `register_*` function adds to them.

| Hook | Lets a plugin say |
|---|---|
| `register_integration_spec` | "this integration exists" - so it appears in `setup`, `verify`, and the service lists |
| `register_classifier` | how to turn its stored credentials into the shape the rest of the system reads |
| `register_env_loader` | how to read its own `FOO_*` environment variables |
| `register_env_presence` | a cheap "is it configured?" check for the startup banner, which runs before the first prompt and must not touch the keyring |

The first three replace things that were closed: a module-level tuple, a closed
`_CLASSIFIERS` dict, and a `load_env_integrations` function with a branch per
integration. The fourth is new - the startup presence check is a separate list
from the full environment loader, so it needed its own hook.

`EffectiveIntegrations` is a strict model with one field per integration, so an
external service was dropped at validation. It now accepts extra fields;
`config/strict_config.py` grew a matching early return so that every *other*
strict model keeps its typo protection, including the "did you mean" hint.

## What does not change

This is the part worth checking, since the whole point is that existing behavior
is untouched:

- **No file under `core/`.** The diff is `integrations/`, one `surfaces/cli`
  file, and `config/strict_config.py`.
- **Built-in integrations behave identically.** Before any plugin registers, the
  derived tables hold exactly what they held on `main`.
- **No call site is renamed.** The eight derived lookups keep their names and are
  recomputed in place on registration, so every existing reader keeps working
  untouched.
- **A plugin cannot take over a built-in.** Registration refuses a service name,
  alias or family member that a built-in already answers to - and refuses one
  another plugin already holds.

## Demo/Screenshot for feature changes and bug fixes -

Installed from scratch on a Yandex Cloud VM: OpenSRE from `main`, the plugin
from its own repository. `integrations setup yandex_cloud` prefills the folder
and cloud from the instance metadata, `verify` reaches the real API across 116
service endpoints, and the integration shows up in `list` and `health` with its
credentials in `~/.opensre`.

https://github.com/user-attachments/assets/f776b2f0-9491-4d52-b422-baa85f650065

## Explain your implementation approach:

**What problem does it solve?** An out-of-tree package can contribute tools and
alert handling but not an integration, so a plugin cannot supply the credentials
its own tools need. This adds the missing registration hooks.

**What alternatives did I consider?**

*Adding Yandex Cloud to this repository directly.* Rejected on #4605 - it puts a
vendor's clients, tools and release cadence in your tree, and the same argument
returns with the next cloud.

*Turning the derived lookups into functions* (`supported_setup_services()`
instead of `SUPPORTED_SETUP_SERVICES`). Cleaner in isolation, but it renames
eight names and touches every reader, which is a much larger diff to review for
no behavioral gain. Instead the tables are recomputed **in place**, so readers
that did `from integrations.registry import SUPPORTED_VERIFY_SERVICES` - which
binds the object, not the name - keep seeing current data. That is also why five
of them changed from `tuple`/`frozenset` to `list`/`set`: an immutable container
cannot be updated in place.

*Requiring a spec before any other hook*, so ownership lives in one place.
Rejected because it forces a call order on plugin authors, and a plugin that only
wants to contribute a classifier has no reason to register a spec.

**Key pieces:**

- `_rebuild_registry()` - recomputes the eight derived lookups; called at import
  and again on each registration. Refills each table without emptying it first,
  so a concurrent reader never sees a gap.
- `register_integration_spec()` - normalizes keys the way every reader reads them
  (stripped, lower-cased), refuses collisions with built-ins and with other
  plugins, then rebuilds. Takes a lock, so two plugins importing concurrently
  cannot interleave.
- `_install_external_hook()` - claims a key and installs the callback as one
  step, attributing the entry to the package the callback came from, so a plugin
  can replace its own hook on reload but not another plugin's.
- `IntegrationServiceChoice` - resolves its Click choices per invocation rather
  than when the decorator runs, otherwise the command object freezes the service
  list at import, before any plugin has registered.

## Testing

`tests/integrations/test_external_registration.py`, 42 tests. Each drives a
public entry point rather than the structure beneath it - `cmd_setup`, the Click
command, `resolve_effective_integrations`, `load_env_integration_services`, and
the service lists as seen from `integrations.verify` and `integrations.app`.
That distinction matters: an earlier version of the demo asserted on
`EffectiveIntegrations` directly and passed while the resolver was still
discarding the key.

Local checks against `main` at fbec9fe6:

```
$ make lint
All checks passed!

$ make format-check
3342 files already formatted

$ make typecheck
Success: no issues found in 1712 source files
```

Full suite, deselecting three tests that flake between runs on this machine
regardless of the patch (`test_list_memories_cache`, `test_theme`,
`test_cli_inventory` - on unpatched `main` I get 5 failures on one run and 6 on
the next):

```
clean main        6 failed, 14156 passed
with this branch  6 failed, 14198 passed
```

Identical failure sets; the +42 is exactly the new tests. The six are
environmental - three want a directory this user cannot write to and this ran as
root, two are wizard tests a sandbox network guard intercepts, one is the
openclaw preflight test.

CI has not run on this branch: the workflows are in `action_required`, which is
what GitHub does with fork PRs until a maintainer approves them. CodeQL in
particular has never looked at this code.

## Scope

This does not close #4605. That issue asks for Yandex Cloud support, which is two
things: reaching Yandex AI Studio as a language model, and reading Yandex Cloud
as an infrastructure source. The first is already being solved by #4505, which
adds `custom-openai` with a user-supplied base URL - AI Studio speaks the OpenAI
API, so once that lands it is just another custom endpoint. The second is the
plugin, which lives outside this repository and needs the hooks in this PR.

Not touched: `_HANDLERS` in `integrations/cli.py`. It is already open in practice
- entries are appended after the literal (`_HANDLERS["temporal"] = _setup_temporal`)
- so a plugin can do the same today. A public wrapper carrying the same ownership
rules would be tidier and is a smaller, separate change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
