### PR TITLE
docs(new-relic): add SDD spec/plan/tasks for New Relic integration (1/4)

### DIFF
--- a/specs/new-relic-integration/plan.md
+++ b/specs/new-relic-integration/plan.md
@@ -1,0 +1,389 @@
+# Plan: New Relic integration
+
+Technical design for [`spec.md`](spec.md). Every choice here references a concrete
+precedent in the repo — the goal is zero invented new patterns.
+
+## ⚠️ Operational restriction on the real key used to validate this plan
+
+The account used to validate Phase 0 (T-00/T-01b) is a real account (`sre@arcotech.io`,
+account id captured in T-01b). The user authorized **read-only** use of this key — every
+query against it is `query { ... }`, never `mutation { ... }`. Any action that would
+change state in New Relic (ack/close an incident, mute a policy, create/edit an alert
+condition, a deployment marker) **requires explicit manual approval before running**,
+with a clear description of what the action would do. This applies both to this
+validation phase and to the `NewRelicClient` implemented later — it does not gain a write
+method without a separate, explicit ask. This is an operational reinforcement of the
+existing scope decision (`spec.md` §3: "Writing to New Relic... This feature is
+read-only"), not a new decision.
+
+⚠️ **Data-sensitivity rule:** any data pulled live from this account (account id,
+condition/policy/entity names, incident ids, email, the Notion workspace URL) is treated
+as sensitive. None of it goes into final code, comments, tests, fixtures, docs, commit
+messages, or PR text — only synthetic values that preserve the discovered *shape*. See
+[`tasks.md`](tasks.md) header for the cross-phase rule.
+
+## 0. Precedents used
+
+| Aspect | Reference in the repo |
+|---|---|
+| Integration package layout | `integrations/honeycomb/` (config/client/verifier/setup separated) |
+| Alerts + metrics tools | `integrations/datadog/tools/__init__.py` (`query_datadog_monitors`, `query_datadog_metrics`) |
+| End-to-end file list | commit `0b59755c` — "add Railway integration" (#4060), 32 files |
+| Vendor-first config (not in `config_models.py`) | commit `5813e207` — "move HoneycombIntegrationConfig into vendor-first config module" (#4435) |
+| Tool metadata with enums | commit `49adcdd2` — "migrate metadata declarations to enums" (#4767) |
+
+Note: Railway put its config in `integrations/config_models.py`; Honeycomb was **moved
+out** of it later (#4435). We follow Honeycomb — `integrations/new_relic/config.py`.
+
+## 1. Naming
+
+| Thing | Value | Justification |
+|---|---|---|
+| Service key | `new_relic` | `registry.py`'s multi-word convention: `victoria_logs`, `mongodb_atlas`, `azure_sql`, `incident_io` |
+| Aliases | `("newrelic", "new relic")` | `service_key()` normalizes the user-facing label |
+| Package | `integrations/new_relic/` | Vendor-first |
+| Env prefix | `NEW_RELIC_` | The vendor's own convention (`NEW_RELIC_LICENSE_KEY` etc.) |
+| Tools | `query_new_relic_alerts`, `query_new_relic_metrics` | Dominant shape `query_<vendor>_<thing>` |
+| Evidence source | `"new_relic"` | `EvidenceSource = str` (open, `core/domain/types/evidence.py`) — nothing to extend in core |
+
+## 2. Client contract
+
+`integrations/new_relic/client.py` — `NewRelicClient(config: NewRelicIntegrationConfig)`.
+
+```
+@property is_configured -> bool          # api_key and account_id present
+probe_access() -> ProbeResult            # used by the verifier
+run_nrql(nrql: str, *, timeout: float) -> dict   # single transport
+query_incidents(*, since_minutes, priority, entity_name, limit) -> dict
+query_metrics(*, nrql, since_minutes, limit) -> dict
+```
+
+`run_nrql` is the **only** place that speaks GraphQL. Both tools go through it.
+
+NerdGraph query:
+
+```graphql
+{ actor { account(id: <ACCOUNT_ID>) { nrql(query: "<NRQL>") { results metadata { facets } } } } }
+```
+
+`ProbeResult` comes from **`integrations/probes.py`**. A same-named class exists in
+`surfaces/cli/wizard/probes.py` — importing that one would break the NFR-6 layer boundary
+(`integrations/` doesn't import from `surfaces/`) and the import-linter in `make lint`.
+
+`probe_access()` performs two checks in a single call and distinguishes them in the
+result (FR-4): identity (`actor { user { name } }`) and account access
+(`actor { account(id: N) { name } }`). If the key is invalid → authentication `errors`.
+If the key is valid but the account isn't → `account` comes back `null`. Different
+messages.
+
+**Mandatory checking order** on every response — GraphQL returns 200 on logical failure:
+
+1. HTTP status (401/403/429/5xx → structured error by class)
+2. `payload["errors"]` non-empty → structured error with the vendor message
+   **sanitized** (no query echo, which may contain account data)
+3. only then navigate `payload["data"]["actor"]["account"]["nrql"]["results"]`
+
+Error return: `{"success": False, "error": <str>, "error_type": <class>}` — the same
+shape `HoneycombClient` and `DatadogClient` already use, so the tools can translate it
+via `tool_unavailable`.
+
+### Constants verified against the official docs
+
+All in `config/constants/new_relic.py` (NFR-5), not scattered:
+
+```
+NEW_RELIC_NRQL_TIMEOUT_SECONDS = 5      # the API's limit, not our choice
+NEW_RELIC_NRQL_LIMIT_MAX       = 5_000  # the API's ceiling
+NEW_RELIC_DEFAULT_INCIDENT_LIMIT = 100  # our own ceiling, for LLM context (NFR-8)
+NEW_RELIC_DEFAULT_WINDOW_MINUTES = 60
+```
+
+`error_type` must distinguish **`timeout`** from **`empty`** (NFR-7). The NerdGraph 5 s
+timeout is the most likely operational failure for this integration on a large account,
+and reporting it as "no alerts found" would make the agent conclude the opposite of the
+truth.
+
+### Alerts tool NRQL
+
+```sql
+SELECT incidentId, event, priority, title, conditionName, policyName,
+       nrqlQuery, threshold, operator, runbookUrl,
+       entity.name, entity.guid, muted, openTime, closeTime
+FROM NrAiIncident
+SINCE <N> minutes ago
+LIMIT <cap>
+```
+
+⚠️ **`event` has no reliable casing.** The official docs show `'Open'`/`'Close'`
+capitalized; the real account tested (2026-08-11) returned lowercase `'open'`/`'close'`.
+The two sources disagree — **never compare with a fixed casing**. Use
+`LOWER(event) = 'open'` in the NRQL itself, or `.lower()` if the filter happens on the
+Python side.
+
+⚠️ **`NrAiIncident` is 1 row per transition, not per incident** (confirmed against a real
+account). A resolved incident produces **two rows sharing the same `incidentId`**: one
+`event=open` (`closeTime=null`) and one `event=close` (`closeTime` populated). An
+incident still open only has the `open` row.
+
+`results.py` pairs rows by `incidentId` — not by `conditionId` + `entity.guid`:
+
+```python
+# one row per incidentId; if a "close" row exists, it wins (it has the final state)
+# status = "open" if only the open row exists (closeTime is None)
+# status = "closed" if the close row exists
+```
+
+Repeated `conditionName`/entity with **different** `incidentId`s are distinct firings of
+the same condition (flapping) — **do not** collapse, it's real signal, not a duplicate.
+`muted` stays flagged, never filtered — deciding to ignore noise is the agent's call, not
+the parser's. `operator` and `title` arrive **HTML-entity-encoded** (`"&gt;="` instead of
+`">="`) — `results.py` decodes with `html.unescape()` before exposing them. `threshold`
+arrives as a JSON string (`"3.0"`) — don't assume a numeric type.
+
+## 3. Files
+
+### 3.1 New — integration
+
+| File | Content |
+|---|---|
+| `config/constants/new_relic.py` | `NEW_RELIC_API_KEY_ENV`, `NEW_RELIC_ACCOUNT_ID_ENV`, `NEW_RELIC_BASE_URL_ENV`, `NEW_RELIC_INSTANCES_ENV` + `__all__` |
+| `integrations/new_relic/config.py` | `DEFAULT_NEW_RELIC_BASE_URL = "https://api.newrelic.com"`; `NewRelicIntegrationConfig(StrictConfigModel)` with `api_key`, `account_id`, `base_url`, `integration_id`; validators `normalize_url(DEFAULT…)` and `normalize_str()` from `integrations/_validators.py` |
+| `integrations/new_relic/__init__.py` | `classify(credentials, record_id)` → `(cfg, "new_relic")` only if `api_key and account_id`; failure via `report_classify_failure` |
+| `integrations/new_relic/client.py` | §2 |
+| `integrations/new_relic/verifier.py` | `verify_new_relic = register_probe_verifier("new_relic", config=NewRelicIntegrationConfig.model_validate, client=NewRelicClient)` |
+| `integrations/new_relic/setup.py` | `NEW_RELIC_SETUP = IntegrationSetupSpec(service="new_relic", fields=(api_key secret, account_id, base_url with a default), verify=verify_new_relic)` |
+
+The verifier does **not** need central registration: `integrations/_verifiers_loader.py`
+scans `integrations/*/verifier.py` and imports it automatically.
+
+### 3.2 New — tools
+
+```
+integrations/new_relic/tools/
+  __init__.py                      # thin entrypoint: imports the public objects
+  new_relic_alerts_tool/
+    __init__.py                    # exports query_new_relic_alerts
+    tool.py                        # metadata + run
+    results.py                     # NrAiIncident -> normalized shape
+  new_relic_metrics_tool/
+    __init__.py
+    tool.py
+    validation.py                  # sanity-checks the NRQL received from the model
+```
+
+The checklist (`docs/adding-tools-and-integrations.md` §1) requires `__init__.py` to be a
+registry entrypoint, with validation / transport / formatting living in sibling modules.
+Honeycomb and Datadog are flattened legacy — **do not** copy the flattening.
+
+Metadata (enums from `core/tool_framework/metadata.py`):
+
+| | alerts | metrics |
+|---|---|---|
+| `name` | `query_new_relic_alerts` | `query_new_relic_metrics` |
+| `source` | `"new_relic"` | `"new_relic"` |
+| `evidence_type` | `EvidenceType.EVENTS` | `EvidenceType.METRICS` |
+| `side_effect_level` | `READ_ONLY` | `READ_ONLY` |
+| `injected_params` | `("api_key", "account_id", "base_url")` | same |
+
+`surfaces=("investigation", "chat")` is **not** a `ToolMetadata` field — it's a ClassVar
+on `core/tool_framework/base.py:61` (default `(ToolSurface.INVESTIGATION,)`) and a kwarg
+of the decorator / `RegisteredTool`. Without declaring it explicitly, the tool only shows
+up in investigation, never in chat.
+
+`is_available(sources)` = `bool(nr.get("connection_verified") and nr.get("account_id"))`.
+`connection_verified` is seeded by `availability_view()` in
+`core/tool_framework/utils/integration_sources.py:19`.
+
+`extract_params(sources)` reads `sources["new_relic"]` and returns creds + window
+defaults. `injected_params` guarantees the verified credential wins over whatever the
+model sends.
+
+**The metrics tool's `validation.py`** is the sensitive spot: the NRQL comes from the
+LLM. Minimal scope — reject anything that isn't a read and cap `LIMIT`. NRQL has no DML,
+so the risk is cost/volume, not writes; but a query with no `LIMIT` and no time clause
+can return a huge payload. Inject default `SINCE`/`LIMIT` when absent.
+
+### 3.3 Edits — integration wiring
+
+| File | Edit |
+|---|---|
+| `config/constants/__init__.py` | re-export the 4 names + `__all__` |
+| `integrations/registry.py` | `IntegrationSpec(service="new_relic", aliases=("newrelic","new relic"), has_verifier=True, direct_effective=True, core_verify=True, setup_order=…, verify_order=…)` |
+| `integrations/_catalog_impl.py` | import `classify` + `NewRelicIntegrationConfig`; entry in the classifiers map (~L412); env loader block (~L673) with `_parse_instances_env("NEW_RELIC_INSTANCES", "new_relic")` and `resolve_env_credential(NEW_RELIC_API_KEY_ENV)`, copying the Honeycomb block |
+| `integrations/catalog.py` | `add("new_relic", _all_env("NEW_RELIC_API_KEY", "NEW_RELIC_ACCOUNT_ID") or _env_is_set("NEW_RELIC_INSTANCES"))` — plain-env only, no keyring at boot. **Datadog** pattern (`_all_env("DD_API_KEY","DD_APP_KEY")`), not Honeycomb: FR-2 requires both fields, so `_any_env` would report "configured" with half a credential |
+| `integrations/effective_models.py` | `new_relic: EffectiveIntegrationEntry \| None = None` |
+| `integrations/cli.py` | `_setup_new_relic()` → `_run_spec_setup(NEW_RELIC_SETUP)` + entry in the map (~L713) |
+| `tools/registry_discovery.py` | `"integrations.new_relic.tools"` (alphabetically ordered list) |
+| `.env.example` | `# New Relic` block in the observability section + commented `NEW_RELIC_INSTANCES=`. **Never** `.env` |
+
+`core_verify=True` because New Relic is a primary observability source — same bucket as
+grafana/datadog/honeycomb/groundcover in `CORE_VERIFY_SERVICES`.
+
+`setup_order` / `verify_order`: pick free slots at the end of the range, without
+renumbering neighbors. **No test pins the full sequence** —
+`tests/integrations/test_registry.py:44-45` recomputes the tuple with the module's own
+logic, it's tautological. But four real invariants in
+`tests/integrations/test_registry_invariants.py` do hold:
+
+1. `test_setup_orders_are_unique` — `setup_order` unique across all specs
+2. `test_verify_orders_are_unique` — same for `verify_order`
+3. `test_every_verifier_has_a_verify_order` — `has_verifier=True` **requires**
+   `verify_order`
+4. registry ↔ `integrations/cli.py::_HANDLERS` is bidirectional:
+   `test_every_setup_spec_has_handler` (registry → handler) and
+   `test_every_cli_handler_is_registered_in_registry` (handler → registry). Declaring
+   `setup_order` without the `_HANDLERS` entry **breaks CI**, and vice versa.
+
+### 3.4 Edits — investigation
+
+| File | Edit |
+|---|---|
+| `integrations/alert_source_catalog.py` | `_ROUTING_TABLE["new_relic"] = routing(("new_relic",), ("new_relic",))`; `_ALIASES_TABLE["new_relic"] = ("new relic","newrelic","nrql","nr alert")` |
+| `tools/investigation/stages/intake/node.py` (~L60) | detection line: `- "new_relic" for New Relic or newrelic.com` |
+| `tools/investigation/reporting/context/provenance.py` | entry in the tool→source map and a provenance block (label "New Relic", account id, window) |
+| `tools/investigation/reporting/context/evidence_catalog.py` | map `"new_relic": "new_relic_alerts"` + `_add_new_relic_*` and a call in the aggregator (~L388) |
+| `tools/investigation/alert_templates.py` | `new_relic` template with `alert_source: "new_relic"` |
+| `config/constants/investigation.py` | `"new_relic"` in `ALERT_TEMPLATE_CHOICES` |
+| `tools/interactive_shell/shared/slash_catalog.py` (~L377) | `/template` help mentions new_relic |
+
+⚠️ **Guardrail:** no regex/keyword routing outside these declarative tables. The
+`AGENTS.md` rule (§Footguns, "Action-agent path") forbids ad-hoc intent routing;
+`_ALIASES_TABLE` is the sanctioned mechanism.
+
+### 3.5 Edits — onboarding / UI
+
+| File | Edit |
+|---|---|
+| `surfaces/cli/wizard/configurators/observability.py` | `_configure_new_relic()` = `configure_from_spec(NEW_RELIC_SETUP, title="New Relic")` |
+| `surfaces/cli/wizard/_integration_configurators.py` | register in **two** maps (dispatch ~L93 and service key ~L128) |
+| `surfaces/cli/wizard/onboard_integrations.py` | `Choice(value="new_relic", label="New Relic", group="Observability", hint="Query alerts and NRQL metrics")` |
+| `surfaces/cli/constants.py` | sample alert entry |
+| `surfaces/interactive_shell/ui/banner/banner_state.py` | `"new_relic": "New Relic"` |
+| `surfaces/interactive_shell/ui/investigation_outcome.py` | `("new_relic", "new_relic")` |
+| `surfaces/interactive_shell/command_registry/investigation.py` | template entries (~L519, ~L529, ~L544) |
+
+### 3.6 Docs
+
+- `docs/new_relic.mdx` — where to create the **User key** (not a License key: it's the
+  mistake everyone makes), where to find the `account_id`, US vs EU, exact commands, and
+  the gotcha that `NrAiIncident` needs alert conditions already configured for there to
+  be anything to read. `AGENTS.md` §Docs rule: cut vendor endpoints, internal function
+  names, and which credential tier a value lands in.
+- `docs/docs.json` — `"new_relic"` in the "Observability and incidents" group (**without**
+  the `.mdx` suffix). Forgetting this leaves the page unreachable on Mintlify.
+- `README.md:256` — move New Relic from the "wanted" column to the supported list.
+- `docs/.../vocabularies/Mintlify/accept.txt` — check whether Vale needs "NRQL" /
+  "NerdGraph" added.
+
+## 4. Tests
+
+Aligned with `AGENTS.md` §Tests: a small suite that pins real failure modes, not line
+coverage.
+
+| File | What it pins |
+|---|---|
+| `tests/integrations/new_relic/test_client.py` | **(a)** `200 + errors` → structured error, not success; **(b)** 401 vs unreachable account → distinct messages; **(c)** 429 and 5xx → structured error with no stack trace; **(d)** a realistic NerdGraph `NrAiIncident` fixture parses; **(e)** empty results ≠ error |
+| `tests/integrations/new_relic/test_setup.py` | `IntegrationSetupSpec` ↔ env round-trip |
+| `tests/integrations/test_registry.py` | spec registered with `has_verifier`/`direct_effective`/`setup_order` (Railway test's mold) |
+| `tests/integrations/test_verify.py` | `resolve_effective_integrations` reads New Relic from env |
+| `tests/tools/test_new_relic_alerts_tool.py` | `BaseToolContract`; `is_available` requires **both** `connection_verified` **and** `account_id`; `extract_params`; not-configured path; `results.py`: open+close pairing by `incidentId` into a single record with a derived `status`; distinct `incidentId`s of the same condition **don't** collapse (flapping); `event` compared without a fixed casing (real lowercase `'open'` and doc-capitalized `'Open'` must both match); `operator`/`title` decoded from HTML entities; `threshold` parsed from a string |
+| `tests/tools/test_new_relic_metrics_tool.py` | same + default `SINCE`/`LIMIT` injection |
+| `tests/tools/test_registry.py` | the real registry discovers both tools |
+| `tests/tools/test_telemetry.py` | tool names in the telemetry list |
+| `tests/tools/conftest.py` | `sources["new_relic"]` fixture |
+
+**Per-service parametrized test tables the original plan overlooked.** These are
+*curated* lists (`_SPECS` / `_CASES` / literal tables), not derived from
+`SUPPORTED_SETUP_SERVICES` — omitting New Relic **doesn't break CI**, it leaves a silent
+gap. Railway was left out of them; Datadog, Honeycomb, and Coralogix are in. Since New
+Relic is `core_verify` observability, it belongs in their group:
+
+| File | What to add |
+|---|---|
+| `tests/integrations/test_setup_spec_env_round_trip.py` | entry in `_SUBMITTED` (~L78) with **non-default** values (EU host, fictitious account id) — a default "round-trips" even in a spec that wrote nothing |
+| `tests/integrations/test_cli_spec_setup.py` | import of the setup module, entry in `_ANSWERS` (~L69) and a `pytest.param` in `_CASES` (~L261) |
+| `tests/integrations/test_env_multi_instance.py` | case `("NEW_RELIC_INSTANCES", "new_relic", {...})` (~L155) |
+| `tests/integrations/test_catalog_silent_fallback_elimination.py` | `_CLASSIFY_PATCH_TARGETS` (~L99) **and** the env table (~L320) — proves a classify failure goes to `report_exception` instead of a silent `(None, None)` |
+| `tests/synthetic/` or `tests/e2e/` | the planner discovers and invokes it through the normal path (mandatory gate for a new integration) |
+
+**Do not** write: a "client was called once" wrapper, a redundant success variant, a
+pure-vocabulary table.
+
+`AGENTS.md` reminder: `make typecheck` covers only `config core gateway integrations
+platform surfaces tools` — **not** `tests/`. Run mypy on the test path manually.
+
+## 5. Execution order
+
+Each phase is independently verifiable. Detail in [`tasks.md`](tasks.md).
+
+```
+Phase 0  Pin the real NrAiIncident shape (blocks the parser)    ← highest risk first
+Phase 1  Config + constants + client + verifier + setup         → verify passes
+Phase 2  Integration wiring (registry/catalog/cli/env)           → integrations show
+Phase 3  Tools + registry_discovery                              → registry discovers
+Phase 4  Investigation wiring (routing/intake/reporting)          → template runs an RCA
+Phase 5  Onboarding + UI                                          → wizard configures
+Phase 6  Docs + tests + CI gates                                  → PR ready
+```
+
+Phase 0 comes before code deliberately: Decision 2 carries the plan's single highest
+risk, and discovering it in Phase 3 would cost the whole parser.
+
+## 6. Plan review (2026-08-11)
+
+The five original uncertain points were verified against the code.
+
+### Resolved
+
+| # | Point | Conclusion |
+|---|---|---|
+| 2 | Does a test pin the `setup_order`/`verify_order` sequence? | **No.** `test_registry.py:44-45` is tautological. What actually holds are 4 uniqueness/bidirectionality invariants — documented in §3.3. Inserting at the end of the range is safe. |
+| 3 | Does multi-instance work with `account_id` in the identity? | **Yes.** `_parse_instances_env` (`_catalog_impl.py:486`) accepts a flat entry or `{"credentials": …}` and returns **one** record with N instances. `account_id` is just another per-instance credentials field — exactly like `dataset` in Honeycomb and `site` in Datadog. |
+| 5 | Does correlation degrade gracefully without a provider? | **Yes, gracefully.** `upstream_correlation/registry.py` returns `None` when no builder matches; only Datadog registers (`_ensure_default_builders_registered`, L103). Leaving it out of scope is safe. |
+
+### Partially resolved
+
+| # | Point | Conclusion |
+|---|---|---|
+| 4 | Which `slash_catalog.py`? | **Both exist.** `tools/interactive_shell/shared/slash_catalog.py:377` has the `/template` help (the §3.4 target). `surfaces/interactive_shell/command_registry/slash_catalog.py` also exists and **has not been inspected** — T-02b still needs to confirm whether it duplicates the template list. |
+
+### Closed in the second round (verification against official docs)
+
+| # | Point | Conclusion |
+|---|---|---|
+| 1 | Is `NrAiIncident` the right source? | **Yes — verified.** All attributes exist with the assumed spelling. Decision 2 holds and got stronger: `nrqlQuery` bridges the two tools. See `spec.md` §4 Decision 2 and §10 (sources). |
+
+Corrections and discoveries from the second round:
+
+1. **`event` is `Open`/`Close` capitalized** — `WHERE event = 'open'` would return zero
+   rows silently. Fixed in §2.
+2. **5 s NRQL-via-API timeout** — a new high risk, became NFR-7/NFR-8. It was the most
+   dangerous gap in the original plan: nothing in it handled timeout, and the default
+   would confuse it with "no alerts."
+3. **`nrqlQuery`, `runbookUrl`, `threshold`, `operator`, `muted`** all exist in the same
+   record — FR-6 and Decision 4 got stronger, not weaker.
+4. **An issue aggregates N incidents and `NrAiIncident` has no issue id** — a real
+   limitation, documented and mitigated by pairing, not ignored.
+
+### Errors fixed in this review
+
+1. `catalog.py` used `_any_env`, contradicting FR-2 (which requires both key **and**
+   account_id) → switched to `_all_env`, the Datadog pattern.
+2. FR-5 justified `secret=True` as "goes to the keyring" — false. `secret` only masks the
+   prompt; the tier comes from the env var's name. Fixed in the spec, with the three
+   names verified against `config/env_file.py:52-63`.
+3. `surfaces` was listed as a `ToolMetadata` field — it isn't; it's a `BaseTool` ClassVar
+   / decorator kwarg.
+4. Four per-service parametrized test tables were missing from §4.
+5. `ProbeResult` has a same-named class in `surfaces/` — importing the wrong one breaks
+   NFR-6.
+
+### Third round — live-account validation (2026-08-11)
+
+Ran the T-00/T-01b curl calls against a real, read-only-authorized account. Found two
+things neither review round nor the docs caught, both already folded into §2 and
+`spec.md` Decision 2 above: `event` casing disagrees between docs (capitalized) and the
+real account (lowercase), and `NrAiIncident` rows are per-transition, not per-incident,
+which changed the dedup key from `conditionId`+`entity.guid` to `incidentId` pairing. Also
+found `operator`/`title` HTML-entity encoding and `threshold` as a JSON string. See T-01b
+in `tasks.md` for the full account.

--- a/specs/new-relic-integration/spec.md
+++ b/specs/new-relic-integration/spec.md
@@ -1,0 +1,255 @@
+# Spec: New Relic integration (alerts + metrics)
+
+- **Status:** draft — awaiting review
+- **Feature ID:** `new-relic-integration`
+- **Upstream issue:** [#139](https://github.com/Tracer-Cloud/opensre/issues/139) (New Relic listed as "wanted" in `README.md:256`)
+- **Date:** 2026-08-11
+
+## 1. Problem
+
+OpenSRE investigates incidents by reading alerts, metrics, logs, and traces from
+observability backends. Today it supports Grafana, Datadog, Honeycomb, Coralogix,
+groundcover, CloudWatch, Sentry, SigNoz, and others — but **not** New Relic, which is the
+primary backend for a relevant slice of users. For those teams, OpenSRE can neither
+identify the alert's origin nor collect metric evidence, which degrades RCA to "guessing
+without data."
+
+## 2. Objective
+
+A user with a New Relic account should be able to:
+
+1. Configure New Relic through onboarding (`opensre onboard`) or via
+   `opensre integrations setup new_relic`, and see the credential get verified.
+2. Trigger an investigation from a New Relic alert and have the source automatically
+   recognized as `new_relic`.
+3. Have the agent collect, without manual intervention, **alerts** (open and recent
+   incidents, with the condition/policy that fired) and **metrics** (via NRQL) as
+   evidence in the RCA.
+
+## 3. Out of scope
+
+| Item | Reason |
+|---|---|
+| Logs tool (`Log` via NRQL) | Not requested. Recorded in §8 as a low-cost extension once the client exists. |
+| Traces / distributed tracing tools | Same reason. Honeycomb and Tempo already cover traces. |
+| Writing to New Relic (ack an incident, create a deployment marker, mute a policy) | This feature is read-only. Every tool declares `SideEffectLevel.READ_ONLY`. **Operational reinforcement:** the real key used to validate this plan (Phase 0) can only run `query`, never `mutation` — any write action, even a test one, requires explicit, clear manual approval from the user before it runs. |
+| Entity/topology lookup (`entitySearch`) | Useful but orthogonal; doesn't block alerts + metrics. |
+| New Relic as a notification *destination* (watchdog alerts) | The watchdog is a separate feature (`tools/system/watch_dog/`). |
+
+## 4. Decisions
+
+Each decision below was open and was closed with a defensible default. **The plan review
+must specifically challenge these four.**
+
+### [DECISION 1] API: NerdGraph (GraphQL), not REST v2
+
+`https://api.newrelic.com/graphql`, header `API-Key: <User key NRAK-…>`.
+
+*Why:* a single API and a single transport cover both alerts and metrics. Alerts REST v2
+is on a deprecation path and would require a second client. NerdGraph is the supported,
+versioned surface.
+
+*Accepted consequence:* GraphQL returns **HTTP 200 with a populated `errors`** field on
+query/partial-authorization failures. The client must treat this as a structured error —
+it is failure mode #1 for this integration and has a dedicated test.
+
+*Verified against official docs (2026-08-11):* US endpoint
+`https://api.newrelic.com/graphql` and EU `https://api.eu.newrelic.com/graphql`; header
+`API-Key` with a **User key** (not a License key). Operational limits confirmed, all with
+design impact:
+
+| Limit | Value | Consequence |
+|---|---|---|
+| **NRQL timeout via API** | **5 s** (default; only via API, not in the UI) | Hard constraint. Wide windows or unaggregated queries will time out. Tools keep a short default window, and the client treats timeout as a structured error, not "no data." |
+| Max `LIMIT` | 5,000 | The NFR-4 cap sits **well** below this (order of 100–200 records) for LLM context reasons, not because of the API limit. |
+| Concurrency | 25 simultaneous requests per user | A single investigation doesn't come close; a fleet of parallel investigations might. |
+| Rate | 3,000 queries per account per minute | No realistic risk in the loop. |
+
+### [DECISION 2] Alerts via NRQL over `NrAiIncident`, not the `aiIssues` GraphQL query
+
+The alerts tool uses `run_nrql()` over the `NrAiIncident` event type, not the
+`actor.account.aiIssues.issues` query.
+
+*Why:* shares exactly the same transport, parser, and error handling as the metrics tool
+(DRY — one tested `run_nrql` serves both). `NrAiIncident` carries what RCA needs:
+`conditionName`, `policyName`, `priority`, `openTime`, `closeTime`, entity name. Using
+`aiIssues` would mean a second, nested GraphQL parsing path with its own cursor
+pagination — more surface for the same diagnostic data.
+
+*✅ VERIFIED against official docs (2026-08-11).* All assumed attributes exist, with the
+exact spelling: `conditionName`, `policyName`, `priority`, `openTime`, `closeTime`,
+`entity.name`, `incidentId`, `conditionId`, `policyId`, `event`.
+
+**Factual correction (docs):** `event` has values **`Open`/`Close` capitalized**, not
+`open`/`close` as originally assumed. NRQL compares strings case-sensitively, so
+`WHERE event = 'open'` returns zero rows — **silently**, with no error.
+
+**✅✅ VALIDATED against a real account (2026-08-11) — and the docs were incomplete.** I
+ran the `plan.md` §2 NRQL against a real production account (via the user's key,
+read-only use, see the operational restriction in §3). Two findings the docs didn't make
+clear:
+
+1. **`event` came back lowercase (`"open"`/`"close"`) on this account**, contradicting
+   the documented capitalization. Conclusion: casing **is not guaranteed by either source
+   alone** — the docs show a capitalized example, the real account returns lowercase.
+   **Design decision:** never compare `event` with a fixed casing. Use
+   `LOWER(event) = 'open'` in the NRQL itself (or `.lower()` on the Python side if the
+   filter is client-side). This closes the risk for good, instead of betting on one
+   spelling.
+2. **`NrAiIncident` emits ONE ROW PER STATE TRANSITION, not one row per incident.** A
+   resolved incident shows up as **two rows sharing the same `incidentId`** — one with
+   `event="open"` (and `closeTime=null`) and another with `event="close"` (and
+   `closeTime` populated). An incident still open only has the `open` row. This changes
+   the dedup strategy from Decision 2: **the pairing key is `incidentId`**, not
+   `conditionId` + `entity.guid`. Repeated firings of the same condition **have distinct
+   `incidentId`s** and are a real flapping signal (e.g. one condition opened and closed 3
+   times in 30 minutes on the test account) — collapsing by condition+entity would
+   destroy that signal instead of cleaning up noise.
+
+**Two additional shape discoveries, only visible with real data (not in the docs):**
+
+| Field | Real behavior | Consequence for the parser |
+|---|---|---|
+| `operator`, `title` | Come back **HTML-entity-encoded** (`"&gt;="` instead of `">="`) | `results.py` needs `html.unescape()` before exposing it to the agent — otherwise the LLM reads a literal `&gt;=`. |
+| `threshold` | JSON **string** (`"3.0"`), not a number | Don't assume a numeric type; parse explicitly if used in a comparison. |
+| `runbookUrl` | `null` on APM-based conditions (`Web Transaction Errors`), populated on custom workload-based conditions | Confirms it's optional — already marked nullable, real behavior matches. |
+
+**Discovery that increases the feature's value.** The docs list attributes I didn't know
+existed that are exactly what an RCA needs:
+
+| Attribute | Why it matters |
+|---|---|
+| **`nrqlQuery`** | The **exact NRQL query the condition evaluates**. The agent reads the alert and can *re-run the alert's own query* via `query_new_relic_metrics`. It's the direct bridge between the two tools — a real capability, not a convenience. |
+| `runbookUrl` | The runbook the team already wrote for this alert. First-order evidence. |
+| `threshold`, `operator`, `valueFunction`, `thresholdDuration` | *Why* it fired, not just *that* it fired. |
+| `muted`, `mutingRuleId`, `closeCause` | Separates signal from noise: a muted incident is not signal. |
+| `title`, `description` | Human context already written. |
+| `entity.guid`, `entity.type`, `targetName` | Enables the topology extension in §8 without changing the parser. |
+
+**Known and accepted limitation.** In New Relic, an *issue* aggregates multiple
+*incidents* (the docs say "in some cases an issue can have thousands of incidents"; an
+issue goes "idle" past 5,000). `NrAiIncident` **does not carry the issue id** —
+correlation and grouping only exist via `aiIssues`. Consequence: if an issue aggregates
+50 incidents, the agent sees 50 records, not one grouped event. If the loss of grouping
+becomes a problem in practice, `aiIssues` comes in as a **complement** (not a
+replacement) — it brings `isCorrelated`, `totalIncidents`, `incidentIds`,
+`acknowledgedAt`, which `NrAiIncident` doesn't have.
+
+**Aggregation strategy in `results.py` (corrected against the real account):** pair rows
+by `incidentId` — each incident becomes **one** logical record with a derived `status`
+(`closeTime is None` → `"open"`; otherwise `"closed"`, using the data from the `close`
+row, which has the final `title`/context). **Do not** collapse different `incidentId`s
+from the same `conditionName`/entity — that's real flapping (confirmed on the test
+account: one condition opened and closed 3× in 30 minutes), not noise to hide. `muted`
+stays flagged, never filtered.
+
+*Retention risk closed.* T-01b ran against the real account: the query returned 20
+incidents within a 30-day window with no error, confirming sufficient retention for RCA
+on that account (the exact per-plan retention number, via the Data Retention UI, has not
+been read — doesn't block, stays as a docs note in case a user's plan has shorter
+retention).
+
+### [DECISION 3] Region via an explicit `base_url`, not a `region` field
+
+`base_url` field defaulting to `https://api.newrelic.com`; EU tenants set
+`https://api.eu.newrelic.com`.
+
+*Why:* it's literally the Honeycomb pattern (`integrations/honeycomb/config.py`, whose
+docstring says `base_url` "only moves for EU tenants"). Reuses the existing
+`normalize_url` validator. A `region: us|eu` field would be one more map to maintain and
+one more translation path to test, for the same UX once documented.
+
+### [DECISION 4] One alerts tool, not two
+
+`query_new_relic_alerts` returns incidents **already enriched** with `conditionName`,
+`policyName`, `nrqlQuery`, `threshold`/`operator`, and `runbookUrl`, instead of a separate
+tool for policy/condition configuration.
+
+*Why:* confirmed during verification — `NrAiIncident` brings **all of this in the same
+record**. There's no second call to make. A separate "condition configuration" tool
+wouldn't have anything to fetch that isn't already here, and would only increase the
+surface the planner has to disambiguate. Verification reinforced this decision rather
+than weakening it.
+
+## 5. Functional requirements
+
+| ID | Requirement |
+|---|---|
+| FR-1 | `NewRelicIntegrationConfig` normalizes `api_key`, `account_id`, `base_url`, `integration_id`. An empty `base_url` falls back to the US default. |
+| FR-2 | `classify()` only recognizes the integration as configured when **both `api_key` and `account_id`** are present. Either one alone doesn't configure anything usable. |
+| FR-3 | The credential resolves in the order store → env → keyring, via `resolve_env_credential` for `NEW_RELIC_API_KEY`. Plain `os.getenv` for this name is forbidden (rule from `docs/adding-tools-and-integrations.md` §Credential resolution). |
+| FR-4 | `opensre integrations verify new_relic` validates the User key **and** access to the given account, distinguishing "invalid key" from "valid key, account unreachable." |
+| FR-5 | `opensre integrations setup new_relic` and the onboarding wizard collect the 3 fields. `api_key` uses `secret=True`, which controls **only prompt masking**. The persistence tier is derived from the env var *name* by `config.env_file.is_sensitive_env_key` ("Fields do not get to choose"): `NEW_RELIC_API_KEY` has terminal token `key` → keyring; `NEW_RELIC_ACCOUNT_ID` (terminal `id`) and `NEW_RELIC_API_URL` (terminal `url`) → `.env`. Verified against `config/env_file.py:52-63`. |
+| FR-6 | `query_new_relic_alerts` returns incidents from a configurable window, filterable by priority and entity, carrying `conditionName`, `policyName`, `nrqlQuery`, `threshold`/`operator`, `runbookUrl`, and `entity.name` (with `operator`/`title` decoded from HTML entities). `muted` incidents come flagged, never silently mixed into the signal. Rows are paired by `incidentId` (the open+close rows of the same transition collapse into one record with a derived `status`); repeated firings of the same condition (distinct `incidentId`s) are **not** collapsed — that's flapping, real signal. `event` is compared without depending on casing (`LOWER(event)`). |
+| FR-7 | `query_new_relic_metrics` accepts an NRQL query and returns normalized results, tagged `EvidenceType.METRICS`. Explicitly accepts the `nrqlQuery` returned by FR-6 as input — re-running the alert's own query is the main bridge between the two tools. |
+| FR-8 | An alert whose source mentions New Relic / `newrelic.com` / NRQL is classified as `alert_source: "new_relic"` at intake. |
+| FR-9 | With New Relic configured, both tools become visible and invokable in the investigation loop with no manual wiring. |
+| FR-10 | New Relic shows up in the RCA report's provenance and evidence catalog. |
+| FR-11 | `NEW_RELIC_INSTANCES` supports multiple accounts, like the other integrations. |
+| FR-12 | An example alert template exists: `/investigate new_relic` / `opensre investigate --template new_relic`. |
+
+## 6. Non-functional requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-1 | **No vendor exception leaks to an external surface.** 401/403/404/429/5xx and GraphQL `errors` return a structured, investigation-friendly error, never a raise. (CWE-209 / `py/stack-trace-exposure`.) |
+| NFR-2 | The User key never appears in logs, in a tool's return value, in observable `extract_params`, or in tool-call kwargs. Goes through `platform/masking/` if it ever ends up composing output. |
+| NFR-3 | Each tool's `input_schema` is JSON Schema accepted by **every** LLM provider — no `"type": ["object","null"]` (draft-07 passes local validation and breaks on the first invoke, because all investigation tools go together in the payload). |
+| NFR-4 | A large result is deliberately capped and truncation is flagged (`truncated`, `fetch_error`), preserving the incidents' causal order. |
+| NFR-5 | No cyclic imports: env var names live in `config/constants/new_relic.py` (a leaf), never inline in the feature module nor in `config/config.py`. |
+| NFR-7 | The 5 s NRQL-via-API timeout is treated as a **distinct structured error** ("query timed out — narrow the window"), never as an empty result. Conflating the two would make the agent conclude "no alerts" when the truth is "it didn't have time." |
+| NFR-8 | Conservative default windows and `LIMIT`, sized for LLM context (order of 100–200 records), not by the API's 5,000 `LIMIT MAX`. |
+| NFR-6 | Respects the boundaries in `docs/ARCHITECTURE.md`: `integrations/new_relic/` does not import from `surfaces/`; `core/` has no knowledge that New Relic exists (routing enters via catalog/registry at runtime). |
+
+## 7. Acceptance criteria
+
+Verifiable, in the order the implementation satisfies them:
+
+1. With `NEW_RELIC_API_KEY` + `NEW_RELIC_ACCOUNT_ID` in the environment,
+   `opensre integrations show` lists `new_relic` as configured.
+2. `opensre integrations verify new_relic` → success with a valid credential; distinct,
+   stack-trace-free messages for an invalid key, an unreachable account, and a 429.
+3. Both tools show up in `tools/registry_discovery.py` and are discovered by the real
+   registry (automated test, not manual inspection).
+4. `opensre investigate --template new_relic` runs an RCA that invokes at least one of
+   the tools and cites New Relic in the evidence.
+5. A fixture test with a **real** NerdGraph payload (including the `200 + errors` case)
+   passes.
+6. `make verify-integrations` is green.
+7. The `CI.md` checklist is green: lint, format, typecheck, tests.
+8. `docs/new_relic.mdx` exists and is registered in `docs/docs.json`.
+9. A screenshot/GIF end-to-end demo is attached to the PR (mandatory gate for a new
+   integration, `docs/adding-tools-and-integrations.md` §Final gate).
+
+## 8. Future extensions (not in this feature)
+
+- `query_new_relic_logs` — NRQL over `Log`. Low marginal cost: reuses `run_nrql`.
+- `entitySearch` to resolve service → entity GUID and enrich topology.
+- Deployment markers as temporal-correlation evidence (`NrMarker`/`Deployment`).
+- A dedicated correlation provider, following `integrations/datadog/correlation/`.
+
+## 9. Risks
+
+Updated after verification against the official docs (2026-08-11).
+
+| Risk | Severity | State / Mitigation |
+|---|---|---|
+| ~~`NrAiIncident` shape diverging from what was assumed~~ | ~~High~~ → **Closed** | Confirmed against docs **and** against a real account (2026-08-11). |
+| ~~`event` with uncertain casing~~ | ~~High~~ → **Closed** | Docs show it capitalized, the real account returned lowercase — the two sources disagree with each other. Mitigated by design: `LOWER(event)`, never a casing-sensitive comparison. |
+| ~~Wrong dedup key (would collapse real flapping)~~ | ~~High~~ → **Closed** | Only discovered with real data: `NrAiIncident` is 1 row per transition, paired by `incidentId`, not `conditionId`+`entity.guid`. Fixed in `results.py` (Decision 2, spec and plan). |
+| 5 s NRQL-via-API timeout | **High** | NFR-7 + NFR-8: short default window, timeout as a distinct error from "no data." Not yet tested against a real timeout (the test account responded well within the limit). |
+| GraphQL 200 + `errors` treated as success | High | Dedicated test; the client checks `errors` **before** `data`. |
+| ~~Insufficient `NrAiIncident` retention on the account~~ | ~~Medium~~ → **Closed** | T-01b confirmed 30 days with no error against a real account. Exact per-plan retention (via the UI) not read — a docs note, not a blocker. |
+| Loss of issue → incidents grouping | Medium | Accepted and documented in Decision 2. `aiIssues` as a future complement if it becomes a problem. |
+| No real New Relic account for the demo gate | Medium | **T-00.** Blocks acceptance criteria 4, 5, and 9 — not Phase 1 (T-03/T-04/T-06 are independent). |
+| 25 requests/user concurrency under a parallel fleet | Low | A single investigation doesn't come close. Recorded for when a fleet exists. |
+| Wrong `account_id` giving a silent empty result | Low | FR-4 separates "account unreachable" from "no data." |
+
+## 10. Verification sources
+
+- [Meet NerdGraph: our GraphQL API](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) — US/EU endpoints, `API-Key` header
+- [New Relic API keys](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/) — User key is the type required by NerdGraph
+- [Alert event attributes](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/violation-event-attributes/) — full attribute list for `NrAiIncident`
+- [Rate limits with NRQL](https://docs.newrelic.com/docs/nrql/using-nrql/rate-limits-nrql-queries/) and [NerdGraph usage limits](https://docs.newrelic.com/docs/apis/nerdgraph/nerdgraph-usage-limits/) — 5 s timeout, 25 concurrent, 3,000 queries/account/min
+- [NRQL result limits increased from 2,000 to 5,000](https://docs.newrelic.com/whats-new/2024/01/whats-new-01-09-nrql-limit-increases/) — `LIMIT MAX`
+- [NerdGraph tutorial: Issue and alert event query APIs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-issues-api-via-github/) — issue↔incidents relationship, `aiIssues` fields, `issueTtl`

--- a/specs/new-relic-integration/tasks.md
+++ b/specs/new-relic-integration/tasks.md
@@ -1,0 +1,231 @@
+# Tasks: New Relic integration
+
+Execution of [`plan.md`](plan.md). Every task has an objective verification gate —
+nothing advances on "looks right."
+
+Convention: `[ ]` pending · `[~]` in progress · `[x]` done with a green gate ·
+`[!]` blocked.
+
+⚠️ **Cross-phase rule, all phases:** any data that came from the real test key (account
+id, condition/policy/entity names, incident ids, email, the Notion URL) is treated as
+sensitive. No real value goes into code, comments, tests, fixtures, docs, commit
+messages, or PR text — only synthetic forms that preserve the discovered *shape*. The key
+is for local validation only, never committed, never in the repo's `.env`.
+
+---
+
+## Phase 0 — Discovery (blocks the parser)
+
+### [x] T-00 · Get access to a real New Relic account
+Done on 2026-08-11. User key confirmed (`data.actor.user` → `sre@arcotech.io`, id
+`1004267780`); `account_id` confirmed by T-01b's incidents query returning 20 real
+records. **Read-only** use — operational restriction documented at the top of
+`plan.md`.
+
+### [x] T-01a · Pin the `NrAiIncident` shape against official docs
+Done on 2026-08-11. **All** assumed attributes confirmed; `event` corrected to
+`Open`/`Close` capitalized; discovered `nrqlQuery`, `runbookUrl`, `threshold`,
+`operator`, `muted`, `closeCause`, `entity.guid`. API limits confirmed (5 s timeout,
+`LIMIT MAX` 5,000, 25 concurrent). Sources in `spec.md` §10.
+The shape risk is **closed** — Decision 2 holds and got stronger.
+
+### [x] T-01b · Confirm retention and capture a real payload
+Done on 2026-08-11 against a real account (`sre@arcotech.io`, **read-only** use — see
+the operational restriction at the top of `plan.md`). The `plan.md` §2 NRQL returned 20
+incidents within a 30-day window with no error — sufficient retention for RCA confirmed
+on that account (exact per-plan retention, via the Data Retention UI, not read — doesn't
+block, stays as a docs note). The real payload revealed 3 corrections the docs did
+**not** cover — see `spec.md` Decision 2 and `plan.md` §2: `event` lowercase on the real
+account (docs show it capitalized — mitigated with `LOWER(event)`, never a fixed
+casing); `NrAiIncident` is 1 row per transition paired by `incidentId`, not by
+`conditionId`+`entity.guid`; `operator`/`title` arrive HTML-entity-encoded; `threshold`
+is a JSON string.
+**No fixture saved yet with the verbatim payload** — the real condition/policy/entity
+names expose the user's account's internal topology in a public OSS repo. T-01c creates
+a synthetic fixture before T-10's gate.
+
+### [x] T-02 · Verify the uncertain points from `plan.md` §6
+Done in the 2026-08-11 review — results in `plan.md` §6. Points 2, 3, and 5 resolved; 5
+plan errors fixed.
+**Remaining:** see T-02b.
+
+### [ ] T-01c · Create a synthetic fixture from the real payload
+**Depends on:** T-01b. The real payload (T-01b) stays **only** in this conversation — it
+never becomes a file in the repo. Recreate the same shape (fields, types, HTML-entity
+encoding in `operator`/`title`, an open+close pair sharing an `incidentId`, `threshold`
+as a string) with **generic/fictitious** `conditionName`/`policyName`/`entity.name` and
+`runbookUrl` (e.g. `checkout-latency`, `checkout-service`,
+`https://runbooks.example.com/...`) — no real name from the user's account.
+**Gate:** `tests/fixtures/new_relic/incidents_response.json` (or inlined per `plan.md`
+§4) contains no token that appears in the real payload captured in T-01b; T-10's test
+passes against this fixture.
+
+### [ ] T-02b · Confirm which `slash_catalog.py` to edit
+Both exist: `tools/interactive_shell/shared/slash_catalog.py:377` (has the `/template`
+help) and `surfaces/interactive_shell/command_registry/slash_catalog.py` (not
+inspected).
+**Gate:** know whether the template list is duplicated in both; §3.4 points at the
+right file(s).
+
+---
+
+## Phase 1 — Integration
+
+### [ ] T-03 · `config/constants/new_relic.py` + re-export
+The 4 env names + `__all__`; re-export in `config/constants/__init__.py`.
+**Gate:** `uv run python -c "from config.constants import NEW_RELIC_API_KEY_ENV"`.
+
+### [ ] T-04 · `integrations/new_relic/config.py` and `__init__.py`
+`NewRelicIntegrationConfig` + `classify()`. FR-1, FR-2.
+**Gate:** normalization test — empty `base_url` → US default; `api_key` without
+`account_id` → `classify` returns `(None, None)`.
+
+### [ ] T-05 · `integrations/new_relic/client.py`
+Plan §2. **No longer depends on T-01b** — the shape is confirmed by the docs; T-01b's
+real fixture hardens the test later, without blocking the code.
+Mandatory checking order: HTTP → `errors` → `data`. NFR-1, NFR-2, NFR-7 (5 s timeout as
+its own `error_type`, distinct from an empty result).
+**Gate:** `tests/integrations/new_relic/test_client.py` with the `plan.md` §4 cases
+passing, including `200 + errors` and **timeout ≠ empty**.
+
+### [ ] T-06 · `verifier.py` + `setup.py`
+`register_probe_verifier`; `IntegrationSetupSpec` with 3 fields (`api_key`
+`secret=True`). FR-4, FR-5.
+**Gate:** `opensre integrations verify new_relic` distinguishes an invalid key, an
+unreachable account, and a 429 — three messages, none with a stack trace.
+
+---
+
+## Phase 2 — Integration wiring
+
+### [ ] T-07 · `registry.py`, `_catalog_impl.py`, `catalog.py`, `effective_models.py`, `cli.py`
+**Depends on:** T-06. `plan.md` §3.3 table.
+FR-3 (`resolve_env_credential`, never `os.getenv` for the key), FR-11, NFR-5.
+Watch out: `catalog.py` uses `_all_env` (not `_any_env`), and `setup_order`/
+`verify_order` must be **unique** with a matching entry in `_HANDLERS` — the 4
+invariants in `plan.md` §3.3 are CI gates.
+**Gate:** with `NEW_RELIC_API_KEY` + `NEW_RELIC_ACCOUNT_ID` in the environment,
+`opensre integrations show` lists `new_relic` (acceptance criterion 1).
+`uv run python -m pytest tests/integrations/test_registry.py tests/integrations/test_registry_invariants.py tests/integrations/test_verify.py`
+
+### [ ] T-08 · `.env.example`
+`# New Relic` block + commented `NEW_RELIC_INSTANCES=`.
+**Gate:** `git status --short` shows no modified `.env`.
+
+---
+
+## Phase 3 — Tools
+
+### [ ] T-09 · `query_new_relic_metrics`
+`new_relic_metrics_tool/` package with `tool.py` + `validation.py`. FR-7, NFR-3, NFR-4,
+NFR-8. Inject default `SINCE`/`LIMIT` when the model's NRQL doesn't include them — with
+the API's 5 s timeout, a query with no window is a guaranteed failure on a large
+account.
+**Gate:** `BaseToolContract` green; default-injection test; a test that the `nrqlQuery`
+returned by T-10 is accepted as valid input (FR-7); `input_schema` with no
+`["type", "null"]`.
+
+### [ ] T-10 · `query_new_relic_alerts`
+**Depends on:** T-01c (synthetic fixture). `new_relic_alerts_tool/` package with
+`tool.py` + `results.py`. FR-6, NFR-4, NFR-8.
+**Gate:** `event` compared without a fixed casing (`LOWER(event)`, tested with both
+`'open'` and `'Open'` — the two sources seen disagree); pairing by `incidentId` (the
+`open` row + the `close` row of the same transition collapse into one record with a
+derived `status`); different `incidentId`s of the same condition **don't** collapse
+(test proves 3 flapping firings show up as 3 records); `operator`/`title` decoded from
+HTML entities (`&gt;=` → `>=`); `threshold` parsed from a string; `muted` flagged and
+**not** filtered; causal order preserved; truncation flagged; the parser runs against
+the T-01c fixture.
+
+### [ ] T-11 · `tools/registry_discovery.py` + telemetry
+**Gate:** `tests/tools/test_registry.py` proves the real registry discovers both tools
+(acceptance criterion 3). `tests/tools/test_telemetry.py` updated.
+
+---
+
+## Phase 4 — Investigation
+
+### [ ] T-12 · Routing and intake
+`alert_source_catalog.py` (routing + aliases) and `intake/node.py`. FR-8.
+No regex/keyword routing outside the declarative tables.
+**Gate:** an alert mentioning "newrelic.com" classifies as `alert_source: "new_relic"`.
+
+### [ ] T-13 · Reporting
+`provenance.py` and `evidence_catalog.py`. FR-10.
+**Gate:** the RCA report cites New Relic in the provenance and the evidence catalog.
+
+### [ ] T-14 · Alert template
+`alert_templates.py`, `config/constants/investigation.py`, `slash_catalog.py` (file
+confirmed by T-02b). FR-12.
+**Gate:** `opensre investigate --template new_relic` runs and invokes at least one of
+the tools (acceptance criterion 4).
+
+---
+
+## Phase 5 — Onboarding and UI
+
+### [ ] T-15 · Wizard + UI labels
+`plan.md` §3.5 table — watch out for the **two** maps in
+`_integration_configurators.py`.
+**Gate:** `opensre onboard` shows New Relic in the Observability group and completes
+setup; `tests/cli/wizard/` covers the choice.
+
+---
+
+## Phase 6 — Docs, tests, and gates
+
+### [ ] T-16 · `docs/new_relic.mdx` + `docs.json` + `README.md`
+**Gate:** entry in `docs/docs.json` **without** the `.mdx` suffix (acceptance criterion
+8); New Relic moved from "wanted" to the supported list in `README.md:256`.
+
+### [ ] T-16b · Per-service parametrized test tables
+Four curated lists that **don't** fail CI if omitted, but leave a silent gap — table in
+`plan.md` §4: `test_setup_spec_env_round_trip.py::_SUBMITTED`,
+`test_cli_spec_setup.py` (`_ANSWERS` + `_CASES` + import), `test_env_multi_instance.py`,
+`test_catalog_silent_fallback_elimination.py` (two places).
+**Gate:** New Relic parametrized in all four, with non-default values.
+
+### [ ] T-17 · Synthetic / e2e coverage
+**Gate:** a test proving the planner discovers and invokes the tools through the normal
+path (mandatory gate for a new integration).
+
+### [ ] T-18 · CI harness
+```bash
+git status --short
+make lint
+make format-check
+make typecheck
+make verify-integrations-smoke
+make verify-integrations          # integration config/wiring changed
+uv run python -m pytest <targets from .github/ci/test_scope_rules.py>
+uv run mypy tests/integrations/new_relic tests/tools   # CI doesn't cover tests/
+```
+**Gate:** all green. List the focused tests run in the PR description.
+
+### [ ] T-19 · PR
+Fill out `.github/PULL_REQUEST_TEMPLATE.md` — includes a **mandatory** AI-usage
+disclosure section. Attach an end-to-end screenshot/GIF (acceptance criterion 9).
+**Gate:** template complete, demo attached, reference to issue #139.
+
+---
+
+## Traceability map
+
+| Requirement | Tasks |
+|---|---|
+| FR-1, FR-2 | T-04 |
+| FR-3, FR-11 | T-07 |
+| FR-4, FR-5 | T-06 |
+| FR-6 | T-10 |
+| FR-7 | T-09 |
+| FR-8 | T-12 |
+| FR-9 | T-11, T-17 |
+| FR-5 (tiers) | T-06, T-16b |
+| FR-10 | T-13 |
+| FR-12 | T-14 |
+| NFR-1, NFR-2 | T-05 |
+| NFR-3, NFR-4 | T-09, T-10 |
+| NFR-7 (timeout ≠ empty) | T-05 |
+| NFR-8 (context-sized caps) | T-09, T-10 |
+| NFR-5 | T-03, T-07 |
+| NFR-6 | T-18 (import-linter in `make lint`) |


### PR DESCRIPTION
Part of #139

<!-- This is PR 1 of 4 in a stacked series adding New Relic support (alerts + metrics). See the series overview at the bottom. -->

#### Describe the changes you have made in this PR -

Adds the Spec-Driven Design (SDD) documents for the New Relic integration: `specs/new-relic-integration/{spec,plan,tasks}.md`. No product code in this PR — pure planning documentation.

- `spec.md` — problem statement, objective, explicit out-of-scope table, 4 contestable design decisions (NerdGraph vs REST v2, `NrAiIncident` vs `aiIssues`, region via `base_url`, one alerts tool vs two), functional/non-functional requirements, acceptance criteria, risks.
- `plan.md` — technical design: precedents used (Honeycomb/Datadog/Railway), naming, the `NewRelicClient` contract, the exact file list for every phase, the testing strategy, and a documented plan-review pass.
- `tasks.md` — the execution checklist (T-00 through T-19) with an explicit verification gate per task, used to drive PRs 2–4.

Two of the four design decisions were validated against a **real, read-only-authorized New Relic account** before writing any code (see `spec.md` §4 Decision 2 and §10 for sources): this caught that `NrAiIncident.event` casing is inconsistent between New Relic's own docs and a live account, and that incident rows are emitted per state-transition (paired by `incidentId`), not per incident — both are reflected in the plan and, later, in the parser (PR 3). No real account data (account id, entity/condition names, etc.) is included anywhere in these docs.

### Demo/Screenshot for feature changes and bug fixes -

Not applicable — documentation only, no runtime behavior change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

<!-- @raildo: please review these 4 boxes yourself before requesting review — I (the assistant) can't attest to your understanding on your behalf. -->

**Explain your implementation approach:**

This PR only adds planning documents, produced with an AI assistant (Claude Code) using a Spec-Driven Development flow: write a spec (what/why) and a plan (how) before any code, then run an adversarial review pass to find and fix errors before implementation starts. Two rounds of review happened: one against the actual repo code (catching a wrong env-detection pattern, a wrong claim about credential storage, and a metadata field that doesn't exist), and one against New Relic's official docs plus a real test account (catching the `event`-casing and incident-row-pairing issues described above). The docs are intentionally free of any real account data.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

### Series overview (New Relic integration, issue #139)

Split into 4 stacked PRs so each is reviewable on its own instead of one ~3,500-line PR:

1. **#4869** — SDD spec/plan/tasks (docs only)
2. #4870 — Config, client, verifier, setup + registry/catalog/CLI wiring
3. #4871 — Alerts + metrics investigation tools
4. Investigation routing/reporting/template + onboarding/UI + docs/tests/CI gates (closes #139)

PRs 2–4 are opened now for visibility but are based on `main` (no push access to create intermediate tracking branches upstream) — until earlier PRs in the series merge, their "Files changed" tab shows the cumulative diff. Their **Commits** tab always shows only that PR's own commit(s); each commit passes lint/type/test in isolation. I'll rebase each subsequent PR onto `main` right after the previous one merges, at which point its diff becomes clean too.

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
