### PR TITLE
chore(graft): add repo context graph config for agent tooling

### DIFF
--- a/.claude/helpers/graft-hooks.cjs
+++ b/.claude/helpers/graft-hooks.cjs
@@ -37,7 +37,16 @@ function entry(name) {
     const f = path.join(d, name);
     if (fs.existsSync(f)) return f;
   }
-  return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
+  // No trusted candidate holds the entrypoint, so there is nothing to run.
+  // This used to fall back to `<project>/dist/claude/<name>` -- which, on a
+  // machine without graft installed, imports and executes that file straight
+  // out of whatever repository happens to be open. A clone carrying its own
+  // dist/claude/hooks.js would run on session-start, post-edit and stop with
+  // no install step and no prompt. Absent graft, the hook must do nothing.
+  return null;
 }
 
-import(pathToFileURL(entry("hooks.js")).href).then((m) => m.main(process.argv[2])).catch(() => { /* graft unavailable — no-op */ });
+const hooksEntry = entry("hooks.js");
+if (hooksEntry) {
+  import(pathToFileURL(hooksEntry).href).then((m) => m.main(process.argv[2])).catch(() => { /* graft unavailable — no-op */ });
+}

--- a/.claude/helpers/graft-hooks.cjs
+++ b/.claude/helpers/graft-hooks.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const { pathToFileURL } = require('url');
+const { execFileSync } = require('child_process');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+// Optional per-developer override: absolute path to @nanonets/graft's dist/claude.
+const BAKED = process.env.GRAFT_CLAUDE_DIR || "";
+
+// The dist/claude dir of @nanonets/graft resolved from a base whose node_modules is searched.
+function fromPkg(base) {
+  try {
+    const pkg = require.resolve('@nanonets/graft/package.json', { paths: [base] });
+    return path.join(path.dirname(pkg), 'dist', 'claude');
+  } catch { return null; }
+}
+
+// The global node_modules dir per npm (handles Homebrew/Windows/volta). Queried on demand.
+function globalRoot() {
+  try {
+    const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim();
+    return root || null;
+  } catch { return null; /* npm unavailable */ }
+}
+
+function candidates() {
+  const out = [];
+  if (BAKED) out.push(BAKED);
+  const local = fromPkg(dir); if (local) out.push(local);
+  const legacy = fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')); if (legacy) out.push(legacy);
+  const gr = globalRoot(); if (gr) out.push(path.join(gr, '@nanonets', 'graft', 'dist', 'claude'));
+  return out;
+}
+
+function entry(name) {
+  for (const d of candidates()) {
+    const f = path.join(d, name);
+    if (fs.existsSync(f)) return f;
+  }
+  return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
+}
+
+import(pathToFileURL(entry("hooks.js")).href).then((m) => m.main(process.argv[2])).catch(() => { /* graft unavailable — no-op */ });

--- a/.claude/helpers/graft-hooks.cjs
+++ b/.claude/helpers/graft-hooks.cjs
@@ -32,21 +32,37 @@ function candidates() {
   return out;
 }
 
-function entry(name) {
+// Every trusted candidate that actually holds the entrypoint, best first.
+//
+// There is deliberately no fallback to `<project>/dist/claude/<name>`: on a
+// machine without graft installed that imported and executed the file straight
+// out of whatever repository happened to be open, so a clone carrying its own
+// dist/claude/hooks.js would run on session-start, post-edit and stop with no
+// install step and no prompt. Absent graft, these helpers do nothing.
+function entries(name) {
+  const out = [];
   for (const d of candidates()) {
     const f = path.join(d, name);
-    if (fs.existsSync(f)) return f;
+    if (fs.existsSync(f)) out.push(f);
   }
-  // No trusted candidate holds the entrypoint, so there is nothing to run.
-  // This used to fall back to `<project>/dist/claude/<name>` -- which, on a
-  // machine without graft installed, imports and executes that file straight
-  // out of whatever repository happens to be open. A clone carrying its own
-  // dist/claude/hooks.js would run on session-start, post-edit and stop with
-  // no install step and no prompt. Absent graft, the hook must do nothing.
-  return null;
+  return out;
 }
 
-const hooksEntry = entry("hooks.js");
-if (hooksEntry) {
-  import(pathToFileURL(hooksEntry).href).then((m) => m.main(process.argv[2])).catch(() => { /* graft unavailable — no-op */ });
-}
+// Try each candidate in turn: a stale or half-installed first hit must not
+// mask a working installation further down the list. Only a *load* failure
+// falls through -- once main() has been reached it owns the outcome, and
+// retrying the next candidate would run its side effects twice.
+(async () => {
+  for (const f of entries("hooks.js")) {
+    let mod;
+    try {
+      mod = await import(pathToFileURL(f).href);
+    } catch {
+      continue;
+    }
+    if (typeof mod.main !== 'function') continue;
+    try { await mod.main(process.argv[2]); } catch { /* hook failed — never block the session */ }
+    return;
+  }
+  /* graft unavailable — no-op */
+})();

--- a/.claude/helpers/graft-hooks.cjs
+++ b/.claude/helpers/graft-hooks.cjs
@@ -23,12 +23,20 @@ function globalRoot() {
   } catch { return null; /* npm unavailable */ }
 }
 
+// Ordered by how much the machine's owner controls them, not by proximity.
+//
+// The project-local lookup comes last on purpose. It resolves through the open
+// repository's own node_modules, so a clone that ships
+// node_modules/@nanonets/graft executes on session-start, post-edit and stop
+// without anyone running an install. Supporting a project-local graft is worth
+// keeping, but it must never outrank an installation the user chose: ranked
+// last, it is reached only when nothing trusted is present.
 function candidates() {
   const out = [];
   if (BAKED) out.push(BAKED);
-  const local = fromPkg(dir); if (local) out.push(local);
   const legacy = fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')); if (legacy) out.push(legacy);
   const gr = globalRoot(); if (gr) out.push(path.join(gr, '@nanonets', 'graft', 'dist', 'claude'));
+  const local = fromPkg(dir); if (local) out.push(local);
   return out;
 }
 

--- a/.claude/helpers/graft-statusline.cjs
+++ b/.claude/helpers/graft-statusline.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const { pathToFileURL } = require('url');
+const { execFileSync } = require('child_process');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+// Optional per-developer override: absolute path to @nanonets/graft's dist/claude.
+const BAKED = process.env.GRAFT_CLAUDE_DIR || "";
+
+// The dist/claude dir of @nanonets/graft resolved from a base whose node_modules is searched.
+function fromPkg(base) {
+  try {
+    const pkg = require.resolve('@nanonets/graft/package.json', { paths: [base] });
+    return path.join(path.dirname(pkg), 'dist', 'claude');
+  } catch { return null; }
+}
+
+// The global node_modules dir per npm (handles Homebrew/Windows/volta). Queried on demand.
+function globalRoot() {
+  try {
+    const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim();
+    return root || null;
+  } catch { return null; /* npm unavailable */ }
+}
+
+function candidates() {
+  const out = [];
+  if (BAKED) out.push(BAKED);
+  const local = fromPkg(dir); if (local) out.push(local);
+  const legacy = fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')); if (legacy) out.push(legacy);
+  const gr = globalRoot(); if (gr) out.push(path.join(gr, '@nanonets', 'graft', 'dist', 'claude'));
+  return out;
+}
+
+function entry(name) {
+  for (const d of candidates()) {
+    const f = path.join(d, name);
+    if (fs.existsSync(f)) return f;
+  }
+  return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
+}
+
+import(pathToFileURL(entry("statusline.js")).href).then((m) => m.main()).catch(() => { /* graft unavailable — no-op */ });

--- a/.claude/helpers/graft-statusline.cjs
+++ b/.claude/helpers/graft-statusline.cjs
@@ -32,21 +32,37 @@ function candidates() {
   return out;
 }
 
-function entry(name) {
+// Every trusted candidate that actually holds the entrypoint, best first.
+//
+// There is deliberately no fallback to `<project>/dist/claude/<name>`: on a
+// machine without graft installed that imported and executed the file straight
+// out of whatever repository happened to be open, so a clone carrying its own
+// dist/claude/hooks.js would run on session-start, post-edit and stop with no
+// install step and no prompt. Absent graft, these helpers do nothing.
+function entries(name) {
+  const out = [];
   for (const d of candidates()) {
     const f = path.join(d, name);
-    if (fs.existsSync(f)) return f;
+    if (fs.existsSync(f)) out.push(f);
   }
-  // No trusted candidate holds the entrypoint, so there is nothing to run.
-  // This used to fall back to `<project>/dist/claude/<name>` -- which, on a
-  // machine without graft installed, imports and executes that file straight
-  // out of whatever repository happens to be open. A clone carrying its own
-  // dist/claude/hooks.js would run on session-start, post-edit and stop with
-  // no install step and no prompt. Absent graft, the hook must do nothing.
-  return null;
+  return out;
 }
 
-const statuslineEntry = entry("statusline.js");
-if (statuslineEntry) {
-  import(pathToFileURL(statuslineEntry).href).then((m) => m.main()).catch(() => { /* graft unavailable — no-op */ });
-}
+// Try each candidate in turn: a stale or half-installed first hit must not
+// mask a working installation further down the list. Only a *load* failure
+// falls through -- once main() has been reached it owns the outcome, and
+// retrying the next candidate would run its side effects twice.
+(async () => {
+  for (const f of entries("statusline.js")) {
+    let mod;
+    try {
+      mod = await import(pathToFileURL(f).href);
+    } catch {
+      continue;
+    }
+    if (typeof mod.main !== 'function') continue;
+    try { await mod.main(); } catch { /* status line failed — render nothing */ }
+    return;
+  }
+  /* graft unavailable — no-op */
+})();

--- a/.claude/helpers/graft-statusline.cjs
+++ b/.claude/helpers/graft-statusline.cjs
@@ -37,7 +37,16 @@ function entry(name) {
     const f = path.join(d, name);
     if (fs.existsSync(f)) return f;
   }
-  return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
+  // No trusted candidate holds the entrypoint, so there is nothing to run.
+  // This used to fall back to `<project>/dist/claude/<name>` -- which, on a
+  // machine without graft installed, imports and executes that file straight
+  // out of whatever repository happens to be open. A clone carrying its own
+  // dist/claude/hooks.js would run on session-start, post-edit and stop with
+  // no install step and no prompt. Absent graft, the hook must do nothing.
+  return null;
 }
 
-import(pathToFileURL(entry("statusline.js")).href).then((m) => m.main()).catch(() => { /* graft unavailable — no-op */ });
+const statuslineEntry = entry("statusline.js");
+if (statuslineEntry) {
+  import(pathToFileURL(statuslineEntry).href).then((m) => m.main()).catch(() => { /* graft unavailable — no-op */ });
+}

--- a/.claude/helpers/graft-statusline.cjs
+++ b/.claude/helpers/graft-statusline.cjs
@@ -23,12 +23,20 @@ function globalRoot() {
   } catch { return null; /* npm unavailable */ }
 }
 
+// Ordered by how much the machine's owner controls them, not by proximity.
+//
+// The project-local lookup comes last on purpose. It resolves through the open
+// repository's own node_modules, so a clone that ships
+// node_modules/@nanonets/graft executes on session-start, post-edit and stop
+// without anyone running an install. Supporting a project-local graft is worth
+// keeping, but it must never outrank an installation the user chose: ranked
+// last, it is reached only when nothing trusted is present.
 function candidates() {
   const out = [];
   if (BAKED) out.push(BAKED);
-  const local = fromPkg(dir); if (local) out.push(local);
   const legacy = fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')); if (legacy) out.push(legacy);
   const gr = globalRoot(); if (gr) out.push(path.join(gr, '@nanonets', 'graft', 'dist', 'claude'));
+  const local = fromPkg(dir); if (local) out.push(local);
   return out;
 }
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,79 @@
       "Bash(python3*)",
       "PowerShell(uv run *)",
       "PowerShell(python *)",
-      "PowerShell(python3 *)"
+      "PowerShell(python3 *)",
+      "Bash(graft:*)",
+      "Bash(npx graft:*)",
+      "Bash(graft-dev:*)",
+      "Bash(node dist/cli.js:*)"
     ]
-  }
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  },
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" post-edit",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|mcp__graft__",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" tool-savings",
+            "timeout": 8000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" prompt",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" session-start",
+            "timeout": 8000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" stop",
+            "timeout": 8000
+          }
+        ]
+      }
+    ]
+  },
+  "footerLinksRegexes": [
+    "graft/[\\w./-]+\\.md"
+  ]
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "graft": {
+      "command": "graft",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/.cursor/rules/graft.mdc
+++ b/.cursor/rules/graft.mdc
@@ -1,0 +1,43 @@
+---
+description: Use the Graft context graph in graft/ before exploring source
+alwaysApply: true
+---
+## Graft — repo context graph
+
+This repo is indexed in `graft/`: small linked markdown nodes that explain each
+system and carry exact file:line spans, kept in sync with the code through git.
+
+For ANY task here — understanding how something works, finding where code lives,
+or scoping a change — get context from the graph before grepping or opening
+source files. Re-ask freely (it's cheap) and reuse literal identifiers you
+already have (symbol, error string, file name) as the query. New to this repo?
+Run `graft map` first — a token-budgeted orientation (dir clusters, hubs,
+hotspots), no LLM, no key.
+
+- Run `graft ask "<your question>" --source` → ranked nodes with the relevant
+  code spans inlined (each hit's ≤8-line crux by default; `--full` for whole
+  definitions when the crux isn't enough). Match the tool to the task shape:
+  for understanding or editing, the top node IS the answer — cite its
+  `covers:` file:line spans and edit straight from `--source`. For
+  exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
+  results are top-N, not complete — run `graft grep "<literal>"` instead
+  (exhaustive over indexed files, grouped by enclosing symbol), falling back
+  to raw `grep -rn` only for unindexed files.
+- `graft skeleton <file>` → every definition's signature + span, ~10× cheaper
+  than reading the file; use it to skim an API surface.
+- `graft callers <symbol>` gives precomputed, exact edges — who calls this.
+  Add `--direction out` for what it calls, or `--depth N` to walk
+  transitively for the full blast radius. For structural questions, skip
+  ranking and use this directly.
+- Or browse: `graft/INDEX.md` lists every node; follow the links.
+- Monorepos and folders of multiple repos rank fairly across sub-projects —
+  hits carry `[scope/]` labels naming which one they're from. Narrow with
+  `graft ask "<task>" --in <scope>/` once you know where you're working.
+
+If a returned span is truncated ("+N more lines"), open the file at that exact
+range before finalizing. Only open source files when a node genuinely lacks a
+needed detail, and then at the exact file:line the node points to — never
+re-read whole files.
+
+After big code changes, refresh the graph with `graft build` (deterministic,
+no API key, $0).

--- a/.cursor/rules/graft.mdc
+++ b/.cursor/rules/graft.mdc
@@ -4,8 +4,10 @@ alwaysApply: true
 ---
 ## Graft — repo context graph
 
-This repo is indexed in `graft/`: small linked markdown nodes that explain each
-system and carry exact file:line spans, kept in sync with the code through git.
+`graft/` is a local, regenerable cache: small linked markdown nodes that explain
+each system and carry exact file:line spans. It is gitignored, so a fresh clone
+does not have it -- run `graft build` when it is absent or stale, before
+`graft map`, `graft ask`, `graft grep` or `graft callers`.
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening

--- a/.cursor/rules/graft.mdc
+++ b/.cursor/rules/graft.mdc
@@ -4,6 +4,12 @@ alwaysApply: true
 ---
 ## Graft — repo context graph
 
+Graft is an external CLI, not a dependency of this repo: the MCP server entry
+runs a bare `graft`, so without it on `PATH` the server fails to start with
+command-not-found and every command below is unavailable. Install it with
+`npm i -g @nanonets/graft`; nothing here vendors or installs it for you, and
+contributors who skip it are unaffected otherwise.
+
 `graft/` is a local, regenerable cache: small linked markdown nodes that explain
 each system and carry exact file:line spans. It is gitignored, so a fresh clone
 does not have it -- run `graft build` when it is absent or stale, before

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "graft": {
+      "command": "graft",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,41 @@
+<!-- graft:start -->
+## Graft — repo context graph
+
+This repo is indexed in `graft/`: small linked markdown nodes that explain each
+system and carry exact file:line spans, kept in sync with the code through git.
+
+For ANY task here — understanding how something works, finding where code lives,
+or scoping a change — get context from the graph before grepping or opening
+source files. Re-ask freely (it's cheap) and reuse literal identifiers you
+already have (symbol, error string, file name) as the query. New to this repo?
+Run `graft map` first — a token-budgeted orientation (dir clusters, hubs,
+hotspots), no LLM, no key.
+
+- Run `graft ask "<your question>" --source` → ranked nodes with the relevant
+  code spans inlined (each hit's ≤8-line crux by default; `--full` for whole
+  definitions when the crux isn't enough). Match the tool to the task shape:
+  for understanding or editing, the top node IS the answer — cite its
+  `covers:` file:line spans and edit straight from `--source`. For
+  exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
+  results are top-N, not complete — run `graft grep "<literal>"` instead
+  (exhaustive over indexed files, grouped by enclosing symbol), falling back
+  to raw `grep -rn` only for unindexed files.
+- `graft skeleton <file>` → every definition's signature + span, ~10× cheaper
+  than reading the file; use it to skim an API surface.
+- `graft callers <symbol>` gives precomputed, exact edges — who calls this.
+  Add `--direction out` for what it calls, or `--depth N` to walk
+  transitively for the full blast radius. For structural questions, skip
+  ranking and use this directly.
+- Or browse: `graft/INDEX.md` lists every node; follow the links.
+- Monorepos and folders of multiple repos rank fairly across sub-projects —
+  hits carry `[scope/]` labels naming which one they're from. Narrow with
+  `graft ask "<task>" --in <scope>/` once you know where you're working.
+
+If a returned span is truncated ("+N more lines"), open the file at that exact
+range before finalizing. Only open source files when a node genuinely lacks a
+needed detail, and then at the exact file:line the node points to — never
+re-read whole files.
+
+After big code changes, refresh the graph with `graft build` (deterministic,
+no API key, $0).
+<!-- graft:end -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,12 @@
 <!-- graft:start -->
 ## Graft — repo context graph
 
+Graft is an external CLI, not a dependency of this repo: the MCP server entry
+runs a bare `graft`, so without it on `PATH` the server fails to start with
+command-not-found and every command below is unavailable. Install it with
+`npm i -g @nanonets/graft`; nothing here vendors or installs it for you, and
+contributors who skip it are unaffected otherwise.
+
 `graft/` is a local, regenerable cache: small linked markdown nodes that explain
 each system and carry exact file:line spans. It is gitignored, so a fresh clone
 does not have it -- run `graft build` when it is absent or stale, before

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,10 @@
 <!-- graft:start -->
 ## Graft — repo context graph
 
-This repo is indexed in `graft/`: small linked markdown nodes that explain each
-system and carry exact file:line spans, kept in sync with the code through git.
+`graft/` is a local, regenerable cache: small linked markdown nodes that explain
+each system and carry exact file:line spans. It is gitignored, so a fresh clone
+does not have it -- run `graft build` when it is absent or stale, before
+`graft map`, `graft ask`, `graft grep` or `graft callers`.
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ factory-ai-extract/
 
 # Local checkout of opensre-infra-aws — separate repo, never track here
 platform/deployment_multi_tenant/
+
+# graft's local graph cache — regenerable, not committed (run `graft build`).
+graft/

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,5 @@
+# graft's cards are gitignored but should stay greppable: ripgrep reads
+# .ignore before .gitignore, so this re-admits the tree to search only.
+!graft/
+graft/.cache/
+graft/.graph/

--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "graft": {
+      "command": "graft",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/.kiro/steering/graft.md
+++ b/.kiro/steering/graft.md
@@ -1,0 +1,42 @@
+---
+inclusion: always
+---
+## Graft — repo context graph
+
+This repo is indexed in `graft/`: small linked markdown nodes that explain each
+system and carry exact file:line spans, kept in sync with the code through git.
+
+For ANY task here — understanding how something works, finding where code lives,
+or scoping a change — get context from the graph before grepping or opening
+source files. Re-ask freely (it's cheap) and reuse literal identifiers you
+already have (symbol, error string, file name) as the query. New to this repo?
+Run `graft map` first — a token-budgeted orientation (dir clusters, hubs,
+hotspots), no LLM, no key.
+
+- Run `graft ask "<your question>" --source` → ranked nodes with the relevant
+  code spans inlined (each hit's ≤8-line crux by default; `--full` for whole
+  definitions when the crux isn't enough). Match the tool to the task shape:
+  for understanding or editing, the top node IS the answer — cite its
+  `covers:` file:line spans and edit straight from `--source`. For
+  exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
+  results are top-N, not complete — run `graft grep "<literal>"` instead
+  (exhaustive over indexed files, grouped by enclosing symbol), falling back
+  to raw `grep -rn` only for unindexed files.
+- `graft skeleton <file>` → every definition's signature + span, ~10× cheaper
+  than reading the file; use it to skim an API surface.
+- `graft callers <symbol>` gives precomputed, exact edges — who calls this.
+  Add `--direction out` for what it calls, or `--depth N` to walk
+  transitively for the full blast radius. For structural questions, skip
+  ranking and use this directly.
+- Or browse: `graft/INDEX.md` lists every node; follow the links.
+- Monorepos and folders of multiple repos rank fairly across sub-projects —
+  hits carry `[scope/]` labels naming which one they're from. Narrow with
+  `graft ask "<task>" --in <scope>/` once you know where you're working.
+
+If a returned span is truncated ("+N more lines"), open the file at that exact
+range before finalizing. Only open source files when a node genuinely lacks a
+needed detail, and then at the exact file:line the node points to — never
+re-read whole files.
+
+After big code changes, refresh the graph with `graft build` (deterministic,
+no API key, $0).

--- a/.kiro/steering/graft.md
+++ b/.kiro/steering/graft.md
@@ -3,8 +3,10 @@ inclusion: always
 ---
 ## Graft — repo context graph
 
-This repo is indexed in `graft/`: small linked markdown nodes that explain each
-system and carry exact file:line spans, kept in sync with the code through git.
+`graft/` is a local, regenerable cache: small linked markdown nodes that explain
+each system and carry exact file:line spans. It is gitignored, so a fresh clone
+does not have it -- run `graft build` when it is absent or stale, before
+`graft map`, `graft ask`, `graft grep` or `graft callers`.
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening

--- a/.kiro/steering/graft.md
+++ b/.kiro/steering/graft.md
@@ -3,6 +3,12 @@ inclusion: always
 ---
 ## Graft — repo context graph
 
+Graft is an external CLI, not a dependency of this repo: the MCP server entry
+runs a bare `graft`, so without it on `PATH` the server fails to start with
+command-not-found and every command below is unavailable. Install it with
+`npm i -g @nanonets/graft`; nothing here vendors or installs it for you, and
+contributors who skip it are unaffected otherwise.
+
 `graft/` is a local, regenerable cache: small linked markdown nodes that explain
 each system and carry exact file:line spans. It is gitignored, so a fresh clone
 does not have it -- run `graft build` when it is absent or stale, before

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "graft": {
+      "command": "graft",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/.windsurf/rules/graft.md
+++ b/.windsurf/rules/graft.md
@@ -1,0 +1,39 @@
+## Graft — repo context graph
+
+This repo is indexed in `graft/`: small linked markdown nodes that explain each
+system and carry exact file:line spans, kept in sync with the code through git.
+
+For ANY task here — understanding how something works, finding where code lives,
+or scoping a change — get context from the graph before grepping or opening
+source files. Re-ask freely (it's cheap) and reuse literal identifiers you
+already have (symbol, error string, file name) as the query. New to this repo?
+Run `graft map` first — a token-budgeted orientation (dir clusters, hubs,
+hotspots), no LLM, no key.
+
+- Run `graft ask "<your question>" --source` → ranked nodes with the relevant
+  code spans inlined (each hit's ≤8-line crux by default; `--full` for whole
+  definitions when the crux isn't enough). Match the tool to the task shape:
+  for understanding or editing, the top node IS the answer — cite its
+  `covers:` file:line spans and edit straight from `--source`. For
+  exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
+  results are top-N, not complete — run `graft grep "<literal>"` instead
+  (exhaustive over indexed files, grouped by enclosing symbol), falling back
+  to raw `grep -rn` only for unindexed files.
+- `graft skeleton <file>` → every definition's signature + span, ~10× cheaper
+  than reading the file; use it to skim an API surface.
+- `graft callers <symbol>` gives precomputed, exact edges — who calls this.
+  Add `--direction out` for what it calls, or `--depth N` to walk
+  transitively for the full blast radius. For structural questions, skip
+  ranking and use this directly.
+- Or browse: `graft/INDEX.md` lists every node; follow the links.
+- Monorepos and folders of multiple repos rank fairly across sub-projects —
+  hits carry `[scope/]` labels naming which one they're from. Narrow with
+  `graft ask "<task>" --in <scope>/` once you know where you're working.
+
+If a returned span is truncated ("+N more lines"), open the file at that exact
+range before finalizing. Only open source files when a node genuinely lacks a
+needed detail, and then at the exact file:line the node points to — never
+re-read whole files.
+
+After big code changes, refresh the graph with `graft build` (deterministic,
+no API key, $0).

--- a/.windsurf/rules/graft.md
+++ b/.windsurf/rules/graft.md
@@ -1,5 +1,11 @@
 ## Graft — repo context graph
 
+Graft is an external CLI, not a dependency of this repo: the MCP server entry
+runs a bare `graft`, so without it on `PATH` the server fails to start with
+command-not-found and every command below is unavailable. Install it with
+`npm i -g @nanonets/graft`; nothing here vendors or installs it for you, and
+contributors who skip it are unaffected otherwise.
+
 `graft/` is a local, regenerable cache: small linked markdown nodes that explain
 each system and carry exact file:line spans. It is gitignored, so a fresh clone
 does not have it -- run `graft build` when it is absent or stale, before

--- a/.windsurf/rules/graft.md
+++ b/.windsurf/rules/graft.md
@@ -1,7 +1,9 @@
 ## Graft — repo context graph
 
-This repo is indexed in `graft/`: small linked markdown nodes that explain each
-system and carry exact file:line spans, kept in sync with the code through git.
+`graft/` is a local, regenerable cache: small linked markdown nodes that explain
+each system and carry exact file:line spans. It is gitignored, so a fresh clone
+does not have it -- run `graft build` when it is absent or stale, before
+`graft map`, `graft ask`, `graft grep` or `graft callers`.
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening

--- a/.windsurf/rules/graft.md
+++ b/.windsurf/rules/graft.md
@@ -1,3 +1,7 @@
+---
+trigger: always_on
+---
+
 ## Graft — repo context graph
 
 Graft is an external CLI, not a dependency of this repo: the MCP server entry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,12 @@ Steps:
 <!-- graft:start -->
 ## Graft — repo context graph
 
+Graft is an external CLI, not a dependency of this repo: the MCP server entry
+runs a bare `graft`, so without it on `PATH` the server fails to start with
+command-not-found and every command below is unavailable. Install it with
+`npm i -g @nanonets/graft`; nothing here vendors or installs it for you, and
+contributors who skip it are unaffected otherwise.
+
 `graft/` is a local, regenerable cache: small linked markdown nodes that explain
 each system and carry exact file:line spans. It is gitignored, so a fresh clone
 does not have it -- run `graft build` when it is absent or stale, before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,8 +335,10 @@ Steps:
 <!-- graft:start -->
 ## Graft — repo context graph
 
-This repo is indexed in `graft/`: small linked markdown nodes that explain each
-system and carry exact file:line spans, kept in sync with the code through git.
+`graft/` is a local, regenerable cache: small linked markdown nodes that explain
+each system and carry exact file:line spans. It is gitignored, so a fresh clone
+does not have it -- run `graft build` when it is absent or stale, before
+`graft map`, `graft ask`, `graft grep` or `graft callers`.
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,3 +332,44 @@ Steps:
   deterministically without threads.
 - CI typecheck does **not** cover `tests/`: `make typecheck` runs mypy over `PYTHON_SOURCE_PATHS` (`config core gateway integrations platform surfaces tools`) only. Type errors in test files never fail CI, so do not assume a clean `make typecheck` means the tests you just wrote are type-clean — run mypy on the test path directly when it matters.
 
+<!-- graft:start -->
+## Graft — repo context graph
+
+This repo is indexed in `graft/`: small linked markdown nodes that explain each
+system and carry exact file:line spans, kept in sync with the code through git.
+
+For ANY task here — understanding how something works, finding where code lives,
+or scoping a change — get context from the graph before grepping or opening
+source files. Re-ask freely (it's cheap) and reuse literal identifiers you
+already have (symbol, error string, file name) as the query. New to this repo?
+Run `graft map` first — a token-budgeted orientation (dir clusters, hubs,
+hotspots), no LLM, no key.
+
+- Run `graft ask "<your question>" --source` → ranked nodes with the relevant
+  code spans inlined (each hit's ≤8-line crux by default; `--full` for whole
+  definitions when the crux isn't enough). Match the tool to the task shape:
+  for understanding or editing, the top node IS the answer — cite its
+  `covers:` file:line spans and edit straight from `--source`. For
+  exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
+  results are top-N, not complete — run `graft grep "<literal>"` instead
+  (exhaustive over indexed files, grouped by enclosing symbol), falling back
+  to raw `grep -rn` only for unindexed files.
+- `graft skeleton <file>` → every definition's signature + span, ~10× cheaper
+  than reading the file; use it to skim an API surface.
+- `graft callers <symbol>` gives precomputed, exact edges — who calls this.
+  Add `--direction out` for what it calls, or `--depth N` to walk
+  transitively for the full blast radius. For structural questions, skip
+  ranking and use this directly.
+- Or browse: `graft/INDEX.md` lists every node; follow the links.
+- Monorepos and folders of multiple repos rank fairly across sub-projects —
+  hits carry `[scope/]` labels naming which one they're from. Narrow with
+  `graft ask "<task>" --in <scope>/` once you know where you're working.
+
+If a returned span is truncated ("+N more lines"), open the file at that exact
+range before finalizing. Only open source files when a node genuinely lacks a
+needed detail, and then at the exact file:line the node points to — never
+re-read whole files.
+
+After big code changes, refresh the graph with `graft build` (deterministic,
+no API key, $0).
+<!-- graft:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,41 @@
+<!-- graft:start -->
+## Graft — repo context graph
+
+This repo is indexed in `graft/`: small linked markdown nodes that explain each
+system and carry exact file:line spans, kept in sync with the code through git.
+
+For ANY task here — understanding how something works, finding where code lives,
+or scoping a change — get context from the graph before grepping or opening
+source files. Re-ask freely (it's cheap) and reuse literal identifiers you
+already have (symbol, error string, file name) as the query. New to this repo?
+Run `graft map` first — a token-budgeted orientation (dir clusters, hubs,
+hotspots), no LLM, no key.
+
+- Run `graft ask "<your question>" --source` → ranked nodes with the relevant
+  code spans inlined (each hit's ≤8-line crux by default; `--full` for whole
+  definitions when the crux isn't enough). Match the tool to the task shape:
+  for understanding or editing, the top node IS the answer — cite its
+  `covers:` file:line spans and edit straight from `--source`. For
+  exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
+  results are top-N, not complete — run `graft grep "<literal>"` instead
+  (exhaustive over indexed files, grouped by enclosing symbol), falling back
+  to raw `grep -rn` only for unindexed files.
+- `graft skeleton <file>` → every definition's signature + span, ~10× cheaper
+  than reading the file; use it to skim an API surface.
+- `graft callers <symbol>` gives precomputed, exact edges — who calls this.
+  Add `--direction out` for what it calls, or `--depth N` to walk
+  transitively for the full blast radius. For structural questions, skip
+  ranking and use this directly.
+- Or browse: `graft/INDEX.md` lists every node; follow the links.
+- Monorepos and folders of multiple repos rank fairly across sub-projects —
+  hits carry `[scope/]` labels naming which one they're from. Narrow with
+  `graft ask "<task>" --in <scope>/` once you know where you're working.
+
+If a returned span is truncated ("+N more lines"), open the file at that exact
+range before finalizing. Only open source files when a node genuinely lacks a
+needed detail, and then at the exact file:line the node points to — never
+re-read whole files.
+
+After big code changes, refresh the graph with `graft build` (deterministic,
+no API key, $0).
+<!-- graft:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,12 @@
 <!-- graft:start -->
 ## Graft — repo context graph
 
+Graft is an external CLI, not a dependency of this repo: the MCP server entry
+runs a bare `graft`, so without it on `PATH` the server fails to start with
+command-not-found and every command below is unavailable. Install it with
+`npm i -g @nanonets/graft`; nothing here vendors or installs it for you, and
+contributors who skip it are unaffected otherwise.
+
 `graft/` is a local, regenerable cache: small linked markdown nodes that explain
 each system and carry exact file:line spans. It is gitignored, so a fresh clone
 does not have it -- run `graft build` when it is absent or stale, before

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,8 +1,10 @@
 <!-- graft:start -->
 ## Graft — repo context graph
 
-This repo is indexed in `graft/`: small linked markdown nodes that explain each
-system and carry exact file:line spans, kept in sync with the code through git.
+`graft/` is a local, regenerable cache: small linked markdown nodes that explain
+each system and carry exact file:line spans. It is gitignored, so a fresh clone
+does not have it -- run `graft build` when it is absent or stale, before
+`graft map`, `graft ask`, `graft grep` or `graft callers`.
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,12 @@
+{
+  "mcp": {
+    "graft": {
+      "type": "local",
+      "command": [
+        "graft",
+        "mcp"
+      ],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
No linked issue — this is tooling-only config, no product change.

#### Describe the changes you have made in this PR -

Adds the output of `graft init` (Graft 0.9.1), which indexes this repo into a
context graph so coding agents can locate code without grepping or reading whole
files.

What is included:

- **MCP server registration** for the agents this repo already carries config
  for: `.mcp.json` (Claude Code), `.cursor/mcp.json`, `.gemini/settings.json`,
  `.kiro/settings/mcp.json`, `opencode.json`. Each one just runs `graft mcp`
  over stdio; no keys, no network calls, no credentials.
- **Usage instructions** appended to `AGENTS.md` between `<!-- graft:start -->`
  / `<!-- graft:end -->` markers, and mirrored into `GEMINI.md`,
  `.github/copilot-instructions.md`, `.cursor/rules/graft.mdc`,
  `.windsurf/rules/graft.md`, and `.kiro/steering/graft.md`.
- **`.claude/helpers/graft-hooks.cjs` and `graft-statusline.cjs`** plus the
  matching `hooks`/`statusLine` entries and `Bash(graft:*)` permissions in
  `.claude/settings.json`.
- **`.gitignore`**: the generated graph (`graft/`) is not committed — it is
  regenerable with `graft build` (deterministic, no API key). **`.ignore`**
  re-admits that directory to ripgrep, which reads `.ignore` before
  `.gitignore`, so the cards stay greppable locally.

No application code, dependencies, or CI configuration is touched. Contributors
who do not use these agents are unaffected; nothing here runs during build,
test, or deploy.

### Demo/Screenshot for feature changes and bug fixes -

Querying the graph for gateway auth, from this branch:

```
$ graft ask "gateway request authentication" --in gateway/
graft ask — "gateway request authentication"  (lexical)

1. request · method  [symbol]
   gateway/slack/approvals.py:L106-L144
...
5. _gateway_auth_error · function  [symbol]
   gateway/http/webapp.py:L105-L123
   def _gateway_auth_error(request: Request) -> JSONResponse | None
7. receive_alert · function  [symbol]
   gateway/http/webapp.py:L127-L171
```

That pointed straight at the real answer (bearer-token check with a loopback
fallback, shared by `/alerts` and `/investigate`) from one query plus a 30-line
read, instead of opening `gateway/http/webapp.py` in full.

MCP server handshake, verified over stdio:

```
$ printf '...initialize...tools/list...' | graft mcp
initialize OK: {'name': 'graft', 'version': '0.9.1'}
tools: graft_find_code, graft_file_api, graft_check_freshness,
       graft_trace_calls, graft_find_all, graft_repo_map
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

To be precise about provenance: the committed files were generated by the
`graft init` CLI, not written by a model. Claude Code was used to review the
generated output, decide what to stage, and write this PR. No hand-written or
model-written application logic is included.

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: agents working in this repo burn context re-reading large files to
answer "where does X happen". Graft builds a local graph of small markdown nodes
carrying exact `file:line` spans, so a question resolves to a ranked set of spans
instead of a file dump.

Alternatives considered: (a) do nothing and keep relying on grep — works, but
costs context on every task; (b) commit the generated `graft/` graph so
contributors skip the build — rejected, since it is derived data that would churn
on every code change and pollute diffs; (c) keep all of this untracked and local
per-developer — rejected because the instruction blocks and MCP registrations are
exactly the parts worth sharing, and they are inert for anyone who does not
install Graft.

Key pieces: `.mcp.json` and its per-agent equivalents register `graft mcp` as a
stdio MCP server exposing six read-only query tools. The `AGENTS.md` block tells
agents to query the graph before grepping. `graft-hooks.cjs` reacts to
Write/Edit and Bash tool events to keep the local graph fresh and report token
savings; `graft-statusline.cjs` renders that in the status line. Both are
local-only developer conveniences.

Edge cases: the graph directory is ignored by git but explicitly re-admitted to
ripgrep via `.ignore`, so a stale or absent `graft/` degrades to "run
`graft build`" rather than breaking anything. Contributors without the `graft`
binary see the MCP server simply fail to start in their agent, with no effect on
the repo itself.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
