### PR TITLE
refactor(billing): convert CreditsOutcome to StrEnum

### DIFF
--- a/gateway/core/billing/credits_client.py
+++ b/gateway/core/billing/credits_client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
-from enum import Enum
+from enum import StrEnum
 from http import HTTPStatus
 from typing import Any
 
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 _CONSUME_PATH = "/api/credits/consume"
 
 
-class CreditsOutcome(Enum):
+class CreditsOutcome(StrEnum):
     """Classification of one credit-consume attempt; policy belongs to callers."""
 
     ALLOWED = "allowed"

--- a/gateway/tests/billing/test_credits_client.py
+++ b/gateway/tests/billing/test_credits_client.py
@@ -196,3 +196,19 @@ def test_metadata_cannot_override_billing_fields(monkeypatch: pytest.MonkeyPatch
     assert sent["json"]["amount"] == 1.0
     assert sent["json"]["organizationId"] == "org_real"
     assert sent["json"]["reason"] == "slack_turn"
+
+
+def test_creditsoutcome_is_strenum_with_identical_values() -> None:
+    # Arrange: the persisted/logged string for each outcome must not move.
+    expected_values = {
+        CreditsOutcome.ALLOWED: "allowed",
+        CreditsOutcome.DENIED: "denied",
+        CreditsOutcome.UNCONFIGURED: "unconfigured",
+        CreditsOutcome.UNAVAILABLE: "unavailable",
+    }
+
+    # Act / Assert: StrEnum members behave as their plain string value.
+    for member, expected in expected_values.items():
+        assert member.value == expected
+        assert member == expected
+        assert isinstance(member, str)


### PR DESCRIPTION
Fixes #4907

#### Describe the changes you have made in this PR -
Converts `CreditsOutcome` in `gateway/core/billing/credits_client.py` from
a plain `Enum` to `StrEnum`. All four member values (`allowed`, `denied`,
`unconfigured`, `unavailable`) are unchanged — only the base class changed.
Added a regression test asserting each member's `.value`, string equality,
and `isinstance(member, str)` to lock in the identical-values guarantee.

### Demo/Screenshot for feature changes and bug fixes -
​```
gateway/tests/billing/test_credits_client.py::test_unconfigured_when_secret_unset PASSED [10%]
gateway/tests/billing/test_credits_client.py::test_unconfigured_when_org_unset PASSED [20%]
gateway/tests/billing/test_credits_client.py::test_402_is_denied PASSED [30%]
gateway/tests/billing/test_credits_client.py::test_2xx_is_allowed PASSED [40%]
gateway/tests/billing/test_credits_client.py::test_transport_error_is_unavailable PASSED [50%]
gateway/tests/billing/test_credits_client.py::test_transport_error_log_omits_exception_detail PASSED [60%]
gateway/tests/billing/test_credits_client.py::test_5xx_is_unavailable PASSED [70%]
gateway/tests/billing/test_credits_client.py::test_request_matches_webapp_contract PASSED [80%]
gateway/tests/billing/test_credits_client.py::test_metadata_cannot_override_billing_fields PASSED [90%]
gateway/tests/billing/test_credits_client.py::test_creditsoutcome_is_strenum_with_identical_values PASSED [100%]

10 passed in 44.20s
​```
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5aa95037-8864-452e-8d9a-58ad180adf71" />

---

## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The task was to migrate `CreditsOutcome` from `Enum` to `StrEnum` without
changing any persisted string values, since these values may be logged or
compared against ledger responses elsewhere. I first added a regression
test verifying `.value`, string equality, and `isinstance(member, str)`
for all four members, confirmed it failed against the original `Enum`
(RED), then changed the base class to `StrEnum` and confirmed it passed
(GREEN). The existing test suite for `consume_credits` already asserts
outcomes via `is CreditsOutcome.X` identity checks, which remain valid
under `StrEnum` since enum members keep identity regardless of base
class — so no other test changes were needed. I confirmed
`requires-python = ">=3.12"` in pyproject.toml, so `enum.StrEnum`
(stdlib since 3.11) needs no extra dependency. I deliberately did not
touch `GuardrailAction` (tracked separately in #4659) or `GateDecision`
(still plain `Enum` in gateway/core/runtime/attention.py, out of scope
for this task) to keep this PR minimal and focused.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



