### PR TITLE
fix(integrations/vercel): log soft-fail when client construction fails

### DIFF
--- a/integrations/vercel/client.py
+++ b/integrations/vercel/client.py
@@ -585,5 +585,6 @@ def make_vercel_client(api_token: str | None, team_id: str | None = None) -> Ver
         return None
     try:
         return VercelClient(VercelConfig(api_token=token, team_id=team_id or ""))
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to create Vercel client: %s", exc, exc_info=True)
         return None

--- a/tests/integrations/vercel/test_client.py
+++ b/tests/integrations/vercel/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -588,6 +589,30 @@ def test_make_vercel_client_forwards_team_id() -> None:
     client = make_vercel_client("tok_test", "team_xyz")
     assert client is not None
     assert client.config.team_id == "team_xyz"
+
+
+def _raise_runtime_error(**_kwargs: Any) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_vercel_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.vercel.client.VercelConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.vercel.client"):
+        result = make_vercel_client("tok_test")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
 
 
 def _raise_value_error() -> None:


### PR DESCRIPTION
Fixes #4901

#### Describe the changes you have made in this PR -

`make_vercel_client()` ended in a bare `except Exception: return None`. Returning
`None` is the intended soft-fail contract, but because nothing was logged, a real
construction failure (bad token shape, malformed team id, a `VercelConfig`
validation error) was indistinguishable from "Vercel is simply not configured" —
the exception was discarded entirely.

This PR keeps the contract and adds the missing observability:

- `integrations/vercel/client.py` — `except Exception as exc:` now logs at
  `WARNING` with `exc_info=True` before returning `None`.
- `tests/integrations/vercel/test_client.py` — new AAA unit test that forces
  `VercelConfig` construction to raise and asserts **both** that the factory
  still returns `None` **and** that a `WARNING` record carrying exception
  context was emitted.

Return type, signature, and every success path are untouched.

The wording and log level deliberately mirror the already-merged soft-fail log in
`integrations/pagerduty/client.py` (SM-115), and the test mirrors
`tests/integrations/pagerduty/test_client.py::test_make_client_logs_soft_fail_on_construction_error`,
so the three sibling clients stay consistent.

Per the issue's "one ID = one file = one PR" rule, this covers **SM-SR-LOG-1**
only. `integrations/argocd/client.py` (#4902) and `integrations/jira/client.py`
(#4903) are left alone.

### Demo/Screenshot for feature changes and bug fixes -

Same forced failure (`VercelConfig` raising `ValueError`), run on `main` and on
this branch:

**Before — silent**

```
$ python demo.py

return value -> None   (soft-fail contract preserved)
```

The cause never reaches the operator.

**After — cause is visible, return value unchanged**

```
$ python demo.py
WARNING integrations.vercel.client: Failed to create Vercel client: api_token must not contain whitespace
Traceback (most recent call last):
  File "D:\oss\opensre\integrations\vercel\client.py", line 587, in make_vercel_client
    return VercelClient(VercelConfig(api_token=token, team_id=team_id or ""))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "demo.py", line 12, in boom
    raise ValueError("api_token must not contain whitespace")
ValueError: api_token must not contain whitespace

return value -> None   (soft-fail contract preserved)
```

**Test — red before the fix, green after**

```
# with the test added but client.py unchanged (RED)
$ pytest tests/integrations/vercel/test_client.py -k soft_fail -q
FAILED tests/integrations/vercel/test_client.py::test_make_vercel_client_logs_soft_fail_on_construction_error
1 failed, 79 deselected

# after the one-line fix (GREEN)
$ pytest tests/integrations/vercel/ -q
80 passed in 22.28s
```

**Required checks**

```
$ ruff check bootstrap config core gateway integrations platform surfaces tools tests/
All checks passed!

$ ruff format --check bootstrap config core gateway integrations platform surfaces tools tests/
3369 files already formatted

$ mypy bootstrap config core gateway integrations platform surfaces tools
Success: no issues found in 1731 source files

$ pytest tests/integrations -n auto -q
2 failed, 3242 passed, 7 skipped
```

The two failures are `tests/integrations/git/test_local.py::test_changed_paths_handles_quoted_filenames`
and `tests/integrations/llm_cli/test_codex_oauth.py::test_codex_auth_payload_and_write_auth_shape`.
Both reproduce identically on a clean checkout of this branch's base commit with
my changes stashed — they are pre-existing Windows-environment failures,
unrelated to this PR, and neither touches the Vercel integration.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**The problem.** The factory is allowed to fail softly — callers treat `None` as
"no Vercel client available" and carry on. That part is correct and I did not
want to change it. What is wrong is that the bare `except Exception` bound no
name and logged nothing, so the exception object was destroyed before anyone
could see it. Debugging a misconfigured Vercel integration meant reading the
source to discover that a silent swallow was even possible.

**Alternatives I considered.**

1. *Re-raise, or return a result object carrying the error.* Rejected — the issue
   explicitly says "Do not change return types," and every caller is written
   against `Client | None`. It would also make an optional integration able to
   break startup.
2. *Route it through `capture_service_error`*, which the request methods in this
   same module use. Rejected — that helper is for failures of a live service
   call (it takes a `method=` and reports to the error pipeline). This is a
   local construction failure with no request behind it, and the sibling
   PagerDuty factory does not use it either.
3. *Log at `DEBUG`.* The issue permits `debug` or `warning`. I chose `WARNING`
   because it matches PagerDuty exactly, and because reaching this branch means
   the user supplied a non-empty token that then failed to build — that is a
   genuine misconfiguration worth surfacing, not routine noise. The empty-token
   case returns earlier and stays silent, so a user with no Vercel setup at all
   sees nothing new.

**Why this implementation.** `logger.warning("Failed to create Vercel client: %s", exc, exc_info=True)`
uses `%s` lazy formatting (so the string is only built if the record is emitted,
per the project's ruff config), includes the short reason inline for a one-line
scan, and attaches the full traceback via `exc_info=True` for anyone who needs
the stack. It sits inside the existing `except`, so no control flow moved.

**The test.** `test_make_vercel_client_logs_soft_fail_on_construction_error`
follows AAA. *Arrange* — `monkeypatch.setattr` swaps
`integrations.vercel.client.VercelConfig` for `_raise_runtime_error`, a helper
taking `**_kwargs` because the factory calls it with keyword arguments. Patching
the config rather than the client is what makes the failure land inside the
`try` block. *Act* — call the factory under
`caplog.at_level(logging.WARNING, logger="integrations.vercel.client")`, scoped
to this module's logger so an unrelated warning elsewhere cannot make it pass.
*Assert* — two things, because both halves of the contract matter: the return is
still `None`, and some record is `WARNING` **with `exc_info is not None`.
Asserting on `exc_info` rather than on message text is deliberate: it pins the
behaviour the issue asks for (exception context preserved) without freezing the
wording, so a future copy edit to the message will not break the test.
`monkeypatch` undoes the patch automatically, leaving no global state behind.

**Edge cases I checked.** Empty / `None` / whitespace-only token still return
`None` before the `try` and log nothing (covered by the three pre-existing
factory tests, still green). The success path never enters the `except`. A
token containing a secret is never passed to the logger — only `str(exc)` and
the traceback are logged, and the factory does not interpolate the token into
any message.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
