### PR TITLE
fix(integrations/jira): log soft-fail when client construction fails

### DIFF
--- a/integrations/jira/client.py
+++ b/integrations/jira/client.py
@@ -297,5 +297,6 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to create Jira client: %s", exc, exc_info=True)
         return None

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -123,3 +124,27 @@ def test_make_jira_client_returns_none_missing_token() -> None:
 
 def test_make_jira_client_returns_none_all_none() -> None:
     assert make_jira_client(None, None, None) is None
+
+
+def _raise_runtime_error(**_kwargs: object) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_jira_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.jira.client.JiraIntegrationConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.jira.client"):
+        result = make_jira_client("https://myteam.atlassian.net", "user@example.com", "token")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text


### PR DESCRIPTION
Fixes #4903

Sibling of #4919 (SM-SR-LOG-1, Vercel), which came back **Greptile 5/5 with no
actionable defects**, and #4920 (SM-SR-LOG-2, Argo CD). Same change, same
reasoning, applied to the Jira factory as a separate PR per the issue's
"one ID = one file = one PR" rule. This completes the SM-SR-LOG set.

#### Describe the changes you have made in this PR -

`make_jira_client()` ended in a bare `except Exception: return None`. Returning
`None` is the intended soft-fail contract, but because nothing was logged, a real
construction failure (a `JiraIntegrationConfig` validation error) was
indistinguishable from "Jira is simply not configured." The exception was
discarded entirely.

This PR keeps the contract and adds the missing observability:

- `integrations/jira/client.py` — `except Exception as exc:` now logs at
  `WARNING` with `exc_info=True` before returning `None`.
- `tests/integrations/test_jira_search_and_factory.py` — new AAA unit test that
  forces `JiraIntegrationConfig` construction to raise and asserts **both** that
  the factory still returns `None` **and** that a `WARNING` record carrying
  exception context was emitted. Placed alongside the existing
  `make_jira_client` factory tests in that file.

Return type, signature, and every success path are untouched. The earlier guard
returns — missing base URL, email, or API token — stay silent, so a user with no
Jira setup at all sees nothing new. Only a genuine construction failure logs.

Wording and log level deliberately mirror the already-merged soft-fail log in
`integrations/pagerduty/client.py` (SM-115), so the sibling clients stay
consistent.

**Scope note:** this is the soft-fail log only. The `_DEFAULT_TIMEOUT` rename in
the same file is tracked separately as SM-SR-TO-2 (#4905) and is deliberately
not touched here.

### Demo/Screenshot for feature changes and bug fixes -

Same forced failure (`JiraIntegrationConfig` raising `ValueError`), run on `main`
and on this branch:

**Before — silent**

```
$ python demo.py

return value -> None   (soft-fail contract preserved)
```

The cause never reaches the operator.

**After — cause is visible, return value unchanged**

```
$ python demo.py
WARNING integrations.jira.client: Failed to create Jira client: base_url must be an https Atlassian site URL
Traceback (most recent call last):
  File "D:\oss\opensre\integrations\jira\client.py", line 293, in make_jira_client
    config = JiraIntegrationConfig(
             ^^^^^^^^^^^^^^^^^^^^^^
  File "demo.py", line 12, in boom
    raise ValueError("base_url must be an https Atlassian site URL")
ValueError: base_url must be an https Atlassian site URL

return value -> None   (soft-fail contract preserved)
```

**Test — red before the fix, green after**

```
# with the test added but client.py unchanged (RED)
$ pytest tests/integrations/test_jira_search_and_factory.py -k soft_fail -q
FAILED tests/integrations/test_jira_search_and_factory.py::test_make_jira_client_logs_soft_fail_on_construction_error
1 failed, 8 deselected

# after the one-line fix (GREEN) — client, factory, and all four Jira tools
$ pytest tests/integrations/test_jira_search_and_factory.py tests/integrations/test_jira_client.py tests/tools/test_jira_*.py -q
45 passed in 8.98s
```

**Required checks**

```
$ ruff check bootstrap config core gateway integrations platform surfaces tools tests/
All checks passed!

$ ruff format --check bootstrap config core gateway integrations platform surfaces tools tests/
3369 files already formatted

$ mypy bootstrap config core gateway integrations platform surfaces tools
Success: no issues found in 1731 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**The problem.** The factory is allowed to fail softly — callers treat `None` as
"no Jira client available" and carry on. That part is correct and I did not want
to change it. What is wrong is that the bare `except Exception` bound no name and
logged nothing, so the exception object was destroyed before anyone could see it.
Of the three clients in this SM-SR-LOG set, Jira is the one where the silence
hurts most in practice: it takes three separate credentials (site URL, account
email, API token), so there are more ways for a user to get the shape wrong and
end up staring at a Jira integration that simply does nothing.

**Alternatives I considered.**

1. *Re-raise, or return a result object carrying the error.* Rejected — the issue
   explicitly says "Do not change return types," and every caller is written
   against `Client | None`. It would also let an optional integration break
   startup.
2. *Widen the scope and also do the `_DEFAULT_TIMEOUT` rename* while I was in
   this file. Rejected — that is SM-SR-TO-2 (#4905), a separate issue, and the
   task says one ID per PR. Mixing them would make both harder to review.
3. *Log at `DEBUG`.* The issue permits `debug` or `warning`. I chose `WARNING`
   to match PagerDuty exactly, and because reaching this branch means the user
   supplied all three credentials and they still failed to build — a genuine
   misconfiguration worth surfacing, not routine noise.

**Why this implementation.** `logger.warning("Failed to create Jira client: %s", exc, exc_info=True)`
uses `%s` lazy formatting (so the string is only built if the record is emitted,
per the project's ruff config), includes the short reason inline for a one-line
scan, and attaches the full traceback via `exc_info=True`. It sits inside the
existing `except`, so no control flow moved. Note the `try` block here wraps both
the config construction and the `JiraClient(config)` call, so a failure in either
is now reported.

**The test.** `test_make_jira_client_logs_soft_fail_on_construction_error`
follows AAA. *Arrange* — `monkeypatch.setattr` swaps
`integrations.jira.client.JiraIntegrationConfig` for `_raise_runtime_error`, a
helper taking `**_kwargs` because the factory calls it with keyword arguments. I
patch the name as bound in the client module, not in `integrations.config_models`,
because that is the reference the factory actually resolves at call time. I pass
all three valid credentials so the call gets past the guard returns and actually
reaches the `try`. *Act* — call the factory under
`caplog.at_level(logging.WARNING, logger="integrations.jira.client")`, scoped to
this module's logger so an unrelated warning elsewhere cannot make it pass.
*Assert* — both halves of the contract: the return is still `None`, and some
record is `WARNING` **with `exc_info is not None`**. Asserting on `exc_info`
rather than on message text pins the behaviour the issue asks for without
freezing the wording. `monkeypatch` undoes the patch automatically.

**Edge cases I checked.** Missing URL, missing email, missing token, and all-`None`
arguments still return `None` before the `try` and log nothing — covered by the
four pre-existing factory tests, still green. The success path never enters the
`except`. No credential is passed to the logger: only `str(exc)` and the
traceback are logged, and the factory does not interpolate the email or API token
into any message. I ran the four Jira tool test files as well as the client tests
to confirm nothing downstream depended on the silence.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
