### PR TITLE
refactor(supabase): use HTTPStatus instead of bare status numbers (#4310)

### DIFF
--- a/integrations/supabase/__init__.py
+++ b/integrations/supabase/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import Any
 from urllib.parse import urlparse
 
@@ -167,7 +168,7 @@ def validate_supabase_config(config: SupabaseConfig) -> SupabaseValidationResult
 
     try:
         status, _ = _make_request(config, "/rest/v1/")
-        if status == 200:
+        if status == HTTPStatus.OK:
             return SupabaseValidationResult(
                 ok=True,
                 detail=f"Connected to Supabase project at {config.url}.",
@@ -213,7 +214,7 @@ def get_service_health(config: SupabaseConfig) -> dict[str, Any]:
     try:
         status, _ = _make_request(config, "/rest/v1/")
         services["postgrest"] = {
-            "healthy": status == 200,
+            "healthy": status == HTTPStatus.OK,
             "status_code": status,
         }
     except Exception as err:
@@ -228,7 +229,7 @@ def get_service_health(config: SupabaseConfig) -> dict[str, Any]:
         elif isinstance(body, str):
             detail = body
         services["auth"] = {
-            "healthy": status == 200,
+            "healthy": status == HTTPStatus.OK,
             "status_code": status,
             "detail": detail,
         }
@@ -239,7 +240,7 @@ def get_service_health(config: SupabaseConfig) -> dict[str, Any]:
     try:
         status, _ = _make_request(config, "/storage/v1/health")
         services["storage"] = {
-            "healthy": status == 200,
+            "healthy": status == HTTPStatus.OK,
             "status_code": status,
         }
     except Exception as err:
@@ -271,7 +272,7 @@ def get_storage_buckets(config: SupabaseConfig) -> dict[str, Any]:
     try:
         status, body = _make_request(config, "/storage/v1/bucket")
 
-        if status != 200:
+        if status != HTTPStatus.OK:
             return tool_unavailable("supabase", f"Storage API returned HTTP {status}.")
 
         raw_buckets: list[dict[str, Any]] = body if isinstance(body, list) else []


### PR DESCRIPTION
Fixes #4310

#### Describe the changes you have made in this PR -

SM-52. `integrations/supabase/__init__.py` compared raw HTTP status numbers when
checking responses from PostgREST, Auth, and Storage. The project rule (AGENTS.md,
"Code Style") is to use `http.HTTPStatus` members instead of bare numeric literals.

- Added `from http import HTTPStatus`.
- Replaced all five bare `200` status comparisons with `HTTPStatus.OK`:
  - `validate_supabase_config` — PostgREST root probe
  - `get_service_health` — `postgrest`, `auth`, and `storage` health checks
  - `get_storage_buckets` — bucket-listing guard
- The `le=200` on `max_results` is a result-size cap, not an HTTP status, and is left alone.

`HTTPStatus` is an `IntEnum`, so `status == HTTPStatus.OK` is exactly equivalent to
`status == 200` for the plain `int` the HTTP client returns. No behavior change, no
change to user-facing messages, one file touched.

### Demo/Screenshot for feature changes and bug fixes -

Scoped tests for the touched module (per `.github/ci/test_scope_rules.py`) plus the
integrations registry smoke gate, all green on this branch:

```
$ uv run python -m pytest tests/integrations/test_supabase.py -q
============================= 38 passed in 12.34s =============================

$ uv run python -m pytest -q tests/integrations/test_verification_registry.py tests/integrations/test_registry.py
============================= 31 passed in 16.75s =============================

$ python -m ruff check config core gateway integrations platform surfaces tools tests
All checks passed!

$ python -m ruff format --check config core gateway integrations platform surfaces tools tests
3348 files already formatted

$ uv run python -m mypy config core gateway integrations platform surfaces tools
Success: no issues found in 1716 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

A bare `200` carries no meaning at the call site; the repo standardises on
`http.HTTPStatus` so status checks read as names.

The one design question was whether the swap can change behavior. It cannot —
`HTTPStatus` subclasses `int`, so every comparison against the `int` returned by
`supabase_http_get` evaluates identically, and the `f"...HTTP {status}."` messages
still interpolate that same raw `int`. The alternative (making `_make_request` return
`HTTPStatus`) would have changed its signature and spilled into the client and its
tests, which the issue rules out — one ID, one file, one PR.

The existing tests already drive these paths with `503` and `403` and with exceptions,
and they pass unchanged, which is the point.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests (n/a — behavior-preserving refactor, existing tests cover the paths)
- [x] My code follows the project's style guidelines and conventions
