### PR TITLE
test(config): pin capability warning facts when PATH tools are missing (#4900)

### DIFF
--- a/tests/config/test_capability_warning_facts.py
+++ b/tests/config/test_capability_warning_facts.py
@@ -1,0 +1,95 @@
+"""Capability warning facts when PATH tools are missing.
+
+Every case drives ``shutil.which`` or passes an explicit tool map, so no
+assertion depends on what happens to be installed on the machine running the
+suite — a host without ``curl`` and a host with it produce the same result.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any
+
+import pytest
+
+from config.constants.runtime_metadata import OPENSRE_ALLOW_NETWORK_ENV
+from config.runtime_metadata.probes import capability_warning_facts, installed_tools
+
+_CURL_WARNING = "curl is not on PATH"
+_NO_SHELL_WARNING = "no interactive shell (bash/sh) on PATH"
+_NETWORK_WARNING = "network egress is blocked for sandboxed code by default"
+
+_EVERY_TOOL_PRESENT = {
+    "kubectl": "/usr/bin/kubectl",
+    "helm": "/usr/bin/helm",
+    "docker": "/usr/bin/docker",
+    "git": "/usr/bin/git",
+    "python": "/usr/bin/python",
+    "python3": "/usr/bin/python3",
+    "curl": "/usr/bin/curl",
+    "bash": "/bin/bash",
+    "sh": "/bin/sh",
+    "buzz": "/usr/bin/buzz",
+}
+
+
+def _which_finds_nothing(cmd: str, *_args: Any, **_kwargs: Any) -> str | None:
+    """Stand in for an empty ``PATH``."""
+    return None
+
+
+def _which_explodes(cmd: str, *_args: Any, **_kwargs: Any) -> str | None:
+    """Fail loudly if ``PATH`` is walked when the caller already supplied tools."""
+    raise AssertionError(f"PATH was walked for {cmd!r} despite an explicit tool map")
+
+
+def test_empty_path_warns_about_curl_and_shell(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no probed tool on PATH, the default (no-argument) call reports every gap."""
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+    monkeypatch.setattr(shutil, "which", _which_finds_nothing)
+
+    facts = capability_warning_facts()
+
+    # Every probed tool resolves to "" — asserted without pinning the tool list,
+    # so adding a probe target later does not break this case.
+    assert set(installed_tools().values()) == {""}
+    assert facts["shell_available"] is False
+    assert facts["network_egress"] is False
+    assert facts["capability_warnings"] == [
+        _CURL_WARNING,
+        _NO_SHELL_WARNING,
+        _NETWORK_WARNING,
+    ]
+
+
+def test_sh_without_bash_still_counts_as_a_shell(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``sh`` alone satisfies the shell check — only losing both tools is a gap."""
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+
+    facts = capability_warning_facts({**_EVERY_TOOL_PRESENT, "bash": ""})
+
+    assert facts["shell_available"] is True
+    assert _NO_SHELL_WARNING not in facts["capability_warnings"]
+
+
+def test_no_warnings_when_tools_present_and_network_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fully equipped environment with egress opted in produces an empty list."""
+    monkeypatch.setenv(OPENSRE_ALLOW_NETWORK_ENV, "1")
+
+    facts = capability_warning_facts(_EVERY_TOOL_PRESENT)
+
+    assert facts["network_egress"] is True
+    assert facts["shell_available"] is True
+    assert facts["capability_warnings"] == []
+
+
+def test_explicit_tool_map_does_not_walk_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Callers that already probed PATH must not pay for a second walk."""
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+    monkeypatch.setattr(shutil, "which", _which_explodes)
+
+    facts = capability_warning_facts(_EVERY_TOOL_PRESENT)
+
+    assert facts["capability_warnings"] == [_NETWORK_WARNING]


### PR DESCRIPTION
Fixes #4900

#### Describe the changes you have made in this PR -

SM-SR-1. Adds one test file — `tests/config/test_capability_warning_facts.py` — for
`config.runtime_metadata.probes.capability_warning_facts`. No product code is touched.

Existing coverage was a single case in `tests/config/test_workspace_identity.py`
(`test_capability_warnings_include_network_default`), and it always passed an explicit
tool map with `bash` present. That left three branches of the function unpinned. The
new file covers them:

| Case | What it pins |
|------|--------------|
| Empty `PATH` (`shutil.which` stubbed to find nothing), called with **no argument** | The default path where the helper probes `PATH` itself; asserts the full warning list — curl, no shell, network — in order |
| `sh` present, `bash` missing | The `bash or sh` fallback: losing only `bash` is not a shell gap |
| Every tool present, `OPENSRE_ALLOW_NETWORK=1` | `network_egress` flips true and the warning list is **empty** |
| Explicit tool map supplied | The documented "do not walk `PATH` again" contract — `shutil.which` raises if called |

Per the "Unit tests only (no live PATH dependency flakiness)" requirement, every case
either stubs `shutil.which` or passes a tool map, so results do not vary with what is
installed on the machine running the suite. The empty-`PATH` case asserts
`set(installed_tools().values()) == {""}` rather than an exact tool list, so adding a
probe target later does not break it.

### Demo/Screenshot for feature changes and bug fixes -

New tests, and the neighbouring file they extend, green:

```
$ uv run python -m pytest tests/config/test_capability_warning_facts.py tests/config/test_workspace_identity.py -q
tests\config\test_capability_warning_facts.py ....                       [ 28%]
tests\config\test_workspace_identity.py ..........                       [100%]
============================= 14 passed in 2.60s ==============================

$ python -m ruff check config core gateway integrations platform surfaces tools tests
All checks passed!

$ python -m ruff format --check config core gateway integrations platform surfaces tools tests
3349 files already formatted

$ uv run python -m mypy tests/config/test_capability_warning_facts.py
Success: no issues found in 1 source file
```

**Mutation check** — a test that cannot fail is not coverage. Temporarily narrowing
the shell derivation in `probes.py` from `resolved.get("bash") or resolved.get("sh")`
to `resolved.get("bash")` makes exactly the intended case fail, and only that one:

```
FAILED tests/config/test_capability_warning_facts.py::test_sh_without_bash_still_counts_as_a_shell
========================= 1 failed, 3 passed in 1.66s =========================
```

The product file was reverted immediately after; it is not part of this diff.

Note: running the whole `tests/config/` directory on my Windows machine shows 5
failures — `test_local_tz_name_reads_iana_from_localtime_symlink` and the four
`test_runtime_metadata_perf.py` timing assertions. They reproduce in isolation without
this branch's file (no `/etc/localtime` on Windows; the perf budget is machine-
dependent), so they are pre-existing and unrelated to this change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`capability_warning_facts` decides what the agent is told it *cannot* do at boot. If a
warning silently stops being emitted, the agent believes it has a shell or egress it
does not have, which surfaces as a confusing mid-turn failure. So the tests assert the
exact strings and the `shell_available` / `network_egress` booleans, not just "a
warning was produced."

The main decision was where to intercept. Asserting against the real `PATH` would make
the suite depend on whether the CI image ships `curl` — the flakiness the issue rules
out. There are two seams: the `tools` parameter and `shutil.which`. I used the
parameter for the classification cases (is `sh` alone a shell? does egress opt-in clear
the list?) and stubbed `shutil.which` for the no-argument path, the branch the existing
test never reached.

The fourth test pins a contract with no observable output — the docstring's promise
that passing `installed_tools` avoids a second `PATH` walk — by making the stub raise
if it is called anyway. Per AGENTS.md the stubs are named `def`s rather than inline
lambdas.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
