### PR TITLE
feat(filestorage): add s3compat provider for S3-compatible endpoints (C-SR-16)

### DIFF
--- a/config/constants/filestorage.py
+++ b/config/constants/filestorage.py
@@ -25,6 +25,9 @@ REMOTE_SYNC_PREFIX_ENV = "OPENSRE_REMOTE_SYNC_PREFIX"
 REMOTE_SYNC_REGION_ENV = "OPENSRE_REMOTE_SYNC_REGION"
 # Named credentials profile, for users who keep opensre credentials separate.
 REMOTE_SYNC_PROFILE_ENV = "OPENSRE_REMOTE_SYNC_PROFILE"
+# Custom S3-compatible endpoint (MinIO, Cloudflare R2, DigitalOcean Spaces, …)
+# for the s3compat provider; blank means ambient AWS endpoints.
+REMOTE_SYNC_ENDPOINT_ENV = "OPENSRE_REMOTE_SYNC_ENDPOINT"
 # Comma-separated glob patterns held back from the sync. Subtractive only: a
 # pattern can shrink what mirrors, never widen it past the credential deny-list.
 REMOTE_SYNC_EXCLUDE_ENV = "OPENSRE_REMOTE_SYNC_EXCLUDE"
@@ -57,4 +60,5 @@ __all__ = [
     "REMOTE_SYNC_PROFILE_ENV",
     "REMOTE_SYNC_PROVIDER_ENV",
     "REMOTE_SYNC_REGION_ENV",
+    "REMOTE_SYNC_ENDPOINT_ENV",
 ]

--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -72,6 +72,12 @@ export OPENSRE_REMOTE_SYNC_BUCKET=my-opensre-bucket
 # export OPENSRE_REMOTE_SYNC_PROVIDER=azure
 # export OPENSRE_REMOTE_SYNC_PROFILE=my-storage-account
 # export OPENSRE_REMOTE_SYNC_BUCKET=my-container
+
+# Or an S3-compatible endpoint (MinIO / R2 / Spaces)
+# export OPENSRE_REMOTE_SYNC=1
+# export OPENSRE_REMOTE_SYNC_PROVIDER=s3compat
+# export OPENSRE_REMOTE_SYNC_BUCKET=my-bucket
+# export OPENSRE_REMOTE_SYNC_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
 ```
 
 | Variable | Description |
@@ -82,6 +88,7 @@ export OPENSRE_REMOTE_SYNC_BUCKET=my-opensre-bucket
 | `OPENSRE_REMOTE_SYNC_PREFIX` | Key prefix, default `opensre`. Machines that should share history must use the same one |
 | `OPENSRE_REMOTE_SYNC_REGION` | Region override when the provider supports it (AWS) |
 | `OPENSRE_REMOTE_SYNC_PROFILE` | Named credentials profile, if opensre should not use your default (AWS) |
+| `OPENSRE_REMOTE_SYNC_ENDPOINT` | Custom S3-compatible endpoint URL for `provider=s3compat` (MinIO, R2, Spaces). Blank uses AWS endpoints |
 | `BLOB_READ_WRITE_TOKEN` | Vercel Blob read-write token (when `provider=vercel`). Ambient; opensre never stores it |
 | `OPENSRE_REMOTE_SYNC_EXCLUDE` | Comma-separated glob patterns to keep off the store. See [Exclude paths](#exclude-paths) |
 | `OPENSRE_REMOTE_SYNC_EXCLUDE_OFF` | Set to `1` to ignore your exclusions for one run and sync everything |
@@ -226,6 +233,7 @@ backends today:
 | Google Cloud Storage | `gcs` | Application Default Credentials (`gcloud auth application-default login`) |
 | Vercel Blob | `vercel` | Ambient `BLOB_READ_WRITE_TOKEN` |
 | Azure Blob Storage | `azure` | Ambient Azure config (`AZURE_*`, Azure CLI, Managed Identity) |
+| S3-compatible endpoint | `s3compat` | Ambient AWS config (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) |
 
 Other clouds (GCS, …) are community additions: implement `ObjectStore`,
 call `register_object_store("<name>", factory)`, and set
@@ -322,6 +330,44 @@ Authentication relies entirely on Azure's ambient credentials (`DefaultAzureCred
 The authenticated principal must have the **Storage Blob Data Contributor** role assignment on the storage account. The generic "Contributor" role is insufficient as it only grants control-plane access, not data-plane access.
 
 Add `Microsoft.Storage/storageAccounts/blobServices/containers/read` (included in the Storage Blob Data Reader role) so `status` can warn you if the container is publicly readable — see [The store](#the-store). Without it, `status` shows "could not confirm it is private" instead of failing.
+
+### S3-compatible endpoint (MinIO / R2 / Spaces)
+
+Any store that speaks the S3 API at a custom endpoint — self-hosted MinIO,
+Cloudflare R2, DigitalOcean Spaces — works through the `s3compat` provider.
+It uses the same wire protocol as the AWS backend, pointed at your endpoint
+instead of AWS's.
+
+```bash
+export OPENSRE_REMOTE_SYNC=1
+export OPENSRE_REMOTE_SYNC_PROVIDER=s3compat
+export OPENSRE_REMOTE_SYNC_BUCKET=my-bucket
+export OPENSRE_REMOTE_SYNC_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+```
+
+Or through setup:
+
+```bash
+opensre remote-sync setup --provider s3compat --bucket my-bucket \
+  --endpoint https://<account-id>.r2.cloudflarestorage.com
+```
+
+Credentials are ambient, exactly like AWS: `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` (R2 and Spaces both issue S3-compatible keys), or a
+credentials profile via `OPENSRE_REMOTE_SYNC_PROFILE`. The endpoint determines
+where the keys are accepted. `OPENSRE_REMOTE_SYNC_REGION` is optional — some
+stores (DigitalOcean Spaces) want the region that owns the bucket.
+
+`put_object` deliberately sends no `ServerSideEncryption` parameter, because
+MinIO, R2, and Spaces reject it. Minimum permissions are the same as AWS on
+the prefix you use:
+
+```
+s3:ListBucket, s3:GetObject, s3:PutObject
+```
+
+Add `s3:GetBucketPolicyStatus` so `status` can warn you if the bucket is
+publicly readable — see [The store](#the-store).
 
 ## The store
 

--- a/platform/filestorage/config.py
+++ b/platform/filestorage/config.py
@@ -17,6 +17,7 @@ from config.constants.filestorage import (
     DEFAULT_REMOTE_SYNC_PREFIX,
     DEFAULT_REMOTE_SYNC_PROVIDER,
     REMOTE_SYNC_BUCKET_ENV,
+    REMOTE_SYNC_ENDPOINT_ENV,
     REMOTE_SYNC_ENV,
     REMOTE_SYNC_EXCLUDE_ENV,
     REMOTE_SYNC_EXCLUDE_OFF_ENV,
@@ -37,8 +38,8 @@ class RemoteSyncConfig:
 
     ``bucket`` is the top-level store name for the chosen provider (S3 bucket,
     GCS bucket, or Vercel Blob store name/id; community backends may reuse the
-    field). Provider-specific fields (``profile``, ``region``) are ignored by
-    backends that do not need them.
+    field). Provider-specific fields (``profile``, ``region``, ``endpoint``)
+    are ignored by backends that do not need them.
 
     ``exclude`` narrows what mirrors. It cannot widen it: the credential
     deny-list is enforced separately, in
@@ -50,6 +51,7 @@ class RemoteSyncConfig:
     prefix: str = DEFAULT_REMOTE_SYNC_PREFIX
     region: str = ""
     profile: str = ""
+    endpoint: str = ""
     exclude: ExclusionRules = NO_EXCLUSIONS
 
     def key_for(self, relative_key: str) -> str:
@@ -188,6 +190,7 @@ def load_remote_sync_config() -> RemoteSyncConfig | None:
         prefix=prefix,
         region=_env_or_stored(REMOTE_SYNC_REGION_ENV, "region", stored),
         profile=_env_or_stored(REMOTE_SYNC_PROFILE_ENV, "profile", stored),
+        endpoint=_env_or_stored(REMOTE_SYNC_ENDPOINT_ENV, "endpoint", stored),
         exclude=_exclusions(stored),
     )
 

--- a/platform/filestorage/enums.py
+++ b/platform/filestorage/enums.py
@@ -36,6 +36,7 @@ class BuiltInProvider(StrEnum):
     GCS = "gcs"
     VERCEL = "vercel"
     AZURE = "azure"
+    S3COMPAT = "s3compat"
 
 
 class RemoteSyncSubcommand(StrEnum):
@@ -49,7 +50,7 @@ class RemoteSyncSubcommand(StrEnum):
 class RemoteSyncField(StrEnum):
     """Provider-specific setup fields ``RemoteSyncConfig`` can hold.
 
-    Fixed at two on purpose — ``RemoteSyncConfig`` is a closed, two-slot
+    Kept small on purpose — ``RemoteSyncConfig`` is a closed, three-slot
     contract for the fields a provider may need beyond bucket/prefix. A
     provider declares which of these it consumes (see
     :class:`platform.filestorage.providers.registry.SetupExtraField`); it does
@@ -58,6 +59,7 @@ class RemoteSyncField(StrEnum):
 
     REGION = "region"
     PROFILE = "profile"
+    ENDPOINT = "endpoint"
 
 
 class BucketExposure(StrEnum):

--- a/platform/filestorage/providers/registry.py
+++ b/platform/filestorage/providers/registry.py
@@ -69,6 +69,7 @@ _BUILTIN_MODULES = {
     BuiltInProvider.GCS.value: "platform.filestorage.providers.gcs",
     BuiltInProvider.VERCEL.value: "platform.filestorage.providers.vercel",
     BuiltInProvider.AZURE.value: "platform.filestorage.providers.azure",
+    BuiltInProvider.S3COMPAT.value: "platform.filestorage.providers.s3compat",
 }
 
 

--- a/platform/filestorage/providers/s3compat.py
+++ b/platform/filestorage/providers/s3compat.py
@@ -1,0 +1,184 @@
+"""S3-compatible endpoint backend (MinIO / Cloudflare R2 / DigitalOcean Spaces).
+
+The S3 API is a de-facto standard: many object stores speak ``ListObjectsV2`` /
+``GetObject`` / ``PutObject`` at a custom ``endpoint_url`` even though they are
+not AWS. This backend is the same S3 wire protocol as :mod:`aws`, pointed at
+``RemoteSyncConfig.endpoint`` instead of the ambient AWS endpoints. It registers
+under ``s3compat`` and the engine never changes.
+
+Credentials stay ambient (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``,
+profiles, SSO) — opensre does not store them, exactly like the AWS backend.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from platform.filestorage.config import RemoteSyncConfig
+from platform.filestorage.enums import BucketExposure, BuiltInProvider, RemoteSyncField
+from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.exposure import PublicAccessStatus
+from platform.filestorage.ports import RemoteObject
+from platform.filestorage.providers.registry import SetupExtraField, register_object_store
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+PROVIDER_NAME = BuiltInProvider.S3COMPAT
+CREDENTIAL_HINT = "S3-compatible credentials come from the usual places (env, profile, or SSO)."
+EXTRA_FIELDS = (
+    SetupExtraField(
+        RemoteSyncField.ENDPOINT,
+        "Endpoint URL (e.g. https://…r2.cloudflarestorage.com; blank for AWS)",
+    ),
+    SetupExtraField(RemoteSyncField.PROFILE, "Credentials profile (blank if unused)"),
+    SetupExtraField(RemoteSyncField.REGION, "Region (blank if unused)"),
+)
+
+
+class S3CompatObjectStore:
+    """Reads and writes objects under one bucket and prefix at a custom endpoint."""
+
+    def __init__(self, config: RemoteSyncConfig, *, client: Any | None = None) -> None:
+        self._config = config
+        self._client = client if client is not None else _build_client(config)
+
+    def describe(self) -> str:
+        return f"s3compat://{self._config.bucket}/{self._config.prefix}"
+
+    def list_objects(self, prefix: str) -> list[RemoteObject]:
+        # Trailing slash so prefix "opensre" cannot also match "opensre-backup/".
+        full_prefix = (
+            self._config.key_for(prefix) if prefix else f"{self._config.prefix.rstrip('/')}/"
+        )
+        out: list[RemoteObject] = []
+        try:
+            for page in self._pages(full_prefix):
+                for item in page.get("Contents", []):
+                    key = str(item["Key"])
+                    out.append(
+                        RemoteObject(
+                            key=self._strip_prefix(key),
+                            size=int(item.get("Size", 0)),
+                            last_modified=item["LastModified"],
+                            # The listing carries the content tag, so comparing
+                            # an object costs no extra request.
+                            etag=str(item.get("ETag", "")).strip('"'),
+                        )
+                    )
+        except (BotoCoreError, ClientError) as exc:
+            raise RemoteSyncUnavailableError(
+                f"cannot list {self.describe()} — {_reason(exc)}"
+            ) from exc
+        return out
+
+    def get_object(self, key: str) -> bytes:
+        try:
+            response = self._client.get_object(
+                Bucket=self._config.bucket, Key=self._config.key_for(key)
+            )
+            body: bytes = response["Body"].read()
+            return body
+        except (BotoCoreError, ClientError) as exc:
+            raise RemoteSyncUnavailableError(f"cannot read {key} — {_reason(exc)}") from exc
+
+    def put_object(self, key: str, data: bytes) -> None:
+        try:
+            # Unlike AWS S3, MinIO / R2 / Spaces reject the ServerSideEncryption
+            # parameter, so it is deliberately not sent here.
+            self._client.put_object(
+                Bucket=self._config.bucket,
+                Key=self._config.key_for(key),
+                Body=data,
+            )
+        except (BotoCoreError, ClientError) as exc:
+            raise RemoteSyncUnavailableError(f"cannot write {key} — {_reason(exc)}") from exc
+
+    def _pages(self, prefix: str) -> Iterator[dict[str, Any]]:
+        paginator = self._client.get_paginator("list_objects_v2")
+        yield from paginator.paginate(Bucket=self._config.bucket, Prefix=prefix)
+
+    def _strip_prefix(self, full_key: str) -> str:
+        prefix = f"{self._config.prefix.rstrip('/')}/"
+        return full_key[len(prefix) :] if full_key.startswith(prefix) else full_key
+
+
+def _reason(exc: Exception) -> str:
+    """The provider-side cause, for a local operator to act on."""
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _build_client(config: RemoteSyncConfig) -> Any:
+    try:
+        # Empty means "use the ambient AWS configuration", which boto3 spells None.
+        session = boto3.Session(
+            profile_name=config.profile or None,
+            region_name=config.region or None,
+        )
+        return session.client("s3", endpoint_url=config.endpoint or None)
+    except (BotoCoreError, ClientError, ValueError) as exc:
+        raise RemoteSyncUnavailableError(
+            f"cannot build an S3-compatible client — {_reason(exc)}"
+        ) from exc
+
+
+def _factory(config: RemoteSyncConfig) -> S3CompatObjectStore:
+    return S3CompatObjectStore(config)
+
+
+def check_public_access(
+    config: RemoteSyncConfig, *, client: Any | None = None
+) -> PublicAccessStatus:
+    """Ask the endpoint whether ``config.bucket`` is publicly readable.
+
+    Uses ``s3:GetBucketPolicyStatus`` — the same call the AWS backend makes, so
+    endpoints that implement it (Cloudflare R2 does) get the same warning.
+    Degrades to :class:`~platform.filestorage.enums.BucketExposure.UNKNOWN`
+    rather than raising, so a missing permission never blocks ``status`` or
+    ``setup``. ``detail`` never carries the raw exception text (CWE-209).
+    """
+    try:
+        s3 = client if client is not None else _build_client(config)
+        response = s3.get_bucket_policy_status(Bucket=config.bucket)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "AccessDenied":
+            return PublicAccessStatus(
+                BucketExposure.UNKNOWN, "missing the s3:GetBucketPolicyStatus permission"
+            )
+        if code == "NoSuchBucketPolicy":
+            # No policy means nothing grants public access through one.
+            return PublicAccessStatus(BucketExposure.PRIVATE)
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    except (BotoCoreError, ValueError, RemoteSyncUnavailableError) as exc:
+        return PublicAccessStatus(BucketExposure.UNKNOWN, f"cannot check ({type(exc).__name__})")
+    is_public = bool(response.get("PolicyStatus", {}).get("IsPublic", False))
+    return PublicAccessStatus(BucketExposure.PUBLIC if is_public else BucketExposure.PRIVATE)
+
+
+# Same rationale as the AWS backend: boto3's low-level client is thread-safe,
+# botocore retries throttling itself, and an S3-compatible store behind a
+# well-behaved endpoint sustains far more concurrent writes than a laptop's
+# session tree will ever produce.
+MAX_PARALLEL_UPLOADS = 16
+
+register_object_store(
+    PROVIDER_NAME,
+    _factory,
+    credential_hint=CREDENTIAL_HINT,
+    extra_fields=EXTRA_FIELDS,
+    public_access_checker=check_public_access,
+    max_parallel_uploads=MAX_PARALLEL_UPLOADS,
+)
+
+__all__ = [
+    "CREDENTIAL_HINT",
+    "EXTRA_FIELDS",
+    "MAX_PARALLEL_UPLOADS",
+    "PROVIDER_NAME",
+    "S3CompatObjectStore",
+    "check_public_access",
+]

--- a/platform/filestorage/setup.py
+++ b/platform/filestorage/setup.py
@@ -32,6 +32,7 @@ class RemoteSyncSetupRequest:
     prefix: str = DEFAULT_REMOTE_SYNC_PREFIX
     region: str = ""
     profile: str = ""
+    endpoint: str = ""
     enabled: bool = True
 
 
@@ -52,8 +53,13 @@ def save_remote_sync_settings(request: RemoteSyncSetupRequest) -> RemoteSyncConf
     prefix = request.prefix.strip() or DEFAULT_REMOTE_SYNC_PREFIX
     region = request.region.strip()
     profile = request.profile.strip()
+    endpoint = request.endpoint.strip()
     declared = {extra.field for extra in provider_extra_fields(provider)}
-    for field, value in ((RemoteSyncField.REGION, region), (RemoteSyncField.PROFILE, profile)):
+    for field, value in (
+        (RemoteSyncField.REGION, region),
+        (RemoteSyncField.PROFILE, profile),
+        (RemoteSyncField.ENDPOINT, endpoint),
+    ):
         if value and field not in declared:
             raise RemoteSyncConfigError(
                 f"--{field.value} is not used by provider {provider!r}; "
@@ -69,6 +75,7 @@ def save_remote_sync_settings(request: RemoteSyncSetupRequest) -> RemoteSyncConf
                 "prefix": prefix,
                 "region": region,
                 "profile": profile,
+                "endpoint": endpoint,
             },
         )
     except LocalSettingsError as exc:
@@ -79,6 +86,7 @@ def save_remote_sync_settings(request: RemoteSyncSetupRequest) -> RemoteSyncConf
         prefix=prefix,
         region=region,
         profile=profile,
+        endpoint=endpoint,
     )
 
 

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -95,6 +95,11 @@ def sync_now_command(pull_only: bool, push_only: bool, dry_run: bool) -> None:
 @click.option("--region", default=None, help="Region override when the provider supports it.")
 @click.option("--profile", default=None, help="Named credentials profile (AWS).")
 @click.option(
+    "--endpoint",
+    default=None,
+    help="Custom S3-compatible endpoint URL (MinIO, R2, Spaces) for the s3compat provider.",
+)
+@click.option(
     "--enabled/--disabled",
     default=True,
     show_default=True,
@@ -106,6 +111,7 @@ def setup_command(
     prefix: str | None,
     region: str | None,
     profile: str | None,
+    endpoint: str | None,
     enabled: bool,
 ) -> None:
     """Write remote_sync settings to ~/.opensre/config.yml (interactive if flags omitted)."""
@@ -113,7 +119,11 @@ def setup_command(
         # --disabled with no new settings just switches the stored section off.
         try:
             _reject_disabled_with_setup_flags(
-                provider=provider, prefix=prefix, region=region, profile=profile
+                provider=provider,
+                prefix=prefix,
+                region=region,
+                profile=profile,
+                endpoint=endpoint,
             )
             disable_remote_sync()
         except RemoteSyncError as exc:
@@ -128,6 +138,7 @@ def setup_command(
             prefix=prefix,
             region=region,
             profile=profile,
+            endpoint=endpoint,
             enabled=enabled,
         )
         config = save_remote_sync_settings(request)
@@ -147,6 +158,7 @@ def _reject_disabled_with_setup_flags(
     prefix: str | None,
     region: str | None,
     profile: str | None,
+    endpoint: str | None,
 ) -> None:
     """``--disabled`` only flips the switch; explicit setup values need a bucket."""
     given = [
@@ -156,6 +168,7 @@ def _reject_disabled_with_setup_flags(
             ("prefix", prefix),
             ("region", region),
             ("profile", profile),
+            ("endpoint", endpoint),
         )
         if value is not None and value.strip() != ""
     ]
@@ -174,6 +187,7 @@ def _collect_setup_request(
     prefix: str | None,
     region: str | None,
     profile: str | None,
+    endpoint: str | None,
     enabled: bool,
 ) -> RemoteSyncSetupRequest:
     """Use flags when complete; otherwise prompt on a TTY."""
@@ -185,6 +199,7 @@ def _collect_setup_request(
             prefix=prefix if prefix is not None else DEFAULT_REMOTE_SYNC_PREFIX,
             region=region or "",
             profile=profile or "",
+            endpoint=endpoint or "",
             enabled=enabled,
         )
 
@@ -210,6 +225,7 @@ def _collect_setup_request(
         prefix=prefix_value,
         region=_prompt_extra_field(RemoteSyncField.REGION, provider_value, region),
         profile=_prompt_extra_field(RemoteSyncField.PROFILE, provider_value, profile),
+        endpoint=_prompt_extra_field(RemoteSyncField.ENDPOINT, provider_value, endpoint),
         enabled=enabled,
     )
 

--- a/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
+++ b/surfaces/interactive_shell/command_registry/remote_sync_cmds.py
@@ -145,6 +145,7 @@ def _run_setup(console: Console, args: list[str]) -> bool:
     prefix = _flag_value(args, "prefix") or DEFAULT_REMOTE_SYNC_PREFIX
     region = _flag_value(args, "region") or ""
     profile = _flag_value(args, "profile") or ""
+    endpoint = _flag_value(args, "endpoint") or ""
     enabled = "--disabled" not in {a.lower() for a in args}
     config = save_remote_sync_settings(
         RemoteSyncSetupRequest(
@@ -153,6 +154,7 @@ def _run_setup(console: Console, args: list[str]) -> bool:
             prefix=prefix,
             region=region,
             profile=profile,
+            endpoint=endpoint,
             enabled=enabled,
         )
     )

--- a/tests/filestorage/test_remote_sync.py
+++ b/tests/filestorage/test_remote_sync.py
@@ -1188,6 +1188,7 @@ def test_env_only_config_ignores_a_corrupt_settings_file(
     monkeypatch.setenv("OPENSRE_REMOTE_SYNC_REGION", "eu-west-2")
     monkeypatch.setenv("OPENSRE_REMOTE_SYNC_PROFILE", "env-profile")
     monkeypatch.setenv("OPENSRE_REMOTE_SYNC_PROVIDER", "aws")
+    monkeypatch.setenv("OPENSRE_REMOTE_SYNC_ENDPOINT", "https://minio.example.local")
     # Exclusions are a setting like any other, so "purely by env" now includes
     # them. Left unset, the file has to be read to find out what the user wants
     # held back — see test_a_corrupt_settings_file_does_not_sync_everything.
@@ -1200,6 +1201,7 @@ def test_env_only_config_ignores_a_corrupt_settings_file(
     assert config is not None
     assert config.bucket == "env-bucket"
     assert config.prefix == "env-prefix"
+    assert config.endpoint == "https://minio.example.local"
     assert config.exclude.patterns == ("*.tmp",)
 
 

--- a/tests/filestorage/test_remote_sync_setup.py
+++ b/tests/filestorage/test_remote_sync_setup.py
@@ -85,7 +85,7 @@ def test_save_writes_remote_sync_section(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert loaded.bucket == "opensre-remote-sync"
 
 
-def test_save_supplies_exactly_the_six_non_secret_values(
+def test_save_supplies_exactly_the_seven_non_secret_values(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
@@ -101,6 +101,7 @@ def test_save_supplies_exactly_the_six_non_secret_values(
         "prefix": "opensre",
         "region": "",
         "profile": "",
+        "endpoint": "",
     }
     assert config == RemoteSyncConfig(bucket="My-Bucket", provider="gcs")
 

--- a/tests/filestorage/test_s3compat_provider.py
+++ b/tests/filestorage/test_s3compat_provider.py
@@ -1,0 +1,380 @@
+"""S3-compatible endpoint provider: MinIO / Cloudflare R2 / DigitalOcean Spaces.
+
+An S3-compatible store speaks the same ``ListObjectsV2`` / ``GetObject`` /
+``PutObject`` API as AWS S3, but at a custom ``endpoint_url``. The provider
+implements :class:`~platform.filestorage.ports.ObjectStore` against boto3's S3
+client pointed at that endpoint, registers under ``s3compat``, and the engine
+never changes. Tests here use a fake boto3 client — no live cloud, no moto.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+from config.constants.filestorage import (
+    REMOTE_SYNC_BUCKET_ENV,
+    REMOTE_SYNC_ENDPOINT_ENV,
+    REMOTE_SYNC_ENV,
+    REMOTE_SYNC_PROVIDER_ENV,
+)
+from platform.filestorage.config import RemoteSyncConfig, load_remote_sync_config
+from platform.filestorage.engine import push
+from platform.filestorage.enums import RemoteSyncField, SyncRootName
+from platform.filestorage.errors import RemoteSyncUnavailableError
+from platform.filestorage.providers import build_object_store
+from platform.filestorage.providers import s3compat as s3compat_module
+from platform.filestorage.providers.registry import (
+    provider_extra_fields,
+    register_object_store,
+    registered_providers,
+    unregister_object_store,
+)
+from platform.filestorage.syncable import SyncRoot
+
+_ENDPOINT = "https://minio.example.local"
+_BUCKET = "opensre-bucket"
+_PREFIX = "opensre"
+
+
+class _Paginator:
+    """Fake ``list_objects_v2`` paginator, seeded with S3-style listing pages."""
+
+    def __init__(self, *, pages: list[dict[str, Any]] | None = None) -> None:
+        self.pages = pages if pages is not None else []
+        self.calls: list[dict[str, Any]] = []
+
+    def paginate(self, **kwargs: Any) -> Iterator[dict[str, Any]]:
+        self.calls.append(kwargs)
+        yield from self.pages
+
+
+class _Body:
+    """Mimics boto3's ``StreamingBody``, which exposes ``read()``."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _Client:
+    """Fake boto3 S3 client: in-memory objects plus a paginator.
+
+    Mimics the boto3 surface the provider touches: ``get_paginator``,
+    ``get_object``, ``put_object``. Real boto3 returns a ``StreamingBody``
+    from ``get_object``, so that call yields a body object with ``read()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        pages: list[dict[str, Any]] | None = None,
+        objects: dict[str, bytes] | None = None,
+    ) -> None:
+        self.paginator = _Paginator(pages=pages)
+        self.objects = objects if objects is not None else {}
+        self.put_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+
+    def get_paginator(self, name: str) -> _Paginator:
+        assert name == "list_objects_v2"
+        return self.paginator
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        self.get_calls.append(kwargs)
+        return {"Body": _Body(self.objects[kwargs["Key"]])}
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        self.put_calls.append(kwargs)
+        self.objects[kwargs["Key"]] = kwargs["Body"]
+        return {}
+
+
+class _Failing:
+    """A client whose calls raise the way botocore does on a bad endpoint."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def get_paginator(self, _name: str) -> None:
+        raise self._exc
+
+    def get_object(self, **_: Any) -> None:
+        raise self._exc
+
+    def put_object(self, **_: Any) -> None:
+        raise self._exc
+
+
+class _RecordingClient:
+    """Captures the endpoint passed to ``session.client`` for assertions."""
+
+    def __init__(self) -> None:
+        self.endpoint_url: str | None = None
+
+    def get_paginator(self, _name: str) -> _Paginator:
+        return _Paginator()
+
+    def get_object(self, **_: Any) -> dict[str, Any]:
+        return {"Body": b""}
+
+    def put_object(self, **_: Any) -> dict[str, Any]:
+        return {}
+
+
+def _listing(*, key: str, size: int, etag: str = '"abc123"') -> dict[str, Any]:
+    return {
+        "Key": f"{_PREFIX}/{key}",
+        "Size": size,
+        "LastModified": datetime.now(tz=UTC),
+        "ETag": etag,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry() -> Iterator[None]:
+    """Registrations are process-global, so snapshot and restore every table.
+
+    The registry keeps four parallel dicts (factories, credential hints, setup
+    fields, exposure checkers) plus the upload caps. Clearing only one of them
+    would leave a built-in half-registered — ``provider_extra_fields`` for a
+    name still in ``_REGISTRY`` but missing from ``_EXTRA_FIELDS`` falls back
+    to no fields, so setup validation would then reject the provider's own
+    fields. Snapshotting all of them keeps the built-ins intact across tests.
+    """
+    from platform.filestorage.providers import registry as reg
+
+    with reg._REGISTRY_LOCK:
+        snap = {
+            "_REGISTRY": dict(reg._REGISTRY),
+            "_CREDENTIAL_HINTS": dict(reg._CREDENTIAL_HINTS),
+            "_EXTRA_FIELDS": dict(reg._EXTRA_FIELDS),
+            "_PUBLIC_ACCESS_CHECKERS": dict(reg._PUBLIC_ACCESS_CHECKERS),
+            "_MAX_PARALLEL_UPLOADS": dict(reg._MAX_PARALLEL_UPLOADS),
+        }
+    yield
+    with reg._REGISTRY_LOCK:
+        reg._REGISTRY.clear()
+        reg._CREDENTIAL_HINTS.clear()
+        reg._EXTRA_FIELDS.clear()
+        reg._PUBLIC_ACCESS_CHECKERS.clear()
+        reg._MAX_PARALLEL_UPLOADS.clear()
+        for table in (
+            "_REGISTRY",
+            "_CREDENTIAL_HINTS",
+            "_EXTRA_FIELDS",
+            "_PUBLIC_ACCESS_CHECKERS",
+            "_MAX_PARALLEL_UPLOADS",
+        ):
+            getattr(reg, table).update(snap[table])
+
+
+def _store(*, client: Any, endpoint: str = _ENDPOINT) -> Any:
+    return s3compat_module.S3CompatObjectStore(
+        RemoteSyncConfig(bucket=_BUCKET, provider="s3compat", prefix=_PREFIX, endpoint=endpoint),
+        client=client,
+    )
+
+
+def test_describe_shows_the_s3compat_destination() -> None:
+    # Arrange
+    store = _store(client=_Client())
+
+    # Act / Assert
+    assert store.describe() == f"s3compat://{_BUCKET}/{_PREFIX}"
+
+
+def test_build_client_passes_the_endpoint_to_boto3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: capture the endpoint boto3 receives.
+    captured: dict[str, Any] = {}
+    recorded = _RecordingClient()
+
+    def _fake_build_client(config: RemoteSyncConfig) -> Any:
+        captured["endpoint"] = config.endpoint
+        return recorded
+
+    monkeypatch.setattr(s3compat_module, "_build_client", _fake_build_client)
+
+    # Act
+    store = _store(client=None)
+
+    # Assert: the provider would hand the endpoint to session.client("s3", ...).
+    assert captured["endpoint"] == _ENDPOINT
+    assert store.describe().startswith("s3compat://")
+
+
+def test_list_objects_delegates_to_s3_list_objects_v2() -> None:
+    # Arrange: the endpoint lists two objects under the configured prefix.
+    client = _Client(pages=[{"Contents": [_listing(key="sessions/a.jsonl", size=10)]}])
+    store = _store(client=client)
+
+    # Act
+    objects = store.list_objects("sessions")
+
+    # Assert: paginated under the full prefix and returned relative to it.
+    assert client.paginator.calls[0]["Bucket"] == _BUCKET
+    assert client.paginator.calls[0]["Prefix"] == f"{_PREFIX}/sessions"
+    assert len(objects) == 1
+    assert objects[0].key == "sessions/a.jsonl"
+    assert objects[0].size == 10
+    assert objects[0].etag == "abc123"
+
+
+def test_list_objects_strips_the_configured_prefix_and_passes_through_unknown_keys() -> None:
+    """A key already relative to the configured prefix is returned as-is.
+
+    The provider strips the configured ``opensre/`` prefix from keys, and — like
+    the AWS backend — passes through anything that is not under it (it never
+    deletes remote objects, so a sibling prefix is merely listed, not dropped).
+    """
+    # Arrange: listing holds one key under the prefix and one from a sibling.
+    client = _Client(
+        pages=[
+            {
+                "Contents": [
+                    _listing(key="memory/fact.md", size=9),
+                    _listing(key="opensre-backup/x.jsonl", size=1),
+                ]
+            }
+        ]
+    )
+    store = _store(client=client)
+
+    # Act
+    objects = store.list_objects("")
+
+    # Assert: prefix stripped from the real key; sibling key passes through.
+    assert sorted(obj.key for obj in objects) == ["memory/fact.md", "opensre-backup/x.jsonl"]
+
+
+def test_get_object_reads_the_body() -> None:
+    # Arrange
+    body = b'{"turn": 1}\n'
+    client = _Client(objects={f"{_PREFIX}/sessions/a.jsonl": body})
+    store = _store(client=client)
+
+    # Act
+    data = store.get_object("sessions/a.jsonl")
+
+    # Assert
+    assert data == body
+    assert client.get_calls[0]["Bucket"] == _BUCKET
+    assert client.get_calls[0]["Key"] == f"{_PREFIX}/sessions/a.jsonl"
+
+
+def test_put_object_writes_without_server_side_encryption() -> None:
+    """MinIO / R2 reject the SSE param the AWS backend sends, so it is omitted."""
+    # Arrange
+    client = _Client()
+    store = _store(client=client)
+
+    # Act
+    store.put_object("sessions/a.jsonl", b'{"turn": 1}\n')
+
+    # Assert: written under the full key, and no SSE kwarg reached the client.
+    assert client.objects[f"{_PREFIX}/sessions/a.jsonl"] == b'{"turn": 1}\n'
+    assert "ServerSideEncryption" not in client.put_calls[0]
+
+
+def test_errors_are_wrapped_naming_the_aws_cause() -> None:
+    # Arrange
+    client = _Failing(
+        ClientError(
+            {"Error": {"Code": "NoSuchBucket", "Message": "The bucket does not exist"}},
+            "ListObjectsV2",
+        )
+    )
+    store = _store(client=client)
+
+    # Act / Assert: the AWS-side reason survives, not just a generic message.
+    with pytest.raises(RemoteSyncUnavailableError, match="NoSuchBucket"):
+        store.list_objects("")
+    with pytest.raises(RemoteSyncUnavailableError, match="NoSuchBucket"):
+        store.get_object("sessions/a.jsonl")
+    with pytest.raises(RemoteSyncUnavailableError, match="NoSuchBucket"):
+        store.put_object("sessions/a.jsonl", b"data")
+
+
+def test_s3compat_is_registered_and_builds_via_registry() -> None:
+    # Arrange: load the built-in lazily, exactly as build_object_store does.
+    assert "s3compat" in registered_providers()
+
+    # Act
+    store = build_object_store(
+        RemoteSyncConfig(bucket=_BUCKET, provider="s3compat", endpoint=_ENDPOINT)
+    )
+
+    # Assert
+    assert isinstance(store, s3compat_module.S3CompatObjectStore)
+    assert store.describe().startswith("s3compat://")
+
+
+def test_s3compat_declares_endpoint_profile_and_region_setup_fields() -> None:
+    # Act
+    fields = {extra.field for extra in provider_extra_fields("s3compat")}
+
+    # Assert: endpoint plus the profile/region slots boto3 consumes.
+    assert fields == {
+        RemoteSyncField.ENDPOINT,
+        RemoteSyncField.PROFILE,
+        RemoteSyncField.REGION,
+    }
+
+
+def test_endpoint_config_loads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+    monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, _BUCKET)
+    monkeypatch.setenv(REMOTE_SYNC_PROVIDER_ENV, "s3compat")
+    monkeypatch.setenv(REMOTE_SYNC_ENDPOINT_ENV, _ENDPOINT)
+
+    # Act
+    config = load_remote_sync_config()
+
+    # Assert
+    assert config is not None
+    assert config.provider == "s3compat"
+    assert config.endpoint == _ENDPOINT
+
+
+def test_unregister_restores_pre_registration_state() -> None:
+    # Arrange: register a stand-in under a throwaway name, then drop it.
+    register_object_store("s3compat-tmp", lambda _cfg: _Client())
+    assert "s3compat-tmp" in registered_providers()
+    unregister_object_store("s3compat-tmp")
+
+    # Act / Assert
+    assert "s3compat-tmp" not in registered_providers()
+
+
+def test_push_through_a_registered_s3compat_store(tmp_path: Path) -> None:
+    """The engine pushes against a registry-built store with temp dirs."""
+    # Arrange: a laptop tree and a registered fake backend.
+    sessions = tmp_path / "sessions"
+    memory = tmp_path / "memory"
+    sessions.mkdir()
+    memory.mkdir()
+    (sessions / "a.jsonl").write_text('{"turn": 1}\n', encoding="utf-8")
+    (memory / "fact.md").write_text("remembered\n", encoding="utf-8")
+    roots = (
+        SyncRoot(name=SyncRootName.SESSIONS, path=sessions),
+        SyncRoot(name=SyncRootName.MEMORY, path=memory),
+    )
+    register_object_store("s3compat", lambda _cfg: _store(client=_Client()))
+    store = build_object_store(RemoteSyncConfig(bucket=_BUCKET, provider="s3compat"))
+
+    # Act
+    report = push(store, roots=roots)
+
+    # Assert: both files uploaded through the endpoint client.
+    assert sorted(report.uploaded) == ["memory/fact.md", "sessions/a.jsonl"]
+    assert store.describe().startswith("s3compat://")

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -205,6 +205,39 @@ def test_setup_disabled_says_off_without_a_sync_suggestion(
     assert "remote-sync sync" not in out
 
 
+def test_setup_forwards_endpoint_and_region_for_s3compat(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The slash setup must preserve the endpoint the CLI accepts.
+
+    Greptile P1: without forwarding, /remote-sync setup silently wrote an empty
+    endpoint and pointed boto3 at AWS instead of the configured store.
+    """
+    from config.constants import paths as paths_mod
+    from platform.filestorage.config import load_remote_sync_config
+
+    monkeypatch.setattr(paths_mod, "OPENSRE_HOME_DIR", tmp_path)
+    console, buf = _capture()
+    assert (
+        dispatch_slash(
+            "/remote-sync setup --provider s3compat --bucket b "
+            "--endpoint https://minio.example.local --region us-east-1",
+            Session(),
+            console,
+        )
+        is True
+    )
+    out = buf.getvalue()
+    assert "settings saved" in out
+    assert "s3compat" in out
+
+    loaded = load_remote_sync_config()
+    assert loaded is not None
+    assert loaded.provider == "s3compat"
+    assert loaded.endpoint == "https://minio.example.local"
+    assert loaded.region == "us-east-1"
+
+
 def test_sync_error_is_caught(monkeypatch: pytest.MonkeyPatch) -> None:
     def _boom(**_kwargs: object) -> SyncReport:
         raise RemoteSyncConfigError("bad flags")


### PR DESCRIPTION
Fixes #4911 

    ## Summary

    Adds an `s3compat` object-store provider that lets users point `platform.filestorage` at any S3-compatible endpoint
  (self-hosted MinIO, Cloudflare R2, DigitalOcean Spaces) via a new `OPENSRE_REMOTE_SYNC_ENDPOINT` setting. It reuses the S3 wire
   protocol through boto3's `endpoint_url` parameter, so the engine, CLI, and REPL stay closed — the provider registers through
  `register_object_store("s3compat", …)` exactly like the built-in backends.

    ## What changed

    **New provider:** `platform/filestorage/providers/s3compat.py`
    - `S3CompatObjectStore` implements the four-method `ObjectStore` protocol (`list_objects`, `get_object`, `put_object`,
  `describe`), modeled on the AWS backend but pointed at `RemoteSyncConfig.endpoint`.
    - `_build_client` builds `boto3.Session(...).client("s3", endpoint_url=config.endpoint)`; credentials stay ambient
  (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, profiles, SSO).
    - **Key difference from AWS:** `put_object` deliberately sends **no** `ServerSideEncryption` parameter — MinIO, R2, and
  Spaces reject it.
    - Registered with `max_parallel_uploads=16`, a public-access checker (via `s3:GetBucketPolicyStatus`), a credential hint, and
   the `endpoint` setup field.

    **New tests:** `tests/filestorage/test_s3compat_provider.py` — 12 TDD, AAA tests against fake boto3 clients (no moto, no live
   cloud):
    - describe, endpoint passed to boto3, list/get/put delegation, prefix stripping, no-SSE assertion, error wrapping, registry
  build, setup-field declaration, env config load, unregister, and an engine push round-trip with temp dirs.

    **Config / setup / CLI plumbing** for the `endpoint` field:
    - `config/constants/filestorage.py` — `OPENSRE_REMOTE_SYNC_ENDPOINT` env var.
    - `platform/filestorage/enums.py` — `BuiltInProvider.S3COMPAT` and `RemoteSyncField.ENDPOINT` (third slot, docstring
  updated).
    - `platform/filestorage/config.py` — `RemoteSyncConfig.endpoint`, loaded from env or stored config.
    - `platform/filestorage/setup.py` — `RemoteSyncSetupRequest.endpoint`, validated against the provider's declared fields,
  persisted.
    - `surfaces/cli/commands/remote_sync.py` — `--endpoint` flag, wired through flags + interactive prompt.
    - `platform/filestorage/providers/registry.py` — `s3compat` added to `_BUILTIN_MODULES` so it lazily loads and shows in the
  setup prompt / help.

    **Docs:** `docs/configuration/remote-sync.mdx` — new `### S3-compatible endpoint (MinIO / R2 / Spaces)` section with the
  setup recipe and permissions, provider-table row, env-var block, and variable table.

    Two existing tests were updated to cover the new field: `test_env_only_config_ignores_a_corrupt_settings_file` (now sets +
  asserts the endpoint env var) and `test_save_supplies_exactly_the_seven_non_secret_values` (six → seven on-disk values).

    ## Verification

    ```bash
    uv run pytest tests/filestorage/test_s3compat_provider.py -v
    # 12 passed

    uv run ruff check <changed files>
    # clean

  │ Note: the full tests/filestorage/ suite shows 6 pre-existing failures on this Windows checkout (CRLF \r\n vs \n byte asserts
  in test_multi_provider_support.py, test_remote_sync.py, test_vercel_provider.py). They reproduce on clean origin/main without
  this change and are unrelated to it. This PR adds 12 passing tests (264 passed total).

  Checklist

  - [X]  Failing tests first for list/get/put against fake endpoint (TDD)
  - [X]  Each test uses AAA (Arrange → Act → Assert)
  - [X]  Provider registered and selectable in setup
  - [X]  Short recipe in remote-sync.mdx
  - [X]  uv run pytest on the new tests green