### PR TITLE
refactor(cli): share cron validation and task-add echo across schedule commands (#4888)

### DIFF
--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from platform.scheduler.credentials import requires_explicit_chat_id
 from platform.scheduler.types import Provider, TaskKind
+from surfaces.cli.commands.scheduling import validate_cron_and_timezone
 
 _console = Console()
 
@@ -102,7 +103,7 @@ def cron_add(
     from platform.scheduler.types import ScheduledTask
 
     # Validate cron expression by constructing the APScheduler trigger
-    _validate_cron_and_timezone(cron_expr, timezone)
+    validate_cron_and_timezone(cron_expr, timezone)
     _validate_chat_id_for_provider(provider, chat_id)
 
     task = ScheduledTask(
@@ -287,27 +288,6 @@ def cron_start() -> None:
     _console.print("[bold]Starting scheduler daemon...[/bold]")
     _console.print("Press Ctrl+C to stop.")
     start_scheduler()
-
-
-def _validate_cron_and_timezone(cron_expr: str, timezone: str) -> None:
-    """Validate cron expression and timezone by constructing an APScheduler trigger.
-
-    Fails fast with a clear error message instead of creating inert tasks.
-    """
-    parts = cron_expr.split()
-    if len(parts) != 5:
-        _console.print("[red]Error: cron expression must have exactly 5 fields.[/red]")
-        _console.print("  Format: minute hour day month day_of_week")
-        _console.print("  Example: 0 9 * * 1-5  (weekdays at 09:00)")
-        raise SystemExit(1)
-
-    try:
-        from apscheduler.triggers.cron import CronTrigger
-
-        CronTrigger.from_crontab(cron_expr, timezone=timezone)
-    except (ValueError, TypeError, KeyError) as exc:
-        _console.print(f"[red]Error: invalid cron expression or timezone: {exc}[/red]")
-        raise SystemExit(1) from exc
 
 
 def _validate_chat_id_for_provider(provider: str, chat_id: str) -> None:

--- a/surfaces/cli/commands/posthog_report.py
+++ b/surfaces/cli/commands/posthog_report.py
@@ -13,7 +13,7 @@ from rich.table import Table
 
 from bootstrap.process import SCHEDULED_COMMAND_PROFILE, configure_process
 from platform.scheduler.delivery import SUPPORTED_DELIVERY_PROVIDERS
-from surfaces.cli.commands.cron import _validate_cron_and_timezone
+from surfaces.cli.commands.scheduling import add_task_and_echo, validate_cron_and_timezone
 
 _console = Console()
 _PROVIDER_CHOICES = [p.value for p in SUPPORTED_DELIVERY_PROVIDERS]
@@ -133,12 +133,11 @@ def posthog_report_schedule_add(
         require_posthog_integration,
         require_report_delivery_provider,
     )
-    from platform.scheduler.store import add_task
     from platform.scheduler.types import Provider, ScheduledTask, TaskKind
 
     require_posthog_integration()
     require_report_delivery_provider(provider)
-    _validate_cron_and_timezone(cron_expr, timezone)
+    validate_cron_and_timezone(cron_expr, timezone)
 
     period = stats_period.strip() or DEFAULT_POSTHOG_PERIOD
     params: dict[str, str] = {"stats_period": period}
@@ -157,10 +156,7 @@ def posthog_report_schedule_add(
         window_hours=0,
         params=params,
     )
-    added = add_task(task)
-    _console.print(f"[green]PostHog report task {added.id} created.[/green]")
-    _console.print(f"  Cron: {added.cron}  TZ: {added.timezone}")
-    _console.print(f"  Provider: {added.provider.value}  Chat: {added.chat_id}")
+    add_task_and_echo(task, label="PostHog report")
     _console.print(f"  Period: {params['stats_period']}")
     if "metrics" in params:
         _console.print(f"  Metrics: {params['metrics']}")

--- a/surfaces/cli/commands/scheduling.py
+++ b/surfaces/cli/commands/scheduling.py
@@ -1,0 +1,64 @@
+"""Scheduling helpers shared by the CLI command groups that create tasks.
+
+Holds no Click commands. ``opensre cron``, ``opensre sentry digest``, and
+``opensre posthog report`` each accept a cron expression and a timezone, and the
+integration-specific groups echo the same confirmation once a task is stored.
+Keeping that here means those command modules depend on one helper rather than
+importing a private function out of a peer command module.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from platform.scheduler.types import ScheduledTask
+
+_console = Console()
+
+#: A standard crontab line: minute, hour, day, month, day_of_week.
+CRON_FIELD_COUNT = 5
+
+
+def validate_cron_and_timezone(cron_expr: str, timezone: str) -> None:
+    """Validate cron expression and timezone by constructing an APScheduler trigger.
+
+    Fails fast with a clear error message instead of creating inert tasks.
+    """
+    parts = cron_expr.split()
+    if len(parts) != CRON_FIELD_COUNT:
+        _console.print(
+            f"[red]Error: cron expression must have exactly {CRON_FIELD_COUNT} fields.[/red]"
+        )
+        _console.print("  Format: minute hour day month day_of_week")
+        _console.print("  Example: 0 9 * * 1-5  (weekdays at 09:00)")
+        raise SystemExit(1)
+
+    try:
+        from apscheduler.triggers.cron import CronTrigger
+
+        CronTrigger.from_crontab(cron_expr, timezone=timezone)
+    except (ValueError, TypeError, KeyError) as exc:
+        _console.print(f"[red]Error: invalid cron expression or timezone: {exc}[/red]")
+        raise SystemExit(1) from exc
+
+
+def add_task_and_echo(task: ScheduledTask, *, label: str) -> ScheduledTask:
+    """Store ``task`` and report the schedule and destination it was created with.
+
+    ``label`` names the kind of task in the confirmation line (for example
+    ``"Sentry digest"``). Returns the stored task, whose ``id`` may differ from
+    the requested one when the store deduplicates an equivalent schedule.
+    """
+    from platform.scheduler.store import add_task
+
+    added = add_task(task)
+    _console.print(f"[green]{label} task {added.id} created.[/green]")
+    _console.print(f"  Cron: {added.cron}  TZ: {added.timezone}")
+    _console.print(f"  Provider: {added.provider.value}  Chat: {added.chat_id}")
+    return added
+
+
+__all__ = ["CRON_FIELD_COUNT", "add_task_and_echo", "validate_cron_and_timezone"]

--- a/surfaces/cli/commands/sentry_digest.py
+++ b/surfaces/cli/commands/sentry_digest.py
@@ -13,7 +13,7 @@ from rich.table import Table
 
 from bootstrap.process import SCHEDULED_COMMAND_PROFILE, configure_process
 from platform.scheduler.delivery import SUPPORTED_DELIVERY_PROVIDERS
-from surfaces.cli.commands.cron import _validate_cron_and_timezone
+from surfaces.cli.commands.scheduling import add_task_and_echo, validate_cron_and_timezone
 
 _console = Console()
 _PROVIDER_CHOICES = [p.value for p in SUPPORTED_DELIVERY_PROVIDERS]
@@ -133,12 +133,11 @@ def sentry_uptime_watch_add(
         require_digest_delivery_provider,
         require_sentry_integration,
     )
-    from platform.scheduler.store import add_task
     from platform.scheduler.types import Provider, ScheduledTask, TaskKind
 
     require_sentry_integration()
     require_digest_delivery_provider(provider)
-    _validate_cron_and_timezone(cron_expr, timezone)
+    validate_cron_and_timezone(cron_expr, timezone)
 
     params: dict[str, str] = {}
     if project_slug.strip():
@@ -155,10 +154,7 @@ def sentry_uptime_watch_add(
         window_hours=0,
         params=params,
     )
-    added = add_task(task)
-    _console.print(f"[green]Sentry uptime watch task {added.id} created.[/green]")
-    _console.print(f"  Cron: {added.cron}  TZ: {added.timezone}")
-    _console.print(f"  Provider: {added.provider.value}  Chat: {added.chat_id}")
+    added = add_task_and_echo(task, label="Sentry uptime watch")
     if params:
         _console.print(f"  Project: {params['project_slug']}")
 
@@ -341,12 +337,11 @@ def sentry_digest_schedule_add(
         require_digest_delivery_provider,
         require_sentry_integration,
     )
-    from platform.scheduler.store import add_task
     from platform.scheduler.types import Provider, ScheduledTask, TaskKind
 
     require_sentry_integration()
     require_digest_delivery_provider(provider)
-    _validate_cron_and_timezone(cron_expr, timezone)
+    validate_cron_and_timezone(cron_expr, timezone)
 
     params: dict[str, str] = {}
     if project_slug.strip():
@@ -361,10 +356,7 @@ def sentry_digest_schedule_add(
         window_hours=24,
         params=params,
     )
-    added = add_task(task)
-    _console.print(f"[green]Sentry digest task {added.id} created.[/green]")
-    _console.print(f"  Cron: {added.cron}  TZ: {added.timezone}")
-    _console.print(f"  Provider: {added.provider.value}  Chat: {added.chat_id}")
+    add_task_and_echo(task, label="Sentry digest")
     if params:
         _console.print(f"  Project: {params['project_slug']}")
 

--- a/tests/cli/test_schedule_add_shared_behavior.py
+++ b/tests/cli/test_schedule_add_shared_behavior.py
@@ -1,0 +1,112 @@
+"""Confirmation output and cron validation shared by the scheduling commands.
+
+Characterization coverage for the ``schedule add`` surface of
+``opensre posthog report`` and ``opensre sentry digest``. Both commands echo the
+same three-line confirmation and reject the same bad cron input, so these tests
+pin that observable behavior independently of which module the logic lives in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from surfaces.cli.commands.posthog_report import posthog_command
+from surfaces.cli.commands.sentry_digest import sentry_command
+
+_POSTHOG_PREREQUISITES = "integrations.posthog.report_prerequisites"
+_SENTRY_PREREQUISITES = "integrations.sentry.digest_prerequisites"
+
+_POSTHOG_ADD = ("report", "schedule", "add")
+_SENTRY_ADD = ("digest", "schedule", "add")
+
+_DELIVERY_ARGS = ("--provider", "telegram", "--chat-id", "-100200300")
+
+
+@pytest.fixture
+def isolated_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the scheduler store at a temp file so tests never touch real tasks."""
+    monkeypatch.setattr(
+        "platform.scheduler.store._default_store_path",
+        lambda: tmp_path / "tasks.json",
+    )
+
+
+def _allow_posthog(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(f"{_POSTHOG_PREREQUISITES}.require_posthog_integration", lambda: None)
+    monkeypatch.setattr(
+        f"{_POSTHOG_PREREQUISITES}.require_report_delivery_provider", lambda _provider: None
+    )
+
+
+def _allow_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(f"{_SENTRY_PREREQUISITES}.require_sentry_integration", lambda: None)
+    monkeypatch.setattr(
+        f"{_SENTRY_PREREQUISITES}.require_digest_delivery_provider", lambda _provider: None
+    )
+
+
+def test_posthog_schedule_add_echoes_standard_confirmation(
+    monkeypatch: pytest.MonkeyPatch, isolated_store: None
+) -> None:
+    """Storing a task reports its cron, timezone, provider, and chat destination."""
+    _allow_posthog(monkeypatch)
+
+    result = CliRunner().invoke(
+        posthog_command,
+        [*_POSTHOG_ADD, "--cron", "0 9 * * 1-5", "--tz", "Europe/London", *_DELIVERY_ARGS],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "PostHog report task" in result.output
+    assert "created." in result.output
+    assert "Cron: 0 9 * * 1-5  TZ: Europe/London" in result.output
+    assert "Provider: telegram  Chat: -100200300" in result.output
+
+
+def test_sentry_digest_schedule_add_echoes_standard_confirmation(
+    monkeypatch: pytest.MonkeyPatch, isolated_store: None
+) -> None:
+    """The Sentry digest add path reports the same fields in the same order."""
+    _allow_sentry(monkeypatch)
+
+    result = CliRunner().invoke(
+        sentry_command,
+        [*_SENTRY_ADD, "--cron", "0 8 * * *", "--tz", "UTC", *_DELIVERY_ARGS],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Sentry digest task" in result.output
+    assert "created." in result.output
+    assert "Cron: 0 8 * * *  TZ: UTC" in result.output
+    assert "Provider: telegram  Chat: -100200300" in result.output
+
+
+def test_cron_expression_must_have_five_fields(
+    monkeypatch: pytest.MonkeyPatch, isolated_store: None
+) -> None:
+    """A four-field expression is refused before any task is stored."""
+    _allow_posthog(monkeypatch)
+
+    result = CliRunner().invoke(
+        posthog_command,
+        [*_POSTHOG_ADD, "--cron", "0 9 * *", *_DELIVERY_ARGS],
+    )
+
+    assert result.exit_code == 1
+    assert "cron expression must have exactly 5 fields" in result.output
+
+
+def test_unknown_timezone_is_refused(monkeypatch: pytest.MonkeyPatch, isolated_store: None) -> None:
+    """The timezone is validated by building the trigger, not by a name list."""
+    _allow_sentry(monkeypatch)
+
+    result = CliRunner().invoke(
+        sentry_command,
+        [*_SENTRY_ADD, "--cron", "0 8 * * *", "--tz", "Mars/Olympus_Mons", *_DELIVERY_ARGS],
+    )
+
+    assert result.exit_code == 1
+    assert "invalid cron expression or timezone" in result.output


### PR DESCRIPTION
Fixes #4888

#### Describe the changes you have made in this PR -

C-SR-5. Extracts the cron/timezone validation and the `add_task` confirmation shared by
`cron.py`, `sentry_digest.py`, and `posthog_report.py` into a new
`surfaces/cli/commands/scheduling.py`.

Two separate duplications existed:

1. **A private cross-module import.** Both `sentry_digest.py` and `posthog_report.py`
   did `from surfaces.cli.commands.cron import _validate_cron_and_timezone` — reaching
   past the underscore into a peer command module, so `cron.py` could not change its
   own private helper without breaking two unrelated command groups.
2. **A copy-pasted store-and-print block.** Three `schedule add` paths repeated the same
   four lines: `add_task(task)`, then a green "created" line, a `Cron/TZ` line, and a
   `Provider/Chat` line.

The new module holds both, and takes no Click commands of its own:

| Helper | Notes |
|---|---|
| `validate_cron_and_timezone` | Moved verbatim from `cron.py`; the bare `5` is now a named `CRON_FIELD_COUNT`, which the error message interpolates so the two cannot drift |
| `add_task_and_echo` | Stores the task and echoes the confirmation; the task kind is passed as `label` (`"Sentry digest"`, `"PostHog report"`, `"Sentry uptime watch"`) and it returns the stored task, which the uptime-watch path needs for its activation notice |

All three command modules import from the shared helper and the private peer import is
gone. Per AGENTS.md ("do not keep compatibility-only forwarding modules after
refactors") `_validate_cron_and_timezone` is removed from `cron.py` rather than left as
an alias — there is one canonical import path.

`cron add` keeps its own echo: its output carries `Name:` and `Kind:` lines the
integration commands do not have, and it records a scheduler operation-log entry.
Forcing it through the shared echo would have changed user-facing output, so it shares
only the validation.

Net effect on the command modules is **-32 lines**.

### Demo/Screenshot for feature changes and bug fixes -

This is a behavior-preserving refactor, so per AGENTS.md it is TDD-guarded: the
characterization tests were written and confirmed green **against the pre-refactor
code**, then kept green through the change.

`tests/cli/test_schedule_add_shared_behavior.py` pins the observable behavior at the
CLI boundary — not at the helper — so it is valid on both sides of the move: both
`schedule add` commands echo cron, timezone, provider, and chat; a four-field cron is
refused; an unknown timezone is refused.

```
# Written first, run BEFORE the refactor (helper still private in cron.py):
$ uv run python -m pytest tests/cli/test_schedule_add_shared_behavior.py -q
4 passed in 7.56s

# Same tests after the refactor, with the existing scheduling CLI tests:
$ uv run python -m pytest tests/cli/test_schedule_add_shared_behavior.py \
    tests/cli/test_cron_command.py tests/cli/test_cron_slack_destination.py \
    tests/cli/test_sentry_digest.py -q
18 passed in 2.37s

$ python -m ruff check config core gateway integrations platform surfaces tools tests
All checks passed!

$ python -m ruff format --check config core gateway integrations platform surfaces tools tests
3368 files already formatted

$ uv run python -m mypy config core gateway integrations platform surfaces tools
Success: no issues found in 1729 source files

$ uv run python .github/ci/check_imports.py
No import cycles found across 1845 first-party modules (8 roots).
Contracts: 4 kept, 0 broken.
All 3 import checks passed.
```

Note: the wider `tests/cli/` run shows 13 failures on my Windows machine
(`test_health`, `test_install_*`, `test_output`, `test_uninstall`, `wizard/test_prompts`).
I confirmed they reproduce identically with this branch stashed — same 13, all
POSIX/terminal-specific — so they are pre-existing and unrelated to this change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The important decision was what *not* to share. `cron add` looks like a third caller of
the same block, but its output has extra fields and it writes an operation-log entry, so
folding it in would have changed what operators see. The issue asks for the helper to be
used by at least two commands; the two integration commands are byte-identical, and
`cron add` shares only the validation.

The second decision was where the seam goes. `add_task_and_echo` returns the stored task
rather than returning `None`, because the uptime-watch path needs `added.id`, `added.cron`,
and `added.timezone` afterwards to build its activation notice — and because the store may
deduplicate, so the returned id is not always the requested one.

Placement follows the AGENTS.md file-placement table: a shared helper module rather than a
new provider-specific branch in an existing file, and `surfaces/cli/commands/scheduling.py`
sits next to its only callers. I ran the import checks specifically because this adds an
edge between command modules; cycles and layer contracts are clean.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
