### PR TITLE
docs(remote-sync): list azure as a built-in backend

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -77,7 +77,7 @@ export OPENSRE_REMOTE_SYNC_BUCKET=my-opensre-bucket
 | Variable | Description |
 |---|---|
 | `OPENSRE_REMOTE_SYNC` | Set to `1` to enable. Nothing uploads until you do |
-| `OPENSRE_REMOTE_SYNC_PROVIDER` | Backend name. Default `aws` (S3). Built-in: `aws`, `gcs`, `vercel`. Community backends register under the same name |
+| `OPENSRE_REMOTE_SYNC_PROVIDER` | Backend name. Default `aws` (S3). Built-in: `aws`, `gcs`, `vercel`, `azure`. Community backends register under the same name |
 | `OPENSRE_REMOTE_SYNC_BUCKET` | Store you own (S3 bucket name, GCS bucket name, or Vercel Blob store name/id). Required |
 | `OPENSRE_REMOTE_SYNC_PREFIX` | Key prefix, default `opensre`. Machines that should share history must use the same one |
 | `OPENSRE_REMOTE_SYNC_REGION` | Region override when the provider supports it (AWS) |

--- a/platform/filestorage/providers/__init__.py
+++ b/platform/filestorage/providers/__init__.py
@@ -1,7 +1,7 @@
 """Cloud backends for remote sync.
 
-Built-in backends (``aws``, ``gcs``, ``vercel``) load lazily via the registry
-when selected. Other clouds (Azure, …) are community modules that call
+Built-in backends (``aws``, ``gcs``, ``vercel``, ``azure``) load lazily via the
+registry when selected. Other clouds are community modules that call
 :func:`register_object_store`; the sync engine, CLI, and REPL do not change.
 """
 

--- a/tools/interactive_shell/shared/slash_catalog.py
+++ b/tools/interactive_shell/shared/slash_catalog.py
@@ -360,7 +360,8 @@ MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
     ),
     "/remote-sync": _mcp(
         "Mirror this machine's sessions and memory to an object store the user "
-        "owns (built-in: aws/S3, vercel Blob). Subcommands: status, sync, setup. "
+        "owns (built-in: aws/S3, gcs, vercel Blob, azure Blob). Subcommands: "
+        "status, sync, setup. "
         "Off until setup or env enable; integration credentials and model keys "
         "are never uploaded.",
         "User asks to sync, back up, set up remote sync, or restore conversations",


### PR DESCRIPTION
Closes #4908

Azure Blob already ships as `platform/filestorage/providers/azure.py` next to aws, gcs and vercel, but a few spots still described it as a community backend. This fixes the wording so all four are listed.

What changed:

- `docs/configuration/remote-sync.mdx`: the `OPENSRE_REMOTE_SYNC_PROVIDER` row now says Built-in: `aws`, `gcs`, `vercel`, `azure`.
- `platform/filestorage/providers/__init__.py`: the module docstring listed only three built-ins and named Azure as a community module. It now lists all four.
- `tools/interactive_shell/shared/slash_catalog.py`: the `/remote-sync` one-liner said "built-in: aws/S3, vercel Blob", so it was missing gcs as well. Now lists all four.

No engine, provider or `core/` changes, wording only.

Tests: `pytest tests/interactive_shell/command_registry/test_slash_catalog.py tests/surfaces/test_remote_sync_surface_contract.py tests/filestorage` passes (261 passed).