### PR TITLE
fix(sandbox): gate chat code execution on approval and close the write-guard gaps (#4931)

### DIFF
--- a/platform/sandbox/runner.py
+++ b/platform/sandbox/runner.py
@@ -93,8 +93,15 @@ _SANDBOX_PREAMBLE = textwrap.dedent(f"""\
     _original_os_open = _os_module.open
 
     def _restricted_os_open(path, flags, *args, **kwargs):
+        # O_TRUNC belongs here even though it is not an access mode: on POSIX
+        # ``os.open(p, O_RDONLY | O_TRUNC)`` empties the file, so a mask of
+        # access modes alone let generated code destroy any file it could name.
         _write_flags = (
-            _os_module.O_WRONLY | _os_module.O_RDWR | _os_module.O_APPEND | _os_module.O_CREAT
+            _os_module.O_WRONLY
+            | _os_module.O_RDWR
+            | _os_module.O_APPEND
+            | _os_module.O_CREAT
+            | _os_module.O_TRUNC
         )
         if flags & _write_flags and not _write_allowed(path):
             raise PermissionError(

--- a/platform/sandbox/runner.py
+++ b/platform/sandbox/runner.py
@@ -1,4 +1,13 @@
-"""Python sandbox runner with timeout and restricted access."""
+"""Python sandbox runner with timeout and restricted access.
+
+**These guards are not a security boundary.** They are injected into the same
+interpreter that runs the supplied code, so code that is *trying* to get out
+can: ``importlib.reload`` restores any patched module, ``ctypes`` and
+``os.posix_spawn`` were never patched, and a child interpreter started by any
+route receives no preamble at all. Treat the restrictions as protection against
+an agent damaging the host by accident, and gate the calling tool on approval
+wherever the code author is not the operator.
+"""
 
 from __future__ import annotations
 
@@ -51,9 +60,17 @@ _NETWORK_BLOCK_PREAMBLE = textwrap.dedent("""\
 # Preamble always injected before user code: restricts filesystem writes and subprocesses.
 _SANDBOX_PREAMBLE = textwrap.dedent(f"""\
     import builtins as _builtins_module
+    import io as _io_module
     import os as _os_module
 
     _ALLOWED_WRITE_ROOTS = ({_SANDBOX_TMP_ROOT!r},)
+
+    def _write_allowed(path):
+        abs_path = _os_module.path.realpath(_os_module.fspath(path))
+        return any(
+            abs_path == root or abs_path.startswith(root + _os_module.sep)
+            for root in _ALLOWED_WRITE_ROOTS
+        )
 
     _original_open = _builtins_module.open
 
@@ -61,17 +78,31 @@ _SANDBOX_PREAMBLE = textwrap.dedent(f"""\
         if isinstance(file, (str, bytes)) or hasattr(file, "__fspath__"):
             mode_str = str(mode)
             if any(c in mode_str for c in ("w", "a", "x")):
-                abs_path = _os_module.path.realpath(_os_module.fspath(file))
-                if not any(
-                    abs_path == root or abs_path.startswith(root + _os_module.sep)
-                    for root in _ALLOWED_WRITE_ROOTS
-                ):
+                if not _write_allowed(file):
                     raise PermissionError(
                         f"Write access denied outside the OpenSRE temp directory: {{file}}"
                     )
         return _original_open(file, mode, *args, **kwargs)
 
     _builtins_module.open = _restricted_open
+    # pathlib.Path.open/write_text/write_bytes resolve io.open, which is a
+    # separate binding from builtins.open. Patching only the latter left every
+    # pathlib write unguarded.
+    _io_module.open = _restricted_open
+
+    _original_os_open = _os_module.open
+
+    def _restricted_os_open(path, flags, *args, **kwargs):
+        _write_flags = (
+            _os_module.O_WRONLY | _os_module.O_RDWR | _os_module.O_APPEND | _os_module.O_CREAT
+        )
+        if flags & _write_flags and not _write_allowed(path):
+            raise PermissionError(
+                f"Write access denied outside the OpenSRE temp directory: {{path}}"
+            )
+        return _original_os_open(path, flags, *args, **kwargs)
+
+    _os_module.open = _restricted_os_open
 
     import subprocess as _subprocess_module
     import os as _os_shell_module
@@ -116,13 +147,17 @@ def run_python_sandbox(
     env: dict[str, str] | None = None,
     allow_network: bool = False,
 ) -> SandboxResult:
-    """Run Python code in a sandboxed subprocess with timeout and access restrictions.
+    """Run Python code in a subprocess with a timeout and best-effort restrictions.
 
     Network access is blocked by replacing ``socket.socket`` and related helpers
     with a class that raises ``PermissionError``. Filesystem writes are restricted
-    to the OpenSRE temp directory, so any attempt to open a file outside that
-    directory for writing raises ``PermissionError``. Execution is capped at
-    *timeout* seconds.
+    to the OpenSRE temp directory via ``builtins.open``, ``io.open`` and
+    ``os.open``. Execution is capped at *timeout* seconds.
+
+    As the module docstring says, none of this contains hostile code — the guards
+    live in the interpreter being guarded. Callers that accept code from anyone
+    other than the operator must add their own gate (see
+    ``PythonExecutionTool.requires_approval``).
 
     Args:
         code: Python source code to execute.
@@ -158,6 +193,10 @@ def run_python_sandbox(
             suffix=".py",
             delete=False,
             dir=OPENSRE_TMP_DIR,
+            # Without this the script is written in the locale encoding (cp1252
+            # on Windows) while the interpreter reads .py as UTF-8, so any
+            # non-ASCII character in generated code dies with a SyntaxError.
+            encoding="utf-8",
         ) as tmp:
             tmp.write(full_code)
             tmp_path = tmp.name
@@ -207,7 +246,10 @@ def run_python_sandbox(
 
 def _sandbox_env(extra_env: dict[str, str] | None) -> dict[str, str]:
     """Build a narrow subprocess environment plus explicitly approved values."""
-    sandbox_env: dict[str, str] = {}
+    # stdout/stderr are decoded as UTF-8 below, so the child must encode as
+    # UTF-8 too. Without this it writes in its locale encoding (cp1252 on
+    # Windows) and every non-ASCII character comes back as mojibake.
+    sandbox_env: dict[str, str] = {"PYTHONIOENCODING": "utf-8"}
     for key in _BASE_ENV_KEYS:
         value = os.environ.get(key)
         if value:

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
+
+import pytest
 
 from config.constants import OPENSRE_TMP_DIR, ensure_opensre_tmp_dir
 from platform.sandbox.runner import (
@@ -218,6 +221,30 @@ class TestSandboxWriteGuardCoversEveryOpenPath:
             "os.write(fd, b'escaped')\n"
             "os.close(fd)\n"
         )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows rejects O_RDONLY|O_TRUNC outright; the truncation risk is POSIX-only",
+    )
+    def test_os_open_truncate_without_write_flag_blocked(self) -> None:
+        """``O_TRUNC`` empties a file even with ``O_RDONLY``.
+
+        It is not an access mode, so a mask built only from O_WRONLY/O_RDWR/
+        O_APPEND/O_CREAT let generated code destroy any file it could name
+        while never asking for write access.
+        """
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as handle:
+            handle.write("important data")
+            path = handle.name
+        try:
+            result = run_python_sandbox(
+                f"import os\nfd = os.open({path!r}, os.O_RDONLY | os.O_TRUNC)\nos.close(fd)\n"
+            )
+            assert not result.success
+            assert "PermissionError" in result.stderr or "PermissionError" in result.stdout
+            assert os.path.getsize(path) > 0
+        finally:
+            os.unlink(path)
 
     def test_pathlib_write_inside_opensre_tmp_still_allowed(self) -> None:
         # The guard must not break the directory the tool is meant to use.

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -179,3 +179,82 @@ class TestSandboxResultModel:
             timed_out=True,
         )
         assert r.success is False
+
+
+class TestSandboxWriteGuardCoversEveryOpenPath:
+    """The write guard must not be limited to ``builtins.open``.
+
+    ``pathlib`` resolves ``io.open`` and low-level writes go through
+    ``os.open``; both are separate bindings, so a guard on ``builtins.open``
+    alone let generated code write anywhere the process could write.
+    """
+
+    @staticmethod
+    def _outside_target() -> str:
+        # The system temp dir is the parent of OPENSRE_TMP_DIR, so a file
+        # placed directly in it is outside the one allowed write root.
+        return os.path.join(tempfile.gettempdir(), "opensre_sandbox_guard_test.txt")
+
+    def _assert_blocked(self, code: str) -> None:
+        target = self._outside_target()
+        try:
+            result = run_python_sandbox(code)
+            assert not result.success
+            assert "PermissionError" in result.stderr or "PermissionError" in result.stdout
+            assert not os.path.exists(target)
+        finally:
+            if os.path.exists(target):
+                os.unlink(target)
+
+    def test_pathlib_write_text_outside_tmp_blocked(self) -> None:
+        target = self._outside_target()
+        self._assert_blocked(f"from pathlib import Path\nPath({target!r}).write_text('escaped')\n")
+
+    def test_os_open_write_outside_tmp_blocked(self) -> None:
+        target = self._outside_target()
+        self._assert_blocked(
+            "import os\n"
+            f"fd = os.open({target!r}, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)\n"
+            "os.write(fd, b'escaped')\n"
+            "os.close(fd)\n"
+        )
+
+    def test_pathlib_write_inside_opensre_tmp_still_allowed(self) -> None:
+        # The guard must not break the directory the tool is meant to use.
+        ensure_opensre_tmp_dir()
+        target = os.path.join(os.fspath(OPENSRE_TMP_DIR), "sandbox_pathlib_write.txt")
+        try:
+            result = run_python_sandbox(
+                f"from pathlib import Path\nPath({target!r}).write_text('ok')\n"
+            )
+            assert result.success, result.stderr
+        finally:
+            if os.path.exists(target):
+                os.unlink(target)
+
+    def test_os_open_read_outside_tmp_still_allowed(self) -> None:
+        # Only writes are restricted; a read-only os.open must still work.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as handle:
+            handle.write("data")
+            path = handle.name
+        try:
+            result = run_python_sandbox(
+                f"import os\nfd = os.open({path!r}, os.O_RDONLY)\n"
+                "print(os.read(fd, 4).decode())\nos.close(fd)\n"
+            )
+            assert result.success, result.stderr
+            assert "data" in result.stdout
+        finally:
+            os.unlink(path)
+
+
+class TestSandboxSourceEncoding:
+    def test_non_ascii_code_runs(self) -> None:
+        """The script is read back as UTF-8, so it must be written as UTF-8.
+
+        Under a non-UTF-8 locale (cp1252 on Windows) the default encoding made
+        any non-ASCII character in generated code fail with a SyntaxError.
+        """
+        result = run_python_sandbox("print('caf\u00e9 \u2014 na\u00efve')")
+        assert result.success, result.stderr
+        assert "café" in result.stdout

--- a/tests/tools/test_python_execution_tool.py
+++ b/tests/tools/test_python_execution_tool.py
@@ -25,6 +25,19 @@ class TestPythonExecutionToolMetadata:
         assert "investigation" in registered.surfaces
         assert "chat" in registered.surfaces
 
+    def test_requires_approval_on_messaging_surfaces(self) -> None:
+        """A remote chat user must not reach code execution unattended.
+
+        The sandbox guards are in-process monkeypatches that executed code can
+        undo, and this tool hands the subprocess a live GITHUB_TOKEN. On the
+        chat surface the code author is whoever is typing at the bot, so the
+        gateway approval gate (``gateway.core.runtime.approvals``) is the
+        control that stands between them and the host.
+        """
+        clear_tool_registry_cache()
+        registered = get_registered_tool_map("chat")["execute_python_code"]
+        assert registered.requires_approval is True
+
     def test_github_token_hidden_from_public_schema(self) -> None:
         clear_tool_registry_cache()
         registered = get_registered_tool_map("chat")["execute_python_code"]

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -33,12 +33,18 @@ class PythonExecutionTool(BaseTool):
     source = "knowledge"
     side_effect_level = SideEffectLevel.READ_ONLY
     surfaces = ("investigation", "chat")
+    # The sandbox restricts accidents, not deliberate escapes: its guards are
+    # in-process monkeypatches that executed code can undo. On messaging
+    # surfaces the code author is a remote chat user (or injected content), and
+    # this process holds an injected GITHUB_TOKEN, so a human approves the run.
+    # Local CLI/investigation turns are unaffected — the gate is gateway-only.
+    requires_approval = True
     injected_params = ["github_token"]
     description = (
         "Execute generated Python code in a restricted subprocess, capture stdout, stderr, "
         "exceptions, and timeout state, and return the result to the agent. Network access is "
-        "blocked by default; opt in only for approved API-backed analysis. Subprocess spawning "
-        "is always blocked. Runtime facts "
+        "blocked by default; opt in only for approved API-backed analysis. Do not spawn "
+        "subprocesses, and do not work around the sandbox guards. Runtime facts "
         f"({_RUNTIME_FACT_KEYS}) are already stated in the conversation's environment block — "
         "answer them from there directly and never call this tool just to re-read them; code "
         "already running for another reason can reuse them via `inputs['opensre_runtime']` "
@@ -60,7 +66,7 @@ class PythonExecutionTool(BaseTool):
     anti_examples = [
         _RUNTIME_FACTS_ANTI_EXAMPLE,
         "Changing local files or shelling out to other processes",
-        f"Calling {', '.join(BLOCKED_INTROSPECTION_COMMANDS)} (all blocked by the sandbox)",
+        f"Calling {', '.join(BLOCKED_INTROSPECTION_COMMANDS)} (all refused by the sandbox)",
         "Probing cloud instance metadata over the network (use the injected cloud facts)",
         "Using allow_network for arbitrary host/port reachability probes or scanning (allow_network is unrestricted once enabled — only for approved API-backed analysis)",
         "Long-running jobs, crawlers, or broad external scans",


### PR DESCRIPTION
Closes #4931

#### Describe the changes you have made in this PR -

`platform/sandbox/runner.py` enforces its restrictions by monkeypatching `builtins.open`,
`subprocess.*`, and `socket.*` **inside the same interpreter that runs the supplied code**.
Code that is trying to get out can undo them. `execute_python_code` is served on the
**chat** surface with `requires_approval` unset, so a Slack/Telegram/Discord user — or
prompt injection in any content the agent reads — reached arbitrary host code execution
unattended, in a process holding an injected `GITHUB_TOKEN`.

Verified against `main` before changing anything:

| Probe | Result on `main` |
|---|---|
| `builtins.open` write outside temp | BLOCKED (the one guarded path) |
| `pathlib.Path.write_text` outside temp | **ALLOWED** |
| `os.open` + `os.write` outside temp | **ALLOWED** |
| `importlib.reload(subprocess)` then spawn a child | **ALLOWED — child ran** |
| child sees the injected credential | **`child sees GITHUB_TOKEN: ghp_FAKE_TOKEN_FOR_AUDIT_ONLY`** |

The last row is the important one, and it is not a hole to be patched: a child interpreter
never receives the preamble, so it has no write guard and no network block by construction.
Blocking `importlib.reload` would just move the bypass to `ctypes`, `os.posix_spawn`, or a
re-import of `_posixsubprocess`.

So this PR does not pretend to make the sandbox a boundary. It does three things:

1. **Puts a human in front of the risk.** `PythonExecutionTool.requires_approval = True`
   routes chat-surface executions through the approve/deny gate the repo already has
   (`gateway/core/runtime/approvals.py`). That gate is gateway-only, so local CLI and
   investigation turns are unchanged.
2. **Closes the two write-guard gaps** — `io.open` (what `pathlib` resolves) and `os.open`
   — as accident-prevention on its own merits. Reads stay unrestricted; writes inside
   `OPENSRE_TMP_DIR` still work.
3. **Stops claiming containment that does not hold.** The tool description told the model
   "Subprocess spawning is always blocked"; the runner docstring now states these are guard
   rails, not a security boundary, and points callers at the approval gate.

**Two encoding bugs surfaced while testing and are fixed here** (both pre-existing, both in
the lines this PR already touches):

- The script was written with `NamedTemporaryFile(mode="w")` in the locale encoding while
  Python reads `.py` as UTF-8 — any non-ASCII character in generated code died with
  `SyntaxError: Non-UTF-8 code ...` under cp1252.
- The child's stdout was decoded as UTF-8 while the child encoded in its locale codec, so
  non-ASCII output came back as mojibake (`caf� � na�ve`). Fixed with `PYTHONIOENCODING`.

### Demo/Screenshot for feature changes and bug fixes -

Same probe re-run after the change — the two write bypasses are closed, and the subprocess
escape is unchanged and openly acknowledged rather than papered over:

```
- builtins.open write outside temp     -> BLOCKED: Write access denied outside the OpenSRE temp directory
- pathlib.Path.write_text outside temp -> BLOCKED: Write access denied outside the OpenSRE temp directory
- os.open + os.write outside temp      -> BLOCKED: Write access denied outside the OpenSRE temp directory
- subprocess after importlib.reload    -> ALLOWED after reload: child ran   <-- by design; see #4931
```

Tests added: `TestSandboxWriteGuardCoversEveryOpenPath` (pathlib and `os.open` writes
refused; writes inside `OPENSRE_TMP_DIR` and read-only `os.open` still work),
`TestSandboxSourceEncoding`, and a `requires_approval` assertion pinning the gate.

```
$ uv run python -m pytest tests/sandbox tests/platform/sandbox tests/tools/test_python_execution_tool.py tests/tools/test_python_execution_runtime_inputs.py -q
67 passed, 2 failed

$ uv run python -m pytest tests/tools tests/quality -q
2917 passed, 4 failed

$ python -m ruff check config core gateway integrations platform surfaces tools tests
All checks passed!

$ python -m ruff format --check config core gateway integrations platform surfaces tools tests
3366 files already formatted

$ uv run python -m mypy config core gateway integrations platform surfaces tools
Success: no issues found in 1728 source files
```

Those 4 failures are pre-existing and Windows-only — I confirmed each reproduces on clean
`main` with this branch stashed. Two are `test_subprocess_primitives` (process signalling);
two are `allow_network` socket tests failing with `WinError 10106` because `_sandbox_env`
drops `SystemRoot`, which Winsock needs. That last one is a genuine Windows bug in the same
function, but it is unrelated to this change and I did not want to bundle it into a security
fix — happy to file it separately.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The tempting fix here is to keep patching: block `importlib.reload`, block `os.posix_spawn`,
block `ctypes`. I deliberately did not, because that produces a sandbox that *looks* stronger
while remaining escapable — the worst of both, since the false assurance is what lets an
untrusted-input path stay wired to it. An in-process guard cannot contain the interpreter it
lives in, so I fixed the reachability instead of the symptom.

`requires_approval` was the right lever because it already exists and is transport-neutral:
Slack, Discord, and Telegram all render it, and it is read only by the gateway, so the local
operator (who *is* the code author) sees no new friction. The alternative — dropping the
`chat` surface — would have removed a feature people use, for a risk a human check addresses.

The write-guard extension is scoped to writes: `_write_allowed` is shared by all three
patched entry points, and `os.open` is only refused when the flags request write access, so
read-only `os.open` keeps working (covered by a test, since silently breaking reads would be
a regression in a tool whose main job is filesystem introspection).

The encoding fixes are included because I hit them while testing this change and both live in
lines this PR already modifies; separating them would have meant shipping a sandbox whose own
test for non-ASCII output fails.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
