### PR TITLE
refactor(pagerduty): name the default timeout constant in seconds

### DIFF
--- a/integrations/pagerduty/client.py
+++ b/integrations/pagerduty/client.py
@@ -17,7 +17,7 @@ from platform.observability.errors.service import capture_service_error
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_TIMEOUT = 30
+_DEFAULT_TIMEOUT_SECONDS = 30
 PagerDutyConfig = PagerDutyIntegrationConfig
 
 
@@ -33,7 +33,7 @@ class PagerDutyClient:
             self._client = httpx.Client(
                 base_url=self.config.base_url,
                 headers=self.config.headers,
-                timeout=_DEFAULT_TIMEOUT,
+                timeout=_DEFAULT_TIMEOUT_SECONDS,
             )
         return self._client
 


### PR DESCRIPTION
Closes #4904

`_DEFAULT_TIMEOUT = 30` carried no unit, so you had to look at the `httpx.Client(...)` call to know it was seconds. Renamed to `_DEFAULT_TIMEOUT_SECONDS`, which is what `integrations/honeycomb`, `integrations/splunk` and `integrations/coralogix` already use.

Value stays `30`, both in-file references updated, no public API or behaviour change. One file only.

Tests: `pytest tests/integrations/pagerduty tests/integrations/test_pagerduty.py` passes (49 passed).