### PR TITLE
refactor(jira): name the default timeout constant in seconds

### DIFF
--- a/integrations/jira/client.py
+++ b/integrations/jira/client.py
@@ -12,7 +12,7 @@ from platform.observability.errors.service import capture_service_error
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_TIMEOUT = 30
+_DEFAULT_TIMEOUT_SECONDS = 30
 
 
 class JiraClient:
@@ -29,7 +29,7 @@ class JiraClient:
         return httpx.Client(
             auth=(self.config.email, self.config.api_token),
             headers={"Content-Type": "application/json", "Accept": "application/json"},
-            timeout=_DEFAULT_TIMEOUT,
+            timeout=_DEFAULT_TIMEOUT_SECONDS,
         )
 
     def create_issue(


### PR DESCRIPTION
Closes #4905

`_DEFAULT_TIMEOUT = 30` carried no unit, so you had to look at the `httpx.Client(...)` call to know it was seconds. Renamed to `_DEFAULT_TIMEOUT_SECONDS`, which is what `integrations/honeycomb`, `integrations/splunk` and `integrations/coralogix` already use.

Value stays `30`, both in-file references updated, no public API or behaviour change. One file only.

Tests: `pytest tests/integrations/test_jira_client.py tests/integrations/test_jira_search_and_factory.py` passes (16 passed).