### PR TITLE
fix(argocd): log swallowed exception in client factory soft-fail path

### DIFF
--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -543,5 +543,6 @@ def make_argocd_client(
                 verify_ssl=_normalize_verify_ssl(verify_ssl),
             )
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to create Argo CD client: %s", exc, exc_info=True)
         return None

--- a/tests/integrations/argocd/test_client.py
+++ b/tests/integrations/argocd/test_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -672,3 +673,25 @@ def test_verify_ssl_false_is_passed_to_http_client(monkeypatch: pytest.MonkeyPat
 
     assert client._get_client() is not None
     assert captured["verify"] is False
+
+
+def _raise_runtime_error(**_kwargs: Any) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Force config construction inside the factory to raise, exercising the
+    # soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.argocd.client.ArgoCDConfig", _raise_runtime_error)
+
+    with caplog.at_level(logging.WARNING, logger="integrations.argocd.client"):
+        result = make_argocd_client("https://argocd.example.com", bearer_token="tok_test")
+
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    )


### PR DESCRIPTION
Closes #4902

`make_argocd_client` caught every construction `Exception` and returned `None` with no log, so a misconfigured Argo CD integration silently failed to build and left nothing to debug from.

Same fix as the PagerDuty one in #4730: log at WARNING with `exc_info=True` and keep the soft-fail `None` return exactly as it was. No return type or behaviour change.

Test follows the same characterization pattern as `test_make_client_logs_soft_fail_on_construction_error` in the PagerDuty suite: patch `ArgoCDConfig` to raise, assert the factory still returns `None` and that a WARNING with exception context was logged. Confirmed it fails without the client change.

Tests: `pytest tests/integrations/argocd` passes (24 passed).