### PR TITLE
fix(jira): log swallowed exception in client factory soft-fail path

### DIFF
--- a/integrations/jira/client.py
+++ b/integrations/jira/client.py
@@ -297,5 +297,6 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to create Jira client: %s", exc, exc_info=True)
         return None

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -123,3 +124,25 @@ def test_make_jira_client_returns_none_missing_token() -> None:
 
 def test_make_jira_client_returns_none_all_none() -> None:
     assert make_jira_client(None, None, None) is None
+
+
+def _raise_runtime_error(**_kwargs: object) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_jira_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Force config construction inside the factory to raise, exercising the
+    # soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.jira.client.JiraIntegrationConfig", _raise_runtime_error)
+
+    with caplog.at_level(logging.WARNING, logger="integrations.jira.client"):
+        result = make_jira_client("https://x.atlassian.net", "user@example.com", "token")
+
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    )


### PR DESCRIPTION
Closes #4903

`make_jira_client` caught every construction `Exception` and returned `None` with no log, so a misconfigured Jira integration silently failed to build and left nothing to debug from.

Same fix as the PagerDuty one in #4730: log at WARNING with `exc_info=True` and keep the soft-fail `None` return exactly as it was. No return type or behaviour change.

Test follows the same characterization pattern as the PagerDuty suite: patch `JiraIntegrationConfig` to raise, assert the factory still returns `None` and that a WARNING with exception context was logged. Confirmed it fails without the client change.

Tests: `pytest tests/integrations/test_jira_search_and_factory.py tests/integrations/test_jira_client.py` passes (17 passed).