### PR TITLE
fix(sandbox): forward SystemRoot so allow_network works on Windows (#4937)

### DIFF
--- a/platform/sandbox/runner.py
+++ b/platform/sandbox/runner.py
@@ -25,6 +25,11 @@ _BASE_ENV_KEYS = (
     "PYTHONPATH",
     "REQUESTS_CA_BUNDLE",
     "SSL_CERT_FILE",
+    # Windows loads the Winsock service provider relative to SystemRoot. Drop
+    # it and every socket call fails with WinError 10106 before any sandbox
+    # rule applies, so ``allow_network=True`` cannot work. Absent on POSIX,
+    # where the lookup below simply skips it.
+    "SystemRoot",
     "TMPDIR",
 )
 

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -9,6 +9,7 @@ from config.constants import OPENSRE_TMP_DIR, ensure_opensre_tmp_dir
 from platform.sandbox.runner import (
     MAX_TIMEOUT,
     SandboxResult,
+    _sandbox_env,
     run_python_sandbox,
 )
 
@@ -179,3 +180,22 @@ class TestSandboxResultModel:
             timed_out=True,
         )
         assert r.success is False
+
+
+class TestSandboxEnvironment:
+    def test_system_root_is_forwarded_for_winsock(self, monkeypatch) -> None:
+        """Windows resolves the Winsock provider relative to ``SystemRoot``.
+
+        Dropping it made every socket call in the child fail with
+        ``WinError 10106`` before any sandbox rule applied, so
+        ``allow_network=True`` could never work there. Set explicitly rather
+        than probing the host so the contract is pinned on every platform.
+        """
+        monkeypatch.setenv("SystemRoot", r"C:\WINDOWS")
+        assert _sandbox_env(None).get("SystemRoot") == r"C:\WINDOWS"
+
+    def test_unlisted_variables_are_not_forwarded(self, monkeypatch) -> None:
+        # The narrow allowlist is the point: secrets in the parent environment
+        # must not reach generated code just because they are set.
+        monkeypatch.setenv("SOME_PRIVATE_API_KEY", "secret-value")
+        assert "SOME_PRIVATE_API_KEY" not in _sandbox_env(None)


### PR DESCRIPTION
Fixes #4937

#### Describe the changes you have made in this PR -

`_sandbox_env` builds a narrow environment for the sandbox subprocess from `_BASE_ENV_KEYS`,
and that allowlist had no `SystemRoot`. Windows resolves the Winsock service provider
relative to it, so every socket call in the sandboxed child failed with `WinError 10106`
before any sandbox rule was reached — `allow_network=True` could not work on Windows at all.

One line: `SystemRoot` added to `_BASE_ENV_KEYS`. It does not exist on POSIX, where the
existing `os.environ.get(key)` lookup skips it, so no platform branch is needed.

**Why it went unnoticed.** In the default path (`allow_network=False`) the preamble replaces
`socket.socket` with a stub that raises `PermissionError`, so real Winsock initialization
never happens and the network-*block* tests pass for an unrelated reason. Only the two
`allow_network=True` tests reach real sockets, and they were failing on Windows — correctly
reporting a broken feature, not a hostile test environment.

### Demo/Screenshot for feature changes and bug fixes -

Root cause isolated to the single variable, with no OpenSRE code involved:

```python
import os, subprocess, sys
code = "import socket; s=socket.socket(); print('socket OK'); s.close()"
for label, env in (
    ("without SystemRoot", {"PATH": os.environ["PATH"]}),
    ("with SystemRoot", {"PATH": os.environ["PATH"], "SystemRoot": os.environ["SystemRoot"]}),
):
    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
    print(label, "->", (r.stdout or r.stderr).strip().splitlines()[-1])
```

```
without SystemRoot -> OSError: [WinError 10106] The requested service provider could not be loaded or initialized
with SystemRoot    -> socket OK
```

Before this change, on Windows:

```
FAILED tests/tools/test_python_execution_tool.py::TestPythonExecutionToolRestrictions::test_network_access_can_be_enabled
FAILED tests/tools/test_python_execution_runtime_inputs.py::test_socket_reachability_check_works_with_allow_network
2 failed
```

After:

```
$ uv run python -m pytest tests/sandbox tests/platform/sandbox tests/tools/test_python_execution_tool.py tests/tools/test_python_execution_runtime_inputs.py -q
63 passed in 13.22s

$ uv run python -m pytest tests/sandbox -q
25 passed in 5.70s

$ python -m ruff check config core gateway integrations platform surfaces tools tests
All checks passed!

$ uv run python -m mypy platform
Success: no issues found in 131 source files
```

Two tests added: one pinning that `SystemRoot` is forwarded (set explicitly via monkeypatch
so the contract holds on every platform, not just Windows CI), and one pinning that an
unlisted variable is still **not** forwarded — the narrow allowlist is the security property
here, and widening it by accident is the risk this change should not introduce.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I found this while auditing the sandbox for #4931 and deliberately kept it out of that PR —
it is a platform bug, not a security fix, and bundling them would have made both harder to
review.

The temptation with a Windows-only failure is to mark the tests skipped. That would have been
wrong: the tests were accurate, and skipping them would have hidden a feature that does not
work on a supported platform. So I isolated the cause down to a bare `subprocess.run` with a
two-key environment before touching anything, which is what let the fix be one line instead of
guesswork.

The second test matters more than it looks. `_BASE_ENV_KEYS` is a security control — it is what
keeps parent-process secrets out of generated code — so a change that adds a key to it should
come with a test that the allowlist is still an allowlist. Without that, the next person to hit
a missing-variable error has no signal that widening it is a trade-off rather than a fix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
