### PR TITLE
test(github): add fixture tests for get_github_star_history

### DIFF
--- a/tests/integrations/github/test_stargazers.py
+++ b/tests/integrations/github/test_stargazers.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
+from http import HTTPStatus
 
 from integrations.github.tools.stargazers import (
     _normalize_days,
@@ -57,13 +58,13 @@ def test_parse_github_timestamp_invalid() -> None:
 
 # ── fixture helpers ───────────────────────────────────────────────────────────
 
-def _make_star_item(days_ago: int) -> dict:
+def _make_star_item(days_ago: int) -> dict[str, str]:
     # Build a starred_at timestamp N days before now
     ts = datetime.now(UTC) - timedelta(days=days_ago)
     return {"starred_at": ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
 
 
-def _repo_payload(stars: int = 5) -> dict:
+def _repo_payload(stars: int = 5) -> dict[str, int | str]:
     return {"stargazers_count": stars, "full_name": "opensre/opensre"}
 
 
@@ -108,7 +109,6 @@ def test_missing_starred_at_returns_unavailable() -> None:
         result = get_github_star_history(owner="opensre", repo="opensre", days=7)
 
     assert result["available"] is False
-    assert result["available"] is False
     assert "timestamps" in result.get("error", "").lower()
 
 
@@ -116,7 +116,7 @@ def test_repo_fetch_error_returns_unavailable() -> None:
     from integrations.github.client import GitHubApiError
 
     def fake_request(method, path, params=None, accept=None):
-        raise GitHubApiError("Not found", status_code=404)
+        raise GitHubApiError("Not found", status_code=HTTPStatus.NOT_FOUND)
 
     with patch(
         "integrations.github.tools.stargazers.GitHubRestClient.request",
@@ -138,7 +138,7 @@ def test_stargazers_fetch_error_returns_unavailable() -> None:
         call_count += 1
         if call_count == 1:
             return _repo_payload(stars=3)
-        raise GitHubApiError("Forbidden", status_code=403)
+        raise GitHubApiError("Forbidden", status_code=HTTPStatus.FORBIDDEN)
 
     with patch(
         "integrations.github.tools.stargazers.GitHubRestClient.request",

--- a/tests/integrations/github/test_stargazers.py
+++ b/tests/integrations/github/test_stargazers.py
@@ -1,0 +1,180 @@
+"""Fixture tests for integrations/github/tools/stargazers.py.
+
+Uses monkeypatch to mock GitHubRestClient.request — no live GitHub API calls.
+Covers: happy path, missing starred_at timestamps, API error on repo fetch,
+API error on stargazers fetch, unexpected payload types.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from integrations.github.tools.stargazers import (
+    _normalize_days,
+    _parse_github_timestamp,
+    get_github_star_history,
+)
+
+
+# ── unit tests for pure helpers ───────────────────────────────────────────────
+
+def test_normalize_days_default() -> None:
+    assert _normalize_days(None) == 30
+
+
+def test_normalize_days_clamps_low() -> None:
+    assert _normalize_days(0) == 1
+
+
+def test_normalize_days_clamps_high() -> None:
+    assert _normalize_days(999) == 365
+
+
+def test_normalize_days_passthrough() -> None:
+    assert _normalize_days(7) == 7
+
+
+def test_parse_github_timestamp_valid() -> None:
+    result = _parse_github_timestamp("2024-06-01T12:00:00Z")
+    assert result is not None
+    assert result.tzinfo is not None
+
+
+def test_parse_github_timestamp_empty_string() -> None:
+    assert _parse_github_timestamp("") is None
+
+
+def test_parse_github_timestamp_none() -> None:
+    assert _parse_github_timestamp(None) is None
+
+
+def test_parse_github_timestamp_invalid() -> None:
+    assert _parse_github_timestamp("not-a-date") is None
+
+
+# ── fixture helpers ───────────────────────────────────────────────────────────
+
+def _make_star_item(days_ago: int) -> dict:
+    # Build a starred_at timestamp N days before now
+    ts = datetime.now(UTC) - timedelta(days=days_ago)
+    return {"starred_at": ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
+
+
+def _repo_payload(stars: int = 5) -> dict:
+    return {"stargazers_count": stars, "full_name": "opensre/opensre"}
+
+
+# ── integration-level fixture tests ──────────────────────────────────────────
+
+def test_happy_path_returns_daily_rows() -> None:
+    # Repo has 2 stars both within the last 7 days
+    star_items = [_make_star_item(1), _make_star_item(3)]
+
+    def fake_request(method, path, params=None, accept=None):
+        if "stargazers" in path:
+            return star_items
+        return _repo_payload(stars=2)
+
+    with patch(
+        "integrations.github.tools.stargazers.GitHubRestClient.request",
+        side_effect=fake_request,
+    ):
+        result = get_github_star_history(owner="opensre", repo="opensre", days=7)
+
+    assert result["available"] is True
+    assert result["stargazers_count"] == 2
+    assert result["stars_in_window"] == 2
+    assert len(result["daily"]) == 7
+    assert result["owner"] == "opensre"
+    assert result["repo"] == "opensre"
+
+
+def test_missing_starred_at_returns_unavailable() -> None:
+    # Stargazer items exist but have no starred_at field
+    star_items = [{"user": "someone"}]
+
+    def fake_request(method, path, params=None, accept=None):
+        if "stargazers" in path:
+            return star_items
+        return _repo_payload(stars=1)
+
+    with patch(
+        "integrations.github.tools.stargazers.GitHubRestClient.request",
+        side_effect=fake_request,
+    ):
+        result = get_github_star_history(owner="opensre", repo="opensre", days=7)
+
+    assert result["available"] is False
+    assert result["available"] is False
+    assert "timestamps" in result.get("error", "").lower()
+
+
+def test_repo_fetch_error_returns_unavailable() -> None:
+    from integrations.github.client import GitHubApiError
+
+    def fake_request(method, path, params=None, accept=None):
+        raise GitHubApiError("Not found", status_code=404)
+
+    with patch(
+        "integrations.github.tools.stargazers.GitHubRestClient.request",
+        side_effect=fake_request,
+    ):
+        result = get_github_star_history(owner="bad", repo="repo", days=7)
+
+    assert result["available"] is False
+    assert result["daily"] == []
+
+
+def test_stargazers_fetch_error_returns_unavailable() -> None:
+    from integrations.github.client import GitHubApiError
+
+    call_count = 0
+
+    def fake_request(method, path, params=None, accept=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _repo_payload(stars=3)
+        raise GitHubApiError("Forbidden", status_code=403)
+
+    with patch(
+        "integrations.github.tools.stargazers.GitHubRestClient.request",
+        side_effect=fake_request,
+    ):
+        result = get_github_star_history(owner="opensre", repo="opensre", days=7)
+
+    assert result["available"] is False
+    assert result["stargazers_count"] == 3
+
+
+def test_zero_stars_returns_empty_daily_rows() -> None:
+    def fake_request(method, path, params=None, accept=None):
+        if "stargazers" in path:
+            return []
+        return _repo_payload(stars=0)
+
+    with patch(
+        "integrations.github.tools.stargazers.GitHubRestClient.request",
+        side_effect=fake_request,
+    ):
+        result = get_github_star_history(owner="opensre", repo="opensre", days=7)
+
+    assert result["available"] is True
+    assert result["stars_in_window"] == 0
+    assert all(row["stars"] == 0 for row in result["daily"])
+
+
+def test_unexpected_repo_payload_returns_unavailable() -> None:
+    def fake_request(method, path, params=None, accept=None):
+        return "not a dict"
+
+    with patch(
+        "integrations.github.tools.stargazers.GitHubRestClient.request",
+        side_effect=fake_request,
+    ):
+        result = get_github_star_history(owner="opensre", repo="opensre", days=7)
+
+    assert result["available"] is False

--- a/tests/integrations/github/test_stargazers.py
+++ b/tests/integrations/github/test_stargazers.py
@@ -8,10 +8,8 @@ API error on stargazers fetch, unexpected payload types.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
-
-import pytest
 from http import HTTPStatus
+from unittest.mock import patch
 
 from integrations.github.tools.stargazers import (
     _normalize_days,
@@ -19,8 +17,8 @@ from integrations.github.tools.stargazers import (
     get_github_star_history,
 )
 
-
 # ── unit tests for pure helpers ───────────────────────────────────────────────
+
 
 def test_normalize_days_default() -> None:
     assert _normalize_days(None) == 30
@@ -58,6 +56,7 @@ def test_parse_github_timestamp_invalid() -> None:
 
 # ── fixture helpers ───────────────────────────────────────────────────────────
 
+
 def _make_star_item(days_ago: int) -> dict[str, str]:
     # Build a starred_at timestamp N days before now
     ts = datetime.now(UTC) - timedelta(days=days_ago)
@@ -70,11 +69,14 @@ def _repo_payload(stars: int = 5) -> dict[str, int | str]:
 
 # ── integration-level fixture tests ──────────────────────────────────────────
 
+
 def test_happy_path_returns_daily_rows() -> None:
     # Repo has 2 stars both within the last 7 days
     star_items = [_make_star_item(1), _make_star_item(3)]
 
-    def fake_request(method, path, params=None, accept=None):
+    def fake_request(
+        method: str, path: str, params: dict | None = None, accept: str | None = None
+    ) -> object:
         if "stargazers" in path:
             return star_items
         return _repo_payload(stars=2)
@@ -97,7 +99,9 @@ def test_missing_starred_at_returns_unavailable() -> None:
     # Stargazer items exist but have no starred_at field
     star_items = [{"user": "someone"}]
 
-    def fake_request(method, path, params=None, accept=None):
+    def fake_request(
+        method: str, path: str, params: dict | None = None, accept: str | None = None
+    ) -> object:
         if "stargazers" in path:
             return star_items
         return _repo_payload(stars=1)
@@ -115,7 +119,9 @@ def test_missing_starred_at_returns_unavailable() -> None:
 def test_repo_fetch_error_returns_unavailable() -> None:
     from integrations.github.client import GitHubApiError
 
-    def fake_request(method, path, params=None, accept=None):
+    def fake_request(
+        method: str, path: str, params: dict | None = None, accept: str | None = None
+    ) -> object:
         raise GitHubApiError("Not found", status_code=HTTPStatus.NOT_FOUND)
 
     with patch(
@@ -133,7 +139,9 @@ def test_stargazers_fetch_error_returns_unavailable() -> None:
 
     call_count = 0
 
-    def fake_request(method, path, params=None, accept=None):
+    def fake_request(
+        method: str, path: str, params: dict | None = None, accept: str | None = None
+    ) -> object:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -151,7 +159,9 @@ def test_stargazers_fetch_error_returns_unavailable() -> None:
 
 
 def test_zero_stars_returns_empty_daily_rows() -> None:
-    def fake_request(method, path, params=None, accept=None):
+    def fake_request(
+        method: str, path: str, params: dict | None = None, accept: str | None = None
+    ) -> object:
         if "stargazers" in path:
             return []
         return _repo_payload(stars=0)
@@ -168,7 +178,9 @@ def test_zero_stars_returns_empty_daily_rows() -> None:
 
 
 def test_unexpected_repo_payload_returns_unavailable() -> None:
-    def fake_request(method, path, params=None, accept=None):
+    def fake_request(
+        method: str, path: str, params: dict | None = None, accept: str | None = None
+    ) -> object:
         return "not a dict"
 
     with patch(


### PR DESCRIPTION
Closes #4892

## Summary

Adds fixture tests for `integrations/github/tools/stargazers.py` in `tests/integrations/github/test_stargazers.py`.

## Tests added

**Pure helper unit tests:**
- `test_normalize_days_default` - returns 30 when None
- `test_normalize_days_clamps_low` - clamps to 1 minimum
- `test_normalize_days_clamps_high` - clamps to 365 maximum
- `test_normalize_days_passthrough` - returns value unchanged when in range
- `test_parse_github_timestamp_valid` - parses valid ISO timestamp
- `test_parse_github_timestamp_empty_string` - returns None for empty string
- `test_parse_github_timestamp_none` - returns None for None input
- `test_parse_github_timestamp_invalid` - returns None for non-date string

**Integration fixture tests (no live GitHub API):**
- `test_happy_path_returns_daily_rows` - 2 stars in window, correct daily rows
- `test_missing_starred_at_returns_unavailable` - items without starred_at field
- `test_repo_fetch_error_returns_unavailable` - GitHubApiError on repo fetch
- `test_stargazers_fetch_error_returns_unavailable` - GitHubApiError on stargazers fetch
- `test_zero_stars_returns_empty_daily_rows` - repo with 0 stars
- `test_unexpected_repo_payload_returns_unavailable` - non-dict repo response

All 14 tests pass with `uv run pytest`.