### PR TITLE
fix(telegram): close <pre>/<s> and keep a bare <> literal when truncating HTML

### DIFF
--- a/integrations/telegram/delivery.py
+++ b/integrations/telegram/delivery.py
@@ -17,7 +17,11 @@ logger = logging.getLogger(__name__)
 
 _MESSAGE_LIMIT = MAX_MESSAGE_SIZE
 _BOT_TOKEN_RE = re.compile(r"(bot)[^/]+(/)")
-_SIMPLE_TAG_NAMES = frozenset({"b", "i", "u", "code"})
+# Every Telegram ``parse_mode=HTML`` element that wraps content, so a cut taken
+# while one is open leaves markup the Bot API rejects. Mirrors the supported set
+# documented in ``integrations.telegram.markdown``; ``<pre>`` in particular is
+# what ``render_markdown_as_telegram_html`` emits for fenced code blocks.
+_BALANCED_TAG_NAMES = frozenset({"a", "b", "code", "i", "pre", "s", "u"})
 
 
 def _strip_trailing_incomplete_tag(chunk: str) -> str:
@@ -42,8 +46,21 @@ def _strip_trailing_partial_entity(chunk: str) -> str:
     return chunk[:amp].rstrip()
 
 
+def _parse_tag(raw_tag: str) -> tuple[str, bool]:
+    """Return ``(element_name, is_closing)`` for *raw_tag*, angle brackets included.
+
+    The name is lowercased, and empty when the tag carries none. ``<>`` and
+    ``< >`` occur in ordinary report text (a SQL ``<>`` predicate, say), so they
+    must fall through as plain text rather than being read as an element.
+    """
+    inner = raw_tag[1:-1].strip()
+    is_closing = inner.startswith("/")
+    parts = inner.removeprefix("/").split(maxsplit=1)
+    return (parts[0].lower() if parts else ""), is_closing
+
+
 def _balance_telegram_markup_tags(fragment: str) -> str:
-    """Append closing tags for open ``b``/``i``/``u``/``code``/``a`` elements at end of *fragment*."""
+    """Append closing tags for Telegram elements still open at the end of *fragment*."""
     stack: list[str] = []
     pos = 0
     while pos < len(fragment):
@@ -53,24 +70,15 @@ def _balance_telegram_markup_tags(fragment: str) -> str:
         end = fragment.find(">", pos)
         if end == -1:
             break
-        raw = fragment[pos : end + 1]
-        low = raw.lower()
-        if low.startswith("<a ") and not low.startswith("</"):
-            stack.append("a")
-        elif low == "</a>":
-            if stack and stack[-1] == "a":
-                stack.pop()
-        elif low.startswith("</"):
-            name = low[2:-1].strip().lower()
-            if name in _SIMPLE_TAG_NAMES and stack and stack[-1] == name:
-                stack.pop()
-        elif not low.startswith("<a ") and low[1] != "/":
-            name = low[1:-1].strip().lower().split()[0]
-            if name in _SIMPLE_TAG_NAMES:
+        name, is_closing = _parse_tag(fragment[pos : end + 1])
+        if name in _BALANCED_TAG_NAMES:
+            if not is_closing:
                 stack.append(name)
+            elif stack and stack[-1] == name:
+                stack.pop()
         pos = end + 1
 
-    return fragment + "".join(f"</{t}>" for t in reversed(stack))
+    return fragment + "".join(f"</{tag}>" for tag in reversed(stack))
 
 
 def truncate_for_telegram_html(text: str, max_len: int, suffix: str = "…") -> str:

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -336,6 +336,38 @@ def test_truncate_for_telegram_html_balances_open_tags_within_limit() -> None:
     assert out.count("<b>") == out.count("</b>")
 
 
+def test_truncate_for_telegram_html_closes_open_pre_block() -> None:
+    # Fenced code blocks render as <pre>, so an evidence dump that straddles the
+    # limit gets cut with <pre> still open and the Bot API rejects the message.
+    src = "<pre>" + ("pool exhausted acquire timeout 30s\n" * 200) + "</pre>"
+    out = truncate_for_telegram_html(src, 4096, suffix="…")
+    assert len(out) <= 4096
+    assert out.count("<pre>") == out.count("</pre>") == 1
+
+
+def test_truncate_for_telegram_html_closes_open_strikethrough() -> None:
+    src = "<s>" + ("superseded " * 500) + "</s>"
+    out = truncate_for_telegram_html(src, 512, suffix="…")
+    assert len(out) <= 512
+    assert out.count("<s>") == out.count("</s>") == 1
+
+
+def test_truncate_for_telegram_html_keeps_bare_angle_pair_as_text() -> None:
+    # "<>" carries no element name: a SQL inequality predicate, not markup.
+    src = "<b>slow query</b> SELECT id FROM jobs WHERE state <> 'done'; " * 100
+    out = truncate_for_telegram_html(src, 4096, suffix="…")
+    assert len(out) <= 4096
+    assert "<>" in out
+    assert out.count("<b>") == out.count("</b>")
+
+
+def test_truncate_for_telegram_html_ignores_whitespace_only_tag() -> None:
+    src = "< > spaced angle pair " * 400
+    out = truncate_for_telegram_html(src, 256, suffix="…")
+    assert len(out) <= 256
+    assert out.endswith("…")
+
+
 def test_truncate_for_telegram_html_noop_when_under_limit() -> None:
     s = "<i>ok</i>"
     assert truncate_for_telegram_html(s, 50) == s


### PR DESCRIPTION
Fixes #4946

#### Describe the changes you have made in this PR -

`truncate_for_telegram_html` exists so a report over Telegram's 4096 character limit gets cut without leaving broken markup behind. Its tag balancer only tracked `b`, `i`, `u` and `code`, and that misses two things.

**Unclosed `<pre>` and `<s>`.** Both are in the tag set Telegram accepts, and `render_markdown_as_telegram_html` emits `<pre>` for every fenced code block (pinned by `test_fenced_code_block_becomes_pre`). Investigation reports put their log and evidence dumps in fenced blocks, and those sit at the end of the report, which is exactly where the cut falls. When the cut lands inside the block, the message goes out with `<pre>` still open and the Bot API rejects the markup. The gateway path hides this because `_edit_final` retries as plain text, so the answer still arrives but with every bit of formatting stripped. `send_telegram_report` and the scheduler's `_deliver_telegram` have no such fallback, so there the message is just lost.

**`IndexError` on a bare `<>`.** The balancer treated anything between `<` and `>` as an element and ran `low[1:-1].strip().lower().split()[0]` on it. For `<>` that split is empty and the index raises. `<>` is not an odd thing to find here, it is the SQL inequality operator, so a report quoting something like `WHERE state <> 'done'` is enough. It only surfaces once the report is over the limit, since that is the only time the balancer runs, which is why it has gone unnoticed.

Both problems are the same scanner being wrong, so I fixed the scanner rather than patching the two symptoms. `_parse_tag` reads a raw tag into `(name, is_closing)` once, and `_balance_telegram_markup_tags` pushes and pops that name against the full set of content-wrapping Telegram elements. A tag carrying no name is not an element, so `<>` and `< >` now fall through as ordinary text. Dropping the `<a ` special case and the `low[1] != "/"` guard leaves the loop shorter than it was before.

Nothing outside this module imports the balancer or the tag constant, so the blast radius is one file.

### Demo/Screenshot for feature changes and bug fixes -

Rendering a report whose evidence block straddles the limit, then truncating it. Before:

```
rendered report: 7120 chars, limit is 4096
after truncation: <pre>=1  </pre>=0
last 55 chars:   ...
ERROR pool exhausted waiting for connection acquire t…

report with a SQL '<>' predicate: 6100 chars
Traceback (most recent call last):
  File "<stdin>", line 28, in <module>
  File "integrations/telegram/delivery.py", line 87, in truncate_for_telegram_html
    chunk = _balance_telegram_markup_tags(chunk)
  File "integrations/telegram/delivery.py", line 68, in _balance_telegram_markup_tags
    name = low[1:-1].strip().lower().split()[0]
IndexError: list index out of range
```

After:

```
rendered report: 7120 chars, limit is 4096
after truncation: <pre>=1  </pre>=1
last 55 chars:   ...
ERROR pool exhausted waiting for connection acq</pre>…

report with a SQL '<>' predicate: 6100 chars
after truncation: ok
```

The four new tests fail on `main` and pass here:

```
$ git stash push -- integrations/telegram/delivery.py
$ uv run pytest tests/utils/test_telegram_delivery.py -q -k "pre_block or strikethrough or angle_pair or whitespace_only_tag"
FAILED tests/utils/test_telegram_delivery.py::test_truncate_for_telegram_html_closes_open_pre_block
FAILED tests/utils/test_telegram_delivery.py::test_truncate_for_telegram_html_closes_open_strikethrough
FAILED tests/utils/test_telegram_delivery.py::test_truncate_for_telegram_html_keeps_bare_angle_pair_as_text
FAILED tests/utils/test_telegram_delivery.py::test_truncate_for_telegram_html_ignores_whitespace_only_tag
4 failed, 25 deselected
```

Local checks:

```
$ uv run ruff check integrations/telegram/delivery.py tests/utils/test_telegram_delivery.py
All checks passed!
$ uv run ruff format --check integrations/telegram/delivery.py tests/utils/test_telegram_delivery.py
2 files already formatted
$ uv run mypy integrations/telegram/delivery.py
Success: no issues found in 1 source file
$ uv run pytest tests/utils/test_telegram_delivery.py tests/integrations/telegram tests/tools/test_telegram_send_message_tool.py tests/scheduler -q
221 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is that truncation is allowed to cut a report at an arbitrary offset, so whatever markup was open at that offset has to be closed again before the text goes to the Bot API. The existing balancer did that, but against a tag set that did not match what the renderer actually produces.

The alternative I considered was leaving the scanner as it was and just adding `pre` and `s` to `_SIMPLE_TAG_NAMES`. That fixes the unclosed block but not the crash, and the branch structure was already awkward: `<a>` was special-cased into its own two branches, and the last branch re-tested `not low.startswith("<a ")` even though the first branch had already excluded it. Adding two more names to that would have made it harder to read, not easier. Splitting the name out into `_parse_tag` collapses all four branches into one push/pop and fixes both bugs at once, so that is the way I went.

The two functions:

- `_parse_tag(raw_tag)` takes a raw tag including its angle brackets and returns the lowercased element name plus whether it is a closing tag. It strips the interior first, checks for the leading `/`, then splits on whitespace and takes the first token. `split(maxsplit=1)` on an empty string returns an empty list rather than raising, so the empty-name case is handled by returning `""`, which is what makes `<>` safe. The name is what gets matched, so `<a href="...">` reduces to `a` and the attributes are ignored.
- `_balance_telegram_markup_tags(fragment)` walks the fragment, and for any tag whose name is in `_BALANCED_TAG_NAMES` either pushes it or pops it when it matches the top of the stack. Whatever is left on the stack at the end gets closed in reverse order.

Edge cases I checked: `<>` and `< >` (no name, ignored, kept as text), `<br/>` and other non-Telegram tags (name is not in the set, ignored, same as before), `<a href="...">` with attributes, a trailing `<` with no `>` (still handled by `_strip_trailing_incomplete_tag` before the balancer sees it), nested `<pre><code>`, and a closing tag that does not match the top of the stack. That last one keeps the original behaviour of not popping, which is the conservative choice given the input is already malformed at that point.

One thing worth noting on the pop rule: I kept `stack[-1] == name` rather than searching the stack, because the renderer emits well-nested output and a looser rule would paper over genuinely broken markup instead of surfacing it.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
