### PR TITLE
fix(registry): load investigation tools correctly in PyInstaller frozen binary

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import sys
 import threading
 from functools import lru_cache
 from types import ModuleType
@@ -124,7 +125,17 @@ def _load_surface_snapshot(surface: str) -> tuple[RegisteredTool, ...]:
     surfaces' vendor executors. Runtime-registered external packages are already
     imported, so they are collected directly. Equivalent to the full snapshot
     filtered by ``surface`` (pinned by the registry-index contract test).
+
+    In a PyInstaller frozen binary the AST scanner cannot locate ``.py`` source
+    files (they are compiled to bytecode and not extracted), so
+    ``build_descriptor_index`` returns only the hand-written fallback entries and
+    Grafana / other integration tools are never discovered.  Fall back to the
+    full dynamic snapshot — which imports via ``importlib`` and works correctly
+    with the bundled bytecode — and filter by surface there.
     """
+    if getattr(sys, "frozen", False):
+        return tuple(t for t in _load_registry_snapshot() if surface in t.surfaces)
+
     from tools.registry_index import build_descriptor_index
 
     index = build_descriptor_index()


### PR DESCRIPTION
Fixes #4873

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Detect the PyInstaller frozen binary context in `_load_surface_snapshot` (`tools/registry.py`) and fall back to the full dynamic registry when running inside a frozen binary.

In a PyInstaller binary, `_load_surface_snapshot` uses an AST-based descriptor index that works by scanning `*.py` source files under `REPO_ROOT`. PyInstaller compiles sources to bytecode and does not extract `.py` files, so `rglob("*.py")` returns nothing. The index falls back to only the hand-written fallback entries (chat transports), and all integration tools — Grafana, Datadog, Kubernetes, etc. — are never loaded. Result: `opensre investigate` produces zero evidence and 10% confidence for every binary user.

The fix: detect `sys.frozen` (set by PyInstaller on every binary it produces) and skip the AST scan. Fall back to `_load_registry_snapshot()` which uses `importlib` to import modules from the bundled compiled bytecode — the path that works correctly in a frozen context.

```python
if getattr(sys, "frozen", False):
    return tuple(t for t in _load_registry_snapshot() if surface in t.surfaces)
```

This restores full investigation tool availability for users who install via `curl -fsSL https://install.opensre.com | bash`.

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->

**Before (binary install):**
```
Loading integrations  grafana  0ms
No tools available for investigation
Investigation  evidence:0 messages:2
Diagnosing  confidence 10%
Cannot be determined from available evidence
```

**After (binary install with fix):**
```
Loading integrations  grafana  18ms
↳  Grafana · Loki  2.1s
↳  Grafana · Mimir  2.1s
↳  Grafana · alerts  2.1s
↳  Grafana · annotations  2.1s
Investigation  evidence:8 messages:9
Diagnosing  confidence 62%
[concrete root cause with remediation steps]
```

Confirmed independently by @Davidson3556 in the issue:
> `REPO_ROOT` resolves to `_MEIPASS` and there are no `.py` files in there, so the AST scan comes back empty and the index falls back to the pinned descriptors. Investigation tools go from 254 to 11, all of them chat transports.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is that `_load_surface_snapshot` relies on the AST-based `build_descriptor_index` to find which modules to import for a given surface. This index scans `.py` source files at `REPO_ROOT`. In a frozen PyInstaller binary, `REPO_ROOT` resolves to `sys._MEIPASS` (the temp extraction directory), and PyInstaller only places compiled `.pyc` bytecode there — no `.py` source files. So the scan returns nothing, the index has only the 11 hand-written fallback entries (all chat transports), and investigation tools are never loaded.

The fix uses `getattr(sys, "frozen", False)` to detect the frozen context — PyInstaller documents this as the canonical detection method. When frozen, we skip the AST scan entirely and fall back to `_load_registry_snapshot()`, which iterates `INTEGRATION_TOOL_PACKAGES` and imports each via `importlib.import_module`. This works because `--collect-submodules integrations` in the build bundles all integration bytecode, making them importable at runtime. The result is then filtered by the requested surface — identical semantics to the normal path, just reached via dynamic import instead of AST scan.

Alternative considered: bundle `.py` source files alongside the bytecode using `--add-data "integrations:integrations"`. Rejected because it doubles the binary size and the dynamic import path already works correctly.

Note: `make typecheck` reports one pre-existing error in `surfaces/interactive_shell/command_registry/diagnostics_cmds.py` that is unrelated to this change. `mypy tools/registry.py` passes cleanly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.