### PR TITLE
fix(packaging): enforce frozen binary runtime parity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,8 @@ jobs:
           VERSION="${TAG_NAME#v}"
           test -f "dist/opensre-${VERSION}.tar.gz"
           test -f "dist/opensre-${VERSION}-py3-none-any.whl"
+          uv run python platform/packaging/validate_wheel.py \
+            "dist/opensre-${VERSION}-py3-none-any.whl"
 
       - name: Upload Python distributions
         uses: actions/upload-artifact@v4
@@ -314,23 +316,9 @@ jobs:
           uv run python -c "import os, shutil, sysconfig; src = os.path.join(sysconfig.get_path('stdlib'), 'platform.py'); shutil.copy(src, os.path.join('.stdlib_vendor', 'platform.py')); print('Staged stdlib platform from ' + src)"
 
       - name: Build binary
-        run: >-
-          uv run pyinstaller surfaces/cli/__main__.py
-          --name opensre
-          --${{ matrix.pyinstaller_mode }}
-          --clean
-          --noconfirm
-          --collect-data surfaces.cli
-          --collect-data config
-          --copy-metadata opensre
-          --collect-data litellm
-          --hidden-import tiktoken_ext
-          --hidden-import tiktoken_ext.openai_public
-          --collect-submodules integrations
-          --collect-submodules surfaces.interactive_shell
-          --collect-submodules tools
-          --add-data "platform:platform"
-          --add-data ".stdlib_vendor:_opensre_stdlib_platform"
+        env:
+          OPENSRE_PYINSTALLER_MODE: ${{ matrix.pyinstaller_mode }}
+        run: uv run pyinstaller opensre.spec --clean --noconfirm
 
       - name: Align bundled libssl with cryptography (macOS onedir)
         if: runner.os == 'macOS' && matrix.pyinstaller_mode == 'onedir'
@@ -418,6 +406,7 @@ jobs:
               ;;
           esac
           "$BINARY_PATH" -h >/dev/null
+          "$BINARY_PATH" _package-smoke
           LITELLM_DATA="./dist/opensre/_internal/litellm/model_prices_and_context_window_backup.json"
           if [ ! -f "$LITELLM_DATA" ]; then
             echo "LiteLLM package data missing from Unix onedir bundle: ${LITELLM_DATA}" >&2
@@ -455,6 +444,7 @@ jobs:
             throw "Binary version mismatch. Expected '$expectedVersion' but saw '$versionText'."
           }
           & ".\dist\${{ matrix.binary_name }}" -h | Out-Null
+          & ".\dist\${{ matrix.binary_name }}" _package-smoke
 
       - name: Package binary archive (Unix)
         if: runner.os != 'Windows'

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@ build/
 develop-eggs/
 dist/
 .stdlib_vendor/
-# PyInstaller generates this from CLI args during the release build.
-opensre.spec
 downloads/
 eggs/
 .eggs/

--- a/opensre.spec
+++ b/opensre.spec
@@ -1,0 +1,97 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from __future__ import annotations
+
+import os
+import runpy
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+
+
+ROOT = Path(SPECPATH).resolve()
+MODE = os.environ.get("OPENSRE_PYINSTALLER_MODE", "onedir")
+if MODE not in {"onedir", "onefile"}:
+    raise ValueError(f"Unsupported OPENSRE_PYINSTALLER_MODE: {MODE!r}")
+
+manifest = runpy.run_path(str(ROOT / "platform/packaging/release_manifest.py"))
+runtime_hidden_imports = manifest["runtime_hidden_imports"]
+skill_data_entries = manifest["skill_data_entries"]
+
+datas = [
+    (str(ROOT / "platform"), "platform"),
+    (str(ROOT / ".stdlib_vendor"), "_opensre_stdlib_platform"),
+]
+datas += collect_data_files("surfaces.cli")
+datas += collect_data_files("config")
+datas += collect_data_files("litellm")
+datas += copy_metadata("opensre")
+datas += list(skill_data_entries(ROOT))
+
+hiddenimports = [
+    "tiktoken_ext",
+    "tiktoken_ext.openai_public",
+    *runtime_hidden_imports(ROOT),
+]
+
+a = Analysis(
+    [str(ROOT / "surfaces/cli/__main__.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+if MODE == "onefile":
+    exe = EXE(
+        pyz,
+        a.scripts,
+        a.binaries,
+        a.datas,
+        [],
+        name="opensre",
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        console=True,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+    )
+else:
+    exe = EXE(
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        name="opensre",
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        console=True,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+    )
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.datas,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        name="opensre",
+    )

--- a/platform/packaging/release_manifest.py
+++ b/platform/packaging/release_manifest.py
@@ -11,6 +11,7 @@ _RUNTIME_PACKAGE_NAMES = (
 )
 _ACTION_SKILLS_DIR = Path("core/agent_harness/prompts/skills")
 _SKILL_DATA_ROOTS = (Path("integrations"), Path("tools"))
+_RUNTIME_DISCOVERY_EXCLUSIONS = frozenset({"investigation_registry", "registry.py"})
 
 
 def _module_name(repo_root: Path, source_path: Path) -> str:
@@ -34,7 +35,11 @@ def runtime_hidden_imports(repo_root: Path) -> tuple[str, ...]:
     for package_name in _RUNTIME_PACKAGE_NAMES:
         package_root = repo_root / Path(*package_name.split("."))
         for source_path in package_root.rglob("*.py"):
-            if "__pycache__" in source_path.parts:
+            if (
+                "__pycache__" in source_path.parts
+                or _RUNTIME_DISCOVERY_EXCLUSIONS.intersection(source_path.parts)
+                or source_path.stem.endswith("_test")
+            ):
                 continue
             module_name = _module_name(repo_root, source_path)
             if module_name:

--- a/platform/packaging/release_manifest.py
+++ b/platform/packaging/release_manifest.py
@@ -1,0 +1,61 @@
+"""Deterministic code and skill-data inputs for release artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_RUNTIME_PACKAGE_NAMES = (
+    "integrations",
+    "surfaces.interactive_shell",
+    "tools",
+)
+_ACTION_SKILLS_DIR = Path("core/agent_harness/prompts/skills")
+_SKILL_DATA_ROOTS = (Path("integrations"), Path("tools"))
+
+
+def _module_name(repo_root: Path, source_path: Path) -> str:
+    relative = source_path.relative_to(repo_root).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def runtime_hidden_imports(repo_root: Path) -> tuple[str, ...]:
+    """Return every module under packages discovered dynamically at runtime.
+
+    PyInstaller's ``collect-submodules`` imports packages while enumerating
+    them. That can silently omit OpenSRE packages when the stdlib ``platform``
+    module wins over the first-party package during analysis. Walking source
+    paths avoids executing application imports while producing the same module
+    inventory for PyInstaller's ``hiddenimports`` input.
+    """
+    modules: set[str] = set()
+    for package_name in _RUNTIME_PACKAGE_NAMES:
+        package_root = repo_root / Path(*package_name.split("."))
+        for source_path in package_root.rglob("*.py"):
+            if "__pycache__" in source_path.parts:
+                continue
+            module_name = _module_name(repo_root, source_path)
+            if module_name:
+                modules.add(module_name)
+    return tuple(sorted(modules))
+
+
+def required_skill_files(repo_root: Path) -> tuple[Path, ...]:
+    """Return built-in action skills and tool workflow-guidance data files."""
+    files = set((repo_root / _ACTION_SKILLS_DIR).rglob("*.md"))
+    for relative_root in _SKILL_DATA_ROOTS:
+        files.update((repo_root / relative_root).rglob("SKILL.md"))
+    return tuple(sorted(path for path in files if path.is_file()))
+
+
+def skill_data_entries(repo_root: Path) -> tuple[tuple[str, str], ...]:
+    """Return PyInstaller ``datas`` entries preserving repo-relative paths."""
+    return tuple(
+        (str(path), str(path.parent.relative_to(repo_root)))
+        for path in required_skill_files(repo_root)
+    )
+
+
+__all__ = ["required_skill_files", "runtime_hidden_imports", "skill_data_entries"]

--- a/platform/packaging/validate_wheel.py
+++ b/platform/packaging/validate_wheel.py
@@ -1,0 +1,36 @@
+"""Validate that a built wheel contains essential runtime data files."""
+
+from __future__ import annotations
+
+import argparse
+import runpy
+from pathlib import Path
+from zipfile import ZipFile
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def missing_skill_files(wheel_path: Path, *, repo_root: Path = ROOT) -> tuple[str, ...]:
+    """Return required skill-data paths absent from ``wheel_path``."""
+    manifest = runpy.run_path(str(repo_root / "platform/packaging/release_manifest.py"))
+    required_skill_files = manifest["required_skill_files"]
+    expected = {path.relative_to(repo_root).as_posix() for path in required_skill_files(repo_root)}
+    with ZipFile(wheel_path) as wheel:
+        archived = set(wheel.namelist())
+    return tuple(sorted(expected - archived))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path, help="Wheel artifact to validate")
+    args = parser.parse_args()
+
+    missing = missing_skill_files(args.wheel)
+    if missing:
+        paths = "\n".join(f"- {path}" for path in missing)
+        raise SystemExit(f"Wheel is missing required skill data:\n{paths}")
+    print(f"Validated required skill data in {args.wheel}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,9 @@ include = [
 
 [tool.setuptools.package-data]
 "surfaces.cli" = ["investigation/sample_alerts/*.json"]
-"core.agent_harness.prompts" = ["skills/*.md"]
+"core.agent_harness.prompts" = ["skills/**/*.md"]
+"integrations" = ["**/SKILL.md"]
+"tools" = ["**/SKILL.md"]
 
 # With pytest-xdist (-n auto), each worker writes a fragment; put them under
 # .pytest_cache/ (already gitignored) instead of .coverage.<hostname>.* at repo root.

--- a/surfaces/cli/commands/__init__.py
+++ b/surfaces/cli/commands/__init__.py
@@ -24,6 +24,7 @@ from surfaces.cli.commands.integrations import integrations
 from surfaces.cli.commands.messaging import messaging
 from surfaces.cli.commands.misses import misses_command
 from surfaces.cli.commands.onboard import onboard
+from surfaces.cli.commands.package_smoke import package_smoke_command
 from surfaces.cli.commands.posthog_report import posthog_command
 from surfaces.cli.commands.remote_sync import remote_sync_command
 from surfaces.cli.commands.sentry_digest import sentry_command
@@ -56,6 +57,7 @@ _COMMANDS: tuple[click.Command, ...] = (
     update_command,
     uninstall_command,
     version_command,
+    package_smoke_command,
 )
 
 

--- a/surfaces/cli/commands/package_smoke.py
+++ b/surfaces/cli/commands/package_smoke.py
@@ -1,0 +1,87 @@
+"""Hidden release-artifact smoke command for essential frozen capabilities."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+_REQUIRED_TOOL_NAMES = frozenset(
+    {
+        "call_x_tool",
+        "execute_python_code",
+        "generate_work_status_report",
+        "kubernetes_list_pods",
+        "query_datadog_all",
+        "query_grafana_logs",
+        "work_task_add",
+    }
+)
+_REQUIRED_ACTION_SKILL_NAMES = frozenset(
+    {
+        "architecture-audit",
+        "github-ci-fix",
+        "github-ci-fix-onboarding",
+        "github-cli",
+        "github-security-fix",
+        "morning-report",
+    }
+)
+_REQUIRED_INTEGRATION_VERIFIER_NAMES = frozenset({"datadog", "grafana", "x_mcp"})
+_GUIDED_TOOL_NAMES = frozenset({"execute_python_code", "generate_work_status_report"})
+_ACTION_SKILL_BODY_MARKERS = {"architecture-audit": "REPORT TEMPLATE from"}
+
+
+@click.command(name="_package-smoke", hidden=True)
+def package_smoke_command() -> None:
+    """Fail unless essential dynamically bundled code and data are available."""
+    from core.agent_harness.prompts.skills.loader import list_action_skills, load_skill_body
+    from integrations._verifiers_loader import register_all_verifiers
+    from integrations.verification import list_verifiers
+    from tools.registry import get_registered_tool_map
+
+    register_all_verifiers()
+    tool_map = get_registered_tool_map()
+    tool_names = set(tool_map)
+    action_skill_names = {skill.name for skill in list_action_skills()}
+    integration_verifier_names = set(list_verifiers())
+
+    missing_tools = sorted(_REQUIRED_TOOL_NAMES - tool_names)
+    missing_action_skills = sorted(_REQUIRED_ACTION_SKILL_NAMES - action_skill_names)
+    missing_action_skill_data = sorted(
+        name
+        for name, marker in _ACTION_SKILL_BODY_MARKERS.items()
+        if marker not in load_skill_body(name)
+    )
+    missing_integration_verifiers = sorted(
+        _REQUIRED_INTEGRATION_VERIFIER_NAMES - integration_verifier_names
+    )
+    missing_guidance = sorted(
+        name
+        for name in _GUIDED_TOOL_NAMES
+        if name not in tool_map or not tool_map[name].skill_guidance
+    )
+    failures = {
+        "missing_tools": missing_tools,
+        "missing_action_skills": missing_action_skills,
+        "missing_action_skill_data": missing_action_skill_data,
+        "missing_integration_verifiers": missing_integration_verifiers,
+        "missing_tool_guidance": missing_guidance,
+    }
+    if any(failures.values()):
+        raise click.ClickException(f"PyInstaller package smoke failed: {json.dumps(failures)}")
+
+    click.echo(
+        json.dumps(
+            {
+                "action_skills": len(action_skill_names),
+                "integration_verifiers": len(integration_verifier_names),
+                "registered_tools": len(tool_names),
+                "status": "ok",
+            },
+            sort_keys=True,
+        )
+    )
+
+
+__all__ = ["package_smoke_command"]

--- a/tests/cli/test_command_help_sync.py
+++ b/tests/cli/test_command_help_sync.py
@@ -13,7 +13,7 @@ from surfaces.interactive_shell.ui.layout import _commands_from_group
 
 
 def test_registered_commands_match_help_table() -> None:
-    registered = {cmd.name for cmd in _COMMANDS}
+    registered = {cmd.name for cmd in _COMMANDS if not cmd.hidden}
     assert None not in registered, (
         "A command in _COMMANDS has no name set. "
         "Ensure every click.Command is decorated with an explicit name."

--- a/tests/cli/test_layout.py
+++ b/tests/cli/test_layout.py
@@ -15,6 +15,15 @@ def _normalized_output(output: str) -> str:
     return " ".join(output.split())
 
 
+def _visible_command_names(group: click.Group) -> list[str]:
+    ctx = click.Context(group)
+    return [
+        name
+        for name in group.list_commands(ctx)
+        if (command := group.get_command(ctx, name)) is not None and not command.hidden
+    ]
+
+
 def test_render_help_shows_all_registered_commands(monkeypatch, capsys) -> None:
     monkeypatch.setattr("surfaces.interactive_shell.ui.banner.banner._is_first_run", lambda: True)
     render_help(cli)
@@ -28,8 +37,7 @@ def test_render_help_shows_all_registered_commands(monkeypatch, capsys) -> None:
     assert "Options:" in output
     assert "Welcome back" not in output
 
-    ctx = click.Context(cli)
-    for name in cli.list_commands(ctx):
+    for name in _visible_command_names(cli):
         assert name in output
 
     for label, description in _options_from_command(cli):
@@ -46,8 +54,7 @@ def test_render_help_includes_uninstall(capsys) -> None:
 def test_render_help_command_list_matches_cli_registry(capsys) -> None:
     render_help(cli)
     output = _normalized_output(capsys.readouterr().out)
-    ctx = click.Context(cli)
-    for name in cli.list_commands(ctx):
+    for name in _visible_command_names(cli):
         assert name in output, f"command '{name}' missing from help output"
 
 

--- a/tests/cli/test_package_smoke.py
+++ b/tests/cli/test_package_smoke.py
@@ -1,0 +1,27 @@
+"""Release-artifact smoke contract for dynamically bundled code and data."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from surfaces.cli.app import cli
+
+
+def test_package_smoke_finds_essential_tools_and_skills() -> None:
+    result = CliRunner().invoke(cli, ["_package-smoke"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["registered_tools"] >= 250
+    assert payload["action_skills"] >= 6
+    assert payload["integration_verifiers"] >= 60
+
+
+def test_package_smoke_command_is_hidden_from_help() -> None:
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "_package-smoke" not in result.output

--- a/tests/interactive_shell/references/test_cli_reference_cache.py
+++ b/tests/interactive_shell/references/test_cli_reference_cache.py
@@ -37,7 +37,7 @@ def test_cold_build_is_silent(capsys: pytest.CaptureFixture[str]) -> None:
 
     text = _reference_with_cli().build_text()
     captured = capsys.readouterr()
-    first_command = sorted(cli.commands.keys())[0]
+    first_command = sorted(name for name, command in cli.commands.items() if not command.hidden)[0]
 
     assert captured.out == ""
     assert captured.err == ""

--- a/tests/interactive_shell/test_parity.py
+++ b/tests/interactive_shell/test_parity.py
@@ -12,7 +12,7 @@ EXCLUDED_COMMANDS = {"agent", "gateway"}
 def test_cli_slash_command_parity():
     """Ensure every top-level Click command has a corresponding slash command in the REPL."""
     # Get all registered top-level commands from the main Click group
-    cli_commands = set(cli.commands.keys())
+    cli_commands = {name for name, command in cli.commands.items() if not command.hidden}
 
     # Filter out excluded commands
     expected_commands = cli_commands - EXCLUDED_COMMANDS

--- a/tests/packaging/test_frozen_tiktoken_bootstrap.py
+++ b/tests/packaging/test_frozen_tiktoken_bootstrap.py
@@ -22,7 +22,7 @@ from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+_SPEC_FILE = _REPO_ROOT / "opensre.spec"
 
 
 @pytest.fixture(autouse=True)
@@ -69,14 +69,14 @@ def test_frozen_build_bootstrap_resolves_encoding(monkeypatch: pytest.MonkeyPatc
     assert encoding.name == "cl100k_base"
 
 
-def test_release_workflow_bundles_tiktoken_plugin() -> None:
+def test_release_spec_bundles_tiktoken_plugin() -> None:
     """The release build must hidden-import tiktoken's plugin module.
 
-    Ties the bootstrap's direct-import target to the PyInstaller build command
+    Ties the bootstrap's direct-import target to the PyInstaller specification
     so renaming or dropping the hidden-import fails fast instead of only
     surfacing as a release-time binary crash.
     """
-    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    spec = _SPEC_FILE.read_text(encoding="utf-8")
 
-    assert "tiktoken_ext.openai_public" in workflow
-    assert "tiktoken_ext" in workflow
+    assert '"tiktoken_ext.openai_public"' in spec
+    assert '"tiktoken_ext"' in spec

--- a/tests/packaging/test_platform_stdlib_loader.py
+++ b/tests/packaging/test_platform_stdlib_loader.py
@@ -20,6 +20,7 @@ import platform as _platform_pkg  # noqa: E402  (first-party package after boots
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+_SPEC_FILE = _REPO_ROOT / "opensre.spec"
 
 _FROZEN_STDLIB_DIR = _platform_pkg._FROZEN_STDLIB_DIR
 _candidate_stdlib_platform_paths = _platform_pkg._candidate_stdlib_platform_paths
@@ -66,15 +67,16 @@ def test_load_stdlib_platform_uses_bundled_copy_when_frozen(monkeypatch, tmp_pat
     assert getattr(module, "OPENSRE_BUNDLED_MARKER", None) == "bundled"
 
 
-def test_release_workflow_bundles_stdlib_platform() -> None:
+def test_release_packaging_bundles_stdlib_platform() -> None:
     """The release build must stage and bundle ``platform.py`` for the binary.
 
-    This ties the workflow's ``--add-data`` destination to ``_FROZEN_STDLIB_DIR``
-    so renaming the constant without updating the workflow fails fast instead of
+    This ties the spec's data destination to ``_FROZEN_STDLIB_DIR`` so renaming
+    the constant without updating the packaging contract fails fast instead of
     only surfacing as a release-time binary crash.
     """
     workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    spec = _SPEC_FILE.read_text(encoding="utf-8")
 
     assert "platform.py" in workflow  # staging step copies the stdlib module
     assert ".stdlib_vendor" in workflow  # staged into a relative dir
-    assert _FROZEN_STDLIB_DIR in workflow  # bundled under the loader's dest dir
+    assert _FROZEN_STDLIB_DIR in spec  # bundled under the loader's dest dir

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -24,6 +24,14 @@ def test_hidden_imports_cover_runtime_discovered_tool_packages() -> None:
     assert "tools.system.work_items.tool" in hidden_imports
 
 
+def test_hidden_imports_exclude_non_runtime_discovery_modules() -> None:
+    hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
+
+    assert "tools.registry" not in hidden_imports
+    assert "tools.investigation_registry" not in hidden_imports
+    assert "tools.investigation_registry.prioritization" not in hidden_imports
+
+
 def test_hidden_imports_cover_runtime_discovered_integration_verifiers() -> None:
     hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
     verifier_modules = {

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -1,0 +1,61 @@
+"""Contracts for deterministic code and data inputs in frozen releases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from platform.packaging.release_manifest import (
+    required_skill_files,
+    runtime_hidden_imports,
+)
+from tools.registry_discovery import INTEGRATION_TOOL_PACKAGES
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+_SPEC_FILE = _REPO_ROOT / "opensre.spec"
+
+
+def test_hidden_imports_cover_runtime_discovered_tool_packages() -> None:
+    hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
+
+    assert set(INTEGRATION_TOOL_PACKAGES) <= hidden_imports
+    assert "integrations.x_mcp.tools.x_mcp_tool" in hidden_imports
+    assert "tools.system.work_items" in hidden_imports
+    assert "tools.system.work_items.tool" in hidden_imports
+
+
+def test_hidden_imports_cover_runtime_discovered_integration_verifiers() -> None:
+    hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
+    verifier_modules = {
+        ".".join(path.relative_to(_REPO_ROOT).with_suffix("").parts)
+        for path in (_REPO_ROOT / "integrations").glob("*/verifier.py")
+    }
+
+    assert verifier_modules <= hidden_imports
+
+
+def test_required_skill_data_covers_action_and_tool_guidance() -> None:
+    relative_paths = {
+        path.relative_to(_REPO_ROOT).as_posix() for path in required_skill_files(_REPO_ROOT)
+    }
+
+    assert "core/agent_harness/prompts/skills/architecture_audit/SKILL.md" in relative_paths
+    assert (
+        "core/agent_harness/prompts/skills/architecture_audit/architecture_audit_report.md"
+        in relative_paths
+    )
+    assert "integrations/github/tools/workflow/SKILL.md" in relative_paths
+    assert "integrations/sentry/tools/skills/sentry-summary/SKILL.md" in relative_paths
+    assert (
+        "tools/system/python_execution_tool/skills/github-star-velocity/SKILL.md" in relative_paths
+    )
+
+
+def test_release_build_uses_checked_in_spec() -> None:
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    spec = _SPEC_FILE.read_text(encoding="utf-8")
+
+    assert "uv run pyinstaller opensre.spec" in workflow
+    assert "OPENSRE_PYINSTALLER_MODE: ${{ matrix.pyinstaller_mode }}" in workflow
+    assert "release_manifest.py" in spec
+    assert "skill_data_entries(ROOT)" in spec

--- a/tests/packaging/test_validate_wheel.py
+++ b/tests/packaging/test_validate_wheel.py
@@ -1,0 +1,50 @@
+"""Tests for release-wheel runtime-data validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from zipfile import ZipFile
+
+from platform.packaging.validate_wheel import missing_skill_files
+
+
+def test_missing_skill_files_reports_absent_runtime_data(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skill_path = repo_root / "core/agent_harness/prompts/skills/example/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("example", encoding="utf-8")
+    manifest_path = repo_root / "platform/packaging/release_manifest.py"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        "def required_skill_files(repo_root):\n"
+        "    return (repo_root / "
+        "'core/agent_harness/prompts/skills/example/SKILL.md',)\n",
+        encoding="utf-8",
+    )
+    wheel_path = tmp_path / "opensre.whl"
+    with ZipFile(wheel_path, "w"):
+        pass
+
+    assert missing_skill_files(wheel_path, repo_root=repo_root) == (
+        "core/agent_harness/prompts/skills/example/SKILL.md",
+    )
+
+
+def test_missing_skill_files_accepts_complete_wheel(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    relative_skill_path = Path("tools/example/SKILL.md")
+    skill_path = repo_root / relative_skill_path
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("example", encoding="utf-8")
+    manifest_path = repo_root / "platform/packaging/release_manifest.py"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        "def required_skill_files(repo_root):\n"
+        "    return (repo_root / 'tools/example/SKILL.md',)\n",
+        encoding="utf-8",
+    )
+    wheel_path = tmp_path / "opensre.whl"
+    with ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr(relative_skill_path.as_posix(), "example")
+
+    assert missing_skill_files(wheel_path, repo_root=repo_root) == ()


### PR DESCRIPTION
Fixes #4949

#### Describe the changes you have made in this PR -

- Replace PyInstaller's import-based `--collect-submodules` calls with a checked-in spec and a deterministic source-tree module manifest. This avoids silently dropping runtime-discovered integrations/tools when the first-party `platform` package conflicts with stdlib `platform` during analysis.
- Bundle built-in action skills, report templates, and tool workflow-guidance `SKILL.md` files in frozen binaries.
- Include the same required skill data in Python wheels and validate the built wheel before publishing.
- Add a hidden `_package-smoke` artifact command that verifies representative dynamic tools, integration verifiers, full action-skill data, and tool guidance inside the built executable.
- Run the artifact smoke in every Linux, macOS, and Windows binary release job.
- Update CLI help contracts so hidden maintenance commands remain executable without becoming user-facing.

### Demo/Screenshot for feature changes and bug fixes - 

Local Python 3.14.2 / PyInstaller 6.20 onedir artifact:

```console
$ ./dist/opensre/opensre --version
opensre, version 0.1
$ ./dist/opensre/opensre _package-smoke
{"action_skills": 6, "integration_verifiers": 60, "registered_tools": 279, "status": "ok"}
$ find dist/opensre -type f -name SKILL.md | wc -l
13
```

Both `onedir` and `onefile` binaries were built and smoke-tested locally. The built wheel validator also found all 13 required `SKILL.md` files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The existing release command asked PyInstaller to discover submodules by importing package trees. That is fragile in this repository because the first-party `platform` package has the same name as the standard-library module, and analysis can silently produce an incomplete module list. I considered adding more individual hidden imports or retaining `collect-submodules` with exclusions, but both approaches remain easy to regress as integrations are added.

The checked-in spec instead reads module names directly from source paths without importing application packages. `release_manifest.py` provides one deterministic inventory for hidden imports and required skill data. `package_smoke.py` validates the runtime result inside the executable rather than trusting build inputs alone. `validate_wheel.py` applies the data-file portion of the same manifest to Python wheels, after review found that wheels also contained zero required skills.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

### Validation

- `make lint`
- `make format-check`
- `make typecheck`
- `make verify-integrations-smoke` (31 passed)
- `uv run python -m pytest tests/packaging tests/cli/test_package_smoke.py tests/cli/test_command_help_sync.py tests/cli/test_layout.py -q` (28 passed)
- Local PyInstaller `onedir` build: version, help, hidden artifact smoke, and bundled skill inventory passed
- Local PyInstaller `onefile` build: version, help, and hidden artifact smoke passed
- Fresh wheel build: `validate_wheel.py` passed with 13 required `SKILL.md` files
