### PR TITLE
refactor(pagerduty): name timeout constant in seconds

### DIFF
--- a/integrations/pagerduty/client.py
+++ b/integrations/pagerduty/client.py
@@ -17,7 +17,7 @@ from platform.observability.errors.service import capture_service_error
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_TIMEOUT = 30
+_DEFAULT_TIMEOUT_SECONDS = 30
 PagerDutyConfig = PagerDutyIntegrationConfig
 
 
@@ -33,7 +33,7 @@ class PagerDutyClient:
             self._client = httpx.Client(
                 base_url=self.config.base_url,
                 headers=self.config.headers,
-                timeout=_DEFAULT_TIMEOUT,
+                timeout=_DEFAULT_TIMEOUT_SECONDS,
             )
         return self._client
 


### PR DESCRIPTION
Fixes #4904

#### Describe the changes you have made in this PR -

Renamed the private PagerDuty client timeout constant from `_DEFAULT_TIMEOUT` to `_DEFAULT_TIMEOUT_SECONDS` and updated its only reference in the same file.

The value remains exactly `30`. This does not change behavior or any public API.

### Demo/Screenshot for feature changes and bug fixes -

Focused validation:

```text
86 passed in 2.25s
31 passed in 3.32s
All checks passed! (ruff)
3382 files already formatted
Success: no issues found in 1737 source files (mypy)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The previous constant name did not state its unit. I renamed only the private constant and its sole in-file reference so the seconds unit is explicit. No alternative implementation was needed because the issue specifically requests a behavior-preserving identifier rename, and the numeric value remains unchanged.

Validation performed:

- `uv run python -m pytest tests/integrations/pagerduty/ tests/integrations/test_pagerduty.py tests/tools/test_pagerduty_incident_detail_tool.py tests/tools/test_pagerduty_incidents_tool.py tests/tools/test_pagerduty_oncall_tool.py tests/tools/test_pagerduty_services_tool.py` — 86 passed
- `make verify-integrations-smoke` — 31 passed
- `make lint` — passed
- `make format-check` — passed
- `make typecheck` — passed
- `git diff --check` — passed

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
