### PR TITLE
docs: add Python API daily-loop CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ if result.answered:
 
 See **[Python API](https://www.opensre.com/docs/python-api)** for sessions, conversations, and custom output sinks.
 
+**For your team's daily loop:** embed OpenSRE in the Python services and automations your teammates already use.
+Start with the in-repo [Python API guide](docs/python-api.mdx), then use it every day to make incident response repeatable.
+
 Other useful commands:
 
 ```bash


### PR DESCRIPTION
Fixes #4895

## Summary
Adds a concise, teammate-focused call to action immediately after the existing Python API example in the Quick Start section. It points readers to the in-repository Python API guide and encourages daily, repeatable use through their Python services and automations.

## Why
The Python API was already documented, but the README did not make the repeat-use path explicit at the point readers first encounter the API snippet. This makes that workflow visible without redesigning or restructuring the README.

## Changes
- Added daily-loop framing for teammates using OpenSRE from Python.
- Linked directly to [`docs/python-api.mdx`](docs/python-api.mdx).
- Kept the change limited to `README.md`; no product, API, or layout changes.

## Validation
- Ran `git diff --check` successfully.
- Reviewed the rendered Markdown structure around the Quick Start / Python API section.

## Impact
Documentation-only change. No runtime behavior, API contract, dependencies, or configuration changes.

## Scope
This PR satisfies the issue criteria for a first-screen Python API and daily-loop CTA while preserving the existing README layout.