### PR TITLE
docs: explain opt-in keyring storage

### DIFF
--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -5,6 +5,25 @@ description: Complete reference of all supported OpenSRE environment variables.
 
 All configuration options for OpenSRE can be set via environment variables. This page provides a complete reference.
 
+## Secret storage
+
+Environment variables are checked before OpenSRE's local stores. For credentials
+entered through `opensre onboard` or `opensre integrations setup`, writes to the
+system keychain are opt-in. Without `OPENSRE_USE_KEYRING`, OpenSRE writes the
+credential to an owner-only fallback file under `~/.opensre/`, which keeps the
+first-run path working without an OS keychain prompt.
+
+Set `OPENSRE_USE_KEYRING=1` before onboarding to prefer the system keychain:
+
+```bash
+OPENSRE_USE_KEYRING=1 opensre onboard
+```
+
+If the keychain cannot store the credential, OpenSRE falls back to the same
+owner-only local file. A value supplied in the process environment or a local
+`.env` file takes precedence when reading credentials. Keep `.env` out of source
+control and never commit real secrets.
+
 ## LLM Providers
 
 | Variable | Default | Description | Module |

--- a/docs/install-local.mdx
+++ b/docs/install-local.mdx
@@ -70,6 +70,27 @@ onboard
 - integration credentials
 - optional communication/reporting integrations
 
+#### Where credentials are saved
+
+OpenSRE keeps environment variables as the first lookup tier. When onboarding
+saves a credential, keyring writes are **opt-in**: by default the value is
+written to an owner-only fallback file under `~/.opensre/`, so first-run setup
+does not trigger an operating-system keychain prompt. The file is local to your
+user account and is created with owner-only permissions.
+
+To prefer the system keychain for new writes, set the flag before onboarding:
+
+```bash
+export OPENSRE_USE_KEYRING=1
+opensre onboard
+```
+
+With that flag enabled, OpenSRE writes to the system keychain and uses the
+owner-only fallback file only when the keychain is unavailable. You can also
+provide a credential directly through your shell or project `.env`; environment
+values take precedence over both local stores. Never commit real credentials to
+`.env` or source control.
+
 ### 4) Verify integration health
 
 From inside the OpenSRE shell:


### PR DESCRIPTION
Fixes #4890

#### Describe the changes you have made in this PR -

Documented the first-run secret-storage behavior in the local installation and environment-variable guides. The docs now state that `OPENSRE_USE_KEYRING` is opt-in for keyring writes, explain that the default path saves credentials to the owner-only fallback file under `~/.opensre/`, and show how to opt into the system keychain. They also clarify `.env` / process-environment precedence and the fallback behavior when the keychain is unavailable. Secret-store defaults and runtime behavior are unchanged.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run python -m pytest -q tests/config/test_secret_store.py
16 passed

git diff --check
passed
```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated documentation
- [x] I can explain the purpose and content of each section I added
- [x] I tested the documented default and opt-in behavior through the existing secret-store test suite
- [x] I modified the output to follow this project's documentation conventions

**Explain your implementation approach:**

The implementation is documentation-only and is intentionally limited to `docs/install-local.mdx` and `docs/configuration/environment-variables.mdx`. The local installation guide explains the first-run path where onboarding writes to the owner-only fallback file without prompting for a keychain. The environment-variable reference documents `OPENSRE_USE_KEYRING=1` as the explicit opt-in for system-keychain writes, including the fallback if that keychain is unavailable. Both pages call out that environment values take precedence and that real secrets must not be committed. No secret-store code or defaults were changed.

## Checklist before requesting a review
- [x] I have added the proper PR title and linked to the issue
- [x] I have performed a self-review of the documentation
- [x] I can explain the purpose of every section added
- [x] I understand why the documented behavior is accurate and tested it
- [x] I have considered the default, opt-in, unavailable-keychain, and `.env` paths
- [x] If it is a core feature, I have added thorough tests (not applicable; documentation-only)
- [x] My changes follow the project's style guidelines and conventions