### PR TITLE
fix(new-relic): put ORDER BY before LIMIT in incident NRQL query

### DIFF
--- a/integrations/new_relic/client.py
+++ b/integrations/new_relic/client.py
@@ -330,7 +330,7 @@ class NewRelicClient:
         # resolved incident as still open.
         nrql = (
             f"{_INCIDENTS_SELECT}{where_clause} "
-            f"SINCE {int(since_minutes)} minutes ago LIMIT {capped_limit} ORDER BY timestamp DESC"
+            f"SINCE {int(since_minutes)} minutes ago ORDER BY timestamp DESC LIMIT {capped_limit}"
         )
         outcome = self.run_nrql(nrql)
         # Callers detect truncation by comparing the raw row count against the

--- a/tests/integrations/new_relic/test_client.py
+++ b/tests/integrations/new_relic/test_client.py
@@ -209,7 +209,7 @@ def test_query_incidents_orders_newest_first_so_a_cutoff_never_drops_the_close_r
     client.query_incidents(since_minutes=30, limit=10)
 
     sent_nrql = mock_http.post.call_args.kwargs["json"]["variables"]["nrql"]
-    assert sent_nrql.index("LIMIT 10") < sent_nrql.index("ORDER BY timestamp DESC")
+    assert sent_nrql.index("ORDER BY timestamp DESC") < sent_nrql.index("LIMIT 10")
 
 
 def test_query_incidents_reports_the_effective_limit_after_clamping(


### PR DESCRIPTION
## Summary
- Fixes a Greptile P1 finding from #4950 (https://github.com/Tracer-Cloud/opensre/pull/4950#discussion_r3768977627): `query_incidents` built NRQL with `LIMIT ... ORDER BY`, but NRQL requires `ORDER BY` before `LIMIT`. NerdGraph rejects the malformed query, so a configured New Relic alert investigation always returned an unavailable result instead of incident evidence.
- Also fixes the existing test that had pinned the (invalid) clause order as correct.

## AI Usage Disclosure
This PR was authored with the assistance of Claude Code, which located the Greptile finding, made the fix, and updated the test that had been asserting the buggy order.

## Test plan
- [x] `uv run python -m pytest tests/integrations/new_relic/test_client.py tests/tools/test_new_relic_alerts_tool.py tests/synthetic/test_new_relic_scenario.py -q` — 35 passed
- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`