### PR TITLE
fix(integrations): log soft-fail in Argo CD and Jira client factories

### DIFF
--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -16,6 +16,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
+from pydantic import ValidationError
 
 from integrations.config_models import ArgoCDIntegrationConfig
 from integrations.probes import ProbeResult
@@ -543,5 +544,16 @@ def make_argocd_client(
                 verify_ssl=_normalize_verify_ssl(verify_ssl),
             )
         )
-    except Exception:
+    except Exception as exc:
+        # `ValidationError` renders the rejected input inline via `input_value=`,
+        # and for a model-level failure that is the whole config mapping — bearer
+        # token and password included. Local `exc_info` logging bypasses Sentry's
+        # scrubber, so swap in a message-only error that keeps the traceback (but
+        # no `__cause__`, which would print the raw text again). Same technique as
+        # `integrations._validation_helpers.report_classify_failure`.
+        safe_exc: BaseException = exc
+        if isinstance(exc, ValidationError):
+            safe_exc = ValueError("Argo CD config validation failed")
+            safe_exc.__traceback__ = exc.__traceback__
+        logger.warning("Failed to create Argo CD client: %s", safe_exc, exc_info=safe_exc)
         return None

--- a/integrations/jira/client.py
+++ b/integrations/jira/client.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from integrations.config_models import JiraIntegrationConfig
 from platform.observability.errors.service import capture_service_error
@@ -297,5 +298,17 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except Exception:
+    except Exception as exc:
+        # `ValidationError` renders the rejected input inline via `input_value=`,
+        # and an error raised against the model rather than one field dumps the
+        # whole config mapping — `api_token` included. Local `exc_info` logging
+        # bypasses Sentry's scrubber, so swap in a message-only error that keeps
+        # the traceback (but no `__cause__`, which would print the raw text
+        # again). Same technique as
+        # `integrations._validation_helpers.report_classify_failure`.
+        safe_exc: BaseException = exc
+        if isinstance(exc, ValidationError):
+            safe_exc = ValueError("Jira config validation failed")
+            safe_exc.__traceback__ = exc.__traceback__
+        logger.warning("Failed to create Jira client: %s", safe_exc, exc_info=safe_exc)
         return None

--- a/tests/integrations/argocd/test_client.py
+++ b/tests/integrations/argocd/test_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -53,6 +54,64 @@ def test_make_argocd_client_requires_base_url_and_auth() -> None:
         make_argocd_client("https://argocd.example.com", username="admin", password="pw")
         is not None
     )
+
+
+def _raise_runtime_error(**_kwargs: Any) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_argocd_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.argocd.client.ArgoCDConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.argocd.client"):
+        result = make_argocd_client("https://argocd.example.com", bearer_token="tok")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_make_argocd_client_soft_fail_log_does_not_echo_config_input(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange: supplying both auth methods is a real misconfiguration that gets
+    # past the factory's guards and reaches ArgoCDConfig's model validator.
+    # A model-level pydantic failure renders the whole input mapping via
+    # `input_value=...`, which is where a bearer token or password would escape.
+    secret_token = "s3cr3t-argocd-bearer-token"
+    secret_password = "s3cr3t-argocd-password"
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.argocd.client"):
+        result = make_argocd_client(
+            "https://argocd.example.com",
+            bearer_token=secret_token,
+            username="admin",
+            password=secret_password,
+        )
+
+    # Assert: the soft-fail contract and the warning both survive, but no part
+    # of the submitted config is echoed. Asserting on `input_value` rather than
+    # only on the literal secrets is deliberate: pydantic elides the middle of a
+    # long mapping, so a secret-substring check passes by accident today and
+    # would stop protecting us if field order or pydantic's truncation changed.
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+    assert "input_value" not in caplog.text
+    assert secret_token not in caplog.text
+    assert secret_password not in caplog.text
 
 
 def test_probe_access_success(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -123,3 +124,67 @@ def test_make_jira_client_returns_none_missing_token() -> None:
 
 def test_make_jira_client_returns_none_all_none() -> None:
     assert make_jira_client(None, None, None) is None
+
+
+def _raise_runtime_error(**_kwargs: object) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_jira_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.jira.client.JiraIntegrationConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.jira.client"):
+        result = make_jira_client("https://myteam.atlassian.net", "user@example.com", "token")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+
+
+_SECRET_API_TOKEN = "s3cr3t-jira-api-token"
+
+
+def _raise_validation_error(**_kwargs: object) -> None:
+    # A genuine pydantic ValidationError raised against the model rather than a
+    # single field, so its rendering carries the whole input mapping — this is
+    # the shape that would leak `api_token` through `input_value=`.
+    JiraConfig(email="user@example.com", api_token=_SECRET_API_TOKEN)  # type: ignore[call-arg]
+
+
+def test_make_jira_client_soft_fail_log_does_not_echo_config_input(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: no input the factory currently accepts can make JiraIntegrationConfig
+    # raise — every field is coerced, and there is no URL-scheme validator as there
+    # is on the ServiceNow model. So the ValidationError has to be injected. The
+    # guard is hardening: it stops a future validator (or a caller passing a
+    # non-string) from turning this warning into a credential disclosure.
+    monkeypatch.setattr("integrations.jira.client.JiraIntegrationConfig", _raise_validation_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.jira.client"):
+        result = make_jira_client(
+            "https://myteam.atlassian.net", "user@example.com", _SECRET_API_TOKEN
+        )
+
+    # Assert: the soft-fail contract and the warning both survive, but no part of
+    # the submitted config is echoed. Asserting on `input_value` rather than only
+    # on the literal secret is deliberate: pydantic elides the middle of a long
+    # mapping, so a secret-substring check can pass by accident and would stop
+    # protecting us if field order or pydantic's truncation changed.
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+    assert "input_value" not in caplog.text
+    assert _SECRET_API_TOKEN not in caplog.text


### PR DESCRIPTION
Fixes #4902
Fixes #4903

#### Describe the changes you have made in this PR -

Both issues are the same defect in two client factories: `make_argocd_client()` and `make_jira_client()` ended in a bare `except Exception: return None`. A real misconfiguration — wrong URL, bad credentials, a config the model rejects — came back to the caller as the same `None` that means "this integration is not set up", with nothing written anywhere. The operator sees an integration silently missing and has no thread to pull.

The fix in both files keeps the `None` return, because callers branch on it, and adds a `WARNING` with the traceback attached. The in-tree precedent is `integrations/pagerduty/client.py:467`, which already does exactly this.

**Why one PR for two issues.** I opened these separately first (#4920, #4921, alongside the merged #4919) and all three were identical three-line changes to sibling files. Reviewing the same diff three times is a poor use of your queue, so this is one PR. Each commit still maps to one issue and one file, so it splits cleanly if you'd rather take them apart.

**The part that isn't boilerplate: the log itself can leak credentials.**

A `pydantic.ValidationError` renders the rejected input inline via `input_value=`, and when the error is raised against the model rather than a single field, that rendering is the *entire* config mapping. For these two models that mapping holds an Argo CD bearer token and password, and a Jira API token. Logging locally with `exc_info` also bypasses Sentry's scrubber, so this would not be caught downstream.

Demonstrated on the Jira model:

```
>>> JiraIntegrationConfig(email="user@example.com", api_token="s3cr3t-jira-api-token")
2 validation errors for JiraIntegrationConfig
base_url
  Field required [type=missing, input_value={'email': 'a@b.com', 'api...'s3cr3t-jira-api-token'}, input_type=dict]
```

So both handlers substitute a message-only `ValueError` that carries the original traceback but no `__cause__` (which would re-print the same text). This is not invented for this PR — `integrations/_validation_helpers.report_classify_failure` already uses the technique, and I followed it.

One subtlety worth flagging for whoever reviews this: **`exc_info=True` does not work here.** Inside an `except` block it resolves through `sys.exc_info()` to the *original* exception and ignores the sanitised one entirely, so the substitution silently does nothing and the credentials still print. The sanitised exception has to be passed as the value: `exc_info=safe_exc`.

**Honest note on reachability, per file:**

- **Argo CD** — reachable. Supplying both `bearer_token` and `username`/`password` is a plausible misconfiguration, it passes the factory's own guards, and it fails at the model validator. That is the model-level case.
- **Jira** — *not* currently reachable. I tried: `JiraIntegrationConfig` coerces every field and has no URL-scheme validator (unlike `ServiceNowIntegrationConfig`), so no string the factory accepts makes it raise. The guard there is hardening, and its test injects the `ValidationError` rather than pretending otherwise. I kept it because the protection is one added validator away from being load-bearing, in a file that holds an API token, and because having one of these two files sanitised and the other not is the kind of asymmetry that gets copied later.

### Demo/Screenshot for feature changes and bug fixes -

Supplying both auth methods to `make_argocd_client` is a real misconfiguration that reaches the model validator.

**Before** — indistinguishable from "not configured", and nothing is logged anywhere:

```
>>> make_argocd_client("https://argocd.example.com", bearer_token="s3cr3t-bearer",
...                    username="admin", password="s3cr3t-password")
None
<no log output>
```

**After** — actual captured output, not reconstructed:

```
WARNING integrations.argocd.client: Failed to create Argo CD client: Argo CD config validation failed
Traceback (most recent call last):
  File "D:\oss\opensre\integrations\argocd\client.py", line 537, in make_argocd_client
    ArgoCDConfig(
  File "...\pydantic\main.py", line 263, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
ValueError: Argo CD config validation failed
return value: None
```

Return value is still `None`, the cause is now visible, and neither `s3cr3t-bearer` nor `s3cr3t-password` appears.

For contrast, this is what the unsanitised `exc_info=True` version logs — captured from the Jira test running against the unpatched file, and the reason the extra handling exists:

```
WARNING integrations.jira.client: Failed to create Jira client: 2 validation errors for JiraIntegrationConfig
base_url
  Field required [type=missing, input_value={'email': 'user@example.c...'s3cr3t-jira-api-token'}, input_type=dict]
```

Tests:

```
$ python -m pytest tests/integrations/test_jira_search_and_factory.py tests/integrations/argocd/test_client.py -q
35 passed
```

Each new test was confirmed to fail against the unpatched file first — the soft-fail tests fail on `assert record.exc_info is not None` (nothing logged at all), and the credential tests fail on `assert "input_value" not in caplog.text`.

Gates:

```
$ ruff check <the four touched files>            All checks passed!
$ ruff format --check <the four touched files>   4 files already formatted
$ mypy integrations/argocd/client.py integrations/jira/client.py
                                                 Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a diagnosability one. Returning `None` for both "not configured" and "configured wrongly" collapses two states an operator needs to tell apart, and the bare `except` meant there was no record anywhere that the second one had happened.

The obvious alternative is to raise instead of returning `None`. I rejected it: callers treat `None` as "skip this integration", and raising would turn a degraded integration into a hard failure of whatever flow touched it. The soft-fail contract is deliberate; only the silence is the bug. So the change is additive — same return value, plus a log line.

The second alternative I considered was logging the exception directly (`exc_info=True`), which is the shortest version and what I wrote first. I dropped it after checking what a `ValidationError` actually prints. Verifying that took two passes: my initial test asserted the secret string was absent from the log and it *passed against the broken code*, because pydantic elides the middle of a long mapping and the credential fields happened to sit in the elided region. That is an accident of field ordering, not a property. The tests now assert `"input_value" not in caplog.text` — the invariant — with the literal-secret check kept only as a secondary assertion.

Key pieces: in each factory, `safe_exc` is the exception actually handed to the logger; it is the original unless it is a `ValidationError`, in which case it becomes a `ValueError` carrying the original `__traceback__`. Assigning `__traceback__` rather than raising `from` is what keeps the stack while dropping the chained text. Four tests were added, two per integration: one that the soft-fail path logs with exception context at all, one that the log does not echo the submitted config.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Two test failures on Windows are pre-existing and unrelated to this PR — `tests/integrations/git/test_local.py::test_changed_paths_handles_quoted_filenames` and `tests/integrations/llm_cli/test_codex_oauth.py::test_codex_auth_payload_and_write_auth_shape`. Both fail identically on a clean checkout of the base commit.
