### PR TITLE
fix(sandbox): forward SystemRoot so allow_network works on Windows

### DIFF
--- a/platform/sandbox/runner.py
+++ b/platform/sandbox/runner.py
@@ -25,6 +25,10 @@ _BASE_ENV_KEYS = (
     "PYTHONPATH",
     "REQUESTS_CA_BUNDLE",
     "SSL_CERT_FILE",
+    # Windows resolves the Winsock service provider catalogue relative to
+    # %SystemRoot%; without it every socket call in the child raises
+    # WinError 10106. Absent on POSIX, where the lookup below skips it.
+    "SystemRoot",
     "TMPDIR",
 )
 

--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import os
 import tempfile
 
+import pytest
+
 from config.constants import OPENSRE_TMP_DIR, ensure_opensre_tmp_dir
 from platform.sandbox.runner import (
     MAX_TIMEOUT,
     SandboxResult,
+    _sandbox_env,
     run_python_sandbox,
 )
 
@@ -72,6 +75,22 @@ class TestSandboxRunnerInputInjection:
         result = run_python_sandbox("x = 1", inputs=None)
         assert result.success
         assert result.inputs == {}
+
+
+class TestSandboxEnvironment:
+    def test_system_root_forwarded_and_allowlist_stays_narrow(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Windows needs %SystemRoot% to initialize Winsock in the child, so a
+        # sandbox without it fails every socket call with WinError 10106 before
+        # allow_network is ever consulted.
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "must-not-leak")
+
+        env = _sandbox_env(None)
+
+        assert env["SystemRoot"] == r"C:\Windows"
+        assert "AWS_SECRET_ACCESS_KEY" not in env
 
 
 class TestSandboxNetworkRestrictions:


### PR DESCRIPTION
Fixes #4937

#### Describe the changes you have made in this PR -

`_sandbox_env` in `platform/sandbox/runner.py` builds the subprocess environment from the `_BASE_ENV_KEYS` allowlist. `SystemRoot` was not on it. Windows resolves the Winsock service provider catalogue relative to `%SystemRoot%`, so every socket call in the sandboxed child raised `WinError 10106` before any sandbox rule was consulted, and `allow_network=True` could not work there at all.

This adds `SystemRoot` to the allowlist, plus a regression test.

Two details worth calling out:

- The bug was invisible by default. With `allow_network=False` the preamble replaces `socket.socket` with a stub that raises `PermissionError`, so real Winsock initialization never happens and the network-block tests pass for an unrelated reason. Only the `allow_network=True` paths reach real sockets.
- No platform branch is needed. `SystemRoot` is absent on POSIX, and the existing `if value:` guard in `_sandbox_env` skips it there.

### Demo/Screenshot for feature changes and bug fixes -

The variable in isolation, independent of OpenSRE (Windows):

```
without SystemRoot -> OSError: [WinError 10106] The requested service provider could not be loaded or initialized
with SystemRoot    -> socket OK
```

Focused suite run locally (macOS), per CI.md section 2 — `platform/sandbox/` maps to `tests/sandbox/`:

```
$ uv run python -m pytest tests/sandbox/ -q
24 passed in 5.12s

$ uv run python -m pytest tests/tools/test_python_execution_tool.py tests/tools/test_python_execution_runtime_inputs.py tests/platform/sandbox/ -q
40 passed in 8.69s
```

The new test fails on `main` and passes with the fix:

```
$ git stash push platform/sandbox/runner.py && uv run python -m pytest tests/sandbox/test_runner.py -k system_root -q
FAILED tests/sandbox/test_runner.py::TestSandboxEnvironment::test_system_root_forwarded_and_allowlist_stays_narrow
1 failed, 23 deselected
```

Baseline checks: `make lint`, `make format-check`, `make typecheck` (plus mypy directly on the changed test file, since CI typecheck does not cover `tests/`), and `make verify-integrations-smoke` — all clean.

I could not run the two Windows tests named in the issue on Windows hardware, so that half rests on the analysis in the issue. The new test is platform-agnostic on purpose: it monkeypatches `SystemRoot` into `os.environ` and asserts `_sandbox_env` forwards it, so it guards the allowlist entry on every CI platform rather than only on the one where the symptom appears.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a missing entry in an environment allowlist. The sandbox deliberately hands the child process a narrow environment, and that narrowness accidentally broke a platform primitive: on Windows the loader needs `%SystemRoot%` to bring up Winsock, so the child could not create a socket even when the caller had explicitly opted into network access.

I considered two alternatives:

1. A Windows-only branch in `_sandbox_env` (`if sys.platform == "win32": ...`). Rejected — it adds a platform conditional to a function that currently has none, for no behavioral gain. The existing `if value:` guard already makes the entry a no-op on POSIX, where the variable does not exist.
2. Copying a broader set of Windows variables (`SystemDrive`, `windir`, `COMSPEC`). Rejected as scope creep. `SystemRoot` is the one the reported failure needs; widening the allowlist speculatively weakens the isolation the allowlist exists to provide.

So the fix is the single allowlist entry, with a comment recording *why* it is there — otherwise it looks like an arbitrary Windows path and is a prime candidate for a future cleanup to delete.

The test asserts both halves of the contract in one case, because they are the same decision: `SystemRoot` is forwarded, and an unrelated variable (`AWS_SECRET_ACCESS_KEY`) is still dropped. A test that only checked the first would pass just as well if someone "fixed" this by forwarding all of `os.environ`. It calls `_sandbox_env` directly rather than spawning a subprocess, so it is fast and does not depend on the host OS.

Edge cases considered: the variable being absent (POSIX — skipped by the existing falsy check, which is why `tests/sandbox/` still passes on macOS); an empty value (also skipped by the same guard); and `extra_env` overriding it, which still works since `extra_env` is applied after the base loop.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
