### PR TITLE
fix(integrations/argocd): log soft-fail when client construction fails

### DIFF
--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -543,5 +543,6 @@ def make_argocd_client(
                 verify_ssl=_normalize_verify_ssl(verify_ssl),
             )
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to create Argo CD client: %s", exc, exc_info=True)
         return None

--- a/tests/integrations/argocd/test_client.py
+++ b/tests/integrations/argocd/test_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -53,6 +54,30 @@ def test_make_argocd_client_requires_base_url_and_auth() -> None:
         make_argocd_client("https://argocd.example.com", username="admin", password="pw")
         is not None
     )
+
+
+def _raise_runtime_error(**_kwargs: Any) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_argocd_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.argocd.client.ArgoCDConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.argocd.client"):
+        result = make_argocd_client("https://argocd.example.com", bearer_token="tok")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
 
 
 def test_probe_access_success(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #4902

#### Describe the changes you have made in this PR -

`make_argocd_client()` ended in a bare `except Exception: return None`. The three request methods in this module already report through `capture_service_error`, so the factory was the one remaining silent path: a malformed config reached the caller as an indistinguishable "not configured" `None`, with no trace of the real cause anywhere.

Keeps the soft-fail contract (still returns `None`, return type unchanged) and logs at WARNING with `exc_info=True`.

Same shape as the two in-tree precedents, deliberately, since this is SM-SR-LOG-2 of a three-file set:

- `integrations/vercel/client.py` (SM-SR-LOG-1, merged as #4919)
- `integrations/pagerduty/client.py`

```python
    except Exception as exc:
        logger.warning("Failed to create Argo CD client: %s", exc, exc_info=True)
        return None
```

### Demo/Screenshot for feature changes and bug fixes -

The new test fails on `main` and passes with the change:

```
$ git stash push integrations/argocd/client.py
$ uv run python -m pytest tests/integrations/argocd/ -q -k soft_fail
FAILED tests/integrations/argocd/test_client.py::test_make_argocd_client_logs_soft_fail_on_construction_error
1 failed, 23 deselected

$ git stash pop
$ uv run python -m pytest tests/integrations/argocd/ -q
24 passed in 2.03s
```

Focused suite per CI.md section 2 (`test_scope_rules.py:509` maps `integrations/argocd/` to `tests/integrations/argocd/`):

```
$ uv run python -m pytest tests/integrations/argocd/ tests/integrations/test_registry.py -q
31 passed

$ make lint            All checks passed!
$ make format-check    3431 files already formatted
$ make typecheck       Success: no issues found in 1769 source files
$ make verify-integrations-smoke   31 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is an information-destroying `except`. The factory has two legitimate reasons to return `None`: the caller supplied no URL or no auth (a normal "not configured" state, handled by the guard above the `try`), and construction genuinely blew up. Collapsing both into the same bare `None` means an operator debugging a missing Argo CD integration has no way to tell "I never set this up" from "my config is malformed", and nothing in the logs to tell them either.

I considered routing this through `capture_service_error` like the request methods do, since that is the richer helper in this package. I rejected it: that helper takes a `method=` and tags the event `surface: "service_client"`, which is a claim about a live API call that failed. A config object refusing to construct is not a service error, it never reached the network, and sending it to Sentry at `error` severity would be noise. The issue also explicitly asks for a debug/warning log with exception context, not a capture.

The other reason to match `vercel` and `pagerduty` character for character is that this is one of three parallel issues over the same pattern. If SM-SR-LOG-2 and SM-SR-LOG-3 each invent their own phrasing, the codebase ends up with three spellings of one idea and the next person has no precedent to copy.

The test forces `ArgoCDConfig` to raise via monkeypatch rather than trying to find a real input that breaks pydantic validation. That keeps it pinned to the branch under test instead of to whatever the current validation rules happen to reject, so a future schema change cannot silently stop exercising this path. It asserts both halves of the contract: `result is None` (soft-fail preserved) and a WARNING record carrying `exc_info` (the cause is now recoverable). Asserting only the log would let someone "fix" this by re-raising.

Edge cases considered: the early `return None` for missing URL or auth is untouched and deliberately does not log, since that is a normal state rather than a failure; and the log interpolates lazily (`%s`, not an f-string) so the message costs nothing when the logger is disabled.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
