### PR TITLE
fix(integrations/jira): log soft-fail when client construction fails

### DIFF
--- a/integrations/jira/client.py
+++ b/integrations/jira/client.py
@@ -297,5 +297,6 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to create Jira client: %s", exc, exc_info=True)
         return None

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -107,6 +109,30 @@ def test_make_jira_client_returns_client() -> None:
     )
     assert client is not None
     assert isinstance(client, JiraClient)
+
+
+def _raise_runtime_error(**_kwargs: Any) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_jira_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.jira.client.JiraIntegrationConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.jira.client"):
+        result = make_jira_client("https://myteam.atlassian.net", "user@example.com", "token")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
 
 
 def test_make_jira_client_returns_none_missing_url() -> None:


### PR DESCRIPTION
Fixes #4903

#### Describe the changes you have made in this PR -

`make_jira_client()` ended in a bare `except Exception: return None`. The five request methods in this module already report through `capture_service_error`, so the factory was the one remaining silent path: a malformed config reached the caller as an indistinguishable "not configured" `None`, with no trace of the real cause anywhere.

Keeps the soft-fail contract (still returns `None`, return type unchanged) and logs at WARNING with `exc_info=True`.

Same shape as the in-tree precedents, deliberately, since this is SM-SR-LOG-3 of a three-file set:

- `integrations/vercel/client.py` (SM-SR-LOG-1, merged as #4919)
- `integrations/argocd/client.py` (SM-SR-LOG-2, PR #4969)
- `integrations/pagerduty/client.py`

```python
    except Exception as exc:
        logger.warning("Failed to create Jira client: %s", exc, exc_info=True)
        return None
```

### Demo/Screenshot for feature changes and bug fixes -

The new test fails on `main` and passes with the change:

```
$ git stash push integrations/jira/client.py
$ uv run python -m pytest tests/integrations/test_jira_search_and_factory.py -q -k soft_fail
FAILED tests/integrations/test_jira_search_and_factory.py::test_make_jira_client_logs_soft_fail_on_construction_error
1 failed, 8 deselected

$ git stash pop
$ uv run python -m pytest tests/integrations/test_jira_search_and_factory.py -q
9 passed
```

Focused suite per CI.md section 2, running the four tool targets `test_scope_rules.py:112` lists for `integrations/jira/`:

```
$ uv run python -m pytest tests/integrations/test_jira_search_and_factory.py \
    tests/tools/test_jira_add_comment_tool.py tests/tools/test_jira_create_issue_tool.py \
    tests/tools/test_jira_issue_detail_tool.py tests/tools/test_jira_search_issues_tool.py -q
37 passed

$ make lint            All checks passed!
$ make format-check    3431 files already formatted
$ make typecheck       Success: no issues found in 1769 source files
```

One note on placement: the `integrations/jira/` rule also lists `tests/integrations/jira/`, but that directory does not exist. The factory's tests live in `tests/integrations/test_jira_search_and_factory.py`, which the rule does not name, so a change to this module does not currently pull in its own factory tests under the focused-scope mapping. I added the test next to the existing `make_jira_client` cases rather than create a new directory for one test, but the rule may be worth a look separately.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is an information-destroying `except`. The factory has two legitimate reasons to return `None`: the caller supplied no URL, email, or token (a normal "not configured" state, handled by the guard above the `try`), and construction genuinely blew up. Collapsing both into the same bare `None` means an operator debugging a missing Jira integration cannot tell "I never set this up" from "my config is malformed", and has nothing in the logs to tell them either.

I considered routing this through `capture_service_error`, the richer helper the request methods in this same file use. I rejected it: that helper takes a `method=` and tags the event `surface: "service_client"`, which asserts that a live API call failed. A config object refusing to construct never reached the network, so sending it to Sentry at `error` severity would be noise against a real outage. The issue asks for a debug/warning log with exception context, not a capture.

Matching `vercel` and `pagerduty` character for character is deliberate. This is the last of three parallel issues over one pattern; if each invents its own phrasing the codebase ends up with three spellings of the same idea and the next contributor has no precedent to copy.

The test forces `JiraIntegrationConfig` to raise via monkeypatch instead of hunting for a real input that trips pydantic validation. That pins it to the branch under test rather than to whatever the current validation rules happen to reject, so a future schema change cannot quietly stop exercising this path. It asserts both halves of the contract: `result is None` (soft-fail preserved) and a WARNING record carrying `exc_info` (the cause is now recoverable). Asserting only the log would leave re-raising as a passing "fix".

Edge cases considered: the three early `return None` guards for missing URL, email, and token are untouched and deliberately do not log, since those are normal states rather than failures; and the message interpolates lazily (`%s`, not an f-string) so it costs nothing when the logger is disabled.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
