### PR TITLE
test(config): pin capability warning facts when PATH tools are missing

### DIFF
--- a/tests/config/test_workspace_identity.py
+++ b/tests/config/test_workspace_identity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from config.constants.runtime_metadata import (
     OPENSRE_ALLOW_NETWORK_ENV,
     OPENSRE_WORKSPACE_REPO_ENV,
@@ -57,6 +59,107 @@ def test_capability_warnings_include_network_default(monkeypatch) -> None:
     assert facts["shell_available"] is True
     assert any("curl" in w for w in facts["capability_warnings"])
     assert any("network egress" in w for w in facts["capability_warnings"])
+
+
+def test_capability_warnings_report_no_shell_when_bash_and_sh_are_both_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: a PATH with neither shell. The agent is told it can run shell
+    # commands, so this gap has to reach the boot warnings rather than surface
+    # as a failed command mid-turn.
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+    tools = {"curl": "/usr/bin/curl", "bash": "", "sh": ""}
+
+    # Act
+    facts = capability_warning_facts(tools)
+
+    # Assert
+    assert facts["shell_available"] is False
+    assert "no interactive shell (bash/sh) on PATH" in facts["capability_warnings"]
+    assert not any("curl" in warning for warning in facts["capability_warnings"])
+
+
+def test_capability_warnings_accept_sh_as_the_shell_when_bash_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: bash absent but sh present. Minimal containers ship only sh, and
+    # warning about it would train operators to ignore the warnings.
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+    tools = {"curl": "/usr/bin/curl", "bash": "", "sh": "/bin/sh"}
+
+    # Act
+    facts = capability_warning_facts(tools)
+
+    # Assert
+    assert facts["shell_available"] is True
+    assert not any("shell" in warning for warning in facts["capability_warnings"])
+
+
+def test_capability_warnings_drop_the_network_line_when_egress_is_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the network warning states the sandbox default, so it must go
+    # when the operator has opted out of that default.
+    monkeypatch.setenv(OPENSRE_ALLOW_NETWORK_ENV, "1")
+    tools = {"curl": "/usr/bin/curl", "bash": "/bin/bash", "sh": "/bin/sh"}
+
+    # Act
+    facts = capability_warning_facts(tools)
+
+    # Assert
+    assert facts["network_egress"] is True
+    assert facts["capability_warnings"] == []
+
+
+def test_capability_warnings_probe_path_only_when_no_tools_are_supplied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the caller passes nothing, so the probe resolves PATH itself.
+    # Substituting installed_tools keeps that branch under test without making
+    # the assertion depend on what happens to be installed on the test machine.
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+    calls: list[int] = []
+
+    def _fake_installed_tools() -> dict[str, str]:
+        calls.append(1)
+        return {"curl": "", "bash": "", "sh": ""}
+
+    monkeypatch.setattr("config.runtime_metadata.probes.installed_tools", _fake_installed_tools)
+
+    # Act
+    facts = capability_warning_facts()
+
+    # Assert
+    assert calls == [1]
+    assert facts["capability_warnings"] == [
+        "curl is not on PATH",
+        "no interactive shell (bash/sh) on PATH",
+        "network egress is blocked for sandboxed code by default",
+    ]
+
+
+def test_capability_warnings_treat_an_empty_mapping_as_an_answer_not_a_missing_arg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: an empty dict is falsy but is still a caller-supplied result. A
+    # `tools or installed_tools()` check would silently fall back to walking the
+    # real PATH here, which is exactly the live-PATH flakiness to keep out.
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+
+    def _fail_if_called() -> dict[str, str]:
+        raise AssertionError("PATH must not be probed when the caller supplied tools")
+
+    monkeypatch.setattr("config.runtime_metadata.probes.installed_tools", _fail_if_called)
+
+    # Act
+    facts = capability_warning_facts({})
+
+    # Assert
+    assert facts["shell_available"] is False
+    assert facts["capability_warnings"] == [
+        "no interactive shell (bash/sh) on PATH",
+        "network egress is blocked for sandboxed code by default",
+    ]
 
 
 def test_capability_warnings_line_in_prompt() -> None:


### PR DESCRIPTION
Fixes #4900

#### Describe the changes you have made in this PR -

`capability_warning_facts()` had exactly one test (`curl` missing, `bash` present, network unset). Every other branch was unpinned, including both of the ones that decide whether a warning is emitted at all.

Tests only. No product code changed, and `config/runtime_metadata/**` is untouched per the issue's constraint.

Four cases, one per distinct branch rather than per literal:

| Case | Pins |
|---|---|
| no `bash` and no `sh` | `shell_available` False, shell warning fires |
| `sh` without `bash` | still a shell, no warning |
| `OPENSRE_ALLOW_NETWORK=1` | `network_egress` True, network line gone |
| `tools` omitted | `installed_tools()` resolves PATH, substituted in the test |

Plus the empty-mapping boundary: `{}` is falsy but is still a caller-supplied answer, so a `tools or installed_tools()` check would silently fall back to walking the real PATH. That test substitutes a probe which raises if called, so live-PATH flakiness is excluded by construction rather than by convention.

### Demo/Screenshot for feature changes and bug fixes -

Coverage is a weak signal for a test-only PR, so I checked these by mutation instead. Two plausible edits to `capability_warning_facts()`, each failing exactly one new test and nothing else:

```
$ # mutant 1: shell_available = bool(resolved.get("bash"))     # drop the sh fallback
FAILED test_capability_warnings_accept_sh_as_the_shell_when_bash_is_missing
1 failed, 13 passed

$ # mutant 2: resolved = tools or installed_tools()            # was: tools is not None
FAILED test_capability_warnings_treat_an_empty_mapping_as_an_answer_not_a_missing_arg
1 failed, 14 passed
```

Worth noting that mutant 2 survived my first draft. The empty-mapping test exists because of it, not the other way round.

```
$ uv run python -m pytest tests/config/test_workspace_identity.py tests/platform/sandbox/ -q
25 passed

$ uv run python -m pytest tests/config/ -q
266 passed

$ make lint            All checks passed!
$ make format-check    3431 files already formatted
$ uv run python -m mypy tests/config/test_workspace_identity.py
Success: no issues found in 1 source file
```

mypy is run directly on the test file because `make typecheck` covers `PYTHON_SOURCE_PATHS` only, so a type error in `tests/` never fails CI.

On placement: the issue asks for one test file under `tests/config/` or `tests/platform/sandbox/`. The existing capability-warning tests already live in `tests/config/test_workspace_identity.py`, so I extended that rather than start a second home for the same function. The filename is a poor fit for what the function does, but renaming it is a separate change and not one to smuggle into a test PR.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`capability_warning_facts()` is small, but what it produces is not decorative: it is the list the agent reads at boot to know what it cannot do. A false negative there means the agent believes it has a shell and discovers otherwise mid-turn, which is the failure the function exists to prevent. That makes the interesting assertions the ones about warnings that must *not* appear, as much as the ones that must.

AGENTS.md asks for a small suite that pins real failure modes over broad line coverage, and specifically warns against multiplying cases that exercise one branch with different literals. So I picked one case per branch and stopped. There is no "bash present, sh absent" case, for example, because it reaches the same `or` short-circuit as the case already covered.

I chose mutation over coverage as the check on whether these are worth their weight. Coverage would have gone green on a test that asserted nothing useful. Reverting the `sh` fallback and swapping `is not None` for `or` are both edits a reasonable person might make while tidying, and each now fails exactly one named test that says why it is wrong.

The `installed_tools` substitution deserves the most explanation. The default path (`tools=None`) must walk the real PATH, but asserting anything about the result would make the test depend on whether the CI image happens to ship `curl`. So the test replaces the probe with a fixture returning a known-empty PATH and asserts on the full ordered warning list, which pins both the branch and the emission order. The empty-mapping variant inverts it: the substituted probe raises, so the test fails loudly if the code ever starts probing when a caller already answered.

Edge cases considered: `{}` versus `None` (the mutation above); `OPENSRE_ALLOW_NETWORK` is explicitly `delenv`'d in the cases that assume the default, so an ambient value in a developer's shell cannot flip them; and the truthy-value parsing (`1`/`true`/`yes`/`on`) is left alone, since testing four spellings of one lowercase-and-compare would be exactly the literal-multiplying AGENTS.md warns about.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
