### PR TITLE
test(session_goal): pin three unguarded rules in evaluate

### DIFF
--- a/tests/core/agent_harness/session_goal/test_evaluate.py
+++ b/tests/core/agent_harness/session_goal/test_evaluate.py
@@ -812,8 +812,17 @@ def test_evidence_is_false_when_the_success_counts_are_not_numbers() -> None:
 
     class _BadResult:
         action_result = _BadCounts()
-        gather_success_count = None
+        # Truthy, so it survives the `or 0` and actually reaches int(). A None
+        # here would normalize to zero and leave the gather guard unexercised.
+        gather_success_count = "three"
         assistant_response_text = "done"
 
-    # Act / Assert
+    class _OnlyGatherIsBad:
+        action_result = None
+        gather_success_count = "three"
+        assistant_response_text = "done"
+
+    # Act / Assert: each count is converted separately, so each guard is
+    # reached on its own rather than only via the first one that raises.
     assert turn_has_session_goal_evidence(_BadResult()) is False
+    assert turn_has_session_goal_evidence(_OnlyGatherIsBad()) is False

--- a/tests/core/agent_harness/session_goal/test_evaluate.py
+++ b/tests/core/agent_harness/session_goal/test_evaluate.py
@@ -735,3 +735,85 @@ def test_achieved_claim_does_not_false_complete_a_long_checklist() -> None:
     # Assert — the claim is ignored, and B..E are still outstanding.
     assert verdict.status == SessionGoalStatus.ACTIVE
     assert "checklist 0/5" in verdict.reason
+
+
+def test_pending_user_choice_outranks_an_achieved_claim_with_evidence() -> None:
+    """A queued choice gates the goal before any other rule is consulted.
+
+    The strongest possible achieve signal (claim + successful tool + a complete
+    checklist) must still lose to an unanswered question, or the session closes
+    a goal whose next step is waiting on the user.
+    """
+    from core.agent_harness.session.pending_choice import PendingUserChoice
+
+    # Arrange
+    session = SessionCore()
+    session.pending_user_choice = PendingUserChoice(
+        title="Which environment?", options=("staging", "production")
+    )
+    goal = SessionGoal(
+        condition="restart the service",
+        checklist=("Pick the environment",),
+        completed=frozenset({0}),
+    )
+    attach_session_goal(session, goal)
+
+    # Act
+    verdict = evaluate_session_goal(
+        goal,
+        _result("Restarted. session_goal:achieved", executed=1, success=1),
+        session=session,
+    )
+
+    # Assert
+    assert verdict.status == SessionGoalStatus.ACTIVE
+    assert verdict.reason == SessionGoalReason.WAITING_USER_CHOICE
+
+
+def test_prior_turn_progress_blocks_the_untagged_same_turn_completion() -> None:
+    """The untagged shortcut is for a goal answered in one turn, not a resumed one.
+
+    Without a claim, a short checklist may auto-complete only when nothing was
+    done before this turn. A goal already carrying progress is mid-walkthrough,
+    so a turn that merely ran a tool must not close the remaining item.
+    """
+    # Arrange: same shape as the untagged same-turn case that does achieve,
+    # differing only in that item 0 was completed on an earlier turn.
+    session = SessionCore()
+    goal = SessionGoal(
+        condition="how many windows users?",
+        checklist=("Query PostHog", "Report the number"),
+        completed=frozenset({0}),
+    )
+    attach_session_goal(session, goal)
+
+    # Act
+    verdict = evaluate_session_goal(
+        goal,
+        _result("Still working on it.", executed=1, success=1),
+        session=session,
+    )
+
+    # Assert
+    assert verdict.status == SessionGoalStatus.ACTIVE
+    assert "checklist 1/2" in verdict.reason
+
+
+def test_evidence_is_false_when_the_success_counts_are_not_numbers() -> None:
+    """A malformed count is absence of evidence, never a crash mid-turn.
+
+    ``executed_success_count`` and ``gather_success_count`` are read off a
+    duck-typed result, so a stub or a partially built turn can carry a
+    non-numeric value. Failing closed keeps a bad count from reading as proof.
+    """
+
+    class _BadCounts:
+        executed_success_count = "two"
+
+    class _BadResult:
+        action_result = _BadCounts()
+        gather_success_count = None
+        assistant_response_text = "done"
+
+    # Act / Assert
+    assert turn_has_session_goal_evidence(_BadResult()) is False


### PR DESCRIPTION
Fixes #4898

#### Describe the changes you have made in this PR -

Tests only, extending the existing `tests/core/agent_harness/session_goal/test_evaluate.py`. No `core/` product code changed, no second evaluate test tree.

First, what I did **not** add. The four rules the issue names are already pinned:

| Rule from the issue | Already covered by |
|---|---|
| incomplete checklist ignores `achieved` | `test_achieved_ignored_when_checklist_incomplete`, `test_achieved_claim_does_not_false_complete_a_long_checklist` |
| short checklist ≤2 + tools ok → achieve | `test_achieved_with_tool_evidence_completes_short_checklist` |
| `investigation_dispatched` blocks achieve | `test_achieved_ignored_while_investigation_dispatched` |
| host-owned may claim without tools | `test_host_owned_achieved_without_tools_completes` |

Restating them would add lines and no signal. So I went through the `evaluate.py` docstring against the branches and added the three documented rules that nothing currently exercises:

- **`pending_user_choice` outranks every other rule.** It is the first gate in `evaluate_session_goal`, ahead of the checklist and the claim, and no test held it there. The case feeds the strongest achieve signal available (claim + successful tool + already-complete checklist) so it also fails if the gate is *moved down*, not only if it is deleted.
- **The untagged same-turn shortcut requires no prior-turn progress.** The docstring says "no prior-turn progress"; `not completed_before` implements it; nothing checked it. The case is the same shape as the untagged case that does achieve, differing only in a completed index carried in from an earlier turn.
- **`turn_has_session_goal_evidence` fails closed on a non-numeric count.** Both counts are read off a duck-typed result via `getattr`, so a stub or a partially built turn can carry a string. Absence of evidence, not a traceback mid-turn.

### Demo/Screenshot for feature changes and bug fixes -

Coverage is a weak signal for a test-only PR, so I checked these by mutating `evaluate.py` instead. Each mutation fails exactly its own test:

```
M1  drop the pending_user_choice gate
    FAILED test_pending_user_choice_outranks_an_achieved_claim_with_evidence
    1 failed, 33 passed

M2  drop `and not completed_before`
    FAILED test_prior_turn_progress_blocks_the_untagged_same_turn_completion
    1 failed, 33 passed

M3  remove the int() try/except in turn_has_session_goal_evidence
    FAILED test_evidence_is_false_when_the_success_counts_are_not_numbers
    1 failed, 33 passed
```

All mutations were reverted; `git status` shows only the test file changed.

I also wrote a fourth case, for the progress-paint guard on the host-owned path, and then deleted it. Mutating that guard already fails `test_slash_capture_waiting_reason_does_not_achieve_host_goal`, so it was a second case over one branch — exactly what AGENTS.md says not to multiply.

```
$ uv run python -m pytest tests/core/agent_harness/session_goal/test_evaluate.py -q
33 passed

$ uv run python -m pytest tests/core/agent_harness/ -q
451 passed

$ make lint            All checks passed!
$ make format-check    3431 files already formatted
$ uv run python -m mypy tests/core/agent_harness/session_goal/test_evaluate.py
Success: no issues found in 1 source file
```

mypy is run directly on the test file because `make typecheck` covers `PYTHON_SOURCE_PATHS` only, so a type error in `tests/` never fails CI.

No bug found. Every documented rule I checked behaves as the docstring describes, so there is nothing to report back under the issue's "if a test reveals a bug, note it and stop" clause.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The instinct on a "extend the tests" issue is to write a case for each bullet in the ticket. I read the existing 30 tests first and found all four bullets already covered, which changes the job: the useful work is not restating the rules but finding which parts of the same documented contract are load-bearing and unheld.

`evaluate_session_goal` is a decision tree where order matters as much as the conditions. That shaped the first test. Asserting only "a pending choice keeps the goal active" would pass even if the gate were relocated below the checklist branch, so the arrangement deliberately makes every *later* branch want to return ACHIEVED. The test then fails on a reordering, not just a deletion, which is the failure mode that actually threatens a precedence rule.

The second test is the mirror of an existing one. `test_same_turn_tool_answer_completes_short_checklist_without_done_tags` is the positive case; mine changes one field, `completed=frozenset({0})`, and expects the opposite outcome. Keeping them the same shape means a reader can see the whole rule by diffing two tests, and it makes the assertion about the guard rather than about incidental setup.

The third is a robustness case rather than a rules case, and I nearly left it out. It earns its place because the function reads both counts off a duck-typed `result` through `getattr`, so the type is not enforced anywhere upstream — the `try/except` is the only thing standing between a malformed stub and a traceback in the middle of a turn. Failing closed is also the safe direction: a count that cannot be parsed must not read as proof the goal was met.

On method: I used mutation rather than coverage to decide whether each test was worth keeping. Coverage would have gone green on assertions that pin nothing, and it is what let me catch that my fourth case was redundant — the mutation it was meant to catch was already caught by an existing test, so the case was deleted rather than shipped.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
