### PR TITLE
feat(background): retrieve a completed RCA from chat and persist notify channels

### DIFF
--- a/config/constants/paths.py
+++ b/config/constants/paths.py
@@ -98,6 +98,35 @@ def host_home() -> Path:
     return OPENSRE_HOME_DIR
 
 
+def _org_root(org_id: str) -> Path:
+    """Root owned by one organization: the mount when this deployment owns it.
+
+    The single implementation of the owner check, shared by :func:`opensre_home`
+    and :func:`deployment_home`. A second copy beside it would be a second
+    tenancy policy to keep in step.
+    """
+    mounted_root = os.getenv(CONTEXT_ROOT_ENV, "").strip()
+    if mounted_root:
+        # The mount is chrooted to exactly one org. If this deployment declares
+        # its owner, refuse a turn for any other org — otherwise a
+        # multi-workspace gateway could write org B's data into org A's volume.
+        # Fail closed.
+        silo_owner = organization_id()
+        if not silo_owner:
+            raise ContextRootOwnerMismatchError(
+                f"{CONTEXT_ROOT_ENV} is set but no organization is configured for this "
+                "deployment; refusing to write a customer's data to an unidentified volume"
+            )
+        if org_id != silo_owner:
+            raise ContextRootOwnerMismatchError(
+                f"context root belongs to {silo_owner!r} but this turn is owned by "
+                f"{org_id!r}; refusing to cross organizations on a shared mount"
+            )
+        return Path(mounted_root).expanduser()
+    _warn_unmounted_org_once(org_id)
+    return OPENSRE_HOME_DIR / ORGS_DIR_NAME / _safe_segment(org_id, label="principal id")
+
+
 def opensre_home() -> Path:
     """The organization's context root, or the host home when unbound.
 
@@ -114,27 +143,26 @@ def opensre_home() -> Path:
     scope = current_scope()
     if scope is None or scope.principal.kind != "org":
         return OPENSRE_HOME_DIR
-    mounted_root = os.getenv(CONTEXT_ROOT_ENV, "").strip()
-    if mounted_root:
-        # The mount is chrooted to exactly one org. If this deployment declares
-        # its owner, refuse a turn for any other org — otherwise a
-        # multi-workspace gateway could write org B's data into org A's volume.
-        # Fail closed.
-        silo_owner = organization_id()
-        if not silo_owner:
-            raise ContextRootOwnerMismatchError(
-                f"{CONTEXT_ROOT_ENV} is set but no organization is configured for this "
-                "deployment; refusing to write a customer's data to an unidentified volume"
-            )
-        if scope.principal.id != silo_owner:
-            raise ContextRootOwnerMismatchError(
-                f"context root belongs to {silo_owner!r} but this turn is owned by "
-                f"{scope.principal.id!r}; refusing to cross organizations on a shared mount"
-            )
-        return Path(mounted_root).expanduser()
-    _warn_unmounted_org_once(scope.principal.id)
-    org_id = _safe_segment(scope.principal.id, label="principal id")
-    return OPENSRE_HOME_DIR / ORGS_DIR_NAME / org_id
+    return _org_root(scope.principal.id)
+
+
+def deployment_home() -> Path:
+    """The organization this deployment serves, whether or not a scope is bound.
+
+    For an artifact two surfaces must share. A background investigation is
+    started in the shell, which binds no scope, and retrieved from a chat
+    transport, which binds the organization, so :func:`opensre_home` would put
+    them on different files. An unbound caller therefore resolves to the
+    configured organization; a machine naming none stays on the host root.
+
+    :func:`_org_root`'s owner check still applies, so this is not a way around
+    the mount's tenancy guarantee.
+    """
+    scope = current_scope()
+    if scope is not None and scope.principal.kind == "org":
+        return _org_root(scope.principal.id)
+    configured = organization_id()
+    return _org_root(configured) if configured else OPENSRE_HOME_DIR
 
 
 def session_home() -> Path:
@@ -206,6 +234,7 @@ __all__ = [
     "SYNTHETIC_SCENARIOS_DIR",
     "ContextRootOwnerMismatchError",
     "UnsafePathSegmentError",
+    "deployment_home",
     "ensure_opensre_tmp_dir",
     "get_memory_dir",
     "get_store_path",

--- a/docs/background-investigations.mdx
+++ b/docs/background-investigations.mdx
@@ -10,15 +10,15 @@ When background mode is on:
 
 - New investigations start in the background
 - The shell stays free for follow-up questions
-- Finished RCAs are tracked in the current session
+- Completed RCAs are kept and can be looked up later from the shell or chat
 - Completion notifications can go to email ([SMTP](/smtp)), Telegram
   ([Telegram](/messaging/telegram)), Rocket.Chat
   ([Rocket.Chat](/messaging/rocketchat)), Buzz
   ([Buzz](/messaging/buzz)), or any combination of those
 
 <Note>
-This feature is **session-local**. If the REPL process exits, in-flight
-background jobs stop with it.
+In-flight jobs stop if the shell exits. Completed RCAs are kept, and you can look
+them up later from the shell or from a chat channel.
 </Note>
 
 This is not the hosted async HTTP API (`POST /api/investigations` and
@@ -39,6 +39,12 @@ This is not the hosted async HTTP API (`POST /api/investigations` and
 | `/tasks` | List session tasks (including background investigations) |
 | `/cancel <task_id>` | Cancel a running background investigation |
 
+From Telegram, Slack, or Discord, use `/background status`, `/background list`,
+`/background show <task_id>`, or `/background notify list` to look up a finished
+RCA. Starting investigations, promoting an RCA with `/background use`, and
+changing channels remain shell-only. The completion notification includes the
+task ID needed for `/background show`.
+
 There is no `opensre background …` CLI command. Background mode is interactive
 shell only.
 
@@ -58,6 +64,8 @@ shell only.
 /background notify set telegram    # or: email, rocketchat, buzz, or email,telegram
 /background notify list            # confirm
 ```
+
+   Channels are remembered, so you only set them once.
 
 4. Start an investigation:
 
@@ -167,7 +175,17 @@ Proactive Slack delivery and further enhancements to chat-based monitoring are c
 
 ## Current limits
 
-- Interactive shell only — no `opensre background …` CLI command
-- Jobs are not persisted across REPL restarts
-- Completion does not automatically replace your active follow-up context
-- You must run `/background use <task_id>` to promote a finished RCA
+- investigations can only be **started** from the interactive shell; chat can look
+  them up but not launch one, and there is no `opensre background …` CLI command
+- in-flight jobs stop if the shell exits; only completed RCAs are kept
+- `/background use` needs the shell, because the full investigation state it
+  promotes is not part of what gets kept
+- completion does not automatically replace your active follow-up context
+- you must run `/background use <task_id>` to promote a finished RCA
+
+## Who can see a completed RCA
+
+Completed RCAs belong to your organization, not to you personally: anyone who can
+message the bot for the same organization can list them and read them. Keep that
+in mind if an investigation touches something you would not post in a team
+channel.

--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -14,6 +14,26 @@ ensure_project_platform_package()
 
 
 @pytest.fixture(autouse=True)
+def _isolate_opensre_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep every gateway test off the developer's real ``~/.opensre``.
+
+    Patch the attribute, not ``OPENSRE_HOME``: that env var is read once at
+    import, while the root helpers re-read the attribute per call.
+
+    Disabling the keyring is not optional here. Redirecting the home makes
+    credential lookup miss ``integrations.json`` and fall through to the OS
+    keychain, which blocks on a GUI prompt, so the pair must move together the
+    way ``tests/conftest.py`` keeps them.
+    """
+    from config.constants import paths
+    from config.secrets.os_keyring import reset_keyring_state
+
+    reset_keyring_state()
+    monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path / "opensre-home")
+
+
+@pytest.fixture(autouse=True)
 def _isolate_gateway_runtime_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Keep every gateway test off the developer's real ``~/.opensre/gateway``.
 

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -233,3 +233,60 @@ def test_gateway_manager_registers_harness_adapters(monkeypatch: pytest.MonkeyPa
     assert "adapters" in calls
     assert "runners" not in calls
     reset_process_runtime_for_tests()
+
+
+# Rich draws tables with these; nothing on the chat path converts them, so they
+# reach Telegram as literal characters inside an 80-column hard-wrapped block.
+_BOX_DRAWING = set("─│┃━╭╮╰╯┏┓┗┛┿┼┤├┬┴┌┐└┘╡╞═")
+
+
+def _seed_record(**overrides: Any) -> str:
+    from platform.background_investigations.store import background_investigation_store
+    from platform.background_investigations.types import BackgroundInvestigationRecord
+
+    fields: dict[str, Any] = {
+        "task_id": "bg-chat-1",
+        "status": "completed",
+        "command": "/investigate checkout-latency",
+        "root_cause": "connection pool saturation on the payments replica",
+        "top_analysis": ("rds cpu spike at 14:02",),
+        "next_steps": ("raise the pool ceiling to 64",),
+    }
+    fields.update(overrides)
+    record = BackgroundInvestigationRecord(**fields)
+    background_investigation_store().save(record)
+    return record.task_id
+
+
+def test_gateway_background_show_returns_the_rca_as_plain_text() -> None:
+    """AC2 and AC3: a completed RCA is retrievable from a chat transport.
+
+    Asserting the absence of box-drawing is the load-bearing half. The Rich table
+    renders fine into the captured console and would 'pass' a content-only
+    assertion while arriving in Telegram as an 80-column hard-wrapped grid of
+    ━ and │ that no sink converts.
+    """
+    task_id = _seed_record()
+
+    sink = _run_gateway_slash(f"/background show {task_id}")
+
+    assert sink.finalized is not None
+    assert "connection pool saturation" in sink.finalized
+    assert "raise the pool ceiling" in sink.finalized
+    assert not _BOX_DRAWING & set(sink.finalized), sink.finalized
+
+
+def test_gateway_background_list_is_plain_and_bounded() -> None:
+    """One line per record, and the root cause is trimmed. An unbounded list of
+    twenty folded RCAs overruns the 4096-character message cap, and the transports
+    tail-truncate, so the closing hint would be the first thing lost."""
+    for index in range(3):
+        _seed_record(task_id=f"bg-many-{index}", root_cause="saturation " * 60)
+
+    sink = _run_gateway_slash("/background list")
+
+    assert sink.finalized is not None
+    assert "bg-many-2" in sink.finalized
+    assert not _BOX_DRAWING & set(sink.finalized), sink.finalized
+    assert len(sink.finalized) < 4096
+    assert "/background show" in sink.finalized

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -101,6 +101,20 @@ def test_gateway_background_write_forms_report_repl_only() -> None:
     assert "uv run opensre" in sink.finalized
 
 
+def test_gateway_background_show_reaches_a_record_past_the_listing_bound() -> None:
+    # Oldest, then enough newer rows to push it out of any recent-N listing while
+    # staying inside the store's own bound, so only a full read finds it.
+    buried = _seed_record(task_id="bg-buried", root_cause="the oldest cause")
+    for index in range(60):
+        _seed_record(task_id=f"bg-bulk-{index:03d}", root_cause=f"cause {index}")
+
+    sink = _run_gateway_slash(f"/background show {buried}")
+
+    assert sink.finalized is not None
+    assert "the oldest cause" in sink.finalized
+    assert "unknown background task" not in sink.finalized
+
+
 def test_gateway_onboard_slash_returns_headless_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
     """Literal /onboard on SessionCore must not spawn a blocking interactive wizard."""
     recorded: list[list[str]] = []

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -301,12 +301,20 @@ def test_gateway_background_show_returns_the_rca_as_plain_text() -> None:
 
 
 def test_gateway_background_show_does_not_leak_delivery_exception_detail() -> None:
+    """Every free-form tail is dropped, whichever adapter produced it.
+
+    ``deliver_telegram_notification`` interpolates ``str(exc)`` from credential
+    loading, so a rule keyed on the ``failed:`` prefix passes it straight to
+    Telegram. The category before the colon is what gets reported; a rule that
+    allowlisted known-safe strings instead would fail open for the next adapter.
+    """
     task_id = _seed_record(
         task_id="bg-chat-redact",
         notification_results={
             "email": "failed: SMTPRecipientsRefused",
-            "telegram": "sent",
+            "telegram": "missing telegram integration: no bot token in /home/ops/.opensre",
             "buzz": "missing buzz integration: Buzz is not configured.",
+            "rocketchat": "sent",
         },
     )
 
@@ -315,8 +323,12 @@ def test_gateway_background_show_does_not_leak_delivery_exception_detail() -> No
     assert sink.finalized is not None
     assert "email:failed" in sink.finalized
     assert "SMTPRecipientsRefused" not in sink.finalized
-    assert "telegram:sent" in sink.finalized
-    assert "missing buzz integration: Buzz is not configured." in sink.finalized
+    assert "telegram:missing telegram integration" in sink.finalized
+    assert "/home/ops/.opensre" not in sink.finalized
+    assert "buzz:missing buzz integration" in sink.finalized
+    assert "Buzz is not configured" not in sink.finalized
+    # A tail-free outcome is reported whole; there is nothing to strip.
+    assert "rocketchat:sent" in sink.finalized
 
 
 def test_gateway_background_list_is_plain_and_bounded() -> None:
@@ -333,3 +345,27 @@ def test_gateway_background_list_is_plain_and_bounded() -> None:
     assert not _BOX_DRAWING & set(sink.finalized), sink.finalized
     assert len(sink.finalized) < 4096
     assert "/background show" in sink.finalized
+
+
+def test_gateway_background_list_stays_under_the_cap_on_worst_case_records() -> None:
+    """The cap has to hold on the record a real incident produces, not a short one.
+
+    ``command`` is operator-supplied alert text and was previously untrimmed, so
+    a listing of long-command records reached ~5.5k characters. The closing hint
+    is the assertion that matters: the transports cut the tail, so overrunning
+    loses exactly the line telling the reader how to read one of these.
+    """
+    alert = "alert:payments checkout latency spike on the eu-west-1 replica " * 6
+    for index in range(20):
+        _seed_record(
+            task_id=f"bg-worst-{index:02d}",
+            command=f"/investigate {alert}",
+            root_cause="saturation " * 60,
+        )
+
+    sink = _run_gateway_slash("/background list")
+
+    assert sink.finalized is not None
+    assert len(sink.finalized) <= 4096, len(sink.finalized)
+    assert sink.finalized.endswith("Use /background show <task_id> for the full RCA.")
+    assert "more" in sink.finalized

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -276,6 +276,25 @@ def test_gateway_background_show_returns_the_rca_as_plain_text() -> None:
     assert not _BOX_DRAWING & set(sink.finalized), sink.finalized
 
 
+def test_gateway_background_show_does_not_leak_delivery_exception_detail() -> None:
+    task_id = _seed_record(
+        task_id="bg-chat-redact",
+        notification_results={
+            "email": "failed: SMTPRecipientsRefused",
+            "telegram": "sent",
+            "buzz": "missing buzz integration: Buzz is not configured.",
+        },
+    )
+
+    sink = _run_gateway_slash(f"/background show {task_id}")
+
+    assert sink.finalized is not None
+    assert "email:failed" in sink.finalized
+    assert "SMTPRecipientsRefused" not in sink.finalized
+    assert "telegram:sent" in sink.finalized
+    assert "missing buzz integration: Buzz is not configured." in sink.finalized
+
+
 def test_gateway_background_list_is_plain_and_bounded() -> None:
     """One line per record, and the root cause is trimmed. An unbounded list of
     twenty folded RCAs overruns the 4096-character message cap, and the transports

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -101,6 +101,16 @@ def test_gateway_background_write_forms_report_repl_only() -> None:
     assert "uv run opensre" in sink.finalized
 
 
+def test_gateway_background_use_is_refused_before_the_record_lookup() -> None:
+    task_id = _seed_record(task_id="bg-use-chat")
+
+    sink = _run_gateway_slash(f"/background use {task_id}")
+
+    assert sink.finalized is not None
+    assert "uv run opensre" in sink.finalized
+    assert "unknown background task" not in sink.finalized
+
+
 def test_gateway_background_show_reaches_a_record_past_the_listing_bound() -> None:
     # Oldest, then enough newer rows to push it out of any recent-N listing while
     # staying inside the store's own bound, so only a full read finds it.

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -283,10 +283,10 @@ def _seed_record(**overrides: Any) -> str:
 
 
 def test_gateway_background_show_returns_the_rca_as_plain_text() -> None:
-    """AC2 and AC3: a completed RCA is retrievable from a chat transport.
+    """A completed RCA is retrievable from a chat transport.
 
     Asserting the absence of box-drawing is the load-bearing half. The Rich table
-    renders fine into the captured console and would 'pass' a content-only
+    renders fine into the captured console and would pass a content-only
     assertion while arriving in Telegram as an 80-column hard-wrapped grid of
     ━ and │ that no sink converts.
     """

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -265,8 +265,8 @@ _BOX_DRAWING = set("─│┃━╭╮╰╯┏┓┗┛┿┼┤├┬┴┌┐
 
 
 def _seed_record(**overrides: Any) -> str:
-    from platform.background_investigations.store import background_investigation_store
-    from platform.background_investigations.types import BackgroundInvestigationRecord
+    from platform.scheduling.background_investigations.store import background_investigation_store
+    from platform.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
     fields: dict[str, Any] = {
         "task_id": "bg-chat-1",

--- a/integrations/smtp/background_adapter.py
+++ b/integrations/smtp/background_adapter.py
@@ -38,11 +38,14 @@ def deliver_email_notification(record: BackgroundInvestigationRecord) -> str:
         next_steps=record.next_steps,
         stats=record.stats,
     )
-    ok, _error = send_smtp_report(report=body, subject=subject, smtp_ctx=smtp_config)
-    # Outcomes are persisted and displayed by ``/background show``. The SMTP
-    # transport's error value may include provider or credential detail, so it
-    # must not cross this external-surface boundary.
-    return "sent" if ok else "failed: SMTP delivery failed"
+    ok, error = send_smtp_report(report=body, subject=subject, smtp_ctx=smtp_config)
+    # ``send_smtp_report`` already narrows a failure to ``type(exc).__name__``,
+    # which is what the local ``/background show`` table needs to tell an auth
+    # failure from a connection one. Redaction for a chat transport belongs at
+    # that sink (``_chat_safe_outcome``), not here — the terminal is not an
+    # external surface, and the sibling adapters keep their reason for the same
+    # reason.
+    return "sent" if ok else f"failed: {error}"
 
 
 class _EmailBackgroundAdapter:

--- a/integrations/smtp/background_adapter.py
+++ b/integrations/smtp/background_adapter.py
@@ -38,8 +38,11 @@ def deliver_email_notification(record: BackgroundInvestigationRecord) -> str:
         next_steps=record.next_steps,
         stats=record.stats,
     )
-    ok, error = send_smtp_report(report=body, subject=subject, smtp_ctx=smtp_config)
-    return "sent" if ok else f"failed: {error}"
+    ok, _error = send_smtp_report(report=body, subject=subject, smtp_ctx=smtp_config)
+    # Outcomes are persisted and displayed by ``/background show``. The SMTP
+    # transport's error value may include provider or credential detail, so it
+    # must not cross this external-surface boundary.
+    return "sent" if ok else "failed: SMTP delivery failed"
 
 
 class _EmailBackgroundAdapter:

--- a/platform/scheduling/background_investigations/store.py
+++ b/platform/scheduling/background_investigations/store.py
@@ -114,15 +114,20 @@ class BackgroundInvestigationStore:
                 return BackgroundInvestigationRecord.from_dict(row)
         return None
 
-    def list_recent(self, limit: int = 20) -> list[BackgroundInvestigationRecord]:
-        """Return at most ``limit`` records newest first; later writes win ties."""
+    def list_recent(self, limit: int | None = 20) -> list[BackgroundInvestigationRecord]:
+        """Return at most ``limit`` records newest first; later writes win ties.
+
+        ``limit=None`` returns the whole document, for a caller that resolves a
+        record by id and must not miss one the bound would have cut.
+        """
         rows = sorted(
             self._load(self.path),
             key=lambda row: coerce_timestamp(row.get("updated_at")),
         )
         rows.reverse()
         records = [BackgroundInvestigationRecord.from_dict(row) for row in rows]
-        return [record for record in records if record is not None][: max(limit, 0)]
+        found = [record for record in records if record is not None]
+        return found if limit is None else found[: max(limit, 0)]
 
     def notify_channels(self) -> tuple[str, ...]:
         """Channels background-RCA notices are delivered to, or empty when unset."""

--- a/platform/scheduling/background_investigations/store.py
+++ b/platform/scheduling/background_investigations/store.py
@@ -1,4 +1,9 @@
-"""Durable background-investigation records shared across processes."""
+"""Durable background-investigation records shared across processes.
+
+Resolved against ``deployment_home()``, so the shell (which binds no scope) and a
+chat transport (which binds the organization) read one document. Records are owned
+by the organization, not the member who ran the investigation.
+"""
 
 from __future__ import annotations
 
@@ -42,10 +47,10 @@ class UnreadableBackgroundInvestigationsError(RuntimeError):
 
 
 def _default_path() -> Path:
-    """Resolve the store path for the currently bound organization scope."""
-    from config.constants.paths import opensre_home
+    """Resolve the store path for the organization this deployment serves."""
+    from config.constants.paths import deployment_home
 
-    return opensre_home() / _STORE_DIRNAME / _STORE_FILENAME
+    return deployment_home() / _STORE_DIRNAME / _STORE_FILENAME
 
 
 class BackgroundInvestigationStore:

--- a/platform/scheduling/background_investigations/store.py
+++ b/platform/scheduling/background_investigations/store.py
@@ -35,6 +35,9 @@ _LOCK_TIMEOUT_SECONDS = 10.0
 _FILE_MODE = 0o600
 
 _STORE_FILENAME = "investigations.json"
+# Preferences share the record document, so they reuse its resolver, lock and
+# atomic write rather than needing a second file to mirror all three.
+_CHANNELS_KEY = "notify_channels"
 _STORE_DIRNAME = "background"
 
 
@@ -80,10 +83,15 @@ class BackgroundInvestigationStore:
     # ── public API ──────────────────────────────────────────────────────────
 
     def save(self, record: BackgroundInvestigationRecord) -> None:
-        """Save ``record`` while preserving creation time and always retaining this write."""
+        """Save ``record`` while preserving creation time and always retaining this write.
+
+        Notification channels live in the same document and are rewritten under the
+        same lock, so neither a record write nor rotation may drop them.
+        """
         path = self.path
         now = self._clock()
         with self._locked(path):
+            channels = self._load_channels(path)
             rows = self._load(path)
             others = [row for row in rows if row.get("task_id") != record.task_id]
             existing = next((r for r in rows if r.get("task_id") == record.task_id), None)
@@ -97,7 +105,7 @@ class BackgroundInvestigationStore:
             # Keep the current write outside rotation so clock rollback cannot evict it.
             others.sort(key=lambda row: coerce_timestamp(row.get("updated_at")))
             keep = max(self._max_records, 1) - 1
-            self._write(path, [*(others[-keep:] if keep else []), record.to_dict()])
+            self._write(path, [*(others[-keep:] if keep else []), record.to_dict()], channels)
 
     def get(self, task_id: str) -> BackgroundInvestigationRecord | None:
         """Return the stored record for ``task_id``, or ``None``."""
@@ -116,12 +124,26 @@ class BackgroundInvestigationStore:
         records = [BackgroundInvestigationRecord.from_dict(row) for row in rows]
         return [record for record in records if record is not None][: max(limit, 0)]
 
+    def notify_channels(self) -> tuple[str, ...]:
+        """Channels background-RCA notices are delivered to, or empty when unset."""
+        return self._load_channels(self.path) or ()
+
+    def set_notify_channels(self, channels: tuple[str, ...]) -> None:
+        """Persist the delivery channels, leaving stored records untouched."""
+        path = self.path
+        with self._locked(path):
+            self._write(path, self._load(path), tuple(channels))
+
     # ── document ────────────────────────────────────────────────────────────
 
-    def _load(self, path: Path) -> list[dict[str, Any]]:
-        """Read rows, returning empty when absent and failing closed when damaged."""
+    def _load_document(self, path: Path) -> dict[str, Any]:
+        """Read the whole document.
+
+        Absent reads as empty; damaged raises, because the next write would
+        otherwise replace a history it could not parse.
+        """
         if not path.is_file():
-            return []
+            return {}
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -132,10 +154,30 @@ class BackgroundInvestigationStore:
             raise UnreadableBackgroundInvestigationsError(
                 f"background investigations file has an unexpected shape: {path}"
             )
-        return [row for row in data["records"] if isinstance(row, dict)]
+        return data
 
-    def _write(self, path: Path, rows: list[dict[str, Any]]) -> None:
-        payload = {"version": _VERSION, "records": rows}
+    def _load(self, path: Path) -> list[dict[str, Any]]:
+        """Read the record rows."""
+        rows = self._load_document(path).get("records", [])
+        return [row for row in rows if isinstance(row, dict)]
+
+    def _load_channels(self, path: Path) -> tuple[str, ...] | None:
+        """Stored channels, or ``None`` when the document names none.
+
+        ``None`` and ``()`` are different answers: an explicit clear must persist
+        as an empty list rather than reading back as "never set".
+        """
+        stored = self._load_document(path).get(_CHANNELS_KEY)
+        if not isinstance(stored, list):
+            return None
+        return tuple(str(value) for value in stored)
+
+    def _write(
+        self, path: Path, rows: list[dict[str, Any]], channels: tuple[str, ...] | None
+    ) -> None:
+        payload: dict[str, Any] = {"version": _VERSION, "records": rows}
+        if channels is not None:
+            payload[_CHANNELS_KEY] = list(channels)
         path.parent.mkdir(parents=True, exist_ok=True)
         descriptor, temp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
         try:

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -315,6 +315,10 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
         print_repl_table(console, table)
         return True
     if sub == "use":
+        # Before the lookup: the promoted state is not persisted, so a chat
+        # surface would otherwise call an id it just listed unknown.
+        if session_terminal(session) is None:
+            return _reject_repl_only(session, console, "use")
         if len(args) < 2:
             console.print(f"[{ERROR}]usage:[/] /background use <task_id>")
             session.mark_latest(ok=False, kind="slash")

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -30,8 +30,12 @@ from surfaces.interactive_shell.ui import (
 from surfaces.shared.error_handling.exception_reporting import report_exception
 
 # A chat message caps at 4096 characters and the transports tail-truncate.
+_CHAT_MESSAGE_CHARS = 4096
 _CHAT_LIST_LIMIT = 10
 _CHAT_CAUSE_CHARS = 120
+_CHAT_COMMAND_CHARS = 120
+_CHAT_NOTIFIED_CHARS = 200
+_LIST_HINT = "Use /background show <task_id> for the full RCA."
 
 
 def _allowed_notify_channels() -> tuple[str, ...]:
@@ -148,35 +152,62 @@ def _plain_status(session: Session, records: dict[str, BackgroundInvestigationRe
 
 
 def _plain_list(records: dict[str, BackgroundInvestigationRecord]) -> str:
-    """One line per record, root cause trimmed.
+    """One line per record, every free-text field trimmed and the body capped.
 
-    Bounded because the transports tail-truncate: an unbounded list drops the
-    closing hint first, which is the line telling the reader how to get the rest.
+    The per-field trims keep an ordinary listing readable; the cap is the part
+    that has to hold. The transports tail-truncate, so an overlong body loses
+    the closing hint first — the one line telling the reader how to get the
+    rest. Both the command and the root cause are operator-supplied and
+    unbounded, so trimming either one alone still overruns. Rows are dropped
+    from the end until the body fits, and the drop is reported, rather than
+    letting the transport cut the message mid-word.
     """
     from platform.text.truncation import truncate
 
-    lines = ["Background investigations", ""]
+    rows: list[str] = []
     for task_id, record in list(records.items())[:_CHAT_LIST_LIMIT]:
         cause = (
             truncate(record.root_cause, _CHAT_CAUSE_CHARS, suffix="…") if record.root_cause else "-"
         )
-        lines.append(f"  {task_id}  [{record.status}]  {record.command}")
-        lines.append(f"      {cause}")
-    remaining = len(records) - _CHAT_LIST_LIMIT
-    if remaining > 0:
-        lines.append(f"  ... and {remaining} more")
-    lines.append("")
-    lines.append("Use /background show <task_id> for the full RCA.")
-    return "\n".join(lines)
+        command = truncate(record.command, _CHAT_COMMAND_CHARS, suffix="…")
+        rows.append(f"  {task_id}  [{record.status}]  {command}\n      {cause}")
+
+    def _body(shown: list[str]) -> str:
+        omitted = len(records) - len(shown)
+        tail = [f"  ... and {omitted} more"] if omitted > 0 else []
+        return "\n".join(["Background investigations", "", *shown, *tail, "", _LIST_HINT])
+
+    while rows and len(_body(rows)) > _CHAT_MESSAGE_CHARS:
+        rows.pop()
+    return _body(rows)
 
 
 def _chat_safe_outcome(outcome: str) -> str:
-    return "failed" if outcome.startswith("failed:") else outcome
+    """The outcome's category, without whatever an adapter appended to it.
+
+    Every adapter returns a free-form tail after the first colon, and
+    ``deliver_telegram_notification`` builds its own from ``str(exc)``. Since
+    ``/background show`` now answers a chat transport, that tail crosses an
+    external-surface boundary. Reporting the category alone still says what
+    happened, and means a new adapter cannot leak through here without being
+    audited first — an allowlist of known-safe strings would have to be revised
+    every time one is added, and would silently fail open until someone did.
+
+    The REPL table prints the full string: a terminal is not an external sink.
+    """
+    category, separator, _detail = outcome.partition(":")
+    return category.strip() if separator else outcome
 
 
 def _plain_show(task_id: str, record: BackgroundInvestigationRecord) -> str:
-    """The same bounded sections the chat notification adapters already send."""
+    """The same bounded sections the chat notification adapters already send.
+
+    The delivery line is trimmed too: ``summary_sections`` budgets each section
+    so the worst case clears the message cap, and an unbounded trailer appended
+    after it would spend that headroom back.
+    """
     from platform.delivery.notifications.rca_summary import summary_sections
+    from platform.text.truncation import truncate
 
     command, root_cause, top_analysis, next_steps = summary_sections(record)
     lines = [
@@ -195,7 +226,7 @@ def _plain_show(task_id: str, record: BackgroundInvestigationRecord) -> str:
         delivered = ", ".join(
             f"{k}:{_chat_safe_outcome(v)}" for k, v in record.notification_results.items()
         )
-        lines += ["", f"Notified: {delivered}"]
+        lines += ["", f"Notified: {truncate(delivered, _CHAT_NOTIFIED_CHARS, suffix='…')}"]
     return "\n".join(lines)
 
 

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -172,6 +172,10 @@ def _plain_list(records: dict[str, BackgroundInvestigationRecord]) -> str:
     return "\n".join(lines)
 
 
+def _chat_safe_outcome(outcome: str) -> str:
+    return "failed" if outcome.startswith("failed:") else outcome
+
+
 def _plain_show(task_id: str, record: BackgroundInvestigationRecord) -> str:
     """The same bounded sections the chat notification adapters already send."""
     from platform.notifications.rca_summary import summary_sections
@@ -190,7 +194,9 @@ def _plain_show(task_id: str, record: BackgroundInvestigationRecord) -> str:
     if next_steps:
         lines += ["", "What to do next:"] + [f"  - {item}" for item in next_steps]
     if record.notification_results:
-        delivered = ", ".join(f"{k}:{v}" for k, v in record.notification_results.items())
+        delivered = ", ".join(
+            f"{k}:{_chat_safe_outcome(v)}" for k, v in record.notification_results.items()
+        )
         lines += ["", f"Notified: {delivered}"]
     return "\n".join(lines)
 

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -15,7 +15,7 @@ from core.agent_harness.spi.session_state import (
     background_notification_channels,
     session_terminal,
 )
-from platform.background_investigations.types import BackgroundInvestigationRecord
+from platform.scheduling.background_investigations.types import BackgroundInvestigationRecord
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import (
@@ -27,7 +27,7 @@ from surfaces.interactive_shell.ui import (
     print_repl_table,
     repl_table,
 )
-from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
+from surfaces.shared.error_handling.exception_reporting import report_exception
 
 # A chat message caps at 4096 characters and the transports tail-truncate.
 _CHAT_LIST_LIMIT = 10
@@ -79,7 +79,7 @@ def _tracked_records(
     """
     records: dict[str, BackgroundInvestigationRecord] = dict(background_investigations(session))
     try:
-        from platform.background_investigations.store import (
+        from platform.scheduling.background_investigations.store import (
             background_investigation_store,
         )
 
@@ -106,7 +106,7 @@ def _notify_channels(session: Session) -> tuple[str, ...]:
     if channels or session_terminal(session) is not None:
         return channels
     try:
-        from platform.background_investigations.store import (
+        from platform.scheduling.background_investigations.store import (
             background_investigation_store,
         )
 
@@ -123,7 +123,7 @@ def _persist_notify_channels(console: Console, channels: tuple[str, ...]) -> Non
     turn to a traceback.
     """
     try:
-        from platform.background_investigations.store import (
+        from platform.scheduling.background_investigations.store import (
             background_investigation_store,
         )
 
@@ -153,7 +153,7 @@ def _plain_list(records: dict[str, BackgroundInvestigationRecord]) -> str:
     Bounded because the transports tail-truncate: an unbounded list drops the
     closing hint first, which is the line telling the reader how to get the rest.
     """
-    from platform.common.truncation import truncate
+    from platform.text.truncation import truncate
 
     lines = ["Background investigations", ""]
     for task_id, record in list(records.items())[:_CHAT_LIST_LIMIT]:
@@ -176,7 +176,7 @@ def _chat_safe_outcome(outcome: str) -> str:
 
 def _plain_show(task_id: str, record: BackgroundInvestigationRecord) -> str:
     """The same bounded sections the chat notification adapters already send."""
-    from platform.notifications.rca_summary import summary_sections
+    from platform.delivery.notifications.rca_summary import summary_sections
 
     command, root_cause, top_analysis, next_steps = summary_sections(record)
     lines = [

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -6,8 +6,6 @@ RCA can be looked up from a chat transport. Write forms stay shell-only.
 
 from __future__ import annotations
 
-from typing import Any
-
 from rich.console import Console
 from rich.markup import escape
 
@@ -17,6 +15,7 @@ from core.agent_harness.spi.session_state import (
     background_notification_channels,
     session_terminal,
 )
+from platform.background_investigations.types import BackgroundInvestigationRecord
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import (
@@ -67,20 +66,20 @@ _BACKGROUND_FIRST_ARGS: tuple[tuple[str, str], ...] = (
 )
 
 
-def _tracked_records(session: Session, console: Console) -> dict[str, Any]:
+def _tracked_records(
+    session: Session, console: Console
+) -> dict[str, BackgroundInvestigationRecord]:
     """Records this session is holding, with the durable ones behind them.
 
     Session-live first: the runner persists only on the way out, so an in-flight
     record is fresher in memory, and only the live copy carries ``final_state``,
     which ``/background use`` needs.
 
-    Never raises. ``dispatch_slash`` puts no ``try`` around the handler, so an
-    escaping error would reach the transport's generic path and log a traceback
-    for what is a readable condition. The reported message stays generic because a
-    chat transport is an external sink and the store's own error text carries the
-    absolute document path.
+    Never raises: ``dispatch_slash`` puts no ``try`` around the handler. The
+    reported message stays generic because a chat transport is an external sink
+    and the store's error text carries the absolute document path.
     """
-    records: dict[str, Any] = dict(background_investigations(session))
+    records: dict[str, BackgroundInvestigationRecord] = dict(background_investigations(session))
     try:
         from platform.background_investigations.store import (
             background_investigation_store,
@@ -99,23 +98,62 @@ def _tracked_records(session: Session, console: Console) -> dict[str, Any]:
     return records
 
 
-def _plain_status(session: Session, records: dict[str, Any]) -> str:
+def _notify_channels(session: Session) -> tuple[str, ...]:
+    """Channels for this session, falling back to the durable ones.
+
+    A chat session has no terminal facet to hold preferences, so without the
+    store it would report "none" however the shell was configured.
+    """
+    channels = background_notification_channels(session)
+    if channels or session_terminal(session) is not None:
+        return channels
+    try:
+        from platform.background_investigations.store import (
+            background_investigation_store,
+        )
+
+        return background_investigation_store().notify_channels()
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+def _persist_notify_channels(console: Console, channels: tuple[str, ...]) -> None:
+    """Write the channels so the next shell starts with them.
+
+    Reported rather than raised: the in-session change already took effect, and
+    the user should know it will not outlive the session rather than lose the
+    turn to a traceback.
+    """
+    try:
+        from platform.background_investigations.store import (
+            background_investigation_store,
+        )
+
+        background_investigation_store().set_notify_channels(channels)
+    except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context="surfaces.interactive_shell.background_notify_persist")
+        console.print(
+            f"[{WARNING}]channels not saved for the next session[/] "
+            f"[{DIM}]({escape(type(exc).__name__)}); they apply to this one.[/]"
+        )
+
+
+def _plain_status(session: Session, records: dict[str, BackgroundInvestigationRecord]) -> str:
     return "\n".join(
         (
             "Background mode",
             f"  enabled: {'yes' if background_mode_enabled(session) else 'no'}",
             f"  tracked jobs: {len(records)}",
-            f"  notify channels: {', '.join(background_notification_channels(session)) or 'none'}",
+            f"  notify channels: {', '.join(_notify_channels(session)) or 'none'}",
         )
     )
 
 
-def _plain_list(records: dict[str, Any]) -> str:
-    """One line per record, newest-looking first, root cause trimmed.
+def _plain_list(records: dict[str, BackgroundInvestigationRecord]) -> str:
+    """One line per record, root cause trimmed.
 
-    Bounded twice over. Chat platforms cap a message at 4096 characters and the
-    transports tail-truncate, so an unbounded list would drop the closing hint
-    first, which is the one line telling the reader how to get the rest.
+    Bounded because the transports tail-truncate: an unbounded list drops the
+    closing hint first, which is the line telling the reader how to get the rest.
     """
     from platform.common.truncation import truncate
 
@@ -134,7 +172,7 @@ def _plain_list(records: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _plain_show(task_id: str, record: Any) -> str:
+def _plain_show(task_id: str, record: BackgroundInvestigationRecord) -> str:
     """The same bounded sections the chat notification adapters already send."""
     from platform.notifications.rca_summary import summary_sections
 
@@ -158,11 +196,7 @@ def _plain_show(task_id: str, record: Any) -> str:
 
 
 def _reply_headless(session: Session, console: Console, message: str) -> bool:
-    """Answer a chat surface in plain text.
-
-    Printed as well as published so the captured-console fallback stays sane and
-    the existing "every form answers" test still sees output.
-    """
+    """Answer a chat surface in plain text, printed as well as published."""
     from surfaces.interactive_shell.command_registry.cli_parity import (
         publish_headless_slash_response,
     )
@@ -182,10 +216,7 @@ def _render_background_status(session: Session, console: Console) -> None:
     table.add_column("value")
     table.add_row("enabled", "yes" if background_mode_enabled(session) else "no")
     table.add_row("tracked jobs", str(len(records)))
-    table.add_row(
-        "notify channels",
-        ", ".join(background_notification_channels(session)) or "none",
-    )
+    table.add_row("notify channels", ", ".join(_notify_channels(session)) or "none")
     print_repl_table(console, table)
 
 
@@ -306,10 +337,14 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
     if sub == "notify":
         action = (args[1].lower() if len(args) > 1 else "list").strip()
         if action == "list":
-            console.print(
-                f"[{DIM}]background notify channels:[/] "
-                f"{', '.join(background_notification_channels(session)) or 'none'}"
-            )
+            channels = _notify_channels(session)
+            if session_terminal(session) is None:
+                return _reply_headless(
+                    session,
+                    console,
+                    f"Background notify channels: {', '.join(channels) or 'none'}",
+                )
+            console.print(f"[{DIM}]background notify channels:[/] {', '.join(channels) or 'none'}")
             return True
         if action == "set":
             if session_terminal(session) is None:
@@ -328,10 +363,11 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
                 )
                 session.mark_latest(ok=False, kind="slash")
                 return True
-            session.terminal.background_notification_preferences.set_channels(requested)
+            preferences = session.terminal.background_notification_preferences
+            preferences.set_channels(requested)
+            _persist_notify_channels(console, preferences.channels)
             console.print(
-                f"[{HIGHLIGHT}]background notify channels set:[/] "
-                f"{', '.join(session.terminal.background_notification_preferences.channels)}"
+                f"[{HIGHLIGHT}]background notify channels set:[/] {', '.join(preferences.channels)}"
             )
             return True
         console.print(f"[{ERROR}]unknown notify subcommand:[/] {escape(action)}")

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -1,6 +1,12 @@
-"""Slash commands for session-local background investigation mode."""
+"""Slash commands for background investigation mode.
+
+Read forms answer from the durable store as well as the session, so a completed
+RCA can be looked up from a chat transport. Write forms stay shell-only.
+"""
 
 from __future__ import annotations
+
+from typing import Any
 
 from rich.console import Console
 from rich.markup import escape
@@ -18,9 +24,14 @@ from surfaces.interactive_shell.ui import (
     DIM,
     ERROR,
     HIGHLIGHT,
+    WARNING,
     print_repl_table,
     repl_table,
 )
+from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
+
+# The store keeps 100 rows; a lookup surface wants the recent ones, not the archive.
+_STORE_READ_LIMIT = 50
 
 
 def _allowed_notify_channels() -> tuple[str, ...]:
@@ -53,12 +64,44 @@ _BACKGROUND_FIRST_ARGS: tuple[tuple[str, str], ...] = (
 )
 
 
+def _tracked_records(session: Session, console: Console) -> dict[str, Any]:
+    """Records this session is holding, with the durable ones behind them.
+
+    Session-live first: the runner persists only on the way out, so an in-flight
+    record is fresher in memory, and only the live copy carries ``final_state``,
+    which ``/background use`` needs.
+
+    Never raises. ``dispatch_slash`` puts no ``try`` around the handler, so an
+    escaping error would reach the transport's generic path and log a traceback
+    for what is a readable condition. The reported message stays generic because a
+    chat transport is an external sink and the store's own error text carries the
+    absolute document path.
+    """
+    records: dict[str, Any] = dict(background_investigations(session))
+    try:
+        from platform.background_investigations.store import (
+            background_investigation_store,
+        )
+
+        stored = background_investigation_store().list_recent(limit=_STORE_READ_LIMIT)
+    except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context="surfaces.interactive_shell.background_read")
+        console.print(
+            f"[{WARNING}]stored background records are unavailable[/] "
+            f"[{DIM}]({escape(type(exc).__name__)}); showing this session only.[/]"
+        )
+        return records
+    for record in stored:
+        records.setdefault(record.task_id, record)
+    return records
+
+
 def _render_background_status(session: Session, console: Console) -> None:
     table = repl_table(title="Background mode\n", title_style=BOLD_BRAND, show_header=False)
     table.add_column("key", style="bold")
     table.add_column("value")
     table.add_row("enabled", "yes" if background_mode_enabled(session) else "no")
-    table.add_row("tracked jobs", str(len(background_investigations(session))))
+    table.add_row("tracked jobs", str(len(_tracked_records(session, console))))
     table.add_row(
         "notify channels",
         ", ".join(background_notification_channels(session)) or "none",
@@ -94,9 +137,9 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
         _render_background_status(session, console)
         return True
     if sub == "list":
-        tracked = background_investigations(session)
+        tracked = _tracked_records(session, console)
         if not tracked:
-            console.print(f"[{DIM}]no background investigations tracked in this session.[/]")
+            console.print(f"[{DIM}]no background investigations tracked.[/]")
             return True
         table = repl_table(title="Background investigations\n", title_style=BOLD_BRAND)
         table.add_column("id", style="bold")
@@ -118,7 +161,7 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
             session.mark_latest(ok=False, kind="slash")
             return True
         task_id = args[1]
-        selected_record = background_investigations(session).get(task_id)
+        selected_record = _tracked_records(session, console).get(task_id)
         if selected_record is None:
             console.print(f"[{ERROR}]unknown background task:[/] {escape(task_id)}")
             session.mark_latest(ok=False, kind="slash")
@@ -158,7 +201,7 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
             session.mark_latest(ok=False, kind="slash")
             return True
         task_id = args[1]
-        selected_record = background_investigations(session).get(task_id)
+        selected_record = _tracked_records(session, console).get(task_id)
         if selected_record is None:
             console.print(f"[{ERROR}]unknown background task:[/] {escape(task_id)}")
             session.mark_latest(ok=False, kind="slash")

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -32,6 +32,9 @@ from surfaces.interactive_shell.utils.error_handling.exception_reporting import 
 
 # The store keeps 100 rows; a lookup surface wants the recent ones, not the archive.
 _STORE_READ_LIMIT = 50
+# A chat message caps at 4096 characters and the transports tail-truncate.
+_CHAT_LIST_LIMIT = 10
+_CHAT_CAUSE_CHARS = 120
 
 
 def _allowed_notify_channels() -> tuple[str, ...]:
@@ -96,12 +99,89 @@ def _tracked_records(session: Session, console: Console) -> dict[str, Any]:
     return records
 
 
+def _plain_status(session: Session, records: dict[str, Any]) -> str:
+    return "\n".join(
+        (
+            "Background mode",
+            f"  enabled: {'yes' if background_mode_enabled(session) else 'no'}",
+            f"  tracked jobs: {len(records)}",
+            f"  notify channels: {', '.join(background_notification_channels(session)) or 'none'}",
+        )
+    )
+
+
+def _plain_list(records: dict[str, Any]) -> str:
+    """One line per record, newest-looking first, root cause trimmed.
+
+    Bounded twice over. Chat platforms cap a message at 4096 characters and the
+    transports tail-truncate, so an unbounded list would drop the closing hint
+    first, which is the one line telling the reader how to get the rest.
+    """
+    from platform.common.truncation import truncate
+
+    lines = ["Background investigations", ""]
+    for task_id, record in list(records.items())[:_CHAT_LIST_LIMIT]:
+        cause = (
+            truncate(record.root_cause, _CHAT_CAUSE_CHARS, suffix="…") if record.root_cause else "-"
+        )
+        lines.append(f"  {task_id}  [{record.status}]  {record.command}")
+        lines.append(f"      {cause}")
+    remaining = len(records) - _CHAT_LIST_LIMIT
+    if remaining > 0:
+        lines.append(f"  ... and {remaining} more")
+    lines.append("")
+    lines.append("Use /background show <task_id> for the full RCA.")
+    return "\n".join(lines)
+
+
+def _plain_show(task_id: str, record: Any) -> str:
+    """The same bounded sections the chat notification adapters already send."""
+    from platform.notifications.rca_summary import summary_sections
+
+    command, root_cause, top_analysis, next_steps = summary_sections(record)
+    lines = [
+        f"Background investigation {task_id}",
+        "",
+        f"  status: {record.status}",
+        f"  command: {command}",
+        "",
+        f"Root cause: {root_cause or '-'}",
+    ]
+    if top_analysis:
+        lines += ["", "Top analysis:"] + [f"  - {item}" for item in top_analysis]
+    if next_steps:
+        lines += ["", "What to do next:"] + [f"  - {item}" for item in next_steps]
+    if record.notification_results:
+        delivered = ", ".join(f"{k}:{v}" for k, v in record.notification_results.items())
+        lines += ["", f"Notified: {delivered}"]
+    return "\n".join(lines)
+
+
+def _reply_headless(session: Session, console: Console, message: str) -> bool:
+    """Answer a chat surface in plain text.
+
+    Printed as well as published so the captured-console fallback stays sane and
+    the existing "every form answers" test still sees output.
+    """
+    from surfaces.interactive_shell.command_registry.cli_parity import (
+        publish_headless_slash_response,
+    )
+
+    console.print(escape(message))
+    publish_headless_slash_response(session, message=message)
+    return True
+
+
 def _render_background_status(session: Session, console: Console) -> None:
+    records = _tracked_records(session, console)
+    if session_terminal(session) is None:
+        _reply_headless(session, console, _plain_status(session, records))
+        return
     table = repl_table(title="Background mode\n", title_style=BOLD_BRAND, show_header=False)
     table.add_column("key", style="bold")
     table.add_column("value")
     table.add_row("enabled", "yes" if background_mode_enabled(session) else "no")
-    table.add_row("tracked jobs", str(len(_tracked_records(session, console))))
+    table.add_row("tracked jobs", str(len(records)))
     table.add_row(
         "notify channels",
         ", ".join(background_notification_channels(session)) or "none",
@@ -141,6 +221,8 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
         if not tracked:
             console.print(f"[{DIM}]no background investigations tracked.[/]")
             return True
+        if session_terminal(session) is None:
+            return _reply_headless(session, console, _plain_list(tracked))
         table = repl_table(title="Background investigations\n", title_style=BOLD_BRAND)
         table.add_column("id", style="bold")
         table.add_column("status")
@@ -166,6 +248,8 @@ def _cmd_background(session: Session, console: Console, args: list[str]) -> bool
             console.print(f"[{ERROR}]unknown background task:[/] {escape(task_id)}")
             session.mark_latest(ok=False, kind="slash")
             return True
+        if session_terminal(session) is None:
+            return _reply_headless(session, console, _plain_show(task_id, selected_record))
         table = repl_table(
             title=f"Background investigation: {task_id}\n",
             title_style=BOLD_BRAND,

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -29,8 +29,6 @@ from surfaces.interactive_shell.ui import (
 )
 from surfaces.interactive_shell.utils.error_handling.exception_reporting import report_exception
 
-# The store keeps 100 rows; a lookup surface wants the recent ones, not the archive.
-_STORE_READ_LIMIT = 50
 # A chat message caps at 4096 characters and the transports tail-truncate.
 _CHAT_LIST_LIMIT = 10
 _CHAT_CAUSE_CHARS = 120
@@ -85,7 +83,7 @@ def _tracked_records(
             background_investigation_store,
         )
 
-        stored = background_investigation_store().list_recent(limit=_STORE_READ_LIMIT)
+        stored = background_investigation_store().list_recent(limit=None)
     except Exception as exc:  # noqa: BLE001
         report_exception(exc, context="surfaces.interactive_shell.background_read")
         console.print(

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -215,9 +215,14 @@ def _start_background_investigation(
 
     # Copy the context so the per-turn storage scope (a ContextVar set by
     # ``bound_storage_scope``) is inherited. Without it ``current_scope()`` is None
-    # on the worker and ``opensre_home()`` resolves the shared host root instead of
-    # the bound organization's, filing one org's records where every org can read
-    # them. Same reason as ``memory_extraction._schedule_coalesced``.
+    # on the worker, and everything it touches that resolves through
+    # ``opensre_home()`` or ``session_home()`` — session transcripts, memory,
+    # integration reads — falls back to the shared host root instead of the bound
+    # organization's. Same reason as ``memory_extraction._schedule_coalesced``.
+    #
+    # The record store no longer depends on this: ``deployment_home()`` falls back
+    # to the configured organization rather than the host root, and a transport
+    # always binds that same organization. Kept because the rest of the worker does.
     thread = threading.Thread(
         target=contextvars.copy_context().run,
         args=(_worker,),

--- a/surfaces/interactive_shell/session/background_investigations.py
+++ b/surfaces/interactive_shell/session/background_investigations.py
@@ -42,7 +42,7 @@ class BackgroundNotificationPreferences:
         read, must not stop the shell from starting; the user sees the same
         empty default they had before preferences were durable.
         """
-        from platform.background_investigations.store import (
+        from platform.scheduling.background_investigations.store import (
             background_investigation_store,
         )
 

--- a/surfaces/interactive_shell/session/background_investigations.py
+++ b/surfaces/interactive_shell/session/background_investigations.py
@@ -8,14 +8,21 @@ runtime and its tests already use.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from platform.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class BackgroundNotificationPreferences:
-    """Session-scoped channel preferences for background RCA completion notifications."""
+    """Channel preferences for background RCA completion notifications.
+
+    A value object. :meth:`set_channels` only updates it; the slash command
+    persists explicitly so a write failure can be reported to the user.
+    """
 
     channels: tuple[str, ...] = ()
 
@@ -26,6 +33,24 @@ class BackgroundNotificationPreferences:
             if normalized and normalized not in cleaned:
                 cleaned.append(normalized)
         self.channels = tuple(cleaned)
+
+    @classmethod
+    def load(cls) -> BackgroundNotificationPreferences:
+        """Channels a previous session persisted, or empty.
+
+        Never raises. A damaged document, or a context root this turn may not
+        read, must not stop the shell from starting; the user sees the same
+        empty default they had before preferences were durable.
+        """
+        from platform.background_investigations.store import (
+            background_investigation_store,
+        )
+
+        try:
+            return cls(channels=background_investigation_store().notify_channels())
+        except Exception:  # noqa: BLE001
+            logger.debug("[background] could not load notify channels", exc_info=True)
+            return cls()
 
 
 __all__ = [

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -117,9 +117,13 @@ class TerminalSession:
     """Completed or in-flight background RCA summaries, keyed by task id."""
 
     background_notification_preferences: BackgroundNotificationPreferences = field(
-        default_factory=BackgroundNotificationPreferences
+        default_factory=BackgroundNotificationPreferences.load
     )
-    """Preferred notification channels for background RCA completion events."""
+    """Preferred notification channels for background RCA completion events.
+
+    Hydrated from the durable store, so channels chosen in an earlier shell still
+    apply. ``load`` never raises and costs one stat when the document is absent.
+    """
 
     background_notices: list[str] = field(default_factory=list)
     """Thread-safe queue of Rich markup messages drained by the REPL main loop."""

--- a/tests/config/test_context_home.py
+++ b/tests/config/test_context_home.py
@@ -253,3 +253,73 @@ def test_a_bound_org_still_uses_the_mount(_home: Path, monkeypatch: pytest.Monke
 
     # Assert
     assert sessions == mount / "users" / ALICE.id
+
+
+# --- deployment_home: the one root the shell and a chat transport share -------
+#
+# opensre_home() keeps an unbound caller on the host root so the CLI never writes
+# into a customer's volume. Background investigation records are the one artifact
+# where that separation is wrong: the shell starts the investigation and a chat
+# transport retrieves it, and on a deployment that names an organization those are
+# the same person looking at the same work.
+
+
+def test_deployment_home_matches_opensre_home_for_a_bound_org(
+    _home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bound callers must see no difference: the two roots agree, mounted or not."""
+    with bound_storage_scope(_member(ACME, ALICE)):
+        assert paths.deployment_home() == paths.opensre_home()
+
+    mount = _home / "workspace" / "memories"
+    monkeypatch.setenv(paths.CONTEXT_ROOT_ENV, str(mount))
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, ACME.id)
+    with bound_storage_scope(_member(ACME, ALICE)):
+        assert paths.deployment_home() == paths.opensre_home() == mount
+
+
+def test_deployment_home_resolves_an_unbound_caller_to_the_configured_org(
+    _home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shell binds no scope. Without this it writes the host root while a chat
+    turn for the same deployment reads the org root, so the two never meet."""
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, ACME.id)
+
+    unbound = paths.deployment_home()
+    with bound_storage_scope(_member(ACME, ALICE)):
+        bound = paths.deployment_home()
+
+    assert unbound == bound == _home / "orgs" / ACME.id
+    # opensre_home() must keep its own contract: unbound stays on the host root.
+    assert paths.opensre_home() == _home
+
+
+def test_deployment_home_stays_on_the_host_root_with_no_organization(_home: Path) -> None:
+    """A laptop names no organization, so nothing changes for it."""
+    assert paths.deployment_home() == _home
+
+
+def test_deployment_home_refuses_a_mount_owned_by_another_org(
+    _home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The owner check is the whole tenancy guarantee; it must survive being
+    shared with a second entry point rather than being reimplemented beside it."""
+    monkeypatch.setenv(paths.CONTEXT_ROOT_ENV, str(_home / "memories"))
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, ACME.id)
+
+    with (
+        bound_storage_scope(_member(GLOBEX, ALICE)),
+        pytest.raises(paths.ContextRootOwnerMismatchError),
+    ):
+        paths.deployment_home()
+
+
+def test_deployment_home_rejects_a_hostile_configured_organization(
+    _home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unbound caller takes the org id from the environment rather than from a
+    validated principal, so it must pass through the same segment check."""
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "../escape")
+
+    with pytest.raises(paths.UnsafePathSegmentError):
+        paths.deployment_home()

--- a/tests/interactive_shell/runtime/test_background_notifications.py
+++ b/tests/interactive_shell/runtime/test_background_notifications.py
@@ -80,6 +80,36 @@ def test_deliver_background_notifications_marks_missing_smtp(monkeypatch) -> Non
     assert results == {"email": "missing smtp integration"}
 
 
+def test_deliver_background_notifications_redacts_smtp_delivery_failure(monkeypatch) -> None:
+    """Persisted notification outcomes must not expose SMTP provider detail."""
+    monkeypatch.setattr(
+        "integrations.catalog.resolve_effective_integrations",
+        lambda: {
+            "smtp": {
+                "config": {
+                    "host": "smtp.example.com",
+                    "from_address": "opensre@example.com",
+                    "default_to": "team@example.com",
+                },
+            }
+        },
+    )
+    secret = "smtp-password-should-not-be-persisted"
+    monkeypatch.setattr(
+        "integrations.smtp.delivery.send_smtp_report",
+        lambda **_: (False, f"authentication failed: {secret}"),
+    )
+
+    record = BackgroundInvestigationRecord(
+        task_id="bg-123", status="completed", command="free-text"
+    )
+
+    results = deliver_background_notifications(record=record, channels=("email",))
+
+    assert results == {"email": "failed: SMTP delivery failed"}
+    assert secret not in results["email"]
+
+
 # --- Telegram (Wave-2655) ---------------------------------------------------
 #
 # Patches below target the SOURCE modules

--- a/tests/interactive_shell/runtime/test_background_notifications.py
+++ b/tests/interactive_shell/runtime/test_background_notifications.py
@@ -80,8 +80,14 @@ def test_deliver_background_notifications_marks_missing_smtp(monkeypatch) -> Non
     assert results == {"email": "missing smtp integration"}
 
 
-def test_deliver_background_notifications_redacts_smtp_delivery_failure(monkeypatch) -> None:
-    """Persisted notification outcomes must not expose SMTP provider detail."""
+def test_deliver_background_notifications_keeps_the_smtp_failure_class(monkeypatch) -> None:
+    """The persisted outcome carries the exception class and nothing more.
+
+    ``send_smtp_report`` already narrows every failure to ``type(exc).__name__``,
+    so the class name is the whole error value — keeping it is what lets the
+    local ``/background show`` table separate an auth failure from a connection
+    one. Redaction for a chat transport happens at that sink, not here.
+    """
     monkeypatch.setattr(
         "integrations.catalog.resolve_effective_integrations",
         lambda: {
@@ -94,11 +100,11 @@ def test_deliver_background_notifications_redacts_smtp_delivery_failure(monkeypa
             }
         },
     )
-    secret = "smtp-password-should-not-be-persisted"
-    monkeypatch.setattr(
-        "integrations.smtp.delivery.send_smtp_report",
-        lambda **_: (False, f"authentication failed: {secret}"),
-    )
+
+    def _refuse(**_kwargs: object) -> tuple[bool, str]:
+        return False, "SMTPAuthenticationError"
+
+    monkeypatch.setattr("integrations.smtp.delivery.send_smtp_report", _refuse)
 
     record = BackgroundInvestigationRecord(
         task_id="bg-123", status="completed", command="free-text"
@@ -106,8 +112,7 @@ def test_deliver_background_notifications_redacts_smtp_delivery_failure(monkeypa
 
     results = deliver_background_notifications(record=record, channels=("email",))
 
-    assert results == {"email": "failed: SMTP delivery failed"}
-    assert secret not in results["email"]
+    assert results == {"email": "failed: SMTPAuthenticationError"}
 
 
 # --- Telegram (Wave-2655) ---------------------------------------------------

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -451,8 +451,8 @@ class TestDispatchSlash:
         assert "investigations.json" not in output
 
     def test_background_notify_set_survives_into_the_next_session(self) -> None:
-        """AC4. Without hydration the document is write-only: the channels persist
-        and the next shell still reads none, so the setting silently never applies."""
+        """Without hydration the document is write-only: the channels persist and
+        the next shell still reads none, so the setting silently never applies."""
         session = Session()
         console, _ = _capture()
         assert dispatch_slash("/background notify set telegram,email", session, console) is True

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -427,6 +427,29 @@ class TestDispatchSlash:
         assert session.terminal.background_notification_preferences.channels == ("telegram",)
         assert "invalid channel" not in buf.getvalue().lower()
 
+    def test_background_list_reports_an_unreadable_store_without_leaking_the_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """dispatch_slash puts no try around the handler, so an escaping store error
+        reaches the transport's generic error path and logs a traceback. The message
+        also carries the absolute document path, and unlike the REPL terminal a chat
+        transport is an external sink, so the path must not reach the reply."""
+        document = tmp_path / "background" / "investigations.json"
+        document.parent.mkdir(parents=True)
+        document.write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(
+            "config.constants.paths.deployment_home", lambda: tmp_path, raising=False
+        )
+        session = SessionCore(store=InMemorySessionStore())
+        console, buf = _capture()
+
+        assert dispatch_slash("/background list", session, console) is True
+
+        output = buf.getvalue()
+        assert "background records" in output.lower()
+        assert str(tmp_path) not in output
+        assert "investigations.json" not in output
+
     def test_background_notify_set_validates_against_the_adapter_registry(self) -> None:
         """AC-4 asks that adapters declare background support rather than a curated
         list deciding it. Registering one makes its channel acceptable without any

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -450,6 +450,36 @@ class TestDispatchSlash:
         assert str(tmp_path) not in output
         assert "investigations.json" not in output
 
+    def test_background_notify_set_survives_into_the_next_session(self) -> None:
+        """AC4. Without hydration the document is write-only: the channels persist
+        and the next shell still reads none, so the setting silently never applies."""
+        session = Session()
+        console, _ = _capture()
+        assert dispatch_slash("/background notify set telegram,email", session, console) is True
+
+        fresh = Session()
+
+        assert fresh.terminal.background_notification_preferences.channels == (
+            "telegram",
+            "email",
+        )
+        listed, buf = _capture()
+        assert dispatch_slash("/background notify list", fresh, listed) is True
+        assert "telegram" in buf.getvalue()
+
+    def test_background_notify_list_reads_the_store_on_a_headless_session(self) -> None:
+        """A chat session has no terminal facet to hold preferences, so it would
+        answer "none" however the shell was configured."""
+        shell = Session()
+        console, _ = _capture()
+        assert dispatch_slash("/background notify set rocketchat", shell, console) is True
+
+        headless = SessionCore(store=InMemorySessionStore())
+        chat_console, buf = _capture()
+        assert dispatch_slash("/background notify list", headless, chat_console) is True
+
+        assert "rocketchat" in buf.getvalue()
+
     def test_background_notify_set_validates_against_the_adapter_registry(self) -> None:
         """AC-4 asks that adapters declare background support rather than a curated
         list deciding it. Registering one makes its channel acceptable without any

--- a/tests/platform/scheduling/background_investigations/test_store.py
+++ b/tests/platform/scheduling/background_investigations/test_store.py
@@ -417,9 +417,9 @@ def test_list_recent_is_newest_first_when_the_document_is_not_ascending(tmp_path
 def test_the_shell_and_a_chat_turn_share_one_document(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """AC2's mechanism. The shell binds no storage scope and a chat transport binds
-    the deployment's organization, so before this the two wrote and read different
-    files and a chat lookup found nothing. Both must land on the org root."""
+    """The shell binds no storage scope and a chat transport binds the deployment's
+    organization, so the two otherwise write and read different files and a chat
+    lookup finds nothing. Both must land on the org root."""
     from config.constants import paths
     from config.constants.billing import ORGANIZATION_ID_ENV
     from config.principal import Actor, Principal, StorageScope

--- a/tests/platform/scheduling/background_investigations/test_store.py
+++ b/tests/platform/scheduling/background_investigations/test_store.py
@@ -457,3 +457,48 @@ def test_a_machine_with_no_organization_keeps_the_plain_layout(
 
     assert (tmp_path / "background" / "investigations.json").is_file()
     assert not (tmp_path / "orgs").exists()
+
+
+def test_notify_channels_survive_a_record_save(tmp_path: Path) -> None:
+    """Records and preferences share one document, so each write must carry the
+    other through. save() re-reads channels inside the lock it already holds."""
+    store = _store(tmp_path)
+    store.set_notify_channels(("telegram", "email"))
+
+    store.save(_record(task_id="bg-after-prefs"))
+
+    assert store.notify_channels() == ("telegram", "email")
+    assert store.get("bg-after-prefs") is not None
+
+
+def test_notify_channels_survive_rotation(tmp_path: Path) -> None:
+    """Rotation rewrites the whole document. Preferences must not age out with the
+    records they sit beside."""
+    store = _store(tmp_path, max_records=3)
+    store.set_notify_channels(("rocketchat",))
+    for index in range(6):
+        store.save(_record(task_id=f"bg-{index}"))
+
+    assert store.notify_channels() == ("rocketchat",)
+    assert len(store.list_recent(limit=100)) == 3
+
+
+def test_setting_channels_preserves_stored_records(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save(_record(task_id="bg-keep"))
+
+    store.set_notify_channels(("buzz",))
+
+    assert store.get("bg-keep") is not None
+    assert store.notify_channels() == ("buzz",)
+
+
+def test_an_explicit_clear_is_not_read_as_unset(tmp_path: Path) -> None:
+    """Clearing channels must persist as an empty list rather than falling back to
+    a default, or turning notifications off would silently not stick."""
+    store = _store(tmp_path)
+    store.set_notify_channels(("telegram",))
+
+    store.set_notify_channels(())
+
+    assert store.notify_channels() == ()

--- a/tests/platform/scheduling/background_investigations/test_store.py
+++ b/tests/platform/scheduling/background_investigations/test_store.py
@@ -412,3 +412,48 @@ def test_list_recent_is_newest_first_when_the_document_is_not_ascending(tmp_path
     store.save(_record(task_id="stepped-back"))
 
     assert [r.task_id for r in store.list_recent()] == ["newer", "older", "stepped-back"]
+
+
+def test_the_shell_and_a_chat_turn_share_one_document(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC2's mechanism. The shell binds no storage scope and a chat transport binds
+    the deployment's organization, so before this the two wrote and read different
+    files and a chat lookup found nothing. Both must land on the org root."""
+    from config.constants import paths
+    from config.constants.billing import ORGANIZATION_ID_ENV
+    from config.principal import Actor, Principal, StorageScope
+    from config.scope_context import bound_storage_scope
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.delenv(paths.CONTEXT_ROOT_ENV, raising=False)
+    monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_acme")
+
+    # The shell writes with nothing bound.
+    BackgroundInvestigationStore().save(_record(task_id="bg-shell"))
+
+    # A Telegram turn reads with the organization bound.
+    scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U_ALICE"))
+    with bound_storage_scope(scope):
+        found = BackgroundInvestigationStore().get("bg-shell")
+
+    assert found is not None
+    assert found.root_cause == "pool saturation"
+    assert (tmp_path / "orgs" / "org_acme" / "background" / "investigations.json").is_file()
+
+
+def test_a_machine_with_no_organization_keeps_the_plain_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A laptop names no organization and has no second surface to share with."""
+    from config.constants import paths
+    from config.constants.billing import ORGANIZATION_ID_ENV
+
+    monkeypatch.setattr(paths, "OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.delenv(paths.CONTEXT_ROOT_ENV, raising=False)
+    monkeypatch.delenv(ORGANIZATION_ID_ENV, raising=False)
+
+    BackgroundInvestigationStore().save(_record(task_id="bg-laptop"))
+
+    assert (tmp_path / "background" / "investigations.json").is_file()
+    assert not (tmp_path / "orgs").exists()


### PR DESCRIPTION
Fixes #4426

Builds on #4959, now merged, so this diff is only the second half.

#### Describe the changes you have made in this PR -

The second half you scoped: a completed RCA is retrievable from Telegram, Slack or Discord, and notify channels survive a restart.

**Pointing `/background list` at the store would have been a no-op.** The REPL binds no storage scope and a chat turn binds an organization, so `opensre_home()` hands them different files and the list stays empty. `deployment_home()` resolves an unbound caller to the organization the deployment already serves, so both land on one document. The mount owner check moves into a shared `_org_root` and still applies.

Reads go through one helper, session records first, and chat surfaces answer in plain text via the existing `publish_headless_slash_response` seam. Preferences become a key in the record document rather than a second file, read inside the lock `save()` already holds so a record write cannot drop them.

**Worth your call:** records resolve to the organization root, so every member of a deployment can read every completed RCA. That follows the placement asked for on the issue; say the word and it moves to `session_home()`.

Duplicate-delivery suppression is deferred: `deliver()` returns a discarded `bool`, so it needs the Protocol widened across nine adapters. No AC requires it.

### Demo/Screenshot for feature changes and bug fixes -

Verified across two real interpreters: an unbound writer, then an organization-bound Telegram-shaped reader whose replies came back free of box-drawing characters. Rich tables reach a transport as literal box-drawing text, so the tests assert their absence.

Full suite 15007 passed, plus lint, format, typecheck and `check-imports-strict`. The one failure in `tests/cli/test_smoke.py` reproduces on clean `origin/main`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Two surfaces need one file. My first design read both roots and merged, guarded on whether the context mount was present. That guard cannot exist: "laptop plus gateway" and "one box, several organizations" set the same environment variables and resolve to the same path, so it is either on for both or off for both. It also gave a different-uid gateway `PermissionError` on every read, and the first save would have copied host records irreversibly into an organization document. Resolving one root for both surfaces removes all three instead of managing them.

`_org_root` holds the mount owner check so there is one tenancy rule rather than two copies. `deployment_home` is the unbound resolution. `_tracked_records` merges session and durable records, and `_plain_status` / `_plain_list` / `_plain_show` render for transports.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
