### PR TITLE
refactor: UsageSurface StrEnum for analytics stamps (#4521)

### DIFF
--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -27,14 +27,33 @@ type JsonScalar = str | bool | int | float
 type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 type Properties = dict[str, JsonValue]
 
-SURFACE_CLI: Final[str] = "cli"
-SURFACE_SLACK: Final[str] = "slack"
-SURFACE_TELEGRAM: Final[str] = "telegram"
-SURFACE_DISCORD: Final[str] = "discord"
-SURFACE_BUZZ: Final[str] = "buzz"
-CANONICAL_SURFACES: Final[frozenset[str]] = frozenset(
-    {SURFACE_CLI, SURFACE_SLACK, SURFACE_TELEGRAM, SURFACE_DISCORD, SURFACE_BUZZ}
-)
+from enum import Enum as _Enum
+
+try:
+    # Python 3.11+: prefer stdlib StrEnum
+    from enum import StrEnum as _StdStrEnum  # type: ignore
+    StrEnum = _StdStrEnum
+except Exception:
+    class StrEnum(str, _Enum):
+        """Lightweight StrEnum fallback for older Python versions."""
+        pass
+
+
+class UsageSurface(StrEnum):
+    CLI = "cli"
+    SLACK = "slack"
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+    BUZZ = "buzz"
+
+# Legacy string constants kept for backwards compatibility with callers/tests
+SURFACE_CLI: Final[str] = UsageSurface.CLI.value
+SURFACE_SLACK: Final[str] = UsageSurface.SLACK.value
+SURFACE_TELEGRAM: Final[str] = UsageSurface.TELEGRAM.value
+SURFACE_DISCORD: Final[str] = UsageSurface.DISCORD.value
+SURFACE_BUZZ: Final[str] = UsageSurface.BUZZ.value
+
+CANONICAL_SURFACES: Final[frozenset[str]] = frozenset({s.value for s in UsageSurface})
 ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
 
 _SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -17,9 +17,9 @@ import contextlib
 import threading
 from collections.abc import Iterator
 from contextvars import ContextVar, Token
+from enum import StrEnum
 from typing import Final
 from uuid import uuid4
-from enum import StrEnum
 
 from config.constants.organization import organization_id
 from platform.analytics.repl_context import get_cli_session_id

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -44,7 +44,7 @@ SURFACE_TELEGRAM: Final[str] = UsageSurface.TELEGRAM.value
 SURFACE_DISCORD: Final[str] = UsageSurface.DISCORD.value
 SURFACE_BUZZ: Final[str] = UsageSurface.BUZZ.value
 
-CANONICAL_SURFACES: Final[frozenset[str]] = frozenset({s.value for s in UsageSurface})
+CANONICAL_SURFACES: Final[frozenset[str]] = frozenset({SURFACE_CLI, SURFACE_SLACK, SURFACE_TELEGRAM, SURFACE_DISCORD, SURFACE_BUZZ})
 ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
 
 _SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -27,16 +27,7 @@ type JsonScalar = str | bool | int | float
 type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 type Properties = dict[str, JsonValue]
 
-from enum import Enum as _Enum
-
-try:
-    # Python 3.11+: prefer stdlib StrEnum
-    from enum import StrEnum as _StdStrEnum  # type: ignore
-    StrEnum = _StdStrEnum
-except Exception:
-    class StrEnum(str, _Enum):
-        """Lightweight StrEnum fallback for older Python versions."""
-        pass
+from enum import StrEnum
 
 
 class UsageSurface(StrEnum):
@@ -45,6 +36,7 @@ class UsageSurface(StrEnum):
     TELEGRAM = "telegram"
     DISCORD = "discord"
     BUZZ = "buzz"
+
 
 # Legacy string constants kept for backwards compatibility with callers/tests
 SURFACE_CLI: Final[str] = UsageSurface.CLI.value

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -19,6 +19,7 @@ from collections.abc import Iterator
 from contextvars import ContextVar, Token
 from typing import Final
 from uuid import uuid4
+from enum import StrEnum
 
 from config.constants.organization import organization_id
 from platform.analytics.repl_context import get_cli_session_id

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -28,8 +28,6 @@ type JsonScalar = str | bool | int | float
 type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 type Properties = dict[str, JsonValue]
 
-from enum import StrEnum
-
 
 class UsageSurface(StrEnum):
     CLI = "cli"

--- a/platform/analytics/usage_context.py
+++ b/platform/analytics/usage_context.py
@@ -44,7 +44,9 @@ SURFACE_TELEGRAM: Final[str] = UsageSurface.TELEGRAM.value
 SURFACE_DISCORD: Final[str] = UsageSurface.DISCORD.value
 SURFACE_BUZZ: Final[str] = UsageSurface.BUZZ.value
 
-CANONICAL_SURFACES: Final[frozenset[str]] = frozenset({SURFACE_CLI, SURFACE_SLACK, SURFACE_TELEGRAM, SURFACE_DISCORD, SURFACE_BUZZ})
+CANONICAL_SURFACES: Final[frozenset[str]] = frozenset(
+    {SURFACE_CLI, SURFACE_SLACK, SURFACE_TELEGRAM, SURFACE_DISCORD, SURFACE_BUZZ}
+)
 ORGANIZATION_GROUP_TYPE: Final[str] = "organization"
 
 _SURFACE: ContextVar[str | None] = ContextVar("analytics_surface", default=None)


### PR DESCRIPTION
Fixes #4521

#### Describe the changes you have made in this PR -

Introduce a string-backed enum `UsageSurface` and preserve legacy `SURFACE_*` string constants for backward compatibility. This keeps emitted analytics stamp string values identical while providing a canonical enum type for future replacement across the codebase.

### Demo/Screenshot for feature changes and bug fixes -

N/A (code-only, small refactor)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- Problem: make UsageSurface a canonical string-based enum so analytics stamp creation can use a single, typed source of truth without changing emitted string values.
- Approach: add `UsageSurface(StrEnum)` in platform/analytics/usage_context.py, export legacy SURFACE_* constants as the enum values, update in-file canonical set; keep change minimal and local to analytics stamping code.
- Alternative: introduce a separate enums module; deferred to keep this PR minimal. A follow-up PR can migrate other modules to import UsageSurface directly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
