### PR TITLE
fix(integrations): log client-factory soft-fail without leaking secrets

### DIFF
--- a/core/tool_framework/telemetry.py
+++ b/core/tool_framework/telemetry.py
@@ -52,7 +52,7 @@ def report_run_error(
     report_exception(
         exc,
         logger=logger or _DEFAULT_LOGGER,
-        message=f"Tool {tool_name} failed: {type(exc).__name__}: {exc}",
+        message=f"Tool {tool_name} failed: {type(exc).__name__}",
         severity=severity,
         tags=tags,
         extras=extras,
@@ -78,7 +78,7 @@ def invoke_tool(
         report_exception(
             exc,
             logger=_DEFAULT_LOGGER,
-            message=f"Tool {name} failed: {type(exc).__name__}: {exc}",
+            message=f"Tool {name} failed: {type(exc).__name__}",
             severity="error",
             tags={"surface": "tool", "tool_name": name, "source": source},
         )

--- a/integrations/_validation_helpers.py
+++ b/integrations/_validation_helpers.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import ValidationError
-
 from platform.observability.errors.boundary import report_exception
 
 
@@ -72,22 +70,10 @@ def report_classify_failure(
 ) -> None:
     """Log + Sentry-capture a classify failure for an integration record.
 
-    ``pydantic.ValidationError`` renders the raw invalid field value (often a
-    secret, e.g. a token or password) inline in its message via
-    ``input_value=...``. Sentry's ``before_send`` hook scrubs that pattern from
-    captured events, but this function also logs locally with ``exc_info``,
-    which bypasses the Sentry scrubber entirely. Swap in a message-only
-    ``ValueError`` so no call site has to do this itself.
-
-    The wrapper reuses the original exception's ``__traceback__`` (but not
-    ``__cause__`` — chaining would print the raw ``ValidationError`` text as
-    part of the chain in local logs, defeating the swap above) so logs and
-    Sentry still point at the vendor model/field that actually failed.
+    ``report_exception`` scrubs ``pydantic.ValidationError`` detail (e.g. a
+    secret rendered via ``input_value=...``) out of local logs before this
+    call reaches it, so no sanitization is needed here.
     """
-    if isinstance(exc, ValidationError):
-        safe_exc = ValueError(f"{integration} config validation failed")
-        safe_exc.__traceback__ = exc.__traceback__
-        exc = safe_exc
     report_exception(
         exc,
         logger=logger,

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -17,6 +17,7 @@ from urllib.parse import quote
 
 import httpx
 
+from integrations._validation_helpers import report_validation_failure
 from integrations.config_models import ArgoCDIntegrationConfig
 from integrations.probes import ProbeResult
 from platform.observability.errors.service import capture_service_error
@@ -543,5 +544,8 @@ def make_argocd_client(
                 verify_ssl=_normalize_verify_ssl(verify_ssl),
             )
         )
-    except Exception:
+    except Exception as exc:
+        report_validation_failure(
+            exc, logger=logger, integration="argocd", method="make_client", include_traceback=True
+        )
         return None

--- a/integrations/jira/client.py
+++ b/integrations/jira/client.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from integrations._validation_helpers import report_validation_failure
 from integrations.config_models import JiraIntegrationConfig
 from platform.observability.errors.service import capture_service_error
 
@@ -297,5 +298,8 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except Exception:
+    except Exception as exc:
+        report_validation_failure(
+            exc, logger=logger, integration="jira", method="make_client", include_traceback=True
+        )
         return None

--- a/platform/observability/errors/boundary.py
+++ b/platform/observability/errors/boundary.py
@@ -46,9 +46,14 @@ def report_exception(
     # line of defense we shouldn't rely on exclusively. The wrapper keeps
     # `exc`'s `__traceback__` (but not `__cause__`/`__context__`, which would
     # print the raw text again as part of the chain) so logs and Sentry still
-    # point at the failing model/field.
+    # point at the failing model/field. Reuse the `integration` tag (every
+    # current caller sets one) for a human phrase instead of falling back to
+    # `message`'s tag-style text (e.g. "classify_failed: integration=... ")
+    # duplicated as the exception's own str().
     if isinstance(exc, ValidationError):
-        safe_exc = ValueError(message)
+        integration = (tags or {}).get("integration")
+        safe_text = f"{integration} config validation failed" if integration else message
+        safe_exc = ValueError(safe_text)
         safe_exc.__traceback__ = exc.__traceback__
         exc = safe_exc
     log_fn = getattr(logger, severity, logger.error)

--- a/platform/observability/errors/boundary.py
+++ b/platform/observability/errors/boundary.py
@@ -18,6 +18,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
+from pydantic import ValidationError
+
 from platform.observability.errors.sentry import capture_exception
 
 
@@ -36,6 +38,19 @@ def report_exception(
     Use at boundaries where an exception is intentionally swallowed (the
     function returns a degraded value to its caller).
     """
+    # `ValidationError.__str__` renders the rejected input inline via
+    # `input_value=...`, which for a model-level failure is the whole input
+    # mapping (secrets included). Swap in a message-only exception before it
+    # reaches either sink: local `exc_info` logging bypasses Sentry's
+    # `before_send` scrubber entirely, and Sentry's regex scrubber is a second
+    # line of defense we shouldn't rely on exclusively. The wrapper keeps
+    # `exc`'s `__traceback__` (but not `__cause__`/`__context__`, which would
+    # print the raw text again as part of the chain) so logs and Sentry still
+    # point at the failing model/field.
+    if isinstance(exc, ValidationError):
+        safe_exc = ValueError(message)
+        safe_exc.__traceback__ = exc.__traceback__
+        exc = safe_exc
     log_fn = getattr(logger, severity, logger.error)
     # Some expected fallback paths (e.g. remote network probe timeouts) should
     # remain visible in logs without dumping a full traceback into the terminal UI.

--- a/tests/core/tool_framework/test_telemetry.py
+++ b/tests/core/tool_framework/test_telemetry.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel, ValidationError, model_validator
 
 from core.tool_framework.telemetry import report_run_error
 
@@ -123,6 +124,54 @@ def test_report_run_error_supports_warning_severity(
     assert error_records == [], "warning severity must not log at error level"
     warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert warning_records, "warning severity must produce a WARNING log record"
+
+
+class _SecretToolConfig(BaseModel):
+    api_key: str
+
+    @model_validator(mode="after")
+    def _reject(self) -> _SecretToolConfig:
+        # A model-level (not field-level) failure renders the *whole* input
+        # mapping via `input_value=...`, which is where a secret escapes.
+        raise ValueError("api_key rejected by policy")
+
+
+def test_report_run_error_validation_error_does_not_echo_secret(
+    captured_sentry_events: list[Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A model-level ValidationError's ``input_value`` can carry a secret field value.
+
+    ``message`` here is caller-built (``f"Tool {tool_name} failed: ..."``) and
+    must not interpolate ``str(exc)`` itself, or the report_exception scrub
+    (keyed off the exception, not the caller's message string) never runs on
+    the actual leaking text. Regression for a Greptile P1 finding on the
+    argocd/jira client-factory soft-fail-logging PR.
+    """
+    secret_api_key = "s3cr3t-tool-api-key"
+    try:
+        _SecretToolConfig.model_validate({"api_key": secret_api_key})
+    except ValidationError as exc:
+        validation_error: BaseException = exc
+    else:
+        raise AssertionError("expected ValidationError")
+
+    with caplog.at_level(logging.ERROR, logger="tools"):
+        report_run_error(
+            validation_error,
+            tool_name="configure_widget",
+            source="widget",
+            component="integrations.widget.tools",
+        )
+
+    assert secret_api_key not in caplog.text
+    assert "input_value" not in caplog.text
+
+    assert len(captured_sentry_events) == 1
+    captured_exc = captured_sentry_events[0].exc
+    assert not isinstance(captured_exc, ValidationError)
+    assert secret_api_key not in str(captured_exc)
+    assert "input_value" not in str(captured_exc)
 
 
 def test_report_run_error_uses_provided_logger(

--- a/tests/integrations/argocd/test_client.py
+++ b/tests/integrations/argocd/test_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -53,6 +54,64 @@ def test_make_argocd_client_requires_base_url_and_auth() -> None:
         make_argocd_client("https://argocd.example.com", username="admin", password="pw")
         is not None
     )
+
+
+def _raise_runtime_error(**_kwargs: Any) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_argocd_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.argocd.client.ArgoCDConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.argocd.client"):
+        result = make_argocd_client("https://argocd.example.com", bearer_token="tok")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_make_argocd_client_soft_fail_log_does_not_echo_config_input(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange: supplying both auth methods is a real misconfiguration that gets
+    # past the factory's guards and reaches ArgoCDConfig's model validator.
+    # A model-level pydantic failure renders the whole input mapping via
+    # `input_value=...`, which is where a bearer token or password would escape.
+    secret_token = "s3cr3t-argocd-bearer-token"
+    secret_password = "s3cr3t-argocd-password"
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.argocd.client"):
+        result = make_argocd_client(
+            "https://argocd.example.com",
+            bearer_token=secret_token,
+            username="admin",
+            password=secret_password,
+        )
+
+    # Assert: the soft-fail contract and the warning both survive, but no part
+    # of the submitted config is echoed. Asserting on `input_value` rather than
+    # only on the literal secrets is deliberate: pydantic elides the middle of a
+    # long mapping, so a secret-substring check passes by accident today and
+    # would stop protecting us if field order or pydantic's truncation changed.
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+    assert "input_value" not in caplog.text
+    assert secret_token not in caplog.text
+    assert secret_password not in caplog.text
 
 
 def test_probe_access_success(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/integrations/test_discord.py
+++ b/tests/integrations/test_discord.py
@@ -80,13 +80,14 @@ def test_classify_validation_error_returns_none_and_reports() -> None:
     Pydantic v2 embeds the failing field's ``input_value`` in the
     ValidationError string, so forwarding the raw error would leak secrets.
     Discord's classify() passes the exception straight through to
-    ``report_classify_failure`` (integrations._validation_helpers), which is
-    responsible for the swap — assert on what actually reaches
-    ``report_exception``, one layer past the mocked-out call in older tests.
+    ``report_classify_failure`` (integrations._validation_helpers), which
+    delegates to ``report_exception`` (platform.observability.errors.boundary)
+    for the swap — assert on what actually reaches ``capture_exception``, one
+    layer past the mocked-out call in older tests.
     """
     secret_value = "leaked-non-hex-secret"
 
-    with patch("integrations._validation_helpers.report_exception") as mock_report:
+    with patch("platform.observability.errors.boundary.capture_exception") as mock_report:
         result = classify(
             {"bot_token": "some-token", "public_key": secret_value},
             record_id="rec-discord",

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -123,3 +124,67 @@ def test_make_jira_client_returns_none_missing_token() -> None:
 
 def test_make_jira_client_returns_none_all_none() -> None:
     assert make_jira_client(None, None, None) is None
+
+
+def _raise_runtime_error(**_kwargs: object) -> None:
+    raise RuntimeError("construction failure")
+
+
+def test_make_jira_client_logs_soft_fail_on_construction_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: force config construction inside the factory to raise, exercising
+    # the soft-fail `except Exception` path. The factory must still return None,
+    # but must no longer swallow the exception silently.
+    monkeypatch.setattr("integrations.jira.client.JiraIntegrationConfig", _raise_runtime_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.jira.client"):
+        result = make_jira_client("https://myteam.atlassian.net", "user@example.com", "token")
+
+    # Assert
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+
+
+_SECRET_API_TOKEN = "s3cr3t-jira-api-token"
+
+
+def _raise_validation_error(**_kwargs: object) -> None:
+    # A genuine pydantic ValidationError raised against the model rather than a
+    # single field, so its rendering carries the whole input mapping — this is
+    # the shape that would leak `api_token` through `input_value=`.
+    JiraConfig(email="user@example.com", api_token=_SECRET_API_TOKEN)  # type: ignore[call-arg]
+
+
+def test_make_jira_client_soft_fail_log_does_not_echo_config_input(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Arrange: no input the factory currently accepts can make JiraIntegrationConfig
+    # raise — every field is coerced, and there is no URL-scheme validator as there
+    # is on the ServiceNow model. So the ValidationError has to be injected. The
+    # guard is hardening: it stops a future validator (or a caller passing a
+    # non-string) from turning this warning into a credential disclosure.
+    monkeypatch.setattr("integrations.jira.client.JiraIntegrationConfig", _raise_validation_error)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="integrations.jira.client"):
+        result = make_jira_client(
+            "https://myteam.atlassian.net", "user@example.com", _SECRET_API_TOKEN
+        )
+
+    # Assert: the soft-fail contract and the warning both survive, but no part of
+    # the submitted config is echoed. Asserting on `input_value` rather than only
+    # on the literal secret is deliberate: pydantic elides the middle of a long
+    # mapping, so a secret-substring check can pass by accident and would stop
+    # protecting us if field order or pydantic's truncation changed.
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING and record.exc_info is not None
+        for record in caplog.records
+    ), caplog.text
+    assert "input_value" not in caplog.text
+    assert _SECRET_API_TOKEN not in caplog.text

--- a/tests/integrations/test_rocketchat.py
+++ b/tests/integrations/test_rocketchat.py
@@ -111,7 +111,7 @@ def test_classify_validation_error_returns_none_and_reports() -> None:
     sanitized wrapper (no secret field values), mirroring the Discord rule."""
     secret_value = "leaked-secret-token"
 
-    with patch("integrations._validation_helpers.report_exception") as mock_report:
+    with patch("platform.observability.errors.boundary.capture_exception") as mock_report:
         result = classify(
             {"auth_token": secret_value, "server_url": "not-a-url", "user_id": "u1"},
             record_id="rec-rocketchat",

--- a/tests/integrations/test_smtp.py
+++ b/tests/integrations/test_smtp.py
@@ -62,7 +62,7 @@ def test_verify_smtp_reports_validation_errors() -> None:
 def test_classify_validation_failure_reports_without_secret_value() -> None:
     secret = "smtp-secret-password"
 
-    with patch("integrations._validation_helpers.report_exception") as mock_report:
+    with patch("platform.observability.errors.boundary.capture_exception") as mock_report:
         result = classify(
             {
                 "host": "smtp.example.com",

--- a/tests/integrations/test_validation_helpers.py
+++ b/tests/integrations/test_validation_helpers.py
@@ -159,7 +159,7 @@ class TestReportClassifyFailure:
         logged_exc = mock_log.warning.call_args.kwargs["exc_info"]
         assert not isinstance(logged_exc, ValidationError)
         assert secret_value not in str(logged_exc)
-        assert str(logged_exc) == "widget config validation failed"
+        assert str(logged_exc) == "classify_failed: integration=widget record_id=rec-1"
 
         captured_exc = mock_cap.call_args[0][0]
         assert not isinstance(captured_exc, ValidationError)

--- a/tests/integrations/test_validation_helpers.py
+++ b/tests/integrations/test_validation_helpers.py
@@ -159,7 +159,7 @@ class TestReportClassifyFailure:
         logged_exc = mock_log.warning.call_args.kwargs["exc_info"]
         assert not isinstance(logged_exc, ValidationError)
         assert secret_value not in str(logged_exc)
-        assert str(logged_exc) == "classify_failed: integration=widget record_id=rec-1"
+        assert str(logged_exc) == "widget config validation failed"
 
         captured_exc = mock_cap.call_args[0][0]
         assert not isinstance(captured_exc, ValidationError)


### PR DESCRIPTION
Fixes #4902, Fixes #4903

Supersedes #4966 — see that PR for the original report. This reimplements the same fix with the sanitization logic centralized instead of duplicated.

### Describe the changes you have made in this PR

`make_argocd_client` and `make_jira_client` had a bare `except Exception: return None` around client construction — any failure (bad config, a `ValidationError`, anything) was swallowed with zero signal.

- Both factories now log at `WARNING` with a traceback on construction failure, via the existing `report_validation_failure` helper (`integrations/_validation_helpers.py`) — the same helper the codebase's docstring already prescribes for "every `except Exception` block in an integration validator."
- `pydantic.ValidationError.__str__` renders the rejected input inline via `input_value=...`, which for a model-level failure is the *whole* config mapping (bearer token / API token / password included). That's a secret-leak risk once these exceptions get logged with `exc_info` or sent to Sentry.
- Moved the scrub (swap the `ValidationError` for a message-only `ValueError` that keeps `__traceback__` but not `__cause__`/`__context__`) into `report_exception` itself (`platform/observability/errors/boundary.py`), the one function all of `capture_service_error`, `report_validation_failure`, and `report_classify_failure` funnel through. Previously the scrub only lived inside `report_classify_failure`'s own body — anything else calling `report_exception` with a `ValidationError` (including these two new factory call sites) was still exposed.
- `report_classify_failure` now relies on `report_exception`'s scrub instead of carrying its own copy.

Net result: one scrub, covering every `report_exception` caller, instead of three copies of the same four lines across `report_classify_failure`, `argocd/client.py`, and `jira/client.py`. Also restores Sentry visibility for these two factory failure paths, matching every other `except` block in both files.

### Demo/Screenshot for feature changes and bug fixes

```
$ uv run pytest tests/integrations/argocd/test_client.py tests/integrations/test_jira_search_and_factory.py \
    tests/integrations/test_validation_helpers.py tests/platform/observability/test_service_errors.py \
    tests/utils/test_errors.py -q
73 passed in 2.07s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

PR #4966 fixed the silent-swallow bug but hand-rolled the `ValidationError` secret-scrub twice (once per client file) instead of reusing the codebase's existing `report_classify_failure` helper, which already implements the identical technique with a docstring explaining the same rationale. It also bypassed `capture_service_error`/`report_validation_failure` entirely in favor of a raw `logger.warning(...)`, so these two failure paths lost Sentry visibility that every neighboring `except` block in both files still has — and the underlying leak in `report_exception` (used by `capture_service_error` everywhere else in these files) was never actually closed, just avoided at these two call sites.

This PR centralizes the fix in `report_exception` so it protects every caller, then has the two factories call the existing `report_validation_failure` helper like a normal validator failure — no new duplicated logic.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.