### PR TITLE
docs: document /remote-sync and remote sync env vars

### DIFF
--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -24,6 +24,20 @@ owner-only local file. A value supplied in the process environment or a local
 `.env` file takes precedence when reading credentials. Keep `.env` out of source
 control and never commit real secrets.
 
+## Remote sync
+
+| Variable | Description |
+|---|---|
+| `OPENSRE_REMOTE_SYNC` | Master switch. Set to `1` to enable remote sync. Nothing uploads until enabled. |
+| `OPENSRE_REMOTE_SYNC_PROVIDER` | Backend name. Default `aws`. Built-in: `aws`, `gcs`, `vercel`, `azure`. |
+| `OPENSRE_REMOTE_SYNC_BUCKET` | Your store name (S3/GCS bucket, Vercel store id, or Azure container). Required when enabled. |
+| `OPENSRE_REMOTE_SYNC_PREFIX` | Key prefix inside the store. Default `opensre`. Machines must use same prefix to share history. |
+| `OPENSRE_REMOTE_SYNC_REGION` | Region override when supported by provider (AWS). |
+| `OPENSRE_REMOTE_SYNC_PROFILE` | Named credentials profile (AWS/Azure) to use instead of default. |
+| `OPENSRE_REMOTE_SYNC_EXCLUDE` | Comma-separated glob patterns to exclude from sync (e.g. `*.tmp,sessions/scratch-*`). |
+| `OPENSRE_REMOTE_SYNC_EXCLUDE_OFF` | Set to `1` to ignore exclusions for a single run and sync everything. |
+| `BLOB_READ_WRITE_TOKEN` | Vercel Blob read-write token (ambient; opensre never stores it). |
+
 ## LLM Providers
 
 | Variable | Default | Description | Module |

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -29,9 +29,10 @@ control and never commit real secrets.
 | Variable | Description |
 |---|---|
 | `OPENSRE_REMOTE_SYNC` | Master switch. Set to `1` to enable remote sync. Nothing uploads until enabled. |
-| `OPENSRE_REMOTE_SYNC_PROVIDER` | Backend name. Default `aws`. Built-in: `aws`, `gcs`, `vercel`, `azure`. |
-| `OPENSRE_REMOTE_SYNC_BUCKET` | Your store name (S3/GCS bucket, Vercel store id, or Azure container). Required when enabled. |
+| `OPENSRE_REMOTE_SYNC_PROVIDER` | Backend name. Default `aws`. Built-in: `aws`, `gcs`, `vercel`, `azure`, `s3compat`. |
+| `OPENSRE_REMOTE_SYNC_BUCKET` | Your store name (S3/GCS bucket, Vercel store id, Azure container, or S3-compatible endpoint bucket). Required when enabled. |
 | `OPENSRE_REMOTE_SYNC_PREFIX` | Key prefix inside the store. Default `opensre`. Machines must use same prefix to share history. |
+| `OPENSRE_REMOTE_SYNC_ENDPOINT_URL` | Endpoint URL override for S3-compatible stores (for example MinIO, R2, Spaces, or other custom S3-compatible backends). |
 | `OPENSRE_REMOTE_SYNC_REGION` | Region override when supported by provider (AWS). |
 | `OPENSRE_REMOTE_SYNC_PROFILE` | Named credentials profile (AWS/Azure) to use instead of default. |
 | `OPENSRE_REMOTE_SYNC_EXCLUDE` | Comma-separated glob patterns to exclude from sync (e.g. `*.tmp,sessions/scratch-*`). |

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -129,6 +129,7 @@ These commands delegate to the same Click CLI you would run outside the REPL.
 | `/login` | Shortcut for `/auth login` (`/login chatgpt`, `/login claude`, `/login deepseek`) |
 | `/onboard` | Interactive onboarding wizard |
 | `/remote` | Connect to and operate remote deployed agents |
+| `/remote-sync` | Manage remote sync to your object store. Subcommands: `status`, `sync`, `setup`. See [Sync to your own object store](/configuration/remote-sync). |
 | `/config` | Show or edit `~/.opensre/config.yml` |
 | `/cron` | Manage scheduled delivery jobs |
 | `/sentry` | Schedule automated Sentry morning digests or uptime watches (Telegram or Slack required) |


### PR DESCRIPTION
Fixes #4909

#### Describe the changes you have made in this PR -
- Added the `/remote-sync` command to the interactive shell command reference and linked it to the remote sync configuration page.
- Documented the `OPENSRE_REMOTE_SYNC_*` environment variables in the configuration reference, keeping the names and wording aligned with the canonical filestorage constants and remote-sync docs.

### Demo/Screenshot for feature changes and bug fixes - 
N/A

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I updated only the two documentation files requested for C-SR-14. The change focuses on the user-facing reference for the `/remote-sync` command and the environment-variable guide for remote sync configuration. I kept the wording aligned with the existing docs and the canonical env-var names from `config/constants/filestorage.py`, without changing any Python code or other files.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.