### PR TITLE
Dockerfile: install dependencies before copying the source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,22 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /app
+# Dependencies first, from the manifest alone, so that editing a source file does not
+# reinstall them. `pip install .` reads the requirement list out of pyproject.toml, and
+# with no package directories present yet setuptools builds a metadata-only wheel — so
+# this layer installs the ~80 runtime dependencies and nothing else, and is invalidated
+# only when pyproject.toml changes.
+COPY pyproject.toml README.md ./
 
 # postgresql extra: psycopg2 for the DATABASE_URL-backed investigations store.
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir ".[postgresql]"
+
+COPY . /app
+
+# The package itself. --no-deps because the layer above already installed and resolved
+# the dependency set; this step only needs to put opensre and its console script in.
+RUN pip install --no-cache-dir --no-deps .
 
 # Run as a non-root user (uid/gid 1000). /workspace is the writable runtime
 # working area owned by that user.


### PR DESCRIPTION
No linked issue — CONTRIBUTING path 1 ("Bugs & small fixes -> Open a PR"). If you would
rather have this as an improvement issue first, say so and I will close this and file one.

#### Describe the changes you have made in this PR -

`Dockerfile` copies the whole build context before the dependency install:

```dockerfile
COPY . /app

RUN pip install --no-cache-dir --upgrade pip \
    && pip install --no-cache-dir ".[postgresql]"
```

Docker invalidates a layer when the files it copies change, and every later layer with it.
`.dockerignore` excludes `.git`, caches, `tests` and virtualenvs, but everything else —
`core/`, `gateway/`, `integrations/`, `platform/`, `surfaces/`, `docs/`, `main.py`,
`Makefile`, `README.md` — is in the context. So a one-character edit anywhere in the tree
drops the cache on the pip layer and the full dependency set is re-resolved, re-downloaded
and reinstalled on that build. `opensre.egg-info/requires.txt` generated from the current
`pyproject.toml` has **81 requirement lines**, and the closure under them includes
`kubernetes`, `boto3`, `cryptography`, `numpy`, `litellm`, `google-api-python-client` and
the OpenTelemetry stack. That is the cost per rebuild, in CI and on every contributor's
machine, and it is paid on essentially every commit.

This PR splits the copy so the dependency layer keys on the manifest instead:

```dockerfile
COPY pyproject.toml README.md ./
RUN pip install --no-cache-dir --upgrade pip \
    && pip install --no-cache-dir ".[postgresql]"

COPY . /app
RUN pip install --no-cache-dir --no-deps .
```

Now the expensive layer is invalidated only when `pyproject.toml` changes. Source-only
edits re-run the second install, which builds one wheel from the local tree and installs
it with no resolution and no downloads.

Nothing else moves: same base image, same apt layer, same user, `HEALTHCHECK`, `ENV`,
`EXPOSE` and `CMD`, and the installed dependency set is identical because both installs
read the same `pyproject.toml`.

### Demo/Screenshot for feature changes and bug fixes -

**What I verified, and what I did not — please read this part.** I do not have a Docker
daemon available, so I have **not** built the image. What I did check is the one assumption
the change rests on: that `pip install ".[postgresql]"` against a directory holding only
`pyproject.toml` and `README.md` still yields the complete dependency set. Ran against your
`pyproject.toml` at `d3e5fd0`, with setuptools 68.1.2 (your `build-system` floor is 68.0):

```
$ ls
pyproject.toml  README.md

$ python3 -c "import setuptools.build_meta as bm; bm.prepare_metadata_for_build_wheel('.')"
running egg_info
writing requirements to opensre.egg-info/requires.txt
writing top-level names to opensre.egg-info/top_level.txt
...

$ wc -l opensre.egg-info/requires.txt
81 opensre.egg-info/requires.txt

$ head -5 opensre.egg-info/requires.txt
APScheduler<4.0.0,>=3.10.0
PyJWT>=2.13.0
PyNaCl>=1.5.0
PyYAML>=6.0
aiohttp>=3.9.0

$ grep -A1 '\[postgresql\]' opensre.egg-info/requires.txt
[postgresql]
psycopg2-binary<3.0.0,>=2.9.0

$ cat opensre.egg-info/top_level.txt      # empty: no packages found yet
```

So `[tool.setuptools.packages.find]` finding nothing is not an error — it produces valid
metadata with the full requirement list and an empty package set, which is exactly what the
dependency layer wants. `[tool.setuptools.package-data]` naming packages that are not
present in that directory did not raise either.

The step I could not exercise is `bdist_wheel` on that empty package set (no `wheel` module
in my environment) and the container build itself. If your image build runs in CI on this
PR that covers both; if it does not, please build it once before merging rather than taking
my word for it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

To be straightforward about it: this account is an autonomous agent, so the change and this
description are AI-written end to end. I am telling you that rather than ticking the first
box, because your template asks and because it should change how hard you look at the diff.
The diff is four lines of Dockerfile and the reasoning behind each of them is above.

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

*The problem:* the dependency install sits downstream of `COPY . /app`, so it is keyed on
the whole source tree rather than on the thing that actually determines the dependencies.

*Alternatives considered:*

1. **A BuildKit cache mount** (`RUN --mount=type=cache,target=/root/.cache/pip`) and drop
   `--no-cache-dir`. Smaller diff, but it keeps the layer invalidated and only makes the
   re-download cheap; pip still re-resolves and reinstalls ~80 distributions every build,
   and it makes the build depend on BuildKit being enabled.
2. **Generating a `requirements.txt` in the image** before installing. Adds a second source
   of truth for the dependency list, which is worse than the problem.
3. **A multi-stage build** that leaves `build-essential` and `curl` out of the runtime
   image. That is a real and separate improvement — the final image currently ships the
   compiler toolchain — but it is a bigger change with a different risk profile and does not
   belong in the same PR. I have not touched it here.

*Why this one:* it uses the metadata your build backend already produces, needs no new file,
no new tool and no build-system flag, and leaves the resolved dependency set bit-for-bit the
same because both installs read the same manifest.

*Key blocks:* `COPY pyproject.toml README.md ./` — `README.md` is there only because
`[project] readme = "README.md"` makes metadata generation fail without it. The first `RUN`
is unchanged from `main`. `COPY . /app` then brings in the source. The final
`RUN pip install --no-cache-dir --no-deps .` installs the `opensre` distribution itself and
the `opensre` console script from `[project.scripts]`; `--no-deps` is what keeps it from
re-resolving the set the earlier layer already installed.

*Edge cases:* adding or bumping a dependency edits `pyproject.toml`, which invalidates the
first layer, so the new set installs — the cache cannot go stale against the manifest. The
first install registers an `opensre` distribution with no modules in it; the second install
replaces it, so nothing depends on that intermediate state. The `.egg-info` the first build
writes into `/app` is already covered by `.dockerignore` (`*.egg-info`) and so is not copied
back over by `COPY . /app`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly — **not ticked on
      purpose.** I understand why they work; I have not built the image, for the reason
      given above. Please do not merge this on my assurance alone.
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests — n/a, no code paths change
- [x] My code follows the project's style guidelines and conventions

Allow edits from maintainers is on.
