### PR TITLE
feat(llm-cli): stream CLI stdout and hand off prose tool-selection turns

### DIFF
--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -50,9 +50,12 @@ from core.llm.transports.sdk.anthropic_cache import (
 from core.llm.transports.sdk.anthropic_cache import (
     tools_with_cache as _anthropic_tools_with_cache,
 )
-from core.llm.types import AgentLLMResponse, ToolCall
+from core.llm.types import AgentLLMResponse, ModelType, ToolCall
 
 logger = logging.getLogger(__name__)
+
+_ASSISTANT_HANDOFF_TOOL_NAME = "assistant_handoff"
+_CLI_PLAIN_TEXT_HANDOFF_CHAR_LIMIT = 360
 
 
 def _anthropic_tool_schema(tool: Any) -> dict[str, Any]:
@@ -773,12 +776,18 @@ class CLIBackedAgentClient:
     """
 
     _TOOL_CALL_INSTRUCTION = (
-        "You are an SRE investigation agent. Use the available tools to investigate "
-        "the alert. On each turn respond with EITHER:\n"
+        "You are a tool-calling adapter for the current OpenSRE phase. Follow the "
+        "System instructions and choose the appropriate available tool. On each "
+        "turn respond with EITHER:\n"
         '  (a) A JSON object: {"tool_calls": [{"id": "<unique_id>", "name": "<tool>",'
         ' "input": {<args>}}]}\n'
-        "  (b) A plain-text final answer when investigation is complete.\n"
-        "Respond with JSON only when calling tools; respond with plain text only for the final answer."
+        "  (b) A concise plain-text final answer only after tool use is complete "
+        "or when no suitable tool exists.\n"
+        "If a tool named assistant_handoff is available and the System instructions "
+        "say to hand off the request, emit an assistant_handoff JSON tool call. "
+        "Do not answer that request in prose during the tool-selection turn. "
+        "Respond with JSON only when calling tools; respond with plain text only "
+        "for the final answer."
     )
 
     def __init__(self, adapter: Any, *, model: str | None = None) -> None:
@@ -788,7 +797,11 @@ class CLIBackedAgentClient:
         self._model = model
         # Reuse one client so any probe cache in the CLI backend applies across
         # ReAct iterations instead of re-probing every invoke.
-        self._cli_client = build_cli_client(adapter, model=self._model)
+        self._cli_client = build_cli_client(
+            adapter,
+            model=self._model,
+            model_type=ModelType.TOOLCALL,
+        )
 
     @property
     def model_id(self) -> str | None:
@@ -819,8 +832,12 @@ class CLIBackedAgentClient:
         instruction = self._TOOL_CALL_INSTRUCTION + tool_block
         prompt = f"{system_block}{instruction}\n\n{flatten_cli_messages_to_prompt(messages)}"
 
-        response = self._cli_client.invoke(prompt)
-        text = response.content.strip()
+        text, force_handoff = self._invoke_cli_for_tool_selection(
+            prompt,
+            handoff_on_plain_text=_should_handoff_initial_cli_prose(messages, tools),
+        )
+        if force_handoff:
+            return _assistant_handoff_response()
 
         # Try to parse a JSON tool call response.
         tool_calls: list[ToolCall] = []
@@ -854,6 +871,36 @@ class CLIBackedAgentClient:
             raw_content=None,  # None so _build_assistant_msg falls through to build_assistant_message
         )
 
+    def _invoke_cli_for_tool_selection(
+        self,
+        prompt: str,
+        *,
+        handoff_on_plain_text: bool,
+    ) -> tuple[str, bool]:
+        if not handoff_on_plain_text:
+            response = self._cli_client.invoke(prompt)
+            return response.content.strip(), False
+
+        chunks: list[str] = []
+        stream = self._cli_client.invoke_stream(prompt)
+        for chunk in stream:
+            chunks.append(chunk)
+            text = "".join(chunks)
+            if _should_force_cli_plain_text_handoff(text):
+                close = getattr(stream, "close", None)
+                if callable(close):
+                    close()
+                return "", True
+
+        text = "".join(chunks).strip()
+        if (
+            text
+            and _try_parse_tool_call_json(text) is None
+            and not _looks_like_cli_structured_response(text)
+        ):
+            return "", True
+        return text, False
+
     @staticmethod
     def build_tool_result_message(tool_calls: list[ToolCall], results: list[Any]) -> dict[str, Any]:
         parts = [
@@ -876,6 +923,74 @@ class CLIBackedAgentClient:
                 return {"role": "assistant", "content": f"{content.strip()}\n\n{tool_json}"}
             return {"role": "assistant", "content": tool_json}
         return {"role": "assistant", "content": content}
+
+
+def _assistant_handoff_response() -> AgentLLMResponse:
+    return AgentLLMResponse(
+        content="",
+        tool_calls=[
+            ToolCall(
+                id="cli_plain_text_handoff_0",
+                name=_ASSISTANT_HANDOFF_TOOL_NAME,
+                input={"content": "chat:conversation"},
+            )
+        ],
+        stop_reason="tool_use",
+        raw_content=None,
+    )
+
+
+def _tool_name(tool: dict[str, Any]) -> str:
+    name = tool.get("name")
+    if isinstance(name, str):
+        return name
+    function = tool.get("function")
+    if isinstance(function, dict):
+        function_name = function.get("name")
+        if isinstance(function_name, str):
+            return function_name
+    return ""
+
+
+def _has_tool_named(tools: list[dict[str, Any]] | None, name: str) -> bool:
+    return any(_tool_name(tool) == name for tool in tools or [])
+
+
+def _messages_have_tool_observation(messages: list[dict[str, Any]]) -> bool:
+    for message in messages:
+        role = message.get("role")
+        if role in {"tool", "toolResult", "tool_result"}:
+            return True
+        content = message.get("content")
+        if role == "user" and isinstance(content, str) and content.startswith("Tool result for "):
+            return True
+    return False
+
+
+def _should_handoff_initial_cli_prose(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> bool:
+    return _has_tool_named(tools, _ASSISTANT_HANDOFF_TOOL_NAME) and not (
+        _messages_have_tool_observation(messages)
+    )
+
+
+def _looks_like_cli_structured_response(text: str) -> bool:
+    stripped = text.lstrip()
+    return (
+        stripped.startswith("{")
+        or stripped.startswith("```")
+        or '"tool_calls"' in stripped
+        or "'tool_calls'" in stripped
+    )
+
+
+def _should_force_cli_plain_text_handoff(text: str) -> bool:
+    stripped = text.lstrip()
+    if len(stripped) < _CLI_PLAIN_TEXT_HANDOFF_CHAR_LIMIT:
+        return False
+    return not _looks_like_cli_structured_response(stripped)
 
 
 def _try_parse_tool_call_json(text: str) -> dict[str, Any] | None:

--- a/integrations/llm_cli/antigravity_cli.py
+++ b/integrations/llm_cli/antigravity_cli.py
@@ -135,6 +135,7 @@ class AntigravityCLIAdapter:
     """Non-interactive Antigravity CLI (``agy -p`` headless mode)."""
 
     name = "antigravity-cli"
+    streams_plain_stdout = True
     binary_env_key = "ANTIGRAVITY_CLI_BIN"
     install_hint = "curl -fsSL https://antigravity.google/cli/install.sh | bash"
     auth_hint = _AUTH_HINT.removesuffix(".")

--- a/integrations/llm_cli/claude_code.py
+++ b/integrations/llm_cli/claude_code.py
@@ -236,6 +236,7 @@ class ClaudeCodeAdapter:
     """Non-interactive Claude Code CLI (``claude -p``, print mode, no TTY)."""
 
     name = "claude-code"
+    streams_plain_stdout = True
     binary_env_key = "CLAUDE_CODE_BIN"
     install_hint = "npm i -g @anthropic-ai/claude-code"
     auth_hint = _AUTH_HINT.removesuffix(".")

--- a/integrations/llm_cli/codex.py
+++ b/integrations/llm_cli/codex.py
@@ -94,6 +94,7 @@ class CodexAdapter:
     """Non-interactive Codex CLI (`codex exec` with read-only sandbox)."""
 
     name = "codex"
+    streams_plain_stdout = True
     binary_env_key = "CODEX_BIN"
     install_hint = "npm i -g @openai/codex"
     auth_hint = "Run: codex login"

--- a/integrations/llm_cli/copilot.py
+++ b/integrations/llm_cli/copilot.py
@@ -209,6 +209,7 @@ class CopilotAdapter:
     """Non-interactive GitHub Copilot CLI (``copilot -p``, programmatic mode)."""
 
     name = "copilot"
+    streams_plain_stdout = True
     binary_env_key = "COPILOT_BIN"
     install_hint = "npm i -g @github/copilot"
     auth_hint = _AUTH_HINT.removesuffix(".")

--- a/integrations/llm_cli/cursor.py
+++ b/integrations/llm_cli/cursor.py
@@ -65,6 +65,7 @@ class CursorAdapter:
     """
 
     name = "cursor"
+    streams_plain_stdout = True
     binary_env_key = "CURSOR_BIN"
     install_hint = "Install Cursor Agent with: curl https://cursor.com/install -fsS | bash"
     auth_hint = "Run: agent login."

--- a/integrations/llm_cli/grok_cli.py
+++ b/integrations/llm_cli/grok_cli.py
@@ -159,6 +159,7 @@ class GrokCLIAdapter:
     """Non-interactive xAI Grok Build CLI (``grok -p``, headless mode, no TTY)."""
 
     name = "grok-cli"
+    streams_plain_stdout = True
     binary_env_key = "GROK_CLI_BIN"
     install_hint = "curl -fsSL https://x.ai/cli/install.sh | bash"
     auth_hint = _AUTH_HINT.removesuffix(".")

--- a/integrations/llm_cli/kimi.py
+++ b/integrations/llm_cli/kimi.py
@@ -128,6 +128,7 @@ class KimiAdapter:
     """Non-interactive Kimi Code CLI (`kimi -p` with --yolo)."""
 
     name = "kimi"
+    streams_plain_stdout = True
     binary_env_key = "KIMI_BIN"
     install_hint = "uv tool install --python 3.13 kimi-cli"
     auth_hint = "Run: kimi login"

--- a/integrations/llm_cli/opencode.py
+++ b/integrations/llm_cli/opencode.py
@@ -120,6 +120,7 @@ class OpenCodeAdapter:
     """Non-interactive OpenCode CLI (`opencode run`, one-shot execution)."""
 
     name = "opencode"
+    streams_plain_stdout = True
     binary_env_key = "OPENCODE_BIN"
     install_hint = (
         "brew install anomalyco/tap/opencode  (macOS/Linux) | choco install opencode (Windows)"

--- a/integrations/llm_cli/pi_cli.py
+++ b/integrations/llm_cli/pi_cli.py
@@ -150,6 +150,7 @@ class PiAdapter:
     """Non-interactive Pi CLI (``pi -p``, print mode, no TTY)."""
 
     name = "pi"
+    streams_plain_stdout = True
     binary_env_key = "PI_BIN"
     install_hint = "npm i -g @earendil-works/pi-coding-agent"
     auth_hint = _AUTH_HINT.removesuffix(".")

--- a/integrations/llm_cli/runner.py
+++ b/integrations/llm_cli/runner.py
@@ -3,19 +3,21 @@
 from __future__ import annotations
 
 import logging
+import queue
 import re
 import subprocess
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
+from dataclasses import dataclass
 from typing import Any
 
 from pydantic import BaseModel
 
-from config.llm_reasoning_effort import get_active_reasoning_effort
+from config.llm_reasoning_effort import ReasoningEffort, get_active_reasoning_effort
 from core.llm.shared.structured_output import StructuredOutputClient
-from core.llm.types import LLMResponse
-from integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
+from core.llm.types import LLMResponse, ModelType
+from integrations.llm_cli.base import CLIInvocation, CLIProbe, LLMCLIAdapter
 from integrations.llm_cli.constants import (
     EX_TEMPFAIL as _EX_TEMPFAIL,
 )
@@ -40,6 +42,8 @@ logger = logging.getLogger(__name__)
 
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 _REDACTED_PROMPT_ARG = "<redacted-prompt>"
+_STREAM_CHUNK_CHARS = 160
+_STREAM_QUEUE_TIMEOUT_SEC = 0.05
 # Avoid re-running `detect()` (two subprocess probes) on every invoke during long
 # investigations. Value is defined in shared constants.
 # POSIX EX_TEMPFAIL (75): the subprocess hit a transient error and can be retried.
@@ -69,6 +73,27 @@ def _sanitize_argv_for_debug(argv: tuple[str, ...], *, prompt: str) -> list[str]
             continue
         redacted.append(arg)
     return redacted
+
+
+def _is_toolcall_model_type(model_type: Any) -> bool:
+    value = getattr(model_type, "value", model_type)
+    return isinstance(value, str) and value == ModelType.TOOLCALL.value
+
+
+@dataclass(frozen=True)
+class _PreparedInvocation:
+    invocation: CLIInvocation
+    merged_env: dict[str, str]
+    auth_probe_unclear: bool
+    auth_probe_detail: str
+
+
+@dataclass(frozen=True)
+class _StreamedProcessResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    emitted: bool
 
 
 class CLIBackedLLMClient:
@@ -113,11 +138,10 @@ class CLIBackedLLMClient:
         """JSON-schema prompt + parse; same contract as API `StructuredOutputClient`."""
         return StructuredOutputClient(self, model)
 
-    def invoke(self, prompt_or_messages: Any) -> LLMResponse:
-        # max_tokens / model_type are stored for API parity but ignored here:
-        # CLI adapters (e.g. codex exec) do not expose a scriptable token limit.
+    def _prepare_invocation(self, prompt_or_messages: Any) -> _PreparedInvocation:
+        # max_tokens is stored for API parity but ignored here: CLI adapters
+        # (e.g. codex exec) do not expose a scriptable token limit.
         _ = self._max_tokens
-        _ = self._model_type
 
         from platform.guardrails.apply import apply_guardrails_to_text
 
@@ -139,11 +163,16 @@ class CLIBackedLLMClient:
             )
         auth_probe_unclear = probe.logged_in is None
 
+        reasoning_effort = (
+            ReasoningEffort.LOW.value
+            if _is_toolcall_model_type(self._model_type)
+            else get_active_reasoning_effort()
+        )
         invocation = self._adapter.build(
             prompt=flat,
             model=self._model,
             workspace="",
-            reasoning_effort=get_active_reasoning_effort(),
+            reasoning_effort=reasoning_effort,
         )
         merged_env = _build_subprocess_env(invocation.env)
         logger.debug(
@@ -153,59 +182,38 @@ class CLIBackedLLMClient:
                 "argv": _sanitize_argv_for_debug(invocation.argv, prompt=flat),
             },
         )
+        return _PreparedInvocation(
+            invocation=invocation,
+            merged_env=merged_env,
+            auth_probe_unclear=auth_probe_unclear,
+            auth_probe_detail=probe.detail,
+        )
 
-        backoff = _TEMPFAIL_BACKOFF_SEC
-        for attempt in range(_TEMPFAIL_MAX_RETRIES + 1):
-            try:
-                proc = subprocess.run(
-                    list(invocation.argv),
-                    input=invocation.stdin,
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    cwd=invocation.cwd,
-                    env=merged_env,
-                    timeout=invocation.timeout_sec,
-                    check=False,
-                )
-            except subprocess.TimeoutExpired as exc:
-                raise CLITimeoutError(
-                    f"{self._adapter.name} CLI timed out after {invocation.timeout_sec:.0f}s."
-                ) from exc
-            except OSError as exc:
-                raise RuntimeError(f"Failed to spawn {self._adapter.name} CLI: {exc}") from exc
+    def _response_from_completed_process(
+        self,
+        *,
+        returncode: int,
+        stdout: str,
+        stderr: str,
+        auth_probe_unclear: bool,
+        auth_probe_detail: str,
+    ) -> LLMResponse:
+        out = _strip_ansi(stdout or "")
+        err = _strip_ansi(stderr or "")
 
-            if proc.returncode == _EX_TEMPFAIL and attempt < _TEMPFAIL_MAX_RETRIES:
-                logger.warning(
-                    "cli_llm_tempfail_retry",
-                    extra={
-                        "provider": self._adapter.name,
-                        "attempt": attempt + 1,
-                        "backoff_sec": backoff,
-                    },
-                )
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            break
-
-        out = _strip_ansi(proc.stdout or "")
-        err = _strip_ansi(proc.stderr or "")
-
-        if proc.returncode != 0:
+        if returncode != 0:
             # Exit code 130 = subprocess terminated by SIGINT (Ctrl+C); raise
             # CLIInterruptedError so callers using `try/except Exception` still
             # observe the failure (KeyboardInterrupt inherits from BaseException
             # and would bypass those handlers). Sentry's `ignore_errors` config
             # filters this type so user-initiated cancellations are not reported
             # as bugs.
-            if proc.returncode == 130:
+            if returncode == 130:
                 raise CLIInterruptedError(f"{self._adapter.name} CLI subprocess interrupted.")
             # Exit code 75 is EX_TEMPFAIL (sysexits.h) — a transient failure
             # the caller should retry. Raise CLITimeoutError so it is treated as
             # an expected operational failure and not forwarded to Sentry.
-            if proc.returncode == _EX_TEMPFAIL:
+            if returncode == _EX_TEMPFAIL:
                 hint = (
                     f"{self._adapter.name} reported a temporary failure (exit 75). "
                     "Retry the request or check network connectivity."
@@ -214,7 +222,7 @@ class CLIBackedLLMClient:
                     hint = f"{hint} {err[:200]}"
                 raise CLITimeoutError(hint)
             base = self._adapter.explain_failure(
-                stdout=out, stderr=err, returncode=proc.returncode
+                stdout=out, stderr=err, returncode=returncode
             ).strip()
             # When the failure message signals an auth problem raise
             # CLIAuthenticationRequired so callers (reraise_cli_runtime_error,
@@ -242,13 +250,13 @@ class CLIBackedLLMClient:
                 message = (
                     f"{base}\n\n"
                     f"Auth status could not be verified before invocation. "
-                    f"{self._adapter.auth_hint} ({probe.detail})"
+                    f"{self._adapter.auth_hint} ({auth_probe_detail})"
                 )
             else:
                 message = base
             raise RuntimeError(message)
 
-        content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)
+        content = self._adapter.parse(stdout=out, stderr=err, returncode=returncode)
         content = _strip_ansi(content).strip()
         if err:
             logger.debug(
@@ -261,10 +269,219 @@ class CLIBackedLLMClient:
         )
         return LLMResponse(content=content)
 
-    def invoke_stream(self, prompt_or_messages: Any) -> Iterator[str]:
-        """Yield the full response as one chunk; real streaming is a follow-up.
+    def invoke(self, prompt_or_messages: Any) -> LLMResponse:
+        prepared = self._prepare_invocation(prompt_or_messages)
+        invocation = prepared.invocation
 
-        Subprocess CLI adapters ``subprocess.run`` to completion, so this
-        satisfies the protocol contract without faking progressive output.
+        backoff = _TEMPFAIL_BACKOFF_SEC
+        for attempt in range(_TEMPFAIL_MAX_RETRIES + 1):
+            try:
+                proc = subprocess.run(
+                    list(invocation.argv),
+                    input=invocation.stdin,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    cwd=invocation.cwd,
+                    env=prepared.merged_env,
+                    timeout=invocation.timeout_sec,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise CLITimeoutError(
+                    f"{self._adapter.name} CLI timed out after {invocation.timeout_sec:.0f}s."
+                ) from exc
+            except OSError as exc:
+                raise RuntimeError(f"Failed to spawn {self._adapter.name} CLI: {exc}") from exc
+
+            if proc.returncode == _EX_TEMPFAIL and attempt < _TEMPFAIL_MAX_RETRIES:
+                logger.warning(
+                    "cli_llm_tempfail_retry",
+                    extra={
+                        "provider": self._adapter.name,
+                        "attempt": attempt + 1,
+                        "backoff_sec": backoff,
+                    },
+                )
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            return self._response_from_completed_process(
+                returncode=proc.returncode,
+                stdout=proc.stdout or "",
+                stderr=proc.stderr or "",
+                auth_probe_unclear=prepared.auth_probe_unclear,
+                auth_probe_detail=prepared.auth_probe_detail,
+            )
+
+        raise CLITimeoutError(f"{self._adapter.name} reported repeated temporary failures.")
+
+    def _run_plain_stdout_stream(
+        self,
+        invocation: CLIInvocation,
+        *,
+        merged_env: dict[str, str],
+    ) -> Generator[str, None, _StreamedProcessResult]:
+        proc: subprocess.Popen[str] | None = None
+        try:
+            proc = subprocess.Popen(
+                list(invocation.argv),
+                stdin=subprocess.PIPE if invocation.stdin is not None else None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=invocation.cwd,
+                env=merged_env,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"Failed to spawn {self._adapter.name} CLI: {exc}") from exc
+
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+        stdout_queue: queue.Queue[str | None] = queue.Queue()
+
+        def _write_stdin() -> None:
+            stdin = proc.stdin
+            if stdin is None or invocation.stdin is None:
+                return
+            try:
+                stdin.write(invocation.stdin)
+                stdin.flush()
+            except BrokenPipeError:
+                return
+            finally:
+                stdin.close()
+
+        def _read_stdout() -> None:
+            stream = proc.stdout
+            if stream is None:
+                stdout_queue.put(None)
+                return
+            pending: list[str] = []
+            try:
+                while True:
+                    char = stream.read(1)
+                    if not char:
+                        break
+                    stdout_chunks.append(char)
+                    pending.append(char)
+                    if char == "\n" or len(pending) >= _STREAM_CHUNK_CHARS:
+                        stdout_queue.put("".join(pending))
+                        pending = []
+                if pending:
+                    stdout_queue.put("".join(pending))
+            finally:
+                stdout_queue.put(None)
+
+        def _read_stderr() -> None:
+            stream = proc.stderr
+            if stream is None:
+                return
+            for chunk in iter(lambda: stream.read(1), ""):
+                stderr_chunks.append(chunk)
+
+        stdin_thread = threading.Thread(
+            target=_write_stdin,
+            name=f"{self._adapter.name}-cli-stdin",
+            daemon=True,
+        )
+        stdout_thread = threading.Thread(
+            target=_read_stdout,
+            name=f"{self._adapter.name}-cli-stdout",
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=_read_stderr,
+            name=f"{self._adapter.name}-cli-stderr",
+            daemon=True,
+        )
+        stdin_thread.start()
+        stdout_thread.start()
+        stderr_thread.start()
+
+        deadline = time.monotonic() + max(invocation.timeout_sec, 0.0)
+        emitted = False
+        stdout_done = False
+        try:
+            while not stdout_done or proc.poll() is None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    proc.kill()
+                    raise CLITimeoutError(
+                        f"{self._adapter.name} CLI timed out after {invocation.timeout_sec:.0f}s."
+                    )
+                try:
+                    item = stdout_queue.get(
+                        timeout=min(_STREAM_QUEUE_TIMEOUT_SEC, max(remaining, 0.0))
+                    )
+                except queue.Empty:
+                    continue
+                if item is None:
+                    stdout_done = True
+                    continue
+                emitted = True
+                yield item
+            returncode = proc.wait(timeout=max(deadline - time.monotonic(), 0.0))
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            stdin_thread.join(timeout=0.1)
+            stdout_thread.join(timeout=0.1)
+            stderr_thread.join(timeout=0.1)
+
+        return _StreamedProcessResult(
+            returncode=returncode,
+            stdout="".join(stdout_chunks),
+            stderr="".join(stderr_chunks),
+            emitted=emitted,
+        )
+
+    def invoke_stream(self, prompt_or_messages: Any) -> Iterator[str]:
+        """Yield response chunks as the backing CLI emits plain stdout.
+
+        Adapters opt in with ``streams_plain_stdout = True`` when stdout is the
+        final answer text. Structured-output adapters stay on the buffered
+        ``invoke`` path so JSON envelopes or status records are parsed before
+        anything reaches the terminal.
         """
-        yield self.invoke(prompt_or_messages).content
+        if getattr(self._adapter, "streams_plain_stdout", False) is not True:
+            yield self.invoke(prompt_or_messages).content
+            return
+
+        prepared = self._prepare_invocation(prompt_or_messages)
+        backoff = _TEMPFAIL_BACKOFF_SEC
+        for attempt in range(_TEMPFAIL_MAX_RETRIES + 1):
+            result = yield from self._run_plain_stdout_stream(
+                prepared.invocation,
+                merged_env=prepared.merged_env,
+            )
+            if (
+                result.returncode == _EX_TEMPFAIL
+                and not result.emitted
+                and attempt < _TEMPFAIL_MAX_RETRIES
+            ):
+                logger.warning(
+                    "cli_llm_tempfail_retry",
+                    extra={
+                        "provider": self._adapter.name,
+                        "attempt": attempt + 1,
+                        "backoff_sec": backoff,
+                    },
+                )
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            self._response_from_completed_process(
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                auth_probe_unclear=prepared.auth_probe_unclear,
+                auth_probe_detail=prepared.auth_probe_detail,
+            )
+            return
+
+        raise CLITimeoutError(f"{self._adapter.name} reported repeated temporary failures.")

--- a/surfaces/interactive_shell/ui/streaming/__init__.py
+++ b/surfaces/interactive_shell/ui/streaming/__init__.py
@@ -7,12 +7,14 @@ does cursor manipulation (cursor-up + erase-line) for in-place redraw,
 which fights ``patch_stdout`` and blocks the input buffer from
 accepting keystrokes.
 
-Instead this path streams **paragraph-by-paragraph**: chunks accumulate
-in ``para_buffer`` and a complete paragraph (text up to the next
-``\\n\\n`` outside an open code-fence) renders as ``rich.Markdown`` the
-moment its boundary is seen. The trailing partial paragraph is
-force-flushed at end-of-stream. Code blocks are kept whole — we never
-split on ``\\n\\n`` while a triple-backtick fence is unclosed.
+Instead this path streams **paragraph-by-paragraph**, with a bounded-latency
+fallback for very long prose paragraphs: chunks accumulate in ``para_buffer``
+and a complete paragraph (text up to the next ``\\n\\n`` outside an open
+code-fence) renders as ``rich.Markdown`` the moment its boundary is seen. Long
+partial prose is also flushed once it grows past a small character budget, so a
+10k-word single paragraph does not sit invisible until end-of-stream. Code
+blocks are kept whole — we never split on ``\\n\\n`` or partial-size thresholds
+while a triple-backtick fence is unclosed.
 
 Streaming progress and cancellation are surfaced through optional
 attributes on the ``console``: ``update_streaming_progress(bytes)`` is
@@ -62,6 +64,9 @@ _CODE_FENCE = "```"
 # the fence to be at line start anyway, so this is a tighter and
 # more accurate check than a naive substring count.
 _CODE_FENCE_LINE_RE = re.compile(rf"^{re.escape(_CODE_FENCE)}", re.MULTILINE)
+_PARTIAL_FLUSH_CHAR_THRESHOLD = 900
+_PARTIAL_FLUSH_MIN_CHARS = 360
+_PARTIAL_FLUSH_SENTENCE_BREAKS = (". ", "? ", "! ", ".\n", "?\n", "!\n")
 # Rich inserts leading vertical space when these block types start a standalone
 # Markdown render. Other blocks do not, so paragraph-by-paragraph streaming must
 # add the consumed ``\n\n`` before rendering them.
@@ -127,6 +132,11 @@ def _format_tokens(token_count: int) -> str:
 
 def _paragraph_has_want_me_to(text: str) -> bool:
     return WANT_ME_TO_MARKER in text.lower()
+
+
+def _has_open_code_fence(text: str) -> bool:
+    """True when ``text`` contains an unclosed line-start fenced block."""
+    return len(_CODE_FENCE_LINE_RE.findall(text)) % 2 == 1
 
 
 @dataclass(frozen=True)
@@ -236,6 +246,7 @@ def stream_to_console_state(
     # are kept whole (we never split on ``\n\n`` while a fence is open).
     buffer: list[str] = list(peeked)
     para_buffer: list[str] = list(peeked)
+    para_chars = sum(len(c) for c in peeked)
     started = time.monotonic()
     progress_hook = getattr(console, "update_streaming_progress", None)
     total_bytes = sum(len(c) for c in peeked)
@@ -262,7 +273,7 @@ def stream_to_console_state(
         # so this stays False for them.
         return bool(getattr(console, "cancel_requested", False))
 
-    def _paint_paragraph_body(text: str) -> None:
+    def _paint_paragraph_body(text: str, *, source_break: bool = True) -> None:
         nonlocal rendered_paragraphs
         visible = strip_session_goal_progress_tags(text)
         if not visible.strip():
@@ -271,7 +282,7 @@ def stream_to_console_state(
         starts_with_self_spacing_block = bool(
             markdown.parsed and markdown.parsed[0].type in _SELF_SPACING_BLOCK_TOKEN_TYPES
         )
-        if rendered_paragraphs and not starts_with_self_spacing_block:
+        if rendered_paragraphs and source_break and not starts_with_self_spacing_block:
             # ``_flush_paragraphs`` consumes the source ``\n\n`` boundary.
             # Restore it explicitly unless Rich adds equivalent leading space
             # for the next standalone block. This matters most after lists,
@@ -281,7 +292,7 @@ def stream_to_console_state(
             console.print(markdown)
         rendered_paragraphs += 1
 
-    def _render_paragraph(text: str) -> None:
+    def _render_paragraph(text: str, *, source_break: bool = True) -> None:
         nonlocal deferred_closer
         # Keep raw ``text`` (with progress tags) for Want-me-to detection; paint
         # only the scrubbed visible body so ``session_goal:…`` never hits the TTY.
@@ -297,12 +308,12 @@ def stream_to_console_state(
                 start -= 2
             head = text[:start].rstrip() if start > 0 else ""
             if head.strip():
-                _paint_paragraph_body(head)
+                _paint_paragraph_body(head, source_break=source_break)
             return
-        _paint_paragraph_body(text)
+        _paint_paragraph_body(text, source_break=source_break)
 
     def _flush_paragraphs(*, force: bool = False) -> None:
-        nonlocal para_buffer
+        nonlocal para_buffer, para_chars
         break_len = len(_PARAGRAPH_BREAK)
         while True:
             text = "".join(para_buffer)
@@ -325,6 +336,7 @@ def stream_to_console_state(
                 _render_paragraph(paragraph)
                 tail = text[idx + break_len :]
                 para_buffer = [tail] if tail else []
+                para_chars = len(tail)
                 rendered = True
                 break
             if not rendered:
@@ -334,6 +346,46 @@ def stream_to_console_state(
             if tail.strip():
                 _render_paragraph(tail)
             para_buffer = []
+            para_chars = 0
+
+    def _partial_flush_index(text: str) -> int:
+        """Return a visible prose boundary for latency flushes, or ``-1``."""
+        if len(text) < _PARTIAL_FLUSH_CHAR_THRESHOLD or _has_open_code_fence(text):
+            return -1
+
+        candidate = text
+        if defer_want_me_to_closer:
+            marker_pos = text.lower().find(WANT_ME_TO_MARKER)
+            if marker_pos >= 0:
+                candidate = text[:marker_pos]
+        if len(candidate) < _PARTIAL_FLUSH_CHAR_THRESHOLD:
+            return -1
+
+        sentence_indices = [
+            candidate.rfind(sep, 0, len(candidate)) + len(sep)
+            for sep in _PARTIAL_FLUSH_SENTENCE_BREAKS
+            if candidate.rfind(sep, 0, len(candidate)) >= _PARTIAL_FLUSH_MIN_CHARS
+        ]
+        if sentence_indices:
+            return max(sentence_indices)
+
+        space_idx = candidate.rfind(" ", 0, len(candidate))
+        if space_idx >= _PARTIAL_FLUSH_MIN_CHARS:
+            return space_idx + 1
+        return _PARTIAL_FLUSH_CHAR_THRESHOLD
+
+    def _flush_partial_if_needed() -> None:
+        nonlocal para_buffer, para_chars
+        if para_chars < _PARTIAL_FLUSH_CHAR_THRESHOLD:
+            return
+        text = "".join(para_buffer)
+        idx = _partial_flush_index(text)
+        if idx <= 0:
+            return
+        _render_paragraph(text[:idx], source_break=False)
+        tail = text[idx:]
+        para_buffer = [tail] if tail else []
+        para_chars = len(tail)
 
     def _maybe_flush_after_append(chunk: str, prev_chunk: str | None) -> None:
         """Cheap fast-path before the O(buffer) join inside ``_flush_paragraphs``.
@@ -355,6 +407,7 @@ def stream_to_console_state(
             return
         if _PARAGRAPH_BREAK in chunk:
             _flush_paragraphs()
+            _flush_partial_if_needed()
             return
         # Cross-chunk boundary: previous chunk ended with ``\n`` and
         # this chunk's leading ``\n`` completes the ``\n\n``.
@@ -366,10 +419,14 @@ def stream_to_console_state(
             and chunk.startswith(newline)
         ):
             _flush_paragraphs()
+            _flush_partial_if_needed()
+            return
+        _flush_partial_if_needed()
 
     if peeked:
         last_progress_at = _maybe_update_progress(time.monotonic(), force=True)
         _flush_paragraphs()
+        _flush_partial_if_needed()
 
     # Track the chunk immediately preceding the current one so the
     # cross-chunk seam check can detect ``\n\n`` straddling the
@@ -386,6 +443,7 @@ def stream_to_console_state(
                 continue
             buffer.append(chunk)
             para_buffer.append(chunk)
+            para_chars += len(chunk)
             total_bytes += len(chunk)
             last_progress_at = _maybe_update_progress(time.monotonic())
             _maybe_flush_after_append(chunk, prev_chunk)

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -1324,6 +1324,88 @@ def test_try_parse_tool_call_json_recovers_when_unfenced_preamble_precedes_json(
     assert parsed["tool_calls"][0]["name"] == "t1"
 
 
+def test_cli_backed_agent_client_streamed_initial_prose_becomes_assistant_handoff() -> None:
+    """A CLI planner that starts writing the answer should hand off instead of running long."""
+
+    from core.llm.transports.sdk.agent_clients import CLIBackedAgentClient
+
+    class _ClosingChunkStream:
+        def __init__(self) -> None:
+            self.closed = False
+            self.yield_count = 0
+
+        def __iter__(self) -> _ClosingChunkStream:
+            return self
+
+        def __next__(self) -> str:
+            if self.closed:
+                raise StopIteration
+            self.yield_count += 1
+            if self.yield_count > 20:
+                pytest.fail("plain-text handoff guard did not stop the CLI stream")
+            return "OpenSRE is a command-line SRE assistant for operational work. "
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _FakeCLI:
+        def __init__(self, stream: _ClosingChunkStream) -> None:
+            self.stream = stream
+
+        def invoke_stream(self, prompt: str) -> _ClosingChunkStream:
+            _ = prompt
+            return self.stream
+
+        def invoke(self, prompt: str) -> object:
+            _ = prompt
+            pytest.fail("handoff guard should use streaming invocation")
+
+    stream = _ClosingChunkStream()
+    client = CLIBackedAgentClient.__new__(CLIBackedAgentClient)
+    client._cli_client = _FakeCLI(stream)
+    result = client.invoke(
+        [{"role": "user", "content": "what is this tool and how do i use it in 10k words"}],
+        tools=[{"name": "assistant_handoff", "input_schema": {"type": "object"}}],
+    )
+
+    assert stream.closed
+    assert stream.yield_count < 20
+    assert result.content == ""
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "assistant_handoff"
+    assert result.tool_calls[0].input == {"content": "chat:conversation"}
+
+
+def test_cli_backed_agent_client_streamed_tool_json_with_handoff_available() -> None:
+    """The prose guard must not swallow valid JSON tool calls."""
+
+    from core.llm.transports.sdk.agent_clients import CLIBackedAgentClient
+
+    class _FakeCLI:
+        def invoke_stream(self, prompt: str) -> object:
+            _ = prompt
+            return iter([('{"tool_calls": [{"id": "c1", "name": "my_tool", "input": {"x": 1}}]}')])
+
+        def invoke(self, prompt: str) -> object:
+            _ = prompt
+            pytest.fail("handoff guard should use streaming invocation")
+
+    client = CLIBackedAgentClient.__new__(CLIBackedAgentClient)
+    client._cli_client = _FakeCLI()
+    result = client.invoke(
+        [{"role": "user", "content": "investigate"}],
+        tools=[
+            {"name": "assistant_handoff", "input_schema": {"type": "object"}},
+            {"name": "my_tool", "input_schema": {"type": "object"}},
+        ],
+    )
+
+    assert result.content == ""
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "my_tool"
+    assert result.tool_calls[0].input == {"x": 1}
+
+
 def test_cli_backed_agent_client_reuses_single_cli_llm_client() -> None:
     """CLIBackedLLMClient should be constructed once so probe cache spans invokes."""
     import types as _types

--- a/tests/integrations/llm_cli/test_runner.py
+++ b/tests/integrations/llm_cli/test_runner.py
@@ -1,13 +1,65 @@
 from __future__ import annotations
 
 import logging
+import os
+import sys
+import time
 from unittest.mock import MagicMock, patch
 
+from core.llm.types import ModelType
+from integrations.llm_cli.base import CLIInvocation, CLIProbe
 from integrations.llm_cli.runner import CLIBackedLLMClient
 
 
 def _mock_probe() -> MagicMock:
     return MagicMock(installed=True, bin_path="/usr/bin/mock-cli", logged_in=True, detail="ok")
+
+
+class _PlainStreamingAdapter:
+    name = "plain-cli"
+    streams_plain_stdout = True
+    binary_env_key = "PLAIN_CLI_BIN"
+    install_hint = "install plain-cli"
+    auth_hint = "plain-cli login"
+    min_version = None
+    default_exec_timeout_sec = 5.0
+
+    def __init__(self, script: str) -> None:
+        self._script = script
+
+    def detect(self) -> CLIProbe:
+        return CLIProbe(
+            installed=True,
+            version="1.0.0",
+            logged_in=True,
+            bin_path=sys.executable,
+            detail="ok",
+        )
+
+    def build(
+        self,
+        *,
+        prompt: str,
+        model: str | None,
+        workspace: str,
+        reasoning_effort: str | None = None,
+    ) -> CLIInvocation:
+        _ = prompt, model, workspace, reasoning_effort
+        return CLIInvocation(
+            argv=(sys.executable, "-c", self._script),
+            stdin=None,
+            cwd=os.getcwd(),
+            env=None,
+            timeout_sec=self.default_exec_timeout_sec,
+        )
+
+    def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        _ = stderr, returncode
+        return stdout.strip()
+
+    def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        _ = stdout, stderr
+        return f"plain-cli exited with code {returncode}"
 
 
 @patch("integrations.llm_cli.runner.subprocess.run")
@@ -123,3 +175,66 @@ def test_runner_uses_adapter_explain_failure_for_quota(mock_run: MagicMock) -> N
         client = CLIBackedLLMClient(mock_adapter)
         with pytest.raises(RuntimeError, match="quota or rate limit exceeded"):
             client.invoke("hello")
+
+
+@patch("integrations.llm_cli.runner.subprocess.run")
+def test_toolcall_cli_invocation_uses_low_reasoning_effort(
+    mock_run: MagicMock,
+    monkeypatch,
+) -> None:
+    captured: dict[str, str | None] = {}
+
+    def build_invocation(
+        *,
+        prompt: str,
+        model: str | None,
+        workspace: str,
+        reasoning_effort: str | None = None,
+    ) -> MagicMock:
+        _ = prompt, model, workspace
+        captured["reasoning_effort"] = reasoning_effort
+        return MagicMock(
+            argv=("/usr/bin/mock-cli",),
+            stdin="hello",
+            cwd="/tmp",
+            env=None,
+            timeout_sec=30.0,
+        )
+
+    monkeypatch.setenv("OPENSRE_REASONING_EFFORT", "high")
+    mock_adapter = MagicMock()
+    mock_adapter.name = "codex"
+    mock_adapter.detect.return_value = _mock_probe()
+    mock_adapter.build.side_effect = build_invocation
+    mock_adapter.parse.return_value = "answer"
+    mock_run.return_value = MagicMock(returncode=0, stdout="answer\n", stderr="")
+
+    with patch("platform.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model_type=ModelType.TOOLCALL)
+        client.invoke("hello")
+
+    assert captured["reasoning_effort"] == "low"
+
+
+def test_invoke_stream_yields_plain_stdout_before_process_exit() -> None:
+    """Plain-text CLI providers should not buffer a long answer until exit."""
+    script = (
+        "import sys, time; "
+        "sys.stdout.write('a' * 200); sys.stdout.flush(); "
+        "time.sleep(1.0); "
+        "sys.stdout.write('done'); sys.stdout.flush()"
+    )
+
+    with patch("platform.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(_PlainStreamingAdapter(script))
+        stream = client.invoke_stream("hello")
+        started = time.monotonic()
+        first = next(stream)
+        first_elapsed = time.monotonic() - started
+        rest = "".join(stream)
+
+    assert first == "a" * 160
+    assert first_elapsed < 0.8
+    assert first + rest == ("a" * 200) + "done"

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -836,10 +836,15 @@ class TestParagraphFlushThrottle:
         monkeypatch.setattr(streaming_module, "Markdown", _SpyMarkdown)
         return parse_count
 
-    def test_long_single_paragraph_renders_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """No ``\\n\\n`` in any chunk → the only Markdown parse is the
-        end-of-stream force-flush. Proves the fast-path skips the join
-        on every intermediate chunk."""
+    def test_long_single_paragraph_renders_progressively(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No ``\\n\\n`` in any chunk still paints before end-of-stream.
+
+        Long prose requests such as "explain OpenSRE in 10k words" may arrive as
+        one giant paragraph. The renderer should not wait for EOS before the
+        user sees body text, while still keeping Markdown parses bounded.
+        """
         parse_count = self._spy_markdown_parses(monkeypatch)
         console, _ = _tty_console()
 
@@ -849,8 +854,9 @@ class TestParagraphFlushThrottle:
 
         assert "word0" in result
         assert "word499" in result
-        # End-of-stream force-flush is the only Markdown construction.
-        assert parse_count[0] == 1, f"expected 1 parse (force-flush), got {parse_count[0]}"
+        assert 2 <= parse_count[0] <= 10, (
+            f"expected bounded progressive parses, got {parse_count[0]}"
+        )
 
     def test_paragraph_boundary_per_chunk_renders_once_per_paragraph(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

CLI-backed LLM adapters now stream plain stdout as it is produced, so the interactive shell can paint long answers incrementally instead of waiting for the subprocess to exit. Adapters opt in with `streams_plain_stdout`; structured JSON envelopes stay on the buffered `invoke` path.

On the tool-selection turn, if `assistant_handoff` is available and the CLI dumps prose instead of tool-call JSON, the adapter forces an `assistant_handoff` rather than treating that dump as the final answer. Tool-call CLI invocations also use low reasoning effort.

The shell streaming path flushes long partial prose paragraphs after a character budget so a single huge paragraph does not stay invisible until end-of-stream.

### Demo/Screenshot for feature changes and bug fixes - 
CLI stdout now yields before process exit (`test_invoke_stream_yields_plain_stdout_before_process_exit`). Long single-paragraph streams render progressively (`test_long_single_paragraph_renders_progressively`). Initial CLI prose with `assistant_handoff` available becomes a handoff (`test_cli_backed_agent_client_streamed_initial_prose_becomes_assistant_handoff`).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
CLI subprocesses previously buffered the full answer behind `subprocess.run`, so the terminal could not paint until the process exited. `invoke_stream` now reads stdout incrementally for adapters that emit the final answer as plain text. Tool-selection still needs JSON tool calls; when a CLI agent answers in prose on that first turn, we abort and hand off instead of presenting the prose as a completed investigation. The shell flush threshold is a latency fallback only — code fences stay whole, and paragraph breaks still flush immediately.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Focused tests run locally:
- `uv run python -m pytest tests/core/runtime/llm/test_agent_llm_client.py tests/integrations/llm_cli/test_runner.py tests/interactive_shell/ui/test_streaming.py` (125 passed)
- `make lint && make format-check && make typecheck`

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.