### PR TITLE
fix(packaging): add the missing package markers that drop code from every wheel

### DIFF
--- a/gateway/tests/main/__init__.py
+++ b/gateway/tests/main/__init__.py
@@ -1,0 +1,1 @@
+"""Gateway agent life-cycle tests."""

--- a/integrations/aws_lambda/__init__.py
+++ b/integrations/aws_lambda/__init__.py
@@ -1,0 +1,4 @@
+"""AWS Lambda integration: read-only function and invocation diagnostics.
+
+Tools live in :mod:`integrations.aws_lambda.tools`.
+"""

--- a/integrations/cloudwatch/__init__.py
+++ b/integrations/cloudwatch/__init__.py
@@ -1,0 +1,4 @@
+"""Amazon CloudWatch integration: read-only metric and alarm diagnostics.
+
+Tools live in :mod:`integrations.cloudwatch.tools`.
+"""

--- a/integrations/ec2/__init__.py
+++ b/integrations/ec2/__init__.py
@@ -1,0 +1,4 @@
+"""Amazon EC2 integration: read-only instance and status diagnostics.
+
+Tools live in :mod:`integrations.ec2.tools`.
+"""

--- a/integrations/elb/__init__.py
+++ b/integrations/elb/__init__.py
@@ -1,0 +1,4 @@
+"""Elastic Load Balancing integration: read-only listener and target-health diagnostics.
+
+Tools live in :mod:`integrations.elb.tools`.
+"""

--- a/integrations/s3/__init__.py
+++ b/integrations/s3/__init__.py
@@ -1,0 +1,4 @@
+"""Amazon S3 integration: read-only bucket and object diagnostics.
+
+Tools live in :mod:`integrations.s3.tools`.
+"""

--- a/tests/core/agent/prompts/test_action_tool_catalog_drift.py
+++ b/tests/core/agent/prompts/test_action_tool_catalog_drift.py
@@ -19,16 +19,28 @@ from tools.registry import get_registered_tools
 #: ``- tool_name — description`` entries under the prompt's "Other tools:" list.
 _CATALOG_ENTRY = re.compile(r"^- ([a-z][a-z0-9_]+) —", re.MULTILINE)
 
-#: Named in prose but not registered as ordinary action tools. Each is a real
-#: capability the model reaches another way, so absence from the registry is
-#: correct rather than drift.
-_NOT_REGISTRY_TOOLS = frozenset(
+#: Names described in prose but intentionally absent from the tool registry.
+#: Empty on purpose — every catalog entry today is a registered tool, and an
+#: exemption here silently removes that name from the drift check.
+_NOT_REGISTRY_TOOLS: frozenset[str] = frozenset()
+
+#: Entries whose prose carries routing nuance that exists nowhere else — the
+#: reason the catalog is kept rather than deleted in favour of the JSON schemas.
+#: Pinned individually: a catalog-wide "at least one" check stays satisfied by
+#: unrelated entries while any single one quietly decays into restatement.
+_ENTRIES_WITH_ROUTING_RULES = frozenset(
     {
-        # Structured handoff to the conversational assistant, handled by the
-        # turn engine rather than dispatched as a registered tool.
-        "assistant_handoff",
+        "code_implement",
+        "investigation_start",
+        "llm_set_provider",
+        "memory_remember",
+        "skill_view",
+        "work_task_schedule_checkin",
     }
 )
+
+#: Words that mark a line as a rule rather than a description.
+_RULE_MARKERS = ("ONLY", "NEVER", "never", "Do NOT", "do NOT", "must", "MUST", "instead", "not a")
 
 
 def _prose_tool_names() -> frozenset[str]:
@@ -61,26 +73,31 @@ def test_every_tool_the_action_prompt_describes_still_exists() -> None:
     )
 
 
-def test_the_prose_catalog_is_not_the_only_record_of_a_tool() -> None:
-    """Prose entries must carry routing nuance, not restate the JSON schema.
+def test_the_entries_that_carry_routing_rules_still_carry_them() -> None:
+    """Prose entries must add rules the JSON schema cannot express.
 
-    Pins the reason the catalog is allowed to exist: an entry that adds no rule
-    is pure duplication of the schema already on the call, and duplication is
-    what drifts.
+    Only 6 of 19 entries carry a rule today, so requiring it of all of them
+    would fail; requiring it of *any* of them is satisfied forever by the six.
+    Each known rule-bearer is pinned instead, so one decaying into pure
+    restatement is caught while the rest stay free to be plain descriptions.
     """
     # Arrange
     start = _SYSTEM_PROMPT_BASE.find("Other tools:")
     catalog = _SYSTEM_PROMPT_BASE[start:]
-    rule_markers = ("ONLY", "NEVER", "never", "Do NOT", "do NOT", "must", "MUST", "instead")
+    bounds = [m.start() for m in _CATALOG_ENTRY.finditer(catalog)] + [len(catalog)]
 
     # Act
-    entries = [line for line in catalog.splitlines() if _CATALOG_ENTRY.match(line)]
-    with_rules = [line for line in entries if any(m in line for m in rule_markers)]
+    rule_bearing = set()
+    for index in range(len(bounds) - 1):
+        block = catalog[bounds[index] : bounds[index + 1]]
+        name = _CATALOG_ENTRY.match(block).group(1)
+        if any(marker in block for marker in _RULE_MARKERS):
+            rule_bearing.add(name)
 
-    # Assert — a catalog of pure restatement should be deleted, not maintained.
-    assert entries, "no catalog entries found"
-    assert with_rules, (
-        "no entry in the action prompt's tool catalog carries a routing rule; "
-        "if the catalog only restates the JSON schemas, delete it rather than "
-        "keeping two descriptions of every tool in sync."
+    # Assert
+    lost = sorted(_ENTRIES_WITH_ROUTING_RULES - rule_bearing)
+    assert lost == [], (
+        f"these catalog entries no longer carry a routing rule: {lost}. Either "
+        "restore the guidance or drop the entry — an entry that only restates "
+        "the JSON schema already on the call is duplication that will drift."
     )

--- a/tests/core/agent/prompts/test_action_tool_catalog_drift.py
+++ b/tests/core/agent/prompts/test_action_tool_catalog_drift.py
@@ -1,0 +1,86 @@
+"""The action prompt's prose tool catalog must agree with the tool registry.
+
+``_SYSTEM_PROMPT_BASE`` describes ~19 tools in prose on the same call that
+carries their JSON schemas. The prose is where the routing nuance lives ("use
+``llm_set_provider`` ONLY when the user names an exact provider"), so it cannot
+simply be deleted — but two descriptions of one tool drift, and the failure is
+silent: the model is told to call a tool that no longer exists, or a new tool
+ships with no routing guidance and is never selected.
+"""
+
+from __future__ import annotations
+
+import re
+
+from core.agent_harness.prompts.action.text import _SYSTEM_PROMPT_BASE
+from core.domain.types.tools import ToolSurface
+from tools.registry import get_registered_tools
+
+#: ``- tool_name — description`` entries under the prompt's "Other tools:" list.
+_CATALOG_ENTRY = re.compile(r"^- ([a-z][a-z0-9_]+) —", re.MULTILINE)
+
+#: Named in prose but not registered as ordinary action tools. Each is a real
+#: capability the model reaches another way, so absence from the registry is
+#: correct rather than drift.
+_NOT_REGISTRY_TOOLS = frozenset(
+    {
+        # Structured handoff to the conversational assistant, handled by the
+        # turn engine rather than dispatched as a registered tool.
+        "assistant_handoff",
+    }
+)
+
+
+def _prose_tool_names() -> frozenset[str]:
+    start = _SYSTEM_PROMPT_BASE.find("Other tools:")
+    assert start != -1, "the action prompt no longer has an 'Other tools:' catalog"
+    return frozenset(_CATALOG_ENTRY.findall(_SYSTEM_PROMPT_BASE[start:]))
+
+
+def _registered_action_tool_names() -> frozenset[str]:
+    names: set[str] = set()
+    for surface in (ToolSurface.ACTION, ToolSurface.CHAT, ToolSurface.INVESTIGATION):
+        names.update(tool.name for tool in get_registered_tools(surface))
+    return frozenset(names)
+
+
+def test_every_tool_the_action_prompt_describes_still_exists() -> None:
+    """A renamed or deleted tool leaves the prompt instructing a dead name."""
+    # Arrange
+    described = _prose_tool_names() - _NOT_REGISTRY_TOOLS
+
+    # Act
+    missing = sorted(described - _registered_action_tool_names())
+
+    # Assert
+    assert missing == [], (
+        "the action prompt describes tools that are not registered on any action "
+        f"surface: {missing}. Rename them in "
+        "core/agent_harness/prompts/action/text.py, or add them to "
+        "_NOT_REGISTRY_TOOLS when the model reaches them another way."
+    )
+
+
+def test_the_prose_catalog_is_not_the_only_record_of_a_tool() -> None:
+    """Prose entries must carry routing nuance, not restate the JSON schema.
+
+    Pins the reason the catalog is allowed to exist: an entry that adds no rule
+    is pure duplication of the schema already on the call, and duplication is
+    what drifts.
+    """
+    # Arrange
+    start = _SYSTEM_PROMPT_BASE.find("Other tools:")
+    catalog = _SYSTEM_PROMPT_BASE[start:]
+    rule_markers = ("ONLY", "NEVER", "never", "Do NOT", "do NOT", "must", "MUST", "instead")
+
+    # Act
+    entries = [line for line in catalog.splitlines() if _CATALOG_ENTRY.match(line)]
+    with_rules = [line for line in entries if any(m in line for m in rule_markers)]
+
+    # Assert — a catalog of pure restatement should be deleted, not maintained.
+    assert entries, "no catalog entries found"
+    assert with_rules, (
+        "no entry in the action prompt's tool catalog carries a routing rule; "
+        "if the catalog only restates the JSON schemas, delete it rather than "
+        "keeping two descriptions of every tool in sync."
+    )

--- a/tests/packaging/test_package_markers.py
+++ b/tests/packaging/test_package_markers.py
@@ -1,0 +1,64 @@
+"""Every shipped directory is a real package, so the wheel carries it.
+
+``[tool.setuptools.packages.find]`` collects only directories holding an
+``__init__.py``. A directory without one still imports from a source checkout —
+Python treats it as a namespace package — so lint, typecheck and the whole test
+suite pass while the installed build is missing it entirely.
+
+Nothing else in CI builds a wheel (``python -m build`` appears once, in
+``release.yml``), which is why five integrations plus the investigation
+pipeline's stage tree shipped unimportable for weeks. The first execution that
+could observe it was a user's install.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Roots listed in ``[tool.setuptools.packages.find]``.
+_SHIPPED_ROOTS = ("bootstrap", "config", "core", "gateway", "integrations", "platform", "tools")
+
+#: Directories that hold data files rather than importable modules.
+_NOT_PACKAGES = frozenset({"__pycache__", "skills", "sample_alerts"})
+
+
+def _directories_needing_a_marker(root: Path) -> list[Path]:
+    """Every directory that must be a package for a module under ``root`` to ship.
+
+    Includes the parents of a module directory, not just the directory itself.
+    ``integrations/ec2/`` holds no module of its own — only ``tools/`` — yet
+    without its own ``__init__.py`` setuptools drops the whole branch.
+    """
+    found: list[Path] = []
+    for path in sorted(root.rglob("*.py")):
+        directory = path.parent
+        if any(part in _NOT_PACKAGES for part in directory.relative_to(_REPO_ROOT).parts):
+            continue
+        while directory != _REPO_ROOT:
+            if directory not in found:
+                found.append(directory)
+            directory = directory.parent
+    return found
+
+
+@pytest.mark.parametrize("root_name", _SHIPPED_ROOTS)
+def test_every_shipped_module_directory_is_an_importable_package(root_name: str) -> None:
+    # Arrange
+    root = _REPO_ROOT / root_name
+
+    # Act
+    missing = [
+        str(directory.relative_to(_REPO_ROOT))
+        for directory in _directories_needing_a_marker(root)
+        if not (directory / "__init__.py").exists()
+    ]
+
+    # Assert
+    assert missing == [], (
+        f"{len(missing)} directory(ies) under {root_name}/ have Python modules but no "
+        f"__init__.py, so setuptools drops them from the wheel: {missing}"
+    )

--- a/tools/investigation/reporting/urls/__init__.py
+++ b/tools/investigation/reporting/urls/__init__.py
@@ -1,0 +1,1 @@
+"""Console URL builders for resources named in an investigation report."""

--- a/tools/investigation/stages/__init__.py
+++ b/tools/investigation/stages/__init__.py
@@ -1,0 +1,1 @@
+"""Semantic stages of the investigation pipeline."""


### PR DESCRIPTION
Problem. 
A directory without __init__.py still imports from a source checkout — Python treats it as a namespace package — but [tool.setuptools.packages.find] only collects directories that have one. So eight directories were invisible to every installed build while passing lint, typecheck and the entire test suite.

The visible symptom was ~65 failed to import lines on startup and Skipping tools.system.*, with integrations silently non-functional after the wizard reported them connected.