### PR TITLE
Fix: gather_unreachable persists dead-host marks past recovery (#4988)

### DIFF
--- a/core/agent_harness/turns/gather_unreachable.py
+++ b/core/agent_harness/turns/gather_unreachable.py
@@ -32,26 +32,36 @@ def store_gather_unreachable(
     tools: dict[str, str],
     sources: dict[str, str],
 ) -> None:
-    """Merge unreachable marks onto ``session`` (setdefault — first reason wins)."""
+    """Reconcile ``session`` with the latest breaker snapshot.
+
+    ``tools``/``sources`` is the breaker's full current down-set, not a
+    delta: a name absent from it recovered (the breaker pops a name on
+    success before snapshotting), so it is dropped from the session-level
+    map rather than kept forever. A name still present keeps its original
+    reason — first reason wins — rather than being overwritten by the new
+    snapshot's summary for the same name.
+    """
     tool_map, source_map = load_gather_unreachable(session)
-    for name, summary in tools.items():
-        tool_map.setdefault(str(name), str(summary))
-    for name, summary in sources.items():
-        source_map.setdefault(str(name), str(summary))
+    new_tool_map = {
+        str(name): tool_map.get(str(name), str(summary)) for name, summary in tools.items()
+    }
+    new_source_map = {
+        str(name): source_map.get(str(name), str(summary)) for name, summary in sources.items()
+    }
     # Prefer mutating existing maps when SessionCore fields are present so
     # ``/new`` ``clear()`` and live references stay consistent.
     existing_tools = getattr(session, _TOOLS_ATTR, None)
     existing_sources = getattr(session, _SOURCES_ATTR, None)
     if isinstance(existing_tools, dict):
         existing_tools.clear()
-        existing_tools.update(tool_map)
+        existing_tools.update(new_tool_map)
     else:
-        setattr(session, _TOOLS_ATTR, tool_map)
+        setattr(session, _TOOLS_ATTR, new_tool_map)
     if isinstance(existing_sources, dict):
         existing_sources.clear()
-        existing_sources.update(source_map)
+        existing_sources.update(new_source_map)
     else:
-        setattr(session, _SOURCES_ATTR, source_map)
+        setattr(session, _SOURCES_ATTR, new_source_map)
 
 
 def clear_gather_unreachable(session: Any) -> None:

--- a/tests/core/agent_harness/test_source_circuit_breaker.py
+++ b/tests/core/agent_harness/test_source_circuit_breaker.py
@@ -388,6 +388,46 @@ def test_session_core_clear_drops_gather_unreachable_carry() -> None:
     assert sources == {}
 
 
+def test_store_gather_unreachable_drops_recovered_tool_from_session() -> None:
+    """A tool absent from a later snapshot recovered and must not stay blocked.
+
+    Regression for #4988: ``store_gather_unreachable`` used to merge via
+    ``setdefault`` only, so a name once marked down was never removed even
+    after the breaker itself stopped reporting it as down.
+    """
+    session = SimpleNamespace()
+
+    # Arrange: first gather turn marks the tool unreachable.
+    store_gather_unreachable(
+        session,
+        tools={"query_grafana_metrics": "timeout"},
+        sources={"grafana": "timeout"},
+    )
+    assert load_gather_unreachable(session)[0] == {"query_grafana_metrics": "timeout"}
+
+    # Act: the tool succeeds on a later turn, so the fresh breaker snapshot no
+    # longer reports it (or its source) as down.
+    store_gather_unreachable(session, tools={}, sources={})
+
+    # Assert: the recovered tool and source are gone, not merely unchanged.
+    tools, sources = load_gather_unreachable(session)
+    assert tools == {}
+    assert sources == {}
+
+
+def test_store_gather_unreachable_keeps_first_reason_for_still_down_tool() -> None:
+    """A name still present in the snapshot keeps its original reason."""
+    session = SimpleNamespace()
+
+    store_gather_unreachable(session, tools={"query_grafana_metrics": "timeout"}, sources={})
+    store_gather_unreachable(
+        session, tools={"query_grafana_metrics": "different reason"}, sources={}
+    )
+
+    tools, _sources = load_gather_unreachable(session)
+    assert tools == {"query_grafana_metrics": "timeout"}
+
+
 def test_prior_source_success_keeps_later_timeout_tool_scoped() -> None:
     breaker = SourceCircuitBreaker()
     hooks = breaker.hooks()


### PR DESCRIPTION
Fixes #4988

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`store_gather_unreachable` (`core/agent_harness/turns/gather_unreachable.py`) merged the
`SourceCircuitBreaker`'s per-run snapshot into the session-level unreachable-tool/source map
using `setdefault` only. `setdefault` can add a key but never remove one, so once a tool or
source was marked unreachable in any turn, it stayed marked unreachable for the rest of the
session — even after it recovered — because a recovered name is *absent* from later snapshots
(the breaker pops a name out of `_tool_down`/`_source_down` on success, before `snapshot()` is
taken), and nothing ever reconciled that absence back into the persisted session map. Every
later `SessionGoal` turn then seeded a fresh breaker from the stale map and silently skipped a
source that had just returned evidence, with no error or indication why.

The fix changes `store_gather_unreachable` to rebuild the session map from the new snapshot on
every call: a name present in the snapshot is kept (and keeps its original down-reason — first
reason wins, unchanged from before), and a name **absent** from the snapshot is dropped, since
its absence means the breaker itself already cleared it. This makes the session-level map track
reality instead of growing monotonically.

### Demo/Screenshot for feature changes and bug fixes -

This is a session-state bookkeeping fix with no UI surface, so the regression test is the
demonstration:

```
tests/core/agent_harness/test_source_circuit_breaker.py::test_store_gather_unreachable_drops_recovered_tool_from_session PASSED
tests/core/agent_harness/test_source_circuit_breaker.py::test_store_gather_unreachable_keeps_first_reason_for_still_down_tool PASSED
```

The first test reproduces the bug end-to-end at the `store_gather_unreachable` level: mark a
tool/source unreachable, then call it again with an empty snapshot (simulating recovery), and
assert the tool/source is gone from the session map rather than still present.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is that `store_gather_unreachable` only ever added keys to the session-persisted
unreachable map (via `dict.setdefault`), with nothing to remove a key once the corresponding
tool/source recovered. I confirmed the mechanism by reading `source_circuit_breaker.py:168-199`:
a successful tool call pops that tool (and, unless another tool on the source already succeeded,
the source) out of `_tool_down`/`_source_down` under lock, *before* `snapshot()` returns a copy
of those two dicts. So `breaker.snapshot()` is not a delta of new failures — it is the breaker's
full, current down-set. That distinction is what made the fix straightforward: since the
snapshot is authoritative for "what's down right now," the session map for each call can simply
be *rebuilt* from the snapshot rather than merged into indefinitely.

I considered two approaches:
1. Explicitly diff the old and new maps and delete only the keys no longer present (an
   in-place `del` for the difference), preserving the rest as-is.
2. Rebuild the new map from the snapshot's keys, looking up each key's existing reason (falling
   back to the snapshot's own reason for a name that's newly down).

I chose (2) because it's shorter and has no separate "compute the removed set" step — the
snapshot itself already defines exactly which keys should exist afterward, so building the new
map directly from it can't drift from that invariant. It also keeps the "first reason wins"
semantics for currently-down names for free: `tool_map.get(name, snapshot_reason)` returns the
existing reason when there is one, otherwise falls back to the reason on the new snapshot,
without needing a separate `setdefault` pass.

Key components:
- `load_gather_unreachable(session)` — unchanged; returns a plain-dict snapshot of whatever is
  currently stored on `session`.
- `store_gather_unreachable(session, *, tools, sources)` — now builds `new_tool_map` /
  `new_source_map` as dict comprehensions over the incoming `tools`/`sources` snapshot, each
  entry keeping the pre-existing reason when the name was already tracked. It then mutates the
  existing session-level dict in place (`clear()` + `update()`) when one is present, or sets a
  fresh dict via `setattr` otherwise — this part is unchanged, since `SessionCore`'s `/new` /
  `clear()` path and any other live references to that dict need to keep seeing the same object.
- `clear_gather_unreachable` — unchanged; not part of this bug.

Edge case I specifically tested: a name that is still down across two consecutive
`store_gather_unreachable` calls must keep its *original* reason, not the newer call's reason —
covered by `test_store_gather_unreachable_keeps_first_reason_for_still_down_tool`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

**Testing:**

Two new regression tests were added to
`tests/core/agent_harness/test_source_circuit_breaker.py` (the existing home of
`store_gather_unreachable`/`load_gather_unreachable` coverage, alongside the `SourceCircuitBreaker`
tests they integrate with):
- `test_store_gather_unreachable_drops_recovered_tool_from_session`
- `test_store_gather_unreachable_keeps_first_reason_for_still_down_tool`

Ran per this repo's `core/` → `tests/core/` scope mapping in
`.github/ci/test_scope_rules.py`:

- `uv run python -m pytest tests/core/agent_harness/test_source_circuit_breaker.py -q` →
  **18 passed** (16 existing + 2 new).
- `uv run python -m pytest tests/core/ -q` → **2091 passed, 33 skipped, 1 failed**. The one
  failure, `tests/core/agent_harness/test_chat_api.py::test_only_chat_api_module_defines_dispatch_chat_turn`,
  is pre-existing and unrelated to this change: it compares a `pathlib.Path.relative_to(...)`
  result against a hardcoded forward-slash literal (`"core/agent_harness/turns/chat_api.py"`),
  which fails on Windows because `Path` renders with backslashes there. Nothing in this PR
  touches `chat_api.py` or any path-formatting code, and the failure reproduces identically on
  `main` before this change.
- `uv run ruff check` and `uv run ruff format --check` on both touched files → clean.
- `uv run mypy` over the full `make typecheck` scope (`bootstrap config core gateway
  integrations platform surfaces tools`) → 69 pre-existing errors from missing third-party type
  stubs in this dev environment (`psycopg2`, `slack_sdk`, `sentry_sdk`, etc.); none reference
  `gather_unreachable.py` or the changed test file.

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
