### PR TITLE
feat(install): add optional Buzz CLI installation for OpenSRE integration

### DIFF
--- a/docs/install-local.mdx
+++ b/docs/install-local.mdx
@@ -48,7 +48,7 @@ The curl installer also soft-installs the [GitHub CLI](https://cli.github.com/) 
 curl -fsSL https://install.opensre.com | OPENSRE_SKIP_GH_INSTALL=1 bash
 ```
 
-The same installers also soft-install the Buzz CLI (`buzz`) when `cargo` and `git` are already on `PATH` — a shallow clone of [block/buzz](https://github.com/block/buzz) plus `cargo install --path crates/buzz-cli`. This step is optional and the compile can take a few minutes. Skip it with:
+The same installers also soft-install the Buzz CLI (`buzz`) when `cargo` and `git` are already on `PATH` — a shallow clone of [block/buzz](https://github.com/block/buzz) at a pinned release tag plus `cargo install --path crates/buzz-cli`. This step is optional and the compile can take a few minutes. Skip it with:
 
 ```bash
 curl -fsSL https://install.opensre.com | OPENSRE_SKIP_BUZZ_INSTALL=1 bash

--- a/docs/install-local.mdx
+++ b/docs/install-local.mdx
@@ -48,6 +48,14 @@ The curl installer also soft-installs the [GitHub CLI](https://cli.github.com/) 
 curl -fsSL https://install.opensre.com | OPENSRE_SKIP_GH_INSTALL=1 bash
 ```
 
+The same installers also soft-install the Buzz CLI (`buzz`) when `cargo` and `git` are already on `PATH` — a shallow clone of [block/buzz](https://github.com/block/buzz) plus `cargo install --path crates/buzz-cli`. This step is optional and the compile can take a few minutes. Skip it with:
+
+```bash
+curl -fsSL https://install.opensre.com | OPENSRE_SKIP_BUZZ_INSTALL=1 bash
+```
+
+On Windows, set `$env:OPENSRE_SKIP_BUZZ_INSTALL=1` before running `install.ps1` (or pipe `irm https://install.opensre.com | iex` with that env var set in the session).
+
 Homebrew installs pull `gh` automatically via `depends_on "gh"` in the OpenSRE formula.
 
 ### 2) Enter the OpenSRE shell

--- a/docs/messaging/buzz.mdx
+++ b/docs/messaging/buzz.mdx
@@ -22,6 +22,8 @@ Steps 1–3 give you **outbound delivery** (investigation reports, watchdog alar
   cargo install --path crates/buzz-cli
   ```
 
+  The OpenSRE curl and PowerShell installers run this automatically when `cargo` and `git` are already installed (skip with `OPENSRE_SKIP_BUZZ_INSTALL=1`).
+
   If you can't put it on `PATH`, point OpenSRE at the binary with `BUZZ_PATH=/path/to/buzz` or the `buzz_path` field during setup.
 - An agent identity (a Nostr keypair). Generate one with the relay's admin tool:
 

--- a/docs/messaging/buzz.mdx
+++ b/docs/messaging/buzz.mdx
@@ -19,10 +19,11 @@ Steps 1–3 give you **outbound delivery** (investigation reports, watchdog alar
 - The **`buzz` CLI** on `PATH`. It is not published to any package registry — build it from the [block/buzz](https://github.com/block/buzz) repo:
 
   ```bash
+  git clone --branch v0.5.0 https://github.com/block/buzz.git && cd buzz
   cargo install --path crates/buzz-cli
   ```
 
-  The OpenSRE curl and PowerShell installers run this automatically when `cargo` and `git` are already installed (skip with `OPENSRE_SKIP_BUZZ_INSTALL=1`).
+  The OpenSRE curl and PowerShell installers run this automatically when `cargo` and `git` are already installed, pinned to a verified release tag (skip with `OPENSRE_SKIP_BUZZ_INSTALL=1`).
 
   If you can't put it on `PATH`, point OpenSRE at the binary with `BUZZ_PATH=/path/to/buzz` or the `buzz_path` field during setup.
 - An agent identity (a Nostr keypair). Generate one with the relay's admin tool:

--- a/install.ps1
+++ b/install.ps1
@@ -970,9 +970,13 @@ function Ensure-OpenSreGithubCli {
 
 function Write-OpenSreBuzzCliManualInstallHint {
     Write-Warning "Install the Buzz CLI manually from https://github.com/block/buzz:"
-    Write-Warning "  git clone https://github.com/block/buzz.git; cd buzz"
+    Write-Warning "  git clone --branch v0.5.0 https://github.com/block/buzz.git; cd buzz"
     Write-Warning "  cargo install --path crates/buzz-cli"
 }
+
+# Pinned tag for reproducible, auditable builds. Update after verifying new releases.
+# See https://github.com/block/buzz/releases for available tags.
+$script:BuzzCliPinnedTag = "v0.5.0"
 
 function Ensure-OpenSreBuzzCli {
     # Soft dependency for Buzz integration. Never fails the OpenSRE install.
@@ -997,13 +1001,21 @@ function Ensure-OpenSreBuzzCli {
 
     Write-OpenSreLine -Message "Installing Buzz CLI (buzz) for OpenSRE Buzz integration (optional; cargo build may take a few minutes)" -Color "Cyan"
 
-    $buzzCloneDir = Join-Path ([System.IO.Path]::GetTempPath()) ("opensre-buzz-clone-" + [System.Guid]::NewGuid().ToString("N"))
-    New-Item -ItemType Directory -Path $buzzCloneDir -Force | Out-Null
+    $buzzCloneDir = $null
+    try {
+        $buzzCloneDir = Join-Path ([System.IO.Path]::GetTempPath()) ("opensre-buzz-clone-" + [System.Guid]::NewGuid().ToString("N"))
+        New-Item -ItemType Directory -Path $buzzCloneDir -Force | Out-Null
+    }
+    catch {
+        Write-Warning "Could not create temporary directory for Buzz CLI clone."
+        Write-OpenSreBuzzCliManualInstallHint
+        return
+    }
 
     try {
-        & git clone --depth 1 https://github.com/block/buzz.git $buzzCloneDir
+        & git clone --depth 1 --branch $script:BuzzCliPinnedTag https://github.com/block/buzz.git $buzzCloneDir
         if ($LASTEXITCODE -ne 0) {
-            Write-Warning "Failed to clone https://github.com/block/buzz for buzz-cli install."
+            Write-Warning "Failed to clone https://github.com/block/buzz (tag $script:BuzzCliPinnedTag) for buzz-cli install."
             Write-OpenSreBuzzCliManualInstallHint
             return
         }
@@ -1023,7 +1035,7 @@ function Ensure-OpenSreBuzzCli {
         }
     }
     finally {
-        if (Test-Path -LiteralPath $buzzCloneDir) {
+        if ($buzzCloneDir -and (Test-Path -LiteralPath $buzzCloneDir)) {
             Remove-Item -LiteralPath $buzzCloneDir -Recurse -Force -ErrorAction SilentlyContinue
         }
     }

--- a/install.ps1
+++ b/install.ps1
@@ -968,6 +968,67 @@ function Ensure-OpenSreGithubCli {
     Write-Warning "Install manually: winget install --id GitHub.cli  (or https://cli.github.com/) for OpenSRE GitHub chat tools."
 }
 
+function Write-OpenSreBuzzCliManualInstallHint {
+    Write-Warning "Install the Buzz CLI manually from https://github.com/block/buzz:"
+    Write-Warning "  git clone https://github.com/block/buzz.git; cd buzz"
+    Write-Warning "  cargo install --path crates/buzz-cli"
+}
+
+function Ensure-OpenSreBuzzCli {
+    # Soft dependency for Buzz integration. Never fails the OpenSRE install.
+    if (Get-Command buzz -ErrorAction SilentlyContinue) {
+        return
+    }
+
+    $skip = [string]$env:OPENSRE_SKIP_BUZZ_INSTALL
+    if ($skip -eq "1" -or $skip -eq "true" -or $skip -eq "TRUE" -or $skip -eq "yes" -or $skip -eq "YES" -or $skip -eq "on" -or $skip -eq "ON") {
+        Write-Warning "Buzz CLI (buzz) is not on PATH; skipped install because OPENSRE_SKIP_BUZZ_INSTALL is set."
+        Write-OpenSreBuzzCliManualInstallHint
+        return
+    }
+
+    $cargo = Get-Command cargo -ErrorAction SilentlyContinue
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if (-not $cargo -or -not $git) {
+        Write-Warning "Buzz CLI (buzz) is not on PATH and cargo/git were not found for auto-install."
+        Write-OpenSreBuzzCliManualInstallHint
+        return
+    }
+
+    Write-OpenSreLine -Message "Installing Buzz CLI (buzz) for OpenSRE Buzz integration (optional; cargo build may take a few minutes)" -Color "Cyan"
+
+    $buzzCloneDir = Join-Path ([System.IO.Path]::GetTempPath()) ("opensre-buzz-clone-" + [System.Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $buzzCloneDir -Force | Out-Null
+
+    try {
+        & git clone --depth 1 https://github.com/block/buzz.git $buzzCloneDir
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to clone https://github.com/block/buzz for buzz-cli install."
+            Write-OpenSreBuzzCliManualInstallHint
+            return
+        }
+
+        $buzzCliPath = Join-Path $buzzCloneDir "crates/buzz-cli"
+        & cargo install --path $buzzCliPath
+        if ($LASTEXITCODE -eq 0) {
+            Write-OpenSreLine -Message "  OK Installed Buzz CLI (buzz) via cargo" -Color "Green"
+            if (-not (Get-Command buzz -ErrorAction SilentlyContinue)) {
+                Write-Warning "buzz was installed but is not on PATH yet."
+                Write-Warning "Add $HOME\.cargo\bin to your PATH, or set BUZZ_PATH to the binary location."
+            }
+        }
+        else {
+            Write-Warning "cargo install of buzz-cli failed."
+            Write-OpenSreBuzzCliManualInstallHint
+        }
+    }
+    finally {
+        if (Test-Path -LiteralPath $buzzCloneDir) {
+            Remove-Item -LiteralPath $buzzCloneDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 function Test-OpenSreAutoLaunchEnabled {
     $value = [string]$env:OPENSRE_AUTO_LAUNCH
     return -not ($value -eq "0" -or $value -eq "false" -or $value -eq "FALSE" -or $value -eq "no" -or $value -eq "NO" -or $value -eq "off" -or $value -eq "OFF")
@@ -1152,6 +1213,7 @@ function Install-OpenSre {
     }
 
     Ensure-OpenSreGithubCli
+    Ensure-OpenSreBuzzCli
 
     $exe = $binaryName.TrimEnd(".exe")
     $sep = "────────────────────────────────────────────"

--- a/install.ps1
+++ b/install.ps1
@@ -974,9 +974,11 @@ function Write-OpenSreBuzzCliManualInstallHint {
     Write-Warning "  cargo install --path crates/buzz-cli"
 }
 
-# Pinned tag for reproducible, auditable builds. Update after verifying new releases.
-# See https://github.com/block/buzz/releases for available tags.
+# Pinned tag and commit SHA for reproducible, auditable, immutable builds.
+# The SHA ensures we build exactly the code we verified, even if the tag is force-pushed.
+# Update both after verifying new releases at https://github.com/block/buzz/releases.
 $script:BuzzCliPinnedTag = "v0.5.0"
+$script:BuzzCliPinnedSha = "4a977c588a540be38bd8ddb268cd24437bac8165"
 
 function Ensure-OpenSreBuzzCli {
     # Soft dependency for Buzz integration. Never fails the OpenSRE install.
@@ -1016,6 +1018,16 @@ function Ensure-OpenSreBuzzCli {
         & git clone --depth 1 --branch $script:BuzzCliPinnedTag https://github.com/block/buzz.git $buzzCloneDir
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "Failed to clone https://github.com/block/buzz (tag $script:BuzzCliPinnedTag) for buzz-cli install."
+            Write-OpenSreBuzzCliManualInstallHint
+            return
+        }
+
+        # Verify the cloned commit matches the expected SHA for immutable source identity.
+        $actualSha = & git -C $buzzCloneDir rev-parse HEAD 2>$null
+        if ($actualSha -ne $script:BuzzCliPinnedSha) {
+            Write-Warning "Buzz CLI source integrity check failed."
+            Write-Warning "Expected commit $script:BuzzCliPinnedSha but got $actualSha."
+            Write-Warning "The upstream tag may have been modified. Aborting automatic install."
             Write-OpenSreBuzzCliManualInstallHint
             return
         }

--- a/install.sh
+++ b/install.sh
@@ -564,9 +564,11 @@ buzz_cli_manual_install_hint() {
   warn "  cargo install --path crates/buzz-cli"
 }
 
-# Pinned tag for reproducible, auditable builds. Update after verifying new releases.
-# See https://github.com/block/buzz/releases for available tags.
+# Pinned tag and commit SHA for reproducible, auditable, immutable builds.
+# The SHA ensures we build exactly the code we verified, even if the tag is force-pushed.
+# Update both after verifying new releases at https://github.com/block/buzz/releases.
 BUZZ_CLI_PINNED_TAG="v0.5.0"
+BUZZ_CLI_PINNED_SHA="4a977c588a540be38bd8ddb268cd24437bac8165"
 
 ensure_buzz_cli() {
   # Soft dependency for Buzz integration. Never fails the OpenSRE install.
@@ -599,6 +601,18 @@ ensure_buzz_cli() {
   fi
 
   if git clone --depth 1 --branch "$BUZZ_CLI_PINNED_TAG" https://github.com/block/buzz.git "$buzz_clone_dir"; then
+    # Verify the cloned commit matches the expected SHA for immutable source identity.
+    local actual_sha=""
+    actual_sha="$(git -C "$buzz_clone_dir" rev-parse HEAD 2>/dev/null || true)"
+    if [ "$actual_sha" != "$BUZZ_CLI_PINNED_SHA" ]; then
+      warn "Buzz CLI source integrity check failed."
+      warn "Expected commit $BUZZ_CLI_PINNED_SHA but got $actual_sha."
+      warn "The upstream tag may have been modified. Aborting automatic install."
+      buzz_cli_manual_install_hint
+      rm -rf "$buzz_clone_dir" 2>/dev/null || true
+      return 0
+    fi
+
     if cargo install --path "${buzz_clone_dir}/crates/buzz-cli"; then
       success "Installed Buzz CLI (buzz) via cargo"
       if ! command -v buzz >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -560,9 +560,13 @@ skip_buzz_cli_install() {
 
 buzz_cli_manual_install_hint() {
   warn "Install the Buzz CLI manually from https://github.com/block/buzz:"
-  warn "  git clone https://github.com/block/buzz.git && cd buzz"
+  warn "  git clone --branch v0.5.0 https://github.com/block/buzz.git && cd buzz"
   warn "  cargo install --path crates/buzz-cli"
 }
+
+# Pinned tag for reproducible, auditable builds. Update after verifying new releases.
+# See https://github.com/block/buzz/releases for available tags.
+BUZZ_CLI_PINNED_TAG="v0.5.0"
 
 ensure_buzz_cli() {
   # Soft dependency for Buzz integration. Never fails the OpenSRE install.
@@ -588,9 +592,13 @@ ensure_buzz_cli() {
   step "Installing Buzz CLI (buzz) for OpenSRE Buzz integration (optional; cargo build may take a few minutes)"
 
   local buzz_clone_dir=""
-  buzz_clone_dir="$(mktemp -d "${TMPDIR:-/tmp}/opensre-buzz-clone.XXXXXX")"
+  if ! buzz_clone_dir="$(mktemp -d "${TMPDIR:-/tmp}/opensre-buzz-clone.XXXXXX" 2>/dev/null)"; then
+    warn "Could not create temporary directory for Buzz CLI clone."
+    buzz_cli_manual_install_hint
+    return 0
+  fi
 
-  if git clone --depth 1 https://github.com/block/buzz.git "$buzz_clone_dir"; then
+  if git clone --depth 1 --branch "$BUZZ_CLI_PINNED_TAG" https://github.com/block/buzz.git "$buzz_clone_dir"; then
     if cargo install --path "${buzz_clone_dir}/crates/buzz-cli"; then
       success "Installed Buzz CLI (buzz) via cargo"
       if ! command -v buzz >/dev/null 2>&1; then
@@ -602,11 +610,11 @@ ensure_buzz_cli() {
       buzz_cli_manual_install_hint
     fi
   else
-    warn "Failed to clone https://github.com/block/buzz for buzz-cli install."
+    warn "Failed to clone https://github.com/block/buzz (tag $BUZZ_CLI_PINNED_TAG) for buzz-cli install."
     buzz_cli_manual_install_hint
   fi
 
-  rm -rf "$buzz_clone_dir"
+  rm -rf "$buzz_clone_dir" 2>/dev/null || true
 }
 
 require_prerequisites() {

--- a/install.sh
+++ b/install.sh
@@ -547,6 +547,68 @@ ensure_github_cli() {
   warn "Install from https://cli.github.com/ for OpenSRE GitHub chat tools."
 }
 
+skip_buzz_cli_install() {
+  case "${OPENSRE_SKIP_BUZZ_INSTALL:-}" in
+    1|true|TRUE|yes|YES|on|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+buzz_cli_manual_install_hint() {
+  warn "Install the Buzz CLI manually from https://github.com/block/buzz:"
+  warn "  git clone https://github.com/block/buzz.git && cd buzz"
+  warn "  cargo install --path crates/buzz-cli"
+}
+
+ensure_buzz_cli() {
+  # Soft dependency for Buzz integration. Never fails the OpenSRE install.
+  if command -v buzz >/dev/null 2>&1; then
+    if install_verbose; then
+      log "Buzz CLI (buzz) already on PATH: $(command -v buzz)"
+    fi
+    return 0
+  fi
+
+  if skip_buzz_cli_install; then
+    warn "Buzz CLI (buzz) is not on PATH; skipped install because OPENSRE_SKIP_BUZZ_INSTALL is set."
+    buzz_cli_manual_install_hint
+    return 0
+  fi
+
+  if ! command -v cargo >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+    warn "Buzz CLI (buzz) is not on PATH and cargo/git were not found for auto-install."
+    buzz_cli_manual_install_hint
+    return 0
+  fi
+
+  step "Installing Buzz CLI (buzz) for OpenSRE Buzz integration (optional; cargo build may take a few minutes)"
+
+  local buzz_clone_dir=""
+  buzz_clone_dir="$(mktemp -d "${TMPDIR:-/tmp}/opensre-buzz-clone.XXXXXX")"
+
+  if git clone --depth 1 https://github.com/block/buzz.git "$buzz_clone_dir"; then
+    if cargo install --path "${buzz_clone_dir}/crates/buzz-cli"; then
+      success "Installed Buzz CLI (buzz) via cargo"
+      if ! command -v buzz >/dev/null 2>&1; then
+        warn "buzz was installed but is not on PATH yet."
+        warn "Add \$HOME/.cargo/bin to your PATH, or set BUZZ_PATH to the binary location."
+      fi
+    else
+      warn "cargo install of buzz-cli failed."
+      buzz_cli_manual_install_hint
+    fi
+  else
+    warn "Failed to clone https://github.com/block/buzz for buzz-cli install."
+    buzz_cli_manual_install_hint
+  fi
+
+  rm -rf "$buzz_clone_dir"
+}
+
 require_prerequisites() {
   need_cmd curl
   need_cmd grep
@@ -1466,6 +1528,7 @@ finish_install() {
   print_install_confirmation
   ensure_on_path
   ensure_github_cli
+  ensure_buzz_cli
   print_success_screen "$installed_version"
   launch_onboarding_after_install
 }

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -330,6 +330,8 @@ def test_install_sh_source_exposes_env_knobs() -> None:
         "launch_onboarding_after_install",
         "ensure_github_cli",
         "ensure_buzz_cli",
+        "BUZZ_CLI_PINNED_TAG",
+        "--branch",
     ):
         assert needle in source, f"install.sh missing {needle!r}"
 
@@ -352,6 +354,8 @@ def test_install_ps1_source_exposes_all_windows_install_knobs() -> None:
         'else { "main" }',
         "main-build",
         "$exe onboard",
+        "$script:BuzzCliPinnedTag",
+        "--branch",
     ):
         assert needle in source, f"install.ps1 missing {needle!r}"
 

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -331,7 +331,9 @@ def test_install_sh_source_exposes_env_knobs() -> None:
         "ensure_github_cli",
         "ensure_buzz_cli",
         "BUZZ_CLI_PINNED_TAG",
+        "BUZZ_CLI_PINNED_SHA",
         "--branch",
+        "rev-parse HEAD",
     ):
         assert needle in source, f"install.sh missing {needle!r}"
 
@@ -355,7 +357,9 @@ def test_install_ps1_source_exposes_all_windows_install_knobs() -> None:
         "main-build",
         "$exe onboard",
         "$script:BuzzCliPinnedTag",
+        "$script:BuzzCliPinnedSha",
         "--branch",
+        "rev-parse HEAD",
     ):
         assert needle in source, f"install.ps1 missing {needle!r}"
 

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -215,6 +215,7 @@ def _run_install_sh(
     env["PATH"] = f"{shim_bin}{os.pathsep}{env.get('PATH', '')}"
     env["OPENSRE_AUTO_LAUNCH"] = "0"
     env["OPENSRE_SKIP_GH_INSTALL"] = "1"
+    env["OPENSRE_SKIP_BUZZ_INSTALL"] = "1"
     env["OPENSRE_INSTALL_VERBOSE"] = "1"
     env["TERM"] = "dumb"
     if env_extra:
@@ -272,6 +273,7 @@ def _run_install_sh(
                 "curl -fsSL https://install.opensre.com | bash",
                 "OPENSRE_AUTO_LAUNCH=0",
                 "OPENSRE_SKIP_GH_INSTALL=1",
+                "OPENSRE_SKIP_BUZZ_INSTALL=1",
                 'depends_on "gh"',
             ),
         ),
@@ -317,6 +319,7 @@ def test_install_sh_source_exposes_env_knobs() -> None:
     for needle in (
         "OPENSRE_AUTO_LAUNCH",
         "OPENSRE_SKIP_GH_INSTALL",
+        "OPENSRE_SKIP_BUZZ_INSTALL",
         "OPENSRE_INSTALL_CHANNEL",
         "OPENSRE_INSTALL_DIR",
         "OPENSRE_VERSION",
@@ -326,6 +329,7 @@ def test_install_sh_source_exposes_env_knobs() -> None:
         'INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-main}"',
         "launch_onboarding_after_install",
         "ensure_github_cli",
+        "ensure_buzz_cli",
     ):
         assert needle in source, f"install.sh missing {needle!r}"
 
@@ -339,6 +343,7 @@ def test_install_ps1_source_exposes_all_windows_install_knobs() -> None:
         "OPENSRE_INSTALL_CHANNEL",
         "OPENSRE_AUTO_LAUNCH",
         "OPENSRE_SKIP_GH_INSTALL",
+        "OPENSRE_SKIP_BUZZ_INSTALL",
         "OPENSRE_VERSION",
         "OPENSRE_MAIN_RELEASE_TAG",
         "OPENSRE_INSTALL_VERBOSE",
@@ -444,13 +449,18 @@ def test_install_sh_skip_gh_and_no_auto_launch_env(tmp_path: Path) -> None:
         env_extra={
             "OPENSRE_AUTO_LAUNCH": "0",
             "OPENSRE_SKIP_GH_INSTALL": "1",
+            "OPENSRE_SKIP_BUZZ_INSTALL": "1",
         },
     )
     combined = result.stdout + result.stderr
     assert result.returncode == 0, combined
     assert "Launching" not in combined
-    # With gh missing and SKIP set, installer warns rather than failing.
-    assert "OPENSRE_SKIP_GH_INSTALL" in combined or (tmp_path / "opt" / "bin" / "opensre").is_file()
+    # With gh/buzz missing and SKIP set, installer warns rather than failing.
+    assert (
+        "OPENSRE_SKIP_GH_INSTALL" in combined
+        or "OPENSRE_SKIP_BUZZ_INSTALL" in combined
+        or (tmp_path / "opt" / "bin" / "opensre").is_file()
+    )
 
 
 @pytest.mark.skipif(shutil.which("brew") is None, reason="Homebrew not installed on this host")

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -95,6 +95,15 @@ def test_install_ps1_soft_installs_github_cli_via_winget() -> None:
     assert "Ensure-OpenSreGithubCli" in source
 
 
+def test_install_ps1_soft_installs_buzz_cli_via_cargo() -> None:
+    source = INSTALL_PS1.read_text()
+
+    assert "function Ensure-OpenSreBuzzCli" in source
+    assert "OPENSRE_SKIP_BUZZ_INSTALL" in source
+    assert "cargo install --path" in source
+    assert "Ensure-OpenSreBuzzCli" in source
+
+
 def test_install_ps1_keeps_download_urls_verbose_only() -> None:
     source = INSTALL_PS1.read_text()
 

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -916,3 +916,130 @@ def test_ensure_github_cli_respects_skip_env(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "OPENSRE_SKIP_GH_INSTALL" in result.stderr
     assert "OpenSRE GitHub chat tools" in result.stderr
+
+
+def _run_ensure_buzz_cli(
+    *,
+    path_dirs: list[Path],
+    env_extra: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Drive ``ensure_buzz_cli`` with a controlled PATH (no real git/cargo clone)."""
+    install_sh = _INSTALL_SH_SHELL
+    path_parts = [str(p) for p in path_dirs]
+    for system_bin in ("/usr/bin", "/bin"):
+        if system_bin not in path_parts:
+            path_parts.append(system_bin)
+    path_value = ":".join(path_parts)
+    env_exports = " ".join(
+        f"{key}={shlex.quote(value)}" for key, value in (env_extra or {}).items()
+    )
+    script = textwrap.dedent(f"""\
+        eval "$(awk '
+            /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
+            in_fn {{ print }}
+            in_fn && /^\\}}$/ {{ in_fn=0 }}
+        ' {install_sh})"
+        export PATH={shlex.quote(path_value)}
+        {env_exports} ensure_buzz_cli
+    """)
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def _write_stub_git(bin_dir: Path, *, succeed: bool) -> None:
+    git = bin_dir / "git"
+    if succeed:
+        git.write_text(
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                if [ "$1" = "clone" ]; then
+                  dest="$5"
+                  mkdir -p "$dest/crates/buzz-cli"
+                  exit 0
+                fi
+                exit 1
+                """
+            )
+        )
+    else:
+        git.write_text("#!/bin/sh\nexit 1\n")
+    git.chmod(0o755)
+
+
+def _write_stub_cargo(bin_dir: Path, *, succeed: bool) -> None:
+    cargo = bin_dir / "cargo"
+    cargo.write_text(f"#!/bin/sh\nexit {0 if succeed else 1}\n")
+    cargo.chmod(0o755)
+
+
+def test_ensure_buzz_cli_skips_when_buzz_present(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    buzz = bin_dir / "buzz"
+    buzz.write_text("#!/bin/sh\necho buzz\n")
+    buzz.chmod(0o755)
+
+    result = _run_ensure_buzz_cli(path_dirs=[bin_dir])
+    assert result.returncode == 0, result.stderr
+    assert "Installing Buzz CLI" not in result.stdout
+    assert "github.com/block/buzz" not in result.stderr
+
+
+def test_ensure_buzz_cli_respects_skip_env(tmp_path: Path) -> None:
+    empty_bin = tmp_path / "empty-bin"
+    empty_bin.mkdir()
+
+    result = _run_ensure_buzz_cli(
+        path_dirs=[empty_bin],
+        env_extra={"OPENSRE_SKIP_BUZZ_INSTALL": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OPENSRE_SKIP_BUZZ_INSTALL" in result.stderr
+    assert "github.com/block/buzz" in result.stderr
+
+
+def test_ensure_buzz_cli_warns_when_cargo_missing(tmp_path: Path) -> None:
+    empty_bin = tmp_path / "empty-bin"
+    empty_bin.mkdir()
+
+    result = _run_ensure_buzz_cli(path_dirs=[empty_bin])
+    assert result.returncode == 0, result.stderr
+    assert "cargo/git were not found" in result.stderr
+    assert "github.com/block/buzz" in result.stderr
+    assert "Installing Buzz CLI" not in result.stdout
+
+
+def test_ensure_buzz_cli_stubbed_git_and_cargo_success(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub_git(bin_dir, succeed=True)
+    _write_stub_cargo(bin_dir, succeed=True)
+
+    result = _run_ensure_buzz_cli(path_dirs=[bin_dir])
+    assert result.returncode == 0, result.stderr
+    assert "Installed Buzz CLI (buzz) via cargo" in result.stdout
+    assert "Installing Buzz CLI" in result.stdout
+
+
+def test_ensure_buzz_cli_stubbed_git_failure_does_not_fail_install(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub_git(bin_dir, succeed=False)
+    _write_stub_cargo(bin_dir, succeed=True)
+
+    result = _run_ensure_buzz_cli(path_dirs=[bin_dir])
+    assert result.returncode == 0, result.stderr
+    assert "Failed to clone" in result.stderr
+    assert "github.com/block/buzz" in result.stderr
+
+
+def test_ensure_buzz_cli_stubbed_cargo_failure_does_not_fail_install(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub_git(bin_dir, succeed=True)
+    _write_stub_cargo(bin_dir, succeed=False)
+
+    result = _run_ensure_buzz_cli(path_dirs=[bin_dir])
+    assert result.returncode == 0, result.stderr
+    assert "cargo install of buzz-cli failed" in result.stderr
+    assert "github.com/block/buzz" in result.stderr

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -933,8 +933,10 @@ def _run_ensure_buzz_cli(
     env_exports = " ".join(
         f"{key}={shlex.quote(value)}" for key, value in (env_extra or {}).items()
     )
+    # Extract functions AND the BUZZ_CLI_PINNED_* global constants
     script = textwrap.dedent(f"""\
         eval "$(awk '
+            /^BUZZ_CLI_PINNED_/ {{ print }}
             /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
             in_fn {{ print }}
             in_fn && /^\\}}$/ {{ in_fn=0 }}
@@ -945,18 +947,25 @@ def _run_ensure_buzz_cli(
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
 
 
-def _write_stub_git(bin_dir: Path, *, succeed: bool) -> None:
+def _write_stub_git(
+    bin_dir: Path, *, succeed: bool, sha: str = "4a977c588a540be38bd8ddb268cd24437bac8165"
+) -> None:
     git = bin_dir / "git"
     if succeed:
         # git clone --depth 1 --branch <tag> <url> <dest>
         # $1=clone $2=--depth $3=1 $4=--branch $5=tag $6=url $7=dest
+        # git -C <dir> rev-parse HEAD -> returns the pinned SHA
         git.write_text(
             textwrap.dedent(
-                """\
+                f"""\
                 #!/bin/sh
                 if [ "$1" = "clone" ]; then
                   dest="$7"
                   mkdir -p "$dest/crates/buzz-cli"
+                  exit 0
+                fi
+                if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ]; then
+                  echo "{sha}"
                   exit 0
                 fi
                 exit 1
@@ -1064,3 +1073,20 @@ def test_ensure_buzz_cli_mktemp_failure_does_not_fail_install(tmp_path: Path) ->
     assert result.returncode == 0, result.stderr
     assert "Could not create temporary directory" in result.stderr
     assert "github.com/block/buzz" in result.stderr
+
+
+def test_ensure_buzz_cli_sha_mismatch_aborts_install(tmp_path: Path) -> None:
+    """Security test: SHA mismatch must abort cargo install and warn about integrity."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # Use a wrong SHA to simulate a compromised or force-pushed tag
+    _write_stub_git(bin_dir, succeed=True, sha="0000000000000000000000000000000000000000")
+    _write_stub_cargo(bin_dir, succeed=True)
+
+    result = _run_ensure_buzz_cli(path_dirs=[bin_dir])
+    assert result.returncode == 0, result.stderr
+    assert "integrity check failed" in result.stderr
+    assert "Expected commit" in result.stderr
+    assert "Aborting automatic install" in result.stderr
+    # Cargo should NOT have been called since we abort before that
+    assert "Installed Buzz CLI" not in result.stdout

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -948,12 +948,14 @@ def _run_ensure_buzz_cli(
 def _write_stub_git(bin_dir: Path, *, succeed: bool) -> None:
     git = bin_dir / "git"
     if succeed:
+        # git clone --depth 1 --branch <tag> <url> <dest>
+        # $1=clone $2=--depth $3=1 $4=--branch $5=tag $6=url $7=dest
         git.write_text(
             textwrap.dedent(
                 """\
                 #!/bin/sh
                 if [ "$1" = "clone" ]; then
-                  dest="$5"
+                  dest="$7"
                   mkdir -p "$dest/crates/buzz-cli"
                   exit 0
                 fi
@@ -1042,4 +1044,23 @@ def test_ensure_buzz_cli_stubbed_cargo_failure_does_not_fail_install(tmp_path: P
     result = _run_ensure_buzz_cli(path_dirs=[bin_dir])
     assert result.returncode == 0, result.stderr
     assert "cargo install of buzz-cli failed" in result.stderr
+    assert "github.com/block/buzz" in result.stderr
+
+
+def test_ensure_buzz_cli_mktemp_failure_does_not_fail_install(tmp_path: Path) -> None:
+    """Regression test: mktemp failure must not exit under set -e."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub_git(bin_dir, succeed=True)
+    _write_stub_cargo(bin_dir, succeed=True)
+
+    # Use a non-existent directory as TMPDIR to force mktemp to fail
+    nonexistent_tmpdir = tmp_path / "nonexistent-tmpdir-for-test"
+
+    result = _run_ensure_buzz_cli(
+        path_dirs=[bin_dir],
+        env_extra={"TMPDIR": str(nonexistent_tmpdir)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Could not create temporary directory" in result.stderr
     assert "github.com/block/buzz" in result.stderr

--- a/tests/e2e/install/test_live_installers.py
+++ b/tests/e2e/install/test_live_installers.py
@@ -61,6 +61,7 @@ def _sanitized_install_env(home: Path, *, extra_path: str = "") -> dict[str, str
     env["HOME"] = str(home)
     env["OPENSRE_AUTO_LAUNCH"] = "0"
     env["OPENSRE_SKIP_GH_INSTALL"] = "1"
+    env["OPENSRE_SKIP_BUZZ_INSTALL"] = "1"
     env["OPENSRE_INSTALL_VERBOSE"] = "1"
     env["TERM"] = "dumb"
     path_parts = [


### PR DESCRIPTION
/fix #4803 
This pull request adds support for soft-installing the Buzz CLI (`buzz`) as an optional dependency during the OpenSRE installation process on both Unix (shell) and Windows (PowerShell) platforms. The installer will attempt to build and install Buzz CLI automatically if `cargo` and `git` are available, unless explicitly skipped via the `OPENSRE_SKIP_BUZZ_INSTALL` environment variable. Comprehensive tests and documentation updates are included to cover the new behavior.

**Buzz CLI Soft-Install Integration:**

* Added `ensure_buzz_cli` (shell) and `Ensure-OpenSreBuzzCli` (PowerShell) functions to attempt a shallow clone and `cargo install` of Buzz CLI if not already present, with robust detection, skip logic via `OPENSRE_SKIP_BUZZ_INSTALL`, and clear manual install hints if prerequisites are missing or installation fails. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR550-R611) [[2]](diffhunk://#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806R971-R1031)
* Updated both installers to call the new Buzz CLI install function as part of the standard install flow. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR1531) [[2]](diffhunk://#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806R1216)

**Documentation Updates:**

* Documented the new Buzz CLI soft-install behavior, how to skip it, and how to manually install or configure Buzz CLI for OpenSRE in the relevant user guides. [[1]](diffhunk://#diff-70111a1e9c035677e5fe8134604711227cf7fff545c4dcdde99e65332c537a49R51-R58) [[2]](diffhunk://#diff-1aca5c192e278fa7ccb32ea0405d8f92215e8b9f563e9f3ded261434ff773526R25-R26)

**Testing Enhancements:**

* Added and updated tests to ensure Buzz CLI install logic is covered, including skip scenarios, missing prerequisites, and error handling for both shell and PowerShell installers. [[1]](diffhunk://#diff-56408f872e83438730fd984725ad75b91cc8f7631c9e887550dd38698e2730cbR218) [[2]](diffhunk://#diff-56408f872e83438730fd984725ad75b91cc8f7631c9e887550dd38698e2730cbR452-R463) [[3]](diffhunk://#diff-70b1517fc4b6f7610305a045f6d20608f76fc2bcf0d3754fefb0c92e6a6bd6cfR98-R106) [[4]](diffhunk://#diff-af0aeeb4f7de8ab9002a0a003cde3637d64eab59fc0504138a3b328fd5a55ecaR919-R1045)
* Ensured that the new environment variable and installer function names are exposed and tested in the test matrix. [[1]](diffhunk://#diff-56408f872e83438730fd984725ad75b91cc8f7631c9e887550dd38698e2730cbR322) [[2]](diffhunk://#diff-56408f872e83438730fd984725ad75b91cc8f7631c9e887550dd38698e2730cbR332) [[3]](diffhunk://#diff-56408f872e83438730fd984725ad75b91cc8f7631c9e887550dd38698e2730cbR346) [[4]](diffhunk://#diff-107bebbfe62373658c20b9381a0509aad1ddd9849825f0a029ede785b5c7b443R64)

This change improves the out-of-the-box experience for users who want Buzz CLI integration, while ensuring installation remains robust and easily skippable for those who do not.