### PR TITLE
docs(shell): add /goal teammate workflow guide (#4896)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,7 @@
               "how-investigations-work",
               "interactive-shell-commands",
               "interactive-shell-assistant",
+              "goals",
               "deployment",
               "api",
               "python-api",

--- a/docs/goals.mdx
+++ b/docs/goals.mdx
@@ -1,0 +1,165 @@
+---
+title: "Goals"
+description: "Give OpenSRE a finish line with /goal and let it work through multi-step questions on its own"
+---
+
+Most questions are answered in one reply. Some are not — "how many Windows users
+signed up last week?" may need OpenSRE to check whether PostHog is connected,
+write a query, run it, and only then answer.
+
+`/goal` gives OpenSRE a **finish line** instead of a single prompt. You state the
+condition once, and OpenSRE keeps taking turns until it reaches it, runs out of
+its turn budget, or you stop it. You can walk away and check the progress line
+when you come back.
+
+## Commands at a glance
+
+| Command | What it does |
+| --- | --- |
+| `/goal` | Show the current goal, or say there is none |
+| `/goal show` | Same as bare `/goal` (`/goal status` also works) |
+| `/goal set <condition>` | Set a finish line and start working on it immediately |
+| `/goal set --max-turns N <condition>` | Same, but cap how many turns it may take |
+| `/goal <condition>` | Shorthand for `/goal set <condition>` |
+| `/goal pause` | Stop the next turn, keep the condition and progress |
+| `/goal resume` | Start working again from where it paused |
+| `/goal edit <condition>` | Change the condition without losing progress |
+| `/goal clear` | Drop the goal entirely (`/goal unset` also works) |
+
+## Try it
+
+Paste this into the interactive shell:
+
+```text
+/goal set --max-turns 4 How many Windows users in the last 7 days? Prefer live PostHog if connected; otherwise draft the HogQL and end with one setup CTA. Do not ask whether to continue.
+```
+
+OpenSRE confirms the goal and immediately starts on it:
+
+```text
+◎ /goal active · 0s · turn 0/4 · +0 tokens
+  condition: How many Windows users in the last 7 days? Prefer live PostHog if connected; otherwise draft the HogQL and end with one setup CTA. Do not ask whether to continue.
+  reason: waiting for an achieved signal
+→ next: condition runs as its own prompt turn (look for [N] ❯ below). /goal · pause · resume · edit · clear
+```
+
+Setting a goal **starts the work** — you do not need to retype the condition as a
+prompt. The confirmation turn itself does not count against the budget, so the
+first real attempt is turn 1 of 4.
+
+<Tip>
+  Write the condition the way you would brief a teammate: say what "done" looks
+  like, and say what to do when something is missing ("otherwise draft the query
+  and end with one setup CTA"). A condition that can never be satisfied will just
+  burn the whole turn budget.
+</Tip>
+
+## Watching progress
+
+Run `/goal` at any time:
+
+```text
+◎ /goal active · 1m 12s · turn 2/4 · +18.4k tokens
+  condition: How many Windows users in the last 7 days? …
+  reason: waiting for an achieved signal
+```
+
+| Part of the line | Meaning |
+| --- | --- |
+| `active` | Current state — see [How a goal ends](#how-a-goal-ends) |
+| `1m 12s` | Time since you set the goal |
+| `turn 2/4` | Turns used out of the budget |
+| `+18.4k tokens` | Tokens spent on this goal since you set it |
+| `condition` | The finish line you asked for |
+| `reason` | Why OpenSRE is still going, or why it stopped |
+
+When OpenSRE breaks the work into steps, `/goal` also prints a checklist with
+`[x]` for finished items and `→` marking the one it is on.
+
+If no goal is set, you get an empty state instead:
+
+```text
+no active goal. Set one with /goal set <condition>.
+```
+
+## Pause and resume
+
+`/goal pause` stops the next turn from firing but keeps everything else —
+condition, turn count, and progress so far:
+
+```text
+◎ /goal paused · 2m 05s · turn 2/4 · +18.4k tokens
+  condition: How many Windows users in the last 7 days? …
+  reason: paused by you
+paused. /goal · resume · edit · clear
+```
+
+While paused you can still chat normally — OpenSRE answers your message and then
+stays put instead of continuing the goal. This is the way to ask a quick
+side question without losing your place.
+
+`/goal resume` picks the work back up from the same turn count:
+
+```text
+/goal resume
+```
+
+## Change the condition
+
+`/goal edit` rewrites the finish line in place, keeping the turns already spent.
+Use it when the goal was nearly right but you want to redirect it:
+
+```text
+/goal edit How many Windows users in the last 7 days, broken down by country?
+```
+
+If the goal is active, the updated condition starts running right away. If it is
+paused, the text changes and it stays paused until you `/goal resume`. Conditions
+longer than 400 characters are shortened.
+
+## Stop the goal
+
+| You want to | Do this |
+| --- | --- |
+| Take a break, keep the goal | `/goal pause` |
+| Interrupt the turn running right now | **Ctrl+C** |
+| Forget the goal completely | `/goal clear` |
+
+`/goal clear` prints `goal cleared.` and removes it — there is nothing left to
+resume.
+
+## How a goal ends
+
+| State | What happened |
+| --- | --- |
+| `active` | Still working |
+| `paused` | You ran `/goal pause` |
+| `achieved` | OpenSRE reached the condition you described |
+| `budget_exhausted` | It used every turn without getting there — read the last reply, then set a narrower goal or raise `--max-turns` |
+| `cancelled` | You interrupted the run with **Ctrl+C** |
+| `cleared` | You ran `/goal clear` |
+
+The turn budget defaults to **5** and exists so an impossible condition cannot
+loop forever. Raise it with `--max-turns` when the work genuinely needs more
+steps.
+
+## `/goal` vs `/work` vs `/background`
+
+| Use | When |
+| --- | --- |
+| `/goal` | One question that needs several turns to answer, and you want OpenSRE to keep going by itself |
+| [`/work`](/work-management) | A durable human todo list that outlives the session |
+| [`/background`](/background-investigations) | An investigation that runs asynchronously and delivers its report to Slack, Telegram, or email |
+
+A goal belongs to the session it was set in and is restored with it, so a goal
+you set in the shell is still there after `/resume`. Goals also work in chat
+transports such as Slack and Telegram — the same status line appears in the
+timeline.
+
+## Related docs
+
+- [Interactive Shell Commands](/interactive-shell-commands) — the full slash command reference
+- [Work Management](/work-management) — `/work` durable todos
+- [Background investigations](/background-investigations) — async RCA delivery
+- [Session History](/sessions) — how sessions persist and resume
+- [PostHog](/posthog) — connect PostHog so product questions can run live

--- a/docs/goals.mdx
+++ b/docs/goals.mdx
@@ -151,10 +151,22 @@ steps.
 | [`/work`](/work-management) | A durable human todo list that outlives the session |
 | [`/background`](/background-investigations) | An investigation that runs asynchronously and delivers its report to Slack, Telegram, or email |
 
+## Where goals live
+
 A goal belongs to the session it was set in and is restored with it, so a goal
-you set in the shell is still there after `/resume`. Goals also work in chat
-transports such as Slack and Telegram — the same status line appears in the
-timeline.
+you set in the shell is still there after `/resume`.
+
+Goals are remembered in chat transports such as Slack and Telegram as well, and
+the same status line appears in the timeline while OpenSRE works. One difference
+matters there: `/goal set` does **not** start the work on its own. OpenSRE stores
+the goal and replies with a hint to run the condition in the interactive shell,
+and the goal sits at turn 0 until you send your next message — that message
+becomes the first turn, and continuation proceeds normally from there.
+
+<Note>
+  Set goals from the interactive shell when you want the work to begin
+  immediately without sending a follow-up message.
+</Note>
 
 ## Related docs
 

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -64,6 +64,7 @@ When you type `/` and browse completions with the arrow keys, the full descripti
 | `/resume <id>` | Restore a past session's conversation context |
 | `/resume <id>:<entry>` | Restore a specific session branch point |
 | `/new` | Start a new session file while keeping LLM context |
+| `/goal` | Set a finish line and keep working toward it across turns — see [Goals](/goals) |
 
 ### Investigation
 
@@ -1241,6 +1242,7 @@ Continue chatting, then optionally:
 
 ## Related docs
 
+- [Goals](/goals) — `/goal` set, pause, resume, edit, clear
 - [Session History](/sessions) — persistence format, privacy, `/new` vs `/clear`
 - [Interactive Shell Privacy](/interactive-shell-privacy) — redaction, env vars, threat model
 - [Investigation overview](/investigation-overview) — RCA workflow, plain-language actions, CLI investigate


### PR DESCRIPTION
Fixes #4896

#### Describe the changes you have made in this PR -

`/goal` had no user-facing documentation and was not listed anywhere in the
interactive shell command reference, so there was no way for a user to discover
`set` / `pause` / `resume` / `edit` / `clear` short of reading the source.

This PR adds `docs/goals.mdx`:

- **Commands at a glance** table covering every subcommand and alias
  (`/goal status`, `/goal unset`, and the bare `/goal <condition>` shorthand)
- **Copy-paste example** — the PostHog `--max-turns 4` condition from the issue
- **Progress line breakdown** — what `active`, duration, `turn 2/4`, token delta,
  `condition`, and `reason` each mean
- **Pause / resume / edit** sections, including that a paused goal still answers a
  normal chat message without continuing, and that `/goal edit` keeps the turns
  already spent
- **End states** table (`active`, `paused`, `achieved`, `budget_exhausted`,
  `cancelled`, `cleared`) and what the default 5-turn budget is for
- **`/goal` vs `/work` vs `/background`** so users pick the right tool

Also registers the page in `docs.json` nav and adds a `/goal` row plus a related-docs
link to `interactive-shell-commands.mdx`, where the command was previously missing
entirely.

All user-facing copy refers to the feature only as `/goal`.

Docs-only change — no Python touched, so the CI quality/test jobs are skipped by
the existing paths filter.

### Demo/Screenshot for feature changes and bug fixes -

The documented output matches what the command actually prints today, e.g. after
`/goal set`:

```text
◎ /goal active · 0s · turn 0/4 · +0 tokens
  condition: How many Windows users in the last 7 days? …
  reason: waiting for an achieved signal
→ next: condition runs as its own prompt turn (look for [N] ❯ below). /goal · pause · resume · edit · clear
