### PR TITLE
refactor(llm-errors): one ordered classifier for provider failures

### DIFF
--- a/core/llm_invoke_errors.py
+++ b/core/llm_invoke_errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 
 @dataclass(frozen=True)
@@ -92,66 +93,85 @@ LLM_PROVIDER_FAILURE_KINDS = frozenset(
     }
 )
 
-_NOT_CONFIGURED_PATTERNS = (
-    "_api_key",  # env-var style, e.g. "requires ANTHROPIC_API_KEY to be set"
-    "api key is not set",
-    "missing api key",
-    "not available for your account",
-    "marketplace",
-    "inference profile",
-    "not configured",
-    "no llm provider",
-    "llm client unavailable",
-    "billing is not enabled",
+
+class ProviderFailureKind(StrEnum):
+    """One verdict per provider failure message; every consumer derives from it."""
+
+    MISSING_KEY = "missing_key"
+    REJECTED_KEY = "rejected_key"
+    QUOTA = "quota"
+    NOT_CONFIGURED = "not_configured"
+    PROVIDER_ERROR = "provider_error"
+
+
+# First match wins, most specific first. MISSING_KEY holds absence phrasings
+# only — never a bare env-var-name match: rejected-key errors also cite
+# *_API_KEY names and must keep their real authentication message.
+_FAILURE_RULES: tuple[tuple[ProviderFailureKind, tuple[str, ...]], ...] = (
+    (
+        ProviderFailureKind.MISSING_KEY,
+        (
+            "missing credentials",
+            "api key is not set",
+            "missing api key",
+            "no api key",
+            "could not resolve authentication method",  # anthropic SDK, key/token both unset
+            "to be set",  # opensre wrapper: "requires ANTHROPIC_API_KEY to be set"
+        ),
+    ),
+    (
+        ProviderFailureKind.REJECTED_KEY,
+        (
+            "invalid",
+            "incorrect",
+            "expired",
+            "revoked",
+            "401",
+            "403",
+            "unauthorized",
+            "forbidden",
+            "authentication",
+            "x-api-key",
+        ),
+    ),
+    (
+        ProviderFailureKind.QUOTA,
+        ("429", "quota", "rate limit", "too many requests", "credit"),
+    ),
+    (
+        ProviderFailureKind.NOT_CONFIGURED,
+        (
+            "_api_key",  # env-var style, e.g. "set the OPENAI_API_KEY environment variable"
+            "not available for your account",
+            "marketplace",
+            "inference profile",
+            "not configured",
+            "no llm provider",
+            "llm client unavailable",
+            "billing is not enabled",
+        ),
+    ),
 )
-_QUOTA_PATTERNS = ("429", "quota", "rate limit", "too many requests", "credit")
-# Provider-SDK phrasings for "no API key at all" (as opposed to an invalid one).
-# Absence phrasings only — never a bare env-var-name match: rejected-key errors
-# also cite *_API_KEY names and must keep their real authentication message.
-_MISSING_KEY_PATTERNS = (
-    "missing credentials",
-    "api key is not set",
-    "missing api key",
-    "no api key",
-    "could not resolve authentication method",  # anthropic SDK, key/token both unset
-    "to be set",  # opensre wrapper: "requires ANTHROPIC_API_KEY to be set"
-)
-# A message matching any of these describes a key that exists but was rejected.
-_REJECTED_KEY_VETO_PATTERNS = (
-    "invalid",
-    "incorrect",
-    "expired",
-    "revoked",
-    "401",
-    "403",
-    "unauthorized",
-    "forbidden",
-)
-_AUTH_PATTERNS = (
-    "authentication",
-    "unauthorized",
-    "401",
-    "403",
-    "forbidden",
-    "invalid api key",
-    "incorrect api key",
-    "invalid api_key",
-    "incorrect api_key",
-    "api_key is invalid",
-    "x-api-key",
-)
+
+
+def classify_llm_provider_failure(message: str) -> ProviderFailureKind:
+    """Classify a provider failure message once; rendering and analytics both read this."""
+    text = message.lower()
+    for kind, patterns in _FAILURE_RULES:
+        if any(pattern in text for pattern in patterns):
+            return kind
+    if "model" in text and "not found" in text:
+        return ProviderFailureKind.NOT_CONFIGURED
+    return ProviderFailureKind.PROVIDER_ERROR
 
 
 def remediate_missing_llm_credentials(message: str, *, provider: str | None = None) -> str | None:
     """Actionable replacement text when an LLM call failed for lack of any API key.
 
-    Returns ``None`` for every other failure (invalid key, quota, timeout, …)
+    Returns ``None`` for every other failure (rejected key, quota, timeout, …)
     so callers fall back to their existing rendering.
     """
-    text = message.lower()
-    if any(pattern in text for pattern in _REJECTED_KEY_VETO_PATTERNS):
-        return None
-    if not any(pattern in text for pattern in _MISSING_KEY_PATTERNS):
+    if classify_llm_provider_failure(message) is not ProviderFailureKind.MISSING_KEY:
         return None
     target = provider.strip() if provider else "<provider>"
     subject = f"No API key is set for {target}" if provider else "No LLM API key is set"
@@ -162,6 +182,17 @@ def remediate_missing_llm_credentials(message: str, *, provider: str | None = No
     )
 
 
+# Analytics vocabulary predates the split of key failures into missing vs
+# rejected; dashboards filter on these four values.
+_ANALYTICS_KIND_BY_FAILURE: dict[ProviderFailureKind, str] = {
+    ProviderFailureKind.MISSING_KEY: "not_configured",
+    ProviderFailureKind.REJECTED_KEY: "auth",
+    ProviderFailureKind.QUOTA: "quota",
+    ProviderFailureKind.NOT_CONFIGURED: "not_configured",
+    ProviderFailureKind.PROVIDER_ERROR: "provider_error",
+}
+
+
 def classify_provider_error_kind(message: str) -> str:
     """Bucket an LLM provider failure message for analytics filtering.
 
@@ -169,16 +200,7 @@ def classify_provider_error_kind(message: str) -> str:
     ``provider_error`` so downstream dashboards can filter provider failures
     without regexing over response text.
     """
-    text = message.lower()
-    if any(pattern in text for pattern in _AUTH_PATTERNS):
-        return "auth"
-    if any(pattern in text for pattern in _QUOTA_PATTERNS):
-        return "quota"
-    if any(pattern in text for pattern in _NOT_CONFIGURED_PATTERNS) or (
-        "model" in text and "not found" in text
-    ):
-        return "not_configured"
-    return "provider_error"
+    return _ANALYTICS_KIND_BY_FAILURE[classify_llm_provider_failure(message)]
 
 
 def classify_llm_invoke_failure(exc: BaseException) -> LLMInvokeFailure | None:

--- a/tests/core/runtime/test_llm_invoke_errors.py
+++ b/tests/core/runtime/test_llm_invoke_errors.py
@@ -8,8 +8,10 @@ import pytest
 
 from core.llm_invoke_errors import (
     LLM_PROVIDER_FAILURE_KINDS,
+    ProviderFailureKind,
     _looks_like_timeout,
     classify_llm_invoke_failure,
+    classify_llm_provider_failure,
     classify_provider_error_kind,
     is_cli_timeout_error,
     remediate_missing_llm_credentials,
@@ -179,3 +181,56 @@ def test_remediate_missing_credentials_matches_anthropic_absence_message() -> No
 
     assert text is not None
     assert "`/auth login anthropic`" in text
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (_OPENAI_MISSING_KEY_MESSAGE, ProviderFailureKind.MISSING_KEY),
+        (
+            "Could not resolve authentication method. Expected either api_key "
+            "or auth_token to be set.",
+            ProviderFailureKind.MISSING_KEY,
+        ),
+        (
+            "AuthenticationError: invalid x-api-key. Check your ANTHROPIC_API_KEY.",
+            ProviderFailureKind.REJECTED_KEY,
+        ),
+        ("Anthropic authentication failed.", ProviderFailureKind.REJECTED_KEY),
+        ("Error code: 429 - too many requests", ProviderFailureKind.QUOTA),
+        ("Anthropic model 'claude-x' was not found.", ProviderFailureKind.NOT_CONFIGURED),
+        ("something unexpected exploded", ProviderFailureKind.PROVIDER_ERROR),
+    ],
+)
+def test_classify_llm_provider_failure_rule_order(
+    message: str, expected: ProviderFailureKind
+) -> None:
+    assert classify_llm_provider_failure(message) == expected
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        _OPENAI_MISSING_KEY_MESSAGE,
+        "Could not resolve authentication method. Expected either api_key or auth_token to be set.",
+        "LLM provider 'anthropic' requires ANTHROPIC_API_KEY to be set.",
+        "AuthenticationError: invalid x-api-key. Check your ANTHROPIC_API_KEY.",
+        "401 Unauthorized: the key from OPENAI_API_KEY was rejected.",
+        "Error code: 429 - rate limit exceeded",
+        "something unexpected exploded",
+    ],
+)
+def test_remediation_and_analytics_always_agree(message: str) -> None:
+    """One classification, two consumers: guidance fires iff analytics says not-configured-ish.
+
+    Regression: the split classifiers disagreed on Anthropic's absence message
+    (analytics said ``auth`` while the user saw missing-key guidance).
+    """
+    remediated = remediate_missing_llm_credentials(message) is not None
+    kind = classify_llm_provider_failure(message)
+    analytics = classify_provider_error_kind(message)
+
+    assert remediated == (kind is ProviderFailureKind.MISSING_KEY)
+    if remediated:
+        assert analytics == "not_configured"
+        assert analytics != "auth"


### PR DESCRIPTION
Follow-up to #5000. The provider-failure string matching in `core/llm_invoke_errors.py` had grown into five overlapping pattern tuples (`_NOT_CONFIGURED_PATTERNS`, `_QUOTA_PATTERNS`, `_MISSING_KEY_PATTERNS`, `_REJECTED_KEY_VETO_PATTERNS`, `_AUTH_PATTERNS`) feeding two independent classifiers that could disagree: Anthropic's missing-key message ("Could not resolve authentication method…") was bucketed as `auth` for analytics while the shell correctly showed missing-key login guidance for the same text.

- One `ProviderFailureKind` StrEnum (`missing_key | rejected_key | quota |  not_configured | provider_error`) and one ordered first-match-wins rule  table (`_FAILURE_RULES`), most specific first. The five tuples are removed  completely — no forwarding names.
- `classify_llm_provider_failure()` is the single classification; both  consumers derive from it:
  - `remediate_missing_llm_credentials()` fires iff the kind is    `missing_key` (the #5000 rejected-key protection becomes rule *order*    instead of a separate veto tuple).
  - `classify_provider_error_kind()` maps the enum onto the existing    four-value analytics vocabulary (`missing_key`→`not_configured`,    `rejected_key`→`auth`), so PostHog dashboards keep filtering on the same  strings.
- Behavior-preservation is characterization-tested: the pre-existing 15-row  analytics table passes unchanged, as do all rejected-key-with-env-name  negatives from #5000. A new property test over seven real provider  messages pins the invariant that remediation, kind, and analytics can  never disagree again.