### PR TITLE
fix(shell): explain first-run choices — greeting, loops picker, alert listener, verify next steps

### DIFF
--- a/surfaces/interactive_shell/command_registry/alerts.py
+++ b/surfaces/interactive_shell/command_registry/alerts.py
@@ -15,6 +15,11 @@ def _cmd_alerts(_session: Session, console: Console, _args: list[str]) -> bool:
     inbox = get_current_inbox()
     if inbox is None:
         console.print(f"[{WARNING}]alert listener is not active.[/]")
+        console.print(
+            f"[{DIM}]Enable it with alert_listener_enabled: true in "
+            "~/.opensre/config.yml (interactive section) or "
+            "OPENSRE_ALERT_LISTENER_ENABLED=1, then restart the shell.[/]"
+        )
         return True
 
     table = repl_table(title="Alert Inbox\n", title_style=BOLD_BRAND, show_header=False)

--- a/surfaces/interactive_shell/command_registry/integrations.py
+++ b/surfaces/interactive_shell/command_registry/integrations.py
@@ -180,9 +180,20 @@ def _print_verify_summary(
         style = WARNING if failed else HIGHLIGHT
         detail = "needs attention" if failed else "ok"
         repl_print(console, f"[{style}]{service} {detail}.[/]")
+        if failed:
+            repl_print(
+                console,
+                f"[{DIM}]Reconfigure with /integrations setup {service} — "
+                "the detail column above names what is missing.[/]",
+            )
         return
     if failed:
         repl_print(console, f"[{WARNING}]{len(failed)} integration(s) need attention.[/]")
+        repl_print(
+            console,
+            f"[{DIM}]Reconfigure with /integrations setup <service> — "
+            "the detail column above names what is missing.[/]",
+        )
     else:
         repl_print(console, f"[{HIGHLIGHT}]all integrations ok.[/]")
 

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -72,7 +72,7 @@ async def run_repl_async(
         else:
             # Fresh interactive start with no scheduled loops: offer the
             # suggested-loops picker before the prompt loop takes stdin.
-            offer_loop_suggestions(session)
+            offer_loop_suggestions(session, out)
 
         await InteractiveShellController(
             runtime_context,

--- a/surfaces/interactive_shell/runtime/startup/loop_suggestions.py
+++ b/surfaces/interactive_shell/runtime/startup/loop_suggestions.py
@@ -26,17 +26,25 @@ from platform.analytics.cli import (
     capture_loop_suggestion_skipped,
 )
 from platform.analytics.source import is_test_run
+from platform.terminal.theme import DIM
 from surfaces.interactive_shell.ui.components.choice_menu import (
     repl_choose_one,
     repl_tty_interactive,
 )
 
 if TYPE_CHECKING:
+    from rich.console import Console
+
     from surfaces.interactive_shell.session import Session
 
 logger = logging.getLogger(__name__)
 
 _MENU_TITLE = "No loops scheduled yet — pick one to set up (Esc to skip)"
+_MENU_EXPLAINER = (
+    "Loops are scheduled check-ins that post a summary here each weekday. "
+    "Picking one runs a first pass now, then offers the schedule — nothing is "
+    "saved until you confirm. Manage them anytime with /loops."
+)
 
 OPTION_CI_CD = "ci_cd"
 OPTION_TASK_MANAGEMENT = "task_management"
@@ -101,7 +109,7 @@ def should_offer_loop_suggestions() -> bool:
     return _no_loops_configured()
 
 
-def offer_loop_suggestions(session: Session) -> None:
+def offer_loop_suggestions(session: Session, console: Console | None = None) -> None:
     """Show the picker and queue the chosen suggestion as the first turn.
 
     Never blocks startup: any unexpected failure is logged and the REPL
@@ -111,6 +119,8 @@ def offer_loop_suggestions(session: Session) -> None:
         if not should_offer_loop_suggestions():
             return
         capture_loop_suggestion_prompted()
+        if console is not None:
+            console.print(f"[{DIM}]{_MENU_EXPLAINER}[/]")
         selected = repl_choose_one(
             title=_MENU_TITLE,
             choices=[(suggestion.option, suggestion.label) for suggestion in LOOP_SUGGESTIONS],

--- a/surfaces/interactive_shell/ui/banner/banner.py
+++ b/surfaces/interactive_shell/ui/banner/banner.py
@@ -193,12 +193,13 @@ def _format_cwd(path: str) -> str:
     return path
 
 
-def _build_identity_block(provider: str, model: str, *, trust_mode: bool) -> Text:
+def _build_identity_block(provider: str, model: str, *, trust_mode: bool, first_run: bool) -> Text:
     """Left column: mascot · blank · greeting · blank · identity line (all left-aligned)."""
     logo = _build_logo_mark()
 
     greeting = Text()
-    greeting.append(f"Welcome back {_get_username()}!", style=f"bold {TEXT}")
+    salutation = "Welcome" if first_run else "Welcome back"
+    greeting.append(f"{salutation} {_get_username()}!", style=f"bold {TEXT}")
 
     # Single flowing line: model · tier · workspace
     cwd = _format_cwd(os.getcwd())
@@ -272,8 +273,9 @@ def build_ready_panel(
     panel_title.append(" · ", style=DIM)
     panel_title.append(f"v{version} ", style=BRAND)
 
-    left = _build_identity_block(provider, model, trust_mode=trust_mode)
-    if _is_first_run():
+    first_run = _is_first_run()
+    left = _build_identity_block(provider, model, trust_mode=trust_mode, first_run=first_run)
+    if first_run:
         right = Text("\n").join(
             [
                 _build_notes_block("Tips for getting started", _TIPS),

--- a/surfaces/interactive_shell/ui/banner/banner_state.py
+++ b/surfaces/interactive_shell/ui/banner/banner_state.py
@@ -146,7 +146,7 @@ def _build_ambient_right_column(session: object = None) -> Text:
         listener_line.append("active", style=SECONDARY)
         parts.append(listener_line)
     else:
-        parts.append(Text("○  not configured", style=DIM))
+        parts.append(Text("○  not configured — /alerts for setup", style=DIM))
 
     parts.append(Text("───", style=DIM))
 

--- a/tests/interactive_shell/runtime/test_loop_suggestions.py
+++ b/tests/interactive_shell/runtime/test_loop_suggestions.py
@@ -1,0 +1,73 @@
+"""Tests for the suggested-loops startup picker."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+import surfaces.interactive_shell.runtime.startup.loop_suggestions as loop_suggestions
+from surfaces.interactive_shell.session import Session
+
+
+def _capture() -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    return Console(file=buf, force_terminal=False, highlight=False, width=120), buf
+
+
+def _offerable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(loop_suggestions, "should_offer_loop_suggestions", lambda: True)
+    monkeypatch.setattr(loop_suggestions, "capture_loop_suggestion_prompted", lambda: None)
+    monkeypatch.setattr(loop_suggestions, "capture_loop_suggestion_skipped", lambda: None)
+    monkeypatch.setattr(loop_suggestions, "capture_loop_suggestion_selected", lambda **_kw: None)
+
+
+def test_picker_explains_what_a_loop_is_before_the_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The menu asks for a commitment; the explainer must say what it entails."""
+    # Arrange: user immediately skips the menu.
+    _offerable(monkeypatch)
+    monkeypatch.setattr(loop_suggestions, "repl_choose_one", lambda **_kw: None)
+    console, buf = _capture()
+
+    # Act
+    loop_suggestions.offer_loop_suggestions(Session(), console)
+
+    # Assert: what it does, that nothing persists unconfirmed, and how to manage.
+    output = buf.getvalue()
+    assert "scheduled check-ins" in output
+    assert "nothing is saved until you confirm" in output
+    assert "/loops" in output
+
+
+def test_selection_queues_the_canned_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    _offerable(monkeypatch)
+    monkeypatch.setattr(
+        loop_suggestions, "repl_choose_one", lambda **_kw: loop_suggestions.OPTION_DAILY_BRIEF
+    )
+    session = Session()
+    console, _buf = _capture()
+
+    # Act
+    loop_suggestions.offer_loop_suggestions(session, console)
+
+    # Assert
+    assert session.terminal.pending_prompt_autosubmit is True
+    assert "morning report" in session.terminal.pending_prompt_default
+
+
+def test_skip_queues_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    _offerable(monkeypatch)
+    monkeypatch.setattr(loop_suggestions, "repl_choose_one", lambda **_kw: None)
+    session = Session()
+
+    # Act
+    loop_suggestions.offer_loop_suggestions(session, None)
+
+    # Assert
+    assert session.terminal.pending_prompt_autosubmit is False
+    assert not session.terminal.pending_prompt_default

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -810,6 +810,8 @@ class TestIntegrationsCommand:
         console, buf = _capture()
         dispatch_slash("/integrations verify", Session(), console)
         assert "need attention" in buf.getvalue()
+        # The summary must name the fix, not just the count.
+        assert "/integrations setup" in buf.getvalue()
 
     def test_verify_all_ok(self, monkeypatch: object) -> None:
         monkeypatch.setattr(
@@ -3181,3 +3183,21 @@ class TestCliDelegatedCommands:
         assert session.history[-1]["ok"] is False
         assert delegated == []
         assert started == []
+
+
+def test_alerts_inactive_prints_enable_instructions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The inactive warning must say how to turn the listener on."""
+    # Arrange
+    import surfaces.interactive_shell.command_registry.alerts as alerts_module
+
+    monkeypatch.setattr(alerts_module, "get_current_inbox", lambda: None)
+    console, buf = _capture()
+
+    # Act
+    dispatch_slash("/alerts", Session(), console)
+
+    # Assert
+    output = buf.getvalue()
+    assert "not active" in output
+    assert "alert_listener_enabled" in output
+    assert "OPENSRE_ALERT_LISTENER_ENABLED" in output

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -202,3 +202,37 @@ def test_ready_box_expands_to_console_width() -> None:
     ]
     assert lines
     assert max(len(line) for line in lines) == 120
+
+
+def test_identity_greeting_matches_first_run_state(monkeypatch: object) -> None:
+    """First run greets 'Welcome'; a returning install greets 'Welcome back'."""
+    # Arrange: fix the username so the assertion is exact.
+    monkeypatch.setattr(banner_module, "_get_username", lambda: "casey")
+
+    # Act
+    first = banner_module._build_identity_block(
+        "openai", "gpt-5.4-mini", trust_mode=False, first_run=True
+    ).plain
+    returning = banner_module._build_identity_block(
+        "openai", "gpt-5.4-mini", trust_mode=False, first_run=False
+    ).plain
+
+    # Assert
+    assert "Welcome casey!" in first
+    assert "Welcome back" not in first
+    assert "Welcome back casey!" in returning
+
+
+def test_ready_box_greets_first_run_without_welcome_back(monkeypatch: object) -> None:
+    # Arrange: a machine where the wizard has never completed.
+    monkeypatch.setattr(banner_module, "_is_first_run", lambda: True)
+    console_file = io.StringIO()
+    console = Console(file=console_file, force_terminal=False, highlight=False, width=120)
+
+    # Act
+    banner_module.render_ready_box(console)
+
+    # Assert
+    output = console_file.getvalue()
+    assert "Welcome" in output
+    assert "Welcome back" not in output

--- a/tests/interactive_shell/ui/test_rendering.py
+++ b/tests/interactive_shell/ui/test_rendering.py
@@ -172,7 +172,8 @@ def test_repl_render_launch_poster_uses_crlf_on_tty(monkeypatch: pytest.MonkeyPa
     assert "38;2;168;212;255" in written
     assert "185;237;175" not in written
     assert "opensre" in written
-    assert "Welcome back" in written
+    # Greeting wording varies by first-run state; only the salutation root is stable.
+    assert "Welcome" in written
     assert "\r\n" in written
     # REPL path must not emit bare \\n (causes double-spaced splash under patch_stdout).
     assert "\r" not in written.replace("\r\n", "")


### PR DESCRIPTION
Onboarding dogfood polish: four places where the shell showed a state without
saying what to do about it, found by walking the first-run experience by hand.

- **First-run greeting** — the ready panel greeted every user with  "Welcome back", including installs where the wizard has never run. The  identity block now uses the same `_is_first_run()` signal the tips column  already uses: fresh installs get "Welcome <name>!", returning installs keep  "Welcome back <name>!".
- **Loops picker explains itself** — the startup picker asked users to "pick  one to set up" without saying what a loop is, what selecting does, or  whether it can be undone. A dim explainer line now precedes the menu:  loops are scheduled weekday check-ins, picking one runs a first pass and  then offers the schedule, nothing is saved until confirmed, manage with  `/loops`. The wording matches the actual mechanics (canned prompt →  `propose_scheduled_delivery` → `/cron add` confirmation). The console is  passed in from `main.py` — optional parameter, no globals.
- **Alert listener says how to enable it** — the banner line becomes  "○ not configured — /alerts for setup", and `/alerts` on an inactive  listener now prints the enable paths (`alert_listener_enabled: true` in  `~/.opensre/config.yml`, or `OPENSRE_ALERT_LISTENER_ENABLED=1`) instead of  only a warning.
- **`/integrations verify` names the fix** — after the table, the summary  adds "Reconfigure with `/integrations setup <service>` — the detail column  above names what is missing", in both the all-integrations and  single-service forms.

<img width="1322" height="927" alt="image" src="https://github.com/user-attachments/assets/5ce4c0d2-d683-4268-8252-a91b9f7021c3" />

