### PR TITLE
feat(gateway/buzz): soft turn timeout and /stop — close two transport-ledger gaps

### DIFF
--- a/gateway/core/middleware/active_turns.py
+++ b/gateway/core/middleware/active_turns.py
@@ -1,10 +1,17 @@
 """In-flight turn cancel registry for gateway chat hosts.
 
 Transports serialize turns per conversation, so a ``/stop`` message cannot
-wait behind the same lock as the running turn. Instead each turn registers its
-``turn_cancel`` Event here under a conversation key; ``/stop`` looks up the
-key **outside** the turn lock, sets the Event, and optionally runs a
-transport-supplied finalize callback (claim outcome + ``Stopped.`` copy).
+wait behind the same lock as the running turn. Instead each accepted turn
+registers its ``turn_cancel`` Event here under a conversation key;
+``/stop`` looks the key up **outside** the turn lock, sets every Event
+registered for it, and optionally runs a transport-supplied finalize
+callback (claim outcome + ``Stopped.`` copy).
+
+Transports that dispatch turns as detached tasks must register at dispatch
+time — before the task first runs — or a ``/stop`` in the same poll batch
+finds nothing to cancel while the accepted turn proceeds. A key may hold
+several turns at once (one running, others queued behind the conversation
+lock); stopping the conversation cancels them all.
 """
 
 from __future__ import annotations
@@ -24,11 +31,55 @@ class _TrackedTurn:
 
 
 class ActiveTurnRegistry:
-    """Thread-safe map of conversation key → in-flight cancel Event."""
+    """Thread-safe map of conversation key → in-flight cancel Events."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._turns: dict[str, _TrackedTurn] = {}
+        self._turns: dict[str, list[_TrackedTurn]] = {}
+
+    def register(
+        self,
+        key: str,
+        event: threading.Event,
+        *,
+        on_user_stop: Callable[[], None] | None = None,
+    ) -> None:
+        """Publish ``event`` for ``key``; pair with :meth:`unregister`."""
+        with self._lock:
+            self._turns.setdefault(key, []).append(
+                _TrackedTurn(event=event, on_user_stop=on_user_stop)
+            )
+
+    def unregister(self, key: str, event: threading.Event) -> None:
+        """Remove ``event`` from ``key``; unknown pairs are a no-op."""
+        with self._lock:
+            turns = self._turns.get(key)
+            if turns is None:
+                return
+            remaining = [turn for turn in turns if turn.event is not event]
+            if remaining:
+                self._turns[key] = remaining
+            else:
+                del self._turns[key]
+
+    def bind_user_stop(
+        self,
+        key: str,
+        event: threading.Event,
+        on_user_stop: Callable[[], None],
+    ) -> None:
+        """Attach the stop finalizer to an already registered ``event``.
+
+        Dispatch-time registration happens before the turn has a sink to
+        finalize; the turn binds the callback once it starts. A stop that
+        lands in between only sets the Event — the turn must check it before
+        invoking the agent.
+        """
+        with self._lock:
+            for turn in self._turns.get(key, []):
+                if turn.event is event:
+                    turn.on_user_stop = on_user_stop
+                    return
 
     @contextmanager
     def track(
@@ -39,26 +90,21 @@ class ActiveTurnRegistry:
         on_user_stop: Callable[[], None] | None = None,
     ) -> Iterator[None]:
         """Publish ``event`` for ``key`` for the duration of one turn."""
-        with self._lock:
-            self._turns[key] = _TrackedTurn(event=event, on_user_stop=on_user_stop)
+        self.register(key, event, on_user_stop=on_user_stop)
         try:
             yield
         finally:
-            with self._lock:
-                current = self._turns.get(key)
-                if current is not None and current.event is event:
-                    del self._turns[key]
+            self.unregister(key, event)
 
     def request_stop(self, key: str) -> bool:
-        """Set the cancel Event for ``key``. Return whether a turn was active."""
+        """Cancel every turn registered for ``key``; return whether any was."""
         with self._lock:
-            tracked = self._turns.get(key)
-        if tracked is None:
-            return False
-        tracked.event.set()
-        if tracked.on_user_stop is not None:
-            tracked.on_user_stop()
-        return True
+            tracked = list(self._turns.get(key, []))
+        for turn in tracked:
+            turn.event.set()
+            if turn.on_user_stop is not None:
+                turn.on_user_stop()
+        return bool(tracked)
 
 
 def is_stop_command(text: str) -> bool:

--- a/gateway/core/middleware/terminal_outcome.py
+++ b/gateway/core/middleware/terminal_outcome.py
@@ -8,10 +8,15 @@ from contextlib import contextmanager
 
 
 class TerminalOutcomeArbiter:
-    """Let only the first terminal path update a turn's external state."""
+    """Let only the first terminal path update a turn's external state.
 
-    def __init__(self) -> None:
-        self.cancel_event = threading.Event()
+    ``cancel_event`` may be supplied by the caller when the Event already
+    exists — e.g. registered for ``/stop`` at dispatch time, before the turn
+    started — so cancellation requested before construction is not lost.
+    """
+
+    def __init__(self, cancel_event: threading.Event | None = None) -> None:
+        self.cancel_event = cancel_event if cancel_event is not None else threading.Event()
         self._lock = threading.Lock()
         self._claimed = False
 

--- a/gateway/tests/buzz/test_background.py
+++ b/gateway/tests/buzz/test_background.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from gateway.core.middleware.active_turns import ActiveTurnRegistry
 from gateway.core.middleware.approvals import ApprovalBroker
 from gateway.transports.buzz import background
 from gateway.transports.buzz.pending_approvals import PendingApprovals
@@ -197,6 +198,7 @@ def _dispatch_coroutine(event: BuzzInboundMessage, *, acknowledge: object) -> ob
         turn_semaphore=asyncio.Semaphore(4),
         approvals=ApprovalBroker(),
         pending_approvals=PendingApprovals(),
+        active_cancels=ActiveTurnRegistry(),
         loop=MagicMock(),
         handle_callback_to_gateway_agent=MagicMock(),
         logger=MagicMock(),

--- a/gateway/tests/buzz/test_inbound_handler.py
+++ b/gateway/tests/buzz/test_inbound_handler.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from gateway.core.middleware.active_turns import ActiveTurnRegistry
 from gateway.core.middleware.approvals import ApprovalBroker
 from gateway.transports.buzz.inbound_handler import handle_polled_inbound_buzz_message
 from gateway.transports.buzz.pending_approvals import PendingApprovals
@@ -46,6 +47,7 @@ def test_unauthorized_sender_never_invokes_the_callback() -> None:
                 turn_semaphore=asyncio.Semaphore(4),
                 approvals=ApprovalBroker(),
                 pending_approvals=PendingApprovals(),
+                active_cancels=ActiveTurnRegistry(),
                 handle_callback_to_gateway_agent=callback,
             )
         )

--- a/gateway/tests/buzz/test_turn_timeout.py
+++ b/gateway/tests/buzz/test_turn_timeout.py
@@ -1,0 +1,206 @@
+"""Buzz soft turn-timeout and /stop parity with the other chat transports.
+
+Buzz was born as a copy of Telegram minus these exact features: a hung turn
+hung its conversation forever, and nothing could stop a running turn. Twin of
+``gateway/tests/telegram/test_turn_timeout.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from core.agent_harness.session import SessionCore
+from core.agent_harness.session.persistence.memory import InMemorySessionStore
+from gateway.core.middleware.active_turns import ActiveTurnRegistry
+from gateway.core.middleware.approvals import ApprovalBroker
+from gateway.transports.buzz.inbound_handler import handle_polled_inbound_buzz_message
+from gateway.transports.buzz.inbound_security import InboundDecision
+from gateway.transports.buzz.pending_approvals import PendingApprovals
+from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.edits: list[str] = []
+        self._msg = 0
+
+    def send_message(self, *, channel: str, content: str) -> dict[str, Any]:
+        _ = (channel, content)
+        self._msg += 1
+        return {"success": True, "event_id": f"ev-{self._msg}"}
+
+    def edit_message(self, *, event_id: str, content: str) -> dict[str, Any]:
+        _ = event_id
+        self.edits.append(content)
+        return {"success": True}
+
+
+class _FakeSessionResolver:
+    def __init__(self, session: SessionCore) -> None:
+        self._session = session
+
+    def resolve(self, **_kwargs: object) -> SessionCore:
+        return self._session
+
+    def rotate(self, **_kwargs: object) -> SessionCore:
+        return self._session
+
+
+def _settings(*, turn_timeout_seconds: float) -> GatewaySettings:
+    return GatewaySettings(
+        relay_url="wss://relay.test",
+        private_key="nsec-test",
+        allowed_pubkeys=["npub-1"],
+        turn_timeout_seconds=turn_timeout_seconds,
+    )
+
+
+def _event(text: str = "hello") -> BuzzInboundMessage:
+    return BuzzInboundMessage(
+        event_id="in-1",
+        pubkey="npub-1",
+        channel_id="chan-1",
+        content=text,
+        created_at=1,
+        reply_event_ids=frozenset(),
+    )
+
+
+@pytest.fixture
+def org_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORGANIZATION_ID", "org_buzz_timeout")
+    monkeypatch.setattr(
+        "gateway.transports.buzz.inbound_handler.enforce_inbound_buzz_message_security",
+        lambda **_kwargs: InboundDecision(allowed=True),
+    )
+
+
+@pytest.mark.usefixtures("org_env")
+def test_turn_timeout_finalizes_placeholder_when_handler_hangs() -> None:
+    """Soft timeout finalizes UX and sets sink.turn_cancel for cooperative stop."""
+    client = _FakeClient()
+    release = threading.Event()
+    session = SessionCore(store=InMemorySessionStore())
+    seen_cancel: list[threading.Event] = []
+
+    def hanging_handler(
+        _text: str,
+        _session: Any,
+        _sink: Any,
+        _logger: logging.Logger,
+    ) -> None:
+        cancel = getattr(_sink, "turn_cancel", None)
+        assert isinstance(cancel, threading.Event)
+        seen_cancel.append(cancel)
+        release.wait(5.0)
+
+    async def _run() -> None:
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            await handle_polled_inbound_buzz_message(
+                _event(),
+                client=client,  # type: ignore[arg-type]
+                session_resolver=_FakeSessionResolver(session),  # type: ignore[arg-type]
+                settings=_settings(turn_timeout_seconds=0.05),
+                executor=executor,
+                chat_locks={},
+                turn_semaphore=asyncio.Semaphore(1),
+                approvals=ApprovalBroker(),
+                pending_approvals=PendingApprovals(),
+                active_cancels=ActiveTurnRegistry(),
+                handle_callback_to_gateway_agent=hanging_handler,
+            )
+        finally:
+            release.set()
+            executor.shutdown(wait=True, cancel_futures=True)
+
+    # Drive the async path from a thread so a hang cannot block pytest forever
+    # if the soft timeout fails to fire.
+    done = threading.Event()
+    error: list[Exception] = []
+
+    def _thread() -> None:
+        try:
+            asyncio.run(_run())
+        except Exception as exc:
+            error.append(exc)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=_thread)
+    worker.start()
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and not any(
+        "taking longer" in text.lower() for text in client.edits
+    ):
+        time.sleep(0.02)
+    release.set()
+    assert done.wait(5.0)
+    worker.join(5.0)
+    assert not error, error
+    assert any("taking longer" in text.lower() for text in client.edits), client.edits
+    assert seen_cancel and seen_cancel[0].is_set()
+
+
+def test_gateway_settings_default_turn_timeout_matches_the_other_transports() -> None:
+    settings = GatewaySettings(
+        relay_url="wss://relay.test",
+        private_key="nsec-test",
+        allowed_pubkeys=["npub-1"],
+    )
+
+    assert settings.turn_timeout_seconds == 240.0
+
+
+def test_stop_command_requests_cancel_of_the_running_turn() -> None:
+    """A `/stop` in the conversation asks the active turn to stop, runs no turn."""
+    from gateway.transports.buzz.background import maybe_handle_stop_command
+    from gateway.transports.buzz.session_rotation import conversation_key
+
+    registry = ActiveTurnRegistry()
+    client = _FakeClient()
+    stop_event = _event("/stop")
+    cancel = threading.Event()
+
+    with registry.track(conversation_key(stop_event), cancel):
+        handled = maybe_handle_stop_command(stop_event, active_cancels=registry, client=client)
+
+    assert handled is True
+    assert cancel.is_set()
+
+
+def test_stop_without_a_running_turn_reports_nothing_to_stop() -> None:
+    from config.constants.gateway import NO_ACTIVE_TURN_MESSAGE
+    from gateway.transports.buzz.background import maybe_handle_stop_command
+
+    sent: list[str] = []
+
+    class _Client:
+        def send_message(self, *, channel: str, content: str) -> dict[str, Any]:
+            _ = channel
+            sent.append(content)
+            return {"success": True, "event_id": "e"}
+
+    handled = maybe_handle_stop_command(
+        _event("/stop"), active_cancels=ActiveTurnRegistry(), client=_Client()
+    )
+
+    assert handled is True
+    assert sent == [NO_ACTIVE_TURN_MESSAGE]
+
+
+def test_a_normal_message_is_not_a_stop_command() -> None:
+    from gateway.transports.buzz.background import maybe_handle_stop_command
+
+    handled = maybe_handle_stop_command(
+        _event("please stop the deploy"), active_cancels=ActiveTurnRegistry(), client=_FakeClient()
+    )
+
+    assert handled is False

--- a/gateway/tests/buzz/test_turn_timeout.py
+++ b/gateway/tests/buzz/test_turn_timeout.py
@@ -29,10 +29,12 @@ from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
 class _FakeClient:
     def __init__(self) -> None:
         self.edits: list[str] = []
+        self.sent: list[str] = []
         self._msg = 0
 
     def send_message(self, *, channel: str, content: str) -> dict[str, Any]:
-        _ = (channel, content)
+        _ = channel
+        self.sent.append(content)
         self._msg += 1
         return {"success": True, "event_id": f"ev-{self._msg}"}
 
@@ -204,3 +206,76 @@ def test_a_normal_message_is_not_a_stop_command() -> None:
     )
 
     assert handled is False
+
+
+def test_stop_in_the_same_batch_finds_the_dispatched_but_unstarted_turn() -> None:
+    """Dispatch-time registration closes the create_task → track window."""
+    from gateway.transports.buzz.background import maybe_handle_stop_command
+    from gateway.transports.buzz.session_rotation import conversation_key
+
+    # Arrange — the poll loop accepted a message and registered its cancel
+    # Event, but the detached turn task has not run a single step yet
+    registry = ActiveTurnRegistry()
+    client = _FakeClient()
+    message = _event("hello")
+    accepted_cancel = threading.Event()
+    registry.register(conversation_key(message), accepted_cancel)
+
+    # Act — a /stop from the same poll batch is checked immediately
+    handled = maybe_handle_stop_command(_event("/stop"), active_cancels=registry, client=client)
+
+    # Assert — the accepted turn is cancelled; no "nothing to stop" reply
+    assert handled is True
+    assert accepted_cancel.is_set()
+    assert client.sent == []
+
+
+@pytest.mark.usefixtures("org_env")
+def test_cancelled_before_start_reports_stopped_without_running_the_agent() -> None:
+    """A turn whose dispatch-time cancel Event is already set never runs."""
+    from config.constants.gateway import USER_STOP_MESSAGE
+    from gateway.transports.buzz.session_rotation import conversation_key
+
+    # Arrange — /stop already cancelled the turn while it was queued
+    client = _FakeClient()
+    session = SessionCore(store=InMemorySessionStore())
+    registry = ActiveTurnRegistry()
+    message = _event()
+    turn_cancel = threading.Event()
+    registry.register(conversation_key(message), turn_cancel)
+    turn_cancel.set()
+    agent_calls: list[str] = []
+    acked: list[bool] = []
+
+    def agent_handler(text: str, _session: Any, _sink: Any, _logger: logging.Logger) -> None:
+        agent_calls.append(text)
+
+    # Act
+    async def _run() -> None:
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            await handle_polled_inbound_buzz_message(
+                message,
+                client=client,  # type: ignore[arg-type]
+                session_resolver=_FakeSessionResolver(session),  # type: ignore[arg-type]
+                settings=_settings(turn_timeout_seconds=5.0),
+                executor=executor,
+                chat_locks={},
+                turn_semaphore=asyncio.Semaphore(1),
+                approvals=ApprovalBroker(),
+                pending_approvals=PendingApprovals(),
+                active_cancels=registry,
+                turn_cancel=turn_cancel,
+                handle_callback_to_gateway_agent=agent_handler,
+                on_handled=lambda: acked.append(True),
+            )
+        finally:
+            executor.shutdown(wait=True, cancel_futures=True)
+
+    asyncio.run(_run())
+
+    # Assert — placeholder edited to the stopped copy, message acknowledged,
+    # agent never ran
+    assert agent_calls == []
+    assert client.edits == [USER_STOP_MESSAGE]
+    assert acked == [True]

--- a/gateway/tests/runtime/test_active_turns.py
+++ b/gateway/tests/runtime/test_active_turns.py
@@ -44,11 +44,50 @@ def test_track_unregisters_even_when_turn_raises() -> None:
     assert registry.request_stop("chat-1") is False
 
 
-def test_newer_track_replaces_key() -> None:
+def test_request_stop_cancels_running_and_queued_turns_for_the_key() -> None:
+    # Arrange — one running turn and one queued behind the conversation lock
     registry = ActiveTurnRegistry()
-    first = threading.Event()
-    second = threading.Event()
-    with registry.track("chat-1", first), registry.track("chat-1", second):
-        assert registry.request_stop("chat-1") is True
-        assert second.is_set()
-        assert not first.is_set()
+    running = threading.Event()
+    queued = threading.Event()
+
+    with registry.track("chat-1", running), registry.track("chat-1", queued):
+        # Act
+        stopped = registry.request_stop("chat-1")
+
+        # Assert — /stop means stop the conversation, not just one turn
+        assert stopped is True
+        assert running.is_set()
+        assert queued.is_set()
+
+
+def test_stop_finds_a_turn_registered_at_dispatch_before_it_starts() -> None:
+    # Arrange — dispatch registered the accepted turn; its task has not run yet
+    registry = ActiveTurnRegistry()
+    accepted = threading.Event()
+    registry.register("chat-1", accepted)
+
+    # Act
+    stopped = registry.request_stop("chat-1")
+
+    # Assert
+    assert stopped is True
+    assert accepted.is_set()
+    registry.unregister("chat-1", accepted)
+    assert registry.request_stop("chat-1") is False
+
+
+def test_bind_user_stop_attaches_finalizer_to_a_registered_event() -> None:
+    # Arrange
+    registry = ActiveTurnRegistry()
+    event = threading.Event()
+    seen: list[str] = []
+    registry.register("chat-1", event)
+
+    # Act
+    registry.bind_user_stop("chat-1", event, lambda: seen.append("stop"))
+    registry.request_stop("chat-1")
+
+    # Assert
+    assert event.is_set()
+    assert seen == ["stop"]
+    registry.unregister("chat-1", event)

--- a/gateway/tests/test_transport_contract.py
+++ b/gateway/tests/test_transport_contract.py
@@ -60,13 +60,7 @@ _REQUIRED_CONCERNS: dict[str, str] = {
 #: the assertion below is exact equality, so closing a gap requires deleting
 #: its entry here, and nothing can be added for a new transport unnoticed.
 _KNOWN_GAPS: dict[str, frozenset[str]] = {
-    "buzz": frozenset(
-        {
-            "turn timeout setting",
-            "stop command handling",
-            "credit metering",
-        }
-    ),
+    "buzz": frozenset({"credit metering"}),
     "telegram": frozenset({"credit metering"}),
 }
 

--- a/gateway/transports/buzz/background.py
+++ b/gateway/transports/buzz/background.py
@@ -8,6 +8,8 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 
+from config.constants.gateway import NO_ACTIVE_TURN_MESSAGE
+from gateway.core.middleware.active_turns import ActiveTurnRegistry, is_stop_command
 from gateway.core.middleware.approvals import ApprovalBroker
 from gateway.core.runtime.polling_thread import PollingBackground, start_polling_background
 from gateway.core.storage import SessionResolver
@@ -21,6 +23,7 @@ from gateway.transports.buzz.runtime import (
     InitializeBuzzPollingRuntime,
     ShutdownBuzzPollingRuntime,
 )
+from gateway.transports.buzz.session_rotation import conversation_key
 from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
 from integrations.buzz.client import BuzzClient
 
@@ -104,6 +107,11 @@ async def _poll_buzz_until_stopped(
                 if _resolve_if_approval_reply(event, resources, settings):
                     poller.acknowledge(event)
                     continue
+                if maybe_handle_stop_command(
+                    event, active_cancels=resources.active_cancels, client=resources.client
+                ):
+                    poller.acknowledge(event)
+                    continue
                 task = asyncio.create_task(
                     _dispatch_turn(
                         event,
@@ -115,6 +123,7 @@ async def _poll_buzz_until_stopped(
                         turn_semaphore=turn_semaphore,
                         approvals=resources.approvals,
                         pending_approvals=resources.pending_approvals,
+                        active_cancels=resources.active_cancels,
                         loop=loop,
                         handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
                         logger=logger,
@@ -179,6 +188,24 @@ async def _drain_active_turns(
         )
 
 
+def maybe_handle_stop_command(
+    event: BuzzInboundMessage,
+    *,
+    active_cancels: ActiveTurnRegistry,
+    client: BuzzClient,
+) -> bool:
+    """Handle a `/stop` without starting a turn. Returns whether it was one.
+
+    A stop for a conversation with no running turn still consumes the message
+    — starting a turn for it would answer a cancellation with an agent reply.
+    """
+    if not is_stop_command(event.content):
+        return False
+    if not active_cancels.request_stop(conversation_key(event)):
+        client.send_message(channel=event.channel_id, content=NO_ACTIVE_TURN_MESSAGE)
+    return True
+
+
 async def _dispatch_turn(
     event: BuzzInboundMessage,
     *,
@@ -190,6 +217,7 @@ async def _dispatch_turn(
     turn_semaphore: asyncio.Semaphore,
     approvals: ApprovalBroker,
     pending_approvals: PendingApprovals,
+    active_cancels: ActiveTurnRegistry,
     loop: asyncio.AbstractEventLoop,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
     logger: logging.Logger,
@@ -222,6 +250,7 @@ async def _dispatch_turn(
             turn_semaphore=turn_semaphore,
             approvals=approvals,
             pending_approvals=pending_approvals,
+            active_cancels=active_cancels,
             loop=loop,
             handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
             on_handled=lambda: acknowledge(event),

--- a/gateway/transports/buzz/background.py
+++ b/gateway/transports/buzz/background.py
@@ -112,6 +112,10 @@ async def _poll_buzz_until_stopped(
                 ):
                     poller.acknowledge(event)
                     continue
+                # Registered before the task exists: a /stop later in this
+                # same batch must find the accepted turn, not "nothing".
+                turn_cancel = threading.Event()
+                resources.active_cancels.register(conversation_key(event), turn_cancel)
                 task = asyncio.create_task(
                     _dispatch_turn(
                         event,
@@ -124,6 +128,7 @@ async def _poll_buzz_until_stopped(
                         approvals=resources.approvals,
                         pending_approvals=resources.pending_approvals,
                         active_cancels=resources.active_cancels,
+                        turn_cancel=turn_cancel,
                         loop=loop,
                         handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
                         logger=logger,
@@ -218,6 +223,7 @@ async def _dispatch_turn(
     approvals: ApprovalBroker,
     pending_approvals: PendingApprovals,
     active_cancels: ActiveTurnRegistry,
+    turn_cancel: threading.Event | None = None,
     loop: asyncio.AbstractEventLoop,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
     logger: logging.Logger,
@@ -251,6 +257,7 @@ async def _dispatch_turn(
             approvals=approvals,
             pending_approvals=pending_approvals,
             active_cancels=active_cancels,
+            turn_cancel=turn_cancel,
             loop=loop,
             handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
             on_handled=lambda: acknowledge(event),
@@ -262,6 +269,9 @@ async def _dispatch_turn(
             event.channel_id,
             exc_info=True,
         )
+    finally:
+        if turn_cancel is not None:
+            active_cancels.unregister(conversation_key(event), turn_cancel)
     acknowledge(event)
 
 

--- a/gateway/transports/buzz/inbound_handler.py
+++ b/gateway/transports/buzz/inbound_handler.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import AbstractContextManager, nullcontext
 
 from config.constants.gateway import TURN_ERROR_MESSAGE, TURN_TIMEOUT_MESSAGE, USER_STOP_MESSAGE
 from config.scope_context import bound_storage_scope
@@ -39,11 +41,18 @@ async def handle_polled_inbound_buzz_message(
     approvals: ApprovalBroker,
     pending_approvals: PendingApprovals,
     active_cancels: ActiveTurnRegistry,
+    turn_cancel: threading.Event | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
     on_handled: Callable[[], None] | None = None,
 ) -> None:
     """Process one long-polled inbound Buzz mention/reply.
+
+    *turn_cancel* is the cancel Event the dispatcher registered in
+    *active_cancels* before scheduling this turn, so a ``/stop`` that lands
+    while the turn is still queued behind the conversation lock is honored
+    here without invoking the agent. Callers that pass ``None`` (direct
+    invocations) get a turn-local Event tracked for the turn's duration.
 
     *on_handled* fires on the executor thread the moment the turn body
     returns, not when the awaiting coroutine resumes. Shutdown cancels the
@@ -111,7 +120,7 @@ async def handle_polled_inbound_buzz_message(
         )
 
         event_loop = loop or asyncio.get_running_loop()
-        terminal = TerminalOutcomeArbiter()
+        terminal = TerminalOutcomeArbiter(cancel_event=turn_cancel)
         sink.turn_cancel = terminal.cancel_event
 
         def _on_turn_timeout() -> None:
@@ -154,13 +163,29 @@ async def handle_polled_inbound_buzz_message(
                 if on_handled is not None:
                     on_handled()
 
+        if turn_cancel is None:
+            registration: AbstractContextManager[None] = active_cancels.track(
+                key,
+                terminal.cancel_event,
+                on_user_stop=_on_user_stop,
+            )
+        else:
+            active_cancels.bind_user_stop(key, turn_cancel, _on_user_stop)
+            registration = nullcontext()
+
+        if terminal.cancel_event.is_set():
+            if terminal.claim():
+                try:
+                    sink.finalize(USER_STOP_MESSAGE)
+                except Exception:
+                    logger.debug("[buzz-gateway] user-stop finalize failed", exc_info=True)
+            if on_handled is not None:
+                on_handled()
+            return
+
         with terminal.timeout_after(settings.turn_timeout_seconds, _on_turn_timeout):
             try:
-                with active_cancels.track(
-                    key,
-                    terminal.cancel_event,
-                    on_user_stop=_on_user_stop,
-                ):
+                with registration:
                     await event_loop.run_in_executor(executor, _run_turn)
             except Exception:
                 logger.exception(

--- a/gateway/transports/buzz/inbound_handler.py
+++ b/gateway/transports/buzz/inbound_handler.py
@@ -7,8 +7,11 @@ import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 
+from config.constants.gateway import TURN_ERROR_MESSAGE, TURN_TIMEOUT_MESSAGE, USER_STOP_MESSAGE
 from config.scope_context import bound_storage_scope
+from gateway.core.middleware.active_turns import ActiveTurnRegistry
 from gateway.core.middleware.approvals import ApprovalBroker, approval_tool_hooks
+from gateway.core.middleware.terminal_outcome import TerminalOutcomeArbiter
 from gateway.core.storage import SessionResolver
 from gateway.core.transport_api import GatewayAgentCallback
 from gateway.transports.buzz.approvals import BuzzApprovalPrompter
@@ -35,6 +38,7 @@ async def handle_polled_inbound_buzz_message(
     turn_semaphore: asyncio.Semaphore,
     approvals: ApprovalBroker,
     pending_approvals: PendingApprovals,
+    active_cancels: ActiveTurnRegistry,
     loop: asyncio.AbstractEventLoop | None = None,
     handle_callback_to_gateway_agent: GatewayAgentCallback,
     on_handled: Callable[[], None] | None = None,
@@ -107,6 +111,28 @@ async def handle_polled_inbound_buzz_message(
         )
 
         event_loop = loop or asyncio.get_running_loop()
+        terminal = TerminalOutcomeArbiter()
+        sink.turn_cancel = terminal.cancel_event
+
+        def _on_turn_timeout() -> None:
+            logger.warning(
+                "[buzz-gateway] turn TIMED OUT after %.0fs channel=%s session=%s",
+                settings.turn_timeout_seconds,
+                event.channel_id,
+                session.session_id[:8],
+            )
+            try:
+                sink.finalize(TURN_TIMEOUT_MESSAGE)
+            except Exception:
+                logger.debug("[buzz-gateway] timeout finalize failed", exc_info=True)
+
+        def _on_user_stop() -> None:
+            if not terminal.claim():
+                return
+            try:
+                sink.finalize(USER_STOP_MESSAGE)
+            except Exception:
+                logger.debug("[buzz-gateway] user-stop finalize failed", exc_info=True)
 
         def _run_turn() -> None:
             try:
@@ -128,7 +154,32 @@ async def handle_polled_inbound_buzz_message(
                 if on_handled is not None:
                     on_handled()
 
-        await event_loop.run_in_executor(executor, _run_turn)
+        with terminal.timeout_after(settings.turn_timeout_seconds, _on_turn_timeout):
+            try:
+                with active_cancels.track(
+                    key,
+                    terminal.cancel_event,
+                    on_user_stop=_on_user_stop,
+                ):
+                    await event_loop.run_in_executor(executor, _run_turn)
+            except Exception:
+                logger.exception(
+                    "[buzz-gateway] turn ERRORED channel=%s session=%s",
+                    event.channel_id,
+                    session.session_id[:8],
+                )
+                if terminal.claim():
+                    try:
+                        sink.render_error(TURN_ERROR_MESSAGE)
+                    except Exception:
+                        logger.debug("[buzz-gateway] error finalize failed", exc_info=True)
+                raise
+        if terminal.claim():
+            logger.info(
+                "[buzz-gateway] turn done channel=%s session=%s",
+                event.channel_id,
+                session.session_id[:8],
+            )
 
 
 __all__ = ["handle_polled_inbound_buzz_message"]

--- a/gateway/transports/buzz/runtime.py
+++ b/gateway/transports/buzz/runtime.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 
+from gateway.core.middleware.active_turns import ActiveTurnRegistry
 from gateway.core.middleware.approvals import ApprovalBroker
 from gateway.core.storage import SessionResolver
 from gateway.core.storage.session.binding_store import BindingStore, open_binding_store
@@ -34,6 +35,8 @@ class BuzzPollingRuntime:
     # Recognizes a reply to a pending approval prompt so the poll loop can
     # resolve it instead of starting a new turn.
     pending_approvals: PendingApprovals = field(default_factory=PendingApprovals)
+    # `/stop` finds the running turn's cancel event by conversation key.
+    active_cancels: ActiveTurnRegistry = field(default_factory=ActiveTurnRegistry)
 
 
 InitializeBuzzPollingRuntime = Callable[[GatewaySettings], BuzzPollingRuntime]

--- a/gateway/transports/buzz/settings.py
+++ b/gateway/transports/buzz/settings.py
@@ -35,6 +35,7 @@ class GatewaySettings(StrictConfigModel):
     # so turns return promptly, and anything slower is re-delivered next start
     # rather than waited on.
     shutdown_drain_seconds: float = Field(default=5.0, gt=0)
+    turn_timeout_seconds: float = Field(default=240.0, gt=0)
     auto_start_enabled: bool = True
 
 
@@ -55,6 +56,7 @@ class BuzzGatewayEnv(BaseSettings):
     gateway_poll_interval_seconds: float = Field(default=15.0, gt=0)
     gateway_max_concurrent: int = Field(default=4, ge=1)
     gateway_stream_edit_interval_seconds: float = Field(default=1.5, gt=0)
+    gateway_turn_timeout_seconds: float = Field(default=240.0, gt=0)
     gateway_auto_start: bool = True
 
     @field_validator("allowed_pubkeys", mode="before")
@@ -155,6 +157,7 @@ def load_gateway_settings() -> GatewaySettings:
             allowed_pubkeys=choose_allowed_pubkeys(env, credentials),
             poll_interval_seconds=env.gateway_poll_interval_seconds,
             stream_edit_interval_seconds=env.gateway_stream_edit_interval_seconds,
+            turn_timeout_seconds=env.gateway_turn_timeout_seconds,
             max_concurrent_turns=env.gateway_max_concurrent,
             auto_start_enabled=env.gateway_auto_start,
         )

--- a/surfaces/interactive_shell/command_registry/session_cmds/goal.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/goal.py
@@ -34,11 +34,40 @@ from platform.common.evidence_compaction import truncate_message
 from platform.terminal.theme import DIM, ERROR, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session
 
-_GOAL_SUBCOMMANDS = frozenset(
-    {"show", "status", "set", "clear", "unset", "pause", "resume", "edit"}
+_USAGE = "/goal [show|set|pause|resume|edit|clear|help]  or  /goal <condition>"
+# A condition is plain prose describing the state to reach or the request to
+# finish; flags come before it. First entry doubles as the empty-state example.
+_SET_EXAMPLES: tuple[str, ...] = (
+    "/goal set gateway p95 latency back under 500ms",
+    "/goal set find out why checkout returns 502s and post the root cause",
+    "/goal set --max-turns 10 fix the failing morning-report delivery to Slack",
 )
-_USAGE = "/goal [show|set|pause|resume|edit|clear]  or  /goal <condition>"
+_EDIT_EXAMPLE = "/goal edit also confirm the fix reached prod-eu-42"
+
+# One example per subcommand, shown on the generic usage path.
+_COMMAND_EXAMPLES: tuple[tuple[str, str], ...] = (
+    ("/goal", "show the active goal and its progress"),
+    (_SET_EXAMPLES[0], "start working toward a condition"),
+    ("/goal pause", "hold the goal without losing it"),
+    ("/goal resume", "continue a paused goal"),
+    (_EDIT_EXAMPLE, "replace the condition, keep progress"),
+    ("/goal clear", "drop the goal"),
+)
 _HELP_FOOTER = "/goal · pause · resume · edit · clear"
+
+
+def _print_set_usage(console: Console) -> None:
+    console.print(f"[{ERROR}]usage:[/] /goal set [--max-turns N] <condition>")
+    console.print(f"[{DIM}]examples:[/]")
+    for example in _SET_EXAMPLES:
+        console.print(f"  [{HIGHLIGHT}]{example}[/]")
+
+
+def _print_goal_usage(console: Console) -> None:
+    console.print(f"[{ERROR}]usage:[/] {_USAGE}")
+    console.print(f"[{DIM}]examples:[/]")
+    for example, what in _COMMAND_EXAMPLES:
+        console.print(f"  [{HIGHLIGHT}]{example}[/] [{DIM}]— {what}[/]")
 
 
 def _persist_goal_state(session: Session) -> None:
@@ -55,7 +84,8 @@ def _show(session: Session, console: Console) -> bool:
     goal = getattr(session, "session_goal", None)
     if not isinstance(goal, SessionGoal) or not session_goal_is_attached(session):
         console.print(
-            f"[{DIM}]no active goal.[/] Set one with [{HIGHLIGHT}]/goal set <condition>[/]."
+            f"[{DIM}]no active goal.[/] Set one with [{HIGHLIGHT}]/goal set <condition>[/] "
+            f"[{DIM}]— e.g.[/] [{HIGHLIGHT}]{_SET_EXAMPLES[0]}[/]"
         )
         return True
     console.print(format_session_goal_progress(goal, session=session), markup=False)
@@ -71,14 +101,14 @@ def _set(session: Session, console: Console, args: list[str]) -> bool:
             try:
                 max_turns = max(1, int(rest.pop(0)))
             except ValueError:
-                console.print(f"[{ERROR}]usage:[/] /goal set [--max-turns N] <condition>")
+                _print_set_usage(console)
                 return True
         else:
             console.print(f"[{ERROR}]unknown flag:[/] {_rich_escape(flag)}")
             return True
     condition = " ".join(rest).strip()
     if not condition:
-        console.print(f"[{ERROR}]usage:[/] /goal set [--max-turns N] <condition>")
+        _print_set_usage(console)
         return True
     goal = SessionGoal(
         condition=condition,
@@ -159,6 +189,7 @@ def _edit(session: Session, console: Console, args: list[str]) -> bool:
     condition = " ".join(args).strip()
     if not condition:
         console.print(f"[{ERROR}]usage:[/] /goal edit <condition>")
+        console.print(f"[{DIM}]e.g.[/] [{HIGHLIGHT}]{_EDIT_EXAMPLE}[/]")
         return True
     condition = truncate_message(condition, MAX_GOAL_CONDITION_CHARS)
     edited = replace(goal, condition=condition)
@@ -204,8 +235,8 @@ def _cmd_goal(session: Session, console: Console, args: list[str]) -> bool:
         return _edit(session, console, args[1:])
     if sub in {"clear", "unset"}:
         return _clear(session, console)
+    if sub == "help":
+        _print_goal_usage(console)
+        return True
     # ``/goal <condition>`` is sugar for ``/goal set <condition>``.
-    if sub not in _GOAL_SUBCOMMANDS:
-        return _set(session, console, args)
-    console.print(f"[{ERROR}]usage:[/] {_USAGE}")
-    return True
+    return _set(session, console, args)

--- a/surfaces/interactive_shell/command_registry/session_cmds/goal.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/goal.py
@@ -64,7 +64,7 @@ def _print_set_usage(console: Console) -> None:
 
 
 def _print_goal_usage(console: Console) -> None:
-    console.print(f"[{ERROR}]usage:[/] {_USAGE}")
+    console.print(f"[{ERROR}]usage:[/] {_rich_escape(_USAGE)}")
     console.print(f"[{DIM}]examples:[/]")
     for example, what in _COMMAND_EXAMPLES:
         console.print(f"  [{HIGHLIGHT}]{example}[/] [{DIM}]— {what}[/]")


### PR DESCRIPTION
Buzz was born as a copy of Telegram minus two behaviors the transport conformance ledger (#5004) records as known gaps: a hung turn hung its conversation forever, and nothing could stop a running turn. This PR closes both; only `credit metering` remains in the buzz ledger entry.

- Soft turn timeout: `turn_timeout_seconds` (default 240s, same as the other  chat transports, env `GATEWAY_TURN_TIMEOUT_SECONDS`). On expiry the  placeholder is finalized with the shared timeout message and  `sink.turn_cancel` is set for cooperative cancellation.
- `/stop` handling: the poll loop consumes `/stop` before dispatch — it cancels  the active turn for that conversation via the runtime's new  `ActiveTurnRegistry`, answers "nothing to stop" when idle, and never starts  an agent turn for a cancellation.
- One terminal outcome per turn: timeout, user stop, error, and normal  completion arbitrate through `TerminalOutcomeArbiter.claim()`.