### PR TITLE
refactor(harness): gateway reaches the agent harness only through its curated public surface

### DIFF
--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -16,6 +16,7 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
     from core.agent_harness.harness import (
         AgentSession,
         ChatDispatcher,
@@ -23,14 +24,25 @@ if TYPE_CHECKING:
         SessionStartupResult,
     )
     from core.agent_harness.investigation_api import InvestigationResult
+    from core.agent_harness.ports import OutputSink
     from core.agent_harness.prompts.grounding import DefaultPromptContextProvider
+    from core.agent_harness.session import SessionCore, SessionManager
+    from core.agent_harness.session.integration_resolution import has_resolved_integrations
+    from core.agent_harness.session_goal.goal import SessionGoal
+    from core.agent_harness.session_goal.progress import (
+        format_session_goal_progress,
+        format_session_goal_status_line,
+    )
+    from core.agent_harness.session_goal.run_until import run_until_session_goal
     from core.agent_harness.turns.action_driver import ActionTurnRunner, ToolCallingDeps
     from core.agent_harness.turns.chat_api import ChatTurnBindings, dispatch_chat_turn
     from core.agent_harness.turns.default_headless_agent import build_default_headless_agent
     from core.agent_harness.turns.evidence_driver import gather_tool_evidence
     from core.agent_harness.turns.evidence_driver import gather_tool_evidence as gather_evidence
+    from core.agent_harness.turns.gather_ports import GatherPorts
     from core.agent_harness.turns.headless_adapters import BufferOutputSink
     from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+    from core.agent_harness.turns.host_cancel import ensure_turn_cancel
     from core.agent_harness.turns.orchestrator import run_turn, stream_answer
     from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
     from core.agent_harness.turns.turn_snapshot import (
@@ -78,6 +90,33 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "stream_answer": ("core.agent_harness.turns.orchestrator", "stream_answer"),
     "ChatTurnBindings": ("core.agent_harness.turns.chat_api", "ChatTurnBindings"),
     "dispatch_chat_turn": ("core.agent_harness.turns.chat_api", "dispatch_chat_turn"),
+    # Host-facing session and goal surface (gateway and embedders).
+    "SessionCore": ("core.agent_harness.session", "SessionCore"),
+    "SessionManager": ("core.agent_harness.session", "SessionManager"),
+    "has_resolved_integrations": (
+        "core.agent_harness.session.integration_resolution",
+        "has_resolved_integrations",
+    ),
+    "SessionGoal": ("core.agent_harness.session_goal.goal", "SessionGoal"),
+    "run_until_session_goal": (
+        "core.agent_harness.session_goal.run_until",
+        "run_until_session_goal",
+    ),
+    "format_session_goal_progress": (
+        "core.agent_harness.session_goal.progress",
+        "format_session_goal_progress",
+    ),
+    "format_session_goal_status_line": (
+        "core.agent_harness.session_goal.progress",
+        "format_session_goal_status_line",
+    ),
+    "DefaultTurnAccounting": (
+        "core.agent_harness.accounting.turn_accounting",
+        "DefaultTurnAccounting",
+    ),
+    "GatherPorts": ("core.agent_harness.turns.gather_ports", "GatherPorts"),
+    "ensure_turn_cancel": ("core.agent_harness.turns.host_cancel", "ensure_turn_cancel"),
+    "OutputSink": ("core.agent_harness.ports", "OutputSink"),
 }
 
 
@@ -101,9 +140,15 @@ __all__ = [
     "ChatDispatcher",
     "ChatTurnBindings",
     "DefaultPromptContextProvider",
+    "DefaultTurnAccounting",
+    "GatherPorts",
     "HeadlessAgent",
     "InvestigationResult",
+    "OutputSink",
     "SessionConfig",
+    "SessionCore",
+    "SessionGoal",
+    "SessionManager",
     "SessionStartupResult",
     "ToolCallingDeps",
     "ToolCallingTurnResult",
@@ -112,8 +157,13 @@ __all__ = [
     "TurnSnapshotSource",
     "build_default_headless_agent",
     "dispatch_chat_turn",
+    "ensure_turn_cancel",
+    "format_session_goal_progress",
+    "format_session_goal_status_line",
     "gather_evidence",
     "gather_tool_evidence",
+    "has_resolved_integrations",
     "run_turn",
+    "run_until_session_goal",
     "stream_answer",
 ]

--- a/gateway/core/middleware/inbound_decision.py
+++ b/gateway/core/middleware/inbound_decision.py
@@ -24,7 +24,7 @@ from typing import Protocol
 
 from config.constants.gateway import NEW_SESSION_MESSAGE, ROTATE_SESSION
 from config.principal import StorageScope
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 from gateway.core.middleware.identity_policy import (
     persist_policy_if_needed,
 )

--- a/gateway/core/runtime/cancel_console.py
+++ b/gateway/core/runtime/cancel_console.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness.turns.host_cancel import ensure_turn_cancel
+from core.agent_harness import ensure_turn_cancel
 
 # Set on the wrapper itself; everything else is proxied to the wrapped console.
 _OWN_ATTRIBUTES = frozenset({"_output", "_cancel_event"})

--- a/gateway/core/runtime/session_agents.py
+++ b/gateway/core/runtime/session_agents.py
@@ -16,10 +16,7 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness.session import SessionCore
-from core.agent_harness.turns.default_headless_agent import build_default_headless_agent
-from core.agent_harness.turns.gather_ports import GatherPorts
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness import GatherPorts, HeadlessAgent, SessionCore, build_default_headless_agent
 from gateway.core.runtime.live_sink import LiveOutputSink
 from gateway.core.runtime.status_messages import status_from_tool_start
 from gateway.core.transport_api import GatewaySink

--- a/gateway/core/runtime/turn_handler.py
+++ b/gateway/core/runtime/turn_handler.py
@@ -20,15 +20,17 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
-from core.agent_harness.harness import AgentSession, SessionConfig
-from core.agent_harness.session import SessionCore, SessionManager
-from core.agent_harness.session_goal.goal import SessionGoal
-from core.agent_harness.session_goal.progress import (
+from core.agent_harness import (
+    AgentSession,
+    DefaultTurnAccounting,
+    SessionConfig,
+    SessionCore,
+    SessionGoal,
+    SessionManager,
     format_session_goal_progress,
     format_session_goal_status_line,
+    run_until_session_goal,
 )
-from core.agent_harness.session_goal.run_until import run_until_session_goal
 from gateway.core.runtime.cancel_console import CancelConsole, ensure_turn_cancel
 from gateway.core.runtime.capability_policy import ensure_gateway_capability_policy
 from gateway.core.runtime.concurrency import TurnConcurrencyGate

--- a/gateway/core/session/thread_history.py
+++ b/gateway/core/session/thread_history.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 
 _MESSAGE_ROLES = frozenset({"user", "assistant"})
 

--- a/gateway/core/storage/session/resolver.py
+++ b/gateway/core/storage/session/resolver.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from core.agent_harness.session import SessionCore, SessionManager
-from core.agent_harness.session.integration_resolution import has_resolved_integrations
+from core.agent_harness import SessionCore, SessionManager, has_resolved_integrations
 from gateway.core.runtime.capability_policy import ensure_gateway_capability_policy
 from gateway.core.session.gateway_chat_context import inject_gateway_chat_context
 

--- a/gateway/core/transport_api/__init__.py
+++ b/gateway/core/transport_api/__init__.py
@@ -27,8 +27,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Protocol, runtime_checkable
 
-from core.agent_harness.ports import OutputSink
-from core.agent_harness.session import SessionCore
+from core.agent_harness import OutputSink, SessionCore
 
 
 class TransportName(StrEnum):

--- a/gateway/tests/test_harness_api_border.py
+++ b/gateway/tests/test_harness_api_border.py
@@ -1,0 +1,41 @@
+"""Gateway reaches the agent harness only through its curated public surface.
+
+``core.agent_harness.__init__`` is the harness's host API — a curated, lazily
+resolved export table that AGENTS.md calls "the package's public surface".
+Gateway code had grown imports of eleven internal submodules
+(``turns.host_cancel``, ``session_goal.run_until``, ``accounting…``), so any
+harness-internal rename broke the gateway. One import path makes the coupling
+surface explicit and reviewable: widening it means editing the harness's own
+export table, not quietly reaching deeper.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SUBMODULE_IMPORT = re.compile(r"^\s*(?:from|import)\s+core\.agent_harness\.[a-z_.]+", re.MULTILINE)
+
+
+def _gateway_sources() -> list[Path]:
+    return [
+        path
+        for path in sorted((REPO_ROOT / "gateway").rglob("*.py"))
+        if "__pycache__" not in path.parts and "tests" not in path.parts
+    ]
+
+
+def test_gateway_imports_the_harness_only_through_its_public_surface() -> None:
+    offenders: dict[str, list[str]] = {}
+    for path in _gateway_sources():
+        hits = _SUBMODULE_IMPORT.findall(path.read_text(encoding="utf-8"))
+        if hits:
+            offenders[str(path.relative_to(REPO_ROOT))] = [h.strip() for h in hits]
+
+    assert offenders == {}, (
+        "gateway imports agent-harness internals; import the name from "
+        "core.agent_harness instead (add it to the curated export table in "
+        f"core/agent_harness/__init__.py if it is genuinely host-facing): {offenders}"
+    )

--- a/gateway/tests/test_harness_api_border.py
+++ b/gateway/tests/test_harness_api_border.py
@@ -7,16 +7,22 @@ Gateway code had grown imports of eleven internal submodules
 harness-internal rename broke the gateway. One import path makes the coupling
 surface explicit and reviewable: widening it means editing the harness's own
 export table, not quietly reaching deeper.
+
+Scanned as AST, not text: regexes miss line-continuation imports, unusual
+module-name characters, and dynamic ``importlib.import_module(...)`` calls.
 """
 
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-_SUBMODULE_IMPORT = re.compile(r"^\s*(?:from|import)\s+core\.agent_harness\.[a-z_.]+", re.MULTILINE)
+_FORBIDDEN_PREFIX = "core.agent_harness."
+
+#: Callables whose string argument names a module to import at runtime.
+_DYNAMIC_IMPORTERS = frozenset({"import_module", "__import__"})
 
 
 def _gateway_sources() -> list[Path]:
@@ -27,12 +33,46 @@ def _gateway_sources() -> list[Path]:
     ]
 
 
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def _submodule_imports(tree: ast.AST) -> list[str]:
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            hits.extend(
+                f"import {alias.name}"
+                for alias in node.names
+                if alias.name.startswith(_FORBIDDEN_PREFIX)
+            )
+        elif isinstance(node, ast.ImportFrom):
+            # ``level`` > 0 is a relative import and cannot name the harness.
+            if node.level == 0 and (node.module or "").startswith(_FORBIDDEN_PREFIX):
+                hits.append(f"from {node.module} import …")
+        elif isinstance(node, ast.Call) and _call_name(node) in _DYNAMIC_IMPORTERS:
+            for arg in node.args[:1]:
+                if (
+                    isinstance(arg, ast.Constant)
+                    and isinstance(arg.value, str)
+                    and arg.value.startswith(_FORBIDDEN_PREFIX)
+                ):
+                    hits.append(f"import_module({arg.value!r})")
+    return hits
+
+
 def test_gateway_imports_the_harness_only_through_its_public_surface() -> None:
     offenders: dict[str, list[str]] = {}
     for path in _gateway_sources():
-        hits = _SUBMODULE_IMPORT.findall(path.read_text(encoding="utf-8"))
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        hits = _submodule_imports(tree)
         if hits:
-            offenders[str(path.relative_to(REPO_ROOT))] = [h.strip() for h in hits]
+            offenders[str(path.relative_to(REPO_ROOT))] = hits
 
     assert offenders == {}, (
         "gateway imports agent-harness internals; import the name from "

--- a/gateway/transports/buzz/session_rotation.py
+++ b/gateway/transports/buzz/session_rotation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from config.principal import StorageScope
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 from gateway.core.middleware.inbound_decision import apply_inbound_decision
 from gateway.core.storage import SessionResolver
 from gateway.transports.buzz.inbound_security import InboundDecision

--- a/gateway/transports/discord/dispatcher.py
+++ b/gateway/transports/discord/dispatcher.py
@@ -17,7 +17,7 @@ from config.constants.gateway import (
 )
 from config.principal import StorageScope
 from config.scope_context import bound_storage_scope
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 from gateway.core.billing.credits_client import CreditsOutcome, consume_credits
 from gateway.core.middleware.active_turns import ActiveTurnRegistry, is_stop_command
 from gateway.core.middleware.approvals import ApprovalBroker, approval_tool_hooks

--- a/gateway/transports/discord/thread_history.py
+++ b/gateway/transports/discord/thread_history.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 from gateway.core.session import seed_session_history
 
 logger = logging.getLogger(__name__)

--- a/gateway/transports/slack/processing/dispatcher.py
+++ b/gateway/transports/slack/processing/dispatcher.py
@@ -16,7 +16,7 @@ from config.constants.gateway import (
 )
 from config.principal import StorageScope
 from config.scope_context import bound_storage_scope
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 from gateway.core.billing.credits_client import CreditsOutcome, consume_credits
 from gateway.core.middleware.active_turns import ActiveTurnRegistry, is_stop_command
 from gateway.core.middleware.approvals import ApprovalBroker, approval_tool_hooks

--- a/gateway/transports/slack/processing/thread_history.py
+++ b/gateway/transports/slack/processing/thread_history.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import re
 
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 from gateway.core.session import seed_session_history
 from integrations.slack.web_client import (
     fetch_channel_messages,

--- a/gateway/transports/telegram/session_rotation.py
+++ b/gateway/transports/telegram/session_rotation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from config.principal import StorageScope
-from core.agent_harness.session import SessionCore
+from core.agent_harness import SessionCore
 from gateway.core.middleware.inbound_decision import apply_inbound_decision
 from gateway.core.storage import SessionResolver
 from gateway.transports.telegram.inbound_security import InboundDecision


### PR DESCRIPTION
Problem. 

The gateway imported eleven internal harness submodules — turns.host_cancel, turns.headless_dispatch, turns.gather_ports, turns.default_headless_agent, session_goal.{goal,progress,run_until}, accounting.turn_accounting, session.integration_resolution, harness, ports. The harness already has a public host API — the curated, lazily-resolved export table in core/agent_harness/__init__.py, which its own AGENTS.md calls "the package's public surface" — but nothing stopped a host from reaching past it, so the gateway grew around it and any harness-internal rename broke the gateway at a distance.

Change.

The curated table now covers what a host genuinely needs — 11 names added (33 total): SessionCore, SessionManager, SessionGoal, run_until_session_goal, format_session_goal_progress, format_session_goal_status_line, DefaultTurnAccounting, GatherPorts, ensure_turn_cancel, OutputSink, has_resolved_integrations. All lazy (PEP 562), so importing the root stays cheap and interactive-shell boot doesn't drag the turn-driver stack — the property that table exists to protect.
Thirteen gateway files migrated to the single import shape from core.agent_harness import … — the four deep-coupled runtime files (turn_handler, session_agents, live_sink's neighbours, cancel_console), transport_api, the resolver, middleware, and all four transports. Zero core.agent_harness.<submodule> references remain in gateway source.
The border is enforced, not documented: gateway/tests/test_harness_api_border.py scans gateway sources and names any submodule import. Written red-first — it failed with the full eleven-module inventory before the migration. Widening the coupling now requires editing the harness's own export table, a visible reviewable act, instead of a quiet deeper import.

This is the mirror image of #5004: that PR gave transports a contract on the gateway side of the bridge (transport_api); this one gives the gateway a contract on the harness side. Both directions of gateway↔harness are now tested boundaries.