### PR TITLE
refactor: surfaces harness-import ledger + gateway manager.py renamed to controller.py

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -26,8 +26,8 @@ forbidden_modules =
 ignore_imports =
     # Composition root: the one edge into the channels composer, which owns all
     # transport and web wiring. Pinned by gateway/tests/test_package_borders.py
-    # (test_only_manager_imports_channels_module).
-    gateway.core.runtime.manager -> gateway.channels
+    # (test_only_controller_imports_the_startup_module).
+    gateway.core.runtime.controller -> gateway.startup
 
 [importlinter:contract:gateway-web-no-transports]
 name = Gateway web surface never imports chat transports

--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -41,7 +41,7 @@ ignore_imports =
     platform.scheduler.executor -> integrations.telegram.formatting
     # surfaces -> gateway (cli + repl gateway commands)
     surfaces.cli.commands.gateway -> gateway.core.runtime.daemon
-    surfaces.cli.gateway_entry -> gateway.core.runtime.manager
+    surfaces.cli.gateway_entry -> gateway.core.runtime.controller
     surfaces.interactive_shell.command_registry.gateway_cmds -> gateway.core.runtime.daemon
     surfaces.interactive_shell.controller -> gateway.web.web_server
     # tools -> integrations (T-4 debt — vendor tools / reporting)

--- a/bootstrap/process.py
+++ b/bootstrap/process.py
@@ -5,7 +5,7 @@ ordered table rather than a branch per step, so adding a step is a table entry
 and a profile cannot invent a different sequence.
 
 Does **not** configure gateway or CLI logging — that stays with the surface
-composition root (``GatewayManager.configure_logging``, CLI stderr).
+composition root (``GatewayController.configure_logging``, CLI stderr).
 
 Does **not** construct :class:`~core.agent_harness.turns.headless_dispatch.HeadlessAgent`
 or run turns — that is ``build_default_headless_agent`` /
@@ -100,7 +100,7 @@ SCHEDULER_WORKER_PROFILE: Final = ProcessProfile(
     # Dedicated blocking scheduler process (`opensre cron start`). Owns its
     # Sentry entrypoint and installs runners at boot. Gateway co-hosts the
     # scheduler differently: GATEWAY_PROFILE + late install_scheduler_runners
-    # in GatewayManager.start_scheduler — do not confuse the two.
+    # in GatewayController.start_scheduler — do not confuse the two.
     steps=frozenset(
         {
             BootStep.ENV,

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -199,7 +199,7 @@ to it instead of re-implementing bootstrap + persistence:
   :meth:`SessionManager.for_session`.
 - **gateway** — process boot is
   :func:`bootstrap.process.configure_process` (``GATEWAY_PROFILE``);
-  `GatewayManager` stays lifecycle-only (credentials → process boot →
+  `GatewayController` stays lifecycle-only (credentials → process boot →
   transports). Per-chat session create/resolve stays on
   `gateway/core/storage/session/resolver.py::SessionResolver` →
   `SessionManager`. Turn dispatch uses `HeadlessAgent` via

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -9,7 +9,7 @@ tests tree.
 |------|------|
 | Production entry (slash ports) | CLI: `opensre gateway start` / `--foreground` (composition root outside this package) |
 | Package main | `main.py` — **fails closed** (no slash-port glue; not a production entry) |
-| Composition root / process | `core/runtime/manager.py` (`GatewayManager`; inject `slash_ports_factory`) |
+| Composition root / process | `core/runtime/controller.py` (`GatewayController`; inject `slash_ports_factory`) |
 | Surface startup (web + chat composer) | `startup.py` (`start_gateway` / `StartedGateway`) |
 | Daemon pidfile / status | `core/runtime/daemon.py` |
 | Turn callback | `core/runtime/turn_handler.py` |
@@ -23,11 +23,11 @@ tests tree.
 | Discord start | `transports/discord/startup.py` (`start_discord_worker`) |
 | Buzz start | `transports/buzz/startup.py` (`start_buzz_worker`) |
 
-Bare `python -m gateway` and `manager.main()` / `start_gateway()` without
+Bare `python -m gateway` and `controller.main()` / `start_gateway()` without
 `slash_ports_factory` exit with a clear error. Unit tests may construct
-`GatewayManager(...)` directly (factory optional there).
+`GatewayController(...)` directly (factory optional there).
 
-## Lifecycle (`GatewayManager`)
+## Lifecycle (`GatewayController`)
 
 ```
 start_gateway()
@@ -46,7 +46,7 @@ start_gateway()
   transport. Daemon pidfile/status stays in `core/runtime/daemon.py` — do not
   fold the process daemon into a "scheduler" package.
 - `gateway.core` must not import `gateway.transports` / `gateway.web`; only
-  `manager.py` imports `gateway.startup`.
+  `controller.py` imports `gateway.startup`.
 - Peer transports and `web` must not import `gateway.startup`.
 
 ## Layout
@@ -56,7 +56,7 @@ Packages are split like `core/agent_harness/prompts/`: **core infra** vs
 
 - `core/` — process and leaf infrastructure (`runtime`, `storage`,
   `billing`, `attachments`, `session`, `config`). No imports from transports
-  or `web`. Only `core/runtime/manager.py` imports `gateway.startup`.
+  or `web`. Only `core/runtime/controller.py` imports `gateway.startup`.
 - `startup.py` — starts/stops web + chat transports as one consumer set.
   Imports `web/` and each peer's `startup` only.
 - `transports/` — chat peers (`slack`, `discord`, `telegram`). Each owns
@@ -71,7 +71,7 @@ Packages are split like `core/agent_harness/prompts/`: **core infra** vs
 ### Dependency rule (acyclic)
 
 ```
-core.manager  →  startup.py  →  transports.{telegram,slack,discord,buzz}.startup
+core.controller  →  startup.py  →  transports.{telegram,slack,discord,buzz}.startup
                            →  web
 peer transports · web  →  core leaves
 (peers never import each other, `gateway.startup`, or each other's packages)
@@ -87,7 +87,7 @@ flat by surface (do not nest a directory named after the Discord PyPI package).
   resolve session, build sink, then call the shared callback. Do not add a
   second production turn-handler class next to `GatewayTurnHandler`.
 - **Logging** is configured once at the gateway process level
-  (`configure_logging` in `GatewayManager.start_gateway`) — that is intentional.
+  (`configure_logging` in `GatewayController.start_gateway`) — that is intentional.
 - **No persistent gateway `Agent` instance.** Each inbound message gets a
   per-chat `Session` from `SessionResolver` and is handled by the shared
   headless dispatch path (`core.agent_harness.turns.headless_dispatch`).
@@ -99,7 +99,7 @@ flat by surface (do not nest a directory named after the Discord PyPI package).
   Do **not** precompute tools at process start; chat sessions carry their own
   integration context after `SessionResolver.resolve`.
 - Per-chat session lifecycle (create / resolve / rotate / restore) is owned by
-  `SessionResolver` → `SessionManager`, not by `GatewayManager`.
+  `SessionResolver` → `SessionManager`, not by `GatewayController`.
 
 ## Tenancy (principal / actor)
 
@@ -137,8 +137,8 @@ POST /investigate ──► try_acquire (busy → 503) ──► same gate
 InvestigationWorker ──► blocking acquire (already claimed) ──► same gate
 ```
 
-- Production chat capacity is on `GatewayTurnHandler(gate=manager.turn_gate)`.
-- `GatewayManager` and Path-2 share :func:`~gateway.core.runtime.concurrency.process_turn_gate`.
+- Production chat capacity is on `GatewayTurnHandler(gate=controller.turn_gate)`.
+- `GatewayController` and Path-2 share :func:`~gateway.core.runtime.concurrency.process_turn_gate`.
 - `ConcurrencyLimitedTurnHandler` is tests-only. Do not reintroduce it under
   `gateway/core/` — production uses `gate=` on `GatewayTurnHandler` only.
 - **Chat + Path-2:** HTTP `/investigate` busy-drops like chat; the investigation

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -13,10 +13,10 @@ transport-specific code.
 |---------------|---------------|-------------------|
 | **Production entry** | CLI composition root (outside `gateway/`) | `opensre gateway start` / `--foreground` (wires slash ports) |
 | **Package main** | `gateway/__main__.py` → `main()` | Fails closed — no slash-port glue |
-| **Composition root (impl)** | `gateway/core/runtime/manager.py` → `GatewayManager` | Injected `slash_ports_factory` from CLI; bare `manager.main` fails closed |
+| **Composition root (impl)** | `gateway/core/runtime/controller.py` → `GatewayController` | Injected `slash_ports_factory` from CLI; bare `controller.main` fails closed |
 | **Background daemon helpers** | `gateway/core/runtime/daemon.py` | Used by CLI `gateway start/stop/status` (pidfile + `components.json`) |
 | **Web surface (web-only task)** | `gateway/web/webapp.py` → `app` | `uvicorn gateway.web.webapp:app` (`MODE=web` in Docker) |
-| **Surface startup** | `gateway/startup.py` → `start_gateway` / `StartedGateway` | Called by `GatewayManager.start_surfaces` |
+| **Surface startup** | `gateway/startup.py` → `start_gateway` / `StartedGateway` | Called by `GatewayController.start_surfaces` |
 | **Chat transport registry** | `gateway/startup.py` → `TRANSPORTS` / `start_transports` | Used by `start_gateway` |
 | **Telegram transport** | `gateway/transports/telegram/startup.py` → `start_telegram_worker` | Via the startup registry |
 | **Slack transport** | `gateway/transports/slack/startup.py` → `start_slack_worker` | Via the startup registry |
@@ -35,7 +35,7 @@ gateway.core.runtime.daemon.start_gateway_daemon
 surfaces/cli/gateway_entry.py  (or Click foreground → same composition root)
         │  wires headless slash ports
         ▼
-gateway.core.runtime.manager.GatewayManager.start_gateway
+gateway.core.runtime.controller.GatewayController.start_gateway
         ├── start_surfaces()  →  gateway.startup.start_gateway
         │     ├── web/web_server  →  web/webapp:app
         │     └── startup.start_transports
@@ -139,8 +139,8 @@ with the same five pieces `gateway/transports/telegram/` and `gateway/transports
 5. **Session binding** via `gateway/core/storage/session/resolver.py` with a new
    `platform` value: map the platform conversation key to a `Session`.
 
-Then wire it in the composition root (`GatewayManager` in
-`gateway/core/runtime/manager.py`) beside the existing transports. Reuse the handler
+Then wire it in the composition root (`GatewayController` in
+`gateway/core/runtime/controller.py`) beside the existing transports. Reuse the handler
 from `GatewayTurnHandler(...)` as-is.
 
 **What you never change:** `GatewayTurnHandler`, `Agent`, prompts, tools.

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -9,9 +9,9 @@ Subpackages:
 
 Entry points:
 
-* Production — ``opensre gateway start`` (CLI wires slash ports into ``GatewayManager``)
+* Production — ``opensre gateway start`` (CLI wires slash ports into ``GatewayController``)
 * Package main — ``python -m gateway`` fails closed (guard in ``__main__.py``)
-* Composition root — :mod:`gateway.core.runtime.manager`
+* Composition root — :mod:`gateway.core.runtime.controller`
 * Daemon helpers — :mod:`gateway.core.runtime.daemon`
 * HTTP app (``MODE=web``) — :mod:`gateway.web.webapp` (``app``)
 * Telegram — :mod:`gateway.transports.telegram.startup`

--- a/gateway/core/AGENTS.md
+++ b/gateway/core/AGENTS.md
@@ -22,7 +22,7 @@ here.
 Shared process setup (env → Sentry → harness adapters → capability warnings →
 LLM preload) lives in
 :func:`bootstrap.process.configure_process` with ``GATEWAY_PROFILE``.
-`GatewayManager.start_gateway` is lifecycle-only after logging + credential
+`GatewayController.start_gateway` is lifecycle-only after logging + credential
 hydrate: configure process, compose **one** `GatewayTurnHandler(gate=…)`, then
 `start_channels()` (delegates to :func:`gateway.channels.start_channels`) and
 `start_scheduler()` (peer of the channels). Do not wrap the turn handler in a

--- a/gateway/core/AGENTS.md
+++ b/gateway/core/AGENTS.md
@@ -2,12 +2,12 @@
 
 Gateway core machinery used by every surface. **Must not** import
 `gateway.transports.*` or `gateway.web` (surfaces). Channel composition lives
-in `gateway.startup`; only `runtime/manager.py` imports that module.
+in `gateway.startup`; only `runtime/controller.py` imports that module.
 Pinned by `gateway/tests/test_package_borders.py`.
 
 | Package | Role |
 |---------|------|
-| `runtime/` | Composition root (`manager`), turn handler, approvals, attention, daemon |
+| `runtime/` | Composition root (`controller`), turn handler, approvals, attention, daemon |
 | `storage/` | Session bindings + investigation stores |
 | `billing/` | Credits client |
 | `attachments/` | Attachment helpers |
@@ -26,7 +26,7 @@ LLM preload) lives in
 hydrate: configure process, compose **one** `GatewayTurnHandler(gate=…)`, then
 `start_channels()` (delegates to :func:`gateway.channels.start_channels`) and
 `start_scheduler()` (peer of the channels). Do not wrap the turn handler in a
-second handler class. Do not reintroduce a bootstrap essay in the manager.
+second handler class. Do not reintroduce a bootstrap essay in the controller.
 Scheduler runners register when the scheduler stage starts
 (:func:`bootstrap.adapters.install_scheduler_runners`).
 

--- a/gateway/core/__init__.py
+++ b/gateway/core/__init__.py
@@ -10,7 +10,7 @@ Subpackages:
 * ``config/`` — logging and gateway config helpers
 
 Must not import ``gateway.transports.*`` or ``gateway.web`` (surfaces).
-Sole exception: :mod:`gateway.core.runtime.manager`, the composition root,
+Sole exception: :mod:`gateway.core.runtime.controller`, the composition root,
 which wires the transports and the web surface together.
 """
 

--- a/gateway/core/runtime/__init__.py
+++ b/gateway/core/runtime/__init__.py
@@ -2,7 +2,7 @@
 
 Composition root: :mod:`gateway.core.runtime.controller` (``GatewayController``).
 Production boot: ``opensre gateway start`` (CLI injects slash ports).
-Package ``python -m gateway`` and bare ``manager.main`` fail closed.
+Package ``python -m gateway`` fails closed.
 Shared contracts: :mod:`gateway.core.transport_api`, :mod:`gateway.core.runtime.errors`.
 """
 

--- a/gateway/core/runtime/__init__.py
+++ b/gateway/core/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Gateway process and turn machinery: lifecycle, dispatch, sink contracts.
 
-Composition root: :mod:`gateway.core.runtime.manager` (``GatewayManager``).
+Composition root: :mod:`gateway.core.runtime.controller` (``GatewayController``).
 Production boot: ``opensre gateway start`` (CLI injects slash ports).
 Package ``python -m gateway`` and bare ``manager.main`` fail closed.
 Shared contracts: :mod:`gateway.core.transport_api`, :mod:`gateway.core.runtime.errors`.

--- a/gateway/core/runtime/concurrency.py
+++ b/gateway/core/runtime/concurrency.py
@@ -70,7 +70,7 @@ class TurnConcurrencyGate:
 def process_turn_gate() -> TurnConcurrencyGate:
     """Return the process-wide gate (lazy from ``OPENSRE_SIZE_PROFILE``).
 
-    :class:`GatewayManager` installs its gate here so chat and Path-2 share one
+    :class:`GatewayController` installs its gate here so chat and Path-2 share one
     semaphore in a full gateway process. Standalone ``WEB_PROFILE`` web creates
     the gate on first investigate/worker use.
     """

--- a/gateway/core/runtime/controller.py
+++ b/gateway/core/runtime/controller.py
@@ -1,6 +1,6 @@
 """Gateway process entrypoint and lifecycle owner.
 
-``GatewayManager`` is the composition root for the OpenSRE background agent:
+``GatewayController`` is the composition root for the OpenSRE background agent:
 logging + credential hydrate, then
 :func:`bootstrap.process.configure_process` (``GATEWAY_PROFILE``), then
 assemble the turn handler and start components —
@@ -54,7 +54,7 @@ SlashPortsFactory = Callable[[], Any]
 CredentialHydratorFactory = Callable[[], GatewayCredentialHydrator | None]
 
 
-class GatewayManager:
+class GatewayController:
     """Composition root and lifecycle handle for the running gateway process."""
 
     def __init__(
@@ -81,7 +81,7 @@ class GatewayManager:
             self.turn_gate = process_turn_gate()
         self._stopped = threading.Event()
 
-    def start_gateway(self, *, wait: bool = True) -> GatewayManager:
+    def start_gateway(self, *, wait: bool = True) -> GatewayController:
         """Credential hydrate, shared process boot, then channels + scheduler."""
         from bootstrap.process import GATEWAY_PROFILE, configure_process
 
@@ -242,10 +242,10 @@ class GatewayManager:
 
 
 _BARE_MANAGER_EXIT = (
-    "GatewayManager requires slash_ports_factory for production chat.\n"
+    "GatewayController requires slash_ports_factory for production chat.\n"
     "Start with: opensre gateway start\n"
     "        or: opensre gateway start --foreground\n"
-    "Unit tests may construct GatewayManager(...) directly.\n"
+    "Unit tests may construct GatewayController(...) directly.\n"
 )
 
 
@@ -253,21 +253,21 @@ def start_gateway(
     *,
     wait: bool = True,
     slash_ports_factory: SlashPortsFactory | None = None,
-) -> GatewayManager:
+) -> GatewayController:
     """Compatibility wrapper — requires ``slash_ports_factory`` (fail closed).
 
     Production boot goes through the CLI composition root
     (``opensre gateway start``), which injects headless slash ports. The
     gateway package must not import the surfaces layer, so bare
-    ``GatewayManager()`` here cannot wire them.
+    ``GatewayController()`` here cannot wire them.
     """
     if slash_ports_factory is None:
         raise SystemExit(_BARE_MANAGER_EXIT)
-    return GatewayManager(slash_ports_factory=slash_ports_factory).start_gateway(wait=wait)
+    return GatewayController(slash_ports_factory=slash_ports_factory).start_gateway(wait=wait)
 
 
 def main() -> None:
-    """Refuse bare manager main — same policy as ``python -m gateway``."""
+    """Refuse bare controller main — same policy as ``python -m gateway``."""
     raise SystemExit(_BARE_MANAGER_EXIT)
 
 

--- a/gateway/core/transport_api/__init__.py
+++ b/gateway/core/transport_api/__init__.py
@@ -2,10 +2,10 @@
 
 In API-framework terms the gateway splits like this:
 
-* ``gateway/transports/<name>/`` — the controllers: platform ingress that
+* ``gateway/transports/<name>/`` — the ingress adapters: platform inbound that
   authorizes, resolves a session, builds a sink, and calls the turn handler.
-* ``gateway/core/middleware/`` — the shared per-turn steps every controller
-  runs (inbound decision, identity policy, approvals, stop/cancel, attention,
+* ``gateway/core/middleware/`` — the shared per-turn steps every ingress
+  adapter runs (inbound decision, identity policy, approvals, stop/cancel, attention,
   conversation locks, terminal outcome).
 * ``gateway/core/runtime/`` — the service layer: the turn handler bridging
   into the agent harness, and process plumbing.

--- a/gateway/startup.py
+++ b/gateway/startup.py
@@ -5,7 +5,7 @@ registry and composes web + chat into a single running handle. Mirrors each
 transport's own ``startup.py`` one level up — those start one platform, this
 starts the gateway.
 
-Only the composition root (:class:`~gateway.core.runtime.manager.GatewayManager`)
+Only the composition root (:class:`~gateway.core.runtime.controller.GatewayController`)
 imports this module. Transports never import it back, and ``gateway.core``
 cannot (core must not depend on transports). The scheduler is not started
 here; the manager starts it as a peer.

--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -16,7 +16,7 @@ ensure_project_platform_package()
 def _isolate_gateway_runtime_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Keep every gateway test off the developer's real ``~/.opensre/gateway``.
 
-    ``GatewayManager.stop()`` clears the component status file, and
+    ``GatewayController.stop()`` clears the component status file, and
     ``start_gateway`` rewrites the pidfile. Both resolve through module globals
     captured at import time, so the root ``OPENSRE_HOME_DIR`` override does not
     reach them: a unit test that merely constructs a manager and stops it

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -26,8 +26,8 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from gateway.core.runtime.controller import GatewayController, start_gateway
 from gateway.core.runtime.errors import GatewayConfigurationError
-from gateway.core.runtime.manager import GatewayManager, start_gateway
 from gateway.startup import TransportName
 from gateway.transports.telegram.inbound_handler import (
     handle_polled_inbound_telegram_message,
@@ -46,8 +46,8 @@ def _patch_non_telegram_components(monkeypatch) -> None:
         "gateway.startup.start_web_server",
         lambda **_kwargs: WebStartup(server=None, status="skipped in lifecycle test"),
     )
-    monkeypatch.setattr(GatewayManager, "start_scheduler", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(GatewayManager, "_publish_status", lambda *_args: None)
+    monkeypatch.setattr(GatewayController, "start_scheduler", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(GatewayController, "_publish_status", lambda *_args: None)
 
     def _skip_transport(**_kwargs: Any) -> None:
         raise GatewayConfigurationError("skipped in lifecycle test")
@@ -93,13 +93,13 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
     background_kwargs: dict[str, Any] = {}
 
     _patch_process_boot(monkeypatch)
-    monkeypatch.setattr("gateway.core.runtime.manager.configure_logging", lambda: logger)
+    monkeypatch.setattr("gateway.core.runtime.controller.configure_logging", lambda: logger)
     _patch_non_telegram_components(monkeypatch)
     monkeypatch.setattr(
         "gateway.transports.telegram.startup.load_gateway_settings", lambda: settings
     )
     monkeypatch.setattr(
-        "gateway.core.runtime.manager.signal.signal",
+        "gateway.core.runtime.controller.signal.signal",
         lambda signum, handler: signal_calls.append((signum, handler)),
     )
     # Patch the agent factory the gateway uses so the turn callback is spyable.
@@ -117,9 +117,9 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
         _start_telegram_gateway_background,
     )
 
-    gateway = GatewayManager().start_gateway(wait=False)
+    gateway = GatewayController().start_gateway(wait=False)
 
-    assert isinstance(gateway, GatewayManager)
+    assert isinstance(gateway, GatewayController)
     assert gateway.logger is logger
     assert gateway.surfaces is not None
     telegram = gateway.surfaces.transports.get(TransportName.TELEGRAM)
@@ -217,12 +217,12 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
 
     monkeypatch.setenv("ORGANIZATION_ID", "org_lifecycle_e2e")
     _patch_process_boot(monkeypatch)
-    monkeypatch.setattr("gateway.core.runtime.manager.configure_logging", lambda: logger)
+    monkeypatch.setattr("gateway.core.runtime.controller.configure_logging", lambda: logger)
     _patch_non_telegram_components(monkeypatch)
     monkeypatch.setattr(
         "gateway.transports.telegram.startup.load_gateway_settings", lambda: settings
     )
-    monkeypatch.setattr("gateway.core.runtime.manager.signal.signal", lambda *_args: None)
+    monkeypatch.setattr("gateway.core.runtime.controller.signal.signal", lambda *_args: None)
 
     def _start_telegram_gateway_background(**kwargs: Any) -> MagicMock:
         background_kwargs.update(kwargs)
@@ -237,7 +237,7 @@ def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatc
         lambda **_kwargs: InboundDecision(allowed=True),
     )
 
-    GatewayManager().start_gateway(wait=False)
+    GatewayController().start_gateway(wait=False)
     callback = background_kwargs["handle_callback_to_gateway_agent"]
     session = SessionCore(store=InMemorySessionStore())
     client = MagicMock()
@@ -280,9 +280,9 @@ def test_gateway_start_continues_without_telegram_configuration(monkeypatch) -> 
     """The unified daemon keeps its other components when Telegram is unconfigured."""
     logger = logging.getLogger("gateway.lifecycle.test")
     _patch_process_boot(monkeypatch)
-    monkeypatch.setattr("gateway.core.runtime.manager.configure_logging", lambda: logger)
-    monkeypatch.setattr("gateway.core.runtime.manager.signal.signal", lambda *_args: None)
-    monkeypatch.setattr("gateway.core.runtime.manager.clear_component_status", lambda: None)
+    monkeypatch.setattr("gateway.core.runtime.controller.configure_logging", lambda: logger)
+    monkeypatch.setattr("gateway.core.runtime.controller.signal.signal", lambda *_args: None)
+    monkeypatch.setattr("gateway.core.runtime.controller.clear_component_status", lambda: None)
     _patch_non_telegram_components(monkeypatch)
 
     def _unconfigured() -> GatewaySettings:
@@ -290,7 +290,7 @@ def test_gateway_start_continues_without_telegram_configuration(monkeypatch) -> 
 
     monkeypatch.setattr("gateway.transports.telegram.startup.load_gateway_settings", _unconfigured)
 
-    gateway = GatewayManager().start_gateway(wait=False)
+    gateway = GatewayController().start_gateway(wait=False)
 
     assert gateway.surfaces is not None
     assert TransportName.TELEGRAM not in gateway.surfaces.transports
@@ -300,21 +300,21 @@ def test_gateway_start_continues_without_telegram_configuration(monkeypatch) -> 
 
 
 def test_start_gateway_wrapper_delegates_to_gateway_instance(monkeypatch) -> None:
-    expected = MagicMock(spec=GatewayManager)
+    expected = MagicMock(spec=GatewayController)
     calls: list[bool] = []
     factory = object()
 
     def _start_gateway(
-        self: GatewayManager,
+        self: GatewayController,
         *,
         wait: bool = True,
-    ) -> GatewayManager:
-        assert isinstance(self, GatewayManager)
+    ) -> GatewayController:
+        assert isinstance(self, GatewayController)
         assert self._slash_ports_factory is factory
         calls.append(wait)
         return expected
 
-    monkeypatch.setattr(GatewayManager, "start_gateway", _start_gateway)
+    monkeypatch.setattr(GatewayController, "start_gateway", _start_gateway)
 
     assert start_gateway(wait=False, slash_ports_factory=factory) is expected  # type: ignore[arg-type]
     assert calls == [False]

--- a/gateway/tests/runtime/test_controller.py
+++ b/gateway/tests/runtime/test_controller.py
@@ -1,4 +1,4 @@
-"""Tests for :mod:`gateway.core.runtime.manager` lifecycle behavior."""
+"""Tests for :mod:`gateway.core.runtime.controller` lifecycle behavior."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from gateway.core.runtime.manager import GatewayManager
+from gateway.core.runtime.controller import GatewayController
 from gateway.startup import StartedGateway, TransportHandle, TransportName
 
 
@@ -33,8 +33,8 @@ def test_start_surfaces_delegates_to_the_startup_module(
         captured["handler"] = handler
         return expected
 
-    monkeypatch.setattr("gateway.core.runtime.manager.gateway_startup.start_gateway", _boot)
-    manager = GatewayManager()
+    monkeypatch.setattr("gateway.core.runtime.controller.gateway_startup.start_gateway", _boot)
+    manager = GatewayController()
     handler = MagicMock(name="chat-handler")
     logger = logging.getLogger("test.manager.surfaces")
 
@@ -50,7 +50,7 @@ def test_start_surfaces_delegates_to_the_startup_module(
 
 def test_wait_blocks_until_stop_not_channel_worker_exit() -> None:
     """The unified daemon should not exit when a chat worker thread ends."""
-    manager = GatewayManager()
+    manager = GatewayController()
     worker_wait = MagicMock(return_value=True)
 
     class FakeWorker:
@@ -92,7 +92,7 @@ def test_manager_stop_never_touches_the_real_gateway_directory() -> None:
 
     real_gateway_dir = Path.home() / ".opensre" / "gateway"
 
-    GatewayManager().stop()
+    GatewayController().stop()
 
     assert real_gateway_dir not in daemon.GATEWAY_COMPONENTS_FILE.parents
     assert real_gateway_dir not in daemon.GATEWAY_PID_FILE.parents
@@ -113,7 +113,7 @@ def test_manager_reload_scheduler_refreshes_component_status(
         "platform.scheduler.runner.refresh_background_scheduler",
         _refresh,
     )
-    manager = GatewayManager()
+    manager = GatewayController()
     monkeypatch.setattr(
         manager,
         "_publish_status",

--- a/gateway/tests/runtime/test_credential_hydration.py
+++ b/gateway/tests/runtime/test_credential_hydration.py
@@ -18,12 +18,12 @@ from config.constants.tenancy import (
     INTEGRATIONS_SECRET_ARN_ENV,
     INTEGRATIONS_STORE_PATH_ENV,
 )
+from gateway.core.runtime.controller import GatewayController
 from gateway.core.runtime.credential_hydration import (
     CredentialHydrationConfig,
     GatewayCredentialHydrator,
 )
 from gateway.core.runtime.errors import GatewayConfigurationError
-from gateway.core.runtime.manager import GatewayManager
 from integrations import store
 from integrations.credentials_api import IntegrationStoreV2
 
@@ -291,7 +291,7 @@ def test_manager_fails_closed_with_generic_error() -> None:
         # The fake only needs hydrate(); cast keeps the factory signature honest.
         return cast(GatewayCredentialHydrator, BrokenHydrator())
 
-    manager = GatewayManager(credential_hydrator_factory=_broken_hydrator)
+    manager = GatewayController(credential_hydrator_factory=_broken_hydrator)
 
     with pytest.raises(GatewayConfigurationError, match="hydration failed"):
         manager._load_credentials(logging.getLogger("test"))

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -211,22 +211,22 @@ def test_gateway_manager_registers_harness_adapters(monkeypatch: pytest.MonkeyPa
     from gateway.startup import StartedGateway
 
     monkeypatch.setattr(
-        "gateway.core.runtime.manager.gateway_startup.start_gateway",
+        "gateway.core.runtime.controller.gateway_startup.start_gateway",
         lambda **_kwargs: StartedGateway(),
     )
     # Keep this test focused on adapter registration (life-cycle tests cover scheduler).
     monkeypatch.setattr(
-        "gateway.core.runtime.manager.GatewayManager.start_scheduler",
+        "gateway.core.runtime.controller.GatewayController.start_scheduler",
         lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(
-        "gateway.core.runtime.manager.GatewayManager._publish_status",
+        "gateway.core.runtime.controller.GatewayController._publish_status",
         lambda *_args, **_kwargs: None,
     )
 
-    from gateway.core.runtime.manager import GatewayManager
+    from gateway.core.runtime.controller import GatewayController
 
-    GatewayManager().start_gateway(wait=False)
+    GatewayController().start_gateway(wait=False)
 
     # GATEWAY_PROFILE registers adapters at boot; scheduler runners come later,
     # when the scheduler stage starts.

--- a/gateway/tests/test_main.py
+++ b/gateway/tests/test_main.py
@@ -14,14 +14,14 @@ def test_gateway_main_fails_closed_without_slash_ports() -> None:
 
 
 def test_manager_main_fails_closed_without_slash_ports() -> None:
-    from gateway.core.runtime import manager as manager_module
+    from gateway.core.runtime import controller as manager_module
 
     with pytest.raises(SystemExit, match="slash_ports_factory"):
         manager_module.main()
 
 
 def test_manager_start_gateway_wrapper_requires_slash_ports() -> None:
-    from gateway.core.runtime.manager import start_gateway
+    from gateway.core.runtime.controller import start_gateway
 
     with pytest.raises(SystemExit, match="slash_ports_factory"):
         start_gateway(wait=False)

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -5,7 +5,7 @@ Pinned rules (see ``gateway/AGENTS.md``):
 * Chat transports are peers — none imports another.
 * ``gateway.web`` never imports ``gateway.transports`` or ``gateway.startup``.
 * ``gateway.core`` never imports chat transports or ``gateway.web``.
-* Only ``gateway.core.runtime.manager`` may import ``gateway.startup``.
+* Only ``gateway.core.runtime.controller`` may import ``gateway.startup``.
 * ``gateway.transports.*`` never imports ``gateway.startup`` or ``gateway.web``.
 * ``gateway.startup`` may import peer ``*.startup`` (and ``gateway.web``); peers
   must not import channels.
@@ -35,7 +35,7 @@ def _discover_transport_packages() -> tuple[str, ...]:
 
 _TRANSPORTS = _discover_transport_packages()
 
-_CHANNELS_COMPOSER = "gateway/core/runtime/manager.py"
+_STARTUP_COMPOSER = "gateway/core/runtime/controller.py"
 
 _TRANSPORT_STARTUP_MODULES = frozenset(f"{package}.startup" for package in _TRANSPORTS)
 
@@ -98,18 +98,18 @@ def test_core_never_imports_chat_transports_or_web() -> None:
     assert offenders == [], "Core imported a surface directly:\n" + "\n".join(offenders)
 
 
-def test_only_manager_imports_channels_module() -> None:
+def test_only_the_controller_imports_the_startup_module() -> None:
     offenders: list[str] = []
     for path in _python_files("gateway.core"):
         rel = str(path.relative_to(REPO_ROOT))
         for name in _imported_modules(path):
-            names_channels = name == "gateway.startup" or name.startswith("gateway.startup.")
-            if names_channels and rel != _CHANNELS_COMPOSER:
+            names_startup = name == "gateway.startup" or name.startswith("gateway.startup.")
+            if names_startup and rel != _STARTUP_COMPOSER:
                 offenders.append(f"{rel} → {name}")
-    assert offenders == [], "Non-manager core imported gateway.startup:\n" + "\n".join(offenders)
+    assert offenders == [], "Non-controller core imported gateway.startup:\n" + "\n".join(offenders)
 
 
-def test_transports_never_import_channels_or_web() -> None:
+def test_transports_never_import_startup_or_web() -> None:
     offenders: list[str] = []
     for package in _TRANSPORTS:
         offenders.extend(_offenders(package, ("gateway.startup", "gateway.web")))
@@ -117,11 +117,11 @@ def test_transports_never_import_channels_or_web() -> None:
     offenders.extend(_offenders("gateway.transports", ("gateway.startup", "gateway.web")))
     # Deduplicate paths that appear both as package and via rglob of parent.
     offenders = sorted(set(offenders))
-    assert offenders == [], "Transport peer imported channels/web:\n" + "\n".join(offenders)
+    assert offenders == [], "Transport peer imported startup/web:\n" + "\n".join(offenders)
 
 
-def test_channels_only_imports_peer_startup_not_transport_internals() -> None:
-    """Channels may compose via ``*.startup``; deeper peer modules stay private."""
+def test_startup_only_imports_peer_startup_not_transport_internals() -> None:
+    """gateway/startup.py composes via ``*.startup``; deeper peer modules stay private."""
     offenders: list[str] = []
     for path in _python_files("gateway.startup"):
         rel = str(path.relative_to(REPO_ROOT))

--- a/gateway/transports/AGENTS.md
+++ b/gateway/transports/AGENTS.md
@@ -2,7 +2,7 @@
 
 One package per inbound chat platform. Peers: **none imports another**.
 
-In API-framework terms, transports are the controllers: platform ingress that
+In API-framework terms, transports are the ingress adapters: platform inbound that
 authorizes, resolves a session, builds a sink, and calls the turn handler. The
 contract they implement is `gateway.core.transport_api`; the shared per-turn
 steps they compose are `gateway.core.middleware`; the facade that starts them
@@ -16,7 +16,7 @@ is `gateway/startup.py`.
 | `buzz/` | `startup.start_buzz_worker` |
 
 Composition of peers lives in `gateway/startup.py` (the transport registry
-plus web + chat start/stop), not here. `GatewayManager` only holds the opaque `ChannelsHandle`.
+plus web + chat start/stop), not here. `GatewayController` only holds the opaque `ChannelsHandle`.
 Transport-specific work (settings load, Discord readiness wait) stays in each
 package's `startup.py`.
 

--- a/gateway/transports/buzz/__init__.py
+++ b/gateway/transports/buzz/__init__.py
@@ -3,7 +3,7 @@
 Inbound Buzz messaging: settings, mention-feed poller, inbound authorization,
 the edit-in-place output sink, approvals, and the background worker. The
 per-message handler it drives is transport-agnostic and injected by the
-composition root (:mod:`gateway.core.runtime.manager`). Mirrors
+composition root (:mod:`gateway.core.runtime.controller`). Mirrors
 :mod:`gateway.transports.telegram` (poll-based, not a persistent socket).
 
 Transport entry: :mod:`gateway.transports.buzz.startup` (``start_buzz_worker``).

--- a/gateway/transports/slack/__init__.py
+++ b/gateway/transports/slack/__init__.py
@@ -7,7 +7,7 @@ Layout:
 - package root — ``settings``, ``client``, ``startup``
 
 The per-message handler the worker drives is transport-agnostic and injected by
-the composition root (:mod:`gateway.core.runtime.manager`). Outbound-only Slack
+the composition root (:mod:`gateway.core.runtime.controller`). Outbound-only Slack
 delivery (webhooks, RCA reports) lives in :mod:`integrations.slack`.
 
 Transport entry: :mod:`gateway.transports.slack.startup` (``start_slack_worker``).

--- a/gateway/transports/telegram/__init__.py
+++ b/gateway/transports/telegram/__init__.py
@@ -3,7 +3,7 @@
 Inbound Telegram messaging: settings, poller, inbound authorization, the
 edit-in-place output sink, and the background worker. The per-message handler
 it drives is transport-agnostic and injected by the composition root
-(:mod:`gateway.core.runtime.manager`). Mirrors :mod:`gateway.transports.slack`.
+(:mod:`gateway.core.runtime.controller`). Mirrors :mod:`gateway.transports.slack`.
 
 Transport entry: :mod:`gateway.transports.telegram.startup` (``start_telegram_worker``).
 """

--- a/platform/deployment_ec2/config.py
+++ b/platform/deployment_ec2/config.py
@@ -56,7 +56,7 @@ SSM_TERMINAL_STATUSES = ("Success", "Failed", "Cancelled", "TimedOut", "Undelive
 GATEWAY_HEALTH_POLL_INTERVAL_SECONDS = 15
 GATEWAY_HEALTH_MAX_ATTEMPTS = 60
 GATEWAY_LOG_TAIL_LINES = 200
-# Transport-agnostic ready line from GatewayManager after components start.
+# Transport-agnostic ready line from GatewayController after components start.
 # Also accept legacy per-transport lines so older images still pass health waits.
 GATEWAY_READY_LOG_SENTINEL = "[gateway] ready"
 GATEWAY_READY_LOG_SENTINELS: tuple[str, ...] = (

--- a/platform/harness_ports.py
+++ b/platform/harness_ports.py
@@ -1,7 +1,7 @@
 """Agent-harness ports — integrations, tools, and repository scope without tier violations.
 
 Adapters register at startup via :func:`surfaces.interactive_shell.ui.output.boundary.install_harness_ports`
-(shell/tests) or the gateway boot path in :mod:`gateway.core.runtime.manager` (duplicate wiring).
+(shell/tests) or the gateway boot path in :mod:`gateway.core.runtime.controller` (duplicate wiring).
 """
 
 from __future__ import annotations

--- a/surfaces/cli/gateway_entry.py
+++ b/surfaces/cli/gateway_entry.py
@@ -2,7 +2,7 @@
 
 ``surfaces`` and ``gateway`` are peer packages: gateway must not import
 surfaces. This module owns the glue — headless slash ports from the
-interactive shell wired into :class:`gateway.core.runtime.manager.GatewayManager`.
+interactive shell wired into :class:`gateway.core.runtime.controller.GatewayController`.
 
 Started by the daemon as ``python -m surfaces.cli.gateway_entry`` (also
 ``opensre gateway start`` / ``opensre gateway start --foreground``).
@@ -18,7 +18,7 @@ from surfaces.interactive_shell.runtime.slash_adapter import (
 )
 
 if TYPE_CHECKING:
-    from gateway.core.runtime.manager import GatewayManager
+    from gateway.core.runtime.controller import GatewayController
 
 
 def gateway_slash_ports_factory() -> SlashPorts:
@@ -26,13 +26,13 @@ def gateway_slash_ports_factory() -> SlashPorts:
     return headless_slash_ports()
 
 
-def start_gateway(*, wait: bool = True) -> GatewayManager:
+def start_gateway(*, wait: bool = True) -> GatewayController:
     """Start the gateway with headless slash ports wired for chat turns."""
     from config.local_env import bootstrap_opensre_env_once
-    from gateway.core.runtime.manager import GatewayManager
+    from gateway.core.runtime.controller import GatewayController
 
     bootstrap_opensre_env_once(override=False)
-    return GatewayManager(
+    return GatewayController(
         slash_ports_factory=gateway_slash_ports_factory,
     ).start_gateway(wait=wait)
 

--- a/surfaces/interactive_shell/command_registry/session_cmds/goal.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/goal.py
@@ -13,7 +13,7 @@ from dataclasses import replace
 from rich.console import Console
 from rich.markup import escape as _rich_escape
 
-from core.agent_harness.session import SessionManager
+from core.agent_harness import SessionManager, format_session_goal_progress
 from core.agent_harness.session.terminal_access import (
     clear_pending_autosubmit,
     set_auto_command,
@@ -29,7 +29,6 @@ from core.agent_harness.session_goal.goal import (
     session_goal_is_attached,
     session_goal_is_paused,
 )
-from core.agent_harness.session_goal.progress import format_session_goal_progress
 from platform.common.evidence_compaction import truncate_message
 from platform.terminal.theme import DIM, ERROR, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session

--- a/surfaces/interactive_shell/command_registry/session_cmds/lifecycle.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/lifecycle.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from core.agent_harness.session import SessionManager
+from core.agent_harness import SessionManager
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, HIGHLIGHT
 

--- a/surfaces/interactive_shell/command_registry/session_cmds/resume.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/resume.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 from rich.markup import escape
 
-from core.agent_harness.session import SessionManager
+from core.agent_harness import SessionManager
 from core.agent_harness.session.persistence.wal_recovery import format_recovery_note
 from surfaces.interactive_shell.command_registry.session_cmds.resume_rendering import (
     render_resumed_session_history,

--- a/surfaces/interactive_shell/grounding/cli_reference.py
+++ b/surfaces/interactive_shell/grounding/cli_reference.py
@@ -9,12 +9,12 @@ from typing import Any
 
 import click
 
+from core.agent_harness import DefaultPromptContextProvider
 from core.agent_harness.grounding.diagnostics import (
     GroundingSource,
     log_grounding_cache_diagnostics,
 )
 from core.agent_harness.grounding.models import CacheStats
-from core.agent_harness.prompts.grounding import DefaultPromptContextProvider
 
 _logger = logging.getLogger(__name__)
 

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -8,7 +8,7 @@ import sys
 from rich.console import Console
 
 from config.repl_config import ReplConfig
-from core.agent_harness.session import SessionManager
+from core.agent_harness import SessionManager
 from surfaces.interactive_shell.controller import InteractiveShellController
 from surfaces.interactive_shell.runtime.context import create_repl_runtime_context
 from surfaces.interactive_shell.runtime.startup.first_launch_github import (

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -10,16 +10,15 @@ from collections.abc import Callable
 
 from rich.console import Console
 
+from core.agent_harness import OutputSink, ToolCallingTurnResult
 from core.agent_harness.error_reporting import DefaultErrorReporter
 from core.agent_harness.llm_resolution import default_llm_factory
-from core.agent_harness.ports import OutputSink
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import (
     ActionTurnRunner,
     ToolCallingDeps,
 )
 from core.agent_harness.turns.turn_plan import TurnPlan
-from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable
 from rich.console import Console
 from rich.markup import escape
 
-from core.agent_harness.ports import OutputSink
+from core.agent_harness import OutputSink
 from core.agent_harness.session_goal.goal import strip_session_goal_progress_tags
 from core.llm.shared.llm_retry import CREDIT_EXHAUSTED_MARKER
 from surfaces.interactive_shell.ui.streaming import (

--- a/surfaces/interactive_shell/runtime/context.py
+++ b/surfaces/interactive_shell/runtime/context.py
@@ -7,7 +7,7 @@ from typing import Self
 from prompt_toolkit import PromptSession
 from pydantic import BaseModel, ConfigDict, Field, InstanceOf, field_validator, model_validator
 
-from core.agent_harness.session import SessionManager
+from core.agent_harness import SessionManager
 from core.domain.alerts import inbox as _alert_inbox
 from platform.observability.trace.spans import set_session_trace_store
 from surfaces.interactive_shell.runtime.core.state import (

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -14,18 +14,23 @@ from dataclasses import dataclass
 
 from rich.console import Console
 
-from core.agent_harness.harness import AgentSession, SessionConfig
+from core.agent_harness import (
+    AgentSession,
+    ChatTurnBindings,
+    SessionConfig,
+    ToolCallingTurnResult,
+    TurnResult,
+    dispatch_chat_turn,
+    format_session_goal_progress,
+    run_until_session_goal,
+)
 from core.agent_harness.ports import AnswerRequest, OutputSink
 from core.agent_harness.session_goal.goal import (
     SessionGoal,
 )
-from core.agent_harness.session_goal.progress import format_session_goal_progress
-from core.agent_harness.session_goal.run_until import run_until_session_goal
-from core.agent_harness.turns.chat_api import ChatTurnBindings, dispatch_chat_turn
 from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.host_cancel import host_cancel_requested
 from core.agent_harness.turns.turn_plan import TurnPlan
-from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.runtime.action_turn import ShellActionRunner
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -13,10 +13,10 @@ from typing import Any, Protocol
 
 from rich.console import Console
 
+from core.agent_harness import ToolCallingTurnResult
 from core.agent_harness.ports import AnswerRequest, OutputSink
 from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.turn_plan import TurnPlan
-from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo

--- a/tests/cli/test_gateway_command.py
+++ b/tests/cli/test_gateway_command.py
@@ -31,11 +31,11 @@ def test_gateway_start_foreground_runs_manager(runner: CliRunner) -> None:
 
 
 def test_gateway_entry_wires_slash_ports() -> None:
-    """Production entry must inject headless slash ports into GatewayManager."""
-    import gateway.core.runtime.manager as manager_module
+    """Production entry must inject headless slash ports into GatewayController."""
+    import gateway.core.runtime.controller as manager_module
 
     mock_manager = MagicMock()
-    with patch.object(manager_module, "GatewayManager", return_value=mock_manager) as ctor:
+    with patch.object(manager_module, "GatewayController", return_value=mock_manager) as ctor:
         from surfaces.cli.gateway_entry import main as entry_main
 
         entry_main()

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -36,11 +36,11 @@ def test_gateway_slash_ports_factory_is_headless_and_exposes_remote_sync() -> No
 
 def test_start_gateway_injects_remote_sync_capable_factory() -> None:
     """Changing gateway_entry must keep slash ports wired for chat turns."""
-    import gateway.core.runtime.manager as manager_module
+    import gateway.core.runtime.controller as manager_module
 
     mock_manager = MagicMock()
     mock_manager.start_gateway.return_value = mock_manager
-    with patch.object(manager_module, "GatewayManager", return_value=mock_manager) as ctor:
+    with patch.object(manager_module, "GatewayController", return_value=mock_manager) as ctor:
         start_gateway(wait=False)
 
     factory = ctor.call_args.kwargs["slash_ports_factory"]

--- a/tests/interactive_shell/test_harness_api_border.py
+++ b/tests/interactive_shell/test_harness_api_border.py
@@ -1,0 +1,116 @@
+"""Surfaces reach the agent harness through its curated surface — or the ledger.
+
+Twin of ``gateway/tests/test_harness_api_border.py``. The interactive shell is
+a thicker host than the gateway — it assembles the agent stack itself — so its
+existing deep imports are pinned in a ledger rather than migrated wholesale:
+hoisting all ~29 modules into the curated ``core.agent_harness.__init__`` table
+at once would un-curate it.
+
+The ledger is asserted with exact equality in both directions, like the
+transport conformance ledger: a *new* deep-import module fails immediately, and
+a module that stops being imported must be deleted here, so the set can only
+shrink. Curating a name into the export table (and migrating its importers) is
+the way an entry gets removed.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_FORBIDDEN_PREFIX = "core.agent_harness."
+_DYNAMIC_IMPORTERS = frozenset({"import_module", "__import__"})
+
+#: Harness submodules surfaces/ still imports directly. Shrink-only.
+_KNOWN_DEEP_IMPORTS = frozenset(
+    {
+        "core.agent_harness.accounting.run_record",
+        "core.agent_harness.accounting.token_accounting",
+        "core.agent_harness.error_reporting",
+        "core.agent_harness.grounding.diagnostics",
+        "core.agent_harness.grounding.models",
+        "core.agent_harness.llm_resolution",
+        "core.agent_harness.ports",
+        "core.agent_harness.prompts.rules",
+        "core.agent_harness.prompts.skills.loader",
+        "core.agent_harness.session",
+        "core.agent_harness.session.integration_resolution",
+        "core.agent_harness.session.persistence.jsonl_store",
+        "core.agent_harness.session.persistence.wal_recovery",
+        "core.agent_harness.session.session_core",
+        "core.agent_harness.session.terminal_access",
+        "core.agent_harness.session.want_me_to",
+        "core.agent_harness.session_goal.goal",
+        "core.agent_harness.tools.tool_context",
+        "core.agent_harness.tools.tool_provider",
+        "core.agent_harness.turns",
+        "core.agent_harness.turns.action_driver",
+        "core.agent_harness.turns.default_reasoning_client",
+        "core.agent_harness.turns.evidence_driver",
+        "core.agent_harness.turns.gather_observation",
+        "core.agent_harness.turns.host_cancel",
+        "core.agent_harness.turns.orchestrator",
+        "core.agent_harness.turns.transcript_compaction",
+        "core.agent_harness.turns.turn_plan",
+        "core.agent_harness.turns.turn_results",
+    }
+)
+
+
+def _surface_sources() -> list[Path]:
+    return [
+        path
+        for path in sorted((REPO_ROOT / "surfaces").rglob("*.py"))
+        if "__pycache__" not in path.parts
+    ]
+
+
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def _deep_modules(tree: ast.AST) -> set[str]:
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.update(
+                alias.name for alias in node.names if alias.name.startswith(_FORBIDDEN_PREFIX)
+            )
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and (node.module or "").startswith(_FORBIDDEN_PREFIX):
+                found.add(node.module)
+        elif isinstance(node, ast.Call) and _call_name(node) in _DYNAMIC_IMPORTERS:
+            for arg in node.args[:1]:
+                if (
+                    isinstance(arg, ast.Constant)
+                    and isinstance(arg.value, str)
+                    and arg.value.startswith(_FORBIDDEN_PREFIX)
+                ):
+                    found.add(arg.value)
+    return found
+
+
+def test_surfaces_deep_imports_only_shrink() -> None:
+    imported: set[str] = set()
+    for path in _surface_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imported |= _deep_modules(tree)
+
+    new = sorted(imported - _KNOWN_DEEP_IMPORTS)
+    assert new == [], (
+        f"surfaces/ grew new harness deep imports: {new}. Import the name from "
+        "core.agent_harness (curate it into the export table in "
+        "core/agent_harness/__init__.py if it is genuinely host-facing)."
+    )
+    migrated = sorted(_KNOWN_DEEP_IMPORTS - imported)
+    assert migrated == [], (
+        f"surfaces/ no longer imports {migrated} directly — remove those entries "
+        "from _KNOWN_DEEP_IMPORTS so the ledger keeps shrinking."
+    )


### PR DESCRIPTION
Two boundary cleanups, same theme: names and imports that say what they are.

1. Surfaces reach the harness through the curated surface — or the ledger
The twin of #5007. Measuring first changed the shape: surfaces/ imports 29 harness submodules across 35 files, versus the gateway's 11. The interactive shell legitimately assembles the agent stack itself (session persistence, prompt internals, tool providers), so hoisting everything into the curated core.agent_harness.__init__ table at once would un-curate it — the opposite of the point.

So this follows the transport-conformance pattern instead:

10 files migrated now — every import whose names the curated table already exports (SessionManager, AgentSession/SessionConfig, run_until_session_goal, dispatch_chat_turn, OutputSink, TurnResult, …).
tests/interactive_shell/test_harness_api_border.py — the same AST scanner as the gateway twin (catches aliased, line-continued, and importlib.import_module(...) forms), plus a 29-entry _KNOWN_DEEP_IMPORTS ledger asserted with exact equality in both directions: a new deep import fails immediately, and a module that stops being imported must be deleted from the ledger. Mutation-checked both ways.
The ledger doubles as the harness owners' curation worklist — each entry resolves by deliberately exporting the name or deciding it's shell-private, and either way the set only shrinks

2. gateway/core/runtime/manager.py → controller.py
GatewayManager → GatewayController — the class is the gateway's process controller (boot, credential hydrate, compose surfaces, scheduler, signals, stop), and "manager" said none of that. Renamed via git mv, ~27 files updated across bootstrap/, platform/, the CLI entry, tests and docs.

Two things surfaced by the rename, both fixed:

A vocabulary collision, resolved deliberately. The transport docs called transports "the controllers" (framing introduced in #5004). Two meanings of controller would be worse than the old vague manager, so transports are now consistently "ingress adapters" — the phrase turn_handler.py's docstring already used — and controller means exactly one thing.
The minimal .importlinter allowlist was doubly stale: it still permitted gateway.core.runtime.manager -> gateway.channels, naming both the old module and a package deleted two PRs ago. Now controller -> gateway.startup. The stale-named border tests went with it — test_only_manager_imports_channels_module was checking gateway.startup under its old name; it and two siblings are now named for what they actually assert.