### PR TITLE
refactor(gateway): worker initialization moves out of the gateway root into transports/startup.py

### DIFF
--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -17,7 +17,8 @@ tests tree.
 | Turn middleware (decision, policy, approvals, stop, locks) | `core/middleware/` |
 | Config / transport errors | `core/runtime/errors.py` (`GatewayConfigurationError`, `GatewayTransportFailedError`) |
 | Web surface (FastAPI) | `web/webapp.py` (`app`) |
-| Transport registry | `startup.py` (`TRANSPORTS` / `start_transports` / `stop_transports`) |
+| Transport registry + worker start/stop | `transports/startup.py` (`TRANSPORTS` / `start_transports`) |
+| Surface facade | `startup.py` (`start_gateway` / `StartedGateway`) |
 | Telegram start | `transports/telegram/startup.py` (`start_telegram_worker`) |
 | Slack start | `transports/slack/startup.py` (`start_slack_worker`) |
 | Discord start | `transports/discord/startup.py` (`start_discord_worker`) |
@@ -57,8 +58,9 @@ Packages are split like `core/agent_harness/prompts/`: **core infra** vs
 - `core/` — process and leaf infrastructure (`runtime`, `storage`,
   `billing`, `attachments`, `session`, `config`). No imports from transports
   or `web`. Only `core/runtime/controller.py` imports `gateway.startup`.
-- `startup.py` — starts/stops web + chat transports as one consumer set.
-  Imports `web/` and each peer's `startup` only.
+- `startup.py` — the facade: web + chat as one consumer set via
+  `transports/startup.py` (which owns the registry and imports each peer's
+  `startup` only).
 - `transports/` — chat peers (`slack`, `discord`, `telegram`). Each owns
   settings, inbound worker, security, output sink, and `startup.py`. Peers
   never import each other or `gateway.startup`/`web`; anything two need belongs in
@@ -71,7 +73,7 @@ Packages are split like `core/agent_harness/prompts/`: **core infra** vs
 ### Dependency rule (acyclic)
 
 ```
-core.controller  →  startup.py  →  transports.{telegram,slack,discord,buzz}.startup
+core.controller  →  startup.py  →  transports/startup.py  →  transports.{telegram,slack,discord,buzz}.startup
                            →  web
 peer transports · web  →  core leaves
 (peers never import each other, `gateway.startup`, or each other's packages)

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -17,7 +17,7 @@ transport-specific code.
 | **Background daemon helpers** | `gateway/core/runtime/daemon.py` | Used by CLI `gateway start/stop/status` (pidfile + `components.json`) |
 | **Web surface (web-only task)** | `gateway/web/webapp.py` → `app` | `uvicorn gateway.web.webapp:app` (`MODE=web` in Docker) |
 | **Surface startup** | `gateway/startup.py` → `start_gateway` / `StartedGateway` | Called by `GatewayController.start_surfaces` |
-| **Chat transport registry** | `gateway/startup.py` → `TRANSPORTS` / `start_transports` | Used by `start_gateway` |
+| **Chat transport registry** | `gateway/transports/startup.py` → `TRANSPORTS` / `start_transports` | Used by `start_gateway` |
 | **Telegram transport** | `gateway/transports/telegram/startup.py` → `start_telegram_worker` | Via the startup registry |
 | **Slack transport** | `gateway/transports/slack/startup.py` → `start_slack_worker` | Via the startup registry |
 | **Discord transport** | `gateway/transports/discord/startup.py` → `start_discord_worker` | Via the startup registry (includes readiness wait) |
@@ -38,7 +38,7 @@ surfaces/cli/gateway_entry.py  (or Click foreground → same composition root)
 gateway.core.runtime.controller.GatewayController.start_gateway
         ├── start_surfaces()  →  gateway.startup.start_gateway
         │     ├── web/web_server  →  web/webapp:app
-        │     └── startup.start_transports
+        │     └── transports/startup.start_transports
         │           (telegram / slack / discord startup)
         └── start_scheduler()   # peer of the surfaces, not a transport
 ```

--- a/gateway/core/transport_api/__init__.py
+++ b/gateway/core/transport_api/__init__.py
@@ -9,8 +9,9 @@ In API-framework terms the gateway splits like this:
   conversation locks, terminal outcome).
 * ``gateway/core/runtime/`` — the service layer: the turn handler bridging
   into the agent harness, and process plumbing.
-* ``gateway/startup.py`` — the facade: the transport registry and the one
-  ``start_gateway`` entry the daemon calls.
+* ``gateway/startup.py`` — the facade: the one ``start_gateway`` entry the
+  daemon calls. The transport registry and worker start/stop loop live with
+  the transports (``gateway/transports/startup.py``).
 
 This package is the contract between them. A transport registers a
 :class:`TransportSpec`, its worker satisfies :class:`TransportWorker`, its sink

--- a/gateway/startup.py
+++ b/gateway/startup.py
@@ -1,122 +1,34 @@
 """Start and stop everything the gateway serves users through.
 
-The one file allowed to import every transport: it holds the transport
-registry and composes web + chat into a single running handle. Mirrors each
-transport's own ``startup.py`` one level up — those start one platform, this
-starts the gateway.
+The facade the process controller calls: one :func:`start_gateway` that brings
+up the web server and every chat transport together and returns the running
+handle. Worker initialization lives with the transports
+(:mod:`gateway.transports.startup`); this module only composes.
 
-Only the composition root (:class:`~gateway.core.runtime.controller.GatewayController`)
-imports this module. Transports never import it back, and ``gateway.core``
-cannot (core must not depend on transports). The scheduler is not started
-here; the manager starts it as a peer.
+Only :class:`~gateway.core.runtime.controller.GatewayController` imports this
+module, and only this module imports ``gateway.transports.startup``.
 """
 
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 
-from gateway.core.runtime.errors import (
-    GatewayConfigurationError,
-    GatewayTransportFailedError,
+from gateway.core.transport_api import GatewayAgentCallback, TransportName
+from gateway.transports.startup import (
+    DEFAULT_STOP_TIMEOUT_SECONDS,
+    TransportHandle,
+    start_transports,
+    stop_transports,
 )
-from gateway.core.transport_api import (
-    GatewayAgentCallback,
-    TransportName,
-    TransportSpec,
-    TransportWorker,
-)
-from gateway.transports.buzz.startup import start_buzz_worker
-from gateway.transports.discord.startup import start_discord_worker
-from gateway.transports.slack.startup import start_slack_worker
-from gateway.transports.telegram.startup import start_telegram_worker
 from gateway.web.startup import start_web_server
 from gateway.web.web_server import WebAppServerHandle
-
-# How long a shutdown waits on each worker before giving up on it.
-DEFAULT_STOP_TIMEOUT_SECONDS = 8.0
 
 # The web app is a thread join, not a network drain, so it gets a smaller slice
 # of the shutdown budget and leaves the rest for in-flight chat turns.
 WEB_STOP_TIMEOUT_SECONDS = 5.0
 
 _WEB_COMPONENT = "web"
-
-
-TRANSPORTS: tuple[TransportSpec, ...] = (
-    TransportSpec(TransportName.TELEGRAM, start_telegram_worker, "polling for messages"),
-    TransportSpec(TransportName.SLACK, start_slack_worker, "inbound connected"),
-    TransportSpec(TransportName.DISCORD, start_discord_worker, "connected via gateway"),
-    TransportSpec(TransportName.BUZZ, start_buzz_worker, "polling for messages"),
-)
-
-
-@dataclass(frozen=True)
-class TransportHandle:
-    """A started transport: the worker to stop, and how to describe it."""
-
-    name: TransportName
-    worker: TransportWorker
-    status: str
-
-
-@dataclass(frozen=True)
-class ChatStartup:
-    """Started chat transports plus the status of every transport that was tried.
-
-    ``statuses`` covers transports that did not start, so the caller can report
-    "not configured" without the callee reaching into its status map.
-    """
-
-    handles: list[TransportHandle]
-    statuses: dict[TransportName, str]
-
-
-def start_transports(
-    *,
-    logger: logging.Logger,
-    handler: GatewayAgentCallback,
-) -> ChatStartup:
-    """Start every configured transport and report what each one did.
-
-    * :class:`GatewayConfigurationError` → ``not configured (…)`` (skipped).
-    * :class:`GatewayTransportFailedError` → ``failed (…)`` (skipped).
-
-    The gateway still serves whichever transports started successfully.
-    """
-    handles: list[TransportHandle] = []
-    statuses: dict[TransportName, str] = {}
-    for spec in TRANSPORTS:
-        try:
-            worker, _settings = spec.start(logger=logger, handler=handler)
-        except GatewayConfigurationError as exc:
-            logger.warning("%s chat disabled: %s", spec.name.capitalize(), exc)
-            statuses[spec.name] = f"not configured ({exc})"
-            continue
-        except GatewayTransportFailedError as exc:
-            logger.warning("%s chat failed: %s", spec.name.capitalize(), exc)
-            statuses[spec.name] = f"failed ({exc})"
-            continue
-        handles.append(TransportHandle(name=spec.name, worker=worker, status=spec.running_status))
-        statuses[spec.name] = spec.running_status
-    return ChatStartup(handles=handles, statuses=statuses)
-
-
-def stop_transports(
-    *,
-    handles: Sequence[TransportHandle],
-    timeout: float = DEFAULT_STOP_TIMEOUT_SECONDS,
-) -> bool:
-    """Stop every started transport and return whether all of them stopped.
-
-    Every worker is asked to stop even after one fails, so a single stuck
-    transport cannot leave the others running.
-    """
-    stopped = True
-    for handle in handles:
-        stopped = handle.worker.stop(timeout=timeout) and stopped
-    return stopped
 
 
 @dataclass
@@ -161,12 +73,7 @@ def start_gateway(
 
 __all__ = [
     "DEFAULT_STOP_TIMEOUT_SECONDS",
-    "TRANSPORTS",
     "WEB_STOP_TIMEOUT_SECONDS",
-    "ChatStartup",
     "StartedGateway",
-    "TransportHandle",
     "start_gateway",
-    "start_transports",
-    "stop_transports",
 ]

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -28,7 +28,7 @@ from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from gateway.core.runtime.controller import GatewayController, start_gateway
 from gateway.core.runtime.errors import GatewayConfigurationError
-from gateway.startup import TransportName
+from gateway.core.transport_api import TransportName
 from gateway.transports.telegram.inbound_handler import (
     handle_polled_inbound_telegram_message,
 )
@@ -53,11 +53,11 @@ def _patch_non_telegram_components(monkeypatch) -> None:
         raise GatewayConfigurationError("skipped in lifecycle test")
 
     monkeypatch.setattr(
-        "gateway.startup.start_slack_worker",
+        "gateway.transports.startup.start_slack_worker",
         _skip_transport,
     )
     monkeypatch.setattr(
-        "gateway.startup.start_discord_worker",
+        "gateway.transports.startup.start_discord_worker",
         _skip_transport,
     )
 

--- a/gateway/tests/runtime/test_controller.py
+++ b/gateway/tests/runtime/test_controller.py
@@ -9,7 +9,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from gateway.core.runtime.controller import GatewayController
-from gateway.startup import StartedGateway, TransportHandle, TransportName
+from gateway.core.transport_api import TransportName
+from gateway.startup import StartedGateway
+from gateway.transports.startup import TransportHandle
 
 
 def test_start_surfaces_delegates_to_the_startup_module(

--- a/gateway/tests/runtime/test_startup_surfaces.py
+++ b/gateway/tests/runtime/test_startup_surfaces.py
@@ -7,13 +7,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from gateway.startup import (
-    ChatStartup,
-    StartedGateway,
-    TransportHandle,
-    TransportName,
-    start_gateway,
-)
+from gateway.core.transport_api import TransportName
+from gateway.startup import StartedGateway, start_gateway
+from gateway.transports.startup import ChatStartup, TransportHandle
 from gateway.web.startup import WebStartup
 
 

--- a/gateway/tests/runtime/test_transport_registry.py
+++ b/gateway/tests/runtime/test_transport_registry.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock
 
-from gateway import startup
 from gateway.core.transport_api import TransportName, TransportSpec
+from gateway.transports import startup
 
 
 def test_start_transports_skips_not_configured_and_failed(

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -113,7 +113,8 @@ def test_transports_never_import_startup_or_web() -> None:
     offenders: list[str] = []
     for package in _TRANSPORTS:
         offenders.extend(_offenders(package, ("gateway.startup", "gateway.web")))
-    # Also scan transports package root (no registry composer left there).
+    # Also scan the transports package root: the composer (startup.py) lives
+    # there now, and it too must never import gateway.startup or gateway.web.
     offenders.extend(_offenders("gateway.transports", ("gateway.startup", "gateway.web")))
     # Deduplicate paths that appear both as package and via rglob of parent.
     offenders = sorted(set(offenders))

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -120,20 +120,48 @@ def test_transports_never_import_startup_or_web() -> None:
     assert offenders == [], "Transport peer imported startup/web:\n" + "\n".join(offenders)
 
 
-def test_startup_only_imports_peer_startup_not_transport_internals() -> None:
-    """gateway/startup.py composes via ``*.startup``; deeper peer modules stay private."""
+def test_composers_only_import_peer_startup_not_transport_internals() -> None:
+    """Both composers reach transports only via ``*.startup`` modules.
+
+    ``gateway/startup.py`` composes web + chat through
+    ``gateway.transports.startup``; that module in turn may import only its
+    peers' ``startup`` submodules — deeper peer modules stay private.
+    """
+    composer_allowed = _TRANSPORT_STARTUP_MODULES | {"gateway.transports.startup"}
     offenders: list[str] = []
-    for path in _python_files("gateway.startup"):
-        rel = str(path.relative_to(REPO_ROOT))
-        for name in _imported_modules(path):
-            if not any(name == p or name.startswith(f"{p}.") for p in _TRANSPORTS):
-                continue
-            if name in _TRANSPORT_STARTUP_MODULES:
-                continue
-            offenders.append(f"{rel} → {name}")
-    assert offenders == [], "channels imported non-startup transport modules:\n" + "\n".join(
+    for source in ("gateway.startup", "gateway.transports.startup"):
+        for path in _python_files(source):
+            rel = str(path.relative_to(REPO_ROOT))
+            for name in _imported_modules(path):
+                if not any(name == p or name.startswith(f"{p}.") for p in _TRANSPORTS):
+                    continue
+                if name in composer_allowed:
+                    continue
+                offenders.append(f"{rel} → {name}")
+    assert offenders == [], "composer imported non-startup transport modules:\n" + "\n".join(
         offenders
     )
+
+
+def test_only_the_gateway_facade_imports_the_transport_composer() -> None:
+    """``gateway.transports.startup`` has exactly one consumer: gateway/startup.py.
+
+    A second importer would be a second place that starts workers — the exact
+    smear this split removed from the gateway package root.
+    """
+    offenders: list[str] = []
+    for path in _python_files("gateway"):
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel in ("gateway/startup.py", "gateway/transports/startup.py"):
+            continue
+        if rel.startswith("gateway/tests/"):
+            # Tests build fixtures from the composer's types; only production
+            # code is barred from starting workers behind the facade's back.
+            continue
+        for name in _imported_modules(path):
+            if name == "gateway.transports.startup":
+                offenders.append(f"{rel} → {name}")
+    assert offenders == [], "worker init leaked past the facade:\n" + "\n".join(offenders)
 
 
 def test_approvals_module_imports_no_transport() -> None:
@@ -310,7 +338,7 @@ def test_every_transport_package_is_registered_in_the_chat_table() -> None:
     row (the transport never starts) or the row without the package.
     """
     # Arrange / Act.
-    from gateway.startup import TRANSPORTS
+    from gateway.transports.startup import TRANSPORTS
 
     on_disk = {package.rsplit(".", 1)[-1] for package in _TRANSPORTS}
     registered = {spec.name.value for spec in TRANSPORTS}

--- a/gateway/tests/test_transport_contract.py
+++ b/gateway/tests/test_transport_contract.py
@@ -80,7 +80,7 @@ def _package_source(transport: str) -> str:
 
 def test_the_registry_lists_every_discovered_transport() -> None:
     """A transport on disk but absent from ``TRANSPORTS`` never starts."""
-    from gateway.startup import TRANSPORTS
+    from gateway.transports.startup import TRANSPORTS
 
     registered = {spec.name for spec in TRANSPORTS}
     assert registered == set(_TRANSPORTS)

--- a/gateway/transports/AGENTS.md
+++ b/gateway/transports/AGENTS.md
@@ -15,8 +15,10 @@ is `gateway/startup.py`.
 | `telegram/` | `startup.start_telegram_worker` |
 | `buzz/` | `startup.start_buzz_worker` |
 
-Composition of peers lives in `gateway/startup.py` (the transport registry
-plus web + chat start/stop), not here. `GatewayController` only holds the opaque `ChannelsHandle`.
+The registry and worker start/stop loop live in this package's own
+`startup.py` — the one module here allowed to import its peers (their
+`startup` submodules only). Web + chat composition stays in
+`gateway/startup.py`. `GatewayController` only holds the opaque `ChannelsHandle`.
 Transport-specific work (settings load, Discord readiness wait) stays in each
 package's `startup.py`.
 

--- a/gateway/transports/startup.py
+++ b/gateway/transports/startup.py
@@ -1,0 +1,121 @@
+"""The transport registry and the one loop that starts and stops the workers.
+
+Owned by the transports group: worker initialization belongs next to the
+platforms it initializes, not at the gateway package root. Every transport is
+started in one pass — there is no per-transport start order — and a transport
+without credentials is skipped, not an error.
+
+This is the only module in the package allowed to import its peers, and only
+their ``startup`` submodules. Importing one platform package never loads this
+module, so peer isolation (one platform ≠ four SDK stacks) is preserved.
+Composed by :func:`gateway.startup.start_gateway`; nothing else imports this.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from gateway.core.runtime.errors import (
+    GatewayConfigurationError,
+    GatewayTransportFailedError,
+)
+from gateway.core.transport_api import (
+    GatewayAgentCallback,
+    TransportName,
+    TransportSpec,
+    TransportWorker,
+)
+from gateway.transports.buzz.startup import start_buzz_worker
+from gateway.transports.discord.startup import start_discord_worker
+from gateway.transports.slack.startup import start_slack_worker
+from gateway.transports.telegram.startup import start_telegram_worker
+
+# How long a shutdown waits on each worker before giving up on it.
+DEFAULT_STOP_TIMEOUT_SECONDS = 8.0
+
+
+TRANSPORTS: tuple[TransportSpec, ...] = (
+    TransportSpec(TransportName.TELEGRAM, start_telegram_worker, "polling for messages"),
+    TransportSpec(TransportName.SLACK, start_slack_worker, "inbound connected"),
+    TransportSpec(TransportName.DISCORD, start_discord_worker, "connected via gateway"),
+    TransportSpec(TransportName.BUZZ, start_buzz_worker, "polling for messages"),
+)
+
+
+@dataclass(frozen=True)
+class TransportHandle:
+    """A started transport: the worker to stop, and how to describe it."""
+
+    name: TransportName
+    worker: TransportWorker
+    status: str
+
+
+@dataclass(frozen=True)
+class ChatStartup:
+    """Started chat transports plus the status of every transport that was tried.
+
+    ``statuses`` covers transports that did not start, so the caller can report
+    "not configured" without the callee reaching into its status map.
+    """
+
+    handles: list[TransportHandle]
+    statuses: dict[TransportName, str]
+
+
+def start_transports(
+    *,
+    logger: logging.Logger,
+    handler: GatewayAgentCallback,
+) -> ChatStartup:
+    """Start every configured transport and report what each one did.
+
+    * :class:`GatewayConfigurationError` → ``not configured (…)`` (skipped).
+    * :class:`GatewayTransportFailedError` → ``failed (…)`` (skipped).
+
+    The gateway still serves whichever transports started successfully.
+    """
+    handles: list[TransportHandle] = []
+    statuses: dict[TransportName, str] = {}
+    for spec in TRANSPORTS:
+        try:
+            worker, _settings = spec.start(logger=logger, handler=handler)
+        except GatewayConfigurationError as exc:
+            logger.warning("%s chat disabled: %s", spec.name.capitalize(), exc)
+            statuses[spec.name] = f"not configured ({exc})"
+            continue
+        except GatewayTransportFailedError as exc:
+            logger.warning("%s chat failed: %s", spec.name.capitalize(), exc)
+            statuses[spec.name] = f"failed ({exc})"
+            continue
+        handles.append(TransportHandle(name=spec.name, worker=worker, status=spec.running_status))
+        statuses[spec.name] = spec.running_status
+    return ChatStartup(handles=handles, statuses=statuses)
+
+
+def stop_transports(
+    *,
+    handles: Sequence[TransportHandle],
+    timeout: float = DEFAULT_STOP_TIMEOUT_SECONDS,
+) -> bool:
+    """Stop every started transport and return whether all of them stopped.
+
+    Every worker is asked to stop even after one fails, so a single stuck
+    transport cannot leave the others running.
+    """
+    stopped = True
+    for handle in handles:
+        stopped = handle.worker.stop(timeout=timeout) and stopped
+    return stopped
+
+
+__all__ = [
+    "DEFAULT_STOP_TIMEOUT_SECONDS",
+    "TRANSPORTS",
+    "ChatStartup",
+    "TransportHandle",
+    "start_transports",
+    "stop_transports",
+]


### PR DESCRIPTION
controller.start_surfaces()
  → gateway/startup.py: start_gateway()          # facade: web + chat, one handle
      - → gateway/transports/startup.py: start_transports()   # registry + worker loop
         - - → transports/{telegram,slack,discord,buzz}/startup.py

gateway/startup.py dropped from ~170 lines to ~80 and knows nothing about workers — no registry, no per-transport start functions, no skip/fail loop. All of that lives in gateway/transports/startup.py, next to the platforms it initializes. Its docstring records the peer-isolation reasoning: importing one platform never loads the composer, so one platform ≠ four SDK stacks still holds.