### PR TITLE
fix(shell,aws): straight /integrations table under recording + role-ARN setup that explains itself

### DIFF
--- a/config/constants/aws.py
+++ b/config/constants/aws.py
@@ -9,6 +9,13 @@ AWS_ACCESS_KEY_ID_ENV = "AWS_ACCESS_KEY_ID"
 AWS_SECRET_ACCESS_KEY_ENV = "AWS_SECRET_ACCESS_KEY"
 AWS_SESSION_TOKEN_ENV = "AWS_SESSION_TOKEN"
 
+#: boto3 reads these two as one unit: an access key id in the environment
+#: without its secret does not fall through to the next credential source, it
+#: raises ``PartialCredentialsError``. The secret is keyring-only, so a plain
+#: ``.env`` can legitimately hold the id alone — it must then stay out of the
+#: process environment.
+AWS_STATIC_KEY_PAIR_ENV: tuple[str, str] = (AWS_ACCESS_KEY_ID_ENV, AWS_SECRET_ACCESS_KEY_ENV)
+
 __all__ = [
     "AWS_ACCESS_KEY_ID_ENV",
     "AWS_EXTERNAL_ID_ENV",
@@ -16,4 +23,5 @@ __all__ = [
     "AWS_ROLE_ARN_ENV",
     "AWS_SECRET_ACCESS_KEY_ENV",
     "AWS_SESSION_TOKEN_ENV",
+    "AWS_STATIC_KEY_PAIR_ENV",
 ]

--- a/docs/aws.mdx
+++ b/docs/aws.mdx
@@ -8,7 +8,7 @@ OpenSRE uses AWS to map your environment: Lambda functions, EKS clusters, S3 buc
 ## Prerequisites
 
 - AWS account with IAM permissions
-- Either a role ARN (recommended) or static access keys
+- Either a role ARN (recommended) or static access keys. A role ARN is *assumed* using your ambient AWS credentials — environment keys, an `aws configure` profile, or an attached instance/task role — so one of those must exist on the machine running OpenSRE
 
 ## Setup
 
@@ -48,6 +48,9 @@ AWS_REGION=us-east-1
 
 <Info>
 Either `AWS_ROLE_ARN` or `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` is required.
+`AWS_ROLE_ARN` alone is not enough on a laptop: the role is assumed with whatever
+credentials boto3 finds (env keys, `~/.aws/credentials`, or an instance/task role), and
+that identity needs `sts:AssumeRole` on the role.
 </Info>
 
 ## IAM permissions
@@ -104,6 +107,7 @@ Detail: Authenticated via assume-role in us-east-1 as arn:aws:iam::123456789012:
 
 | Symptom | Fix |
 | --- | --- |
+| **Unable to locate credentials** (role ARN setup) | You chose IAM Role ARN but nothing on this machine has base AWS credentials. The setup wizard detects this when you pick the role option and offers to switch to Access Key + Secret, or to pause while you run `aws configure` / export `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` for an identity allowed to assume the role. If you set `AWS_ROLE_ARN` by hand instead of through the wizard, provide one of those base credentials |
 | **AccessDenied on STS** | Ensure the caller has `sts:AssumeRole` permission on the target role |
 | **InvalidClientTokenId** | Check that `AWS_ACCESS_KEY_ID` is correct and the key is active |
 | **Could not connect to endpoint** | Check `AWS_REGION` and network connectivity |

--- a/integrations/aws/__init__.py
+++ b/integrations/aws/__init__.py
@@ -11,20 +11,26 @@ from integrations.config_models import AWSIntegrationConfig
 logger = logging.getLogger(__name__)
 
 
+def _text(credentials: dict[str, Any], key: str, default: str = "") -> str:
+    """Stored optional fields are ``None`` when unset; the config model wants ``str``."""
+    value = credentials.get(key)
+    return default if value is None else str(value)
+
+
 def classify(
     credentials: dict[str, Any], record_id: str
 ) -> tuple[AWSIntegrationConfig | None, str | None]:
     raw: dict[str, Any] = {
-        "region": credentials.get("region", "us-east-1"),
-        "role_arn": credentials.get("role_arn", ""),
-        "external_id": credentials.get("external_id", ""),
+        "region": _text(credentials, "region", "us-east-1"),
+        "role_arn": _text(credentials, "role_arn"),
+        "external_id": _text(credentials, "external_id"),
         "integration_id": record_id,
     }
     if credentials.get("access_key_id") and credentials.get("secret_access_key"):
         raw["credentials"] = {
-            "access_key_id": credentials.get("access_key_id", ""),
-            "secret_access_key": credentials.get("secret_access_key", ""),
-            "session_token": credentials.get("session_token", ""),
+            "access_key_id": _text(credentials, "access_key_id"),
+            "secret_access_key": _text(credentials, "secret_access_key"),
+            "session_token": _text(credentials, "session_token"),
         }
     try:
         return AWSIntegrationConfig.model_validate(raw), "aws"

--- a/integrations/aws/credential_chain.py
+++ b/integrations/aws/credential_chain.py
@@ -1,0 +1,27 @@
+"""Local probe for the ambient AWS credential chain the role mode relies on."""
+
+from __future__ import annotations
+
+import boto3
+
+# What each ambient source is, in the words a user needs to act on it.
+AMBIENT_SOURCES_HINT = (
+    "environment keys (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY), "
+    "an `aws configure` profile in ~/.aws/credentials, "
+    "or an attached instance/task role"
+)
+
+
+def has_ambient_credentials() -> bool:
+    """True when boto3 can resolve base credentials without any prompt.
+
+    A local lookup only — env, shared files, and the lazily-consulted instance
+    metadata provider — so it never blocks setup on a network round trip.
+    """
+    try:
+        return boto3.session.Session().get_credentials() is not None
+    except Exception:
+        return False
+
+
+__all__ = ["AMBIENT_SOURCES_HINT", "has_ambient_credentials"]

--- a/integrations/aws/credential_chain.py
+++ b/integrations/aws/credential_chain.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import boto3
-
 # What each ambient source is, in the words a user needs to act on it.
 AMBIENT_SOURCES_HINT = (
     "environment keys (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY), "
@@ -18,8 +16,11 @@ def has_ambient_credentials() -> bool:
     A local lookup only — env, shared files, and the lazily-consulted instance
     metadata provider — so it never blocks setup on a network round trip.
     """
+    from integrations.aws.env import base_session
+
     try:
-        return boto3.session.Session().get_credentials() is not None
+        session = base_session()
+        return session is not None and session.get_credentials() is not None
     except Exception:
         return False
 

--- a/integrations/aws/credential_chain.py
+++ b/integrations/aws/credential_chain.py
@@ -11,15 +11,19 @@ AMBIENT_SOURCES_HINT = (
 
 
 def has_ambient_credentials() -> bool:
-    """True when boto3 can resolve base credentials without any prompt.
+    """True when base credentials resolve from *local* sources, instantly.
 
-    A local lookup only — env, shared files, and the lazily-consulted instance
-    metadata provider — so it never blocks setup on a network round trip.
+    Env, the keyring-paired static key, and ``~/.aws`` profiles — not the ECS
+    or EC2 metadata endpoints. This answers "should setup warn before the user
+    types anything?", so it must not wait out network timeouts on a laptop or
+    behind a proxy. An attached instance role is therefore reported as absent
+    here; the role-mode gate offers "continue with the role anyway" for exactly
+    that machine, and the verifier's real STS call still uses the full chain.
     """
     from integrations.aws.env import base_session
 
     try:
-        session = base_session()
+        session = base_session(local_only=True)
         return session is not None and session.get_credentials() is not None
     except Exception:
         return False

--- a/integrations/aws/env.py
+++ b/integrations/aws/env.py
@@ -5,6 +5,54 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from config.constants.aws import (
+    AWS_ACCESS_KEY_ID_ENV,
+    AWS_SECRET_ACCESS_KEY_ENV,
+    AWS_SESSION_TOKEN_ENV,
+    AWS_STATIC_KEY_PAIR_ENV,
+)
+
+
+def _static_pair_is_half_set() -> bool:
+    """One of the static key pair is in ``os.environ`` without the other."""
+    first, second = AWS_STATIC_KEY_PAIR_ENV
+    return bool(os.environ.get(first)) != bool(os.environ.get(second))
+
+
+def base_session(*, region: str | None = None) -> Any:
+    """A boto3 session for OpenSRE's own base identity, whatever supplies it.
+
+    Order: a *complete* static pair resolved the OpenSRE way (process env, then
+    the keyring / fallback file — so the id in ``.env`` pairs with the secret in
+    the keyring), else boto3's normal chain (``~/.aws`` profiles, instance or
+    task role, …). OpenSRE keeps ``AWS_SECRET_ACCESS_KEY`` keyring-only, so its
+    ``.env`` legitimately loads ``AWS_ACCESS_KEY_ID`` alone into the process;
+    boto3 reads the pair as one unit and would raise ``PartialCredentialsError``
+    on that lone id instead of falling through, so with a half-pair the ``env``
+    provider is dropped from the chain. Returns ``None`` when boto3 is missing.
+    """
+    try:
+        import boto3
+        import botocore.session
+    except ImportError:
+        return None
+    from config.llm_credentials import resolve_env_credential
+
+    access_key_id = resolve_env_credential(AWS_ACCESS_KEY_ID_ENV)
+    secret_access_key = resolve_env_credential(AWS_SECRET_ACCESS_KEY_ENV)
+    if access_key_id and secret_access_key:
+        return boto3.session.Session(
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            aws_session_token=resolve_env_credential(AWS_SESSION_TOKEN_ENV) or None,
+            region_name=region,
+        )
+    if not _static_pair_is_half_set():
+        return boto3.session.Session(region_name=region)
+    core = botocore.session.get_session()
+    core.get_component("credential_provider").remove("env")
+    return boto3.session.Session(botocore_session=core, region_name=region)
+
 
 def _missing_env_error(
     missing: list[str], *, context: str, hint: str | None = None
@@ -23,26 +71,21 @@ def _missing_env_error(
 
 def make_boto3_client(service: str):
     """Return a boto3 client for the given service using the configured AWS region."""
-    try:
-        import boto3 as _boto3
-    except ImportError:
+    session = base_session(region=os.getenv("AWS_REGION", "us-east-1"))
+    if session is None:
         return None
-    return _boto3.client(service, region_name=os.getenv("AWS_REGION", "us-east-1"))  # type: ignore[call-overload]
+    return session.client(service)  # type: ignore[call-overload]
 
 
 def require_aws_credentials(*, context: str) -> dict[str, Any] | None:
-    try:
-        import boto3
-    except ImportError:
+    session = base_session()
+    if session is None:
         return {
             "success": False,
             "error": "boto3 not available",
             "context": context,
         }
-
-    session = boto3.session.Session()
-    credentials = session.get_credentials()
-    if credentials is not None:
+    if session.get_credentials() is not None:
         return None
 
     missing: list[str] = []

--- a/integrations/aws/env.py
+++ b/integrations/aws/env.py
@@ -19,7 +19,13 @@ def _static_pair_is_half_set() -> bool:
     return bool(os.environ.get(first)) != bool(os.environ.get(second))
 
 
-def base_session(*, region: str | None = None) -> Any:
+#: boto3 providers that reach the network: the ECS container-credentials
+#: endpoint and EC2 instance metadata (169.254.169.254). On a machine that is
+#: neither, they wait out connect timeouts before reporting "no credentials".
+_NETWORK_CREDENTIAL_PROVIDERS: tuple[str, ...] = ("container-role", "iam-role")
+
+
+def base_session(*, region: str | None = None, local_only: bool = False) -> Any:
     """A boto3 session for OpenSRE's own base identity, whatever supplies it.
 
     Order: a *complete* static pair resolved the OpenSRE way (process env, then
@@ -29,7 +35,12 @@ def base_session(*, region: str | None = None) -> Any:
     ``.env`` legitimately loads ``AWS_ACCESS_KEY_ID`` alone into the process;
     boto3 reads the pair as one unit and would raise ``PartialCredentialsError``
     on that lone id instead of falling through, so with a half-pair the ``env``
-    provider is dropped from the chain. Returns ``None`` when boto3 is missing.
+    provider is dropped from the chain.
+
+    *local_only* also drops the network providers (ECS / EC2 metadata). Use it
+    for a pre-check that must answer instantly — a setup prompt deciding
+    whether to warn — never for a real call, where an attached instance role
+    is exactly the credential to find. Returns ``None`` when boto3 is missing.
     """
     try:
         import boto3
@@ -47,10 +58,17 @@ def base_session(*, region: str | None = None) -> Any:
             aws_session_token=resolve_env_credential(AWS_SESSION_TOKEN_ENV) or None,
             region_name=region,
         )
-    if not _static_pair_is_half_set():
+    to_remove: list[str] = []
+    if _static_pair_is_half_set():
+        to_remove.append("env")
+    if local_only:
+        to_remove.extend(_NETWORK_CREDENTIAL_PROVIDERS)
+    if not to_remove:
         return boto3.session.Session(region_name=region)
     core = botocore.session.get_session()
-    core.get_component("credential_provider").remove("env")
+    resolver = core.get_component("credential_provider")
+    for name in to_remove:
+        resolver.remove(name)
     return boto3.session.Session(botocore_session=core, region_name=region)
 
 

--- a/integrations/aws/role_mode_gate.py
+++ b/integrations/aws/role_mode_gate.py
@@ -34,9 +34,8 @@ class GateOption:
 
 
 NO_AMBIENT_CREDENTIALS_NOTICE = (
-    "IAM Role ARN is assumed with base AWS credentials already on this machine — "
-    f"{AMBIENT_SOURCES_HINT}. None were found, so validation would fail with "
-    '"Unable to locate credentials" before reaching your role.'
+    "No base AWS credentials found on this machine. A role is assumed *with* base "
+    f"credentials — {AMBIENT_SOURCES_HINT} — so this option cannot work here yet."
 )
 
 CONFIGURE_FIRST_INSTRUCTION = (
@@ -51,18 +50,18 @@ GATE_OPTIONS: tuple[GateOption, ...] = (
     GateOption(
         RoleGateChoice.USE_KEYS,
         "Use an access key + secret instead",
-        "Simplest on a laptop. The key needs the read-only policies from the AWS docs.",
+        "simplest on a laptop; the key needs the read-only policies from the AWS docs",
     ),
     GateOption(
         RoleGateChoice.CONFIGURE_FIRST,
-        "I'll configure base credentials in this shell first",
-        "Run `aws configure` (or export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) for an "
-        "identity allowed sts:AssumeRole on the role, then re-run setup.",
+        "Configure base credentials first, then come back",
+        "run `aws configure` or export AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY for an "
+        "identity allowed sts:AssumeRole on the role, then re-run setup",
     ),
     GateOption(
         RoleGateChoice.CONTINUE_ROLE,
         "Continue with the role anyway",
-        "Only useful if OpenSRE will run on EC2/ECS/Lambda with an attached role.",
+        "only for OpenSRE running on EC2/ECS/Lambda with an attached role",
     ),
 )
 

--- a/integrations/aws/role_mode_gate.py
+++ b/integrations/aws/role_mode_gate.py
@@ -1,0 +1,108 @@
+"""Decide how AWS setup proceeds when the role mode has no base credentials.
+
+Assuming a role needs credentials boto3 can already find; the role mode
+collects only the ARN. On a machine with none, letting the user type an ARN and
+then failing STS is a dead end. This module holds the decision so the CLI and
+the onboarding wizard steer identically; each supplies its own way of asking.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+from integrations.aws.credential_chain import AMBIENT_SOURCES_HINT, has_ambient_credentials
+
+ROLE_MODE = "role"
+KEYS_MODE = "keys"
+
+
+class RoleGateChoice(StrEnum):
+    """What the user picked when the ambient credential chain was empty."""
+
+    USE_KEYS = "keys"
+    CONFIGURE_FIRST = "configure-first"
+    CONTINUE_ROLE = "continue-role"
+
+
+@dataclass(frozen=True)
+class GateOption:
+    value: RoleGateChoice
+    label: str
+    hint: str
+
+
+NO_AMBIENT_CREDENTIALS_NOTICE = (
+    "IAM Role ARN is assumed with base AWS credentials already on this machine — "
+    f"{AMBIENT_SOURCES_HINT}. None were found, so validation would fail with "
+    '"Unable to locate credentials" before reaching your role.'
+)
+
+CONFIGURE_FIRST_INSTRUCTION = (
+    "Configure base credentials in this shell — `aws configure`, or export "
+    "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY for an identity allowed sts:AssumeRole on "
+    "the role — then run setup again and pick IAM Role ARN."
+)
+
+GATE_QUESTION = "How would you like to continue?"
+
+GATE_OPTIONS: tuple[GateOption, ...] = (
+    GateOption(
+        RoleGateChoice.USE_KEYS,
+        "Use an access key + secret instead",
+        "Simplest on a laptop. The key needs the read-only policies from the AWS docs.",
+    ),
+    GateOption(
+        RoleGateChoice.CONFIGURE_FIRST,
+        "I'll configure base credentials in this shell first",
+        "Run `aws configure` (or export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) for an "
+        "identity allowed sts:AssumeRole on the role, then re-run setup.",
+    ),
+    GateOption(
+        RoleGateChoice.CONTINUE_ROLE,
+        "Continue with the role anyway",
+        "Only useful if OpenSRE will run on EC2/ECS/Lambda with an attached role.",
+    ),
+)
+
+#: How a surface asks the gate question: shows the notice, offers GATE_OPTIONS,
+#: returns the picked choice (or None when the user cancelled).
+AskGate = Callable[[], RoleGateChoice | None]
+
+
+class ConfigureCredentialsFirst(Exception):
+    """The user chose to configure base credentials before setting up the role."""
+
+
+def gate_role_mode(mode: str, *, ask: AskGate) -> str:
+    """Return the mode to continue with after checking the role mode's prerequisite.
+
+    Only the role mode is gated. When the ambient chain is empty, *ask* runs and
+    the answer steers: keys mode, the role anyway, or
+    :class:`ConfigureCredentialsFirst` so the surface can leave setup cleanly
+    with the instruction to come back.
+    """
+    if mode != ROLE_MODE or has_ambient_credentials():
+        return mode
+    choice = ask()
+    if choice is None or choice is RoleGateChoice.CONFIGURE_FIRST:
+        raise ConfigureCredentialsFirst
+    if choice is RoleGateChoice.USE_KEYS:
+        return KEYS_MODE
+    return ROLE_MODE
+
+
+__all__ = [
+    "CONFIGURE_FIRST_INSTRUCTION",
+    "GATE_OPTIONS",
+    "GATE_QUESTION",
+    "KEYS_MODE",
+    "NO_AMBIENT_CREDENTIALS_NOTICE",
+    "ROLE_MODE",
+    "AskGate",
+    "ConfigureCredentialsFirst",
+    "GateOption",
+    "RoleGateChoice",
+    "gate_role_mode",
+]

--- a/integrations/aws/setup.py
+++ b/integrations/aws/setup.py
@@ -1,7 +1,10 @@
 """What AWS needs before it is considered configured.
 
 Auth is a picker (IAM role ARN *or* access key + secret). Region is always
-asked; the picker only scopes the auth fields. The either/or rule also lives
+asked; the picker only scopes the auth fields. The role mode assumes the role
+with the ambient boto3 credential chain (env keys, a shared profile, or an
+attached instance/task role) — it does not collect base credentials, so the
+label says so and the verifier explains what to configure when none exist. The either/or rule also lives
 on ``AWSIntegrationConfig`` (the model
 :func:`integrations.aws.verifier.verify_aws` validates against), so setup and
 health checks agree for any surface that skips the picker.
@@ -107,7 +110,7 @@ AWS_SETUP = IntegrationSetupSpec(
     modes=(
         SetupMode(
             value="role",
-            label="IAM Role ARN",
+            label="IAM Role ARN (assumed with your ambient AWS credentials)",
             fields=(ROLE_ARN_FIELD, EXTERNAL_ID_FIELD),
         ),
         SetupMode(

--- a/integrations/aws/setup.py
+++ b/integrations/aws/setup.py
@@ -29,6 +29,45 @@ from config.constants.aws import (
 from integrations.aws.verifier import verify_aws
 from integrations.setup_flow import IntegrationSetupSpec, SetupField, SetupMode
 
+_ROLE_ARN_PREFIX = "arn:aws:iam::"
+_ROLE_ARN_EXAMPLE = "arn:aws:iam::123456789012:role/OpenSREReadOnly"
+
+
+_WHERE_TO_FIND = (
+    "Find it in the AWS console: IAM → Roles → pick the role → ARN (or `aws iam list-roles`)."
+)
+
+
+def validate_role_arn(value: str) -> str | None:
+    """Reject anything that is not an IAM *role* ARN — before STS is called.
+
+    Says what the answer was and what is needed instead: a user ARN, the
+    role's unique ID (``AROA…``), a bare role name, or something else. The
+    failure STS would give later is about credentials, not the ARN, so the
+    slip has to be caught here to be explainable.
+    """
+    text = value.strip()
+    if text.startswith(_ROLE_ARN_PREFIX) and ":role/" in text and not text.endswith(":role/"):
+        return None
+    if ":user/" in text:
+        return (
+            "That is an IAM *user* ARN. This option needs a *role* — an identity your user "
+            "assumes, not the user itself. If you only have a user, choose Access Key + Secret "
+            f"instead. A role ARN looks like {_ROLE_ARN_EXAMPLE}. {_WHERE_TO_FIND}"
+        )
+    if text.startswith("AROA"):
+        return (
+            "That is the role's unique ID, not its ARN. "
+            f"A role ARN looks like {_ROLE_ARN_EXAMPLE}. {_WHERE_TO_FIND}"
+        )
+    if "arn:" not in text and "/" not in text and " " not in text:
+        return (
+            f"That looks like a role *name*; the full ARN is needed, e.g. "
+            f"arn:aws:iam::<account-id>:role/{text}. {_WHERE_TO_FIND}"
+        )
+    return f"An IAM role ARN looks like {_ROLE_ARN_EXAMPLE}. {_WHERE_TO_FIND}"
+
+
 REGION_FIELD = "region"
 ROLE_ARN_FIELD = "role_arn"
 EXTERNAL_ID_FIELD = "external_id"
@@ -74,6 +113,7 @@ AWS_SETUP = IntegrationSetupSpec(
             label="IAM Role ARN",
             env_var=AWS_ROLE_ARN_ENV,
             required=False,
+            validate=validate_role_arn,
         ),
         SetupField(
             name=EXTERNAL_ID_FIELD,
@@ -126,6 +166,7 @@ AWS_SETUP = IntegrationSetupSpec(
 
 __all__ = [
     "ACCESS_KEY_ID_FIELD",
+    "validate_role_arn",
     "AWS_SETUP",
     "EXTERNAL_ID_FIELD",
     "REGION_FIELD",

--- a/integrations/aws/setup.py
+++ b/integrations/aws/setup.py
@@ -112,11 +112,13 @@ AWS_SETUP = IntegrationSetupSpec(
             value="role",
             label="IAM Role ARN (assumed with your ambient AWS credentials)",
             fields=(ROLE_ARN_FIELD, EXTERNAL_ID_FIELD),
+            required_fields=(ROLE_ARN_FIELD,),
         ),
         SetupMode(
             value="keys",
             label="Access Key + Secret",
             fields=(ACCESS_KEY_ID_FIELD, SECRET_ACCESS_KEY_FIELD, SESSION_TOKEN_FIELD),
+            required_fields=(ACCESS_KEY_ID_FIELD, SECRET_ACCESS_KEY_FIELD),
         ),
     ),
     verify=_verify_aws_setup,

--- a/integrations/aws/verifier.py
+++ b/integrations/aws/verifier.py
@@ -19,12 +19,25 @@ ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE = (
 )
 
 
+def _base_sts_client(region: str) -> Any:
+    """STS client for OpenSRE's own base identity — the one that assumes the role.
+
+    Built from :func:`integrations.aws.env.base_session`, so a lone
+    ``AWS_ACCESS_KEY_ID`` loaded from ``.env`` (its secret lives in the keyring)
+    cannot block the profile / instance-role chain. Kept as one seam so tests
+    substitute a fake here and never reach STS.
+    """
+    from integrations.aws.env import base_session
+
+    return base_session(region=region).client("sts")
+
+
 def _build_sts_client(aws_config: AWSIntegrationConfig) -> tuple[Any, str, str]:
     region = aws_config.region
     role_arn = aws_config.role_arn
     external_id = aws_config.external_id
     if role_arn:
-        base_sts_client = boto3.client("sts", region_name=region)
+        base_sts_client = _base_sts_client(region)
         assume_role_args: dict[str, str] = {
             "RoleArn": role_arn,
             "RoleSessionName": "TracerIntegrationVerify",

--- a/integrations/aws/verifier.py
+++ b/integrations/aws/verifier.py
@@ -5,9 +5,18 @@ from __future__ import annotations
 from typing import Any
 
 import boto3
+from botocore.exceptions import NoCredentialsError
 
 from integrations.config_models import AWSIntegrationConfig
 from integrations.verification import register_verifier, result
+
+ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE = (
+    "IAM Role ARN is assumed with your ambient AWS credentials, and none were "
+    "found. Configure a base identity that may call sts:AssumeRole on the role "
+    "(AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, an `aws configure` profile, or "
+    "an attached instance/task role) and run setup again — or choose "
+    '"Access Key + Secret" instead.'
+)
 
 
 def _build_sts_client(aws_config: AWSIntegrationConfig) -> tuple[Any, str, str]:
@@ -60,6 +69,10 @@ def verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         sts_client, region, mode = _build_sts_client(aws_config)
         identity = sts_client.get_caller_identity()
+    except NoCredentialsError:
+        # Only the role path reaches STS without explicit keys; static keys
+        # would have been passed to the client and this error cannot arise.
+        return result("aws", source, "failed", ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE)
     except Exception as exc:
         return result("aws", source, "failed", f"AWS STS check failed: {exc}")
 

--- a/integrations/aws/verifier.py
+++ b/integrations/aws/verifier.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import boto3
-from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import NoCredentialsError, PartialCredentialsError
 
 from integrations.config_models import AWSIntegrationConfig
 from integrations.verification import register_verifier, result
@@ -73,6 +73,17 @@ def verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
         # Only the role path reaches STS without explicit keys; static keys
         # would have been passed to the client and this error cannot arise.
         return result("aws", source, "failed", ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE)
+    except PartialCredentialsError as exc:
+        missing = exc.kwargs.get("cred_var", "one of the AWS_* variables")
+        return result(
+            "aws",
+            source,
+            "failed",
+            f"This shell has half a key pair in the environment: {missing} is not set. "
+            "The role is assumed with those base credentials, so set both "
+            "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (or unset both and use an "
+            "`aws configure` profile), then run setup again.",
+        )
     except Exception as exc:
         return result("aws", source, "failed", f"AWS STS check failed: {exc}")
 

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import questionary
@@ -203,9 +204,38 @@ def _setup_new_relic() -> None:
 
 
 def _setup_aws() -> None:
+    from integrations.aws.role_mode_gate import (
+        CONFIGURE_FIRST_INSTRUCTION,
+        GATE_OPTIONS,
+        GATE_QUESTION,
+        NO_AMBIENT_CREDENTIALS_NOTICE,
+        ConfigureCredentialsFirst,
+        RoleGateChoice,
+        gate_role_mode,
+    )
     from integrations.aws.setup import AWS_SETUP
 
-    _run_spec_setup(AWS_SETUP)
+    def _ask_gate() -> RoleGateChoice | None:
+        print(f"\n  {NO_AMBIENT_CREDENTIALS_NOTICE}\n")
+        picked = _select(
+            GATE_QUESTION,
+            choices=[
+                questionary.Choice(f"{o.label} — {o.hint}", value=str(o.value))
+                for o in GATE_OPTIONS
+            ],
+            instruction="(use arrow keys)",
+        )
+        return None if picked is None else RoleGateChoice(picked)
+
+    def _gate(mode: str) -> str:
+        try:
+            return gate_role_mode(mode, ask=_ask_gate)
+        except ConfigureCredentialsFirst:
+            print(f"\n  {CONFIGURE_FIRST_INSTRUCTION}")
+            print("  Nothing was saved.")
+            sys.exit(0)
+
+    _run_spec_setup(AWS_SETUP, on_mode_chosen=_gate)
 
 
 def _setup_slack() -> None:
@@ -519,7 +549,11 @@ def _setup_discord() -> None:
     _run_spec_setup(DISCORD_SETUP)
 
 
-def _run_spec_setup(spec: IntegrationSetupSpec) -> None:
+def _run_spec_setup(
+    spec: IntegrationSetupSpec,
+    *,
+    on_mode_chosen: Callable[[str], str] | None = None,
+) -> None:
     """Prompt for a spec's fields, then validate, verify, and persist them.
 
     Fields are prefilled from the stored credentials so re-running setup is a
@@ -527,9 +561,9 @@ def _run_spec_setup(spec: IntegrationSetupSpec) -> None:
     did not re-type. When the spec declares a picker (``mode_prompt``), only the
     chosen mode's fields are asked; fields belonging to another mode are cleared.
 
-    Each field is checked as it is answered so a blank required value fails
-    immediately, rather than after the user has worked through the rest of the
-    prompts.
+    Each field is checked as it is answered so a blank required value is
+    re-asked immediately, rather than surfacing after the user has worked
+    through the rest of the prompts.
     """
     from integrations.setup_flow import apply_setup
     from integrations.store import get_integration
@@ -546,6 +580,10 @@ def _run_spec_setup(spec: IntegrationSetupSpec) -> None:
         if mode is None:
             print("\nAborted.")
             sys.exit(1)
+        if on_mode_chosen is not None:
+            # A vendor may check the mode's prerequisite the moment it is
+            # picked and steer to another mode before any credential is typed.
+            mode = on_mode_chosen(mode)
 
     collectable = {field.name for field in spec.collectable_fields(mode)}
 
@@ -560,17 +598,23 @@ def _run_spec_setup(spec: IntegrationSetupSpec) -> None:
             values[field.name] = ""
             continue
         default = str(stored.get(field.name) or "") or field.default
-        value = _p(field.question, default=default, secret=field.secret)
         # A field with a default is never missing — apply_setup substitutes it —
-        # so only a defaultless required field can fail here.
-        if not value and field.required and not field.default:
-            _die(f"{field.label} is required.")
+        # so only a defaultless required field can be blank here. Ask again
+        # rather than exit: an empty answer at an interactive prompt is not a
+        # fatal error, and Ctrl+C is the way out.
+        while True:
+            value = _p(field.question, default=default, secret=field.secret)
+            if value or not spec.is_required(field, mode) or field.default:
+                break
+            print(f"  {field.label} is required. Enter a value, or press Ctrl+C to cancel.")
         values[field.name] = value
 
     print(f"\n  Validating {spec.service} credentials...")
     outcome = apply_setup(spec, values)
     if not outcome.ok:
-        _die(outcome.detail)
+        print(f"  error: {outcome.detail}", file=sys.stderr)
+        print(f"  Nothing was saved. Run `opensre integrations setup {spec.service}` to try again.")
+        sys.exit(1)
     print(f"  {outcome.detail}")
     print("  Next:")
     print(f"    - opensre integrations verify {spec.service}")

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -217,13 +217,16 @@ def _setup_aws() -> None:
 
     def _ask_gate() -> RoleGateChoice | None:
         print(f"\n  {NO_AMBIENT_CREDENTIALS_NOTICE}\n")
+        print("  Your options:")
+        for number, option in enumerate(GATE_OPTIONS, start=1):
+            print(f"    {number}. {option.label}")
+            print(f"       {option.hint}")
+        print()
         picked = _select(
             GATE_QUESTION,
-            choices=[
-                questionary.Choice(f"{o.label} — {o.hint}", value=str(o.value))
-                for o in GATE_OPTIONS
-            ],
-            instruction="(use arrow keys)",
+            choices=[questionary.Choice(o.label, value=str(o.value)) for o in GATE_OPTIONS],
+            use_shortcuts=True,
+            instruction="(press 1-3, or use arrow keys and Enter)",
         )
         return None if picked is None else RoleGateChoice(picked)
 
@@ -604,9 +607,14 @@ def _run_spec_setup(
         # fatal error, and Ctrl+C is the way out.
         while True:
             value = _p(field.question, default=default, secret=field.secret)
-            if value or not spec.is_required(field, mode) or field.default:
-                break
-            print(f"  {field.label} is required. Enter a value, or press Ctrl+C to cancel.")
+            if not value and spec.is_required(field, mode) and not field.default:
+                print(f"  {field.label} is required. Enter a value, or press Ctrl+C to cancel.")
+                continue
+            problem = field.validate(value) if value and field.validate else None
+            if problem is not None:
+                print(f"  {problem}")
+                continue
+            break
         values[field.name] = value
 
     print(f"\n  Validating {spec.service} credentials...")

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -230,13 +230,16 @@ def _setup_aws() -> None:
         )
         return None if picked is None else RoleGateChoice(picked)
 
+    def _leave_to_configure_credentials() -> NoReturn:
+        print(f"\n  {CONFIGURE_FIRST_INSTRUCTION}")
+        print("  Nothing was saved.")
+        sys.exit(0)
+
     def _gate(mode: str) -> str:
         try:
             return gate_role_mode(mode, ask=_ask_gate)
         except ConfigureCredentialsFirst:
-            print(f"\n  {CONFIGURE_FIRST_INSTRUCTION}")
-            print("  Nothing was saved.")
-            sys.exit(0)
+            _leave_to_configure_credentials()
 
     _run_spec_setup(AWS_SETUP, on_mode_chosen=_gate)
 

--- a/integrations/setup_flow.py
+++ b/integrations/setup_flow.py
@@ -86,6 +86,15 @@ class SetupMode:
     integration's always-on fields — Alertmanager's "None (unauthenticated)".
     """
 
+    required_fields: tuple[str, ...] = ()
+    """Subset of :attr:`fields` that must be non-empty when this mode is chosen.
+
+    A mode-gated field is declared ``required=False`` on the spec because it is
+    unset under every *other* mode; this is where "required within this mode"
+    lives, so a blank answer is refused at the prompt instead of surfacing later
+    as a config-model validation error.
+    """
+
 
 @dataclass(frozen=True)
 class SetupField:
@@ -198,6 +207,13 @@ class IntegrationSetupSpec:
     returns a note for the success detail and a failure is surfaced there rather
     than rolling back the save.
     """
+
+    def is_required(self, field: SetupField, mode: str | None) -> bool:
+        """Whether *field* must be non-empty: spec-required, or required by *mode*."""
+        if field.required:
+            return True
+        chosen = next((one for one in self.modes if one.value == mode), None)
+        return chosen is not None and field.name in chosen.required_fields
 
     def collectable_fields(self, mode: str | None) -> tuple[SetupField, ...]:
         """Fields a collection surface should prompt for under *mode*.

--- a/integrations/setup_flow.py
+++ b/integrations/setup_flow.py
@@ -146,6 +146,15 @@ class SetupField:
     example, whose config-model default is ``streamable-http``.
     """
 
+    validate: Callable[[str], str | None] | None = None
+    """Shape check applied to a non-empty answer at the prompt.
+
+    Returns an error message to show (the surface re-asks) or ``None`` when
+    the value is acceptable. For the checks the config model would only reject
+    later with a stack of validation errors — a role *ID* pasted where a role
+    *ARN* belongs.
+    """
+
     @property
     def question(self) -> str:
         """The text to prompt with."""

--- a/platform/logging/__init__.py
+++ b/platform/logging/__init__.py
@@ -3,5 +3,10 @@
 from __future__ import annotations
 
 from platform.logging.quiet_third_party import quiet_noisy_third_party_loggers
+from platform.logging.shell_handler import ShellLogHandler, install_shell_log_handler
 
-__all__ = ["quiet_noisy_third_party_loggers"]
+__all__ = [
+    "ShellLogHandler",
+    "install_shell_log_handler",
+    "quiet_noisy_third_party_loggers",
+]

--- a/platform/logging/quiet_third_party.py
+++ b/platform/logging/quiet_third_party.py
@@ -25,10 +25,14 @@ _WARNING_FLOOR = (
     "httpcore.http11",
 )
 
+# urllib3 logs every connection retry at WARNING ("Retrying (Retry(total=2,
+# …)) after connection broken by …") — the client's internal retry loop, not
+# an outcome. The outcome (unreachable service) is reported by the caller.
 _ERROR_FLOOR = (
     "mcp",
     "mcp.client",
     "mcp.client.session",
+    "urllib3.connectionpool",
 )
 
 _MCP_SCHEMA_NOISE = "not listed by server, cannot validate"

--- a/platform/logging/shell_handler.py
+++ b/platform/logging/shell_handler.py
@@ -1,0 +1,92 @@
+"""Root log handler for terminal surfaces that animate on the tty.
+
+Two things go wrong when WARNING+ records reach a REPL's terminal through the
+default path (Python's ``logging.lastResort`` → the ``sys.stderr`` captured at
+import):
+
+* Under ``prompt_toolkit.patch_stdout(raw=True)`` that stream bypasses the
+  proxy that repairs bare ``\\n`` in raw mode, so the next line starts wherever
+  the record ended.
+* A record emitted from a worker thread while a Rich ``console.status``
+  spinner animates races the spinner's ``\\r`` + erase-line frames on the same
+  tty; a frame landing mid-line corrupts the terminal's cursor column, and
+  everything rendered afterwards staircases across the screen.
+
+:class:`ShellLogHandler` fixes both by printing through the surface's own Rich
+console when one is provided: ``Console.print`` holds the console lock and a
+running spinner repaints around it, so the record lands whole, above the
+animation, at column 0. Without a console it writes to whatever ``sys.stderr``
+is at emit time, which under ``patch_stdout`` is the proxy.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+ConsoleProvider = Callable[[], "Console | None"]
+
+
+class ShellLogHandler(logging.Handler):
+    """Emit records through the surface console, else the live ``sys.stderr``."""
+
+    def __init__(self, console_provider: ConsoleProvider | None = None) -> None:
+        super().__init__()
+        self._console_provider = console_provider
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = self.format(record)
+            console = self._console_provider() if self._console_provider else None
+            if console is not None:
+                # One terminal row per record. A record longer than the
+                # console wraps in the terminal while a running Live spinner
+                # still counts it as one row; its teardown cursor-up then
+                # lands on the wrong row and everything after drifts.
+                # markup=False / highlight=False: log text is not Rich markup.
+                console.print(
+                    message,
+                    markup=False,
+                    highlight=False,
+                    overflow="ellipsis",
+                    no_wrap=True,
+                    crop=True,
+                )
+                return
+            stream = sys.stderr
+            stream.write(message + "\n")
+            stream.flush()
+        except Exception:
+            self.handleError(record)
+
+
+def install_shell_log_handler(
+    console_provider: ConsoleProvider | None = None,
+    *,
+    level: int = logging.ERROR,
+) -> None:
+    """Install :class:`ShellLogHandler` on the root logger once.
+
+    The floor is ERROR: the shell is a product surface, and a WARNING such as
+    "[kubernetes] probe_access failed" duplicates what the surface already
+    reports in its own words (the integrations table's ``failed`` row with a
+    reason). Idempotent; a root logger that already has handlers (an embedding
+    host, a test harness) is left alone.
+    """
+    root = logging.getLogger()
+    if any(isinstance(handler, ShellLogHandler) for handler in root.handlers):
+        return
+    if root.handlers:
+        return
+    handler = ShellLogHandler(console_provider)
+    handler.setLevel(level)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(handler)
+
+
+__all__ = ["ShellLogHandler", "install_shell_log_handler"]

--- a/platform/logging/shell_handler.py
+++ b/platform/logging/shell_handler.py
@@ -24,12 +24,10 @@ from __future__ import annotations
 import logging
 import sys
 from collections.abc import Callable
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from rich.console import Console
+from rich.console import Console
 
-ConsoleProvider = Callable[[], "Console | None"]
+ConsoleProvider = Callable[[], Console | None]
 
 
 class ShellLogHandler(logging.Handler):

--- a/platform/observability/errors/service.py
+++ b/platform/observability/errors/service.py
@@ -62,15 +62,18 @@ def capture_service_error(
     extras: dict[str, Any] | None = None,
     include_traceback: bool | None = None,
 ) -> None:
-    severity = "warning" if _is_transient_vendor_error(exc) else "error"
+    # An unreachable service is an operational fact, not a fault in our code —
+    # the same fact that already drops the traceback below decides severity:
+    # a refused connection or timeout is a warning, like a 5xx, not an error.
+    unreachable = _is_service_unreachable(exc)
+    severity = "warning" if unreachable or _is_transient_vendor_error(exc) else "error"
     merged_extras: dict[str, Any] = dict(extras) if extras else {}
     merged_extras.pop("surface", None)
     merged_extras["method"] = method
-    # An unreachable service is an operational fact, not a fault in our code:
-    # the stack is 60 lines of HTTP client internals and drowns the shell. Keep
+    # The stack is 60 lines of HTTP client internals and drowns the shell. Keep
     # it for anything else, where the stack points at the actual bug.
     if include_traceback is None:
-        include_traceback = not _is_service_unreachable(exc)
+        include_traceback = not unreachable
     report_exception(
         exc,
         logger=logger,

--- a/surfaces/cli/wizard/configurators/aws.py
+++ b/surfaces/cli/wizard/configurators/aws.py
@@ -1,10 +1,84 @@
-"""Configurator handler for the AWS integration."""
+"""Configurator handler for the AWS integration.
+
+The role mode assumes the ARN with boto3's ambient credential chain and never
+collects base credentials itself. On a machine with none, letting the user
+type an ARN and then failing STS is a dead end — so the mode gate checks the
+chain the moment "IAM Role ARN" is picked and offers the ways forward.
+"""
 
 from __future__ import annotations
 
+from integrations.aws.credential_chain import AMBIENT_SOURCES_HINT, has_ambient_credentials
 from integrations.aws.setup import AWS_SETUP
+from platform.terminal.theme import SECONDARY, WARNING
+from surfaces.cli.wizard._ui import Choice, WizardBack, _choose, _console
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
+
+ROLE_MODE = "role"
+KEYS_MODE = "keys"
+
+_CONTINUE_ROLE = "continue-role"
+_CONFIGURE_ELSEWHERE = "configure-elsewhere"
+
+NO_AMBIENT_CREDENTIALS_NOTICE = (
+    "IAM Role ARN is assumed with base AWS credentials already on this machine — "
+    f"{AMBIENT_SOURCES_HINT}. None were found, so validation would fail with "
+    '"Unable to locate credentials" before reaching your role.'
+)
+
+
+def _resolve_missing_base_credentials() -> str:
+    """Steer the role mode when the ambient credential chain is empty.
+
+    Returns the mode to continue with, or raises :class:`WizardBack` when the
+    user chooses to configure base credentials first — the wizard reports the
+    service as skipped and they re-run setup once the chain exists.
+    """
+    if has_ambient_credentials():
+        return ROLE_MODE
+    _console.print(f"[{WARNING}]{NO_AMBIENT_CREDENTIALS_NOTICE}[/]")
+    choice = _choose(
+        "How would you like to continue?",
+        [
+            Choice(
+                value=KEYS_MODE,
+                label="Use an access key + secret instead",
+                hint="Simplest on a laptop. The key needs the read-only policies from the AWS docs.",
+            ),
+            Choice(
+                value=_CONFIGURE_ELSEWHERE,
+                label="I'll configure base credentials in this shell first",
+                hint="Run `aws configure` (or export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) "
+                "for an identity allowed sts:AssumeRole on the role, then re-run setup.",
+            ),
+            Choice(
+                value=_CONTINUE_ROLE,
+                label="Continue with the role anyway",
+                hint="Only useful if OpenSRE will run on EC2/ECS/Lambda with an attached role.",
+            ),
+        ],
+        default=KEYS_MODE,
+    )
+    if choice == KEYS_MODE:
+        return KEYS_MODE
+    if choice == _CONFIGURE_ELSEWHERE:
+        _console.print(
+            f"[{SECONDARY}]Configure base credentials in this shell, then run "
+            "`opensre onboard` (or `/integrations` → aws) again and pick IAM Role ARN.[/]"
+        )
+        raise WizardBack
+    return ROLE_MODE
+
+
+def _gate_aws_mode(mode: str) -> str:
+    """Mode gate for :func:`configure_from_spec`; only the role mode needs one."""
+    if mode != ROLE_MODE:
+        return mode
+    return _resolve_missing_base_credentials()
 
 
 def _configure_aws() -> tuple[str, str]:
-    return configure_from_spec(AWS_SETUP, title="AWS")
+    return configure_from_spec(AWS_SETUP, title="AWS", on_mode_chosen=_gate_aws_mode)
+
+
+__all__ = ["NO_AMBIENT_CREDENTIALS_NOTICE", "ROLE_MODE", "KEYS_MODE"]

--- a/surfaces/cli/wizard/configurators/aws.py
+++ b/surfaces/cli/wizard/configurators/aws.py
@@ -1,84 +1,45 @@
 """Configurator handler for the AWS integration.
 
-The role mode assumes the ARN with boto3's ambient credential chain and never
-collects base credentials itself. On a machine with none, letting the user
-type an ARN and then failing STS is a dead end — so the mode gate checks the
-chain the moment "IAM Role ARN" is picked and offers the ways forward.
+The role mode's prerequisite check lives in :mod:`integrations.aws.role_mode_gate`
+so the CLI and this wizard steer identically; this module only supplies the
+wizard's way of asking.
 """
 
 from __future__ import annotations
 
-from integrations.aws.credential_chain import AMBIENT_SOURCES_HINT, has_ambient_credentials
+from integrations.aws.role_mode_gate import (
+    CONFIGURE_FIRST_INSTRUCTION,
+    GATE_OPTIONS,
+    GATE_QUESTION,
+    NO_AMBIENT_CREDENTIALS_NOTICE,
+    ConfigureCredentialsFirst,
+    RoleGateChoice,
+    gate_role_mode,
+)
 from integrations.aws.setup import AWS_SETUP
 from platform.terminal.theme import SECONDARY, WARNING
 from surfaces.cli.wizard._ui import Choice, WizardBack, _choose, _console
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 
-ROLE_MODE = "role"
-KEYS_MODE = "keys"
 
-_CONTINUE_ROLE = "continue-role"
-_CONFIGURE_ELSEWHERE = "configure-elsewhere"
-
-NO_AMBIENT_CREDENTIALS_NOTICE = (
-    "IAM Role ARN is assumed with base AWS credentials already on this machine — "
-    f"{AMBIENT_SOURCES_HINT}. None were found, so validation would fail with "
-    '"Unable to locate credentials" before reaching your role.'
-)
-
-
-def _resolve_missing_base_credentials() -> str:
-    """Steer the role mode when the ambient credential chain is empty.
-
-    Returns the mode to continue with, or raises :class:`WizardBack` when the
-    user chooses to configure base credentials first — the wizard reports the
-    service as skipped and they re-run setup once the chain exists.
-    """
-    if has_ambient_credentials():
-        return ROLE_MODE
+def _ask_gate() -> RoleGateChoice | None:
     _console.print(f"[{WARNING}]{NO_AMBIENT_CREDENTIALS_NOTICE}[/]")
-    choice = _choose(
-        "How would you like to continue?",
-        [
-            Choice(
-                value=KEYS_MODE,
-                label="Use an access key + secret instead",
-                hint="Simplest on a laptop. The key needs the read-only policies from the AWS docs.",
-            ),
-            Choice(
-                value=_CONFIGURE_ELSEWHERE,
-                label="I'll configure base credentials in this shell first",
-                hint="Run `aws configure` (or export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) "
-                "for an identity allowed sts:AssumeRole on the role, then re-run setup.",
-            ),
-            Choice(
-                value=_CONTINUE_ROLE,
-                label="Continue with the role anyway",
-                hint="Only useful if OpenSRE will run on EC2/ECS/Lambda with an attached role.",
-            ),
-        ],
-        default=KEYS_MODE,
+    picked = _choose(
+        GATE_QUESTION,
+        [Choice(value=str(o.value), label=o.label, hint=o.hint) for o in GATE_OPTIONS],
+        default=str(RoleGateChoice.USE_KEYS),
     )
-    if choice == KEYS_MODE:
-        return KEYS_MODE
-    if choice == _CONFIGURE_ELSEWHERE:
-        _console.print(
-            f"[{SECONDARY}]Configure base credentials in this shell, then run "
-            "`opensre onboard` (or `/integrations` → aws) again and pick IAM Role ARN.[/]"
-        )
-        raise WizardBack
-    return ROLE_MODE
+    return RoleGateChoice(picked)
 
 
 def _gate_aws_mode(mode: str) -> str:
-    """Mode gate for :func:`configure_from_spec`; only the role mode needs one."""
-    if mode != ROLE_MODE:
-        return mode
-    return _resolve_missing_base_credentials()
+    try:
+        return gate_role_mode(mode, ask=_ask_gate)
+    except ConfigureCredentialsFirst:
+        _console.print(f"[{SECONDARY}]{CONFIGURE_FIRST_INSTRUCTION}[/]")
+        # The wizard reports the service as skipped and moves on.
+        raise WizardBack from None
 
 
 def _configure_aws() -> tuple[str, str]:
     return configure_from_spec(AWS_SETUP, title="AWS", on_mode_chosen=_gate_aws_mode)
-
-
-__all__ = ["NO_AMBIENT_CREDENTIALS_NOTICE", "ROLE_MODE", "KEYS_MODE"]

--- a/surfaces/cli/wizard/configurators/spec_configurator.py
+++ b/surfaces/cli/wizard/configurators/spec_configurator.py
@@ -82,17 +82,23 @@ def configure_from_spec(
             default = _joined_values(
                 stored, separator=",", fallback=_string_value(stored, field.default)
             )
-            values[field.name] = _prompt_value(
-                field.question,
-                # A stored value wins over the spec's default, so re-running
-                # onboarding is a series of enters rather than a retype.
-                default=default,
-                secret=field.secret,
-                # Only reached when the field has no default to fall back on:
-                # _prompt_value substitutes the default before it consults this,
-                # so a defaulted field never re-prompts and never returns blank.
-                allow_empty=not spec.is_required(field, mode),
-            )
+            while True:
+                answer = _prompt_value(
+                    field.question,
+                    # A stored value wins over the spec's default, so re-running
+                    # onboarding is a series of enters rather than a retype.
+                    default=default,
+                    secret=field.secret,
+                    # Only reached when the field has no default to fall back on:
+                    # _prompt_value substitutes the default before it consults this,
+                    # so a defaulted field never re-prompts and never returns blank.
+                    allow_empty=not spec.is_required(field, mode),
+                )
+                problem = field.validate(answer) if answer and field.validate else None
+                if problem is None:
+                    break
+                _console.print(f"[{SECONDARY}]{problem}[/]")
+            values[field.name] = answer
         with _console.status(f"Validating {title} credentials...", spinner="dots"):
             outcome = apply_setup(spec, values)
         _render_integration_result(

--- a/surfaces/cli/wizard/configurators/spec_configurator.py
+++ b/surfaces/cli/wizard/configurators/spec_configurator.py
@@ -91,7 +91,7 @@ def configure_from_spec(
                 # Only reached when the field has no default to fall back on:
                 # _prompt_value substitutes the default before it consults this,
                 # so a defaulted field never re-prompts and never returns blank.
-                allow_empty=not field.required,
+                allow_empty=not spec.is_required(field, mode),
             )
         with _console.status(f"Validating {title} credentials...", spinner="dots"):
             outcome = apply_setup(spec, values)

--- a/surfaces/cli/wizard/configurators/spec_configurator.py
+++ b/surfaces/cli/wizard/configurators/spec_configurator.py
@@ -15,6 +15,8 @@ guidance differ, so those are the arguments.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from integrations.setup_flow import IntegrationSetupSpec, apply_setup
 from platform.terminal.theme import SECONDARY
 from surfaces.cli.wizard._ui import (
@@ -29,14 +31,25 @@ from surfaces.cli.wizard._ui import (
 )
 from surfaces.cli.wizard.integration_validators.shared import IntegrationHealthResult
 
+#: Vendor hook run after the mode picker and before its fields are prompted.
+#: Returns the mode to continue with — the same one, or a different one when
+#: the vendor steered the user (a prerequisite the chosen mode needs is absent).
+ModeGate = Callable[[str], str]
+
 
 def configure_from_spec(
-    spec: IntegrationSetupSpec, *, title: str, intro: str = ""
+    spec: IntegrationSetupSpec,
+    *,
+    title: str,
+    intro: str = "",
+    on_mode_chosen: ModeGate | None = None,
 ) -> tuple[str, str]:
     """Prompt for *spec*'s fields until they verify, then persist them.
 
-    Returns the pair the wizard's configurator table expects: the display name
-    and the ``.env`` path that was written.
+    *on_mode_chosen* lets a vendor check a mode's prerequisites at the moment
+    it is picked — before the user types credentials that cannot work — and
+    steer to another mode. Returns the pair the wizard's configurator table
+    expects: the display name and the ``.env`` path that was written.
     """
     _, credentials = _integration_defaults(spec.service)
     if intro:
@@ -49,6 +62,8 @@ def configure_from_spec(
                 [Choice(value=m.value, label=m.label) for m in spec.modes],
                 default=spec.modes[0].value,
             )
+            if on_mode_chosen is not None:
+                mode = on_mode_chosen(mode)
         collectable = {field.name for field in spec.collectable_fields(mode)}
         values: dict[str, str | None] = {}
         for field in spec.fields:

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -35,7 +35,7 @@ async def run_repl_async(
 ) -> int:
     """Run the shell on an existing event loop and return its exit code."""
     from platform.analytics.cli import identify_saved_github_username
-    from platform.logging import quiet_noisy_third_party_loggers
+    from platform.logging import install_shell_log_handler, quiet_noisy_third_party_loggers
 
     # Keep MCP schema-cache warnings / httpx chatter off the transcript —
     # progress is soft status lines, not library WARNINGs.
@@ -44,6 +44,10 @@ async def run_repl_async(
 
     cfg = config or ReplConfig.load()
     out = console or _DEFAULT_CONSOLE
+    # WARNING+ records print through the shell console, so one emitted from a
+    # probe thread while a status spinner animates lands whole above it instead
+    # of racing the spinner's redraw on the tty and staircasing what follows.
+    install_shell_log_handler(lambda: out)
     pt_session = build_prompt_session()
     runtime_context = create_repl_runtime_context(pt_session=pt_session)
     session = runtime_context.session

--- a/surfaces/interactive_shell/ui/components/rendering.py
+++ b/surfaces/interactive_shell/ui/components/rendering.py
@@ -18,7 +18,9 @@ from typing import Any
 from rich import box
 from rich.console import Console
 from rich.markup import escape
+from rich.segment import Segment
 from rich.table import Table
+from rich.text import Text
 
 import platform.terminal.theme as ui_theme
 
@@ -64,18 +66,32 @@ def _normalize_repl_line_endings(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\n", "\r\n")
 
 
-def _console_retains_output(console: Console) -> bool:
-    """True when the console keeps its own copy of what it prints.
+def _console_is_capturing(console: Console) -> bool:
+    """True inside an open ``capture()`` block, where output must not reach the file."""
+    return console._buffer_index > 0
 
-    ``record`` and an open ``capture()`` both buffer inside the ``Console``
-    object rather than at its file, so the direct ``sys.stdout`` write below
-    would be invisible to them even though the console targets stdout.
+
+def _feed_record_buffer(console: Console, plain_text: str) -> None:
+    """Append text the direct-stdout path wrote so ``export_text`` still sees it.
+
+    Every slash command runs under ``capture_console_segment``, which turns on
+    ``record`` so the analytics transcript gets a plain-text copy of what was
+    printed. That must not push tables onto the row-by-row ``console.print``
+    path — under ``patch_stdout(raw=True)`` each row is a bare ``\\n`` and the
+    table staircases across the screen. Recording is fed here instead.
     """
-    return bool(console.record) or console._buffer_index > 0
+    if not console.record:
+        return
+    # A delegating console (StreamingConsole) exports from the console it
+    # renders through; the record buffer that matters lives on that one.
+    owner = getattr(console, "_output", None) or console
+    with owner._record_buffer_lock:
+        owner._record_buffer.append(Segment(plain_text))
 
 
 def _write_repl_tty_buffered(
     *,
+    console: Console,
     width: int,
     leading_blank: bool,
     render_to_buffer: Callable[[Console], None],
@@ -89,15 +105,24 @@ def _write_repl_tty_buffered(
         width=width,
     )
     render_to_buffer(buf_console)
-    rendered = _normalize_repl_line_endings(buf.getvalue())
+    styled = buf.getvalue()
+    rendered = _normalize_repl_line_endings(styled)
     if leading_blank:
         rendered = "\r\n" + rendered
+    # Start at column zero regardless of where the previous writer (a status
+    # spinner's teardown, a wrapped log line) left the cursor; otherwise the
+    # first row begins mid-line and the rows below inherit the offset.
+    # Start at column zero regardless of where the previous writer (a status
+    # spinner's teardown, a wrapped log line) left the cursor; otherwise the
+    # first row begins mid-line and the rows below inherit the offset.
+    rendered = "\r" + rendered
     token = _REPL_OUTPUT_PREPARED.set(True)
     try:
         sys.stdout.write(rendered)
         sys.stdout.flush()
     finally:
         _REPL_OUTPUT_PREPARED.reset(token)
+    _feed_record_buffer(console, Text.from_ansi(styled).plain)
 
 
 def print_repl_table(console: Console, table: Table, *, width: int | None = None) -> None:
@@ -117,8 +142,9 @@ def print_repl_table(console: Console, table: Table, *, width: int | None = None
     """
     leading_blank = width is None
     width = width if width is not None else _prepare_tty_for_rich(console)
-    if console.file is sys.stdout and sys.stdout.isatty() and not _console_retains_output(console):
+    if console.file is sys.stdout and sys.stdout.isatty() and not _console_is_capturing(console):
         _write_repl_tty_buffered(
+            console=console,
             width=width,
             leading_blank=leading_blank,
             render_to_buffer=lambda buf_console: buf_console.print(table),
@@ -141,8 +167,9 @@ def print_repl_json(console: Console, json_str: str) -> None:
     sequence being left in stdin by a prompt_toolkit toolbar flush.
     """
     width = _prepare_tty_for_rich(console)
-    if console.file is sys.stdout and sys.stdout.isatty() and not _console_retains_output(console):
+    if console.file is sys.stdout and sys.stdout.isatty() and not _console_is_capturing(console):
         _write_repl_tty_buffered(
+            console=console,
             width=width,
             leading_blank=True,
             render_to_buffer=lambda buf_console: buf_console.print_json(json_str),
@@ -213,7 +240,7 @@ def repl_render_launch_poster(
     """Render splash + welcome panel using REPL-safe CRLF writes."""
     from surfaces.interactive_shell.ui.terminal_ui import render_terminal_ui
 
-    if console.file is sys.stdout and sys.stdout.isatty() and not _console_retains_output(console):
+    if console.file is sys.stdout and sys.stdout.isatty() and not _console_is_capturing(console):
         width = _prepare_tty_for_rich(console)
         buf = io.StringIO()
         buf_console = Console(
@@ -227,6 +254,7 @@ def repl_render_launch_poster(
         render_terminal_ui(buf_console, session=session, first_run=False)
         prefix = _theme_notice_line(theme_notice) if theme_notice else ""
         _repl_write_buffer(prefix + buf.getvalue())
+        _feed_record_buffer(console, Text.from_ansi(buf.getvalue()).plain)
         return
 
     if theme_notice:

--- a/tests/cli/wizard/test_configurator_aws.py
+++ b/tests/cli/wizard/test_configurator_aws.py
@@ -1,9 +1,7 @@
 """AWS wizard: the role mode is gated on the ambient credential chain.
 
-Assuming a role needs base credentials boto3 can find; on a bare laptop the
-wizard used to collect the ARN and fail STS with "Unable to locate
-credentials". The gate runs when "IAM Role ARN" is picked and offers the ways
-forward instead.
+The decision lives in :mod:`integrations.aws.role_mode_gate` (shared with the
+CLI); these tests pin the wizard's adapter — how it asks, and how it leaves.
 """
 
 from __future__ import annotations
@@ -13,6 +11,7 @@ from typing import Any
 import pytest
 
 import surfaces.cli.wizard.configurators.aws as aws_configurator
+from integrations.aws import role_mode_gate as gate
 from surfaces.cli.wizard._ui import WizardBack
 
 
@@ -41,28 +40,28 @@ def test_role_mode_passes_through_when_ambient_credentials_exist(
     monkeypatch: pytest.MonkeyPatch, quiet_console: list[str]
 ) -> None:
     # Arrange — a profile / env keys / instance role is present
-    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: True)
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: True)
     offered = _pick(monkeypatch, "unused")
 
     # Act
-    mode = aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
+    mode = aws_configurator._gate_aws_mode(gate.ROLE_MODE)
 
     # Assert — no notice, no extra question
-    assert mode == aws_configurator.ROLE_MODE
+    assert mode == gate.ROLE_MODE
     assert offered == []
     assert quiet_console == []
 
 
 def test_keys_mode_is_never_gated(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange — even with no ambient chain, static keys need no prerequisite
-    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
     offered = _pick(monkeypatch, "unused")
 
     # Act
-    mode = aws_configurator._gate_aws_mode(aws_configurator.KEYS_MODE)
+    mode = aws_configurator._gate_aws_mode(gate.KEYS_MODE)
 
     # Assert
-    assert mode == aws_configurator.KEYS_MODE
+    assert mode == gate.KEYS_MODE
     assert offered == []
 
 
@@ -70,21 +69,17 @@ def test_missing_chain_explains_and_steers_to_keys_by_default(
     monkeypatch: pytest.MonkeyPatch, quiet_console: list[str]
 ) -> None:
     # Arrange — bare laptop; user accepts the recommended way forward
-    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
-    offered = _pick(monkeypatch, aws_configurator.KEYS_MODE)
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
+    offered = _pick(monkeypatch, str(gate.RoleGateChoice.USE_KEYS))
 
     # Act
-    mode = aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
+    mode = aws_configurator._gate_aws_mode(gate.ROLE_MODE)
 
     # Assert — the user was told why, offered all three paths, and lands on keys
-    assert mode == aws_configurator.KEYS_MODE
-    assert any(aws_configurator.NO_AMBIENT_CREDENTIALS_NOTICE in line for line in quiet_console)
-    assert offered[0]["default"] == aws_configurator.KEYS_MODE
-    assert set(offered[0]["values"]) == {
-        aws_configurator.KEYS_MODE,
-        aws_configurator._CONFIGURE_ELSEWHERE,
-        aws_configurator._CONTINUE_ROLE,
-    }
+    assert mode == gate.KEYS_MODE
+    assert any(gate.NO_AMBIENT_CREDENTIALS_NOTICE in line for line in quiet_console)
+    assert offered[0]["default"] == str(gate.RoleGateChoice.USE_KEYS)
+    assert set(offered[0]["values"]) == {str(c) for c in gate.RoleGateChoice}
 
 
 def test_choosing_to_configure_credentials_first_leaves_setup_cleanly(
@@ -92,27 +87,46 @@ def test_choosing_to_configure_credentials_first_leaves_setup_cleanly(
 ) -> None:
     """The wizard treats WizardBack as 'skipped' — no dead-end retry loop."""
     # Arrange
-    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
-    _pick(monkeypatch, aws_configurator._CONFIGURE_ELSEWHERE)
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
+    _pick(monkeypatch, str(gate.RoleGateChoice.CONFIGURE_FIRST))
 
     # Act / Assert
     with pytest.raises(WizardBack):
-        aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
-    assert any(
-        "aws configure" in line or "run setup" in line.lower() or "onboard" in line
-        for line in quiet_console
-    )
+        aws_configurator._gate_aws_mode(gate.ROLE_MODE)
+    assert any(gate.CONFIGURE_FIRST_INSTRUCTION in line for line in quiet_console)
 
 
 def test_user_may_insist_on_the_role_for_an_instance_role_deployment(
     monkeypatch: pytest.MonkeyPatch, quiet_console: list[str]
 ) -> None:
     # Arrange — user knows OpenSRE will run on EC2/ECS with an attached role
-    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
-    _pick(monkeypatch, aws_configurator._CONTINUE_ROLE)
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
+    _pick(monkeypatch, str(gate.RoleGateChoice.CONTINUE_ROLE))
 
     # Act
-    mode = aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
+    mode = aws_configurator._gate_aws_mode(gate.ROLE_MODE)
 
     # Assert
-    assert mode == aws_configurator.ROLE_MODE
+    assert mode == gate.ROLE_MODE
+
+
+def test_role_mode_requires_the_arn_and_keys_mode_requires_id_and_secret() -> None:
+    """The prompt refuses a blank ARN in role mode — no pydantic dead end."""
+    from integrations.aws.setup import (
+        ACCESS_KEY_ID_FIELD,
+        AWS_SETUP,
+        EXTERNAL_ID_FIELD,
+        ROLE_ARN_FIELD,
+        SECRET_ACCESS_KEY_FIELD,
+        SESSION_TOKEN_FIELD,
+    )
+
+    by_name = {field.name: field for field in AWS_SETUP.fields}
+
+    assert AWS_SETUP.is_required(by_name[ROLE_ARN_FIELD], gate.ROLE_MODE) is True
+    assert AWS_SETUP.is_required(by_name[EXTERNAL_ID_FIELD], gate.ROLE_MODE) is False
+    assert AWS_SETUP.is_required(by_name[ACCESS_KEY_ID_FIELD], gate.KEYS_MODE) is True
+    assert AWS_SETUP.is_required(by_name[SECRET_ACCESS_KEY_FIELD], gate.KEYS_MODE) is True
+    assert AWS_SETUP.is_required(by_name[SESSION_TOKEN_FIELD], gate.KEYS_MODE) is False
+    # And each mode's fields stay optional under the other mode (they are cleared there).
+    assert AWS_SETUP.is_required(by_name[ROLE_ARN_FIELD], gate.KEYS_MODE) is False

--- a/tests/cli/wizard/test_configurator_aws.py
+++ b/tests/cli/wizard/test_configurator_aws.py
@@ -1,0 +1,118 @@
+"""AWS wizard: the role mode is gated on the ambient credential chain.
+
+Assuming a role needs base credentials boto3 can find; on a bare laptop the
+wizard used to collect the ARN and fail STS with "Unable to locate
+credentials". The gate runs when "IAM Role ARN" is picked and offers the ways
+forward instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import surfaces.cli.wizard.configurators.aws as aws_configurator
+from surfaces.cli.wizard._ui import WizardBack
+
+
+@pytest.fixture
+def quiet_console(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    printed: list[str] = []
+    monkeypatch.setattr(
+        aws_configurator._console, "print", lambda *args, **_kw: printed.append(str(args[0]))
+    )
+    return printed
+
+
+def _pick(monkeypatch: pytest.MonkeyPatch, value: str) -> list[dict[str, Any]]:
+    """Stub the wizard picker to answer *value* and record what was offered."""
+    offered: list[dict[str, Any]] = []
+
+    def _fake_choose(prompt: str, choices: list[Any], **kwargs: Any) -> str:
+        offered.append({"prompt": prompt, "values": [c.value for c in choices], **kwargs})
+        return value
+
+    monkeypatch.setattr(aws_configurator, "_choose", _fake_choose)
+    return offered
+
+
+def test_role_mode_passes_through_when_ambient_credentials_exist(
+    monkeypatch: pytest.MonkeyPatch, quiet_console: list[str]
+) -> None:
+    # Arrange — a profile / env keys / instance role is present
+    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: True)
+    offered = _pick(monkeypatch, "unused")
+
+    # Act
+    mode = aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
+
+    # Assert — no notice, no extra question
+    assert mode == aws_configurator.ROLE_MODE
+    assert offered == []
+    assert quiet_console == []
+
+
+def test_keys_mode_is_never_gated(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange — even with no ambient chain, static keys need no prerequisite
+    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
+    offered = _pick(monkeypatch, "unused")
+
+    # Act
+    mode = aws_configurator._gate_aws_mode(aws_configurator.KEYS_MODE)
+
+    # Assert
+    assert mode == aws_configurator.KEYS_MODE
+    assert offered == []
+
+
+def test_missing_chain_explains_and_steers_to_keys_by_default(
+    monkeypatch: pytest.MonkeyPatch, quiet_console: list[str]
+) -> None:
+    # Arrange — bare laptop; user accepts the recommended way forward
+    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
+    offered = _pick(monkeypatch, aws_configurator.KEYS_MODE)
+
+    # Act
+    mode = aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
+
+    # Assert — the user was told why, offered all three paths, and lands on keys
+    assert mode == aws_configurator.KEYS_MODE
+    assert any(aws_configurator.NO_AMBIENT_CREDENTIALS_NOTICE in line for line in quiet_console)
+    assert offered[0]["default"] == aws_configurator.KEYS_MODE
+    assert set(offered[0]["values"]) == {
+        aws_configurator.KEYS_MODE,
+        aws_configurator._CONFIGURE_ELSEWHERE,
+        aws_configurator._CONTINUE_ROLE,
+    }
+
+
+def test_choosing_to_configure_credentials_first_leaves_setup_cleanly(
+    monkeypatch: pytest.MonkeyPatch, quiet_console: list[str]
+) -> None:
+    """The wizard treats WizardBack as 'skipped' — no dead-end retry loop."""
+    # Arrange
+    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
+    _pick(monkeypatch, aws_configurator._CONFIGURE_ELSEWHERE)
+
+    # Act / Assert
+    with pytest.raises(WizardBack):
+        aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
+    assert any(
+        "aws configure" in line or "run setup" in line.lower() or "onboard" in line
+        for line in quiet_console
+    )
+
+
+def test_user_may_insist_on_the_role_for_an_instance_role_deployment(
+    monkeypatch: pytest.MonkeyPatch, quiet_console: list[str]
+) -> None:
+    # Arrange — user knows OpenSRE will run on EC2/ECS with an attached role
+    monkeypatch.setattr(aws_configurator, "has_ambient_credentials", lambda: False)
+    _pick(monkeypatch, aws_configurator._CONTINUE_ROLE)
+
+    # Act
+    mode = aws_configurator._gate_aws_mode(aws_configurator.ROLE_MODE)
+
+    # Assert
+    assert mode == aws_configurator.ROLE_MODE

--- a/tests/cli/wizard/test_spec_configurator.py
+++ b/tests/cli/wizard/test_spec_configurator.py
@@ -150,3 +150,62 @@ def test_failed_verification_re_asks_instead_of_leaving_the_wizard(run: _Run) ->
     assert title == "Demo"
     # Three fields asked twice: the first round failed, the second succeeded.
     assert len(run.asked) == 6
+
+
+_MODED_SPEC = setup_flow.IntegrationSetupSpec(
+    service="demo-moded",
+    # Mode-gated fields are optional at the spec level (as every real moded
+    # spec declares them): the un-chosen mode's fields are cleared, not asked.
+    fields=(
+        setup_flow.SetupField(
+            name="token", label="Demo token", env_var="DEMO_TOKEN", required=False
+        ),
+        setup_flow.SetupField(name="user", label="Demo user", env_var="DEMO_USER", required=False),
+        setup_flow.SetupField(
+            name="password", label="Demo password", env_var="DEMO_PASSWORD", required=False
+        ),
+    ),
+    mode_prompt="Auth method:",
+    modes=(
+        setup_flow.SetupMode(value="token", label="Token", fields=("token",)),
+        setup_flow.SetupMode(value="basic", label="Basic", fields=("user", "password")),
+    ),
+    verify=lambda _source, _config: {"status": "passed", "detail": "ok"},
+)
+
+
+def test_mode_gate_can_steer_to_a_different_mode_before_fields_are_asked(
+    run: _Run, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vendor may swap the picked mode when its prerequisite is missing."""
+    # Arrange — user picks "token"; the gate finds it unusable and steers to "basic"
+    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "token")
+    gated_with: list[str] = []
+
+    def steer_to_basic(mode: str) -> str:
+        gated_with.append(mode)
+        return "basic"
+
+    run.answers = {"Demo user": "u", "Demo password": "p"}
+
+    # Act
+    spec_configurator.configure_from_spec(_MODED_SPEC, title="Demo", on_mode_chosen=steer_to_basic)
+
+    # Assert — the gate saw the picked mode; only the steered mode's fields were asked
+    assert gated_with == ["token"]
+    asked = [entry["label"] for entry in run.asked]
+    assert asked == ["Demo user", "Demo password"]
+
+
+def test_without_a_mode_gate_the_picked_mode_is_used_unchanged(
+    run: _Run, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "token")
+    run.answers = {"Demo token": "t"}
+
+    # Act
+    spec_configurator.configure_from_spec(_MODED_SPEC, title="Demo")
+
+    # Assert
+    assert [entry["label"] for entry in run.asked] == ["Demo token"]

--- a/tests/cli/wizard/test_spec_configurator.py
+++ b/tests/cli/wizard/test_spec_configurator.py
@@ -167,7 +167,9 @@ _MODED_SPEC = setup_flow.IntegrationSetupSpec(
     ),
     mode_prompt="Auth method:",
     modes=(
-        setup_flow.SetupMode(value="token", label="Token", fields=("token",)),
+        setup_flow.SetupMode(
+            value="token", label="Token", fields=("token",), required_fields=("token",)
+        ),
         setup_flow.SetupMode(value="basic", label="Basic", fields=("user", "password")),
     ),
     verify=lambda _source, _config: {"status": "passed", "detail": "ok"},
@@ -209,3 +211,38 @@ def test_without_a_mode_gate_the_picked_mode_is_used_unchanged(
 
     # Assert
     assert [entry["label"] for entry in run.asked] == ["Demo token"]
+
+
+def test_a_field_required_by_the_chosen_mode_may_not_be_left_empty(
+    run: _Run, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Optional at spec level (unset in other modes), required within this mode.
+
+    AWS's role ARN: blank must be refused at the prompt, not surface later as a
+    config-model "requires either role_arn or credentials" validation error.
+    """
+    # Arrange — user picks "token"; the spec says token is required in that mode
+    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "token")
+    run.answers = {"Demo token": "t"}
+
+    # Act
+    spec_configurator.configure_from_spec(_MODED_SPEC, title="Demo")
+
+    # Assert — the token prompt does not allow an empty answer
+    token_prompt = next(entry for entry in run.asked if entry["label"] == "Demo token")
+    assert token_prompt["allow_empty"] is False
+
+
+def test_the_same_field_stays_optional_when_another_mode_is_chosen(
+    run: _Run, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange — "basic" is chosen; its fields are optional at every level
+    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "basic")
+    run.answers = {"Demo user": "u", "Demo password": "p"}
+
+    # Act
+    spec_configurator.configure_from_spec(_MODED_SPEC, title="Demo")
+
+    # Assert
+    asked = {entry["label"]: entry["allow_empty"] for entry in run.asked}
+    assert asked == {"Demo user": True, "Demo password": True}

--- a/tests/integrations/aws/test_base_session.py
+++ b/tests/integrations/aws/test_base_session.py
@@ -90,3 +90,60 @@ def test_nothing_anywhere_means_no_credentials(
 
     # Assert
     assert has_ambient_credentials() is False
+
+
+def _provider_names(session: object) -> list[str]:
+    resolver = session._session.get_component("credential_provider")  # type: ignore[attr-defined]
+    return [p.METHOD for p in resolver.providers]
+
+
+@pytest.mark.usefixtures("isolated_aws_env")
+def test_local_only_drops_the_network_credential_providers() -> None:
+    """The setup gate's pre-check must answer instantly on a laptop or behind a proxy.
+
+    boto3's chain ends with the ECS container endpoint and EC2 instance
+    metadata; on a machine that is neither, they wait out connect timeouts
+    (measured: ~4s with IMDS blackholed) before saying "no credentials". The
+    pre-check only decides whether to warn, so it looks at local sources only.
+    """
+    # Act
+    names = _provider_names(aws_env.base_session(local_only=True))
+
+    # Assert
+    assert "container-role" not in names
+    assert "iam-role" not in names
+    assert "shared-credentials-file" in names  # local sources stay
+
+
+@pytest.mark.usefixtures("isolated_aws_env")
+def test_the_default_session_keeps_the_full_chain_for_real_calls() -> None:
+    """On EC2/ECS the attached role *is* the credential; the STS call must find it."""
+    # Act
+    names = _provider_names(aws_env.base_session())
+
+    # Assert
+    assert "container-role" in names
+    assert "iam-role" in names
+
+
+def test_has_ambient_credentials_is_local_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange — record what base_session is asked for
+    seen: dict[str, object] = {}
+
+    class _NoCreds:
+        def get_credentials(self) -> None:
+            return None
+
+    def _fake_base_session(*, region: str | None = None, local_only: bool = False) -> _NoCreds:
+        seen["local_only"] = local_only
+        return _NoCreds()
+
+    monkeypatch.setattr(aws_env, "base_session", _fake_base_session)
+    from integrations.aws.credential_chain import has_ambient_credentials
+
+    # Act
+    result = has_ambient_credentials()
+
+    # Assert
+    assert result is False
+    assert seen == {"local_only": True}

--- a/tests/integrations/aws/test_base_session.py
+++ b/tests/integrations/aws/test_base_session.py
@@ -1,0 +1,92 @@
+"""``base_session`` — OpenSRE's own base identity for boto3, half-pair safe.
+
+OpenSRE keeps ``AWS_SECRET_ACCESS_KEY`` keyring-only, so its ``.env`` loads
+``AWS_ACCESS_KEY_ID`` alone into the process. boto3 reads the pair as one unit
+and raises ``PartialCredentialsError`` on a lone id instead of falling through
+to ``~/.aws`` — which broke the role mode for anyone who had ever set up static
+keys. ``base_session`` pairs the id with the keyring secret when both resolve,
+and otherwise drops boto3's ``env`` provider so the chain falls through.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import integrations.aws.env as aws_env
+
+
+def _resolve_from_process_env(key: str, *, default: str = "") -> str:
+    """Stand-in for the OpenSRE resolver: process env only, no keyring."""
+    return os.environ.get(key, default)
+
+
+def _resolve_nothing(_key: str, *, default: str = "") -> str:
+    return default
+
+
+@pytest.fixture
+def isolated_aws_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """No real profiles or keys can leak in; a fake profile file is provided."""
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE"):
+        monkeypatch.delenv(name, raising=False)
+    creds = tmp_path / "credentials"
+    creds.write_text("[default]\naws_access_key_id = AKIAFROMPROFILE\naws_secret_access_key = s\n")
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "config"))
+    # The OpenSRE resolver only sees the process env in these tests (no keyring).
+    monkeypatch.setattr("config.llm_credentials.resolve_env_credential", _resolve_from_process_env)
+    return creds
+
+
+@pytest.mark.usefixtures("isolated_aws_env")
+def test_a_lone_access_key_id_does_not_block_the_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reporter's machine: id from .env, secret in the keyring, profile in ~/.aws."""
+    # Arrange — half a pair in the environment
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAHALFPAIRFROMDOTENV")
+
+    # Act
+    credentials = aws_env.base_session().get_credentials()
+
+    # Assert — boto3 fell through to the profile instead of raising
+    assert credentials is not None
+    assert credentials.method == "shared-credentials-file"
+    assert credentials.access_key == "AKIAFROMPROFILE"
+
+
+@pytest.mark.usefixtures("isolated_aws_env")
+def test_a_complete_pair_is_used_explicitly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When id and secret both resolve, that identity wins over any profile."""
+    # Arrange
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    # Act
+    credentials = aws_env.base_session().get_credentials()
+
+    # Assert
+    assert credentials is not None
+    assert credentials.method == "explicit"
+    assert credentials.access_key == "AKIAEXAMPLE"
+
+
+def test_nothing_anywhere_means_no_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The bare-laptop case the role-mode gate is built for."""
+    # Arrange
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "nope"))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nope-config"))
+    monkeypatch.setattr("config.llm_credentials.resolve_env_credential", _resolve_nothing)
+    # Instance-metadata lookups must not run in a unit test
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+    # Act
+    from integrations.aws.credential_chain import has_ambient_credentials
+
+    # Assert
+    assert has_ambient_credentials() is False

--- a/tests/integrations/aws/test_cli_setup_role_gate.py
+++ b/tests/integrations/aws/test_cli_setup_role_gate.py
@@ -104,3 +104,50 @@ def test_configure_first_prints_the_instruction_and_exits_zero(
     assert exit_info.value.code == 0
     assert any(gate.CONFIGURE_FIRST_INSTRUCTION in line for line in seen["printed"])
     assert seen["prompts"] == []
+
+
+def test_an_invalid_role_arn_is_asked_again_with_the_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A role ID pasted as the ARN is refused at the prompt, not by STS later."""
+    import dataclasses
+
+    import integrations.aws.setup as aws_setup
+
+    # Arrange — credentials present so the gate is silent; first ARN answer is the
+    # role's unique ID, second is a real ARN
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: True)
+    verified: list[dict[str, Any]] = []
+
+    def _fake_verify(_source: str, config: dict[str, Any]) -> dict[str, str]:
+        verified.append(dict(config))
+        return {"status": "passed", "detail": "ok"}
+
+    monkeypatch.setattr(
+        aws_setup, "AWS_SETUP", dataclasses.replace(aws_setup.AWS_SETUP, verify=_fake_verify)
+    )
+    monkeypatch.setattr("integrations.setup_flow.upsert_integration", lambda *_a: None)
+    monkeypatch.setattr("integrations.setup_flow.sync_env_secret", lambda *_a: None)
+    monkeypatch.setattr("integrations.setup_flow.sync_env_values", lambda *_a, **_k: "/tmp/.env")
+    monkeypatch.setattr(
+        "integrations.setup_flow.push_webapp_org_integration", lambda *_a, **_k: None
+    )
+    seen = _script_cli(
+        monkeypatch,
+        mode_pick=gate.ROLE_MODE,
+        gate_pick=None,
+        answers=[
+            "us-east-1",
+            "AROAVYB3PA5RPMNFXNNJM",  # rejected
+            "arn:aws:iam::123456789012:role/OpenSREReadOnly",  # accepted
+            "",  # external id
+        ],
+    )
+
+    # Act
+    cli._setup_aws()
+
+    # Assert — the ARN prompt ran twice, the reason was printed, and setup went on
+    assert seen["prompts"].count("IAM Role ARN") == 2
+    assert any("unique ID" in line for line in seen["printed"])
+    assert verified and verified[0]["role_arn"] == "arn:aws:iam::123456789012:role/OpenSREReadOnly"

--- a/tests/integrations/aws/test_cli_setup_role_gate.py
+++ b/tests/integrations/aws/test_cli_setup_role_gate.py
@@ -1,0 +1,106 @@
+"""``opensre integrations setup aws`` — the surface behind the shell's /integrations setup.
+
+The wizard already gated the role mode; the CLI did not, so a shell user with
+no ambient credentials still typed an ARN and hit "Unable to locate
+credentials". Both surfaces now share :mod:`integrations.aws.role_mode_gate`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import integrations.cli as cli
+from integrations.aws import role_mode_gate as gate
+
+
+@pytest.fixture
+def no_ambient_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
+
+
+def _script_cli(
+    monkeypatch: pytest.MonkeyPatch, *, mode_pick: str, gate_pick: str | None, answers: list[str]
+) -> dict[str, Any]:
+    """Drive the CLI prompts: mode picker, then the gate question, then fields."""
+    seen: dict[str, Any] = {"selects": [], "prompts": [], "printed": []}
+    picks = [mode_pick, gate_pick]
+
+    def _fake_select(message: str, choices: list[Any], **_kw: Any) -> Any:
+        seen["selects"].append(message)
+        return picks.pop(0)
+
+    def _fake_p(label: str, default: str = "", secret: bool = False) -> str:
+        seen["prompts"].append(label)
+        return answers.pop(0)
+
+    monkeypatch.setattr(cli, "_select", _fake_select)
+    monkeypatch.setattr(cli, "_p", _fake_p)
+    monkeypatch.setattr(
+        "builtins.print", lambda *a, **_k: seen["printed"].append(" ".join(map(str, a)))
+    )
+    return seen
+
+
+@pytest.mark.usefixtures("no_ambient_credentials")
+def test_role_pick_without_credentials_asks_the_gate_and_can_switch_to_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange — user picks the role mode, then "use keys instead"; keys prompts follow
+    import dataclasses
+
+    import integrations.aws.setup as aws_setup
+
+    verified: list[dict[str, Any]] = []
+
+    def _fake_verify(_source: str, config: dict[str, Any]) -> dict[str, str]:
+        verified.append(dict(config))
+        return {"status": "passed", "detail": "ok"}
+
+    monkeypatch.setattr(
+        aws_setup, "AWS_SETUP", dataclasses.replace(aws_setup.AWS_SETUP, verify=_fake_verify)
+    )
+    monkeypatch.setattr("integrations.setup_flow.upsert_integration", lambda *_a: None)
+    monkeypatch.setattr("integrations.setup_flow.sync_env_secret", lambda *_a: None)
+    monkeypatch.setattr("integrations.setup_flow.sync_env_values", lambda *_a, **_k: "/tmp/.env")
+    monkeypatch.setattr(
+        "integrations.setup_flow.push_webapp_org_integration", lambda *_a, **_k: None
+    )
+    seen = _script_cli(
+        monkeypatch,
+        mode_pick=gate.ROLE_MODE,
+        gate_pick=str(gate.RoleGateChoice.USE_KEYS),
+        answers=["us-east-1", "AKIAEXAMPLE", "secret", ""],  # region, key id, secret, token
+    )
+
+    # Act
+    cli._setup_aws()
+
+    # Assert — the gate question was asked, and only keys-mode fields were prompted
+    assert seen["selects"] == ["AWS authentication method:", gate.GATE_QUESTION]
+    assert "IAM Role ARN" not in seen["prompts"]
+    assert "AWS_ACCESS_KEY_ID" in seen["prompts"]
+    assert verified and verified[0].get("access_key_id") == "AKIAEXAMPLE"
+
+
+@pytest.mark.usefixtures("no_ambient_credentials")
+def test_configure_first_prints_the_instruction_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    seen = _script_cli(
+        monkeypatch,
+        mode_pick=gate.ROLE_MODE,
+        gate_pick=str(gate.RoleGateChoice.CONFIGURE_FIRST),
+        answers=[],
+    )
+
+    # Act
+    with pytest.raises(SystemExit) as exit_info:
+        cli._setup_aws()
+
+    # Assert — a clean, deliberate exit with the way back, not an error
+    assert exit_info.value.code == 0
+    assert any(gate.CONFIGURE_FIRST_INSTRUCTION in line for line in seen["printed"])
+    assert seen["prompts"] == []

--- a/tests/integrations/aws/test_role_arn_validation.py
+++ b/tests/integrations/aws/test_role_arn_validation.py
@@ -1,0 +1,79 @@
+"""Role ARN shape is checked at the prompt; partial env credentials get their own message."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from integrations.aws.setup import validate_role_arn
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "arn:aws:iam::395261708130:role/OpenSREReadOnly",
+        "  arn:aws:iam::123456789012:role/path/Nested  ",
+    ],
+)
+def test_a_role_arn_is_accepted(value: str) -> None:
+    assert validate_role_arn(value) is None
+
+
+def test_the_roles_unique_id_is_rejected_with_a_pointer_to_the_arn() -> None:
+    """The slip seen in the field: the ``AROA…`` unique ID pasted where the ARN belongs."""
+    problem = validate_role_arn("AROAVYB3PA5RPMNFXNNJM")
+
+    assert problem is not None
+    assert "unique ID" in problem
+    assert "arn:aws:iam::" in problem
+
+
+def test_a_user_arn_is_rejected_and_told_a_role_is_needed() -> None:
+    """The slip in the field: the user's own ARN pasted where a role belongs."""
+    problem = validate_role_arn("arn:aws:iam::395261708130:user/yauhen")
+
+    assert problem is not None
+    assert "user" in problem and "role" in problem
+    assert "Access Key + Secret" in problem
+    assert "IAM → Roles" in problem
+
+
+def test_a_bare_role_name_is_rejected_with_the_arn_pattern_filled_in() -> None:
+    problem = validate_role_arn("OpenSREReadOnly")
+
+    assert problem is not None
+    assert "role/OpenSREReadOnly" in problem
+    assert "<account-id>" in problem
+
+
+def test_anything_else_is_rejected_with_an_example() -> None:
+    problem = validate_role_arn("arn:aws:iam::123:role/")
+
+    assert problem is not None
+    assert "arn:aws:iam::123456789012:role/OpenSREReadOnly" in problem
+
+
+def test_partial_env_credentials_name_the_missing_variable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AWS_ACCESS_KEY_ID set without its secret is not 'no credentials' — say which half is missing."""
+    from botocore.exceptions import PartialCredentialsError
+
+    from integrations.aws.verifier import ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE, verify_aws
+
+    class _BaseSTSClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            raise PartialCredentialsError(provider="env", cred_var="AWS_SECRET_ACCESS_KEY")
+
+    monkeypatch.setattr(
+        "integrations.aws.verifier.boto3.client", lambda *_a, **_k: _BaseSTSClient()
+    )
+
+    result = verify_aws(
+        "setup", {"role_arn": "arn:aws:iam::123456789012:role/x", "region": "us-east-1"}
+    )
+
+    assert result["status"] == "failed"
+    # Half a key pair is its own situation — not "none were found" plus a footnote.
+    assert ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE not in result["detail"]
+    assert "AWS_SECRET_ACCESS_KEY is not set" in result["detail"]
+    assert "set both" in result["detail"]

--- a/tests/integrations/aws/test_role_arn_validation.py
+++ b/tests/integrations/aws/test_role_arn_validation.py
@@ -65,7 +65,7 @@ def test_partial_env_credentials_name_the_missing_variable(monkeypatch: pytest.M
             raise PartialCredentialsError(provider="env", cred_var="AWS_SECRET_ACCESS_KEY")
 
     monkeypatch.setattr(
-        "integrations.aws.verifier.boto3.client", lambda *_a, **_k: _BaseSTSClient()
+        "integrations.aws.verifier._base_sts_client", lambda _region: _BaseSTSClient()
     )
 
     result = verify_aws(

--- a/tests/integrations/aws/test_role_mode_gate.py
+++ b/tests/integrations/aws/test_role_mode_gate.py
@@ -1,0 +1,60 @@
+"""The AWS role-mode gate: shared decision for the CLI and the wizard."""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations.aws import role_mode_gate as gate
+
+
+def test_role_mode_is_untouched_when_the_chain_has_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: True)
+    asked: list[bool] = []
+
+    # Act
+    mode = gate.gate_role_mode(gate.ROLE_MODE, ask=lambda: asked.append(True) or None)
+
+    # Assert — no question asked
+    assert mode == gate.ROLE_MODE
+    assert asked == []
+
+
+def test_keys_mode_never_asks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
+    asked: list[bool] = []
+
+    mode = gate.gate_role_mode(gate.KEYS_MODE, ask=lambda: asked.append(True) or None)
+
+    assert mode == gate.KEYS_MODE
+    assert asked == []
+
+
+@pytest.mark.parametrize(
+    ("choice", "expected_mode"),
+    [
+        (gate.RoleGateChoice.USE_KEYS, gate.KEYS_MODE),
+        (gate.RoleGateChoice.CONTINUE_ROLE, gate.ROLE_MODE),
+    ],
+)
+def test_empty_chain_steers_by_the_users_choice(
+    monkeypatch: pytest.MonkeyPatch, choice: gate.RoleGateChoice, expected_mode: str
+) -> None:
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
+
+    mode = gate.gate_role_mode(gate.ROLE_MODE, ask=lambda: choice)
+
+    assert mode == expected_mode
+
+
+@pytest.mark.parametrize("choice", [gate.RoleGateChoice.CONFIGURE_FIRST, None])
+def test_configure_first_or_cancel_leaves_setup(
+    monkeypatch: pytest.MonkeyPatch, choice: gate.RoleGateChoice | None
+) -> None:
+    """Both mean "not now": the surface prints the instruction and exits cleanly."""
+    monkeypatch.setattr(gate, "has_ambient_credentials", lambda: False)
+
+    with pytest.raises(gate.ConfigureCredentialsFirst):
+        gate.gate_role_mode(gate.ROLE_MODE, ask=lambda: choice)

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,0 +1,25 @@
+"""No AWS test may reach a real account.
+
+A test that misses a patch must fail with "no credentials", never make a live
+STS / EC2 / S3 call against whatever ``~/.aws`` profile the developer has. This
+happened once: an AWS role-path test in this tree bypassed its ``boto3.client``
+fake and called ``sts:AssumeRole`` on a personal account. These env vars make
+boto3's chain find nothing (no shared files, no instance metadata) unless a
+test sets its own; scoped to ``tests/integrations`` because that is where the
+AWS verifier, catalog, and vendor client tests live.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_real_aws_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-credentials"))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-config"))
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")

--- a/tests/integrations/telegram/test_cli_setup_characterization.py
+++ b/tests/integrations/telegram/test_cli_setup_characterization.py
@@ -145,15 +145,24 @@ def test_typed_channel_name_is_stored_as_the_resolved_numeric_id(
     assert telegram.store[0][1]["credentials"]["default_chat_id"] == _CHAT_ID
 
 
-def test_blank_chat_id_is_rejected(monkeypatch: pytest.MonkeyPatch, telegram: _Telegram) -> None:
-    """Token-only setup used to be allowed; it produces an undeliverable integration."""
-    _prompts(monkeypatch, telegram, _TOKEN, "")
+def test_blank_chat_id_is_asked_again_not_accepted(
+    monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
+) -> None:
+    """Token-only setup used to be allowed; it produces an undeliverable integration.
 
-    with pytest.raises(SystemExit):
-        cli._setup_telegram()
+    A blank chat id is refused at the prompt and asked again — never saved,
+    never a fatal exit that throws the user out of setup.
+    """
+    # Arrange — blank chat id first, then a real one on the re-ask
+    _prompts(monkeypatch, telegram, _TOKEN, "", _CHAT_REFERENCE)
 
-    assert telegram.verified == []
-    assert telegram.store == []
+    # Act
+    cli._setup_telegram()
+
+    # Assert — the chat id was asked twice; nothing verified/saved until it was real
+    labels = [label for label, _secret in telegram.asked]
+    assert labels.count("Default chat ID or @channelname") == 2
+    assert telegram.verified and telegram.store
 
 
 def test_unreachable_chat_exits_without_saving(
@@ -169,19 +178,20 @@ def test_unreachable_chat_exits_without_saving(
     assert (telegram.store, telegram.keyring, telegram.env) == ([], [], [])
 
 
-def test_blank_token_exits_before_the_next_prompt(
+def test_blank_token_is_asked_again_before_the_next_prompt(
     monkeypatch: pytest.MonkeyPatch, telegram: _Telegram
 ) -> None:
-    """Fail on the field that is blank, not after working through the rest."""
-    _prompts(monkeypatch, telegram, "")
+    """Catch the blank field where it happens — re-ask it — not after the rest."""
+    # Arrange — blank token, then the real token, then the chat id
+    _prompts(monkeypatch, telegram, "", _TOKEN, _CHAT_REFERENCE)
 
-    with pytest.raises(SystemExit):
-        cli._setup_telegram()
+    # Act
+    cli._setup_telegram()
 
-    # Only the token was asked for — the chat id prompt is never reached.
-    assert [label for label, _secret in telegram.asked] == ["Telegram bot token"]
-    assert telegram.verified == []
-    assert telegram.store == []
+    # Assert — the token prompt ran twice before the chat id prompt was ever reached
+    labels = [label for label, _secret in telegram.asked]
+    assert labels[:2] == ["Telegram bot token", "Telegram bot token"]
+    assert telegram.verified and telegram.store
 
 
 def test_failed_verification_exits_without_saving(

--- a/tests/integrations/test_catalog_multi_instance.py
+++ b/tests/integrations/test_catalog_multi_instance.py
@@ -131,6 +131,51 @@ def test_classify_aws_with_role_arn_in_instance_credentials_works() -> None:
     assert resolved["aws"].region == "us-east-1"
 
 
+def test_classify_aws_static_keys_saved_by_setup_resolve() -> None:
+    """The wizard's keys mode must round-trip through the store.
+
+    ``setup_flow._collect_credentials`` stores an unset optional field as
+    ``None`` (a tested contract), so a record written by "Access Key + Secret"
+    carries ``role_arn=None``, ``external_id=None``, ``session_token=None``.
+    ``classify`` used ``.get(key, "")``, whose default only applies to a
+    *missing* key, and passed ``None`` into ``str`` fields — STS verification
+    passed, the wizard said "Saved", and the very same record then failed to
+    resolve ("did not resolve into a usable runtime config").
+    """
+    # Arrange — exactly the shape apply_setup persists for the keys mode
+    saved_by_setup = {
+        "id": "aws-99986a60",
+        "service": "aws",
+        "status": "active",
+        "instances": [
+            {
+                "name": "default",
+                "tags": {},
+                "credentials": {
+                    "region": "us-east-1",
+                    "role_arn": None,
+                    "external_id": None,
+                    "access_key_id": "AKIAEXAMPLE",
+                    "secret_access_key": "secret",
+                    "session_token": None,
+                },
+            }
+        ],
+    }
+
+    # Act
+    resolved = classify_integrations([saved_by_setup])
+
+    # Assert — resolves as static-key auth with the optionals normalized to ""
+    assert "aws" in resolved
+    aws = resolved["aws"]
+    assert aws.credentials is not None
+    assert aws.credentials.access_key_id == "AKIAEXAMPLE"
+    assert aws.credentials.session_token == ""
+    assert aws.role_arn == ""
+    assert aws.external_id == ""
+
+
 def test_classify_with_migrated_v1_aws_record_works() -> None:
     """Backward compat: passing a v1 AWS record with top-level role_arn still
     works because classify migrates on the fly."""

--- a/tests/integrations/test_cli_spec_setup.py
+++ b/tests/integrations/test_cli_spec_setup.py
@@ -454,22 +454,48 @@ def test_failed_verification_exits_without_saving(
 
 
 @pytest.mark.parametrize(("module", "attr", "handler"), _CASES)
-def test_blank_required_field_exits_before_the_next_prompt(
+def test_blank_required_field_is_asked_again_not_fatal(
     monkeypatch: pytest.MonkeyPatch, run: _Run, module: Any, attr: str, handler: Any
 ) -> None:
-    """Fail on the field that is blank, not after working through the rest."""
+    """A blank required answer re-asks that field; it never exits the setup.
+
+    An empty answer at an interactive prompt is a normal thing to type, not an
+    error to bail on — bailing left the user with "X is required", a non-zero
+    exit, and no way forward but starting over. Ctrl+C is the way out.
+    """
     spec = getattr(module, attr)
     prompted = _prompted(spec)
     first_required = next((f for f in prompted if f.required and not f.default), None)
     if first_required is None:
         pytest.skip(f"{spec.service} has no required prompted field without a default")
-    _install(monkeypatch, module, attr, run, blank=first_required.name)
 
-    with pytest.raises(SystemExit):
-        handler()
+    # Arrange — script the prompts: every field answered normally, except the
+    # required one is answered blank first and with the real value on re-ask.
+    def _fake_verify(_source: str, config: dict[str, Any]) -> dict[str, str]:
+        run.verified.append(dict(config))
+        return {"status": "passed", "detail": "ok"}
 
-    assert len(run.asked) == 1 + [f.name for f in prompted].index(first_required.name)
-    assert (run.verified, run.store) == ([], [])
+    monkeypatch.setattr(module, attr, dataclasses.replace(spec, verify=_fake_verify))
+    answers = _ANSWERS[spec.service]
+    queue: list[str] = []
+    for field in prompted:
+        if field.name == first_required.name:
+            queue.append("")
+        queue.append(answers[field.name])
+
+    def _fake_p(label: str, default: str = "", secret: bool = False) -> str:
+        run.asked.append((label, default, secret))
+        return queue.pop(0)
+
+    monkeypatch.setattr(cli, "_p", _fake_p)
+
+    # Act
+    handler()
+
+    # Assert — asked twice (blank, then real), then verified and saved
+    labels = [label for label, _default, _secret in run.asked]
+    assert labels.count(first_required.question) == 2
+    assert run.verified and run.store
 
 
 # --- Mode-picker integrations (Slack, Alertmanager, OpenSearch) ----------------

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -552,13 +552,17 @@ def test_verify_aws_assume_role_passes(monkeypatch: pytest.MonkeyPatch) -> None:
                 "Arn": "arn:aws:sts::123456789012:assumed-role/TracerReadOnly/TracerIntegrationVerify",
             }
 
-    def _fake_boto3_client(service_name: str, **kwargs: Any) -> Any:
+    def _fake_assumed_client(service_name: str, **kwargs: Any) -> Any:
         assert service_name == "sts"
-        if kwargs.get("aws_access_key_id"):
-            return _AssumedSTSClient()
-        return _BaseSTSClient()
+        assert kwargs.get("aws_access_key_id") == "ASIA_TEST"
+        return _AssumedSTSClient()
 
-    monkeypatch.setattr("integrations.aws.verifier.boto3.client", _fake_boto3_client)
+    # The base client (the identity that assumes the role) comes from one seam;
+    # the assumed client is built with the returned temporary keys.
+    monkeypatch.setattr(
+        "integrations.aws.verifier._base_sts_client", lambda _region: _BaseSTSClient()
+    )
+    monkeypatch.setattr("integrations.aws.verifier.boto3.client", _fake_assumed_client)
 
     result = _verify_aws(
         "local store",
@@ -587,12 +591,9 @@ def test_verify_aws_role_without_base_credentials_explains_the_prerequisite(
         def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
             raise NoCredentialsError()
 
-    def _fake_boto3_client(service_name: str, **kwargs: Any) -> Any:
-        assert service_name == "sts"
-        assert "aws_access_key_id" not in kwargs
-        return _BaseSTSClient()
-
-    monkeypatch.setattr("integrations.aws.verifier.boto3.client", _fake_boto3_client)
+    monkeypatch.setattr(
+        "integrations.aws.verifier._base_sts_client", lambda _region: _BaseSTSClient()
+    )
 
     # Act
     result = _verify_aws(

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -574,6 +574,42 @@ def test_verify_aws_assume_role_passes(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "123456789012" in result["detail"]
 
 
+def test_verify_aws_role_without_base_credentials_explains_the_prerequisite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Role ARN alone on a bare machine: say what to configure, not a raw boto3 error."""
+    from botocore.exceptions import NoCredentialsError
+
+    from integrations.aws.verifier import ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE
+
+    # Arrange — no ambient credential chain, so assume_role cannot even be called
+    class _BaseSTSClient:
+        def assume_role(self, **_kwargs: Any) -> dict[str, Any]:
+            raise NoCredentialsError()
+
+    def _fake_boto3_client(service_name: str, **kwargs: Any) -> Any:
+        assert service_name == "sts"
+        assert "aws_access_key_id" not in kwargs
+        return _BaseSTSClient()
+
+    monkeypatch.setattr("integrations.aws.verifier.boto3.client", _fake_boto3_client)
+
+    # Act
+    result = _verify_aws(
+        "local store",
+        {
+            "role_arn": "arn:aws:iam::123456789012:role/opensre-setup-s3-access",
+            "region": "ap-south-1",
+        },
+    )
+
+    # Assert — actionable message; the raw "Unable to locate credentials" is not surfaced
+    assert result["status"] == "failed"
+    assert result["detail"] == ROLE_NEEDS_BASE_CREDENTIALS_MESSAGE
+    assert "sts:AssumeRole" in result["detail"]
+    assert "Access Key + Secret" in result["detail"]
+
+
 def test_verify_tracer_passes_with_env_jwt(monkeypatch: pytest.MonkeyPatch) -> None:
     class _FakeTracerClient:
         def __init__(self, base_url: str, org_id: str, jwt_token: str) -> None:

--- a/tests/interactive_shell/ui/test_rendering.py
+++ b/tests/interactive_shell/ui/test_rendering.py
@@ -53,8 +53,61 @@ def test_print_repl_json_tty_uses_single_buffered_write(monkeypatch: pytest.Monk
 
     assert len(fake_stdout.writes) == 1
     rendered = re.sub(r"\x1b\[[0-9;]*m", "", fake_stdout.writes[0])
-    assert rendered.startswith("\r\n")
+    # Column-zero reset, then the leading blank line: immune to wherever a
+    # spinner teardown or wrapped log line left the cursor.
+    assert rendered.startswith("\r\r\n")
     assert '"ok": true' in rendered
+
+
+def test_print_repl_table_stays_on_the_crlf_path_while_recording(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every slash command records its console; that must not force row-by-row prints.
+
+    Under ``patch_stdout(raw=True)`` each ``console.print`` row ends in a bare
+    ``\\n`` and the table staircases. Recording is fed from the buffered write
+    instead, so the screen gets one CRLF write and the transcript still sees the
+    table.
+    """
+    from rich.table import Table
+
+    from surfaces.interactive_shell.ui.components.rendering import print_repl_table
+
+    class _FakeStdout:
+        def __init__(self) -> None:
+            self.writes: list[str] = []
+
+        def write(self, text: str) -> int:
+            self.writes.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+        def isatty(self) -> bool:
+            return True
+
+    # Arrange — a recording console (what capture_console_segment does) on a TTY
+    fake_stdout = _FakeStdout()
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+    console = Console(force_terminal=True, width=80)
+    console.record = True
+    table = Table()
+    table.add_column("service")
+    table.add_column("status")
+    table.add_row("github", "passed")
+    table.add_row("slack", "passed")
+
+    # Act
+    print_repl_table(console, table, width=60)
+
+    # Assert — one CRLF write on screen, and the recorder still has the rows
+    assert len(fake_stdout.writes) == 1
+    written = fake_stdout.writes[0]
+    assert written.count("\n") == written.count("\r\n")
+    assert "github" in written
+    exported = console.export_text(clear=True)
+    assert "github" in exported and "slack" in exported
 
 
 def test_render_integrations_table_empty_shows_hint() -> None:

--- a/tests/platform/logging/test_quiet_third_party.py
+++ b/tests/platform/logging/test_quiet_third_party.py
@@ -46,3 +46,21 @@ def test_quiet_noisy_third_party_loggers_hides_mcp_schema_warnings() -> None:
     finally:
         mcp.setLevel(previous_mcp)
         client.setLevel(previous_client)
+
+
+def test_urllib3_connection_retries_stay_off_the_user_tty() -> None:
+    """urllib3 logs each retry at WARNING; the outcome is reported by the caller."""
+    from platform.logging.quiet_third_party import quiet_noisy_third_party_loggers
+
+    # Arrange
+    pool = logging.getLogger("urllib3.connectionpool")
+    previous = pool.level
+    try:
+        # Act
+        quiet_noisy_third_party_loggers()
+
+        # Assert — "Retrying (Retry(total=2, …))" is below the floor
+        assert pool.level == logging.ERROR
+        assert not pool.isEnabledFor(logging.WARNING)
+    finally:
+        pool.setLevel(previous)

--- a/tests/platform/logging/test_shell_handler.py
+++ b/tests/platform/logging/test_shell_handler.py
@@ -1,0 +1,133 @@
+"""Shell log handler: records go through the surface console, atomically with spinners."""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+import threading
+
+import pytest
+from rich.console import Console
+
+from platform.logging.shell_handler import ShellLogHandler, install_shell_log_handler
+
+
+def _isolated_logger(name: str, handler: logging.Handler) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.propagate = False
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def test_record_prints_through_the_provided_console() -> None:
+    # Arrange — a console the surface renders on, and a handler bound to it
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=80)
+    handler = ShellLogHandler(lambda: console)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = _isolated_logger("test.shell_handler.console", handler)
+
+    # Act
+    logger.warning("[kubernetes] probe_access failed")
+
+    # Assert — landed on the console, not on sys.stderr
+    assert buf.getvalue() == "[kubernetes] probe_access failed\n"
+
+
+def test_record_from_a_worker_thread_lands_whole_while_a_spinner_is_live() -> None:
+    """The race behind the staircase: a probe thread logs while status() animates."""
+    # Arrange
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=True, width=80)
+    handler = ShellLogHandler(lambda: console)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = _isolated_logger("test.shell_handler.spinner", handler)
+    message = "Retrying (Retry(total=2)) after connection broken: Connection refused"
+
+    # Act — log from a worker thread while the spinner holds the console
+    with console.status("Verifying integrations…", spinner="dots"):
+        worker = threading.Thread(target=lambda: logger.warning(message))
+        worker.start()
+        worker.join(5.0)
+
+    # Assert — the message appears once, on its own line, uninterrupted
+    out = buf.getvalue()
+    assert out.count(message) == 1
+    assert message + "\n" in out
+
+
+def test_a_record_wider_than_the_console_takes_exactly_one_row() -> None:
+    """A wrapped record desyncs a live spinner's row accounting; crop instead.
+
+    Rich's Live counts each printed record as one row and rewinds the cursor by
+    that count on teardown. A record that wraps in the terminal breaks the count
+    and every table row rendered afterwards starts further from column zero.
+    """
+    # Arrange — a 60-column console and a 300-char urllib3-style retry warning
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=60)
+    handler = ShellLogHandler(lambda: console)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = _isolated_logger("test.shell_handler.onerow", handler)
+
+    # Act
+    logger.warning("Retrying (Retry(total=2)) after connection broken by " + "x" * 250)
+
+    # Assert — one terminal row, cropped with an ellipsis, never wrapped
+    out = buf.getvalue()
+    assert out.count("\n") == 1
+    first_row = out.split("\n")[0]
+    assert len(first_row) == 60
+    assert first_row.endswith("…")
+
+
+def test_falls_back_to_the_live_stderr_without_a_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stream swapped in after construction (patch_stdout) still receives it."""
+    # Arrange
+    original = io.StringIO()
+    later = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", original)
+    handler = ShellLogHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = _isolated_logger("test.shell_handler.stderr", handler)
+    monkeypatch.setattr(sys, "stderr", later)
+
+    # Act
+    logger.warning("late")
+
+    # Assert
+    assert later.getvalue() == "late\n"
+    assert original.getvalue() == ""
+
+
+def test_install_is_idempotent_on_an_unconfigured_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange — a truly empty root (pytest's own capture handlers hidden)
+    root = logging.getLogger()
+    monkeypatch.setattr(root, "handlers", [])
+
+    # Act
+    install_shell_log_handler()
+    install_shell_log_handler()
+
+    # Assert — one handler, ERROR floor: WARNINGs duplicate what the surface
+    # already reports (a failed probe is a table row, not a log line)
+    assert len(root.handlers) == 1
+    assert isinstance(root.handlers[0], ShellLogHandler)
+    assert root.handlers[0].level == logging.ERROR
+
+
+def test_install_leaves_a_host_configured_root_logger_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange — an embedding host already configured logging
+    root = logging.getLogger()
+    host_handler = logging.NullHandler()
+    monkeypatch.setattr(root, "handlers", [host_handler])
+
+    # Act
+    install_shell_log_handler()
+
+    # Assert
+    assert root.handlers == [host_handler]

--- a/tests/platform/observability/test_service_error_traceback.py
+++ b/tests/platform/observability/test_service_error_traceback.py
@@ -92,3 +92,42 @@ def test_a_real_bug_keeps_its_traceback() -> None:
     # Assert
     assert "Traceback" in output
     assert "KeyError" in output
+
+
+def _log_level(exc: Exception, *, method: str) -> int:
+    seen: list[logging.LogRecord] = []
+
+    class _Recorder(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            seen.append(record)
+
+    logger = logging.getLogger(f"test.service_error.level.{method}.{id(exc)}")
+    logger.handlers = [_Recorder()]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    capture_service_error(exc, logger=logger, integration="kubernetes", method=method)
+    assert len(seen) == 1
+    return seen[0].levelno
+
+
+def test_an_unreachable_service_is_a_warning_not_an_error() -> None:
+    """Severity agrees with the traceback rule: a stopped cluster is not a code fault.
+
+    The shell prints ERROR records to the user; a refused connection would then
+    surface as ``[kubernetes] probe_access failed`` on top of the integrations
+    table row that already reports it with a reason.
+    """
+    # Act
+    level = _log_level(_wrapped_connection_error(), method="probe_access")
+
+    # Assert
+    assert level == logging.WARNING
+
+
+def test_a_genuine_fault_is_still_an_error() -> None:
+    """Anything that is not unreachable / 429 / 5xx keeps ERROR and its stack."""
+    # Act
+    level = _log_level(_raised(KeyError("items")), method="list_pods")
+
+    # Assert
+    assert level == logging.ERROR

--- a/tests/platform/observability/test_service_errors.py
+++ b/tests/platform/observability/test_service_errors.py
@@ -56,20 +56,29 @@ class TestCaptureServiceError:
             assert mock_report.call_args.kwargs["severity"] == "error"
 
     def test_generic_exception_uses_error_severity(self, mock_logger: logging.Logger) -> None:
-        exc = ConnectionError("refused")
+        exc = KeyError("items")
         with patch("platform.observability.errors.service.report_exception") as mock_report:
             capture_service_error(
                 exc, logger=mock_logger, integration="datadog", method="search_logs"
             )
             assert mock_report.call_args.kwargs["severity"] == "error"
 
-    def test_timeout_exception_uses_error_severity(self, mock_logger: logging.Logger) -> None:
+    def test_connection_refused_uses_warning_severity(self, mock_logger: logging.Logger) -> None:
+        # Unreachable service: an operational fact, same rule that drops its traceback.
+        exc = ConnectionError("refused")
+        with patch("platform.observability.errors.service.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="datadog", method="search_logs"
+            )
+            assert mock_report.call_args.kwargs["severity"] == "warning"
+
+    def test_timeout_exception_uses_warning_severity(self, mock_logger: logging.Logger) -> None:
         exc = httpx.ReadTimeout("timed out")
         with patch("platform.observability.errors.service.report_exception") as mock_report:
             capture_service_error(
                 exc, logger=mock_logger, integration="splunk", method="search_logs"
             )
-            assert mock_report.call_args.kwargs["severity"] == "error"
+            assert mock_report.call_args.kwargs["severity"] == "warning"
 
     def test_tags_contain_surface_and_integration(self, mock_logger: logging.Logger) -> None:
         exc = RuntimeError("boom")


### PR DESCRIPTION
## Summary

Two user-reported problems, unrelated, fixed on one branch.

### 1. `/integrations` table rendered as a diagonal staircase

Every slash command runs inside `capture_console_segment`, which turns on
`console.record` so the analytics transcript gets a plain-text copy of the
output. `print_repl_table` already had a TTY-safe path (render to a buffer,
one write, `\r\n` per row) but its guard treated a recording console as
"keeps its own copy — a direct stdout write would be invisible", skipped the
safe path, and fell back to row-by-row `console.print`. Under
`patch_stdout(raw=True)` each of those rows ends in a bare `\n`, which moves
down without returning to column 0, so every row inherits the previous row's
ending column. Recording and the safe path were mutually exclusive, and
recording always won; it only looked intermittent because the drift needs
the cursor displaced first (a long spinner run with wrapped probe warnings).

- `rendering.py`: the guard now only bails inside an open `capture()`. Under
  plain recording it takes the CRLF write and feeds the rendered plain text
  into the owning console's record buffer, so the transcript still sees the
  table. Applied to `print_repl_table`, `print_repl_json`, and the launch
  poster. A leading `\r` makes the write immune to wherever a spinner
  teardown left the cursor.
- The REPL had no root log handler, so library WARNINGs fell through to
  Python's last-resort stderr writer, racing the status spinner on the tty.
  `platform/logging/shell_handler.py` prints WARNING+ records through the
  shell's own Rich console (atomic with a live spinner, one row per record)
  and is installed once at REPL start; a non-REPL host keeps its own
  handlers.
- Noise that this made visible, cleaned at the source: `urllib3
  .connectionpool` retry chatter floored to ERROR in `quiet_third_party.py`
  (the outcome is reported by the caller); the shell handler's floor is
  ERROR because a WARNING such as `[kubernetes] probe_access failed`
  duplicates the table's own `failed` row; and `capture_service_error` now
  logs an unreachable service at WARNING, matching the rule the same
  function already used to drop its traceback ("an operational fact, not a
  fault in our code").

Verified by driving the real REPL in a pty at the reporter's 210×59 geometry
and rendering the raw bytes through a VT emulator: baseline STAIRCASE (row
indents 27, 24, 21, …), fixed STRAIGHT on five consecutive runs, and the
`Retrying (Retry(total=2, …))` / `[kubernetes] probe_access failed` lines no
longer appear above the table while the `kubernetes │ failed │ …` row still
does.

Before:
<img width="1359" height="761" alt="image" src="https://github.com/user-attachments/assets/ac45077f-2776-48cd-b96b-044d09a74957" />

After:
<img width="1312" height="447" alt="image" src="https://github.com/user-attachments/assets/d0fb5dc1-c502-4cc0-9de6-b3f878725fab" />


### 2. AWS "IAM Role ARN" setup was a dead end without base credentials

Assuming a role needs base credentials boto3 can find; the wizard's role mode
collected only the ARN and external ID, then failed STS with the raw
`Unable to locate credentials`. On a fresh laptop that is every user.

- `integrations/aws/credential_chain.py`: local, network-free probe of the
  ambient boto3 chain.
- `surfaces/cli/wizard/configurators/aws.py`: when "IAM Role ARN" is picked
  and the chain is empty, explain why in one sentence and offer three paths —
  switch to access key + secret (default, in place), configure base
  credentials first (prints the `aws configure` / env-var instruction and
  leaves setup cleanly via `WizardBack`), or continue with the role for
  EC2/ECS/Lambda deployments with an attached role.
- `spec_configurator.py`: one generic `on_mode_chosen` hook so any vendor can
  gate a mode on a prerequisite; no AWS knowledge in the shared loop.
- `integrations/aws/verifier.py`: the non-wizard path (`AWS_ROLE_ARN` set by
  hand) returns an actionable message instead of the raw boto3 error; mode
  label and `docs/aws.mdx` no longer imply a role ARN alone is sufficient.

Before:

<img width="682" height="262" alt="image" src="https://github.com/user-attachments/assets/83dd00c2-610c-42ef-9527-1fbe3691bc20" />


After:

<img width="1225" height="735" alt="image" src="https://github.com/user-attachments/assets/8cb7f5e7-e4c1-48c6-a62b-b19ee9ba7687" />

<img width="1905" height="694" alt="image" src="https://github.com/user-attachments/assets/dff153d2-c667-42b5-8ff8-73b08aa79838" />

