### PR TITLE
fix(interactive-shell): escape the background CLI task command header

### DIFF
--- a/surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py
@@ -68,7 +68,7 @@ def start_background_cli_task(
     use_pty: bool = False,
 ) -> TaskRecord | None:
     """Start a subprocess as a REPL task while streaming output above the prompt."""
-    console.print(f"[bold]$ {display_command}[/bold]")
+    console.print(f"[bold]$ {escape(display_command)}[/bold]")
     task = session.task_registry.create(kind, command=display_command)
     task.mark_running()
     # Created at launch so the flushed prompt-log latency spans the full task

--- a/tests/interactive_shell/runtime/test_subprocess_runner.py
+++ b/tests/interactive_shell/runtime/test_subprocess_runner.py
@@ -1644,13 +1644,11 @@ def test_run_opensre_cli_command_allows_integrations_list_without_blocking(
 def test_start_background_cli_task_echoes_command_markup_literally(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The ``$ <command>`` header must escape Rich markup, like every sibling echo.
+    """The ``$ <command>`` header must render Rich markup literally.
 
-    An alert payload carrying a bracketed path (``[/api/checkout]``) reads as a
-    closing tag and raises ``MarkupError`` before the task is even created, so the
-    subprocess never runs; a lowercase bracketed word (``[error]``) reads as an
-    opening tag and is silently swallowed, showing a command the user did not run.
+    ``[/api/checkout]`` raised ``MarkupError``; ``[error]`` was swallowed.
     """
+    monkeypatch.setenv("OPENSRE_PROMPT_LOG_LOCAL_DISABLED", "1")
 
     class _FakeProcess:
         returncode = 0

--- a/tests/interactive_shell/runtime/test_subprocess_runner.py
+++ b/tests/interactive_shell/runtime/test_subprocess_runner.py
@@ -1639,3 +1639,44 @@ def test_run_opensre_cli_command_allows_integrations_list_without_blocking(
     assert start_calls, "background task starter was not invoked"
     assert "integrations" in start_calls[0]
     assert "list" in start_calls[0]
+
+
+def test_start_background_cli_task_echoes_command_markup_literally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``$ <command>`` header must escape Rich markup, like every sibling echo.
+
+    An alert payload carrying a bracketed path (``[/api/checkout]``) reads as a
+    closing tag and raises ``MarkupError`` before the task is even created, so the
+    subprocess never runs; a lowercase bracketed word (``[error]``) reads as an
+    opening tag and is silently swallowed, showing a command the user did not run.
+    """
+
+    class _FakeProcess:
+        returncode = 0
+        stdout = io.StringIO("")
+        stderr = io.StringIO("")
+
+        def poll(self) -> int:
+            return 0
+
+    monkeypatch.setattr(_BACKGROUND_TASK_POPEN, lambda _command, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.subprocess_runner.threading.Thread",
+        _ImmediateThread,
+    )
+
+    display_command = 'opensre investigate --alert "[error] 5xx spike on [/api/checkout]"'
+    session = Session()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    task = start_background_cli_task(
+        display_command=display_command,
+        argv_list=["python", "-m", "cli", "investigate"],
+        session=session,
+        console=console,
+    )
+
+    assert task is not None
+    assert f"$ {display_command}" in buf.getvalue().replace("\n", "")


### PR DESCRIPTION
Fixes #5016

#### Describe the changes you have made in this PR -

The `$ <command>` header printed when a background CLI task starts put the command
straight into a Rich markup string:

```python
console.print(f"[bold]$ {display_command}[/bold]")
```

A command carrying a bracketed path — an alert payload like `5xx spike on
[/api/checkout]` — reads as a Rich closing tag and raises `MarkupError`. The print sits
one line above `session.task_registry.create(...)`, so the task record is never created
and the subprocess never runs. A lowercase bracketed word (`[error]`) takes the other
branch: Rich consumes it as an opening tag and the text disappears from the echo, so the
header shows a command the user did not run.

Five sibling sites print that same header and all escape first:

| Site | Code |
|---|---|
| `subprocess_runner/repl_presenter.py:136` | `f"[bold]$ {escape(display_command)}[/bold]"` |
| `tools/interactive_shell/actions/task_cancel.py:91` | `f"[bold]$ {escape(command)}[/bold]"` |
| `tools/interactive_shell/actions/slash.py:247` | `f"[bold]$ {escape(stripped)}[/bold]"` |
| `tools/interactive_shell/actions/llm_provider.py:64` | `f"[bold]$ /model set {escape(target)}[/bold]"` |
| `command_registry/session_cmds/resume_rendering.py:61` | `f"[bold]$ {escape(text)}[/bold]"` |

`repl_presenter.py` is the closest one: `run_opensre_cli_command_result` sends foreground
and streaming commands through `presenter.print_bold_command`, which escapes, and
background commands through `start_background_cli_task`, which did not — the same string,
two paths, one guard. `BACKGROUND` is the default execution mode for `opensre`
subcommands (only read-only and `fleet` run in the foreground), so the unescaped path was
the common one, and `cli_exec` reaches it with LLM-proposed payloads too.

The fix is `escape(display_command)`. `escape` is already imported in the file and
already applied to the three other values it prints (lines 140, 216, 248); line 71 was the
only interpolation that skipped it.

### Demo/Screenshot for feature changes and bug fixes -

The launcher is a REPL path, so the regression test is the demonstration. Against `main`,
with only the one-word source change stashed:

```
$ git stash push surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py
$ uv run python -m pytest tests/interactive_shell/runtime/test_subprocess_runner.py -q -k markup_literally

surfaces/interactive_shell/runtime/subprocess_runner/background_task_executor.py:71:
    console.print(f"[bold]$ {display_command}[/bold]")
E   rich.errors.MarkupError: closing tag '[/api/checkout]' at position 58 doesn't match any open tag
1 failed, 54 deselected in 1.06s
```

With the fix:

```
$ uv run python -m pytest tests/interactive_shell/runtime/test_subprocess_runner.py -q -k markup_literally
1 passed, 54 deselected in 0.90s
```

The header now renders the command literally, brackets and all:

```
$ opensre investigate --alert "[error] 5xx spike on [/api/checkout]"
```

Local checks per `CI.md`. `classify()` maps the two changed paths to
`tests/interactive_shell/`, so that is the scoped target:

```
$ make lint
All checks passed!

$ make format-check
3492 files already formatted

$ make typecheck
Success: no issues found in 1799 source files

$ uv run python -m pytest tests/interactive_shell/ -q
1514 passed, 1 skipped in 23.85s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

Tooling: an AI coding assistant applied the one-word edit and drafted the test; I chose
the fix site, verified both failure modes against Rich directly, reviewed the diff line by
line, and ran the harness locally.

**Explain your implementation approach:**

The problem is that one of six sites rendering the `$ <command>` header trusted its input
as markup. Every other site escapes, so the question was not which convention to invent
but why this one call was outside it — and the answer is that the background launcher
prints the header itself rather than going through the presenter that the foreground and
streaming paths share.

I considered routing the launcher through `ReplSubprocessPresenter.print_bold_command` so
one function owns the header for all three execution modes. I rejected it: the launcher
takes a `Console`, not a presenter, and the presenter lives a layer up and constructs the
launcher's caller, so threading it down would add an import edge and a parameter to fix a
missing `escape`. The file already imports `escape` and uses it three lines away on every
other value it prints; matching that is the smaller and more honest change.

I also considered escaping earlier, where `display_command` is built in
`tools/interactive_shell/cli.py`. That is wrong: the string is also passed to
`task_registry.create`, `PromptRecorder`, and `session.record`, none of which render Rich
markup, and pre-escaping would put literal backslashes into the task record and the
prompt log. Escaping belongs at the render boundary, which is what the sibling sites do.

Key components: `escape` is `rich.markup.escape`, which backslash-prefixes `[` so Rich
emits it literally. Nothing else about the launch path changes — the same string still
reaches the task registry, the recorder, and the session history unescaped, so `/tasks`
output and prompt-log telemetry are byte-identical.

Edge cases covered by the test, which asserts the full header round-trips: a closing-tag
form (`[/api/checkout]`, the crash), an opening-tag form (`[error]`, the silent
swallow), and both in one command. A command with no brackets is unaffected —
`escape` is a no-op on it, which is why the other 54 tests in the file are untouched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: **Allow edits from maintainers** is enabled.
