### PR TITLE
refactor(groundcover): move GroundcoverIntegrationConfig to groundcover.config

### DIFF
--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -271,7 +271,6 @@ from integrations.config_models import (
     DatadogIntegrationConfig,
     DiscordBotConfig,
     GrafanaIntegrationConfig,
-    GroundcoverIntegrationConfig,
     HelmIntegrationConfig,
     IncidentIoIntegrationConfig,
     JiraIntegrationConfig,
@@ -301,6 +300,7 @@ from integrations.gitlab import DEFAULT_GITLAB_BASE_URL, build_gitlab_config
 from integrations.gitlab import classify as _classify_gitlab
 from integrations.grafana import classify as _classify_grafana
 from integrations.groundcover import classify as _classify_groundcover
+from integrations.groundcover.config import GroundcoverIntegrationConfig
 from integrations.helm import classify as _classify_helm
 from integrations.honeycomb import classify as _classify_honeycomb
 from integrations.honeycomb.config import HoneycombIntegrationConfig

--- a/integrations/config_models.py
+++ b/integrations/config_models.py
@@ -25,8 +25,6 @@ from integrations._validators import (
 from platform.common.url_validation import validate_https_or_loopback_http_url
 
 _LOCAL_GRAFANA_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0"}
-DEFAULT_GROUNDCOVER_MCP_URL = "https://mcp.groundcover.com/api/mcp"
-DEFAULT_GROUNDCOVER_TIMEZONE = "UTC"
 DEFAULT_DATADOG_SITE = "datadoghq.com"
 DEFAULT_CORALOGIX_BASE_URL = "https://api.coralogix.com"
 DEFAULT_OPSGENIE_BASE_URLS: dict[str, str] = {
@@ -144,61 +142,6 @@ class DatadogIntegrationConfig(StrictConfigModel):
             "DD-APPLICATION-KEY": self.app_key,
             "Content-Type": "application/json",
         }
-
-
-class GroundcoverIntegrationConfig(StrictConfigModel):
-    """Normalized groundcover credentials used by resolution and verification flows.
-
-    groundcover is reached through its public streamable-HTTP MCP endpoint. The
-    bearer ``api_key`` is a read-only service-account token; ``tenant_uuid`` and
-    ``backend_id`` are optional routing selectors only needed when the account
-    has multiple workspaces/backends.
-    """
-
-    api_key: str = ""
-    mcp_url: str = DEFAULT_GROUNDCOVER_MCP_URL
-    tenant_uuid: str = ""
-    backend_id: str = ""
-    timezone: str = DEFAULT_GROUNDCOVER_TIMEZONE
-    integration_id: str = ""
-
-    _normalize_api_key = field_validator("api_key", mode="before")(normalize_bearer())
-    _normalize_strs = field_validator("tenant_uuid", "backend_id", "integration_id", mode="before")(
-        normalize_str()
-    )
-    _normalize_timezone = field_validator("timezone", mode="before")(
-        normalize_with_default(DEFAULT_GROUNDCOVER_TIMEZONE)
-    )
-
-    @field_validator("mcp_url", mode="before")
-    @classmethod
-    def _normalize_mcp_url(cls, value: object) -> str:
-        normalized = normalize_url(DEFAULT_GROUNDCOVER_MCP_URL)(value)
-        return validate_https_or_loopback_http_url(
-            normalized, service_name="groundcover", field_name="mcp_url"
-        )
-
-    @property
-    def is_configured(self) -> bool:
-        return bool(self.api_key and self.mcp_url)
-
-    @property
-    def request_headers(self) -> dict[str, str]:
-        """HTTP headers for the MCP transport.
-
-        Only auth and timezone are always sent; tenant/backend routing headers
-        are added when configured so single-workspace accounts work with no
-        routing while multi-workspace accounts stay scoped to one context.
-        """
-        headers: dict[str, str] = {
-            "Authorization": f"Bearer {self.api_key}",
-            "X-Timezone": self.timezone,
-        }
-        if self.tenant_uuid:
-            headers["X-Tenant-UUID"] = self.tenant_uuid
-        if self.backend_id:
-            headers["X-Backend-Id"] = self.backend_id
-        return headers
 
 
 class CoralogixIntegrationConfig(StrictConfigModel):

--- a/integrations/groundcover/__init__.py
+++ b/integrations/groundcover/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
-from integrations.config_models import GroundcoverIntegrationConfig
+from integrations.groundcover.config import GroundcoverIntegrationConfig
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/groundcover/client.py
+++ b/integrations/groundcover/client.py
@@ -23,7 +23,7 @@ from typing import Any, cast
 import httpx
 from mcp import ClientSession, types  # type: ignore[import-not-found]
 
-from integrations.config_models import GroundcoverIntegrationConfig
+from integrations.groundcover.config import GroundcoverIntegrationConfig
 from integrations.mcp_streamable_http_compat import streamable_http_client
 from integrations.probes import ProbeResult
 from platform.observability.errors.service import capture_service_error

--- a/integrations/groundcover/config.py
+++ b/integrations/groundcover/config.py
@@ -1,0 +1,72 @@
+"""Groundcover integration configuration."""
+
+from __future__ import annotations
+
+from pydantic import field_validator
+
+from config.strict_config import StrictConfigModel
+from integrations._validators import (
+    normalize_bearer,
+    normalize_str,
+    normalize_url,
+    normalize_with_default,
+)
+from platform.common.url_validation import validate_https_or_loopback_http_url
+
+DEFAULT_GROUNDCOVER_MCP_URL = "https://mcp.groundcover.com/api/mcp"
+DEFAULT_GROUNDCOVER_TIMEZONE = "UTC"
+
+
+class GroundcoverIntegrationConfig(StrictConfigModel):
+    """Normalized groundcover credentials used by resolution and verification flows.
+
+    groundcover is reached through its public streamable-HTTP MCP endpoint. The
+    bearer ``api_key`` is a read-only service-account token; ``tenant_uuid`` and
+    ``backend_id`` are optional routing selectors only needed when the account
+    has multiple workspaces/backends.
+    """
+
+    api_key: str = ""
+    mcp_url: str = DEFAULT_GROUNDCOVER_MCP_URL
+    tenant_uuid: str = ""
+    backend_id: str = ""
+    timezone: str = DEFAULT_GROUNDCOVER_TIMEZONE
+    integration_id: str = ""
+
+    _normalize_api_key = field_validator("api_key", mode="before")(normalize_bearer())
+    _normalize_strs = field_validator("tenant_uuid", "backend_id", "integration_id", mode="before")(
+        normalize_str()
+    )
+    _normalize_timezone = field_validator("timezone", mode="before")(
+        normalize_with_default(DEFAULT_GROUNDCOVER_TIMEZONE)
+    )
+
+    @field_validator("mcp_url", mode="before")
+    @classmethod
+    def _normalize_mcp_url(cls, value: object) -> str:
+        normalized = normalize_url(DEFAULT_GROUNDCOVER_MCP_URL)(value)
+        return validate_https_or_loopback_http_url(
+            normalized, service_name="groundcover", field_name="mcp_url"
+        )
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.api_key and self.mcp_url)
+
+    @property
+    def request_headers(self) -> dict[str, str]:
+        """HTTP headers for the MCP transport.
+
+        Only auth and timezone are always sent; tenant/backend routing headers
+        are added when configured so single-workspace accounts work with no
+        routing while multi-workspace accounts stay scoped to one context.
+        """
+        headers: dict[str, str] = {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Timezone": self.timezone,
+        }
+        if self.tenant_uuid:
+            headers["X-Tenant-UUID"] = self.tenant_uuid
+        if self.backend_id:
+            headers["X-Backend-Id"] = self.backend_id
+        return headers

--- a/integrations/groundcover/setup.py
+++ b/integrations/groundcover/setup.py
@@ -18,7 +18,10 @@ from config.constants.groundcover import (
     GROUNDCOVER_TENANT_UUID_ENV,
     GROUNDCOVER_TIMEZONE_ENV,
 )
-from integrations.config_models import DEFAULT_GROUNDCOVER_MCP_URL, DEFAULT_GROUNDCOVER_TIMEZONE
+from integrations.groundcover.config import (
+    DEFAULT_GROUNDCOVER_MCP_URL,
+    DEFAULT_GROUNDCOVER_TIMEZONE,
+)
 from integrations.groundcover.verifier import verify_groundcover
 from integrations.setup_flow import IntegrationSetupSpec, SetupField
 

--- a/tests/integrations/groundcover/test_client.py
+++ b/tests/integrations/groundcover/test_client.py
@@ -16,7 +16,7 @@ import pytest
 from mcp import types
 
 import integrations.groundcover.client as gc_client
-from integrations.config_models import GroundcoverIntegrationConfig
+from integrations.groundcover.config import GroundcoverIntegrationConfig
 
 
 def _config(**overrides: Any) -> GroundcoverIntegrationConfig:

--- a/tests/integrations/test_groundcover_integration.py
+++ b/tests/integrations/test_groundcover_integration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from integrations.config_models import GroundcoverIntegrationConfig
+from integrations.groundcover.config import GroundcoverIntegrationConfig
 from integrations.groundcover.verifier import verify_groundcover as _verify_groundcover
 from integrations.probes import ProbeResult
 from integrations.verify import resolve_effective_integrations


### PR DESCRIPTION
part of #3551 
Relocate GroundcoverIntegrationConfig and related constants to a dedicated config module for better organization and clarity. Update import paths throughout the codebase accordingly.