### PR TITLE
refactor(investigation): use shared agent runtime

### DIFF
--- a/core/agent/goals.py
+++ b/core/agent/goals.py
@@ -29,6 +29,7 @@ class Goal:
     description: str
     success_criteria: str
     verify: Callable[[GoalObservation], bool] | None = None
+    nudge: Callable[[GoalObservation], str] | None = None
 
 
 def goal_met(goal: Goal, observation: GoalObservation) -> bool:
@@ -80,6 +81,8 @@ def should_accept_with_goal(
         return True, None
     if at_ceiling:
         return True, None
+    if goal.nudge is not None:
+        return False, goal.nudge(observation)
     nudge = (
         f"Goal not yet met: {goal.description}. "
         f"Success criteria: {goal.success_criteria}. "

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -299,13 +299,12 @@ shape; if it answers directly without tools it is the direct-answer shape.
 `turns/orchestrator.py` (`run_turn`) → `core/agent/agent.py` (facade + wiring)
 → `core/agent/react_loop.py` (`run_react_loop`, the tool-calling algorithm).
 
-## Investigation agent — the tool-calling shape with a custom loop
+## Investigation agent — shared loop, investigation-owned policy
 
 `tools/investigation/stages/gather_evidence/agent.py::ConnectedInvestigationAgent`
-composes the shared `EventEmitterMixin` and `ToolFilterMixin` mixins
-(`core.agent.mixins`) instead of subclassing `Agent`, with a specialised ReAct
-`run()` (seed calls, evidence collection, duplicate detection, stagnation
-handling). It is still the tool-calling shape — composition, not a forked loop.
+assembles an `AgentConfig` and calls `build_agent()`. Seed calls, evidence
+collection, duplicate detection, and stagnation handling remain
+investigation-owned policy around the shared `Agent.run()` loop.
 
 ## Construct once → many turns
 
@@ -402,9 +401,8 @@ which owns the actual think → call-tools → observe algorithm.
 
 - `core/agent/mixins.py` — `EventEmitterMixin` (event dispatch),
   `ToolFilterMixin` (tool-narrowing hook), `SteeringMixin` (`steer`/`follow_up`
-  to nudge a run in progress). `Agent` composes all three;
-  `ConnectedInvestigationAgent` composes the first two instead of subclassing
-  `Agent` (see "Investigation agent" above).
+  to nudge a run in progress). `Agent` composes all three; investigation policy
+  reaches them through the built `Agent` (see "Investigation agent" above).
 - `core/agent/provider_hooks.py` — `ProviderHookDelegate`, a fail-open wrapper
   around `core.provider.ProviderHooks` applied around each LLM call. A raised
   hook exception is logged and swallowed; it never breaks the loop.

--- a/core/agent_harness/agent_builder.py
+++ b/core/agent_harness/agent_builder.py
@@ -15,6 +15,7 @@ from core.agent.goals import Goal
 from core.events import RuntimeEventCallback
 from core.execution import ToolExecutionHooks
 from core.llm.types import AgentLLMClient, ResolvedIntegrations
+from core.provider import ProviderHooks
 from core.types import RuntimeTool
 
 RuntimeToolT = TypeVar("RuntimeToolT", bound=RuntimeTool)
@@ -34,6 +35,7 @@ class AgentConfig(Generic[RuntimeToolT]):  # noqa: UP046
     max_iterations: int
     tool_resources: dict[str, Any] = field(default_factory=dict)
     tool_hooks: ToolExecutionHooks | None = None
+    provider_hooks: ProviderHooks | None = None
     on_runtime_event: RuntimeEventCallback | None = None
     goal: Goal | None = None
 
@@ -54,6 +56,7 @@ def build_agent(  # noqa: UP047
         max_iterations=config.max_iterations,
         tool_resources=config.tool_resources,
         tool_hooks=config.tool_hooks,
+        provider_hooks=config.provider_hooks,
         on_runtime_event=config.on_runtime_event,
         goal=config.goal,
     )

--- a/core/agent_harness/llm_resolution.py
+++ b/core/agent_harness/llm_resolution.py
@@ -16,6 +16,13 @@ def default_llm_factory() -> Any:
     return get_llm(LLMRole.AGENT)
 
 
+def default_reasoning_llm_factory() -> Any:
+    """Return the default reasoning LLM client."""
+    from core.llm.factory import LLMRole, get_llm
+
+    return get_llm(LLMRole.REASONING)
+
+
 def resolve_provider_models(settings: object, provider: str) -> tuple[str, str]:
     """Return the active ``(reasoning_model, toolcall_model)`` for a provider."""
     try:
@@ -65,4 +72,4 @@ def resolve_provider_models(settings: object, provider: str) -> tuple[str, str]:
     return (reasoning_model or "default", toolcall_model or reasoning_model or "default")
 
 
-__all__ = ["default_llm_factory", "resolve_provider_models"]
+__all__ = ["default_llm_factory", "default_reasoning_llm_factory", "resolve_provider_models"]

--- a/docs/investigation-pipeline-architecture.md
+++ b/docs/investigation-pipeline-architecture.md
@@ -67,7 +67,7 @@ empty plan.
 
 `ConnectedInvestigationAgent.run()` in
 `tools/investigation/stages/gather_evidence/agent.py` configures the shared
-`core.agent.Agent` through `build_agent()`. Before the
+`core.agent.Agent` runtime. Before the
 model's first turn: the tool set is narrowed to a hard cap
 (`select_investigation_tools`, `MAX_AGENT_TOOL_SCHEMAS = 32`) using the plan
 from stage 3 if present, otherwise alert-source relevance ranking. A handful

--- a/docs/investigation-pipeline-architecture.md
+++ b/docs/investigation-pipeline-architecture.md
@@ -66,7 +66,8 @@ empty plan.
 ### 4. The ReAct loop — the core evidence-gathering agent
 
 `ConnectedInvestigationAgent.run()` in
-`tools/investigation/stages/gather_evidence/agent.py`. Before the
+`tools/investigation/stages/gather_evidence/agent.py` configures the shared
+`core.agent.Agent` through `build_agent()`. Before the
 model's first turn: the tool set is narrowed to a hard cap
 (`select_investigation_tools`, `MAX_AGENT_TOOL_SCHEMAS = 32`) using the plan
 from stage 3 if present, otherwise alert-source relevance ranking. A handful

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -177,7 +177,10 @@ def test_run_gracefully_handles_model_not_found_runtime_error() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -228,7 +231,10 @@ def test_run_re_raises_unmatched_runtime_error() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -255,7 +261,10 @@ def test_run_gracefully_handles_cli_timeout() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -289,7 +298,10 @@ def test_run_gracefully_handles_api_timeout_runtime_error() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -329,7 +341,10 @@ def test_run_gracefully_handles_tool_unsupported_model(error_msg: str) -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -367,7 +382,10 @@ def test_run_gracefully_handles_single_tool_call_only_model() -> None:
     mock_tracker = MagicMock()
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -946,7 +964,10 @@ def test_invalid_hook_return_false_none_raises_at_call_site() -> None:
     }
     agent = _BadAgent()
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker",
             return_value=mock_tracker,
@@ -1341,7 +1362,10 @@ def _run_agent_with_scripted_llm(
     }
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker", return_value=MagicMock()
         ),

--- a/tests/core/agent/test_goals.py
+++ b/tests/core/agent/test_goals.py
@@ -123,6 +123,23 @@ def test_should_accept_nudges_until_ceiling() -> None:
     assert nudge is None
 
 
+def test_should_accept_uses_goal_specific_nudge() -> None:
+    goal = Goal(
+        description="investigate",
+        success_criteria="root cause named",
+        verify=lambda _observation: False,
+        nudge=lambda observation: f"Need more evidence after lap {observation.iteration + 1}.",
+    )
+
+    assert should_accept_with_goal(
+        goal,
+        final_text="not yet",
+        evidence_count=1,
+        iteration=0,
+        max_iterations=3,
+    ) == (False, "Need more evidence after lap 1.")
+
+
 def test_no_goal_always_accepts() -> None:
     assert should_accept_with_goal(
         None,

--- a/tests/synthetic/test_new_relic_scenario.py
+++ b/tests/synthetic/test_new_relic_scenario.py
@@ -135,7 +135,10 @@ def test_planner_discovers_and_invokes_new_relic_alerts_through_the_real_loop() 
     }
 
     with (
-        patch("tools.investigation.stages.gather_evidence.agent.get_llm", return_value=mock_llm),
+        patch(
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            return_value=mock_llm,
+        ),
         patch(
             "tools.investigation.stages.gather_evidence.agent.get_tracker", return_value=MagicMock()
         ),

--- a/tests/tools/investigation/stages/diagnose/test_diagnose_llm_resolution.py
+++ b/tests/tools/investigation/stages/diagnose/test_diagnose_llm_resolution.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.domain.diagnosis import InvestigationResult
+from tools.investigation.stages.diagnose import node
+
+
+class _StructuredDiagnosisCall:
+    def __init__(self, schema: Any) -> None:
+        self._schema = schema
+
+    def with_config(self, **_kwargs: Any) -> _StructuredDiagnosisCall:
+        return self
+
+    def invoke(self, _prompt: str) -> Any:
+        return self._schema.model_validate(
+            {
+                "root_cause": "The checkout deployment exhausted its connection pool.",
+                "root_cause_category": "unknown",
+                "validity_score": 0.8,
+            }
+        )
+
+
+class _ReasoningLLM:
+    @staticmethod
+    def with_structured_output(schema: Any) -> _StructuredDiagnosisCall:
+        return _StructuredDiagnosisCall(schema)
+
+
+def test_diagnosis_parsing_uses_injected_harness_reasoning_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(node, "default_reasoning_llm_factory", _ReasoningLLM)
+
+    result = node._parse_via_structured_output(  # noqa: SLF001 - stage seam under test
+        "Root cause: connection pool exhausted.",
+        {"query_logs": {"errors": 12}},
+    )
+
+    assert isinstance(result, InvestigationResult)
+    assert "connection pool" in result.root_cause

--- a/tests/tools/investigation/stages/gather_evidence/test_cli_backed_investigation_agent.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_cli_backed_investigation_agent.py
@@ -121,8 +121,8 @@ class TestGetInvestigationAgentClass:
         from tools.investigation.stages.gather_evidence.agent import get_investigation_agent_class
 
         monkeypatch.setattr(
-            "tools.investigation.stages.gather_evidence.agent.get_llm",
-            lambda _role: mock.MagicMock(spec=CLIBackedAgentClient),
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            lambda: mock.MagicMock(spec=CLIBackedAgentClient),
         )
         assert get_investigation_agent_class() is CLIBackedInvestigationAgent
 
@@ -132,7 +132,7 @@ class TestGetInvestigationAgentClass:
         from tools.investigation.stages.gather_evidence.agent import get_investigation_agent_class
 
         monkeypatch.setattr(
-            "tools.investigation.stages.gather_evidence.agent.get_llm",
-            lambda _role: mock.MagicMock(spec=AnthropicAgentClient),
+            "tools.investigation.stages.gather_evidence.agent.default_llm_factory",
+            lambda: mock.MagicMock(spec=AnthropicAgentClient),
         )
         assert get_investigation_agent_class() is ConnectedInvestigationAgent

--- a/tests/tools/investigation/stages/intake/test_intake_llm_resolution.py
+++ b/tests/tools/investigation/stages/intake/test_intake_llm_resolution.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.domain.alerts.extraction import AlertDetails
+from tools.investigation.stages.intake import node
+
+
+class _StructuredAlertCall:
+    def with_config(self, **_kwargs: Any) -> _StructuredAlertCall:
+        return self
+
+    @staticmethod
+    def invoke(_prompt: str) -> AlertDetails:
+        return AlertDetails(
+            alert_name="Checkout errors",
+            severity="critical",
+            is_noise=False,
+            alert_source="grafana",
+        )
+
+
+class _ReasoningLLM:
+    @staticmethod
+    def with_structured_output(_schema: Any) -> _StructuredAlertCall:
+        return _StructuredAlertCall()
+
+
+def test_alert_extraction_uses_injected_harness_reasoning_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(node, "default_reasoning_llm_factory", _ReasoningLLM)
+
+    details = node._extract_alert_details(  # noqa: SLF001 - stage seam under test
+        {"raw_alert": {"message": "checkout is returning 500s"}}  # type: ignore[arg-type]
+    )
+
+    assert isinstance(details, AlertDetails)
+    assert details.alert_name == "Checkout errors"

--- a/tests/tools/investigation/test_agent_loop_redaction_wiring.py
+++ b/tests/tools/investigation/test_agent_loop_redaction_wiring.py
@@ -1,14 +1,4 @@
-"""The investigation loop itself must share one redaction per tool payload.
-
-``_redacted_view`` reuses the redaction done when a tool call is announced.
-Unit-testing that helper does not prove the loop calls it — the loop could go
-back to ``redact_tool_view(tc.input, output)`` and every unit test would still
-pass, because the *output* is identical either way and only the work doubles.
-
-So this drives one real iteration of ``ConnectedInvestigationAgent.run`` with a
-stubbed LLM and stubbed tools, and counts how many times the loop walks a tool
-input. It is the only test here that fails if the wiring is undone.
-"""
+"""The investigation wrapper delegates its tool loop without repeating redaction work."""
 
 from __future__ import annotations
 
@@ -16,22 +6,18 @@ from typing import Any
 
 import pytest
 
+from core.agent import Agent
 from core.llm.types import AgentLLMResponse, ToolCall
 from tools.investigation.stages.gather_evidence import agent as agent_module
 from tools.investigation.stages.gather_evidence.agent import ConnectedInvestigationAgent
-from tools.investigation.stages.gather_evidence.tools import build_connected_tool_context
 
 TOOL_INPUT: dict[str, Any] = {"query": "status:error", "api_key": "sk-should-be-hidden"}
 
 
-def _tool_call() -> ToolCall:
-    return ToolCall(id="call-1", name="query_logs", input=TOOL_INPUT)
-
-
 class _LLM:
-    """Requests one tool call, then concludes."""
+    """Request one tool call, then return a complete conclusion."""
 
-    model = "fake-model"
+    model_id = "fake-model"
 
     def __init__(self) -> None:
         self._invocations = 0
@@ -39,88 +25,104 @@ class _LLM:
     def tool_schemas(self, _tools: Any) -> list[Any]:
         return []
 
-    def build_assistant_message(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
-        return {"role": "assistant", "content": ""}
+    def build_assistant_message(self, content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": call.id, "name": call.name, "arguments": call.input} for call in tool_calls
+            ],
+        }
 
-    def build_tool_result_message(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
-        return {"role": "tool", "content": ""}
+    def build_tool_result_message(
+        self, _tool_calls: list[ToolCall], results: list[Any]
+    ) -> dict[str, Any]:
+        return {"role": "tool", "content": str(results)}
 
     def invoke(self, *_args: Any, **_kwargs: Any) -> AgentLLMResponse:
         self._invocations += 1
-        calls = [_tool_call()] if self._invocations == 1 else []
-        return AgentLLMResponse(content="", tool_calls=calls)
+        if self._invocations == 1:
+            return AgentLLMResponse(
+                content="",
+                tool_calls=[ToolCall(id="call-1", name="query_logs", input=TOOL_INPUT)],
+            )
+        return AgentLLMResponse(
+            content=(
+                "Triage complete: checkout only.\n"
+                "Status — confirmed: errors | open: cause | next: mitigate | owner: on-call\n"
+                "Hypotheses:\n1. Bad deploy — confirm: logs; rule out: healthy deploy\n"
+                "Verification:\n1. Logs (H1): errors found\n"
+                "Follow-up questions:\n1. Was checkout deployed?\n"
+                "Remediation trade-offs: N/A — single clear fix path\n"
+                "Root cause: a bad deploy."
+            ),
+            tool_calls=[],
+        )
+
+
+class _Tool:
+    name = "query_logs"
+    source = "test"
+
+    @staticmethod
+    def validate_public_input(_value: dict[str, Any]) -> None:
+        return None
+
+    @staticmethod
+    def extract_params(_resolved: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    @staticmethod
+    def run(**_kwargs: Any) -> dict[str, Any]:
+        return {"hits": 1}
 
 
 class _Tracker:
-    def start(self, *_a: object, **_k: object) -> None:
+    def start(self, *_args: object, **_kwargs: object) -> None:
         """Ignore progress."""
 
-    def record_tool_start(self, *_a: object, **_k: object) -> None:
+    def record_tool_start(self, *_args: object, **_kwargs: object) -> None:
         """Ignore progress."""
 
-    def record_tool_end(self, *_a: object, **_k: object) -> None:
+    def record_tool_end(self, *_args: object, **_kwargs: object) -> None:
         """Ignore progress."""
 
-    def complete(self, *_a: object, **_k: object) -> None:
+    def complete(self, *_args: object, **_kwargs: object) -> None:
         """Ignore progress."""
 
 
-@pytest.fixture
-def loop_harness(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
-    """Stub everything around the loop and record each top-level redaction walk."""
+def test_investigation_uses_built_agent_and_redacts_tool_input_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     walked: list[Any] = []
-    real_redact = agent_module.redact_sensitive
-
-    def _counting(value: Any) -> Any:
-        walked.append(value)
-        return real_redact(value)
+    built: list[Agent[Any]] = []
+    real_redact_view = agent_module.redact_tool_view
+    real_build_agent = agent_module.build_agent
 
     def _counting_view(tool_input: Any, output: Any = None) -> Any:
-        return agent_module.RedactedToolView(
-            tool_input=_counting(tool_input),
-            output=None if output is None else _counting(output),
-        )
+        walked.append(tool_input)
+        return real_redact_view(tool_input, output)
 
-    monkeypatch.setattr(agent_module, "redact_sensitive", _counting)
+    def _record_build(config: Any) -> Agent[Any]:
+        agent = real_build_agent(config)
+        built.append(agent)
+        return agent
+
     monkeypatch.setattr(agent_module, "redact_tool_view", _counting_view)
-
-    # Collapse the surrounding machinery so only the loop's own logic runs.
+    monkeypatch.setattr(agent_module, "build_agent", _record_build)
     monkeypatch.setattr(agent_module, "get_tracker", _Tracker)
-    monkeypatch.setattr(agent_module, "get_llm", lambda _role: _LLM())
-    monkeypatch.setattr(agent_module, "get_available_tools", lambda _resolved: [])
-    monkeypatch.setattr(agent_module, "select_investigation_tools", lambda _tools, _state: [])
-    monkeypatch.setattr(
-        agent_module,
-        "build_connected_tool_context",
-        lambda _r, _t: build_connected_tool_context({}, []),
+    monkeypatch.setattr(agent_module, "get_available_tools", lambda _resolved: [_Tool()])
+    monkeypatch.setattr(agent_module, "select_investigation_tools", lambda tools, _state: tools)
+    monkeypatch.setattr(agent_module, "build_seed_calls", lambda _state, _tools, _llm: [])
+    monkeypatch.setattr(agent_module, "build_investigation_system_prompt", lambda _state: "sys")
+    monkeypatch.setattr(agent_module, "format_alert_context", lambda _state, _tools: "alert")
+
+    result = ConnectedInvestigationAgent(llm_factory=_LLM).run(
+        {"resolved_integrations": {}, "alert_name": "cpu"}  # type: ignore[arg-type]
     )
-    monkeypatch.setattr(agent_module, "build_seed_calls", lambda _s, _t, _l: [])
-    monkeypatch.setattr(agent_module, "build_investigation_system_prompt", lambda _s: "system")
-    monkeypatch.setattr(agent_module, "format_alert_context", lambda _s, _t: "alert")
-    monkeypatch.setattr(agent_module, "estimate_message_tokens", lambda *_a, **_k: 10)
-    monkeypatch.setattr(agent_module, "system_and_tools_overhead", lambda *_a, **_k: 0)
-    monkeypatch.setattr(agent_module, "context_budget_ceiling_for_model", lambda *_a, **_k: 100000)
-    monkeypatch.setattr(agent_module, "enforce_context_budget", lambda messages, **_k: messages)
-    monkeypatch.setattr(
-        agent_module, "execute_tools", lambda calls, *_a: [{"hits": 1}] * len(calls)
-    )
-    monkeypatch.setattr(agent_module, "merge_tool_evidence", lambda *_a, **_k: None)
-    monkeypatch.setattr(agent_module, "tool_event_payload", lambda *_a, **_k: {})
-    monkeypatch.setattr(agent_module, "tool_call_signature", lambda tc: tc.id)
-    return walked
 
-
-def test_loop_walks_each_tool_input_once(loop_harness: list[Any]) -> None:
-    """One tool call through the real loop must redact its input exactly once."""
-    # Arrange
-    agent = ConnectedInvestigationAgent()
-    state: dict[str, Any] = {"resolved_integrations": {}, "alert_name": "cpu"}
-
-    # Act
-    agent.run(state)  # type: ignore[arg-type]
-
-    # Assert
-    inputs_walked = [value for value in loop_harness if value is TOOL_INPUT]
-    assert len(inputs_walked) == 1, (
-        f"the loop redaction-walked one tool input {len(inputs_walked)} times"
-    )
+    assert len(built) == 1
+    assert isinstance(built[0], Agent)
+    assert isinstance(result, dict)
+    assert isinstance(result["evidence_entries"], list)
+    assert len([value for value in walked if value is TOOL_INPUT]) == 1

--- a/tests/tools/investigation/test_boundaries.py
+++ b/tests/tools/investigation/test_boundaries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 from core.domain.types.tools import ToolSurface
@@ -36,3 +37,24 @@ def test_investigation_tool_is_registry_discoverable() -> None:
     investigation_tool = tools_by_name["run_investigation"]
     assert investigation_tool.origin_module == "tools.investigation"
     assert investigation_tool.surfaces == ("chat",)
+
+
+def test_llm_calling_stages_do_not_import_the_llm_factory_directly() -> None:
+    stage_paths = (
+        Path("tools/investigation/stages/gather_evidence/agent.py"),
+        Path("tools/investigation/stages/intake/node.py"),
+        Path("tools/investigation/stages/diagnose/node.py"),
+    )
+    offenders: list[str] = []
+    for path in stage_paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            imports_factory = isinstance(node, ast.ImportFrom) and node.module == "core.llm.factory"
+            imports_factory = imports_factory or (
+                isinstance(node, ast.Import)
+                and any(alias.name == "core.llm.factory" for alias in node.names)
+            )
+            if imports_factory:
+                offenders.append(f"{path}:{node.lineno}")
+
+    assert offenders == []

--- a/tests/tools/investigation/test_tool_payload_redaction.py
+++ b/tests/tools/investigation/test_tool_payload_redaction.py
@@ -1,14 +1,4 @@
-"""A tool's input must be redacted once per call, not once per sink.
-
-Redaction deep-copies the whole payload to strip credentials. The investigation
-loop announces a tool call (redacting its input), then pairs the result with
-that input when the output lands. Redacting a second time to build the pair
-doubles the walk on every tool call — and tool inputs carry log queries and
-result sets, so the tree is not small.
-
-``RedactedToolView`` exists to be shared across sinks; these tests pin that the
-loop actually shares it.
-"""
+"""Seed evidence shares one redacted input across progress and state sinks."""
 
 from __future__ import annotations
 
@@ -16,17 +6,9 @@ from typing import Any
 
 import pytest
 
+from core.llm.types import ToolCall
 from tools.investigation.stages.gather_evidence import agent as agent_module
 from tools.investigation.stages.gather_evidence.agent import ConnectedInvestigationAgent
-
-
-class _Call:
-    """Minimal stand-in for a ``ToolCall``."""
-
-    def __init__(self, call_id: str, tool_input: dict[str, Any]) -> None:
-        self.id = call_id
-        self.name = "query_logs"
-        self.input = tool_input
 
 
 class _NullTracker:
@@ -37,86 +19,35 @@ class _NullTracker:
         """Ignore progress."""
 
 
-def _agent() -> ConnectedInvestigationAgent:
-    instance = ConnectedInvestigationAgent.__new__(ConnectedInvestigationAgent)
-    instance._tracker = _NullTracker()
-    instance._redacted_inputs = {}
-    instance._on_tuple_event = None
-    instance._on_runtime_event = None
-    return instance
-
-
-@pytest.fixture
-def counted_redactions(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
-    """Record every value handed to the top-level redaction walk."""
+def test_seed_input_is_redacted_once_across_start_and_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     walked: list[Any] = []
-    real = agent_module.redact_sensitive
+    real_redact = agent_module.redact_sensitive
+    real_redact_view = agent_module.redact_tool_view
 
     def _counting(value: Any) -> Any:
         walked.append(value)
-        return real(value)
+        return real_redact(value)
+
+    def _counting_view(tool_input: Any, output: Any = None) -> Any:
+        walked.append(tool_input)
+        return real_redact_view(tool_input, output)
 
     monkeypatch.setattr(agent_module, "redact_sensitive", _counting)
-    monkeypatch.setattr(
-        agent_module,
-        "redact_tool_view",
-        lambda tool_input, output=None: agent_module.RedactedToolView(
-            tool_input=_counting(tool_input),
-            output=None if output is None else _counting(output),
-        ),
-    )
-    return walked
-
-
-def test_tool_input_is_redacted_once_across_start_and_end(
-    counted_redactions: list[Any],
-) -> None:
-    """Announcing the call and attaching its output must share one redaction."""
-    # Arrange
-    agent = _agent()
+    monkeypatch.setattr(agent_module, "redact_tool_view", _counting_view)
+    agent = ConnectedInvestigationAgent()
+    agent._tracker = _NullTracker()
     tool_input = {"query": "status:error", "api_key": "sk-secret"}
-    call = _Call("call-1", tool_input)
+    tool_call = ToolCall(id="seed-1", name="query_logs", input=tool_input)
 
-    # Act
-    agent._record_tool_start(call)
-    view = agent._redacted_view(call, output={"hits": 3})
-
-    # Assert
-    inputs_walked = [value for value in counted_redactions if value is tool_input]
-    assert len(inputs_walked) == 1, (
-        f"tool input was redaction-walked {len(inputs_walked)} times for one call"
+    redacted_input = agent._record_seed_start(tool_call)
+    redacted = agent._record_seed_end(
+        tool_call,
+        {"hits": 3},
+        redacted_input=redacted_input,
     )
-    assert view.tool_input["api_key"] != "sk-secret", "redaction must still apply"
-    assert view.output == {"hits": 3}
 
-
-def test_an_unannounced_call_still_gets_a_redacted_input() -> None:
-    """Reuse must not become a hole: no cached input means redact it now."""
-    # Arrange
-    agent = _agent()
-    call = _Call("call-unseen", {"query": "status:error", "password": "hunter2"})
-
-    # Act — no _record_tool_start for this call.
-    view = agent._redacted_view(call, output={"hits": 1})
-
-    # Assert
-    assert view.tool_input["password"] != "hunter2"
-
-
-def test_each_call_consumes_only_its_own_cached_input() -> None:
-    """Two in-flight calls must not swap payloads."""
-    # Arrange
-    agent = _agent()
-    first = _Call("call-a", {"query": "alpha"})
-    second = _Call("call-b", {"query": "beta"})
-
-    # Act
-    agent._record_tool_start(first)
-    agent._record_tool_start(second)
-    view_b = agent._redacted_view(second, output=None)
-    view_a = agent._redacted_view(first, output=None)
-
-    # Assert
-    assert view_a.tool_input["query"] == "alpha"
-    assert view_b.tool_input["query"] == "beta"
-    assert agent._redacted_inputs == {}, "cached inputs must drain as calls complete"
+    assert len([value for value in walked if value is tool_input]) == 1
+    assert redacted.tool_input["api_key"] != "sk-secret"
+    assert redacted.output == {"hits": 3}

--- a/tools/investigation/stages/diagnose/node.py
+++ b/tools/investigation/stages/diagnose/node.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict, cast
 
 from pydantic import BaseModel
 
+from core.agent_harness.llm_resolution import default_reasoning_llm_factory
 from core.domain.alerts.alert_source import resolve_alert_source
 from core.domain.diagnosis import (
     InvestigationResult,
@@ -97,8 +98,6 @@ def _parse_via_structured_output(
     *,
     alert_source: str = "",
 ) -> InvestigationResult:
-    from core.llm.factory import LLMRole, get_llm
-
     prompt = f"""Extract the structured diagnosis from this investigation conclusion.
 
 Investigation conclusion:
@@ -130,7 +129,7 @@ Extract incident-command fields when present:
         remediation_tradeoffs: str
         validity_score: float
 
-    llm = get_llm(LLMRole.REASONING)
+    llm = default_reasoning_llm_factory()
     schema_model = build_diagnosis_schema(taxonomy_categories_for_alert_source(alert_source))
     raw_schema = (
         llm.with_structured_output(schema_model)

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -1,29 +1,36 @@
-"""ReAct investigation agent — the core think → call tools → observe loop."""
+"""Investigation orchestration over the shared tool-calling ``Agent`` runtime."""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
 from typing import Any, cast
 
 from config.constants.investigation import MAX_INVESTIGATION_LOOPS
-from core import (
-    RuntimeEventCallback,
-    TupleEventCallback,
-    context_budget_ceiling_for_model,
-    enforce_context_budget,
-    estimate_message_tokens,
-    execute_tools,
-    summarise,
-    system_and_tools_overhead,
-    tool_source,
+from core import RuntimeEventCallback, TupleEventCallback, execute_tools, summarise, tool_source
+from core.agent.goals import Goal, GoalObservation
+from core.agent_harness.agent_builder import AgentConfig, build_agent
+from core.agent_harness.llm_resolution import default_llm_factory
+from core.events import (
+    AgentEndEvent,
+    AgentStartEvent,
+    ProviderRequestEndEvent,
+    RuntimeEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    TurnStartEvent,
+    runtime_event_from_tuple,
+    tuple_payload_from_event,
 )
-from core.agent.mixins import EventEmitterMixin, ToolFilterMixin
-from core.llm.factory import LLMRole, get_llm
 from core.llm.types import ToolCall
 from core.llm_invoke_errors import classify_llm_invoke_failure
-from core.messages import MessageMapper
+from core.messages import MessageMapper, RuntimeMessage, ToolResultRuntimeMessage
+from core.provider import ProviderHooks, ProviderRequest
 from core.state import InvestigationState
 from core.state.evidence import EvidenceEntry
+from core.tool_framework.registered_tool import RegisteredTool
+from core.types import RuntimeTool
 from platform.observability import debug_print
 from platform.observability import get_progress_tracker as get_tracker
 from platform.observability.trace.redaction import (
@@ -37,10 +44,8 @@ from tools.investigation.stages.gather_evidence.incident_command import (
     incident_command_conclusion_complete,
 )
 from tools.investigation.stages.gather_evidence.loop import (
-    InvestigationToolCallCache,
+    InvestigationLoopController,
     degraded_investigation_from_llm_failure,
-    duplicate_call_result,
-    tool_call_signature,
 )
 from tools.investigation.stages.gather_evidence.prompt import (
     build_investigation_system_prompt,
@@ -59,21 +64,36 @@ from tools.investigation.stages.gather_evidence.tools import (
 
 logger = logging.getLogger(__name__)
 
-
-def _mark_messages(messages: list[dict[str, Any]], key: str) -> None:
-    for msg in messages:
-        msg[key] = True
+LlmFactory = Callable[[], Any]
 
 
-class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
-    """ReAct loop scoped to the tools enabled by connected integrations.
+@dataclass
+class _ConclusionState:
+    nudge: str | None = None
 
-    Owns a specialised investigation ``run()`` — seed calls, evidence collection,
-    duplicate detection, and stagnation handling — assembling its config (LLM,
-    tools, prompt, resolved integrations) inline from ``state``. Uses two agent
-    hooks: :class:`~core.agent.mixins.EventEmitterMixin` for event dispatch and
-    :class:`~core.agent.mixins.ToolFilterMixin` for tool narrowing.
+
+@dataclass
+class _RuntimeState:
+    controller: InvestigationLoopController
+    tracker: Any
+    tool_context: dict[str, Any]
+    evidence_entries: list[EvidenceEntry]
+    loops_completed: int = 0
+    last_messages: list[RuntimeMessage] | None = None
+
+
+class ConnectedInvestigationAgent:
+    """Run the investigation policy through ``AgentConfig`` and ``build_agent``.
+
+    Seed evidence, tool selection, duplicate suppression, and conclusion policy
+    remain investigation-owned; the think -> call-tools -> observe loop is the
+    shared :class:`core.agent.Agent` implementation.
     """
+
+    def __init__(self, *, llm_factory: LlmFactory | None = None) -> None:
+        self._llm_factory = llm_factory
+        self._on_tuple_event: TupleEventCallback | None = None
+        self._on_runtime_event: RuntimeEventCallback | None = None
 
     def _should_accept_conclusion(
         self,
@@ -82,14 +102,7 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         iteration: int,  # noqa: ARG002 — used by overrides
         final_text: str = "",
     ) -> tuple[bool, str | None]:
-        """Decide what to do when the LLM stops requesting tools.
-
-        Reject once when the final text omits required incident-command markers,
-        so the model reformats before diagnose parses the conclusion.
-
-        Override in subclasses (e.g. :class:`CLIBackedInvestigationAgent`) to
-        nudge the model back into tool calls before accepting a conclusion.
-        """
+        """Accept complete incident-command output, nudging incomplete output once."""
         last_text = final_text or getattr(self, "_last_assistant_text", "") or ""
         if (
             last_text.strip()
@@ -101,39 +114,70 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         return True, None
 
     def _build_system_prompt(self, state: dict[str, Any]) -> str:
-        """Produce the LLM system prompt from an augmented state dict.
-
-        Extension point for bench harnesses that need to swap the prompt body
-        without reimplementing the state/tool_context merge.
-        """
+        """Produce the investigation system prompt from augmented state."""
         return build_investigation_system_prompt(state)
 
-    def _record_tool_start(self, tc: ToolCall) -> None:
-        redacted = redact_tool_view(tc.input)
-        self._redacted_inputs[tc.id] = redacted.tool_input
-        self._tracker.record_tool_start(tc.name, redacted.tool_input, event_key=tc.id)
-        self._emit("tool_start", tool_event_payload(tc, redacted=redacted))
+    def _filter_tools[RuntimeToolT: RuntimeTool](
+        self, tools: list[RuntimeToolT]
+    ) -> list[RuntimeToolT]:
+        """Return the tools exposed to the investigation; subclasses may narrow them."""
+        return tools
 
-    def _redacted_view(self, tc: ToolCall, output: Any) -> RedactedToolView:
-        """Pair the output with the input redaction already done at tool start.
+    def _dispatch_runtime(self, event: RuntimeEvent) -> None:
+        if self._on_runtime_event is not None:
+            try:
+                self._on_runtime_event(event)
+            except Exception:  # noqa: BLE001 - observers must not break investigations
+                logger.debug("runtime investigation observer failed", exc_info=True)
+        payload = tuple_payload_from_event(event)
+        if payload is not None and self._on_tuple_event is not None:
+            try:
+                self._on_tuple_event(*payload)
+            except Exception:  # noqa: BLE001 - observers must not break investigations
+                logger.debug("tuple investigation observer failed", exc_info=True)
 
-        Redaction deep-copies the whole payload, and a tool's input is walked
-        once when the call is announced. Re-walking it to attach the output
-        doubles that work on every tool call in the loop.
-        """
-        tool_input = self._redacted_inputs.pop(tc.id, None)
-        if tool_input is None:
-            return redact_tool_view(tc.input, output)
-        return RedactedToolView(tool_input=tool_input, output=redact_sensitive(output))
+    def _dispatch_tuple(self, kind: str, data: dict[str, Any]) -> None:
+        event = runtime_event_from_tuple(kind, data)
+        if event is not None:
+            self._dispatch_runtime(event)
+        elif self._on_tuple_event is not None:
+            try:
+                self._on_tuple_event(kind, data)
+            except Exception:  # noqa: BLE001 - observers must not break investigations
+                logger.debug("tuple investigation observer failed", exc_info=True)
 
-    def _record_tool_end(self, tc: ToolCall, output: Any, *, redacted: RedactedToolView) -> None:
+    def _record_seed_start(self, tool_call: ToolCall) -> RedactedToolView:
+        redacted = redact_tool_view(tool_call.input)
+        self._tracker.record_tool_start(
+            tool_call.name,
+            redacted.tool_input,
+            event_key=tool_call.id,
+        )
+        self._dispatch_tuple("tool_start", tool_event_payload(tool_call, redacted=redacted))
+        return redacted
+
+    def _record_seed_end(
+        self,
+        tool_call: ToolCall,
+        output: Any,
+        *,
+        redacted_input: RedactedToolView,
+    ) -> RedactedToolView:
+        redacted = RedactedToolView(
+            tool_input=redacted_input.tool_input,
+            output=redact_sensitive(output),
+        )
         self._tracker.record_tool_end(
-            tc.name,
+            tool_call.name,
             redacted.output,
-            event_key=tc.id,
+            event_key=tool_call.id,
             tool_input=redacted.tool_input,
         )
-        self._emit("tool_end", tool_event_payload(tc, output=output, redacted=redacted))
+        self._dispatch_tuple(
+            "tool_end",
+            tool_event_payload(tool_call, output=output, redacted=redacted),
+        )
+        return redacted
 
     def run(
         self,
@@ -141,47 +185,41 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
         on_event: TupleEventCallback | None = None,
         on_runtime_event: RuntimeEventCallback | None = None,
     ) -> dict[str, Any]:
-        """Run the full investigation. Returns a dict of state updates."""
+        """Run one investigation and return partial state updates."""
         self._on_tuple_event = on_event
         self._on_runtime_event = on_runtime_event
         self._tracker = get_tracker()
-        #: Redacted tool inputs from tool_start, consumed when the output lands.
-        self._redacted_inputs: dict[str, Any] = {}
         self._tracker.start("investigation_agent", "Running investigation agent loop")
 
         state_dict = cast(dict[str, Any], state)
         resolved = dict(state.get("resolved_integrations") or {})
-        available_tools = list(self._filter_tools(get_available_tools(resolved)))
+        available_tools = list(self._filter_tools(list(get_available_tools(resolved))))
         tools = list(select_investigation_tools(available_tools, state_dict))
         tool_context = build_connected_tool_context(resolved, tools)
         tool_by_name = {tool.name: tool for tool in tools}
-
         if not tools:
             logger.warning("No tools available for investigation")
 
-        llm = get_llm(LLMRole.AGENT)
-        msg_mapper = MessageMapper(llm)
-        tool_schemas = llm.tool_schemas(tools)
-
+        llm = (self._llm_factory or default_llm_factory)()
         prompt_state = {**state_dict, **tool_context}
         system = self._build_system_prompt(prompt_state)
         alert_text = format_alert_context(prompt_state, tools)
         messages: list[dict[str, Any]] = [{"role": "user", "content": alert_text}]
-
-        prompt_tokens = estimate_message_tokens(messages, system=system, tools=tool_schemas)
-        logger.debug(
-            "[agent] first-turn prompt budget: ~%d tokens (%d tool schemas from %d available)",
-            prompt_tokens,
-            len(tool_schemas),
-            len(available_tools),
-        )
-
         evidence: dict[str, Any] = {}
         evidence_entries: list[EvidenceEntry] = []
-        executed_hypotheses: list[dict[str, Any]] = []
-        tool_call_cache = InvestigationToolCallCache()
+        controller = InvestigationLoopController(
+            stagnation_nudge=STAGNATION_NUDGE,
+            checkpoint_nudge=POST_TRIAGE_CHECKPOINT,
+            max_stagnant_iterations=MAX_STAGNANT_ITERATIONS,
+        )
+        runtime_state = _RuntimeState(
+            controller=controller,
+            tracker=self._tracker,
+            tool_context=tool_context,
+            evidence_entries=evidence_entries,
+        )
 
-        self._emit(
+        self._dispatch_tuple(
             "agent_start",
             {
                 "tool_count": len(tools),
@@ -189,259 +227,328 @@ class ConnectedInvestigationAgent(EventEmitterMixin, ToolFilterMixin):
                 "available_action_names": tool_context["available_action_names"],
             },
         )
-
-        seed_calls = build_seed_calls(state_dict, tools, llm)
-        if seed_calls:
-            logger.debug("[agent] seeding %d primary tool calls before LLM loop", len(seed_calls))
-            for tc in seed_calls:
-                self._record_tool_start(tc)
-            executed_hypotheses.append(
-                {
-                    "hypothesis": "Seed primary integration tools",
-                    "actions": [tc.name for tc in seed_calls],
-                    "loop_iteration": -1,
-                }
-            )
-            seed_results = execute_tools(seed_calls, tools, resolved)
-            seed_msgs = msg_mapper.to_tool_result_provider_messages(seed_calls, seed_results)
-
-            seed_assistant_msg = msg_mapper.to_synthetic_assistant_provider_message(seed_calls)
-            _mark_messages([seed_assistant_msg, *seed_msgs], "_opensre_seed")
-            messages.append(seed_assistant_msg)
-            messages.extend(seed_msgs)
-
-            for tc, output in zip(seed_calls, seed_results):
-                tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=-1)
-                redacted = self._redacted_view(tc, output)
-                merge_tool_evidence(evidence, tc.name, output, tc.input, redacted=redacted)
-                evidence_entries.append(
-                    EvidenceEntry(
-                        key=tc.name,
-                        data=redacted.output,
-                        tool_name=tc.name,
-                        tool_args=redacted.tool_input,
-                        source=tool_source(tool_by_name, tc.name),
-                        loop_iteration=-1,
-                    )
-                )
-                self._record_tool_end(tc, output, redacted=redacted)
-                debug_print(f"[seed:{tc.name}] → {summarise(output)}")
-
-        # Expose planned tools and live evidence to _should_accept_conclusion overrides.
-        # Both are set before the loop so they're always initialised; evidence is a
-        # reference to the same mutable dict the loop populates, so overrides always
-        # see the current state without an extra assignment inside the loop body.
-        # Only track names that exist in the tool schema the LLM actually receives —
-        # hallucinated or expired names would otherwise cause futile nudge cycles.
-        _available_tool_names = {t.name for t in tools}
-        self._planned_actions: list[str] = [
-            str(name)
-            for name in (state_dict.get("planned_actions") or [])
-            if str(name).strip() and str(name) in _available_tool_names
-        ]
-        self._current_evidence: dict[str, Any] = evidence
-
-        context_ceiling = context_budget_ceiling_for_model(getattr(llm, "_model", None))
-        full_overhead = system_and_tools_overhead(system, tool_schemas)
-        system_only_overhead = system_and_tools_overhead(system, None)
-        stagnant_iterations = 0
-        force_conclusion = False
-        self._last_assistant_text = ""
-        self._conclusion_format_nudged = False
-        self._post_triage_checkpoint_sent = False
-        loops_completed = 0
-        for iteration in range(MAX_INVESTIGATION_LOOPS):
-            logger.debug("[agent] iteration=%d", iteration)
-            self._emit("llm_start", {"iteration": iteration})
-            active_tool_schemas: list[dict[str, Any]] = [] if force_conclusion else tool_schemas
-            active_overhead = system_only_overhead if force_conclusion else full_overhead
-            enforce_context_budget(
-                messages, fixed_overhead_tokens=active_overhead, ceiling=context_ceiling
-            )
-            try:
-                response = llm.invoke(messages, system=system, tools=active_tool_schemas)
-
-            except Exception as err:
-                failure = classify_llm_invoke_failure(err)
-                if failure is None:
-                    raise
-                return degraded_investigation_from_llm_failure(
-                    failure,
-                    err=err,
-                    tracker=self._tracker,
-                    _emit=self._emit,
-                    evidence=evidence,
-                    evidence_entries=evidence_entries,
-                    messages=messages,
-                    executed_hypotheses=executed_hypotheses,
-                    tool_context=tool_context,
-                    investigation_loop_count=loops_completed,
-                )
-
-            loops_completed = iteration + 1
-
-            messages.append(msg_mapper.to_assistant_provider_message(response))
-            self._last_assistant_text = str(getattr(response, "content", "") or "")
-
-            if not response.has_tool_calls:
-                accept, nudge = self._should_accept_conclusion(
-                    evidence_count=len(evidence_entries),
-                    iteration=iteration,
-                )
-                if accept:
-                    logger.debug("[agent] no tool calls — done after %d iterations", iteration + 1)
-                    break
-                if nudge is None:
-                    raise ValueError(
-                        f"{type(self).__name__}._should_accept_conclusion returned "
-                        "(False, None) — a nudge string is required when rejecting "
-                        "the conclusion, otherwise the LLM will loop on an unchanged "
-                        "message history until MAX_INVESTIGATION_LOOPS."
-                    )
-                messages.append({"role": "user", "content": nudge})
-                continue
-
-            cached_entries = [
-                tool_call_cache.lookup(tool_call_signature(tc)) for tc in response.tool_calls
-            ]
-            duplicate_flags = [cached is not None for cached in cached_entries]
-            fresh_calls = [
-                tc
-                for tc, cached in zip(response.tool_calls, cached_entries, strict=True)
-                if cached is None
-            ]
-            for tc in fresh_calls:
-                self._record_tool_start(tc)
-
-            executed_hypotheses.append(
-                {
-                    "hypothesis": f"Agent iteration {iteration}",
-                    "actions": [tc.name for tc in fresh_calls],
-                    "loop_iteration": iteration,
-                }
-            )
-
-            fresh_results = iter(execute_tools(fresh_calls, tools, resolved) if fresh_calls else [])
-            results: list[Any] = []
-            for tc, cached_entry in zip(response.tool_calls, cached_entries, strict=True):
-                if cached_entry is not None:
-                    results.append(duplicate_call_result(tc, cached_entry))
-                    continue
-                output = next(fresh_results)
-                tool_call_cache.store(tool_call_signature(tc), output, loop_iteration=iteration)
-                results.append(output)
-
-            tool_result_messages = msg_mapper.to_tool_result_provider_messages(
-                response.tool_calls, results
-            )
-            if duplicate_flags and all(duplicate_flags):
-                _mark_messages([messages[-1], *tool_result_messages], "_opensre_duplicate_result")
-            messages.extend(tool_result_messages)
-
-            for tc, output, is_dup in zip(response.tool_calls, results, duplicate_flags):
-                if is_dup:
-                    debug_print(f"[{tc.name}] → duplicate call suppressed")
-                    continue
-                redacted = self._redacted_view(tc, output)
-                merge_tool_evidence(evidence, tc.name, output, tc.input, redacted=redacted)
-                evidence_entries.append(
-                    EvidenceEntry(
-                        key=tc.name,
-                        data=redacted.output,
-                        tool_name=tc.name,
-                        tool_args=redacted.tool_input,
-                        source=tool_source(tool_by_name, tc.name),
-                        loop_iteration=iteration,
-                    )
-                )
-                self._record_tool_end(tc, output, redacted=redacted)
-                debug_print(f"[{tc.name}] → {summarise(output)}")
-
-            if iteration == 0 and fresh_calls and not self._post_triage_checkpoint_sent:
-                messages.append({"role": "user", "content": POST_TRIAGE_CHECKPOINT})
-                self._post_triage_checkpoint_sent = True
-
-            if fresh_calls:
-                stagnant_iterations = 0
-            else:
-                stagnant_iterations += 1
-                if messages and messages[-1].get("role") == "user":
-                    last_content = messages[-1]["content"]
-                    if isinstance(last_content, list):
-                        last_content.append({"type": "text", "text": STAGNATION_NUDGE})
-                    else:
-                        messages[-1]["content"] = f"{last_content}\n\n{STAGNATION_NUDGE}"
-                else:
-                    messages.append({"role": "user", "content": STAGNATION_NUDGE})
-                if stagnant_iterations >= MAX_STAGNANT_ITERATIONS:
-                    logger.warning(
-                        "[agent] %d consecutive duplicate-only iterations — forcing "
-                        "tool-free conclusion before MAX_INVESTIGATION_LOOPS",
-                        stagnant_iterations,
-                    )
-                    force_conclusion = True
-        else:
-            logger.warning(
-                "[agent] hit MAX_INVESTIGATION_LOOPS=%d without finishing",
-                MAX_INVESTIGATION_LOOPS,
-            )
-
-        self._emit(
-            "agent_end",
-            {
-                "evidence_count": len(evidence_entries),
-                "message_count": len(messages),
-                "investigation_loop_count": loops_completed,
-                "investigation_iteration_cap": MAX_INVESTIGATION_LOOPS,
-            },
+        self._run_seed_calls(
+            state_dict=state_dict,
+            llm=llm,
+            tools=tools,
+            resolved=resolved,
+            tool_by_name=tool_by_name,
+            controller=controller,
+            messages=messages,
+            evidence=evidence,
+            evidence_entries=evidence_entries,
         )
 
+        available_tool_names = {tool.name for tool in tools}
+        self._planned_actions = [
+            str(name)
+            for name in (state_dict.get("planned_actions") or [])
+            if str(name).strip() and str(name) in available_tool_names
+        ]
+        self._current_evidence = controller.current_evidence
+        for name, value in evidence.items():
+            if name != "tool_outputs":
+                self._current_evidence[name] = value
+        self._last_assistant_text = ""
+        self._conclusion_format_nudged = False
+
+        conclusion_state = _ConclusionState()
+        goal = self._build_goal(conclusion_state)
+        on_shared_event = self._build_runtime_observer(runtime_state)
+        provider_hooks = self._build_provider_hooks(runtime_state)
+        config = AgentConfig(
+            llm=llm,
+            system=system,
+            tools=tuple(tools),
+            resolved_integrations=resolved,
+            max_iterations=MAX_INVESTIGATION_LOOPS,
+            tool_hooks=controller.hooks(),
+            provider_hooks=provider_hooks,
+            on_runtime_event=on_shared_event,
+            goal=goal,
+        )
+        shared_agent = build_agent(config)
+        controller.bind_queue_message(shared_agent.steer)
+
+        try:
+            run_result = shared_agent.run(messages)
+        except Exception as err:
+            failure = classify_llm_invoke_failure(err)
+            if failure is None:
+                raise
+            self._merge_fresh_results(
+                controller,
+                evidence=evidence,
+                evidence_entries=evidence_entries,
+                tool_by_name=tool_by_name,
+            )
+            partial_messages = self._provider_messages(
+                llm,
+                runtime_state.last_messages or [],
+                controller,
+            )
+            return degraded_investigation_from_llm_failure(
+                failure,
+                err=err,
+                tracker=self._tracker,
+                _emit=self._dispatch_tuple,
+                evidence=evidence,
+                evidence_entries=evidence_entries,
+                messages=partial_messages,
+                executed_hypotheses=controller.executed_hypotheses,
+                tool_context=tool_context,
+                investigation_loop_count=runtime_state.loops_completed,
+            )
+
+        self._merge_fresh_results(
+            controller,
+            evidence=evidence,
+            evidence_entries=evidence_entries,
+            tool_by_name=tool_by_name,
+        )
+        provider_messages = self._provider_messages(llm, run_result.messages, controller)
         self._tracker.complete(
             "investigation_agent",
             fields_updated=["evidence", "evidence_entries", "agent_messages"],
-            message=f"evidence:{len(evidence_entries)} messages:{len(messages)}",
+            message=f"evidence:{len(evidence_entries)} messages:{len(provider_messages)}",
         )
-
         updates = {
             "evidence": evidence,
-            "evidence_entries": [e.model_dump() for e in evidence_entries],
-            "agent_messages": messages,
-            "executed_hypotheses": executed_hypotheses,
-            "investigation_loop_count": loops_completed,
+            "evidence_entries": [entry.model_dump() for entry in evidence_entries],
+            "agent_messages": provider_messages,
+            "executed_hypotheses": controller.executed_hypotheses,
+            "investigation_loop_count": run_result.llm_iterations_used,
             "investigation_iteration_cap": MAX_INVESTIGATION_LOOPS,
         }
         updates.update(tool_context)
         return updates
+
+    def _build_goal(self, state: _ConclusionState) -> Goal:
+        def _verify(observation: GoalObservation) -> bool:
+            self._last_assistant_text = observation.final_text
+            accept, nudge = self._should_accept_conclusion(
+                evidence_count=len(self._current_evidence),
+                iteration=observation.iteration,
+                final_text=observation.final_text,
+            )
+            if not accept and nudge is None:
+                raise ValueError(
+                    f"{type(self).__name__}._should_accept_conclusion returned "
+                    "(False, None) — a nudge string is required when rejecting "
+                    "the conclusion."
+                )
+            state.nudge = nudge
+            return accept
+
+        def _nudge(_observation: GoalObservation) -> str:
+            if state.nudge is None:
+                raise ValueError("Investigation conclusion was rejected without a nudge.")
+            return state.nudge
+
+        return Goal(
+            description="complete the investigation",
+            success_criteria="the investigation-specific conclusion policy accepts the answer",
+            verify=_verify,
+            nudge=_nudge,
+        )
+
+    def _build_runtime_observer(
+        self,
+        state: _RuntimeState,
+    ) -> RuntimeEventCallback:
+        def _observe(event: RuntimeEvent) -> None:
+            if isinstance(event, AgentStartEvent):
+                return
+            if isinstance(event, TurnStartEvent):
+                state.controller.begin_iteration(event.iteration)
+            elif isinstance(event, ProviderRequestEndEvent):
+                state.loops_completed = max(state.loops_completed, event.iteration + 1)
+            elif isinstance(event, ToolExecutionStartEvent):
+                if state.controller.is_duplicate(event.tool_call_id):
+                    return
+                state.tracker.record_tool_start(
+                    event.tool_name,
+                    event.args,
+                    event_key=event.tool_call_id,
+                )
+            elif isinstance(event, ToolExecutionEndEvent):
+                if state.controller.is_duplicate(event.tool_call_id):
+                    return
+                state.tracker.record_tool_end(
+                    event.tool_name,
+                    event.result,
+                    event_key=event.tool_call_id,
+                    tool_input=event.args,
+                )
+                debug_print(f"[{event.tool_name}] → {summarise(event.result)}")
+            elif isinstance(event, AgentEndEvent):
+                event = replace(
+                    event,
+                    data={
+                        **event.data,
+                        "evidence_count": len(state.controller.fresh_results())
+                        + len(state.evidence_entries),
+                        "investigation_loop_count": state.loops_completed,
+                        "investigation_iteration_cap": MAX_INVESTIGATION_LOOPS,
+                    },
+                )
+            self._dispatch_runtime(event)
+
+        return _observe
+
+    @staticmethod
+    def _build_provider_hooks(state: _RuntimeState) -> ProviderHooks:
+        def _capture(messages: Sequence[RuntimeMessage]) -> Sequence[RuntimeMessage]:
+            state.last_messages = list(messages)
+            return messages
+
+        def _force_conclusion(request: ProviderRequest) -> ProviderRequest:
+            if not state.controller.force_conclusion:
+                return request
+            logger.warning(
+                "[agent] repeated duplicate-only iterations — forcing tool-free conclusion"
+            )
+            return replace(request, tools=[])
+
+        return ProviderHooks(
+            transform_messages=_capture,
+            before_provider_request=_force_conclusion,
+        )
+
+    def _run_seed_calls(
+        self,
+        *,
+        state_dict: dict[str, Any],
+        llm: Any,
+        tools: list[RegisteredTool],
+        resolved: dict[str, Any],
+        tool_by_name: Mapping[str, RegisteredTool],
+        controller: InvestigationLoopController,
+        messages: list[dict[str, Any]],
+        evidence: dict[str, Any],
+        evidence_entries: list[EvidenceEntry],
+    ) -> None:
+        seed_calls = build_seed_calls(state_dict, tools, llm)
+        if not seed_calls:
+            return
+        logger.debug("[agent] seeding %d primary tool calls before LLM loop", len(seed_calls))
+        redacted_inputs = [self._record_seed_start(tool_call) for tool_call in seed_calls]
+        controller.executed_hypotheses.append(
+            {
+                "hypothesis": "Seed primary integration tools",
+                "actions": [tool_call.name for tool_call in seed_calls],
+                "loop_iteration": -1,
+            }
+        )
+        seed_results = execute_tools(seed_calls, tools, resolved)
+        mapper = MessageMapper(llm)
+        seed_assistant = mapper.to_synthetic_assistant_provider_message(seed_calls)
+        seed_messages = mapper.to_tool_result_provider_messages(seed_calls, seed_results)
+        for message in [seed_assistant, *seed_messages]:
+            message["_opensre_seed"] = True
+        messages.extend([seed_assistant, *seed_messages])
+
+        for tool_call, output, redacted_input in zip(
+            seed_calls,
+            seed_results,
+            redacted_inputs,
+            strict=True,
+        ):
+            controller.record_seed(tool_call, output)
+            redacted = self._record_seed_end(
+                tool_call,
+                output,
+                redacted_input=redacted_input,
+            )
+            merge_tool_evidence(
+                evidence,
+                tool_call.name,
+                output,
+                tool_call.input,
+                redacted=redacted,
+            )
+            evidence_entries.append(
+                EvidenceEntry(
+                    key=tool_call.name,
+                    data=redacted.output,
+                    tool_name=tool_call.name,
+                    tool_args=redacted.tool_input,
+                    source=tool_source(tool_by_name, tool_call.name),
+                    loop_iteration=-1,
+                )
+            )
+            debug_print(f"[seed:{tool_call.name}] → {summarise(output)}")
+
+    @staticmethod
+    def _merge_fresh_results(
+        controller: InvestigationLoopController,
+        *,
+        evidence: dict[str, Any],
+        evidence_entries: list[EvidenceEntry],
+        tool_by_name: Mapping[str, RegisteredTool],
+    ) -> None:
+        for tool_call, output in controller.fresh_results():
+            redacted = redact_tool_view(tool_call.input, output)
+            merge_tool_evidence(
+                evidence,
+                tool_call.name,
+                output,
+                tool_call.input,
+                redacted=redacted,
+            )
+            evidence_entries.append(
+                EvidenceEntry(
+                    key=tool_call.name,
+                    data=redacted.output,
+                    tool_name=tool_call.name,
+                    tool_args=redacted.tool_input,
+                    source=tool_source(tool_by_name, tool_call.name),
+                    loop_iteration=controller.iteration_for(tool_call.id),
+                )
+            )
+
+    @staticmethod
+    def _provider_messages(
+        llm: Any,
+        messages: Sequence[RuntimeMessage],
+        controller: InvestigationLoopController,
+    ) -> list[dict[str, Any]]:
+        mapper = MessageMapper(llm)
+        provider_messages: list[dict[str, Any]] = []
+        for message in messages:
+            metadata = dict(getattr(message, "metadata", {}) or {})
+            tool_calls = tuple(getattr(message, "tool_calls", ()) or ())
+            if tool_calls and all(controller.was_suppressed(call) for call in tool_calls):
+                metadata["_opensre_duplicate_result"] = True
+            if isinstance(message, ToolResultRuntimeMessage) and metadata.get(
+                "_opensre_duplicate_result"
+            ):
+                duplicate_payloads = [controller.duplicate_payload(call) for call in tool_calls]
+                rendered = mapper.to_tool_result_provider_messages(
+                    list(tool_calls),
+                    [payload for payload in duplicate_payloads if payload is not None],
+                )
+            else:
+                rendered = mapper.to_provider_messages([message])
+            for provider_message in rendered:
+                provider_messages.append({**provider_message, **metadata})
+        return provider_messages
 
 
 InvestigationAgent = ConnectedInvestigationAgent
 
 
 def get_investigation_agent_class() -> type[ConnectedInvestigationAgent]:
-    """Return the investigation agent class appropriate for the current LLM provider.
-
-    Callers that need a fixed class (e.g. bench harness, integration tests) should
-    pass an explicit ``agent_class`` to the pipeline rather than calling this.
-    """
+    """Return the investigation policy appropriate for the active agent LLM."""
     from core.llm.transports.sdk.agent_clients import CLIBackedAgentClient
 
-    if isinstance(get_llm(LLMRole.AGENT), CLIBackedAgentClient):
+    if isinstance(default_llm_factory(), CLIBackedAgentClient):
         return CLIBackedInvestigationAgent
     return ConnectedInvestigationAgent
 
 
 class CLIBackedInvestigationAgent(ConnectedInvestigationAgent):
-    """Investigation agent for CLI-backed LLMs (Codex, Claude Code CLI, etc.).
-
-    CLI models receive the full conversation history flattened into a single
-    text prompt per invoke. They tend to emit a plain-text final answer as
-    soon as they see accumulated tool results, exiting the ReAct loop before
-    all planned tools have been called.
-
-    This subclass overrides the conclusion hook to nudge the model to call
-    every planned tool before accepting its final answer. The outer
-    MAX_INVESTIGATION_LOOPS cap still bounds worst-case runtime.
-    """
+    """Require CLI-backed models to call every planned tool before concluding."""
 
     def _should_accept_conclusion(
         self,
@@ -452,22 +559,12 @@ class CLIBackedInvestigationAgent(ConnectedInvestigationAgent):
     ) -> tuple[bool, str | None]:
         planned = getattr(self, "_planned_actions", [])
         evidence = getattr(self, "_current_evidence", None)
-
-        if not planned or evidence is None:
+        if not planned or evidence is None or iteration >= MAX_INVESTIGATION_LOOPS - 2:
             return super()._should_accept_conclusion(
                 evidence_count=evidence_count,
                 iteration=iteration,
                 final_text=final_text,
             )
-
-        # Leave room for a final text-only iteration after the nudge fires.
-        if iteration >= MAX_INVESTIGATION_LOOPS - 2:
-            return super()._should_accept_conclusion(
-                evidence_count=evidence_count,
-                iteration=iteration,
-                final_text=final_text,
-            )
-
         uncalled = [name for name in planned if name not in evidence]
         if not uncalled:
             return super()._should_accept_conclusion(
@@ -475,9 +572,15 @@ class CLIBackedInvestigationAgent(ConnectedInvestigationAgent):
                 iteration=iteration,
                 final_text=final_text,
             )
-
-        tool_list = ", ".join(uncalled)
         return False, (
-            f"You have not yet called these planned investigation tools: {tool_list}. "
+            f"You have not yet called these planned investigation tools: {', '.join(uncalled)}. "
             "Call them now using the JSON tool_calls format before writing your final answer."
         )
+
+
+__all__ = [
+    "CLIBackedInvestigationAgent",
+    "ConnectedInvestigationAgent",
+    "InvestigationAgent",
+    "get_investigation_agent_class",
+]

--- a/tools/investigation/stages/gather_evidence/loop.py
+++ b/tools/investigation/stages/gather_evidence/loop.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 import json
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any
 
 from config.constants.investigation import (
     INVESTIGATION_TOOL_CACHE_MAX_CHARS,
     INVESTIGATION_TOOL_CACHE_MAX_ENTRIES,
     MAX_INVESTIGATION_LOOPS,
+)
+from core.execution import (
+    BeforeToolCallResult,
+    ToolExecutionHooks,
+    ToolExecutionRequest,
+    ToolExecutionResult,
 )
 from core.llm.types import ToolCall
 from core.llm_invoke_errors import LLMInvokeFailure
@@ -146,6 +153,149 @@ def duplicate_call_result(tool_call: ToolCall, cached: CachedToolResult) -> dict
             max_chars=_MAX_CACHED_RESULT_CHARS,
         ),
     }
+
+
+class InvestigationLoopController:
+    """Preserve investigation-specific replay and stagnation policy around ``Agent.run``."""
+
+    def __init__(
+        self,
+        *,
+        stagnation_nudge: str,
+        checkpoint_nudge: str,
+        max_stagnant_iterations: int,
+    ) -> None:
+        self._cache = InvestigationToolCallCache()
+        self._stagnation_nudge = stagnation_nudge
+        self._checkpoint_nudge = checkpoint_nudge
+        self._max_stagnant_iterations = max_stagnant_iterations
+        self._queue_message: Callable[[str], None] | None = None
+        self._iteration = 0
+        self._duplicate_calls: dict[str, CachedToolResult] = {}
+        self._suppressed_calls: set[tuple[str, str]] = set()
+        self._duplicate_payloads: dict[tuple[str, str], dict[str, Any]] = {}
+        self._call_iterations: dict[str, int] = {}
+        self._call_order: dict[str, int] = {}
+        self._results_by_order: dict[int, tuple[ToolCall, Any]] = {}
+        self._next_call_order = 0
+        self._lock = Lock()
+        self._checkpoint_sent = False
+        self._stagnant_iterations = 0
+        self.force_conclusion = False
+        self.executed_hypotheses: list[dict[str, Any]] = []
+        self.current_evidence: dict[str, Any] = {}
+
+    def bind_queue_message(self, queue_message: Callable[[str], None]) -> None:
+        """Bind the shared agent's steering seam after construction."""
+        self._queue_message = queue_message
+
+    def begin_iteration(self, iteration: int) -> None:
+        """Record the runtime iteration used by the next requested tool batch."""
+        self._iteration = iteration
+
+    def record_seed(self, tool_call: ToolCall, result: Any) -> None:
+        """Make a seed result eligible for duplicate replay in the shared loop."""
+        self._cache.store(tool_call_signature(tool_call), result, loop_iteration=-1)
+
+    def hooks(self) -> ToolExecutionHooks:
+        """Return execution hooks that suppress duplicate investigation calls."""
+        return ToolExecutionHooks(
+            before_tool_batch=self._before_batch,
+            before_tool_call=self._before_call,
+            after_tool_call=self._after_call,
+        )
+
+    def is_duplicate(self, tool_call_id: str) -> bool:
+        """Return whether the current run suppressed ``tool_call_id``."""
+        return tool_call_id in self._duplicate_calls
+
+    def was_suppressed(self, tool_call: ToolCall) -> bool:
+        """Return whether ``tool_call`` was suppressed at any point in this run."""
+        return (tool_call.id, tool_call_signature(tool_call)) in self._suppressed_calls
+
+    def duplicate_payload(self, tool_call: ToolCall) -> dict[str, Any] | None:
+        """Return the historical replay payload for a suppressed call."""
+        return self._duplicate_payloads.get((tool_call.id, tool_call_signature(tool_call)))
+
+    def fresh_results(self) -> list[tuple[ToolCall, Any]]:
+        """Return newly executed tool results in provider request order."""
+        return [self._results_by_order[index] for index in sorted(self._results_by_order)]
+
+    def iteration_for(self, tool_call_id: str) -> int:
+        """Return the loop iteration associated with a requested tool call."""
+        return self._call_iterations.get(tool_call_id, self._iteration)
+
+    def _before_batch(self, tool_calls: Sequence[ToolCall]) -> None:
+        duplicate_calls: dict[str, CachedToolResult] = {}
+        fresh_names: list[str] = []
+        for tool_call in tool_calls:
+            self._call_iterations[tool_call.id] = self._iteration
+            self._call_order[tool_call.id] = self._next_call_order
+            self._next_call_order += 1
+            cached = self._cache.lookup(tool_call_signature(tool_call))
+            if cached is None:
+                fresh_names.append(tool_call.name)
+            else:
+                duplicate_calls[tool_call.id] = cached
+        self._duplicate_calls = duplicate_calls
+        self._suppressed_calls.update(
+            (tool_call.id, tool_call_signature(tool_call))
+            for tool_call in tool_calls
+            if tool_call.id in duplicate_calls
+        )
+        self.executed_hypotheses.append(
+            {
+                "hypothesis": f"Agent iteration {self._iteration}",
+                "actions": fresh_names,
+                "loop_iteration": self._iteration,
+            }
+        )
+        if fresh_names:
+            self._stagnant_iterations = 0
+            return
+        self._stagnant_iterations += 1
+        if self._queue_message is not None:
+            self._queue_message(self._stagnation_nudge)
+        if self._stagnant_iterations >= self._max_stagnant_iterations:
+            self.force_conclusion = True
+
+    def _before_call(self, request: ToolExecutionRequest) -> BeforeToolCallResult | None:
+        cached = self._duplicate_calls.get(request.tool_call.id)
+        if cached is None:
+            return None
+        payload = duplicate_call_result(request.tool_call, cached)
+        with self._lock:
+            self._duplicate_payloads[
+                (request.tool_call.id, tool_call_signature(request.tool_call))
+            ] = payload
+        return BeforeToolCallResult(
+            blocked=True,
+            reason=json.dumps(payload, default=str),
+            details=payload,
+            metadata={"suppressed_duplicate": True},
+        )
+
+    def _after_call(
+        self,
+        request: ToolExecutionRequest,
+        result: ToolExecutionResult,
+    ) -> None:
+        with self._lock:
+            payload = result.compat_payload()
+            self._cache.store(
+                tool_call_signature(request.tool_call),
+                payload,
+                loop_iteration=self.iteration_for(request.tool_call.id),
+            )
+            self._results_by_order[self._call_order[request.tool_call.id]] = (
+                request.tool_call,
+                payload,
+            )
+            self.current_evidence[request.tool_call.name] = payload
+            if self._iteration == 0 and not self._checkpoint_sent:
+                self._checkpoint_sent = True
+                if self._queue_message is not None:
+                    self._queue_message(self._checkpoint_nudge)
 
 
 def degraded_investigation_from_llm_failure(

--- a/tools/investigation/stages/intake/node.py
+++ b/tools/investigation/stages/intake/node.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import Any, cast
 
+from core.agent_harness.llm_resolution import default_reasoning_llm_factory
 from core.domain.alerts.extraction import (
     AlertDetails,
     build_alert_details_model,
@@ -16,7 +17,6 @@ from core.domain.alerts.extraction import (
     make_problem_md,
 )
 from core.domain.types.incident_window import resolve_incident_window
-from core.llm.factory import LLMRole, get_llm
 from core.state import InvestigationState
 from platform.observability import (
     debug_print,
@@ -163,7 +163,7 @@ def _extract_alert_details(state: InvestigationState) -> AlertDetails:
     text = format_raw_alert(raw_alert)
     prompt = _EXTRACT_PROMPT.format(text=text)
 
-    llm = get_llm(LLMRole.REASONING)
+    llm = default_reasoning_llm_factory()
     try:
         details = cast(
             AlertDetails,

--- a/tools/investigation/stages/plan_evidence/node.py
+++ b/tools/investigation/stages/plan_evidence/node.py
@@ -29,6 +29,8 @@ def plan_actions(state: InvestigationState) -> dict[str, Any]:
         return {}
 
     state_any = dict(state)
+    # Integration resolution is owned by the preceding pipeline stage; planning
+    # only consumes that snapshot and never resolves providers itself.
     raw_resolved = state_any.get("resolved_integrations")
     resolved = raw_resolved if isinstance(raw_resolved, dict) else {}
     available_tools = _available_investigation_tools(resolved)


### PR DESCRIPTION
Fixes #4439

#### Describe the changes you have made in this PR -

- Refactored `ConnectedInvestigationAgent` to assemble `AgentConfig`, call `build_agent()`, and delegate the think → tool-call → observe lifecycle to the shared `core.agent.Agent` runtime.
- Kept investigation-owned behavior at the boundary: seed calls, bounded duplicate replay, stagnation nudges, forced conclusion, evidence merging/redaction, progress callbacks, and CLI-specific conclusion policy.
- Added the missing `provider_hooks` builder seam and goal-specific nudge support needed to preserve those policies without forking the shared ReAct loop.
- Routed intake and diagnosis structured-output clients through `core.agent_harness.llm_resolution` instead of importing `get_llm()` directly.
- Verified that evidence planning only consumes the already-resolved integration snapshot and documented that ownership in the stage.
- Added mock-client stage tests, a build-agent delegation regression test, and an AST import-boundary test.

This removes a second investigation-specific ReAct implementation. Future fixes to budgeting, runtime events, provider conversion, and tool execution now apply to evidence gathering through the same runtime used by the rest of OpenSRE.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ make format-check
3503 files already formatted

$ make lint
All checks passed!

$ make typecheck
Success: no issues found in 1804 source files

$ uv run python -m pytest tests/tools/investigation tests/agent/test_investigation.py tests/core/agent/test_goals.py tests/core/agent/test_agent_run.py tests/core/agent/test_react_loop_spans.py tests/core/agent_harness/test_evidence_driver_context.py tests/benchmarks/cloudopsbench/tests/test_bench_agent.py tests/synthetic/test_new_relic_scenario.py -q
176 passed in 5.19s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The duplicated gather-evidence loop was replaced with a small investigation policy wrapper around `Agent.run()`. `InvestigationLoopController` adapts duplicate suppression and stagnation behavior to the shared runtime's tool and steering hooks. Provider hooks capture partial transcripts on invoke failure and remove tool schemas when repeated duplicate-only turns require a final answer. A goal verifier retains the existing investigation and CLI conclusion rules.

I considered wrapping intake and diagnosis in no-tool `Agent` instances. I kept their structured-output calls direct because the harness contract classifies direct, tool-free answers as a separate shape; only client resolution needed centralization there. I also avoided changing prompt construction, evidence semantics, or integration resolution ownership.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
