### PR TITLE
fix(cli): simplify GitHub integration onboarding

### DIFF
--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -339,6 +339,15 @@ def _github_browser_authorize() -> str | None:
     return token.access_token
 
 
+def _github_browser_auth_token() -> str:
+    """Authorize in the browser, falling back to manual token entry."""
+    token = _github_browser_authorize()
+    if token:
+        return token
+    print("  Falling back to manual token entry.")
+    return _p("GitHub PAT / auth token", secret=True)
+
+
 def _setup_github_auth_token(mode: str) -> str:
     """Resolve a GitHub MCP auth token, offering browser sign-in for remote modes."""
     if mode == "stdio":
@@ -365,10 +374,7 @@ def _setup_github_auth_token(mode: str) -> str:
     if auth_method == "none":
         return ""
     if auth_method == "browser":
-        token = _github_browser_authorize()
-        if token:
-            return token
-        print("  Falling back to manual token entry.")
+        return _github_browser_auth_token()
     return _p("GitHub PAT / auth token", secret=True)
 
 
@@ -453,25 +459,30 @@ def _setup_github() -> str | None:
     from integrations.github.setup import GITHUB_SETUP
     from integrations.setup_flow import apply_setup
 
-    print("  Connect OpenSRE to GitHub through the hosted GitHub MCP server.")
-    advanced = _confirm(
-        "Customize advanced settings (transport, server URL, toolsets, repo scope)?",
-        default=False,
+    print("  Connect OpenSRE to your GitHub repositories.")
+    setup_path = _select(
+        "How would you like to connect?",
+        choices=[
+            questionary.Choice("Sign in with GitHub (recommended)", value="recommended"),
+            questionary.Choice("Customize connection", value="customize"),
+        ],
+        default="recommended",
     )
-    if advanced is None:
+    if setup_path is None:
         print("\nAborted.")
         sys.exit(1)
+    customize = setup_path == "customize"
 
     credentials: dict[str, Any] = {}
     repo_view: str = "auto"
     repo_visibility: str = "any"
 
-    if advanced:
+    if customize:
         repo_view, repo_visibility = _github_advanced_setup(credentials)
     else:
         credentials["mode"] = DEFAULT_GITHUB_MCP_MODE
         credentials["url"] = DEFAULT_GITHUB_MCP_URL
-        credentials["auth_token"] = _setup_github_auth_token(DEFAULT_GITHUB_MCP_MODE)
+        credentials["auth_token"] = _github_browser_auth_token()
         credentials["toolsets"] = list(DEFAULT_GITHUB_MCP_TOOLSETS)
 
     print("\n  Validating GitHub MCP integration...")
@@ -486,7 +497,7 @@ def _setup_github() -> str | None:
         # Only the advanced path offers the verbose repo listing.
         level = (
             _prompt_github_repo_report_level()
-            if advanced
+            if customize
             else cast(GitHubMcpDisplayDetailLevel, "summary")
         )
         print()

--- a/tests/cli/test_integrations_setup_github.py
+++ b/tests/cli/test_integrations_setup_github.py
@@ -9,7 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 import integrations.setup_flow as setup_flow
-from integrations.cli import _setup_github, cmd_setup
+from integrations.cli import _github_browser_auth_token, _setup_github, cmd_setup
 from integrations.github.mcp import GitHubMCPValidationResult
 from surfaces.cli.app import cli
 
@@ -23,19 +23,44 @@ def _prompt_answering(answer: object) -> object:
     return _prompt
 
 
-def _mock_confirm(monkeypatch: pytest.MonkeyPatch, *, advanced: bool) -> None:
-    """Mock the advanced-settings confirm prompt at the top of ``_setup_github``."""
-    monkeypatch.setattr("integrations.cli.questionary.confirm", _prompt_answering(advanced))
+def _mock_github_setup_path(monkeypatch: pytest.MonkeyPatch, *, customize: bool) -> None:
+    """Choose a GitHub setup path and keep automatic repository defaults."""
 
+    def _select(message: str, *_args: object, **_kwargs: object) -> object:
+        if message == "How would you like to connect?":
+            return "customize" if customize else "recommended"
+        return "auto"
 
-def _mock_select_auto(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Mock the transport-mode select prompt to answer "auto"."""
-    monkeypatch.setattr("integrations.cli.questionary.select", _prompt_answering("auto"))
+    monkeypatch.setattr("integrations.cli._select", _select)
 
 
 def _patch_apply_setup(monkeypatch: pytest.MonkeyPatch, fake: object) -> None:
     """Patch ``apply_setup`` where the function-local import resolves it."""
     monkeypatch.setattr(setup_flow, "apply_setup", fake)
+
+
+def test_github_browser_auth_falls_back_to_manual_token(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("integrations.cli._github_browser_authorize", lambda: None)
+    monkeypatch.setattr("integrations.cli._p", lambda *_args, **_kwargs: "ghp_manual")
+
+    assert _github_browser_auth_token() == "ghp_manual"
+    assert "Falling back to manual token entry" in capsys.readouterr().out
+
+
+def test_setup_github_can_cancel_at_connection_choice(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("integrations.cli._select", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(SystemExit) as exc:
+        _setup_github()
+
+    assert exc.value.code == 1
+    assert "Aborted." in capsys.readouterr().out
 
 
 def test_setup_github_prints_connected_and_saves_on_validation_success(
@@ -50,10 +75,9 @@ def test_setup_github_prints_connected_and_saves_on_validation_success(
         return next(answers)
 
     monkeypatch.setattr("integrations.cli._p", fake_p)
-    _mock_confirm(monkeypatch, advanced=True)
+    _mock_github_setup_path(monkeypatch, customize=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "ghp_x")
     monkeypatch.setattr("integrations.cli._prompt_github_repo_report_level", lambda: "full")
-    _mock_select_auto(monkeypatch)
 
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
@@ -102,7 +126,7 @@ def test_setup_github_simple_path_uses_hosted_defaults(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Declining advanced settings saves hosted defaults without transport/URL prompts."""
+    """Recommended setup signs in with hosted defaults and no advanced prompts."""
 
     def fake_p(_label: str, default: str = "", secret: bool = False) -> str:
         raise AssertionError("simple path should not call _p")
@@ -111,8 +135,14 @@ def test_setup_github_simple_path_uses_hosted_defaults(
         raise AssertionError("simple path should not prompt for repo detail level")
 
     monkeypatch.setattr("integrations.cli._p", fake_p)
-    _mock_confirm(monkeypatch, advanced=False)
-    monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "gho_browser")
+    setup_choices: list[tuple[str, list[object], str]] = []
+
+    def _select(message: str, choices: list[object], *, default: str) -> str:
+        setup_choices.append((message, choices, default))
+        return "recommended"
+
+    monkeypatch.setattr("integrations.cli._select", _select)
+    monkeypatch.setattr("integrations.cli._github_browser_authorize", lambda: "gho_browser")
     monkeypatch.setattr("integrations.cli._prompt_github_repo_report_level", _no_level_prompt)
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
@@ -140,6 +170,14 @@ def test_setup_github_simple_path_uses_hosted_defaults(
 
     out = capsys.readouterr().out
     assert out.count("Validating GitHub MCP integration") == 1
+    assert len(setup_choices) == 1
+    message, choices, default = setup_choices[0]
+    assert message == "How would you like to connect?"
+    assert [(choice.title, choice.value) for choice in choices] == [
+        ("Sign in with GitHub (recommended)", "recommended"),
+        ("Customize connection", "customize"),
+    ]
+    assert default == "recommended"
     # Concise summary: no access-source / starred / repo enumeration noise.
     assert "Access source" not in out
     assert "Starred" not in out
@@ -164,9 +202,8 @@ def test_setup_github_exits_without_save_on_validation_failure(
         return next(answers)
 
     monkeypatch.setattr("integrations.cli._p", fake_p)
-    _mock_confirm(monkeypatch, advanced=True)
+    _mock_github_setup_path(monkeypatch, customize=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "")
-    _mock_select_auto(monkeypatch)
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
@@ -203,9 +240,8 @@ def test_cmd_setup_github_skips_saved_line_on_validation_failure(
         return next(answers)
 
     monkeypatch.setattr("integrations.cli._p", fake_p)
-    _mock_confirm(monkeypatch, advanced=True)
+    _mock_github_setup_path(monkeypatch, customize=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "x")
-    _mock_select_auto(monkeypatch)
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
@@ -240,10 +276,9 @@ def test_cmd_setup_github_prints_saved_after_success(
         return next(answers)
 
     monkeypatch.setattr("integrations.cli._p", fake_p)
-    _mock_confirm(monkeypatch, advanced=True)
+    _mock_github_setup_path(monkeypatch, customize=True)
     monkeypatch.setattr("integrations.cli._setup_github_auth_token", lambda _mode: "tok")
     monkeypatch.setattr("integrations.cli._prompt_github_repo_report_level", lambda: "standard")
-    _mock_select_auto(monkeypatch)
     monkeypatch.setattr(
         "integrations.github.mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(

--- a/tests/cli/test_integrations_setup_github.py
+++ b/tests/cli/test_integrations_setup_github.py
@@ -29,7 +29,11 @@ def _mock_github_setup_path(monkeypatch: pytest.MonkeyPatch, *, customize: bool)
     def _select(message: str, *_args: object, **_kwargs: object) -> object:
         if message == "How would you like to connect?":
             return "customize" if customize else "recommended"
-        return "auto"
+        if message == "Which repository view should we use to verify access?":
+            return "auto"
+        if message == "Filter repositories by visibility (best-effort)":
+            return "any"
+        raise AssertionError(f"Unexpected select prompt: {message}")
 
     monkeypatch.setattr("integrations.cli._select", _select)
 


### PR DESCRIPTION
Fixes #5026

#### Describe the changes you have made in this PR -

- Replaces the advanced-settings confirmation with two ordered setup paths: recommended GitHub sign-in first, customization second.
- Starts browser/device authorization immediately on the recommended path while preserving the existing PAT fallback.
- Keeps MCP URL, toolsets, authentication choices, repository scope, and validation detail on the custom path.
- Adds regression coverage for prompt order, hosted defaults, cancellation, and browser-auth fallback.

### Demo/Screenshot for feature changes and bug fixes -

```text
  Setting up github

  Connect OpenSRE to your GitHub repositories.
? How would you like to connect? (Use arrow keys)
 » Sign in with GitHub (recommended)
   Customize connection
```

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/integrations/ tests/cli/test_integrations_setup_github.py` (3,379 passed, 6 skipped)
- Manual TTY verification with `uv run opensre integrations setup github`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The previous yes/no question framed customization as the primary decision, even though most users should take the hosted browser-auth path. I considered only rewording that confirmation, but it would still lead with the exceptional path and require a second authentication prompt.

The implementation instead uses the existing select UI to expose two explicit paths. The recommended path applies the hosted MCP defaults and calls browser authorization directly. `_github_browser_auth_token` centralizes the existing browser-to-PAT fallback so both recommended and custom browser authentication behave consistently. The custom path continues to use `_github_advanced_setup` and retains its existing controls.

Tests assert the visible choice order and default, verify both setup paths, and cover cancellation and fallback behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
