### PR TITLE
fix(investigation): preserve duplicate loop policy

### DIFF
--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core import (
+    TupleEventCallback,
     context_budget_ceiling_for_model,
     enforce_context_budget,
     estimate_message_tokens,
@@ -1344,6 +1345,7 @@ def _run_agent_with_scripted_llm(
     *,
     invoke: Any,
     tools: list[MagicMock],
+    on_event: TupleEventCallback | None = None,
 ) -> tuple[dict[str, Any], MagicMock]:
     mock_llm = MagicMock()
     mock_llm._model = "gpt-4o"
@@ -1374,13 +1376,14 @@ def _run_agent_with_scripted_llm(
             return_value=tools,
         ),
     ):
-        result = ConnectedInvestigationAgent().run(state)
+        result = ConnectedInvestigationAgent().run(state, on_event=on_event)
     return result, mock_llm
 
 
 def test_run_suppresses_duplicate_tool_calls() -> None:
     """A tool re-requested with identical arguments is NOT executed again."""
     tool = _fake_tool("list_posthog_tools")
+    tool_events: list[tuple[str, str | None]] = []
     responses = [
         _tool_call_response([ToolCall(id="c1", name="list_posthog_tools", input={})]),
         # identical call — must be suppressed, not re-run
@@ -1388,7 +1391,11 @@ def test_run_suppresses_duplicate_tool_calls() -> None:
         _text_response(_incident_command_diagnosis("Final diagnosis.")),
     ]
 
-    result, mock_llm = _run_agent_with_scripted_llm(invoke=responses, tools=[tool])
+    result, mock_llm = _run_agent_with_scripted_llm(
+        invoke=responses,
+        tools=[tool],
+        on_event=lambda kind, data: tool_events.append((kind, data.get("id"))),
+    )
 
     # Executed exactly once despite being requested twice.
     assert tool.run.call_count == 1
@@ -1407,6 +1414,34 @@ def test_run_suppresses_duplicate_tool_calls() -> None:
     assert duplicate_messages[0]["role"] == "assistant"
     assert "suppressed_duplicate" in duplicate_messages[1]["content"]
     assert mock_llm.invoke.call_count == 3
+    assert [event for event in tool_events if event[0] in {"tool_start", "tool_end"}] == [
+        ("tool_start", "c1"),
+        ("tool_end", "c1"),
+    ]
+
+
+def test_run_preserves_fresh_transcript_when_provider_reuses_call_id() -> None:
+    """Later suppression must not relabel an earlier call that reused the same ID."""
+    tool = _fake_tool("list_posthog_tools")
+    responses = [
+        _tool_call_response([ToolCall(id="c", name="list_posthog_tools", input={})]),
+        _tool_call_response([ToolCall(id="c", name="list_posthog_tools", input={})]),
+        _text_response(_incident_command_diagnosis("Final diagnosis.")),
+    ]
+
+    result = _run_agent_with_scripted_llm(invoke=responses, tools=[tool])[0]
+
+    assert result["agent_messages"][1].get("_opensre_duplicate_result") is None
+    assert result["agent_messages"][2].get("_opensre_duplicate_result") is None
+    first_result = json.loads(json.loads(result["agent_messages"][2]["content"])[0])
+    assert first_result["ok"] is True
+    duplicate_messages = [
+        message
+        for message in result["agent_messages"]
+        if message.get("_opensre_duplicate_result") is True
+    ]
+    assert len(duplicate_messages) == 2
+    assert result["evidence_entries"][0]["loop_iteration"] == 0
 
 
 def test_run_does_not_suppress_calls_with_different_args() -> None:
@@ -1451,6 +1486,32 @@ def test_run_forces_conclusion_when_stuck_repeating() -> None:
     assert result["agent_messages"][-1]["content"] == _incident_command_diagnosis(
         "Final diagnosis: insufficient evidence."
     )
+
+
+def test_run_forces_conclusion_after_repeated_validation_error() -> None:
+    """A deterministic validation failure is cached so repeats count as stagnation."""
+    tool = _fake_tool("query_logs")
+    tool.validate_public_input.return_value = "invalid query"
+    call_number = 0
+
+    def invoke(messages: Any, system: Any, tools: Any) -> MagicMock:  # noqa: ARG001
+        nonlocal call_number
+        if not tools:
+            return _text_response(
+                _incident_command_diagnosis("Final diagnosis: query was invalid.")
+            )
+        call_number += 1
+        return _tool_call_response(
+            [ToolCall(id=f"c{call_number}", name="query_logs", input={"q": "bad"})]
+        )
+
+    result, mock_llm = _run_agent_with_scripted_llm(invoke=invoke, tools=[tool])
+
+    assert tool.run.call_count == 0
+    assert mock_llm.invoke.call_count < 6
+    assert mock_llm.invoke.call_args_list[-1].kwargs["tools"] == []
+    assert result["evidence_entries"][0]["data"] == {"error": "invalid query"}
+    assert result["evidence_entries"][0]["loop_iteration"] == 0
 
 
 def test_truncate_content_distributes_across_multiple_blocks() -> None:

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -364,7 +364,10 @@ class ConnectedInvestigationAgent:
             elif isinstance(event, ProviderRequestEndEvent):
                 state.loops_completed = max(state.loops_completed, event.iteration + 1)
             elif isinstance(event, ToolExecutionStartEvent):
-                if state.controller.is_duplicate(event.tool_call_id):
+                if state.controller.is_duplicate_event(
+                    iteration=event.iteration,
+                    tool_call_id=event.tool_call_id,
+                ):
                     return
                 state.tracker.record_tool_start(
                     event.tool_name,
@@ -372,7 +375,15 @@ class ConnectedInvestigationAgent:
                     event_key=event.tool_call_id,
                 )
             elif isinstance(event, ToolExecutionEndEvent):
-                if state.controller.is_duplicate(event.tool_call_id):
+                state.controller.record_runtime_result(
+                    iteration=event.iteration,
+                    tool_call_id=event.tool_call_id,
+                    result=event.result,
+                )
+                if state.controller.is_duplicate_event(
+                    iteration=event.iteration,
+                    tool_call_id=event.tool_call_id,
+                ):
                     return
                 state.tracker.record_tool_end(
                     event.tool_name,
@@ -410,9 +421,19 @@ class ConnectedInvestigationAgent:
             )
             return replace(request, tools=[])
 
+        def _classify_tool_calls(request: ProviderRequest, response: Any) -> Any:
+            tool_calls = tuple(getattr(response, "tool_calls", ()) or ())
+            if tool_calls:
+                state.controller.prepare_batch(
+                    tool_calls,
+                    iteration=int(request.metadata.get("iteration", 0)),
+                )
+            return response
+
         return ProviderHooks(
             transform_messages=_capture,
             before_provider_request=_force_conclusion,
+            after_provider_response=_classify_tool_calls,
         )
 
     def _run_seed_calls(
@@ -503,7 +524,7 @@ class ConnectedInvestigationAgent:
                     tool_name=tool_call.name,
                     tool_args=redacted.tool_input,
                     source=tool_source(tool_by_name, tool_call.name),
-                    loop_iteration=controller.iteration_for(tool_call.id),
+                    loop_iteration=controller.iteration_for(tool_call),
                 )
             )
 

--- a/tools/investigation/stages/gather_evidence/loop.py
+++ b/tools/investigation/stages/gather_evidence/loop.py
@@ -43,6 +43,14 @@ class CachedToolResult:
     loop_iteration: int
 
 
+@dataclass(frozen=True)
+class _CallOccurrence:
+    tool_call: ToolCall
+    iteration: int
+    order: int
+    cached: CachedToolResult | None
+
+
 def _estimate_payload_chars(result: Any) -> int:
     """Approximate serialized size for cache byte budgeting."""
     try:
@@ -171,11 +179,11 @@ class InvestigationLoopController:
         self._max_stagnant_iterations = max_stagnant_iterations
         self._queue_message: Callable[[str], None] | None = None
         self._iteration = 0
-        self._duplicate_calls: dict[str, CachedToolResult] = {}
-        self._suppressed_calls: set[tuple[str, str]] = set()
-        self._duplicate_payloads: dict[tuple[str, str], dict[str, Any]] = {}
-        self._call_iterations: dict[str, int] = {}
-        self._call_order: dict[str, int] = {}
+        self._occurrences_by_object: dict[int, _CallOccurrence] = {}
+        self._occurrences_by_event: dict[tuple[int, str], _CallOccurrence] = {}
+        self._prepared_batches: set[tuple[int, tuple[int, ...]]] = set()
+        self._duplicate_payloads: dict[int, dict[str, Any]] = {}
+        self._recorded_occurrences: set[int] = set()
         self._results_by_order: dict[int, tuple[ToolCall, Any]] = {}
         self._next_call_order = 0
         self._lock = Lock()
@@ -200,58 +208,53 @@ class InvestigationLoopController:
     def hooks(self) -> ToolExecutionHooks:
         """Return execution hooks that suppress duplicate investigation calls."""
         return ToolExecutionHooks(
-            before_tool_batch=self._before_batch,
+            before_tool_batch=self.prepare_batch,
             before_tool_call=self._before_call,
             after_tool_call=self._after_call,
         )
 
-    def is_duplicate(self, tool_call_id: str) -> bool:
-        """Return whether the current run suppressed ``tool_call_id``."""
-        return tool_call_id in self._duplicate_calls
+    def prepare_batch(
+        self,
+        tool_calls: Sequence[ToolCall],
+        *,
+        iteration: int | None = None,
+    ) -> None:
+        """Classify a provider tool batch before runtime start events are emitted."""
+        call_iteration = self._iteration if iteration is None else iteration
+        batch_key = (call_iteration, tuple(id(tool_call) for tool_call in tool_calls))
+        if batch_key in self._prepared_batches:
+            return
+        self._prepared_batches.add(batch_key)
 
-    def was_suppressed(self, tool_call: ToolCall) -> bool:
-        """Return whether ``tool_call`` was suppressed at any point in this run."""
-        return (tool_call.id, tool_call_signature(tool_call)) in self._suppressed_calls
-
-    def duplicate_payload(self, tool_call: ToolCall) -> dict[str, Any] | None:
-        """Return the historical replay payload for a suppressed call."""
-        return self._duplicate_payloads.get((tool_call.id, tool_call_signature(tool_call)))
-
-    def fresh_results(self) -> list[tuple[ToolCall, Any]]:
-        """Return newly executed tool results in provider request order."""
-        return [self._results_by_order[index] for index in sorted(self._results_by_order)]
-
-    def iteration_for(self, tool_call_id: str) -> int:
-        """Return the loop iteration associated with a requested tool call."""
-        return self._call_iterations.get(tool_call_id, self._iteration)
-
-    def _before_batch(self, tool_calls: Sequence[ToolCall]) -> None:
-        duplicate_calls: dict[str, CachedToolResult] = {}
         fresh_names: list[str] = []
+        duplicate_count = 0
         for tool_call in tool_calls:
-            self._call_iterations[tool_call.id] = self._iteration
-            self._call_order[tool_call.id] = self._next_call_order
-            self._next_call_order += 1
             cached = self._cache.lookup(tool_call_signature(tool_call))
+            occurrence = _CallOccurrence(
+                tool_call=tool_call,
+                iteration=call_iteration,
+                order=self._next_call_order,
+                cached=cached,
+            )
+            self._next_call_order += 1
+            self._occurrences_by_object[id(tool_call)] = occurrence
+            self._occurrences_by_event[(call_iteration, tool_call.id)] = occurrence
             if cached is None:
                 fresh_names.append(tool_call.name)
             else:
-                duplicate_calls[tool_call.id] = cached
-        self._duplicate_calls = duplicate_calls
-        self._suppressed_calls.update(
-            (tool_call.id, tool_call_signature(tool_call))
-            for tool_call in tool_calls
-            if tool_call.id in duplicate_calls
-        )
+                duplicate_count += 1
+
         self.executed_hypotheses.append(
             {
-                "hypothesis": f"Agent iteration {self._iteration}",
+                "hypothesis": f"Agent iteration {call_iteration}",
                 "actions": fresh_names,
-                "loop_iteration": self._iteration,
+                "loop_iteration": call_iteration,
             }
         )
         if fresh_names:
             self._stagnant_iterations = 0
+            return
+        if duplicate_count == 0:
             return
         self._stagnant_iterations += 1
         if self._queue_message is not None:
@@ -259,15 +262,52 @@ class InvestigationLoopController:
         if self._stagnant_iterations >= self._max_stagnant_iterations:
             self.force_conclusion = True
 
+    def is_duplicate_event(self, *, iteration: int, tool_call_id: str) -> bool:
+        """Return whether the classified runtime event belongs to a duplicate call."""
+        occurrence = self._occurrences_by_event.get((iteration, tool_call_id))
+        return occurrence is not None and occurrence.cached is not None
+
+    def was_suppressed(self, tool_call: ToolCall) -> bool:
+        """Return whether this exact provider call occurrence was suppressed."""
+        occurrence = self._occurrences_by_object.get(id(tool_call))
+        return occurrence is not None and occurrence.cached is not None
+
+    def duplicate_payload(self, tool_call: ToolCall) -> dict[str, Any] | None:
+        """Return the historical replay payload for a suppressed call."""
+        return self._duplicate_payloads.get(id(tool_call))
+
+    def fresh_results(self) -> list[tuple[ToolCall, Any]]:
+        """Return newly executed tool results in provider request order."""
+        return [self._results_by_order[index] for index in sorted(self._results_by_order)]
+
+    def iteration_for(self, tool_call: ToolCall) -> int:
+        """Return the loop iteration associated with this exact call occurrence."""
+        occurrence = self._occurrences_by_object.get(id(tool_call))
+        return self._iteration if occurrence is None else occurrence.iteration
+
+    def record_runtime_result(
+        self,
+        *,
+        iteration: int,
+        tool_call_id: str,
+        result: Any,
+    ) -> None:
+        """Record early executor results that bypass ``after_tool_call`` hooks."""
+        occurrence = self._occurrences_by_event.get((iteration, tool_call_id))
+        if occurrence is None or occurrence.cached is not None:
+            return
+        self._record_result(occurrence, result)
+
     def _before_call(self, request: ToolExecutionRequest) -> BeforeToolCallResult | None:
-        cached = self._duplicate_calls.get(request.tool_call.id)
-        if cached is None:
+        occurrence = self._occurrences_by_object.get(id(request.tool_call))
+        if occurrence is None:
+            self.prepare_batch([request.tool_call])
+            occurrence = self._occurrences_by_object[id(request.tool_call)]
+        if occurrence.cached is None:
             return None
-        payload = duplicate_call_result(request.tool_call, cached)
+        payload = duplicate_call_result(request.tool_call, occurrence.cached)
         with self._lock:
-            self._duplicate_payloads[
-                (request.tool_call.id, tool_call_signature(request.tool_call))
-            ] = payload
+            self._duplicate_payloads[id(request.tool_call)] = payload
         return BeforeToolCallResult(
             blocked=True,
             reason=json.dumps(payload, default=str),
@@ -280,19 +320,29 @@ class InvestigationLoopController:
         request: ToolExecutionRequest,
         result: ToolExecutionResult,
     ) -> None:
+        occurrence = self._occurrences_by_object.get(id(request.tool_call))
+        if occurrence is None:
+            self.prepare_batch([request.tool_call])
+            occurrence = self._occurrences_by_object[id(request.tool_call)]
+        self._record_result(occurrence, result.compat_payload())
+
+    def _record_result(self, occurrence: _CallOccurrence, payload: Any) -> None:
         with self._lock:
-            payload = result.compat_payload()
+            occurrence_key = id(occurrence.tool_call)
+            if occurrence_key in self._recorded_occurrences:
+                return
+            self._recorded_occurrences.add(occurrence_key)
             self._cache.store(
-                tool_call_signature(request.tool_call),
+                tool_call_signature(occurrence.tool_call),
                 payload,
-                loop_iteration=self.iteration_for(request.tool_call.id),
+                loop_iteration=occurrence.iteration,
             )
-            self._results_by_order[self._call_order[request.tool_call.id]] = (
-                request.tool_call,
+            self._results_by_order[occurrence.order] = (
+                occurrence.tool_call,
                 payload,
             )
-            self.current_evidence[request.tool_call.name] = payload
-            if self._iteration == 0 and not self._checkpoint_sent:
+            self.current_evidence[occurrence.tool_call.name] = payload
+            if occurrence.iteration == 0 and not self._checkpoint_sent:
                 self._checkpoint_sent = True
                 if self._queue_message is not None:
                     self._queue_message(self._checkpoint_nudge)


### PR DESCRIPTION
Follow-up to #5025 (original issue: #4439)

#### Describe the changes you have made in this PR -

- Classify each provider tool-call occurrence before shared-runtime start events are emitted, so suppressed duplicate calls do not leave unmatched progress events.
- Cache validation and unknown-tool failures observed at runtime, preserving duplicate replay and stagnation convergence for calls that return before `after_tool_call`.
- Scope suppression metadata, replay payloads, ordering, and loop provenance to the exact `ToolCall` occurrence rather than its provider ID, which may be reused across turns.
- Add regression coverage for balanced tool callbacks, reused call-ID transcripts, evidence provenance, and repeated validation-error convergence.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ make lint
All checks passed!

$ make format-check
3514 files already formatted

$ make typecheck
Success: no issues found in 1812 source files

$ uv run python -m pytest tests/tools/investigation tests/agent/test_investigation.py tests/core/agent/test_goals.py tests/core/agent/test_agent_run.py tests/core/agent/test_react_loop_spans.py tests/core/agent_harness/test_evidence_driver_context.py tests/benchmarks/cloudopsbench/tests/test_bench_agent.py tests/synthetic/test_new_relic_scenario.py -q
178 passed in 3.36s
```

Regression behavior now pinned:

```text
repeated validation failure: concludes in fewer than 6 LLM turns (previously hit all 20)
duplicate callback sequence: tool_start(c1), tool_end(c1) (no unmatched duplicate start)
reused call ID: original result remains fresh at loop_iteration=0
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The shared runtime emits tool-start events before execution hooks run, while validation and unknown-tool failures return before the existing `after_tool_call` hook. The investigation controller therefore classifies the response through the provider-response hook, with the execution batch hook retained as an idempotent fallback. Runtime end events record early failures only when the normal after-call path did not already record the occurrence.

Occurrence state is keyed by the in-memory `ToolCall` object for transcript conversion and by `(iteration, call ID)` for runtime events. This keeps provider IDs reusable across turns without relabeling older messages or overwriting their evidence provenance. I considered changing the shared executor to invoke after-call hooks for validation failures, but kept the fix investigation-local to avoid changing hook semantics for every agent surface.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
