### PR TITLE
refactor(harness): HeadlessAgent.handle is the one host loop for shell and gateway; HeadlessPorts + DefaultPorts are the only construction path

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -22,8 +22,8 @@ Process boot (`configure_process`) and headless construction
 | Happy path (already booted) | `AgentSession.start()` → repeated `.chat` / `.investigate` |
 | Embedded / script | `start_embedded_session()` → repeated `.chat` / `.investigate` |
 | Multi-step / keep-going | `start` / `start_embedded_session` → `.chat_until_goal(...)` (`SessionGoal` loop) |
-| Custom host | **`DefaultPorts(...).agent(...)`** (only construction seam) → `attach_agent` once → many `.chat` |
-| Gateway | `SessionAgentPool` → factory once / session → `bind_turn` → `run_until_session_goal` (same SessionGoal policy as shell) |
+| Custom host | **`DefaultPorts(...).agent(...)`** (or `HeadlessPorts` in-memory; the only construction seam) → `agent.handle(text, TurnBinding(...))` per message |
+| Gateway | `SessionAgentPool` → `DefaultPorts.agent` once / session → `agent.handle(text, TurnBinding(...))` per message (the goal loop lives inside `handle`; same policy as shell) |
 | Scheduled one-shot | `AgentSession.run_headless_turn(...)` (not the multi-turn pattern) |
 
 `SessionGoal` (`session_goal/` component — `goal` + `run_until`) is
@@ -152,7 +152,7 @@ subpackage. Default port implementations live with the concern they serve, not i
     `_build_evidence_agent` factory that returns an `AgentConfig` handed to
     `build_agent`.
   - `headless_dispatch.py` — headless programmatic entry point
-    (`HeadlessAgent`, constructed with the ports then `.dispatch(message)` per turn)
+    (`HeadlessAgent`, built by a port family; `.handle(text, binding)` per message, `.dispatch` underneath)
     plus in-memory port adapters for
     API / test runs. `tools` is required — surfaces that want a text-only
     turn pass `NullToolProvider()` explicitly.

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -192,7 +192,7 @@ class AgentSession:
         call :meth:`attach_agent` — they must not re-copy this wiring ad hoc.
         """
         from core.agent_harness.ports import TurnBinding
-        from core.agent_harness.turns.default_ports import DefaultPorts
+        from core.agent_harness.turns.port_families import DefaultPorts
 
         agent = DefaultPorts(
             session=session, output=output, console=console, logger=logger, surface=surface
@@ -234,7 +234,7 @@ class AgentSession:
 
         ``prepare_session`` runs after session create (e.g. pin a project scope)
         and before the agent is built. ``console``, ``logger`` and ``surface``
-        are the :class:`~core.agent_harness.turns.default_ports.DefaultPorts`
+        are the :class:`~core.agent_harness.turns.port_families.DefaultPorts`
         fields; ``tools`` and ``gather`` the ports its ``agent()`` takes;
         ``is_tty`` is bound on the first turn. A host that needs more (its own
         sink, prompts, error reporter, an action ``llm_factory``) builds through

--- a/core/agent_harness/runtime.py
+++ b/core/agent_harness/runtime.py
@@ -1,6 +1,7 @@
 """Agent runtime: build and run the agent that executes turns.
 
-The headless agent, the default port family it is built on (``DefaultPorts``),
+The headless agent, the two port families it is built on (``DefaultPorts``,
+``HeadlessPorts``),
 the default tool provider a host configures with its port factories, the
 per-turn binding, the action-turn runner, and the gather ports. Importing this loads ``core.agent``;
 hosts import it when a turn is dispatched, not at boot.
@@ -11,9 +12,9 @@ from __future__ import annotations
 from core.agent_harness.ports import TurnBinding
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import ActionTurnRunner
-from core.agent_harness.turns.default_ports import DefaultPorts
 from core.agent_harness.turns.gather_ports import GatherPorts
 from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.port_families import DefaultPorts, HeadlessPorts
 
 __all__ = [
     "ActionTurnRunner",
@@ -21,5 +22,6 @@ __all__ = [
     "DefaultToolProvider",
     "GatherPorts",
     "HeadlessAgent",
+    "HeadlessPorts",
     "TurnBinding",
 ]

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -295,9 +295,12 @@ class HeadlessAgent:
             self.bind_turn(replace(binding, accounting=accounting))
             return self.dispatch(message)
 
+        # The goal loop reads and writes goal state on the session this turn
+        # states, not on whatever the previous binding left behind.
+        session = binding.session if binding.session is not None else self._session
         return run_until_session_goal(
             _one_turn,
-            self._session,
+            session,
             text,
             cancel_requested=cancel_requested,
             on_progress=on_progress,

--- a/core/agent_harness/turns/headless_dispatch.py
+++ b/core/agent_harness/turns/headless_dispatch.py
@@ -28,6 +28,9 @@ Example::
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import replace
+
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.ports import (
     AnswerRequest,
@@ -49,15 +52,13 @@ from core.agent_harness.ports import (
     TurnAccounting,
     TurnBinding,
 )
-from core.agent_harness.prompts.grounding import (
-    DefaultPromptContextProvider,
-    supports_default_prompt_context,
-)
+from core.agent_harness.session_goal.goal import SessionGoal
+from core.agent_harness.session_goal.run_until import run_until_session_goal
 from core.agent_harness.turns.action_driver import ActionTurnRunner
 from core.agent_harness.turns.chat_api import ChatTurnBindings, dispatch_chat_turn
 from core.agent_harness.turns.evidence_driver import gather_tool_evidence
 from core.agent_harness.turns.gather_observation import GatheredEvidence
-from core.agent_harness.turns.gather_ports import GATHER_DISABLED, GatherPorts
+from core.agent_harness.turns.gather_ports import GatherPorts
 from core.agent_harness.turns.headless_adapters import (
     BufferOutputSink,
     EmptyPromptContextProvider,
@@ -77,54 +78,42 @@ from core.execution import ToolExecutionHooks
 
 
 class HeadlessAgent:
-    """Runs full agent turns headlessly from a fixed set of configured ports.
+    """Runs agent turns from a fixed set of ports; built by a port family.
 
-    Construct once with the ports, then call :meth:`dispatch` per message.
-    ``tools`` is required — a surface that genuinely wants a text-only turn
-    passes :class:`NullToolProvider` explicitly. Every other port defaults to
-    the in-memory headless adapter from ``headless_adapters`` (the family a
-    script or test runs on with zero configuration); the product family is
-    :class:`~core.agent_harness.turns.default_ports.DefaultPorts`.
+    Every port is required here — the two families supply them:
+    :class:`~core.agent_harness.turns.port_families.HeadlessPorts` (in-memory;
+    scripts and tests) and :class:`~core.agent_harness.turns.port_families.DefaultPorts`
+    (the product defaults; gateway and shell). Hosts do not call this
+    constructor.
 
-    Per-turn values — session, output, accounting, hooks, ``confirm_fn``,
-    ``is_tty`` — are bound with :meth:`bind_turn`; whole-stage replacements
-    with :meth:`bind_stages`. Neither is a constructor concern.
-
-    ``gather`` is a :class:`~core.agent_harness.turns.gather_ports.GatherPorts`
-    describing the evidence pass. It defaults to ``GATHER_DISABLED`` because the
-    pass reaches out to live integrations — a caller opts in with ``GatherPorts()``.
+    Per message a host calls :meth:`handle` with a :class:`TurnBinding`; it
+    binds the turn, dispatches, and continues while a session goal is
+    attached. :meth:`dispatch` is the single-turn verb underneath; whole-stage
+    replacements for tests go through :meth:`bind_stages`.
     """
 
     def __init__(
         self,
         *,
         tools: ToolProvider,
-        session: SessionState | None = None,
-        output: OutputSink | None = None,
-        prompts: PromptContextProvider | None = None,
-        reasoning: ReasoningClientProvider | None = None,
-        run_factory: RunRecordFactory | None = None,
-        error_reporter: ErrorReporter | None = None,
-        gather: GatherPorts | None = None,
+        session: SessionState,
+        output: OutputSink,
+        prompts: PromptContextProvider,
+        reasoning: ReasoningClientProvider,
+        run_factory: RunRecordFactory,
+        error_reporter: ErrorReporter,
+        gather: GatherPorts,
         llm_factory: LlmFactory | None = None,
     ) -> None:
         self._tools = tools
         self._llm_factory = llm_factory
-        self._session: SessionState = session if session is not None else InMemorySessionState()
-        self._output: OutputSink = output if output is not None else BufferOutputSink()
-        self._prompts: PromptContextProvider = (
-            prompts
-            if prompts is not None
-            else (
-                DefaultPromptContextProvider(self._session)
-                if supports_default_prompt_context(self._session)
-                else EmptyPromptContextProvider()
-            )
-        )
-        self._reasoning = reasoning if reasoning is not None else StaticReasoningClientProvider()
-        self._run_factory = run_factory if run_factory is not None else SimpleRunRecordFactory()
-        self._error_reporter = error_reporter if error_reporter is not None else NoopErrorReporter()
-        self._gather_ports = gather if gather is not None else GATHER_DISABLED
+        self._session: SessionState = session
+        self._output: OutputSink = output
+        self._prompts: PromptContextProvider = prompts
+        self._reasoning = reasoning
+        self._run_factory = run_factory
+        self._error_reporter = error_reporter
+        self._gather_ports = gather
         # Turn-scoped state; see bind_turn / bind_stages.
         self._accounting: TurnAccounting | None = None
         self._confirm_fn: ConfirmFn | None = None
@@ -282,8 +271,40 @@ class HeadlessAgent:
         self._answer_override = answer
         self._gather_override = gather_evidence
 
+    def handle(
+        self,
+        text: str,
+        binding: TurnBinding,
+        *,
+        accounting_factory: Callable[[str], TurnAccounting] | None = None,
+        cancel_requested: Callable[[], bool] | None = None,
+        on_progress: Callable[[SessionGoal], None] | None = None,
+    ) -> TurnResult:
+        """Handle one inbound message: bind the turn, dispatch, continue while a session goal is attached.
+
+        The one host loop — gateway and shell call this and nothing else per
+        message. ``binding`` states the whole turn; ``accounting_factory``
+        (message → accounting) is applied per outer turn because the goal loop
+        may dispatch several, each with different text; ``None`` uses the
+        default per-message accounting. ``cancel_requested`` is checked between
+        outer turns; ``on_progress`` receives the goal after each.
+        """
+
+        def _one_turn(message: str) -> TurnResult:
+            accounting = accounting_factory(message) if accounting_factory is not None else None
+            self.bind_turn(replace(binding, accounting=accounting))
+            return self.dispatch(message)
+
+        return run_until_session_goal(
+            _one_turn,
+            self._session,
+            text,
+            cancel_requested=cancel_requested,
+            on_progress=on_progress,
+        ).last_result
+
     def dispatch(self, message: str) -> TurnResult:
-        """Run one full turn for ``message`` via the common chat host API."""
+        """Run one turn for ``message`` on the currently bound turn (see :meth:`handle`)."""
         return dispatch_chat_turn(
             message,
             self._session,

--- a/core/agent_harness/turns/port_families.py
+++ b/core/agent_harness/turns/port_families.py
@@ -1,16 +1,17 @@
-"""The product's default port family for one session, and the agent built on it.
+"""The two port families an agent is built on: in-memory and product defaults.
 
-**This is the single headless construction seam.** Gateway ``SessionAgentPool``,
-the REPL and ``AgentSession.start`` all build through :meth:`DefaultPorts.agent`
-— they are not parallel stacks. A host varies the agent through its ports: it
-passes its own :class:`~core.agent_harness.ports.ToolProvider` (usually a
-configured :class:`~core.agent_harness.tools.tool_provider.DefaultToolProvider`),
-prompt provider and gather ports; reasoning, run records and error reporting
-are this family's and are not host-configurable.
+**This is the single construction seam.** :class:`HeadlessPorts` is the
+in-memory family (scripts, tests, a turn with zero configuration);
+:class:`DefaultPorts` is the product family (gateway ``SessionAgentPool``, the
+REPL, ``AgentSession.start``). Both build through ``.agent(...)``; hosts never
+call :class:`HeadlessAgent` directly. A host varies the agent through the ports
+it passes to ``agent()`` — its :class:`~core.agent_harness.ports.ToolProvider`
+(usually a configured :class:`~core.agent_harness.tools.tool_provider.DefaultToolProvider`),
+prompt provider and gather ports; the family owns the rest.
 
-Per-turn values (``confirm_fn``, ``is_tty``, hooks, accounting, stage overrides)
-are bound on the agent with :meth:`HeadlessAgent.bind_turn` /
-:meth:`HeadlessAgent.bind_stages`.
+Per-message values are bound on the agent with :meth:`HeadlessAgent.handle`
+(a :class:`~core.agent_harness.ports.TurnBinding`); whole-stage replacements
+for tests with :meth:`HeadlessAgent.bind_stages`.
 
 Process boot (``configure_process``) is a **different layer** — adapters and
 env — and does not build agents.
@@ -35,16 +36,79 @@ from core.agent_harness.ports import (
     PromptContextProvider,
     ReasoningClientProvider,
     RunRecordFactory,
+    SessionState,
     ToolProvider,
 )
-from core.agent_harness.prompts.grounding import DefaultPromptContextProvider
+from core.agent_harness.prompts.grounding import (
+    DefaultPromptContextProvider,
+    supports_default_prompt_context,
+)
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.default_reasoning_client import DefaultReasoningClientProvider
 from core.agent_harness.turns.gather_ports import GATHER_DISABLED, GatherPorts
+from core.agent_harness.turns.headless_adapters import (
+    BufferOutputSink,
+    EmptyPromptContextProvider,
+    InMemorySessionState,
+    NoopErrorReporter,
+    SimpleRunRecordFactory,
+    StaticReasoningClientProvider,
+)
 from core.agent_harness.turns.headless_dispatch import HeadlessAgent
 
 if TYPE_CHECKING:
     from core.agent_harness.session.session_core import SessionCore
+
+
+@dataclass(frozen=True)
+class HeadlessPorts:
+    """The in-memory family: a turn runs with zero configuration.
+
+    ``session`` defaults to an in-memory state, ``output`` to a buffer sink,
+    ``reasoning`` to "no client" (the conversational assistant is skipped) —
+    inject a client to get an answer. ``tools`` is required on ``agent()``: a
+    text-only turn passes :class:`~core.agent_harness.turns.headless_adapters.NullToolProvider`
+    explicitly.
+    """
+
+    session: SessionState | None = None
+    output: OutputSink | None = None
+    reasoning: ReasoningClientProvider | None = None
+
+    @cached_property
+    def _session(self) -> SessionState:
+        return self.session if self.session is not None else InMemorySessionState()
+
+    @cached_property
+    def _output(self) -> OutputSink:
+        return self.output if self.output is not None else BufferOutputSink()
+
+    def prompts(self) -> PromptContextProvider:
+        if supports_default_prompt_context(self._session):
+            return DefaultPromptContextProvider(self._session)
+        return EmptyPromptContextProvider()
+
+    def agent(
+        self,
+        *,
+        tools: ToolProvider,
+        prompts: PromptContextProvider | None = None,
+        gather: GatherPorts | None = None,
+        llm_factory: LlmFactory | None = None,
+    ) -> HeadlessAgent:
+        return HeadlessAgent(
+            tools=tools,
+            session=self._session,
+            output=self._output,
+            prompts=prompts if prompts is not None else self.prompts(),
+            reasoning=(
+                self.reasoning if self.reasoning is not None else StaticReasoningClientProvider()
+            ),
+            run_factory=SimpleRunRecordFactory(),
+            error_reporter=NoopErrorReporter(),
+            gather=gather if gather is not None else GATHER_DISABLED,
+            llm_factory=llm_factory,
+        )
 
 
 @dataclass(frozen=True)
@@ -129,4 +193,4 @@ class DefaultPorts:
         )
 
 
-__all__ = ["DefaultPorts"]
+__all__ = ["DefaultPorts", "HeadlessPorts"]

--- a/docs/hosting-the-agent.mdx
+++ b/docs/hosting-the-agent.mdx
@@ -19,40 +19,44 @@ Everything a host touches comes through four modules. Nothing else under
 | Role | You want to… | Import |
 | --- | --- | --- |
 | **Embed** | run turns with the standard ports | `core.agent_harness` — `AgentSession`, `SessionConfig`, `SessionCore`, `SessionManager`, `TurnResult`, `ToolCallingTurnResult`, `OutputSink` |
-| **Host** | build one agent from your ports, bind it per turn | `core.agent_harness.runtime` — `DefaultPorts`, `HeadlessAgent`, `TurnBinding`, `GatherPorts`, `DefaultToolProvider`, `ActionTurnRunner` |
+| **Host** | build one agent from your ports, handle it per message | `core.agent_harness.runtime` — `DefaultPorts`, `HeadlessPorts`, `HeadlessAgent`, `TurnBinding`, `GatherPorts`, `DefaultToolProvider`, `ActionTurnRunner` |
 | **Host** | call helpers around a turn | `core.agent_harness.spi.<role>` — `session_goal`, `session_flags`, `cancel`, `accounting`, `prompt_chrome`, `integrations`, `grounding`, `defaults` |
 | **Implement** | satisfy a protocol the harness calls | `core.agent_harness.ports` — `OutputSink`, `ToolProvider`, `PromptContextProvider`, `ReasoningClientProvider`, `RunRecordFactory`, `ErrorReporter`, `TurnAccounting`, `SessionState`, and the rebind mix-ins `ConsoleBindable` / `OutputBindable` / `SessionBindable` |
 
 ## The host loop
 
-Build once, bind per turn, dispatch:
+Build once, then one call per inbound message:
 
 ```python
 from core.agent_harness.runtime import DefaultPorts, GatherPorts, TurnBinding
 
 # 1. Build — the default port family for this session, plus your ports.
 agent = DefaultPorts(
-    session=session,           # a SessionCore from AgentSession / SessionManager
-    output=my_sink,            # your OutputSink
-    error_reporter=my_reporter # optional; default logs at debug
+    session=session,            # a SessionCore from AgentSession / SessionManager
+    output=my_sink,             # your OutputSink
+    error_reporter=my_reporter, # optional; default logs at debug
 ).agent(
-    tools=my_tool_provider,    # optional; a configured DefaultToolProvider or your own
-    prompts=my_prompts,        # optional; default grounding provider
-    gather=GatherPorts(),      # opt in to the evidence pass; default is disabled
+    tools=my_tool_provider,     # optional; a configured DefaultToolProvider or your own
+    prompts=my_prompts,         # optional; default grounding provider
+    gather=GatherPorts(),       # opt in to the evidence pass; default is disabled
 )
 
-# 2. Bind — state the whole turn. Nothing carries over from the previous turn.
-agent.bind_turn(TurnBinding(
-    session=session,           # None keeps the current session
-    accounting=my_accounting,  # optional; default accounts per message
-    tool_hooks=approval_hooks, # None means "no hooks this turn"
-    console=turn_console,      # for cooperative cancel and progress lines
-    confirm_fn=ask_user,       # None means "no confirmation callback"
-    is_tty=False,
-))
-
-# 3. Dispatch.
-result = agent.dispatch(text)
+# 2. Handle — state the whole turn; the agent binds it, dispatches, and keeps
+#    going while a session goal is attached. Nothing carries over from the
+#    previous message.
+result = agent.handle(
+    text,
+    TurnBinding(
+        session=session,           # None keeps the current session
+        tool_hooks=approval_hooks, # None means "no hooks this turn"
+        console=turn_console,      # for cooperative cancel and progress lines
+        confirm_fn=ask_user,       # None means "no confirmation callback"
+        is_tty=False,
+    ),
+    accounting_factory=None,       # message -> TurnAccounting; None = default per message
+    cancel_requested=lambda: cancel.is_set(),
+    on_progress=render_goal_progress,
+)
 ```
 
 `DefaultPorts` holds what does not vary per host — reasoning client, run
@@ -61,11 +65,17 @@ inputs those defaults need (`console`, `logger`, `surface`). Every port you pass
 to `agent()` replaces that default. `TurnBinding` is a value, not a set of
 keyword arguments: a field you omit is *this turn's value* (no hooks, no
 callback), never "leave alone", so a pooled agent cannot inherit another
-conversation's hooks by omission.
+conversation's hooks by omission. `handle` is the only per-message call a host
+makes; `dispatch` (one engine turn) sits underneath it.
+
+The in-memory family is `HeadlessPorts` — a script or test says
+`HeadlessPorts().agent(tools=NullToolProvider())` and has an agent with zero
+configuration. There is one construction verb, `<family>.agent(...)`; hosts do
+not call `HeadlessAgent(...)` directly.
 
 ## The same loop in the two shipped hosts
 
-The gateway keeps one agent per logical session and rebinds it per inbound
+The gateway keeps one agent per logical session and calls `handle` per inbound
 message:
 
 ```python
@@ -74,11 +84,15 @@ agent = DefaultPorts(session=session, output=live_sink, console=console, logger=
                               observer_factory=…, subprocess_presenter_factory=…, slash_ports_factory=…),
     gather=GatherPorts(),
 )
-agent.bind_turn(TurnBinding(session=session, accounting=DefaultTurnAccounting(session, text),
-                            tool_hooks=sink.tool_hooks, console=turn_console, is_tty=False))
+result = agent.handle(
+    text,
+    TurnBinding(session=session, tool_hooks=sink.tool_hooks, console=turn_console, is_tty=False),
+    cancel_requested=cancel.is_set,
+    on_progress=post_status_line,
+)
 ```
 
-The interactive shell builds one agent at startup and rebinds it per prompt:
+The interactive shell builds one agent at startup and calls `handle` per prompt:
 
 ```python
 agent = DefaultPorts(session=session, output=ShellOutputSink(console), console=console,
@@ -87,10 +101,18 @@ agent = DefaultPorts(session=session, output=ShellOutputSink(console), console=c
     prompts=shell_prompt_context_provider(session),
     gather=shell_gather_ports(session, console),   # console progress lines + session persistence
 )
+result = agent.handle(
+    text,
+    TurnBinding(session=session, output=sink, tool_hooks=hooks, console=console, confirm_fn=ask, is_tty=tty),
+    accounting_factory=lambda message: ShellTurnAccounting(session, message, recorder),
+    cancel_requested=lambda: host_cancel_requested(sink),
+    on_progress=print_checklist,
+)
 ```
 
 Neither host replaces a stage of the agent (action selection, evidence
-gathering, answering). They differ only in ports.
+gathering, answering) and neither writes its own turn loop. They differ only in
+ports and in what they do with the result.
 
 ## What you implement vs what you call
 
@@ -111,8 +133,8 @@ gathering, answering). They differ only in ports.
 - **One agent per logical session; one turn at a time on it.** `bind_turn`
   mutates per-turn state; the gateway holds a per-session lock across
   `dispatch`. Do not share one agent between concurrent turns.
-- **State the whole turn.** Build a fresh `TurnBinding` per turn; to change one
-  field mid-turn use `dataclasses.replace(binding, …)`.
+- **State the whole turn.** Build a fresh `TurnBinding` per message and pass it
+  to `handle`; do not call `bind_turn`/`dispatch` yourself.
 - **Bind on the worker thread you dispatch from.** Storage scope is a
   `ContextVar`; if you hand the turn to a thread pool, wrap it with
   `config.scope_context.in_current_scope` on the calling thread.

--- a/gateway/core/runtime/session_agents.py
+++ b/gateway/core/runtime/session_agents.py
@@ -2,7 +2,7 @@
 
 Keeps agent construction out of :class:`GatewayTurnHandler` so the handler
 stays a thin dispatch/finalize orchestrator. Construction goes through
-:meth:`~core.agent_harness.turns.default_ports.DefaultPorts.agent`
+:meth:`~core.agent_harness.turns.port_families.DefaultPorts.agent`
 once per session — not a second port-wiring stack.
 """
 

--- a/gateway/core/runtime/turn_handler.py
+++ b/gateway/core/runtime/turn_handler.py
@@ -20,14 +20,12 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness import AgentSession, SessionConfig, SessionCore, SessionManager
+from core.agent_harness import SessionCore, SessionManager
 from core.agent_harness.runtime import TurnBinding
-from core.agent_harness.spi.accounting import DefaultTurnAccounting
 from core.agent_harness.spi.session_goal import (
     SessionGoal,
     format_session_goal_progress,
     format_session_goal_status_line,
-    run_until_session_goal,
 )
 from gateway.core.runtime.cancel_console import CancelConsole, ensure_turn_cancel
 from gateway.core.runtime.capability_policy import ensure_gateway_capability_policy
@@ -56,12 +54,10 @@ class GatewayTurnHandler:
     """Services one inbound gateway message per call (a :data:`GatewayAgentCallback`).
 
     One :class:`HeadlessAgent` is kept per logical session and reused across
-    turns; per-turn sinks, accounting, and tool hooks are rebound via
-    :meth:`HeadlessAgent.bind_turn`. Concurrent turns for different sessions
-    stay isolated. Chat goes through :func:`run_until_session_goal` (one action
-    turn; session-goal continuation only when a ``SessionGoal`` is attached via
-    structured handoff or an explicit host attach — same policy as the
-    interactive shell).
+    turns; each message goes through :meth:`HeadlessAgent.handle` with a
+    :class:`TurnBinding` (sink hooks, cancel console) — the same call the
+    interactive shell makes. Concurrent turns for different sessions stay
+    isolated.
 
     When ``gate`` is set, capacity is checked here before the turn runs — the
     manager must not wrap this class in a second "turn handler".
@@ -81,7 +77,6 @@ class GatewayTurnHandler:
             slash_ports_factory=slash_ports_factory,
         )
         # Gateway already bootstrapped env at process start; turns must not reload.
-        self._session_api = AgentSession(SessionConfig(load_env=False))
         self._gate = gate
         self._busy_message = busy_message
 
@@ -132,25 +127,13 @@ class GatewayTurnHandler:
             try:
                 if surface:
                     capture_gateway_turn_started(surface=surface)
-                agent.bind_turn(
-                    TurnBinding(
-                        session=session,
-                        accounting=DefaultTurnAccounting(session, text),
-                        tool_hooks=getattr(sink, "tool_hooks", None),
-                        console=turn_console,
-                        is_tty=False,
-                    )
-                )
-
-                def _chat(message: str) -> Any:
-                    return self._session_api.chat(message, agent=agent)
 
                 def _cancel_requested() -> bool:
                     return isinstance(cancel, threading.Event) and cancel.is_set()
 
                 def _on_progress(goal: SessionGoal) -> None:
                     # Same progress contract as the interactive shell: paint mid-loop
-                    # and scrub happens inside run_until_session_goal. Gateway sinks
+                    # and scrub happens inside the agent's goal loop. Gateway sinks
                     # get a compact status line; full text goes to debug logs.
                     full = format_session_goal_progress(goal, session=session)
                     compact = format_session_goal_status_line(goal, session=session)
@@ -161,13 +144,17 @@ class GatewayTurnHandler:
                         if callable(set_status):
                             set_status(compact)
 
-                turn_result = run_until_session_goal(
-                    _chat,
-                    session,
+                turn_result = agent.handle(
                     text,
+                    TurnBinding(
+                        session=session,
+                        tool_hooks=getattr(sink, "tool_hooks", None),
+                        console=turn_console,
+                        is_tty=False,
+                    ),
                     cancel_requested=_cancel_requested,
                     on_progress=_on_progress,
-                ).last_result
+                )
                 outbound_text = turn_result.primary_response_text
                 logger.debug(
                     "gateway_turn done intent=%s answered=%s outbound_chars=%s",

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -21,7 +21,6 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
@@ -39,6 +38,7 @@ from gateway.transports.telegram.settings import (
 )
 from gateway.web.startup import WebStartup
 from tests.shared.default_ports_stub import default_ports_stub
+from tests.shared.fake_agent import attach_real_handle
 
 
 def _patch_non_telegram_components(monkeypatch) -> None:
@@ -90,6 +90,7 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
     logger = logging.getLogger("gateway.lifecycle.test")
     handle = MagicMock()
     agent_cls = MagicMock()
+    attach_real_handle(agent_cls.return_value)
     signal_calls: list[tuple[int, Any]] = []
     background_kwargs: dict[str, Any] = {}
 
@@ -182,8 +183,10 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
         "shell_run",
         "{'command': 'pwd'}",
     )
+    # The host passes no accounting: the agent's default per-message accounting
+    # (DefaultTurnAccounting) applies — pinned in test_default_accounting_is_resolved_fresh_per_message.
     turn_binding = agent_cls.return_value.bind_turn.call_args.args[0]
-    assert isinstance(turn_binding.accounting, DefaultTurnAccounting)
+    assert turn_binding.accounting is None
 
 
 def test_polled_telegram_message_reaches_start_gateway_agent_callback(monkeypatch) -> None:

--- a/gateway/tests/runtime/test_session_agents.py
+++ b/gateway/tests/runtime/test_session_agents.py
@@ -16,6 +16,7 @@ from gateway.core.runtime.live_sink import LiveOutputSink
 from gateway.core.runtime.session_agents import SessionAgentPool
 from gateway.core.runtime.turn_handler import GatewayTurnHandler
 from tests.shared.default_ports_stub import default_ports_stub
+from tests.shared.fake_agent import fake_agent
 
 
 @pytest.fixture(autouse=True)
@@ -141,8 +142,7 @@ def test_pool_rebinds_current_session_on_cache_hit(monkeypatch: pytest.MonkeyPat
 
 
 def test_turn_handler_reuses_headless_agent_across_turns(monkeypatch: pytest.MonkeyPatch) -> None:
-    agent = MagicMock()
-    agent.dispatch.return_value = _empty_result()
+    agent = fake_agent(dispatch_result=_empty_result())
     factory = MagicMock(return_value=agent)
     monkeypatch.setattr(
         "gateway.core.runtime.session_agents.DefaultPorts", default_ports_stub(factory)

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -19,6 +19,7 @@ from tests.core.agent.orchestration.cross_surface_parity_harness import (
     RecordingGatewaySink,
 )
 from tests.shared.default_ports_stub import default_ports_stub
+from tests.shared.fake_agent import fake_agent
 
 
 @pytest.fixture(autouse=True)
@@ -42,8 +43,7 @@ def _patch_headless_agent(monkeypatch: Any, result: TurnResult) -> MagicMock:
     """
     from core.agent_harness.tools.tool_provider import DefaultToolProvider
 
-    agent = MagicMock()
-    agent.dispatch.return_value = result
+    agent = fake_agent(dispatch_result=result)
     factory = MagicMock()
 
     def _build(**kwargs: Any) -> MagicMock:

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -11,14 +11,12 @@ Only a caller that injects a whole stage (``execute_actions`` /
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 from rich.console import Console
 
 from core.agent_harness import (
-    AgentSession,
     OutputSink,
-    SessionConfig,
     ToolCallingTurnResult,
     TurnResult,
 )
@@ -28,7 +26,6 @@ from core.agent_harness.spi.cancel import host_cancel_requested
 from core.agent_harness.spi.session_goal import (
     SessionGoal,
     format_session_goal_progress,
-    run_until_session_goal,
 )
 from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.turn_plan import TurnPlan
@@ -161,7 +158,7 @@ def execute_shell_turn(
     output: OutputSink | None = None,
     tool_hooks: ToolExecutionHooks | None = None,
 ) -> TurnResult:
-    """Execute one submitted interactive-shell turn via :meth:`AgentSession.chat`.
+    """Execute one submitted interactive-shell turn via :meth:`HeadlessAgent.handle`.
 
     Pass a long-lived ``agent`` (the REPL builds one at startup and rebinds it
     per turn) so the tool stack is not rebuilt every turn; without one, an agent
@@ -182,7 +179,6 @@ def execute_shell_turn(
         confirm_fn=confirm_fn,
         is_tty=is_tty,
     )
-    agent.bind_turn(binding)
     _bind_injected_stages(
         agent,
         session,
@@ -194,18 +190,6 @@ def execute_shell_turn(
         request_exit=request_exit,
         tool_hooks=tool_hooks,
     )
-    # Shell already owns env/session boot; do not reload env per turn.
-    chat_host = AgentSession(SessionConfig(load_env=False))
-
-    def _chat(message: str) -> TurnResult:
-        # Fresh accounting per outer iteration (nudge text changes each turn).
-        agent.bind_turn(
-            replace(
-                binding,
-                accounting=ShellTurnAccounting(session=session, text=message, recorder=recorder),
-            )
-        )
-        return chat_host.chat(message, agent=agent)
 
     def _on_progress(goal: SessionGoal) -> None:
         rendered = format_session_goal_progress(goal, session=session)
@@ -213,16 +197,16 @@ def execute_shell_turn(
             # Checklist uses ``[x]`` / ``[ ]`` — Rich markup must stay off.
             console.print(rendered, markup=False)
 
-    # Always one action-agent turn first. Session-goal loop continues only when that
-    # turn (or a prior turn) attached a SessionGoal via structured handoff /
-    # explicit host attach — never via user-text keyword detection.
-    return run_until_session_goal(
-        _chat,
-        session,
+    def _accounting(message: str) -> ShellTurnAccounting:
+        return ShellTurnAccounting(session=session, text=message, recorder=recorder)
+
+    return agent.handle(
         text,
+        binding,
+        accounting_factory=_accounting,
         cancel_requested=lambda: host_cancel_requested(resolved_output),
         on_progress=_on_progress,
-    ).last_result
+    )
 
 
 __all__ = ["execute_shell_turn"]

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -26,6 +26,7 @@ from core.agent_harness.turns.headless_dispatch import (
     HeadlessAgent,
     NoopTurnAccounting,
 )
+from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import TurnResult
 from core.domain.types.tools import ToolSurface
 from core.llm.types import AgentLLMResponse, ToolCall
@@ -310,16 +311,15 @@ def _dispatch_turn(
     gather_enabled: bool = True,
 ) -> TurnResult:
     output = BufferOutputSink()
-    agent = HeadlessAgent(
+    agent = HeadlessPorts(
+        session=session, output=output, reasoning=DefaultReasoningClientProvider(output=output)
+    ).agent(
         tools=DefaultToolProvider(
             session,
             console(),
             slash_ports_factory=headless_slash_ports,
         ),
-        session=session,
-        output=output,
         prompts=DefaultPromptContextProvider(session),
-        reasoning=DefaultReasoningClientProvider(output=output),
         gather=GatherPorts(enabled=gather_enabled),
     )
     agent.bind_turn(TurnBinding(accounting=NoopTurnAccounting()))
@@ -355,7 +355,7 @@ def _install_gateway_dispatch_spy(
     ``SessionAgentPool`` builds agents via ``DefaultPorts(...).agent(...)``; the
     stub routes both halves through one ``build`` over the real family.
     """
-    from core.agent_harness.turns.default_ports import DefaultPorts as real_ports
+    from core.agent_harness.turns.port_families import DefaultPorts as real_ports
 
     def _spy_build(
         *,

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -16,10 +16,11 @@ from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnRes
 from gateway.core.runtime.turn_handler import GatewayTurnHandler
 from surfaces.interactive_shell.session import Session
 from tests.shared.default_ports_stub import default_ports_stub
+from tests.shared.fake_agent import fake_agent
 
 
 def test_gateway_turn_handler_delegates_to_agent_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
-    agent = MagicMock()
+    agent = fake_agent()
     agent.dispatch.return_value = TurnResult(
         final_intent="cli_agent_handled",
         action_result=ToolCallingTurnResult(
@@ -70,7 +71,7 @@ def test_gateway_turn_handler_delegates_to_agent_dispatch(monkeypatch: pytest.Mo
 def test_gateway_turn_handler_does_not_finalize_answered_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    agent = MagicMock()
+    agent = fake_agent()
     agent.dispatch.return_value = TurnResult(
         final_intent="cli_agent_fallback",
         action_result=ToolCallingTurnResult(0, 0, 0, False, False),

--- a/tests/core/agent_harness/test_accounting_consume_once.py
+++ b/tests/core/agent_harness/test_accounting_consume_once.py
@@ -8,7 +8,7 @@ from core.agent_harness.runtime import TurnBinding
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.turns.headless_adapters import NullToolProvider
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 
@@ -57,7 +57,7 @@ def test_dispatch_consumes_bound_accounting(monkeypatch: Any) -> None:
     _stub_dispatch(monkeypatch)
     session = SessionCore(store=InMemorySessionStore())
     first = _SpyAccounting("first")
-    agent = HeadlessAgent(tools=NullToolProvider(), session=session)
+    agent = HeadlessPorts(session=session).agent(tools=NullToolProvider())
     agent.bind_turn(TurnBinding(accounting=first))
     agent.dispatch("one")
     assert first.finalized == ["first"]
@@ -71,7 +71,7 @@ def test_second_dispatch_without_rebind_does_not_reuse_prior_accounting(
     _stub_dispatch(monkeypatch)
     session = SessionCore(store=InMemorySessionStore())
     first = _SpyAccounting("first")
-    agent = HeadlessAgent(tools=NullToolProvider(), session=session)
+    agent = HeadlessPorts(session=session).agent(tools=NullToolProvider())
     agent.bind_turn(TurnBinding(accounting=first))
     agent.dispatch("one")
     agent.dispatch("two")
@@ -81,7 +81,7 @@ def test_second_dispatch_without_rebind_does_not_reuse_prior_accounting(
 def test_bind_turn_supplies_fresh_accounting_each_message(monkeypatch: Any) -> None:
     _stub_dispatch(monkeypatch)
     session = SessionCore(store=InMemorySessionStore())
-    agent = HeadlessAgent(tools=NullToolProvider(), session=session)
+    agent = HeadlessPorts(session=session).agent(tools=NullToolProvider())
     a = _SpyAccounting("a")
     b = _SpyAccounting("b")
     agent.bind_turn(TurnBinding(accounting=a))

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -8,6 +8,7 @@ and ``bind_turn`` refreshes the runner when output or hooks change.
 from __future__ import annotations
 
 import inspect
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -401,3 +402,33 @@ def test_both_hosts_reach_the_agent_through_handle_only() -> None:
         assert "agent.handle(" in source, module.__name__
         assert "run_until_session_goal(" not in source, module.__name__
         assert "AgentSession(" not in source, module.__name__
+
+
+def test_handle_runs_the_goal_loop_on_the_session_the_binding_states(monkeypatch: Any) -> None:
+    """A rebound session is the goal loop's session, not the previously bound one.
+
+    Gateway resolves a fresh ``SessionCore`` per message; if ``handle`` handed the
+    loop the agent's *previous* session, goal state would be read from and
+    written to a stale object.
+    """
+    from core.agent_harness.turns import headless_dispatch
+    from core.agent_harness.turns.headless_adapters import InMemorySessionState
+    from core.agent_harness.turns.port_families import HeadlessPorts
+
+    seen: dict[str, Any] = {}
+
+    def _spy_loop(chat: Any, session: Any, message: str, **kwargs: Any) -> Any:
+        seen["session"] = session
+        return SimpleNamespace(last_result=chat(message))
+
+    monkeypatch.setattr(headless_dispatch, "run_until_session_goal", _spy_loop)
+    previous = InMemorySessionState()
+    current = InMemorySessionState()
+    agent = HeadlessPorts(session=previous).agent(tools=NullToolProvider())
+    agent.bind_stages(
+        execute_actions=lambda _text, **_kw: ToolCallingTurnResult(0, 0, 0, False, True)
+    )
+
+    agent.handle("hello", TurnBinding(session=current))
+
+    assert seen["session"] is current

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 from core.agent_harness.runtime import ActionTurnRunner, TurnBinding
 from core.agent_harness.turns.headless_adapters import BufferOutputSink, NullToolProvider
 from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.session import Session
@@ -71,7 +72,7 @@ def test_headless_dispatch_uses_bound_methods_not_nested_defs() -> None:
 def test_bind_turn_rebuilds_action_runner_when_output_changes() -> None:
     first = BufferOutputSink()
     second = BufferOutputSink()
-    agent = HeadlessAgent(tools=NullToolProvider(), output=first)
+    agent = HeadlessPorts(output=first).agent(tools=NullToolProvider())
     before = agent._action_runner  # noqa: SLF001
     assert before.output is first
 
@@ -83,7 +84,7 @@ def test_bind_turn_rebuilds_action_runner_when_output_changes() -> None:
 
 def test_bind_turn_rebuilds_action_runner_when_tool_hooks_change() -> None:
     hooks = ToolExecutionHooks()
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     before = agent._action_runner  # noqa: SLF001
 
     agent.bind_turn(TurnBinding(tool_hooks=hooks))
@@ -93,7 +94,7 @@ def test_bind_turn_rebuilds_action_runner_when_tool_hooks_change() -> None:
 
 
 def test_bind_turn_keeps_runner_when_only_accounting_changes() -> None:
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     before = agent._action_runner  # noqa: SLF001
     agent.bind_turn(TurnBinding(accounting=MagicMock()))
     assert agent._action_runner is before  # noqa: SLF001
@@ -176,7 +177,7 @@ def test_a_sink_without_hooks_clears_the_previous_sinks_hooks() -> None:
     that can never arrive.
     """
     # Arrange
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     approval_hooks = MagicMock()
     agent.bind_turn(TurnBinding(tool_hooks=approval_hooks))
     assert agent._tool_hooks is approval_hooks  # noqa: SLF001
@@ -199,7 +200,7 @@ def test_a_binding_states_the_whole_turn_and_replace_carries_it_forward() -> Non
     from dataclasses import replace
 
     # Arrange
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     approval_hooks = MagicMock()
     confirm = MagicMock()
     binding = TurnBinding(tool_hooks=approval_hooks, confirm_fn=confirm, is_tty=True)
@@ -340,3 +341,63 @@ def test_a_stage_injected_on_one_turn_does_not_carry_into_the_next() -> None:
 
     # Assert — the agent is back on its own action stage.
     assert agent._execute_actions_override is None  # noqa: SLF001
+
+
+def test_handle_is_the_one_host_loop_binding_each_outer_turn() -> None:
+    """``handle`` binds the turn, dispatches, and re-binds accounting per outer turn.
+
+    Gateway and shell call this and nothing else per message; the accounting
+    factory is applied per outer turn because a session goal may run several,
+    each with different text.
+    """
+    from dataclasses import replace
+
+    from core.agent_harness.turns.port_families import HeadlessPorts
+
+    # Arrange — an agent whose action stage handles every turn; record what got bound.
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
+    seen: list[tuple[str, Any]] = []
+    original_bind = agent.bind_turn
+
+    def _spy_bind(binding: TurnBinding) -> None:
+        seen.append(("bind", getattr(binding.accounting, "label", None)))
+        original_bind(binding)
+
+    def _fake_execute(text: str, *, confirm_fn=None, is_tty=None, turn_plan=None):  # type: ignore[no-untyped-def]
+        seen.append(("dispatch", text))
+        return ToolCallingTurnResult(0, 0, 0, False, True, response_text="ok")
+
+    agent.bind_turn = _spy_bind  # type: ignore[method-assign]
+    agent.bind_stages(execute_actions=_fake_execute)
+    hooks = MagicMock()
+    binding = TurnBinding(tool_hooks=hooks, is_tty=True)
+
+    def _accounting(message: str) -> Any:
+        accounting = MagicMock()
+        accounting.label = f"acct:{message}"
+        accounting.finalize.side_effect = lambda result: result
+        return accounting
+
+    # Act
+    result = agent.handle("hello", binding, accounting_factory=_accounting)
+
+    # Assert — one bind (with the factory's accounting) then one dispatch; the
+    # rest of the binding (hooks, tty) is carried unchanged.
+    assert seen == [("bind", "acct:hello"), ("dispatch", "hello")]
+    assert result.action_result is not None
+    assert agent._tool_hooks is hooks and agent._is_tty is True  # noqa: SLF001
+    assert replace(binding, accounting=None) == binding
+
+
+def test_both_hosts_reach_the_agent_through_handle_only() -> None:
+    """The host loop lives once, on the agent: neither host calls run_until_session_goal itself."""
+    import inspect
+
+    import gateway.core.runtime.turn_handler as gateway_turn
+    import surfaces.interactive_shell.runtime.shell_turn_execution as shell_turn
+
+    for module in (gateway_turn, shell_turn):
+        source = inspect.getsource(module)
+        assert "agent.handle(" in source, module.__name__
+        assert "run_until_session_goal(" not in source, module.__name__
+        assert "AgentSession(" not in source, module.__name__

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -111,7 +111,7 @@ def test_execute_shell_turn_adds_no_stage_of_its_own() -> None:
 
     from rich.console import Console
 
-    import surfaces.interactive_shell.runtime.shell_turn_execution as ste
+    from surfaces.interactive_shell.runtime import shell_turn_execution as ste
     from surfaces.interactive_shell.runtime.shell_agent import build_shell_agent
 
     source = inspect.getsource(ste.execute_shell_turn)
@@ -394,7 +394,7 @@ def test_both_hosts_reach_the_agent_through_handle_only() -> None:
     import inspect
 
     import gateway.core.runtime.turn_handler as gateway_turn
-    import surfaces.interactive_shell.runtime.shell_turn_execution as shell_turn
+    from surfaces.interactive_shell.runtime import shell_turn_execution as shell_turn
 
     for module in (gateway_turn, shell_turn):
         source = inspect.getsource(module)

--- a/tests/core/agent_harness/test_agent_shapes.py
+++ b/tests/core/agent_harness/test_agent_shapes.py
@@ -10,6 +10,7 @@ from core.agent_harness.ports import ExecuteActions, StreamAnswerFn
 from core.agent_harness.turns.headless_adapters import NullToolProvider
 from core.agent_harness.turns.headless_dispatch import HeadlessAgent
 from core.agent_harness.turns.orchestrator import run_turn, stream_answer
+from core.agent_harness.turns.port_families import HeadlessPorts
 
 
 def _accept_answer(answer: StreamAnswerFn) -> StreamAnswerFn:
@@ -23,13 +24,13 @@ def _accept_execute_actions(driver: ExecuteActions) -> ExecuteActions:
 def test_stream_answer_matches_stream_answer_fn_seam() -> None:
     # stream_answer takes session/output/prompts first; the bound seam is thinner.
     # Pin that HeadlessAgent._answer matches the Protocol shape run_turn uses.
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     accepted = _accept_answer(agent._answer)
     assert accepted.__func__ is HeadlessAgent._answer
 
 
 def test_headless_agent_execute_actions_matches_execute_actions_seam() -> None:
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     # Bound methods are new objects per access; the seam is the underlying function.
     accepted = _accept_execute_actions(agent._execute_actions)
     assert accepted.__func__ is HeadlessAgent._execute_actions

--- a/tests/core/agent_harness/test_chat_api.py
+++ b/tests/core/agent_harness/test_chat_api.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.turns.chat_api import ChatTurnBindings, dispatch_chat_turn
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent, NullToolProvider
+from core.agent_harness.turns.headless_dispatch import NullToolProvider
+from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 
@@ -107,7 +108,7 @@ def test_headless_agent_dispatch_uses_dispatch_chat_turn(monkeypatch: Any) -> No
         _fake_dispatch,
     )
 
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     result = agent.dispatch("ping")
 
     assert result is expected

--- a/tests/core/agent_harness/test_chat_turns.py
+++ b/tests/core/agent_harness/test_chat_turns.py
@@ -7,10 +7,10 @@ from typing import Any
 from core.agent_harness.harness import AgentSession, SessionConfig
 from core.agent_harness.runtime import TurnBinding
 from core.agent_harness.turns.headless_dispatch import (
-    HeadlessAgent,
     NullToolProvider,
     StaticReasoningClientProvider,
 )
+from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 
@@ -67,11 +67,9 @@ def test_headless_bind_turn_swaps_output() -> None:
 
     first = BufferOutputSink()
     second = BufferOutputSink()
-    agent = HeadlessAgent(
-        tools=NullToolProvider(),
-        output=first,
-        reasoning=StaticReasoningClientProvider(client=_Echo()),
-    )
+    agent = HeadlessPorts(
+        output=first, reasoning=StaticReasoningClientProvider(client=_Echo())
+    ).agent(tools=NullToolProvider())
     before_runner = agent._action_runner  # noqa: SLF001
     agent.bind_turn(TurnBinding(output=second))
     assert agent._output is second  # noqa: SLF001

--- a/tests/core/agent_harness/test_developer_agent_api.py
+++ b/tests/core/agent_harness/test_developer_agent_api.py
@@ -16,7 +16,6 @@ from typing import Any
 import pytest
 
 from core.agent_harness.harness import AgentSession, SessionConfig
-from core.agent_harness.turns.default_ports import DefaultPorts
 from core.agent_harness.turns.gather_ports import GATHER_DISABLED
 from core.agent_harness.turns.headless_adapters import (
     BufferOutputSink,
@@ -25,6 +24,7 @@ from core.agent_harness.turns.headless_adapters import (
     StaticReasoningClientProvider,
 )
 from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.port_families import DefaultPorts, HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 
@@ -110,11 +110,11 @@ def _controlled_agent(
     prompts: Any | None = None,
 ) -> tuple[HeadlessAgent, Any]:
     sink = output if output is not None else BufferOutputSink()
-    agent = HeadlessAgent(
+    agent = HeadlessPorts(
+        output=sink, reasoning=StaticReasoningClientProvider(client=_EchoClient())
+    ).agent(
         tools=NullToolProvider(),
-        output=sink,
         prompts=prompts if prompts is not None else EmptyPromptContextProvider(),
-        reasoning=StaticReasoningClientProvider(client=_EchoClient()),
         gather=GATHER_DISABLED,
     )
     return agent, sink

--- a/tests/core/agent_harness/test_gather_ports.py
+++ b/tests/core/agent_harness/test_gather_ports.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from core.agent_harness.turns.gather_ports import GatherPorts
+from core.agent_harness.turns.port_families import HeadlessPorts
 
 
 class _Session:
@@ -70,9 +71,8 @@ class TestAgentForwardsThePorts:
         def _persist(_executed: list[tuple[Any, Any]]) -> None:
             return None
 
-        agent = headless_dispatch.HeadlessAgent(
+        agent = HeadlessPorts(session=headless_dispatch.InMemorySessionState()).agent(
             tools=headless_dispatch.NullToolProvider(),
-            session=headless_dispatch.InMemorySessionState(),
             gather=GatherPorts(on_progress=_on_progress, persist=_persist, max_iterations=9),
         )
 
@@ -94,9 +94,8 @@ class TestAgentForwardsThePorts:
 
         monkeypatch.setattr(headless_dispatch, "gather_tool_evidence", _never)
 
-        agent = headless_dispatch.HeadlessAgent(
+        agent = HeadlessPorts(session=headless_dispatch.InMemorySessionState()).agent(
             tools=headless_dispatch.NullToolProvider(),
-            session=headless_dispatch.InMemorySessionState(),
             gather=GatherPorts(enabled=False),
         )
 

--- a/tests/core/agent_harness/test_harness_start.py
+++ b/tests/core/agent_harness/test_harness_start.py
@@ -122,7 +122,7 @@ def test_builder_exposes_the_prompts_port() -> None:
     # Arrange
     import inspect
 
-    from core.agent_harness.turns.default_ports import DefaultPorts
+    from core.agent_harness.turns.port_families import DefaultPorts
 
     # Act / Assert
     assert "prompts" in inspect.signature(DefaultPorts.agent).parameters

--- a/tests/core/agent_harness/test_port_families.py
+++ b/tests/core/agent_harness/test_port_families.py
@@ -10,8 +10,8 @@ from rich.console import Console
 from core.agent_harness.runtime import TurnBinding
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
-from core.agent_harness.turns.default_ports import DefaultPorts
 from core.agent_harness.turns.headless_adapters import BufferOutputSink
+from core.agent_harness.turns.port_families import DefaultPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.execution import ToolExecutionHooks
 

--- a/tests/core/agent_harness/test_public_api.py
+++ b/tests/core/agent_harness/test_public_api.py
@@ -125,6 +125,7 @@ RUNTIME = frozenset(
         "DefaultToolProvider",
         "GatherPorts",
         "HeadlessAgent",
+        "HeadlessPorts",
         "TurnBinding",
     }
 )

--- a/tests/core/agent_harness/test_run_headless_turn.py
+++ b/tests/core/agent_harness/test_run_headless_turn.py
@@ -56,7 +56,7 @@ def test_run_headless_turn_wires_startup_sink_and_dispatch(
             return SessionStartupResult(session=session, prompts=prompts)
 
     monkeypatch.setattr(
-        "core.agent_harness.turns.default_ports.DefaultPorts",
+        "core.agent_harness.turns.port_families.DefaultPorts",
         default_ports_stub(_fake_build),
     )
     monkeypatch.setattr(
@@ -105,7 +105,7 @@ def test_run_headless_turn_prepare_session_runs_before_agent_build(
             return SessionStartupResult(session=session, prompts=None)
 
     monkeypatch.setattr(
-        "core.agent_harness.turns.default_ports.DefaultPorts",
+        "core.agent_harness.turns.port_families.DefaultPorts",
         default_ports_stub(_fake_build),
     )
     monkeypatch.setattr(

--- a/tests/core/agent_harness/test_session_bindable_ports.py
+++ b/tests/core/agent_harness/test_session_bindable_ports.py
@@ -17,8 +17,8 @@ from core.agent_harness.turns.headless_adapters import (
     SimpleRunRecordFactory,
     StaticReasoningClientProvider,
 )
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
 from core.agent_harness.turns.host_cancel import ensure_turn_cancel
+from core.agent_harness.turns.port_families import HeadlessPorts
 
 
 class _SpyTools:
@@ -68,14 +68,14 @@ def test_headless_agent_bind_session_invokes_session_bindable() -> None:
     first = InMemorySessionState(session_id="a")
     second = InMemorySessionState(session_id="b")
     tools = _SpyTools()
-    agent = HeadlessAgent(tools=tools, session=first)
+    agent = HeadlessPorts(session=first).agent(tools=tools)
     agent.bind_session(second)
     assert tools.sessions == [second]
 
 
 def test_headless_agent_bind_turn_console_invokes_console_bindable() -> None:
     tools = _SpyTools()
-    agent = HeadlessAgent(tools=tools, session=InMemorySessionState())
+    agent = HeadlessPorts(session=InMemorySessionState()).agent(tools=tools)
     agent.bind_turn(TurnBinding(console="second"))
     assert tools.consoles == ["second"]
 
@@ -96,11 +96,8 @@ def test_headless_agent_bind_turn_output_retargets_reasoning() -> None:
     first = BufferOutputSink()
     second = BufferOutputSink()
     reasoning = DefaultReasoningClientProvider(output=first)
-    agent = HeadlessAgent(
-        tools=NullToolProvider(),
-        session=InMemorySessionState(),
-        output=first,
-        reasoning=reasoning,
+    agent = HeadlessPorts(session=InMemorySessionState(), output=first, reasoning=reasoning).agent(
+        tools=NullToolProvider()
     )
     agent.bind_turn(TurnBinding(output=second))
     reasoning._handle_unavailable(RuntimeError("boom"), context="test")

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -10,7 +10,7 @@ import pytest
 
 from core.agent import Agent, AgentRunResult
 from core.agent_harness.runtime import TurnBinding
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.port_families import HeadlessPorts
 from core.events import (
     MessageUpdateEvent,
     RuntimeEvent,
@@ -146,10 +146,9 @@ def test_agent_exposes_headless_dispatch_entrypoint(monkeypatch: pytest.MonkeyPa
         StaticReasoningClientProvider,
     )
 
-    agent = HeadlessAgent(
-        tools=NullToolProvider(),
-        reasoning=StaticReasoningClientProvider(client=EchoReasoningClient()),
-    )
+    agent = HeadlessPorts(
+        reasoning=StaticReasoningClientProvider(client=EchoReasoningClient())
+    ).agent(tools=NullToolProvider())
     result = agent.dispatch("hello")
 
     assert result.assistant_response_text == "hello from headless"
@@ -171,10 +170,9 @@ def test_one_headless_agent_dispatches_multiple_messages(monkeypatch: pytest.Mon
         StaticReasoningClientProvider,
     )
 
-    agent = HeadlessAgent(
-        tools=NullToolProvider(),
-        reasoning=StaticReasoningClientProvider(client=EchoReasoningClient()),
-    )
+    agent = HeadlessPorts(
+        reasoning=StaticReasoningClientProvider(client=EchoReasoningClient())
+    ).agent(tools=NullToolProvider())
     first = agent.dispatch("one")
     second = agent.dispatch("two")
 
@@ -189,7 +187,7 @@ def test_provided_accounting_is_consumed_once() -> None:
     from core.agent_harness.turns.headless_dispatch import NoopTurnAccounting, NullToolProvider
 
     accounting = NoopTurnAccounting()
-    agent = HeadlessAgent(tools=NullToolProvider())
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
     agent.bind_turn(TurnBinding(accounting=accounting))
     assert agent._take_accounting("a") is accounting
     # Slot cleared so a forgotten bind_turn cannot leak the prior turn's prompt.
@@ -203,7 +201,7 @@ def test_default_accounting_is_resolved_fresh_per_message() -> None:
     class _PersistentState(InMemorySessionState):
         store = object()  # persistent-backed session selects DefaultTurnAccounting
 
-    agent = HeadlessAgent(tools=NullToolProvider(), session=_PersistentState())
+    agent = HeadlessPorts(session=_PersistentState()).agent(tools=NullToolProvider())
 
     first = agent._take_accounting("msg-a")
     second = agent._take_accounting("msg-b")

--- a/tests/shared/fake_agent.py
+++ b/tests/shared/fake_agent.py
@@ -26,7 +26,21 @@ def fake_agent(*, dispatch_result: Any = None) -> MagicMock:
 
 
 def attach_real_handle(agent: MagicMock) -> MagicMock:
-    """Give an existing mock agent the real host loop; returns the same mock."""
+    """Give an existing mock agent the real host loop; returns the same mock.
+
+    ``agent.bound_session`` stands for the real agent's currently bound session
+    (``None`` until a binding with a session is applied); ``bind_turn`` on the
+    mock is left to the test to assert on, so it is tracked here explicitly.
+    """
+    agent.bound_session = None
+    original_bind = agent.bind_turn
+
+    def _bind(binding: Any) -> Any:
+        if binding.session is not None:
+            agent.bound_session = binding.session
+        return original_bind(binding)
+
+    agent.bind_turn = MagicMock(side_effect=_bind)
 
     def _handle(
         text: str,
@@ -41,7 +55,9 @@ def attach_real_handle(agent: MagicMock) -> MagicMock:
             agent.bind_turn(replace(binding, accounting=accounting))
             return agent.dispatch(message)
 
-        session = binding.session
+        # Same selection as HeadlessAgent.handle: the session this turn states,
+        # else the agent's currently bound one.
+        session = binding.session if binding.session is not None else agent.bound_session
         return run_until_session_goal(
             _one_turn,
             session,

--- a/tests/shared/fake_agent.py
+++ b/tests/shared/fake_agent.py
@@ -1,0 +1,57 @@
+"""A mock agent whose ``handle`` is the harness's real host loop over the mock's ``bind_turn``/``dispatch``.
+
+Host tests fake the agent to assert what the host binds and dispatches. Since
+hosts call :meth:`HeadlessAgent.handle`, the fake must run the same loop the
+real agent does — bind the turn, dispatch, continue while a session goal is
+attached — so ``bind_turn.call_args`` and ``dispatch.call_count`` keep meaning
+what they meant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+from unittest.mock import MagicMock
+
+from core.agent_harness.spi.session_goal import run_until_session_goal
+
+
+def fake_agent(*, dispatch_result: Any = None) -> MagicMock:
+    """A ``MagicMock`` agent with a real ``handle``; ``dispatch`` returns ``dispatch_result``."""
+    agent = MagicMock()
+    if dispatch_result is not None:
+        agent.dispatch.return_value = dispatch_result
+    attach_real_handle(agent)
+    return agent
+
+
+def attach_real_handle(agent: MagicMock) -> MagicMock:
+    """Give an existing mock agent the real host loop; returns the same mock."""
+
+    def _handle(
+        text: str,
+        binding: Any,
+        *,
+        accounting_factory: Any = None,
+        cancel_requested: Any = None,
+        on_progress: Any = None,
+    ) -> Any:
+        def _one_turn(message: str) -> Any:
+            accounting = accounting_factory(message) if accounting_factory is not None else None
+            agent.bind_turn(replace(binding, accounting=accounting))
+            return agent.dispatch(message)
+
+        session = binding.session
+        return run_until_session_goal(
+            _one_turn,
+            session,
+            text,
+            cancel_requested=cancel_requested,
+            on_progress=on_progress,
+        ).last_result
+
+    agent.handle.side_effect = _handle
+    return agent
+
+
+__all__ = ["attach_real_handle", "fake_agent"]


### PR DESCRIPTION
Follow-up to #5029. Two things an engineer reading the harness should now see without doubt: **one per-message API that both hosts call**, and **one way to construct an agent**.

**1. One host loop, provided by the harness — `HeadlessAgent.handle`**
Both hosts hand-rolled the same loop in different words: `bind_turn(TurnBinding(...))`, a `_chat` closure, `run_until_session_goal(...)`, and an `AgentSession` used only as a wrapper around `agent.dispatch` (the shell built a throwaway `AgentSession(SessionConfig(load_env=False))` per turn; the gateway kept `self._session_api`). Now:

```python
handle(text, binding, *, accounting_factory=None, cancel_requested=None, on_progress=None) -> TurnResult
```

binds the turn, dispatches, and continues while a session goal is attached. Gateway and shell each call it once per message and nothing else; dispatch is the single-turn verb underneath. accounting_factory (message → TurnAccounting) is applied per outer turn because the goal loop may dispatch several with different text; None uses the agent's default per-message accounting — so the gateway no longer passes DefaultTurnAccounting by hand.

2. One construction verb — <family>.agent(...)
HeadlessAgent.__init__ is now ports-required (no None → in-memory adapter chain). The in-memory family has a name: HeadlessPorts(session?, output?, reasoning?).agent(tools=…), beside DefaultPorts in core/agent_harness/turns/port_families.py (default_ports.py retired). Hosts, scripts and the ~25 test sites that constructed HeadlessAgent(...) directly all say <family>.agent(...). Runtime door: +HeadlessPorts (7 names).

Hosts after this PR

gateway/core/runtime/turn_handler.py: agent.handle(text, TurnBinding(session, tool_hooks, console, is_tty=False), cancel_requested=…, on_progress=…); _session_api removed.
surfaces/interactive_shell/runtime/shell_turn_execution.py: agent.handle(text, binding, accounting_factory=ShellTurnAccounting per message, cancel_requested=host_cancel_requested(sink), on_progress=print checklist); the throwaway AgentSession is gone.

Docs / internal notes: docs/hosting-the-agent.mdx host loop is build → handle, both shipped hosts shown as the same call, HeadlessPorts documented; core/agent_harness/AGENTS.md table rows updated.

No user-visible behaviour change.

Tests

test_handle_is_the_one_host_loop_binding_each_outer_turn — bind with the factory's accounting, then dispatch; hooks/tty carried in the binding.
test_both_hosts_reach_the_agent_through_handle_only — neither host source contains run_until_session_goal( or AgentSession(; both contain agent.handle(.
tests/shared/fake_agent.py — a mock agent whose handle is the real loop over the mock's bind_turn/dispatch, so gateway tests' bind_turn.call_args / dispatch.call_count assertions keep their meaning.
test_default_ports.py → test_port_families.py; direct constructions converted to HeadlessPorts(...).agent(...); runtime-door pin updated.

