### PR TITLE
refactor(harness): repoint door-eligible shell imports (runtime/ports/spi.prompt_chrome); shell ledger 10→8

### DIFF
--- a/core/agent_harness/spi/prompt_chrome.py
+++ b/core/agent_harness/spi/prompt_chrome.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+from core.agent_harness.prompts.rules import normalize_three_tier_spacing
 from core.agent_harness.session.want_me_to import WANT_ME_TO_MARKER, closer_tail_from
 from core.agent_harness.session_goal.goal import strip_shell_prompt_chrome
 
-__all__ = ["WANT_ME_TO_MARKER", "closer_tail_from", "strip_shell_prompt_chrome"]
+__all__ = [
+    "WANT_ME_TO_MARKER",
+    "closer_tail_from",
+    "normalize_three_tier_spacing",
+    "strip_shell_prompt_chrome",
+]

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -13,8 +13,8 @@ from rich.console import Console
 
 from core.agent_harness import OutputSink, ToolCallingTurnResult
 from core.agent_harness.ports import LlmFactory
+from core.agent_harness.runtime import ActionTurnRunner
 from core.agent_harness.spi.defaults import DefaultErrorReporter
-from core.agent_harness.turns.action_driver import ActionTurnRunner
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -20,14 +20,13 @@ from core.agent_harness import (
     ToolCallingTurnResult,
     TurnResult,
 )
-from core.agent_harness.ports import AnswerRequest
+from core.agent_harness.ports import AnswerRequest, GatheredEvidence
 from core.agent_harness.runtime import HeadlessAgent, TurnBinding
 from core.agent_harness.spi.cancel import host_cancel_requested
 from core.agent_harness.spi.session_goal import (
     SessionGoal,
     format_session_goal_progress,
 )
-from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -14,8 +14,7 @@ from typing import Any, Protocol
 from rich.console import Console
 
 from core.agent_harness import OutputSink, ToolCallingTurnResult
-from core.agent_harness.ports import AnswerRequest
-from core.agent_harness.turns.gather_observation import GatheredEvidence
+from core.agent_harness.ports import AnswerRequest, GatheredEvidence
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.session import Session

--- a/surfaces/interactive_shell/ui/streaming/__init__.py
+++ b/surfaces/interactive_shell/ui/streaming/__init__.py
@@ -38,8 +38,11 @@ from rich.console import Console
 from rich.markdown import Markdown
 
 import platform.terminal.theme as ui_theme
-from core.agent_harness.prompts.rules import normalize_three_tier_spacing
-from core.agent_harness.spi.prompt_chrome import WANT_ME_TO_MARKER, closer_tail_from
+from core.agent_harness.spi.prompt_chrome import (
+    WANT_ME_TO_MARKER,
+    closer_tail_from,
+    normalize_three_tier_spacing,
+)
 from core.agent_harness.spi.session_goal import strip_session_goal_progress_tags
 from surfaces.interactive_shell.ui.components.token_format import (
     _CHARS_PER_TOKEN,

--- a/tests/core/agent_harness/test_public_api.py
+++ b/tests/core/agent_harness/test_public_api.py
@@ -102,7 +102,12 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
         }
     ),
     "prompt_chrome": frozenset(
-        {"WANT_ME_TO_MARKER", "closer_tail_from", "strip_shell_prompt_chrome"}
+        {
+            "WANT_ME_TO_MARKER",
+            "closer_tail_from",
+            "normalize_three_tier_spacing",
+            "strip_shell_prompt_chrome",
+        }
     ),
     "integrations": frozenset({"has_resolved_integrations", "resolve_integrations"}),
     "grounding": frozenset(

--- a/tests/interactive_shell/test_harness_api_border.py
+++ b/tests/interactive_shell/test_harness_api_border.py
@@ -36,13 +36,11 @@ def _is_public_door(module: str) -> bool:
 _KNOWN_DEEP_IMPORTS = frozenset(
     {
         "core.agent_harness.llm_resolution",
-        "core.agent_harness.prompts.rules",
         "core.agent_harness.prompts.skills.loader",
         "core.agent_harness.session.persistence.jsonl_store",
         "core.agent_harness.session.persistence.wal_recovery",
         "core.agent_harness.tools.tool_context",
         "core.agent_harness.turns.action_driver",
-        "core.agent_harness.turns.gather_observation",
         "core.agent_harness.turns.transcript_compaction",
         "core.agent_harness.turns.turn_plan",
     }


### PR DESCRIPTION
- action_turn.py: ActionTurnRunner from core.agent_harness.runtime. shell_turn_execution.py, turn_seams.py: GatheredEvidence from core.agent_harness.ports.
- normalize_three_tier_spacing exported from spi.prompt_chrome — it knows the harness's three-tier markers, same role as WANT_ME_TO_MARKER / closer_tail_from / strip_shell_prompt_chrome; the streaming renderer imports it from there. Chosen over moving it to surfaces/ so marker knowledge stays in one place.
- Shell deep-import ledger 10 → 8 (prompts.rules, turns.gather_observation retired). turns.action_driver stays for one real gap: ui/action_rendering.py imports SELF_RECORDING_ACTION_TOOL_NAMES, a constant with no role home yet — listed honestly rather than repointed.
- Pins updated (prompt_chrome role list, ledger). No behaviour change.