### PR TITLE
refactor(wizard): simplify integration configuration and update wizard mode handling

### DIFF
--- a/surfaces/cli/wizard/_integration_configurators.py
+++ b/surfaces/cli/wizard/_integration_configurators.py
@@ -61,21 +61,15 @@ __all__ = [
 ]
 
 
-def _configure_selected_integrations(*, mode: str = "quickstart") -> tuple[list[str], str | None]:
-    """Configure one integration, or skip. ``mode`` only changes the prompt text."""
+def _configure_selected_integrations() -> tuple[list[str], str | None]:
+    """Configure one integration, or skip."""
     configured: list[str] = []
     last_env_path: str | None = None
 
-    if mode == "focused":
-        _console.print(
-            f"[{SECONDARY}]Choose one integration to configure now "
-            f"(or skip and start the agent).[/]"
-        )
-    else:
-        _console.print(
-            f"[{SECONDARY}]Pick one integration to wire up now, or skip this step "
-            f"and come back later.[/]"
-        )
+    _console.print(
+        f"[{SECONDARY}]Pick one integration to wire up now, or skip this step "
+        f"and come back later.[/]"
+    )
     integration_choices = list(ONBOARD_INTEGRATION_CHOICES)
     selected_service = _choose(
         "Choose an integration to configure",

--- a/surfaces/cli/wizard/_ui.py
+++ b/surfaces/cli/wizard/_ui.py
@@ -137,8 +137,8 @@ def _local_defaults() -> dict[str, str | bool | None]:
     if is_oauth_backend:
         auth_method = OAUTH_AUTH_METHOD
     wizard_mode = _string_value(wizard.get("mode"), "quickstart")
-    if wizard_mode == "aha":
-        wizard_mode = "focused"
+    if wizard_mode in {"aha", "focused"}:
+        wizard_mode = "quickstart"
     return {
         "wizard_mode": wizard_mode,
         "provider": provider_value if raw_provider_value else None,
@@ -627,7 +627,7 @@ def _render_integration_result(
             _console.print(detail_text)
 
 
-def _render_next_steps(*, focused: bool = False) -> None:
+def _render_next_steps() -> None:
     """Print suggested commands after onboarding."""
     _console.print(Rule(style=DIM))
 
@@ -638,28 +638,15 @@ def _render_next_steps(*, focused: bool = False) -> None:
     _console.print(Rule(style=DIM))
     _console.print()
 
-    if focused:
-        next_steps: tuple[tuple[str, str], ...] = (
-            (
-                "opensre",
-                'Start the agent and ask: "what OpenSRE version am I running?"',
-            ),
-            (
-                "opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json",
-                "Run a sample investigation",
-            ),
-            ("opensre", "Start the agent and run /loops to review starter loops"),
-        )
-    else:
-        next_steps = (
-            ("opensre", "Start the interactive agent and run /loops"),
-            (
-                "opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json",
-                "Run root-cause analysis on a sample alert",
-            ),
-            ("opensre doctor", "Verify your full environment setup"),
-            ("opensre onboard", "Re-run this setup at any time"),
-        )
+    next_steps: tuple[tuple[str, str], ...] = (
+        ("opensre", "Start the interactive agent and run /loops"),
+        (
+            "opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json",
+            "Run root-cause analysis on a sample alert",
+        ),
+        ("opensre doctor", "Verify your full environment setup"),
+        ("opensre onboard", "Re-run this setup at any time"),
+    )
 
     for cmd, description in next_steps:
         cmd_line = Text()

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -660,11 +660,6 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         "How do you want to get started?",
         [
             Choice(
-                value="focused",
-                label="Focused",
-                hint="Provider, one integration, then run the agent",
-            ),
-            Choice(
                 value="quickstart", label="Quickstart", hint="Local setup with the usual defaults"
             ),
             Choice(
@@ -674,8 +669,8 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             ),
         ],
         default=default_wizard_mode
-        if default_wizard_mode in {"focused", "quickstart", "advanced"}
-        else "focused",
+        if default_wizard_mode in {"quickstart", "advanced"}
+        else "quickstart",
     )
 
     store_path = get_store_path()
@@ -951,9 +946,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
     _step_header(3, WIZARD_TOTAL_STEPS, "Integrations")
     try:
         configured_integrations, integration_env_path = (
-            _integration_configurators_module._configure_selected_integrations(
-                mode=wizard_mode,
-            )
+            _integration_configurators_module._configure_selected_integrations()
         )
     except KeyboardInterrupt:
         cancelled = Text()
@@ -977,5 +970,5 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             provider, persisted_auth_method, credential_state=credential_state
         ),
     )
-    _render_next_steps(focused=wizard_mode == "focused")
+    _render_next_steps()
     return 0

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -5011,9 +5011,9 @@ def test_credential_line_for_saved_summary_ollama_host_verified() -> None:
     )
 
 
-@pytest.mark.parametrize("stale_mode", ["aha", "banana", ""])
+@pytest.mark.parametrize("stale_mode", ["aha", "focused", "banana", ""])
 def test_run_wizard_falls_back_when_saved_mode_is_not_offered(monkeypatch, stale_mode) -> None:
-    """A saved mode that is no longer offered must default to 'focused'.
+    """A saved mode that is no longer offered must default to 'quickstart'.
 
     Saved defaults outlive the modes they name — a value persisted by an older
     build, or a mode removed in a refactor, must not be passed to the chooser as
@@ -5040,7 +5040,7 @@ def test_run_wizard_falls_back_when_saved_mode_is_not_offered(monkeypatch, stale
         flow.run_wizard()
 
     # Assert
-    assert seen["default"] == "focused"
+    assert seen["default"] == "quickstart"
 
 
 def test_run_wizard_blank_llm_key_defers_setup_instead_of_ending(monkeypatch, tmp_path) -> None:

--- a/tests/cli/wizard/test_integration_configurators.py
+++ b/tests/cli/wizard/test_integration_configurators.py
@@ -1,4 +1,4 @@
-"""Focused onboarding uses mode-specific prompt copy for the integration chooser."""
+"""Onboarding maps retired wizard modes and configures one integration."""
 
 from __future__ import annotations
 
@@ -10,40 +10,19 @@ from surfaces.cli.wizard import _integration_configurators as configurators
 from surfaces.cli.wizard import _ui
 
 
-def test_local_defaults_maps_legacy_aha_mode_to_focused(
+@pytest.mark.parametrize("legacy_mode", ["aha", "focused"])
+def test_local_defaults_maps_legacy_mode_to_quickstart(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
+    legacy_mode: str,
 ) -> None:
     monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "store.json")
     monkeypatch.setattr(
         _ui,
         "load_local_config",
-        lambda _path: {"wizard": {"mode": "aha"}, "targets": {"local": {}}},
+        lambda _path: {"wizard": {"mode": legacy_mode}, "targets": {"local": {}}},
     )
-    assert _ui._local_defaults()["wizard_mode"] == "focused"
-
-
-def test_configure_selected_integrations_focused_prompt(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    printed: list[str] = []
-
-    monkeypatch.setattr(
-        configurators._console,
-        "print",
-        lambda msg, **_kwargs: printed.append(str(msg)),
-    )
-    monkeypatch.setattr(
-        configurators,
-        "_choose",
-        lambda *_args, **_kwargs: "skip",
-    )
-
-    configured, env_path = configurators._configure_selected_integrations(mode="focused")
-
-    assert configured == []
-    assert env_path is None
-    assert any("Choose one integration" in line for line in printed)
+    assert _ui._local_defaults()["wizard_mode"] == "quickstart"
 
 
 def test_configure_selected_integrations_default_prompt(
@@ -60,7 +39,6 @@ def test_configure_selected_integrations_default_prompt(
     configurators._configure_selected_integrations()
 
     assert any("come back later" in line for line in printed)
-    assert not any("Choose one integration" in line for line in printed)
 
 
 def test_configure_selected_integrations_runs_one_handler(
@@ -76,7 +54,7 @@ def test_configure_selected_integrations_runs_one_handler(
         lambda: calls.append("datadog") or ("datadog", "/tmp/.env"),
     )
 
-    configured, env_path = configurators._configure_selected_integrations(mode="focused")
+    configured, env_path = configurators._configure_selected_integrations()
 
     assert calls == ["datadog"]
     assert configured == ["datadog"]


### PR DESCRIPTION
- Removed the 'mode' parameter from `_configure_selected_integrations` and adjusted the prompt message.
- Updated the wizard mode handling to default to 'quickstart' instead of 'focused' for legacy modes.
- Consolidated next steps rendering logic in `_render_next_steps` to remove conditional checks.
- Deleted the now-redundant focused integrations test file