### PR TITLE
fix(github): require baseline checks before CI success

### DIFF
--- a/docs/github-ci-fix.mdx
+++ b/docs/github-ci-fix.mdx
@@ -66,9 +66,10 @@ the current PR CI is failing, fix and push
 4. It refuses fork PRs because it only pushes to branches in the same repository.
 5. After approval, it checks out the PR head branch and applies the fix.
 6. If files changed, it commits only the fix-run changes and pushes the PR branch.
-7. It verifies the exact pushed commit, allows one minute for its checks to register,
-   waits for applicable workflows, and reports whether they passed, failed, were
-   superseded by another push, or did not finish within 15 minutes.
+7. It verifies the exact pushed commit, waits for workflows and external checks from
+   the pre-fix head to re-register, and allows one minute for newly applicable checks.
+   It then reports whether the observed checks passed, failed, were superseded by
+   another push, or did not finish within 15 minutes.
 
 If no checks are failing, OpenSRE says so and does not push. It does **not** open a new PR.
 

--- a/integrations/github/tools/ci_fix/context.py
+++ b/integrations/github/tools/ci_fix/context.py
@@ -85,6 +85,9 @@ class CiFixContext:
     skipped_check_names: tuple[str, ...]
     failing_checks: tuple[FailingCheck, ...]
     task: str
+    expected_workflow_names: tuple[str, ...] = ()
+    expected_external_check_names: tuple[str, ...] = ()
+    actions_run_expected: bool = False
 
 
 def parse_pr_url(pr_url: str | None) -> PullRequestRef | None:
@@ -155,6 +158,30 @@ def gather_ci_fix_context(
         )
 
     rollup = _list_value(pr.get("statusCheckRollup"))
+    expected_workflow_names = tuple(
+        sorted(
+            {
+                workflow_name
+                for item in rollup
+                if (workflow_name := str(item.get("workflowName") or "").strip())
+            }
+        )
+    )
+    expected_external_check_names = tuple(
+        sorted(
+            {
+                _check_name(item)
+                for item in rollup
+                if not str(item.get("workflowName") or "").strip()
+                and not _actions_ids(str(item.get("detailsUrl") or item.get("targetUrl") or ""))[0]
+            }
+        )
+    )
+    actions_run_expected = any(
+        str(item.get("workflowName") or "").strip()
+        or _actions_ids(str(item.get("detailsUrl") or item.get("targetUrl") or ""))[0]
+        for item in rollup
+    )
     checks = tuple(
         _failing_check_from_rollup(repo_full_name, item, github_token=github_token)
         for item in rollup
@@ -181,6 +208,9 @@ def gather_ci_fix_context(
         skipped_check_names=tuple(_check_name(item) for item in rollup if _is_skipped(item)),
         failing_checks=checks,
         task="",
+        expected_workflow_names=expected_workflow_names,
+        expected_external_check_names=expected_external_check_names,
+        actions_run_expected=actions_run_expected,
     )
     return replace(ctx, task=_build_task(ctx))
 

--- a/integrations/github/tools/ci_fix/runner.py
+++ b/integrations/github/tools/ci_fix/runner.py
@@ -178,7 +178,7 @@ def with_push_output(
             **result,
             "response_text": (
                 f"Fixed failing CI for {owner}/{repo}#{number}, pushed {push.branch_name}, "
-                "and all PR checks passed."
+                "and the pushed commit's observed checks passed."
             ),
         }
     if verification.state is CheckState.FAILED:

--- a/integrations/github/tools/ci_fix/verification.py
+++ b/integrations/github/tools/ci_fix/verification.py
@@ -18,7 +18,7 @@ DEFAULT_SETTLE_SECONDS = 30
 DEFAULT_HEAD_PROPAGATION_SECONDS = 30
 
 _PR_CHECK_FIELDS = "headRefOid,statusCheckRollup"
-_WORKFLOW_RUN_FIELDS = "databaseId,status"
+_WORKFLOW_RUN_FIELDS = "databaseId,status,workflowName"
 _WORKFLOW_RUNS_KEY = "runs"
 _WORKFLOW_RUN_COMPLETED = "completed"
 _FAILED_CONCLUSIONS = frozenset(
@@ -74,10 +74,17 @@ def wait_for_pr_checks(
     started_at = monotonic()
     deadline = started_at + max(0, timeout_seconds)
     expected_skips = set(ctx.skipped_check_names)
-    actions_run_required = any(check.run_id or check.workflow_name for check in ctx.failing_checks)
-    required_external_checks = {
+    actions_run_required = ctx.actions_run_expected or any(
+        check.run_id or check.workflow_name for check in ctx.failing_checks
+    )
+    required_workflows = set(ctx.expected_workflow_names)
+    required_workflows.update(
+        check.workflow_name for check in ctx.failing_checks if check.workflow_name
+    )
+    required_external_checks = set(ctx.expected_external_check_names)
+    required_external_checks.update(
         check.name for check in ctx.failing_checks if not check.run_id and not check.workflow_name
-    }
+    )
     last_names: tuple[str, ...] = ()
     terminal_signature: tuple[str, ...] = ()
     terminal_since: float | None = None
@@ -108,18 +115,19 @@ def wait_for_pr_checks(
                 observed_head_sha=head_sha,
             )
 
-        # Give the exact commit's checks time to register, then settle only
-        # completed workflows. Workflow identities join the signature below so
-        # another run appearing during settlement resets the clock.
+        # Require baseline workflow and external-check identities before
+        # settling. Individual jobs stay optional because workflow conditions
+        # can legitimately change which siblings run on the fix commit.
         if head_sha == expected_head_sha:
-            workflows_complete, workflow_signature = _workflow_runs_state(
+            workflows_complete, workflow_signature, workflow_names = _workflow_runs_state(
                 repo=repo,
                 github_token=github_token,
                 expected_head_sha=expected_head_sha,
                 require_run=actions_run_required,
             )
         else:
-            workflows_complete, workflow_signature = False, ()
+            workflows_complete, workflow_signature, workflow_names = False, (), ()
+        workflows_registered = required_workflows.issubset(set(workflow_names))
         external_checks_registered = required_external_checks.issubset(set(last_names))
         registration_complete = (
             expected_head_seen_at is not None
@@ -129,6 +137,7 @@ def wait_for_pr_checks(
             head_sha == expected_head_sha
             and checks
             and workflows_complete
+            and workflows_registered
             and external_checks_registered
             and registration_complete
         ):
@@ -175,7 +184,7 @@ def _workflow_runs_state(
     github_token: str | None,
     expected_head_sha: str,
     require_run: bool,
-) -> tuple[bool, tuple[str, ...]]:
+) -> tuple[bool, tuple[str, ...], tuple[str, ...]]:
     payload = run_gh_json(
         [
             "run",
@@ -202,7 +211,16 @@ def _workflow_runs_state(
             for run in runs
         )
     )
-    return complete, signature
+    workflow_names = tuple(
+        sorted(
+            {
+                str(run.get("workflowName") or "").strip()
+                for run in runs
+                if str(run.get("workflowName") or "").strip()
+            }
+        )
+    )
+    return complete, signature, workflow_names
 
 
 def _verification_signature(

--- a/tests/tools/test_github_ci_fix.py
+++ b/tests/tools/test_github_ci_fix.py
@@ -60,6 +60,12 @@ _PR_PAYLOAD: dict[str, Any] = {
             "detailsUrl": "https://github.com/Tracer-Cloud/opensre/actions/runs/1/job/3",
             "workflowName": "CI",
         },
+        {
+            "__typename": "StatusContext",
+            "context": "external security scan",
+            "state": "SUCCESS",
+            "targetUrl": "https://ci.example.test/runs/1",
+        },
     ],
 }
 
@@ -85,6 +91,8 @@ _CTX = CiFixContext(
         ),
     ),
     task="Fix CI.",
+    expected_workflow_names=("CI",),
+    actions_run_expected=True,
 )
 
 
@@ -135,6 +143,9 @@ def test_gather_ci_fix_context_builds_task_with_failing_logs() -> None:
     assert ctx.number == 4597
     assert ctx.head_branch == "feat/fix-ci"
     assert ctx.skipped_check_names == ()
+    assert ctx.expected_workflow_names == ("CI",)
+    assert ctx.expected_external_check_names == ("external security scan",)
+    assert ctx.actions_run_expected is True
     assert ctx.failing_checks[0].name == "test (integrations-and-misc)"
     assert "pytest failed" in ctx.task
     assert "Head branch to edit and push: feat/fix-ci" in ctx.task
@@ -363,7 +374,7 @@ def test_run_ci_fix_success_pushes_existing_pr_branch(
     assert result["checks_state"] == "passed"
     assert result["response_text"] == (
         "Fixed failing CI for Tracer-Cloud/opensre#4597, pushed feat/fix-ci, "
-        "and all PR checks passed."
+        "and the pushed commit's observed checks passed."
     )
     assert "checking out feat/fix-ci" in prompts[0]
     mock_push.assert_called_once()

--- a/tests/tools/test_github_ci_fix_verification.py
+++ b/tests/tools/test_github_ci_fix_verification.py
@@ -34,6 +34,8 @@ _CONTEXT = CiFixContext(
         ),
     ),
     task="Fix CI.",
+    expected_workflow_names=("CI",),
+    actions_run_expected=True,
 )
 
 
@@ -41,7 +43,7 @@ _CONTEXT = CiFixContext(
 def _completed_workflow_runs(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "integrations.github.tools.ci_fix.verification._workflow_runs_state",
-        lambda **_kwargs: (True, ("1:completed",)),
+        lambda **_kwargs: (True, ("1:completed",), ("CI",)),
     )
 
 
@@ -71,14 +73,14 @@ def test_workflow_runs_state_uses_exact_commit() -> None:
         {"runs": []},
         {
             "runs": [
-                {"databaseId": 1, "status": "completed"},
-                {"databaseId": 2, "status": "in_progress"},
+                {"databaseId": 1, "status": "completed", "workflowName": "CI"},
+                {"databaseId": 2, "status": "in_progress", "workflowName": "Security"},
             ]
         },
         {
             "runs": [
-                {"databaseId": 1, "status": "completed"},
-                {"databaseId": 2, "status": "completed"},
+                {"databaseId": 1, "status": "completed", "workflowName": "CI"},
+                {"databaseId": 2, "status": "completed", "workflowName": "Security"},
             ]
         },
     ]
@@ -92,19 +94,19 @@ def test_workflow_runs_state_uses_exact_commit() -> None:
             github_token="tok",
             expected_head_sha="new-sha",
             require_run=True,
-        ) == (False, ())
+        ) == (False, (), ())
         assert _workflow_runs_state(
             repo="Tracer-Cloud/opensre",
             github_token="tok",
             expected_head_sha="new-sha",
             require_run=True,
-        ) == (False, ("1:completed", "2:in_progress"))
+        ) == (False, ("1:completed", "2:in_progress"), ("CI", "Security"))
         assert _workflow_runs_state(
             repo="Tracer-Cloud/opensre",
             github_token="tok",
             expected_head_sha="new-sha",
             require_run=True,
-        ) == (True, ("1:completed", "2:completed"))
+        ) == (True, ("1:completed", "2:completed"), ("CI", "Security"))
 
     assert run_gh.call_args_list[0].args[0][:4] == ["run", "list", "--commit", "new-sha"]
 
@@ -374,10 +376,10 @@ def test_wait_for_pr_checks_waits_for_late_check_in_running_workflow(
     elapsed = iter((0.0, 0.0, 31.0, 32.0, 62.0))
     workflow_states = iter(
         (
-            (False, ("1:in_progress",)),
-            (False, ("1:in_progress",)),
-            (True, ("1:completed",)),
-            (True, ("1:completed",)),
+            (False, ("1:in_progress",), ("CI",)),
+            (False, ("1:in_progress",), ("CI",)),
+            (True, ("1:completed",), ("CI",)),
+            (True, ("1:completed",), ("CI",)),
         )
     )
     monkeypatch.setattr(
@@ -403,9 +405,10 @@ def test_wait_for_pr_checks_waits_for_late_check_in_running_workflow(
     assert result.failing_checks == ("tests",)
 
 
-def test_wait_for_pr_checks_resets_settle_for_late_second_workflow(
+def test_wait_for_pr_checks_waits_for_expected_workflow_after_settle_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    context = replace(_CONTEXT, expected_workflow_names=("CI", "Security"))
     late_failure = {
         "headRefOid": "new-sha",
         "statusCheckRollup": [
@@ -431,12 +434,12 @@ def test_wait_for_pr_checks_resets_settle_for_late_second_workflow(
     ]
     workflow_states = iter(
         (
-            (True, ("1:completed",)),
-            (True, ("1:completed",)),
-            (True, ("1:completed", "2:completed")),
-            (True, ("1:completed", "2:completed")),
-            (True, ("1:completed", "2:completed")),
-            (True, ("1:completed", "2:completed")),
+            (True, ("1:completed",), ("CI",)),
+            (True, ("1:completed",), ("CI",)),
+            (True, ("1:completed",), ("CI",)),
+            (False, ("1:completed", "2:in_progress"), ("CI", "Security")),
+            (True, ("1:completed", "2:completed"), ("CI", "Security")),
+            (True, ("1:completed", "2:completed"), ("CI", "Security")),
         )
     )
     elapsed = iter((0.0, 60.0, 89.0, 91.0, 120.0, 122.0, 152.0))
@@ -450,7 +453,7 @@ def test_wait_for_pr_checks_resets_settle_for_late_second_workflow(
         side_effect=responses,
     ):
         result = wait_for_pr_checks(
-            _CONTEXT,
+            context,
             github_token="tok",
             expected_head_sha="new-sha",
             registration_seconds=60,
@@ -463,7 +466,11 @@ def test_wait_for_pr_checks_resets_settle_for_late_second_workflow(
     assert result.failing_checks == ("security",)
 
 
-def test_wait_for_pr_checks_registration_grace_catches_late_external_check() -> None:
+def test_wait_for_pr_checks_waits_for_late_expected_external_check() -> None:
+    context = replace(
+        _CONTEXT,
+        expected_external_check_names=("external security scan",),
+    )
     late_pending = {
         "headRefOid": "new-sha",
         "statusCheckRollup": [
@@ -496,19 +503,20 @@ def test_wait_for_pr_checks_registration_grace_catches_late_external_check() -> 
     }
     responses = [
         _rollup(sha="new-sha", name="quality", conclusion="SUCCESS", status="COMPLETED"),
+        _rollup(sha="new-sha", name="quality", conclusion="SUCCESS", status="COMPLETED"),
+        _rollup(sha="new-sha", name="quality", conclusion="SUCCESS", status="COMPLETED"),
         late_pending,
         late_failure,
         late_failure,
-        late_failure,
     ]
-    elapsed = iter((0.0, 0.0, 31.0, 40.0, 70.0, 100.0))
+    elapsed = iter((0.0, 0.0, 61.0, 91.0, 100.0, 110.0, 140.0))
 
     with patch(
         "integrations.github.tools.ci_fix.verification.run_gh_json",
         side_effect=responses,
     ):
         result = wait_for_pr_checks(
-            _CONTEXT,
+            context,
             github_token="tok",
             expected_head_sha="new-sha",
             registration_seconds=60,


### PR DESCRIPTION
Follow-up to #5032

#### Describe the changes you have made in this PR -

- Capture all workflow names and external check identities visible on the pre-fix PR head.
- Require those baseline identities to re-register on the exact pushed commit before verification can settle.
- Keep individual workflow jobs conditional, so an absent sibling job does not cause a false timeout.
- Describe a successful result as the pushed commit's observed checks rather than claiming unknown future checks passed.

### Demo/Screenshot for feature changes and bug fixes - 

Focused GitHub-tool suite:

```text
collected 215 items
215 passed
```

The regression tests hold the verifier open beyond its former success deadline when:

```text
known second workflow registers late -> verifier waits and reports its failure
known external check registers late  -> verifier waits and reports its failure
conditional sibling job is absent    -> verifier still settles normally
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

GitHub does not expose a definitive “all checks have registered” event. #5032 therefore combined a registration window with a stable exact-commit signature, but it only required the originally failing external check and any one Actions run. A known workflow or successful external check from the pre-fix head could still arrive after that window.

The context gatherer now catalogs baseline workflow names and external check identities before applying the fix. Verification requires those identities on the pushed SHA in addition to the registration and settlement windows. It intentionally tracks workflows rather than every job name because workflow conditions can legitimately omit sibling jobs on the fix commit. Newly applicable checks remain covered by the registration/stability window, and the response explicitly describes the resulting verdict as observed rather than unbounded.

I considered requiring every old check name, but that would turn conditional job changes into false timeouts. Workflow-level identity plus external-check identity is the narrow fail-closed contract that preserves conditional-job behavior.

Validation:

- `make lint`
- `make format-check`
- `make typecheck`
- Scoped GitHub tool tests: 215 passed

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and understand how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
