### PR TITLE
refactor(harness): HeadlessAgent enforces one turn at a time (AgentBusyError); headless_agent.py, public-first method order, shell seams own their adapters

### DIFF
--- a/bootstrap/process.py
+++ b/bootstrap/process.py
@@ -7,7 +7,7 @@ and a profile cannot invent a different sequence.
 Does **not** configure gateway or CLI logging — that stays with the surface
 composition root (``GatewayController.configure_logging``, CLI stderr).
 
-Does **not** construct :class:`~core.agent_harness.turns.headless_dispatch.HeadlessAgent`
+Does **not** construct :class:`~core.agent_harness.turns.headless_agent.HeadlessAgent`
 or run turns — that is ``DefaultPorts.agent`` /
 :class:`~core.agent_harness.harness.AgentSession` after boot. Bootstrap and
 headless construction are separate layers, not duplicated stacks.

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -5,7 +5,7 @@ tool-calling loop (`core.agent.Agent` via `build_agent`) and the direct-answer
 path (`stream_answer` via the `StreamAnswerFn` seam in `ports.py`, no tools).
 It was extracted out of `interactive_shell` so the same harness can run the
 interactive terminal and be invoked headlessly via
-`agent_harness.turns.headless_dispatch`.
+`agent_harness.turns.headless_agent`.
 
 ## Host API (teach this)
 
@@ -151,7 +151,7 @@ subpackage. Default port implementations live with the concern they serve, not i
   - `evidence_driver.py` — bounded evidence-gather loop, via a
     `_build_evidence_agent` factory that returns an `AgentConfig` handed to
     `build_agent`.
-  - `headless_dispatch.py` — headless programmatic entry point
+  - `headless_agent.py` — headless programmatic entry point
     (`HeadlessAgent`, built by a port family; `.handle(text, binding)` per message, `.dispatch` underneath)
     plus in-memory port adapters for
     API / test runs. `tools` is required — surfaces that want a text-only
@@ -211,7 +211,7 @@ to it instead of re-implementing bootstrap + persistence:
   :meth:`AgentSession.run_headless_turn` (or ``start`` + ``chat``).
   That is the same ``run_turn`` engine as the shell; do not reassemble
   ``BufferOutputSink`` + ``DefaultPorts`` in integrations.
-  Ephemeral in-memory sessions (``headless_dispatch.InMemorySessionState``)
+  Ephemeral in-memory sessions (``headless_adapters.InMemorySessionState``)
   bypass ``SessionManager`` by design when tests need no JSONL.
 
 `Session` (formerly `ReplSession`) is the in-memory session object used by every

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -1,35 +1,26 @@
-"""``AgentSession`` — the public host API for chat and investigation.
+"""``AgentSession`` — the embedder's entry point for chat and investigation.
 
-Every surface (shell, gateway, embedder, CLI, web) talks to the agent through
-this module. Chat turns terminate at ``dispatch_chat_turn``; investigations use
-the installed payload runner (wired at process boot). Session lifecycle
-(create / resolve / rotate / restore) belongs to
-:class:`~core.agent_harness.session.lifecycle.SessionManager`; the session API
-sits one layer above and adds env resolution and prompt context.
+Create the session, attach an agent, run turns::
 
-Construct **one** agent per logical session, then many turns::
-
-    session = AgentSession.start(config)  # or attach_agent(custom_headless)
+    session = AgentSession.start(config)  # builds the default agent
     result = session.chat("…")            # turn 1
     follow = session.chat("…")            # turn 2 — same attached agent
-    report = session.investigate({…})     # Path-2 (no attached chat agent required)
+    report = session.investigate({…})     # needs no attached chat agent
 
-Embedded scripts that need local adapters: ``bootstrap.embedded.start_embedded_session``.
+Embedded scripts that need local adapters use
+``bootstrap.embedded.start_embedded_session``. Scheduled one-shots may use
+:meth:`AgentSession.run_headless_turn`; a loop keeps one agent for the loop.
 
-Custom ports (live gateway sink, REPL)::
+A host with its own ports (the gateway pool, the REPL) builds the agent through
+:class:`~core.agent_harness.turns.port_families.DefaultPorts` and drives it
+with :meth:`HeadlessAgent.handle` per message; it may still attach it here to
+use :meth:`chat` and :meth:`investigate`.
 
-    session = AgentSession(SessionConfig(load_env=False))
-    session.startup()
-    session.attach_agent(DefaultPorts(session=…, output=sink).agent(tools=…))
-    session.chat(text)                   # reuse the same agent across messages
-
-Gateway chat reuses one ``HeadlessAgent`` per session via ``SessionAgentPool``
-(``bind_turn`` each message). Scheduled **one-shots** may use
-:meth:`run_headless_turn`; multi-turn loops should keep one agent for the loop.
-There is no ``dispatch_message_to_headless_agent`` free function.
-
-Must not import ``surfaces.interactive_shell``. Surfaces inject prompt
-context through :class:`SessionConfig`.
+Session lifecycle (create / resolve / rotate / restore) belongs to
+:class:`~core.agent_harness.session.lifecycle.SessionManager`; this module adds
+env resolution and prompt context on top. Must not import
+``surfaces.interactive_shell``; surfaces inject prompt context through
+:class:`SessionConfig`.
 """
 
 from __future__ import annotations
@@ -120,86 +111,6 @@ class AgentSession:
         self._agent: ChatDispatcher | None = None
         self._bound_session: SessionCore | None = None
 
-    def _resolve_env_variables(self) -> None:
-        """Load local OpenSRE env defaults into the process, once.
-
-        Delegates to :func:`config.local_env.bootstrap_opensre_env_once` so CLI,
-        gateway, and web share one path (project ``.env`` + wizard defaults).
-        ``override=False``: a variable already set in the real environment wins.
-        """
-        if self._config.load_env:
-            from config.local_env import bootstrap_opensre_env_once
-
-            bootstrap_opensre_env_once(override=False)
-
-    def _load_or_create_session(self) -> SessionCore:
-        """Resume a persisted session if ``session_id`` was given, else create one.
-
-        Delegates entirely to :class:`SessionManager` — this method does not
-        duplicate its bootstrap/restore logic, it just picks which lifecycle
-        call to make based on whether the surface is resuming.
-        """
-        manager = self._session_manager
-        if self._config.session_id:
-            # SessionManager.resolve()'s own default is True: a resumed
-            # session needs tools ready immediately.
-            warm = (
-                True if self._config.warm_integrations is None else self._config.warm_integrations
-            )
-            return manager.resolve(
-                self._config.session_id,
-                hydrate_integrations=self._config.hydrate_integrations,
-                warm_integrations=warm,
-                persistent_tasks=self._config.persistent_tasks,
-            )
-        # SessionManager.create()'s own default is False: a fresh session can
-        # warm lazily on first turn.
-        warm = False if self._config.warm_integrations is None else self._config.warm_integrations
-        return manager.create(
-            hydrate_integrations=self._config.hydrate_integrations,
-            warm_integrations=warm,
-            persistent_tasks=self._config.persistent_tasks,
-            open_store=self._config.open_store,
-        )
-
-    def resolve_integrations(self, session: SessionCore) -> dict[str, Any]:
-        """Return resolved integration configs for ``session``."""
-        from core.agent_harness.session.integration_resolution import resolve_and_cache_integrations
-
-        return resolve_and_cache_integrations(session)
-
-    def _load_context(self) -> PromptContextProvider | None:
-        """Return the surface's grounding-context provider, if any."""
-        return self._config.prompts
-
-    def _attach_default_headless(
-        self,
-        *,
-        session: SessionCore,
-        output: OutputSink,
-        prompts: PromptContextProvider | None,
-        tools: ToolProvider | None = None,
-        gather: GatherPorts | None = None,
-        console: Any | None = None,
-        logger: logging.Logger | None = None,
-        surface: str | None = None,
-        is_tty: bool | None = None,
-    ) -> None:
-        """Attach the agent built on the default port family (one construction recipe).
-
-        Used by :meth:`start` and :meth:`run_headless_turn`. Custom hosts
-        (gateway pool, REPL) build through :class:`DefaultPorts` themselves and
-        call :meth:`attach_agent` — they must not re-copy this wiring ad hoc.
-        """
-        from core.agent_harness.ports import TurnBinding
-        from core.agent_harness.turns.port_families import DefaultPorts
-
-        agent = DefaultPorts(
-            session=session, output=output, console=console, logger=logger, surface=surface
-        ).agent(tools=tools, prompts=prompts, gather=gather)
-        agent.bind_turn(TurnBinding(is_tty=is_tty))
-        self.attach_agent(agent)
-
     @classmethod
     def start(
         cls,
@@ -288,11 +199,6 @@ class AgentSession:
             is_tty=is_tty,
         ).chat(message)
 
-    @property
-    def agent(self) -> ChatDispatcher | None:
-        """The attached chat dispatcher, if one has been bound."""
-        return self._agent
-
     def startup(self) -> SessionStartupResult:
         """Run process boot (optional), env, session bootstrap/resume, and context.
 
@@ -313,6 +219,11 @@ class AgentSession:
     def attach_agent(self, agent: ChatDispatcher) -> None:
         """Bind a chat dispatcher for :meth:`chat` reuse."""
         self._agent = agent
+
+    @property
+    def agent(self) -> ChatDispatcher | None:
+        """The attached chat dispatcher, if one has been bound."""
+        return self._agent
 
     def chat(
         self,
@@ -389,6 +300,86 @@ class AgentSession:
             opensre_evaluate=opensre_evaluate,
             investigation_metadata=investigation_metadata,
         )
+
+    def resolve_integrations(self, session: SessionCore) -> dict[str, Any]:
+        """Return resolved integration configs for ``session``."""
+        from core.agent_harness.session.integration_resolution import resolve_and_cache_integrations
+
+        return resolve_and_cache_integrations(session)
+
+    def _attach_default_headless(
+        self,
+        *,
+        session: SessionCore,
+        output: OutputSink,
+        prompts: PromptContextProvider | None,
+        tools: ToolProvider | None = None,
+        gather: GatherPorts | None = None,
+        console: Any | None = None,
+        logger: logging.Logger | None = None,
+        surface: str | None = None,
+        is_tty: bool | None = None,
+    ) -> None:
+        """Attach the agent built on the default port family (one construction recipe).
+
+        Used by :meth:`start` and :meth:`run_headless_turn`. Custom hosts
+        (gateway pool, REPL) build through :class:`DefaultPorts` themselves and
+        call :meth:`attach_agent` — they must not re-copy this wiring ad hoc.
+        """
+        from core.agent_harness.ports import TurnBinding
+        from core.agent_harness.turns.port_families import DefaultPorts
+
+        agent = DefaultPorts(
+            session=session, output=output, console=console, logger=logger, surface=surface
+        ).agent(tools=tools, prompts=prompts, gather=gather)
+        agent.bind_turn(TurnBinding(is_tty=is_tty))
+        self.attach_agent(agent)
+
+    def _resolve_env_variables(self) -> None:
+        """Load local OpenSRE env defaults into the process, once.
+
+        Delegates to :func:`config.local_env.bootstrap_opensre_env_once` so CLI,
+        gateway, and web share one path (project ``.env`` + wizard defaults).
+        ``override=False``: a variable already set in the real environment wins.
+        """
+        if self._config.load_env:
+            from config.local_env import bootstrap_opensre_env_once
+
+            bootstrap_opensre_env_once(override=False)
+
+    def _load_or_create_session(self) -> SessionCore:
+        """Resume a persisted session if ``session_id`` was given, else create one.
+
+        Delegates entirely to :class:`SessionManager` — this method does not
+        duplicate its bootstrap/restore logic, it just picks which lifecycle
+        call to make based on whether the surface is resuming.
+        """
+        manager = self._session_manager
+        if self._config.session_id:
+            # SessionManager.resolve()'s own default is True: a resumed
+            # session needs tools ready immediately.
+            warm = (
+                True if self._config.warm_integrations is None else self._config.warm_integrations
+            )
+            return manager.resolve(
+                self._config.session_id,
+                hydrate_integrations=self._config.hydrate_integrations,
+                warm_integrations=warm,
+                persistent_tasks=self._config.persistent_tasks,
+            )
+        # SessionManager.create()'s own default is False: a fresh session can
+        # warm lazily on first turn.
+        warm = False if self._config.warm_integrations is None else self._config.warm_integrations
+        return manager.create(
+            hydrate_integrations=self._config.hydrate_integrations,
+            warm_integrations=warm,
+            persistent_tasks=self._config.persistent_tasks,
+            open_store=self._config.open_store,
+        )
+
+    def _load_context(self) -> PromptContextProvider | None:
+        """Return the surface's grounding-context provider, if any."""
+        return self._config.prompts
 
 
 __all__ = [

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -3,7 +3,7 @@
 These are the seams that keep ``agent/`` decoupled from any concrete surface.
 The interactive shell implements them as adapters over its ``Session``,
 Rich console, tool registry, and grounding caches; the headless adapters in
-:mod:`core.agent_harness.turns.headless_dispatch` implement minimal in-memory versions for API / test runs.
+:mod:`core.agent_harness.turns.headless_agent` implement minimal in-memory versions for API / test runs.
 
 Nothing here imports ``interactive_shell``.
 """

--- a/core/agent_harness/runtime.py
+++ b/core/agent_harness/runtime.py
@@ -14,12 +14,13 @@ from core.agent_harness.ports import TurnBinding
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import ActionTurnRunner
 from core.agent_harness.turns.gather_ports import GatherPorts
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.headless_agent import AgentBusyError, HeadlessAgent
 from core.agent_harness.turns.port_families import DefaultPorts, HeadlessPorts
 from core.agent_harness.turns.turn_plan import TurnPlan
 
 __all__ = [
     "ActionTurnRunner",
+    "AgentBusyError",
     "DefaultPorts",
     "DefaultToolProvider",
     "GatherPorts",

--- a/core/agent_harness/turns/headless_agent.py
+++ b/core/agent_harness/turns/headless_agent.py
@@ -1,34 +1,24 @@
-"""Headless programmatic entry point and in-memory port adapters.
+"""The agent a host runs turns on.
 
-This is the proof that the agent is decoupled from any terminal: a caller (an
-HTTP handler, a script, a test) can run a full turn with only a message. All the
-surface concerns are satisfied by the in-memory adapters below, but every
-dependency is injectable so a real surface can override any of them.
+Built by a port family (:mod:`core.agent_harness.turns.port_families`), then
+driven one message at a time::
 
-Example::
+    from core.agent_harness.runtime import HeadlessPorts, TurnBinding
+    from core.agent_harness.turns.headless_adapters import NullToolProvider
 
-    from core.agent_harness.turns.headless_dispatch import (
-        HeadlessAgent,
-        InMemorySessionState,
-        NullToolProvider,
-        StaticReasoningClientProvider,
-    )
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
+    result = agent.handle("hi there", TurnBinding())
+    print(result.primary_response_text)
 
-    class _Echo:
-        def invoke_stream(self, prompt):
-            yield "hello"
-
-    agent = HeadlessAgent(
-        tools=NullToolProvider(),
-        reasoning=StaticReasoningClientProvider(client=_Echo()),
-    )
-    result = agent.dispatch("hi there")
-    print(result.assistant_response_text)  # -> "hello"
+A host with real ports uses ``DefaultPorts`` the same way; the gateway and the
+interactive shell are both that program.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import replace
 
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
@@ -59,22 +49,21 @@ from core.agent_harness.turns.chat_api import ChatTurnBindings, dispatch_chat_tu
 from core.agent_harness.turns.evidence_driver import gather_tool_evidence
 from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.gather_ports import GatherPorts
-from core.agent_harness.turns.headless_adapters import (
-    BufferOutputSink,
-    EmptyPromptContextProvider,
-    InMemorySessionState,
-    NoopErrorReporter,
-    NoopTurnAccounting,
-    NullToolProvider,
-    SimpleRunRecord,
-    SimpleRunRecordFactory,
-    StaticReasoningClientProvider,
-)
+from core.agent_harness.turns.headless_adapters import NoopTurnAccounting
 from core.agent_harness.turns.host_cancel import host_cancel_requested
 from core.agent_harness.turns.orchestrator import stream_answer
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.execution import ToolExecutionHooks
+
+
+class AgentBusyError(RuntimeError):
+    """A second turn was started on an agent that is still handling one.
+
+    One agent serves one turn at a time: ``bind_turn`` mutates per-turn state,
+    so an overlapping turn would read another conversation's binding. Hosts
+    that pool agents hold one per logical session and serialize its turns.
+    """
 
 
 class HeadlessAgent:
@@ -89,7 +78,9 @@ class HeadlessAgent:
     Per message a host calls :meth:`handle` with a :class:`TurnBinding`; it
     binds the turn, dispatches, and continues while a session goal is
     attached. :meth:`dispatch` is the single-turn verb underneath; whole-stage
-    replacements for tests go through :meth:`bind_stages`.
+    replacements for tests go through :meth:`bind_stages`. One agent serves
+    one turn at a time — an overlapping :meth:`handle` or :meth:`dispatch`
+    raises :class:`AgentBusyError`.
     """
 
     def __init__(
@@ -122,44 +113,64 @@ class HeadlessAgent:
         self._execute_actions_override: ExecuteActions | None = None
         self._answer_override: StreamAnswerFn | None = None
         self._gather_override: EvidenceGatherer | None = None
+        # Reentrant so handle() may call dispatch() on the same thread; a second
+        # thread fails the non-blocking acquire and gets AgentBusyError.
+        self._turn_lock = threading.RLock()
         self._action_runner = self._new_action_runner()
 
-    def _new_action_runner(self) -> ActionTurnRunner:
-        return ActionTurnRunner(
-            output=self._output,
-            tools=self._tools,
-            llm_factory=self._llm_factory,
-            error_reporter=self._error_reporter,
-            tool_hooks=self._tool_hooks,
-        )
+    def handle(
+        self,
+        text: str,
+        binding: TurnBinding,
+        *,
+        accounting_factory: Callable[[str], TurnAccounting] | None = None,
+        cancel_requested: Callable[[], bool] | None = None,
+        on_progress: Callable[[SessionGoal], None] | None = None,
+    ) -> TurnResult:
+        """Handle one inbound message: bind the turn, dispatch, continue while a session goal is attached.
 
-    def _ports(self) -> tuple[object, ...]:
-        """Every port this agent holds; rebinding asks each for the capability it needs."""
-        return (
-            self._tools,
-            self._prompts,
-            self._reasoning,
-            self._run_factory,
-            self._error_reporter,
-            self._gather_ports.on_progress,
-            self._gather_ports.persist,
-        )
-
-    def bind_session(self, session: SessionState) -> None:
-        """Retarget this agent at a freshly resolved session.
-
-        Gateway ``SessionManager.resolve`` returns a new ``SessionCore`` each
-        turn (same id, restored state). Cached agents must follow that object
-        so tools/prompts see current integrations and chat metadata.
-
-        Every port that implements :class:`~core.agent_harness.ports.SessionBindable`
-        is rebound; a session-aware port that lacks the protocol is a type/test
-        gap, not a runtime miss.
+        The one host loop — gateway and shell call this and nothing else per
+        message. ``binding`` states the whole turn; ``accounting_factory``
+        (message → accounting) is applied per outer turn because the goal loop
+        may dispatch several, each with different text; ``None`` uses the
+        default per-message accounting. ``cancel_requested`` is checked between
+        outer turns; ``on_progress`` receives the goal after each.
         """
-        self._session = session
-        for port in self._ports():
-            if isinstance(port, SessionBindable):
-                port.bind_session(session)
+
+        def _one_turn(message: str) -> TurnResult:
+            accounting = accounting_factory(message) if accounting_factory is not None else None
+            self.bind_turn(replace(binding, accounting=accounting))
+            return self.dispatch(message)
+
+        # The goal loop reads and writes goal state on the session this turn
+        # states, not on whatever the previous binding left behind.
+        session = binding.session if binding.session is not None else self._session
+        with self._one_turn_at_a_time():
+            return run_until_session_goal(
+                _one_turn,
+                session,
+                text,
+                cancel_requested=cancel_requested,
+                on_progress=on_progress,
+            ).last_result
+
+    def dispatch(self, message: str) -> TurnResult:
+        """Run one turn for ``message`` on the currently bound turn (see :meth:`handle`)."""
+        with self._one_turn_at_a_time():
+            return dispatch_chat_turn(
+                message,
+                self._session,
+                ChatTurnBindings(
+                    execute_actions=self._execute_actions_override or self._execute_actions,
+                    answer=self._answer_override or self._answer,
+                    gather=self._gather_override or self._gather,
+                    accounting=self._take_accounting(message),
+                    confirm_fn=self._confirm_fn,
+                    is_tty=self._is_tty,
+                    surface=self._prompts.surface(),
+                    output=self._output,
+                ),
+            )
 
     def bind_turn(self, binding: TurnBinding) -> None:
         """Bind the turn's ports and values; the whole binding replaces the previous one.
@@ -192,6 +203,47 @@ class HeadlessAgent:
         self._is_tty = binding.is_tty
         if runner_changed:
             self._action_runner = self._new_action_runner()
+
+    def bind_session(self, session: SessionState) -> None:
+        """Retarget this agent at a freshly resolved session.
+
+        Gateway ``SessionManager.resolve`` returns a new ``SessionCore`` each
+        turn (same id, restored state). Cached agents must follow that object
+        so tools/prompts see current integrations and chat metadata.
+
+        Every port that implements :class:`~core.agent_harness.ports.SessionBindable`
+        is rebound; a session-aware port that lacks the protocol is a type/test
+        gap, not a runtime miss.
+        """
+        self._session = session
+        for port in self._ports():
+            if isinstance(port, SessionBindable):
+                port.bind_session(session)
+
+    def bind_stages(
+        self,
+        *,
+        execute_actions: ExecuteActions | None = None,
+        answer: StreamAnswerFn | None = None,
+        gather_evidence: EvidenceGatherer | None = None,
+    ) -> None:
+        """Replace whole stages for the next dispatches; ``None`` restores the port-driven default.
+
+        The per-turn counterpart of the constructor's stage overrides, for a
+        long-lived agent that hosts many turns with different injected seams.
+        """
+        self._execute_actions_override = execute_actions
+        self._answer_override = answer
+        self._gather_override = gather_evidence
+
+    @contextmanager
+    def _one_turn_at_a_time(self) -> Iterator[None]:
+        if not self._turn_lock.acquire(blocking=False):
+            raise AgentBusyError("this agent is already handling a turn")
+        try:
+            yield
+        finally:
+            self._turn_lock.release()
 
     def _take_accounting(self, message: str) -> TurnAccounting:
         """Return turn accounting and clear the slot (consume-once).
@@ -255,84 +307,26 @@ class HeadlessAgent:
             is_cancelled=lambda: host_cancel_requested(self._output),
         )
 
-    def bind_stages(
-        self,
-        *,
-        execute_actions: ExecuteActions | None = None,
-        answer: StreamAnswerFn | None = None,
-        gather_evidence: EvidenceGatherer | None = None,
-    ) -> None:
-        """Replace whole stages for the next dispatches; ``None`` restores the port-driven default.
+    def _ports(self) -> tuple[object, ...]:
+        """Every port this agent holds; rebinding asks each for the capability it needs."""
+        return (
+            self._tools,
+            self._prompts,
+            self._reasoning,
+            self._run_factory,
+            self._error_reporter,
+            self._gather_ports.on_progress,
+            self._gather_ports.persist,
+        )
 
-        The per-turn counterpart of the constructor's stage overrides, for a
-        long-lived agent that hosts many turns with different injected seams.
-        """
-        self._execute_actions_override = execute_actions
-        self._answer_override = answer
-        self._gather_override = gather_evidence
-
-    def handle(
-        self,
-        text: str,
-        binding: TurnBinding,
-        *,
-        accounting_factory: Callable[[str], TurnAccounting] | None = None,
-        cancel_requested: Callable[[], bool] | None = None,
-        on_progress: Callable[[SessionGoal], None] | None = None,
-    ) -> TurnResult:
-        """Handle one inbound message: bind the turn, dispatch, continue while a session goal is attached.
-
-        The one host loop — gateway and shell call this and nothing else per
-        message. ``binding`` states the whole turn; ``accounting_factory``
-        (message → accounting) is applied per outer turn because the goal loop
-        may dispatch several, each with different text; ``None`` uses the
-        default per-message accounting. ``cancel_requested`` is checked between
-        outer turns; ``on_progress`` receives the goal after each.
-        """
-
-        def _one_turn(message: str) -> TurnResult:
-            accounting = accounting_factory(message) if accounting_factory is not None else None
-            self.bind_turn(replace(binding, accounting=accounting))
-            return self.dispatch(message)
-
-        # The goal loop reads and writes goal state on the session this turn
-        # states, not on whatever the previous binding left behind.
-        session = binding.session if binding.session is not None else self._session
-        return run_until_session_goal(
-            _one_turn,
-            session,
-            text,
-            cancel_requested=cancel_requested,
-            on_progress=on_progress,
-        ).last_result
-
-    def dispatch(self, message: str) -> TurnResult:
-        """Run one turn for ``message`` on the currently bound turn (see :meth:`handle`)."""
-        return dispatch_chat_turn(
-            message,
-            self._session,
-            ChatTurnBindings(
-                execute_actions=self._execute_actions_override or self._execute_actions,
-                answer=self._answer_override or self._answer,
-                gather=self._gather_override or self._gather,
-                accounting=self._take_accounting(message),
-                confirm_fn=self._confirm_fn,
-                is_tty=self._is_tty,
-                surface=self._prompts.surface(),
-                output=self._output,
-            ),
+    def _new_action_runner(self) -> ActionTurnRunner:
+        return ActionTurnRunner(
+            output=self._output,
+            tools=self._tools,
+            llm_factory=self._llm_factory,
+            error_reporter=self._error_reporter,
+            tool_hooks=self._tool_hooks,
         )
 
 
-__all__ = [
-    "BufferOutputSink",
-    "EmptyPromptContextProvider",
-    "HeadlessAgent",
-    "InMemorySessionState",
-    "NoopErrorReporter",
-    "NoopTurnAccounting",
-    "NullToolProvider",
-    "SimpleRunRecord",
-    "SimpleRunRecordFactory",
-    "StaticReasoningClientProvider",
-]
+__all__ = ["AgentBusyError", "HeadlessAgent"]

--- a/core/agent_harness/turns/port_families.py
+++ b/core/agent_harness/turns/port_families.py
@@ -54,7 +54,7 @@ from core.agent_harness.turns.headless_adapters import (
     SimpleRunRecordFactory,
     StaticReasoningClientProvider,
 )
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.headless_agent import HeadlessAgent
 
 if TYPE_CHECKING:
     from core.agent_harness.session.session_core import SessionCore

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -92,7 +92,7 @@ flat by surface (do not nest a directory named after the Discord PyPI package).
   (`configure_logging` in `GatewayController.start_gateway`) — that is intentional.
 - **No persistent gateway `Agent` instance.** Each inbound message gets a
   per-chat `Session` from `SessionResolver` and is handled by the shared
-  headless dispatch path (`core.agent_harness.turns.headless_dispatch`).
+  headless dispatch path (`core.agent_harness.turns.headless_agent`).
 - The turn handler callback signature is exactly four arguments: `text`,
   `session`, `sink`, and `logger`. Do not reintroduce `chat_id` into this
   contract; the sink owns chat transport details.

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -1,27 +1,21 @@
-"""Compose one interactive-shell turn on the harness's ``HeadlessAgent``.
+"""One interactive-shell turn: build (or reuse) the shell agent, then ``handle``.
 
-The shell builds its agent on the default port family with its own ports
-(prompt provider, console sink, error reporter, gather progress and
-persistence, tool-provider port factories) and drives the agent's own stages.
-Only a caller that injects a whole stage (``execute_actions`` /
-``gather_evidence`` / ``answer_agent`` — the test seams typed in
-``turn_seams``) gets an adapter bound over it.
+The shell's ports are supplied by ``shell_agent``; the agent's own stages run.
+A test that injects a whole stage (``execute_actions`` / ``gather_evidence`` /
+``answer_agent``) goes through the seams in ``turn_seams``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
 
 from rich.console import Console
 
 from core.agent_harness import (
     OutputSink,
-    ToolCallingTurnResult,
     TurnResult,
 )
-from core.agent_harness.ports import AnswerRequest, GatheredEvidence
-from core.agent_harness.runtime import HeadlessAgent, TurnBinding, TurnPlan
+from core.agent_harness.runtime import HeadlessAgent, TurnBinding
 from core.agent_harness.spi.cancel import host_cancel_requested
 from core.agent_harness.spi.session_goal import (
     SessionGoal,
@@ -35,109 +29,10 @@ from surfaces.interactive_shell.runtime.turn_seams import (
     AnswerShellQuestion,
     GatherEvidence,
     RunActionToolTurn,
+    bind_injected_stages,
 )
 from surfaces.interactive_shell.session import Session
-from surfaces.interactive_shell.utils.telemetry import LlmRunInfo, PromptRecorder
-
-
-@dataclass(frozen=True)
-class _InjectedActionStage:
-    """Adapts an injected ``RunActionToolTurn`` seam to the ``ExecuteActions`` protocol."""
-
-    seam: RunActionToolTurn
-    session: Session
-    console: Console
-    output: OutputSink
-    request_exit: Callable[[], None] | None
-    tool_hooks: ToolExecutionHooks | None
-
-    def execute_actions(
-        self,
-        text: str,
-        *,
-        confirm_fn: Callable[[str], str] | None = None,
-        is_tty: bool | None = None,
-        turn_plan: TurnPlan | None = None,
-    ) -> ToolCallingTurnResult:
-        return self.seam(
-            text,
-            self.session,
-            self.console,
-            confirm_fn=confirm_fn,
-            is_tty=is_tty,
-            request_exit=self.request_exit,
-            turn_plan=turn_plan,
-            output=self.output,
-            tool_hooks=self.tool_hooks,
-        )
-
-
-@dataclass(frozen=True)
-class _InjectedAnswerStage:
-    """Adapts an injected ``AnswerShellQuestion`` seam to the ``StreamAnswerFn`` protocol."""
-
-    seam: AnswerShellQuestion
-    session: Session
-    console: Console
-    output: OutputSink
-
-    def answer(self, text: str, request: AnswerRequest) -> LlmRunInfo | None:
-        return self.seam(text, self.session, self.console, output=self.output, request=request)
-
-
-@dataclass(frozen=True)
-class _InjectedGatherStage:
-    """Adapts an injected ``GatherEvidence`` seam to the ``EvidenceGatherer`` protocol."""
-
-    seam: GatherEvidence
-    session: Session
-    console: Console
-
-    def gather_evidence(
-        self, text: str, *, turn_plan: TurnPlan | None = None
-    ) -> str | GatheredEvidence | None:
-        resolved = turn_plan.resolved_integrations if turn_plan is not None else None
-        return self.seam(text, self.session, self.console, resolved_integrations=resolved)
-
-
-def _bind_injected_stages(
-    agent: HeadlessAgent,
-    session: Session,
-    console: Console,
-    output: OutputSink,
-    *,
-    execute_actions: RunActionToolTurn | None,
-    answer_agent: AnswerShellQuestion | None,
-    gather_evidence: GatherEvidence | None,
-    request_exit: Callable[[], None] | None,
-    tool_hooks: ToolExecutionHooks | None,
-) -> None:
-    """Bind an adapter over each injected seam (test-only); an omitted seam is the agent's own stage.
-
-    Stated whole per turn, like :class:`TurnBinding`: a stage injected on one
-    turn does not carry into the next, so a long-lived REPL agent never keeps
-    a test's fake stage by omission. A caller that wants a stage across turns
-    passes the seam on every call.
-    """
-    agent.bind_stages(
-        execute_actions=(
-            _InjectedActionStage(
-                execute_actions, session, console, output, request_exit, tool_hooks
-            ).execute_actions
-            if execute_actions is not None
-            else None
-        ),
-        answer=(
-            _InjectedAnswerStage(answer_agent, session, console, output).answer
-            if answer_agent is not None
-            else None
-        ),
-        gather_evidence=(
-            _InjectedGatherStage(gather_evidence, session, console).gather_evidence
-            if gather_evidence is not None
-            else None
-        ),
-    )
+from surfaces.interactive_shell.utils.telemetry import PromptRecorder
 
 
 def execute_shell_turn(
@@ -177,7 +72,7 @@ def execute_shell_turn(
         confirm_fn=confirm_fn,
         is_tty=is_tty,
     )
-    _bind_injected_stages(
+    bind_injected_stages(
         agent,
         session,
         console,

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -1,21 +1,22 @@
-"""Injection contracts for the interactive-shell turn seams.
+"""Test-injection seams for the interactive-shell turn.
 
-These protocols describe exactly what ``execute_shell_turn`` requires from the
-action / gather / answer adapters it composes, so an injected test double is
-checked at type-time rather than at runtime. The default adapters
-(``action_turn``, ``answer_turn``, ``integration_tool_gathering``) satisfy them.
+The three protocols are the shell-shaped callables a test may inject to replace
+a whole stage; the adapters bind one over the agent's ``ExecuteActions`` /
+``StreamAnswerFn`` / ``EvidenceGatherer`` protocols. In production nothing is
+injected and the agent's own stages run.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 from rich.console import Console
 
 from core.agent_harness import OutputSink, ToolCallingTurnResult
 from core.agent_harness.ports import AnswerRequest, GatheredEvidence
-from core.agent_harness.runtime import TurnPlan
+from core.agent_harness.runtime import HeadlessAgent, TurnPlan
 from core.execution import ToolExecutionHooks
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
@@ -73,8 +74,109 @@ class AnswerShellQuestion(Protocol):
         """Answer the question, returning the LLM run info or None."""
 
 
+@dataclass(frozen=True)
+class _InjectedActionStage:
+    """Adapts an injected ``RunActionToolTurn`` seam to the ``ExecuteActions`` protocol."""
+
+    seam: RunActionToolTurn
+    session: Session
+    console: Console
+    output: OutputSink
+    request_exit: Callable[[], None] | None
+    tool_hooks: ToolExecutionHooks | None
+
+    def execute_actions(
+        self,
+        text: str,
+        *,
+        confirm_fn: Callable[[str], str] | None = None,
+        is_tty: bool | None = None,
+        turn_plan: TurnPlan | None = None,
+    ) -> ToolCallingTurnResult:
+        return self.seam(
+            text,
+            self.session,
+            self.console,
+            confirm_fn=confirm_fn,
+            is_tty=is_tty,
+            request_exit=self.request_exit,
+            turn_plan=turn_plan,
+            output=self.output,
+            tool_hooks=self.tool_hooks,
+        )
+
+
+@dataclass(frozen=True)
+class _InjectedAnswerStage:
+    """Adapts an injected ``AnswerShellQuestion`` seam to the ``StreamAnswerFn`` protocol."""
+
+    seam: AnswerShellQuestion
+    session: Session
+    console: Console
+    output: OutputSink
+
+    def answer(self, text: str, request: AnswerRequest) -> LlmRunInfo | None:
+        return self.seam(text, self.session, self.console, output=self.output, request=request)
+
+
+@dataclass(frozen=True)
+class _InjectedGatherStage:
+    """Adapts an injected ``GatherEvidence`` seam to the ``EvidenceGatherer`` protocol."""
+
+    seam: GatherEvidence
+    session: Session
+    console: Console
+
+    def gather_evidence(
+        self, text: str, *, turn_plan: TurnPlan | None = None
+    ) -> str | GatheredEvidence | None:
+        resolved = turn_plan.resolved_integrations if turn_plan is not None else None
+        return self.seam(text, self.session, self.console, resolved_integrations=resolved)
+
+
+def bind_injected_stages(
+    agent: HeadlessAgent,
+    session: Session,
+    console: Console,
+    output: OutputSink,
+    *,
+    execute_actions: RunActionToolTurn | None,
+    answer_agent: AnswerShellQuestion | None,
+    gather_evidence: GatherEvidence | None,
+    request_exit: Callable[[], None] | None,
+    tool_hooks: ToolExecutionHooks | None,
+) -> None:
+    """Bind an adapter over each injected seam (test-only); an omitted seam is the agent's own stage.
+
+    Stated whole per turn, like :class:`TurnBinding`: a stage injected on one
+    turn does not carry into the next, so a long-lived REPL agent never keeps
+    a test's fake stage by omission. A caller that wants a stage across turns
+    passes the seam on every call.
+    """
+    agent.bind_stages(
+        execute_actions=(
+            _InjectedActionStage(
+                execute_actions, session, console, output, request_exit, tool_hooks
+            ).execute_actions
+            if execute_actions is not None
+            else None
+        ),
+        answer=(
+            _InjectedAnswerStage(answer_agent, session, console, output).answer
+            if answer_agent is not None
+            else None
+        ),
+        gather_evidence=(
+            _InjectedGatherStage(gather_evidence, session, console).gather_evidence
+            if gather_evidence is not None
+            else None
+        ),
+    )
+
+
 __all__ = [
     "AnswerShellQuestion",
     "GatherEvidence",
     "RunActionToolTurn",
+    "bind_injected_stages",
 ]

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -21,11 +21,8 @@ from core.agent_harness.session import InMemorySessionStore
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.default_reasoning_client import DefaultReasoningClientProvider
 from core.agent_harness.turns.gather_ports import GatherPorts
-from core.agent_harness.turns.headless_dispatch import (
-    BufferOutputSink,
-    HeadlessAgent,
-    NoopTurnAccounting,
-)
+from core.agent_harness.turns.headless_adapters import BufferOutputSink, NoopTurnAccounting
+from core.agent_harness.turns.headless_agent import HeadlessAgent
 from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import TurnResult
 from core.domain.types.tools import ToolSurface

--- a/tests/core/agent_harness/test_accounting_consume_once.py
+++ b/tests/core/agent_harness/test_accounting_consume_once.py
@@ -48,7 +48,7 @@ def _stub_dispatch(monkeypatch: Any) -> None:
         return bindings.accounting.finalize(_empty_result())
 
     monkeypatch.setattr(
-        "core.agent_harness.turns.headless_dispatch.dispatch_chat_turn",
+        "core.agent_harness.turns.headless_agent.dispatch_chat_turn",
         _dispatch,
     )
 

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -12,12 +12,15 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from core.agent_harness.runtime import ActionTurnRunner, TurnBinding
 from core.agent_harness.turns.headless_adapters import BufferOutputSink, NullToolProvider
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.headless_agent import HeadlessAgent
 from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.execution import ToolExecutionHooks
+from surfaces.interactive_shell.runtime.turn_seams import bind_injected_stages
 from surfaces.interactive_shell.session import Session
 
 
@@ -60,7 +63,7 @@ def test_action_turn_runner_run_accepts_confirm_fn(monkeypatch: Any) -> None:
     assert captured["is_tty"] is False
 
 
-def test_headless_dispatch_uses_bound_methods_not_nested_defs() -> None:
+def test_headless_agent_uses_bound_methods_not_nested_defs() -> None:
     source = inspect.getsource(HeadlessAgent.dispatch)
     assert "def execute_actions" not in source
     assert "def answer" not in source
@@ -121,7 +124,7 @@ def test_execute_shell_turn_adds_no_stage_of_its_own() -> None:
     assert "ShellActionRunner" not in source
 
     agent = build_shell_agent(Session(), Console(file=io.StringIO(), force_terminal=False))
-    ste._bind_injected_stages(  # noqa: SLF001
+    bind_injected_stages(
         agent,
         Session(),
         Console(file=io.StringIO()),
@@ -326,9 +329,8 @@ def test_a_stage_injected_on_one_turn_does_not_carry_into_the_next() -> None:
     assert agent._execute_actions_override is not None  # noqa: SLF001
 
     # Act — turn 2 omits the seam; bind only, do not dispatch (needs an LLM).
-    from surfaces.interactive_shell.runtime import shell_turn_execution as ste
 
-    ste._bind_injected_stages(  # noqa: SLF001
+    bind_injected_stages(
         agent,
         Session(),
         console,
@@ -411,7 +413,7 @@ def test_handle_runs_the_goal_loop_on_the_session_the_binding_states(monkeypatch
     loop the agent's *previous* session, goal state would be read from and
     written to a stale object.
     """
-    from core.agent_harness.turns import headless_dispatch
+    from core.agent_harness.turns import headless_agent
     from core.agent_harness.turns.headless_adapters import InMemorySessionState
     from core.agent_harness.turns.port_families import HeadlessPorts
 
@@ -421,7 +423,7 @@ def test_handle_runs_the_goal_loop_on_the_session_the_binding_states(monkeypatch
         seen["session"] = session
         return SimpleNamespace(last_result=chat(message))
 
-    monkeypatch.setattr(headless_dispatch, "run_until_session_goal", _spy_loop)
+    monkeypatch.setattr(headless_agent, "run_until_session_goal", _spy_loop)
     previous = InMemorySessionState()
     current = InMemorySessionState()
     agent = HeadlessPorts(session=previous).agent(tools=NullToolProvider())
@@ -432,3 +434,45 @@ def test_handle_runs_the_goal_loop_on_the_session_the_binding_states(monkeypatch
     agent.handle("hello", TurnBinding(session=current))
 
     assert seen["session"] is current
+
+
+def test_a_second_thread_cannot_start_a_turn_while_one_is_running() -> None:
+    """One agent serves one turn at a time; an overlapping turn raises, it does not interleave.
+
+    ``bind_turn`` mutates per-turn state, so two concurrent turns on one agent
+    would read each other's binding. The pool's per-session lock keeps this
+    from happening in the gateway; the agent now enforces it itself.
+    """
+    import threading
+
+    from core.agent_harness.runtime import AgentBusyError
+    from core.agent_harness.turns.port_families import HeadlessPorts
+
+    # Arrange — an action stage that blocks until the test releases it.
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _blocking_execute(text: str, **_kw: Any) -> ToolCallingTurnResult:
+        entered.set()
+        release.wait(timeout=5)
+        return ToolCallingTurnResult(0, 0, 0, False, True)
+
+    agent = HeadlessPorts().agent(tools=NullToolProvider())
+    agent.bind_stages(execute_actions=_blocking_execute)
+    first = threading.Thread(target=agent.handle, args=("one", TurnBinding()))
+
+    # Act — start turn one, then try turn two while it is mid-flight.
+    first.start()
+    assert entered.wait(timeout=5)
+    try:
+        with pytest.raises(AgentBusyError):
+            agent.handle("two", TurnBinding())
+        with pytest.raises(AgentBusyError):
+            agent.dispatch("two")
+    finally:
+        release.set()
+        first.join(timeout=5)
+
+    # Assert — once turn one finished, the agent takes a turn again.
+    agent.bind_stages(execute_actions=lambda _t, **_k: ToolCallingTurnResult(0, 0, 0, False, True))
+    assert agent.handle("three", TurnBinding()) is not None

--- a/tests/core/agent_harness/test_agent_shapes.py
+++ b/tests/core/agent_harness/test_agent_shapes.py
@@ -8,7 +8,7 @@ from typing import get_type_hints
 from core.agent import Agent
 from core.agent_harness.ports import ExecuteActions, StreamAnswerFn
 from core.agent_harness.turns.headless_adapters import NullToolProvider
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.headless_agent import HeadlessAgent
 from core.agent_harness.turns.orchestrator import run_turn, stream_answer
 from core.agent_harness.turns.port_families import HeadlessPorts
 

--- a/tests/core/agent_harness/test_chat_api.py
+++ b/tests/core/agent_harness/test_chat_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.turns.chat_api import ChatTurnBindings, dispatch_chat_turn
-from core.agent_harness.turns.headless_dispatch import NullToolProvider
+from core.agent_harness.turns.headless_adapters import NullToolProvider
 from core.agent_harness.turns.port_families import HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
@@ -104,7 +104,7 @@ def test_headless_agent_dispatch_uses_dispatch_chat_turn(monkeypatch: Any) -> No
         return expected
 
     monkeypatch.setattr(
-        "core.agent_harness.turns.headless_dispatch.dispatch_chat_turn",
+        "core.agent_harness.turns.headless_agent.dispatch_chat_turn",
         _fake_dispatch,
     )
 

--- a/tests/core/agent_harness/test_chat_turns.py
+++ b/tests/core/agent_harness/test_chat_turns.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.agent_harness.harness import AgentSession, SessionConfig
 from core.agent_harness.runtime import TurnBinding
-from core.agent_harness.turns.headless_dispatch import (
+from core.agent_harness.turns.headless_adapters import (
     NullToolProvider,
     StaticReasoningClientProvider,
 )

--- a/tests/core/agent_harness/test_developer_agent_api.py
+++ b/tests/core/agent_harness/test_developer_agent_api.py
@@ -23,7 +23,7 @@ from core.agent_harness.turns.headless_adapters import (
     NullToolProvider,
     StaticReasoningClientProvider,
 )
-from core.agent_harness.turns.headless_dispatch import HeadlessAgent
+from core.agent_harness.turns.headless_agent import HeadlessAgent
 from core.agent_harness.turns.port_families import DefaultPorts, HeadlessPorts
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
@@ -99,7 +99,7 @@ def _unhandled_actions(*_args: Any, **_kwargs: Any) -> ToolCallingTurnResult:
 def stub_action_planner(monkeypatch: Any) -> None:
     """Keep the action planner off the network so Echo can answer."""
     monkeypatch.setattr(
-        "core.agent_harness.turns.headless_dispatch.ActionTurnRunner.run",
+        "core.agent_harness.turns.headless_agent.ActionTurnRunner.run",
         lambda _self, *_args, **_kwargs: _unhandled_actions(),
     )
 

--- a/tests/core/agent_harness/test_gather_ports.py
+++ b/tests/core/agent_harness/test_gather_ports.py
@@ -55,7 +55,7 @@ class TestAgentForwardsThePorts:
     def test_progress_and_persist_reach_the_gather_phase(self, monkeypatch) -> None:
         # Arrange: a REPL supplies both so the user sees live tool lines and the
         # calls land in session history.
-        from core.agent_harness.turns import headless_dispatch
+        from core.agent_harness.turns import headless_adapters, headless_agent
 
         seen: dict[str, Any] = {}
 
@@ -63,7 +63,7 @@ class TestAgentForwardsThePorts:
             seen.update(kwargs)
             return "evidence"
 
-        monkeypatch.setattr(headless_dispatch, "gather_tool_evidence", _fake_gather)
+        monkeypatch.setattr(headless_agent, "gather_tool_evidence", _fake_gather)
 
         def _on_progress(_kind: str, _data: dict[str, Any]) -> None:
             return None
@@ -71,8 +71,8 @@ class TestAgentForwardsThePorts:
         def _persist(_executed: list[tuple[Any, Any]]) -> None:
             return None
 
-        agent = HeadlessPorts(session=headless_dispatch.InMemorySessionState()).agent(
-            tools=headless_dispatch.NullToolProvider(),
+        agent = HeadlessPorts(session=headless_adapters.InMemorySessionState()).agent(
+            tools=headless_adapters.NullToolProvider(),
             gather=GatherPorts(on_progress=_on_progress, persist=_persist, max_iterations=9),
         )
 
@@ -87,15 +87,15 @@ class TestAgentForwardsThePorts:
 
     def test_disabled_ports_skip_the_phase_entirely(self, monkeypatch) -> None:
         # Arrange
-        from core.agent_harness.turns import headless_dispatch
+        from core.agent_harness.turns import headless_adapters, headless_agent
 
         def _never(*_args: Any, **_kwargs: Any) -> str | None:
             raise AssertionError("gather ran while disabled")
 
-        monkeypatch.setattr(headless_dispatch, "gather_tool_evidence", _never)
+        monkeypatch.setattr(headless_agent, "gather_tool_evidence", _never)
 
-        agent = HeadlessPorts(session=headless_dispatch.InMemorySessionState()).agent(
-            tools=headless_dispatch.NullToolProvider(),
+        agent = HeadlessPorts(session=headless_adapters.InMemorySessionState()).agent(
+            tools=headless_adapters.NullToolProvider(),
             gather=GatherPorts(enabled=False),
         )
 

--- a/tests/core/agent_harness/test_public_api.py
+++ b/tests/core/agent_harness/test_public_api.py
@@ -136,6 +136,7 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
 RUNTIME = frozenset(
     {
         "ActionTurnRunner",
+        "AgentBusyError",
         "DefaultPorts",
         "DefaultToolProvider",
         "GatherPorts",

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -131,7 +131,7 @@ def _agent(
     )
 
 
-def test_agent_exposes_headless_dispatch_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_agent_exposes_headless_agent_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
     class EchoReasoningClient:
         def invoke_stream(self, _prompt: str) -> Iterator[str]:
             yield "hello from headless"
@@ -141,7 +141,7 @@ def test_agent_exposes_headless_dispatch_entrypoint(monkeypatch: pytest.MonkeyPa
         lambda: FakeLLM(iter([AgentLLMResponse(content="", tool_calls=[], raw_content=None)])),
     )
 
-    from core.agent_harness.turns.headless_dispatch import (
+    from core.agent_harness.turns.headless_adapters import (
         NullToolProvider,
         StaticReasoningClientProvider,
     )
@@ -165,7 +165,7 @@ def test_one_headless_agent_dispatches_multiple_messages(monkeypatch: pytest.Mon
         "core.agent_harness.turns.action_driver.default_llm_factory",
         lambda: FakeLLM(iter([AgentLLMResponse(content="", tool_calls=[], raw_content=None)])),
     )
-    from core.agent_harness.turns.headless_dispatch import (
+    from core.agent_harness.turns.headless_adapters import (
         NullToolProvider,
         StaticReasoningClientProvider,
     )
@@ -184,7 +184,7 @@ def test_one_headless_agent_dispatches_multiple_messages(monkeypatch: pytest.Mon
 
 def test_provided_accounting_is_consumed_once() -> None:
     """Bound accounting is take-once — hosts must rebind per message."""
-    from core.agent_harness.turns.headless_dispatch import NoopTurnAccounting, NullToolProvider
+    from core.agent_harness.turns.headless_adapters import NoopTurnAccounting, NullToolProvider
 
     accounting = NoopTurnAccounting()
     agent = HeadlessPorts().agent(tools=NullToolProvider())
@@ -196,7 +196,7 @@ def test_provided_accounting_is_consumed_once() -> None:
 
 def test_default_accounting_is_resolved_fresh_per_message() -> None:
     from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
-    from core.agent_harness.turns.headless_dispatch import InMemorySessionState, NullToolProvider
+    from core.agent_harness.turns.headless_adapters import InMemorySessionState, NullToolProvider
 
     class _PersistentState(InMemorySessionState):
         store = object()  # persistent-backed session selects DefaultTurnAccounting

--- a/tests/interactive_shell/test_remote_sync_cmds.py
+++ b/tests/interactive_shell/test_remote_sync_cmds.py
@@ -275,7 +275,7 @@ def test_help_section_includes_remote_sync() -> None:
     assert "/remote-sync" in {c.name for c in sections["Remote sync"]}
 
 
-def test_repl_and_headless_dispatch_same_command_object() -> None:
+def test_repl_and_headless_agent_same_command_object() -> None:
     """Gateway headless ports must not register a fork of /remote-sync."""
     from surfaces.interactive_shell.runtime.slash_adapter import repl_slash_ports
 


### PR DESCRIPTION
Follow-up to #5036. Two things: the agent now owns its last invariant that was held by discipline elsewhere, and a readability pass over the harness core files so a cold reader meets the public API first and every docstring is true.

**1. One turn at a time, enforced by the agent**
`HeadlessAgent.bind_turn` mutates per-turn state, so two overlapping turns on one agent would read each other's binding. Until now that was prevented only by the gateway pool's per-session lock and the shell being single-threaded. The agent now holds a reentrant lock acquired **non-blocking** in `handle` and `dispatch` (RLock so `handle → dispatch` nests on the same thread); a second thread raises **`AgentBusyError`** (a `RuntimeError` subclass, exported via `core.agent_harness.runtime`) instead of interleaving. One private context manager guards both entry points; zero cost on the happy path.

**2. Readability review (SoC / clean code)**
- `core/agent_harness/turns/headless_dispatch.py` → **`headless_agent.py`** — the file is named after what it holds. Its module docstring example constructed `HeadlessAgent(...)` directly, which has been impossible since #5031; replaced by the real program (`HeadlessPorts().agent(...).handle(...)`). `__all__` is now only what the module defines (`AgentBusyError`, `HeadlessAgent`); the in-memory adapters are imported from `headless_adapters` by everyone (19 importers repointed). Methods are **public-first in call order**: `handle`, `dispatch`, `bind_turn`, `bind_session`, `bind_stages`, then private helpers.
- `core/agent_harness/harness.py` — docstring rewritten (embed → attach → run; host pointer to `DefaultPorts` + `handle`); dropped drift (`bind_turn each message`, a "there is no `dispatch_message_to_headless_agent`" line, "Path-2"). `AgentSession` public methods first, the three private startup steps last.
- `surfaces/interactive_shell/runtime/shell_turn_execution.py` — the three test-injection stage adapters and their binder moved into **`turn_seams.py`** (the seams and their adapters belong together; `bind_injected_stages` is the public name). The turn module is one screen: build (or reuse) → `TurnBinding` → seams (no-op in production) → `handle`. 210 → 105 lines.

`gateway/core/runtime/turn_handler.py` and `turns/port_families.py` were reviewed and left as they read cleanly.

Not changed, deliberately: `AgentSession.chat_until_goal`. It and `HeadlessAgent.handle` are one-line callers of the single loop function `run_until_session_goal` — the embedder verb and the host verb; delegating one to the other would add a conditional path because an attached agent may be any `ChatDispatcher`.

No user-visible behaviour change.

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, I used AI assistance (Claude Code)
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: after seven passes the harness API was right but two things still hurt a cold reader — the agent's "one turn at a time" rule lived in the pool, not the agent, so misuse was silent; and the core files carried a stale docstring, a module named after an old verb, a second door for the in-memory adapters, private helpers ahead of the public API, and a turn module dominated by test-only adapters.

Alternatives considered: (a) a boolean in-turn flag — rejected, an RLock gives the same non-blocking check plus correct same-thread nesting for `handle → dispatch` without a second flag; (b) guarding only `handle` — rejected, `dispatch` is a public entry point too and the invariant is the agent's; (c) delegating `chat_until_goal` to `handle` — rejected after reading it: both call the one loop function; a delegation would add a conditional path.

Why this shape: the invariant is stated once (one context manager, one named error a host can catch); each core file now reads top-down as "what a host uses, then how it works"; seams and their adapters share a module so the turn module shows only the turn.

Key pieces: `HeadlessAgent._one_turn_at_a_time` / `AgentBusyError`, `turns/headless_agent.py`, `turn_seams.bind_injected_stages`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions