### PR TITLE
fix(guardrails): stop malformed patterns/keywords from aborting rule …

### DIFF
--- a/platform/guardrails/rules.py
+++ b/platform/guardrails/rules.py
@@ -72,6 +72,17 @@ def load_rules(path: Path | None = None) -> list[GuardrailRule]:
     return rules
 
 
+def _as_list(raw: dict[str, Any], key: str, rule_name: str) -> list[Any]:
+    """``raw[key]`` as a list, or ``[]`` if absent or not a list (e.g. ``key: null``)."""
+    value = raw.get(key, [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        logger.warning("Rule %r has non-list %r: %r, ignoring", rule_name, key, value)
+        return []
+    return value
+
+
 def _parse_rule(raw: dict[str, Any]) -> GuardrailRule | None:
     """Parse a single rule entry from the YAML config.
 
@@ -90,14 +101,13 @@ def _parse_rule(raw: dict[str, Any]) -> GuardrailRule | None:
         return None
 
     compiled_patterns: list[re.Pattern[str]] = []
-    for pat_str in raw.get("patterns", []):
+    for pat_str in _as_list(raw, "patterns", name):
         try:
             compiled_patterns.append(re.compile(pat_str, re.IGNORECASE))
         except re.error as exc:
             logger.warning("Invalid regex %r in rule %r: %s — skipping pattern", pat_str, name, exc)
 
-    raw_keywords = raw.get("keywords", [])
-    keywords = tuple(str(kw).lower() for kw in raw_keywords)
+    keywords = tuple(str(kw).lower() for kw in _as_list(raw, "keywords", name))
 
     if not compiled_patterns and not keywords:
         logger.warning("Rule %r has no patterns or keywords, skipping", name)

--- a/tests/platform/guardrails/test_rules.py
+++ b/tests/platform/guardrails/test_rules.py
@@ -157,6 +157,61 @@ class TestLoadRules:
         assert rules[0].description == "Credit cards"
         assert rules[0].replacement == "[CC_REDACTED]"
 
+    def test_null_patterns_treated_as_empty(self, tmp_path: Path) -> None:
+        path = _write_config(
+            tmp_path,
+            {
+                "rules": [
+                    {
+                        "name": "null_patterns",
+                        "action": "redact",
+                        "patterns": None,
+                        "keywords": ["x"],
+                    },
+                ]
+            },
+        )
+        rules = load_rules(path)
+        assert len(rules) == 1
+        assert rules[0].patterns == ()
+        assert rules[0].keywords == ("x",)
+
+    def test_null_keywords_treated_as_empty(self, tmp_path: Path) -> None:
+        path = _write_config(
+            tmp_path,
+            {
+                "rules": [
+                    {
+                        "name": "null_keywords",
+                        "action": "redact",
+                        "patterns": ["x"],
+                        "keywords": None,
+                    },
+                ]
+            },
+        )
+        rules = load_rules(path)
+        assert len(rules) == 1
+        assert rules[0].keywords == ()
+
+    def test_non_list_patterns_treated_as_empty(self, tmp_path: Path) -> None:
+        path = _write_config(
+            tmp_path,
+            {
+                "rules": [
+                    {
+                        "name": "scalar_patterns",
+                        "action": "redact",
+                        "patterns": "not-a-list",
+                        "keywords": ["x"],
+                    },
+                ]
+            },
+        )
+        rules = load_rules(path)
+        assert len(rules) == 1
+        assert rules[0].patterns == ()
+
     def test_multiple_rules(self, tmp_path: Path) -> None:
         path = _write_config(
             tmp_path,


### PR DESCRIPTION
…loading

A rule with `patterns: null` (or any non-list value) under `patterns` or `keywords` raised an uncaught TypeError from load_rules(), unlike every other malformed field in the same parser, which logs a warning and skips just the bad part. Since load_rules() backs the guardrail engine singleton, one bad rule in guardrails.yml took down redaction for the whole file instead of degrading gracefully.

Adds _as_list() to coerce patterns/keywords to a list (or [] with a warning) before iterating.

Fixes #4847

Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve? A patterns or keywords field set to null crashed the whole guardrails file instead of just being skipped, and a stray string there silently turned into garbage single-letter regexes instead of an error.
- What alternative approaches did you consider? Wrapping the whole rule-parsing function in one big try/except and dropping the entire rule on any error, but that would hide unrelated bugs behind the same generic failure.
- Why did you choose this specific implementation? A simple check , is this actually a list?" before using the value catches both the crash and the silent-garbage case in one place, matching how every other bad field in this file is already handled.
- What are the key functions/components and what do they do? _as_list() is the only new piece: it returns the field as a list if it already is one, empty if it's missing or null, and empty-with-a-warning for anything else, and both patterns and keywords now go through it.

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
