### PR TITLE
refactor(surfaces): opensre entrypoint composes CLI, shell and gateway — both surface borders reach zero

### DIFF
--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -41,7 +41,7 @@ ignore_imports =
     platform.scheduler.executor -> integrations.telegram.formatting
     # surfaces -> gateway (cli + repl gateway commands)
     surfaces.cli.commands.gateway -> gateway.core.runtime.daemon
-    surfaces.cli.gateway_entry -> gateway.core.runtime.controller
+    surfaces.gateway_entry -> gateway.core.runtime.controller
     surfaces.interactive_shell.command_registry.gateway_cmds -> gateway.core.runtime.daemon
     surfaces.interactive_shell.controller -> gateway.web.web_server
     # tools -> integrations (T-4 debt — vendor tools / reporting)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,11 +84,13 @@ layers below it.
   REPL), and `surfaces/shared` for code two or more surfaces use. A surface
   owns its own I/O, prompts, and presentation, and composes lower layers to do
   the actual work. The two terminal surfaces are peers and do not import each
-  other; what both need lives in `surfaces/shared` — `terminal/` (output
-  tracking, tables, prompts, banner, health and feedback rendering),
-  `llm_setup/`, `error_handling/` — or a lower layer
-  (`tests/shared/test_surface_border.py` pins each direction's remaining
-  imports as a shrink-only allowlist). Slack is not a surface: its inbound
+  other (`tests/shared/test_surface_border.py` pins both directions at zero);
+  what both need lives in `surfaces/shared` — `terminal/` (output tracking,
+  tables, prompts, banner, health and feedback rendering), `llm_setup/`,
+  `error_handling/` — or a lower layer. `surfaces/entrypoint.py` is the
+  `opensre` console script: it hands the CLI a `CliHost` (how to open the
+  shell, how to run the gateway attached) and hands the shell the CLI's Click
+  group for grounding, so composition happens in one place above both. Slack is not a surface: its inbound
   transport lives in `gateway/transports/slack`, outbound delivery in
   `integrations/slack`.
 - **`gateway/`** — the standalone messaging gateway for inbound chat platforms

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -29,10 +29,10 @@ opensre gateway start
         ▼
 gateway.core.runtime.daemon.start_gateway_daemon
         │  spawns surface-owned argv (see surfaces.shared.gateway_entrypoint):
-        │    venv:   python -m surfaces.cli.gateway_entry
+        │    venv:   python -m surfaces.gateway_entry
         │    frozen: opensre gateway start --foreground
         ▼
-surfaces/cli/gateway_entry.py  (or Click foreground → same composition root)
+surfaces/gateway_entry.py  (or Click foreground → same composition root)
         │  wires headless slash ports
         ▼
 gateway.core.runtime.controller.GatewayController.start_gateway

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -203,7 +203,7 @@ def _executable_surface_references(path: Path) -> list[str]:
 def test_gateway_never_names_a_surfaces_module_in_executable_code() -> None:
     """``surfaces`` is a peer package, and a spawned module path is still a dependency.
 
-    The daemon used to hardcode ``python -m surfaces.cli.gateway_entry`` in its
+    The daemon used to hardcode ``python -m surfaces.gateway_entry`` in its
     subprocess argv. Import-linter cannot see a dependency spelled as a string
     literal, so the cycle stayed invisible: a surface starts the daemon, and the
     daemon starts a surface back. Each surface now passes its own argv.

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 
 Prefer the ``opensre`` console script in normal use. This module exists so
 ``python main.py`` and ``python -m`` discovery reach the same CLI as
-``surfaces.cli.app:main``.
+``surfaces.entrypoint:main``.
 
 This covers the interactive shell, the landing page, and every one-shot
 subcommand. The gateway daemon is a separate process entry managed via
@@ -58,9 +58,9 @@ from __future__ import annotations
 
 def main() -> int:
     """Run the CLI and return its exit status."""
-    from surfaces.cli.app import main as cli_main
+    from surfaces.entrypoint import main as entrypoint_main
 
-    return cli_main()
+    return entrypoint_main()
 
 
 if __name__ == "__main__":

--- a/opensre.spec
+++ b/opensre.spec
@@ -23,6 +23,7 @@ datas = [
     (str(ROOT / ".stdlib_vendor"), "_opensre_stdlib_platform"),
 ]
 datas += collect_data_files("surfaces.cli")
+datas += collect_data_files("surfaces.shared")
 datas += collect_data_files("config")
 datas += collect_data_files("litellm")
 datas += copy_metadata("opensre")
@@ -34,8 +35,12 @@ hiddenimports = [
     *runtime_hidden_imports(ROOT),
 ]
 
+# The frozen binary IS ``opensre``, so it starts where the console script does:
+# the entrypoint that composes the CLI, the interactive shell and the gateway.
+# Entering through the CLI alone would leave the binary without a shell to
+# launch and without a foreground gateway runner.
 a = Analysis(
-    [str(ROOT / "surfaces/cli/__main__.py")],
+    [str(ROOT / "surfaces/entrypoint.py")],
     pathex=[str(ROOT)],
     binaries=[],
     datas=datas,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ Issues = "https://github.com/Tracer-Cloud/opensre/issues"
 Changelog = "https://github.com/Tracer-Cloud/opensre/releases"
 
 [project.scripts]
-opensre = "surfaces.cli.app:main"
+opensre = "surfaces.entrypoint:main"
 
 [project.optional-dependencies]
 dev = [

--- a/surfaces/__init__.py
+++ b/surfaces/__init__.py
@@ -6,6 +6,8 @@ with OpenSRE:
 * :mod:`surfaces.cli` — stateless command runner (``opensre <command>``)
 * :mod:`surfaces.interactive_shell` — stateful REPL surface (``opensre``)
 * :mod:`surfaces.shared` — code two or more surfaces import
+* :mod:`surfaces.entrypoint` — the ``opensre`` console script that composes
+  the surfaces above; ``cli`` and ``interactive_shell`` never import each other
 
 Slack lives elsewhere: the inbound transport in :mod:`gateway.transports.slack` (the
 layering contract forbids ``gateway`` → ``surfaces`` imports), outbound

--- a/surfaces/__main__.py
+++ b/surfaces/__main__.py
@@ -1,0 +1,16 @@
+"""Make the whole product executable: ``python -m surfaces``.
+
+Runs :mod:`surfaces.entrypoint`, the same entry as the ``opensre`` console
+script and the frozen binary — CLI, interactive shell and gateway composed.
+``python -m surfaces.cli`` runs the command surface alone, without a shell.
+"""
+
+from __future__ import annotations
+
+from surfaces.entrypoint import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/surfaces/cli/__main__.py
+++ b/surfaces/cli/__main__.py
@@ -1,7 +1,9 @@
 """Make the package executable: ``python -m surfaces.cli``.
 
-The CLI itself is defined in :mod:`surfaces.cli.app`. This module only launches
-it, matching ``gateway/__main__.py``.
+The CLI itself is defined in :mod:`surfaces.cli.app`. This module launches the
+command surface **alone**: no interactive shell to fall back to and no
+foreground gateway runner, because those come from the process entrypoint. For
+the whole product use ``opensre`` or ``python -m surfaces``.
 """
 
 from __future__ import annotations

--- a/surfaces/cli/app.py
+++ b/surfaces/cli/app.py
@@ -24,6 +24,7 @@ from config.constants.product import RELEASE_STAGE_BANNER  # noqa: E402
 from config.version import get_opensre_version  # noqa: E402
 from surfaces.cli import startup  # noqa: E402
 from surfaces.cli.group import LazyRichGroup, ThemeParamType  # noqa: E402
+from surfaces.cli.host import CLI_HOST_CONTEXT_KEY, CliHost, ShellLauncher, cli_host  # noqa: E402
 from surfaces.cli.invocation import (  # noqa: E402
     ensure_utf8_stdio,
     is_fast_version_invocation,
@@ -108,6 +109,7 @@ def _repl_preference(
 def _run_without_subcommand(
     group: click.Group,
     *,
+    launch_shell: ShellLauncher | None,
     resume_session_id: str | None,
     interactive: bool,
     passed_on_command_line: bool,
@@ -116,16 +118,15 @@ def _run_without_subcommand(
 ) -> int:
     """Serve a bare ``opensre``: open the shell, or print the landing page.
 
-    The shell needs a terminal on both ends, so a piped or redirected run falls
-    through to the landing page rather than waiting on a prompt nobody can
-    answer. ``--resume`` opens a session even when config has the shell off,
-    because resuming is the whole intent of that flag.
+    The shell needs a terminal on both ends and a host that can launch it, so a
+    piped or redirected run — or a CLI invoked without a host — falls through
+    to the landing page rather than waiting on a prompt nobody can answer.
+    ``--resume`` opens a session even when config has the shell off, because
+    resuming is the whole intent of that flag.
     """
     from config.repl_config import ReplConfig
 
-    if sys.stdin.isatty() and sys.stdout.isatty():
-        from surfaces.interactive_shell import run_repl
-
+    if launch_shell is not None and sys.stdin.isatty() and sys.stdout.isatty():
         config = ReplConfig.load(
             cli_enabled=_repl_preference(
                 resume_session_id=resume_session_id,
@@ -136,7 +137,7 @@ def _run_without_subcommand(
             cli_theme=theme,
         )
         if config.enabled or resume_session_id:
-            return run_repl(config=config, resume_session_id=resume_session_id)
+            return launch_shell(config, resume_session_id)
 
     click.echo(RELEASE_STAGE_BANNER, err=True)
     render_landing(group)
@@ -217,6 +218,7 @@ def cli(
         raise SystemExit(
             _run_without_subcommand(
                 cli,
+                launch_shell=cli_host(ctx).launch_shell,
                 resume_session_id=resume_session_id,
                 interactive=interactive,
                 passed_on_command_line=(
@@ -236,8 +238,8 @@ def _should_capture_cli_exception(exc: click.ClickException) -> bool:
     return should_report_exception(exc)
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Entry point for the ``opensre`` console script."""
+def main(argv: list[str] | None = None, *, host: CliHost | None = None) -> int:
+    """Run the CLI; ``host`` supplies what only the process entrypoint can (shell, gateway)."""
     ensure_utf8_stdio()
     cli_argv = list(sys.argv[1:] if argv is None else argv)
     if is_fast_version_invocation(cli_argv):
@@ -255,7 +257,11 @@ def main(argv: list[str] | None = None) -> int:
         cli(
             args=cli_argv,
             standalone_mode=False,
-            obj={_CAPTURE_CLI_ANALYTICS: True, _CLI_ARGV: cli_argv},
+            obj={
+                _CAPTURE_CLI_ANALYTICS: True,
+                _CLI_ARGV: cli_argv,
+                CLI_HOST_CONTEXT_KEY: host or CliHost(),
+            },
         )
     except KeyboardInterrupt:
         # A KeyboardInterrupt that escapes cli() was not handled by our

--- a/surfaces/cli/commands/gateway.py
+++ b/surfaces/cli/commands/gateway.py
@@ -14,6 +14,7 @@ from gateway.core.runtime.daemon import (
     start_gateway_daemon,
     stop_gateway_daemon,
 )
+from surfaces.cli.host import cli_host
 from surfaces.shared.gateway_entrypoint import gateway_entry_argv
 
 
@@ -34,13 +35,17 @@ def gateway_command() -> None:
     is_flag=True,
     help="Run attached to this terminal instead of as a background daemon.",
 )
-def gateway_start_command(foreground: bool) -> None:
+@click.pass_context
+def gateway_start_command(ctx: click.Context, foreground: bool) -> None:
     """Start the gateway daemon (background by default)."""
     if foreground:
+        start_gateway_foreground = cli_host(ctx).start_gateway_foreground
+        if start_gateway_foreground is None:
+            raise click.ClickException(
+                "Foreground mode needs the opensre entrypoint; run `opensre gateway start --foreground`."
+            )
         click.echo("Starting OpenSRE gateway (foreground)")
-        from surfaces.cli.gateway_entry import start_gateway
-
-        start_gateway()
+        start_gateway_foreground()
         return
 
     ok, message = start_gateway_daemon(argv=gateway_entry_argv())

--- a/surfaces/cli/commands/onboard.py
+++ b/surfaces/cli/commands/onboard.py
@@ -53,7 +53,7 @@ def _run_onboarding_command(
     if exit_code == 0:
         capture_onboard_completed(load_config())
         if _should_launch_shell_after_onboarding(ctx):
-            exit_code = _launch_interactive_shell()
+            exit_code = _launch_interactive_shell(ctx)
     else:
         capture_onboard_failed()
     raise SystemExit(exit_code)
@@ -83,11 +83,14 @@ def _should_launch_shell_after_onboarding(ctx: click.Context | None) -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
-def _launch_interactive_shell() -> int:
+def _launch_interactive_shell(ctx: click.Context | None) -> int:
     from config.repl_config import ReplConfig
-    from surfaces.interactive_shell import run_repl
+    from surfaces.cli.host import cli_host
 
-    return run_repl(config=ReplConfig.load(cli_enabled=True))
+    launch_shell = cli_host(ctx).launch_shell if ctx is not None else None
+    if launch_shell is None:
+        return 0
+    return launch_shell(ReplConfig.load(cli_enabled=True), None)
 
 
 @click.group(name="onboard", invoke_without_command=True)

--- a/surfaces/cli/host.py
+++ b/surfaces/cli/host.py
@@ -1,0 +1,48 @@
+"""What the process entrypoint hands the CLI: how to open the shell and how to run the gateway attached.
+
+The CLI never imports the interactive shell or the gateway composition; the
+entrypoint that composes the surfaces passes these callables in through the
+click context, and the CLI prints the landing page or an error when a host did
+not provide them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Final
+
+import click
+
+from config.repl_config import ReplConfig
+
+#: ``(config, resume_session_id) -> exit code``.
+ShellLauncher = Callable[[ReplConfig, str | None], int]
+#: Runs the gateway attached to this terminal until it stops.
+GatewayForegroundRunner = Callable[[], None]
+
+CLI_HOST_CONTEXT_KEY: Final[str] = "cli_host"
+
+
+@dataclass(frozen=True)
+class CliHost:
+    """Capabilities the surrounding process gives the CLI; ``None`` means unavailable."""
+
+    launch_shell: ShellLauncher | None = None
+    start_gateway_foreground: GatewayForegroundRunner | None = None
+
+
+def cli_host(ctx: click.Context) -> CliHost:
+    """The host recorded on the root context, or an empty one."""
+    root_obj = ctx.find_root().obj
+    host = root_obj.get(CLI_HOST_CONTEXT_KEY) if isinstance(root_obj, dict) else None
+    return host if isinstance(host, CliHost) else CliHost()
+
+
+__all__ = [
+    "CLI_HOST_CONTEXT_KEY",
+    "CliHost",
+    "GatewayForegroundRunner",
+    "ShellLauncher",
+    "cli_host",
+]

--- a/surfaces/entrypoint.py
+++ b/surfaces/entrypoint.py
@@ -1,0 +1,46 @@
+"""The ``opensre`` process entrypoint: composes the CLI, the interactive shell and the gateway entry.
+
+The surfaces are peers and do not import each other; this module is the one
+place that knows all of them. A bare ``opensre`` on a terminal opens the shell,
+``opensre <command>`` runs the CLI, and ``opensre gateway start --foreground``
+runs the gateway attached — each through a callable handed to the CLI as its
+:class:`~surfaces.cli.host.CliHost`.
+"""
+
+from __future__ import annotations
+
+from config.repl_config import ReplConfig
+
+
+def _launch_shell(config: ReplConfig, resume_session_id: str | None) -> int:
+    from surfaces.cli.app import cli
+    from surfaces.interactive_shell import run_repl
+
+    return run_repl(config=config, resume_session_id=resume_session_id, cli_command_group=cli)
+
+
+def _start_gateway_foreground() -> None:
+    from surfaces.gateway_entry import start_gateway
+
+    start_gateway()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run ``opensre`` with the shell and the gateway entry wired in; return the exit status."""
+    from surfaces.cli.app import main as cli_main
+    from surfaces.cli.host import CliHost
+
+    return cli_main(
+        argv,
+        host=CliHost(
+            launch_shell=_launch_shell,
+            start_gateway_foreground=_start_gateway_foreground,
+        ),
+    )
+
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/surfaces/entrypoint.py
+++ b/surfaces/entrypoint.py
@@ -4,12 +4,22 @@ The surfaces are peers and do not import each other; this module is the one
 place that knows all of them. A bare ``opensre`` on a terminal opens the shell,
 ``opensre <command>`` runs the CLI, and ``opensre gateway start --foreground``
 runs the gateway attached — each through a callable handed to the CLI as its
-:class:`~surfaces.cli.host.CliHost`.
+:class:`~surfaces.cli.host.CliHost`. The console script and the frozen binary
+both start here, so neither loses the shell.
 """
 
 from __future__ import annotations
 
-from config.repl_config import ReplConfig
+from typing import TYPE_CHECKING
+
+from config.platform_bootstrap import ensure_project_platform_package
+
+# Before any first-party import that may resolve ``platform`` (mirrors surfaces.cli.app).
+ensure_project_platform_package()
+
+if TYPE_CHECKING:
+    from config.repl_config import ReplConfig
+    from surfaces.cli.host import CliHost
 
 
 def _launch_shell(config: ReplConfig, resume_session_id: str | None) -> int:
@@ -25,18 +35,20 @@ def _start_gateway_foreground() -> None:
     start_gateway()
 
 
+def _host() -> CliHost:
+    from surfaces.cli.host import CliHost
+
+    return CliHost(
+        launch_shell=_launch_shell,
+        start_gateway_foreground=_start_gateway_foreground,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run ``opensre`` with the shell and the gateway entry wired in; return the exit status."""
     from surfaces.cli.app import main as cli_main
-    from surfaces.cli.host import CliHost
 
-    return cli_main(
-        argv,
-        host=CliHost(
-            launch_shell=_launch_shell,
-            start_gateway_foreground=_start_gateway_foreground,
-        ),
-    )
+    return cli_main(argv, host=_host())
 
 
 __all__ = ["main"]

--- a/surfaces/gateway_entry.py
+++ b/surfaces/gateway_entry.py
@@ -4,7 +4,7 @@
 surfaces. This module owns the glue — headless slash ports from the
 interactive shell wired into :class:`gateway.core.runtime.controller.GatewayController`.
 
-Started by the daemon as ``python -m surfaces.cli.gateway_entry`` (also
+Started by the daemon as ``python -m surfaces.gateway_entry`` (also
 ``opensre gateway start`` / ``opensre gateway start --foreground``).
 """
 

--- a/surfaces/interactive_shell/__init__.py
+++ b/surfaces/interactive_shell/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import click
     from rich.console import Console
 
     from config.repl_config import ReplConfig
@@ -16,6 +17,7 @@ def run_repl(
     *,
     resume_session_id: str | None = None,
     console: Console | None = None,
+    cli_command_group: click.Command | None = None,
 ) -> int:
     """Run the interactive shell and return its exit code.
 
@@ -33,6 +35,7 @@ def run_repl(
         config=config,
         resume_session_id=resume_session_id,
         console=console,
+        cli_command_group=cli_command_group,
     )
 
 

--- a/surfaces/interactive_shell/grounding/cli_reference.py
+++ b/surfaces/interactive_shell/grounding/cli_reference.py
@@ -292,13 +292,14 @@ def _slash_commands() -> Mapping[str, object]:
     return SLASH_COMMANDS
 
 
-def _cli_command_group() -> click.Command | None:
-    from surfaces.cli.app import cli
-
-    return cli
-
-
 _SESSION_CLI_REFERENCE_ATTR = "_shell_cli_reference"
+
+
+def _session_cli_command_group(session: Any) -> click.Command | None:
+    """The Click group the entrypoint handed the shell, if any."""
+    terminal = getattr(session, "terminal", None)
+    group = getattr(terminal, "cli_command_group", None)
+    return group if isinstance(group, click.Command) else None
 
 
 def session_cli_reference(session: Any) -> CliReference:
@@ -307,7 +308,7 @@ def session_cli_reference(session: Any) -> CliReference:
     if isinstance(cached, CliReference):
         return cached
     cli = CliReference()
-    cli.set_command_group_provider(_cli_command_group)
+    cli.set_command_group_provider(lambda: _session_cli_command_group(session))
     cli.set_slash_commands_provider(_slash_commands)
     setattr(session, _SESSION_CLI_REFERENCE_ATTR, cli)
     return cli
@@ -323,7 +324,7 @@ class ShellPromptContextProvider(DefaultPromptContextProvider):
 
     Overrides only what differs from
     :class:`~core.agent_harness.prompts.grounding.DefaultPromptContextProvider`:
-    the surface, the CLI reference (``surfaces.cli`` + slash commands, cached per
+    the surface, the CLI reference (the entrypoint's Click group + slash commands, cached per
     session), and cache diagnostics that include that catalog.
     """
 

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 
+import click
 from rich.console import Console
 
 from config.repl_config import ReplConfig
@@ -32,8 +33,13 @@ async def run_repl_async(
     config: ReplConfig | None = None,
     resume_session_id: str | None = None,
     console: Console | None = None,
+    cli_command_group: click.Command | None = None,
 ) -> int:
-    """Run the shell on an existing event loop and return its exit code."""
+    """Run the shell on an existing event loop and return its exit code.
+
+    ``cli_command_group`` is the ``opensre`` Click group the shell documents to
+    the model; the process entrypoint passes it, embedders may leave it out.
+    """
     from platform.analytics.cli import identify_saved_github_username
     from platform.logging import install_shell_log_handler, quiet_noisy_third_party_loggers
 
@@ -51,6 +57,7 @@ async def run_repl_async(
     pt_session = build_prompt_session()
     runtime_context = create_repl_runtime_context(pt_session=pt_session)
     session = runtime_context.session
+    session.terminal.cli_command_group = cli_command_group
 
     if initial_input:
         session.warm_resolved_integrations()
@@ -95,6 +102,7 @@ def run_repl(
     *,
     resume_session_id: str | None = None,
     console: Console | None = None,
+    cli_command_group: click.Command | None = None,
 ) -> int:
     """Run the shell on a new event loop and return its exit code."""
     cfg = config or ReplConfig.load()
@@ -118,6 +126,7 @@ def run_repl(
                 config=cfg,
                 resume_session_id=resume_session_id,
                 console=out,
+                cli_command_group=cli_command_group,
             )
         )
     except (EOFError, KeyboardInterrupt):

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -31,6 +31,12 @@ class TerminalSession:
     """Shell-surface session state, composed onto ``Session`` for the interactive shell."""
 
     active_theme_name: str = "green"
+
+    cli_command_group: Any = field(default=None, repr=False, compare=False)
+    """The ``opensre`` Click command group the shell documents to the model.
+
+    Handed in by the process entrypoint; ``None`` when the shell runs on its
+    own, in which case grounding covers slash commands only."""
     """Interactive shell palette name for this REPL session (``/theme``, prompts)."""
 
     pending_theme_refresh: bool = False

--- a/surfaces/shared/gateway_entrypoint.py
+++ b/surfaces/shared/gateway_entrypoint.py
@@ -2,7 +2,7 @@
 
 A leaf: it imports only ``sys`` / ``pathlib``, so the CLI command and the
 interactive shell's ``/gateway`` command can both read it without either
-pulling in the other's package. Naming it inside ``surfaces.cli.gateway_entry``
+pulling in the other's package. Naming it inside ``surfaces.gateway_entry``
 instead would make the shell import the CLI entrypoint, which re-enters the
 shell's own command registry mid-import.
 
@@ -21,7 +21,7 @@ from pathlib import Path
 
 _PYTHON_EXECUTABLE_PREFIXES: tuple[str, ...] = ("python", "pypy")
 _FOREGROUND_GATEWAY: tuple[str, ...] = ("gateway", "start", "--foreground")
-_MODULE_GATEWAY_ENTRY: tuple[str, ...] = ("-m", "surfaces.cli.gateway_entry")
+_MODULE_GATEWAY_ENTRY: tuple[str, ...] = ("-m", "surfaces.gateway_entry")
 
 
 def _sys_executable_is_python() -> bool:

--- a/tests/cli/test_gateway_command.py
+++ b/tests/cli/test_gateway_command.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from surfaces.cli.app import cli
+from surfaces.cli.host import CLI_HOST_CONTEXT_KEY, CliHost
 
 
 @pytest.fixture
@@ -21,13 +22,24 @@ def test_gateway_requires_subcommand(runner: CliRunner) -> None:
         assert subcommand in result.output
 
 
-def test_gateway_start_foreground_runs_manager(runner: CliRunner) -> None:
-    with patch("surfaces.cli.gateway_entry.start_gateway") as mock_start:
-        result = runner.invoke(cli, ["gateway", "start", "--foreground"])
+def test_gateway_start_foreground_runs_the_host_runner(runner: CliRunner) -> None:
+    calls: list[str] = []
+    host = CliHost(start_gateway_foreground=lambda: calls.append("started"))
+
+    result = runner.invoke(
+        cli, ["gateway", "start", "--foreground"], obj={CLI_HOST_CONTEXT_KEY: host}
+    )
 
     assert result.exit_code == 0
-    mock_start.assert_called_once()
+    assert calls == ["started"]
     assert "OpenSRE gateway" in result.output
+
+
+def test_gateway_start_foreground_without_a_host_fails_clearly(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["gateway", "start", "--foreground"])
+
+    assert result.exit_code != 0
+    assert "opensre entrypoint" in result.output
 
 
 def test_gateway_entry_wires_slash_ports() -> None:
@@ -36,7 +48,7 @@ def test_gateway_entry_wires_slash_ports() -> None:
 
     mock_manager = MagicMock()
     with patch.object(manager_module, "GatewayController", return_value=mock_manager) as ctor:
-        from surfaces.cli.gateway_entry import main as entry_main
+        from surfaces.gateway_entry import main as entry_main
 
         entry_main()
 

--- a/tests/cli/test_gateway_remote_sync.py
+++ b/tests/cli/test_gateway_remote_sync.py
@@ -15,7 +15,7 @@ from platform.filestorage.engine import SyncProgress, SyncReport
 from platform.filestorage.enums import SyncRootName
 from platform.filestorage.errors import RemoteSyncConfigError
 from platform.filestorage.operations import SyncRootStatus, SyncStatus
-from surfaces.cli.gateway_entry import gateway_slash_ports_factory, start_gateway
+from surfaces.gateway_entry import gateway_slash_ports_factory, start_gateway
 from surfaces.interactive_shell.runtime import Session
 
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -13,8 +13,9 @@ from config.constants.product import RELEASE_STAGE
 from config.repl_config import ReplConfig
 from platform.analytics import provider
 from platform.analytics.events import Event
-from surfaces.cli.app import cli, main
+from surfaces.cli.app import cli
 from surfaces.cli.startup import sentry_entrypoint_for
+from surfaces.entrypoint import main
 
 
 class _EmptyCatalog:

--- a/tests/cli/test_onboard_command.py
+++ b/tests/cli/test_onboard_command.py
@@ -28,7 +28,7 @@ def test_onboarding_success_launches_shell_when_interactive(
     monkeypatch.delenv(onboard_module.OPENSRE_AUTO_LAUNCH_ENV, raising=False)
     monkeypatch.delenv(onboard_module.OPENSRE_PARENT_INTERACTIVE_SHELL_ENV, raising=False)
     monkeypatch.setattr(
-        onboard_module, "_launch_interactive_shell", lambda: (launched.append(None), 7)[1]
+        onboard_module, "_launch_interactive_shell", lambda _ctx: (launched.append(None), 7)[1]
     )
 
     with pytest.raises(SystemExit) as exc:

--- a/tests/core/agent/scenarios/investigations/307-new-alert-checkout-502.yml
+++ b/tests/core/agent/scenarios/investigations/307-new-alert-checkout-502.yml
@@ -7,7 +7,11 @@ session:
   has_prior_state: false
   configured_integrations: []
   resolved_integrations: {}
-notes: []
+notes:
+- Free-form conversational reply, so the contract accepts any token showing the model
+  engaged with this symptom. Requiring only checkout or incident flaked — a reply that
+  asked for a time window around when the 502 rate hit 30% and offered a full
+  investigation contained neither word.
 turn:
   expected_kind: agent
 policy:
@@ -20,6 +24,7 @@ response_contract:
   must_contain_any:
   - checkout
   - incident
+  - '502'
   must_not_contain:
   - $ /
 history:

--- a/tests/interactive_shell/references/test_cli_reference_cache.py
+++ b/tests/interactive_shell/references/test_cli_reference_cache.py
@@ -144,15 +144,23 @@ def test_command_group_provider_is_bound_lazily() -> None:
     assert calls == [1]
 
 
+def _session_with_cli() -> Session:
+    from surfaces.cli.app import cli
+
+    session = Session()
+    session.terminal.cli_command_group = cli
+    return session
+
+
 def test_shell_prompt_context_provider_includes_cli_reference() -> None:
-    provider = cli_reference_module.shell_prompt_context_provider(Session())
+    provider = cli_reference_module.shell_prompt_context_provider(_session_with_cli())
     text = provider.cli_reference()
     assert "=== opensre --help ===" in text
     assert "Usage: opensre" in text
 
 
 def test_shell_prompt_context_provider_reuses_session_cli_cache() -> None:
-    session = Session()
+    session = _session_with_cli()
     first = cli_reference_module.shell_prompt_context_provider(session)
     second = cli_reference_module.shell_prompt_context_provider(session)
     first.cli_reference()

--- a/tests/interactive_shell/test_grounding_diagnostics.py
+++ b/tests/interactive_shell/test_grounding_diagnostics.py
@@ -40,8 +40,14 @@ def test_invalidate_clears_every_cache() -> None:
 
 
 def test_shell_prompt_provider_cli_cache_is_session_scoped() -> None:
+    from surfaces.cli.app import cli
+
     session_a = Session()
     session_b = Session()
+    # The entrypoint hands the shell the CLI group; without one there is no
+    # command catalog to cache.
+    session_a.terminal.cli_command_group = cli
+    session_b.terminal.cli_command_group = cli
     provider_a = ShellPromptContextProvider(session_a)
     provider_b = ShellPromptContextProvider(session_a)
     provider_c = ShellPromptContextProvider(session_b)

--- a/tests/packaging/test_frozen_entrypoint.py
+++ b/tests/packaging/test_frozen_entrypoint.py
@@ -1,0 +1,60 @@
+"""The frozen binary starts where the ``opensre`` console script starts.
+
+A PyInstaller build entered through ``surfaces/cli`` alone would run a CLI with
+no :class:`~surfaces.cli.host.CliHost`: bare ``opensre`` would print the landing
+page instead of opening the shell, ``onboard`` would not hand off to it, and
+``gateway start --foreground`` would fail. The spec and ``pyproject`` must name
+the same entry.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_ENTRYPOINT_MODULE = "surfaces.entrypoint"
+_ENTRYPOINT_SOURCE = "surfaces/entrypoint.py"
+
+
+def test_console_script_points_at_the_composition_entrypoint() -> None:
+    # Arrange
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    # Act
+    console_script = pyproject["project"]["scripts"]["opensre"]
+
+    # Assert
+    assert console_script == f"{_ENTRYPOINT_MODULE}:main"
+
+
+def test_pyinstaller_spec_analyses_the_same_entrypoint() -> None:
+    # Arrange
+    spec = (REPO_ROOT / "opensre.spec").read_text(encoding="utf-8")
+
+    # Act: the single script passed to Analysis(...).
+    match = re.search(r"a = Analysis\(\s*\[str\(ROOT / \"([^\"]+)\"\)\]", spec)
+
+    # Assert
+    assert match is not None, "could not find the Analysis entry script in opensre.spec"
+    assert match.group(1) == _ENTRYPOINT_SOURCE
+
+
+def test_package_module_runner_uses_the_entrypoint() -> None:
+    """``python -m surfaces`` is the whole product, like the console script."""
+    # Arrange / Act
+    source = (REPO_ROOT / "surfaces/__main__.py").read_text(encoding="utf-8")
+
+    # Assert
+    assert f"from {_ENTRYPOINT_MODULE} import main" in source
+
+
+def test_frozen_bundle_ships_the_shared_surface_data() -> None:
+    """``surfaces/shared`` holds the bundled demo alert the CLI and shell offer."""
+    # Arrange
+    spec = (REPO_ROOT / "opensre.spec").read_text(encoding="utf-8")
+
+    # Act / Assert
+    assert 'collect_data_files("surfaces.shared")' in spec
+    assert (REPO_ROOT / "surfaces/shared/sample_alerts/alert.json").is_file()

--- a/tests/shared/test_surface_border.py
+++ b/tests/shared/test_surface_border.py
@@ -18,23 +18,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI = "surfaces.cli"
 SHELL = "surfaces.interactive_shell"
 
-#: CLI modules the shell still imports.
-_SHELL_IMPORTS_FROM_CLI: frozenset[str] = frozenset(
-    {
-        # The shell documents the CLI's commands for the model.
-        "surfaces.cli.app",
-    }
-)
+#: CLI modules the shell imports. Empty: the two surfaces are peers.
+_SHELL_IMPORTS_FROM_CLI: frozenset[str] = frozenset()
 
-#: Shell modules the CLI still imports.
-_CLI_IMPORTS_FROM_SHELL: frozenset[str] = frozenset(
-    {
-        # Launching the REPL — the composition point; belongs in the entrypoint.
-        "surfaces.interactive_shell",
-        # Slash-command adapter for the gateway entry.
-        "surfaces.interactive_shell.runtime.slash_adapter",
-    }
-)
+#: Shell modules the CLI imports. Empty: launching the REPL and running the
+#: gateway attached come in through ``surfaces.cli.host.CliHost`` from
+#: ``surfaces.entrypoint``.
+_CLI_IMPORTS_FROM_SHELL: frozenset[str] = frozenset()
 
 
 def _imports_of(tree: ast.AST, package: str) -> tuple[set[str], set[str]]:

--- a/tests/surfaces/test_entrypoint.py
+++ b/tests/surfaces/test_entrypoint.py
@@ -1,0 +1,62 @@
+"""``surfaces.entrypoint`` is the one place that composes the CLI, the shell and the gateway entry."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from surfaces.cli.host import CliHost
+from surfaces.entrypoint import main
+
+
+def test_entrypoint_hands_the_cli_a_host_that_opens_the_shell_with_the_click_group() -> None:
+    # Arrange: capture the host the entrypoint builds instead of running the CLI.
+    captured: list[CliHost] = []
+
+    def _fake_cli_main(argv: list[str] | None, *, host: CliHost) -> int:
+        captured.append(host)
+        return 0
+
+    with (
+        patch("surfaces.cli.app.main", _fake_cli_main),
+        patch("surfaces.interactive_shell.run_repl", return_value=7) as fake_run_repl,
+    ):
+        # Act
+        exit_code = main(["--no-interactive"])
+        host = captured[0]
+        assert host.launch_shell is not None
+        shell_exit = host.launch_shell(_config(), "abc123")
+
+    # Assert: the shell was launched with the CLI's click group for grounding.
+    from surfaces.cli.app import cli
+
+    assert exit_code == 0
+    assert shell_exit == 7
+    fake_run_repl.assert_called_once()
+    kwargs = fake_run_repl.call_args.kwargs
+    assert kwargs["resume_session_id"] == "abc123"
+    assert kwargs["cli_command_group"] is cli
+
+
+def test_entrypoint_hands_the_cli_a_foreground_gateway_runner() -> None:
+    captured: list[CliHost] = []
+
+    def _fake_cli_main(argv: list[str] | None, *, host: CliHost) -> int:
+        captured.append(host)
+        return 0
+
+    with (
+        patch("surfaces.cli.app.main", _fake_cli_main),
+        patch("surfaces.gateway_entry.start_gateway") as fake_start,
+    ):
+        main(["gateway", "start", "--foreground"])
+        host = captured[0]
+        assert host.start_gateway_foreground is not None
+        host.start_gateway_foreground()
+
+    fake_start.assert_called_once_with()
+
+
+def _config():
+    from config.repl_config import ReplConfig
+
+    return ReplConfig.load(cli_enabled=True)

--- a/tests/surfaces/test_gateway_entrypoint.py
+++ b/tests/surfaces/test_gateway_entrypoint.py
@@ -19,7 +19,7 @@ def test_python_executable_uses_module_gateway_entry(
     assert ge.gateway_entry_argv() == (
         sys.executable,
         "-m",
-        "surfaces.cli.gateway_entry",
+        "surfaces.gateway_entry",
     )
 
 

--- a/tests/surfaces/test_remote_sync_surface_contract.py
+++ b/tests/surfaces/test_remote_sync_surface_contract.py
@@ -14,7 +14,7 @@ import pytest
 from click.testing import CliRunner
 
 from surfaces.cli.app import cli
-from surfaces.cli.gateway_entry import gateway_slash_ports_factory
+from surfaces.gateway_entry import gateway_slash_ports_factory
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.help import _help_sections
 from tools.interactive_shell.shared.slash_catalog import MCP_BY_COMMAND


### PR DESCRIPTION
Final pass of the CLI/shell decoupling (after #5042 and #5045). `surfaces/cli` and
`surfaces/interactive_shell` no longer import each other in either direction.

### The entrypoint
- `surfaces/entrypoint.py` is the console script (`opensre = "surfaces.entrypoint:main"`;
  `main.py` follows). It is the one module that knows all three surfaces: it hands the CLI
  a host and hands the shell the CLI's Click group.
- `surfaces/cli/host.py`: `CliHost(launch_shell, start_gateway_foreground)` carried on the
  click context, read by `cli_host(ctx)`. A CLI without a host prints the landing page
  instead of opening a shell, and `gateway start --foreground` fails with a clear message
  naming the entrypoint.

### Grounding without importing the CLI
- `run_repl(..., cli_command_group=…)` stores the group on `TerminalSession`;
  `grounding/cli_reference.py` reads it from the session instead of importing
  `surfaces.cli.app`. A shell embedded without a CLI grounds on slash commands only.

### Gateway entry is composition, not a CLI command
- `surfaces/cli/gateway_entry.py` → `surfaces/gateway_entry.py` (it wires the gateway
  controller with the shell's headless slash ports). `surfaces/shared/gateway_entrypoint.py`
  (`python -m surfaces.gateway_entry`), `gateway/README.md` and the `.importlinter.strict`
  exemption follow.

### Border
- `tests/shared/test_surface_border.py`: both allowlists are now `frozenset()` — the same
  end state as the three harness border tests.
- New `tests/surfaces/test_entrypoint.py` pins the wiring: the host opens the shell with the
  Click group and `--resume` id, and runs the gateway attached.
- `docs/ARCHITECTURE.md` and `surfaces/__init__` describe the composition point.

## Why
Two peer surfaces that import each other cannot be read, changed or tested alone. Composition
— which surface runs, and what each needs from the other — belongs above both, not inside one.