### PR TITLE
fix(sandbox): make basic capability warnings actionable

### DIFF
--- a/config/runtime_metadata/probes.py
+++ b/config/runtime_metadata/probes.py
@@ -34,6 +34,7 @@ _TOOLS_TO_PROBE = (
     "python",
     "python3",
     "curl",
+    "grep",
     "bash",
     "sh",
     "buzz",
@@ -287,7 +288,8 @@ def capability_warning_facts(tools: dict[str, str] | None = None) -> dict[str, A
     """Honest capability gaps the agent should surface at boot, not mid-turn.
 
     ``network_egress`` is false unless ``OPENSRE_ALLOW_NETWORK=1`` — matching the
-    sandbox default (blocked egress). Shell presence is derived from ``bash``/``sh``.
+    sandbox default (blocked egress). Shell and Python presence accept either
+    supported executable name.
     """
     resolved = tools if tools is not None else installed_tools()
     missing = sorted(name for name, path in resolved.items() if not path)
@@ -298,13 +300,25 @@ def capability_warning_facts(tools: dict[str, str] | None = None) -> dict[str, A
         "on",
     }
     shell_available = bool(resolved.get("bash") or resolved.get("sh"))
+    python_available = bool(resolved.get("python") or resolved.get("python3"))
     warnings: list[str] = []
     if "curl" in missing:
-        warnings.append("curl is not on PATH")
+        warnings.append("curl is not on PATH — install curl and add it to PATH")
     if not shell_available:
-        warnings.append("no interactive shell (bash/sh) on PATH")
+        warnings.append(
+            "no interactive shell (bash/sh) on PATH — install bash or sh and add it to PATH"
+        )
+    if "grep" in missing:
+        warnings.append("grep is not on PATH — install grep and add it to PATH")
     if not allow_network:
-        warnings.append("network egress is blocked for sandboxed code by default")
+        warnings.append(
+            "network egress is blocked for sandboxed code by default — use a configured "
+            "integration for outbound HTTP"
+        )
+    if not python_available:
+        warnings.append(
+            "python/python3 is not on PATH — install Python 3 and add python3 or python to PATH"
+        )
     return {
         "network_egress": allow_network,
         "shell_available": shell_available,

--- a/platform/sandbox/capabilities.py
+++ b/platform/sandbox/capabilities.py
@@ -10,12 +10,9 @@ with a short detail string.
 from __future__ import annotations
 
 import shutil
-import subprocess
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-
-_PROBE_TIMEOUT_SECONDS = 2.0
 
 
 class Capability(StrEnum):
@@ -46,18 +43,8 @@ def _python_available() -> bool:
 
 
 def _shell_available() -> bool:
-    """True when a shell interpreter can run a generated script."""
-    shell = shutil.which("bash") or shutil.which("sh")
-    if shell is None:
-        return False
-    result = subprocess.run(
-        [shell, "-c", "exit 0"],
-        capture_output=True,
-        check=False,
-        text=True,
-        timeout=_PROBE_TIMEOUT_SECONDS,
-    )
-    return result.returncode == 0
+    """True when a shell interpreter exists to run generated scripts."""
+    return bool(shutil.which("bash") or shutil.which("sh"))
 
 
 def _file_read_available() -> bool:
@@ -74,19 +61,8 @@ def _file_read_available() -> bool:
 
 
 def _file_grep_available() -> bool:
-    """True when grep can search local input."""
-    grep = shutil.which("grep")
-    if grep is None:
-        return False
-    result = subprocess.run(
-        [grep, "-q", "OpenSRE"],
-        capture_output=True,
-        check=False,
-        input="OpenSRE\n",
-        text=True,
-        timeout=_PROBE_TIMEOUT_SECONDS,
-    )
-    return result.returncode == 0
+    """True when grep exists to search local files."""
+    return shutil.which("grep") is not None
 
 
 def _network_available() -> bool:

--- a/platform/sandbox/capabilities.py
+++ b/platform/sandbox/capabilities.py
@@ -10,9 +10,12 @@ with a short detail string.
 from __future__ import annotations
 
 import shutil
+import subprocess
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+
+_PROBE_TIMEOUT_SECONDS = 2.0
 
 
 class Capability(StrEnum):
@@ -21,6 +24,7 @@ class Capability(StrEnum):
     PYTHON = "python execution"
     SHELL = "shell commands"
     FILE_READ = "file reading"
+    FILE_GREP = "file search with grep"
     NETWORK = "network requests"
 
 
@@ -42,8 +46,18 @@ def _python_available() -> bool:
 
 
 def _shell_available() -> bool:
-    """True when a shell interpreter exists to run generated scripts."""
-    return bool(shutil.which("bash") or shutil.which("sh"))
+    """True when a shell interpreter can run a generated script."""
+    shell = shutil.which("bash") or shutil.which("sh")
+    if shell is None:
+        return False
+    result = subprocess.run(
+        [shell, "-c", "exit 0"],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=_PROBE_TIMEOUT_SECONDS,
+    )
+    return result.returncode == 0
 
 
 def _file_read_available() -> bool:
@@ -57,6 +71,22 @@ def _file_read_available() -> bool:
         return True
     except OSError:
         return False
+
+
+def _file_grep_available() -> bool:
+    """True when grep can search local input."""
+    grep = shutil.which("grep")
+    if grep is None:
+        return False
+    result = subprocess.run(
+        [grep, "-q", "OpenSRE"],
+        capture_output=True,
+        check=False,
+        input="OpenSRE\n",
+        text=True,
+        timeout=_PROBE_TIMEOUT_SECONDS,
+    )
+    return result.returncode == 0
 
 
 def _network_available() -> bool:
@@ -78,8 +108,20 @@ _PROBES: tuple[tuple[Capability, str], ...] = (
     (Capability.PYTHON, "_python_available"),
     (Capability.SHELL, "_shell_available"),
     (Capability.FILE_READ, "_file_read_available"),
+    (Capability.FILE_GREP, "_file_grep_available"),
     (Capability.NETWORK, "_network_available"),
 )
+
+_CAPABILITY_FIXES: dict[Capability, str] = {
+    Capability.PYTHON: "make the process temp directory writable, then run `make install`.",
+    Capability.SHELL: "install bash or sh and add it to PATH.",
+    Capability.FILE_READ: "run OpenSRE from a readable working directory.",
+    Capability.FILE_GREP: "install grep and add it to PATH.",
+    Capability.NETWORK: (
+        "use a configured integration for outbound HTTP; raw sandbox network access "
+        "is blocked by default."
+    ),
+}
 
 
 def probe_capabilities() -> dict[Capability, CapabilityStatus]:
@@ -105,7 +147,7 @@ def unavailable_capability_warnings(
     return [
         f"{status.capability} is unavailable in this environment"
         + (f" ({status.detail})" if status.detail else "")
-        + " — the agent will not be able to use it."
+        + f" — the agent will not be able to use it. Fix: {_CAPABILITY_FIXES[status.capability]}"
         for status in checked.values()
         if not status.available
     ]

--- a/tests/platform/sandbox/test_capabilities.py
+++ b/tests/platform/sandbox/test_capabilities.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from config.constants.runtime_metadata import OPENSRE_ALLOW_NETWORK_ENV
 from platform.sandbox.capabilities import (
     Capability,
+    _file_grep_available,
     _file_read_available,
     _network_available,
+    _shell_available,
     boot_capability_warnings,
     probe_capabilities,
     unavailable_capability_warnings,
@@ -25,6 +28,46 @@ def test_python_execution_is_detected() -> None:
 def test_file_read_is_detected() -> None:
     results = probe_capabilities()
     assert results[Capability.FILE_READ].available is True
+
+
+def test_shell_probe_rejects_a_failed_script(monkeypatch: Any) -> None:
+    # Arrange
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def _run(command: list[str], **kwargs: Any) -> Any:
+        calls.append((command, kwargs))
+        return type("Result", (), {"returncode": 1})()
+
+    monkeypatch.setattr("platform.sandbox.capabilities.shutil.which", lambda _name: "/bin/sh")
+    monkeypatch.setattr("platform.sandbox.capabilities.subprocess.run", _run)
+
+    # Act
+    available = _shell_available()
+
+    # Assert
+    assert available is False
+    assert calls[0][0] == ["/bin/sh", "-c", "exit 0"]
+    assert calls[0][1]["timeout"] > 0
+
+
+def test_file_grep_probe_rejects_a_failed_search(monkeypatch: Any) -> None:
+    # Arrange
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def _run(command: list[str], **kwargs: Any) -> Any:
+        calls.append((command, kwargs))
+        return type("Result", (), {"returncode": 2})()
+
+    monkeypatch.setattr("platform.sandbox.capabilities.shutil.which", lambda _name: "/bin/grep")
+    monkeypatch.setattr("platform.sandbox.capabilities.subprocess.run", _run)
+
+    # Act
+    available = _file_grep_available()
+
+    # Assert
+    assert available is False
+    assert calls[0][0] == ["/bin/grep", "-q", "OpenSRE"]
+    assert calls[0][1]["input"] == "OpenSRE\n"
 
 
 def test_every_capability_is_reported() -> None:
@@ -47,6 +90,7 @@ def test_warnings_name_only_the_unavailable_ones() -> None:
     assert len(warnings) == 1
     assert "network" in warnings[0].lower()
     assert "blocked by policy" in warnings[0]
+    assert "configured integration" in warnings[0]
 
 
 def test_no_warnings_when_everything_works() -> None:
@@ -138,6 +182,36 @@ def test_boot_capability_warnings_merges_path_and_sandbox(monkeypatch: Any) -> N
         "dup",
         "network requests is unavailable",
     ]
+
+
+def test_boot_warnings_make_every_basic_capability_actionable(
+    monkeypatch: Any,
+) -> None:
+    # Arrange
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+    monkeypatch.setattr(
+        "platform.sandbox.capabilities.unavailable_capability_warnings",
+        lambda _results=None: [],
+    )
+    installed_tools = {
+        "bash": "",
+        "curl": "",
+        "grep": "",
+        "python": "",
+        "python3": "",
+        "sh": "",
+    }
+
+    # Act
+    warnings = boot_capability_warnings(installed_tools=installed_tools)
+    rendered = "\n".join(warnings).lower()
+
+    # Assert
+    assert "install curl" in rendered
+    assert "install bash or sh" in rendered
+    assert "install grep" in rendered
+    assert "configured integration" in rendered
+    assert "install python 3" in rendered
 
 
 def test_file_read_available_when_cwd_is_empty(tmp_path: Any, monkeypatch: Any) -> None:

--- a/tests/platform/sandbox/test_capabilities.py
+++ b/tests/platform/sandbox/test_capabilities.py
@@ -30,44 +30,38 @@ def test_file_read_is_detected() -> None:
     assert results[Capability.FILE_READ].available is True
 
 
-def test_shell_probe_rejects_a_failed_script(monkeypatch: Any) -> None:
+def test_shell_probe_reports_missing_interpreters(monkeypatch: Any) -> None:
     # Arrange
-    calls: list[tuple[list[str], dict[str, Any]]] = []
+    probed: list[str] = []
 
-    def _run(command: list[str], **kwargs: Any) -> Any:
-        calls.append((command, kwargs))
-        return type("Result", (), {"returncode": 1})()
+    def _which(name: str) -> None:
+        probed.append(name)
 
-    monkeypatch.setattr("platform.sandbox.capabilities.shutil.which", lambda _name: "/bin/sh")
-    monkeypatch.setattr("platform.sandbox.capabilities.subprocess.run", _run)
+    monkeypatch.setattr("platform.sandbox.capabilities.shutil.which", _which)
 
     # Act
     available = _shell_available()
 
     # Assert
     assert available is False
-    assert calls[0][0] == ["/bin/sh", "-c", "exit 0"]
-    assert calls[0][1]["timeout"] > 0
+    assert probed == ["bash", "sh"]
 
 
-def test_file_grep_probe_rejects_a_failed_search(monkeypatch: Any) -> None:
+def test_file_grep_probe_reports_missing_executable(monkeypatch: Any) -> None:
     # Arrange
-    calls: list[tuple[list[str], dict[str, Any]]] = []
+    probed: list[str] = []
 
-    def _run(command: list[str], **kwargs: Any) -> Any:
-        calls.append((command, kwargs))
-        return type("Result", (), {"returncode": 2})()
+    def _which(name: str) -> None:
+        probed.append(name)
 
-    monkeypatch.setattr("platform.sandbox.capabilities.shutil.which", lambda _name: "/bin/grep")
-    monkeypatch.setattr("platform.sandbox.capabilities.subprocess.run", _run)
+    monkeypatch.setattr("platform.sandbox.capabilities.shutil.which", _which)
 
     # Act
     available = _file_grep_available()
 
     # Assert
     assert available is False
-    assert calls[0][0] == ["/bin/grep", "-q", "OpenSRE"]
-    assert calls[0][1]["input"] == "OpenSRE\n"
+    assert probed == ["grep"]
 
 
 def test_every_capability_is_reported() -> None:


### PR DESCRIPTION
Fixes #4882

#### Describe the changes you have made in this PR -

- Add explicit shell-script and file-grep capability coverage using the existing PATH-fact model.
- Keep binary checks side-effect free: startup verifies presence without executing external commands.
- Add `grep` to runtime PATH facts and make curl, shell, grep, network, Python, and sandbox warnings name a concrete remediation.
- Add deterministic regression coverage for missing shell, grep, and other PATH tools.

### Demo/Screenshot for feature changes and bug fixes -

With all five basic capabilities unavailable, the boot-warning facts now report actionable guidance:

```text
curl is not on PATH — install curl and add it to PATH
no interactive shell (bash/sh) on PATH — install bash or sh and add it to PATH
grep is not on PATH — install grep and add it to PATH
network egress is blocked for sandboxed code by default — use a configured integration for outbound HTTP
python/python3 is not on PATH — install Python 3 and add python3 or python to PATH
```

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `make test-scope` (36 passed)
- `uv run python -m pytest tests/config/test_workspace_identity.py -q` (10 passed)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The existing capability pipeline already merged PATH facts with sandbox probes, so this change extends that design rather than adding another warning path. PATH facts remain responsible for binary presence and now include `grep`; the sandbox capability module uses the same definition for shell and grep so `shell_available`, tool paths, and boot warnings cannot contradict one another. These checks are side-effect free and make no network request.

I considered executing shell and grep commands to test usability, but that would make startup execute PATH-resolved binaries and could conflict with the PATH-based runtime facts. The implementation instead preserves the established presence-probe contract, while the existing Python and network sandbox probes continue to verify actual policy behavior. Warning generation keeps the existing ordering and now attaches capability-specific remediation.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
