### PR TITLE
feat(remote-sync): add opt-in sync on shell exit

### DIFF
--- a/docs/configuration/remote-sync.mdx
+++ b/docs/configuration/remote-sync.mdx
@@ -78,6 +78,16 @@ opensre remote-sync sync --push-only   # upload only
 
 In the shell: `/remote-sync status` and `/remote-sync sync`.
 
+To run one full sync automatically after an interactive shell session exits:
+
+```bash
+opensre --sync-on-exit
+```
+
+Run setup first. The flag applies only to that invocation; a normal `opensre`
+session remains manual-only. If the automatic sync fails, OpenSRE prints a
+warning without changing the shell's exit status.
+
 <Warning>
 Remote sync is for a **personal machine**. Org-bound Slack/Discord turns are refused — those already persist under the org context root.
 </Warning>

--- a/surfaces/cli/app.py
+++ b/surfaces/cli/app.py
@@ -111,6 +111,7 @@ def _run_without_subcommand(
     *,
     launch_shell: ShellLauncher | None,
     resume_session_id: str | None,
+    sync_on_exit: bool,
     interactive: bool,
     passed_on_command_line: bool,
     layout: str | None,
@@ -137,7 +138,12 @@ def _run_without_subcommand(
             cli_theme=theme,
         )
         if config.enabled or resume_session_id:
-            return launch_shell(config, resume_session_id)
+            exit_code = launch_shell(config, resume_session_id)
+            if sync_on_exit:
+                from surfaces.cli.commands.remote_sync import run_remote_sync_on_exit
+
+                run_remote_sync_on_exit()
+            return exit_code
 
     click.echo(RELEASE_STAGE_BANNER, err=True)
     render_landing(group)
@@ -169,6 +175,11 @@ def _run_without_subcommand(
     help="Resume a previous interactive shell session by ID, prefix, or name substring.",
 )
 @click.option(
+    "--sync-on-exit",
+    is_flag=True,
+    help="Sync sessions and memory after the interactive shell exits.",
+)
+@click.option(
     "--layout",
     type=click.Choice(["classic", "pinned"]),
     default=None,
@@ -191,6 +202,7 @@ def cli(
     yes: bool,
     interactive: bool,
     resume_session_id: str | None,
+    sync_on_exit: bool,
     layout: str | None,
     theme: str | None,
 ) -> None:
@@ -220,6 +232,7 @@ def cli(
                 cli,
                 launch_shell=cli_host(ctx).launch_shell,
                 resume_session_id=resume_session_id,
+                sync_on_exit=sync_on_exit,
                 interactive=interactive,
                 passed_on_command_line=(
                     interactive_source is not None and interactive_source.name == "COMMANDLINE"

--- a/surfaces/cli/commands/remote_sync.py
+++ b/surfaces/cli/commands/remote_sync.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+
 import click
 
 from config.constants.filestorage import (
@@ -26,6 +28,7 @@ from platform.filestorage.setup import (
     save_remote_sync_settings,
 )
 from surfaces.cli.commands.remote_sync_progress import CliProgress
+from surfaces.cli.telemetry import capture_exception
 
 
 @click.group(name="remote-sync", invoke_without_command=True)
@@ -74,6 +77,30 @@ def sync_now_command(pull_only: bool, push_only: bool, dry_run: bool) -> None:
     for line in format_report_lines(report, dry_run=dry_run):
         click.echo(line)
     raise SystemExit(SUCCESS)
+
+
+def run_remote_sync_on_exit() -> None:
+    """Run remote sync without changing the interactive shell's exit result."""
+    try:
+        report = run_remote_sync()
+    except Exception as exc:  # noqa: BLE001 - an optional exit hook must fail soft
+        with suppress(Exception):
+            capture_exception(exc, context="surfaces.cli.sync_on_exit")
+        click.echo(
+            "Automatic remote sync failed; run 'opensre remote-sync sync' for details.",
+            err=True,
+        )
+        return
+
+    if report is None:
+        click.echo(
+            "Automatic remote sync skipped because remote sync is off; "
+            "run 'opensre remote-sync setup' first.",
+            err=True,
+        )
+        return
+    for line in format_report_lines(report):
+        click.echo(line)
 
 
 @remote_sync_command.command(name=RemoteSyncSubcommand.SETUP.value)
@@ -229,4 +256,4 @@ def _prompt_extra_field(field: RemoteSyncField, provider: str, current: str | No
     return str(click.prompt(extra.prompt, default=current or "", show_default=False))
 
 
-__all__ = ["remote_sync_command"]
+__all__ = ["remote_sync_command", "run_remote_sync_on_exit"]

--- a/tests/cli/test_sync_on_exit.py
+++ b/tests/cli/test_sync_on_exit.py
@@ -1,0 +1,203 @@
+"""Opt-in remote sync after the interactive shell exits."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from config.constants.filestorage import (
+    REMOTE_SYNC_BUCKET_ENV,
+    REMOTE_SYNC_ENV,
+    REMOTE_SYNC_EXCLUDE_OFF_ENV,
+    REMOTE_SYNC_PROVIDER_ENV,
+)
+from config.repl_config import ReplConfig
+from platform.filestorage import operations as sync_operations
+from platform.filestorage.enums import SyncRootName
+from platform.filestorage.ports import RemoteObject
+from platform.filestorage.providers.registry import (
+    register_object_store,
+    unregister_object_store,
+)
+from platform.filestorage.syncable import SyncRoot
+from surfaces.entrypoint import main
+
+
+class _FakeObjectStore:
+    """In-memory ObjectStore that records when the existing engine reaches it."""
+
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.objects: dict[str, bytes] = {}
+
+    def list_objects(self, _prefix: str) -> list[RemoteObject]:
+        self.events.append("sync")
+        return []
+
+    def get_object(self, key: str) -> bytes:
+        return self.objects[key]
+
+    def put_object(self, key: str, data: bytes) -> None:
+        self.objects[key] = data
+
+    def describe(self) -> str:
+        return "fake://sync-on-exit"
+
+
+class _FailingObjectStore(_FakeObjectStore):
+    def list_objects(self, _prefix: str) -> list[RemoteObject]:
+        self.events.append("sync")
+        raise RuntimeError("store unavailable")
+
+
+@pytest.fixture
+def register_store() -> Iterator[Callable[[str, _FakeObjectStore], None]]:
+    registered: list[str] = []
+
+    def register(name: str, store: _FakeObjectStore) -> None:
+        register_object_store(name, lambda _config: store)
+        registered.append(name)
+
+    yield register
+
+    for name in registered:
+        unregister_object_store(name)
+
+
+def _prepare_interactive_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("surfaces.cli.app.startup.run", lambda *_args: None)
+    monkeypatch.setattr("surfaces.cli.app.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("surfaces.cli.app.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("surfaces.cli.app.shutdown_analytics", lambda **_kwargs: None)
+    monkeypatch.setattr("surfaces.cli.app.sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("surfaces.cli.app.sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(
+        "config.repl_config.ReplConfig.load",
+        classmethod(lambda _cls, **_kwargs: ReplConfig(enabled=True)),
+    )
+
+
+def _configure_remote_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    provider: str,
+    root: SyncRoot,
+) -> None:
+    monkeypatch.setenv(REMOTE_SYNC_ENV, "1")
+    monkeypatch.setenv(REMOTE_SYNC_BUCKET_ENV, "test-bucket")
+    monkeypatch.setenv(REMOTE_SYNC_EXCLUDE_OFF_ENV, "1")
+    monkeypatch.setenv(REMOTE_SYNC_PROVIDER_ENV, provider)
+    monkeypatch.setattr(sync_operations, "syncable_roots", lambda: (root,))
+
+
+def _arrange_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    register_store: Callable[[str, _FakeObjectStore], None],
+    *,
+    provider: str,
+    store_type: type[_FakeObjectStore] = _FakeObjectStore,
+) -> tuple[list[str], _FakeObjectStore]:
+    events: list[str] = []
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    (sessions / "turn.jsonl").write_text('{"turn": 1}\n', encoding="utf-8")
+    root = SyncRoot(name=SyncRootName.SESSIONS, path=sessions)
+    store = store_type(events)
+    register_store(provider, store)
+    _prepare_interactive_cli(monkeypatch)
+    _configure_remote_sync(monkeypatch, provider=provider, root=root)
+    return events, store
+
+
+def test_sync_on_exit_runs_existing_engine_after_shell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    register_store: Callable[[str, _FakeObjectStore], None],
+) -> None:
+    # Arrange
+    events, store = _arrange_sync(
+        monkeypatch,
+        tmp_path,
+        register_store,
+        provider="sync-on-exit-success",
+    )
+
+    def _run_shell(**_kwargs: object) -> int:
+        events.append("shell")
+        assert store.objects == {}
+        return 0
+
+    # Act
+    with patch("surfaces.interactive_shell.run_repl", side_effect=_run_shell):
+        exit_code = main(["--sync-on-exit"])
+
+    # Assert
+    assert exit_code == 0
+    assert events == ["shell", "sync"]
+    assert store.objects == {"sessions/turn.jsonl": b'{"turn": 1}\n'}
+
+
+def test_repl_exit_stays_manual_without_sync_on_exit_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    register_store: Callable[[str, _FakeObjectStore], None],
+) -> None:
+    # Arrange
+    events, store = _arrange_sync(
+        monkeypatch,
+        tmp_path,
+        register_store,
+        provider="sync-on-exit-default",
+    )
+
+    def _run_shell(**_kwargs: object) -> int:
+        events.append("shell")
+        return 0
+
+    # Act
+    with patch("surfaces.interactive_shell.run_repl", side_effect=_run_shell):
+        exit_code = main([])
+
+    # Assert
+    assert exit_code == 0
+    assert events == ["shell"]
+    assert store.objects == {}
+
+
+def test_sync_on_exit_failure_preserves_shell_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    register_store: Callable[[str, _FakeObjectStore], None],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Arrange
+    events, _store = _arrange_sync(
+        monkeypatch,
+        tmp_path,
+        register_store,
+        provider="sync-on-exit-failure",
+        store_type=_FailingObjectStore,
+    )
+    captured: list[BaseException] = []
+    monkeypatch.setattr(
+        "surfaces.cli.commands.remote_sync.capture_exception",
+        lambda exc, **_kwargs: captured.append(exc),
+    )
+
+    def _run_shell(**_kwargs: object) -> int:
+        events.append("shell")
+        return 7
+
+    # Act
+    with patch("surfaces.interactive_shell.run_repl", side_effect=_run_shell):
+        exit_code = main(["--sync-on-exit"])
+
+    # Assert
+    assert exit_code == 7
+    assert events == ["shell", "sync"]
+    assert [type(exc) for exc in captured] == [RuntimeError]
+    assert "Automatic remote sync failed" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #4880

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- adds an opt-in `opensre --sync-on-exit` flag for interactive shell launches
- runs the existing `run_remote_sync` engine only after the REPL returns, so persisted session state is ready to mirror
- keeps the normal `opensre` path manual-only and preserves the shell exit code when automatic sync fails
- renders the existing sync report on success and a concise recovery hint on failure
- documents the opt-in and covers success, default-off, and fail-soft paths with an in-memory `ObjectStore`

### Demo/Screenshot for feature changes and bug fixes - 

```console
$ uv run opensre --help | grep -A1 -- '--sync-on-exit'
    --sync-on-exit                    Sync sessions and memory after the
interactive shell exits.

$ uv run python -m pytest tests/cli/test_sync_on_exit.py -q
3 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I chose the smallest surface-only option accepted by the issue: a top-level CLI flag rather than a background service or a new persistent setting. The root CLI owns whether a shell launch receives the exit hook, while the remote-sync command module owns the feature-specific I/O. After the shell launcher returns, `run_remote_sync_on_exit` delegates to the existing stateless `run_remote_sync` engine and reuses its report formatter. It catches `Exception` because a third-party `ObjectStore` may leak an unexpected failure; the exception is captured server-side, the terminal receives a generic recovery command, and the original shell exit code is retained. Without the flag, no sync code runs.

Validation:
- `make lint` — passed
- `make format-check` — passed
- `make typecheck` — passed
- `uv run python -m pytest tests/cli/test_sync_on_exit.py tests/cli/test_main.py tests/cli/test_remote_sync_command.py tests/surfaces/test_remote_sync_surface_contract.py -q` — 65 passed
- `uv run python -m pytest tests/cli/ -q` — 790 passed, 3 skipped, with one unrelated PTY onboarding failure that reproduces on unchanged `upstream/main` (`OpenCode CLI` selection lands on `GitHub Copilot CLI`)

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
