### PR TITLE
fix(signoz): use HTTPStatus instead of a bare 404 literal in client.py

### DIFF
--- a/integrations/signoz/client.py
+++ b/integrations/signoz/client.py
@@ -176,7 +176,7 @@ class SigNozClient:
         except httpx.HTTPStatusError as err:
             message = _extract_http_error_message(err)
             if err.response.status_code == HTTPStatus.NOT_FOUND:
-                return None, f"404: {message or 'not found'}"
+                return None, f"{HTTPStatus.NOT_FOUND}: {message or 'not found'}"
             return None, message
         except Exception as err:
             return None, str(err)
@@ -300,7 +300,7 @@ class SigNozClient:
 
         response_json, error_message = self._query_range_post(payload)
         if error_message:
-            if "not found" in error_message.lower() or "404" in error_message:
+            if "not found" in error_message.lower() or str(HTTPStatus.NOT_FOUND) in error_message:
                 return {
                     "source": "signoz_metrics",
                     "available": True,


### PR DESCRIPTION
Closes #4295

## Summary

SM-37: `integrations/signoz/client.py` compared a bare `"404"` string literal against a status code / error message in two spots, instead of the named `HTTPStatus.NOT_FOUND` enum already used on the line above for the actual comparison.

- `_query_range_post`: the returned error message now formats `HTTPStatus.NOT_FOUND` instead of the literal `"404"`.
- `_query_metrics_via_api`: the substring check for the not-found case now checks `str(HTTPStatus.NOT_FOUND)` instead of `"404"`.

Behavior is unchanged: `HTTPStatus.NOT_FOUND`'s `str()` renders as `"404"` (IntEnum has used int's `__str__` since Python 3.11), so both strings are byte-identical to before.

One file changed, per the task's rule.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean
- [x] `tests/integrations/signoz/`, `tests/integrations/test_signoz.py`, `tests/tools/test_signoz_tools.py` - 30 passed, including the tests exercising the 404 path