### PR TITLE
fix(signoz): use HTTPStatus instead of a bare 404 literal in client.py

### DIFF
--- a/integrations/signoz/client.py
+++ b/integrations/signoz/client.py
@@ -176,7 +176,7 @@ class SigNozClient:
         except httpx.HTTPStatusError as err:
             message = _extract_http_error_message(err)
             if err.response.status_code == HTTPStatus.NOT_FOUND:
-                return None, f"404: {message or 'not found'}"
+                return None, f"{HTTPStatus.NOT_FOUND}: {message or 'not found'}"
             return None, message
         except Exception as err:
             return None, str(err)
@@ -300,7 +300,7 @@ class SigNozClient:
 
         response_json, error_message = self._query_range_post(payload)
         if error_message:
-            if "not found" in error_message.lower() or "404" in error_message:
+            if "not found" in error_message.lower() or str(HTTPStatus.NOT_FOUND) in error_message:
                 return {
                     "source": "signoz_metrics",
                     "available": True,


### PR DESCRIPTION
Fixes #4295

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`integrations/signoz/client.py` had two spots that compared/formatted a bare `"404"` string literal instead of the project's required `http.HTTPStatus` enum, even though `HTTPStatus.NOT_FOUND` was already imported and used one line above for the actual status comparison:

- `_query_range_post`: the returned error message built `f"404: {message}"` instead of using `HTTPStatus.NOT_FOUND`.
- `_query_metrics_via_api`: the not-found detection checked `"404" in error_message` instead of `str(HTTPStatus.NOT_FOUND) in error_message`.

Both are now `HTTPStatus.NOT_FOUND`. Behavior is unchanged: since Python 3.11, `IntEnum.__str__` delegates to `int.__str__`, so `str(HTTPStatus.NOT_FOUND)` and `f"{HTTPStatus.NOT_FOUND}"` both render as `"404"`, byte-identical to the old literal. One file changed, per the task's scope rule.

### Demo/Screenshot for feature changes and bug fixes -

Diff:

```diff
-                return None, f"404: {message or 'not found'}"
+                return None, f"{HTTPStatus.NOT_FOUND}: {message or 'not found'}"
...
-            if "not found" in error_message.lower() or "404" in error_message:
+            if "not found" in error_message.lower() or str(HTTPStatus.NOT_FOUND) in error_message:
```

Verification run:

```
ruff check integrations/signoz/client.py        -> All checks passed!
ruff format --check integrations/signoz/client.py -> 1 file already formatted
mypy integrations/signoz/client.py               -> Success: no issues found in 1 source file
pytest tests/integrations/signoz/ tests/integrations/test_signoz.py tests/tools/test_signoz_tools.py -q
  -> 30 passed in 2.35s (includes the tests exercising the 404 path)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: two places compared/rendered an HTTP status as a bare `"404"` literal rather than the project's mandated `http.HTTPStatus` enum. The fix keeps the exact same runtime behavior while replacing the literal with the already-imported `HTTPStatus.NOT_FOUND`, relying on the documented Python 3.11+ guarantee that `IntEnum.__str__`/`__format__` render the same digits as the raw literal did. No alternative approach was needed: this is a direct literal substitution with no behavioral branch to redesign. The key change is confined to `SigNozClient._query_range_post` (error message formatting) and `SigNozClient._query_metrics_via_api` (not-found detection), both of which are covered by the existing `tests/integrations/signoz/test_client.py` and `tests/integrations/test_signoz.py` suites that already exercise the 404 path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
