### PR TITLE
refactor(investigation): spell out _SESSION_EVENT_POLL_S unit suffix

### DIFF
--- a/tools/investigation/session_runner.py
+++ b/tools/investigation/session_runner.py
@@ -18,7 +18,7 @@ from tools.investigation.alert_templates import build_alert_template
 
 _logger = logging.getLogger(__name__)
 
-_SESSION_EVENT_POLL_S = 0.25
+_SESSION_EVENT_POLL_SECONDS = 0.25
 
 StreamRendererFn = Callable[[Iterator[StreamEvent]], dict[str, Any]]
 
@@ -163,7 +163,7 @@ def run_session_alert_payload(
                     _cancel_pump()
                     raise KeyboardInterrupt
                 try:
-                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
+                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_SECONDS)
                 except queue.Empty:
                     continue
                 if isinstance(item, BaseException):


### PR DESCRIPTION
Fixes #4324

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`tools/investigation/session_runner.py` had a module-level duration constant named with a short unit suffix, `_SESSION_EVENT_POLL_S`, instead of spelling out the unit. Renamed it to `_SESSION_EVENT_POLL_SECONDS` and updated its one use site (`event_queue.get(timeout=...)`). This is a private constant used only within this file (confirmed via a repo-wide grep, no other references), so no third file was touched. No behavior change: same value (`0.25`), same use site, rename only.

### Demo/Screenshot for feature changes and bug fixes -

Full diff (2 lines changed):

```diff
-_SESSION_EVENT_POLL_S = 0.25
+_SESSION_EVENT_POLL_SECONDS = 0.25
...
-                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
+                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_SECONDS)
```

Verification run:

```
make lint                                          -> All checks passed!
ruff format --check tools/investigation/session_runner.py -> 1 file already formatted
mypy tools/investigation/session_runner.py         -> Success: no issues found in 1 source file
pytest tests/tools/investigation/test_session_runner.py -q -> 6 passed in 1.45s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: a private module-level constant used a short unit suffix (`_S`) instead of spelling out the unit, per the task's naming convention rule. The fix is a pure rename: `_SESSION_EVENT_POLL_S` -> `_SESSION_EVENT_POLL_SECONDS`, with its single use site updated to match. No other approach was considered since this is a scoped rename with an explicit stop-and-ask rule if a third file breaks; a repo-wide grep confirmed the constant is private and has exactly one definition and one use, both in this file, so nothing else needed to change.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
