### PR TITLE
docs(ci): require Greptile re-review after updates

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -112,6 +112,12 @@ the repository's merge requirements are satisfied: required GitHub checks are
 green, actionable human or automated review feedback (including Greptile) is
 addressed, and resolved conversations are closed out.
 
+After each completed PR update, once commits are pushed, the PR description is
+current, and addressed threads are resolved, trigger a Greptile re-review by
+following [CONTRIBUTING.md](CONTRIBUTING.md#greptile-code-review). Repeat until
+Greptile reports 5/5 with no unresolved comments. Do not re-trigger while a
+review is already running.
+
 Use relevant built-in capabilities or locally installed skills, when available,
 for PR monitoring, CI diagnosis, and review remediation rather than duplicating
 tool-specific procedures in this document. Keep monitoring after each update;


### PR DESCRIPTION
Follow-up to #4965

#### Describe the changes you have made in this PR -

Makes the Greptile re-review step explicit in `CI.md`, the repository's precedence document for push and PR readiness.

After a completed PR update, contributors must first push the commits, update the PR description, and resolve addressed threads. They then follow the canonical Greptile procedure in `CONTRIBUTING.md`, repeat until the review reaches 5/5 with no unresolved comments, and avoid re-triggering a review that is already running.

The detailed trigger procedure remains in `CONTRIBUTING.md` rather than being duplicated in `CI.md`.

### Demo/Screenshot for feature changes and bug fixes -

Rendered process requirement:

> After each completed PR update, once commits are pushed, the PR description is current, and addressed threads are resolved, trigger a Greptile re-review by following CONTRIBUTING.md. Repeat until Greptile reports 5/5 with no unresolved comments. Do not re-trigger while a review is already running.

Validation: used the `CI.md` docs/process-only shortcut and confirmed that the commit contains only `CI.md`. The pre-existing untracked local notes file was left untouched.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I added one normative paragraph to the existing post-PR follow-through section. It links to the canonical contributor instructions instead of duplicating the tool command, and distinguishes a completed update from intermediate commits so contributors do not spam reviews.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the relevant PR discussion
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
