### PR TITLE
fix: remediate GitHub code quality finding #3317

### DIFF
--- a/config/llm_auth/__init__.py
+++ b/config/llm_auth/__init__.py
@@ -1,14 +1,13 @@
 """Config-owned storage helpers for LLM provider auth metadata.
 
-``credentials`` is loaded on first attribute access so leaf importers
-(``provider_catalog``, keychain migration) never pull in
-:mod:`config.secrets.store` through this package init — that edge was a
-cyclic-import with ``store`` → ``keychain_import`` → ``llm_auth``.
+Credential operations are imported from :mod:`config.llm_auth.credentials`
+directly, never re-exported here: this init must stay free of that module so
+leaf importers (``provider_catalog``, keychain migration) never pull in
+:mod:`config.secrets.store` — that edge was a cyclic-import with
+``store`` → ``keychain_import`` → ``llm_auth``.
 """
 
 from __future__ import annotations
-
-from typing import Any
 
 from config.llm_auth.auth_method import (
     API_KEY_AUTH_METHOD,
@@ -37,34 +36,11 @@ from config.llm_auth.records import (
     save_provider_auth_record,
 )
 
-# Names resolved from :mod:`config.llm_auth.credentials` via ``__getattr__``.
-_CREDENTIAL_EXPORTS: frozenset[str] = frozenset(
-    {
-        "CredentialResolution",
-        "CredentialSource",
-        "CredentialStatus",
-        "MissingLLMCredentialError",
-        "delete",
-        "has_api_key_env_status",
-        "require_for_request",
-        "resolve_api_key_env_for_request",
-        "resolve_for_request",
-        "save_api_key",
-        "source_for_api_key_env",
-        "status",
-        "verify",
-    }
-)
-
 __all__ = [
     "API_KEY_PROVIDER_ENVS",
     "API_KEY_AUTH_METHOD",
-    "CredentialResolution",
-    "CredentialSource",
-    "CredentialStatus",
     "KEYLESS_PROVIDER_VALUES",
     "LLM_AUTH_METHOD_ENV",
-    "MissingLLMCredentialError",
     "OAUTH_AUTH_METHOD",
     "OAUTH_BACKEND_PROVIDER_BY_PROVIDER",
     "OAUTH_PROVIDER_BY_BACKEND_PROVIDER",
@@ -72,34 +48,13 @@ __all__ = [
     "ProviderSpec",
     "SUPPORTED_PROVIDER_VALUES",
     "canonical_llm_provider",
-    "delete",
     "delete_provider_auth_record",
     "effective_llm_provider",
     "get_configured_llm_auth_method",
-    "has_api_key_env_status",
     "normalize_llm_auth_method",
     "provider_auth_record_name",
     "provider_spec",
-    "require_for_request",
     "resolve_provider_auth_record",
-    "resolve_api_key_env_for_request",
-    "resolve_for_request",
-    "save_api_key",
     "save_provider_auth_record",
-    "source_for_api_key_env",
-    "status",
     "supports_oauth_auth_method",
-    "verify",
 ]
-
-
-def __getattr__(name: str) -> Any:
-    if name in _CREDENTIAL_EXPORTS:
-        from config.llm_auth import credentials as _credentials
-
-        return getattr(_credentials, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> list[str]:
-    return sorted(__all__)

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -7,6 +7,7 @@ import keyring.errors
 import pytest
 from keyring.backend import KeyringBackend
 
+import config.llm_auth
 from config.llm_auth.credentials import resolve_for_request, status
 from config.llm_auth.records import resolve_provider_auth_record, save_provider_auth_record
 from config.llm_credentials import resolve_env_credential
@@ -35,6 +36,12 @@ class _NoBackendKeyring(MemoryKeyring):
 
     def delete_password(self, _service: str, _username: str) -> None:
         raise keyring.errors.NoKeyringError("No recommended backend was available")
+
+
+def test_package_exports_are_all_defined() -> None:
+    """Every ``__all__`` name must be a real attribute so ``import *`` cannot raise."""
+    for name in config.llm_auth.__all__:
+        assert hasattr(config.llm_auth, name), name
 
 
 def test_resolve_auth_profile_accepts_subscription_aliases() -> None:


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code quality finding #3317](https://github.com/Tracer-Cloud/opensre/security/quality/findings/3317).

**Alert summary**
Explicit export is not defined

**Fix summary**
All 306 config tests pass.

## Summary

**Finding**: CodeQL `py/undefined-export` — `verify` (and 12 sibling credential names) appeared in `config/llm_auth/__init__.py`'s `__all__` but had no static definition; they were resolved lazily through a module-level `__getattr__` that CodeQL cannot trace.

**Root cause & fix**: The lazy re-export facade was dead code. Every consumer in the repo imports credential names from the canonical module `config.llm_auth.credentials` directly — nothing used the package-level re-exports. Per the repo convention ("do not keep compatibility-only forwarding modules after refactors; use one canonical import path"), I removed the facade instead of patching around the alert.

**Files changed**:
- `config/llm_auth/__init__.py` — removed `_CREDENTIAL_EXPORTS`, the `__getattr__`/`__dir__` machinery, the 13 lazy credential names from `__all__`, and the now-unused `typing.Any` import; updated the docstring to state that credential operations are imported from `config.llm_auth.credentials` directly (the init still never imports it, preserving the cyclic-import fix the laziness existed for).
- `tests/config/test_llm_auth.py` — added `test_package_exports_are_all_defined`, pinning the finding's bug class: every `__all__` name must resolve so `from config.llm_auth import *` can never raise.

**Reliability improvement**: `__all__` now lists only statically defined names, so the export surface is verifiable by both CodeQL and the interpreter — no runtime indirection that a future rename in `credentials.py` could silently break. This also resolves the sibling findings for the other 12 lazily-exported names, not just `verify`.

**Verification**: `tests/config` suite (306 passed), `ruff check`, `ruff format --check`, and mypy on the touched source file all clean (the 4 mypy errors in the test file are pre-existing on untouched lines; CI's typecheck doesn't cover `tests/`).

**Files changed**
- `config/llm_auth/__init__.py`
- `tests/config/test_llm_auth.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.