### PR TITLE
Remove unused looks_like_correction keyword router

### DIFF
--- a/surfaces/interactive_shell/runtime/AGENTS.md
+++ b/surfaces/interactive_shell/runtime/AGENTS.md
@@ -38,8 +38,8 @@ owner module instead of broadening module responsibilities.
   `core.agent_harness.session.background`).
 - `core/state.py` — `ReplState`, `SpinnerState`: runtime state and transition
   helpers only (see State ownership rules below).
-- `core/turn_detection.py` — pure text classifiers for cancel/confirm/
-  correction detection only.
+- `core/turn_detection.py` — pure text classifiers for cancel/confirm
+  detection only.
 - `core/confirmation.py` — prompt-mediated confirmation waiting only.
 - `turn_host.py` — `run_input_loop` (read/handle input until exit),
   `run_agent_turn_queue` (consume queued prompts via an injected `run_turn`),

--- a/surfaces/interactive_shell/runtime/core/turn_detection.py
+++ b/surfaces/interactive_shell/runtime/core/turn_detection.py
@@ -2,25 +2,6 @@
 
 from __future__ import annotations
 
-import re
-
-_INTERVENTION_CORRECTION_RE = re.compile(
-    r"("
-    r"no(?=[,.!?]|$)"
-    r"|nope\b"
-    r"|nvm\b"
-    r"|nevermind\b|never\s*mind\b"
-    r"|wrong\b"
-    r"|wait(?=[,.!?]|$)"
-    r"|stop(?=[,.!?]|$)"
-    r"|actually\b"
-    r"|scratch\s+that\b"
-    r"|instead(?=[,.!?]|$)"
-    r"|(?:let'?s\s+)?do\s+[^.\n]{1,60}\s+instead\b"
-    r"|try\s+[^.\n]{1,60}\s+instead\b"
-    r")",
-    re.IGNORECASE,
-)
 _CONFIRMATION_TOKENS: frozenset[str] = frozenset({"", "y", "yes", "n", "no"})
 _CANCEL_REQUEST_TOKENS: frozenset[str] = frozenset({"/cancel", "/stop", "/abort"})
 
@@ -33,15 +14,7 @@ def looks_like_cancel_request(text: str | None) -> bool:
     return (text or "").strip().lower() in _CANCEL_REQUEST_TOKENS
 
 
-def looks_like_correction(text: str) -> bool:
-    stripped = text.lstrip()
-    if not stripped or stripped.startswith("```"):
-        return False
-    return _INTERVENTION_CORRECTION_RE.match(stripped[:80]) is not None
-
-
 __all__ = [
     "looks_like_cancel_request",
     "looks_like_confirmation_answer",
-    "looks_like_correction",
 ]

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -526,55 +526,6 @@ def test_run_initial_input_dispatches_as_non_tty(monkeypatch: pytest.MonkeyPatch
     assert calls[0]["is_tty"] is False
 
 
-class TestLooksLikeCorrection:
-    """Unit tests for the ``_looks_like_correction`` heuristic.
-
-    Pins the v1 catches, false-positive guards, and limitations so future
-    iteration on ``_INTERVENTION_CORRECTION_RE`` has a regression baseline.
-    """
-
-    @pytest.mark.parametrize(
-        "text",
-        [
-            "no, do that instead",
-            "nope",
-            "nvm",
-            "never mind",
-            "actually, let's check Datadog first",
-            "scratch that, run the synthetic test",
-            "wait, wrong dashboard",
-            "let's do an EKS health check instead",
-            "try a token refresh instead",
-            "wrong dashboard, fix it",
-            "instead, log a warning",
-            "Wait!",  # case-insensitive
-            "NO.",
-        ],
-    )
-    def test_correction_cues_match(self, text: str) -> None:
-        assert loop_turn_detection.looks_like_correction(text) is True
-
-    @pytest.mark.parametrize(
-        "text",
-        [
-            # Punctuation-lookahead guards reject content uses of cue words.
-            "stop the server before redeploying",
-            "instead of returning null, log a warning",
-            "no problem, I'll handle it",
-            "wait for the result",
-            # v1 limitation: cue must be at start of message.
-            "hmm, scratch that",
-            "doesn't work, try X instead",
-            # Edge cases.
-            "",
-            "   ",
-            "```\nstop the server\n```",
-        ],
-    )
-    def test_non_correction_text_does_not_match(self, text: str) -> None:
-        assert loop_turn_detection.looks_like_correction(text) is False
-
-
 class TestLooksLikeConfirmationAnswer:
     """Unit tests for the y/n token recognizer.
 


### PR DESCRIPTION
Fixes #5084

#### Describe the changes you have made in this PR -
Removed `looks_like_correction`, its `_INTERVENTION_CORRECTION_RE` regex, and the `__all__` entry from `turn_detection.py`, and dropped the now-unused `import re`. Also removed the `TestLooksLikeCorrection` test class from `test_terminal_runtime.py`, since it only tested the function being removed.

**Explain your implementation approach:**
I confirmed via a repo-wide search (`rg -n "looks_like_correction|_INTERVENTION_CORRECTION_RE" --type py`) that this function and its regex were referenced only in their own definition and their own tests, with no callers anywhere else in the codebase. Since the code was completely dead, the simplest and safest change was a straight deletion rather than trying to wire it up to a caller, which would have been a much bigger, out-of-scope change. I left `looks_like_confirmation_answer`, `looks_like_cancel_request`, and every other module in `runtime/core/` untouched, as scoped by the issue.

#### Demo/Screenshot for feature changes and bug fixes -
Not applicable — this is a dead-code removal with no behavior change. Ran `python -m py_compile` on both changed files to confirm they're syntactically valid.
