### PR TITLE
docs: add aws_lambda verification recipe

### DIFF
--- a/docs/aws_lambda_verification.md
+++ b/docs/aws_lambda_verification.md
@@ -13,57 +13,118 @@ Scope
 
 Prerequisites
 
-- Valid AWS credentials available to the environment (any standard boto3 chain):
+- Valid AWS credentials available to the environment (boto3 credential chain):
   - AWS_ACCESS_KEY_ID
   - AWS_SECRET_ACCESS_KEY
   - AWS_SESSION_TOKEN (if required)
-  - AWS_DEFAULT_REGION or AWS_REGION
+- Region configuration: the tools use the environment variable AWS_REGION (falling
+  back to "us-east-1") via the project's boto3 wrapper. Set AWS_REGION to the
+  target region. Setting AWS_DEFAULT_REGION is harmless but not relied upon by
+  the client helper.
 - boto3 and requests installed in the running environment (the repo dev env
   normally provides these).
 - A real Lambda function name to test (example: my-lambda-function). Use a
   non-production function or redact sensitive output before posting evidence.
 
+Required IAM permissions (minimum)
+
+The verification commands exercise Lambda and CloudWatch Logs APIs. The test
+identity must have at least these actions on the target account / resources:
+
+- lambda:GetFunctionConfiguration
+- lambda:GetFunction
+- lambda:ListFunctions (optional, used by list code path)
+- logs:FilterLogEvents
+- logs:GetLogEvents
+- logs:DescribeLogGroups (optional, for discovery)
+
+If you prefer a fine-grained role, scope these actions to the relevant function
+ARN and the /aws/lambda/{function_name} log group.
+
 Verification steps (single-file Python invocations)
 
 Notes:
-- These commands call the same Python functions used by the tool wrappers.
-- Run them from the repo root so the package imports resolve.
+- These one-liners invoke the repository's internal tool wrappers. They are a
+  developer-facing verification method; do not consider the Python symbol names
+  to be public API. The tools are also callable from the interactive shell
+  surfaces.
+- Run from the repo root so package imports resolve.
 - Redact any customer or host-identifying details before adding evidence to the
   issue.
 
-1) Verify AWS verifier (optional sanity check):
+1) Sanity check: AWS verifier (optional)
 
    uv run opensre integrations verify aws
 
    Expectation: verifier passes and reports account access. If it fails, stop
    and fix credentials first — do not proceed to claim the tools.
 
-2) get_lambda_configuration (lightweight configuration)
+2) Lambda configuration (user-facing name: "Lambda configuration") — quick check
 
-   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_config_tool import get_lambda_configuration; print(json.dumps(get_lambda_configuration('my-lambda-function'), indent=2))"
+Developer command (internal):
 
-   Expected: JSON with found=true and fields like runtime, handler, timeout.
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_config_tool import get_lambda_configuration as _cmd; print(json.dumps(_cmd('my-lambda-function'), indent=2))"
 
-3) inspect_lambda_function (configuration + optional code)
+Sanitized example output:
 
-   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_inspect_tool import inspect_lambda_function; print(json.dumps(inspect_lambda_function('my-lambda-function', include_code=False), indent=2))"
+   {
+     "found": true,
+     "function_name": "my-lambda-function",
+     "runtime": "python3.12",
+     "handler": "handler.main",
+     "timeout": 300
+   }
 
-   Expected: JSON similar to configuration; when include_code=True the tool may
-   return extracted files (if small) — redact file contents or only show file
-   names and counts.
+3) Lambda inspect (user-facing name: "Lambda config") — configuration + optional code
 
-4) get_lambda_invocation_logs (invocation logs, recent invocations)
+Developer command (internal):
 
-   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_invocation_logs_tool import get_lambda_invocation_logs; print(json.dumps(get_lambda_invocation_logs('my-lambda-function', limit=20), indent=2))"
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_inspect_tool import inspect_lambda_function as _cmd; print(json.dumps(_cmd('my-lambda-function', include_code=False), indent=2))"
 
-   Expected: JSON with invocation_count, invocations (summaries), or recent_logs.
+Sanitized example output:
 
-5) get_lambda_errors (filtered errors)
+   {
+     "found": true,
+     "function_name": "my-lambda-function",
+     "function_arn": "arn:aws:lambda:...:function:my-lambda-function",
+     "runtime": "python3.12",
+     "timeout": 300
+   }
 
-   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_errors_tool import get_lambda_errors; print(json.dumps(get_lambda_errors('my-lambda-function', limit=50), indent=2))"
+4) Invocation logs (user-facing name: "Lambda logs")
 
-   Expected: JSON with error-focused logs (same shape as invocation logs but
-   filtered). An empty result is a valid outcome but must be reported as such.
+Developer command (internal):
+
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_invocation_logs_tool import get_lambda_invocation_logs as _cmd; print(json.dumps(_cmd('my-lambda-function', limit=20), indent=2))"
+
+Sanitized example output:
+
+   {
+     "found": true,
+     "function_name": "my-lambda-function",
+     "invocation_count": 2,
+     "invocations": [
+       {"request_id": "r1", "duration_ms": 100, "memory_used_mb": 128}
+     ]
+   }
+
+5) Errors (user-facing name: "Lambda errors")
+
+Developer command (internal):
+
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_errors_tool import get_lambda_errors as _cmd; print(json.dumps(_cmd('my-lambda-function', limit=50), indent=2))"
+
+Sanitized example output:
+
+   {
+     "found": true,
+     "function_name": "my-lambda-function",
+     "invocations": []
+   }
+
+If a tool returns only an error or an empty result, record the exact command and
+output in the issue and file a follow-up bug if the output looks like a stub or
+an unexpected failure.
 
 Recording evidence
 

--- a/docs/aws_lambda_verification.md
+++ b/docs/aws_lambda_verification.md
@@ -78,14 +78,3 @@ Out of scope (do not do here)
 - Rewriting client code or the tools themselves. If a tool fails and shows a
   design problem, open a separate bug referencing this issue.
 - Adding CI tests that require live AWS credentials.
-
-If verification exposes a reproducible bug
-
-- File a new issue with: failing command, truncated output, and suggested
-  severity. Link the new issue from #5105.
-
-Change log
-
-- Created docs/aws_lambda_verification.md to satisfy "environment recipe"
-  requirement for #5105.
-

--- a/docs/aws_lambda_verification.md
+++ b/docs/aws_lambda_verification.md
@@ -1,0 +1,91 @@
+Purpose
+
+Provide an environment recipe and exact verification steps so issue #5105 can be
+claimed. This file explains minimal prerequisites and runnable commands that
+exercise the four registered aws_lambda tools without changing code.
+
+Scope
+
+- What to do: produce reproducible evidence that each tool returns real data
+  from AWS in a developer environment.
+- What not to do: do not add an integrations verifier, do not change tool code,
+  do not add CI tests that require live AWS credentials.
+
+Prerequisites
+
+- Valid AWS credentials available to the environment (any standard boto3 chain):
+  - AWS_ACCESS_KEY_ID
+  - AWS_SECRET_ACCESS_KEY
+  - AWS_SESSION_TOKEN (if required)
+  - AWS_DEFAULT_REGION or AWS_REGION
+- boto3 and requests installed in the running environment (the repo dev env
+  normally provides these).
+- A real Lambda function name to test (example: my-lambda-function). Use a
+  non-production function or redact sensitive output before posting evidence.
+
+Verification steps (single-file Python invocations)
+
+Notes:
+- These commands call the same Python functions used by the tool wrappers.
+- Run them from the repo root so the package imports resolve.
+- Redact any customer or host-identifying details before adding evidence to the
+  issue.
+
+1) Verify AWS verifier (optional sanity check):
+
+   uv run opensre integrations verify aws
+
+   Expectation: verifier passes and reports account access. If it fails, stop
+   and fix credentials first — do not proceed to claim the tools.
+
+2) get_lambda_configuration (lightweight configuration)
+
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_config_tool import get_lambda_configuration; print(json.dumps(get_lambda_configuration('my-lambda-function'), indent=2))"
+
+   Expected: JSON with found=true and fields like runtime, handler, timeout.
+
+3) inspect_lambda_function (configuration + optional code)
+
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_inspect_tool import inspect_lambda_function; print(json.dumps(inspect_lambda_function('my-lambda-function', include_code=False), indent=2))"
+
+   Expected: JSON similar to configuration; when include_code=True the tool may
+   return extracted files (if small) — redact file contents or only show file
+   names and counts.
+
+4) get_lambda_invocation_logs (invocation logs, recent invocations)
+
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_invocation_logs_tool import get_lambda_invocation_logs; print(json.dumps(get_lambda_invocation_logs('my-lambda-function', limit=20), indent=2))"
+
+   Expected: JSON with invocation_count, invocations (summaries), or recent_logs.
+
+5) get_lambda_errors (filtered errors)
+
+   uv run python -c "import json; from integrations.aws_lambda.tools.lambda_errors_tool import get_lambda_errors; print(json.dumps(get_lambda_errors('my-lambda-function', limit=50), indent=2))"
+
+   Expected: JSON with error-focused logs (same shape as invocation logs but
+   filtered). An empty result is a valid outcome but must be reported as such.
+
+Recording evidence
+
+For each tool, paste a short evidence block in the issue comments consisting of:
+- command used (exact copy/paste)
+- truncated JSON output (redact keys, hostnames, tokens)
+- whether it was run via the Python one-liner above or from an interactive shell
+
+Out of scope (do not do here)
+
+- Adding a verifier for `aws_lambda` (the issue explicitly forbids adding one).
+- Rewriting client code or the tools themselves. If a tool fails and shows a
+  design problem, open a separate bug referencing this issue.
+- Adding CI tests that require live AWS credentials.
+
+If verification exposes a reproducible bug
+
+- File a new issue with: failing command, truncated output, and suggested
+  severity. Link the new issue from #5105.
+
+Change log
+
+- Created docs/aws_lambda_verification.md to satisfy "environment recipe"
+  requirement for #5105.
+


### PR DESCRIPTION
Fixes https://github.com/Tracer-Cloud/opensre/issues/5105

Why

Provide an environment recipe and exact verification steps so maintainers/testers can prove the four aws_lambda tools return real AWS data. The issue requested a reproducible verification procedure and evidence, not code changes.

What

- Adds docs/aws_lambda_verification.md with prerequisites, one-line commands to run each tool, evidence format, redaction guidance, and acceptance checklist.
- No production code changed and no verifier added.

Approach

- Keep instructions minimal and executable from the repo root using the existing Python tool wrappers.
- Require manual execution with real AWS credentials; includes guidance on redaction and filing follow-up bugs.

Acceptance criteria

- A reviewer can run the listed commands and post truncated evidence to the related issue (ticket #5105).

Notes

- This change does not add live-credential CI tests or any secrets.
- If verification exposes a reproducible bug, file a separate issue and link it to #5105.

Files changed

- docs/aws_lambda_verification.md