### PR TITLE
refactor(wizard): use HTTPStatus in the remote probe range check (SM-56)

### DIFF
--- a/surfaces/cli/wizard/probes.py
+++ b/surfaces/cli/wizard/probes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import asdict, dataclass
+from http import HTTPStatus
 from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlparse
@@ -61,10 +62,10 @@ def probe_remote_target(timeout_seconds: float = 3.0) -> ProbeResult:
     request = Request(url, method="GET")
     try:
         with _open_probe_request(request, timeout_seconds) as response:
-            status = getattr(response, "status", 200)
+            status = getattr(response, "status", HTTPStatus.OK)
             return ProbeResult(
                 target="remote",
-                reachable=200 <= status < 500,
+                reachable=HTTPStatus.OK <= status < HTTPStatus.INTERNAL_SERVER_ERROR,
                 detail=f"Tracer remote target reachable at {url} (HTTP {status})",
             )
     except URLError as err:


### PR DESCRIPTION
Closes #4314 (SM-56).

One ID, one file, one PR — only `surfaces/cli/wizard/probes.py` is touched.

## What changed

Two bare status literals in `probe_remote_target`:

```diff
-            status = getattr(response, "status", 200)
+            status = getattr(response, "status", HTTPStatus.OK)
             return ProbeResult(
                 target="remote",
-                reachable=200 <= status < 500,
+                reachable=HTTPStatus.OK <= status < HTTPStatus.INTERNAL_SERVER_ERROR,
```

plus `from http import HTTPStatus`. No other bare HTTP status numbers remain in the file.

## Verification

- `ruff check` — All checks passed
- `ruff format --check` — already formatted
- `mypy` — no errors attributable to this file (the 8 errors it reports are pre-existing missing stubs for `sentry_sdk` and `anthropic` in other modules, present on a clean checkout too)
- `pytest tests/cli/wizard/test_flow.py` — **92 passed** (the only test module that exercises `wizard.probes`). Since this is a no-behavior-change refactor, green before and after is the correct proof.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is that `probes.py` encoded the reachability rule as bare integers, so a reader has to know that 200 is OK and 500 is the first server-error code to understand what `200 <= status < 500` means.

The alternative I considered was module-level named constants (e.g. `_MIN_OK = 200`), but the task specifies `http.HTTPStatus` and the stdlib enum is strictly better here — it is the shared vocabulary the rest of the codebase already uses (`integrations/servicenow/verifier.py` and `gateway/transports/telegram/poller/client.py` both import it).

The one thing worth checking closely, and the reason I did not treat this as a blind find-and-replace: `status` is interpolated into a **user-facing** string, `f"...(HTTP {status})"`. Swapping the `getattr` default from `200` to `HTTPStatus.OK` changes the type of that default. On Python ≤ 3.10 an `IntEnum` formats as `HTTPStatus.OK`, which would have altered the message. From 3.11 onward `IntEnum.__str__` is `int.__str__`, so it renders `200`. This project sets `requires-python = ">=3.12"`, so the message is byte-identical — I confirmed that on 3.12 rather than assuming it.

`HTTPStatus.MULTIPLE_CHOICES` (300) would have been wrong for the upper bound: the existing rule deliberately treats 3xx and 4xx as *reachable* (the host answered), so `INTERNAL_SERVER_ERROR` is the correct boundary to preserve behavior.