### PR TITLE
refactor(scheduler): use HTTPStatus in the Slack delivery success check (SM-55)

### DIFF
--- a/platform/scheduling/scheduler/executor.py
+++ b/platform/scheduling/scheduler/executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from http import HTTPStatus
 
 from platform.scheduling.scheduler.claim_store import complete_run, try_claim
 from platform.scheduling.scheduler.credentials import (
@@ -448,7 +449,7 @@ def _deliver_slack(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
         )
         if not response.ok:
             return False, f"Slack API error: {response.error}", ""
-        if not 200 <= response.status_code < 300:
+        if not HTTPStatus.OK <= response.status_code < HTTPStatus.MULTIPLE_CHOICES:
             error_text = response.text[:200] if response.text else f"HTTP {response.status_code}"
             return False, f"Slack HTTP error: {error_text}", ""
         if response.data.get("ok") is not True:


### PR DESCRIPTION
Closes #4313 (SM-55).

One ID, one file, one PR — only `platform/scheduling/scheduler/executor.py` is touched.

> Note: the issue lists the path as `platform/scheduler/executor.py`; the file now lives at `platform/scheduling/scheduler/executor.py`. Same file, it just moved.

## What changed

```diff
-        if not 200 <= response.status_code < 300:
+        if not HTTPStatus.OK <= response.status_code < HTTPStatus.MULTIPLE_CHOICES:
```

plus `from http import HTTPStatus`.

## What deliberately did not change

The file contains two other `200`s that are **not** status codes and must stay as they are:

- `response.text[:200]` on the line directly below the change — a slice that truncates the error body.
- `properties["error"] = error[:200]` in `_emit_analytics` — same idea.

A blind find-and-replace on `200` would have corrupted both.

## Verification

- `ruff check` — All checks passed
- `ruff format --check` — already formatted
- `mypy` — no errors attributable to this file
- `pytest tests/scheduler/test_executor.py tests/scheduler/test_delivery.py` — **39 passed**. No-behavior-change refactor, so green before and after is the proof.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`_deliver_slack` checks that Slack returned a 2xx before trusting the response body. Written as `200 <= status_code < 300` that is idiomatic but unnamed; `HTTPStatus.OK <= ... < HTTPStatus.MULTIPLE_CHOICES` says "the 2xx range" in the vocabulary the rest of the codebase already uses.

The upper bound differs from the sibling task SM-56 and that is intentional. Here the test is a **success** check, so the exclusive upper bound is 300 — `MULTIPLE_CHOICES`. In the wizard probe the test is a **reachability** check that deliberately counts 3xx and 4xx as reachable, so its bound is `INTERNAL_SERVER_ERROR`. Reusing one constant across both would have changed behavior in one of them.

The main risk in a task phrased as "replace bare status numbers" is over-application. I grepped every three-digit literal in the file first and found three hits, only one of which is a status code — the other two are `[:200]` slices on error text. I left those untouched and called it out above so a reviewer can confirm the scope quickly.