### PR TITLE
feat(cli): list registered tools by integration

### DIFF
--- a/surfaces/cli/list_registered_tools.py
+++ b/surfaces/cli/list_registered_tools.py
@@ -1,0 +1,58 @@
+"""Print registered tool names grouped by integration."""
+
+from integrations.registry import INTEGRATION_SPECS
+from tools.registry import get_registered_tools
+from tools.registry_discovery import INTEGRATION_TOOL_PACKAGES
+
+
+def get_integration_names() -> set[str]:
+    """Return all known integration names."""
+    names = {spec.service for spec in INTEGRATION_SPECS}
+
+    names.update(package.split(".")[1] for package in INTEGRATION_TOOL_PACKAGES)
+
+    return names
+
+
+def get_integration_from_module(origin_module: str) -> str | None:
+    """Return the integration owning an integration tool module."""
+    parts = origin_module.split(".")
+
+    if len(parts) >= 3 and parts[0] == "integrations" and parts[2] == "tools":
+        return parts[1]
+
+    return None
+
+
+def get_registered_tools_by_integration() -> dict[str, list[str]]:
+    """Group registered tool names by integration."""
+    integration_names = sorted(get_integration_names())
+    result: dict[str, list[str]] = {name: [] for name in integration_names}
+
+    for tool in get_registered_tools():
+        integration = get_integration_from_module(tool.origin_module)
+
+        if integration is None:
+            continue
+
+        result[integration].append(tool.name)
+
+    return {name: sorted(tool_names) for name, tool_names in sorted(result.items())}
+
+
+def main() -> None:
+    tools_by_integration = get_registered_tools_by_integration()
+
+    for integration, tools in tools_by_integration.items():
+        print(f"{integration}:")
+
+        if not tools:
+            print("  (no registered tools)")
+            continue
+
+        for tool in tools:
+            print(f"  - {tool}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/surfaces/cli/test_list_registered_tools.py
+++ b/tests/surfaces/cli/test_list_registered_tools.py
@@ -1,0 +1,96 @@
+"""Tests for listing registered tools by integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from integrations.registry import INTEGRATION_SPECS
+from surfaces.cli import list_registered_tools
+from surfaces.cli.list_registered_tools import (
+    get_integration_from_module,
+    get_integration_names,
+    get_registered_tools_by_integration,
+)
+from tools.registry_discovery import INTEGRATION_TOOL_PACKAGES
+
+
+def _expected_integration_names() -> set[str]:
+    return {
+        *{spec.service for spec in INTEGRATION_SPECS},
+        *{package.split(".")[1] for package in INTEGRATION_TOOL_PACKAGES},
+    }
+
+
+def test_get_integration_names_includes_specs_and_tool_packages() -> None:
+    assert get_integration_names() == _expected_integration_names()
+
+
+def test_get_integration_from_module_only_matches_integration_tools() -> None:
+    assert get_integration_from_module("integrations.aws.tools.foo") == "aws"
+    assert get_integration_from_module("integrations.aws.verifier") is None
+    assert get_integration_from_module("tools.system.watch_dog") is None
+
+
+def test_registered_tools_are_sorted_and_grouped() -> None:
+    result = get_registered_tools_by_integration()
+
+    assert list(result) == sorted(result)
+    assert _expected_integration_names() <= set(result)
+
+    for tools in result.values():
+        assert tools == sorted(tools)
+
+
+def test_registered_tools_are_grouped_by_integration(monkeypatch) -> None:
+    monkeypatch.setattr(
+        list_registered_tools,
+        "get_integration_names",
+        lambda: {"github", "redis", "trello"},
+    )
+    monkeypatch.setattr(
+        list_registered_tools,
+        "get_registered_tools",
+        lambda: [
+            SimpleNamespace(
+                name="redis_b",
+                origin_module="integrations.redis.tools.foo",
+            ),
+            SimpleNamespace(
+                name="github_tool",
+                origin_module="integrations.github.tools.bar",
+            ),
+            SimpleNamespace(
+                name="redis_a",
+                origin_module="integrations.redis.tools.baz",
+            ),
+            SimpleNamespace(
+                name="core_tool",
+                origin_module="tools.system.foo",
+            ),
+        ],
+    )
+    assert list_registered_tools.get_registered_tools_by_integration() == {
+        "github": ["github_tool"],
+        "redis": ["redis_a", "redis_b"],
+        "trello": [],
+    }
+
+
+def test_main_shows_integrations_with_no_tools(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        list_registered_tools,
+        "get_registered_tools_by_integration",
+        lambda: {
+            "empty": [],
+            "github": ["search_github_issues"],
+        },
+    )
+
+    list_registered_tools.main()
+
+    assert capsys.readouterr().out == (
+        "empty:\n  (no registered tools)\ngithub:\n  - search_github_issues\n"
+    )


### PR DESCRIPTION
Fixes #5089

#### Describe the changes you have made in this PR -

- Added a repo-root runnable CLI utility to list registered tool names grouped by integration.
- Placed the utility under `surfaces/cli` because it composes information from both integrations and tools registries.
- Uses `INTEGRATION_SPECS` and `INTEGRATION_TOOL_PACKAGES` to include all known integrations, including integrations with no registered tools.
- Groups runtime-discovered tools by their owning `integrations.<vendor>.tools` package using `origin_module`.
- Sorts both integration names and tool names to keep the output stable and diffable.
- Added tests covering integration discovery, module ownership parsing, grouping, stable ordering, filtering non-integration tools, and integrations with no tools.

### Demo/Screenshot for feature changes and bug fixes -

Run from the repository root:

```bash
uv run python -m surfaces.cli.list_registered_tools
```

Demo output:

```text
airflow:
  (no registered tools)
alertmanager:
  - alertmanager_alerts
  - alertmanager_silences
alicloud:
  (no registered tools)
argocd:
  - argocd_application_diff
  - argocd_application_status
aws:
  - execute_aws_operation
```

Tests:

```bash
uv run pytest tests/surfaces/cli/test_list_registered_tools.py -v
```

Also verified with:

```bash
make lint
make format-check
make typecheck
```

The generated output was run twice and compared with `diff` to verify stable output.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [ ] No, I wrote all the code myself
* [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The goal is to provide a reproducible view of which tools each integration registers.

The initial implementation was placed under `integrations`, but this violated the project's import boundary because integrations must not depend on the tools registry layer.

After reviewing the architecture convention, the utility was moved to `surfaces/cli`, which is the appropriate composition layer for combining information from multiple subsystems.

The implementation builds the integration set from two existing sources:

* `INTEGRATION_SPECS` provides known integrations, including integrations with no tools.
* `INTEGRATION_TOOL_PACKAGES` provides per-vendor tool packages that participate in tool discovery.

Registered tools are loaded through the existing `get_registered_tools()` API. Each tool's `origin_module` is used to determine its owning integration when the module follows the `integrations.<vendor>.tools...` structure.

The main components are:

* `get_integration_names()` — builds the complete known integration set.
* `get_integration_from_module()` — extracts the owning integration from an integration tool module path.
* `get_registered_tools_by_integration()` — groups registered tool names by integration and sorts the result.
* `main()` — prints the generated list, explicitly showing integrations with no registered tools.

The implementation is read-only and reuses the existing registries without changing tool registration or discovery behavior.

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] **I can explain the purpose of every function, class, and logic block I added**
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [x] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.