### PR TITLE
refactor(gateway): one builder for the CLI and REPL status lines (#5085)

### DIFF
--- a/surfaces/cli/commands/gateway.py
+++ b/surfaces/cli/commands/gateway.py
@@ -8,18 +8,17 @@ import click
 
 from gateway.core.process import (
     GATEWAY_LOG_FILE,
-    gateway_daemon_pid,
-    read_component_status,
     read_gateway_log_tail,
     start_gateway_daemon,
     stop_gateway_daemon,
 )
 from surfaces.cli.host import cli_host
 from surfaces.shared.gateway_entrypoint import gateway_entry_argv
+from surfaces.shared.gateway_status import read_gateway_status
 
 
 def _echo_components() -> None:
-    for name, detail in read_component_status().items():
+    for name, detail in read_gateway_status().components:
         click.echo(f"  {name}: {detail}")
 
 
@@ -69,10 +68,12 @@ def gateway_stop_command() -> None:
 @gateway_command.command("status")
 def gateway_status_command() -> None:
     """Show the gateway daemon and its components (web, telegram, scheduler)."""
-    pid = gateway_daemon_pid()
-    click.echo(f"OpenSRE gateway: {f'running (pid {pid})' if pid else 'stopped'}")
-    _echo_components()
-    click.echo(f"Logs: {GATEWAY_LOG_FILE}")
+    daemon, *rest = read_gateway_status().rows()
+    click.echo(f"{daemon[0]}: {daemon[1]}")
+    *components, logs = rest
+    for name, detail in components:
+        click.echo(f"  {name}: {detail}")
+    click.echo(f"{logs[0]}: {logs[1]}")
 
 
 @gateway_command.command("logs")

--- a/surfaces/interactive_shell/command_registry/gateway_cmds.py
+++ b/surfaces/interactive_shell/command_registry/gateway_cmds.py
@@ -7,8 +7,6 @@ from rich.markup import escape
 
 from gateway.core.process import (
     GATEWAY_LOG_FILE,
-    gateway_daemon_pid,
-    read_component_status,
     read_gateway_log_tail,
     start_gateway_daemon,
     stop_gateway_daemon,
@@ -17,6 +15,7 @@ from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT
 from surfaces.shared.gateway_entrypoint import gateway_entry_argv
+from surfaces.shared.gateway_status import read_gateway_status
 
 _USAGE = "/gateway [start|stop|status|logs [lines]]"
 
@@ -34,12 +33,14 @@ def _cmd_gateway(_session: Session, console: Console, args: list[str]) -> bool:
     elif sub == "stop":
         _print_outcome(console, *stop_gateway_daemon())
     elif sub == "status":
-        pid = gateway_daemon_pid()
-        state = f"[{HIGHLIGHT}]running (pid {pid})[/]" if pid else f"[{DIM}]stopped[/]"
-        console.print(f"OpenSRE gateway: {state}")
-        for name, detail in read_component_status().items():
+        status = read_gateway_status()
+        daemon, *rest = status.rows()
+        style = HIGHLIGHT if status.running else DIM
+        console.print(f"{daemon[0]}: [{style}]{escape(daemon[1])}[/]")
+        *components, logs = rest
+        for name, detail in components:
             console.print(f"  {escape(name)}: {escape(detail)}")
-        console.print(f"[{DIM}]logs: {GATEWAY_LOG_FILE}[/]")
+        console.print(f"[{DIM}]{logs[0]}: {escape(logs[1])}[/]")
     elif sub == "logs":
         lines = int(args[1]) if len(args) > 1 and args[1].isdigit() else 30
         if tail := read_gateway_log_tail(lines):

--- a/surfaces/shared/gateway_status.py
+++ b/surfaces/shared/gateway_status.py
@@ -1,0 +1,73 @@
+"""What `gateway status` says, without deciding how it looks.
+
+``opensre gateway status`` and the REPL's ``/gateway status`` show the same
+two things -- the daemon's PID and each component's line from
+``read_component_status()`` -- and used to build that list twice. The copies
+drifted.
+
+This module owns the content and its order. It deliberately owns nothing about
+rendering: the CLI writes plain text through ``click.echo`` and the shell
+writes rich markup through ``console.print`` and must escape values first.
+A shared printer would have to strip the shell's theme or push markup into
+piped CLI output, so the surfaces keep their own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gateway.core.process import (
+    GATEWAY_LOG_FILE,
+    gateway_daemon_pid,
+    read_component_status,
+)
+
+#: Label for the trailing log-file line, shared so the two surfaces cannot
+#: disagree on it again.
+LOGS_LABEL = "Logs"
+
+#: Label for the leading daemon line.
+DAEMON_LABEL = "OpenSRE gateway"
+
+
+@dataclass(frozen=True)
+class GatewayStatus:
+    """A snapshot of what the two status surfaces render."""
+
+    pid: int | None
+    components: tuple[tuple[str, str], ...]
+    log_file: str
+
+    @property
+    def running(self) -> bool:
+        return self.pid is not None
+
+    @property
+    def daemon_state(self) -> str:
+        """The daemon line's value, without any styling.
+
+        The shell colours running and stopped differently, so it asks
+        ``running`` rather than matching on this string.
+        """
+        return f"running (pid {self.pid})" if self.pid else "stopped"
+
+    def rows(self) -> tuple[tuple[str, str], ...]:
+        """Every line as an ordered ``(label, value)`` pair.
+
+        Daemon first, then one row per component in the order
+        ``read_component_status()`` returns them, then the log file.
+        """
+        return (
+            (DAEMON_LABEL, self.daemon_state),
+            *self.components,
+            (LOGS_LABEL, self.log_file),
+        )
+
+
+def read_gateway_status() -> GatewayStatus:
+    """Collect the current gateway status."""
+    return GatewayStatus(
+        pid=gateway_daemon_pid(),
+        components=tuple(read_component_status().items()),
+        log_file=str(GATEWAY_LOG_FILE),
+    )

--- a/tests/cli/test_gateway_command.py
+++ b/tests/cli/test_gateway_command.py
@@ -72,7 +72,9 @@ def test_gateway_start_spawns_daemon(runner: CliRunner) -> None:
 
 
 def test_gateway_status_reports_stopped(runner: CliRunner) -> None:
-    with patch("surfaces.cli.commands.gateway.gateway_daemon_pid", return_value=None):
+    # The PID lookup now happens in the shared status builder that both the
+    # CLI and the REPL read from, so that is where it is patched.
+    with patch("surfaces.shared.gateway_status.gateway_daemon_pid", return_value=None):
         result = runner.invoke(cli, ["gateway", "status"])
 
     assert result.exit_code == 0

--- a/tests/shared/test_gateway_status.py
+++ b/tests/shared/test_gateway_status.py
@@ -1,0 +1,82 @@
+"""The gateway status content both terminal surfaces render.
+
+`opensre gateway status` and the REPL's `/gateway status` used to build this
+list twice and drifted. These tests pin the content and its order in one
+place, which is the point of the shared builder.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from surfaces.shared.gateway_status import (
+    DAEMON_LABEL,
+    LOGS_LABEL,
+    GatewayStatus,
+    read_gateway_status,
+)
+
+
+def _status(pid: int | None = None, components: tuple[tuple[str, str], ...] = ()) -> GatewayStatus:
+    return GatewayStatus(pid=pid, components=components, log_file="/tmp/gateway.log")
+
+
+class TestDaemonState:
+    def test_running_reports_the_pid(self) -> None:
+        assert _status(pid=4242).daemon_state == "running (pid 4242)"
+        assert _status(pid=4242).running is True
+
+    def test_stopped_when_there_is_no_pid(self) -> None:
+        assert _status().daemon_state == "stopped"
+        assert _status().running is False
+
+
+class TestRows:
+    def test_daemon_first_then_components_then_logs(self) -> None:
+        rows = _status(pid=1, components=(("web", "up"), ("telegram", "down"))).rows()
+        assert rows == (
+            (DAEMON_LABEL, "running (pid 1)"),
+            ("web", "up"),
+            ("telegram", "down"),
+            (LOGS_LABEL, "/tmp/gateway.log"),
+        )
+
+    def test_component_order_is_preserved(self) -> None:
+        components = (("c", "3"), ("a", "1"), ("b", "2"))
+        assert tuple(r[0] for r in _status(components=components).rows()[1:-1]) == ("c", "a", "b")
+
+    def test_no_components_still_yields_daemon_and_logs(self) -> None:
+        rows = _status().rows()
+        assert len(rows) == 2
+        assert rows[0][0] == DAEMON_LABEL
+        assert rows[-1][0] == LOGS_LABEL
+
+    def test_logs_row_is_always_last(self) -> None:
+        rows = _status(pid=9, components=(("web", "up"),)).rows()
+        assert rows[-1] == (LOGS_LABEL, "/tmp/gateway.log")
+
+
+class TestReadGatewayStatus:
+    def test_reads_pid_and_components_from_the_gateway_process_module(self) -> None:
+        with (
+            patch("surfaces.shared.gateway_status.gateway_daemon_pid", return_value=77),
+            patch(
+                "surfaces.shared.gateway_status.read_component_status",
+                return_value={"web": "listening on 8080"},
+            ),
+        ):
+            status = read_gateway_status()
+
+        assert status.pid == 77
+        assert status.components == (("web", "listening on 8080"),)
+        assert status.rows()[0] == (DAEMON_LABEL, "running (pid 77)")
+
+    def test_components_are_a_tuple_so_the_snapshot_cannot_be_mutated(self) -> None:
+        with (
+            patch("surfaces.shared.gateway_status.gateway_daemon_pid", return_value=None),
+            patch(
+                "surfaces.shared.gateway_status.read_component_status",
+                return_value={"web": "stopped"},
+            ),
+        ):
+            assert isinstance(read_gateway_status().components, tuple)


### PR DESCRIPTION
Closes #5085.

## Acceptance

- [x] **One module owns the status content and ordering; both surfaces call it** — `surfaces/shared/gateway_status.py`
- [x] **`surfaces/cli` and `surfaces/interactive_shell` still import nothing from each other** — `tests/shared/test_surface_border.py` green (3 passed)
- [x] **Shell still escapes component text and keeps its theme colours**
- [x] **CLI output unchanged apart from the drift fix** — see below
- [x] **lint / format / typecheck / test**

## A builder, not a printer

`read_gateway_status()` returns a frozen `GatewayStatus`; `.rows()` gives ordered `(label, value)` pairs — daemon line, one row per component in `read_component_status()` order, log file last. Each surface formats them itself, exactly as the issue asked.

The shell picks its style from `status.running` rather than by matching on the state string, so the colour logic never depends on wording.

## Which direction the drift was fixed

**Toward the CLI.** The shell's `/gateway status` log line changes from `logs:` to `Logs:`. **CLI output is byte-identical** — I captured `gateway status` on `main` and on this branch with the same stubs:

```
OpenSRE gateway: stopped
  web: stopped
  telegram: stopped
Logs: C:\Users\Dipak\.opensre\gateway\gateway.log
```

Identical both ways. The shell also now escapes the daemon state and the log path, which it previously interpolated raw.

## One existing test updated

`test_gateway_status_reports_stopped` patched `surfaces.cli.commands.gateway.gateway_daemon_pid`, which the CLI no longer imports. It now patches `surfaces.shared.gateway_status.gateway_daemon_pid` — the seam both surfaces read through, so the same patch would work for a REPL test too.

## Verification

- `ruff check surfaces/ <tests>` — All checks passed
- `ruff format --check` — 4 files already formatted
- `mypy surfaces/shared/gateway_status.py` — no errors for the new module
- `pytest tests/shared/test_gateway_status.py tests/shared/test_surface_border.py tests/cli/test_gateway_command.py` — **17 passed, 1 failed**

The one failure is `test_gateway_entry_wires_slash_ports`, which **fails identically on a clean `main`** — I confirmed by stashing. Not from this PR.

Adds 8 tests for the builder: daemon state both ways, row order, component order preserved, empty components, logs always last, and that `read_gateway_status` reads through the patched seam.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The duplication is real but the two renderings are legitimately different, so the whole question is *where to cut*. Cutting at the printer would have forced one surface to lose something — either the shell's rich theming, or clean text for a piped CLI. Cutting at the content leaves both free.

I returned `(label, value)` pairs rather than a formatted string per line, because the shell needs to wrap the *value* in markup while leaving the label plain, and it needs to indent component rows but not the daemon or logs rows. A pre-joined string would have had to be re-split to do either.

`GatewayStatus` is a frozen dataclass with `components` as a tuple rather than the dict `read_component_status()` returns, so a caller cannot mutate a snapshot the other surface is also holding. `running` is exposed separately from `daemon_state` specifically so the shell's colour choice does not string-match on `"stopped"`.

The alternative I rejected was putting this in `gateway/core/process.py` next to the data it reads. It is presentation ordering, not process control, and `surfaces/shared/` is documented as the home for exactly what two peer surfaces share.