### PR TITLE
fix(session-goal): round before branching in format_token_count_compact

### DIFF
--- a/core/agent_harness/session_goal/progress.py
+++ b/core/agent_harness/session_goal/progress.py
@@ -47,7 +47,11 @@ def format_token_count_compact(count: int) -> str:
     value = max(0, int(count))
     if value < 1000:
         return str(value)
-    if value < 1_000_000:
+    # Branch on the rounded-to-one-decimal magnitude, not the raw value: a
+    # count like 999_950 rounds to "1000.0" at .1f precision, and comparing
+    # the raw value against 1_000_000 let that render as the broken "1000k"
+    # instead of rolling into the M branch below.
+    if round(value / 1000.0, 1) < 1000:
         scaled = value / 1000.0
         text = f"{scaled:.1f}".rstrip("0").rstrip(".")
         return f"{text}k"

--- a/tests/core/agent_harness/session_goal/test_progress.py
+++ b/tests/core/agent_harness/session_goal/test_progress.py
@@ -161,6 +161,16 @@ def test_format_duration_and_token_compacts() -> None:
     assert format_token_count_compact(3_400_000) == "3.4M"
 
 
+def test_format_token_count_compact_rolls_over_at_the_million_boundary() -> None:
+    """A count that rounds to 1000k at one-decimal precision must read as 1M."""
+    from core.agent_harness.session_goal.progress import format_token_count_compact
+
+    assert format_token_count_compact(999_949) == "999.9k"
+    assert format_token_count_compact(999_950) == "1M"
+    assert format_token_count_compact(999_999) == "1M"
+    assert format_token_count_compact(1_000_000) == "1M"
+
+
 def test_session_goal_payload_round_trips_started_at_and_token_baseline() -> None:
     from core.agent_harness.session_goal.goal import mark_session_goal_started
     from core.agent_harness.session_goal.persist import (


### PR DESCRIPTION
Fixes #5178

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`format_token_count_compact()` picked its "k" vs "M" branch by comparing the raw integer count against `1_000_000`, but rendered the "k" branch at one-decimal precision. For counts in `[999_950, 999_999]`, `value / 1000.0` rounds to `"1000.0"` at that precision, so the function returned the broken literal string `"1000k"` instead of rolling into `"1M"` — a discontinuity right at the boundary where `1_000_000` itself correctly renders `"1M"`.

Fix: branch on `round(value / 1000.0, 1) < 1000` (the rounded magnitude) instead of the raw value, so anything that would render as `"1000.x"` at k-scale falls through to the M branch. One-line condition change plus a comment explaining why, and a regression test at the boundary.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`):
```
$ python3 -c "
from core.agent_harness.session_goal.progress import format_token_count_compact as f
for v in (999_499, 999_949, 999_950, 999_990, 999_999, 1_000_000):
    print(v, '->', f(v))
"
999499 -> 999.5k
999949 -> 999.9k
999950 -> 1000k
999990 -> 1000k
999999 -> 1000k
1000000 -> 1M
```

After this PR:
```
999499 -> 999.5k
999949 -> 999.9k
999950 -> 1M
999990 -> 1M
999999 -> 1M
1000000 -> 1M
```

Focused test run:
```
$ uv run python -m pytest tests/core/agent_harness/session_goal/test_progress.py -v
...
test_format_token_count_compact_rolls_over_at_the_million_boundary PASSED
============================== 19 passed in 1.18s ==============================

$ uv run python -m pytest tests/core/ -q
============= 2152 passed, 30 skipped, 1 xfailed in 44.30s =============

$ make lint && make format-check && make typecheck
All checks passed!
3580 files already formatted
Success: no issues found in 1859 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`format_token_count_compact()` renders the `/goal` status line's token-spend readout. It has two thresholds (`< 1000` → raw digits, `< 1_000_000` → "k", else "M"), and the middle branch formats with `.1f` precision. The bug is a classic round-then-branch-vs-branch-then-round mismatch: the branch decision used the unrounded value, but the displayed text is rounded, so a count that rounds up to "1000" at k-scale never got the chance to become "1M".

I considered reformatting first and checking whether the resulting string equals `"1000"` (string-based re-route), but comparing the rounded numeric magnitude against the same `1000` boundary the code already used is more direct and avoids a second string-parsing path. It also generalizes: the `M` branch has the identical structure and would have the same class of bug at the *next* order of magnitude, though that's out of scope for `int` token counts in practice.

Regression test added at the exact boundary (`999_949` unaffected, `999_950`/`999_999` fixed, `1_000_000` unaffected) plus the existing three assertions kept passing.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
