### PR TITLE
refactor(platform): the turn host's types stop naming the package they left

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -82,7 +82,7 @@ and explicit host APIs remain for older readers. Checklist progress uses
 
 Do **not** duplicate the default port stack outside `DefaultHeadlessBuild`.
 The interactive shell builds a `HeadlessAgent` via `AgentBuildConfig` and
-`DefaultHeadlessBuild.agent` (not `GatewayTurnHandler`). Do not reintroduce
+`DefaultHeadlessBuild.agent` (not `TurnHandler`). Do not reintroduce
 peer `bootstrap.adapters` copies under surfaces or gateway.
 
 **Bind ports:** session-aware defaults implement
@@ -204,7 +204,7 @@ to it instead of re-implementing bootstrap + persistence:
   transports). Per-chat session create/resolve stays on
   `gateway/core/storage/session/resolver.py::SessionResolver` →
   `SessionManager`. Turn dispatch uses `HeadlessAgent` via
-  `platform/turn_host/turn_handler.py`'s `GatewayTurnHandler` with
+  `platform/turn_host/turn_handler.py`'s `TurnHandler` with
   :class:`~core.agent_harness.tools.tool_provider.DefaultToolProvider`
   built from the **live per-chat session** each turn (same tool resolution as
   shell). There is no separate gateway-owned ``Agent`` instance.
@@ -321,7 +321,7 @@ from bootstrap.embedded import start_embedded_session
 session = start_embedded_session()    # EMBEDDED_PROFILE + default agent
 result = session.chat("…")            # turn 1
 result = session.chat("…")            # turn 2 — same attached agent
-report = session.investigate({…})     # Path-2 verb (separate stage machine)
+report = session.investigate({…})     # investigation pipeline (separate stage machine)
 ```
 
 ``AgentSession.start`` must not import ``bootstrap`` (layer contract). Surfaces
@@ -335,7 +335,7 @@ explicit ``boot_process``).
 | Chat session (gateway) | `SessionAgentPool` keeps one `HeadlessAgent` per session id; each turn rebinds transport output via `BindableOutput.bind`, then `bind_turn` (session / accounting / console / tool_hooks) | `AgentSession.chat` / `agent.dispatch` |
 | Embedder / script | `start_embedded_session()` or `attach_agent(HeadlessAgent…)` once | repeated `chat` / `dispatch` |
 | Scheduled loop | Prefer one agent for the loop’s lifetime when multi-turn; `run_headless_turn` is OK for true one-shot digests | do not treat one-shot as the multi-turn pattern |
-| Interactive shell | `build_shell_agent` → `DefaultHeadlessBuild.agent` once; `HeadlessAgent.handle` per submission (not `GatewayTurnHandler`) | `HeadlessAgent.handle` |
+| Interactive shell | `build_shell_agent` → `DefaultHeadlessBuild.agent` once; `HeadlessAgent.handle` per submission (not `TurnHandler`) | `HeadlessAgent.handle` |
 
 Same-session turns must not overlap on one pooled agent (gateway holds a
 per-session lock). Different sessions stay concurrent under the capacity gate.
@@ -379,11 +379,11 @@ over ``run_turn``). Do **not** add new top-level chat entrypoints that call
 | Host | Process boot | Host call |
 |------|--------------|-----------|
 | CLI / interactive shell | `configure_process(CLI_PROFILE)` + shell Rich adapters | `build_shell_agent` → `HeadlessAgent.handle` |
-| Gateway chat | `configure_process(GATEWAY_PROFILE)` | `GatewayTurnHandler` → `SessionAgentPool` → `AgentSession.chat` |
-| Standalone web | `configure_process(WEB_PROFILE)` | `AgentSession.investigate` (Path 2) |
+| Gateway chat | `configure_process(GATEWAY_PROFILE)` | `TurnHandler` → `SessionAgentPool` → `AgentSession.chat` |
+| Standalone web | `configure_process(WEB_PROFILE)` | `AgentSession.investigate` |
 | Scheduled digests | adapters via profile; runners via `install_scheduler_runners` | `AgentSession.run_headless_turn` → `chat` |
 
-Do **not** route the REPL through `GatewayTurnHandler` (that callback
+Do **not** route the REPL through `TurnHandler` (that callback
 finalizes a chat sink with `is_tty=False`). The shell is a TTY host of the
 same `HeadlessAgent` construction seam. Do **not** invent a second public
 investigate entrypoint beside ``AgentSession.investigate``.

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -287,7 +287,7 @@ class AgentSession:
         opensre_evaluate: bool = False,
         investigation_metadata: tuple[str, str] | None = None,
     ) -> InvestigationResult:
-        """Run a Path-2 investigation and return a typed result.
+        """Run an investigation and return a typed result.
 
         Uses the payload runner installed at process boot
         (:func:`core.agent_harness.investigation_api.install_investigation_payload_runner`).

--- a/core/agent_harness/turns/chat_api.py
+++ b/core/agent_harness/turns/chat_api.py
@@ -4,7 +4,7 @@ The **public** host API is :class:`~core.agent_harness.harness.AgentSession`
 (``chat`` / ``investigate``). Adapters (shell TTY dispatcher, ``HeadlessAgent``)
 build :class:`ChatTurnBindings` from their surface ports, then call
 :func:`dispatch_chat_turn` from inside ``.dispatch``. This module must not
-import ``surfaces`` or ``gateway``. Investigation stays on Path 2 via
+import ``surfaces`` or ``gateway``. Investigation is
 :meth:`AgentSession.investigate` (installed payload runner).
 """
 

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -39,21 +39,25 @@ start_gateway()
   → ready
 ```
 
-- **Surface startup:** `gateway/startup.py` starts web and all chat transports.
-  The controller retains `StartedGateway`.
-- Missing chat credentials → `not configured`; readiness/runtime failures →
-  `failed`. The rest still start.
-- **Scheduler** is a **platform** component (`platform.scheduling.scheduler`). The gateway
-  process *may host* it (`start_scheduler()` → `scheduler_runners().gated(…).install()`
-  + `start_background_scheduler()`). It is not a consumer surface, not a
-  transport, and there is no `gateway/scheduler/` package. Do not move runner
-  code into `gateway/core/lifecycle/`.
-- **Daemon** is pidfile + spawn in `core/process/supervision.py`. Do not fold it
-  into a scheduler package. The child argv is surface-owned (`python -m
-  surfaces.gateway_entry`, or `opensre gateway start --foreground` when frozen).
-- `gateway.core` must not import `gateway.transports` / `gateway.web`; only
-  `controller.py` imports `gateway.startup`.
-- Peer transports and `web` must not import `gateway.startup`.
+`gateway/startup.py` starts web and all chat transports; the controller
+retains `StartedGateway`. Missing chat credentials are `not configured`;
+readiness or runtime failures are `failed`; the rest still start.
+
+The scheduler is a platform component (`platform.scheduling.scheduler`).
+This process may host it (`start_scheduler()` →
+`scheduler_runners().gated(…).install()` plus `start_background_scheduler()`).
+It is not a consumer surface or a transport, and there is no
+`gateway/scheduler/` package. Do not move runner code into
+`gateway/core/lifecycle/`.
+
+The daemon is pidfile plus spawn in `core/process/supervision.py`. Do not
+fold it into a scheduler package. The child argv is surface-owned
+(`python -m surfaces.gateway_entry`, or `opensre gateway start --foreground`
+when frozen).
+
+`gateway.core` must not import `gateway.transports` or `gateway.web`; only
+`controller.py` imports `gateway.startup`. Peer transports and `web` must
+not import `gateway.startup`.
 
 ## Layout
 
@@ -97,14 +101,16 @@ flat by surface (do not nest a directory named after the Discord PyPI package).
 
 The package holds two different things, and only one of them faces outward:
 
-- **The deployment** — the daemon, the transports, the web app, storage. A
-  surface may drive the *process* (start, stop, status) and nothing else.
-  The task scheduler is hosted here when this process is the long-lived runner;
-  CLI/shell own loop CRUD and call `request_scheduler_reload()` after writes.
-- **The turn service** — `GatewayTurnHandler`, the middleware steps and the
-  session-agent pool. A surface never imports this. A surface that runs turns
-  is a **channel**: it implements `platform.turn_host` (turn contract) / `gateway.transports` (registry) and is handed to
-  the turn service, the same way the four chat transports are.
+The deployment is the daemon, the transports, the web app, and storage. A
+surface may start, stop, or query that process and nothing else. The task
+scheduler is hosted here when this process is the long-lived runner; CLI
+and shell own loop CRUD and call `request_scheduler_reload()` after writes.
+
+The turn service is `TurnHandler`, the middleware steps, and the
+session-agent pool. A surface never imports that. A surface that runs
+turns is a channel: it implements the `platform.turn_host` turn contract
+and is registered in `gateway.transports`, then handed to the turn
+service the same way the four chat transports are.
 
 ## Channel vs producer
 
@@ -112,7 +118,7 @@ Two ways work reaches the agent. Mixing them is how a second turn engine appears
 
 | | Has a user and turn output? | Entry |
 |--|------------------------|--------|
-| **Channel** (Slack, Telegram, Discord, Buzz) | Yes | `GatewayTurnHandler` — `(text, session, output, logger)` |
+| **Channel** (Slack, Telegram, Discord, Buzz) | Yes | `TurnHandler` — `(text, session, output, logger)` |
 | **Interactive shell** | Yes | *today:* `HeadlessAgent.handle` with `AgentBuildConfig`. *Target:* the **chat** verb, like any other channel — it has a user and turn output, so the rule already covers it. The build config is shared; the turn entry is not yet. |
 | **Producer** (`platform.scheduling.scheduler`, scheduled digest/PR runners) | No | Embed: `AgentSession.run_headless_turn` (and investigation payload runners) |
 
@@ -120,7 +126,7 @@ Agent construction hooks live in `core.agent_harness.agent_build_config.AgentBui
 
 The gateway **process** may host the scheduler (same `process_turn_gate`). That
 does not make the scheduler a channel: `platform.scheduling.scheduler` must not import
-`GatewayTurnHandler`. Pinned by
+`TurnHandler`. Pinned by
 `tests/test_package_borders.py::test_scheduler_never_imports_the_gateway_turn_handler`.
 
 `POST /investigate` is the investigation embed verb (`AgentSession.investigate`),
@@ -139,7 +145,7 @@ to hold, not in how hard the work is.
 
 | Verb | Entry | Shape | Gets |
 |------|-------|-------|------|
-| **chat** | `GatewayTurnHandler.__call__(text, session, output, logger)` | returns `None`; every result reaches the user through turn output | capacity gate, capability policy, `SessionAgentPool` reuse, approvals, cancel console, identity policy, turn timeout, terminal outcome, at-capacity copy |
+| **chat** | `TurnHandler.__call__(text, session, output, logger)` | returns `None`; every result reaches the user through turn output | capacity gate, capability policy, `SessionAgentPool` reuse, approvals, cancel console, identity policy, turn timeout, terminal outcome, at-capacity copy |
 | **investigate** | `AgentSession.investigate(...)` (the harness Embed API) | returns a payload to the caller | the process capacity gate only |
 
 `POST /investigate` and `InvestigationWorker` use **investigate** and that is
@@ -158,38 +164,35 @@ there is nothing to hand back. A caller that needs the turn's outcome as a
 value — the shell wants `TurnResult` for accounting, the prompt recorder, and
 `final_intent` — is not served by this signature as written. Widening it is a
 contract change for all four transports, so decide it deliberately rather than
-adding a second entry beside `GatewayTurnHandler`.
+adding a second entry beside `TurnHandler`.
 
 ## Gateway turn dispatch
 
-- **One turn handler:** `GatewayTurnHandler` (optional `gate=` for capacity).
-  Transport Slack/Discord/Telegram *dispatchers* are ingress only — authorize,
-  resolve session, build turn output, then call the shared callback. Do not add a
-  second production turn-handler class next to `GatewayTurnHandler`.
-- **Logging** is configured once at the gateway process level
-  (`configure_logging` in `GatewayController.start_gateway`) — that is intentional.
-- **No persistent gateway `Agent` instance.** Each inbound message gets a
-  per-chat `Session` from `SessionResolver` and is handled by the shared
-  headless dispatch path (`core.agent_harness.turns.headless_agent`).
-- The turn handler callback signature is exactly four arguments: `text`,
-  `session`, `output`, and `logger`. Do not reintroduce `chat_id` into this
-  contract; the output owns chat transport details.
-- Resolve action tools from the live per-chat `Session` each turn via
-  `DefaultToolProvider(session, console)` — same as the interactive shell.
-  Do **not** precompute tools at process start; chat sessions carry their own
-  integration context after `SessionResolver.resolve`.
-- Per-chat session lifecycle (create / resolve / rotate / restore) is owned by
-  `SessionResolver` → `SessionManager`, not by `GatewayController`.
+Every chat transport uses one `TurnHandler` (optional `gate=` for capacity).
+Slack, Discord, and Telegram dispatchers are ingress only: authorize, resolve
+the session, build turn output, then call the shared callback. Do not add a
+second production turn-handler class.
+
+Logging is configured once at process start (`configure_logging` in
+`GatewayController.start_gateway`). There is no long-lived gateway `Agent`:
+each inbound message gets a per-chat `Session` from `SessionResolver` and
+goes through headless dispatch (`core.agent_harness.turns.headless_agent`).
+
+The callback takes exactly four arguments: `text`, `session`, `output`,
+`logger`. Do not put `chat_id` on this contract; the output owns transport
+details. Resolve action tools from the live per-chat `Session` each turn via
+`DefaultToolProvider(session, console)`, same as the interactive shell. Do
+not precompute tools at process start. Session create / resolve / rotate /
+restore belong to `SessionResolver` → `SessionManager`, not `GatewayController`.
 
 ## Tenancy (principal / actor)
 
 Slack, Discord, and Telegram each resolve a `StorageScope` in their own
-`transports/<peer>/principal.py` (peer isolation — no cross-imports):
+`transports/<peer>/principal.py` (peer isolation — no cross-imports).
 
-- **Principal** = silo `ORGANIZATION_ID` (fail closed if missing)
-- **Actor** = platform user id
-- Turn runs under `bound_storage_scope` so bindings/sessions/integrations land
-  on the org mount or `~/.opensre/orgs/<id>/`
+Principal is the silo `ORGANIZATION_ID` (fail closed if missing). Actor is
+the platform user id. The turn runs under `bound_storage_scope` so bindings,
+sessions, and integrations land on the org mount or `~/.opensre/orgs/<id>/`.
 
 CLI / interactive shell stay unbound (legacy empty principal/actor ids).
 `SessionResolver` may adopt a same-document legacy empty-id row into the scoped
@@ -211,20 +214,22 @@ Two different **in-process** limits — do not conflate them:
 | **Per-transport** | `max_concurrent_turns` (defaults to the same profile limit via `turn_limit_for_profile`; override with `*_GATEWAY_MAX_CONCURRENT`) | Caps how many inbound messages that transport may process in parallel *before* they hit the shared turn handler. Does not replace the process gate. |
 
 ```text
-Telegram/Slack/Discord ──► GatewayTurnHandler.try_acquire ──► process_turn_gate()
+Telegram/Slack/Discord ──► TurnHandler.try_acquire ──► process_turn_gate()
 Scheduler (agent + investigate runners) ──► blocking acquire ──► same gate
 POST /investigate ──► try_acquire (busy → 503) ──► same gate
 InvestigationWorker ──► blocking acquire (already claimed) ──► same gate
 ```
 
-- Production chat capacity is on `GatewayTurnHandler(gate=controller.turn_gate)`.
-- `GatewayController` and Path-2 share :func:`~platform.turn_host.concurrency.process_turn_gate`.
-- `ConcurrencyLimitedTurnHandler` is tests-only. Do not reintroduce it under
-  `gateway/core/` — production uses `gate=` on `GatewayTurnHandler` only.
-- **Chat + Path-2:** HTTP `/investigate` busy-drops like chat; the investigation
-  worker blocks like scheduler runners. Analytics: chat uses `gateway_turn_*`
-  with `surface` ∈ {slack,telegram,discord}; investigate uses separate
-  `investigation_*` events (no dedicated capacity-reject event yet).
+Production chat capacity is on `TurnHandler(gate=controller.turn_gate)`.
+`GatewayController` and HTTP investigate share
+:func:`~platform.turn_host.concurrency.process_turn_gate`.
+`ConcurrencyLimitedTurnHandler` is tests-only; production uses `gate=` on
+`TurnHandler` only.
+
+HTTP `POST /investigate` busy-drops like chat. `InvestigationWorker` waits
+like scheduler runners. Chat analytics use `gateway_turn_*` with `surface`
+in {slack, telegram, discord}; investigate uses `investigation_*` events
+(no dedicated capacity-reject event yet).
 
 ## Agent lifetime
 
@@ -246,14 +251,15 @@ the loop; true one-shot digests may use `AgentSession.run_headless_turn`.
 
 ## Host parity (chat surfaces)
 
-Same turn engine for Slack / Telegram / Discord: ingress → `GatewayTurnHandler`
-→ `SessionAgentPool` → `AgentSession.chat`. Web investigate is Path-2 (separate
-verb) — see Capacity above. Values: **yes** / **partial** / **no** / **n/a**.
+Same turn engine for Slack / Telegram / Discord: ingress → `TurnHandler`
+→ `SessionAgentPool` → `AgentSession.chat`. Web `POST /investigate` is a
+separate verb (`AgentSession.investigate`); see Capacity. Values: **yes** /
+**partial** / **no** / **n/a**.
 
 | Concern | Slack | Telegram | Discord | Web |
 |---------|-------|----------|---------|-----|
 | Cancel / stop mid-turn | **yes** — soft timeout + user `/stop` via `ActiveTurnRegistry` → `output.turn_cancel` | **yes** — same | **yes** — same | **partial** — queued investigate cancel only |
-| Approvals / `before_tool_call` | **yes** — Block Kit + `approval_tool_hooks` | **yes** — inline keyboard + `approval_tool_hooks` | **yes** — components + `approval_tool_hooks` | **n/a** — Path-2 |
+| Approvals / `before_tool_call` | **yes** — Block Kit + `approval_tool_hooks` | **yes** — inline keyboard + `approval_tool_hooks` | **yes** — components + `approval_tool_hooks` | **n/a** — investigate |
 | Tool resolution | **yes** — live `DefaultToolProvider(session)` | **yes** — same | **yes** — same | **n/a** — investigate runner |
 | Output redaction | **yes** — `user_facing_error_message` | **yes** — same | **yes** — same | **yes** — `type(exc).__name__` only |
 | Principal / actor | **yes** — `slack/principal.py` | **yes** — `telegram/principal.py` | **yes** — `discord/principal.py` | **partial** — Clerk org audit; no `StorageScope` |
@@ -263,7 +269,7 @@ verb) — see Capacity above. Values: **yes** / **partial** / **no** / **n/a**.
 
 - Gateway chat disables `task_cancel` / investigation / llm_provider
   (`platform.turn_host.capability_policy.ensure_gateway_capability_policy`).
-- Path-2 web investigate shares the process gate but has no chat approval prompter.
+- Web investigate shares the process gate but has no chat approval prompter.
 - Soft turn timeout **and** user `/stop` / `stop` / `/cancel` set
   `output.turn_cancel` so the ReAct loop / remaining tools stop cooperatively
   (shell `cancel_requested` parity via `CancelConsole` + `ActiveTurnRegistry`).

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -22,7 +22,7 @@ transport-specific code.
 | **Telegram transport** | `gateway/transports/telegram/startup.py` → `start_telegram_worker` | Via the startup registry |
 | **Slack transport** | `gateway/transports/slack/startup.py` → `start_slack_worker` | Via the startup registry |
 | **Discord transport** | `gateway/transports/discord/startup.py` → `start_discord_worker` | Via the startup registry (includes readiness wait) |
-| **Per-message turn** | `platform/turn_host/turn_handler.py` → `GatewayTurnHandler` | Injected into chat transports as the agent callback |
+| **Per-message turn** | `platform/turn_host/turn_handler.py` → `TurnHandler` | Injected into chat transports as the agent callback |
 
 ```text
 opensre gateway start
@@ -50,25 +50,28 @@ Layout: `core/` (runtime, storage, …), `startup.py` (surface composer),
 
 ## How the pieces fit (surfaces, gateway, integrations)
 
-Three things that are easy to mix up:
+Three things that are easy to mix up.
 
-- **Surface** — a way a person talks *to* the agent (message in, answer out). Today
-  there are three: the interactive shell (`surfaces/interactive_shell`, you type in
-  a terminal), the CLI one-shot (`surfaces/cli`, one command → one answer), and the
-  **gateway** (`gateway/`, you chat with the agent from a chat app).
-- **Gateway** — one specific surface: the always-on process that connects a chat app
-  to the agent. It speaks **Telegram** (long poll), **Slack** (Socket Mode *or*
-  Events API HTTP), and **Discord** (Gateway WebSocket). Slack's two inbound modes
-  share the same turn stack; only how the payload arrives differs
-  (`gateway/transports/slack/transport/`).
-- **Integrations + tools** — the *outbound* / teammate side: the agent reading and
-  posting on a platform. Slack's shared client is `integrations/slack/web_client.py`.
-  Common Slack tools: `slack_send_message` (webhook), `slack_reply_message` (bot
-  token, any channel), `slack_read_messages` (history / thread),
-  `slack_list_team_members` (roster), plus search / join / react helpers under
-  `integrations/slack/tools/`. See `docs/messaging/slack.mdx` for OAuth scopes.
-  Telegram has `telegram_send_message`; Discord is gateway chat + delivery today
-  (no investigation tool pack yet — see `docs/messaging/discord.mdx`).
+A surface is how a person talks to the agent (message in, answer out). Today
+there are three: the interactive shell (`surfaces/interactive_shell`), the
+CLI one-shot (`surfaces/cli`), and the gateway (`gateway/`, chat apps).
+
+The gateway is the always-on process that connects a chat app to the agent.
+It speaks Telegram (long poll), Slack (Socket Mode or Events API HTTP), and
+Discord (Gateway WebSocket). Slack's two inbound modes share the same turn
+stack; only how the payload arrives differs
+(`gateway/transports/slack/transport/`).
+
+Integrations and tools are the outbound / teammate side: the agent reading
+and posting on a platform. Slack's shared client is
+`integrations/slack/web_client.py`. Common Slack tools:
+`slack_send_message` (webhook), `slack_reply_message` (bot token, any
+channel), `slack_read_messages` (history / thread),
+`slack_list_team_members` (roster), plus search / join / react helpers
+under `integrations/slack/tools/`. See `docs/messaging/slack.mdx` for
+OAuth scopes. Telegram has `telegram_send_message`; Discord is gateway
+chat plus delivery today (no investigation tool pack yet — see
+`docs/messaging/discord.mdx`).
 
 Inbound and outbound are independent per platform:
 
@@ -80,7 +83,7 @@ Inbound and outbound are independent per platform:
 
 **One core for every surface.** Shell, CLI, and the gateway transports all hand the
 message to the same place: a session-scoped `HeadlessAgent`
-(`agent.handle(...)` via `GatewayTurnHandler`). They differ only in *how they
+(`agent.handle(...)` via `TurnHandler`). They differ only in *how they
 receive input and send output* — never in how the agent thinks.
 
 ## Quick start
@@ -147,15 +150,15 @@ with the same five pieces `gateway/transports/telegram/` and `gateway/transports
    messages and calls the shared handler with `(text, session, output, logger)`.
 3. **Inbound security**: authorize each message and audit-log it
    (`integrations/messaging_security`).
-4. **Turn output** (implement `GatewayOutputSink` from
+4. **Turn output** (implement `TurnOutput` from
    `platform/turn_host/turn_output.py`): streams status and delivers the answer.
 5. **Session binding** via `gateway/core/storage/session/resolver.py` with a new
    `platform` value: map the platform conversation key to a `Session`.
 
 Then register it in the composition root (`GatewayController` in
 `gateway/core/lifecycle/controller.py`) beside the existing transports. Reuse the handler
-from `GatewayTurnHandler(...)` as-is.
+from `TurnHandler(...)` as-is.
 
-**What you never change:** `GatewayTurnHandler`, harness prompts/tools, or the
+**What you never change:** `TurnHandler`, harness prompts/tools, or the
 session agent pool. Keeping the handler transport-agnostic is exactly what makes
 a new platform a small, self-contained add.

--- a/gateway/core/AGENTS.md
+++ b/gateway/core/AGENTS.md
@@ -54,7 +54,7 @@ Shared process setup (env → Sentry → harness adapters → capability warning
 LLM preload) is :func:`bootstrap.process.configure_process` with
 ``GATEWAY_PROFILE``. After logging and credentials,
 `GatewayController.start_gateway` configures the process, builds **one**
-`GatewayTurnHandler(gate=…)`, then `start_surfaces()` and `start_scheduler()`.
+`TurnHandler(gate=…)`, then `start_surfaces()` and `start_scheduler()`.
 Do not wrap the turn handler. Do not duplicate process boot in the controller.
 Hosting is a thin call: `scheduler_runners().gated(turn_gate).install()` then
 :func:`platform.scheduling.scheduler.runner.start_background_scheduler`. Reload is

--- a/gateway/core/lifecycle/controller.py
+++ b/gateway/core/lifecycle/controller.py
@@ -40,8 +40,8 @@ from platform.turn_host.concurrency import (
     process_turn_gate,
     set_process_turn_gate,
 )
-from platform.turn_host.turn_callback import GatewayAgentCallback
-from platform.turn_host.turn_handler import GatewayTurnHandler
+from platform.turn_host.turn_callback import TurnCallback
+from platform.turn_host.turn_handler import TurnHandler
 
 # The reload watcher only polls a flag, so it should never need the full
 # shutdown budget; cap it so chat workers keep the rest.
@@ -73,7 +73,7 @@ class GatewayController:
             set_process_turn_gate(turn_gate)
             self.turn_gate = turn_gate
         else:
-            # Same instance Path-2 investigate / InvestigationWorker use.
+            # Same gate POST /investigate and InvestigationWorker use.
             self.turn_gate = process_turn_gate()
         self._stopped = threading.Event()
 
@@ -90,7 +90,7 @@ class GatewayController:
         # same object — do not wrap it in a second "turn handler". Action tools
         # resolve per turn from each chat's live session inside the handler.
         console = Console(force_terminal=False)
-        handler = GatewayTurnHandler(
+        handler = TurnHandler(
             console=console,
             slash_ports_factory=self._slash_ports_factory,
             agent_build=chat_agent_build_config(),
@@ -116,7 +116,7 @@ class GatewayController:
         self,
         *,
         logger: logging.Logger,
-        handler: GatewayAgentCallback,
+        handler: TurnCallback,
     ) -> None:
         """Start web + every chat transport together (via :mod:`gateway.startup`)."""
         self.surfaces = gateway_startup.start_gateway(logger=logger, handler=handler)

--- a/gateway/core/storage/security_audit.py
+++ b/gateway/core/storage/security_audit.py
@@ -4,17 +4,15 @@ One JSON object per line under ``~/.opensre/gateway/security-audit.jsonl``,
 covering approval create/resolve/expire and investigation create/cancel, so
 the record outlives the process that wrote it.
 
-Scope, which is narrower than "audit log" usually implies:
-
-- **One host, one file.** The path is host-global, not per-org-silo.
-- **The lock serializes writers in one process only.** Concurrent gateway
-  workers append to the same file without coordination, so ordering across
-  processes is whatever the filesystem gives. This is not a shared audit
-  store for a multi-worker or multi-host deployment.
-- **Writes are best-effort.** A failed append is logged and swallowed; it
-  must never fail the caller's action.
-- **``detail`` is caller-supplied and unvalidated.** Keeping bodies and
-  secrets out of it is a contract with callers, not something enforced here.
+Scope is narrower than a typical audit log. The path is host-global, not
+per-org. The lock serializes writers in one process only: concurrent
+gateway workers append to the same file without coordination, so
+cross-process order is whatever the filesystem gives. This is not a
+shared store for a multi-worker or multi-host deployment. Writes are
+best-effort: a failed append is logged and swallowed so it never fails
+the caller's action. ``detail`` is caller-supplied and unvalidated;
+keeping bodies and secrets out of it is a contract with callers, not
+enforced here.
 """
 
 from __future__ import annotations

--- a/gateway/startup.py
+++ b/gateway/startup.py
@@ -22,7 +22,7 @@ from gateway.transports.startup import (
 )
 from gateway.web.startup import start_web_server
 from gateway.web.web_server import WebAppServerHandle
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 # The web app is a thread join, not a network drain, so it gets a smaller slice
 # of the shutdown budget and leaves the rest for in-flight chat turns.
@@ -52,7 +52,7 @@ class StartedGateway:
 def start_gateway(
     *,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> StartedGateway:
     """Start web and every chat transport together.
 

--- a/gateway/tests/runtime/concurrency_limited_handler.py
+++ b/gateway/tests/runtime/concurrency_limited_handler.py
@@ -1,6 +1,6 @@
 """Test-only capacity wrapper for arbitrary gateway callbacks.
 
-Production chat uses :class:`~platform.turn_host.turn_handler.GatewayTurnHandler`
+Production chat uses :class:`~platform.turn_host.turn_handler.TurnHandler`
 with ``gate=``. This helper stays under ``gateway/tests/`` so it cannot be
 mistaken for a second production turn-handler class (Wave C4 quarantine).
 """
@@ -11,17 +11,17 @@ import logging
 
 from core.agent_harness.session import SessionCore
 from platform.turn_host.concurrency import TurnConcurrencyGate
-from platform.turn_host.turn_callback import GatewayAgentCallback
-from platform.turn_host.turn_output import GatewayOutputSink
+from platform.turn_host.turn_callback import TurnCallback
+from platform.turn_host.turn_output import TurnOutput
 
 
 class ConcurrencyLimitedTurnHandler:
-    """Capacity wrapper for arbitrary :data:`GatewayAgentCallback` callables."""
+    """Capacity wrapper for arbitrary :data:`TurnCallback` callables."""
 
     def __init__(
         self,
         *,
-        handler: GatewayAgentCallback,
+        handler: TurnCallback,
         gate: TurnConcurrencyGate,
         busy_message: str = "OpenSRE is at capacity. Please try again shortly.",
     ) -> None:
@@ -33,7 +33,7 @@ class ConcurrencyLimitedTurnHandler:
         self,
         text: str,
         session: SessionCore,
-        output: GatewayOutputSink,
+        output: TurnOutput,
         logger: logging.Logger,
     ) -> None:
         if not self._gate.try_acquire():
@@ -46,8 +46,8 @@ class ConcurrencyLimitedTurnHandler:
 
 
 def gated_callback(
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
     gate: TurnConcurrencyGate,
-) -> GatewayAgentCallback:
+) -> TurnCallback:
     """Wrap an arbitrary callback with the shared capacity gate (tests only)."""
     return ConcurrencyLimitedTurnHandler(handler=handler, gate=gate)

--- a/gateway/tests/runtime/test_concurrency_gate.py
+++ b/gateway/tests/runtime/test_concurrency_gate.py
@@ -83,10 +83,10 @@ def test_chat_handler_refuses_excess_turn_without_calling_handler() -> None:
 def test_gateway_turn_handler_gate_refuses_excess_without_second_wrapper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Production path: capacity lives on GatewayTurnHandler itself."""
+    """Production path: capacity lives on TurnHandler itself."""
     from rich.console import Console
 
-    from platform.turn_host.turn_handler import GatewayTurnHandler
+    from platform.turn_host.turn_handler import TurnHandler
 
     gate = TurnConcurrencyGate(1)
     entered = threading.Event()
@@ -98,7 +98,7 @@ def test_gateway_turn_handler_gate_refuses_excess_without_second_wrapper(
         def finalize(self, text: str) -> None:
             finalized.append(text)
 
-    handler = GatewayTurnHandler(console=Console(force_terminal=False), gate=gate)
+    handler = TurnHandler(console=Console(force_terminal=False), gate=gate)
 
     def _fake_run(self, text, session, sink, logger, **_kwargs):  # noqa: ANN001
         # ``**_kwargs`` absorbs the caller-context keywords ``run`` forwards.
@@ -107,7 +107,7 @@ def test_gateway_turn_handler_gate_refuses_excess_without_second_wrapper(
         entered.set()
         release.wait(1)
 
-    monkeypatch.setattr(GatewayTurnHandler, "_run_turn", _fake_run)
+    monkeypatch.setattr(TurnHandler, "_run_turn", _fake_run)
 
     first = threading.Thread(
         target=handler,

--- a/gateway/tests/runtime/test_session_agents.py
+++ b/gateway/tests/runtime/test_session_agents.py
@@ -14,7 +14,7 @@ from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from platform.turn_host.bindable_output import BindableOutput
 from platform.turn_host.session_agents import SessionAgentPool
-from platform.turn_host.turn_handler import GatewayTurnHandler
+from platform.turn_host.turn_handler import TurnHandler
 from tests.shared.default_headless_build_stub import default_headless_build_stub
 from tests.shared.fake_agent import fake_agent
 
@@ -151,7 +151,7 @@ def test_turn_handler_reuses_headless_agent_across_turns(monkeypatch: pytest.Mon
     )
 
     session = SessionCore(store=InMemorySessionStore())
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     logger = logging.getLogger("test.reuse")
     handler("one", session, MagicMock(), logger)
     handler("two", session, MagicMock(), logger)

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -12,9 +12,9 @@ from rich.console import Console
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.tools.action_tools import get_action_tool
-from platform.turn_host.turn_handler import GatewayTurnHandler
+from platform.turn_host.turn_handler import TurnHandler
 from tests.core.agent.orchestration.cross_surface_parity_harness import (
-    RecordingGatewayOutputSink,
+    RecordingTurnOutput,
     headless_slash_ports,
 )
 
@@ -23,10 +23,10 @@ def _gateway_console() -> Console:
     return Console(file=io.StringIO(), force_terminal=False, highlight=False, width=100)
 
 
-def _run_gateway_slash(message: str) -> RecordingGatewayOutputSink:
+def _run_gateway_slash(message: str) -> RecordingTurnOutput:
     session = SessionCore(store=InMemorySessionStore())
-    sink = RecordingGatewayOutputSink()
-    handler = GatewayTurnHandler(
+    sink = RecordingTurnOutput()
+    handler = TurnHandler(
         console=_gateway_console(),
         slash_ports_factory=headless_slash_ports,
     )

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -16,9 +16,9 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from platform.turn_host.session_agents import SessionAgentPool
-from platform.turn_host.turn_handler import GatewayTurnHandler
+from platform.turn_host.turn_handler import TurnHandler
 from tests.core.agent.orchestration.cross_surface_parity_harness import (
-    RecordingGatewayOutputSink,
+    RecordingTurnOutput,
 )
 from tests.shared.default_headless_build_stub import default_headless_build_stub
 from tests.shared.fake_agent import fake_agent
@@ -108,7 +108,7 @@ def test_turn_handler_resolves_action_tools_from_live_session(monkeypatch: Any) 
     chat_integrations = {"slack": {"webhook_url": "https://hooks.example/test"}}
     session.resolved_integrations_cache = chat_integrations
 
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("send slack update", session, MagicMock(), logging.getLogger("test.turn_handler"))
 
     tool_provider = agent_cls.return_value.tools_for_test
@@ -179,7 +179,7 @@ def test_turn_handler_continues_outer_loop_for_active_session_goal(
         ),
     )
     sink = MagicMock()
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("go", session, sink, logging.getLogger("test"))
 
     assert len(calls) == 2
@@ -225,7 +225,7 @@ def test_turn_handler_flushes_session_goal_for_next_resolve(
             host_owned=True,
         ),
     )
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("side question", session, MagicMock(), logging.getLogger("test"))
 
     goal_records = [
@@ -258,7 +258,7 @@ def test_turn_handler_finalizes_fallback_on_empty_response(monkeypatch: Any) -> 
     """An empty, non-answered turn still finalizes so the placeholder status can't hang."""
     _patch_headless_agent(monkeypatch, _empty_turn_result())
     sink = MagicMock()
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("/", SessionCore(store=InMemorySessionStore()), sink, logging.getLogger("test"))
     sink.finalize.assert_called_once_with("I didn't have anything to add for that.")
 
@@ -268,7 +268,7 @@ def test_turn_handler_skips_finalize_when_answer_was_streamed(monkeypatch: Any) 
     result = _empty_turn_result(llm_run=MagicMock())  # answered=True
     _patch_headless_agent(monkeypatch, result)
     sink = MagicMock()
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("hi", SessionCore(store=InMemorySessionStore()), sink, logging.getLogger("test"))
     sink.finalize.assert_not_called()
 
@@ -287,7 +287,7 @@ def test_turn_handler_skips_finalize_when_turn_cancelled(monkeypatch: Any) -> No
         return _empty_turn_result()
 
     agent_cls.return_value.dispatch.side_effect = _dispatch
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("hi", SessionCore(store=InMemorySessionStore()), sink, logging.getLogger("test"))
     sink.finalize.assert_not_called()
     console = agent_cls.return_value.bind_turn.call_args.args[0].console
@@ -301,7 +301,7 @@ def test_turn_handler_binds_cancel_console_each_turn(monkeypatch: Any) -> None:
 
     agent_cls = _patch_headless_agent(monkeypatch, _empty_turn_result())
     sink = MagicMock()
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("hi", SessionCore(store=InMemorySessionStore()), sink, logging.getLogger("test"))
     console = agent_cls.return_value.bind_turn.call_args.args[0].console
     assert isinstance(console, CancelConsole)
@@ -315,7 +315,7 @@ def test_turn_handler_forwards_sink_tool_hooks_to_agent(monkeypatch: Any) -> Non
     sink = MagicMock()
     hooks = object()
     sink.tool_hooks = hooks
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("hi", SessionCore(store=InMemorySessionStore()), sink, logging.getLogger("test"))
     agent = agent_cls.return_value
     assert agent.bind_turn.call_args.args[0].tool_hooks is hooks
@@ -329,7 +329,7 @@ def test_turn_handler_tolerates_sinks_without_tool_hooks(monkeypatch: Any) -> No
             self.finalized = text
 
     agent_cls = _patch_headless_agent(monkeypatch, _empty_turn_result())
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("hi", SessionCore(store=InMemorySessionStore()), _BareSink(), logging.getLogger("test"))
     agent = agent_cls.return_value
     assert agent.bind_turn.call_args.args[0].tool_hooks is None
@@ -338,12 +338,12 @@ def test_turn_handler_tolerates_sinks_without_tool_hooks(monkeypatch: Any) -> No
 def test_turn_handler_disables_unsupported_gateway_capabilities(monkeypatch: Any) -> None:
     _patch_headless_agent(monkeypatch, _empty_turn_result())
     session = SessionCore(store=InMemorySessionStore())
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
 
     handler(
         "hello",
         session,
-        RecordingGatewayOutputSink(),
+        RecordingTurnOutput(),
         logging.getLogger("test"),
     )
 
@@ -365,11 +365,11 @@ def test_turn_handler_preserves_supported_capabilities(monkeypatch: Any) -> None
         }
     )
 
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler(
         "hello",
         session,
-        RecordingGatewayOutputSink(),
+        RecordingTurnOutput(),
         logging.getLogger("test.gateway.capabilities"),
     )
 
@@ -386,11 +386,11 @@ def test_turn_handler_capability_gating_is_stable_across_turns(monkeypatch: Any)
     session = SessionCore(store=InMemorySessionStore())
     session.available_capabilities["shell_commands"] = ("shell",)
 
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     logger = logging.getLogger("test.gateway.capabilities")
 
-    handler("first turn", session, RecordingGatewayOutputSink(), logger)
-    handler("second turn", session, RecordingGatewayOutputSink(), logger)
+    handler("first turn", session, RecordingTurnOutput(), logger)
+    handler("second turn", session, RecordingTurnOutput(), logger)
 
     assert session.available_capabilities["investigation"] == ()
     assert session.available_capabilities["llm_provider"] == ()
@@ -415,7 +415,7 @@ def test_turn_handler_emits_gateway_turn_analytics(monkeypatch: Any) -> None:
     from platform.analytics.usage_context import UsageSurface, bound_usage_context
 
     session = SessionCore(store=InMemorySessionStore())
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     with bound_usage_context(surface=UsageSurface.SLACK, user_id="U1"):
         handler("hi", session, MagicMock(), logging.getLogger("test"))
 
@@ -436,7 +436,7 @@ def test_turn_handler_holds_the_session_lock_for_the_whole_turn(monkeypatch: Any
     # Arrange: record when the lock is held relative to the dispatch.
     _patch_headless_agent(monkeypatch, _empty_turn_result())
     events: list[str] = []
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     real_session_agent = handler._pool.session_agent
 
     @contextmanager
@@ -468,16 +468,14 @@ def test_turn_handler_forwards_agent_build_to_the_pool(
 
     monkeypatch.setattr(SessionAgentPool, "__init__", _init)
     agent_build = AgentBuildConfig()
-    GatewayTurnHandler(console=Console(force_terminal=False), agent_build=agent_build)
+    TurnHandler(console=Console(force_terminal=False), agent_build=agent_build)
     assert seen == [agent_build]
 
 
-def _handler_with_fake_agent(
-    monkeypatch: Any, result: TurnResult
-) -> tuple[GatewayTurnHandler, MagicMock]:
+def _handler_with_fake_agent(monkeypatch: Any, result: TurnResult) -> tuple[TurnHandler, MagicMock]:
     """A handler plus the fake agent it will build, so tests can read the binding."""
     factory = _patch_headless_agent(monkeypatch, result)
-    return GatewayTurnHandler(console=Console(force_terminal=False)), factory.return_value
+    return TurnHandler(console=Console(force_terminal=False)), factory.return_value
 
 
 def _last_binding(agent: MagicMock) -> Any:
@@ -498,8 +496,8 @@ def test_run_returns_the_turn_result_that_the_callback_discards(monkeypatch: Any
     session = SessionCore(store=InMemorySessionStore())
 
     # Act
-    returned = handler.run("hello", session, RecordingGatewayOutputSink(), logging.getLogger("t"))
-    discarded = handler("hello", session, RecordingGatewayOutputSink(), logging.getLogger("t"))
+    returned = handler.run("hello", session, RecordingTurnOutput(), logging.getLogger("t"))
+    discarded = handler("hello", session, RecordingTurnOutput(), logging.getLogger("t"))
 
     # Assert
     assert returned is expected
@@ -523,7 +521,7 @@ def test_run_forwards_the_callers_terminal_context_to_the_turn(monkeypatch: Any)
     handler.run(
         "hello",
         SessionCore(store=InMemorySessionStore()),
-        RecordingGatewayOutputSink(),
+        RecordingTurnOutput(),
         logging.getLogger("t"),
         console=caller_console,
         confirm_fn=_confirm,
@@ -550,7 +548,7 @@ def test_run_without_caller_context_is_the_transport_path(monkeypatch: Any) -> N
     handler(
         "hello",
         SessionCore(store=InMemorySessionStore()),
-        RecordingGatewayOutputSink(),
+        RecordingTurnOutput(),
         logging.getLogger("t"),
     )
 
@@ -568,8 +566,8 @@ def test_run_returns_none_and_says_at_capacity_when_the_gate_refuses(monkeypatch
     _patch_headless_agent(monkeypatch, _empty_turn_result())
     gate = TurnConcurrencyGate(1)
     assert gate.try_acquire() is True  # the only slot is taken
-    handler = GatewayTurnHandler(console=Console(force_terminal=False), gate=gate)
-    sink = RecordingGatewayOutputSink()
+    handler = TurnHandler(console=Console(force_terminal=False), gate=gate)
+    sink = RecordingTurnOutput()
 
     # Act
     returned = handler.run(

--- a/gateway/tests/test_package_borders.py
+++ b/gateway/tests/test_package_borders.py
@@ -10,7 +10,7 @@ Pinned rules (see ``gateway/AGENTS.md``):
 * ``gateway.startup`` may import peer ``*.startup`` (and ``gateway.web``); peers
   must not import channels.
 * ``gateway.core`` names no chat vendor; a transport names only its own.
-* ``platform.scheduling.scheduler`` never imports ``GatewayTurnHandler`` (producer, not a
+* ``platform.scheduling.scheduler`` never imports ``TurnHandler`` (producer, not a
   chat channel — see ``gateway/AGENTS.md`` Channel vs producer).
 """
 
@@ -244,7 +244,7 @@ def test_scheduler_never_imports_the_gateway_turn_handler() -> None:
 
     The gateway process may host ``platform.scheduling.scheduler`` (same capacity gate).
     Runners still enter through ``AgentSession.run_headless_turn``, not
-    ``GatewayTurnHandler``. Importing the handler here is how someone "fixes"
+    ``TurnHandler``. Importing the handler here is how someone "fixes"
     the scheduler into a fifth chat channel.
     """
     banned = ("platform.turn_host.turn_handler",)
@@ -256,9 +256,9 @@ def test_scheduler_never_imports_the_gateway_turn_handler() -> None:
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom):
                 for alias in node.names:
-                    if alias.name == "GatewayTurnHandler":
+                    if alias.name == "TurnHandler":
                         rel = path.relative_to(REPO_ROOT)
-                        offenders.append(f"{rel} → GatewayTurnHandler")
+                        offenders.append(f"{rel} → TurnHandler")
     assert offenders == [], "scheduler imported the chat turn handler:\n" + "\n".join(offenders)
 
 
@@ -292,7 +292,7 @@ _QUARANTINED_HANDLER_NAMES = frozenset(
 
 
 def test_concurrency_limited_handler_stays_out_of_production_gateway() -> None:
-    """Wave C4: capacity wrapper is tests-only; production uses GatewayTurnHandler(gate=)."""
+    """Wave C4: capacity wrapper is tests-only; production uses TurnHandler(gate=)."""
     offenders: list[str] = []
     for path in _python_files("gateway"):
         if "tests" in path.parts:

--- a/gateway/transports/buzz/background.py
+++ b/gateway/transports/buzz/background.py
@@ -25,7 +25,7 @@ from gateway.transports.buzz.runtime import (
 from gateway.transports.buzz.session_rotation import conversation_key
 from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
 from integrations.buzz.client import BuzzClient
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ def start_buzz_gateway_background(
     logger: logging.Logger,
     initialize_runtime: InitializeBuzzPollingRuntime,
     shutdown_runtime: ShutdownBuzzPollingRuntime,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
+    handle_callback_to_gateway_agent: TurnCallback,
 ) -> PollingBackground:
     """Start Buzz mention polling in a background thread."""
 
@@ -75,7 +75,7 @@ async def _poll_buzz_until_stopped(
     stop_event: threading.Event,
     logger: logging.Logger,
     resources: BuzzPollingRuntime,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
+    handle_callback_to_gateway_agent: TurnCallback,
 ) -> None:
     """Poll the mention feed and dispatch (or resolve approvals) until shutdown.
 
@@ -225,7 +225,7 @@ async def _dispatch_turn(
     active_cancels: ActiveTurnRegistry,
     turn_cancel: threading.Event | None = None,
     loop: asyncio.AbstractEventLoop,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
+    handle_callback_to_gateway_agent: TurnCallback,
     logger: logging.Logger,
     acknowledge: Callable[[BuzzInboundMessage], None],
 ) -> None:

--- a/gateway/transports/buzz/inbound_handler.py
+++ b/gateway/transports/buzz/inbound_handler.py
@@ -24,7 +24,7 @@ from gateway.transports.buzz.session_rotation import conversation_key, resolve_o
 from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
 from integrations.buzz.client import BuzzClient
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ async def handle_polled_inbound_buzz_message(
     active_cancels: ActiveTurnRegistry,
     turn_cancel: threading.Event | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
+    handle_callback_to_gateway_agent: TurnCallback,
     on_handled: Callable[[], None] | None = None,
 ) -> None:
     """Process one long-polled inbound Buzz mention/reply.

--- a/gateway/transports/buzz/startup.py
+++ b/gateway/transports/buzz/startup.py
@@ -20,13 +20,13 @@ from gateway.transports.buzz.settings import (
     GatewaySettings,
     load_gateway_settings,
 )
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 
 def start_buzz_worker(
     *,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> tuple[PollingBackground, GatewaySettings]:
     """Load Buzz settings and start the mention-poll background worker.
 

--- a/gateway/transports/discord/background.py
+++ b/gateway/transports/discord/background.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from gateway.core.storage.session.binding_store import BindingStore, open_binding_store
 from gateway.transports.discord.settings import DiscordGatewaySettings
 from gateway.transports.discord.worker import run_discord_gateway_thread
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 
 class DiscordGatewayBackground:
@@ -50,7 +50,7 @@ def start_discord_gateway_background(
     *,
     settings: DiscordGatewaySettings,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> DiscordGatewayBackground:
     """Connect to Discord and dispatch inbound messages until stopped."""
     bindings = open_binding_store()

--- a/gateway/transports/discord/dispatcher.py
+++ b/gateway/transports/discord/dispatcher.py
@@ -42,7 +42,7 @@ from gateway.transports.discord.thread_history import (
 )
 from integrations.messaging_security import MessagingPlatform
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 # Discord's reaction API takes the literal Unicode emoji (URL-encoded), not a name.
 _WORKING_EMOJI = "\N{EYES}"
@@ -59,7 +59,7 @@ class DiscordTurnDispatcher:
         settings: DiscordGatewaySettings,
         bot_token: str,
         session_resolver: SessionResolver,
-        handler: GatewayAgentCallback,
+        handler: TurnCallback,
         logger: logging.Logger,
         bot_user_id: str = "",
         approvals: ApprovalBroker | None = None,

--- a/gateway/transports/discord/startup.py
+++ b/gateway/transports/discord/startup.py
@@ -13,13 +13,13 @@ from gateway.transports.discord.settings import (
     DiscordGatewaySettings,
     load_discord_gateway_settings,
 )
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 
 def start_discord_worker(
     *,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> tuple[DiscordGatewayBackground, DiscordGatewaySettings]:
     """Load Discord settings and start the Gateway WebSocket background worker.
 

--- a/gateway/transports/discord/worker.py
+++ b/gateway/transports/discord/worker.py
@@ -25,7 +25,7 @@ from gateway.transports.discord.events import (
 )
 from gateway.transports.discord.feedback import record_feedback_interaction
 from gateway.transports.discord.settings import DiscordGatewaySettings
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 _PLATFORM_DISCORD = "discord"
 _THREAD_HISTORY_LIMIT = 40
@@ -98,7 +98,7 @@ def run_discord_gateway_thread(
     *,
     settings: DiscordGatewaySettings,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
     bindings: BindingStore,
     executor: ThreadPoolExecutor,
     stop_event: threading.Event,
@@ -124,7 +124,7 @@ async def _discord_gateway_main(
     *,
     settings: DiscordGatewaySettings,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
     bindings: BindingStore,
     executor: ThreadPoolExecutor,
     stop_event: threading.Event,

--- a/gateway/transports/slack/delivery/output_sink.py
+++ b/gateway/transports/slack/delivery/output_sink.py
@@ -51,7 +51,7 @@ class SlackOutputSink:
         tool_hooks: ToolExecutionHooks | None = None,
     ) -> None:
         # Per-turn tool-execution hooks (e.g. the Block Kit approval gate),
-        # read duck-typed by GatewayTurnHandler when building the agent.
+        # read duck-typed by TurnHandler when building the agent.
         self.tool_hooks = tool_hooks
         # Set per turn by this transport's dispatcher; the turn handler reads it
         # to give tools a cooperative cancel signal on soft timeout or stop.

--- a/gateway/transports/slack/processing/dispatcher.py
+++ b/gateway/transports/slack/processing/dispatcher.py
@@ -49,7 +49,7 @@ from gateway.transports.slack.processing.thread_history import (
 from gateway.transports.slack.settings import SlackGatewaySettings
 from integrations.messaging_security import MessagingPlatform
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 
 # Only an explicit 402 from the credit ledger posts this; UNCONFIGURED /
@@ -64,7 +64,7 @@ class SlackTurnDispatcher:
         settings: SlackGatewaySettings,
         messaging: SlackMessagingClient,
         session_resolver: SessionResolver,
-        handler: GatewayAgentCallback,
+        handler: TurnCallback,
         logger: logging.Logger,
         bot_user_id: str = "",
         approvals: ApprovalBroker | None = None,

--- a/gateway/transports/slack/startup.py
+++ b/gateway/transports/slack/startup.py
@@ -35,7 +35,7 @@ from gateway.transports.slack.transport.socket_mode.worker import (
     start_slack_gateway_background,
 )
 from gateway.transports.slack.turn_stack import build_slack_turn_stack
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 SlackWorker = SlackGatewayBackground | SlackHttpServerHandle
 
@@ -48,7 +48,7 @@ def _env_flag(name: str) -> bool:
 
 
 def _start_socket_mode(
-    *, settings: SlackGatewaySettings, logger: logging.Logger, handler: GatewayAgentCallback
+    *, settings: SlackGatewaySettings, logger: logging.Logger, handler: TurnCallback
 ) -> SlackWorker:
     return start_slack_gateway_background(settings=settings, logger=logger, handler=handler)
 
@@ -80,7 +80,7 @@ def _build_handled_event_repository(logger: logging.Logger) -> HandledSlackEvent
 
 
 def _start_events_api_http(
-    *, settings: SlackGatewaySettings, logger: logging.Logger, handler: GatewayAgentCallback
+    *, settings: SlackGatewaySettings, logger: logging.Logger, handler: TurnCallback
 ) -> SlackWorker:
     stack = build_slack_turn_stack(settings=settings, logger=logger, handler=handler)
 
@@ -117,7 +117,7 @@ _TRANSPORT_STARTERS: Mapping[
 def start_slack_worker(
     *,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> tuple[SlackWorker, SlackGatewaySettings]:
     """Load Slack settings and start the configured inbound transport.
 

--- a/gateway/transports/slack/transport/socket_mode/worker.py
+++ b/gateway/transports/slack/transport/socket_mode/worker.py
@@ -22,7 +22,7 @@ from gateway.transports.slack.transport.socket_mode.heartbeat import (
     ConnectionHeartbeat,
 )
 from gateway.transports.slack.turn_stack import build_slack_turn_stack
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 _PLATFORM_SLACK = "slack"
 _EVENTS_API_REQUEST_TYPE = "events_api"
@@ -74,7 +74,7 @@ def start_slack_gateway_background(
     *,
     settings: SlackGatewaySettings,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> SlackGatewayBackground:
     """Connect to Slack over Socket Mode and dispatch inbound messages until stopped."""
     stack = build_slack_turn_stack(settings=settings, logger=logger, handler=handler)

--- a/gateway/transports/slack/turn_stack.py
+++ b/gateway/transports/slack/turn_stack.py
@@ -21,7 +21,7 @@ from gateway.transports.slack.client import SlackWebApiClient
 from gateway.transports.slack.delivery.channel_intro import ChannelIntroGreeter
 from gateway.transports.slack.processing.dispatcher import SlackTurnDispatcher
 from gateway.transports.slack.settings import SlackGatewaySettings
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 _PLATFORM_SLACK = "slack"
 
@@ -65,7 +65,7 @@ def build_slack_turn_stack(
     *,
     settings: SlackGatewaySettings,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> SlackTurnStack:
     """Construct the Slack turn collaborators for one gateway process."""
     web_client = WebClient(token=settings.bot_token)

--- a/gateway/transports/startup.py
+++ b/gateway/transports/startup.py
@@ -28,7 +28,7 @@ from gateway.transports.registration import TransportRegistration
 from gateway.transports.slack.startup import start_slack_worker
 from gateway.transports.telegram.startup import start_telegram_worker
 from gateway.transports.worker import TransportWorker
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 # How long a shutdown waits on each worker before giving up on it.
 DEFAULT_STOP_TIMEOUT_SECONDS = 8.0
@@ -66,7 +66,7 @@ class ChatStartup:
 def start_transports(
     *,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> ChatStartup:
     """Start every configured transport and report what each one did.
 

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -20,7 +20,7 @@ from gateway.transports.telegram.runtime import (
     TelegramPollingRuntime,
 )
 from gateway.transports.telegram.settings import GatewaySettings
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 
 def start_telegram_gateway_background(
@@ -29,7 +29,7 @@ def start_telegram_gateway_background(
     logger: logging.Logger,
     initialize_runtime: InitializeTelegramPollingRuntime,
     shutdown_runtime: ShutdownTelegramPollingRuntime,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
+    handle_callback_to_gateway_agent: TurnCallback,
 ) -> PollingBackground:
     """Start Telegram polling in a background thread."""
 
@@ -65,7 +65,7 @@ async def _poll_telegram_until_stopped(
     stop_event: threading.Event,
     logger: logging.Logger,
     resources: TelegramPollingRuntime,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
+    handle_callback_to_gateway_agent: TurnCallback,
 ) -> None:
     """Poll Telegram updates and dispatch them until shutdown is requested."""
     poller = TelegramPoller(settings.bot_token)

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -25,7 +25,7 @@ from gateway.transports.telegram.principal import (
 from gateway.transports.telegram.session_rotation import resolve_or_rotate_session
 from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ async def handle_polled_inbound_telegram_message(
     approvals: ApprovalBroker,
     active_cancels: ActiveTurnRegistry,
     loop: asyncio.AbstractEventLoop | None = None,
-    handle_callback_to_gateway_agent: GatewayAgentCallback,
+    handle_callback_to_gateway_agent: TurnCallback,
 ) -> None:
     """Process one long-polled inbound Telegram update."""
     user_lock = chat_locks.setdefault(event.user_id, asyncio.Lock())

--- a/gateway/transports/telegram/startup.py
+++ b/gateway/transports/telegram/startup.py
@@ -20,13 +20,13 @@ from gateway.transports.telegram.settings import (
     GatewaySettings,
     load_gateway_settings,
 )
-from platform.turn_host.turn_callback import GatewayAgentCallback
+from platform.turn_host.turn_callback import TurnCallback
 
 
 def start_telegram_worker(
     *,
     logger: logging.Logger,
-    handler: GatewayAgentCallback,
+    handler: TurnCallback,
 ) -> tuple[PollingBackground, GatewaySettings]:
     """Load Telegram settings and start the long-poll background worker.
 

--- a/gateway/web/AGENTS.md
+++ b/gateway/web/AGENTS.md
@@ -17,13 +17,13 @@ Pinned by `gateway/tests/test_package_borders.py`.
 Importing `gateway.web.webapp` (uvicorn or in-process via
 `serve_webapp_in_thread`) runs `configure_process(WEB_PROFILE)` — env, Sentry
 (`webapp`), and harness adapters. That is intentional so `MODE=web` and
-embedded web both get Path-2 investigate registration without a CLI/manager boot. Do
+embedded web both register `AgentSession.investigate` without a CLI/manager boot. Do
 **not** add a second harness-registration site in `web/`; adapters stay in
 `bootstrap.adapters` only. In a full gateway process, `GATEWAY_PROFILE` already
 ran; `WEB_PROFILE` may still run (separate idempotency key) — steps must stay
 safe to re-enter, not invent a divergent registry.
 
-## Capacity (Path-2)
+## Capacity
 
 `POST /investigate` and `InvestigationWorker` take
 :func:`~platform.turn_host.concurrency.process_turn_gate` — the same

--- a/platform/turn_host/bindable_output.py
+++ b/platform/turn_host/bindable_output.py
@@ -2,7 +2,7 @@
 
 A gateway session reuses one :class:`HeadlessAgent` across inbound messages.
 Each turn has its own transport destination, so this object stays on the agent
-and :meth:`bind` points it at that turn's :class:`GatewayOutputSink` before
+and :meth:`bind` points it at that turn's :class:`TurnOutput` before
 dispatch.
 """
 
@@ -12,7 +12,7 @@ import threading
 from collections.abc import Iterable, Iterator
 from typing import Any
 
-from platform.turn_host.turn_output import GatewayOutputSink
+from platform.turn_host.turn_output import TurnOutput
 
 
 class BindableOutput:
@@ -23,14 +23,14 @@ class BindableOutput:
     """
 
     def __init__(self) -> None:
-        self._inner: GatewayOutputSink | None = None
+        self._inner: TurnOutput | None = None
 
-    def bind(self, output: GatewayOutputSink) -> None:
+    def bind(self, output: TurnOutput) -> None:
         """Point subsequent writes at ``output`` for the current turn."""
         self._inner = output
 
     @property
-    def bound(self) -> GatewayOutputSink | None:
+    def bound(self) -> TurnOutput | None:
         """Currently bound transport destination, if any."""
         return self._inner
 
@@ -48,7 +48,7 @@ class BindableOutput:
         cancel = getattr(inner, "turn_cancel", None)
         return cancel if isinstance(cancel, threading.Event) else None
 
-    def _require(self) -> GatewayOutputSink:
+    def _require(self) -> TurnOutput:
         inner = self._inner
         if inner is None:
             raise RuntimeError("gateway turn output not bound")

--- a/platform/turn_host/cancel_console.py
+++ b/platform/turn_host/cancel_console.py
@@ -1,8 +1,8 @@
 """Gateway console wrapper: Rich console + ``cancel_requested`` (shell parity).
 
-One Event per turn (``sink.turn_cancel``). Soft timeout and ``/stop``
+One Event per turn (``output.turn_cancel``). Soft timeout and ``/stop``
 (:class:`~gateway.core.middleware.active_turns.ActiveTurnRegistry`) both ``set()``
-it. :class:`GatewayTurnHandler` binds this wrapper so tools and ReAct see
+it. :class:`TurnHandler` binds this wrapper so tools and ReAct see
 ``cancel_requested`` like the interactive shell's ``StreamingConsole``.
 
 The Event itself is created/attached by

--- a/platform/turn_host/concurrency.py
+++ b/platform/turn_host/concurrency.py
@@ -1,13 +1,13 @@
 """Process-wide turn concurrency shared by every Gateway ingress.
 
-Production chat turns take the gate via :class:`GatewayTurnHandler` (``gate=``).
-Path-2 ``POST /investigate`` and :class:`InvestigationWorker` use the same
-process gate (:func:`process_turn_gate`) so HTTP investigate cannot starve
-chat or the reverse. Scheduled runs take the same instance: the controller builds
+Production chat turns take the gate via :class:`TurnHandler` (``gate=``).
+``POST /investigate`` and :class:`InvestigationWorker` use the same process
+gate (:func:`process_turn_gate`) so HTTP investigate cannot starve chat or
+the reverse. Scheduled runs take the same instance: the controller builds
 ``SchedulerRunners`` and calls ``.gated(turn_gate)`` before installing them.
 
-A callback wrapper for arbitrary handlers lives under tests only — not in
-production ``gateway/core/``.
+A callback wrapper for arbitrary handlers is tests-only, not production
+``gateway/core/``.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ def turn_limit_for_profile(profile: SizeProfile | str | None = None) -> int:
 
 
 class TurnConcurrencyGate:
-    """A process-wide capacity gate for agent turns (chat + Path-2 + scheduler)."""
+    """A process-wide capacity gate for chat, investigate, and scheduled turns."""
 
     def __init__(self, limit: int) -> None:
         if limit < 1:
@@ -76,7 +76,7 @@ AT_CAPACITY_MESSAGE = "OpenSRE is at capacity. Please try again shortly."
 def process_turn_gate() -> TurnConcurrencyGate:
     """Return the process-wide gate (lazy from ``OPENSRE_SIZE_PROFILE``).
 
-    :class:`GatewayController` installs its gate here so chat and Path-2 share one
+    :class:`GatewayController` installs its gate here so chat and investigate share one
     semaphore in a full gateway process. Standalone ``WEB_PROFILE`` web creates
     the gate on first investigate/worker use.
     """

--- a/platform/turn_host/session_agents.py
+++ b/platform/turn_host/session_agents.py
@@ -1,6 +1,6 @@
-"""Session-scoped :class:`HeadlessAgent` pool for the gateway turn handler.
+"""Session-scoped :class:`HeadlessAgent` pool for the turn handler.
 
-Keeps agent construction out of :class:`GatewayTurnHandler` so the handler
+Keeps agent construction out of :class:`TurnHandler` so the handler
 stays a thin dispatch/finalize orchestrator. Construction goes through
 :meth:`~core.agent_harness.turns.headless_build.DefaultHeadlessBuild.agent`
 once per session — not a second port-construction path.
@@ -28,7 +28,7 @@ from core.agent_harness.runtime import (
 from platform.turn_host.bindable_output import BindableOutput
 from platform.turn_host.capability_policy import ensure_gateway_capability_policy
 from platform.turn_host.status_messages import status_from_tool_start
-from platform.turn_host.turn_output import GatewayOutputSink
+from platform.turn_host.turn_output import TurnOutput
 
 
 class _ToolStatusObserver:
@@ -87,7 +87,7 @@ class SessionAgentPool:
         self,
         *,
         session: SessionCore,
-        output: GatewayOutputSink,
+        output: TurnOutput,
         logger: logging.Logger,
     ) -> Iterator[HeadlessAgent]:
         """Hold this session's agent for the whole turn.
@@ -108,7 +108,7 @@ class SessionAgentPool:
         self,
         *,
         session: SessionCore,
-        output: GatewayOutputSink,
+        output: TurnOutput,
         logger: logging.Logger,
     ) -> HeadlessAgent:
         """Return a session-scoped agent with ``output`` bound for this turn.

--- a/platform/turn_host/turn_callback.py
+++ b/platform/turn_host/turn_callback.py
@@ -1,4 +1,4 @@
-"""The per-message entry the host exposes to chat transports.
+"""The per-message entry the host exposes to a channel.
 
 Signature: ``(text, session, output, logger)``. Every inbound chat message ends
 in one call to this. Transports depend on this contract; this module must not
@@ -11,6 +11,6 @@ import logging
 from collections.abc import Callable
 
 from core.agent_harness import SessionCore
-from platform.turn_host.turn_output import GatewayOutputSink
+from platform.turn_host.turn_output import TurnOutput
 
-GatewayAgentCallback = Callable[[str, SessionCore, GatewayOutputSink, logging.Logger], None]
+TurnCallback = Callable[[str, SessionCore, TurnOutput, logging.Logger], None]

--- a/platform/turn_host/turn_handler.py
+++ b/platform/turn_host/turn_handler.py
@@ -1,6 +1,6 @@
-"""Dispatch one inbound gateway message through the shared headless agent.
+"""Dispatch one inbound message through the shared headless agent.
 
-This is the **only** gateway turn handler. Transport dispatchers
+This is the **only** turn handler. Transport dispatchers
 (Slack/Discord/Telegram) are ingress adapters: they authorize, resolve a
 session, build turn output, then call this callback. Process-wide capacity is an
 optional gate on the same object — not a second handler.
@@ -9,9 +9,9 @@ Transport-agnostic: takes ``(text, session, output, logger)``, runs the turn, an
 finalizes outbound text on the output. Agent reuse is handled by
 :class:`SessionAgentPool`.
 
-Two entries, one turn. :meth:`GatewayTurnHandler.__call__` is the
-``GatewayAgentCallback`` the four chat transports use and returns nothing.
-:meth:`GatewayTurnHandler.run` is the same turn for an in-process caller that
+Two entries, one turn. :meth:`TurnHandler.__call__` is the
+``TurnCallback`` the four chat transports use and returns nothing.
+:meth:`TurnHandler.run` is the same turn for an in-process caller that
 needs the outcome as a value and has a terminal to bind — it returns the
 ``TurnResult`` (``None`` at capacity) and accepts the caller's console,
 ``confirm_fn`` and ``is_tty``. Every keyword defaults to the transport path, so
@@ -52,11 +52,11 @@ from platform.turn_host.cancel_console import CancelConsole
 from platform.turn_host.concurrency import AT_CAPACITY_MESSAGE, TurnConcurrencyGate
 from platform.turn_host.session_agents import SessionAgentPool
 from platform.turn_host.status_messages import EMPTY_RESPONSE_MESSAGE
-from platform.turn_host.turn_output import GatewayOutputSink
+from platform.turn_host.turn_output import TurnOutput
 
 
-class GatewayTurnHandler:
-    """Services one inbound gateway message per call (a :data:`GatewayAgentCallback`).
+class TurnHandler:
+    """Services one inbound gateway message per call (a :data:`TurnCallback`).
 
     One :class:`HeadlessAgent` is kept per logical session and reused across
     turns; each message goes through :meth:`HeadlessAgent.handle` with a
@@ -91,17 +91,17 @@ class GatewayTurnHandler:
         self,
         text: str,
         session: SessionCore,
-        output: GatewayOutputSink,
+        output: TurnOutput,
         logger: logging.Logger,
     ) -> None:
-        """The :data:`GatewayAgentCallback`: chat transports reply through the output."""
+        """The :data:`TurnCallback`: chat transports reply through the output."""
         self.run(text, session, output, logger)
 
     def run(
         self,
         text: str,
         session: SessionCore,
-        output: GatewayOutputSink,
+        output: TurnOutput,
         logger: logging.Logger,
         *,
         console: Console | None = None,
@@ -136,7 +136,7 @@ class GatewayTurnHandler:
         self,
         text: str,
         session: SessionCore,
-        output: GatewayOutputSink,
+        output: TurnOutput,
         logger: logging.Logger,
         *,
         console: Console | None,
@@ -233,4 +233,4 @@ class GatewayTurnHandler:
                 raise
 
 
-__all__ = ["GatewayTurnHandler"]
+__all__ = ["TurnHandler"]

--- a/platform/turn_host/turn_output.py
+++ b/platform/turn_host/turn_output.py
@@ -1,8 +1,8 @@
-"""Per-turn output the host writes and a chat transport must accept.
+"""Everything one turn shows the person who asked.
 
-This is the gateway's :class:`~core.agent_harness.OutputSink`: the same
-ephemeral turn-delivery port the harness already names, plus live tool-status
-and the final chat answer. It is not a store, a notifier, or a callback.
+Progress lines, streamed answer text, the live tool status, and the final
+answer all go out through here. A channel implements it; the host only writes
+to it, and never reads back.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ from core.agent_harness import OutputSink
 
 
 @runtime_checkable
-class GatewayOutputSink(OutputSink, Protocol):
+class TurnOutput(OutputSink, Protocol):
     def set_tool_status(self, text: str) -> None:
         """Show live tool progress for the running turn."""
 

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -28,7 +28,7 @@ from core.agent_harness.turns.turn_results import TurnResult
 from core.domain.types.tools import ToolSurface
 from core.llm.types import AgentLLMResponse, ToolCall
 from core.tool_framework.registered_tool import RegisteredTool
-from platform.turn_host.turn_handler import GatewayTurnHandler
+from platform.turn_host.turn_handler import TurnHandler
 from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.runtime.slash_adapter import headless_slash_ports
 from surfaces.interactive_shell.session import Session
@@ -177,7 +177,7 @@ class FakeReasoningClient:
         yield PARITY_ANSWER
 
 
-class RecordingGatewayOutputSink:
+class RecordingTurnOutput:
     """Minimal gateway sink that records stream/finalize output for assertions."""
 
     def __init__(self) -> None:
@@ -395,11 +395,11 @@ def snapshot_gateway_handler(
     integrations: dict[str, Any] | None = None,
 ) -> TurnSnapshot:
     session = fresh_session(integrations=integrations)
-    sink = RecordingGatewayOutputSink()
+    sink = RecordingTurnOutput()
     captured: list[TurnResult] = []
     _install_gateway_dispatch_spy(monkeypatch, captured)
     before = probe_run_count()
-    handler = GatewayTurnHandler(
+    handler = TurnHandler(
         console=console(),
         slash_ports_factory=headless_slash_ports,
     )
@@ -460,14 +460,14 @@ def run_gateway_turn_with_sink(
     monkeypatch: Any,
     *,
     integrations: dict[str, Any] | None = None,
-) -> tuple[TurnSnapshot, RecordingGatewayOutputSink]:
+) -> tuple[TurnSnapshot, RecordingTurnOutput]:
     """Run one gateway turn and return both routing snapshot and transport sink."""
     session = fresh_session(integrations=integrations)
-    sink = RecordingGatewayOutputSink()
+    sink = RecordingTurnOutput()
     captured: list[TurnResult] = []
     _install_gateway_dispatch_spy(monkeypatch, captured)
     before = probe_run_count()
-    handler = GatewayTurnHandler(
+    handler = TurnHandler(
         console=console(),
         slash_ports_factory=headless_slash_ports,
     )

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -13,7 +13,7 @@ from core.agent_harness.session import InMemorySessionStore
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
-from platform.turn_host.turn_handler import GatewayTurnHandler
+from platform.turn_host.turn_handler import TurnHandler
 from surfaces.interactive_shell.session import Session
 from tests.shared.default_headless_build_stub import default_headless_build_stub
 from tests.shared.fake_agent import fake_agent
@@ -41,7 +41,7 @@ def test_gateway_turn_handler_delegates_to_agent_dispatch(monkeypatch: pytest.Mo
 
     session = Session(store=InMemorySessionStore())
     sink = MagicMock()
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("hello gateway", session, sink, logging.getLogger("test.gateway.module"))
 
     # The message is dispatched per-turn; session-stable ports are wired once,
@@ -86,7 +86,7 @@ def test_gateway_turn_handler_does_not_finalize_answered_turn(
 
     session = Session(store=InMemorySessionStore())
     sink = MagicMock()
-    handler = GatewayTurnHandler(console=Console(force_terminal=False))
+    handler = TurnHandler(console=Console(force_terminal=False))
     handler("why", session, sink, logging.getLogger("test.gateway.module.answer"))
 
     sink.finalize.assert_not_called()

--- a/tests/core/agent/orchestration/test_cross_surface_parity.py
+++ b/tests/core/agent/orchestration/test_cross_surface_parity.py
@@ -4,7 +4,7 @@ Surfaces under test:
 
 * ``shell`` — ``execute_shell_turn`` (interactive REPL / CLI one-shot)
 * ``headless`` — ``HeadlessAgent.dispatch``
-* ``gateway_handler`` — ``GatewayTurnHandler`` (Telegram/API gateway)
+* ``gateway_handler`` — ``TurnHandler`` (Telegram/API gateway)
 
 Each test wires ONE tool registry and ONE pair of LLMs, drives the same message
 through all three entry points, and asserts identical routing + response shape.
@@ -19,11 +19,11 @@ import pytest
 
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 from core.agent_harness.tools.action_tools import get_action_tool
-from platform.turn_host.turn_handler import GatewayTurnHandler
+from platform.turn_host.turn_handler import TurnHandler
 from tests.core.agent.orchestration.cross_surface_parity_harness import (
     ALL_SURFACES,
     PARITY_ANSWER,
-    RecordingGatewayOutputSink,
+    RecordingTurnOutput,
     assert_surfaces_match,
     collect_all_surfaces,
     console,
@@ -190,8 +190,8 @@ def test_gateway_handler_outbound_finalize_on_action_only_turn(
     configure(tools=[probe_tool()], action_mode="tool")
 
     session = fresh_session()
-    sink = RecordingGatewayOutputSink()
-    handler = GatewayTurnHandler(console=console())
+    sink = RecordingTurnOutput()
+    handler = TurnHandler(console=console())
     handler("run probe", session, sink, logging.getLogger("test.parity.gateway.outbound"))
 
     assert sink.finalized is not None


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Follow-up to #5177. The turn host moved to `platform/turn_host/`, but its three
public types kept `Gateway` prefixes:

| Was | Now |
| --- | --- |
| `GatewayTurnHandler` | `TurnHandler` |
| `GatewayAgentCallback` | `TurnCallback` |
| `GatewayOutputSink` | `TurnOutput` |

42 files, 198 occurrences. `docs/NAMING.md` rules out the package-name prefix,
and the module path already qualifies these — `turn_host.turn_handler.TurnHandler`
reads without the stutter `TurnHostTurnHandler` would have added.

**`TurnOutput`, not `TurnOutputSink`.** "Sink" names the shape of the
abstraction (things go in, nothing comes back) rather than its job, and the
docstring showed what that costs — it defined the type by what it is *not*:

> the same ephemeral turn-delivery port the harness already names, plus live
> tool-status and the final chat answer. **It is not a store, a notifier, or a
> callback.**

Three disclaimers is a name not carrying its weight. Every method on the type —
`print`, `render_response_header`, `render_error`, `stream`, `set_tool_status`,
`finalize` — shows something to the person who asked. The docstring now says so
directly, and the name matches both the module (`turn_output.py`) and the
parameter it is always bound to (`output: TurnOutput`).

**Deliberately not renamed:**

- `capture_gateway_turn_started` / `_completed` / `_failed` — these are
  **analytics event names**. Renaming the Python symbol is harmless; renaming
  what reaches PostHog splits every existing dashboard and funnel at the rename
  date.
- `GatewayController` — one reference in `concurrency.py`, and it is correct:
  that controller really is `gateway/core/lifecycle/controller.py`.
- `normalize_gateway_status` — status copy for the chat placeholder message.
  Genuinely about chat gateways.

**Prose, not just symbols.** A type rename leaves docstrings lying, so the five
that still described these as gateway things were corrected — including
`turn_handler.py`, which opened with *"This is the **only** gateway turn
handler"* in a file that is no longer in the gateway.

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards

**Explain your implementation approach:**

A package that changed tiers left every type inside it claiming the old tier.
That is the kind of staleness that survives because nothing fails — the imports
resolve, the tests pass, and only a reader is misled.

The interesting decision was `GatewayOutputSink`. The mechanical answer was
`TurnOutputSink`; the better answer dropped "sink" entirely. Words like sink and
wire describe the plumbing an abstraction resembles rather than the work it
does, and they tend to appear where the job was never pinned down. This type's
own docstring was the evidence, defining itself by exclusion. Naming it for what
it shows the user made the docstring shorter and removed the need for the
disclaimers.