### PR TITLE
fix: remediate GitHub code scanning finding #2125

### DIFF
--- a/gateway/tests/runtime/test_conversation_locks.py
+++ b/gateway/tests/runtime/test_conversation_locks.py
@@ -64,11 +64,15 @@ def test_idle_entries_are_pruned_at_capacity() -> None:
     assert len(registry) <= 2
 
 
+def _fail_turn() -> None:
+    raise RuntimeError("turn failed")
+
+
 def test_exception_releases_conversation_for_next_turn() -> None:
     registry = ConversationLockRegistry()
 
     with pytest.raises(RuntimeError, match="turn failed"), registry.hold("conversation"):
-        raise RuntimeError("turn failed")
+        _fail_turn()
 
     with registry.hold("conversation"):
         pass


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2125](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2125).

**Alert summary**
Unreachable code

**Fix summary**
Done.

**Change:** `gateway/tests/runtime/test_conversation_locks.py` — extracted the bare `raise RuntimeError("turn failed")` inside the `pytest.raises(...)` / `registry.hold(...)` block into a named `_fail_turn()` helper and called it from the `with` body.

**Why this fixes the alert:** CodeQL's `py/unreachable-statement` doesn't model `pytest.raises` suppressing the exception via `__exit__`, so a bare `raise` as the `with` body made it treat line 73 onward as unreachable. Since CodeQL treats a function call as returning, calling `_fail_turn()` makes the follow-up block reachable in its analysis. Runtime behavior is unchanged — the same exception is raised and the test still verifies the lock is released for the next turn. This is the exact fix pattern AGENTS.md prescribes for this footgun ("For the bare-`raise` case, extract a `_raise()` helper").

**Verification:** all 4 tests in the file pass; ruff lint and format checks pass. No commit made.

**Files changed**
- `gateway/tests/runtime/test_conversation_locks.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.