### PR TITLE
fix: remediate GitHub code scanning finding #2196

### DIFF
--- a/tests/core/agent_harness/test_headless_build.py
+++ b/tests/core/agent_harness/test_headless_build.py
@@ -35,7 +35,7 @@ def test_default_headless_build_sets_gateway_surface() -> None:
 
 def test_default_headless_build_is_exported_from_runtime_and_the_buffer_sink_is_not() -> None:
     import core.agent_harness as pkg
-    from core.agent_harness import runtime
+    import core.agent_harness.runtime as runtime
 
     assert runtime.DefaultHeadlessBuild is DefaultHeadlessBuild
     assert not hasattr(pkg, "DefaultHeadlessBuild")


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2196](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2196).

**Alert summary**
Module is imported with 'import' and 'import from'

**Fix summary**
Fixed. All 7 tests pass, ruff clean.

**Change** — `tests/core/agent_harness/test_headless_build.py:38`: replaced `from core.agent_harness import runtime` with `import core.agent_harness.runtime as runtime`.

**Why it addresses the rule** — CodeQL's `py/import-and-import-from` flags the same module (`core.agent_harness`) being imported both as `import core.agent_harness as pkg` and `from core.agent_harness import runtime` in the test body. Using a plain submodule import for `runtime` leaves only one import style for the package, removing the finding at its source rather than silencing it. The test's semantics are unchanged: `runtime` still binds the same module object, and the assertions on export boundaries (`runtime.DefaultHeadlessBuild`, absence of `BufferOutputSink`) still exercise the same contract, so no new test is needed.

**Verification** — `uv run pytest tests/core/agent_harness/test_headless_build.py` (7 passed), `ruff check` and `ruff format --check` clean. No commit made.

**Files changed**
- `tests/core/agent_harness/test_headless_build.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.