### PR TITLE
fix: remediate GitHub code scanning finding #2186

### DIFF
--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -230,16 +230,13 @@ def _setup_aws() -> None:
         )
         return None if picked is None else RoleGateChoice(picked)
 
-    def _leave_to_configure_credentials() -> NoReturn:
-        print(f"\n  {CONFIGURE_FIRST_INSTRUCTION}")
-        print("  Nothing was saved.")
-        sys.exit(0)
-
     def _gate(mode: str) -> str:
         try:
             return gate_role_mode(mode, ask=_ask_gate)
         except ConfigureCredentialsFirst:
-            _leave_to_configure_credentials()
+            print(f"\n  {CONFIGURE_FIRST_INSTRUCTION}")
+            print("  Nothing was saved.")
+            raise SystemExit(0) from None
 
     _run_spec_setup(AWS_SETUP, on_mode_chosen=_gate)
 


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2186](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2186).

**Alert summary**
Explicit returns mixed with implicit (fall through) returns

**Fix summary**
Done. All checks pass.

**Change** — `integrations/cli.py:233-244`: removed the `_leave_to_configure_credentials()` `NoReturn` helper and moved its exit messaging directly into `_gate`'s `except ConfigureCredentialsFirst` branch, which now ends with an explicit `raise SystemExit(0) from None` instead of a call to a `sys.exit`-ing helper.

**Why it addresses `py/mixed-returns`** — CodeQL does not model `NoReturn` (a documented footgun in AGENTS.md), so it treated the helper call as an ordinary call that returns, making the `except` branch look like an implicit `return None` mixed with the `try` branch's explicit `return`. Ending the branch with a `raise` statement makes every exit from `_gate` explicit to CodeQL's control-flow analysis, removing the finding structurally rather than silencing it. `raise SystemExit(0)` is behaviorally identical to `sys.exit(0)`, and the pattern matches the wizard sibling `surfaces/cli/wizard/configurators/aws.py:41` (`raise WizardBack from None`).

**Tests** — no new test needed: `tests/integrations/aws/test_cli_setup_role_gate.py::test_configure_first_prints_the_instruction_and_exits_zero` already pins the exact behavior (exit code 0, instruction printed, no field prompts).

**Verification** — `uv run pytest tests/integrations/aws/test_cli_setup_role_gate.py` (3 passed), `ruff check` + `ruff format --check` clean, `mypy integrations/cli.py` clean. No commit made.

**Files changed**
- `integrations/cli.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.