### PR TITLE
fix: remediate GitHub code scanning finding #2183

### DIFF
--- a/gateway/tests/slack/test_dispatcher_scope_borders.py
+++ b/gateway/tests/slack/test_dispatcher_scope_borders.py
@@ -28,7 +28,6 @@ from gateway.transports.slack.processing.events import SlackInboundMessage
 from gateway.transports.slack.processing.principal import slack_scope
 from gateway.transports.slack.settings import SlackGatewaySettings
 
-_SECURITY = "gateway.transports.slack.processing.security"
 TEST_ORG = "org_border_acme"
 
 


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2183](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2183).

**Alert summary**
Unused global variable

**Fix summary**
Done. All 6 tests pass, lint and format clean.

**Change:** removed the dead assignment `_SECURITY = "gateway.transports.slack.processing.security"` from `gateway/tests/slack/test_dispatcher_scope_borders.py:31`.

**Why this fixes the alert:** CodeQL's `py/unused-global-variable` flags module-level variables that are assigned but never read. `_SECURITY` had zero references in this file — sibling tests (`test_security.py`, `test_dispatcher.py`) each define their own copy for `patch(f"{_SECURITY}...")` targets, but this file never patches the security module, so its copy was a leftover. The right-hand side is a pure string literal with no side effects, so deleting the assignment (the rule's recommended remedy for unintentional dead variables) is the correct minimal fix rather than renaming it to look intentionally unused.

**Test note:** no new test is warranted — the finding is dead code in a test module, not vulnerable runtime behavior; removal is verified by the existing suite staying green.

**Verification:** `uv run pytest gateway/tests/slack/test_dispatcher_scope_borders.py` (6 passed), `ruff check` and `ruff format --check` both clean.

**Files changed**
- `gateway/tests/slack/test_dispatcher_scope_borders.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.