### PR TITLE
fix: remediate GitHub code scanning finding #2182

### DIFF
--- a/gateway/tests/slack/test_dispatcher.py
+++ b/gateway/tests/slack/test_dispatcher.py
@@ -18,8 +18,6 @@ from gateway.transports.slack.processing.events import SlackInboundMessage
 from gateway.transports.slack.processing.principal import slack_scope
 from gateway.transports.slack.settings import SlackGatewaySettings
 
-_SECURITY = "gateway.transports.slack.processing.security"
-
 
 @pytest.fixture(autouse=True)
 def _isolate_slack_integration_store():


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2182](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2182).

**Alert summary**
Unused global variable

**Fix summary**
Done.

**Change:** Removed the unused module-level constant `_SECURITY = "gateway.transports.slack.processing.security"` from `gateway/tests/slack/test_dispatcher.py:21`.

**Why this addresses the rule:** CodeQL's `py/unused-global-variable` flags module-level assignments that are never read. This constant was a leftover — `gateway/tests/slack/test_security.py` defines and actually uses an identical `_SECURITY` constant for its `patch(f"{_SECURITY}...")` calls, but the dispatcher test file never references it (a repo-wide grep confirms no other reader; it's underscore-private, so no cross-module import concern per the AGENTS.md footgun). The RHS is a plain string literal with no side effects, so deleting the assignment is the minimal, provably safe fix — no rename-to-`_unused` workaround needed.

**No new test:** the finding is dead code in a test module, not a testable behavior.

**Verification:** all 21 tests in `gateway/tests/slack/test_dispatcher.py` pass; `ruff check` and `ruff format --check` are clean on the file.

**Files changed**
- `gateway/tests/slack/test_dispatcher.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.