### PR TITLE
fix: remediate GitHub code scanning finding #2144

### DIFF
--- a/tests/tools/test_posthog_mcp_tool.py
+++ b/tests/tools/test_posthog_mcp_tool.py
@@ -485,8 +485,6 @@ def test_list_tools_truncates_long_descriptions() -> None:
 
 def test_query_values_survive_gather_truncation() -> None:
     """Row values must outlive the gather loop's head-first result truncation."""
-    import json
-
     from core.agent_harness.turns.evidence_driver import _MAX_PER_TOOL_CHARS, _truncate
     from integrations.posthog_mcp.tools.posthog_mcp_tool import _normalize_tool_result
 


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2144](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2144).

**Alert summary**
Module is imported more than once

**Fix summary**
Done. Fix for alert #2144 (`py/repeated-import`):

- **tests/tools/test_posthog_mcp_tool.py:488** — deleted the function-local `import json` inside `test_query_values_survive_gather_truncation`. The module already imports `json` at line 5, so the second import was a no-op that only confused readers; the rest of the function's local imports (`_truncate`, `_normalize_tool_result`) are untouched.

This addresses the rule at its source — the duplicate import no longer exists, so no dismissal or suppression is needed, and no new test applies (there's no behavior change).

Verification: all 42 tests in `tests/tools/test_posthog_mcp_tool.py` pass; `ruff check` and `ruff format --check` are clean. No commit made.

**Files changed**
- `tests/tools/test_posthog_mcp_tool.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.