### PR TITLE
fix: remediate GitHub code scanning finding #2133

### DIFF
--- a/gateway/transports/slack/transport/socket_mode/worker.py
+++ b/gateway/transports/slack/transport/socket_mode/worker.py
@@ -24,7 +24,6 @@ from gateway.transports.slack.transport.socket_mode.heartbeat import (
 from gateway.transports.slack.turn_stack import build_slack_turn_stack
 from platform.turn_host.turn_callback import TurnCallback
 
-_PLATFORM_SLACK = "slack"
 _EVENTS_API_REQUEST_TYPE = "events_api"
 _INTERACTIVE_REQUEST_TYPE = "interactive"
 


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2133](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2133).

**Alert summary**
Unused global variable

**Fix summary**
Done. All checks pass.

**Change:** Deleted the unused module-level constant `_PLATFORM_SLACK = "slack"` from `gateway/transports/slack/transport/socket_mode/worker.py:27`.

**Why this fixes the alert:** CodeQL's `py/unused-global-variable` flagged the constant because nothing in the module (or anywhere else) reads it — the only real user of a `_PLATFORM_SLACK` constant is `gateway/transports/slack/turn_stack.py`, which defines its own copy at line 26 and passes it to `SessionResolver` at line 83. The copy in `worker.py` was leftover dead code (likely from before the turn-stack extraction), and the leading underscore means it isn't part of any public API. Deleting the assignment removes the finding at its source; the RHS is a pure string literal with no side effects.

**No test added:** removing a dead constant has no testable behavior — existing Slack gateway tests cover the module's real behavior and confirm nothing regressed.

**Verification:**
- `ruff check` + `ruff format --check` on the file — clean
- `mypy` on the file — no issues
- `uv run pytest gateway/tests/slack` — 198 passed

**Files changed**
- `gateway/transports/slack/transport/socket_mode/worker.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.