### PR TITLE
test(config): pin capability warning facts when PATH tools are missing

### DIFF
--- a/tests/config/test_workspace_identity.py
+++ b/tests/config/test_workspace_identity.py
@@ -67,6 +67,36 @@ def test_capability_warnings_include_network_default(monkeypatch) -> None:
     assert any("network egress" in w for w in facts["capability_warnings"])
 
 
+def test_capability_warnings_include_missing_shell(monkeypatch) -> None:
+    # Arrange
+    monkeypatch.delenv(OPENSRE_ALLOW_NETWORK_ENV, raising=False)
+    tools = {"bash": "", "sh": ""}
+
+    # Act
+    facts = capability_warning_facts(tools)
+
+    # Assert
+    assert facts["shell_available"] is False
+    assert any("no interactive shell" in warning for warning in facts["capability_warnings"])
+
+
+def test_capability_warnings_include_network_opt_in(monkeypatch) -> None:
+    # Arrange
+    monkeypatch.setenv(OPENSRE_ALLOW_NETWORK_ENV, "1")
+    tools = {
+        "curl": "/usr/bin/curl",
+        "bash": "/bin/bash",
+        "sh": "/bin/sh",
+    }
+
+    # Act
+    facts = capability_warning_facts(tools)
+
+    # Assert
+    assert facts["network_egress"] is True
+    assert not any("network egress" in warning for warning in facts["capability_warnings"])
+
+
 def test_capability_warnings_line_in_prompt() -> None:
     block = render_static_runtime_facts(
         {


### PR DESCRIPTION
## Summary

- add unit coverage for missing shell executables in capability warning facts
- add coverage for the network opt-in path
- use injected tool mappings to avoid live PATH dependencies

## Testing

- `uv run ruff format --check tests/config/test_workspace_identity.py`
- `uv run ruff check tests/config/test_workspace_identity.py`
- `uv run pytest tests/config/test_workspace_identity.py -v`

All 13 tests pass.

Closes #4900S