### PR TITLE
feat(shell): the interactive shell runs the same turn as Slack

### DIFF
--- a/core/agent_harness/turns/answer_finalize.py
+++ b/core/agent_harness/turns/answer_finalize.py
@@ -65,17 +65,17 @@ class AnswerFinalizeResult:
     finish_stream: bool
 
 
-def finish_streamed_response(output: OutputSink | None, text: str) -> None:
+def finish_streamed_response(output: OutputSink | None, answer: str) -> None:
     """Flush deferred/rewritten gather paint on surfaces that support it."""
     if output is None:
         return
     finish = getattr(output, "finish_streamed_response", None)
     if callable(finish):
-        finish(text)
+        finish(answer)
         return
     finalize = getattr(output, "finalize", None)
     if callable(finalize):
-        finalize(text)
+        finalize(answer)
 
 
 def _offered_upgrade_ctas(session: SessionState) -> set[str]:

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -97,9 +97,9 @@ class BufferOutputSink:
         self.streamed.append(text)
         return text
 
-    def finish_streamed_response(self, text: str) -> None:
+    def finish_streamed_response(self, answer: str) -> None:
         # Headless tests assert on ``TurnResult.assistant_response_text``.
-        _ = text
+        _ = answer
 
     @property
     def text(self) -> str:

--- a/gateway/tests/runtime/test_concurrency_gate.py
+++ b/gateway/tests/runtime/test_concurrency_gate.py
@@ -62,8 +62,8 @@ def test_chat_handler_refuses_excess_turn_without_calling_handler() -> None:
         release.wait(1)
 
     class Sink:
-        def finalize(self, text: str) -> None:
-            finalized.append(text)
+        def finalize(self, answer: str) -> None:
+            finalized.append(answer)
 
     handler = ConcurrencyLimitedTurnHandler(handler=blocking_handler, gate=gate)
     first = threading.Thread(
@@ -95,8 +95,8 @@ def test_gateway_turn_handler_gate_refuses_excess_without_second_wrapper(
     ran: list[str] = []
 
     class Sink:
-        def finalize(self, text: str) -> None:
-            finalized.append(text)
+        def finalize(self, answer: str) -> None:
+            finalized.append(answer)
 
     handler = TurnHandler(console=Console(force_terminal=False), gate=gate)
 

--- a/gateway/tests/runtime/test_session_agents.py
+++ b/gateway/tests/runtime/test_session_agents.py
@@ -249,3 +249,63 @@ def test_different_sessions_still_run_concurrently(monkeypatch: pytest.MonkeyPat
 
     # Assert
     assert len(reached) == 2, reached
+
+
+def test_drop_session_removes_cached_agent_and_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    pool = _fake_agent_pool(monkeypatch)
+    session = SessionCore(store=InMemorySessionStore())
+    logger = logging.getLogger("test.pool.drop")
+    first = pool.agent_for(session=session, output=MagicMock(), logger=logger)
+    assert pool.cached_session_ids == frozenset({session.session_id})
+
+    pool.drop_session(session.session_id)
+
+    assert pool.cached_session_ids == frozenset()
+    second = pool.agent_for(session=session, output=MagicMock(), logger=logger)
+    assert second is not first
+
+
+def test_retain_only_current_session_drops_stale_ids_after_rotation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shell /new and /resume rotate session_id; the REPL keeps one TurnHandler."""
+    constructed: list[str] = []
+
+    class _FakeAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            constructed.append(str(kwargs["session"].session_id))
+            self.bind_turn = MagicMock()
+            self.bind_session = MagicMock()
+
+    monkeypatch.setattr(
+        "platform.turn_host.session_agents.DefaultHeadlessBuild",
+        default_headless_build_stub(lambda **kwargs: _FakeAgent(**kwargs)),
+    )
+    pool = SessionAgentPool(
+        console=Console(force_terminal=False),
+        retain_only_current_session=True,
+    )
+    logger = logging.getLogger("test.pool.retain")
+    first = SessionCore(store=InMemorySessionStore())
+    second = SessionCore(store=InMemorySessionStore())
+
+    pool.agent_for(session=first, output=MagicMock(), logger=logger)
+    assert pool.cached_session_ids == frozenset({first.session_id})
+
+    pool.agent_for(session=second, output=MagicMock(), logger=logger)
+    assert pool.cached_session_ids == frozenset({second.session_id})
+    assert constructed == [first.session_id, second.session_id]
+
+
+def test_gateway_default_retains_multiple_session_agents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chat hosts many conversations on one TurnHandler — do not cull peers."""
+    pool = _fake_agent_pool(monkeypatch)
+    assert pool._retain_only_current_session is False
+    logger = logging.getLogger("test.pool.gateway")
+    a = SessionCore(store=InMemorySessionStore())
+    b = SessionCore(store=InMemorySessionStore())
+    pool.agent_for(session=a, output=MagicMock(), logger=logger)
+    pool.agent_for(session=b, output=MagicMock(), logger=logger)
+    assert pool.cached_session_ids == frozenset({a.session_id, b.session_id})

--- a/gateway/tests/runtime/test_turn_handler.py
+++ b/gateway/tests/runtime/test_turn_handler.py
@@ -325,8 +325,8 @@ def test_turn_handler_tolerates_sinks_without_tool_hooks(monkeypatch: Any) -> No
     """Sinks without tool_hooks (Telegram today) run unhooked — documented host gap."""
 
     class _BareSink:
-        def finalize(self, text: str) -> None:
-            self.finalized = text
+        def finalize(self, answer: str) -> None:
+            self.finalized = answer
 
     agent_cls = _patch_headless_agent(monkeypatch, _empty_turn_result())
     handler = TurnHandler(console=Console(force_terminal=False))

--- a/gateway/transports/buzz/output_sink.py
+++ b/gateway/transports/buzz/output_sink.py
@@ -96,30 +96,30 @@ class BuzzOutputSink:
         self._finalize(text or EMPTY_RESPONSE_MESSAGE)
         return text
 
-    def set_tool_status(self, text: str) -> None:
-        self._set_status(text)
+    def set_tool_status(self, status: str) -> None:
+        self._set_status(status)
 
-    def finish_streamed_response(self, text: str) -> None:
-        self._finalize(text or EMPTY_RESPONSE_MESSAGE)
+    def finish_streamed_response(self, answer: str) -> None:
+        self._finalize(answer or EMPTY_RESPONSE_MESSAGE)
 
-    def _set_status(self, text: str) -> None:
-        self._status_text = normalize_gateway_status(text)
+    def _set_status(self, status: str) -> None:
+        self._status_text = normalize_gateway_status(status)
         self._edit_preview(self._status_text)
 
-    def _edit_preview(self, text: str) -> None:
+    def _edit_preview(self, preview: str) -> None:
         if not self._event_id:
             return
-        preview = truncate(text or self._status_text, MAX_MESSAGE_SIZE, suffix="…")
+        preview = truncate(preview or self._status_text, MAX_MESSAGE_SIZE, suffix="…")
         with self._lock:
             result = self._client.edit_message(event_id=self._event_id, content=preview)
             if result["success"]:
                 self._last_edit = time.monotonic()
 
-    def finalize(self, text: str) -> None:
-        self._finalize(text)
+    def finalize(self, answer: str) -> None:
+        self._finalize(answer)
 
-    def _finalize(self, text: str) -> None:
-        final = truncate(text, MAX_MESSAGE_SIZE, suffix="…")
+    def _finalize(self, answer: str) -> None:
+        final = truncate(answer, MAX_MESSAGE_SIZE, suffix="…")
         if self._event_id and self._edit_final(final):
             logger.info("outbound channel=%s text=%r", self._channel_id, _log_preview(final))
             # Release the id so the next session-goal turn cannot overwrite this answer.
@@ -129,12 +129,12 @@ class BuzzOutputSink:
             logger.info("outbound channel=%s text=%r", self._channel_id, _log_preview(final))
             self._event_id = ""
 
-    def _edit_final(self, text: str) -> bool:
-        result = self._client.edit_message(event_id=self._event_id, content=text)
+    def _edit_final(self, answer: str) -> bool:
+        result = self._client.edit_message(event_id=self._event_id, content=answer)
         return bool(result["success"])
 
-    def _send_final(self, text: str) -> bool:
-        result = self._client.send_message(channel=self._channel_id, content=text)
+    def _send_final(self, answer: str) -> bool:
+        result = self._client.send_message(channel=self._channel_id, content=answer)
         return bool(result["success"])
 
 

--- a/gateway/transports/discord/output_sink.py
+++ b/gateway/transports/discord/output_sink.py
@@ -81,14 +81,14 @@ class DiscordOutputSink:
                 self._edit_preview(combined)
         return "".join(parts)
 
-    def set_tool_status(self, text: str) -> None:
-        self._set_status(text)
+    def set_tool_status(self, status: str) -> None:
+        self._set_status(status)
 
-    def finish_streamed_response(self, text: str) -> None:
-        self.finalize(text)
+    def finish_streamed_response(self, answer: str) -> None:
+        self.finalize(answer)
 
-    def finalize(self, text: str) -> None:
-        body = (text or EMPTY_RESPONSE_MESSAGE).strip()
+    def finalize(self, answer: str) -> None:
+        body = (answer or EMPTY_RESPONSE_MESSAGE).strip()
         chunks = split_discord_content(body)
         if not chunks:
             return
@@ -140,16 +140,16 @@ class DiscordOutputSink:
                 bot_token=self._bot_token,
             )
 
-    def _set_status(self, text: str) -> None:
-        status = normalize_gateway_status(text)
+    def _set_status(self, status: str) -> None:
+        status = normalize_gateway_status(status)
         self._edit_preview(f"*{status}*")
 
-    def _edit_preview(self, text: str) -> None:
+    def _edit_preview(self, preview: str) -> None:
         with self._lock:
             if not self._message_id:
                 self._message_id = send_message(
                     channel_id=self._channel_id,
-                    content=text[:2000],
+                    content=preview[:2000],
                     bot_token=self._bot_token,
                 )
                 return
@@ -159,7 +159,7 @@ class DiscordOutputSink:
             if edit_message(
                 channel_id=self._channel_id,
                 message_id=self._message_id,
-                content=text[:2000],
+                content=preview[:2000],
                 bot_token=self._bot_token,
             ):
                 self._last_edit = now

--- a/gateway/transports/slack/delivery/output_sink.py
+++ b/gateway/transports/slack/delivery/output_sink.py
@@ -124,17 +124,17 @@ class SlackOutputSink:
         self._finalize(text or EMPTY_RESPONSE_MESSAGE)
         return text
 
-    def set_tool_status(self, text: str) -> None:
-        self._set_status(text)
+    def set_tool_status(self, status: str) -> None:
+        self._set_status(status)
 
-    def finalize(self, text: str) -> None:
-        self._finalize(text)
+    def finalize(self, answer: str) -> None:
+        self._finalize(answer)
 
-    def finish_streamed_response(self, text: str) -> None:
-        self._finalize(text or EMPTY_RESPONSE_MESSAGE)
+    def finish_streamed_response(self, answer: str) -> None:
+        self._finalize(answer or EMPTY_RESPONSE_MESSAGE)
 
-    def _set_status(self, text: str) -> None:
-        status = normalize_gateway_status(text)
+    def _set_status(self, status: str) -> None:
+        status = normalize_gateway_status(status)
         with self._lock:
             if self._turn_stream.note_task(status):
                 return
@@ -148,25 +148,25 @@ class SlackOutputSink:
         if ts:
             self._client.delete_message(channel=self._channel_id, ts=ts)
 
-    def _edit_preview(self, text: str) -> None:
+    def _edit_preview(self, preview: str) -> None:
         if not self._message_ts:
             return
-        preview = truncate(text, SLACK_MAX_MESSAGE_CHARS, suffix="…")
+        preview = truncate(preview, SLACK_MAX_MESSAGE_CHARS, suffix="…")
         with self._lock:
             if self._message_ts and self._client.update_message(
                 channel=self._channel_id, ts=self._message_ts, text=preview
             ):
                 self._last_update = time.monotonic()
 
-    def _finalize(self, text: str) -> None:
+    def _finalize(self, answer: str) -> None:
         with self._lock:
             if self._turn_stream.is_open:
-                if self._turn_stream.finish(text, blocks=self._closing_blocks()):
+                if self._turn_stream.finish(answer, blocks=self._closing_blocks()):
                     logger.info(
                         "outbound channel=%s thread_ts=%s mode=stream chars=%d",
                         self._channel_id,
                         self._thread_ts,
-                        len(text),
+                        len(answer),
                     )
                     return
                 # Stream broke mid-turn: deliver the full answer the classic way.
@@ -178,20 +178,20 @@ class SlackOutputSink:
                 )
             elif self._turn_stream.closed:
                 # Prior stopStream (session goal continuation, or a raced finalize).
-                # Open a fresh stream so later-turn text is not treated as already
+                # Open a fresh stream so later-turn answer is not treated as already
                 # delivered; if start fails, fall through to classic post.
                 if self._turn_stream.ensure_started_for_continuation() and self._turn_stream.finish(
-                    text, blocks=self._closing_blocks()
+                    answer, blocks=self._closing_blocks()
                 ):
                     logger.info(
                         "outbound channel=%s thread_ts=%s mode=stream-continuation chars=%d",
                         self._channel_id,
                         self._thread_ts,
-                        len(text),
+                        len(answer),
                     )
                     return
-        final = truncate(markdown_to_slack_mrkdwn(text), SLACK_MAX_MESSAGE_CHARS, suffix="…")
-        blocks = self._final_blocks(text)
+        final = truncate(markdown_to_slack_mrkdwn(answer), SLACK_MAX_MESSAGE_CHARS, suffix="…")
+        blocks = self._final_blocks(answer)
         mode = "edit"
         with self._lock:
             delivered = self._message_ts is not None and self._client.update_message(
@@ -227,7 +227,7 @@ class SlackOutputSink:
                 len(final),
             )
 
-    def _final_blocks(self, text: str) -> Blocks | None:
+    def _final_blocks(self, answer: str) -> Blocks | None:
         """Compose the final reply: a ``markdown`` block + a context footer.
 
         Slack built the markdown block for LLM output: standard markdown
@@ -238,7 +238,7 @@ class SlackOutputSink:
         text-only; the mrkdwn text is always sent alongside as the
         notification/fallback rendering.
         """
-        body = text.strip()
+        body = answer.strip()
         if not body or len(body) > SLACK_MAX_MARKDOWN_BLOCK_CHARS:
             return None
         return [{"type": "markdown", "text": body}, *self._closing_blocks()]
@@ -264,12 +264,12 @@ def _format_duration(seconds: float) -> str:
     return f"{whole // 60}m {whole % 60:02d}s"
 
 
-def _as_status_line(text: str) -> str:
+def _as_status_line(status: str) -> str:
     """Render an in-progress status as one italic mrkdwn line.
 
     Mirrors the "is thinking…" affordance in Claude Tag / Slack assistant
-    threads: progress reads as muted meta-text, clearly distinct from the
+    threads: progress reads as muted meta-status, clearly distinct from the
     final answer that replaces it.
     """
-    line = " ".join(text.split())
+    line = " ".join(status.split())
     return f"_{line}_" if line else line

--- a/gateway/transports/telegram/output_sink.py
+++ b/gateway/transports/telegram/output_sink.py
@@ -90,19 +90,19 @@ class TelegramOutputSink:
         self._finalize(text or EMPTY_RESPONSE_MESSAGE)
         return text
 
-    def set_tool_status(self, text: str) -> None:
-        self._set_status(text)
+    def set_tool_status(self, status: str) -> None:
+        self._set_status(status)
 
-    def finish_streamed_response(self, text: str) -> None:
-        self._finalize(text or EMPTY_RESPONSE_MESSAGE)
+    def finish_streamed_response(self, answer: str) -> None:
+        self._finalize(answer or EMPTY_RESPONSE_MESSAGE)
 
-    def _set_status(self, text: str) -> None:
-        self._status_text = normalize_gateway_status(text)
+    def _set_status(self, status: str) -> None:
+        self._status_text = normalize_gateway_status(status)
         self._client.send_chat_action(self._chat_id, "typing")
         self._edit_preview(self._status_text)
 
-    def _edit_preview(self, text: str) -> None:
-        preview = truncate(text or self._status_text, MAX_MESSAGE_SIZE, suffix="…")
+    def _edit_preview(self, preview: str) -> None:
+        preview = truncate(preview or self._status_text, MAX_MESSAGE_SIZE, suffix="…")
         with self._lock:
             if not self._message_id:
                 # Prior answer was finalized (goal continuation). Open a fresh
@@ -116,11 +116,11 @@ class TelegramOutputSink:
             if ok:
                 self._last_edit = time.monotonic()
 
-    def finalize(self, text: str) -> None:
-        self._finalize(text)
+    def finalize(self, answer: str) -> None:
+        self._finalize(answer)
 
-    def _finalize(self, text: str) -> None:
-        final = truncate(text, MAX_MESSAGE_SIZE, suffix="…")
+    def _finalize(self, answer: str) -> None:
+        final = truncate(answer, MAX_MESSAGE_SIZE, suffix="…")
         html_final = markdown_to_telegram_html(final)
         if self._message_id and self._edit_final(html_final, final):
             logger.info("outbound chat=%s text=%r", self._chat_id, _log_preview(final))
@@ -132,7 +132,7 @@ class TelegramOutputSink:
             self._message_id = ""
 
     def _edit_final(self, html_text: str, plain_text: str) -> bool:
-        # Render the answer's Markdown as Telegram HTML, falling back to plain text
+        # Render the answer's Markdown as Telegram HTML, falling back to plain answer
         # if the API rejects the markup so a message is never lost to a bad tag.
         ok, _ = self._client.edit_message_text(
             self._chat_id, self._message_id, html_text, parse_mode="HTML"

--- a/platform/turn_host/bindable_output.py
+++ b/platform/turn_host/bindable_output.py
@@ -90,15 +90,15 @@ class BindableOutput:
                 return
             yield chunk
 
-    def finalize(self, text: str) -> None:
-        self._require().finalize(text)
+    def finalize(self, answer: str) -> None:
+        self._require().finalize(answer)
 
-    def finish_streamed_response(self, text: str) -> None:
+    def finish_streamed_response(self, answer: str) -> None:
         finish = getattr(self._require(), "finish_streamed_response", None)
         if callable(finish):
-            finish(text)
+            finish(answer)
             return
-        self.finalize(text)
+        self.finalize(answer)
 
     def set_tool_status(self, status: str) -> None:
         set_status = getattr(self._require(), "set_tool_status", None)

--- a/platform/turn_host/session_agents.py
+++ b/platform/turn_host/session_agents.py
@@ -58,6 +58,7 @@ class SessionAgentPool:
         console: Console,
         slash_ports_factory: SlashPortsFactory | None = None,
         agent_build: AgentBuildConfig | None = None,
+        retain_only_current_session: bool = False,
     ) -> None:
         self._console = console
         self._slash_ports_factory = slash_ports_factory
@@ -68,6 +69,11 @@ class SessionAgentPool:
                 apply_capability_policy=ensure_gateway_capability_policy,
             )
         )
+        # Interactive shell keeps one TurnHandler for the REPL lifetime while
+        # /new and /resume rotate session_id in place. When this flag is set,
+        # handing out an agent for the live id drops every other cached entry
+        # so rotations do not accumulate unreachable agents, outputs, and locks.
+        self._retain_only_current_session = retain_only_current_session
         self._agents: dict[str, HeadlessAgent] = {}
         self._outputs: dict[str, BindableOutput] = {}
         # One agent serves every turn of a session, and each turn rebinds its
@@ -76,6 +82,20 @@ class SessionAgentPool:
         # sessions are independent and stay concurrent.
         self._session_locks: dict[str, threading.Lock] = {}
         self._locks_guard = threading.Lock()
+
+    def drop_session(self, session_id: str) -> None:
+        """Forget a session's cached agent, bindable output, and lock."""
+        if not session_id:
+            return
+        self._agents.pop(session_id, None)
+        self._outputs.pop(session_id, None)
+        with self._locks_guard:
+            self._session_locks.pop(session_id, None)
+
+    def _drop_sessions_except(self, keep_session_id: str) -> None:
+        for session_id in tuple(self._agents):
+            if session_id != keep_session_id:
+                self.drop_session(session_id)
 
     def _lock_for(self, session_id: str) -> threading.Lock:
         """The lock guarding one session's agent, created on first use."""
@@ -120,6 +140,8 @@ class SessionAgentPool:
         if policy is not None:
             policy(session)
         session_id = str(getattr(session, "session_id", "") or "")
+        if self._retain_only_current_session and session_id:
+            self._drop_sessions_except(session_id)
         session_output = self._outputs.get(session_id) if session_id else None
         if session_output is None:
             session_output = BindableOutput()

--- a/platform/turn_host/status_messages.py
+++ b/platform/turn_host/status_messages.py
@@ -32,17 +32,17 @@ def initial_status_message() -> str:
     return random.choice(INITIAL_STATUSES)
 
 
-def normalize_gateway_status(text: str) -> str:
-    """Swap empty or legacy ``Working…`` copy for real status text."""
-    stripped = text.strip()
+def normalize_gateway_status(status: str) -> str:
+    """Swap empty or legacy ``Working…`` copy for a real status line."""
+    stripped = status.strip()
     if not stripped or _WORKING_PLACEHOLDER.fullmatch(stripped):
         return initial_status_message()
-    return text
+    return status
 
 
 _GENERIC_ERROR = "Something went wrong handling that request. Please try again."
 
-# Shown when a turn streams no text at all, so the placeholder is not left blank.
+# Shown when a turn streams no status at all, so the placeholder is not left blank.
 EMPTY_RESPONSE_MESSAGE = "I didn't have anything to add for that."
 
 

--- a/platform/turn_host/turn_handler.py
+++ b/platform/turn_host/turn_handler.py
@@ -106,16 +106,18 @@ class TurnHandler:
         *,
         console: Console | None = None,
         confirm_fn: ConfirmFn | None = None,
-        is_tty: bool = False,
+        is_tty: bool | None = False,
         accounting_factory: Callable[[str], TurnAccounting] | None = None,
+        on_progress: Callable[[SessionGoal], None] | None = None,
     ) -> TurnResult | None:
         """Run one turn and return its result, or ``None`` when at capacity.
 
         Same turn as :meth:`__call__` — one capacity gate, one agent pool, one
         ``handle`` call. The keywords carry a caller's terminal context; every
         default is what a chat transport gets, so omitting them all is the
-        transport path exactly. ``None`` means the gate refused the turn and
-        the at-capacity sentence is already on the output.
+        transport path exactly — including ``on_progress``, which falls back
+        to the compact status line a chat placeholder can hold. ``None`` means the
+        gate refused the turn and the at-capacity sentence is already on the output.
         """
         with turn_slot(self._gate) as running:
             if not running:
@@ -130,6 +132,7 @@ class TurnHandler:
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
                 accounting_factory=accounting_factory,
+                on_progress=on_progress,
             )
 
     def _run_turn(
@@ -141,8 +144,9 @@ class TurnHandler:
         *,
         console: Console | None,
         confirm_fn: ConfirmFn | None,
-        is_tty: bool,
+        is_tty: bool | None,
         accounting_factory: Callable[[str], TurnAccounting] | None,
+        on_progress: Callable[[SessionGoal], None] | None,
     ) -> TurnResult:
         session_id = getattr(session, "session_id", None)
         surface = get_surface()
@@ -170,10 +174,10 @@ class TurnHandler:
                 def _cancel_requested() -> bool:
                     return isinstance(cancel, threading.Event) and cancel.is_set()
 
-                def _on_progress(goal: SessionGoal) -> None:
-                    # Same progress contract as the interactive shell: paint mid-loop
-                    # and scrub happens inside the agent's goal loop. Gateway
-                    # output gets a compact status line; full text goes to debug logs.
+                def _status_line_progress(goal: SessionGoal) -> None:
+                    # A channel with no terminal gets one compact status line and
+                    # the full text in debug logs. A caller that can render more
+                    # passes its own ``on_progress`` instead of using this.
                     full = format_session_goal_progress(goal, session=session)
                     compact = format_session_goal_status_line(goal, session=session)
                     if full:
@@ -194,7 +198,7 @@ class TurnHandler:
                     ),
                     accounting_factory=accounting_factory,
                     cancel_requested=_cancel_requested,
-                    on_progress=_on_progress,
+                    on_progress=on_progress or _status_line_progress,
                 )
                 outbound_text = turn_result.primary_response_text
                 logger.debug(

--- a/platform/turn_host/turn_handler.py
+++ b/platform/turn_host/turn_handler.py
@@ -76,16 +76,22 @@ class TurnHandler:
         agent_build: AgentBuildConfig | None = None,
         gate: TurnConcurrencyGate | None = None,
         busy_message: str = AT_CAPACITY_MESSAGE,
+        retain_only_current_session: bool = False,
     ) -> None:
         self._console = console
         self._pool = SessionAgentPool(
             console=console,
             slash_ports_factory=slash_ports_factory,
             agent_build=agent_build,
+            retain_only_current_session=retain_only_current_session,
         )
         # Gateway already bootstrapped env at process start; turns must not reload.
         self._gate = gate
         self._busy_message = busy_message
+
+    def drop_session(self, session_id: str) -> None:
+        """Drop a pooled agent for ``session_id`` (after /new, /resume, or chat rotate)."""
+        self._pool.drop_session(session_id)
 
     def __call__(
         self,

--- a/platform/turn_host/turn_output.py
+++ b/platform/turn_host/turn_output.py
@@ -14,8 +14,8 @@ from core.agent_harness import OutputSink
 
 @runtime_checkable
 class TurnOutput(OutputSink, Protocol):
-    def set_tool_status(self, text: str) -> None:
+    def set_tool_status(self, status: str) -> None:
         """Show live tool progress for the running turn."""
 
-    def finalize(self, text: str) -> None:
+    def finalize(self, answer: str) -> None:
         """Deliver the turn's final answer to the chat."""

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -200,6 +200,9 @@ class InteractiveShellController:
             turn_handler=TurnHandler(
                 console=self.service_console,
                 agent_build=shell_agent_build_config(request_exit=self.prompt.request_exit),
+                # One handler for the REPL lifetime; /new and /resume rotate
+                # session_id on the live handle — keep only that id's agent.
+                retain_only_current_session=True,
             ),
         )
         # Prompt echoes belong in the same stream as everything else this turn

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -187,7 +187,8 @@ class InteractiveShellController:
             self.spinner,
             self.runtime_context.pt_session,
         )
-        from surfaces.interactive_shell.runtime.shell_agent import build_shell_agent
+        from platform.turn_host.turn_handler import TurnHandler
+        from surfaces.interactive_shell.runtime.shell_agent import shell_agent_build_config
 
         self.turn_runtime = AgentTurnResources(
             session=self.session,
@@ -196,10 +197,9 @@ class InteractiveShellController:
             invalidate_prompt=lambda: self.prompt.invalidate_prompt(),
             request_exit=self.prompt.request_exit,
             console=self.service_console,
-            agent=build_shell_agent(
-                self.session,
-                self.service_console,
-                request_exit=self.prompt.request_exit,
+            turn_handler=TurnHandler(
+                console=self.service_console,
+                agent_build=shell_agent_build_config(request_exit=self.prompt.request_exit),
             ),
         )
         # Prompt echoes belong in the same stream as everything else this turn

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -15,6 +15,7 @@ from core.agent_harness import OutputSink
 from core.agent_harness.spi.defaults import DefaultErrorReporter
 from core.agent_harness.spi.session_goal import strip_session_goal_progress_tags
 from core.llm.shared.llm_retry import CREDIT_EXHAUSTED_MARKER
+from surfaces.interactive_shell.ui import DIM
 from surfaces.interactive_shell.ui.streaming import (
     StreamPaintResult,
     finish_deferred_closer,
@@ -74,6 +75,24 @@ class ShellOutputSink:
                 "or add a different provider.[/]"
             )
 
+    def set_tool_status(self, status: str) -> None:
+        """Show live progress for the running turn.
+
+        A chat placeholder holds one status line and rewrites it. A terminal has
+        no placeholder to rewrite, so each status is its own dim line.
+        """
+        if status:
+            self._console.print(f"[{DIM}]{escape(status)}[/]")
+
+    def finalize(self, answer: str) -> None:
+        """Deliver the turn's final answer.
+
+        Reached only when the turn produced text without streaming it — a
+        streamed answer already painted itself through :meth:`stream`.
+        """
+        if answer:
+            self._console.print(answer, markup=False)
+
     def stream(
         self,
         *,
@@ -101,7 +120,7 @@ class ShellOutputSink:
             suppress_if_starts_with=suppress_if_starts_with,
         )
 
-    def finish_streamed_response(self, text: str) -> None:
+    def finish_streamed_response(self, answer: str) -> None:
         """Flush a deferred / rewritten Want-me-to closer after gather normalize."""
         paint = self._paint
         defer = self._defer_want_me_to_closer
@@ -109,15 +128,15 @@ class ShellOutputSink:
         self._defer_want_me_to_closer = False
         if not defer or paint is None:
             return
-        if not paint.deferred_closer and text == paint.text:
+        if not paint.deferred_closer and answer == paint.text:
             return
         # Non-TTY deferred holds the entire answer until normalize.
         if not self._console.is_terminal and paint.deferred_closer:
-            publish_full_response(self._console, text)
+            publish_full_response(self._console, answer)
             return
         finish_deferred_closer(
             self._console,
-            text,
+            answer,
             footer_elapsed_s=paint.footer_elapsed_s,
             footer_total_bytes=paint.footer_total_bytes,
         )

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -58,6 +58,7 @@ def execute_shell_turn(
         handler = TurnHandler(
             console=console,
             agent_build=shell_agent_build_config(request_exit=request_exit),
+            retain_only_current_session=True,
         )
 
     def _on_progress(goal: SessionGoal) -> None:

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -7,30 +7,25 @@ A test that injects a whole stage (``execute_actions`` / ``gather_evidence`` /
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 from rich.console import Console
 
 from core.agent_harness import (
-    OutputSink,
+    ToolCallingTurnResult,
     TurnResult,
 )
-from core.agent_harness.runtime import HeadlessAgent, TurnBinding
-from core.agent_harness.spi.cancel import host_cancel_requested
 from core.agent_harness.spi.session_goal import (
     SessionGoal,
     format_session_goal_progress,
 )
 from core.execution import ToolExecutionHooks
-from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
+from platform.turn_host.turn_handler import TurnHandler
+from platform.turn_host.turn_output import TurnOutput
+from surfaces.interactive_shell.runtime.agent_harness_adapters import ShellOutputSink
 from surfaces.interactive_shell.runtime.core.turn_accounting import ShellTurnAccounting
-from surfaces.interactive_shell.runtime.shell_agent import build_shell_agent
-from surfaces.interactive_shell.runtime.turn_seams import (
-    AnswerShellQuestion,
-    GatherEvidence,
-    RunActionToolTurn,
-    bind_injected_stages,
-)
+from surfaces.interactive_shell.runtime.shell_agent import shell_agent_build_config
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry import PromptRecorder
 
@@ -44,45 +39,26 @@ def execute_shell_turn(
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
     request_exit: Callable[[], None] | None = None,
-    agent: HeadlessAgent | None = None,
-    execute_actions: RunActionToolTurn | None = None,
-    gather_evidence: GatherEvidence | None = None,
-    answer_agent: AnswerShellQuestion | None = None,
-    output: OutputSink | None = None,
+    handler: TurnHandler | None = None,
+    output: TurnOutput | None = None,
     tool_hooks: ToolExecutionHooks | None = None,
 ) -> TurnResult:
-    """Execute one submitted interactive-shell turn via :meth:`HeadlessAgent.handle`.
+    """Run one submitted shell turn through the shared turn host.
 
-    Pass a long-lived ``agent`` (the REPL builds one at startup and rebinds it
-    per turn) so the tool stack is not rebuilt every turn; without one, an agent
-    is built for this call. ``execute_actions`` / ``gather_evidence`` /
-    ``answer_agent`` replace a whole stage — the test injection seams typed in
-    ``turn_seams``.
+    The same :class:`TurnHandler` the chat transports use, built with the
+    shell's own :func:`shell_agent_build_config` so the REPL keeps its tools,
+    prompts and gather phase. Pass a long-lived ``handler`` (the REPL builds one
+    at startup) so the tool stack is not rebuilt every turn.
     """
-    resolved_output = resolve_output_sink(console, output)
-    if agent is None:
-        agent = build_shell_agent(
-            session, console, output=resolved_output, request_exit=request_exit
+    resolved_output: TurnOutput = output if output is not None else ShellOutputSink(console)
+    # The host reads per-turn tool hooks off the output, the same way a chat
+    # transport supplies them.
+    resolved_output.tool_hooks = tool_hooks  # type: ignore[attr-defined]
+    if handler is None:
+        handler = TurnHandler(
+            console=console,
+            agent_build=shell_agent_build_config(request_exit=request_exit),
         )
-    binding = TurnBinding(
-        session=session,
-        output=resolved_output,
-        tool_hooks=tool_hooks,
-        console=console,
-        confirm_fn=confirm_fn,
-        is_tty=is_tty,
-    )
-    bind_injected_stages(
-        agent,
-        session,
-        console,
-        resolved_output,
-        execute_actions=execute_actions,
-        answer_agent=answer_agent,
-        gather_evidence=gather_evidence,
-        request_exit=request_exit,
-        tool_hooks=tool_hooks,
-    )
 
     def _on_progress(goal: SessionGoal) -> None:
         rendered = format_session_goal_progress(goal, session=session)
@@ -93,13 +69,31 @@ def execute_shell_turn(
     def _accounting(message: str) -> ShellTurnAccounting:
         return ShellTurnAccounting(session=session, text=message, recorder=recorder)
 
-    return agent.handle(
+    result = handler.run(
         text,
-        binding,
+        session,
+        resolved_output,
+        logging.getLogger("opensre.interactive_shell"),
+        console=console,
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
         accounting_factory=_accounting,
-        cancel_requested=lambda: host_cancel_requested(resolved_output),
         on_progress=_on_progress,
     )
+    if result is None:
+        # The process gate refused the turn; the host already said so on the
+        # output. Report a turn that ran nothing rather than inventing an answer.
+        return TurnResult(
+            final_intent="cli_agent_at_capacity",
+            action_result=ToolCallingTurnResult(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+                has_unhandled_clause=False,
+                handled=False,
+            ),
+        )
+    return result
 
 
 __all__ = ["execute_shell_turn"]

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 from rich.console import Console
 
 if TYPE_CHECKING:
-    from core.agent_harness.runtime import HeadlessAgent
+    from platform.turn_host.turn_handler import TurnHandler
 
 from platform.analytics.repl_context import bound_repl_turn_context
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
@@ -71,8 +71,8 @@ class AgentTurnResources:
     #: terminal; an embedding caller passes its console so agent responses and
     #: tool output land in the same stream as the startup renders.
     console: Console | None = None
-    #: Session-scoped agent; rebound to each turn's streaming console.
-    agent: HeadlessAgent | None = None
+    #: Session-scoped turn host; each turn binds its own streaming console.
+    turn_handler: TurnHandler | None = None
 
 
 def _streaming_console(
@@ -198,7 +198,7 @@ async def _run_agent_turn_loop(
                 confirm_fn=confirm,
                 is_tty=None,
                 request_exit=runtime.request_exit,
-                agent=runtime.agent,
+                handler=runtime.turn_handler,
             )
     except asyncio.CancelledError:
         await emit(AgentEvent(type="turn_interrupted"))

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -208,11 +208,11 @@ class RecordingTurnOutput:
         self.streamed.append(text)
         return text
 
-    def finish_streamed_response(self, text: str) -> None:
-        self.finalize(text)
+    def finish_streamed_response(self, answer: str) -> None:
+        self.finalize(answer)
 
-    def finalize(self, text: str) -> None:
-        self.finalized = text
+    def finalize(self, answer: str) -> None:
+        self.finalized = answer
 
     @property
     def outbound_text(self) -> str:

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -16,9 +16,9 @@ from rich.console import Console
 import config.constants.platform as platform_module
 import surfaces.interactive_shell.runtime.action_turn as action_turn
 import surfaces.interactive_shell.runtime.llm_provider_adapter as llm_provider_adapter
-import surfaces.interactive_shell.runtime.shell_turn_execution as shell_turn_execution
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 import surfaces.interactive_shell.runtime.subprocess_runner as subprocess_runner
+import tests.shared.harness_turn_driver as harness_turn_driver
 import tools.interactive_shell.shell.execution as shell_execution
 from core.llm.types import AgentLLMResponse, ToolCall
 from platform.scheduling.task_types import TaskKind, TaskStatus
@@ -36,7 +36,7 @@ from tools.interactive_shell.action_names import (
 )
 
 _ACTION_LLM_FACTORY_PATCH = "core.agent_harness.turns.action_driver.default_llm_factory"
-execute_shell_turn = shell_turn_execution.execute_shell_turn
+run_harness_turn = harness_turn_driver.run_harness_turn
 
 
 def _capture() -> tuple[Console, io.StringIO]:
@@ -1283,10 +1283,10 @@ def test_execute_cli_actions_counts_planned_and_executed(monkeypatch: object) ->
 
     session = Session()
     console, _ = _capture()
-    # Analytics now fire from ShellTurnAccounting inside execute_shell_turn,
+    # Analytics now fire from ShellTurnAccounting inside run_harness_turn,
     # not from run_action_tool_turn directly. Drive the full turn with a no-op
     # answer agent so no real LLM is invoked.
-    result = execute_shell_turn(
+    result = run_harness_turn(
         "run `pwd`",
         session,
         console,
@@ -1361,8 +1361,8 @@ def test_execute_cli_actions_executes_matched_clause_ignoring_unhandled(
 
     session = Session()
     console, _ = _capture()
-    # Analytics now fire from ShellTurnAccounting inside execute_shell_turn.
-    result = execute_shell_turn(
+    # Analytics now fire from ShellTurnAccounting inside run_harness_turn.
+    result = run_harness_turn(
         "check health",
         session,
         console,

--- a/tests/core/agent/orchestration/test_model_question_misroute.py
+++ b/tests/core/agent/orchestration/test_model_question_misroute.py
@@ -21,8 +21,8 @@ from collections.abc import Iterator
 import pytest
 from rich.console import Console
 
-import surfaces.interactive_shell.runtime.shell_turn_execution as shell_turn_execution
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
+import tests.shared.harness_turn_driver as harness_turn_driver
 from core.agent_harness.prompts.grounding import DefaultPromptContextProvider
 from core.agent_harness.prompts.grounding import provider as default_prompt_context
 from surfaces.interactive_shell.command_registry import dispatch_slash
@@ -96,7 +96,7 @@ def test_model_question_routed_to_slash_is_never_answered(
 
     session = Session()
     console, buf = _capture()
-    result = shell_turn_execution.execute_shell_turn(
+    result = harness_turn_driver.run_harness_turn(
         _PROMPT,
         session,
         console,
@@ -145,7 +145,7 @@ def test_model_question_answered_when_handed_off(
 
     session = Session()
     console, _ = _capture()
-    result = shell_turn_execution.execute_shell_turn(
+    result = harness_turn_driver.run_harness_turn(
         _PROMPT,
         session,
         console,
@@ -207,7 +207,7 @@ def test_model_question_handoff_answers_from_active_llm_context(
         ),
     ]
     console, buf = _capture()
-    result = shell_turn_execution.execute_shell_turn(
+    result = harness_turn_driver.run_harness_turn(
         _PROMPT,
         session,
         console,

--- a/tests/core/agent/test_observe_answer_summary.py
+++ b/tests/core/agent/test_observe_answer_summary.py
@@ -16,9 +16,9 @@ from core.agent_harness.ports import AnswerRequest
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
-from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry.recorder import LlmRunInfo
+from tests.shared.harness_turn_driver import run_harness_turn
 
 _OBSERVATION = "Integration status from `/integrations`:\n- sentry: missing (Not configured.)"
 
@@ -57,7 +57,7 @@ def test_discovery_output_is_summarized_into_a_direct_answer() -> None:
         return LlmRunInfo(response_text="No — Sentry is not configured.")
 
     session = Session()
-    execute_shell_turn(
+    run_harness_turn(
         "is sentry installed?",
         session,
         _console(),
@@ -94,7 +94,7 @@ def test_no_observation_keeps_silent_handled_turn() -> None:
         return None
 
     session = Session()
-    execute_shell_turn(
+    run_harness_turn(
         "deploy the remote instance",
         session,
         _console(),
@@ -131,7 +131,7 @@ def test_literal_slash_command_skips_observation_summary() -> None:
         return None
 
     session = Session()
-    execute_shell_turn(
+    run_harness_turn(
         "/integrations list",
         session,
         _console(),
@@ -168,7 +168,7 @@ def test_failed_discovery_is_not_summarized() -> None:
         return None
 
     session = Session()
-    execute_shell_turn(
+    run_harness_turn(
         "is sentry installed?",
         session,
         _console(),
@@ -206,7 +206,7 @@ def test_observation_is_reset_each_turn() -> None:
 
     session = Session()
     session.last_command_observation = "stale observation from a previous turn"
-    execute_shell_turn(
+    run_harness_turn(
         "deploy the remote instance",
         session,
         _console(),

--- a/tests/core/agent/test_pipeline_tool_gathering.py
+++ b/tests/core/agent/test_pipeline_tool_gathering.py
@@ -12,8 +12,8 @@ from core.agent_harness.ports import AnswerRequest
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
-from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.session import Session
+from tests.shared.harness_turn_driver import run_harness_turn
 
 
 def _console() -> Console:
@@ -56,7 +56,7 @@ def _record_answer() -> tuple[list[dict[str, Any]], Callable[..., None]]:
 def test_gather_string_threads_offscreen_observation() -> None:
     calls, fake_answer = _record_answer()
 
-    execute_shell_turn(
+    run_harness_turn(
         "question",
         Session(),
         _console(),
@@ -74,7 +74,7 @@ def test_gather_string_threads_offscreen_observation() -> None:
 def test_gather_none_passes_through_without_observation() -> None:
     calls, fake_answer = _record_answer()
 
-    execute_shell_turn(
+    run_harness_turn(
         "question",
         Session(),
         _console(),
@@ -110,7 +110,7 @@ def test_existing_command_observation_skips_gather() -> None:
             handled=True,
         )
 
-    execute_shell_turn(
+    run_harness_turn(
         "question",
         Session(),
         _console(),

--- a/tests/core/agent/test_turn_loop.py
+++ b/tests/core/agent/test_turn_loop.py
@@ -13,9 +13,9 @@ from core.agent_harness.turns.orchestrator import run_turn
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
-from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry.recorder import LlmRunInfo
+from tests.shared.harness_turn_driver import run_harness_turn
 
 
 class _Recorder:
@@ -51,7 +51,7 @@ def test_recorder_flushes_once_for_chat_fallback() -> None:
     def _answer(*_args: Any, **_kwargs: Any) -> LlmRunInfo:
         return run_info
 
-    result = execute_shell_turn(
+    result = run_harness_turn(
         "question",
         Session(),
         _console(),
@@ -81,7 +81,7 @@ def test_recorder_flushes_once_for_silent_handled_turn() -> None:
             response_text="command output",
         )
 
-    result = execute_shell_turn(
+    result = run_harness_turn(
         "run something",
         session,
         _console(),

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -104,21 +104,21 @@ def test_bind_turn_keeps_runner_when_only_accounting_changes() -> None:
     assert agent._action_runner is before  # noqa: SLF001
 
 
-def test_execute_shell_turn_adds_no_stage_of_its_own() -> None:
-    """The shell drives the agent's own answer/gather/action stages by default.
+def test_harness_turn_driver_adds_no_stage_of_its_own() -> None:
+    """The driver runs the agent's own answer/gather/action stages by default.
 
-    Answering and gathering are configured by the shell's ports (prompts, sink,
-    reporter, gather progress/persist), not replaced. Only an injected test
-    seam gets an adapter bound over it.
+    Answering and gathering are configured by the shell's build config (prompts,
+    output, reporter, gather progress/persist), not replaced. Only a stage the
+    test names gets an adapter bound over it.
     """
     import io
 
     from rich.console import Console
 
-    from surfaces.interactive_shell.runtime import shell_turn_execution as ste
     from surfaces.interactive_shell.runtime.shell_agent import build_shell_agent
+    from tests.shared import harness_turn_driver
 
-    source = inspect.getsource(ste.execute_shell_turn)
+    source = inspect.getsource(harness_turn_driver.run_harness_turn)
     assert "build_shell_agent" in source
     assert "_ShellTurnBindings" not in source
     assert "ShellActionRunner" not in source
@@ -235,7 +235,7 @@ def test_long_lived_shell_agent_receives_each_turns_confirm_fn_and_tty() -> None
     from rich.console import Console
 
     from surfaces.interactive_shell.runtime.shell_agent import build_shell_agent
-    from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
+    from tests.shared.harness_turn_driver import run_harness_turn
 
     # Arrange — agent built like the controller does: no confirm_fn, no is_tty.
     seen: list[tuple[Any, Any]] = []
@@ -251,7 +251,7 @@ def test_long_lived_shell_agent_receives_each_turns_confirm_fn_and_tty() -> None
     agent = build_shell_agent(Session(), console)
 
     # Act — one turn on the long-lived agent, with this turn's confirm_fn / tty.
-    execute_shell_turn(
+    run_harness_turn(
         "run something",
         Session(),
         console,
@@ -308,7 +308,7 @@ def test_a_stage_injected_on_one_turn_does_not_carry_into_the_next() -> None:
     from rich.console import Console
 
     from surfaces.interactive_shell.runtime.shell_agent import build_shell_agent
-    from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
+    from tests.shared.harness_turn_driver import run_harness_turn
 
     # Arrange — a long-lived agent; turn 1 injects a fake action stage.
     console = Console(file=io.StringIO(), force_terminal=False)
@@ -317,7 +317,7 @@ def test_a_stage_injected_on_one_turn_does_not_carry_into_the_next() -> None:
     def _fake_execute(text: str, session: Any, console: Any, **_kw: Any) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(0, 0, 0, False, True, response_text="fake")
 
-    execute_shell_turn(
+    run_harness_turn(
         "turn one",
         Session(),
         console,
@@ -392,18 +392,28 @@ def test_handle_is_the_one_host_loop_binding_each_outer_turn() -> None:
     assert replace(binding, accounting=None) == binding
 
 
-def test_both_hosts_reach_the_agent_through_handle_only() -> None:
-    """The host loop lives once, on the agent: neither host calls run_until_session_goal itself."""
+def test_one_host_drives_the_agent_and_the_shell_goes_through_it() -> None:
+    """There is one host loop, and the shell reaches it rather than repeating it.
+
+    The turn host calls ``agent.handle``; the interactive shell calls the host.
+    A shell that grew its own ``agent.handle`` would be a second turn engine —
+    exactly what routing it through :class:`TurnHandler` removed.
+    """
     import inspect
 
-    import platform.turn_host.turn_handler as gateway_turn
+    import platform.turn_host.turn_handler as turn_host
     from surfaces.interactive_shell.runtime import shell_turn_execution as shell_turn
 
-    for module in (gateway_turn, shell_turn):
-        source = inspect.getsource(module)
-        assert "agent.handle(" in source, module.__name__
-        assert "run_until_session_goal(" not in source, module.__name__
-        assert "AgentSession(" not in source, module.__name__
+    host_source = inspect.getsource(turn_host)
+    assert "agent.handle(" in host_source
+    assert "run_until_session_goal(" not in host_source
+    assert "AgentSession(" not in host_source
+
+    shell_source = inspect.getsource(shell_turn)
+    assert "handler.run(" in shell_source
+    assert "agent.handle(" not in shell_source
+    assert "run_until_session_goal(" not in shell_source
+    assert "AgentSession(" not in shell_source
 
 
 def test_handle_runs_the_goal_loop_on_the_session_the_binding_states(monkeypatch: Any) -> None:

--- a/tests/core/agent_harness/test_host_cancel_turn.py
+++ b/tests/core/agent_harness/test_host_cancel_turn.py
@@ -45,8 +45,8 @@ class _CancelSink:
         self.streamed.append(text)
         return text
 
-    def finalize(self, text: str) -> None:
-        _ = text
+    def finalize(self, answer: str) -> None:
+        _ = answer
 
 
 def test_host_cancel_requested_reads_sink_event() -> None:
@@ -141,14 +141,14 @@ def test_bindable_output_stream_stops_when_turn_cancel_set() -> None:
                 parts.append(str(chunk))
             return "".join(parts)
 
-        def finalize(self, text: str) -> None:
-            _ = text
+        def finalize(self, answer: str) -> None:
+            _ = answer
 
         def render_error(self, message: str) -> None:
             _ = message
 
-        def set_tool_status(self, text: str) -> None:
-            _ = text
+        def set_tool_status(self, status: str) -> None:
+            _ = status
 
     inner = _Inner()
     bindable = BindableOutput()

--- a/tests/core/agent_harness/test_session_bindable_ports.py
+++ b/tests/core/agent_harness/test_session_bindable_ports.py
@@ -135,8 +135,8 @@ def test_bindable_output_exposes_turn_cancel_property() -> None:
             _ = (label, chunks)
             return ""
 
-        def finalize(self, text: str) -> None:
-            _ = text
+        def finalize(self, answer: str) -> None:
+            _ = answer
 
     inner = _Inner()
     bindable = BindableOutput()

--- a/tests/e2e/grafana_validation/test_grafana_cloud_queries.py
+++ b/tests/e2e/grafana_validation/test_grafana_cloud_queries.py
@@ -1,19 +1,35 @@
 import pytest
 from _pytest.outcomes import Skipped
 
+from integrations.grafana.base import _is_transport_failure
 from integrations.grafana.client import get_grafana_client
 from tests.e2e.grafana_validation.env_requirements import require_grafana_query_env
 
 
-@pytest.fixture(scope="session")
-def grafana_client():
+def _grafana_client_or_skip():
+    """Build a live client, or skip when Grafana is unreachable (CI flake).
+
+    ``get_grafana_client`` discovers datasources and re-raises transport
+    timeouts so the product circuit breaker can trip. Live validation must
+    treat the same failures as skips, not ERROR.
+    """
     require_grafana_query_env()
-    client = get_grafana_client()
+    try:
+        client = get_grafana_client()
+    except Exception as exc:
+        if _is_transport_failure(exc):
+            pytest.skip(f"Grafana live query hit a transient network failure: {exc}")
+        raise
     if not client.is_configured:
         pytest.skip(
             "Grafana client not configured (set GRAFANA_READ_TOKEN and GRAFANA_INSTANCE_URL if needed)"
         )
     return client
+
+
+@pytest.fixture(scope="session")
+def grafana_client():
+    return _grafana_client_or_skip()
 
 
 def _assert_query_success_or_skip_auth(result: dict) -> None:
@@ -71,6 +87,28 @@ def test_assert_query_success_or_skip_auth_skips_timeout():
                 ),
             }
         )
+
+
+def test_grafana_client_or_skip_skips_read_timeout_during_build(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(
+        "tests.e2e.grafana_validation.test_grafana_cloud_queries.require_grafana_query_env",
+        lambda: None,
+    )
+
+    def _boom() -> object:
+        raise requests.exceptions.ReadTimeout(
+            "HTTPSConnectionPool(host='tracerbio.grafana.net', port=443): "
+            "Read timed out. (read timeout=10)"
+        )
+
+    monkeypatch.setattr(
+        "tests.e2e.grafana_validation.test_grafana_cloud_queries.get_grafana_client",
+        _boom,
+    )
+    with pytest.raises(Skipped, match="transient network failure"):
+        _grafana_client_or_skip()
 
 
 def test_assert_query_success_or_skip_auth_skips_tempo_ring_failure():

--- a/tests/interactive_shell/runtime/test_shell_session_goal.py
+++ b/tests/interactive_shell/runtime/test_shell_session_goal.py
@@ -11,8 +11,8 @@ from rich.console import Console
 from core.agent_harness.session_goal.goal import SessionGoalStatus
 from core.agent_harness.turns.assistant_handoff import AssistantHandoff
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
-from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.session import Session
+from tests.shared.harness_turn_driver import run_harness_turn
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -22,7 +22,7 @@ _FIVE_STEP = (
 )
 
 
-def test_execute_shell_turn_continues_when_action_emits_session_goal() -> None:
+def test_run_harness_turn_continues_when_action_emits_session_goal() -> None:
     session = Session()
     console = Console(force_terminal=False)
     answer_calls: list[str] = []
@@ -61,7 +61,7 @@ def test_execute_shell_turn_continues_when_action_emits_session_goal() -> None:
         n = len(answer_calls)
         return MagicMock(response_text=f"step done session_goal:done={n - 1}")
 
-    result = execute_shell_turn(
+    result = run_harness_turn(
         _FIVE_STEP,
         session,
         console,
@@ -78,7 +78,7 @@ def test_execute_shell_turn_continues_when_action_emits_session_goal() -> None:
     assert "session_goal:" not in (result.assistant_response_text or "")
 
 
-def test_execute_shell_turn_prints_checklist_progress(capsys: Any) -> None:
+def test_run_harness_turn_prints_checklist_progress(capsys: Any) -> None:
     session = Session()
     console = Console(force_terminal=True)
     answer_calls: list[str] = []
@@ -102,7 +102,7 @@ def test_execute_shell_turn_prints_checklist_progress(capsys: Any) -> None:
         n = len(answer_calls)
         return MagicMock(response_text=f"session_goal:done={n - 1}")
 
-    execute_shell_turn(
+    run_harness_turn(
         "run checklist",
         session,
         console,
@@ -125,7 +125,7 @@ def test_execute_shell_turn_prints_checklist_progress(capsys: Any) -> None:
     assert "checklist complete" in painted or "achieved" in painted
 
 
-def test_execute_shell_turn_does_not_loop_on_user_prose_alone() -> None:
+def test_run_harness_turn_does_not_loop_on_user_prose_alone() -> None:
     session = Session()
     console = Console(force_terminal=False)
     answer_calls: list[str] = []
@@ -144,7 +144,7 @@ def test_execute_shell_turn_does_not_loop_on_user_prose_alone() -> None:
         answer_calls.append(text)
         return MagicMock(response_text="one turn only")
 
-    execute_shell_turn(
+    run_harness_turn(
         _FIVE_STEP,
         session,
         console,
@@ -159,7 +159,7 @@ def test_execute_shell_turn_does_not_loop_on_user_prose_alone() -> None:
     assert session.session_goal is None
 
 
-def test_execute_shell_turn_continues_from_typed_assistant_handoff() -> None:
+def test_run_harness_turn_continues_from_typed_assistant_handoff() -> None:
     """Schema-only session_goal (no content tags) must still multi-turn."""
     session = Session()
     console = Console(force_terminal=False)
@@ -199,7 +199,7 @@ def test_execute_shell_turn_continues_from_typed_assistant_handoff() -> None:
         n = len(answer_calls)
         return MagicMock(response_text=f"step done session_goal:done={n - 1}")
 
-    result = execute_shell_turn(
+    result = run_harness_turn(
         _FIVE_STEP,
         session,
         console,

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -13,13 +13,13 @@ from core.llm.types import AgentLLMResponse, ToolCall
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
-from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.runtime.turn_host import run_agent_turn_queue
 from surfaces.interactive_shell.runtime.utils import input_policy as loop_input_policy
 from surfaces.interactive_shell.session import Session
 from tests.core.agent.orchestration.action_execution_test_harness import (
     FakeActionLLM,
 )
+from tests.shared.harness_turn_driver import run_harness_turn
 from tools.interactive_shell.actions import (
     investigation as _investigation_tool,
 )
@@ -217,7 +217,7 @@ def test_queued_literal_quit_requests_runtime_exit() -> None:
 
         async def _run_turn(text: str) -> None:
             await asyncio.to_thread(
-                execute_shell_turn,
+                run_harness_turn,
                 text,
                 session,
                 console,
@@ -237,7 +237,7 @@ def test_queued_literal_quit_requests_runtime_exit() -> None:
     asyncio.run(_scenario())
 
 
-def test_execute_shell_turn_nitro_prompt_uses_cli_agent_actions(
+def test_run_harness_turn_nitro_prompt_uses_cli_agent_actions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     nitro_prompt = (
@@ -272,7 +272,7 @@ def test_execute_shell_turn_nitro_prompt_uses_cli_agent_actions(
 
     session = Session()
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
-    execute_shell_turn(
+    run_harness_turn(
         nitro_prompt,
         session,
         console,
@@ -287,7 +287,7 @@ def test_execute_shell_turn_nitro_prompt_uses_cli_agent_actions(
     assert llm_calls == []
 
 
-def test_execute_shell_turn_nitro_prompt_executes_remote_then_investigation(
+def test_run_harness_turn_nitro_prompt_executes_remote_then_investigation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     nitro_prompt = (
@@ -343,7 +343,7 @@ def test_execute_shell_turn_nitro_prompt_executes_remote_then_investigation(
 
     session = Session()
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
-    execute_shell_turn(
+    run_harness_turn(
         nitro_prompt,
         session,
         console,

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -14,7 +14,6 @@ import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from platform.terminal.theme import BOLD_SKILL, HIGHLIGHT
 from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
-from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
 from surfaces.interactive_shell.ui.input_prompt.rendering import (
@@ -26,6 +25,7 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
     FakeActionLLM,
     no_tool_response,
 )
+from tests.shared.harness_turn_driver import run_harness_turn
 
 
 def test_slash_invoke_tool_start_does_not_record_cli_agent() -> None:
@@ -299,7 +299,7 @@ def test_chat_turn_records_single_cli_agent_history_entry() -> None:
     ) -> _FakeLlmRun:
         return _FakeLlmRun()
 
-    execute_shell_turn(
+    run_harness_turn(
         "what broke in prod?",
         session,
         console,

--- a/tests/interactive_shell/utils/telemetry/test_execution_integration.py
+++ b/tests/interactive_shell/utils/telemetry/test_execution_integration.py
@@ -7,9 +7,9 @@ from rich.console import Console
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
-from surfaces.interactive_shell.runtime.shell_turn_execution import execute_shell_turn
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
+from tests.shared.harness_turn_driver import run_harness_turn
 
 
 class _FakeRecorder:
@@ -28,7 +28,7 @@ def _console() -> Console:
     return Console(file=io.StringIO(), force_terminal=False, highlight=False)
 
 
-def test_execute_shell_turn_cli_agent_empty_response_is_recorded_empty() -> None:
+def test_run_harness_turn_cli_agent_empty_response_is_recorded_empty() -> None:
     recorder = _FakeRecorder()
 
     def fake_execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
@@ -45,7 +45,7 @@ def test_execute_shell_turn_cli_agent_empty_response_is_recorded_empty() -> None
 
     session = Session()
     output = io.StringIO()
-    execute_shell_turn(
+    run_harness_turn(
         "show datadog integration details",
         session,
         Console(file=output, force_terminal=False, highlight=False),

--- a/tests/shared/harness_turn_driver.py
+++ b/tests/shared/harness_turn_driver.py
@@ -1,0 +1,100 @@
+"""Run one harness turn with stages swapped out, without going through a surface.
+
+Tests that exercise the agent loop used to drive it through
+``execute_shell_turn``, which meant the harness suite depended on the
+interactive shell's turn function and on its stage-injection seams. This helper
+does the same job directly: build an agent, bind the turn, replace whichever
+stages the test names, and hand back the :class:`TurnResult`.
+
+Production code must not import this. The shell reaches the agent through
+:class:`platform.turn_host.turn_handler.TurnHandler`; nothing else does.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness import OutputSink, TurnResult
+from core.agent_harness.ports import ToolExecutionHooks, TurnBinding
+from core.agent_harness.runtime import HeadlessAgent
+from core.agent_harness.spi.session_goal import SessionGoal, format_session_goal_progress
+from core.agent_harness.turns.host_cancel import host_cancel_requested
+from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
+from surfaces.interactive_shell.runtime.core.turn_accounting import ShellTurnAccounting
+from surfaces.interactive_shell.runtime.shell_agent import build_shell_agent
+from surfaces.interactive_shell.runtime.turn_seams import (
+    AnswerShellQuestion,
+    GatherEvidence,
+    RunActionToolTurn,
+    bind_injected_stages,
+)
+from surfaces.interactive_shell.session import Session
+
+
+def run_harness_turn(
+    text: str,
+    session: Session,
+    console: Console,
+    *,
+    recorder: Any = None,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    request_exit: Callable[[], None] | None = None,
+    agent: HeadlessAgent | None = None,
+    execute_actions: RunActionToolTurn | None = None,
+    gather_evidence: GatherEvidence | None = None,
+    answer_agent: AnswerShellQuestion | None = None,
+    output: OutputSink | None = None,
+    tool_hooks: ToolExecutionHooks | None = None,
+) -> TurnResult:
+    """One turn through :meth:`HeadlessAgent.handle` with the named stages replaced.
+
+    An omitted stage is the agent's own. Pass ``agent`` to reuse one across
+    turns; otherwise one is built for this call.
+    """
+    resolved_output = resolve_output_sink(console, output)
+    if agent is None:
+        agent = build_shell_agent(
+            session, console, output=resolved_output, request_exit=request_exit
+        )
+    bind_injected_stages(
+        agent,
+        session,
+        console,
+        resolved_output,
+        execute_actions=execute_actions,
+        answer_agent=answer_agent,
+        gather_evidence=gather_evidence,
+        request_exit=request_exit,
+        tool_hooks=tool_hooks,
+    )
+
+    def _on_progress(goal: SessionGoal) -> None:
+        rendered = format_session_goal_progress(goal, session=session)
+        if rendered:
+            # Checklist uses ``[x]`` / ``[ ]`` — Rich markup must stay off.
+            console.print(rendered, markup=False)
+
+    def _accounting(message: str) -> ShellTurnAccounting:
+        return ShellTurnAccounting(session=session, text=message, recorder=recorder)
+
+    return agent.handle(
+        text,
+        TurnBinding(
+            session=session,
+            output=resolved_output,
+            tool_hooks=tool_hooks,
+            console=console,
+            confirm_fn=confirm_fn,
+            is_tty=is_tty,
+        ),
+        accounting_factory=_accounting,
+        cancel_requested=lambda: host_cancel_requested(resolved_output),
+        on_progress=_on_progress,
+    )
+
+
+__all__ = ["run_harness_turn"]


### PR DESCRIPTION
The interactive shell now reaches the agent through `platform.turn_host.TurnHandler.run()` instead of building its own agent.

**What the shell gains:** the process capacity gate, capability policy, pooled agent reuse, turn timeout and terminal outcome. It was outside all of them - not a bug it had, a guarantee set it was not in.

**What it keeps:** its own tools, prompts and gather phase, because the REPL builds its handler with `shell_agent_build_config()`. `AgentBuildConfig` (#5075) is what makes one host serve two very different callers.

`build_shell_agent` no longer appears in `controller.py` or `shell_turn_execution.py`.

**Three supporting changes, each preventing a regression:**

- **`run()` takes `on_progress`.** The host sends a compact status line a chat
  placeholder can hold; the REPL prints the full session-goal block with
  `markup=False`. Defaults to the host's renderer, so transports are untouched.
- **`run()` takes `is_tty: bool | None`.** `None` means "detect from stdin"
  (`execution_confirm.py:84`). An earlier draft of this PR collapsed `None` to
  `True`, which would have made a piped or redirected shell claim a terminal and
  prompt for confirmation. `TurnBinding.is_tty` was already `bool | None`; the
  host was narrowing it for no reason.
- **`ShellOutputSink` satisfies `TurnOutput`** — `set_tool_status` prints its
  own dim line, since a terminal has no placeholder to rewrite, and `finalize`
  handles a turn that produced text without streaming it.

**Harness tests stop driving the agent through a surface.** 16 files called
`execute_shell_turn`; 10 of them were harness tests using its stage-injection
seams — `tests/core/agent_harness/`, `tests/core/agent/` — not shell tests.
Those moved to `tests/shared/harness_turn_driver.py`, whose docstring states the
rule: *production code must not import this*. The 5 that genuinely exercise the
shell path stayed where they were.