### PR TITLE
refactor(harness): the host-capability seams say what they return

### DIFF
--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -18,6 +18,7 @@ from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.domain.types.tools import ToolSurface
 from core.execution import ToolExecutionHooks
+from core.llm.types import AgentLLMClient
 
 # A tool-loop event callback: ``(kind, data)`` where kind is e.g. "tool_start".
 ToolEventObserver = Callable[[str, dict[str, Any]], None]
@@ -26,8 +27,9 @@ ToolEventObserver = Callable[[str, dict[str, Any]], None]
 ConfirmFn = Callable[[str], str]
 
 # Builds the LLM client the action runner drives; hosts and tests inject one
-# to replace the configured provider.
-LlmFactory = Callable[[], Any]
+# to replace the configured provider. The loop calls ``invoke`` and
+# ``tool_schemas`` and nothing else, which is what ``AgentLLMClient`` states.
+LlmFactory = Callable[[], AgentLLMClient]
 
 
 @runtime_checkable
@@ -370,10 +372,14 @@ SubprocessPresenterFactory = Callable[
 # Host capabilities an action tool calls back into: named commands, LLM-provider
 # switching, task cancellation and investigation launch. Their contracts live in
 # ``tools`` beside the tools that call them (see
-# ``tools.interactive_shell.shared.host_ports.ExecutionGate``), so the seams stay
-# untyped here — ``core`` only carries a capability from the host to the tool,
-# and typing them here would mean ``core`` importing ``tools``.
-InvestigationPortsFactory = Callable[[], Any]
-LlmProviderPortsFactory = Callable[[], Any]
-TaskCancelPortsFactory = Callable[[], Any]
-SlashPortsFactory = Callable[[], Any]
+# ``tools.interactive_shell.shared.host_ports.ExecutionGate``), and naming those
+# Protocols here would mean ``core`` importing ``tools``.
+#
+# The return is ``object``, not ``Any``: ``core`` calls the factory and hands the
+# result to ``ActionToolContext`` without reading a single attribute, and
+# ``object`` is the type that says so. ``Any`` would silence a typo here as
+# readily as it silences the import ``core`` is avoiding.
+InvestigationPortsFactory = Callable[[], object]
+LlmProviderPortsFactory = Callable[[], object]
+TaskCancelPortsFactory = Callable[[], object]
+SlashPortsFactory = Callable[[], object]

--- a/tests/core/agent_harness/test_host_seam_types.py
+++ b/tests/core/agent_harness/test_host_seam_types.py
@@ -1,0 +1,77 @@
+"""The host-capability seams state what they return, and cannot drift back to ``Any``.
+
+These four seams carry a capability from a host down to a tool. ``core`` calls
+each factory and hands the result straight to the tool context without reading
+an attribute, so the return is ``object``: honest about what ``core`` knows, and
+still enough for a type checker to reject a typo.
+
+``Any`` was the previous declaration and is what these tests exist to prevent.
+It is not a smaller version of ``object`` — it switches checking off, so a
+misspelled attribute on a port bundle would have compiled.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from core.agent_harness.ports import (
+    InvestigationPortsFactory,
+    LlmFactory,
+    LlmProviderPortsFactory,
+    SlashPortsFactory,
+    TaskCancelPortsFactory,
+)
+from core.llm.types import AgentLLMClient
+
+#: The seams that hand a host capability to a tool. ``core`` forwards these.
+_FORWARDED_SEAMS = {
+    "InvestigationPortsFactory": InvestigationPortsFactory,
+    "LlmProviderPortsFactory": LlmProviderPortsFactory,
+    "SlashPortsFactory": SlashPortsFactory,
+    "TaskCancelPortsFactory": TaskCancelPortsFactory,
+}
+
+
+def _return_type(alias: object) -> object:
+    """The return annotation of a ``Callable[[], R]`` alias."""
+    args = typing.get_args(alias)
+    assert args, f"expected a Callable alias, got {alias!r}"
+    return args[-1]
+
+
+def test_the_llm_seam_names_the_client_the_loop_actually_drives() -> None:
+    """``LlmFactory`` returns ``AgentLLMClient`` — the two methods the loop calls.
+
+    The loop calls ``invoke`` and ``tool_schemas`` and nothing else, which is
+    exactly what ``AgentLLMClient`` declares. A factory returning something else
+    is a wiring mistake the type checker should catch, not a runtime surprise.
+    """
+    # Arrange / Act
+    returns = _return_type(LlmFactory)
+
+    # Assert
+    assert returns is AgentLLMClient
+
+
+def test_forwarded_seams_return_object_not_any() -> None:
+    """``core`` does not know these types, and ``object`` is how it says so.
+
+    Naming the real port Protocols here would mean ``core`` importing ``tools``,
+    which the layer contract forbids. ``object`` respects that and still rejects
+    an attribute read; ``Any`` would silence the read as readily as the import.
+    """
+    # Arrange / Act
+    returns = {name: _return_type(alias) for name, alias in _FORWARDED_SEAMS.items()}
+
+    # Assert
+    assert returns == dict.fromkeys(_FORWARDED_SEAMS, object)
+    assert typing.Any not in returns.values()
+
+
+def test_forwarded_seams_take_no_arguments() -> None:
+    """Each is called with no arguments; a host binds its own state in the closure."""
+    # Arrange / Act
+    parameter_lists = {name: typing.get_args(alias)[0] for name, alias in _FORWARDED_SEAMS.items()}
+
+    # Assert
+    assert parameter_lists == dict.fromkeys(_FORWARDED_SEAMS, [])


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

The five `Callable[[], Any]` seams in `core/agent_harness/ports.py` — the
architecture review's finding 7. **Zero remain** in `core/`, `platform/` or
`gateway/`.

This was the only finding that got *worse* while the others improved: three more
untyped seams arrived alongside `AgentBuildConfig` before the newer ones were
converted to call-Protocols. This closes the originals and adds a test so it
cannot drift a third time.

**Two problems, two fixes.**

```python
LlmFactory = Callable[[], AgentLLMClient]     # was Callable[[], Any]
```

AgentLLMClient already exists in core/llm/types.py and declares exactly
invoke and tool_schemas — precisely what the loop calls (3 × llm.invoke(,
1 × llm.tool_schemas(). No new Protocol, and no cycle: core.llm does not
import core.agent_harness.

```
InvestigationPortsFactory = Callable[[], object]   # was Callable[[], Any]
LlmProviderPortsFactory   = Callable[[], object]
TaskCancelPortsFactory    = Callable[[], object]
SlashPortsFactory         = Callable[[], object]
```

These four had a documented reason to be untyped, and it is still true: their
real Protocols live above core (SlashPorts, LlmProviderPorts,
TaskCancelPorts in surfaces/, InvestigationLaunchPorts in tools/), and
naming them here would mean core importing tools. The review filed them as
plain debt; that was partly wrong.

But the reason argues against Any, not against typing. core calls each
factory and hands the result to ActionToolContext without reading a single
attribute. object is the type that says so, and unlike Any it rejects a
misspelled attribute. The comment in the file now records both halves.

A shared interface was considered and rejected. All four Protocols extend
ExecutionGate, so typing them as that base would compile. It would also make
them mutually substitutable — slash ports would satisfy a task-cancel
parameter — because each adds distinct methods the base does not carry
(command_exists, tool_description, dispatch_cancel). That is worse than
object: it looks type-safe while accepting four incompatible things. Per-port
typing is the real answer, and it needs those Protocols below core — a package
move like #5177, not an annotation change, so not in this PR.