### PR TITLE
test(scheduler): the delivery support matrix stops living in prose

### DIFF
--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -74,7 +74,7 @@ Packages are split like `core/agent_harness/prompts/`: **core infra** vs
   settings, inbound worker, security, turn output, and `startup.py`. Peers
   never import each other or `gateway.startup`/`web`; anything two need belongs in
   `core/` (per-turn steps in `gateway.core.middleware`) or
-  `platform.turn_host` (turn handler, output sink, session agents).
+  `platform.turn_host` (turn handler, turn output, session agents).
 - `web/` — web surface (FastAPI app, investigations API, worker/artifacts).
   May import `core/`; must not import chat transports or `gateway.startup`.
 - `core/storage/session/resolver.py` — per-conversation session binding

--- a/gateway/core/middleware/active_turns.py
+++ b/gateway/core/middleware/active_turns.py
@@ -70,7 +70,7 @@ class ActiveTurnRegistry:
     ) -> None:
         """Attach the stop finalizer to an already registered ``event``.
 
-        Dispatch-time registration happens before the turn has a sink to
+        Dispatch-time registration happens before the turn has an output to
         finalize; the turn binds the callback once it starts. A stop that
         lands in between only sets the Event — the turn must check it before
         invoking the agent.

--- a/gateway/tests/buzz/test_turn_output_continuation.py
+++ b/gateway/tests/buzz/test_turn_output_continuation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from gateway.transports.buzz.output_sink import BuzzOutputSink
+from gateway.transports.buzz.turn_output import BuzzTurnOutput
 
 
 def _client() -> MagicMock:
@@ -23,7 +23,7 @@ def test_a_second_goal_turn_sends_a_new_message() -> None:
     """
     # Arrange.
     client = _client()
-    sink = BuzzOutputSink(client=client, channel_id="c1", edit_interval_seconds=0.0)
+    sink = BuzzTurnOutput(client=client, channel_id="c1", edit_interval_seconds=0.0)
     sends_after_placeholder = client.send_message.call_count
 
     # Act.

--- a/gateway/tests/discord/test_dispatcher_multi_actor.py
+++ b/gateway/tests/discord/test_dispatcher_multi_actor.py
@@ -113,13 +113,13 @@ def test_alice_and_bob_parallel_turns_get_distinct_sessions(
         ),
         patch("gateway.transports.discord.dispatcher.add_reaction", return_value=True),
         patch("gateway.transports.discord.dispatcher.remove_reaction", return_value=True),
-        patch("gateway.transports.discord.output_sink.send_message", return_value="msg-status"),
-        patch("gateway.transports.discord.output_sink.edit_message", return_value=True),
+        patch("gateway.transports.discord.turn_output.send_message", return_value="msg-status"),
+        patch("gateway.transports.discord.turn_output.edit_message", return_value=True),
         patch(
-            "gateway.transports.discord.output_sink.edit_message_with_components", return_value=True
+            "gateway.transports.discord.turn_output.edit_message_with_components", return_value=True
         ),
         patch(
-            "gateway.transports.discord.output_sink.send_message_with_components",
+            "gateway.transports.discord.turn_output.send_message_with_components",
             return_value="msg-final",
         ),
     ):

--- a/gateway/tests/discord/test_turn_output.py
+++ b/gateway/tests/discord/test_turn_output.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from gateway.transports.discord.output_sink import DiscordOutputSink
+from gateway.transports.discord.turn_output import DiscordTurnOutput
 
 
 @pytest.fixture
@@ -55,23 +55,23 @@ def _patch_discord_client(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         return "msg-extra"
 
     monkeypatch.setattr(
-        "gateway.transports.discord.output_sink.send_message",
+        "gateway.transports.discord.turn_output.send_message",
         _send_message,
     )
     monkeypatch.setattr(
-        "gateway.transports.discord.output_sink.edit_message",
+        "gateway.transports.discord.turn_output.edit_message",
         _edit_message,
     )
     monkeypatch.setattr(
-        "gateway.transports.discord.output_sink.edit_message_with_components",
+        "gateway.transports.discord.turn_output.edit_message_with_components",
         _edit_with_components,
     )
     monkeypatch.setattr(
-        "gateway.transports.discord.output_sink.send_message_with_components",
+        "gateway.transports.discord.turn_output.send_message_with_components",
         _send_with_components,
     )
     monkeypatch.setattr(
-        "gateway.transports.discord.output_sink.feedback_components",
+        "gateway.transports.discord.turn_output.feedback_components",
         lambda: [],
     )
     return state
@@ -81,7 +81,7 @@ def test_render_error_hides_raw_detail_behind_generic_copy(
     _patch_discord_client: dict[str, Any],
 ) -> None:
     # Arrange
-    sink = DiscordOutputSink(
+    sink = DiscordTurnOutput(
         bot_token="tok",
         channel_id="chan-1",
         edit_interval_seconds=0.0,
@@ -102,7 +102,7 @@ def test_render_error_keeps_credit_exhaustion_guidance(
 ) -> None:
     from core.llm.shared.llm_retry import CREDIT_EXHAUSTED_MARKER
 
-    sink = DiscordOutputSink(
+    sink = DiscordTurnOutput(
         bot_token="tok",
         channel_id="chan-1",
         edit_interval_seconds=0.0,
@@ -117,7 +117,7 @@ def test_sink_accepts_tool_hooks_attribute(
     _patch_discord_client: dict[str, Any],
 ) -> None:
     hooks = MagicMock(name="approval_hooks")
-    sink = DiscordOutputSink(
+    sink = DiscordTurnOutput(
         bot_token="tok",
         channel_id="chan-1",
         edit_interval_seconds=0.0,
@@ -136,7 +136,7 @@ def test_a_second_goal_turn_posts_instead_of_overwriting(
     already read, and returning early would drop the later turn entirely.
     """
     # Arrange.
-    sink = DiscordOutputSink(bot_token="t", channel_id="c", edit_interval_seconds=0.0)
+    sink = DiscordTurnOutput(bot_token="t", channel_id="c", edit_interval_seconds=0.0)
     sink._message_id = "msg-1"
 
     # Act: two turns of one continued goal.

--- a/gateway/tests/discord/test_turn_output_redaction.py
+++ b/gateway/tests/discord/test_turn_output_redaction.py
@@ -4,20 +4,20 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from gateway.transports.discord.output_sink import DiscordOutputSink
+from gateway.transports.discord.turn_output import DiscordTurnOutput
 
 
 def test_render_error_hides_raw_detail_behind_generic_copy() -> None:
     with (
         patch(
-            "gateway.transports.discord.output_sink.send_message",
+            "gateway.transports.discord.turn_output.send_message",
             return_value="msg-1",
         ),
         patch(
-            "gateway.transports.discord.output_sink.edit_message_with_components"
+            "gateway.transports.discord.turn_output.edit_message_with_components"
         ) as edit_components,
     ):
-        sink = DiscordOutputSink(
+        sink = DiscordTurnOutput(
             bot_token="tok",
             channel_id="ch-1",
             edit_interval_seconds=0.0,

--- a/gateway/tests/ingress/test_polled_turn_sequence.py
+++ b/gateway/tests/ingress/test_polled_turn_sequence.py
@@ -1,0 +1,222 @@
+"""Telegram and Buzz run one inbound turn in the same order.
+
+The two polled transports assemble the same turn twice, in their own files.
+Roughly 60 lines of that assembly are identical once the platform name is
+masked, which is why consolidating them keeps being proposed — and why it needs
+a guard first: an extraction must be provable not to reorder claim, finalize or
+dispatch for either transport.
+
+This records what one turn does, through each transport's real handler, and
+asserts the two recordings match. It is a characterization test: it pins today's
+behaviour so a refactor has something to be equal to, not a behaviour anyone
+designed from scratch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from core.agent_harness.session import SessionCore
+from core.agent_harness.session.persistence.memory import InMemorySessionStore
+from gateway.core.middleware.active_turns import ActiveTurnRegistry
+from gateway.core.middleware.approvals import ApprovalBroker
+
+
+class _Recorder:
+    """The ordered facts one turn produces, whichever transport ran it."""
+
+    def __init__(self) -> None:
+        self.steps: list[str] = []
+        self.turn_thread: str | None = None
+
+    def note(self, step: str) -> None:
+        self.steps.append(step)
+
+
+class _RecordingResolver:
+    def __init__(self, session: SessionCore, recorder: _Recorder) -> None:
+        self._session = session
+        self._recorder = recorder
+
+    def resolve(self, **_kwargs: object) -> SessionCore:
+        self._recorder.note("session_resolved")
+        return self._session
+
+    def rotate(self, **_kwargs: object) -> SessionCore:
+        return self._session
+
+
+def _recording_callback(recorder: _Recorder):
+    """A turn callback that records what the host handed it."""
+
+    def _callback(text: str, session: Any, sink: Any, _logger: logging.Logger) -> None:
+        if isinstance(getattr(sink, "turn_cancel", None), threading.Event):
+            recorder.note("cancel_armed_before_turn")
+        if session is not None:
+            recorder.note("session_bound_to_turn")
+        if text:
+            recorder.note("text_delivered")
+        recorder.turn_thread = threading.current_thread().name
+        recorder.note("turn_dispatched")
+
+    return _callback
+
+
+class _TelegramClient:
+    def send_chat_action(self, chat_id: str, action: str) -> None: ...
+
+    def send_message(self, chat_id: str, text: str, **_kw: Any) -> tuple[bool, str, str]:
+        _ = (chat_id, text)
+        return True, "", "msg-1"
+
+    def edit_message_text(
+        self, chat_id: str, message_id: str, text: str, **_kw: Any
+    ) -> tuple[bool, str]:
+        _ = (chat_id, message_id, text)
+        return True, ""
+
+
+@pytest.fixture(autouse=True)
+def _isolated_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep identity policy off the developer's real integration store."""
+    monkeypatch.setenv("ORGANIZATION_ID", "org_polled_parity")
+    from gateway.core.middleware import identity_policy
+
+    monkeypatch.setattr(identity_policy, "get_integration", lambda *_a, **_kw: None)
+
+
+def _run_telegram_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+    from gateway.transports.telegram.inbound_handler import (
+        handle_polled_inbound_telegram_message,
+    )
+    from gateway.transports.telegram.inbound_security import InboundDecision
+    from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
+
+    monkeypatch.setattr(
+        "gateway.transports.telegram.inbound_handler.enforce_inbound_telegram_message_security",
+        lambda **_kw: InboundDecision(allowed=True),
+    )
+    session = SessionCore(store=InMemorySessionStore())
+
+    async def _run() -> None:
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            await handle_polled_inbound_telegram_message(
+                TelegramInboundMessage(
+                    update_id=1,
+                    user_id="user-1",
+                    chat_id="chat-1",
+                    message_id="m1",
+                    text="hello",
+                ),
+                client=_TelegramClient(),  # type: ignore[arg-type]
+                session_resolver=_RecordingResolver(session, recorder),  # type: ignore[arg-type]
+                settings=GatewaySettings(
+                    bot_token="tok", allowed_user_ids=["user-1"], turn_timeout_seconds=30.0
+                ),
+                executor=executor,
+                chat_locks={},
+                turn_semaphore=asyncio.Semaphore(1),
+                approvals=ApprovalBroker(),
+                active_cancels=ActiveTurnRegistry(),
+                handle_callback_to_gateway_agent=_recording_callback(recorder),
+            )
+        finally:
+            executor.shutdown(wait=True)
+
+    asyncio.run(_run())
+
+
+def _run_buzz_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+    from gateway.transports.buzz.inbound_handler import handle_polled_inbound_buzz_message
+    from gateway.transports.buzz.pending_approvals import PendingApprovals
+    from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
+
+    _ = monkeypatch
+    session = SessionCore(store=InMemorySessionStore())
+    sender = "a" * 64
+
+    async def _run() -> None:
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            await handle_polled_inbound_buzz_message(
+                BuzzInboundMessage(
+                    event_id="ev1",
+                    pubkey=sender,
+                    channel_id="chan-1",
+                    content="@bot hello",
+                    created_at=100,
+                    reply_event_ids=frozenset(),
+                ),
+                client=_BuzzClient(),  # type: ignore[arg-type]
+                session_resolver=_RecordingResolver(session, recorder),  # type: ignore[arg-type]
+                settings=GatewaySettings(
+                    private_key="k", allowed_pubkeys=[sender], turn_timeout_seconds=30.0
+                ),
+                executor=executor,
+                chat_locks={},
+                turn_semaphore=asyncio.Semaphore(1),
+                approvals=ApprovalBroker(),
+                pending_approvals=PendingApprovals(),
+                active_cancels=ActiveTurnRegistry(),
+                handle_callback_to_gateway_agent=_recording_callback(recorder),
+            )
+        finally:
+            executor.shutdown(wait=True)
+
+    asyncio.run(_run())
+
+
+class _BuzzClient:
+    def send_message(self, **_kw: Any) -> dict[str, Any]:
+        return {"success": True, "error": "", "event_id": "ev-out"}
+
+    def edit_message(self, **_kw: Any) -> dict[str, Any]:
+        return {"success": True, "error": "", "event_id": "ev-out"}
+
+
+def test_both_polled_transports_run_a_turn_in_the_same_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared sequence, recorded from each transport's real handler.
+
+    Equality is the point: an extraction that reorders one transport's claim,
+    dispatch or cancel arming shows up here as two different lists.
+    """
+    # Arrange
+    telegram, buzz = _Recorder(), _Recorder()
+
+    # Act
+    _run_telegram_turn(monkeypatch, telegram)
+    _run_buzz_turn(monkeypatch, buzz)
+
+    # Assert
+    assert telegram.steps == buzz.steps, (telegram.steps, buzz.steps)
+    assert telegram.steps[0] == "session_resolved"
+    assert "cancel_armed_before_turn" in telegram.steps
+    assert telegram.steps[-1] == "turn_dispatched"
+
+
+def test_both_polled_transports_run_the_turn_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The turn body runs on the executor, so polling is never blocked by a turn."""
+    # Arrange
+    telegram, buzz = _Recorder(), _Recorder()
+    main_thread = threading.current_thread().name
+
+    # Act
+    _run_telegram_turn(monkeypatch, telegram)
+    _run_buzz_turn(monkeypatch, buzz)
+
+    # Assert
+    assert telegram.turn_thread is not None
+    assert telegram.turn_thread != main_thread
+    assert buzz.turn_thread is not None
+    assert buzz.turn_thread != main_thread

--- a/gateway/tests/ingress/test_polled_turn_sequence.py
+++ b/gateway/tests/ingress/test_polled_turn_sequence.py
@@ -3,8 +3,8 @@
 The two polled transports assemble the same turn twice, in their own files.
 Roughly 60 lines of that assembly are identical once the platform name is
 masked, which is why consolidating them keeps being proposed — and why it needs
-a guard first: an extraction must be provable not to reorder claim, finalize or
-dispatch for either transport.
+a guard first: an extraction must be provable not to reorder claim, timeout,
+cancel tracking, dispatch or finalize for either transport.
 
 This records what one turn does, through each transport's real handler, and
 asserts the two recordings match. It is a characterization test: it pins today's
@@ -18,6 +18,7 @@ import asyncio
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
@@ -26,6 +27,21 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from gateway.core.middleware.active_turns import ActiveTurnRegistry
 from gateway.core.middleware.approvals import ApprovalBroker
+
+# Happy-path order both handlers must produce. Reordering claim, timeout,
+# cancel tracking or dispatch changes this list.
+_HAPPY_PATH_STEPS = (
+    "session_resolved",
+    "timeout_armed",
+    "cancel_tracked",
+    "cancel_armed_before_turn",
+    "session_bound_to_turn",
+    "text_delivered",
+    "turn_dispatched",
+    "cancel_untracked",
+    "timeout_disarmed",
+    "terminal_claimed",
+)
 
 
 class _Recorder:
@@ -68,8 +84,70 @@ def _recording_callback(recorder: _Recorder):
     return _callback
 
 
+def _instrument_host_sequence(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+    """Record claim, cancel tracking, timeout arming, and sink finalize.
+
+    The callback only sees what the host passed *into* the turn. Reordering
+    ``track`` / ``timeout_after`` / ``claim`` / ``finalize`` around that
+    callback would still match if we ignored those operations.
+    """
+    from gateway.core.middleware.active_turns import ActiveTurnRegistry
+    from gateway.core.middleware.terminal_outcome import TerminalOutcomeArbiter
+    from gateway.transports.buzz import inbound_handler as buzz_handler
+    from gateway.transports.buzz.output_sink import BuzzOutputSink
+    from gateway.transports.telegram import inbound_handler as telegram_handler
+    from gateway.transports.telegram.output_sink import TelegramOutputSink
+
+    class _RecordingTerminal(TerminalOutcomeArbiter):
+        def claim(self) -> bool:
+            won = super().claim()
+            if won:
+                recorder.note("terminal_claimed")
+            return won
+
+        @contextmanager
+        def timeout_after(self, timeout_seconds: float, on_timeout: Any) -> Any:
+            recorder.note("timeout_armed")
+            with super().timeout_after(timeout_seconds, on_timeout):
+                yield
+            recorder.note("timeout_disarmed")
+
+    monkeypatch.setattr(telegram_handler, "TerminalOutcomeArbiter", _RecordingTerminal)
+    monkeypatch.setattr(buzz_handler, "TerminalOutcomeArbiter", _RecordingTerminal)
+
+    original_track = ActiveTurnRegistry.track
+
+    @contextmanager
+    def recording_track(
+        self: ActiveTurnRegistry,
+        key: str,
+        event: threading.Event,
+        *,
+        on_user_stop: Any = None,
+    ) -> Any:
+        recorder.note("cancel_tracked")
+        with original_track(self, key, event, on_user_stop=on_user_stop):
+            yield
+        recorder.note("cancel_untracked")
+
+    monkeypatch.setattr(ActiveTurnRegistry, "track", recording_track)
+
+    def _wrap_finalize(cls: type) -> None:
+        original = cls.finalize
+
+        def finalize(self: Any, answer: str) -> None:
+            recorder.note("sink_finalized")
+            original(self, answer)
+
+        monkeypatch.setattr(cls, "finalize", finalize)
+
+    _wrap_finalize(TelegramOutputSink)
+    _wrap_finalize(BuzzOutputSink)
+
+
 class _TelegramClient:
-    def send_chat_action(self, chat_id: str, action: str) -> None: ...
+    def send_chat_action(self, chat_id: str, action: str) -> None:
+        pass
 
     def send_message(self, chat_id: str, text: str, **_kw: Any) -> tuple[bool, str, str]:
         _ = (chat_id, text)
@@ -80,6 +158,14 @@ class _TelegramClient:
     ) -> tuple[bool, str]:
         _ = (chat_id, message_id, text)
         return True, ""
+
+
+class _BuzzClient:
+    def send_message(self, **_kw: Any) -> dict[str, Any]:
+        return {"success": True, "error": "", "event_id": "ev-out"}
+
+    def edit_message(self, **_kw: Any) -> dict[str, Any]:
+        return {"success": True, "error": "", "event_id": "ev-out"}
 
 
 @pytest.fixture(autouse=True)
@@ -98,6 +184,7 @@ def _run_telegram_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> 
     from gateway.transports.telegram.inbound_security import InboundDecision
     from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
 
+    _instrument_host_sequence(monkeypatch, recorder)
     monkeypatch.setattr(
         "gateway.transports.telegram.inbound_handler.enforce_inbound_telegram_message_security",
         lambda **_kw: InboundDecision(allowed=True),
@@ -118,7 +205,9 @@ def _run_telegram_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> 
                 client=_TelegramClient(),  # type: ignore[arg-type]
                 session_resolver=_RecordingResolver(session, recorder),  # type: ignore[arg-type]
                 settings=GatewaySettings(
-                    bot_token="tok", allowed_user_ids=["user-1"], turn_timeout_seconds=30.0
+                    bot_token="tok",
+                    allowed_user_ids=["user-1"],
+                    turn_timeout_seconds=30.0,
                 ),
                 executor=executor,
                 chat_locks={},
@@ -135,10 +224,15 @@ def _run_telegram_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> 
 
 def _run_buzz_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
     from gateway.transports.buzz.inbound_handler import handle_polled_inbound_buzz_message
+    from gateway.transports.buzz.inbound_security import InboundDecision
     from gateway.transports.buzz.pending_approvals import PendingApprovals
     from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
 
-    _ = monkeypatch
+    _instrument_host_sequence(monkeypatch, recorder)
+    monkeypatch.setattr(
+        "gateway.transports.buzz.inbound_handler.enforce_inbound_buzz_message_security",
+        lambda **_kw: InboundDecision(allowed=True),
+    )
     session = SessionCore(store=InMemorySessionStore())
     sender = "a" * 64
 
@@ -157,7 +251,9 @@ def _run_buzz_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None
                 client=_BuzzClient(),  # type: ignore[arg-type]
                 session_resolver=_RecordingResolver(session, recorder),  # type: ignore[arg-type]
                 settings=GatewaySettings(
-                    private_key="k", allowed_pubkeys=[sender], turn_timeout_seconds=30.0
+                    private_key="k",
+                    allowed_pubkeys=[sender],
+                    turn_timeout_seconds=30.0,
                 ),
                 executor=executor,
                 chat_locks={},
@@ -173,21 +269,13 @@ def _run_buzz_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None
     asyncio.run(_run())
 
 
-class _BuzzClient:
-    def send_message(self, **_kw: Any) -> dict[str, Any]:
-        return {"success": True, "error": "", "event_id": "ev-out"}
-
-    def edit_message(self, **_kw: Any) -> dict[str, Any]:
-        return {"success": True, "error": "", "event_id": "ev-out"}
-
-
 def test_both_polled_transports_run_a_turn_in_the_same_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The shared sequence, recorded from each transport's real handler.
 
-    Equality is the point: an extraction that reorders one transport's claim,
-    dispatch or cancel arming shows up here as two different lists.
+    Equality is the point: an extraction that reorders claim, timeout,
+    cancel tracking, dispatch or finalize shows up as two different lists.
     """
     # Arrange
     telegram, buzz = _Recorder(), _Recorder()
@@ -197,10 +285,9 @@ def test_both_polled_transports_run_a_turn_in_the_same_order(
     _run_buzz_turn(monkeypatch, buzz)
 
     # Assert
-    assert telegram.steps == buzz.steps, (telegram.steps, buzz.steps)
-    assert telegram.steps[0] == "session_resolved"
-    assert "cancel_armed_before_turn" in telegram.steps
-    assert telegram.steps[-1] == "turn_dispatched"
+    assert telegram.steps == list(_HAPPY_PATH_STEPS)
+    assert buzz.steps == list(_HAPPY_PATH_STEPS)
+    assert "sink_finalized" not in telegram.steps
 
 
 def test_both_polled_transports_run_the_turn_off_the_event_loop(

--- a/gateway/tests/ingress/test_polled_turn_sequence.py
+++ b/gateway/tests/ingress/test_polled_turn_sequence.py
@@ -27,12 +27,12 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from gateway.core.middleware.active_turns import ActiveTurnRegistry
 from gateway.core.middleware.approvals import ApprovalBroker
-from gateway.transports.buzz.output_sink import BuzzOutputSink
-from gateway.transports.telegram.output_sink import TelegramOutputSink
+from gateway.transports.buzz.turn_output import BuzzTurnOutput
+from gateway.transports.telegram.turn_output import TelegramTurnOutput
 
 _REAL_TRACK = ActiveTurnRegistry.track
-_REAL_TELEGRAM_FINALIZE = TelegramOutputSink.finalize
-_REAL_BUZZ_FINALIZE = BuzzOutputSink.finalize
+_REAL_TELEGRAM_FINALIZE = TelegramTurnOutput.finalize
+_REAL_BUZZ_FINALIZE = BuzzTurnOutput.finalize
 
 # Happy-path order both handlers must produce. Reordering claim, timeout,
 # cancel tracking or dispatch changes this list.
@@ -77,8 +77,8 @@ class _RecordingResolver:
 def _recording_callback(recorder: _Recorder):
     """A turn callback that records what the host handed it."""
 
-    def _callback(text: str, session: Any, sink: Any, _logger: logging.Logger) -> None:
-        if isinstance(getattr(sink, "turn_cancel", None), threading.Event):
+    def _callback(text: str, session: Any, output: Any, _logger: logging.Logger) -> None:
+        if isinstance(getattr(output, "turn_cancel", None), threading.Event):
             recorder.note("cancel_armed_before_turn")
         if session is not None:
             recorder.note("session_bound_to_turn")
@@ -93,7 +93,7 @@ def _recording_callback(recorder: _Recorder):
 def _instrument_host_sequence(
     monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
 ) -> ActiveTurnRegistry:
-    """Record claim, cancel tracking, timeout arming, and sink finalize.
+    """Record claim, cancel tracking, timeout arming, and reply finalize.
 
     The callback only sees what the host passed *into* the turn. Reordering
     ``track`` / ``timeout_after`` / ``claim`` / ``finalize`` around that
@@ -102,9 +102,9 @@ def _instrument_host_sequence(
     from gateway.core.middleware.active_turns import ActiveTurnRegistry
     from gateway.core.middleware.terminal_outcome import TerminalOutcomeArbiter
     from gateway.transports.buzz import inbound_handler as buzz_handler
-    from gateway.transports.buzz.output_sink import BuzzOutputSink
+    from gateway.transports.buzz.turn_output import BuzzTurnOutput
     from gateway.transports.telegram import inbound_handler as telegram_handler
-    from gateway.transports.telegram.output_sink import TelegramOutputSink
+    from gateway.transports.telegram.turn_output import TelegramTurnOutput
 
     class _RecordingTerminal(TerminalOutcomeArbiter):
         def claim(self) -> bool:
@@ -146,8 +146,8 @@ def _instrument_host_sequence(
 
         monkeypatch.setattr(cls, "finalize", finalize)
 
-    _wrap_finalize(TelegramOutputSink, _REAL_TELEGRAM_FINALIZE)
-    _wrap_finalize(BuzzOutputSink, _REAL_BUZZ_FINALIZE)
+    _wrap_finalize(TelegramTurnOutput, _REAL_TELEGRAM_FINALIZE)
+    _wrap_finalize(BuzzTurnOutput, _REAL_BUZZ_FINALIZE)
     return registry
 
 

--- a/gateway/tests/ingress/test_polled_turn_sequence.py
+++ b/gateway/tests/ingress/test_polled_turn_sequence.py
@@ -27,6 +27,12 @@ from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from gateway.core.middleware.active_turns import ActiveTurnRegistry
 from gateway.core.middleware.approvals import ApprovalBroker
+from gateway.transports.buzz.output_sink import BuzzOutputSink
+from gateway.transports.telegram.output_sink import TelegramOutputSink
+
+_REAL_TRACK = ActiveTurnRegistry.track
+_REAL_TELEGRAM_FINALIZE = TelegramOutputSink.finalize
+_REAL_BUZZ_FINALIZE = BuzzOutputSink.finalize
 
 # Happy-path order both handlers must produce. Reordering claim, timeout,
 # cancel tracking or dispatch changes this list.
@@ -84,7 +90,9 @@ def _recording_callback(recorder: _Recorder):
     return _callback
 
 
-def _instrument_host_sequence(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+def _instrument_host_sequence(
+    monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+) -> ActiveTurnRegistry:
     """Record claim, cancel tracking, timeout arming, and sink finalize.
 
     The callback only sees what the host passed *into* the turn. Reordering
@@ -115,34 +123,32 @@ def _instrument_host_sequence(monkeypatch: pytest.MonkeyPatch, recorder: _Record
     monkeypatch.setattr(telegram_handler, "TerminalOutcomeArbiter", _RecordingTerminal)
     monkeypatch.setattr(buzz_handler, "TerminalOutcomeArbiter", _RecordingTerminal)
 
-    original_track = ActiveTurnRegistry.track
+    registry = ActiveTurnRegistry()
 
     @contextmanager
     def recording_track(
-        self: ActiveTurnRegistry,
         key: str,
         event: threading.Event,
         *,
         on_user_stop: Any = None,
     ) -> Any:
         recorder.note("cancel_tracked")
-        with original_track(self, key, event, on_user_stop=on_user_stop):
+        with _REAL_TRACK(registry, key, event, on_user_stop=on_user_stop):
             yield
         recorder.note("cancel_untracked")
 
-    monkeypatch.setattr(ActiveTurnRegistry, "track", recording_track)
+    monkeypatch.setattr(registry, "track", recording_track)
 
-    def _wrap_finalize(cls: type) -> None:
-        original = cls.finalize
-
+    def _wrap_finalize(cls: type, original: Any) -> None:
         def finalize(self: Any, answer: str) -> None:
             recorder.note("sink_finalized")
             original(self, answer)
 
         monkeypatch.setattr(cls, "finalize", finalize)
 
-    _wrap_finalize(TelegramOutputSink)
-    _wrap_finalize(BuzzOutputSink)
+    _wrap_finalize(TelegramOutputSink, _REAL_TELEGRAM_FINALIZE)
+    _wrap_finalize(BuzzOutputSink, _REAL_BUZZ_FINALIZE)
+    return registry
 
 
 class _TelegramClient:
@@ -184,7 +190,7 @@ def _run_telegram_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> 
     from gateway.transports.telegram.inbound_security import InboundDecision
     from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
 
-    _instrument_host_sequence(monkeypatch, recorder)
+    registry = _instrument_host_sequence(monkeypatch, recorder)
     monkeypatch.setattr(
         "gateway.transports.telegram.inbound_handler.enforce_inbound_telegram_message_security",
         lambda **_kw: InboundDecision(allowed=True),
@@ -213,7 +219,7 @@ def _run_telegram_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> 
                 chat_locks={},
                 turn_semaphore=asyncio.Semaphore(1),
                 approvals=ApprovalBroker(),
-                active_cancels=ActiveTurnRegistry(),
+                active_cancels=registry,
                 handle_callback_to_gateway_agent=_recording_callback(recorder),
             )
         finally:
@@ -228,7 +234,7 @@ def _run_buzz_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None
     from gateway.transports.buzz.pending_approvals import PendingApprovals
     from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
 
-    _instrument_host_sequence(monkeypatch, recorder)
+    registry = _instrument_host_sequence(monkeypatch, recorder)
     monkeypatch.setattr(
         "gateway.transports.buzz.inbound_handler.enforce_inbound_buzz_message_security",
         lambda **_kw: InboundDecision(allowed=True),
@@ -260,7 +266,7 @@ def _run_buzz_turn(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None
                 turn_semaphore=asyncio.Semaphore(1),
                 approvals=ApprovalBroker(),
                 pending_approvals=PendingApprovals(),
-                active_cancels=ActiveTurnRegistry(),
+                active_cancels=registry,
                 handle_callback_to_gateway_agent=_recording_callback(recorder),
             )
         finally:

--- a/gateway/tests/slack/test_turn_output.py
+++ b/gateway/tests/slack/test_turn_output.py
@@ -6,8 +6,8 @@ from gateway.transports.slack.client import (
     SLACK_MAX_MARKDOWN_BLOCK_CHARS,
     SLACK_MAX_MESSAGE_CHARS,
 )
-from gateway.transports.slack.delivery.output_sink import (
-    SlackOutputSink,
+from gateway.transports.slack.delivery.turn_output import (
+    SlackTurnOutput,
 )
 
 
@@ -81,8 +81,8 @@ class _FakeMessagingClient:
         return [chunk for append in self.stream_appends for chunk in append["chunks"]]
 
 
-def _sink(client: _FakeMessagingClient) -> SlackOutputSink:
-    return SlackOutputSink(
+def _sink(client: _FakeMessagingClient) -> SlackTurnOutput:
+    return SlackTurnOutput(
         client=client,
         channel_id="C222",
         thread_ts="1700.100",

--- a/gateway/tests/telegram/test_telegram_turn_output.py
+++ b/gateway/tests/telegram/test_telegram_turn_output.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock
 
-from gateway.transports.telegram.output_sink import TelegramOutputSink
 from gateway.transports.telegram.poller.client import TelegramBotClient
+from gateway.transports.telegram.turn_output import TelegramTurnOutput
 from platform.delivery.notifications.limits import MAX_MESSAGE_SIZE
 
 
@@ -13,7 +13,7 @@ def test_initial_status_is_not_working_placeholder() -> None:
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
 
-    TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sent = client.send_message.call_args.args[1]
     assert sent != "Working…"
@@ -25,7 +25,7 @@ def test_set_status_never_shows_working_placeholder() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.set_tool_status("Working…")
 
@@ -38,7 +38,7 @@ def test_render_response_header_uses_friendly_assistant_status() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.render_response_header("assistant")
 
@@ -50,7 +50,7 @@ def test_stream_throttles_edits() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=10.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=10.0)
     text = sink.stream(label="assistant", chunks=["hello", " world"])
     assert text == "hello world"
     assert client.edit_message_text.call_count >= 1
@@ -60,7 +60,7 @@ def test_finalize_truncates_long_text() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
     sink.finalize("x" * 5000)
     edited = client.edit_message_text.call_args[0][2]
     assert len(edited) <= MAX_MESSAGE_SIZE
@@ -70,7 +70,7 @@ def test_finalize_logs_outbound_edited_message(caplog) -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     with caplog.at_level(logging.INFO, logger="gateway"):
         sink.finalize("hello\nteam")
@@ -82,7 +82,7 @@ def test_finalize_logs_outbound_fallback_send(caplog) -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.side_effect = [(True, "", "1"), (True, "", "2")]
     client.edit_message_text.return_value = (False, "edit failed")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     with caplog.at_level(logging.INFO, logger="gateway"):
         sink.finalize("fallback message")
@@ -94,7 +94,7 @@ def test_finalize_renders_headers_and_tables_as_html() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.finalize("## Open PRs\n\n| # | Title |\n|---|---|\n| 3811 | docs fix |\n\n---\n\n**Done**")
 
@@ -109,7 +109,7 @@ def test_finalize_renders_markdown_as_html() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.finalize("**bold** and `code`")
 
@@ -124,7 +124,7 @@ def test_finalize_falls_back_to_plain_when_html_rejected() -> None:
     client.send_message.return_value = (True, "", "1")
     # HTML edit fails (bad markup); plain retry succeeds.
     client.edit_message_text.side_effect = [(False, "can't parse entities"), (True, "")]
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.finalize("**bold**")
 
@@ -141,7 +141,7 @@ def test_render_error_appends_auth_login_hint_on_credit_exhaustion() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.render_error(f"Anthropic {CREDIT_EXHAUSTED_MARKER}. Original error: 400")
 
@@ -153,7 +153,7 @@ def test_render_error_no_auth_hint_for_generic_error() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.render_error("something else broke")
 
@@ -166,7 +166,7 @@ def test_render_error_strips_raw_exception_detail() -> None:
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     # Act: hand render_error a raw exception string with a secret in it.
     sink.render_error("RuntimeError: token sk-DO-NOT-LEAK rejected by db-host:5432")
@@ -191,7 +191,7 @@ def test_goal_continuation_keeps_both_streamed_answers() -> None:
         (True, "", "2"),  # continuation placeholder / answer
     ]
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     first = sink.stream(label="assistant", chunks=["step one"])
     second = sink.stream(label="assistant", chunks=["step two"])
@@ -219,7 +219,7 @@ def test_finalize_after_finished_turn_sends_a_new_message() -> None:
         (True, "", "2"),
     ]
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     sink.finalize("step one")
     sink.finalize("step two from finalize")
@@ -248,7 +248,7 @@ def test_a_second_goal_turn_posts_a_new_message_instead_of_overwriting() -> None
     client = MagicMock(spec=TelegramBotClient)
     client.send_message.return_value = (True, "", "1")
     client.edit_message_text.return_value = (True, "")
-    sink = TelegramOutputSink(client=client, chat_id="123", edit_interval_seconds=0.0)
+    sink = TelegramTurnOutput(client=client, chat_id="123", edit_interval_seconds=0.0)
 
     # Act: two turns of one continued goal.
     sink.finalize("turn one answer")

--- a/gateway/tests/test_transport_contract.py
+++ b/gateway/tests/test_transport_contract.py
@@ -51,9 +51,9 @@ _REQUIRED_CONCERNS: dict[str, str] = {
     "stop command handling": "is_stop_command",
     # Turns are metered.
     "credit metering": "consume_credits",
-    # The sink cooperates with host-side cancellation instead of relying on
-    # the harness patching the attribute on.
-    "sink declares turn_cancel": "self.turn_cancel",
+    # Turn output cooperates with host-side cancellation instead of relying
+    # on the harness patching the attribute on.
+    "turn output declares turn_cancel": "self.turn_cancel",
 }
 
 #: Concerns each existing transport is known to lack. Ledger, not allowlist:

--- a/gateway/transports/__init__.py
+++ b/gateway/transports/__init__.py
@@ -1,6 +1,6 @@
 """Chat transports: Slack, Discord, Telegram, Buzz.
 
-Each package owns its settings, inbound worker, security, sink, and
+Each package owns its settings, inbound worker, security, turn output, and
 ``startup``. Peers do not import each other. Shared turn steps come from
 ``gateway.core``. The process starts every configured transport in one pass.
 """

--- a/gateway/transports/buzz/__init__.py
+++ b/gateway/transports/buzz/__init__.py
@@ -1,7 +1,7 @@
 """Buzz poll transport for the gateway.
 
 Inbound Buzz messaging: settings, mention-feed poller, inbound authorization,
-the edit-in-place output sink, approvals, and the background worker. The
+the edit-in-place turn output, approvals, and the background worker. The
 per-message handler it drives is transport-agnostic and injected by the
 composition root (:mod:`gateway.core.lifecycle.controller`). Mirrors
 :mod:`gateway.transports.telegram` (poll-based, not a persistent socket).

--- a/gateway/transports/buzz/inbound_handler.py
+++ b/gateway/transports/buzz/inbound_handler.py
@@ -17,11 +17,11 @@ from gateway.core.middleware.terminal_outcome import TerminalOutcomeArbiter
 from gateway.core.storage import SessionResolver
 from gateway.transports.buzz.approvals import BuzzApprovalPrompter
 from gateway.transports.buzz.inbound_security import enforce_inbound_buzz_message_security
-from gateway.transports.buzz.output_sink import BuzzOutputSink
 from gateway.transports.buzz.pending_approvals import PendingApprovals
 from gateway.transports.buzz.principal import PrincipalResolutionError, resolve_buzz_scope
 from gateway.transports.buzz.session_rotation import conversation_key, resolve_or_rotate_session
 from gateway.transports.buzz.settings import BuzzInboundMessage, GatewaySettings
+from gateway.transports.buzz.turn_output import BuzzTurnOutput
 from integrations.buzz.client import BuzzClient
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
 from platform.turn_host.turn_callback import TurnCallback
@@ -104,7 +104,7 @@ async def handle_polled_inbound_buzz_message(
             preview,
         )
 
-        sink = BuzzOutputSink(
+        output = BuzzTurnOutput(
             client=client,
             channel_id=event.channel_id,
             edit_interval_seconds=settings.stream_edit_interval_seconds,
@@ -121,7 +121,7 @@ async def handle_polled_inbound_buzz_message(
 
         event_loop = loop or asyncio.get_running_loop()
         terminal = TerminalOutcomeArbiter(cancel_event=turn_cancel)
-        sink.turn_cancel = terminal.cancel_event
+        output.turn_cancel = terminal.cancel_event
 
         def _on_turn_timeout() -> None:
             logger.warning(
@@ -131,7 +131,7 @@ async def handle_polled_inbound_buzz_message(
                 session.session_id[:8],
             )
             try:
-                sink.finalize(TURN_TIMEOUT_MESSAGE)
+                output.finalize(TURN_TIMEOUT_MESSAGE)
             except Exception:
                 logger.debug("[buzz-gateway] timeout finalize failed", exc_info=True)
 
@@ -139,7 +139,7 @@ async def handle_polled_inbound_buzz_message(
             if not terminal.claim():
                 return
             try:
-                sink.finalize(USER_STOP_MESSAGE)
+                output.finalize(USER_STOP_MESSAGE)
             except Exception:
                 logger.debug("[buzz-gateway] user-stop finalize failed", exc_info=True)
 
@@ -156,7 +156,7 @@ async def handle_polled_inbound_buzz_message(
                     handle_callback_to_gateway_agent(
                         event.content,
                         session,
-                        sink,
+                        output,
                         logger,
                     )
             finally:
@@ -176,7 +176,7 @@ async def handle_polled_inbound_buzz_message(
         if terminal.cancel_event.is_set():
             if terminal.claim():
                 try:
-                    sink.finalize(USER_STOP_MESSAGE)
+                    output.finalize(USER_STOP_MESSAGE)
                 except Exception:
                     logger.debug("[buzz-gateway] user-stop finalize failed", exc_info=True)
             if on_handled is not None:
@@ -195,7 +195,7 @@ async def handle_polled_inbound_buzz_message(
                 )
                 if terminal.claim():
                     try:
-                        sink.render_error(TURN_ERROR_MESSAGE)
+                        output.render_error(TURN_ERROR_MESSAGE)
                     except Exception:
                         logger.debug("[buzz-gateway] error finalize failed", exc_info=True)
                 raise

--- a/gateway/transports/buzz/turn_output.py
+++ b/gateway/transports/buzz/turn_output.py
@@ -1,4 +1,4 @@
-"""Buzz gateway output sink with throttled status editing.
+"""Buzz turn output with throttled status editing.
 
 Unlike Telegram, Buzz content is already markdown (Desktop renders it
 directly), so no HTML transform is needed on the way out. Status updates edit
@@ -36,7 +36,7 @@ def _log_preview(text: str) -> str:
     return preview
 
 
-class BuzzOutputSink:
+class BuzzTurnOutput:
     """Stream assistant output back through the Buzz channel."""
 
     def __init__(
@@ -47,7 +47,7 @@ class BuzzOutputSink:
         edit_interval_seconds: float = 1.5,
         tool_hooks: object | None = None,
     ) -> None:
-        # Set per turn by the host cancel plumbing; declared here so the sink
+        # Set per turn by the host cancel plumbing; declared here so this class
         # cooperates with cancellation like every other transport's, instead of
         # relying on ``ensure_turn_cancel`` patching the attribute on.
         self.turn_cancel: threading.Event | None = None
@@ -138,4 +138,4 @@ class BuzzOutputSink:
         return bool(result["success"])
 
 
-__all__ = ["BuzzOutputSink"]
+__all__ = ["BuzzTurnOutput"]

--- a/gateway/transports/discord/client.py
+++ b/gateway/transports/discord/client.py
@@ -1,4 +1,4 @@
-"""Discord REST helpers for the gateway output sink."""
+"""Discord REST helpers for posting turn replies."""
 
 from __future__ import annotations
 

--- a/gateway/transports/discord/dispatcher.py
+++ b/gateway/transports/discord/dispatcher.py
@@ -29,7 +29,6 @@ from gateway.core.storage import SessionResolver
 from gateway.transports.discord.approvals import DiscordApprovalPrompter
 from gateway.transports.discord.client import add_reaction, remove_reaction, send_message
 from gateway.transports.discord.events import DiscordInboundMessage
-from gateway.transports.discord.output_sink import DiscordOutputSink
 from gateway.transports.discord.principal import PrincipalResolutionError, resolve_discord_scope
 from gateway.transports.discord.security import (
     DiscordInboundDecision,
@@ -40,6 +39,7 @@ from gateway.transports.discord.thread_history import (
     seed_session_from_discord_thread,
     session_needs_thread_seed,
 )
+from gateway.transports.discord.turn_output import DiscordTurnOutput
 from integrations.messaging_security import MessagingPlatform
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
 from platform.turn_host.turn_callback import TurnCallback
@@ -218,7 +218,7 @@ class DiscordTurnDispatcher:
                 emoji=_WORKING_EMOJI,
                 bot_token=self._bot_token,
             )
-            sink = DiscordOutputSink(
+            output = DiscordTurnOutput(
                 bot_token=self._bot_token,
                 channel_id=inbound.channel_id,
                 edit_interval_seconds=self._settings.status_update_interval_seconds,
@@ -231,11 +231,11 @@ class DiscordTurnDispatcher:
                 ),
             )
             terminal = TerminalOutcomeArbiter()
-            sink.turn_cancel = terminal.cancel_event
+            output.turn_cancel = terminal.cancel_event
 
             def _on_turn_timeout() -> None:
                 try:
-                    sink.finalize(TURN_TIMEOUT_MESSAGE)
+                    output.finalize(TURN_TIMEOUT_MESSAGE)
                 except Exception:
                     self._logger.debug("[discord-gateway] timeout finalize failed", exc_info=True)
                 remove_reaction(
@@ -255,7 +255,7 @@ class DiscordTurnDispatcher:
                 if not terminal.claim():
                     return
                 try:
-                    sink.finalize(USER_STOP_MESSAGE)
+                    output.finalize(USER_STOP_MESSAGE)
                 except Exception:
                     self._logger.debug("[discord-gateway] user-stop finalize failed", exc_info=True)
                 remove_reaction(
@@ -303,11 +303,11 @@ class DiscordTurnDispatcher:
                             user_id=inbound.user_id or None,
                         ),
                     ):
-                        self._handler(agent_text, session, sink, self._logger)
+                        self._handler(agent_text, session, output, self._logger)
                 except Exception:
                     if terminal.claim():
                         with suppress(Exception):
-                            sink.render_error(TURN_ERROR_MESSAGE)
+                            output.render_error(TURN_ERROR_MESSAGE)
                         remove_reaction(
                             channel_id=inbound.channel_id,
                             message_id=inbound.message_id,

--- a/gateway/transports/discord/turn_output.py
+++ b/gateway/transports/discord/turn_output.py
@@ -1,4 +1,4 @@
-"""Discord gateway output sink."""
+"""Discord turn output."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ from platform.turn_host.status_messages import (
 logger = logging.getLogger("gateway")
 
 
-class DiscordOutputSink:
+class DiscordTurnOutput:
     """Stream assistant output back to a Discord channel or thread."""
 
     def __init__(

--- a/gateway/transports/slack/__init__.py
+++ b/gateway/transports/slack/__init__.py
@@ -2,7 +2,7 @@
 
 Layout:
 - ``inbound/`` — event parsing, authorization, attachments, dispatcher
-- ``outbound/`` — thread-reply sink, approvals, feedback, streamed replies
+- ``outbound/`` — thread-reply posting, approvals, feedback, streamed replies
 - ``connection/`` — Socket Mode worker and heartbeat
 - package root — ``settings``, ``client``, ``startup``
 

--- a/gateway/transports/slack/client.py
+++ b/gateway/transports/slack/client.py
@@ -25,7 +25,7 @@ Blocks = Sequence[dict[str, Any]]
 
 
 class SlackMessagingClient(Protocol):
-    """The messaging surface the Slack output sink needs."""
+    """The messaging surface the Slack turn output needs."""
 
     def post_message(
         self,
@@ -185,7 +185,7 @@ class SlackWebApiClient:
         # Streaming is documented under Slack's AI-apps surface; whether it
         # works without the Agents feature toggle is workspace/app-dependent,
         # so the first failure with a permanent-looking error disables it for
-        # this process and the sink falls back to placeholder editing.
+        # this process and this class falls back to placeholder editing.
         if self._streaming_unsupported:
             return None
         try:

--- a/gateway/transports/slack/delivery/turn_output.py
+++ b/gateway/transports/slack/delivery/turn_output.py
@@ -1,10 +1,10 @@
-"""Slack output sink: streamed timeline reply with placeholder-edit fallback.
+"""Slack turn output: streamed timeline reply with placeholder-edit fallback.
 
 Preferred delivery is Slack's streaming surface (``chat.startStream`` →
 ``chat.appendStream`` → ``chat.stopStream``): tool progress renders as
 timeline task cards and the answer streams as native markdown, like Claude
 Tag. When streaming is unavailable (feature-gated workspace, old plan, API
-error) the sink falls back to the classic flow — one status placeholder
+error) this class falls back to the classic flow — one status placeholder
 posted in-thread, edited in place while the turn runs, replaced by the final
 answer.
 """
@@ -38,7 +38,7 @@ from platform.turn_host.status_messages import (
 logger = logging.getLogger("gateway")
 
 
-class SlackOutputSink:
+class SlackTurnOutput:
     """Stream assistant output back to the triggering Slack thread."""
 
     def __init__(
@@ -79,7 +79,7 @@ class SlackOutputSink:
         )
         if self._message_ts is None:
             logger.warning(
-                "[slack-sink] placeholder post FAILED channel=%s thread_ts=%s; "
+                "[slack-turn-output] placeholder post FAILED channel=%s thread_ts=%s; "
                 "final answer will be posted as a new message",
                 channel_id,
                 thread_ts,
@@ -171,7 +171,7 @@ class SlackOutputSink:
                     return
                 # Stream broke mid-turn: deliver the full answer the classic way.
                 logger.warning(
-                    "[slack-sink] stream delivery failed channel=%s thread_ts=%s; "
+                    "[slack-turn-output] stream delivery failed channel=%s thread_ts=%s; "
                     "falling back to a plain message",
                     self._channel_id,
                     self._thread_ts,
@@ -220,7 +220,7 @@ class SlackOutputSink:
             # Both the in-place edit and the fresh post failed: the user is left
             # staring at the "Digging in…" placeholder with no answer.
             logger.error(
-                "[slack-sink] DELIVERY FAILED channel=%s thread_ts=%s chars=%d "
+                "[slack-turn-output] DELIVERY FAILED channel=%s thread_ts=%s chars=%d "
                 "(both update and post rejected)",
                 self._channel_id,
                 self._thread_ts,

--- a/gateway/transports/slack/delivery/turn_stream.py
+++ b/gateway/transports/slack/delivery/turn_stream.py
@@ -1,8 +1,8 @@
 """One turn's streamed Slack message — the ``chat.startStream`` state machine.
 
-Separate from the sink: the sink chooses a delivery path and renders blocks,
-this owns stream lifecycle (start / append / stop), chunk throttling, and the
-open-task bookkeeping the timeline surface needs.
+Separate from turn output: that class chooses a delivery path and renders
+blocks; this owns stream lifecycle (start / append / stop), chunk throttling,
+and the open-task bookkeeping the timeline surface needs.
 """
 
 from __future__ import annotations
@@ -142,7 +142,7 @@ class TurnStream:
             # Content is fully appended; a failed stop only leaves the
             # streaming indicator until Slack expires it. Don't re-post.
             logger.warning(
-                "[slack-sink] chat.stopStream failed channel=%s ts=%s",
+                "[slack-turn-output] chat.stopStream failed channel=%s ts=%s",
                 self._channel_id,
                 self._ts,
             )

--- a/gateway/transports/slack/processing/dispatcher.py
+++ b/gateway/transports/slack/processing/dispatcher.py
@@ -32,7 +32,7 @@ from gateway.transports.slack.client import (
     mark_turn_working,
 )
 from gateway.transports.slack.delivery.approvals import ThreadApprovalPrompter
-from gateway.transports.slack.delivery.output_sink import SlackOutputSink
+from gateway.transports.slack.delivery.turn_output import SlackTurnOutput
 from gateway.transports.slack.processing.events import SlackInboundFile, SlackInboundMessage
 from gateway.transports.slack.processing.principal import (
     PrincipalResolutionError,
@@ -263,7 +263,7 @@ class SlackTurnDispatcher:
                 channel_id=inbound.channel_id,
                 thread_ts=inbound.thread_ts,
             )
-            sink = SlackOutputSink(
+            output = SlackTurnOutput(
                 client=self._messaging,
                 channel_id=inbound.channel_id,
                 thread_ts=inbound.thread_ts,
@@ -271,7 +271,7 @@ class SlackTurnDispatcher:
                 tool_hooks=approval_tool_hooks(prompter),
             )
             terminal = TerminalOutcomeArbiter()
-            sink.turn_cancel = terminal.cancel_event
+            output.turn_cancel = terminal.cancel_event
 
             def _on_turn_timeout() -> None:
                 self._logger.warning(
@@ -281,7 +281,7 @@ class SlackTurnDispatcher:
                     session.session_id[:8],
                 )
                 try:
-                    sink.finalize(TURN_TIMEOUT_MESSAGE)
+                    output.finalize(TURN_TIMEOUT_MESSAGE)
                 except Exception:
                     self._logger.debug("[slack-gateway] timeout finalize failed", exc_info=True)
                 mark_turn_failed(
@@ -294,7 +294,7 @@ class SlackTurnDispatcher:
                 if not terminal.claim():
                     return
                 try:
-                    sink.finalize(USER_STOP_MESSAGE)
+                    output.finalize(USER_STOP_MESSAGE)
                 except Exception:
                     self._logger.debug("[slack-gateway] user-stop finalize failed", exc_info=True)
                 mark_turn_failed(
@@ -337,7 +337,7 @@ class SlackTurnDispatcher:
                             user_id=inbound.user_id or None,
                         ),
                     ):
-                        self._handler(agent_text, session, sink, self._logger)
+                        self._handler(agent_text, session, output, self._logger)
                 except Exception:
                     self._logger.exception(
                         "[slack-gateway] turn ERRORED after %.1fs channel=%s session=%s",
@@ -351,7 +351,7 @@ class SlackTurnDispatcher:
                     # already owns the outcome.
                     if terminal.claim():
                         try:
-                            sink.render_error(TURN_ERROR_MESSAGE)
+                            output.render_error(TURN_ERROR_MESSAGE)
                         except Exception:
                             self._logger.debug(
                                 "[slack-gateway] error finalize failed", exc_info=True
@@ -397,7 +397,7 @@ def _agent_text_with_slack_context(inbound: SlackInboundMessage) -> str:
 
     Short metadata line only; do not list tools. Omit thread ts so channel
     reads stay channel-wide (including it would collapse history to one
-    thread). The reply sink and session seeding already target the triggering
+    thread). Reply posting and session seeding already target the triggering
     thread. The speaker is included as a
     Slack mention token so multi-user threads stay attributable ("what is my
     name?" must resolve to the asker, not whoever spoke earlier); echoed back

--- a/gateway/transports/telegram/__init__.py
+++ b/gateway/transports/telegram/__init__.py
@@ -1,7 +1,7 @@
 """Telegram long-poll transport for the gateway.
 
 Inbound Telegram messaging: settings, poller, inbound authorization, the
-edit-in-place output sink, and the background worker. The per-message handler
+edit-in-place turn output, and the background worker. The per-message handler
 it drives is transport-agnostic and injected by the composition root
 (:mod:`gateway.core.lifecycle.controller`). Mirrors :mod:`gateway.transports.slack`.
 

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -16,7 +16,6 @@ from gateway.transports.telegram.approvals import TelegramApprovalPrompter
 from gateway.transports.telegram.inbound_security import (
     enforce_inbound_telegram_message_security,
 )
-from gateway.transports.telegram.output_sink import TelegramOutputSink
 from gateway.transports.telegram.poller.client import TelegramBotClient
 from gateway.transports.telegram.principal import (
     PrincipalResolutionError,
@@ -24,6 +23,7 @@ from gateway.transports.telegram.principal import (
 )
 from gateway.transports.telegram.session_rotation import resolve_or_rotate_session
 from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
+from gateway.transports.telegram.turn_output import TelegramTurnOutput
 from platform.analytics.usage_context import UsageSurface, bound_usage_context
 from platform.turn_host.turn_callback import TurnCallback
 
@@ -87,7 +87,7 @@ async def handle_polled_inbound_telegram_message(
                 preview,
             )
 
-            sink = TelegramOutputSink(
+            output = TelegramTurnOutput(
                 client=client,
                 chat_id=event.chat_id,
                 edit_interval_seconds=settings.stream_edit_interval_seconds,
@@ -102,7 +102,7 @@ async def handle_polled_inbound_telegram_message(
 
             event_loop = loop or asyncio.get_running_loop()
             terminal = TerminalOutcomeArbiter()
-            sink.turn_cancel = terminal.cancel_event
+            output.turn_cancel = terminal.cancel_event
 
             def _on_turn_timeout() -> None:
                 logger.warning(
@@ -112,7 +112,7 @@ async def handle_polled_inbound_telegram_message(
                     session.session_id[:8],
                 )
                 try:
-                    sink.finalize(TURN_TIMEOUT_MESSAGE)
+                    output.finalize(TURN_TIMEOUT_MESSAGE)
                 except Exception:
                     logger.debug(
                         "[telegram-gateway] timeout finalize failed",
@@ -123,7 +123,7 @@ async def handle_polled_inbound_telegram_message(
                 if not terminal.claim():
                     return
                 try:
-                    sink.finalize(USER_STOP_MESSAGE)
+                    output.finalize(USER_STOP_MESSAGE)
                 except Exception:
                     logger.debug("[telegram-gateway] user-stop finalize failed", exc_info=True)
 
@@ -139,7 +139,7 @@ async def handle_polled_inbound_telegram_message(
                     handle_callback_to_gateway_agent(
                         event.text,
                         session,
-                        sink,
+                        output,
                         logger,
                     )
 
@@ -159,7 +159,7 @@ async def handle_polled_inbound_telegram_message(
                     )
                     if terminal.claim():
                         try:
-                            sink.render_error(TURN_ERROR_MESSAGE)
+                            output.render_error(TURN_ERROR_MESSAGE)
                         except Exception:
                             logger.debug(
                                 "[telegram-gateway] error finalize failed",

--- a/gateway/transports/telegram/turn_output.py
+++ b/gateway/transports/telegram/turn_output.py
@@ -1,4 +1,4 @@
-"""Telegram output sink with typing indicator and throttled message streaming."""
+"""Telegram turn output with typing indicator and throttled message streaming."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ def _log_preview(text: str) -> str:
     return preview
 
 
-class TelegramOutputSink:
+class TelegramTurnOutput:
     """Stream assistant output back through the Telegram Bot API."""
 
     def __init__(

--- a/gateway/web/AGENTS.md
+++ b/gateway/web/AGENTS.md
@@ -1,7 +1,7 @@
 # gateway/web/ — web surface
 
 FastAPI app for health probes, alert intake, and investigations.
-Not a chat transport — does not bind a turn handler or output sink.
+Not a chat transport — does not bind a turn handler or turn output.
 
 | May import | Must not |
 |------------|----------|

--- a/gateway/web/__init__.py
+++ b/gateway/web/__init__.py
@@ -4,7 +4,7 @@ Primary entry: :mod:`gateway.web.webapp` (``app``) — used by
 ``uvicorn gateway.web.webapp:app`` when ``MODE=web``, and by the gateway
 daemon / interactive shell via :mod:`gateway.web.web_server`.
 
-Not a chat transport: does not bind a turn handler or sink. May import
+Not a chat transport: does not bind a turn handler or turn output. May import
 ``gateway.core``; must not import ``gateway.transports``.
 """
 

--- a/tests/scheduler/test_delivery_conformance.py
+++ b/tests/scheduler/test_delivery_conformance.py
@@ -1,0 +1,114 @@
+"""Which providers each delivery consumer actually supports, stated once.
+
+``Provider`` offers six members to every caller, and no caller supports all
+six. Each consumer picks a subset, and until now those subsets lived in prose:
+the enum docstring says consumers "define their own documented subset rather
+than exposing a choice that would silently fail".
+
+This file is that documentation as an assertion. Each expectation below is
+compared for exact equality against what the code can actually reach, so a new
+provider, a removed branch, or a consumer quietly widening its support fails
+here rather than at a user's delivery time.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from platform.scheduling.scheduler import delivery, executor
+from platform.scheduling.scheduler.types import Provider
+from tools.system.watch_dog import runner
+from tools.system.watch_dog.config import WATCHDOG_SUPPORTED_PROVIDERS
+
+#: Every member the vocabulary offers a caller.
+ALL_PROVIDERS = frozenset(Provider)
+
+#: What ``executor._deliver_single`` has an explicit branch for. Anything else
+#: reaches the ``else`` and fails the task with "Unsupported provider".
+EXECUTOR_DELIVERS = frozenset(
+    {
+        Provider.TELEGRAM,
+        Provider.SLACK,
+        Provider.DISCORD,
+        Provider.ROCKETCHAT,
+        Provider.INTERACTIVE_SHELL,
+    }
+)
+
+#: What ``delivery._DELIVERY_SPECS`` knows how to check readiness and print
+#: setup hints for. Narrower than what the executor can send to.
+DELIVERY_SPECS_COVER = frozenset({Provider.TELEGRAM, Provider.SLACK, Provider.ROCKETCHAT})
+
+#: What the watchdog's dispatcher distinguishes. Telegram is the documented
+#: fallthrough, so it has no branch of its own.
+WATCHDOG_BRANCHES = frozenset({Provider.ROCKETCHAT, Provider.BUZZ})
+
+
+def _providers_named_in(function: object) -> frozenset[Provider]:
+    """Every ``Provider.MEMBER`` the function's own source mentions."""
+    source = textwrap.dedent(inspect.getsource(function))
+    names = {
+        node.attr
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "Provider"
+    }
+    return frozenset(Provider[name] for name in names if name in Provider.__members__)
+
+
+def test_the_executor_delivers_to_exactly_these_providers() -> None:
+    """The send path's branches are the real answer to "can this be delivered?"."""
+    # Arrange / Act
+    reachable = _providers_named_in(executor._deliver_single)
+
+    # Assert
+    assert reachable == EXECUTOR_DELIVERS
+
+
+def test_buzz_is_offered_by_the_vocabulary_and_refused_by_the_executor() -> None:
+    """A scheduled task set to ``buzz`` fails at delivery, not at creation.
+
+    ``Provider.BUZZ`` exists because the watchdog delivers to it. Cron delivery
+    does not, so the enum offers a cron task a choice its executor will refuse
+    with "Unsupported provider". Pinned so the gap stays visible; delete this
+    test when the executor grows a buzz branch or the vocabularies split.
+    """
+    # Assert
+    assert Provider.BUZZ in ALL_PROVIDERS
+    assert Provider.BUZZ not in EXECUTOR_DELIVERS
+
+
+def test_the_spec_list_is_narrower_than_what_the_executor_can_send_to() -> None:
+    """Readiness and setup hints cover fewer providers than delivery reaches.
+
+    ``interactive_shell`` is excluded on purpose — it is a local inbox, not a
+    chat/webhook channel, so digest CLIs must not offer it. ``discord`` is not:
+    the executor delivers to it while ``any_delivery_ready`` and the setup hints
+    do not know it exists.
+    """
+    # Arrange / Act
+    specs = frozenset(delivery.SUPPORTED_DELIVERY_PROVIDERS)
+
+    # Assert
+    assert specs == DELIVERY_SPECS_COVER
+    assert Provider.INTERACTIVE_SHELL in EXECUTOR_DELIVERS - specs
+    assert Provider.DISCORD in EXECUTOR_DELIVERS - specs
+
+
+def test_the_watchdog_declares_what_its_dispatcher_can_build() -> None:
+    """Declared support must match the dispatcher, or a provider routes silently.
+
+    ``_build_dispatcher`` branches on Rocket.Chat and Buzz and falls through to
+    Telegram. Adding a member to ``WATCHDOG_SUPPORTED_PROVIDERS`` without a
+    branch would not raise — it would deliver that alarm to Telegram.
+    """
+    # Arrange / Act
+    declared = frozenset(WATCHDOG_SUPPORTED_PROVIDERS)
+    branched = _providers_named_in(runner._build_dispatcher)
+
+    # Assert
+    assert branched == WATCHDOG_BRANCHES
+    assert declared == branched | {Provider.TELEGRAM}

--- a/tests/scheduler/test_delivery_conformance.py
+++ b/tests/scheduler/test_delivery_conformance.py
@@ -46,23 +46,33 @@ DELIVERY_SPECS_COVER = frozenset({Provider.TELEGRAM, Provider.SLACK, Provider.RO
 WATCHDOG_BRANCHES = frozenset({Provider.ROCKETCHAT, Provider.BUZZ})
 
 
-def _providers_named_in(function: object) -> frozenset[Provider]:
-    """Every ``Provider.MEMBER`` the function's own source mentions."""
+def _providers_branched_on(function: object) -> frozenset[Provider]:
+    """``Provider.MEMBER`` values compared in ``if`` / ``elif`` tests.
+
+    Mentions used only for logging, validation, or diagnostics are ignored:
+    a reference is not a delivery branch.
+    """
     source = textwrap.dedent(inspect.getsource(function))
-    names = {
-        node.attr
-        for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "Provider"
-    }
-    return frozenset(Provider[name] for name in names if name in Provider.__members__)
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        for sub in ast.walk(node.test):
+            if (
+                isinstance(sub, ast.Attribute)
+                and isinstance(sub.value, ast.Name)
+                and sub.value.id == "Provider"
+                and sub.attr in Provider.__members__
+            ):
+                names.add(sub.attr)
+    return frozenset(Provider[name] for name in names)
 
 
 def test_the_executor_delivers_to_exactly_these_providers() -> None:
     """The send path's branches are the real answer to "can this be delivered?"."""
     # Arrange / Act
-    reachable = _providers_named_in(executor._deliver_single)
+    reachable = _providers_branched_on(executor._deliver_single)
 
     # Assert
     assert reachable == EXECUTOR_DELIVERS
@@ -107,7 +117,7 @@ def test_the_watchdog_declares_what_its_dispatcher_can_build() -> None:
     """
     # Arrange / Act
     declared = frozenset(WATCHDOG_SUPPORTED_PROVIDERS)
-    branched = _providers_named_in(runner._build_dispatcher)
+    branched = _providers_branched_on(runner._build_dispatcher)
 
     # Assert
     assert branched == WATCHDOG_BRANCHES


### PR DESCRIPTION
`Provider` offers six members to every caller. No caller supports all six, and
until now each consumer's subset lived in prose — the enum docstring even says
consumers *"define their own documented subset rather than exposing a choice
that would silently fail."* This makes that documentation an assertion.

**Writing it down surfaced three different answers to "supported" in one
package:**

| | Supports |
| --- | --- |
| `Provider` offers | telegram, slack, discord, rocketchat, interactive_shell, **buzz** |
| `executor._deliver_single` | telegram, slack, discord, rocketchat, interactive_shell |
| `delivery._DELIVERY_SPECS` | telegram, slack, rocketchat |
| watchdog | telegram, rocketchat, buzz |

**`buzz` is offered to a cron task and refused by its executor.** It is in the
vocabulary because the watchdog delivers to it; `_deliver_single` has no branch,
so it reaches the `else` and fails with *"Unsupported provider"* — at delivery
time, not at creation. That is finding 6's "the enum offers choices that
silently fail", made concrete.

**`discord` is delivered but unknown to readiness.** The executor sends to it
while `any_delivery_ready()` and the setup hints do not know it exists.
`interactive_shell` is in the same gap *deliberately* — documented as a local
inbox so digest CLIs do not offer it as a channel — and the test distinguishes
the intentional exclusion from the accidental one.

*The watchdog fallthrough is a live hazard.** `_build_dispatcher` branches on
Rocket.Chat and Buzz and falls through to Telegram. Adding a member to
`WATCHDOG_SUPPORTED_PROVIDERS` without a branch would not raise — that alarm
would go to Telegram. The test asserts `declared == branched | {TELEGRAM}`.

Sets are read from the code by AST rather than restated, so the branches are the
source of truth and only the expectations are compared.