### PR TITLE
fix(kafka): make ConsumerGroupTopicPartitions import resilient across confluent-kafka versions

### DIFF
--- a/integrations/kafka/__init__.py
+++ b/integrations/kafka/__init__.py
@@ -251,9 +251,19 @@ def get_consumer_group_lag(
 
     try:
         from confluent_kafka import TopicPartition
-        from confluent_kafka.admin import (  # type: ignore[attr-defined]
-            ConsumerGroupTopicPartitions,
-        )
+
+        try:
+            # confluent-kafka >=2.15.0 moved this class out of the public
+            # confluent_kafka.admin namespace (now private there as
+            # _ConsumerGroupTopicPartitions); the library's own
+            # list_consumer_group_offsets docstring points at this location.
+            from confluent_kafka._model import (
+                ConsumerGroupTopicPartitions,  # type: ignore[attr-defined]
+            )
+        except ImportError:
+            from confluent_kafka.admin import (  # type: ignore[attr-defined,no-redef]
+                ConsumerGroupTopicPartitions,
+            )
 
         admin = _get_admin_client(config)
         consumer = _get_consumer(config)

--- a/tests/integrations/test_kafka.py
+++ b/tests/integrations/test_kafka.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 
-import integrations.kafka as kafka_module
 from integrations.kafka import (
     KafkaConfig,
     KafkaValidationResult,
@@ -197,8 +196,8 @@ class TestGetConsumerGroupLagImportCompat:
         from confluent_kafka._model import ConsumerGroupTopicPartitions as ModelClass
 
         admin = _FakeAdminClient()
-        monkeypatch.setattr(kafka_module, "_get_admin_client", lambda _config: admin)
-        monkeypatch.setattr(kafka_module, "_get_consumer", lambda _config: _FakeConsumer())
+        monkeypatch.setattr("integrations.kafka._get_admin_client", lambda _config: admin)
+        monkeypatch.setattr("integrations.kafka._get_consumer", lambda _config: _FakeConsumer())
 
         result = get_consumer_group_lag(self._config(), group_id="verify-group")
 
@@ -230,8 +229,8 @@ class TestGetConsumerGroupLagImportCompat:
         )
 
         admin = _FakeAdminClient()
-        monkeypatch.setattr(kafka_module, "_get_admin_client", lambda _config: admin)
-        monkeypatch.setattr(kafka_module, "_get_consumer", lambda _config: _FakeConsumer())
+        monkeypatch.setattr("integrations.kafka._get_admin_client", lambda _config: admin)
+        monkeypatch.setattr("integrations.kafka._get_consumer", lambda _config: _FakeConsumer())
 
         result = get_consumer_group_lag(self._config(), group_id="verify-group")
 

--- a/tests/integrations/test_kafka.py
+++ b/tests/integrations/test_kafka.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+import pytest
+
 import integrations.kafka as kafka_module
 from integrations.kafka import (
     KafkaConfig,
@@ -191,6 +193,7 @@ class TestGetConsumerGroupLagImportCompat:
         return KafkaConfig(bootstrap_servers="broker:9092")
 
     def test_uses_the_model_location_when_available(self, monkeypatch: Any) -> None:
+        pytest.importorskip("confluent_kafka")
         from confluent_kafka._model import ConsumerGroupTopicPartitions as ModelClass
 
         admin = _FakeAdminClient()
@@ -205,10 +208,11 @@ class TestGetConsumerGroupLagImportCompat:
     def test_falls_back_to_the_admin_location_when_model_lacks_it(self, monkeypatch: Any) -> None:
         """Simulates an older confluent-kafka where the class is only public
         under confluent_kafka.admin, by hiding it from confluent_kafka._model
-        and installing a distinct stand-in class at the admin location — so
+        and installing a distinct stand-in class at the admin location, so
         the assertion (isinstance of *that* stand-in) can only pass if the
         except branch actually ran, not the try branch.
         """
+        pytest.importorskip("confluent_kafka")
         import confluent_kafka._model as model_module
         import confluent_kafka.admin as admin_module
 
@@ -237,9 +241,10 @@ class TestGetConsumerGroupLagImportCompat:
 
     def test_raises_clean_error_when_neither_location_has_it(self, monkeypatch: Any) -> None:
         """Both locations missing the class is a genuinely broken confluent-kafka
-        install — confirms that case fails closed through the outer except
+        install. Confirms that case fails closed through the outer except
         (tool_unavailable), not with an unrelated traceback.
         """
+        pytest.importorskip("confluent_kafka")
         import confluent_kafka._model as model_module
         import confluent_kafka.admin as admin_module
 

--- a/tests/integrations/test_kafka.py
+++ b/tests/integrations/test_kafka.py
@@ -1,9 +1,13 @@
 """Unit tests for the Kafka integration module."""
 
+from typing import Any
+
+import integrations.kafka as kafka_module
 from integrations.kafka import (
     KafkaConfig,
     KafkaValidationResult,
     build_kafka_config,
+    get_consumer_group_lag,
     kafka_config_from_env,
 )
 
@@ -120,3 +124,129 @@ class TestKafkaValidationResult:
     def test_error_result(self) -> None:
         result = KafkaValidationResult(ok=False, detail="Connection refused.")
         assert result.ok is False
+
+
+class _FakeTopicPartitionOffset:
+    def __init__(self, topic: str, partition: int, offset: int) -> None:
+        self.topic = topic
+        self.partition = partition
+        self.offset = offset
+        self.error = None
+
+
+class _FakeGroupResult:
+    def __init__(self, topic_partitions: list[Any]) -> None:
+        self.topic_partitions = topic_partitions
+
+
+class _FakeFuture:
+    def __init__(self, result: Any) -> None:
+        self._result = result
+
+    def result(self) -> Any:
+        return self._result
+
+
+class _FakeAdminClient:
+    """Records the exact object passed to list_consumer_group_offsets.
+
+    That object's *type* is what proves which import branch
+    (confluent_kafka._model vs confluent_kafka.admin) get_consumer_group_lag
+    actually took — it constructs ConsumerGroupTopicPartitions(group_id) from
+    whichever location it imported and passes that instance straight through.
+    """
+
+    def __init__(self) -> None:
+        self.captured_request: Any = None
+
+    def list_consumer_group_offsets(self, requests: list[Any]) -> dict[str, _FakeFuture]:
+        self.captured_request = requests[0]
+        offset = _FakeTopicPartitionOffset("verify-topic", 0, offset=5)
+        return {"verify-group": _FakeFuture(_FakeGroupResult([offset]))}
+
+
+class _FakeConsumer:
+    def get_watermark_offsets(self, _tp: Any, timeout: float) -> tuple[int, int]:
+        # get_consumer_group_lag calls this with timeout= as a keyword, so
+        # the parameter name must match even though the value is unused.
+        del timeout
+        return (0, 20)
+
+    def close(self) -> None:
+        pass
+
+
+class TestGetConsumerGroupLagImportCompat:
+    """Pins which confluent_kafka location ConsumerGroupTopicPartitions
+    resolves from, per the two branches in get_consumer_group_lag's nested
+    try/except. Both branches construct the SAME callable
+    (ConsumerGroupTopicPartitions(group_id)) and pass it straight through to
+    admin.list_consumer_group_offsets, so asserting the *type* of the object
+    the fake admin client actually received is what proves the executed
+    branch, not just that lag math still works (which would pass even if the
+    import silently resolved to the wrong location, or none at all).
+    """
+
+    def _config(self) -> KafkaConfig:
+        return KafkaConfig(bootstrap_servers="broker:9092")
+
+    def test_uses_the_model_location_when_available(self, monkeypatch: Any) -> None:
+        from confluent_kafka._model import ConsumerGroupTopicPartitions as ModelClass
+
+        admin = _FakeAdminClient()
+        monkeypatch.setattr(kafka_module, "_get_admin_client", lambda _config: admin)
+        monkeypatch.setattr(kafka_module, "_get_consumer", lambda _config: _FakeConsumer())
+
+        result = get_consumer_group_lag(self._config(), group_id="verify-group")
+
+        assert result["available"] is True
+        assert isinstance(admin.captured_request, ModelClass)
+
+    def test_falls_back_to_the_admin_location_when_model_lacks_it(self, monkeypatch: Any) -> None:
+        """Simulates an older confluent-kafka where the class is only public
+        under confluent_kafka.admin, by hiding it from confluent_kafka._model
+        and installing a distinct stand-in class at the admin location — so
+        the assertion (isinstance of *that* stand-in) can only pass if the
+        except branch actually ran, not the try branch.
+        """
+        import confluent_kafka._model as model_module
+        import confluent_kafka.admin as admin_module
+
+        monkeypatch.delattr(model_module, "ConsumerGroupTopicPartitions", raising=False)
+
+        class _FallbackConsumerGroupTopicPartitions:
+            def __init__(self, group_id: str) -> None:
+                self.group_id = group_id
+
+        monkeypatch.setattr(
+            admin_module,
+            "ConsumerGroupTopicPartitions",
+            _FallbackConsumerGroupTopicPartitions,
+            raising=False,
+        )
+
+        admin = _FakeAdminClient()
+        monkeypatch.setattr(kafka_module, "_get_admin_client", lambda _config: admin)
+        monkeypatch.setattr(kafka_module, "_get_consumer", lambda _config: _FakeConsumer())
+
+        result = get_consumer_group_lag(self._config(), group_id="verify-group")
+
+        assert result["available"] is True
+        assert isinstance(admin.captured_request, _FallbackConsumerGroupTopicPartitions)
+        assert admin.captured_request.group_id == "verify-group"
+
+    def test_raises_clean_error_when_neither_location_has_it(self, monkeypatch: Any) -> None:
+        """Both locations missing the class is a genuinely broken confluent-kafka
+        install — confirms that case fails closed through the outer except
+        (tool_unavailable), not with an unrelated traceback.
+        """
+        import confluent_kafka._model as model_module
+        import confluent_kafka.admin as admin_module
+
+        monkeypatch.delattr(model_module, "ConsumerGroupTopicPartitions", raising=False)
+        monkeypatch.delattr(admin_module, "ConsumerGroupTopicPartitions", raising=False)
+
+        result = get_consumer_group_lag(self._config(), group_id="verify-group")
+
+        assert result["available"] is False
+        assert "ConsumerGroupTopicPartitions" in result["error"]


### PR DESCRIPTION
<!-- Add issue number above -->

Related to #5132 (Verify kafka: 2 registered tools) - found while live-verifying that integration against a real broker, not itself a full verification pass.

#### Describe the changes you have made in this PR -

`get_kafka_consumer_group_lag` raised `ImportError: cannot import name 'ConsumerGroupTopicPartitions'` on a fresh install. Root cause: `pyproject.toml` pins `confluent-kafka>=2.14.0` with no upper bound, and `confluent-kafka>=2.15.0` moved this class out of the public `confluent_kafka.admin` namespace (it is now private there as `_ConsumerGroupTopicPartitions`). This breaks every fresh install of the `kafka` extra today, not just one environment - it is not a test-only issue.

The library's own `list_consumer_group_offsets` docstring points at `confluent_kafka._model.ConsumerGroupTopicPartitions` as the current public location. The import now tries that first and falls back to the old `confluent_kafka.admin` location for any older resolved version still within the `>=2.14.0` constraint, rather than just swapping one hardcoded path for another and reintroducing the same fragility against the next resolved version.

### Demo/Screenshot for feature changes and bug fixes -

Verified against a live single-node KRaft Kafka broker (`apache/kafka:3.8.0` in Docker), not only the existing mocked test suite (which mocks at the `admin.list_consumer_group_offsets` call level and would not catch an import-time failure):

```
# Before the fix
$ get_kafka_consumer_group_lag(bootstrap_servers='localhost:9092', group_id='verify-group')
{"source": "kafka", "available": false, "error": "cannot import name 'ConsumerGroupTopicPartitions' from 'confluent_kafka.admin' ..."}

# After the fix - produced 20 messages, consumed 5
$ get_kafka_consumer_group_lag(bootstrap_servers='localhost:9092', group_id='verify-group')
{"available": true, "group_id": "verify-group", "total_lag": 15, "partitions": [...]}
```

```
ruff check / ruff format --check / mypy   -> all clean
make check-imports                         -> all clean
pytest tests/integrations/test_kafka.py tests/tools/test_kafka_consumer_group_tool.py tests/tools/test_kafka_topic_health_tool.py
  -> 59 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Found this by actually running the kafka integration against a live broker rather than trusting the existing mocked test suite, which passes regardless since it never imports the real `confluent_kafka` module at the point of failure. Confirmed the exact installed version (2.15.0) and inspected `confluent_kafka.admin` directly to see the class was renamed private there, then checked the library's own `list_consumer_group_offsets` docstring to find the currently-correct public location rather than guessing. Chose a try/except fallback over a hard version pin because the existing `>=2.14.0` constraint already allows older resolved versions that may still use the old location, and a single hardcoded path (old or new) would just move the fragility rather than remove it.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
