### PR TITLE
fix(openobserve): fix default query table name and start/end time units

### DIFF
--- a/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
+++ b/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
@@ -136,21 +136,35 @@ def query_openobserve_logs(
     effective_limit = _bounded_limit(limit, max_results)
     now = datetime.now(UTC)
     start = now - timedelta(minutes=max(1, time_range_minutes))
-    normalized_query = query.strip() or (
-        "SELECT * FROM \"default\" WHERE level = 'error' ORDER BY _timestamp DESC"
-    )
+    stream_name = stream.strip()
+    normalized_query = query.strip()
+    if not normalized_query:
+        if not stream_name:
+            return tool_unavailable(
+                "openobserve",
+                "No query given and no stream configured to build a default one "
+                "against - set OPENOBSERVE_STREAM or pass an explicit query.",
+                records=[],
+            )
+        normalized_query = (
+            f"SELECT * FROM \"{stream_name}\" WHERE level = 'error' ORDER BY _timestamp DESC"
+        )
 
     endpoint = f"{base}/api/{(org or 'default').strip()}/_search"
     payload: dict[str, Any] = {
         "query": {
             "sql": normalized_query,
-            "start_time": int(start.timestamp() * 1000),
-            "end_time": int(now.timestamp() * 1000),
+            # OpenObserve's _search API takes start_time/end_time in
+            # microseconds since epoch, not milliseconds — a millisecond
+            # value silently matches nothing (no error) rather than raising,
+            # since it resolves to a time range near the Unix epoch.
+            "start_time": int(start.timestamp() * 1_000_000),
+            "end_time": int(now.timestamp() * 1_000_000),
         },
         "size": effective_limit,
     }
-    if stream.strip():
-        payload["stream_name"] = stream.strip()
+    if stream_name:
+        payload["stream_name"] = stream_name
 
     headers = {"Content-Type": "application/json"}
     headers.update(_auth_headers(auth_token, user, secret))

--- a/tests/tools/test_integration_wave_tools.py
+++ b/tests/tools/test_integration_wave_tools.py
@@ -131,6 +131,7 @@ def test_openobserve_tool_caps_size_and_output(monkeypatch: Any) -> None:
         base_url="https://openobserve.example.invalid",
         org="acme",
         api_token="oo-token",
+        stream="app_logs",
         limit=1000,
         max_results=4,
     )
@@ -138,7 +139,7 @@ def test_openobserve_tool_caps_size_and_output(monkeypatch: Any) -> None:
     assert captured["size"] == 4
     assert (
         captured["sql"]
-        == "SELECT * FROM \"default\" WHERE level = 'error' ORDER BY _timestamp DESC"
+        == "SELECT * FROM \"app_logs\" WHERE level = 'error' ORDER BY _timestamp DESC"
     )
     assert result["available"] is True
     assert len(result["records"]) == 4

--- a/tests/tools/test_openobserve_logs_tool.py
+++ b/tests/tools/test_openobserve_logs_tool.py
@@ -187,6 +187,7 @@ def test_uses_bearer_authorization_when_api_token_present(
     query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert captured["headers"]["Authorization"] == "Bearer oo-token"
     assert captured["headers"]["Content-Type"] == "application/json"
@@ -209,6 +210,7 @@ def test_uses_basic_authorization_when_only_username_password_present(
         base_url="https://oo.example.invalid",
         username="alice",
         password="secret",
+        stream="app_logs",
     )
     expected = base64.b64encode(b"alice:secret").decode("ascii")
     assert captured["headers"]["Authorization"] == f"Basic {expected}"
@@ -230,6 +232,7 @@ def test_bearer_takes_precedence_over_basic(monkeypatch: pytest.MonkeyPatch) -> 
         api_token="oo-token",
         username="alice",
         password="secret",
+        stream="app_logs",
     )
     # When both are provided, bearer wins
     assert captured["headers"]["Authorization"] == "Bearer oo-token"
@@ -255,6 +258,7 @@ def test_endpoint_uses_default_org_when_blank(monkeypatch: pytest.MonkeyPatch) -
         base_url="https://oo.example.invalid/",  # trailing slash should be stripped
         org="",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert captured["url"] == "https://oo.example.invalid/api/default/_search"
 
@@ -274,6 +278,7 @@ def test_endpoint_includes_provided_org(monkeypatch: pytest.MonkeyPatch) -> None
         base_url="https://oo.example.invalid",
         org="acme",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert captured["url"] == "https://oo.example.invalid/api/acme/_search"
 
@@ -293,9 +298,10 @@ def test_default_sql_used_when_query_blank(monkeypatch: pytest.MonkeyPatch) -> N
         base_url="https://oo.example.invalid",
         api_token="oo-token",
         query="",
+        stream="app_logs",
     )
     sql = captured["payload"]["query"]["sql"]
-    assert sql == "SELECT * FROM \"default\" WHERE level = 'error' ORDER BY _timestamp DESC"
+    assert sql == "SELECT * FROM \"app_logs\" WHERE level = 'error' ORDER BY _timestamp DESC"
 
 
 def test_provided_query_is_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -335,12 +341,18 @@ def test_payload_includes_size_and_time_window(monkeypatch: pytest.MonkeyPatch) 
         api_token="oo-token",
         time_range_minutes=15,
         max_results=42,
+        stream="app_logs",
     )
     payload = captured["payload"]
     assert payload["size"] == 42
     assert "start_time" in payload["query"]
     assert "end_time" in payload["query"]
     assert payload["query"]["end_time"] > payload["query"]["start_time"]
+    # microseconds, not milliseconds - OpenObserve's _search API silently
+    # matches nothing on a millisecond value instead of raising.
+    expected_window_us = 15 * 60 * 1_000_000
+    actual_window = payload["query"]["end_time"] - payload["query"]["start_time"]
+    assert abs(actual_window - expected_window_us) < 1_000_000
 
 
 def test_stream_name_only_included_when_provided(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -354,11 +366,13 @@ def test_stream_name_only_included_when_provided(monkeypatch: pytest.MonkeyPatch
         "integrations.openobserve.tools.openobserve_logs_tool.httpx.post", _fake_post
     )
 
-    # Without stream
+    # Without stream - needs an explicit query since an empty stream can no
+    # longer build a default one (see test_no_stream_and_no_query_is_unavailable)
     query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
         stream="",
+        query="SELECT * FROM \"whatever\" WHERE level = 'error'",
     )
     # With stream
     query_openobserve_logs(
@@ -387,6 +401,7 @@ def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> N
         api_token="oo-token",
         limit=1000,
         max_results=4,
+        stream="app_logs",
     )
     assert captured["size"] == 4
     assert result["available"] is True
@@ -410,6 +425,7 @@ def test_records_from_top_level_hits_list(monkeypatch: pytest.MonkeyPatch) -> No
     result = query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert result["records"] == [{"a": 1}, {"a": 2}]
 
@@ -434,6 +450,7 @@ def test_records_from_elastic_style_nested_hits(monkeypatch: pytest.MonkeyPatch)
     result = query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert result["records"] == [{"msg": "boom"}, {"msg": "kaboom"}]
 
@@ -449,8 +466,9 @@ def test_records_from_records_field(monkeypatch: pytest.MonkeyPatch) -> None:
     result = query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
-    # Only dict items are kept — strings are filtered out
+    # Only dict items are kept - strings are filtered out
     assert result["records"] == [{"x": 1}, {"x": 2}]
 
 
@@ -465,6 +483,7 @@ def test_records_from_data_field(monkeypatch: pytest.MonkeyPatch) -> None:
     result = query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert result["records"] == [{"y": 9}]
 
@@ -480,6 +499,7 @@ def test_records_empty_on_unrecognized_shape(monkeypatch: pytest.MonkeyPatch) ->
     result = query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert result["available"] is True
     assert result["records"] == []
@@ -504,6 +524,7 @@ def test_returns_unavailable_on_http_error_status(monkeypatch: pytest.MonkeyPatc
     result = query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert result["available"] is False
     assert "HTTP 502 from OpenObserve" in result["error"]
@@ -519,7 +540,30 @@ def test_returns_unavailable_on_request_exception(monkeypatch: pytest.MonkeyPatc
     result = query_openobserve_logs(
         base_url="https://oo.example.invalid",
         api_token="oo-token",
+        stream="app_logs",
     )
     assert result["available"] is False
     assert "connection refused" in result["error"]
+    assert result["records"] == []
+
+
+def test_no_stream_and_no_query_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither stream nor an explicit query gives no valid table for the SQL
+    FROM clause - the old fallback hardcoded FROM "default", which is the org
+    name, not a real stream, and fails with a 400 against a real server.
+    """
+
+    def _fail_if_called(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("httpx.post should not be called without a stream or query")
+
+    monkeypatch.setattr(
+        "integrations.openobserve.tools.openobserve_logs_tool.httpx.post", _fail_if_called
+    )
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert result["available"] is False
+    assert "OPENOBSERVE_STREAM" in result["error"]
     assert result["records"] == []


### PR DESCRIPTION
<!-- Add issue number above -->

Related to #5140 (Verify openobserve: 1 registered tool) - found while live-verifying that integration against a real instance, not itself a full verification pass.

#### Describe the changes you have made in this PR -

Two independent, confirmed bugs in `query_openobserve_logs`:

1. **Wrong default table name.** The fallback query (used whenever no explicit `query` is given) hardcoded `FROM "default"` - that's the org name, not a stream name - so it fails with a 400 against a real OpenObserve instance unless the user's stream happens to be literally named `default`. Now uses the configured `OPENOBSERVE_STREAM` in the default query, and returns a clear `tool_unavailable` (rather than guessing a wrong table name) when neither a stream nor an explicit query is available.
2. **Wrong time unit.** `start_time`/`end_time` were computed in milliseconds (`timestamp() * 1000`); OpenObserve's `_search` API expects microseconds. This does not error - it silently matches nothing, since the resulting window sits near the Unix epoch. Every default-query call was returning zero results even when matching logs existed.

### Demo/Screenshot for feature changes and bug fixes -

Verified against a live OpenObserve instance (`public.ecr.aws/zinclabs/openobserve` in Docker) with real ingested log data, hand-crafting both time-unit variants directly against the raw API to isolate the exact cause before touching code:

```
# Raw API call, start_time/end_time in milliseconds (the old behavior)
$ curl .../_search -d '{"query":{"sql":"SELECT * FROM \"verify_stream\" ...", "start_time": <ms>, "end_time": <ms>}}'
{"hits":[],"total":0,...}

# Same call, microseconds (the fix)
{"hits":[{"_timestamp":...,"level":"error","message":"verify service error: timeout",...}],"total":2,...}

# Tool call before the fix (default query, stream configured)
$ query_openobserve_logs(base_url=..., stream='verify_stream', ...)
{"available": false, "error": "Client error '400 Bad Request' ..."}

# After the fix
{"available": true, "total_returned": 1, "records": [{"level": "error", "message": "verify service error: timeout", ...}]}
```

```
ruff check / ruff format --check / mypy   -> all clean
make check-imports                         -> all clean
pytest tests/tools/test_openobserve_logs_tool.py tests/integrations/test_openobserve.py -> 41 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Found both bugs by actually running the tool against a live OpenObserve instance rather than trusting the existing mocked test suite, which passes regardless since its mocks never exercise a real server's validation of the SQL or its interpretation of the time fields. Isolated the second bug by hand-crafting the raw HTTP request with both millisecond and microsecond values directly against the live API to prove the unit mismatch conclusively before changing any code, rather than guessing. The 16 existing tests that broke were not testing incorrect behavior on purpose - they were unit tests whose mocked `httpx.post` never got a chance to reject the hardcoded `"default"` table name the way a real server does, so they happened to reach their real assertions (auth headers, payload shape, response parsing) via a request that would have failed in production. Fixed each to pass an explicit `stream` (their actual, unaffected intent), rather than loosening the new guard to keep them passing unmodified.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
