### PR TITLE
test(harness): shared turn-seam stubs and fake LlmRunInfo helper

### DIFF
--- a/tests/core/agent_harness/session/test_upgrade_cta_accept.py
+++ b/tests/core/agent_harness/session/test_upgrade_cta_accept.py
@@ -11,7 +11,7 @@ from core.agent_harness.session.pending_offer import (
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from surfaces.interactive_shell.session import Session
-
+from tests.shared.harness_turn_driver import answer_with_text, no_evidence
 
 def test_l0_cta_arms_integration_setup_offer_and_yes_expands() -> None:
     session = Session()
@@ -34,8 +34,8 @@ def test_l0_cta_arms_integration_setup_offer_and_yes_expands() -> None:
         "how many windows users last 7 days",
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "should-not-run",
-        answer=lambda *_a, **_k: type("Run", (), {"response_text": "Draft outline."})(),
+        gather=no_evidence,
+        answer=answer_with_text("Draft outline."),
         accounting=DefaultTurnAccounting(session, "ask"),
     )
 

--- a/tests/core/agent_harness/session/test_upgrade_cta_accept.py
+++ b/tests/core/agent_harness/session/test_upgrade_cta_accept.py
@@ -13,6 +13,7 @@ from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from surfaces.interactive_shell.session import Session
 from tests.shared.harness_turn_driver import answer_with_text, no_evidence
 
+
 def test_l0_cta_arms_integration_setup_offer_and_yes_expands() -> None:
     session = Session()
     session.resolved_integrations_cache = {}

--- a/tests/shared/harness_turn_driver.py
+++ b/tests/shared/harness_turn_driver.py
@@ -18,8 +18,15 @@ from typing import Any
 from rich.console import Console
 
 from core.agent_harness import OutputSink, TurnResult
-from core.agent_harness.ports import ToolExecutionHooks, TurnBinding
+from core.agent_harness.ports import (
+    AnswerRequest,
+    GatheredEvidence,
+    StreamAnswerFn,
+    ToolExecutionHooks,
+    TurnBinding,
+)
 from core.agent_harness.runtime import HeadlessAgent
+from core.agent_harness.spi.accounting import LlmRunInfo
 from core.agent_harness.spi.session_goal import SessionGoal, format_session_goal_progress
 from core.agent_harness.turns.host_cancel import host_cancel_requested
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink
@@ -97,4 +104,23 @@ def run_harness_turn(
     )
 
 
-__all__ = ["run_harness_turn"]
+def no_evidence(text: str, *, turn_plan: Any = None) -> GatheredEvidence | None:
+    """An EvidenceGatherer that finds nothing."""
+    return None
+
+
+def fake_llm_run(*, response_text: str = "") -> LlmRunInfo:
+    """A real LlmRunInfo for turn tests; fill whatever the type requires."""
+    return LlmRunInfo(response_text=response_text)
+
+
+def answer_with_text(response_text: str) -> StreamAnswerFn:
+    """An answer stage returning one fixed response."""
+
+    def _answer(text: str, request: AnswerRequest) -> LlmRunInfo:
+        return fake_llm_run(response_text=response_text)
+
+    return _answer
+
+
+__all__ = ["answer_with_text", "fake_llm_run", "no_evidence", "run_harness_turn"]


### PR DESCRIPTION
Fixes #5187

#### Describe the changes you have made in this PR -
- Added shared test helpers (`no_evidence`, `fake_llm_run`, `answer_with_text`) to `tests/shared/harness_turn_driver.py`.
- Replaced anonymous lambda turn-stage fakes in `test_upgrade_cta_accept.py` with these new shared stubs, conforming to the established Protocol interfaces.

### Demo/Screenshot for feature changes and bug fixes - 
N/A (Code health/test refactoring only, no UI/feature changes).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
This PR extracts ad-hoc test fakes (`lambda *_a, **_k: ...`) into reusable shared stubs in `tests/shared/harness_turn_driver.py` (`no_evidence`, `fake_llm_run`, `answer_with_text`). By doing so, we ensure that test doubles strictly match their required `Protocol` signatures instead of silently swallowing all arguments, preventing future divergence and making the tests more robust.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
