### PR TITLE
fix(prefect): mark prefect as a directly-effective integration

### DIFF
--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -392,7 +392,7 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(service="clickhouse", has_verifier=True, verify_order=23),
     IntegrationSpec(service="alicloud", direct_effective=True),
     IntegrationSpec(service="notion"),
-    IntegrationSpec(service="prefect", has_verifier=True, verify_order=51),
+    IntegrationSpec(service="prefect", has_verifier=True, direct_effective=True, verify_order=51),
     IntegrationSpec(
         service="posthog",
         has_verifier=True,

--- a/tests/integrations/test_catalog_multi_instance.py
+++ b/tests/integrations/test_catalog_multi_instance.py
@@ -333,3 +333,25 @@ def test_resolve_effective_integrations_carries_instances_through_pydantic() -> 
     assert [i["name"] for i in all_inst] == ["prod", "staging"]
     assert "config" in all_inst[0]  # shape preserved through Pydantic
     assert "integration_id" in all_inst[0]
+
+
+def test_resolve_effective_integrations_publishes_store_configured_prefect() -> None:
+    """Regression: prefect's IntegrationSpec was missing direct_effective=True,
+    so classify_integrations() resolved a store-saved prefect config correctly
+    but resolve_effective_integrations() silently dropped it — it only
+    publishes services listed in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES. This
+    broke `opensre integrations verify prefect` ("missing" even with valid
+    store credentials) and the prefect tools' is_available() check, which
+    reads from this same resolution."""
+    from integrations.catalog import resolve_effective_integrations
+
+    store_record = {
+        "id": "prefect-1",
+        "service": "prefect",
+        "status": "active",
+        "credentials": {"api_url": "http://localhost:4200/api", "api_key": ""},
+    }
+    resolved = resolve_effective_integrations(store_integrations=[store_record])
+    assert "prefect" in resolved
+    assert resolved["prefect"]["source"] == "local store"
+    assert resolved["prefect"]["config"]["api_url"] == "http://localhost:4200/api"

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -86,6 +86,21 @@ def test_railway_is_registered_as_a_configurable_verified_integration() -> None:
     assert "railway" not in SKIP_CLASSIFIED_SERVICES
 
 
+def test_prefect_is_registered_as_a_directly_effective_integration() -> None:
+    # #(prefect verify sweep): prefect's classify() resolves store credentials
+    # into a config object just like dagster/temporal, but its spec was missing
+    # direct_effective=True — resolve_effective_integrations() only publishes
+    # services listed in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES, so a prefect
+    # integration saved in the local store silently never resolved, breaking
+    # both `opensre integrations verify prefect` and the prefect tools'
+    # is_available() check for any store-configured instance.
+    prefect = next(spec for spec in INTEGRATION_SPECS if spec.service == "prefect")
+
+    assert prefect.has_verifier is True
+    assert prefect.direct_effective is True
+    assert "prefect" not in SKIP_CLASSIFIED_SERVICES
+
+
 def test_resolve_management_service_keeps_posthog_and_posthog_mcp_distinct() -> None:
     # Like sentry / sentry_mcp, bare posthog is the REST integration and
     # posthog_mcp is the separate MCP flow — they must not alias each other.

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -87,12 +87,12 @@ def test_railway_is_registered_as_a_configurable_verified_integration() -> None:
 
 
 def test_prefect_is_registered_as_a_directly_effective_integration() -> None:
-    # #(prefect verify sweep): prefect's classify() resolves store credentials
-    # into a config object just like dagster/temporal, but its spec was missing
-    # direct_effective=True — resolve_effective_integrations() only publishes
-    # services listed in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES, so a prefect
-    # integration saved in the local store silently never resolved, breaking
-    # both `opensre integrations verify prefect` and the prefect tools'
+    # prefect's classify() resolves store credentials into a config object
+    # just like dagster/temporal, but its spec was missing direct_effective=True
+    # — resolve_effective_integrations() only publishes services listed in
+    # DIRECT_CLASSIFIED_EFFECTIVE_SERVICES, so a prefect integration saved in
+    # the local store silently never resolved, breaking both
+    # `opensre integrations verify prefect` and the prefect tools'
     # is_available() check for any store-configured instance.
     prefect = next(spec for spec in INTEGRATION_SPECS if spec.service == "prefect")
 


### PR DESCRIPTION
Fixes #5147

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Found while live-verifying Prefect's two registered investigation tools (`prefect_flow_runs`, `prefect_worker_health`) against a real local Prefect server. Prefect's `IntegrationSpec` in `integrations/registry.py` was missing `direct_effective=True`, unlike the structurally identical `dagster` and `temporal` specs (same pattern: a `classify()` function that resolves store credentials into a config object, registered via `register_verifier`).

`resolve_effective_integrations()` only publishes services listed in `DIRECT_CLASSIFIED_EFFECTIVE_SERVICES` (derived from `spec.direct_effective`). Without that flag, `classify_integrations()` correctly resolved a store-saved Prefect config into a `PrefectIntegrationConfig` object, but `resolve_effective_integrations()` silently dropped it before it ever reached the "effective" dict `opensre integrations verify` and the tool `is_available()` checks read from.

Reproduced live: saved a real `prefect` record to `~/.opensre/integrations.json` (`api_url` pointing at a local `prefect server start` instance), and `opensre integrations verify prefect` reported `missing` — "Credentials for prefect are saved in the local store... but they did not resolve into a usable runtime config" — even though the credentials were valid and reachable. Both `prefect_flow_runs` and `prefect_worker_health` gate on the same `sources.get("prefect", {}).get("connection_verified")` check, so any Prefect integration configured via the local store (the only documented setup path for Prefect — there is no `opensre integrations setup prefect` wizard) was silently unusable by the investigation/chat tools.

Fix is a one-line addition of `direct_effective=True` to the `prefect` `IntegrationSpec`, matching `dagster`/`temporal`.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix, against a real local Prefect server with a valid store-configured integration:
```
SERVICE │ SOURCE │ STATUS    │ DETAIL
━━━━━━━━┿━━━━━━━━┿━━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
prefect │ -      │ ⚠ missing │ Credentials for prefect are saved in the local
        │        │           │ store (prefect-verify), but they did not resolve
        │        │           │ into a usable runtime config. Check required
        │        │           │ fields and re-run setup.
```

After the fix, same store record, same live server:
```
SERVICE │ SOURCE      │ STATUS   │ DETAIL
━━━━━━━━┿━━━━━━━━━━━━━┿━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
prefect │ local store │ ✓ passed │ Configured for Prefect at
        │             │          │ http://localhost:4201/api.
```

Then both registered tools invoked directly against the same live server (real flow runs — one success, one induced failure with a real traceback — and a real online worker in a `process` work pool):
```
prefect_flow_runs -> failed_runs: [{'id': 'a13a97bb-...', 'state_type': 'FAILED', ...}]
                      logs include the real RuntimeError traceback from the failed task
prefect_worker_health -> work_pools: [{'name': 'verify-pool', 'status': 'READY', ...}]
                          workers: [{'name': 'ProcessWorker ...', 'status': 'ONLINE', ...}]
```

Regression test proof: reverted the one-line fix locally and reran the two new tests — both failed with the exact symptom above (`direct_effective is False`, `'prefect' not in resolved`), then restored the fix and confirmed green.

Local checks run: `make lint`, `make format-check`, `make typecheck` (all clean), `tests/integrations/` (3558 passed, 7 skipped), `tests/tools/test_prefect_flow_runs_tool.py`, `tests/tools/test_prefect_worker_health_tool.py` (31 passed).

**Note:** while verifying this fix I found the same root cause (`IntegrationSpec` missing `direct_effective=True`, service silently unresolvable from the local store) also affects `bitbucket` and `supabase` — reproduced the same way with a synthetic store record. Scoping this PR to prefect only since that's what was under verification; flagging separately rather than bundling unrelated services into this fix.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This bug was found while live-verifying Prefect's investigation tools end to end (real local Prefect server, real flow runs, real worker) as part of a broader integration-verification sweep. The `is_available` check on both Prefect tools, and the CLI `verify` command, both go through `integrations.catalog.resolve_effective_integrations()`. I traced why a store-configured Prefect integration with valid credentials was reported as "missing" by comparing its resolution path against `classify_integrations()` (which succeeded) versus `resolve_effective_integrations()` (which dropped it), and found the difference was the `DIRECT_CLASSIFIED_EFFECTIVE_SERVICES` allowlist built from each `IntegrationSpec.direct_effective` flag. Dagster and Temporal, which use the identical `classify()`-based resolution pattern, both had the flag set; Prefect's spec did not. The fix is the minimal one-line correction. I added two regression tests: a static registry invariant test (mirroring the existing `railway` test in the same file) and a behavioral test that calls `resolve_effective_integrations()` with an injected store record to pin the actual end-to-end symptom, not just the spec field.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.