### PR TITLE
fix(telegram): dispatch turns as tasks so approvals can resolve

### DIFF
--- a/gateway/tests/telegram/test_background.py
+++ b/gateway/tests/telegram/test_background.py
@@ -80,10 +80,13 @@ def _run_loop(
     *,
     resources: TelegramPollingRuntime,
     stop_event: threading.Event,
+    shutdown_drain_seconds: float = 2.0,
 ) -> asyncio.Task[None]:
     return asyncio.create_task(
         background._poll_telegram_until_stopped(
-            settings=GatewaySettings(bot_token="tok", shutdown_drain_seconds=2.0),
+            settings=GatewaySettings(
+                bot_token="tok", shutdown_drain_seconds=shutdown_drain_seconds
+            ),
             stop_event=stop_event,
             logger=LOGGER,
             resources=resources,
@@ -173,26 +176,35 @@ async def test_a_failing_turn_does_not_stop_polling() -> None:
 
 
 @pytest.mark.asyncio
-async def test_in_flight_turns_finish_before_shutdown_returns() -> None:
-    """Detached turns are drained, not cancelled mid-flight by ``asyncio.run``."""
+async def test_shutdown_cancels_the_turn_body_not_only_its_await() -> None:
+    """A turn that outlives the drain budget gets its cancel Event set.
+
+    Cancelling the task only unwinds the ``await``; the turn body runs on the
+    executor and never sees that. It stops when its ``turn_cancel`` Event is
+    set, and only then does ``executor.shutdown(wait=True)`` return inside the
+    shutdown budget instead of blocking to the turn timeout.
+    """
     # Arrange
     poller = _FakePoller([TelegramPollResult(messages=[_message()])])
     turn_started = asyncio.Event()
-    turn_finished = False
+    seen: list[threading.Event] = []
 
-    async def _slow_turn(_event, **_kwargs) -> None:
-        nonlocal turn_finished
+    async def _turn_outliving_the_budget(_event, *, turn_cancel=None, **_kwargs) -> None:
+        seen.append(turn_cancel)
         turn_started.set()
-        await asyncio.sleep(0.05)
-        turn_finished = True
+        await asyncio.sleep(30)
 
     stop_event = threading.Event()
 
     with (
         patch.object(background, "TelegramPoller", lambda _token: poller),
-        patch.object(background, "handle_polled_inbound_telegram_message", _slow_turn),
+        patch.object(
+            background, "handle_polled_inbound_telegram_message", _turn_outliving_the_budget
+        ),
     ):
-        loop_task = _run_loop(resources=_resources(), stop_event=stop_event)
+        loop_task = _run_loop(
+            resources=_resources(), stop_event=stop_event, shutdown_drain_seconds=0.05
+        )
         await asyncio.wait_for(turn_started.wait(), timeout=2.0)
 
         # Act — shut down while the turn is still running.
@@ -200,7 +212,8 @@ async def test_in_flight_turns_finish_before_shutdown_returns() -> None:
         await asyncio.wait_for(loop_task, timeout=3.0)
 
     # Assert
-    assert turn_finished is True
+    assert seen and seen[0] is not None
+    assert seen[0].is_set(), "drain cancelled the await but left the turn body running"
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/telegram/test_background.py
+++ b/gateway/tests/telegram/test_background.py
@@ -1,25 +1,34 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from gateway.core.middleware.active_turns import ActiveTurnRegistry
+from gateway.core.middleware.approvals import ApprovalBroker
+from gateway.transports.telegram import background
 from gateway.transports.telegram.background import start_telegram_gateway_background
+from gateway.transports.telegram.poller.poller import TelegramPollResult
 from gateway.transports.telegram.runtime import (
+    TelegramPollingRuntime,
     initialize_telegram_polling_runtime,
     shutdown_telegram_polling_runtime,
 )
-from gateway.transports.telegram.settings import GatewaySettings
+from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
+
+LOGGER = logging.getLogger("gateway.test")
 
 
 @patch("gateway.transports.telegram.background.TelegramPoller")
 def test_start_starts_poll_thread(mock_poller_cls: MagicMock) -> None:
-    from gateway.transports.telegram.poller.poller import TelegramPollResult
-
     mock_poller_cls.return_value.poll_once.return_value = TelegramPollResult()
-    logger = logging.getLogger("gateway.test")
     handle = start_telegram_gateway_background(
         settings=GatewaySettings(bot_token="tok"),
-        logger=logger,
+        logger=LOGGER,
         initialize_runtime=initialize_telegram_polling_runtime,
         shutdown_runtime=shutdown_telegram_polling_runtime,
         handle_callback_to_gateway_agent=lambda *_args: None,
@@ -27,3 +36,198 @@ def test_start_starts_poll_thread(mock_poller_cls: MagicMock) -> None:
     assert handle is not None
     handle.stop(timeout=1.0)
     mock_poller_cls.assert_called_once_with("tok")
+
+
+def _message(text: str = "hello", *, chat_id: str = "chat-1") -> TelegramInboundMessage:
+    return TelegramInboundMessage(
+        update_id=1,
+        user_id="user-1",
+        chat_id=chat_id,
+        message_id="msg-1",
+        text=text,
+    )
+
+
+def _resources() -> TelegramPollingRuntime:
+    return TelegramPollingRuntime(
+        client=MagicMock(),
+        bindings=MagicMock(),
+        session_resolver=MagicMock(),
+        chat_locks={},
+        executor=MagicMock(),
+        approvals=ApprovalBroker(),
+        active_cancels=ActiveTurnRegistry(),
+    )
+
+
+class _FakePoller:
+    """Serves scripted batches, then empty ones, counting every call."""
+
+    def __init__(self, batches: list[TelegramPollResult]) -> None:
+        self._batches = list(batches)
+        self.calls = 0
+
+    def poll_once(self) -> TelegramPollResult:
+        self.calls += 1
+        if self._batches:
+            return self._batches.pop(0)
+        # Real getUpdates long-polls; keep the idle loop off a hot spin.
+        time.sleep(0.01)
+        return TelegramPollResult()
+
+
+def _run_loop(
+    *,
+    resources: TelegramPollingRuntime,
+    stop_event: threading.Event,
+) -> asyncio.Task[None]:
+    return asyncio.create_task(
+        background._poll_telegram_until_stopped(
+            settings=GatewaySettings(bot_token="tok", shutdown_drain_seconds=2.0),
+            stop_event=stop_event,
+            logger=LOGGER,
+            resources=resources,
+            handle_callback_to_gateway_agent=lambda *_args: None,
+        )
+    )
+
+
+async def _wait_until(predicate, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise AssertionError("condition never became true")
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_polling_continues_while_a_turn_is_in_flight() -> None:
+    """Regression: a turn awaiting approval must not freeze the poll loop.
+
+    The click that resolves an approval only ever arrives on a *later*
+    ``poll_once``. A loop that awaits the turn inline is still suspended on
+    that turn, so it can never reach the poll that would deliver the click —
+    the request always expires to denied no matter how fast the user clicks.
+    """
+    # Arrange
+    poller = _FakePoller([TelegramPollResult(messages=[_message()])])
+    turn_started = asyncio.Event()
+    release_turn = asyncio.Event()
+
+    async def _turn_blocked_on_approval(_event, **_kwargs) -> None:
+        turn_started.set()
+        await release_turn.wait()
+
+    stop_event = threading.Event()
+
+    with (
+        patch.object(background, "TelegramPoller", lambda _token: poller),
+        patch.object(
+            background,
+            "handle_polled_inbound_telegram_message",
+            _turn_blocked_on_approval,
+        ),
+    ):
+        loop_task = _run_loop(resources=_resources(), stop_event=stop_event)
+
+        # Act
+        await asyncio.wait_for(turn_started.wait(), timeout=2.0)
+        polls_when_turn_began = poller.calls
+        await _wait_until(lambda: poller.calls > polls_when_turn_began)
+
+        # Assert — the loop polled again while the turn was still blocked.
+        assert poller.calls > polls_when_turn_began
+        assert not release_turn.is_set()  # the turn never unblocked itself
+
+        stop_event.set()
+        release_turn.set()
+        await asyncio.wait_for(loop_task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_a_failing_turn_does_not_stop_polling() -> None:
+    """A detached turn's exception is logged, never left to kill the loop."""
+    # Arrange
+    poller = _FakePoller([TelegramPollResult(messages=[_message()])])
+
+    async def _exploding_turn(_event, **_kwargs) -> None:
+        msg = "turn blew up"
+        raise RuntimeError(msg)
+
+    stop_event = threading.Event()
+
+    with (
+        patch.object(background, "TelegramPoller", lambda _token: poller),
+        patch.object(background, "handle_polled_inbound_telegram_message", _exploding_turn),
+    ):
+        loop_task = _run_loop(resources=_resources(), stop_event=stop_event)
+
+        # Act
+        await _wait_until(lambda: poller.calls >= 3)
+
+        # Assert
+        assert not loop_task.done()
+        stop_event.set()
+        await asyncio.wait_for(loop_task, timeout=2.0)
+        assert loop_task.exception() is None
+
+
+@pytest.mark.asyncio
+async def test_in_flight_turns_finish_before_shutdown_returns() -> None:
+    """Detached turns are drained, not cancelled mid-flight by ``asyncio.run``."""
+    # Arrange
+    poller = _FakePoller([TelegramPollResult(messages=[_message()])])
+    turn_started = asyncio.Event()
+    turn_finished = False
+
+    async def _slow_turn(_event, **_kwargs) -> None:
+        nonlocal turn_finished
+        turn_started.set()
+        await asyncio.sleep(0.05)
+        turn_finished = True
+
+    stop_event = threading.Event()
+
+    with (
+        patch.object(background, "TelegramPoller", lambda _token: poller),
+        patch.object(background, "handle_polled_inbound_telegram_message", _slow_turn),
+    ):
+        loop_task = _run_loop(resources=_resources(), stop_event=stop_event)
+        await asyncio.wait_for(turn_started.wait(), timeout=2.0)
+
+        # Act — shut down while the turn is still running.
+        stop_event.set()
+        await asyncio.wait_for(loop_task, timeout=3.0)
+
+    # Assert
+    assert turn_finished is True
+
+
+@pytest.mark.asyncio
+async def test_stop_command_is_handled_without_dispatching_a_turn() -> None:
+    """`/stop` still resolves through the registry, never as a new turn."""
+    # Arrange
+    poller = _FakePoller([TelegramPollResult(messages=[_message("/stop")])])
+    dispatched = False
+
+    async def _turn(_event, **_kwargs) -> None:
+        nonlocal dispatched
+        dispatched = True
+
+    resources = _resources()
+    stop_event = threading.Event()
+
+    with (
+        patch.object(background, "TelegramPoller", lambda _token: poller),
+        patch.object(background, "handle_polled_inbound_telegram_message", _turn),
+    ):
+        loop_task = _run_loop(resources=resources, stop_event=stop_event)
+
+        # Act
+        await _wait_until(lambda: poller.calls >= 2)
+        stop_event.set()
+        await asyncio.wait_for(loop_task, timeout=2.0)
+
+    # Assert
+    assert dispatched is False
+    resources.client.send_message.assert_called_once()

--- a/gateway/tests/telegram/test_background.py
+++ b/gateway/tests/telegram/test_background.py
@@ -231,3 +231,40 @@ async def test_stop_command_is_handled_without_dispatching_a_turn() -> None:
     # Assert
     assert dispatched is False
     resources.client.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_in_same_batch_cancels_the_turn_dispatched_before_it() -> None:
+    """Regression: `/stop` must find a turn dispatched earlier in the same batch.
+
+    Dispatch is detached, so the turn has not reached its own registration by
+    the time `/stop` is read. Unless the cancel Event is registered at dispatch,
+    `/stop` reports "no active turn" and the turn it meant to stop runs on.
+    """
+    # Arrange
+    poller = _FakePoller([TelegramPollResult(messages=[_message("hello"), _message("/stop")])])
+    started = asyncio.Event()
+    cancel_seen: list[bool] = []
+
+    async def _turn(_event, *, turn_cancel=None, **_kwargs) -> None:
+        cancel_seen.append(turn_cancel is not None and turn_cancel.is_set())
+        started.set()
+
+    resources = _resources()
+    stop_event = threading.Event()
+
+    with (
+        patch.object(background, "TelegramPoller", lambda _token: poller),
+        patch.object(background, "handle_polled_inbound_telegram_message", _turn),
+    ):
+        loop_task = _run_loop(resources=resources, stop_event=stop_event)
+
+        # Act
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        stop_event.set()
+        await asyncio.wait_for(loop_task, timeout=2.0)
+
+    # Assert — /stop found the turn, so no "nothing to stop" reply went out,
+    # and the turn itself observed the cancellation.
+    assert resources.client.send_message.call_args_list == []
+    assert cancel_seen == [True]

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -19,7 +19,7 @@ from gateway.transports.telegram.runtime import (
     ShutdownTelegramPollingRuntime,
     TelegramPollingRuntime,
 )
-from gateway.transports.telegram.settings import GatewaySettings
+from gateway.transports.telegram.settings import GatewaySettings, TelegramInboundMessage
 from infrastructure.turn_host.turn_callback import TurnCallback
 
 
@@ -67,9 +67,19 @@ async def _poll_telegram_until_stopped(
     resources: TelegramPollingRuntime,
     handle_callback_to_gateway_agent: TurnCallback,
 ) -> None:
-    """Poll Telegram updates and dispatch them until shutdown is requested."""
+    """Poll Telegram updates and dispatch them until shutdown is requested.
+
+    Turn dispatch is fired as a background task, never awaited inline: a turn
+    can sit blocked in ``ApprovalBroker.wait`` for up to
+    ``MAX_APPROVAL_WAIT_SECONDS``, and this same loop is the only thing that
+    can ever deliver the button click that unblocks it. Awaiting the turn here
+    would stall polling for the whole approval wait, so the click resolving it
+    could never be observed and every approval would expire to denied. The Buzz
+    transport documents and avoids the same trap.
+    """
     poller = TelegramPoller(settings.bot_token)
     turn_semaphore = asyncio.Semaphore(settings.max_concurrent_turns)
+    pending_tasks: set[asyncio.Task[None]] = set()
 
     resources.client.delete_webhook()
 
@@ -93,20 +103,99 @@ async def _poll_telegram_until_stopped(
                     if not resources.active_cancels.request_stop(event.chat_id):
                         resources.client.send_message(event.chat_id, NO_ACTIVE_TURN_MESSAGE)
                     continue
-                await handle_polled_inbound_telegram_message(
-                    event,
-                    client=resources.client,
-                    session_resolver=resources.session_resolver,
-                    settings=settings,
-                    executor=resources.executor,
-                    chat_locks=resources.chat_locks,
-                    turn_semaphore=turn_semaphore,
-                    approvals=resources.approvals,
-                    active_cancels=resources.active_cancels,
-                    loop=loop,
-                    handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
+                task = asyncio.create_task(
+                    _dispatch_turn(
+                        event,
+                        settings=settings,
+                        logger=logger,
+                        resources=resources,
+                        turn_semaphore=turn_semaphore,
+                        loop=loop,
+                        handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
+                    )
                 )
+                pending_tasks.add(task)
+                task.add_done_callback(pending_tasks.discard)
 
         except Exception:
             logger.error("Error while polling Telegram updates", exc_info=True)
             await asyncio.to_thread(stop_event.wait, 2)
+
+    await _drain_active_turns(pending_tasks, settings=settings, logger=logger)
+
+
+async def _dispatch_turn(
+    event: TelegramInboundMessage,
+    *,
+    settings: GatewaySettings,
+    logger: logging.Logger,
+    resources: TelegramPollingRuntime,
+    turn_semaphore: asyncio.Semaphore,
+    loop: asyncio.AbstractEventLoop,
+    handle_callback_to_gateway_agent: TurnCallback,
+) -> None:
+    """Run one turn to completion, logging rather than raising on failure.
+
+    The turn is detached from the poll loop, so its exception has nowhere to
+    surface: the loop's own ``except`` no longer covers it, and an unretrieved
+    task exception is reported only when the task is garbage collected. The
+    turn's own error path has already told the chat by then, so this logs the
+    failure and lets polling carry on.
+    """
+    try:
+        await handle_polled_inbound_telegram_message(
+            event,
+            client=resources.client,
+            session_resolver=resources.session_resolver,
+            settings=settings,
+            executor=resources.executor,
+            chat_locks=resources.chat_locks,
+            turn_semaphore=turn_semaphore,
+            approvals=resources.approvals,
+            active_cancels=resources.active_cancels,
+            loop=loop,
+            handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
+        )
+    except Exception:
+        logger.error(
+            "[telegram-gateway] turn dispatch failed user=%s chat=%s",
+            event.user_id,
+            event.chat_id,
+            exc_info=True,
+        )
+
+
+async def _drain_active_turns(
+    pending_tasks: set[asyncio.Task[None]],
+    *,
+    settings: GatewaySettings,
+    logger: logging.Logger,
+) -> None:
+    """Let in-flight turns finish before the event loop closes under them.
+
+    ``asyncio.run`` cancels whatever is still pending once this coroutine
+    returns, so a detached turn would otherwise die mid-flight and never post
+    its outcome to the chat.
+
+    The wait is deliberately bounded rather than generous: polling has already
+    stopped, so nothing can deliver a button click any more, and a turn parked
+    in ``ApprovalBroker.wait`` would otherwise hold shutdown for the full
+    ``MAX_APPROVAL_WAIT_SECONDS`` expiry. Whatever misses the budget is
+    cancelled and logged.
+    """
+    if not pending_tasks:
+        return
+
+    _done, still_running = await asyncio.wait(
+        pending_tasks, timeout=settings.shutdown_drain_seconds
+    )
+    for task in still_running:
+        task.cancel()
+    if still_running:
+        logger.warning(
+            "[telegram-gateway] shutting down with %d unfinished turn(s)",
+            len(still_running),
+        )
+
+
+__all__ = ["start_telegram_gateway_background"]

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -69,13 +69,8 @@ async def _poll_telegram_until_stopped(
 ) -> None:
     """Poll Telegram updates and dispatch them until shutdown is requested.
 
-    Turn dispatch is fired as a background task, never awaited inline: a turn
-    can sit blocked in ``ApprovalBroker.wait`` for up to
-    ``MAX_APPROVAL_WAIT_SECONDS``, and this same loop is the only thing that
-    can ever deliver the button click that unblocks it. Awaiting the turn here
-    would stall polling for the whole approval wait, so the click resolving it
-    could never be observed and every approval would expire to denied. The Buzz
-    transport documents and avoids the same trap.
+    Dispatch is detached, never awaited inline: this loop is the only thing that
+    delivers the button click resolving a turn blocked in ``ApprovalBroker.wait``.
     """
     poller = TelegramPoller(settings.bot_token)
     turn_semaphore = asyncio.Semaphore(settings.max_concurrent_turns)
@@ -103,6 +98,10 @@ async def _poll_telegram_until_stopped(
                     if not resources.active_cancels.request_stop(event.chat_id):
                         resources.client.send_message(event.chat_id, NO_ACTIVE_TURN_MESSAGE)
                     continue
+                # Registered before the task exists: a /stop later in this same
+                # batch must find the accepted turn, not "nothing".
+                turn_cancel = threading.Event()
+                resources.active_cancels.register(event.chat_id, turn_cancel)
                 task = asyncio.create_task(
                     _dispatch_turn(
                         event,
@@ -110,6 +109,7 @@ async def _poll_telegram_until_stopped(
                         logger=logger,
                         resources=resources,
                         turn_semaphore=turn_semaphore,
+                        turn_cancel=turn_cancel,
                         loop=loop,
                         handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
                     )
@@ -131,16 +131,14 @@ async def _dispatch_turn(
     logger: logging.Logger,
     resources: TelegramPollingRuntime,
     turn_semaphore: asyncio.Semaphore,
+    turn_cancel: threading.Event,
     loop: asyncio.AbstractEventLoop,
     handle_callback_to_gateway_agent: TurnCallback,
 ) -> None:
     """Run one turn to completion, logging rather than raising on failure.
 
-    The turn is detached from the poll loop, so its exception has nowhere to
-    surface: the loop's own ``except`` no longer covers it, and an unretrieved
-    task exception is reported only when the task is garbage collected. The
-    turn's own error path has already told the chat by then, so this logs the
-    failure and lets polling carry on.
+    Detached from the poll loop, so an exception here reaches no other handler.
+    Always unregisters ``turn_cancel``, including on failure.
     """
     try:
         await handle_polled_inbound_telegram_message(
@@ -153,6 +151,7 @@ async def _dispatch_turn(
             turn_semaphore=turn_semaphore,
             approvals=resources.approvals,
             active_cancels=resources.active_cancels,
+            turn_cancel=turn_cancel,
             loop=loop,
             handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
         )
@@ -163,6 +162,8 @@ async def _dispatch_turn(
             event.chat_id,
             exc_info=True,
         )
+    finally:
+        resources.active_cancels.unregister(event.chat_id, turn_cancel)
 
 
 async def _drain_active_turns(
@@ -171,17 +172,10 @@ async def _drain_active_turns(
     settings: GatewaySettings,
     logger: logging.Logger,
 ) -> None:
-    """Let in-flight turns finish before the event loop closes under them.
+    """Let in-flight turns finish before ``asyncio.run`` closes the loop.
 
-    ``asyncio.run`` cancels whatever is still pending once this coroutine
-    returns, so a detached turn would otherwise die mid-flight and never post
-    its outcome to the chat.
-
-    The wait is deliberately bounded rather than generous: polling has already
-    stopped, so nothing can deliver a button click any more, and a turn parked
-    in ``ApprovalBroker.wait`` would otherwise hold shutdown for the full
-    ``MAX_APPROVAL_WAIT_SECONDS`` expiry. Whatever misses the budget is
-    cancelled and logged.
+    Bounded: polling has stopped, so no click can resolve an approval wait any
+    more. Whatever misses ``shutdown_drain_seconds`` is cancelled.
     """
     if not pending_tasks:
         return

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -74,7 +74,10 @@ async def _poll_telegram_until_stopped(
     """
     poller = TelegramPoller(settings.bot_token)
     turn_semaphore = asyncio.Semaphore(settings.max_concurrent_turns)
-    pending_tasks: set[asyncio.Task[None]] = set()
+    pending_turns: dict[asyncio.Task[None], threading.Event] = {}
+
+    def _forget(task: asyncio.Task[None]) -> None:
+        pending_turns.pop(task, None)
 
     resources.client.delete_webhook()
 
@@ -114,14 +117,14 @@ async def _poll_telegram_until_stopped(
                         handle_callback_to_gateway_agent=handle_callback_to_gateway_agent,
                     )
                 )
-                pending_tasks.add(task)
-                task.add_done_callback(pending_tasks.discard)
+                pending_turns[task] = turn_cancel
+                task.add_done_callback(_forget)
 
         except Exception:
             logger.error("Error while polling Telegram updates", exc_info=True)
             await asyncio.to_thread(stop_event.wait, 2)
 
-    await _drain_active_turns(pending_tasks, settings=settings, logger=logger)
+    await _drain_active_turns(pending_turns, settings=settings, logger=logger)
 
 
 async def _dispatch_turn(
@@ -167,7 +170,7 @@ async def _dispatch_turn(
 
 
 async def _drain_active_turns(
-    pending_tasks: set[asyncio.Task[None]],
+    pending_turns: dict[asyncio.Task[None], threading.Event],
     *,
     settings: GatewaySettings,
     logger: logging.Logger,
@@ -175,15 +178,21 @@ async def _drain_active_turns(
     """Let in-flight turns finish before ``asyncio.run`` closes the loop.
 
     Bounded: polling has stopped, so no click can resolve an approval wait any
-    more. Whatever misses ``shutdown_drain_seconds`` is cancelled.
+    more. Whatever misses ``shutdown_drain_seconds`` has its cancel Event set
+    before its task is cancelled — the turn body runs on the executor, which
+    cancelling the awaiting task does not reach, so only the Event stops it in
+    time for ``executor.shutdown(wait=True)``.
     """
-    if not pending_tasks:
+    if not pending_turns:
         return
 
     _done, still_running = await asyncio.wait(
-        pending_tasks, timeout=settings.shutdown_drain_seconds
+        set(pending_turns), timeout=settings.shutdown_drain_seconds
     )
     for task in still_running:
+        turn_cancel = pending_turns.get(task)
+        if turn_cancel is not None:
+            turn_cancel.set()
         task.cancel()
     if still_running:
         logger.warning(

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import AbstractContextManager, nullcontext
 
 from config.constants.gateway import TURN_ERROR_MESSAGE, TURN_TIMEOUT_MESSAGE, USER_STOP_MESSAGE
 from config.scope_context import bound_storage_scope
@@ -41,10 +43,16 @@ async def handle_polled_inbound_telegram_message(
     turn_semaphore: asyncio.Semaphore,
     approvals: ApprovalBroker,
     active_cancels: ActiveTurnRegistry,
+    turn_cancel: threading.Event | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
     handle_callback_to_gateway_agent: TurnCallback,
 ) -> None:
-    """Process one long-polled inbound Telegram update."""
+    """Process one long-polled inbound Telegram update.
+
+    ``turn_cancel`` is the Event the dispatcher already registered for this
+    chat, so a ``/stop`` arriving before the turn started is honoured rather
+    than lost.
+    """
     user_lock = chat_locks.setdefault(event.user_id, asyncio.Lock())
     decision = enforce_inbound_telegram_message_security(
         user_id=event.user_id,
@@ -101,7 +109,7 @@ async def handle_polled_inbound_telegram_message(
             )
 
             event_loop = loop or asyncio.get_running_loop()
-            terminal = TerminalOutcomeArbiter()
+            terminal = TerminalOutcomeArbiter(turn_cancel)
             output.turn_cancel = terminal.cancel_event
 
             def _on_turn_timeout() -> None:
@@ -143,13 +151,29 @@ async def handle_polled_inbound_telegram_message(
                         logger,
                     )
 
+            if turn_cancel is None:
+                registration: AbstractContextManager[None] = active_cancels.track(
+                    event.chat_id,
+                    terminal.cancel_event,
+                    on_user_stop=_on_user_stop,
+                )
+            else:
+                active_cancels.bind_user_stop(event.chat_id, turn_cancel, _on_user_stop)
+                registration = nullcontext()
+
+            # A /stop that landed between dispatch registration and here only set
+            # the Event; nothing has run yet, so answer it instead of the agent.
+            if terminal.cancel_event.is_set():
+                if terminal.claim():
+                    try:
+                        output.finalize(USER_STOP_MESSAGE)
+                    except Exception:
+                        logger.debug("[telegram-gateway] user-stop finalize failed", exc_info=True)
+                return
+
             with terminal.timeout_after(settings.turn_timeout_seconds, _on_turn_timeout):
                 try:
-                    with active_cancels.track(
-                        event.chat_id,
-                        terminal.cancel_event,
-                        on_user_stop=_on_user_stop,
-                    ):
+                    with registration:
                         await event_loop.run_in_executor(executor, _run_turn)
                 except Exception:
                     logger.exception(

--- a/gateway/transports/telegram/settings.py
+++ b/gateway/transports/telegram/settings.py
@@ -27,6 +27,7 @@ class GatewaySettings(StrictConfigModel):
     max_concurrent_turns: int = Field(default_factory=turn_limit_for_profile, ge=1)
     stream_edit_interval_seconds: float = Field(default=1.5, gt=0)
     turn_timeout_seconds: float = Field(default=240.0, gt=0)
+    shutdown_drain_seconds: float = Field(default=5.0, gt=0)
     auto_start_enabled: bool = True
 
 


### PR DESCRIPTION
Fixes #5076

#### Describe the changes you have made in this PR -

The Telegram poll loop awaited turn dispatch inline, so a turn blocked in `ApprovalBroker.wait` held the one coroutine that could ever deliver the button click resolving it. The click only arrives on a later `poll_once`, which the suspended loop can never reach — so every Telegram approval expired to denied after `MAX_APPROVAL_WAIT_SECONDS` regardless of how fast the user clicked, and polling for every other chat stayed frozen for that window.

**`gateway/transports/telegram/background.py`**
- Turn dispatch is now fired with `asyncio.create_task` into a `pending_tasks` set, never awaited inline — the same pattern `gateway/transports/buzz/background.py` already documents and uses for this exact failure mode.
- New `_dispatch_turn` wraps the turn so a detached task's exception is logged. The loop's own `except` no longer covers it, and an unretrieved task exception would otherwise surface only at garbage-collection time.
- New `_drain_active_turns` gives in-flight turns a bounded window on shutdown, because `asyncio.run` cancels whatever is still pending once the loop coroutine returns. The budget is deliberately small: polling has stopped, so nothing can deliver a click any more, and a turn parked in `ApprovalBroker.wait` would otherwise hold shutdown for the full expiry.

**`gateway/transports/telegram/settings.py`**
- Adds `shutdown_drain_seconds` (default `5.0`), mirroring the existing Buzz setting the drain budget needs.

**`gateway/tests/telegram/test_background.py`**
- Four tests: the deadlock itself, detached-task error isolation, the shutdown drain, and `/stop` still resolving through the registry without dispatching a turn.

No behaviour change to the turn itself, the inbound security checks, or the `/stop` path.

### Demo/Screenshot for feature changes and bug fixes -

The two new regression tests fail against `main` and pass with the fix.

**Against `main`** (fix reverted, new tests kept):

```
FAILED gateway/tests/telegram/test_background.py::test_polling_continues_while_a_turn_is_in_flight
FAILED gateway/tests/telegram/test_background.py::test_a_failing_turn_does_not_stop_polling
========================= 2 failed, 3 passed in 5.70s ==========================
```

**With the fix applied:**

```
gateway/tests/telegram/test_background.py::test_start_starts_poll_thread PASSED
gateway/tests/telegram/test_background.py::test_polling_continues_while_a_turn_is_in_flight PASSED
gateway/tests/telegram/test_background.py::test_a_failing_turn_does_not_stop_polling PASSED
gateway/tests/telegram/test_background.py::test_in_flight_turns_finish_before_shutdown_returns PASSED
gateway/tests/telegram/test_background.py::test_stop_command_is_handled_without_dispatching_a_turn PASSED
============================== 5 passed in 5.08s ===============================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!-- to be completed by the author before requesting review -->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
