### PR TITLE
fix(shell): /exit stops replaying its own farewell

### DIFF
--- a/platform/analytics/provider.py
+++ b/platform/analytics/provider.py
@@ -857,8 +857,12 @@ class Analytics:
         with contextlib.suppress(queue.Full):
             self._queue.put_nowait(None)
         if flush and self._worker is not None:
+            # One budget for the whole drain, not one per wait: these run back to
+            # back, so passing ``timeout`` to each made a documented 0.5s exit
+            # block for 1.0s whenever a send outlived it.
+            deadline = time.monotonic() + timeout
             self._drained.wait(timeout=timeout)
-            self._worker.join(timeout=timeout)
+            self._worker.join(timeout=max(0.0, deadline - time.monotonic()))
 
     def _ensure_worker(self) -> None:
         if self._worker is not None:

--- a/surfaces/interactive_shell/utils/telemetry/turn_outcome.py
+++ b/surfaces/interactive_shell/utils/telemetry/turn_outcome.py
@@ -34,6 +34,13 @@ _SUMMARY_ONLY_SLASH_ROOTS: frozenset[str] = frozenset(
         "/help",
         "/?",
         "/investigate",
+        # The user has already read the resume hint and the goodbye on screen,
+        # and neither tells the model anything. Replaying the capture printed
+        # the whole farewell a second time, with the spinner's frames
+        # transcribed one after another — ``console.status`` animates in place
+        # but ``export_text`` records every frame it wrote.
+        "/exit",
+        "/quit",
     }
 )
 

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -1001,7 +1001,8 @@ def test_shutdown_flush_spends_one_budget_not_two(
             return None
 
     class _SlowClient:
-        def __init__(self, *_args: object, **_kwargs: object) -> None: ...
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
 
         def __enter__(self) -> _SlowClient:
             return self

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -979,6 +979,55 @@ def test_shutdown_flush_false_returns_without_waiting_on_slow_worker(
     assert elapsed < 0.2
 
 
+def test_shutdown_flush_spends_one_budget_not_two(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A drain that outlives its budget blocks ``/exit`` for ``timeout``, not twice it.
+
+    ``shutdown`` waits on the drained Event and then joins the worker. Passing
+    the full ``timeout`` to each made a documented 0.5s interactive exit block
+    for 1.0s whenever a send was still in flight — the two waits run back to
+    back, so the budget has to be shared.
+    """
+    # Arrange: a worker whose send outlives any budget we give the drain.
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda *_a, **_k: None)
+
+    class _SlowResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _SlowClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None: ...
+
+        def __enter__(self) -> _SlowClient:
+            return self
+
+        def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+            return None
+
+        def post(self, _url: str, **_kwargs: object) -> _SlowResponse:
+            time.sleep(2.0)
+            return _SlowResponse()
+
+    monkeypatch.setattr(provider.httpx, "Client", _SlowClient)
+
+    analytics = provider.Analytics()
+    analytics.capture(Event.CLI_INVOKED, {"interactive": True})
+    budget = 0.25
+
+    # Act
+    started = time.perf_counter()
+    analytics.shutdown(flush=True, timeout=budget)
+    elapsed = time.perf_counter() - started
+
+    # Assert: one budget, with room for scheduling — never two.
+    assert elapsed < budget * 1.6, f"drain took {elapsed:.2f}s against a {budget}s budget"
+
+
 def test_atexit_registers_non_blocking_shutdown(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/interactive_shell/utils/test_turn_outcome.py
+++ b/tests/interactive_shell/utils/test_turn_outcome.py
@@ -126,3 +126,40 @@ def test_truncate_analytics_text() -> None:
     truncated = truncate_analytics_text(long_text, max_chars=50)
     assert len(truncated) <= 50
     assert truncated.endswith("[truncated]")
+
+
+def test_exit_does_not_replay_its_farewell_to_the_user() -> None:
+    """``/exit`` records the outcome line only, not the console text it just printed.
+
+    Every slash command runs under ``capture_console_segment``, which tees: the
+    output renders live *and* is recorded, and the recording becomes the turn's
+    ``response_text``. For ``/exit`` that meant the resume hint and the goodbye
+    were printed once by the command and once more as the turn's response.
+
+    The spinner made it obvious. ``console.status`` animates by rewriting one
+    line, but ``export_text`` records every frame it wrote, so the replay showed
+    ``⠋ finishing up…⠙ finishing up…⠹ finishing up…`` as plain text.
+    """
+    # Arrange: what the exit path actually prints, spinner frames included.
+    captured = (
+        "Resume this session with:\n"
+        "/resume f659a4f9-3911-4ed2-bc8c-8e02da5f887c\n"
+        "opensre --resume f659a4f9-3911-4ed2-bc8c-8e02da5f887c\n"
+        "⠋ finishing up…⠙ finishing up…⠹ finishing up…\n"
+        "goodbye."
+    )
+
+    # Act
+    outcome = format_terminal_turn_outcome("/exit", kind="slash", ok=True, captured_output=captured)
+
+    # Assert
+    assert outcome == "slash /exit (succeeded)"
+    assert "goodbye." not in outcome
+    assert "finishing up" not in outcome
+
+
+def test_quit_is_summary_only_like_its_alias() -> None:
+    """``/quit`` runs the same handler, so it must not replay either."""
+    # Assert
+    assert slash_command_is_summary_only("/exit") is True
+    assert slash_command_is_summary_only("/quit") is True


### PR DESCRIPTION
Issue: #5219 

#### Describe the changes you have made in this PR -

`/exit` printed the resume hint and `goodbye.` twice, the second copy carrying
raw spinner frames. **It never ran twice** — it was rendered twice.

Every slash command runs under `capture_console_segment`, which tees: the output
renders live *and* is recorded through Rich's `record` mode. That recording
becomes the turn's `response_text`, which the shell prints. Hence two copies.

The spinner is what made it obvious rather than merely redundant.
`console.status` animates by rewriting one line; `export_text` records **every
frame it wrote**. So the live block has no spinner at all and the replay shows
three frames as plain text — nothing repeated, the frames were transcribed.

`_SUMMARY_ONLY_SLASH_ROOTS` already exists for exactly this: commands whose
console output the model does not need. It held `/`, `/help`, `/?` and
`/investigate`. A resume hint and a goodbye tell the model nothing, so `/exit`
and `/quit` (same handler) join it. `response_text` becomes
`slash /exit (succeeded)`.

**Deliberately not fixed here:** the replay is not unique to `/exit` — any slash
command outside that set behaves the same way. Whether that is a defect or the
model legitimately needing the output is a design question, and widening the
list would answer it by accident.