### PR TITLE
fix(llm): make investigation agent tool selection deterministic (#3105)

### DIFF
--- a/config/llm_sampling.py
+++ b/config/llm_sampling.py
@@ -1,0 +1,62 @@
+"""Sampling controls for the agent tool-calling tier, deterministic by default.
+
+Callers must read these at request-build time, not client construction:
+``core.llm.factory`` caches one client per ``(role, transport, provider)`` and
+the cache key excludes sampling, so a constructor-resolved value would be frozen
+at first construction.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Callable
+from typing import Final
+
+AGENT_TEMPERATURE_ENV: Final[str] = "OPENSRE_AGENT_TEMPERATURE"
+AGENT_SEED_ENV: Final[str] = "OPENSRE_AGENT_SEED"
+
+DEFAULT_AGENT_TEMPERATURE: Final[float] = 0.0
+DEFAULT_AGENT_SEED: Final[int] = 0
+
+_DEFER_VALUES: Final[frozenset[str]] = frozenset({"none", "default"})
+
+
+def _resolve[Value: (float, int)](
+    env_name: str, default: Value, parse: Callable[[str], Value]
+) -> Value | None:
+    """Read a sampling knob from the environment; ``None`` means omit the param.
+
+    Unparseable values fall back to ``default`` so a typo cannot silently
+    restore provider sampling.
+    """
+    raw = os.getenv(env_name, "").strip().lower()
+    if not raw:
+        return default
+    if raw in _DEFER_VALUES:
+        return None
+    try:
+        value = parse(raw)
+    except ValueError:
+        return default
+    return value if math.isfinite(value) else default
+
+
+def get_agent_temperature() -> float | None:
+    """Sampling temperature for agent tool-calling requests, or ``None`` to omit."""
+    return _resolve(AGENT_TEMPERATURE_ENV, DEFAULT_AGENT_TEMPERATURE, float)
+
+
+def get_agent_seed() -> int | None:
+    """Sampling seed for agent requests on providers that accept one, or ``None`` to omit."""
+    return _resolve(AGENT_SEED_ENV, DEFAULT_AGENT_SEED, int)
+
+
+__all__ = [
+    "AGENT_SEED_ENV",
+    "AGENT_TEMPERATURE_ENV",
+    "DEFAULT_AGENT_SEED",
+    "DEFAULT_AGENT_TEMPERATURE",
+    "get_agent_seed",
+    "get_agent_temperature",
+]

--- a/core/llm/client_builders.py
+++ b/core/llm/client_builders.py
@@ -95,6 +95,7 @@ def _native_sdk_agent_client(route: LLMRoute) -> AgentLLMClient:
             base_url=resolved.base_url,
             api_key_env=resolved.api_key_env,
             api_key_default=resolved.api_key_default,
+            temperature=resolved.temperature,
         )
 
     if is_custom_anthropic_provider(provider):

--- a/core/llm/shared/openai_chat_completions.py
+++ b/core/llm/shared/openai_chat_completions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import time
 from collections.abc import Callable, Iterator
 from http import HTTPStatus
@@ -21,6 +22,18 @@ _RETRY_MAX_ATTEMPTS = 3
 
 AGENT_CLIENT_TIMEOUT_SEC: float = 90.0
 LLM_CLIENT_TIMEOUT_SEC: float = 60.0
+
+_OPENAI_O_SERIES_RE = re.compile(r"(?:^|[^A-Za-z0-9])o\d", re.IGNORECASE)
+_OPENAI_GPT5_RE = re.compile(r"(?:^|[^A-Za-z0-9])gpt-5", re.IGNORECASE)
+
+
+def is_openai_reasoning_model(model: str) -> bool:
+    """Whether the model is o-series or gpt-5, which reject ``max_tokens`` and ``temperature``.
+
+    Matches after a separator too, so vendor-prefixed routes (``openai/o4-mini``,
+    ``azure/o3``) and LiteLLM model ids are detected.
+    """
+    return bool(_OPENAI_O_SERIES_RE.search(model) or _OPENAI_GPT5_RE.search(model))
 
 
 def get_attr_or_item(value: Any, key: str, default: Any = None) -> Any:

--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -15,6 +15,7 @@ ensure_tiktoken_encodings_discoverable()
 from litellm import completion  # noqa: E402
 from pydantic import BaseModel  # noqa: E402
 
+from config.constants.llm import OPENAI_API_KEY_ENV  # noqa: E402
 from core.context_budget import strip_internal_message_markers  # noqa: E402
 from core.llm.shared.openai_chat_completions import (  # noqa: E402
     AGENT_CLIENT_TIMEOUT_SEC,
@@ -25,6 +26,7 @@ from core.llm.shared.openai_chat_completions import (  # noqa: E402
     build_tool_result_messages,
     invoke_with_litellm_agent_retries,
     invoke_with_litellm_llm_retries,
+    is_openai_reasoning_model,
     llm_response_from_completion,
     normalize_messages_openai,
     prepend_system_message,
@@ -114,8 +116,16 @@ class LiteLLMAgentClient:
             kwargs["api_base"] = self._api_base
         if self._api_version is not None:
             kwargs["api_version"] = self._api_version
-        if self._temperature is not None:
-            kwargs["temperature"] = self._temperature
+        from config.llm_sampling import get_agent_seed, get_agent_temperature
+
+        configured = self._temperature
+        temperature = configured if configured is not None else get_agent_temperature()
+        if temperature is not None and not is_openai_reasoning_model(self._litellm_model):
+            kwargs["temperature"] = temperature
+        # LiteLLM runs with drop_params off, so it raises on a backend that has no seed.
+        seed = get_agent_seed()
+        if seed is not None and self._api_key_env == OPENAI_API_KEY_ENV:
+            kwargs["seed"] = seed
         if self._vertex_project is not None:
             kwargs["vertex_project"] = self._vertex_project
         if self._vertex_location is not None:

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from config.constants.llm import OPENAI_API_KEY_ENV
 from core.context_budget import strip_internal_message_markers
 from core.llm.shared.llm_retry import (
     maybe_raise_credit_exhausted,
@@ -22,6 +23,7 @@ from core.llm.shared.openai_chat_completions import (
     _RETRY_INITIAL_BACKOFF_SEC,
     _RETRY_MAX_ATTEMPTS,
     AGENT_CLIENT_TIMEOUT_SEC,
+    is_openai_reasoning_model,
 )
 from core.llm.shared.openai_chat_completions import (
     build_assistant_message as build_openai_compat_assistant_message,
@@ -189,6 +191,11 @@ class AnthropicAgentClient:
             kwargs["system"] = _anthropic_cached_system(system) if cache else system
         if tools:
             kwargs["tools"] = _anthropic_tools_with_cache(tools) if cache else tools
+        from config.llm_sampling import get_agent_temperature
+
+        temperature = get_agent_temperature()
+        if temperature is not None:
+            kwargs["temperature"] = temperature
 
         backoff = _RETRY_INITIAL_BACKOFF_SEC
         last_err: Exception | None = None
@@ -446,6 +453,11 @@ class BedrockConverseAgentClient:
             kwargs["system"] = [{"text": system}]
         if tools:
             kwargs["toolConfig"] = {"tools": tools}
+        from config.llm_sampling import get_agent_temperature
+
+        temperature = get_agent_temperature()
+        if temperature is not None:
+            kwargs["inferenceConfig"]["temperature"] = temperature
 
         backoff = _RETRY_INITIAL_BACKOFF_SEC
         response: dict[str, Any] | None = None
@@ -510,23 +522,18 @@ class BedrockConverseAgentClient:
         return raw_content
 
 
-_OPENAI_O_SERIES_RE = re.compile(r"(?:^|[^A-Za-z0-9])o\d", re.IGNORECASE)
-_OPENAI_GPT5_RE = re.compile(r"(?:^|[^A-Za-z0-9])gpt-5", re.IGNORECASE)
-
-
 def _supports_openai_parallel_tool_calls_param(api_key_env: str) -> bool:
     """Return whether this client targets OpenAI's native chat-completions API."""
-    return api_key_env == "OPENAI_API_KEY"
+    return api_key_env == OPENAI_API_KEY_ENV
+
+
+def _supports_openai_seed_param(api_key_env: str) -> bool:
+    """Whether ``seed`` may be sent: it is OpenAI-native, and proxies reject it."""
+    return api_key_env == OPENAI_API_KEY_ENV
 
 
 def _openai_max_token_kwarg(model: str) -> str:
-    # OpenAI o-series (o1, o3, o4-mini, …) and gpt-5 series reject max_tokens.
-    # O-series: matches a bare ``o<digit>`` token at the start of the name or
-    # following a non-alphanumeric separator, so vendor-prefixed routes
-    # (``openai/o4-mini``, ``azure/o3``) and custom deployments are detected.
-    # gpt-5: matches ``gpt-5`` at the start or after a separator, covering
-    # gpt-5, gpt-5o, gpt-5o-mini, and future gpt-5* variants.
-    if _OPENAI_O_SERIES_RE.search(model) or _OPENAI_GPT5_RE.search(model):
+    if is_openai_reasoning_model(model):
         return "max_completion_tokens"
     return "max_tokens"
 
@@ -553,6 +560,7 @@ class OpenAIAgentClient:
         base_url: str | None = None,
         api_key_env: str = "OPENAI_API_KEY",
         api_key_default: str = "",
+        temperature: float | None = None,
         credential_resolver: Callable[[str], str] | None = None,
     ) -> None:
         from openai import OpenAI
@@ -565,6 +573,7 @@ class OpenAIAgentClient:
         self._model = model
         self._max_tokens = max_tokens
         self._api_key_env = api_key_env
+        self._temperature = temperature
 
     @property
     def model_id(self) -> str | None:
@@ -659,6 +668,15 @@ class OpenAIAgentClient:
                 kwargs["tool_choice"] = "auto"
                 if _supports_openai_parallel_tool_calls_param(api_key_env):
                     kwargs["parallel_tool_calls"] = True
+            from config.llm_sampling import get_agent_seed, get_agent_temperature
+
+            configured = getattr(self, "_temperature", None)
+            temperature = configured if configured is not None else get_agent_temperature()
+            if temperature is not None and not is_openai_reasoning_model(self._model):
+                kwargs["temperature"] = temperature
+            seed = get_agent_seed()
+            if seed is not None and _supports_openai_seed_param(api_key_env):
+                kwargs["seed"] = seed
 
         backoff = _RETRY_INITIAL_BACKOFF_SEC
         last_err: Exception | None = None

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -196,6 +196,31 @@ Want credentials only from the environment, never on disk? Set
 | --- | --- | --- |
 | `OPENSRE_REASONING_EFFORT` |  | Effort for extended-thinking models: `low`, `medium`, `high`, or `xhigh` |
 
+## Agent sampling
+
+Investigations constrain tool-choice sampling by default, so the same alert tends to produce the
+same tool calls. Raise the temperature only if you want the agent to explore alternatives.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENSRE_AGENT_TEMPERATURE` | `0` | Sampling temperature for tool-calling turns. Set `none` to use the provider's own default |
+| `OPENSRE_AGENT_SEED` | `0` | Sampling seed, sent only to OpenAI. Set `none` to omit it |
+
+Both apply to the agent tier (investigations and the interactive shell's action agent) and leave
+chat and reasoning models alone.
+
+How much you get depends on the model, because reasoning models fix their own sampling:
+
+- **OpenAI/Azure reasoning models** (`gpt-5*`, `o3`, and the default `gpt-5.4-mini`) reject a
+  temperature, so only the seed is sent. Azure takes neither, since seed is OpenAI-only.
+  Pick a non-reasoning model such as `gpt-4o` if you want temperature control.
+- **Anthropic, Bedrock, and OpenAI-compatible gateways** get the temperature.
+- **CLI-backed providers** (Codex, Claude Code) accept no sampling options at all.
+
+A provider that pins its own temperature keeps it: MiniMax stays at its required `1.0`. Values
+outside a provider's accepted range are rejected by that provider: Anthropic caps temperature at
+`1.0`, OpenAI at `2.0`.
+
 ## CLI investigation tools
 
 <AccordionGroup>

--- a/tests/core/runtime/llm/test_agent_llm_client.py
+++ b/tests/core/runtime/llm/test_agent_llm_client.py
@@ -1116,6 +1116,7 @@ def test_get_llm_agent_routes_deepseek_to_openai_compatible_client(
             base_url: str | None = None,
             api_key_env: str = "OPENAI_API_KEY",
             api_key_default: str = "",
+            temperature: float | None = None,
         ) -> None:
             captured.update(
                 {
@@ -1124,6 +1125,7 @@ def test_get_llm_agent_routes_deepseek_to_openai_compatible_client(
                     "base_url": base_url,
                     "api_key_env": api_key_env,
                     "api_key_default": api_key_default,
+                    "temperature": temperature,
                 }
             )
 
@@ -1886,3 +1888,142 @@ def test_bedrock_converse_emits_provider_usage(monkeypatch: pytest.MonkeyPatch) 
 
     assert result.content == "ok"
     assert usage == [(_MISTRAL_MODEL, 200, 30)]
+
+
+@pytest.fixture(autouse=True)
+def _clear_agent_sampling_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep a developer's shell from leaking sampling overrides into assertions."""
+    monkeypatch.delenv("OPENSRE_AGENT_TEMPERATURE", raising=False)
+    monkeypatch.delenv("OPENSRE_AGENT_SEED", raising=False)
+
+
+def _capture_openai_kwargs(
+    *, model: str, api_key_env: str = "OPENAI_API_KEY", responses: bool = False
+) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def capture_create(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return _make_fake_openai_response(content="ok")
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    if responses:
+        client._client = types.SimpleNamespace(
+            responses=types.SimpleNamespace(create=capture_create)
+        )
+    else:
+        client._client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=capture_create))
+        )
+    client._model = model
+    client._max_tokens = 1024
+    client._api_key_env = api_key_env
+    client.invoke(messages=[{"role": "user", "content": "alert"}])
+    return captured
+
+
+def test_anthropic_agent_client_sends_deterministic_temperature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_anthropic(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def capture_create(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return types.SimpleNamespace(content=[], stop_reason="end_turn", usage=None)
+
+    client = AnthropicAgentClient.__new__(AnthropicAgentClient)
+    client._client = types.SimpleNamespace(messages=types.SimpleNamespace(create=capture_create))
+    client._model = "claude-opus-5"
+    client._max_tokens = 1024
+    client._cache_markers_enabled = False
+
+    client.invoke(messages=[{"role": "user", "content": "alert"}])
+
+    assert captured["temperature"] == 0.0
+    assert "seed" not in captured
+
+
+def test_bedrock_converse_nests_temperature_in_inference_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    captured: dict[str, Any] = {}
+
+    def converse(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return _make_converse_response(text="ok")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "boto3",
+        types.SimpleNamespace(
+            client=lambda *_args, **_kwargs: types.SimpleNamespace(converse=converse)
+        ),
+    )
+
+    from core.llm.transports.sdk.agent_clients import BedrockConverseAgentClient
+
+    BedrockConverseAgentClient(model=_MISTRAL_MODEL).invoke(
+        messages=[{"role": "user", "content": [{"text": "hi"}]}]
+    )
+
+    assert captured["inferenceConfig"]["temperature"] == 0.0
+    assert "temperature" not in captured
+
+
+def test_openai_agent_client_sends_temperature_and_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """seed=0 is falsy, so it must still reach the wire."""
+    _install_fake_openai(monkeypatch)
+
+    captured = _capture_openai_kwargs(model="gpt-4o")
+
+    assert captured["temperature"] == 0.0
+    assert captured["seed"] == 0
+
+
+def test_openai_compat_endpoint_omits_seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_openai(monkeypatch)
+
+    captured = _capture_openai_kwargs(model="deepseek-v4", api_key_env="DEEPSEEK_API_KEY")
+
+    assert captured["temperature"] == 0.0
+    assert "seed" not in captured
+
+
+@pytest.mark.parametrize("model", ["o3", "gpt-5", "openai/o4-mini"])
+def test_openai_reasoning_models_omit_temperature(
+    monkeypatch: pytest.MonkeyPatch, model: str
+) -> None:
+    _install_fake_openai(monkeypatch)
+
+    captured = _capture_openai_kwargs(model=model)
+
+    assert "temperature" not in captured
+    assert captured["seed"] == 0
+
+
+def test_openai_responses_api_omits_both_sampling_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_openai(monkeypatch)
+
+    captured = _capture_openai_kwargs(model="gpt-5.6", responses=True)
+
+    assert "temperature" not in captured
+    assert "seed" not in captured
+
+
+def test_agent_sampling_env_overrides_reach_the_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_openai(monkeypatch)
+    monkeypatch.setenv("OPENSRE_AGENT_TEMPERATURE", "0.9")
+    monkeypatch.setenv("OPENSRE_AGENT_SEED", "none")
+
+    captured = _capture_openai_kwargs(model="gpt-4o")
+
+    assert captured["temperature"] == 0.9
+    assert "seed" not in captured

--- a/tests/core/runtime/llm/test_litellm_compat.py
+++ b/tests/core/runtime/llm/test_litellm_compat.py
@@ -19,6 +19,13 @@ class _FakeMessage:
         return {"role": "assistant", "content": self.content, "tool_calls": self.tool_calls}
 
 
+@pytest.fixture(autouse=True)
+def _clear_agent_sampling_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep a developer's shell from leaking sampling overrides into assertions."""
+    monkeypatch.delenv("OPENSRE_AGENT_TEMPERATURE", raising=False)
+    monkeypatch.delenv("OPENSRE_AGENT_SEED", raising=False)
+
+
 def _fake_response(*, content: str = "ok", tool_calls: list[Any] | None = None) -> Any:
     message = _FakeMessage(content=content, tool_calls=tool_calls)
     choice = types.SimpleNamespace(message=message, finish_reason="stop")
@@ -266,3 +273,96 @@ def test_litellm_llm_client_invoke_stream_retries_before_emit(monkeypatch) -> No
 
     assert chunks == ["ok"]
     assert len(attempts) == 2
+
+
+def test_litellm_agent_client_applies_deterministic_sampling_by_default() -> None:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_response()
+
+    client = LiteLLMAgentClient(
+        litellm_model="openai/gpt-4o",
+        api_key_env="OPENAI_API_KEY",
+        credential_resolver=lambda _env: "sk-key",
+        completion_func=completion,
+    )
+    client.invoke([{"role": "user", "content": "hi"}])
+
+    assert captured["temperature"] == 0.0
+    assert captured["seed"] == 0
+
+
+def test_litellm_agent_client_omits_temperature_for_reasoning_models() -> None:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_response()
+
+    client = LiteLLMAgentClient(
+        litellm_model="openai/o3",
+        api_key_env="OPENAI_API_KEY",
+        credential_resolver=lambda _env: "sk-key",
+        completion_func=completion,
+    )
+    client.invoke([{"role": "user", "content": "hi"}])
+
+    assert "temperature" not in captured
+    assert captured["seed"] == 0
+
+
+def test_litellm_agent_client_sends_seed_only_to_openai() -> None:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_response()
+
+    client = LiteLLMAgentClient(
+        litellm_model="anthropic/claude-opus-5",
+        api_key_env="ANTHROPIC_API_KEY",
+        credential_resolver=lambda _env: "sk-key",
+        completion_func=completion,
+    )
+    client.invoke([{"role": "user", "content": "hi"}])
+
+    assert captured["temperature"] == 0.0
+    assert "seed" not in captured
+
+
+def test_litellm_agent_client_keeps_a_provider_pinned_temperature() -> None:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_response()
+
+    client = LiteLLMAgentClient(
+        litellm_model="openai/minimax-m2",
+        api_key_env=None,
+        temperature=1.0,
+        completion_func=completion,
+    )
+    client.invoke([{"role": "user", "content": "hi"}])
+
+    assert captured["temperature"] == 1.0
+
+
+def test_litellm_reasoning_client_is_not_given_agent_sampling() -> None:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_response()
+
+    client = LiteLLMLLMClient(
+        litellm_model="openai/deepseek-v4-pro",
+        api_key_env=None,
+        completion_func=completion,
+    )
+    client.invoke("hi")
+
+    assert "temperature" not in captured
+    assert "seed" not in captured

--- a/tests/core/runtime/llm/test_llm_sampling.py
+++ b/tests/core/runtime/llm/test_llm_sampling.py
@@ -1,0 +1,130 @@
+"""Unit tests for agent-tier sampling knobs and their per-transport application."""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+from config.llm_sampling import (
+    AGENT_SEED_ENV,
+    AGENT_TEMPERATURE_ENV,
+    get_agent_seed,
+    get_agent_temperature,
+)
+from core.llm.transports.litellm.clients import LiteLLMAgentClient
+from core.llm.transports.sdk.agent_clients import OpenAIAgentClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_sampling_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(AGENT_TEMPERATURE_ENV, raising=False)
+    monkeypatch.delenv(AGENT_SEED_ENV, raising=False)
+
+
+def test_defaults_are_deterministic() -> None:
+    assert get_agent_temperature() == 0.0
+    assert get_agent_seed() == 0
+
+
+@pytest.mark.parametrize("value", ["none", "default", " DEFAULT "])
+def test_opt_out_values_defer_to_the_provider(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(AGENT_TEMPERATURE_ENV, value)
+    monkeypatch.setenv(AGENT_SEED_ENV, value)
+    assert get_agent_temperature() is None
+    assert get_agent_seed() is None
+
+
+def test_env_overrides_are_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(AGENT_TEMPERATURE_ENV, "0.7")
+    monkeypatch.setenv(AGENT_SEED_ENV, "42")
+    assert get_agent_temperature() == 0.7
+    assert get_agent_seed() == 42
+
+
+@pytest.mark.parametrize("bad", ["hot", "nan", "inf", "-inf"])
+def test_unusable_values_keep_determinism(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    """A typo must not silently restore provider sampling.
+
+    nan/inf parse as floats but are not JSON-serializable, so letting them
+    through would fail inside the provider SDK instead of here.
+    """
+    monkeypatch.setenv(AGENT_TEMPERATURE_ENV, bad)
+    assert get_agent_temperature() == 0.0
+
+
+def test_unparseable_seed_keeps_determinism(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(AGENT_SEED_ENV, "0.5")
+    assert get_agent_seed() == 0
+
+
+def _fake_completion_response() -> Any:
+    message = types.SimpleNamespace(content="ok", tool_calls=[])
+    message.model_dump = lambda **_: {"role": "assistant", "content": "ok"}
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=message, finish_reason="stop")], usage=None
+    )
+
+
+def _sdk_sampling(model: str, api_key_env: str, pinned: float | None) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def create(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_completion_response()
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    )
+    client._model = model
+    client._max_tokens = 1024
+    client._api_key_env = api_key_env
+    client._temperature = pinned
+    client.invoke(messages=[{"role": "user", "content": "hi"}])
+    return {k: v for k, v in captured.items() if k in ("temperature", "seed")}
+
+
+def _litellm_sampling(model: str, api_key_env: str, pinned: float | None) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def completion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _fake_completion_response()
+
+    LiteLLMAgentClient(
+        litellm_model=f"openai/{model}",
+        api_key_env=api_key_env,
+        credential_resolver=lambda _env: "sk-key",
+        temperature=pinned,
+        completion_func=completion,
+    ).invoke([{"role": "user", "content": "hi"}])
+    return {k: v for k, v in captured.items() if k in ("temperature", "seed")}
+
+
+_SAMPLING_CASES = [
+    ("gpt-4o", "OPENAI_API_KEY", None, {"temperature": 0.0, "seed": 0}),
+    ("gpt-5.4-mini", "OPENAI_API_KEY", None, {"seed": 0}),
+    ("o3", "OPENAI_API_KEY", None, {"seed": 0}),
+    ("deepseek-v4", "DEEPSEEK_API_KEY", None, {"temperature": 0.0}),
+    ("MiniMax-M2", "MINIMAX_API_KEY", 1.0, {"temperature": 1.0}),
+]
+
+
+@pytest.mark.parametrize(("model", "api_key_env", "pinned", "expected"), _SAMPLING_CASES)
+def test_both_transports_send_the_same_sampling_params(
+    model: str, api_key_env: str, pinned: float | None, expected: dict[str, Any]
+) -> None:
+    """The SDK and LiteLLM routes must not disagree about one model's capabilities.
+
+    They did, twice. Only the SDK knew o-series reject ``temperature``, so routing
+    the agent tier through LiteLLM raised ``UnsupportedParamsError`` before the
+    request left the process; and only LiteLLM honoured a provider-pinned
+    temperature, so MiniMax lost its required 1.0 on the default transport.
+
+    ``gpt-5.4-mini`` is the shipped OpenAI/Azure default, so its row is the one
+    most users actually exercise.
+    """
+    assert _sdk_sampling(model, api_key_env, pinned) == expected
+    assert _litellm_sampling(model, api_key_env, pinned) == expected


### PR DESCRIPTION
Fixes #3105

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Candidate assembly turned out **not** to be the cause; it is already deterministic. The registry name-sorts every discovery hop (`tools/registry.py`), `tool_planning.score_tools` orders by `(-score, secondary, name)` (a total order, since tool names are unique registry-wide), all four `tool_schemas()` builders preserve that order into the provider request, and `core/execution.py` writes parallel tool results back by submission index rather than completion order.

The variance came from the sampling layer. The agent tool-calling clients in `core/llm/transports/sdk/agent_clients.py` built request kwargs with **no `temperature` and no `seed`**; neither word appeared anywhere in the file. The sibling reasoning clients in `transports/sdk/llm_clients.py` already had this plumbing, and the agent clients were simply never given it.

**Scope note:** this targets the **agent tier**, which the interactive shell's action agent shares with investigations. Chat and reasoning models are unchanged.

**How much this buys you depends on the configured model, and the default is worth being blunt about.** `OPENAI_REASONING_MODEL` and `AZURE_OPENAI_REASONING_MODEL` both default to `gpt-5.4-mini` (`config/llm_models.py`), which is a reasoning model and rejects `temperature`:

| configuration | what it gains |
| --- | --- |
| Anthropic (repo default provider), Bedrock, OpenAI-compat gateways | `temperature=0` |
| OpenAI on the default `gpt-5.4-mini` | `seed=0` only |
| OpenAI on a non-reasoning model (`gpt-4o`) | `temperature=0` plus `seed=0` |
| Azure on the default `gpt-5.4-mini` | nothing; reasoning model, and `seed` is OpenAI-only |
| CLI-backed providers (Codex, Claude Code) | nothing; they take no sampling options |

That is a property of the models rather than something this PR can route around, since a model that fixes its own sampling cannot be given a temperature. The docs table says which case a user is in. If you would rather the default agent model be one that *can* be pinned, that is a separate call and I am happy to open it as its own issue.

**On the issue's stated dependency** ("depends on the synthetic test-suite triage signal landing first, so we can measure before/after"): that signal has largely landed. `tests/synthetic/rds_postgres/trajectory_policy.py` computes the tool-selection metrics you would want (`flat_actions`, `lcs_ratio`, `edit_distance`, `coverage`, `extra_actions`, `redundancy_count`), there are golden scenarios with committed `_baseline/*.json`, and `make test-rds-synthetic` runs them.

### Demo/Screenshot for feature changes and bug fixes -

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

**Same alert, five runs each, through the CLI** (gemini provider, `gemma-4-31b-it`, 10 tools available):

<img width="2160" height="1228" alt="verification_live" src="https://github.com/user-attachments/assets/ba87fc9e-755e-4445-bc16-8d39fdb952bd" />

```
BEFORE (main), nothing sent, so the provider sampled at its own default
  [{"get_sre_guidance":{"keywords":["OOMKilled","memory leak","kubernetes"]}}]
  [{"get_sre_guidance":{"keywords":["OOMKilled","pod_oomkilled","memory limit"]}}]
  [{"get_sre_guidance":{"keywords":["OOMKilled","CrashLoopBackOff","memory limit"]}}]
  [{"get_sre_guidance":{"keywords":["payments","critical"]}}]
  [{"get_sre_guidance":{"keywords":["OOMKilled","CrashLoopBackOff","memory limit"]}}]
                                        -> 4 distinct opening calls out of 5

AFTER (this PR), temperature=0
  [{"get_sre_guidance":{"topic":"recovery_remediation"}}]
  [{"get_sre_guidance":{"topic":"recovery_remediation"}}]
  [{"get_sre_guidance":{"topic":"recovery_remediation"}}, ...]
  [{"get_sre_guidance":{"topic":"recovery_remediation"}}, ...]
  [{"get_sre_guidance":{"topic":"playbooks_overview"}},   ...]
                                        -> 2 distinct opening calls out of 5
```

**What each agent route now sends.** The provider SDK is swapped for a recorder, so this needs no credentials and is exactly reproducible:

<img width="2160" height="1148" alt="verification" src="https://github.com/user-attachments/assets/1c3d1e00-5fae-4cb6-ba10-7de7d7ce2939" />


```
                            BEFORE (main)   AFTER (this PR)
  anthropic  claude-opus-5           {}     {'temperature': 0.0}
  openai     gpt-5.4-mini (default)  {}     {'seed': 0}
  openai     gpt-4o                  {}     {'temperature': 0.0, 'seed': 0}
  openai     o3                      {}     {'seed': 0}
  compat     deepseek-v4             {}     {'temperature': 0.0}
  compat     MiniMax-M2 (pins 1.0)   {}     {'temperature': 1.0}
  litellm    openai/gpt-4o           {}     {'temperature': 0.0, 'seed': 0}
  litellm    openai/o3               {}     {'seed': 0}
  litellm    anthropic/claude-opus-5 {}     {'temperature': 0.0}
```

`{}` means nothing was sent, so the provider sampled at its own default, which is the bug. Reasoning models keep only `seed` because they reject a temperature; compat routes drop `seed` because it is OpenAI-only; MiniMax keeps its provider-pinned `1.0`, so no route regressed.

```
$ make lint                        -> All checks passed!
$ make format-check                -> 3498 files already formatted
$ make typecheck                   -> Success: no issues found in 1861 source files
$ make check-imports               -> All 3 import checks passed
$ make check-imports-strict        -> OpenSRE package layers (transitive) KEPT
$ uv run pytest tests/core/runtime/llm/ tests/config/ -q  -> 699 passed
```

`check-imports-strict` matters here because `config/llm_sampling.py` is new: `config` stays the bottom layer and no fourth `ignore_imports` T-4 debt entry was added.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!--
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

I first ruled out the obvious suspect, candidate ordering, by tracing the registry, the scorer's sort key, all four schema builders and the parallel-execution result write-back, all of which are already deterministic. That left unconstrained provider sampling as the only run-to-run variable in this repo, so the fix is one deterministic default rather than any change to prompt or tool logic.

The alternative I considered, and which an earlier draft used, was threading `temperature` through each client's `__init__`. I rejected it: `core.llm.factory` caches one client per `(role, transport, provider)` and `client_cache_key.py` excludes sampling, so a constructor-resolved value is frozen at first construction and would go stale. Resolving at request-build time also kept `client_builders.py` and the LiteLLM routing table almost entirely out of the diff. The one place a constructor argument *is* correct is a provider-pinned temperature, because that is fixed catalog config rather than a runtime knob.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
