### PR TITLE
test: use AgentTool fake in gather discovery budget tests

### DIFF
--- a/tests/core/agent_harness/test_gather_discovery_budget.py
+++ b/tests/core/agent_harness/test_gather_discovery_budget.py
@@ -13,6 +13,8 @@ This guard caps discovery-style MCP bridge calls (``list_*_tools`` /
 
 from __future__ import annotations
 
+from typing import Any
+
 from core.agent_harness.turns.gather_discovery_budget import (
     DEFAULT_MAX_DISCOVERY_CALLS,
     is_gather_discovery_call,
@@ -23,17 +25,35 @@ from core.agent_harness.turns.gather_discovery_budget import (
 )
 from core.execution import ToolExecutionRequest, ToolExecutionResult
 from core.llm.types import ToolCall
+from core.types import AgentTool, AgentToolContext
+
+
+def _execute_test_tool(
+    _arguments: dict[str, Any],
+    _context: AgentToolContext,
+) -> str:
+    raise AssertionError("test tool should not execute")
+
+
+def _test_tool(name: str, source: str) -> AgentTool:
+    return AgentTool(
+        name=name,
+        description="test tool",
+        input_schema={"type": "object", "properties": {}},
+        execute=_execute_test_tool,
+        source=source,
+    )
 
 
 def _request(
-    tool: str,
+    tool_name: str,
     arguments: dict,
     *,
     source: str = "posthog_mcp",
 ) -> ToolExecutionRequest:
     return ToolExecutionRequest(
-        tool_call=ToolCall(id="tc", name=tool, input=arguments),
-        tool=type("T", (), {"source": source})(),  # type: ignore[arg-type]
+        tool_call=ToolCall(id="tc", name=tool_name, input=arguments),
+        tool=_test_tool(tool_name, source),
         arguments=arguments,
         source=source,
         resolved_integrations={},


### PR DESCRIPTION
Fixes #5204

#### Describe the changes you have made in this PR -

Replaced the anonymous `type("T", (), {"source": source})()` fake used for `ToolExecutionRequest.tool` in `test_gather_discovery_budget.py` with an `AgentTool`-backed test helper.

The fake tool now honors the `RuntimeTool` contract while preserving the test intent: these tests exercise gather-discovery budget decisions, not actual tool execution. The test executor raises if it is accidentally called.

### Demo/Screenshot for feature changes and bug fixes - 

Targeted test run:

```bash
.venv/bin/python -m pytest tests/core/agent_harness/test_gather_discovery_budget.py
```

Result:

```text
11 passed in 1.22s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The test helper was constructing `ToolExecutionRequest` with an anonymous object that only exposed `source`, plus a `type: ignore`. Since `ToolExecutionRequest.tool` expects a `RuntimeTool`, and `RuntimeTool` is `AgentTool | RegisteredTool`, the test now constructs a minimal `AgentTool` with the requested name, source, object input schema, and a named executor. The executor raises `AssertionError` because the tests should only pass requests through the before/after hooks; they should never execute the fake tool.

I kept the change local to the test helper so all existing classification and budget tests continue to exercise the same request names and arguments.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
