### PR TITLE
feat(hermes): detect API session history failures

### DIFF
--- a/integrations/hermes/correlator.py
+++ b/integrations/hermes/correlator.py
@@ -91,6 +91,7 @@ def default_routing_matrix() -> dict[str, RouteDestination]:
         "oom_killed": RouteDestination.TELEGRAM_WITH_RCA,
         "crash_loop": RouteDestination.PAGER,
         "context_window_exceeded": RouteDestination.TELEGRAM,
+        "session_history_unavailable": RouteDestination.TELEGRAM,
         "auth_failure": RouteDestination.TELEGRAM_WITH_RCA,
         "rate_limit": RouteDestination.TELEGRAM,
         "database_wal_growth": RouteDestination.TELEGRAM_WITH_RCA,

--- a/integrations/hermes/rules.py
+++ b/integrations/hermes/rules.py
@@ -26,6 +26,7 @@ real hermes-agent GitHub issues:
 * ``database_wal_growth``      — sqlite / postgres WAL pressure
 * ``deadlock``                 — explicit deadlock detection
 * ``disk_full``                — ENOSPC / no space left on device
+* ``session_history_unavailable`` — persisted API session history failed open
 """
 
 from __future__ import annotations
@@ -44,11 +45,11 @@ from integrations.hermes.incident import HermesIncident, IncidentSeverity, LogLe
 class PatternRule:
     """Rule that emits one incident per matching log record.
 
-    Patterns are matched case-insensitively against ``record.message``
-    only. ``record.raw`` (which includes the timestamp/level/logger
-    prefix) is intentionally excluded so a keyword appearing in a
-    logger name — e.g. ``oom_monitor`` — cannot fire an OOM rule on
-    an otherwise benign message.
+    Patterns are matched against ``record.message`` only. ``record.raw``
+    (which includes the timestamp/level/logger prefix) is intentionally
+    excluded so a keyword appearing in a logger name — e.g.
+    ``oom_monitor`` — cannot fire an OOM rule on an otherwise benign
+    message. ``logger_names`` optionally binds a rule to named emitters.
     """
 
     name: str
@@ -56,11 +57,14 @@ class PatternRule:
     title_template: str
     patterns: tuple[re.Pattern[str], ...]
     min_level: LogLevel = LogLevel.WARNING
+    logger_names: frozenset[str] | None = None
 
     def evaluate(self, record: LogRecord) -> HermesIncident | None:
         if record.is_continuation:
             return None
         if record.level.severity_rank < self.min_level.severity_rank:
+            return None
+        if self.logger_names is not None and record.logger not in self.logger_names:
             return None
         for pattern in self.patterns:
             if pattern.search(record.message):
@@ -228,6 +232,14 @@ def default_pattern_rules() -> list[PatternRule | RepeatRule]:
                 re.compile(r"disk (?:is )?full", re.IGNORECASE),
             ),
             min_level=LogLevel.WARNING,
+        ),
+        PatternRule(
+            name="session_history_unavailable",
+            severity=IncidentSeverity.MEDIUM,
+            title_template="Session history unavailable in {logger}",
+            patterns=(re.compile(r"^Failed to load session history for .+: .+$"),),
+            min_level=LogLevel.WARNING,
+            logger_names=frozenset({"gateway.platforms.api_server"}),
         ),
         RepeatRule(
             name="crash_loop",

--- a/tests/hermes/test_correlator.py
+++ b/tests/hermes/test_correlator.py
@@ -15,6 +15,7 @@ from integrations.hermes.correlator import (
     default_routing_matrix,
 )
 from integrations.hermes.incident import HermesIncident, IncidentSeverity, LogLevel, LogRecord
+from integrations.hermes.rules import default_pattern_rules
 
 
 def _record(seconds: int = 0) -> LogRecord:
@@ -193,6 +194,12 @@ class TestCorrelateAllAndDefaults:
         assert matrix["disk_full"] is RouteDestination.PAGER
         assert matrix["oom_killed"] is RouteDestination.TELEGRAM_WITH_RCA
         assert matrix["rate_limit"] is RouteDestination.TELEGRAM
+        assert matrix["session_history_unavailable"] is RouteDestination.TELEGRAM
+
+    def test_default_routing_matrix_covers_every_pattern_rule(self) -> None:
+        matrix = default_routing_matrix()
+        pattern_rule_names = {rule.name for rule in default_pattern_rules()}
+        assert pattern_rule_names <= matrix.keys()
 
 
 class TestCorrelatingSink:

--- a/tests/hermes/test_rules.py
+++ b/tests/hermes/test_rules.py
@@ -95,6 +95,62 @@ def test_default_pattern_rules_match_metamorphic_message_variants(
         assert incident.rule == rule_name
 
 
+def test_session_history_rule_matches_pinned_stock_emitter() -> None:
+    rules = {r.name: r for r in default_pattern_rules()}
+    rule = rules["session_history_unavailable"]
+    record = _rec(
+        "Failed to load session history for session_opaque: database unavailable",
+        level=LogLevel.WARNING,
+        logger_name="gateway.platforms.api_server",
+    )
+    incident = rule.evaluate(record)
+    assert incident is not None
+    assert incident.rule == "session_history_unavailable"
+
+
+@pytest.mark.parametrize(
+    "message,logger_name",
+    [
+        (
+            "Failed to load session history for session_opaque: database unavailable",
+            "third_party.bridge",
+        ),
+        (
+            "conversation history fetch failed status=unavailable",
+            "gateway.platforms.api_server",
+        ),
+        (
+            "[discord] Failed to fetch channel history: forbidden",
+            "gateway.platforms.api_server",
+        ),
+        (
+            "[Slack] Failed to fetch thread context: timeout",
+            "gateway.platforms.api_server",
+        ),
+        (
+            "Matrix: fetch history error: unavailable",
+            "gateway.platforms.api_server",
+        ),
+        (
+            'operator quoted "Failed to load session history for session_opaque: timeout"',
+            "gateway.platforms.api_server",
+        ),
+        (
+            "FAILED TO LOAD SESSION HISTORY FOR session_opaque: timeout",
+            "gateway.platforms.api_server",
+        ),
+    ],
+)
+def test_session_history_rule_rejects_other_emitters_and_messages(
+    message: str,
+    logger_name: str,
+) -> None:
+    rules = {r.name: r for r in default_pattern_rules()}
+    rule = rules["session_history_unavailable"]
+    record = _rec(message, level=LogLevel.WARNING, logger_name=logger_name)
+    assert rule.evaluate(record) is None
+
+
 def test_pattern_rules_respect_min_level() -> None:
     rules = {r.name: r for r in default_pattern_rules()}
     rule = rules["oom_killed"]

--- a/tests/synthetic/hermes/011-session-history-unavailable/README.md
+++ b/tests/synthetic/hermes/011-session-history-unavailable/README.md
@@ -1,0 +1,36 @@
+# 011-session-history-unavailable — Hermes API session history fails open
+
+## Source contract
+
+- Emitter: `NousResearch/hermes-agent` `gateway/platforms/api_server.py::_conversation_history_for_session`
+- Source pinned by the issue: [`530028c`](https://github.com/NousResearch/hermes-agent/blob/530028c213ae9eed5d7f1a826451e0edf24a11d2/gateway/platforms/api_server.py#L4182-L4190)
+- Verified unchanged on current `main`: [`739bc55`](https://github.com/NousResearch/hermes-agent/blob/739bc555b1932e66c169b20edec3a48368e2dd3f/gateway/platforms/api_server.py#L4211-L4219)
+- Logging contract: [`hermes_logging.py`](https://github.com/NousResearch/hermes-agent/blob/739bc555b1932e66c169b20edec3a48368e2dd3f/hermes_logging.py#L330-L338)
+- Watched log: `~/.hermes/logs/errors.log`
+- Logger allowlist: `gateway.platforms.api_server`
+- Level: `WARNING`
+- Case-sensitive message template: `Failed to load session history for %s: %s`
+
+The source catches an exception from the persisted-session message lookup, emits
+this warning, and immediately returns an empty conversation. It does not retry
+or emit a recovery marker on this path, so the warning is the fail-open event.
+
+## Fixture provenance
+
+`errors.log` is a sanitized, source-derived byte-faithful rendering of the
+pinned emitter, not a captured production log. The Python logging header matches
+the format accepted by `integrations.hermes.parser`; the message preserves the
+emitter's exact static text and replaces only the session identifier and
+exception with opaque values.
+
+The `session_history_unavailable` rule binds both the exact logger and message.
+A first event is `MEDIUM` and routes explicitly to `TELEGRAM`, without RCA. Its
+fingerprint intentionally groups this rule and logger across session IDs during
+the correlator window because a shared history-store failure can affect several
+sessions. The second hit is deduplicated; the third hit is delivered as `HIGH`
+to the same explicit `TELEGRAM` route, still without RCA. The fixture stays below
+the warning-burst threshold and does not emit `error_severity`.
+
+Discord channel history, Slack thread context, Matrix room history, and custom
+bridge transcript failures have different emitters and semantics. They are not
+matched by this rule.

--- a/tests/synthetic/hermes/011-session-history-unavailable/answer.yml
+++ b/tests/synthetic/hermes/011-session-history-unavailable/answer.yml
@@ -1,0 +1,11 @@
+expected_incidents:
+  - rule: "session_history_unavailable"
+    severity: "medium"
+    logger: "gateway.platforms.api_server"
+    title_contains: "Session history unavailable"
+
+expected_incident_count:
+  session_history_unavailable: "==1"
+  warning_burst: "==0"
+  error_severity: "==0"
+  traceback: "==0"

--- a/tests/synthetic/hermes/011-session-history-unavailable/errors.log
+++ b/tests/synthetic/hermes/011-session-history-unavailable/errors.log
@@ -1,0 +1,1 @@
+2026-08-23 14:03:12,150 WARNING gateway.platforms.api_server: Failed to load session history for session_opaque: history backend unavailable

--- a/tests/synthetic/hermes/011-session-history-unavailable/scenario.yml
+++ b/tests/synthetic/hermes/011-session-history-unavailable/scenario.yml
@@ -1,0 +1,4 @@
+scenario_id: "011-session-history-unavailable"
+title: "Hermes API session history lookup fails open"
+source: "https://github.com/NousResearch/hermes-agent/blob/739bc555b1932e66c169b20edec3a48368e2dd3f/gateway/platforms/api_server.py#L4211-L4219"
+log_file: "errors.log"

--- a/tests/synthetic/hermes/README.md
+++ b/tests/synthetic/hermes/README.md
@@ -1,10 +1,11 @@
 # Hermes Synthetic Suite
 
-Real-world Hermes log fixtures used to lock in the behavior of
-`integrations.hermes.IncidentClassifier`. Each scenario captures a production
-pattern observed on a Hermes deployment, ships the raw `errors.log`
-slice that triggered it, and declares — in `answer.yml` — the incidents
-the classifier is expected to emit.
+Hermes log fixtures used to lock in the behavior of
+`integrations.hermes.IncidentClassifier`. A scenario must use either a captured
+log slice or a sanitized, byte-faithful rendering of a named first-party emitter
+pinned to a source commit. Its README must state the provenance. A reconstructed
+warning with self-authored vocabulary is not evidence for a default rule. Each
+scenario declares the expected incidents in `answer.yml`.
 
 The suite runs offline: there is no LLM, no live infrastructure, and no
 mocking. The classifier is rule-based, so the assertions are exact.
@@ -65,9 +66,10 @@ asserts the total per-rule emission count using the operators `==`,
 
 ## Adding a new scenario
 
-1. Capture a slice of the Hermes log that demonstrates the pattern.
-   Strip irrelevant lines but keep timestamps intact — the classifier
-   uses them for the warning-burst window.
+1. Capture a Hermes log slice, or pin a named first-party emitter and create a
+   sanitized byte-faithful line in the supported parser format. Document which
+   provenance type you used. Strip irrelevant captured lines but keep timestamps
+   intact — the classifier uses them for the warning-burst window.
 2. Create a new numbered directory `NNN-short-name/` under this folder.
 3. Drop the log into `errors.log` and write the two YAML files.
 4. Run `uv run pytest tests/synthetic/hermes -q` to confirm the

--- a/tests/synthetic/hermes/test_session_history_routing_e2e.py
+++ b/tests/synthetic/hermes/test_session_history_routing_e2e.py
@@ -1,0 +1,85 @@
+"""End-to-end routing proof for the stock Hermes session-history warning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from integrations.hermes.agent import HermesAgent
+from integrations.hermes.classifier import IncidentClassifier
+from integrations.hermes.correlating_sink import CorrelatingSink
+from integrations.hermes.correlator import IncidentCorrelator, RouteDestination
+from integrations.hermes.incident import HermesIncident, IncidentSeverity
+
+pytestmark = pytest.mark.synthetic
+
+_SCENARIO_DIR = Path(__file__).parent / "011-session-history-unavailable"
+
+
+def test_stock_session_history_warning_reaches_telegram_route() -> None:
+    log_path = _SCENARIO_DIR / "errors.log"
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    delivered: list[HermesIncident] = []
+    sink = CorrelatingSink(
+        correlator=IncidentCorrelator(),
+        routes={RouteDestination.TELEGRAM: delivered.append},
+    )
+    agent = HermesAgent(
+        sink=sink,
+        log_path=log_path,
+        classifier=IncidentClassifier(),
+    )
+
+    emitted = agent.process(lines)
+
+    assert delivered == emitted
+    assert len(delivered) == 1
+    incident = delivered[0]
+    assert incident.rule == "session_history_unavailable"
+    assert incident.severity is IncidentSeverity.MEDIUM
+    assert incident.logger == "gateway.platforms.api_server"
+    assert incident.records[0].raw == lines[0]
+    assert sink.metrics_snapshot()["delivered"] == 1
+
+
+def test_repeated_stock_warning_deduplicates_then_escalates_on_telegram() -> None:
+    log_path = _SCENARIO_DIR / "errors.log"
+    source_line = log_path.read_text(encoding="utf-8").strip()
+    lines = [
+        source_line.replace("14:03:12,150", f"14:03:{second:02d},150").replace(
+            "session_opaque", f"session_{second}"
+        )
+        for second in (12, 13, 14)
+    ]
+
+    delivered: list[HermesIncident] = []
+    sink = CorrelatingSink(
+        correlator=IncidentCorrelator(),
+        routes={RouteDestination.TELEGRAM: delivered.append},
+    )
+    agent = HermesAgent(
+        sink=sink,
+        log_path=log_path,
+        classifier=IncidentClassifier(),
+    )
+
+    emitted = agent.process(lines)
+
+    assert len(emitted) == 3
+    assert [incident.severity for incident in delivered] == [
+        IncidentSeverity.MEDIUM,
+        IncidentSeverity.HIGH,
+    ]
+    assert all(incident.rule == "session_history_unavailable" for incident in delivered)
+    assert delivered[1].fingerprint.endswith(":escalated")
+    assert sink.metrics_snapshot() == {
+        "delivered": 2,
+        "suppressed": 1,
+        "escalated": 1,
+        "dropped": 0,
+        "unrouted": 0,
+        "sink_errors": 0,
+    }


### PR DESCRIPTION
Closes #5458.

Related stock emitter:
- issue-pinned source: [`NousResearch/hermes-agent@530028c`](https://github.com/NousResearch/hermes-agent/blob/530028c213ae9eed5d7f1a826451e0edf24a11d2/gateway/platforms/api_server.py#L4182-L4190)
- verified unchanged on current `main`: [`739bc55`](https://github.com/NousResearch/hermes-agent/blob/739bc555b1932e66c169b20edec3a48368e2dd3f/gateway/platforms/api_server.py#L4211-L4219)

#### Describe the changes you have made in this PR -

Adds a narrowly scoped default Hermes incident rule for the stock API session-history fail-open path:

```python
logger.warning("Failed to load session history for %s: %s", session_id, exc)
return []
```

The rule:

- is named `session_history_unavailable`;
- requires the exact `gateway.platforms.api_server` logger;
- matches the anchored, case-sensitive stock message contract;
- emits `MEDIUM` on the first warning;
- routes explicitly to `TELEGRAM` without RCA;
- intentionally fingerprints across session IDs, so a shared history-store failure is one outage bucket;
- suppresses the second duplicate and delivers the third as `HIGH` to the same explicit `TELEGRAM` route.

The PR also adds:

- an optional exact logger allowlist to `PatternRule`;
- negative tests for unrelated Discord, Slack, Matrix, custom bridge, quoted, and wrong-case messages;
- a registry-versus-routing invariant for every built-in pattern rule;
- a source-derived, byte-faithful fixture with pinned emitter and logging provenance;
- a real `HermesAgent` parser → classifier → correlator → sink proof for first-hit and repeated-hit routing;
- synthetic-suite guidance that rejects self-authored warning vocabulary as default-rule evidence.

Discord channel history, Slack thread context, Matrix room history, and the custom bridge vocabulary from the motivating deployment are deliberately out of scope because they have different emitters and semantics.

### Validation

```text
uv run pytest tests/hermes tests/synthetic/hermes -q
217 passed

make lint
All checks passed

make format-check
3672 files already formatted

make typecheck
Success: no issues found in 1907 source files
```

`make test` also completed its local unit phase with 342 passed and 1 skipped. Its second target is a live Prefect/ECS investigation and cannot complete in this environment without AWS and Anthropic credentials.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The stock `gateway.platforms.api_server` warning is the smallest stable contract for this failure mode. `PatternRule` now supports an optional exact logger allowlist, which binds the built-in to that named emitter while preserving existing rules. The message matcher keeps only the emitter's static text and dynamic `%s` slots; it does not infer generic conversation-context vocabulary.

The explicit correlator entry makes routing intentional rather than relying on unknown-rule severity fallback. The synthetic end-to-end test loads the same byte-faithful fixture through the real agent, classifier, correlator, and TELEGRAM-only sink, so it cannot pass through the prior MEDIUM unknown-rule fallback (`DROP`).

---

## Checklist before requesting a review
- [x] I have linked the matching OpenSRE issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Impact: backward compatible with released code. The replaced broad rule existed only in this unmerged PR. Fixture identifiers are opaque and contain no customer content, credentials, or production hostnames.
