### PR TITLE
refactor(harness): type ReasoningClientProvider.get by its real contract

### DIFF
--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -16,7 +16,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
-from core.llm.types import AgentLLMClient
+from core.llm.types import AgentLLMClient, StreamingReasoningClient
 from core.tool.execution import ToolExecutionHooks
 
 # A tool-loop event callback: ``(kind, data)`` where kind is e.g. "tool_start".
@@ -220,8 +220,8 @@ class PromptContextProvider(Protocol):
 class ReasoningClientProvider(Protocol):
     """Provides the streaming reasoning LLM client for the assistant answer."""
 
-    def get(self) -> Any | None:
-        raise NotImplementedError
+    def get(self) -> StreamingReasoningClient | None:
+        """Return the reasoning client, or ``None`` when one cannot be built."""
 
 
 @runtime_checkable

--- a/core/agent_harness/turns/default_reasoning_client.py
+++ b/core/agent_harness/turns/default_reasoning_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from rich.markup import escape
 
@@ -10,6 +10,7 @@ from core.agent_harness.ports import (
     ErrorReporter,
     OutputSink,
 )
+from core.llm.types import StreamingReasoningClient
 
 
 def _llm_client_unavailable_message(exc: Exception) -> str:
@@ -46,7 +47,7 @@ class DefaultReasoningClientProvider:
         """Retarget LLM-unavailable error rendering after ``bind_turn(output=)``."""
         self._output = output
 
-    def get(self) -> Any | None:
+    def get(self) -> StreamingReasoningClient | None:
         try:
             from core.llm.factory import LLMRole, get_llm
         except Exception as exc:
@@ -55,7 +56,10 @@ class DefaultReasoningClientProvider:
             )
             return None
         try:
-            return get_llm(LLMRole.REASONING)
+            # ``get_llm`` stays untyped for this role on purpose: other callers
+            # use the same client for structured output, not streaming. This
+            # provider promises only the streaming contract, so narrow here.
+            return cast(StreamingReasoningClient, get_llm(LLMRole.REASONING))
         except Exception as exc:
             self._handle_unavailable(
                 exc, context="core.agent_harness.default_reasoning_client.create"

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -23,6 +23,7 @@ from core.agent_harness.turns.turn_results import (
     ToolCallingTurnResult,
     TurnResult,
 )
+from core.llm.types import StreamingReasoningClient
 
 
 @dataclass
@@ -227,7 +228,7 @@ class SimpleRunRecordFactory:
 class StaticReasoningClientProvider:
     """Provides a fixed reasoning client (or None to skip the assistant)."""
 
-    client: Any | None = None
+    client: StreamingReasoningClient | None = None
 
     def bind_session(self, session: Any) -> None:
         """Client is fixed at construction — ignore session retargets."""
@@ -237,5 +238,5 @@ class StaticReasoningClientProvider:
         """No sink of its own — accept rebind for :class:`OutputBindable` parity."""
         _ = output
 
-    def get(self) -> Any | None:
+    def get(self) -> StreamingReasoningClient | None:
         return self.client


### PR DESCRIPTION
Fixes #5245

#### Describe the changes you have made in this PR -

`ReasoningClientProvider.get()` was declared `Any | None`, erasing the contract for every caller reading the seam.

**The type is `StreamingReasoningClient`, not `AgentLLMClient`.** The issue asks for `AgentLLMClient | None`, but that Protocol does not describe this seam:

- `AgentLLMClient` documents itself as *"deliberately narrow: only the two methods `Agent` invokes on its `llm` (`tool_schemas` and `invoke`)"*. It has no `invoke_stream`.
- The only thing the answer path ever calls on this client is `invoke_stream` — `orchestrator._stream_response` passes `chunks=client.invoke_stream(turn_prompt.messages())`.
- `core/llm/types.py` already declares exactly that contract, twelve lines below `AgentLLMClient`:

  ```python
  @runtime_checkable
  class StreamingReasoningClient(Protocol):
      """The streaming LLM contract the conversational assistant answer depends on."""

      def invoke_stream(self, prompt_or_messages: Any) -> Iterator[str]: ...
  ```

Typing the seam as `AgentLLMClient` would name a contract its only consumer does not use, so this PR uses `StreamingReasoningClient | None`. Glad to switch if `AgentLLMClient` was intended for a reason I have not spotted.

**Why a `cast` rather than a factory overload.** `get_llm` already overloads `Literal[LLMRole.AGENT] -> AgentLLMClient`, so adding a `REASONING` overload looked natural — but it would mistype other callers: `integrations/daily_update.py` calls `.with_structured_output(...)` on the same role, and `integrations/opensre/llm_eval_judge.py` uses it too. The factory is genuinely broader than streaming. The narrowing therefore happens at this provider's own boundary, matching existing practice in `core/`.

**Files**
- `core/agent_harness/ports.py` — `ReasoningClientProvider.get() -> StreamingReasoningClient | None`. Per AGENTS.md Code Style, this changed Protocol method also drops its `raise NotImplementedError` body for a docstring-only one. Pre-existing stubs elsewhere are untouched, as the issue's ground rules require.
- `core/agent_harness/turns/default_reasoning_client.py` — the core-owned implementation, plus the cast at the `get_llm` boundary.
- `core/agent_harness/turns/headless_adapters.py` — `StaticReasoningClientProvider`, field and return.

No behaviour change: types only.

Note: this issue appears to be a duplicate of #5229 — the batch was filed twice, at 09:12 and 09:16.

### Demo/Screenshot for feature changes and bug fixes -

Type-only change, so the gates are the proof. Both checks named in the issue:

```
$ make typecheck
Success: no issues found in 1860 source files

$ make check-imports
No import cycles found across 1992 first-party modules (8 roots).
=== [2/3] Import layers (import-linter) ===
=== [3/3] Forbidden direct import edges (module + nested) ===
No forbidden direct import edges found (module baseline: 0, nested baseline: 0).
All 3 import checks passed.
```

Tests:

```
$ uv run pytest tests/core/agent_harness gateway/tests -q
1284 passed, 1 warning in 31.02s

$ make lint
All checks passed!
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!-- to be completed by the author before requesting review -->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions
