### PR TITLE
fix(embedded): gather repeated GitHub star velocity

### DIFF
--- a/bootstrap/embedded.py
+++ b/bootstrap/embedded.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from bootstrap.process import EMBEDDED_PROFILE, configure_process
 from core.agent_harness import AgentSession, OutputSink, SessionConfig, SessionCore
 from core.agent_harness.ports import PromptContextProvider
+from core.agent_harness.runtime import GatherPhase
 
 
 def embedded_boot_step() -> None:
@@ -36,18 +37,26 @@ def start_embedded_session(
     output: OutputSink | None = None,
     prompts: PromptContextProvider | None = None,
     prepare_session: Callable[[SessionCore], None] | None = None,
+    gather: GatherPhase | None = None,
 ) -> AgentSession:
-    """Return a started :class:`AgentSession` with local adapters installed.
+    """Return a started session with local adapters and live gathering enabled.
 
     ``config.boot_process`` is filled in when the caller left it unset; a
-    caller that supplies its own boot step keeps it.
+    caller that supplies its own boot step keeps it. Pass a disabled
+    :class:`GatherPhase` to opt out of live integration reads.
     """
     from dataclasses import replace
 
     cfg = config or SessionConfig()
     if cfg.boot_process is None:
         cfg = replace(cfg, boot_process=embedded_boot_step)
-    return AgentSession.start(cfg, output=output, prompts=prompts, prepare_session=prepare_session)
+    return AgentSession.start(
+        cfg,
+        output=output,
+        prompts=prompts,
+        prepare_session=prepare_session,
+        gather=gather if gather is not None else GatherPhase(),
+    )
 
 
 __all__ = ["embedded_boot_step", "start_embedded_session"]

--- a/integrations/github/repo_scope.py
+++ b/integrations/github/repo_scope.py
@@ -132,6 +132,26 @@ def _infer_workspace_repo_scope(
     return detect_git_remote_repo_scope(cwd)
 
 
+def _mark_public_workspace_scope(
+    scope: tuple[str, str],
+    *,
+    cached: tuple[str, ...] | None,
+    env: Mapping[str, str] | None,
+    cwd: str | Path | None,
+) -> tuple[str, ...]:
+    """Preserve public access when a resolved scope is the current workspace."""
+    if (
+        cached is not None
+        and len(cached) >= 3
+        and cached[:2] == scope
+        and cached[2] == _PUBLIC_WORKSPACE_SCOPE_MARKER
+    ):
+        return cached
+    if _infer_workspace_repo_scope(env=env, cwd=cwd) == scope:
+        return (*scope, _PUBLIC_WORKSPACE_SCOPE_MARKER)
+    return scope
+
+
 def apply_github_repo_scope(
     resolved: dict[str, Any],
     owner: str,
@@ -172,14 +192,34 @@ class _GithubVcsRepoScopeProvider:
     ) -> tuple[str, ...] | None:
         from_message = parse_github_repository_reference(message)
         if from_message:
-            return from_message
+            return _mark_public_workspace_scope(
+                from_message,
+                cached=cached,
+                env=env,
+                cwd=cwd,
+            )
+        # This is the scope selected from the prior turn's user message. Keep
+        # it ahead of generated conversation prose, which may contain
+        # slash-shaped rates such as ``0.43/day`` that resemble a bare repo.
+        if cached:
+            if len(cached) == 2:
+                return _mark_public_workspace_scope(
+                    (cached[0], cached[1]),
+                    cached=cached,
+                    env=env,
+                    cwd=cwd,
+                )
+            return cached
         if conversation_messages:
             for _role, content in reversed(conversation_messages):
                 from_history = parse_github_repository_reference(content)
                 if from_history:
-                    return from_history
-        if cached:
-            return cached
+                    return _mark_public_workspace_scope(
+                        from_history,
+                        cached=cached,
+                        env=env,
+                        cwd=cwd,
+                    )
         workspace_scope = _infer_workspace_repo_scope(env=env, cwd=cwd)
         if workspace_scope is None:
             return None

--- a/integrations/github/repo_scope.py
+++ b/integrations/github/repo_scope.py
@@ -135,19 +135,14 @@ def _infer_workspace_repo_scope(
 def _mark_public_workspace_scope(
     scope: tuple[str, str],
     *,
-    cached: tuple[str, ...] | None,
     env: Mapping[str, str] | None,
     cwd: str | Path | None,
 ) -> tuple[str, ...]:
-    """Preserve public access when a resolved scope is the current workspace."""
-    if (
-        cached is not None
-        and len(cached) >= 3
-        and cached[:2] == scope
-        and cached[2] == _PUBLIC_WORKSPACE_SCOPE_MARKER
+    """Allow public access only while a resolved scope is the current workspace."""
+    workspace_scope = _infer_workspace_repo_scope(env=env, cwd=cwd)
+    if workspace_scope is not None and tuple(part.casefold() for part in workspace_scope) == tuple(
+        part.casefold() for part in scope
     ):
-        return cached
-    if _infer_workspace_repo_scope(env=env, cwd=cwd) == scope:
         return (*scope, _PUBLIC_WORKSPACE_SCOPE_MARKER)
     return scope
 
@@ -194,7 +189,6 @@ class _GithubVcsRepoScopeProvider:
         if from_message:
             return _mark_public_workspace_scope(
                 from_message,
-                cached=cached,
                 env=env,
                 cwd=cwd,
             )
@@ -202,21 +196,17 @@ class _GithubVcsRepoScopeProvider:
         # it ahead of generated conversation prose, which may contain
         # slash-shaped rates such as ``0.43/day`` that resemble a bare repo.
         if cached:
-            if len(cached) == 2:
-                return _mark_public_workspace_scope(
-                    (cached[0], cached[1]),
-                    cached=cached,
-                    env=env,
-                    cwd=cwd,
-                )
-            return cached
+            return _mark_public_workspace_scope(
+                (cached[0], cached[1]),
+                env=env,
+                cwd=cwd,
+            )
         if conversation_messages:
             for _role, content in reversed(conversation_messages):
                 from_history = parse_github_repository_reference(content)
                 if from_history:
                     return _mark_public_workspace_scope(
                         from_history,
-                        cached=cached,
                         env=env,
                         cwd=cwd,
                     )

--- a/tests/bootstrap/test_embedded_session.py
+++ b/tests/bootstrap/test_embedded_session.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from bootstrap.embedded import embedded_boot_step, start_embedded_session
 from core.agent_harness.harness import SessionConfig
+from core.agent_harness.runtime import GatherPhase
 
 
 def test_start_embedded_session_supplies_the_boot_step(monkeypatch: Any) -> None:
@@ -51,6 +52,37 @@ def test_a_caller_supplied_boot_step_is_kept(monkeypatch: Any) -> None:
 
     # Assert.
     assert captured["config"].boot_process is _mine
+
+
+def test_embedded_session_enables_live_gathering_by_default(monkeypatch: Any) -> None:
+    """The Python chat API must be able to read its installed integration tools."""
+    captured: dict[str, Any] = {}
+
+    def _fake_start(_config: SessionConfig | None = None, **kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("bootstrap.embedded.AgentSession.start", staticmethod(_fake_start))
+
+    start_embedded_session()
+
+    assert captured["gather"] == GatherPhase()
+
+
+def test_embedded_session_keeps_caller_gather_policy(monkeypatch: Any) -> None:
+    """Embedded hosts can still disable live integration reads explicitly."""
+    captured: dict[str, Any] = {}
+    disabled = GatherPhase(enabled=False)
+
+    def _fake_start(_config: SessionConfig | None = None, **kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("bootstrap.embedded.AgentSession.start", staticmethod(_fake_start))
+
+    start_embedded_session(gather=disabled)
+
+    assert captured["gather"] is disabled
 
 
 def test_embedded_session_boots_adapters_so_integrations_resolve() -> None:

--- a/tests/bootstrap/test_embedded_star_velocity.py
+++ b/tests/bootstrap/test_embedded_star_velocity.py
@@ -1,0 +1,182 @@
+"""Scripted Python API coverage for repeated GitHub star-velocity turns."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from bootstrap.embedded import start_embedded_session
+from bootstrap.process import reset_process_runtime_for_tests
+from core.agent_harness.harness import SessionConfig
+from core.llm.factory import LLMRole
+from core.llm.types import AgentLLMResponse, ToolCall
+from platform.harness_ports import reset_harness_ports
+
+
+class _StarVelocityScriptedLLM:
+    """Handoff star questions, then call the GitHub history tool."""
+
+    model_id = "scripted-star-velocity"
+
+    def __init__(self) -> None:
+        self.star_history_calls = 0
+
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, str]]:
+        return [{"name": str(tool.name)} for tool in tools]
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        del system
+        tool_names = {str(schema.get("name")) for schema in tools or []}
+        if "assistant_handoff" in tool_names:
+            if any(message.get("role") == "tool" for message in messages):
+                return AgentLLMResponse(content="", tool_calls=[], raw_content=None)
+            return AgentLLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="handoff-star-velocity",
+                        name="assistant_handoff",
+                        input={
+                            "content": "Fetch GitHub star history.",
+                            "requires_gather": True,
+                        },
+                    )
+                ],
+                raw_content=None,
+            )
+        if "get_github_star_history" in tool_names:
+            if any(message.get("role") == "tool" for message in messages):
+                return AgentLLMResponse(
+                    content="GitHub star history fetched.",
+                    tool_calls=[],
+                    raw_content=None,
+                )
+            self.star_history_calls += 1
+            return AgentLLMResponse(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id=f"star-history-{self.star_history_calls}",
+                        name="get_github_star_history",
+                        input={"days": 7},
+                    )
+                ],
+                raw_content=None,
+            )
+        raise AssertionError(f"unexpected tool schemas: {sorted(tool_names)}")
+
+    @staticmethod
+    def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": call.id, "name": call.name, "input": call.input} for call in tool_calls
+            ],
+        }
+
+    @staticmethod
+    def build_tool_result_message(
+        _tool_calls: list[ToolCall], results: list[Any]
+    ) -> dict[str, Any]:
+        return {"role": "tool", "content": json.dumps(results, default=str)}
+
+    @staticmethod
+    def with_structured_output(schema: Any) -> Any:
+        class _GoalReached:
+            @staticmethod
+            def invoke(_prompt: str) -> Any:
+                return schema(verdict="GOAL_REACHED")
+
+        return _GoalReached()
+
+
+class _DefiniteStarAnswerLLM:
+    model_id = "scripted-star-answer"
+
+    def __init__(self) -> None:
+        self.observations: list[str] = []
+
+    def invoke_stream(self, messages: list[dict[str, Any]]) -> Any:
+        prompt = json.dumps(messages, default=str)
+        assert "get_github_star_history" in prompt
+        assert "stargazers_count" in prompt and "100" in prompt
+        assert "stars_in_window" in prompt and "3" in prompt
+        self.observations.append(prompt)
+        yield "Tracer-Cloud/opensre has 100 stars and gained 3 in 7 days (0.43/day), an upward trend."
+
+
+def test_embedded_session_retries_star_velocity_with_live_github_data(
+    monkeypatch: Any,
+) -> None:
+    """Repeated Python API turns keep gathering until each answer is definite."""
+    prompts = (
+        "what is our current github star developer velocity?",
+        (
+            "What do you mean? Just look up the github star velocity on "
+            "https://github.com/Tracer-Cloud/opensre"
+        ),
+        "No this is wrong you should get to the definite answer",
+    )
+    scripted = _StarVelocityScriptedLLM()
+    answer = _DefiniteStarAnswerLLM()
+
+    def _get_llm(role: LLMRole) -> Any:
+        if role is LLMRole.AGENT:
+            return scripted
+        if role is LLMRole.REASONING:
+            return answer
+        raise AssertionError(f"unexpected LLM role: {role}")
+
+    def _github_request(_self: Any, _method: str, path: str, **_kwargs: Any) -> Any:
+        if path == "/repos/Tracer-Cloud/opensre":
+            return {"stargazers_count": 100}
+        if path == "/repos/Tracer-Cloud/opensre/stargazers":
+            return [
+                {"starred_at": "2026-08-18T10:00:00Z"},
+                {"starred_at": "2026-08-19T10:00:00Z"},
+                {"starred_at": "2026-08-20T10:00:00Z"},
+            ]
+        raise AssertionError(f"unexpected GitHub path: {path}")
+
+    def _prepare_session(state: Any) -> None:
+        state.resolved_integrations_cache = {}
+
+    reset_harness_ports()
+    reset_process_runtime_for_tests()
+    monkeypatch.setenv("OPENSRE_WORKSPACE_REPO", "Tracer-Cloud/opensre")
+    monkeypatch.setattr("core.llm.factory.get_llm", _get_llm)
+    monkeypatch.setattr(
+        "integrations.github.tools.stargazers._now_utc",
+        lambda: datetime(2026, 8, 20, 12, 0, tzinfo=UTC),
+    )
+    monkeypatch.setattr(
+        "integrations.github.tools.stargazers.GitHubRestClient.request",
+        _github_request,
+    )
+
+    session = start_embedded_session(
+        SessionConfig(
+            load_env=False,
+            hydrate_integrations=False,
+            warm_integrations=False,
+            persistent_tasks=False,
+            open_store=False,
+        ),
+        prepare_session=_prepare_session,
+    )
+
+    results = [session.chat(prompt) for prompt in prompts]
+
+    assert scripted.star_history_calls == 3
+    assert len(answer.observations) == 3
+    assert [result.gather_success_count for result in results] == [1, 1, 1]
+    assert all("100 stars" in result.primary_response_text for result in results)
+    assert all("upward trend" in result.primary_response_text for result in results)

--- a/tests/interactive_shell/tools/test_tool_gathering.py
+++ b/tests/interactive_shell/tools/test_tool_gathering.py
@@ -287,7 +287,11 @@ def test_resolve_gather_integrations_enriches_github_from_repo_url() -> None:
     gh = resolved["github"]
     assert gh["owner"] == "Tracer-Cloud"
     assert gh["repo"] == "opensre"
-    assert session.vcs_repo_scopes["github"] == ("Tracer-Cloud", "opensre")
+    assert session.vcs_repo_scopes["github"] == (
+        "Tracer-Cloud",
+        "opensre",
+        "public_workspace",
+    )
 
 
 def test_resolve_gather_integrations_adds_public_workspace_github(

--- a/tests/tools/test_github_repo_scope.py
+++ b/tests/tools/test_github_repo_scope.py
@@ -182,6 +182,26 @@ def test_prompt_repository_does_not_enable_public_fallback() -> None:
     assert GITHUB_VCS_REPO_SCOPE_PROVIDER.apply({}, scope) == {}
 
 
+def test_prompt_workspace_repository_keeps_public_fallback() -> None:
+    scope = GITHUB_VCS_REPO_SCOPE_PROVIDER.infer(
+        message="Check stars for https://github.com/Tracer-Cloud/opensre",
+        conversation_messages=[],
+        env={"OPENSRE_WORKSPACE_REPO": "Tracer-Cloud/opensre"},
+        cwd="/not/a/repository",
+        cached=None,
+    )
+    assert scope is not None
+
+    assert GITHUB_VCS_REPO_SCOPE_PROVIDER.apply({}, scope) == {
+        "github": {
+            "connection_verified": False,
+            "public_repository": True,
+            "owner": "Tracer-Cloud",
+            "repo": "opensre",
+        }
+    }
+
+
 def test_workspace_scope_keeps_configured_github_authenticated() -> None:
     scope = GITHUB_VCS_REPO_SCOPE_PROVIDER.infer(
         message="What is our current GitHub star developer velocity?",

--- a/tests/tools/test_github_repo_scope.py
+++ b/tests/tools/test_github_repo_scope.py
@@ -184,7 +184,7 @@ def test_prompt_repository_does_not_enable_public_fallback() -> None:
 
 def test_prompt_workspace_repository_keeps_public_fallback() -> None:
     scope = GITHUB_VCS_REPO_SCOPE_PROVIDER.infer(
-        message="Check stars for https://github.com/Tracer-Cloud/opensre",
+        message="Check stars for https://github.com/tracer-cloud/OpenSRE",
         conversation_messages=[],
         env={"OPENSRE_WORKSPACE_REPO": "Tracer-Cloud/opensre"},
         cwd="/not/a/repository",
@@ -196,10 +196,23 @@ def test_prompt_workspace_repository_keeps_public_fallback() -> None:
         "github": {
             "connection_verified": False,
             "public_repository": True,
-            "owner": "Tracer-Cloud",
-            "repo": "opensre",
+            "owner": "tracer-cloud",
+            "repo": "OpenSRE",
         }
     }
+
+
+def test_cached_public_scope_is_revalidated_after_workspace_change() -> None:
+    scope = GITHUB_VCS_REPO_SCOPE_PROVIDER.infer(
+        message="Check the velocity again",
+        conversation_messages=[],
+        env={"OPENSRE_WORKSPACE_REPO": "other-org/other-repo"},
+        cwd="/not/a/repository",
+        cached=("Tracer-Cloud", "opensre", "public_workspace"),
+    )
+    assert scope == ("Tracer-Cloud", "opensre")
+
+    assert GITHUB_VCS_REPO_SCOPE_PROVIDER.apply({}, scope) == {}
 
 
 def test_workspace_scope_keeps_configured_github_authenticated() -> None:


### PR DESCRIPTION
Fixes #4883

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Enable the embedded Python session API's read-only gather phase by default, while preserving an explicit disabled gather policy supplied by a caller.
- Preserve the public-workspace GitHub scope when the user names the current repository directly.
- Reuse the resolved repository scope before scanning generated assistant prose on follow-up turns, preventing values such as `0.43/day` from being mistaken for an `owner/repo` reference.
- Revalidate cached public-workspace access on every turn and compare GitHub repository casing canonically, so a changed workspace cannot retain stale unauthenticated access.
- Add a scripted Python API smoke test for the issue's exact three-turn sequence. Each turn invokes the real registered `get_github_star_history` tool and must return a numeric, directional answer.

### Demo/Screenshot for feature changes and bug fixes - 

```text
Live local Python API smoke (DeepSeek + GitHub public API):

Attempt 1 (gathered=2): 10,702 stars; about 34 stars/day over 7 days versus
about 62/day over 30 days, so growth is cooling.

Attempt 2 (gathered=1): 10,702 stars; the same numeric short- and long-window
rates and cooling trend were returned after the repository URL was supplied.

Attempt 3 (gathered=2): a definite 34 stars/day current velocity, 10,702 total
stars, and a cooling trend at roughly 55% of the 30-day rate.
```

Local validation:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python .github/ci/run_test_scope.py --base upstream/main` — 3,605 passed, 7 skipped
- Exact targeted suite — 29 passed
- CI regression rerun: `test_resolve_gather_integrations_enriches_github_from_repo_url` — passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The Python entry point installed integration adapters but started `AgentSession` with gathering disabled, so turns could not retrieve live star history. `start_embedded_session` now supplies the standard gather phase unless the caller explicitly provides another policy.

A second failure appeared on repeated turns: generated answers containing a rate such as `0.43/day` matched the permissive bare-repository parser and replaced the correct cached GitHub scope. The provider now gives the current user message first priority, then retains the already resolved session scope before considering older prose. Explicit references to the current workspace are marked as safe for the existing unauthenticated public GitHub fallback; references to another repository are not.
That marker is revalidated case-insensitively on later turns and removed if the process workspace changes.

I considered adding a goal-verification retry in `core/`, but rejected it because the missing integration gather wiring and scope corruption were the concrete causes, and the issue explicitly excludes core changes. The regression test drives the public embedded API through all three required prompts and uses the production tool registry/tool implementation with only the external GitHub response and LLM decisions scripted.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
