### PR TITLE
docs(ci): require GitHub review thread follow-through

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -112,6 +112,13 @@ the repository's merge requirements are satisfied: required GitHub checks are
 green, actionable human or automated review feedback (including Greptile) is
 addressed, and resolved conversations are closed out.
 
+A green check does not mean review feedback is clear. GitHub Code Quality and
+GitHub Advanced Security can post inline review threads even when their checks
+pass. After checks complete, and again after every push, inspect all unresolved
+conversations and latest reviews, including feedback from
+`github-code-quality` and `github-advanced-security`. Validate each finding,
+push an appropriate fix, reply, and resolve the addressed thread.
+
 After each completed PR update, once commits are pushed, the PR description is
 current, and addressed threads are resolved, trigger a Greptile re-review by
 following [CONTRIBUTING.md](CONTRIBUTING.md#greptile-code-review). Repeat until

--- a/CI.md
+++ b/CI.md
@@ -116,8 +116,10 @@ A green check does not mean review feedback is clear. GitHub Code Quality and
 GitHub Advanced Security can post inline review threads even when their checks
 pass. After checks complete, and again after every push, inspect all unresolved
 conversations and latest reviews, including feedback from
-`github-code-quality` and `github-advanced-security`. Validate each finding,
-push an appropriate fix, reply, and resolve the addressed thread.
+`github-code-quality` and `github-advanced-security`. Validate each finding. For
+actionable feedback, push an appropriate fix, reply, and resolve the addressed
+thread. For an incorrect or non-actionable finding, reply with the rationale
+and resolve the thread without changing code.
 
 After each completed PR update, once commits are pushed, the PR description is
 current, and addressed threads are resolved, trigger a Greptile re-review by


### PR DESCRIPTION
Fixes # N/A

Related to #5259.

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Clarifies that green GitHub checks do not guarantee that review feedback is clear.
- Requires contributors to inspect unresolved conversations and latest reviews after checks complete and after every push.
- Explicitly calls out inline feedback from GitHub Code Quality and GitHub Advanced Security, then defines fix and no-code resolution paths for validated findings.

### Demo/Screenshot for feature changes and bug fixes -

Process documentation only. The new `CI.md` requirement covers the failure mode observed on #5259: checks were green while `github-code-quality` and `github-advanced-security` still had unresolved inline review threads.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The existing post-PR section already required actionable automated feedback to be addressed, but its concrete follow-through steps named only Greptile. I added one focused paragraph at that decision point rather than duplicating review guidance elsewhere. It explains the non-obvious distinction between successful checks and unresolved inline reviews, identifies the two GitHub reviewers contributors must not overlook, and states the required remediation loop for both actionable and rejected findings.

No runtime behavior changes. Per the docs/process-only shortcut in `CI.md`, validation was `git status --short` plus `git diff --check` and manual review of the rendered Markdown source.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
