### PR TITLE
fix(github): populate structured_content from text when the MCP server omits it

### DIFF
--- a/integrations/github/helpers.py
+++ b/integrations/github/helpers.py
@@ -123,16 +123,9 @@ def resolve_github_mcp_config(
 
 
 def _structured_content_or_text_fallback(result: dict[str, Any]) -> Any:
-    """Return the MCP tool's structured payload, parsing ``text`` as JSON when
-    the server omitted ``structuredContent``.
+    """Return ``structured_content`` if present, else ``text`` parsed as JSON.
 
-    The real GitHub Copilot MCP server (the default/documented endpoint) does
-    not populate ``structuredContent`` for list_commits, search_issues,
-    search_code, or get_repository_tree — only ``actions.py``'s own
-    ``_extract_json_text`` fallback caught this; the simpler tools
-    (commits/issues/search_code/repository_tree) read ``structured_content``
-    directly and got ``None`` on every real call. ``text`` carries the same
-    data as a raw JSON string for those tools, so it is the fallback source.
+    Returns ``None`` when ``text`` is empty or not valid JSON.
     """
     structured = result.get("structured_content")
     if structured is not None:
@@ -158,8 +151,7 @@ def normalize_github_tool_result(result: dict[str, Any]) -> dict[str, Any]:
     consistent unavailable-source response. Otherwise returns a dict with
     ``source="github"``, ``available=True``, and the original ``tool``,
     ``arguments``, ``text``, ``content`` keys preserved, and
-    ``structured_content`` filled from ``text`` (see
-    :func:`_structured_content_or_text_fallback`) when the server omitted it.
+    ``structured_content`` normalized via :func:`_structured_content_or_text_fallback`.
     """
     if result.get("is_error"):
         return tool_unavailable(

--- a/integrations/github/helpers.py
+++ b/integrations/github/helpers.py
@@ -19,6 +19,7 @@ Exports:
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from core.tool_framework.utils.tool_availability import tool_unavailable
@@ -121,6 +122,30 @@ def resolve_github_mcp_config(
     )
 
 
+def _structured_content_or_text_fallback(result: dict[str, Any]) -> Any:
+    """Return the MCP tool's structured payload, parsing ``text`` as JSON when
+    the server omitted ``structuredContent``.
+
+    The real GitHub Copilot MCP server (the default/documented endpoint) does
+    not populate ``structuredContent`` for list_commits, search_issues,
+    search_code, or get_repository_tree — only ``actions.py``'s own
+    ``_extract_json_text`` fallback caught this; the simpler tools
+    (commits/issues/search_code/repository_tree) read ``structured_content``
+    directly and got ``None`` on every real call. ``text`` carries the same
+    data as a raw JSON string for those tools, so it is the fallback source.
+    """
+    structured = result.get("structured_content")
+    if structured is not None:
+        return structured
+    text = str(result.get("text") or "").strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
 def normalize_github_tool_result(result: dict[str, Any]) -> dict[str, Any]:
     """Normalize a raw GitHub MCP tool result into the tool-framework payload.
 
@@ -132,7 +157,9 @@ def normalize_github_tool_result(result: dict[str, Any]) -> dict[str, Any]:
     ``tool_unavailable("github", ...)`` envelope so the framework surfaces a
     consistent unavailable-source response. Otherwise returns a dict with
     ``source="github"``, ``available=True``, and the original ``tool``,
-    ``arguments``, ``text``, ``structured_content``, ``content`` keys preserved.
+    ``arguments``, ``text``, ``content`` keys preserved, and
+    ``structured_content`` filled from ``text`` (see
+    :func:`_structured_content_or_text_fallback`) when the server omitted it.
     """
     if result.get("is_error"):
         return tool_unavailable(
@@ -147,6 +174,6 @@ def normalize_github_tool_result(result: dict[str, Any]) -> dict[str, Any]:
         "tool": result.get("tool"),
         "arguments": result.get("arguments", {}),
         "text": result.get("text", ""),
-        "structured_content": result.get("structured_content"),
+        "structured_content": _structured_content_or_text_fallback(result),
         "content": result.get("content", []),
     }

--- a/integrations/github/tools/file_contents.py
+++ b/integrations/github/tools/file_contents.py
@@ -17,6 +17,21 @@ from integrations.github.helpers import (
 from integrations.github.mcp import call_github_mcp_tool
 
 
+def _file_from_resource_text(content: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Fallback file payload built from an EmbeddedResource content item.
+
+    The real GitHub Copilot MCP server does not populate ``structuredContent``
+    for get_file_contents, and its ``text`` is a status line ("successfully
+    downloaded text file..."), not JSON — the file body instead arrives as a
+    ``resource_text`` entry in ``content``. Returns None when no such entry
+    is present (e.g. a binary file returned as ``resource_blob``).
+    """
+    for item in content:
+        if item.get("type") == "resource_text":
+            return {"uri": item.get("uri", ""), "content": item.get("text", "")}
+    return None
+
+
 def _get_github_file_contents_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     gh = sources["github"]
     return {
@@ -97,5 +112,8 @@ def get_github_file_contents(
         arguments["sha"] = sha
     result = call_github_mcp_tool(config, "get_file_contents", arguments)
     payload = normalize_github_tool_result(result)
-    payload["file"] = payload.pop("structured_content", None)
+    structured = payload.pop("structured_content", None)
+    if structured is None:
+        structured = _file_from_resource_text(payload.get("content", []))
+    payload["file"] = structured
     return payload

--- a/integrations/github/tools/file_contents.py
+++ b/integrations/github/tools/file_contents.py
@@ -18,13 +18,10 @@ from integrations.github.mcp import call_github_mcp_tool
 
 
 def _file_from_resource_text(content: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """Fallback file payload built from an EmbeddedResource content item.
+    """Return ``{uri, content}`` from the first ``resource_text`` content item.
 
-    The real GitHub Copilot MCP server does not populate ``structuredContent``
-    for get_file_contents, and its ``text`` is a status line ("successfully
-    downloaded text file..."), not JSON — the file body instead arrives as a
-    ``resource_text`` entry in ``content``. Returns None when no such entry
-    is present (e.g. a binary file returned as ``resource_blob``).
+    Returns ``None`` when no such item is present (e.g. a binary file arrives
+    as ``resource_blob`` instead).
     """
     for item in content:
         if item.get("type") == "resource_text":

--- a/tests/tools/test_github_file_contents_tool.py
+++ b/tests/tools/test_github_file_contents_tool.py
@@ -83,3 +83,46 @@ def test_run_happy_path() -> None:
         )
     assert result["available"] is True
     assert result["file"]["name"] == "main.py"
+
+
+def test_run_falls_back_to_resource_text_when_structured_content_absent() -> None:
+    """Regression: the real GitHub Copilot MCP server never populates
+    structuredContent for get_file_contents — confirmed live. Its `text` is a
+    status line ("successfully downloaded..."), not JSON, so the fallback has
+    to read the file body from the resource_text content item instead."""
+    fake_result = {
+        "is_error": False,
+        "tool": "get_file_contents",
+        "arguments": {},
+        "text": "successfully downloaded text file (SHA: abc123)",
+        "structured_content": None,
+        "content": [
+            {"type": "text", "text": "successfully downloaded text file (SHA: abc123)"},
+            {
+                "type": "resource_text",
+                "uri": "repo://org/repo/sha/abc123/contents/main.py",
+                "text": "def main(): pass",
+            },
+        ],
+    }
+    mock_config = MagicMock()
+    with (
+        patch("integrations.github.helpers.github_mcp_config_from_env", return_value=None),
+        patch(
+            "integrations.github.helpers.build_github_mcp_config",
+            return_value=mock_config,
+        ),
+        patch(
+            "integrations.github.tools.file_contents.call_github_mcp_tool", return_value=fake_result
+        ),
+    ):
+        result = get_github_file_contents(
+            owner="org",
+            repo="repo",
+            path="main.py",
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+    assert result["available"] is True
+    assert result["file"]["content"] == "def main(): pass"

--- a/tests/tools/test_github_helpers.py
+++ b/tests/tools/test_github_helpers.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from integrations.github.helpers import github_creds, resolve_github_mcp_config
+from integrations.github.helpers import (
+    github_creds,
+    normalize_github_tool_result,
+    resolve_github_mcp_config,
+)
 from integrations.github.mcp import DEFAULT_GITHUB_MCP_MODE
 
 
@@ -82,3 +86,50 @@ def test_resolve_github_mcp_config_does_not_treat_default_mode_as_override() -> 
         return_value=env_config,
     ):
         assert resolve_github_mcp_config(None, DEFAULT_GITHUB_MCP_MODE, None) is env_config
+
+
+def test_normalize_github_tool_result_parses_text_when_structured_content_absent() -> None:
+    """Regression: the real GitHub Copilot MCP server never populates
+    structuredContent for list_commits/search_issues/search_code/
+    get_repository_tree — confirmed live against Tracer-Cloud/opensre. Every
+    caller that did ``payload.pop("structured_content", None)`` got None on
+    every real call, even though ``text`` carried the same data as a raw
+    JSON string."""
+    result = {
+        "is_error": False,
+        "tool": "list_commits",
+        "arguments": {},
+        "text": '[{"sha": "abc", "message": "fix bug"}]',
+        "structured_content": None,
+        "content": [],
+    }
+    payload = normalize_github_tool_result(result)
+    assert payload["structured_content"] == [{"sha": "abc", "message": "fix bug"}]
+
+
+def test_normalize_github_tool_result_prefers_native_structured_content() -> None:
+    result = {
+        "is_error": False,
+        "tool": "list_commits",
+        "arguments": {},
+        "text": '[{"sha": "should-not-be-used"}]',
+        "structured_content": [{"sha": "native"}],
+        "content": [],
+    }
+    payload = normalize_github_tool_result(result)
+    assert payload["structured_content"] == [{"sha": "native"}]
+
+
+def test_normalize_github_tool_result_stays_none_on_non_json_text() -> None:
+    # get_file_contents' text is a status line ("successfully downloaded..."),
+    # not JSON — the fallback must not raise, just leave structured_content None.
+    result = {
+        "is_error": False,
+        "tool": "get_file_contents",
+        "arguments": {},
+        "text": "successfully downloaded text file (SHA: abc123)",
+        "structured_content": None,
+        "content": [],
+    }
+    payload = normalize_github_tool_result(result)
+    assert payload["structured_content"] is None


### PR DESCRIPTION
Part of #5121 (covers the 12 read-only investigation tools; the remaining ~13 write/mutation tools -- ci_fix, security_fix, workflow mutations, community follow-up -- are not addressed by this PR, so it should not auto-close that issue)

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Found while live-verifying GitHub's read-only investigation tools against a real GitHub Copilot MCP session (`https://api.githubcopilot.com/mcp/`, using a real token derived from `gh auth token`) targeting `Tracer-Cloud/opensre`.

`list_github_commits`, `search_github_issues`, `search_github_code`, and `get_github_repository_tree` all build their primary output field the same way: `payload["<field>"] = payload.pop("structured_content", None)`. Against the real GitHub Copilot MCP server, `structuredContent` is **never populated** for these four tool calls — confirmed by inspecting the raw MCP `CallToolResult` directly. The same data is present, but only as a raw JSON string in the result's `text` field. The net effect: every real call to these four tools returned `commits`/`issues`/`matches`/`tree` as `None`, even though `available: True` and the tool nominally "succeeded" — the actual data was silently unreachable except by manually parsing the LLM-facing `text` string.

`get_github_repository_tree` looked especially broken in initial testing (empty tree for a directory I know exists), but that turned out to be my own test parameter mistake (non-recursive fetch with a nested path filter — git's non-recursive tree API only returns root-level entries, so that's correct behavior, not a bug). The `structured_content: None` issue was separate and real.

Notably, `integrations/github/tools/actions.py`'s tools (`list_github_actions_workflow_runs`, etc.) already work correctly, because they don't rely on `structuredContent` at all — they have their own `_extract_json_text`/`_extract_list` helpers that parse `result["text"]` as JSON directly. This PR applies the same fallback centrally in `normalize_github_tool_result` (`integrations/github/helpers.py`), so `list_github_commits`, `search_github_issues`, and `search_github_code` and `get_github_repository_tree` are fixed without any changes to their own files — they just call `normalize_github_tool_result` and already do `payload.pop("structured_content", None)`.

`get_github_file_contents` needed a separate, targeted fix: its `text` is a status line (`"successfully downloaded text file (SHA: ...)"`), not JSON, so the generic text-fallback doesn't apply. The real file body instead arrives as a `resource_text` entry in the MCP `content` list. Added `_file_from_resource_text` in `file_contents.py` to read it from there when `structured_content` is absent.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix, against the real GitHub Copilot MCP server (`Tracer-Cloud/opensre`, real token):
```
commits is None: True
issues is None: True
matches is None: True
file is None: True
tree is None: True
```

After the fix, same live server, same calls:
```
commits is None: False | count: 3
issues is None: False | total_count: 241
matches is None: False | total_count: 5
file is None: False | content len: 4765
tree is None: False | tree entries: 6
```

Regression test proof: reverted the fix locally (`git stash` on the two source files) and reran the new tests — both failed with the exact symptom above (`assert None == [...]`, `TypeError: 'NoneType' object is not subscriptable`), then restored the fix and confirmed green.

Local checks run: `make lint`, `make format-check`, `make typecheck` (all clean), the full `integrations/github/tools/` scoped test suite per `.github/ci/test_scope_rules.py` (186 passed).

**Also observed while testing (not fixed here, not code bugs):**
- `search_github_issues` returns `total_count: 0` for a bare free-text query (`"verify"`) against the real GitHub Copilot MCP server, even though the identical query string via `gh api search/issues` returns 523 results. This looks like a limitation/quirk of the remote GitHub Copilot MCP server's `search_issues` tool itself (structured qualifiers like `is:open` work fine, 242 results), not something in this repo's code to fix.
- `get_github_star_history` 404s against `Tracer-Cloud/opensre` specifically — confirmed via direct `curl`/`gh api` that GitHub's stargazers-with-timestamps endpoint itself 404s for that repo (10,706 stars), while the identical request against a small repo (0 stars) returns 200. Looks like GitHub disables timestamped stargazer listing above some popularity threshold. The tool's existing error handling for this case is already reasonable.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This was found while live-verifying GitHub's read-only investigation tools end-to-end against a real GitHub Copilot MCP session rather than mocked responses. The existing unit tests all mocked `structured_content` as already populated, which is exactly the unrealistic shape that masked this bug — the real server never sends it for these tool calls. I compared the working (`actions.py`) and broken (`commits.py`/`issues.py`/`search_code.py`/`repository_tree.py`) tool implementations side by side and found `actions.py` already solves this with its own text-parsing fallback; the fix centralizes that same fallback into the shared `normalize_github_tool_result` helper so the four simpler tools inherit it automatically, rather than duplicating the parsing logic five times. `get_github_file_contents` needed a distinct fix because its `text` field isn't JSON for this specific MCP tool — I confirmed this by inspecting the raw MCP `CallToolResult.content` items directly, which showed the file body living in a `resource_text` embedded-resource item instead.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
