### PR TITLE
fix(github): bound the community-followups comment scan

### DIFF
--- a/integrations/github/client.py
+++ b/integrations/github/client.py
@@ -17,6 +17,14 @@ from config.constants import (
 
 JsonPayload = dict[str, Any] | list[Any]
 
+# Safety net for paginate(): GitHub's Link-header pagination has no inherent
+# upper bound, and some endpoints (e.g. /issues/comments, which returns every
+# comment across the whole repository rather than one issue) can run to
+# thousands of pages on an active repo, turning one tool call into a
+# multi-minute scan. 50 pages at the default 100/page is 5,000 items -- ample
+# for any bounded listing (open issues/PRs), while capping runaway endpoints.
+_DEFAULT_PAGINATE_MAX_PAGES = 50
+
 
 @dataclass(frozen=True)
 class GitHubApiError(RuntimeError):
@@ -139,7 +147,15 @@ class GitHubRestClient:
         params: dict[str, Any] | None = None,
         accept: str = "application/vnd.github+json",
         api_version: str = "2022-11-28",
+        max_pages: int = _DEFAULT_PAGINATE_MAX_PAGES,
     ) -> list[dict[str, Any]]:
+        """Follow Link-header pagination, stopping after ``max_pages`` pages.
+
+        Silently returns whatever was collected so far once the cap is hit,
+        rather than raising -- callers on a bounded listing never reach the
+        cap; callers on an unbounded one get a usable partial result instead
+        of an effectively hung tool call.
+        """
         if not self._token and not self._allow_unauthenticated_read:
             raise GitHubApiError(
                 "GitHub token is required. Configure github_token, GITHUB_TOKEN, or GH_TOKEN."
@@ -147,7 +163,9 @@ class GitHubRestClient:
 
         url: str | None = self._url(path, params=params)
         items: list[dict[str, Any]] = []
-        while url:
+        pages_fetched = 0
+        while url and pages_fetched < max_pages:
+            pages_fetched += 1
             req = request.Request(
                 url,
                 method="GET",

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -81,7 +81,11 @@ def summarize_community_followups(
         if comments is not None:
             normalized_comments = comments
         else:
-            since = datetime.now(UTC) - timedelta(days=max(1, since_days))
+            # Upper bound avoids OverflowError from timedelta's own bounded
+            # range (~2.7M days) on an absurd caller-supplied value; 10 years is
+            # already far beyond what "recent" means for this tool.
+            bounded_since_days = min(max(1, since_days), 3650)
+            since = datetime.now(UTC) - timedelta(days=bounded_since_days)
             normalized_comments = GitHubRestClient(github_token).paginate(
                 f"/repos/{owner}/{repo}/issues/comments",
                 params={

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
@@ -53,6 +54,11 @@ def _community_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "comments": {"type": "array"},
             "maintainer_logins": {"type": "array", "items": {"type": "string"}},
             "per_page": {"type": "integer"},
+            "since_days": {
+                "type": "integer",
+                "default": 30,
+                "description": "Only consider comments updated in the last N days.",
+            },
             "github_token": {"type": "string"},
         },
         "required": [],
@@ -67,18 +73,24 @@ def summarize_community_followups(
     comments: list[dict[str, Any]] | None = None,
     maintainer_logins: list[str] | None = None,
     per_page: int = 100,
+    since_days: int = 30,
     github_token: str | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     try:
-        normalized_comments = (
-            comments
-            if comments is not None
-            else GitHubRestClient(github_token).paginate(
+        if comments is not None:
+            normalized_comments = comments
+        else:
+            since = datetime.now(UTC) - timedelta(days=max(1, since_days))
+            normalized_comments = GitHubRestClient(github_token).paginate(
                 f"/repos/{owner}/{repo}/issues/comments",
-                params={"per_page": max(1, min(per_page, 100))},
+                params={
+                    "per_page": max(1, min(per_page, 100)),
+                    "since": since.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "sort": "updated",
+                    "direction": "desc",
+                },
             )
-        )
     except GitHubApiError as exc:
         return tool_unavailable(
             "github",

--- a/tests/integrations/test_github_client.py
+++ b/tests/integrations/test_github_client.py
@@ -113,6 +113,32 @@ def test_paginate_follows_link_header(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(calls) == 2
 
 
+def test_paginate_stops_at_max_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: paginate() followed every Link-header page with no cap, so
+    an endpoint that returns the whole repository's history (e.g.
+    /issues/comments, not scoped to one issue) could run to thousands of
+    pages on an active repo -- observed live as a 100+ second hang against
+    Tracer-Cloud/opensre before this fix."""
+    calls: list[str] = []
+
+    def fake_urlopen(req: request.Request, timeout: int = 0) -> _Response:  # noqa: ARG001
+        calls.append(req.full_url)
+        return _Response(
+            [{"id": len(calls)}],
+            headers={
+                "Link": '<https://api.github.com/repos/o/r/issues/comments?page=X>; rel="next"'
+            },
+        )
+
+    monkeypatch.setattr("integrations.github.client.request.urlopen", fake_urlopen)
+    client = GitHubRestClient(github_token="tok")
+
+    items = client.paginate("/repos/o/r/issues/comments", max_pages=3)
+
+    assert len(calls) == 3
+    assert len(items) == 3
+
+
 def test_http_error_preserves_status_and_rate_limit_headers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/tools/test_github_community_followup_tool.py
+++ b/tests/tools/test_github_community_followup_tool.py
@@ -39,3 +39,23 @@ def test_run_skips_the_api_call_when_comments_are_supplied() -> None:
         comments=[{"id": 1, "body": "any questions?", "user": {"login": "someone"}}],
     )
     assert result["available"] is True
+
+
+def test_run_clamps_absurd_since_days_instead_of_overflowing() -> None:
+    """Regression (Greptile): since_days was only lower-bounded before being
+    passed to timedelta(days=...). An absurdly large caller-supplied value
+    (the public schema accepts any integer) raises OverflowError, which
+    propagates uncaught past the tool framework's structured
+    tool_unavailable() error contract entirely."""
+    mock_client = MagicMock()
+    mock_client.paginate.return_value = []
+    with patch(
+        "integrations.github.tools.community_followup_tool.GitHubRestClient",
+        return_value=mock_client,
+    ):
+        result = summarize_community_followups(
+            owner="org", repo="repo", since_days=10**18, github_token="tok"
+        )
+
+    assert result["available"] is True
+    mock_client.paginate.assert_called_once()

--- a/tests/tools/test_github_community_followup_tool.py
+++ b/tests/tools/test_github_community_followup_tool.py
@@ -1,0 +1,41 @@
+"""Tests for summarize_community_followups (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from integrations.github.tools.community_followup_tool import summarize_community_followups
+from tests.tools.conftest import BaseToolContract
+
+
+class TestSummarizeCommunityFollowupsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return summarize_community_followups.__opensre_registered_tool__
+
+
+def test_run_scopes_the_comments_query_to_since_days() -> None:
+    """Regression: the endpoint returns every comment across the whole repo
+    (not one issue), so an unscoped query could run to thousands of pages on
+    an active repo. since_days must bound it via GitHub's `since` param."""
+    mock_client = MagicMock()
+    mock_client.paginate.return_value = []
+    with patch(
+        "integrations.github.tools.community_followup_tool.GitHubRestClient",
+        return_value=mock_client,
+    ):
+        summarize_community_followups(owner="org", repo="repo", since_days=7, github_token="tok")
+
+    mock_client.paginate.assert_called_once()
+    args, kwargs = mock_client.paginate.call_args
+    assert args[0] == "/repos/org/repo/issues/comments"
+    assert "since" in kwargs["params"]
+    assert kwargs["params"]["sort"] == "updated"
+
+
+def test_run_skips_the_api_call_when_comments_are_supplied() -> None:
+    result = summarize_community_followups(
+        owner="org",
+        repo="repo",
+        comments=[{"id": 1, "body": "any questions?", "user": {"login": "someone"}}],
+    )
+    assert result["available"] is True


### PR DESCRIPTION
Part of #5121 (covers one of the read-only investigation tools; the remaining write/mutation tools are not addressed by this PR, so it should not auto-close that issue)

#### Describe the changes you have made in this PR -

Found while live-verifying `summarize_community_followups` against a real GitHub Copilot MCP session targeting `Tracer-Cloud/opensre`. The tool queries `/repos/{owner}/{repo}/issues/comments`, which returns every comment across the **whole repository** (not scoped to one issue). `GitHubRestClient.paginate()` follows every `Link`-header page with no cap of any kind (`while url:`), so on an active repository with thousands of issues and comments this call ran to hundreds of pages. Reproduced live: the call was still running after 100+ seconds against `Tracer-Cloud/opensre` and had to be killed.

Two changes:

1. `GitHubRestClient.paginate()` now accepts `max_pages` (default 50 pages / 5,000 items at the default page size) and stops there, returning whatever was collected rather than raising. This is a shared safety net for every caller of `paginate()`, not just this one tool — the same unbounded-`while` pattern could bite any future endpoint that returns a repo-wide (rather than per-resource) listing.
2. `summarize_community_followups` adds a `since_days` parameter (default 30), passed as GitHub's native `since` query param plus `sort=updated&direction=desc`. This is also the semantically correct fix, not just a performance workaround: the tool's own stated purpose is "finding unanswered contributor questions" and "meeting agenda follow-ups" — recent activity, not a full-repository comment history scan.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix, against `Tracer-Cloud/opensre` (real token, real repo):
```
$ time summarize_community_followups(owner="Tracer-Cloud", repo="opensre", per_page=20, github_token=token)
[killed after 100+ seconds, still running]
```

After the fix, same call with `since_days=7`:
```
$ time summarize_community_followups(owner="Tracer-Cloud", repo="opensre", per_page=100, since_days=7, github_token=token)
{"source": "github", "available": true, "unanswered_questions": [...real, current PR/issue comments...]}
real  0m5.6s
```

Regression test proof: reverted the fix locally (`git stash` on the two source files) and reran the two new tests — both failed with the exact symptom (`TypeError: unexpected keyword argument 'max_pages'`, and `since` missing from the request params), then restored the fix and confirmed green.

Local checks run: `make lint`, `make format-check`, `make typecheck` (all clean), `tests/integrations/test_github_client.py` + `tests/tools/test_github_community_followup_tool.py` (new file — no test coverage existed for this tool before) + the full `integrations/github/tools/` scoped suite per `.github/ci/test_scope_rules.py` (203 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Found this while live-verifying GitHub's read-only investigation tools end-to-end (real MCP session, real repo, real token) rather than against mocked responses — the call visibly hung well past what any reasonable tool-call timeout in an investigation loop would allow. I traced it to `GitHubRestClient.paginate()`'s unconditional `while url:` loop and confirmed via `/repos/{owner}/{repo}/issues/comments`'s actual API docs that it supports a `since` filter, which is both the fix and the semantically correct scope for what this tool is meant to do. I added the `max_pages` cap at the shared client level (rather than only in this one caller) because the underlying defect — no bound on pagination depth — is a property of the client, and any other endpoint that returns a repo-wide rather than per-resource listing would hit the same failure mode.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.