### PR TITLE
fix(github): stop using the search API for issue-mutation idempotency checks

### DIFF
--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -550,32 +550,40 @@ def _validate_proposal_marker(proposal: GitHubIssueMutationProposal) -> str | No
     return None
 
 
-def _quoted_search_term(term: str) -> str:
-    cleaned = term.replace('"', "")
-    return f'"{cleaned}"'
+# One page of the most-recent issues is enough to catch an idempotent retry,
+# which lands within moments of the original creation, not months later.
+_RECENT_ISSUES_SCAN_LIMIT = 100
 
 
-def _search_issues_for_marker(
+def _recent_issues_with_marker(
     client: GitHubRestClient,
     *,
     owner: str,
     repo: str,
     marker: str,
-    search_area: Literal["body", "comments"],
 ) -> list[dict[str, Any]]:
+    """Recently-created issues whose body contains ``marker``.
+
+    Uses the issues list endpoint rather than /search/issues: GitHub's search
+    index has an observed multi-second propagation lag after issue creation,
+    which lets a rapid idempotent retry slip past a search-based dedup check
+    and create a duplicate issue (reproduced live).
+    """
     result = client.request(
         "GET",
-        "/search/issues",
+        f"/repos/{owner}/{repo}/issues",
         params={
-            "q": (f"repo:{owner}/{repo} is:issue in:{search_area} {_quoted_search_term(marker)}")
+            "state": "all",
+            "per_page": _RECENT_ISSUES_SCAN_LIMIT,
+            "sort": "created",
+            "direction": "desc",
         },
     )
-    if not isinstance(result, dict):
+    if not isinstance(result, list):
         return []
-    items = result.get("items")
-    if not isinstance(items, list):
-        return []
-    return [item for item in items if isinstance(item, dict)]
+    return [
+        item for item in result if isinstance(item, dict) and marker in str(item.get("body") or "")
+    ]
 
 
 def _marker_exists_on_issue(
@@ -586,16 +594,20 @@ def _marker_exists_on_issue(
     issue_number: int,
     marker: str,
 ) -> bool:
-    return any(
-        item.get("number") == issue_number
-        for item in _search_issues_for_marker(
-            client,
-            owner=owner,
-            repo=repo,
-            marker=marker,
-            search_area="comments",
-        )
+    """Whether a comment containing ``marker`` already exists on the issue.
+
+    Lists the issue's own comments (bounded to one issue, immediately
+    consistent) rather than the repo-wide search API, for the same reason as
+    :func:`_recent_issues_with_marker`.
+    """
+    result = client.request(
+        "GET",
+        f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
+        params={"per_page": 100},
     )
+    if not isinstance(result, list):
+        return False
+    return any(isinstance(item, dict) and marker in str(item.get("body") or "") for item in result)
 
 
 @tool(
@@ -641,12 +653,11 @@ def execute_github_issue_mutation(
         return _mutation_rejected(marker_error)
     try:
         if parsed.operation == "create":
-            existing_items = _search_issues_for_marker(
+            existing_items = _recent_issues_with_marker(
                 client,
                 owner=owner,
                 repo=repo,
                 marker=parsed.idempotency_marker,
-                search_area="body",
             )
             if existing_items:
                 return {

--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Literal, cast
 
 from core.domain.types.tools import ToolSurface
@@ -593,17 +594,26 @@ def _marker_exists_on_issue(
     repo: str,
     issue_number: int,
     marker: str,
+    total_comments: int,
 ) -> bool:
     """Whether a comment containing ``marker`` already exists on the issue.
 
     Lists the issue's own comments (bounded to one issue, immediately
     consistent) rather than the repo-wide search API, for the same reason as
-    :func:`_recent_issues_with_marker`.
+    :func:`_recent_issues_with_marker`. Unlike the repo-wide comments
+    endpoint, this per-issue one does not support `sort`/`direction` and
+    always returns oldest-first, so a plain first-page fetch would miss a
+    marker on an issue with more than one page of comments -- exactly the
+    case an idempotency check has to catch. Fetches the last page directly,
+    computed from the issue's own comment count, so the newest comments
+    (where a retry's marker lands) are always the ones scanned.
     """
+    per_page = 100
+    last_page = max(1, math.ceil(max(total_comments, 1) / per_page))
     result = client.request(
         "GET",
         f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
-        params={"per_page": 100},
+        params={"per_page": per_page, "page": last_page},
     )
     if not isinstance(result, list):
         return False
@@ -678,7 +688,8 @@ def execute_github_issue_mutation(
         issue_number = parsed.target.get("issue_number")
         if not isinstance(issue_number, int):
             return _mutation_rejected("proposal target.issue_number is required")
-        client.request("GET", f"/repos/{owner}/{repo}/issues/{issue_number}")
+        issue_before = client.request("GET", f"/repos/{owner}/{repo}/issues/{issue_number}")
+        total_comments = issue_before.get("comments", 0) if isinstance(issue_before, dict) else 0
         comment_body = str(parsed.payload.get("comment_body", ""))
         comment_already_recorded = _marker_exists_on_issue(
             client,
@@ -686,6 +697,7 @@ def execute_github_issue_mutation(
             repo=repo,
             issue_number=issue_number,
             marker=parsed.idempotency_marker,
+            total_comments=total_comments,
         )
         if comment_body and not comment_already_recorded:
             client.request(

--- a/tests/tools/test_github_workflow_tools.py
+++ b/tests/tools/test_github_workflow_tools.py
@@ -239,7 +239,7 @@ def test_execute_tool_schema_has_no_confirm_parameter() -> None:
     assert tool.requires_approval is False
 
 
-def test_execute_create_searches_idempotency_marker_before_create() -> None:
+def test_execute_create_lists_recent_issues_for_idempotency_marker_before_create() -> None:
     proposal = propose_github_issue_mutation_from_slack(
         owner="o",
         repo="r",
@@ -251,9 +251,9 @@ def test_execute_create_searches_idempotency_marker_before_create() -> None:
 
     def fake_request(self: GitHubRestClient, method: str, path: str, **kwargs: Any) -> Any:
         calls.append((method, path, kwargs))
-        if path == "/search/issues":
-            return {"total_count": 0, "items": []}
-        if path == "/repos/o/r/issues":
+        if path == "/repos/o/r/issues" and method == "GET":
+            return []
+        if path == "/repos/o/r/issues" and method == "POST":
             return {"number": 99, "html_url": "https://github.com/o/r/issues/99"}
         raise AssertionError((method, path))
 
@@ -264,9 +264,11 @@ def test_execute_create_searches_idempotency_marker_before_create() -> None:
 
     assert result["executed"] is True
     assert result["side_effect"] == "created_github_issue"
-    assert [call[1] for call in calls] == ["/search/issues", "/repos/o/r/issues"]
-    assert "in:body" in calls[0][2]["params"]["q"]
-    assert proposal["idempotency_marker"] in calls[0][2]["params"]["q"]
+    assert [(call[0], call[1]) for call in calls] == [
+        ("GET", "/repos/o/r/issues"),
+        ("POST", "/repos/o/r/issues"),
+    ]
+    assert calls[0][2]["params"]["sort"] == "created"
 
 
 def test_execute_create_returns_existing_issue_for_idempotency_marker() -> None:
@@ -277,10 +279,11 @@ def test_execute_create_returns_existing_issue_for_idempotency_marker() -> None:
         slack_text="ship this",
         slack_url="https://slack.example/archives/C/p1",
     )["proposal"]
+    marker = proposal["idempotency_marker"]
 
     def fake_request(self: GitHubRestClient, method: str, path: str, **_kwargs: Any) -> Any:
-        if path == "/search/issues":
-            return {"total_count": 1, "items": [{"number": 12, "html_url": "existing"}]}
+        if path == "/repos/o/r/issues" and method == "GET":
+            return [{"number": 12, "html_url": "existing", "body": f"...\n{marker}\n..."}]
         raise AssertionError((method, path))
 
     with patch.object(GitHubRestClient, "request", fake_request):
@@ -308,10 +311,9 @@ def test_execute_update_adds_comment_and_preserves_body() -> None:
         calls.append((method, path, kwargs))
         if path == "/repos/o/r/issues/51" and method == "GET":
             return {"number": 51, "body": "original"}
-        if path == "/search/issues":
-            assert "in:comments" in kwargs["params"]["q"]
-            return {"total_count": 0, "items": []}
-        if path == "/repos/o/r/issues/51/comments":
+        if path == "/repos/o/r/issues/51/comments" and method == "GET":
+            return []
+        if path == "/repos/o/r/issues/51/comments" and method == "POST":
             assert "PR shipped" in kwargs["body"]["body"]
             return {"id": 1}
         if path == "/repos/o/r/issues/51" and method == "PATCH":
@@ -326,11 +328,11 @@ def test_execute_update_adds_comment_and_preserves_body() -> None:
         )
 
     assert result["executed"] is True
-    assert [call[1] for call in calls] == [
-        "/repos/o/r/issues/51",
-        "/search/issues",
-        "/repos/o/r/issues/51/comments",
-        "/repos/o/r/issues/51",
+    assert [(call[0], call[1]) for call in calls] == [
+        ("GET", "/repos/o/r/issues/51"),
+        ("GET", "/repos/o/r/issues/51/comments"),
+        ("POST", "/repos/o/r/issues/51/comments"),
+        ("PATCH", "/repos/o/r/issues/51"),
     ]
 
 
@@ -349,10 +351,9 @@ def test_execute_close_comments_before_closing_and_preserves_body() -> None:
         calls.append((method, path, kwargs))
         if path == "/repos/o/r/issues/51" and method == "GET":
             return {"number": 51, "body": "original"}
-        if path == "/search/issues":
-            assert "in:comments" in kwargs["params"]["q"]
-            return {"total_count": 0, "items": []}
-        if path == "/repos/o/r/issues/51/comments":
+        if path == "/repos/o/r/issues/51/comments" and method == "GET":
+            return []
+        if path == "/repos/o/r/issues/51/comments" and method == "POST":
             return {"id": 1}
         if path == "/repos/o/r/issues/51" and method == "PATCH":
             assert kwargs["body"] == {"state": "closed", "state_reason": "completed"}
@@ -365,11 +366,11 @@ def test_execute_close_comments_before_closing_and_preserves_body() -> None:
         )
 
     assert result["executed"] is True
-    assert [call[1] for call in calls] == [
-        "/repos/o/r/issues/51",
-        "/search/issues",
-        "/repos/o/r/issues/51/comments",
-        "/repos/o/r/issues/51",
+    assert [(call[0], call[1]) for call in calls] == [
+        ("GET", "/repos/o/r/issues/51"),
+        ("GET", "/repos/o/r/issues/51/comments"),
+        ("POST", "/repos/o/r/issues/51/comments"),
+        ("PATCH", "/repos/o/r/issues/51"),
     ]
 
 
@@ -383,15 +384,16 @@ def test_execute_update_skips_duplicate_comment_for_seen_marker() -> None:
         slack_url="https://slack.example/archives/C/p2",
         labels=["done"],
     )["proposal"]
+    marker = proposal["idempotency_marker"]
     calls: list[tuple[str, str, dict[str, Any]]] = []
 
     def fake_request(self: GitHubRestClient, method: str, path: str, **kwargs: Any) -> Any:
         calls.append((method, path, kwargs))
         if path == "/repos/o/r/issues/51" and method == "GET":
             return {"number": 51, "body": "original"}
-        if path == "/search/issues":
-            return {"total_count": 1, "items": [{"number": 51}]}
-        if path == "/repos/o/r/issues/51/comments":
+        if path == "/repos/o/r/issues/51/comments" and method == "GET":
+            return [{"id": 1, "body": f"...\n{marker}\n..."}]
+        if path == "/repos/o/r/issues/51/comments" and method == "POST":
             raise AssertionError("duplicate comment should not be posted")
         if path == "/repos/o/r/issues/51" and method == "PATCH":
             return {"number": 51}
@@ -404,10 +406,10 @@ def test_execute_update_skips_duplicate_comment_for_seen_marker() -> None:
 
     assert result["executed"] is True
     assert result["comment_already_recorded"] is True
-    assert [call[1] for call in calls] == [
-        "/repos/o/r/issues/51",
-        "/search/issues",
-        "/repos/o/r/issues/51",
+    assert [(call[0], call[1]) for call in calls] == [
+        ("GET", "/repos/o/r/issues/51"),
+        ("GET", "/repos/o/r/issues/51/comments"),
+        ("PATCH", "/repos/o/r/issues/51"),
     ]
 
 
@@ -442,6 +444,38 @@ def test_execute_mutation_rejects_payload_without_marker() -> None:
     assert result["executed"] is False
     assert result["side_effect"] == "github_issue_mutation_rejected"
     assert "idempotency marker" in result["error"]
+
+
+def test_execute_create_does_not_rely_on_search_issues_endpoint() -> None:
+    """Regression: the create-dedup check used to query /search/issues, whose
+    index has an observed multi-second propagation lag after issue creation
+    (reproduced live against a real repo). A rapid idempotent retry could
+    slip past the search-based check and create a duplicate issue. The dedup
+    check must use the immediately-consistent issues list endpoint instead,
+    never /search/issues."""
+    proposal = propose_github_issue_mutation_from_slack(
+        owner="o",
+        repo="r",
+        operation="create",
+        slack_text="ship this",
+        slack_url="https://slack.example/archives/C/p1",
+    )["proposal"]
+
+    def fake_request(self: GitHubRestClient, method: str, path: str, **_kwargs: Any) -> Any:
+        if path == "/search/issues":
+            raise AssertionError("dedup check must not use the eventually-consistent search API")
+        if path == "/repos/o/r/issues" and method == "GET":
+            return []
+        if path == "/repos/o/r/issues" and method == "POST":
+            return {"number": 99, "html_url": "https://github.com/o/r/issues/99"}
+        raise AssertionError((method, path))
+
+    with patch.object(GitHubRestClient, "request", fake_request):
+        result = execute_github_issue_mutation(
+            owner="o", repo="r", proposal=proposal, github_token="tok"
+        )
+
+    assert result["executed"] is True
 
 
 def test_execute_mutation_returns_api_errors() -> None:

--- a/tests/tools/test_github_workflow_tools.py
+++ b/tests/tools/test_github_workflow_tools.py
@@ -413,6 +413,49 @@ def test_execute_update_skips_duplicate_comment_for_seen_marker() -> None:
     ]
 
 
+def test_execute_update_finds_marker_beyond_the_first_comment_page() -> None:
+    """Regression (Greptile): the per-issue comments endpoint does not support
+    sort/direction and always returns oldest-first, unlike the repo-wide
+    comments endpoint used for create-dedup. On an issue with more than one
+    page of comments, fetching only page 1 would miss a marker posted
+    recently -- exactly the case an idempotency check has to catch -- and
+    the tool would post a duplicate follow-up comment."""
+    proposal = propose_github_issue_mutation_from_slack(
+        owner="o",
+        repo="r",
+        operation="update",
+        issue_number=51,
+        slack_text="PR shipped",
+        slack_url="https://slack.example/archives/C/p2",
+        labels=["done"],
+    )["proposal"]
+    marker = proposal["idempotency_marker"]
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def fake_request(self: GitHubRestClient, method: str, path: str, **kwargs: Any) -> Any:
+        calls.append((method, path, kwargs))
+        if path == "/repos/o/r/issues/51" and method == "GET":
+            # 150 prior comments -> the marker (posted most recently) lives
+            # on page 2, not page 1.
+            return {"number": 51, "body": "original", "comments": 150}
+        if path == "/repos/o/r/issues/51/comments" and method == "GET":
+            assert kwargs["params"]["page"] == 2, "must fetch the last page, not page 1"
+            return [{"id": 200, "body": f"...\n{marker}\n..."}]
+        if path == "/repos/o/r/issues/51/comments" and method == "POST":
+            raise AssertionError("duplicate comment should not be posted")
+        if path == "/repos/o/r/issues/51" and method == "PATCH":
+            return {"number": 51}
+        raise AssertionError((method, path, kwargs))
+
+    with patch.object(GitHubRestClient, "request", fake_request):
+        result = execute_github_issue_mutation(
+            owner="o", repo="r", proposal=proposal, github_token="tok"
+        )
+
+    assert result["executed"] is True
+    assert result["comment_already_recorded"] is True
+
+
 def test_execute_mutation_rejects_malformed_proposal_without_api_call() -> None:
     with patch.object(GitHubRestClient, "request") as request:
         result = execute_github_issue_mutation(


### PR DESCRIPTION
Part of #5121 (covers one of the write-capable tools; the remaining ci_fix/security_fix/github_cli tools are not addressed by this PR, so it should not auto-close that issue)

#### Describe the changes you have made in this PR -

Found while live-verifying \`execute_github_issue_mutation\` against a real repo (a fork I control, Issues enabled, real token). This tool's duplicate-prevention checks — before creating an issue from a proposal, and before posting a duplicate follow-up comment — both queried GitHub's \`/search/issues\` endpoint for the proposal's idempotency marker.

Reproduced live: I generated one proposal, then called \`execute_github_issue_mutation\` with it three times back-to-back. Instead of the second and third calls detecting the first issue already existed, each one created a **new duplicate issue** (issues #3, #4, #5 in my test repo, all with the identical idempotency marker in their body). GitHub's search index has an observed propagation lag after a write — confirmed directly: right after creating an issue, \`/search/issues\` for its exact marker returned 0 results; waiting ~8 seconds, it found it correctly.

Both dedup checks now use the immediately-consistent list endpoints instead of search:
- Create-dedup: the most recent page of \`GET /repos/{owner}/{repo}/issues\` (sorted \`created\`, \`desc\`) scanned client-side for the marker. Bounded to one page (100 issues) since an idempotent retry lands within moments of the original, not months later.
- Comment-dedup: \`GET /repos/{owner}/{repo}/issues/{number}/comments\` (bounded to the single issue) scanned client-side for the marker.

This is a real improvement, not a complete guarantee: re-tested the same three-calls-in-a-row scenario after the fix with a 3-second gap between calls and it correctly detected the existing issue every time. A literally zero-delay double call (which no real agent tool-calling loop produces — LLM inference and network round trips alone take well over that) can still theoretically race, since GitHub's REST API doesn't offer a strongly-consistent read-after-write guarantee for this resource. The fix narrows the practical race window from "GitHub's search index catching up" (multi-second-plus, observed) down to "GitHub's ordinary list-API propagation" (observed well under 3 seconds), which covers any realistic calling pattern.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix, three back-to-back calls with the identical proposal, real repo:
\`\`\`
first execute:  created_github_issue  issue 3
second execute: created_github_issue  issue 4   <- should have been "existing_github_issue"
third execute:  created_github_issue  issue 5   <- should have been "existing_github_issue"
\`\`\`

After the fix, same scenario with a realistic ~3s gap:
\`\`\`
first execute:                created_github_issue   issue 6
second execute (3s later):    existing_github_issue   executed: False   issue 6
\`\`\`

Regression test proof: reverted the fix locally and reran the affected tests — 6 failed (5 existing tests that had asserted the old \`/search/issues\` call sequence, plus 1 new test asserting \`/search/issues\` is never called), all failing with either an unexpected-path \`AssertionError\` or the explicit "must not use the eventually-consistent search API" message. Restored the fix and confirmed all green.

Local checks run: \`make lint\`, \`make format-check\`, \`make typecheck\` (all clean), \`tests/tools/test_github_workflow_tools.py\` (49 passed) and the full \`integrations/github/tools/\` scoped suite per \`.github/ci/test_scope_rules.py\` (183 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Found this by actually exercising \`execute_github_issue_mutation\`'s idempotency guarantee against a real repo rather than trusting the existing mocked tests, which all assumed \`/search/issues\` responds instantly and consistently. I reproduced the duplicate-creation bug live, then confirmed the root cause by directly querying \`/search/issues\` for a just-created issue's marker (0 results) and again a few seconds later (found it) — that isolated the propagation lag as the cause rather than a logic bug in the marker-matching code itself. The fix swaps both search calls for the corresponding list endpoints, which reflect writes immediately, bounded appropriately for each check's actual scope (a page of recent issues for create-dedup; one issue's own comments for comment-dedup) so the fix doesn't trade one performance problem for another. I updated the five existing tests that had encoded the old \`/search/issues\` call sequence as their expected behavior, and added one explicit regression test asserting the search endpoint is never called at all.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.