### PR TITLE
refactor(tool): update DefaultToolProvider to use registered presenter factory

### DIFF
--- a/core/agent_harness/tools/tool_provider.py
+++ b/core/agent_harness/tools/tool_provider.py
@@ -76,22 +76,6 @@ class DefaultToolProvider:
         self._console = console
         self._tool_context = None
 
-    def _resolved_presenter_factory(self) -> SubprocessPresenterFactory | None:
-        """The host's presenter factory, else the one registered at process boot.
-
-        Without the fallback the default port stack has no presenter, so
-        ``shell_run`` refuses every call and the agent degrades into describing
-        a plan it cannot run. A host factory always wins.
-        """
-        if self._subprocess_presenter_factory is not None:
-            return self._subprocess_presenter_factory
-        import platform.harness_ports as harness_ports
-
-        registered: SubprocessPresenterFactory | None = (
-            harness_ports.get_subprocess_presenter_factory()
-        )
-        return registered
-
     def action_tools(
         self,
         *,
@@ -100,7 +84,7 @@ class DefaultToolProvider:
         resolved_integrations: dict[str, Any] | None = None,
     ) -> list[Any]:
         subprocess_presenter = None
-        presenter_factory = self._resolved_presenter_factory()
+        presenter_factory = self._subprocess_presenter_factory
         if presenter_factory is not None:
             subprocess_presenter = presenter_factory(
                 self._session,

--- a/core/agent_harness/turns/headless_build.py
+++ b/core/agent_harness/turns/headless_build.py
@@ -50,6 +50,7 @@ from core.agent_harness.turns.headless_adapters import (
     StaticReasoningClientProvider,
 )
 from core.agent_harness.turns.headless_agent import HeadlessAgent
+from platform.harness_ports import get_subprocess_presenter_factory
 
 if TYPE_CHECKING:
     from core.agent_harness.session.session_core import SessionCore
@@ -145,8 +146,18 @@ class DefaultHeadlessBuild:
         )
 
     def tools(self) -> ToolProvider:
-        """A bare :class:`DefaultToolProvider`; hosts pass their own configured one to :meth:`agent`."""
-        return DefaultToolProvider(self.session, self._console, tool_action_logger=self._logger)
+        """A bare :class:`DefaultToolProvider`; hosts pass their own configured one to :meth:`agent`.
+
+        The presenter factory is the one registered at process boot so
+        ``shell_run`` can execute. A host that wants a different presenter
+        passes its own :class:`DefaultToolProvider`.
+        """
+        return DefaultToolProvider(
+            self.session,
+            self._console,
+            tool_action_logger=self._logger,
+            subprocess_presenter_factory=get_subprocess_presenter_factory(),
+        )
 
     def prompts(self) -> PromptContextProvider:
         if self.surface is not None:

--- a/tests/bootstrap/test_subprocess_presenter_port.py
+++ b/tests/bootstrap/test_subprocess_presenter_port.py
@@ -62,10 +62,21 @@ def test_resetting_the_harness_ports_clears_the_presenter() -> None:
     assert harness_ports.get_subprocess_presenter_factory() is None
 
 
-def test_an_explicit_presenter_wins_over_the_registered_one() -> None:
-    """A host with its own presenter (TTY console) must not get the headless default."""
+def test_default_headless_build_injects_the_registered_presenter() -> None:
+    """The default port stack takes the boot-registered factory at construction.
+
+    Hosts that pass their own ``DefaultToolProvider`` keep that factory. The
+    family's bare default is what ``AgentSession.start()`` uses, so it must
+    receive the registered presenter or ``shell_run`` refuses every call. The
+    provider itself must not look the factory up — a missing constructor arg
+    stays missing even when one is registered.
+    """
     # Arrange.
+    from core.agent_harness.session import SessionCore
+    from core.agent_harness.session.persistence.memory import InMemorySessionStore
     from core.agent_harness.tools.tool_provider import DefaultToolProvider
+    from core.agent_harness.turns.headless_adapters import BufferOutputSink
+    from core.agent_harness.turns.headless_build import DefaultHeadlessBuild
 
     def _registered(*_args: object, **_kwargs: object) -> object:
         return object()
@@ -76,7 +87,13 @@ def test_an_explicit_presenter_wins_over_the_registered_one() -> None:
     harness_ports.set_subprocess_presenter_factory(_registered)
     with_explicit = DefaultToolProvider(object(), object(), subprocess_presenter_factory=_explicit)
     without = DefaultToolProvider(object(), object())
+    default_tools = DefaultHeadlessBuild(
+        session=SessionCore(store=InMemorySessionStore()),
+        output=BufferOutputSink(),
+    ).tools()
 
     # Act / Assert.
-    assert with_explicit._resolved_presenter_factory() is _explicit  # noqa: SLF001
-    assert without._resolved_presenter_factory() is _registered  # noqa: SLF001
+    assert with_explicit._subprocess_presenter_factory is _explicit  # noqa: SLF001
+    assert without._subprocess_presenter_factory is None  # noqa: SLF001
+    assert isinstance(default_tools, DefaultToolProvider)
+    assert default_tools._subprocess_presenter_factory is _registered  # noqa: SLF001


### PR DESCRIPTION
/fix #5237 
This pull request refactors how the subprocess presenter factory is managed and injected throughout the agent harness, ensuring that the default presenter is properly set for headless builds and clarifying the intended behavior for host overrides. The main focus is to make the presenter factory dependency explicit and to prevent implicit global lookups in the `DefaultToolProvider`.

Dependency injection and presenter factory management:

* Removed the `_resolved_presenter_factory` method from `DefaultToolProvider`, making the subprocess presenter factory an explicit constructor argument rather than relying on a fallback global registration. This clarifies the flow of dependencies and avoids hidden lookups. [[1]](diffhunk://#diff-3232330c1e6265e2ed356fbfc13f0d14f990c07b722739f21d4a845b48b502ccL79-L94) [[2]](diffhunk://#diff-3232330c1e6265e2ed356fbfc13f0d14f990c07b722739f21d4a845b48b502ccL103-R87)
* Updated `DefaultHeadlessBuild.tools()` to explicitly inject the globally registered subprocess presenter factory at construction time, ensuring the default tool provider receives the correct presenter for headless sessions. [[1]](diffhunk://#diff-ec75ff85e52a9034025fcbcf7f861c4cc0b7ccbd37726f45d4a93fa8f5f85ff7L148-R160) [[2]](diffhunk://#diff-ec75ff85e52a9034025fcbcf7f861c4cc0b7ccbd37726f45d4a93fa8f5f85ff7R53)

Testing and documentation improvements:

* Refactored and renamed the related test to confirm that the default headless build injects the registered presenter factory, and clarified assertions to match the new dependency flow. The test now verifies explicit and default behaviors for presenter factory assignment. [[1]](diffhunk://#diff-7b7bc2da4f65bac91faedd24bedba0ebef452471bba3a96e09e5cba2f259fe91L65-R79) [[2]](diffhunk://#diff-7b7bc2da4f65bac91faedd24bedba0ebef452471bba3a96e09e5cba2f259fe91R90-R99)
