### PR TITLE
feat(reasoning): inject client factory into DefaultReasoningClientProvider

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -162,6 +162,8 @@ subpackage. Default port implementations live with the concern they serve, not i
     and the neutral turn-result models.
   - `default_reasoning_client.py` — `DefaultReasoningClientProvider`, kept with the
     reasoning-client family (`stream_answer`, `StaticReasoningClientProvider`).
+    The client factory is injected at construction; `DefaultHeadlessBuild.reasoning`
+    supplies `default_reasoning_llm_factory`. `get()` swallows factory failures.
 - `tools/` — action-tool wiring over the canonical registry (`action_tools.py`,
   `tool_context.py`) and `tool_provider.py` (`DefaultToolProvider`).
 - `accounting/` — session-scoped token accounting and LLM run metadata, plus the

--- a/core/agent_harness/turns/default_reasoning_client.py
+++ b/core/agent_harness/turns/default_reasoning_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from rich.markup import escape
@@ -30,10 +31,12 @@ class DefaultReasoningClientProvider:
     def __init__(
         self,
         *,
+        client_factory: Callable[[], Any],
         output: OutputSink | None = None,
         error_reporter: ErrorReporter | None = None,
         session: Any | None = None,
     ) -> None:
+        self._client_factory = client_factory
         self._output = output
         self._error_reporter = error_reporter
         self._session = session
@@ -48,18 +51,14 @@ class DefaultReasoningClientProvider:
 
     def get(self) -> Any | None:
         try:
-            from core.llm.factory import LLMRole, get_llm
+            return self._client_factory()
         except Exception as exc:
-            self._handle_unavailable(
-                exc, context="core.agent_harness.default_reasoning_client.import"
+            context = (
+                "core.agent_harness.default_reasoning_client.import"
+                if isinstance(exc, ImportError)
+                else "core.agent_harness.default_reasoning_client.create"
             )
-            return None
-        try:
-            return get_llm(LLMRole.REASONING)
-        except Exception as exc:
-            self._handle_unavailable(
-                exc, context="core.agent_harness.default_reasoning_client.create"
-            )
+            self._handle_unavailable(exc, context=context)
             return None
 
     def _handle_unavailable(self, exc: Exception, *, context: str) -> None:

--- a/core/agent_harness/turns/headless_build.py
+++ b/core/agent_harness/turns/headless_build.py
@@ -24,6 +24,7 @@ from rich.console import Console
 
 from core.agent_harness.accounting.run_record import DefaultRunRecordFactory
 from core.agent_harness.error_reporting import DefaultErrorReporter
+from core.agent_harness.llm_resolution import default_reasoning_llm_factory
 from core.agent_harness.ports import (
     ErrorReporter,
     LlmFactory,
@@ -155,7 +156,10 @@ class DefaultHeadlessBuild:
 
     def reasoning(self) -> ReasoningClientProvider:
         return DefaultReasoningClientProvider(
-            output=self.output, error_reporter=self._error_reporter, session=self.session
+            client_factory=default_reasoning_llm_factory,
+            output=self.output,
+            error_reporter=self._error_reporter,
+            session=self.session,
         )
 
     def run_factory(self) -> RunRecordFactory:

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 
 from rich.console import Console
 
+from core.agent_harness.llm_resolution import default_reasoning_llm_factory
 from core.agent_harness.prompts.grounding import DefaultPromptContextProvider
 from core.agent_harness.runtime import TurnBinding
 from core.agent_harness.session import InMemorySessionStore
@@ -309,7 +310,11 @@ def _dispatch_turn(
 ) -> TurnResult:
     output = BufferOutputSink()
     agent = InMemoryHeadlessBuild(
-        session=session, output=output, reasoning=DefaultReasoningClientProvider(output=output)
+        session=session,
+        output=output,
+        reasoning=DefaultReasoningClientProvider(
+            client_factory=default_reasoning_llm_factory, output=output
+        ),
     ).agent(
         tools=DefaultToolProvider(
             session,

--- a/tests/core/agent_harness/test_headless_build.py
+++ b/tests/core/agent_harness/test_headless_build.py
@@ -112,6 +112,26 @@ def test_primary_response_text_prefers_assistant() -> None:
     assert empty_assistant.primary_response_text == "from action"
 
 
+def test_default_headless_build_supplies_the_reasoning_client_factory(monkeypatch) -> None:
+    """The default family injects ``default_reasoning_llm_factory`` into the provider."""
+    sentinel = object()
+
+    def _factory() -> object:
+        return sentinel
+
+    monkeypatch.setattr(
+        "core.agent_harness.turns.headless_build.default_reasoning_llm_factory",
+        _factory,
+    )
+    session = SimpleNamespace(
+        configured_integrations=[],
+        resolved_integrations_cache={},
+        session_id="s1",
+    )
+    provider = DefaultHeadlessBuild(session=session, output=BufferOutputSink()).reasoning()
+    assert provider.get() is sentinel
+
+
 def test_default_headless_build_takes_the_hosts_tool_provider_and_forwards_the_llm_factory() -> (
     None
 ):

--- a/tests/core/agent_harness/test_llm_client_preload_and_errors.py
+++ b/tests/core/agent_harness/test_llm_client_preload_and_errors.py
@@ -42,17 +42,25 @@ def test_non_import_error_message_is_unchanged() -> None:
     assert "Restart" not in message
 
 
-def test_reasoning_provider_renders_actionable_message_on_import_error(monkeypatch) -> None:
+def test_reasoning_provider_returns_injected_client() -> None:
+    client = object()
+    provider = DefaultReasoningClientProvider(client_factory=lambda: client)
+    assert provider.get() is client
+
+
+def test_reasoning_provider_renders_actionable_message_on_import_error() -> None:
     rendered: list[str] = []
 
     class FakeOutput:
         def render_error(self, message: str) -> None:
             rendered.append(message)
 
-    # Force the lazy import inside get() to fail like a stale process would.
-    monkeypatch.setitem(sys.modules, "core.llm.factory", None)
+    def _raise_import_error() -> object:
+        raise ImportError("cannot import name 'x'")
 
-    provider = DefaultReasoningClientProvider(output=FakeOutput())
+    provider = DefaultReasoningClientProvider(
+        client_factory=_raise_import_error, output=FakeOutput()
+    )
     result = provider.get()
 
     assert result is None

--- a/tests/core/agent_harness/test_session_bindable_ports.py
+++ b/tests/core/agent_harness/test_session_bindable_ports.py
@@ -83,7 +83,7 @@ def test_headless_agent_bind_turn_console_invokes_console_bindable() -> None:
 def test_default_reasoning_provider_is_output_bindable() -> None:
     first = BufferOutputSink()
     second = BufferOutputSink()
-    reasoning = DefaultReasoningClientProvider(output=first)
+    reasoning = DefaultReasoningClientProvider(client_factory=lambda: None, output=first)
     assert isinstance(reasoning, OutputBindable)
     assert isinstance(StaticReasoningClientProvider(), OutputBindable)
     reasoning.bind_output(second)
@@ -95,7 +95,7 @@ def test_default_reasoning_provider_is_output_bindable() -> None:
 def test_headless_agent_bind_turn_output_retargets_reasoning() -> None:
     first = BufferOutputSink()
     second = BufferOutputSink()
-    reasoning = DefaultReasoningClientProvider(output=first)
+    reasoning = DefaultReasoningClientProvider(client_factory=lambda: None, output=first)
     agent = InMemoryHeadlessBuild(
         session=InMemorySessionState(), output=first, reasoning=reasoning
     ).agent(tools=NullToolProvider())


### PR DESCRIPTION
/fix #5238 
This pull request refactors the way the reasoning client is constructed and injected throughout the agent harness, improving testability and flexibility. The main change is to have `DefaultReasoningClientProvider` accept a `client_factory` argument, which is now injected by the default headless build and in tests, rather than relying on internal imports. This decouples the provider from direct dependencies and makes error handling more robust.

**Reasoning Client Construction and Injection:**

* `DefaultReasoningClientProvider` now requires a `client_factory` argument at construction, rather than importing and calling `get_llm` internally. This makes the client instantiation explicit and injectable. [[1]](diffhunk://#diff-c08d99b64e2c303225497d09a195d19279320ce9043f4e096f43602d6a9ec5faR34-R39) [[2]](diffhunk://#diff-c08d99b64e2c303225497d09a195d19279320ce9043f4e096f43602d6a9ec5faL51-R61)
* The default headless build (`DefaultHeadlessBuild`) is updated to inject `default_reasoning_llm_factory` as the `client_factory` when constructing the reasoning provider. [[1]](diffhunk://#diff-ec75ff85e52a9034025fcbcf7f861c4cc0b7ccbd37726f45d4a93fa8f5f85ff7R27) [[2]](diffhunk://#diff-ec75ff85e52a9034025fcbcf7f861c4cc0b7ccbd37726f45d4a93fa8f5f85ff7L158-R162) [[3]](diffhunk://#diff-7c3fc35c9c7aaa153175c0220b61f13a2424adbc526c67e60b2913d020b3e225R165-R166)

**Test Updates and Improvements:**

* All test usages of `DefaultReasoningClientProvider` are updated to provide a `client_factory` lambda or function, ensuring tests remain compatible and more controllable. [[1]](diffhunk://#diff-004e198f954825ce730e0ea14589190e7a65a3574ad76f2e097bb36b6185b8a3L312-R317) [[2]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aL86-R86) [[3]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aL98-R98)
* New tests are added to verify that the default headless build supplies the correct reasoning client factory and that the provider returns the injected client. [[1]](diffhunk://#diff-ca1bbaf349f4ba82d8ab3d993ee459d7406a2ef1aa2c5327ec737bb514f0e365R115-R134) [[2]](diffhunk://#diff-4192e99d393dd6db6b60b58e660dfe1c08c2823c94bb159d06f1aae53e2d29a0L45-R63)
* The test for actionable error messages on import errors is updated to use the new injection approach, simulating import errors via the injected factory.

These changes collectively improve modularity, make the codebase easier to test, and clarify the responsibilities of the reasoning client provider.