### PR TITLE
feat(cli): add secure one-shot ask command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ opensre onboard
 opensre
 ```
 
+**Headless CLI** — run one agent turn non-interactively from a terminal, script, or CI job:
+
+```bash
+opensre ask "why is checkout-api slow?"
+```
+
+See **[Headless CLI](https://www.opensre.com/docs/headless-cli)** for stdin prompts, JSON output, and tool approvals.
+
 **One-shot investigation** — run the agent once against an alert file:
 
 ```bash

--- a/core/agent_harness/runtime.py
+++ b/core/agent_harness/runtime.py
@@ -19,6 +19,7 @@ from core.agent_harness.ports import TurnBinding
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import ActionTurnRunner
 from core.agent_harness.turns.gather_phase import MAX_REPORT_GATHER_ITERATIONS, GatherPhase
+from core.agent_harness.turns.headless_adapters import BufferOutputSink
 from core.agent_harness.turns.headless_agent import AgentBusyError, HeadlessAgent
 from core.agent_harness.turns.headless_build import DefaultHeadlessBuild, InMemoryHeadlessBuild
 from core.agent_harness.turns.turn_plan import TurnPlan
@@ -29,6 +30,7 @@ __all__ = [
     "AgentBuildConfig",
     "AgentBusyError",
     "AgentConfig",
+    "BufferOutputSink",
     "DefaultHeadlessBuild",
     "DescribeTool",
     "DefaultToolProvider",

--- a/core/agent_harness/runtime.py
+++ b/core/agent_harness/runtime.py
@@ -19,7 +19,6 @@ from core.agent_harness.ports import TurnBinding
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import ActionTurnRunner
 from core.agent_harness.turns.gather_phase import MAX_REPORT_GATHER_ITERATIONS, GatherPhase
-from core.agent_harness.turns.headless_adapters import BufferOutputSink
 from core.agent_harness.turns.headless_agent import AgentBusyError, HeadlessAgent
 from core.agent_harness.turns.headless_build import DefaultHeadlessBuild, InMemoryHeadlessBuild
 from core.agent_harness.turns.turn_plan import TurnPlan
@@ -30,7 +29,6 @@ __all__ = [
     "AgentBuildConfig",
     "AgentBusyError",
     "AgentConfig",
-    "BufferOutputSink",
     "DefaultHeadlessBuild",
     "DescribeTool",
     "DefaultToolProvider",

--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -47,6 +47,7 @@ from core.agent_harness.turns.source_circuit_breaker import SourceCircuitBreaker
 from core.domain.alerts.alert_source import secondary_tool_sources
 from core.events import runtime_event_callback_from_observer
 from core.state import MAX_CONVERSATION_MESSAGES
+from core.tool.execution import ToolExecutionHooks, compose_tool_execution_hooks
 from platform.analytics.react_turn import run_react_agent_with_telemetry
 from platform.harness_ports import enrich_resolved_with_repo_scopes
 from platform.observability.trace.prompts import persist_turn_system_prompt
@@ -289,6 +290,7 @@ def gather_tool_evidence(
     resolved_integrations: dict[str, Any] | None = None,
     max_iterations: int | None = None,
     is_cancelled: Callable[[], bool] | None = None,
+    tool_hooks: ToolExecutionHooks | None = None,
 ) -> GatheredEvidence | None:
     """Run a bounded tool-calling loop and return collected evidence, or None.
 
@@ -331,7 +333,9 @@ def gather_tool_evidence(
         tool_resources = cancel_tool_resources(is_cancelled)
         seed_tools, seed_sources = load_gather_unreachable(session)
         breaker = SourceCircuitBreaker(seed_tools=seed_tools, seed_sources=seed_sources)
-        gather_hooks = with_gather_discovery_budget(breaker.hooks())
+        gather_hooks = with_gather_discovery_budget(
+            compose_tool_execution_hooks(tool_hooks, breaker.hooks())
+        )
         if agent_factory is None:
             agent = _build_evidence_agent(
                 llm=llm,

--- a/core/agent_harness/turns/headless_agent.py
+++ b/core/agent_harness/turns/headless_agent.py
@@ -305,6 +305,7 @@ class HeadlessAgent:
             on_progress=self._gather_phase.on_progress,
             persist=self._gather_phase.persist,
             is_cancelled=lambda: host_cancel_requested(self._output),
+            tool_hooks=self._tool_hooks,
         )
 
     def _ports(self) -> tuple[object, ...]:

--- a/core/tool/execution.py
+++ b/core/tool/execution.py
@@ -156,6 +156,73 @@ class ToolExecutionHooks:
     before_tool_batch: BeforeToolBatchHook | None = None
 
 
+def compose_tool_execution_hooks(
+    *candidates: ToolExecutionHooks | None,
+) -> ToolExecutionHooks:
+    """Run multiple hook sets in order without discarding any lifecycle stage."""
+    hooks = tuple(candidate for candidate in candidates if candidate is not None)
+    if not hooks:
+        return ToolExecutionHooks()
+
+    def before_tool_call(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
+        decision: BeforeToolCallResult | None = None
+        for hook_set in hooks:
+            callback = hook_set.before_tool_call
+            if callback is None:
+                continue
+            current = callback(request)
+            if current is None:
+                continue
+            decision = current
+            if current.blocked:
+                return current
+        return decision
+
+    def after_tool_call(
+        request: ToolExecutionRequest,
+        result: ToolExecutionResult,
+    ) -> ToolExecutionPatch | None:
+        patched = result
+        changed = False
+        for hook_set in hooks:
+            callback = hook_set.after_tool_call
+            if callback is None:
+                continue
+            patch = callback(request, patched)
+            if patch is None:
+                continue
+            patched = _apply_patch(patched, patch)
+            changed = True
+        if not changed:
+            return None
+        return ToolExecutionPatch(
+            content=patched.content,
+            details=patched.details,
+            is_error=patched.is_error,
+            terminate=patched.terminate,
+            metadata=patched.metadata,
+        )
+
+    def on_tool_update(request: ToolExecutionRequest, update: Any) -> None:
+        for hook_set in hooks:
+            callback = hook_set.on_tool_update
+            if callback is not None:
+                callback(request, update)
+
+    def before_tool_batch(tool_calls: Sequence[ToolCall]) -> None:
+        for hook_set in hooks:
+            callback = hook_set.before_tool_batch
+            if callback is not None:
+                callback(tool_calls)
+
+    return ToolExecutionHooks(
+        before_tool_call=before_tool_call,
+        after_tool_call=after_tool_call,
+        on_tool_update=on_tool_update,
+        before_tool_batch=before_tool_batch,
+    )
+
+
 def execute_tool_calls(
     tool_calls: list[ToolCall],
     tools: Sequence[RuntimeTool],

--- a/docs/ask.mdx
+++ b/docs/ask.mdx
@@ -1,0 +1,71 @@
+---
+title: "Ask from the CLI"
+slug: "ask"
+description: "Run one configured OpenSRE agent request from a script or terminal."
+---
+
+Use `opensre ask` for a single agent turn that prints its response and exits. It
+uses the provider, integrations, and tools configured by `opensre onboard`.
+
+```bash
+opensre ask "why did checkout latency increase today?"
+```
+
+Pass `-` as the prompt to read all of standard input:
+
+```bash
+cat incident-notes.txt | opensre ask -
+```
+
+For a structured alert investigation, use `opensre investigate` instead.
+
+## Tool approvals
+
+Read-only tools run automatically. Tools that mutate state, contact an external
+service, explicitly require approval, or do not declare their side effects are
+denied by default.
+
+Authorize only the tools needed for this invocation by repeating
+`--allowed-tool`:
+
+```bash
+opensre ask "inspect the repository and run its focused tests" \
+  --allowed-tool shell_run \
+  --allowed-tool github_cli
+```
+
+An unknown tool name is rejected before the agent starts. The authorization is
+not saved and applies only to that process. The root `--yes` (`-y`) option does
+not authorize agent tools.
+
+`--dangerously-bypass-approvals` authorizes every approval-gated tool for that
+invocation. Use it only in a trusted environment where the prompt and connected
+integrations are controlled:
+
+```bash
+opensre ask "perform the requested maintenance" --dangerously-bypass-approvals
+```
+
+Do not combine the bypass flag with `--allowed-tool`. Neither option bypasses
+the operating-system permissions or sandboxing that applies to OpenSRE.
+
+## JSON output and exit codes
+
+Put the global `--json` option before `ask` for machine-readable output:
+
+```bash
+opensre --json ask "summarize current service health"
+```
+
+The command writes one JSON object with `status`, `response`, `denied_tools`,
+and `error`. The `error` value is either `null` or an object with `message` and
+`suggestion`.
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | The agent completed the request. |
+| `1` | Setup or agent execution failed. |
+| `2` | The command arguments were invalid. |
+| `3` | A tool required approval and was denied. |
+| `130` | The invocation was interrupted with `SIGINT`. |
+| `143` | The invocation was terminated with `SIGTERM`. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -99,7 +99,7 @@
             "group": "Deploy and APIs",
             "pages": [
               "deployment",
-              "ask",
+              "headless-cli",
               "api",
               "python-api",
               "hosting-the-agent"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -99,6 +99,7 @@
             "group": "Deploy and APIs",
             "pages": [
               "deployment",
+              "ask",
               "api",
               "python-api",
               "hosting-the-agent"

--- a/docs/headless-cli.mdx
+++ b/docs/headless-cli.mdx
@@ -1,11 +1,12 @@
 ---
-title: "Ask from the CLI"
-slug: "ask"
-description: "Run one configured OpenSRE agent request from a script or terminal."
+title: "Headless CLI"
+slug: "headless-cli"
+description: "Run one OpenSRE agent turn non-interactively from a terminal, script, or CI job."
 ---
 
-Use `opensre ask` for a single agent turn that prints its response and exits. It
-uses the provider, integrations, and tools configured by `opensre onboard`.
+`opensre ask` is OpenSRE’s headless, one-shot CLI command. It runs one agent
+turn, prints the response, and exits instead of opening the interactive shell.
+It uses the provider, integrations, and tools configured by `opensre onboard`.
 
 ```bash
 opensre ask "why did checkout latency increase today?"

--- a/surfaces/cli/ask/__init__.py
+++ b/surfaces/cli/ask/__init__.py
@@ -1,2 +1,1 @@
 """One-shot agent execution for the CLI."""
-

--- a/surfaces/cli/ask/__init__.py
+++ b/surfaces/cli/ask/__init__.py
@@ -1,0 +1,2 @@
+"""One-shot agent execution for the CLI."""
+

--- a/surfaces/cli/ask/approval.py
+++ b/surfaces/cli/ask/approval.py
@@ -1,0 +1,98 @@
+"""Invocation-scoped approval policy for ``opensre ask``."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+
+from core.domain.types.tools import ToolSurface
+from core.tool.contracts import RuntimeTool, SideEffectLevel
+from core.tool.execution import BeforeToolCallResult, ToolExecutionHooks, ToolExecutionRequest
+from platform.harness_ports import get_surface_tool_map
+
+_GATED_SIDE_EFFECTS = frozenset({SideEffectLevel.MUTATING, SideEffectLevel.EXTERNAL})
+
+
+class ApprovalTracker:
+    """Thread-safe record of tools denied during one invocation."""
+
+    def __init__(self) -> None:
+        self._denied: dict[str, None] = {}
+        self._lock = threading.Lock()
+
+    def record_denial(self, tool_name: str) -> None:
+        """Record ``tool_name`` once while preserving first-seen order."""
+        with self._lock:
+            self._denied.setdefault(tool_name, None)
+
+    @property
+    def denied_tools(self) -> tuple[str, ...]:
+        """Return denied tool names in first-seen order."""
+        with self._lock:
+            return tuple(self._denied)
+
+
+def approval_required(tool: RuntimeTool) -> bool:
+    """Return whether ``tool`` needs explicit authority for this invocation."""
+    if bool(getattr(tool, "requires_approval", False)):
+        return True
+    level = getattr(tool, "side_effect_level", None)
+    if level is None:
+        return True
+    return level in _GATED_SIDE_EFFECTS
+
+
+def registered_ask_tool_names() -> frozenset[str]:
+    """Return every registered tool name the ask action or gather phases can reach."""
+    names: set[str] = set()
+    for surface in (ToolSurface.ACTION, ToolSurface.INVESTIGATION):
+        names.update(get_surface_tool_map(surface))
+    return frozenset(names)
+
+
+def unknown_allowed_tools(allowed_tools: Iterable[str]) -> tuple[str, ...]:
+    """Return sorted allowlist entries absent from ask's executable tool surfaces."""
+    known = registered_ask_tool_names()
+    return tuple(sorted({name for name in allowed_tools if name not in known}))
+
+
+def build_approval_hooks(
+    *,
+    allowed_tools: Iterable[str],
+    bypass_approvals: bool,
+    tracker: ApprovalTracker,
+) -> ToolExecutionHooks:
+    """Build fail-closed hooks for one ``opensre ask`` invocation."""
+    allowed = frozenset(allowed_tools)
+
+    def before_tool_call(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
+        if not approval_required(request.tool):
+            return None
+        tool_name = request.tool_call.name
+        if bypass_approvals or tool_name in allowed:
+            return BeforeToolCallResult(
+                approved=True,
+                metadata={"ask_approval": "bypass" if bypass_approvals else "allowlist"},
+            )
+        tracker.record_denial(tool_name)
+        return BeforeToolCallResult(
+            blocked=True,
+            terminate=True,
+            reason=(
+                f"Approval required for {tool_name}. Re-run with "
+                f"--allowed-tool {tool_name}, or use "
+                "--dangerously-bypass-approvals in a trusted environment."
+            ),
+            metadata={"ask_approval": "denied"},
+        )
+
+    return ToolExecutionHooks(before_tool_call=before_tool_call)
+
+
+__all__ = [
+    "ApprovalTracker",
+    "approval_required",
+    "build_approval_hooks",
+    "registered_ask_tool_names",
+    "unknown_allowed_tools",
+]

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -1,0 +1,289 @@
+"""Run one configured agent turn and normalize its CLI outcome."""
+
+from __future__ import annotations
+
+import signal
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import IntEnum, StrEnum
+from io import StringIO
+from types import FrameType
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness.harness import AgentSession, SessionConfig
+from core.agent_harness.ports import TurnBinding
+from core.agent_harness.session import SessionManager
+from core.agent_harness.tools.tool_provider import DefaultToolProvider
+from core.agent_harness.turns.gather_phase import GatherPhase
+from core.agent_harness.turns.headless_adapters import BufferOutputSink
+from core.agent_harness.turns.headless_agent import HeadlessAgent
+from core.agent_harness.turns.headless_build import DefaultHeadlessBuild
+from core.agent_harness.turns.host_cancel import ensure_turn_cancel
+from core.agent_harness.turns.turn_results import TurnResult
+from core.tool.execution import ToolExecutionHooks
+from platform.errors import OpenSREError
+from surfaces.cli.ask.approval import ApprovalTracker, build_approval_hooks
+
+
+class AskStatus(StrEnum):
+    SUCCESS = "success"
+    APPROVAL_DENIED = "approval_denied"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+class AskExitCode(IntEnum):
+    SUCCESS = 0
+    ERROR = 1
+    APPROVAL_DENIED = 3
+    SIGINT = 130
+    SIGTERM = 143
+
+
+@dataclass(frozen=True, slots=True)
+class AskError:
+    """Stable structured error returned by ``opensre --json ask``."""
+
+    message: str
+    suggestion: str | None = None
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {"message": self.message, "suggestion": self.suggestion}
+
+
+@dataclass(frozen=True, slots=True)
+class AskOutcome:
+    """Normalized process outcome for one ask invocation."""
+
+    status: AskStatus
+    response: str
+    denied_tools: tuple[str, ...] = ()
+    error: AskError | None = None
+    exit_code: AskExitCode = AskExitCode.SUCCESS
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status.value,
+            "response": self.response,
+            "denied_tools": list(self.denied_tools),
+            "error": self.error.as_dict() if self.error is not None else None,
+        }
+
+
+class AskSignal(BaseException):
+    """Signal raised inside the command so session cleanup can finish."""
+
+    def __init__(self, signum: int) -> None:
+        super().__init__(signum)
+        self.signum = signum
+
+
+class _CancellableConsole:
+    def __init__(self, cancel_event: threading.Event) -> None:
+        self._cancel_event = cancel_event
+        self._console = Console(force_terminal=False, file=StringIO())
+
+    @property
+    def cancel_requested(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._console, name)
+
+
+@dataclass(frozen=True, slots=True)
+class _BoundDispatcher:
+    agent: HeadlessAgent
+    binding: TurnBinding
+
+    def dispatch(self, message: str) -> TurnResult:
+        """Run one message through the shared host entrypoint."""
+        return self.agent.handle(message, self.binding)
+
+
+@contextmanager
+def _ask_signal_scope(cancel_event: threading.Event) -> Iterator[None]:
+    previous: dict[signal.Signals, Any] = {}
+
+    def handle(signum: int, _frame: FrameType | None) -> None:
+        cancel_event.set()
+        raise AskSignal(signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        previous[sig] = signal.getsignal(sig)
+        signal.signal(sig, handle)
+    try:
+        yield
+    finally:
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)
+
+
+def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
+    manager = SessionManager()
+    agent_session = AgentSession(
+        SessionConfig(
+            load_env=True,
+            hydrate_integrations=True,
+            warm_integrations=True,
+            persistent_tasks=False,
+            open_store=False,
+            session_manager=manager,
+        )
+    )
+    output = BufferOutputSink()
+    cancel_event = ensure_turn_cancel(output)
+    console = _CancellableConsole(cancel_event)
+    session = None
+    try:
+        with _ask_signal_scope(cancel_event):
+            startup = agent_session.startup()
+            session = startup.session
+            for capability in ("investigation", "llm_provider", "task_cancel"):
+                session.available_capabilities[capability] = ()
+
+            from surfaces.interactive_shell.runtime.slash_adapter import headless_slash_ports
+
+            tools = DefaultToolProvider(
+                session,
+                console,
+                slash_ports_factory=headless_slash_ports,
+            )
+            agent = DefaultHeadlessBuild(
+                session=session,
+                output=output,
+                console=console,
+            ).agent(
+                tools=tools,
+                prompts=startup.prompts,
+                gather=GatherPhase(),
+            )
+            agent_session.attach_agent(
+                _BoundDispatcher(
+                    agent=agent,
+                    binding=TurnBinding(
+                        session=session,
+                        output=output,
+                        tool_hooks=hooks,
+                        console=console,
+                        is_tty=False,
+                    ),
+                )
+            )
+            return agent_session.chat(prompt)
+    finally:
+        if session is not None:
+            manager.close(session, extract_memory=False)
+
+
+def _successful_turn(result: TurnResult) -> bool:
+    action = result.action_result
+    action_ok = (
+        action.handled
+        and not action.has_unhandled_clause
+        and action.accounting_status == "completed"
+    )
+    return bool(
+        (result.answered or action_ok) and not result.cancelled and result.primary_response_text
+    )
+
+
+def _approval_denied_outcome(
+    tracker: ApprovalTracker,
+    *,
+    response: str = "",
+) -> AskOutcome | None:
+    denied_tools = tracker.denied_tools
+    if not denied_tools:
+        return None
+    return AskOutcome(
+        status=AskStatus.APPROVAL_DENIED,
+        response=response or "Approval denied for: " + ", ".join(denied_tools),
+        denied_tools=denied_tools,
+        exit_code=AskExitCode.APPROVAL_DENIED,
+    )
+
+
+def run_ask(
+    prompt: str,
+    *,
+    allowed_tools: tuple[str, ...],
+    bypass_approvals: bool,
+) -> AskOutcome:
+    """Execute one ask turn with invocation-scoped approval authority."""
+    tracker = ApprovalTracker()
+    hooks = build_approval_hooks(
+        allowed_tools=allowed_tools,
+        bypass_approvals=bypass_approvals,
+        tracker=tracker,
+    )
+    try:
+        result = _run_agent_turn(prompt, hooks)
+    except AskSignal as exc:
+        code = AskExitCode.SIGINT if exc.signum == signal.SIGINT else AskExitCode.SIGTERM
+        return AskOutcome(
+            status=AskStatus.CANCELLED,
+            response="Agent execution cancelled.",
+            exit_code=code,
+        )
+    except OpenSREError as exc:
+        denied = _approval_denied_outcome(tracker)
+        if denied is not None:
+            return denied
+        return AskOutcome(
+            status=AskStatus.ERROR,
+            response="",
+            error=AskError(message=exc.message, suggestion=exc.suggestion),
+            exit_code=AskExitCode.ERROR,
+        )
+    except Exception as exc:
+        denied = _approval_denied_outcome(tracker)
+        if denied is not None:
+            return denied
+        from surfaces.cli.telemetry import report_exception
+
+        report_exception(exc, context="surfaces.cli.ask")
+        return AskOutcome(
+            status=AskStatus.ERROR,
+            response="",
+            error=AskError(message=str(exc) or type(exc).__name__),
+            exit_code=AskExitCode.ERROR,
+        )
+
+    denied = _approval_denied_outcome(
+        tracker,
+        response=result.primary_response_text,
+    )
+    if denied is not None:
+        return denied
+    if result.cancelled:
+        return AskOutcome(
+            status=AskStatus.CANCELLED,
+            response=result.primary_response_text or "Agent execution cancelled.",
+            exit_code=AskExitCode.SIGINT,
+        )
+    if not _successful_turn(result):
+        response = result.primary_response_text
+        return AskOutcome(
+            status=AskStatus.ERROR,
+            response=response,
+            error=AskError(message=response or "The agent did not complete the request."),
+            exit_code=AskExitCode.ERROR,
+        )
+    return AskOutcome(
+        status=AskStatus.SUCCESS,
+        response=result.primary_response_text,
+    )
+
+
+__all__ = [
+    "AskError",
+    "AskExitCode",
+    "AskOutcome",
+    "AskStatus",
+    "run_ask",
+]

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import signal
 import threading
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
@@ -17,7 +17,6 @@ from rich.console import Console
 from core.agent_harness import AgentSession, SessionConfig, SessionManager, TurnResult
 from core.agent_harness.ports import TurnBinding
 from core.agent_harness.runtime import (
-    BufferOutputSink,
     DefaultHeadlessBuild,
     DefaultToolProvider,
     GatherPhase,
@@ -95,6 +94,33 @@ class _CancellableConsole:
         return getattr(self._console, name)
 
 
+class _AskOutputSink:
+    """Discard intermediate rendering while preserving streamed answer text."""
+
+    def print(self, message: str = "") -> None:
+        _ = message
+
+    def render_response_header(self, label: str) -> None:
+        _ = label
+
+    def render_error(self, message: str) -> None:
+        _ = message
+
+    def stream(
+        self,
+        *,
+        label: str,
+        chunks: Iterable[str],
+        suppress_if_starts_with: str | None = None,
+        defer_want_me_to_closer: bool = False,
+    ) -> str:
+        _ = (label, suppress_if_starts_with, defer_want_me_to_closer)
+        return "".join(str(chunk) for chunk in chunks)
+
+    def finish_streamed_response(self, answer: str) -> None:
+        _ = answer
+
+
 @dataclass(frozen=True, slots=True)
 class _BoundDispatcher:
     agent: HeadlessAgent
@@ -135,7 +161,7 @@ def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
             session_manager=manager,
         )
     )
-    output = BufferOutputSink()
+    output = _AskOutputSink()
     cancel_event = ensure_turn_cancel(output)
     console = _CancellableConsole(cancel_event)
     session = None

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -14,16 +14,16 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness.harness import AgentSession, SessionConfig
+from core.agent_harness import AgentSession, SessionConfig, SessionManager, TurnResult
 from core.agent_harness.ports import TurnBinding
-from core.agent_harness.session import SessionManager
-from core.agent_harness.tools.tool_provider import DefaultToolProvider
-from core.agent_harness.turns.gather_phase import GatherPhase
-from core.agent_harness.turns.headless_adapters import BufferOutputSink
-from core.agent_harness.turns.headless_agent import HeadlessAgent
-from core.agent_harness.turns.headless_build import DefaultHeadlessBuild
-from core.agent_harness.turns.host_cancel import ensure_turn_cancel
-from core.agent_harness.turns.turn_results import TurnResult
+from core.agent_harness.runtime import (
+    BufferOutputSink,
+    DefaultHeadlessBuild,
+    DefaultToolProvider,
+    GatherPhase,
+    HeadlessAgent,
+)
+from core.agent_harness.spi.cancel import ensure_turn_cancel
 from core.tool.execution import ToolExecutionHooks
 from platform.errors import OpenSREError
 from surfaces.cli.ask.approval import ApprovalTracker, build_approval_hooks
@@ -143,16 +143,15 @@ def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
         with _ask_signal_scope(cancel_event):
             startup = agent_session.startup()
             session = startup.session
-            for capability in ("investigation", "llm_provider", "task_cancel"):
+            for capability in (
+                "investigation",
+                "llm_provider",
+                "slash_commands",
+                "task_cancel",
+            ):
                 session.available_capabilities[capability] = ()
 
-            from surfaces.interactive_shell.runtime.slash_adapter import headless_slash_ports
-
-            tools = DefaultToolProvider(
-                session,
-                console,
-                slash_ports_factory=headless_slash_ports,
-            )
+            tools = DefaultToolProvider(session, console)
             agent = DefaultHeadlessBuild(
                 session=session,
                 output=output,

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -132,11 +132,13 @@ class _BoundDispatcher:
 
 
 @contextmanager
-def _ask_signal_scope(cancel_event: threading.Event) -> Iterator[None]:
+def ask_signal_scope(cancel_event: threading.Event | None = None) -> Iterator[None]:
+    """Map process termination signals to ``AskSignal`` within one CLI scope."""
+    event = cancel_event or threading.Event()
     previous: dict[signal.Signals, Any] = {}
 
     def handle(signum: int, _frame: FrameType | None) -> None:
-        cancel_event.set()
+        event.set()
         raise AskSignal(signum)
 
     for sig in (signal.SIGINT, signal.SIGTERM):
@@ -166,7 +168,7 @@ def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
     console = _CancellableConsole(cancel_event)
     session = None
     try:
-        with _ask_signal_scope(cancel_event):
+        with ask_signal_scope(cancel_event):
             startup = agent_session.startup()
             session = startup.session
             for capability in (
@@ -233,6 +235,16 @@ def _approval_denied_outcome(
     )
 
 
+def cancelled_outcome(signum: int) -> AskOutcome:
+    """Return the stable cancelled result for an ask process signal."""
+    code = AskExitCode.SIGINT if signum == signal.SIGINT else AskExitCode.SIGTERM
+    return AskOutcome(
+        status=AskStatus.CANCELLED,
+        response="Agent execution cancelled.",
+        exit_code=code,
+    )
+
+
 def run_ask(
     prompt: str,
     *,
@@ -249,12 +261,7 @@ def run_ask(
     try:
         result = _run_agent_turn(prompt, hooks)
     except AskSignal as exc:
-        code = AskExitCode.SIGINT if exc.signum == signal.SIGINT else AskExitCode.SIGTERM
-        return AskOutcome(
-            status=AskStatus.CANCELLED,
-            response="Agent execution cancelled.",
-            exit_code=code,
-        )
+        return cancelled_outcome(exc.signum)
     except OpenSREError as exc:
         denied = _approval_denied_outcome(tracker)
         if denied is not None:
@@ -309,6 +316,9 @@ __all__ = [
     "AskError",
     "AskExitCode",
     "AskOutcome",
+    "AskSignal",
     "AskStatus",
+    "ask_signal_scope",
+    "cancelled_outcome",
     "run_ask",
 ]

--- a/surfaces/cli/commands/__init__.py
+++ b/surfaces/cli/commands/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from surfaces.cli.commands.agent import fleet
+from surfaces.cli.commands.ask import ask_command
 from surfaces.cli.commands.auth import auth_command
 from surfaces.cli.commands.config import config_command
 from surfaces.cli.commands.cron import cron_command
@@ -33,6 +34,7 @@ from surfaces.cli.commands.watchdog import watchdog_command
 from surfaces.cli.commands.work import work_command
 
 _COMMANDS: tuple[click.Command, ...] = (
+    ask_command,
     investigate_command,
     onboard,
     auth_command,

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -9,7 +9,14 @@ import click
 
 from platform.process.runtime_flags import is_json_output
 from surfaces.cli.ask.approval import unknown_allowed_tools
-from surfaces.cli.ask.service import AskOutcome, AskStatus, run_ask
+from surfaces.cli.ask.service import (
+    AskOutcome,
+    AskSignal,
+    AskStatus,
+    ask_signal_scope,
+    cancelled_outcome,
+    run_ask,
+)
 
 
 def _resolve_prompt(value: str) -> str:
@@ -66,11 +73,15 @@ def ask_command(
             f"unknown registered tool name(s): {names}",
             param_hint="--allowed-tool",
         )
-    outcome = run_ask(
-        _resolve_prompt(prompt),
-        allowed_tools=allowed_tools,
-        bypass_approvals=dangerously_bypass_approvals,
-    )
+    try:
+        with ask_signal_scope():
+            outcome = run_ask(
+                _resolve_prompt(prompt),
+                allowed_tools=allowed_tools,
+                bypass_approvals=dangerously_bypass_approvals,
+            )
+    except AskSignal as exc:
+        outcome = cancelled_outcome(exc.signum)
     _render_outcome(outcome)
     if outcome.exit_code:
         raise SystemExit(int(outcome.exit_code))

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -1,0 +1,79 @@
+"""One-shot configured agent command."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+from platform.process.runtime_flags import is_json_output
+from surfaces.cli.ask.approval import unknown_allowed_tools
+from surfaces.cli.ask.service import AskOutcome, AskStatus, run_ask
+
+
+def _resolve_prompt(value: str) -> str:
+    prompt = sys.stdin.read() if value == "-" else value
+    prompt = prompt.strip()
+    if not prompt:
+        raise click.UsageError("PROMPT must not be empty.")
+    return prompt
+
+
+def _render_outcome(outcome: AskOutcome) -> None:
+    if is_json_output():
+        click.echo(json.dumps(outcome.as_dict(), ensure_ascii=False))
+        return
+    if outcome.status is AskStatus.SUCCESS:
+        click.echo(outcome.response)
+        return
+    if outcome.response:
+        click.echo(outcome.response, err=True)
+    if outcome.error is not None:
+        click.echo(outcome.error.message, err=True)
+        if outcome.error.suggestion:
+            click.echo(f"Suggestion: {outcome.error.suggestion}", err=True)
+
+
+@click.command(name="ask")
+@click.argument("prompt")
+@click.option(
+    "--allowed-tool",
+    "allowed_tools",
+    multiple=True,
+    metavar="TOOL",
+    help="Authorize a registered tool for this invocation. Repeat as needed.",
+)
+@click.option(
+    "--dangerously-bypass-approvals",
+    is_flag=True,
+    help="Authorize every approval-gated tool for this invocation.",
+)
+def ask_command(
+    prompt: str,
+    allowed_tools: tuple[str, ...],
+    dangerously_bypass_approvals: bool,
+) -> None:
+    """Run one configured OpenSRE agent request and exit."""
+    if allowed_tools and dangerously_bypass_approvals:
+        raise click.UsageError(
+            "--allowed-tool cannot be combined with --dangerously-bypass-approvals."
+        )
+    unknown = unknown_allowed_tools(allowed_tools)
+    if unknown:
+        names = ", ".join(unknown)
+        raise click.BadParameter(
+            f"unknown registered tool name(s): {names}",
+            param_hint="--allowed-tool",
+        )
+    outcome = run_ask(
+        _resolve_prompt(prompt),
+        allowed_tools=allowed_tools,
+        bypass_approvals=dangerously_bypass_approvals,
+    )
+    _render_outcome(outcome)
+    if outcome.exit_code:
+        raise SystemExit(int(outcome.exit_code))
+
+
+__all__ = ["ask_command"]

--- a/surfaces/cli/layout.py
+++ b/surfaces/cli/layout.py
@@ -16,7 +16,7 @@ from surfaces.shared.terminal.banner import build_ready_panel
 #: than "start here".
 _LANDING_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("opensre onboard", "Configure your LLM provider and integrations (start here)"),
-    ('opensre "why is checkout-api slow?"', "Ask the agent a question directly"),
+    ('opensre ask "why is checkout-api slow?"', "Ask the agent a question directly"),
     ("opensre investigate -i alert.json", "Run a root-cause investigation on an alert"),
     ("opensre doctor", "Check this machine is set up correctly"),
     ("opensre --help", "See every command"),
@@ -25,7 +25,7 @@ _LANDING_EXAMPLES: tuple[tuple[str, str], ...] = (
 
 #: Commands a new user needs, in the order they need them. Anything not listed
 #: falls through to "More commands", so a newly added command is never hidden.
-_GETTING_STARTED: tuple[str, ...] = ("onboard", "doctor", "health", "investigate")
+_GETTING_STARTED: tuple[str, ...] = ("onboard", "ask", "doctor", "health", "investigate")
 
 #: Day-to-day operation once configured.
 _EVERYDAY: tuple[str, ...] = (

--- a/tests/cli/test_ask_approval.py
+++ b/tests/cli/test_ask_approval.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from core.llm.types import ToolCall
+from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool.execution import ToolExecutionRequest
+from surfaces.cli.ask.approval import (
+    ApprovalTracker,
+    approval_required,
+    build_approval_hooks,
+)
+
+
+def _tool(
+    *,
+    side_effect_level: SideEffectLevel | None,
+    requires_approval: bool = False,
+) -> RegisteredTool:
+    return RegisteredTool(
+        name="example_tool",
+        description="Example tool",
+        input_schema={"type": "object", "properties": {}},
+        source="knowledge",
+        run=lambda: {"ok": True},
+        side_effect_level=side_effect_level,
+        requires_approval=requires_approval,
+    )
+
+
+def _request(tool: RegisteredTool) -> ToolExecutionRequest:
+    return ToolExecutionRequest(
+        tool_call=ToolCall(id="call-1", name=tool.name, input={}),
+        tool=tool,
+        arguments={},
+        source=tool.source,
+        resolved_integrations={},
+    )
+
+
+@pytest.mark.parametrize("level", [SideEffectLevel.NONE, SideEffectLevel.READ_ONLY])
+def test_explicit_safe_tools_run_without_approval(level: SideEffectLevel) -> None:
+    assert approval_required(_tool(side_effect_level=level)) is False
+
+
+@pytest.mark.parametrize(
+    "level",
+    [None, SideEffectLevel.MUTATING, SideEffectLevel.EXTERNAL],
+)
+def test_risky_or_unclassified_tools_require_approval(
+    level: SideEffectLevel | None,
+) -> None:
+    assert approval_required(_tool(side_effect_level=level)) is True
+
+
+def test_requires_approval_overrides_read_only_metadata() -> None:
+    assert approval_required(
+        _tool(side_effect_level=SideEffectLevel.READ_ONLY, requires_approval=True)
+    )
+
+
+def test_default_policy_denies_and_records_tool() -> None:
+    tracker = ApprovalTracker()
+    hooks = build_approval_hooks(
+        allowed_tools=(),
+        bypass_approvals=False,
+        tracker=tracker,
+    )
+
+    assert hooks.before_tool_call is not None
+    decision = hooks.before_tool_call(_request(_tool(side_effect_level=None)))
+
+    assert decision is not None
+    assert decision.blocked is True
+    assert decision.terminate is True
+    assert tracker.denied_tools == ("example_tool",)
+
+
+@pytest.mark.parametrize(
+    ("allowed_tools", "bypass"),
+    [(("example_tool",), False), ((), True)],
+)
+def test_explicit_authority_approves_tool(
+    allowed_tools: tuple[str, ...],
+    bypass: bool,
+) -> None:
+    tracker = ApprovalTracker()
+    hooks = build_approval_hooks(
+        allowed_tools=allowed_tools,
+        bypass_approvals=bypass,
+        tracker=tracker,
+    )
+
+    assert hooks.before_tool_call is not None
+    decision = hooks.before_tool_call(_request(_tool(side_effect_level=None)))
+
+    assert decision is not None
+    assert decision.approved is True
+    assert decision.blocked is False
+    assert tracker.denied_tools == ()

--- a/tests/cli/test_ask_approval.py
+++ b/tests/cli/test_ask_approval.py
@@ -76,6 +76,22 @@ def test_default_policy_denies_and_records_tool() -> None:
     assert tracker.denied_tools == ("example_tool",)
 
 
+def test_allowlist_matching_is_exact_and_case_sensitive() -> None:
+    tracker = ApprovalTracker()
+    hooks = build_approval_hooks(
+        allowed_tools=("EXAMPLE_TOOL",),
+        bypass_approvals=False,
+        tracker=tracker,
+    )
+
+    assert hooks.before_tool_call is not None
+    decision = hooks.before_tool_call(_request(_tool(side_effect_level=SideEffectLevel.MUTATING)))
+
+    assert decision is not None
+    assert decision.blocked is True
+    assert tracker.denied_tools == ("example_tool",)
+
+
 @pytest.mark.parametrize(
     ("allowed_tools", "bypass"),
     [(("example_tool",), False), ((), True)],

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -5,6 +5,7 @@ import signal
 
 from click.testing import CliRunner
 
+from surfaces.cli.app import cli
 from surfaces.cli.ask.service import (
     AskError,
     AskExitCode,
@@ -41,6 +42,22 @@ def test_ask_passes_prompt_and_invocation_authority(monkeypatch) -> None:
         "allowed_tools": ("grafana_query",),
         "bypass_approvals": False,
     }
+
+
+def test_root_yes_does_not_bypass_ask_approvals(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(prompt: str, **kwargs: object) -> AskOutcome:
+        captured.update(prompt=prompt, **kwargs)
+        return _success()
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(cli, ["-y", "ask", "check latency"])
+
+    assert result.exit_code == 0
+    assert captured["bypass_approvals"] is False
 
 
 def test_ask_reads_prompt_from_stdin(monkeypatch) -> None:
@@ -135,4 +152,5 @@ def test_ask_json_output_is_one_stable_document(monkeypatch) -> None:
         "denied_tools": [],
         "error": {"message": "failed", "suggestion": "retry"},
     }
+    assert result.stderr == ""
     assert result.output.count("\n") == 1

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from surfaces.cli.ask.service import AskError, AskExitCode, AskOutcome, AskStatus
+from surfaces.cli.commands.ask import ask_command
+
+
+def _success(response: str = "done") -> AskOutcome:
+    return AskOutcome(status=AskStatus.SUCCESS, response=response)
+
+
+def test_ask_passes_prompt_and_invocation_authority(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(prompt: str, **kwargs: object) -> AskOutcome:
+        captured.update(prompt=prompt, **kwargs)
+        return _success()
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(
+        ask_command,
+        ["check latency", "--allowed-tool", "grafana_query"],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "done\n"
+    assert captured == {
+        "prompt": "check latency",
+        "allowed_tools": ("grafana_query",),
+        "bypass_approvals": False,
+    }
+
+
+def test_ask_reads_prompt_from_stdin(monkeypatch) -> None:
+    seen: list[str] = []
+
+    def fake_run(prompt: str, **_kwargs: object) -> AskOutcome:
+        seen.append(prompt)
+        return _success()
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(ask_command, ["-"], input="from stdin\n")
+
+    assert result.exit_code == 0
+    assert seen == ["from stdin"]
+
+
+def test_ask_rejects_empty_prompt(monkeypatch) -> None:
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+
+    result = CliRunner().invoke(ask_command, ["-"], input="  \n")
+
+    assert result.exit_code == 2
+    assert "PROMPT must not be empty" in result.output
+
+
+def test_ask_rejects_conflicting_approval_options(monkeypatch) -> None:
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+
+    result = CliRunner().invoke(
+        ask_command,
+        ["prompt", "--allowed-tool", "one", "--dangerously-bypass-approvals"],
+    )
+
+    assert result.exit_code == 2
+    assert "cannot be combined" in result.output
+
+
+def test_ask_rejects_unknown_allowed_tool_before_execution(monkeypatch) -> None:
+    called = False
+
+    def fake_run(*_args: object, **_kwargs: object) -> AskOutcome:
+        nonlocal called
+        called = True
+        return _success()
+
+    monkeypatch.setattr(
+        "surfaces.cli.commands.ask.unknown_allowed_tools",
+        lambda _v: ("typo",),
+    )
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(ask_command, ["prompt", "--allowed-tool", "typo"])
+
+    assert result.exit_code == 2
+    assert "unknown registered tool name(s): typo" in result.output
+    assert called is False
+
+
+def test_ask_json_output_is_one_stable_document(monkeypatch) -> None:
+    outcome = AskOutcome(
+        status=AskStatus.ERROR,
+        response="",
+        error=AskError(message="failed", suggestion="retry"),
+        exit_code=AskExitCode.ERROR,
+    )
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", lambda *_a, **_kw: outcome)
+    monkeypatch.setattr("surfaces.cli.commands.ask.is_json_output", lambda: True)
+
+    result = CliRunner().invoke(ask_command, ["prompt"])
+
+    assert result.exit_code == AskExitCode.ERROR
+    assert json.loads(result.output) == {
+        "status": "error",
+        "response": "",
+        "denied_tools": [],
+        "error": {"message": "failed", "suggestion": "retry"},
+    }
+    assert result.output.count("\n") == 1

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import json
+import signal
 
 from click.testing import CliRunner
 
-from surfaces.cli.ask.service import AskError, AskExitCode, AskOutcome, AskStatus
+from surfaces.cli.ask.service import (
+    AskError,
+    AskExitCode,
+    AskOutcome,
+    AskSignal,
+    AskStatus,
+)
 from surfaces.cli.commands.ask import ask_command
 
 
@@ -50,6 +57,20 @@ def test_ask_reads_prompt_from_stdin(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert seen == ["from stdin"]
+
+
+def test_ask_interrupt_while_reading_stdin_returns_signal_exit(monkeypatch) -> None:
+    def interrupt(_value: str) -> str:
+        raise AskSignal(signal.SIGINT)
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+    monkeypatch.setattr("surfaces.cli.commands.ask._resolve_prompt", interrupt)
+    monkeypatch.setattr("surfaces.cli.commands.ask.is_json_output", lambda: True)
+
+    result = CliRunner().invoke(ask_command, ["-"])
+
+    assert result.exit_code == 130
+    assert json.loads(result.output)["status"] == "cancelled"
 
 
 def test_ask_rejects_empty_prompt(monkeypatch) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -8,7 +8,7 @@ import pytest
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.llm.types import ToolCall
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool.execution import ToolExecutionRequest
+from core.tool.execution import ToolExecutionHooks, ToolExecutionRequest
 from surfaces.cli.ask import service
 from surfaces.cli.ask.service import AskExitCode, AskSignal, AskStatus
 
@@ -51,6 +51,47 @@ def _risky_request() -> ToolExecutionRequest:
     )
 
 
+class _FakeSessionManager:
+    def __init__(self) -> None:
+        self.closed: list[tuple[object, bool]] = []
+
+    def close(self, session: object, *, extract_memory: bool) -> None:
+        self.closed.append((session, extract_memory))
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.available_capabilities: dict[str, object] = {}
+
+
+class _FakeAgentSession:
+    session = _FakeSession()
+
+    def __init__(self, _config: object) -> None:
+        self.attached: object | None = None
+
+    def startup(self) -> object:
+        return type(
+            "Startup",
+            (),
+            {"session": self.session, "prompts": object()},
+        )()
+
+    def attach_agent(self, agent: object) -> None:
+        self.attached = agent
+
+    def chat(self, _prompt: str) -> TurnResult:
+        raise RuntimeError("turn failed")
+
+
+class _FakeHeadlessBuild:
+    def __init__(self, **_kwargs: object) -> None:
+        pass
+
+    def agent(self, **_kwargs: object) -> object:
+        return object()
+
+
 def test_run_ask_returns_success(monkeypatch) -> None:
     monkeypatch.setattr(service, "_run_agent_turn", lambda _prompt, _hooks: _turn())
 
@@ -59,6 +100,24 @@ def test_run_ask_returns_success(monkeypatch) -> None:
     assert outcome.status is AskStatus.SUCCESS
     assert outcome.response == "answer"
     assert outcome.exit_code is AskExitCode.SUCCESS
+
+
+def test_agent_turn_closes_ephemeral_session_after_failure(monkeypatch) -> None:
+    manager = _FakeSessionManager()
+    _FakeAgentSession.session = _FakeSession()
+    monkeypatch.setattr(service, "SessionManager", lambda: manager)
+    monkeypatch.setattr(service, "AgentSession", _FakeAgentSession)
+    monkeypatch.setattr(service, "DefaultHeadlessBuild", _FakeHeadlessBuild)
+    monkeypatch.setattr(
+        service,
+        "DefaultToolProvider",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    with pytest.raises(RuntimeError, match="turn failed"):
+        service._run_agent_turn("prompt", ToolExecutionHooks())
+
+    assert manager.closed == [(_FakeAgentSession.session, False)]
 
 
 def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import signal
+import threading
+
+import pytest
+
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from core.llm.types import ToolCall
+from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool.execution import ToolExecutionRequest
+from surfaces.cli.ask import service
+from surfaces.cli.ask.service import AskExitCode, AskSignal, AskStatus
+
+
+def _turn(
+    response: str = "answer",
+    *,
+    answered: bool = True,
+    cancelled: bool = False,
+) -> TurnResult:
+    return TurnResult(
+        final_intent="cli_agent_cancelled" if cancelled else "answer",
+        action_result=ToolCallingTurnResult(
+            planned_count=0,
+            executed_count=0,
+            executed_success_count=0,
+            has_unhandled_clause=False,
+            handled=False,
+        ),
+        assistant_response_text=response,
+        llm_run=object() if answered else None,
+    )
+
+
+def _risky_request() -> ToolExecutionRequest:
+    tool = RegisteredTool(
+        name="shell_run",
+        description="Run shell",
+        input_schema={"type": "object", "properties": {}},
+        source="shell",
+        run=lambda: None,
+        side_effect_level=SideEffectLevel.MUTATING,
+    )
+    return ToolExecutionRequest(
+        tool_call=ToolCall(id="call-1", name=tool.name, input={}),
+        tool=tool,
+        arguments={},
+        source=tool.source,
+        resolved_integrations={},
+    )
+
+
+def test_run_ask_returns_success(monkeypatch) -> None:
+    monkeypatch.setattr(service, "_run_agent_turn", lambda _prompt, _hooks: _turn())
+
+    outcome = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
+
+    assert outcome.status is AskStatus.SUCCESS
+    assert outcome.response == "answer"
+    assert outcome.exit_code is AskExitCode.SUCCESS
+
+
+def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:
+    def deny_then_fail(_prompt: str, hooks) -> TurnResult:
+        assert hooks.before_tool_call is not None
+        decision = hooks.before_tool_call(_risky_request())
+        assert decision is not None and decision.blocked
+        raise RuntimeError("downstream detail")
+
+    monkeypatch.setattr(service, "_run_agent_turn", deny_then_fail)
+
+    outcome = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
+
+    assert outcome.status is AskStatus.APPROVAL_DENIED
+    assert outcome.denied_tools == ("shell_run",)
+    assert outcome.exit_code is AskExitCode.APPROVAL_DENIED
+    assert "downstream detail" not in outcome.response
+
+
+def test_run_ask_maps_incomplete_and_cancelled_turns(monkeypatch) -> None:
+    monkeypatch.setattr(
+        service,
+        "_run_agent_turn",
+        lambda _prompt, _hooks: _turn("", answered=False),
+    )
+    incomplete = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
+
+    monkeypatch.setattr(
+        service,
+        "_run_agent_turn",
+        lambda _prompt, _hooks: _turn("stopped", cancelled=True),
+    )
+    cancelled = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
+
+    assert incomplete.status is AskStatus.ERROR
+    assert incomplete.exit_code is AskExitCode.ERROR
+    assert cancelled.status is AskStatus.CANCELLED
+    assert cancelled.exit_code is AskExitCode.SIGINT
+
+
+@pytest.mark.parametrize(
+    ("signum", "exit_code"),
+    [(signal.SIGINT, AskExitCode.SIGINT), (signal.SIGTERM, AskExitCode.SIGTERM)],
+)
+def test_run_ask_maps_signals(monkeypatch, signum: int, exit_code: AskExitCode) -> None:
+    def raise_signal(_prompt: str, _hooks) -> TurnResult:
+        raise AskSignal(signum)
+
+    monkeypatch.setattr(service, "_run_agent_turn", raise_signal)
+
+    outcome = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
+
+    assert outcome.status is AskStatus.CANCELLED
+    assert outcome.exit_code is exit_code
+
+
+def test_signal_scope_requests_cancel_and_restores_handlers(monkeypatch) -> None:
+    prior = {signal.SIGINT: object(), signal.SIGTERM: object()}
+    installed: dict[signal.Signals, object] = {}
+    restored: dict[signal.Signals, object] = {}
+
+    monkeypatch.setattr(signal, "getsignal", lambda sig: prior[sig])
+
+    def fake_signal(sig: signal.Signals, handler: object) -> None:
+        if sig in installed:
+            restored[sig] = handler
+        else:
+            installed[sig] = handler
+
+    monkeypatch.setattr(signal, "signal", fake_signal)
+    cancel_event = threading.Event()
+
+    with pytest.raises(AskSignal), service._ask_signal_scope(cancel_event):
+        handler = installed[signal.SIGINT]
+        assert callable(handler)
+        handler(signal.SIGINT, None)
+
+    assert cancel_event.is_set()
+    assert restored == prior

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -131,7 +131,7 @@ def test_signal_scope_requests_cancel_and_restores_handlers(monkeypatch) -> None
     monkeypatch.setattr(signal, "signal", fake_signal)
     cancel_event = threading.Event()
 
-    with pytest.raises(AskSignal), service._ask_signal_scope(cancel_event):
+    with pytest.raises(AskSignal), service.ask_signal_scope(cancel_event):
         handler = installed[signal.SIGINT]
         assert callable(handler)
         handler(signal.SIGINT, None)

--- a/tests/core/agent/test_tool_registry.py
+++ b/tests/core/agent/test_tool_registry.py
@@ -67,6 +67,15 @@ def test_tool_specs_include_required_fields() -> None:
         assert "input_schema" in spec
 
 
+def test_action_tools_classify_side_effects() -> None:
+    tools = _action_tools(Session())
+    unclassified = sorted(
+        tool.name for tool in tools if getattr(tool, "side_effect_level", None) is None
+    )
+
+    assert unclassified == []
+
+
 def test_action_kind_to_tool_names_are_openai_compatible() -> None:
     """Guard against the dotted-name regression that broke all 56 live
     planner scenarios on OpenAI-style providers (HTTP 400 on

--- a/tests/core/agent_harness/test_gather_phase.py
+++ b/tests/core/agent_harness/test_gather_phase.py
@@ -12,8 +12,10 @@ from typing import Any
 
 import pytest
 
+from core.agent_harness.ports import TurnBinding
 from core.agent_harness.turns.gather_phase import GatherPhase
 from core.agent_harness.turns.headless_build import InMemoryHeadlessBuild
+from core.tool.execution import ToolExecutionHooks
 
 
 class _Session:
@@ -84,6 +86,26 @@ class TestAgentForwardsGatherPhase:
         assert seen["on_progress"] is _on_progress
         assert seen["persist"] is _persist
         assert seen["max_iterations"] == 9
+
+    def test_turn_tool_hooks_reach_the_gather_phase(self, monkeypatch) -> None:
+        from core.agent_harness.turns import headless_adapters, headless_agent
+
+        seen: dict[str, Any] = {}
+
+        def _fake_gather(_message: str, _session: Any, **kwargs: Any) -> str | None:
+            seen.update(kwargs)
+            return "evidence"
+
+        monkeypatch.setattr(headless_agent, "gather_tool_evidence", _fake_gather)
+        hooks = ToolExecutionHooks()
+        agent = InMemoryHeadlessBuild(session=headless_adapters.InMemorySessionState()).agent(
+            tools=headless_adapters.NullToolProvider(),
+            gather=GatherPhase(),
+        )
+        agent.bind_turn(TurnBinding(tool_hooks=hooks))
+
+        assert agent._gather("why is it slow?") == "evidence"  # noqa: SLF001
+        assert seen["tool_hooks"] is hooks
 
     def test_disabled_gather_skips_the_phase_entirely(self, monkeypatch) -> None:
         # Arrange

--- a/tests/core/tool/test_execution.py
+++ b/tests/core/tool/test_execution.py
@@ -17,6 +17,7 @@ from core.tool.execution import (
     ToolExecutionRequest,
     ToolExecutionResult,
     _requires_sequential_execution,
+    compose_tool_execution_hooks,
     execute_tool_calls,
     execute_tools,
 )
@@ -111,6 +112,60 @@ def test_before_hook_can_block_with_structured_result() -> None:
     assert result.is_error is True
     assert result.content == "blocked"
     assert result.details == {"policy": "deny"}
+
+
+def test_composed_before_hooks_stop_at_first_block() -> None:
+    seen: list[str] = []
+
+    def first(_request: ToolExecutionRequest) -> None:
+        seen.append("first")
+
+    def deny(_request: ToolExecutionRequest) -> BeforeToolCallResult:
+        seen.append("deny")
+        return BeforeToolCallResult(blocked=True, reason="denied")
+
+    def never(_request: ToolExecutionRequest) -> None:
+        seen.append("never")
+
+    hooks = compose_tool_execution_hooks(
+        ToolExecutionHooks(before_tool_call=first),
+        ToolExecutionHooks(before_tool_call=deny),
+        ToolExecutionHooks(before_tool_call=never),
+    )
+
+    result = execute_tool_calls([_call()], [_tool()], {}, hooks=hooks)[0]
+
+    assert result.is_error is True
+    assert result.content == "denied"
+    assert seen == ["first", "deny"]
+
+
+def test_composed_after_hooks_receive_prior_patches() -> None:
+    seen: list[str] = []
+
+    def first(
+        _request: ToolExecutionRequest,
+        _result: ToolExecutionResult,
+    ) -> ToolExecutionPatch:
+        return ToolExecutionPatch(content="first", metadata={"first": True})
+
+    def second(
+        _request: ToolExecutionRequest,
+        result: ToolExecutionResult,
+    ) -> ToolExecutionPatch:
+        seen.append(str(result.content))
+        return ToolExecutionPatch(content="second", metadata={"second": True})
+
+    hooks = compose_tool_execution_hooks(
+        ToolExecutionHooks(after_tool_call=first),
+        ToolExecutionHooks(after_tool_call=second),
+    )
+
+    result = execute_tool_calls([_call()], [_tool()], {}, hooks=hooks)[0]
+
+    assert result.content == "second"
+    assert result.metadata == {"tool_name": "echo", "first": True, "second": True}
+    assert seen == ["first"]
 
 
 def test_before_hook_receives_executed_tools_source() -> None:

--- a/tests/interactive_shell/test_parity.py
+++ b/tests/interactive_shell/test_parity.py
@@ -4,9 +4,9 @@ from surfaces.cli.app import cli
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 
 # Commands that are intentionally excluded from the REPL (e.g. they don't make sense in session).
-# 'agent' is excluded because the REPL itself is the agent entry point.
+# 'agent' and 'ask' are excluded because the REPL itself is the agent entry point.
 # 'gateway' is excluded because it starts a standalone local HTTP server process.
-EXCLUDED_COMMANDS = {"agent", "gateway"}
+EXCLUDED_COMMANDS = {"agent", "ask", "gateway"}
 
 
 def test_cli_slash_command_parity():

--- a/tools/interactive_shell/actions/assistant_handoff.py
+++ b/tools/interactive_shell/actions/assistant_handoff.py
@@ -11,7 +11,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema, string_array_property, string_property
 
 
@@ -127,6 +127,7 @@ assistant_handoff_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.NONE,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_assistant_handoff,

--- a/tools/interactive_shell/actions/cli_command.py
+++ b/tools/interactive_shell/actions/cli_command.py
@@ -10,7 +10,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema, string_property
 from tools.interactive_shell.cli import run_opensre_cli_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
@@ -50,6 +50,7 @@ cli_exec_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_cli_command,

--- a/tools/interactive_shell/actions/implementation.py
+++ b/tools/interactive_shell/actions/implementation.py
@@ -10,7 +10,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema, string_property
 from tools.interactive_shell.implementation.claude_code_executor import (
     run_claude_code_implementation,
@@ -44,6 +44,7 @@ code_implement_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_implementation,

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema, string_property
 from platform.scheduling.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (
@@ -141,6 +141,7 @@ investigation_start_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.EXTERNAL,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_investigation,

--- a/tools/interactive_shell/actions/llm_provider.py
+++ b/tools/interactive_shell/actions/llm_provider.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema
 from tools.interactive_shell.shared import allow_tool
 
@@ -80,6 +80,7 @@ llm_set_provider_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_llm_provider,

--- a/tools/interactive_shell/actions/sample_alert.py
+++ b/tools/interactive_shell/actions/sample_alert.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema, string_property
 from platform.scheduling.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (
@@ -119,6 +119,7 @@ alert_sample_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.EXTERNAL,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_sample_alert_action,

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -10,7 +10,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema, string_property
 from tools.interactive_shell.shell.runner import run_shell_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
@@ -78,6 +78,7 @@ shell_run_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_shell,

--- a/tools/interactive_shell/actions/slash.py
+++ b/tools/interactive_shell/actions/slash.py
@@ -18,7 +18,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from tools.interactive_shell.shared import plan_foreground_tool
 from tools.interactive_shell.shared.slash_catalog import (
     slash_invoke_input_schema,
@@ -266,6 +266,7 @@ slash_invoke_tool = RegisteredTool(
     input_schema=slash_invoke_input_schema(),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_slash,

--- a/tools/interactive_shell/actions/synthetic.py
+++ b/tools/interactive_shell/actions/synthetic.py
@@ -12,7 +12,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema, string_property
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 from tools.interactive_shell.synthetic.runner import run_synthetic_test
@@ -80,6 +80,7 @@ synthetic_run_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_synthetic,

--- a/tools/interactive_shell/actions/task_cancel.py
+++ b/tools/interactive_shell/actions/task_cancel.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils.schema import object_schema
 from platform.scheduling.task_types import TaskKind, TaskStatus
 from tools.interactive_shell.shared import plan_foreground_tool
@@ -124,6 +124,7 @@ task_cancel_tool = RegisteredTool(
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
     parallel_safe=False,
     accepts_runtime_context=True,
     run=run_task_cancel,


### PR DESCRIPTION
Fixes #5028

#### Describe the changes you have made in this PR -

- Add `opensre ask PROMPT` with stdin (`-`), stable JSON output, documented exit codes, and SIGINT/SIGTERM cleanup.
- Run one ephemeral turn through the shared `HeadlessAgent` instead of creating a parallel agent runtime.
- Add invocation-scoped tool authorization with safe/read-only automatic execution, repeatable `--allowed-tool`, fail-closed unclassified tools, and an explicit `--dangerously-bypass-approvals` escape hatch.
- Apply the host approval hooks to both action and gather tool execution, preserving the existing gather discovery and circuit-breaker hooks.
- Classify the remaining interactive action tools by side-effect level and document the Headless CLI workflow in the guide and README.
- Keep persistent permissions and interactive approval flows out of scope for this milestone; those remain in #5048.

### Demo/Screenshot for feature changes and bug fixes -

```console
$ printf 'Reply with exactly: ask demo ok\n' | uv run --no-sync opensre --json ask -
{"status": "success", "response": "ask demo ok", "denied_tools": [], "error": null}

$ uv run --no-sync opensre --json ask 'Run the shell command printf approval-demo'
{"status": "approval_denied", "response": "Approval denied for: shell_run", "denied_tools": ["shell_run"], "error": null}
$ echo $?
3

$ uv run --no-sync opensre --json ask 'Run the shell command printf approval-demo' --allowed-tool shell_run
{"status": "success", "response": "approval-demo", "denied_tools": [], "error": null}
```

Local validation:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/cli/test_ask_approval.py tests/cli/test_ask_command.py tests/cli/test_ask_service.py tests/cli/test_cli_inventory.py -q` (43 passed)
- `uv run python -m pytest tests/core/agent/test_tool_registry.py tests/cli/test_ask_approval.py -q` (31 passed)
- `uv run python -m pytest tests/shared/terminal/test_splash_layout.py -q` (9 passed)
- `uv run python -m pytest tests/interactive_shell/test_harness_api_border.py tests/interactive_shell/test_parity.py tests/shared/test_surface_border.py tests/cli/test_ask_service.py tests/cli/test_ask_command.py -q` (18 passed)
- `uv run python -m pytest tests/core/agent_harness/test_harness_api.py tests/core/agent_harness/test_headless_build.py tests/interactive_shell/test_harness_api_border.py tests/shared/test_surface_border.py tests/cli/test_ask_service.py -q` (28 passed)
- `uv run python -m pytest tests/cli/test_ask_command.py tests/cli/test_ask_service.py -q` (13 passed)
- `uv run python -m pytest tests/cli/test_ask_approval.py tests/cli/test_ask_command.py tests/cli/test_ask_service.py -q` (25 passed; includes root `-y` isolation, exact allowlisting, and failure cleanup)
- Real blocked-stdin signal probe: `SIGINT` returned exit `130` and `{"status":"cancelled", ...}` on stdout with no stderr.
- Focused core hook suites passed in their implementation slice (`tests/core/tool/test_execution.py`, `tests/core/agent_harness/test_gather_phase.py`; 34 passed)
- Full repository coverage suite deferred to PR CI at the request of the issue author.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The command composes the existing session lifecycle, headless agent, action tools, and gather phase for one ephemeral turn. I considered adding a separate CLI-specific execution loop, but rejected it because that would duplicate routing and tool behavior. Approval is enforced at the shared tool-execution seam so the same invocation authority covers action and gather calls. Missing side-effect metadata is treated as approval-gated, which keeps the new unattended surface fail-closed while preserving the interactive shell's existing behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
