### PR TITLE
fix(agent-harness): require an explicit llm_factory for the action turn

### DIFF
--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -24,7 +24,6 @@ from core.agent.cancel import tool_resources_cancel_requested
 from core.agent.goals import Goal
 from core.agent_harness.accounting.self_recording_tools import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.agent_builder import AgentConfig, build_agent
-from core.agent_harness.llm_resolution import default_llm_factory
 from core.agent_harness.ports import (
     ConfirmFn,
     ErrorReporter,
@@ -662,7 +661,7 @@ def _build_action_agent(
     agent_tools: list[Any],
     turn_snapshot: TurnSnapshot | None,
     resolved_integrations: dict[str, Any],
-    llm_factory: LlmFactory | None,
+    llm_factory: LlmFactory,
     tool_hooks: ToolExecutionHooks | None,
     tool_resources: dict[str, Any],
     observer: Any,
@@ -706,8 +705,7 @@ def _build_action_agent(
         system = "Execute the explicit slash_invoke tool call."
         user_message = message
     else:
-        factory = llm_factory if llm_factory is not None else default_llm_factory
-        llm = factory()
+        llm = llm_factory()
         envelope = build_action_system_prompt_envelope(
             # No turn plan means no surface is known here; setup facts are
             # omitted rather than guessed (see _setup_state_for_surface).
@@ -762,9 +760,9 @@ class _ActionTurnArgs:
 
     output: OutputSink
     tools: ToolProvider
+    llm_factory: LlmFactory
     confirm_fn: ConfirmFn | None = None
     is_tty: bool | None = None
-    llm_factory: LlmFactory | None = None
     turn_plan: TurnPlan | None = None
     error_reporter: ErrorReporter | None = None
     tool_hooks: ToolExecutionHooks | None = None
@@ -780,13 +778,26 @@ class ActionTurnRunner:
 
     Only ``turn_plan``, ``is_tty`` and ``confirm_fn`` change between turns, so
     they stay arguments to :meth:`run`.
+
+    ``llm_factory`` is required: the composition root must wire a real factory
+    (e.g. :func:`~core.agent_harness.llm_resolution.default_llm_factory`)
+    explicitly rather than relying on a silent fallback deep in the turn
+    driver. A missing factory fails here, at construction, not mid-turn.
     """
 
     output: OutputSink
     tools: ToolProvider
-    llm_factory: LlmFactory | None = None
+    llm_factory: LlmFactory
     error_reporter: ErrorReporter | None = None
     tool_hooks: ToolExecutionHooks | None = None
+
+    def __post_init__(self) -> None:
+        if self.llm_factory is None:
+            raise ValueError(
+                "No LLM provider configured for the action turn: ActionTurnRunner "
+                "requires an explicit llm_factory. Wire one at the composition root "
+                "(e.g. core.agent_harness.llm_resolution.default_llm_factory)."
+            )
 
     def run(
         self,

--- a/core/agent_harness/turns/headless_agent.py
+++ b/core/agent_harness/turns/headless_agent.py
@@ -94,7 +94,7 @@ class HeadlessAgent:
         run_factory: RunRecordFactory,
         error_reporter: ErrorReporter,
         gather: GatherPhase,
-        llm_factory: LlmFactory | None = None,
+        llm_factory: LlmFactory,
     ) -> None:
         self._tools = tools
         self._llm_factory = llm_factory

--- a/core/agent_harness/turns/headless_build.py
+++ b/core/agent_harness/turns/headless_build.py
@@ -24,6 +24,7 @@ from rich.console import Console
 
 from core.agent_harness.accounting.run_record import DefaultRunRecordFactory
 from core.agent_harness.error_reporting import DefaultErrorReporter
+from core.agent_harness.llm_resolution import default_llm_factory
 from core.agent_harness.ports import (
     ErrorReporter,
     LlmFactory,
@@ -102,7 +103,7 @@ class InMemoryHeadlessBuild:
             run_factory=SimpleRunRecordFactory(),
             error_reporter=NoopErrorReporter(),
             gather=gather if gather is not None else GATHER_DISABLED,
-            llm_factory=llm_factory,
+            llm_factory=llm_factory if llm_factory is not None else default_llm_factory,
         )
 
 
@@ -184,7 +185,7 @@ class DefaultHeadlessBuild:
             run_factory=self.run_factory(),
             error_reporter=self._error_reporter,
             gather=gather if gather is not None else GATHER_DISABLED,
-            llm_factory=llm_factory,
+            llm_factory=llm_factory if llm_factory is not None else default_llm_factory,
         )
 
 

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -13,7 +13,7 @@ from rich.console import Console
 
 from core.agent_harness import OutputSink, ToolCallingTurnResult
 from core.agent_harness.ports import LlmFactory
-from core.agent_harness.runtime import ActionTurnRunner, TurnPlan
+from core.agent_harness.runtime import ActionTurnRunner, TurnPlan, default_llm_factory
 from core.agent_harness.spi.defaults import DefaultErrorReporter
 from core.tool.execution import ToolExecutionHooks
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
@@ -65,7 +65,7 @@ def run_action_tool_turn(
     runner = ActionTurnRunner(
         output=sink,
         tools=shell_tool_provider(session, console, request_exit=request_exit),
-        llm_factory=llm_factory,
+        llm_factory=llm_factory if llm_factory is not None else default_llm_factory,
         error_reporter=DefaultErrorReporter(),
         tool_hooks=tool_hooks,
     )

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -35,7 +35,25 @@ from tools.interactive_shell.action_names import (
     ToolKind,
 )
 
-_ACTION_LLM_FACTORY_PATCH = "core.agent_harness.turns.action_driver.default_llm_factory"
+_ACTION_LLM_FACTORY_PATCHES = (
+    "core.agent_harness.turns.headless_build.default_llm_factory",
+    "surfaces.interactive_shell.runtime.action_turn.default_llm_factory",
+)
+
+
+def _patch_action_llm_factory(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
+    """Patch the default LLM factory wherever the exercised call path resolves it.
+
+    Tests in this file drive the action turn through both entry points --
+    ``run_harness_turn`` (-> HeadlessAgent -> headless_build.default_llm_factory)
+    and ``action_turn.run_action_tool_turn`` directly (its own module-level
+    default_llm_factory binding) -- so both locations are patched; the unused
+    one is simply never read.
+    """
+    for target in _ACTION_LLM_FACTORY_PATCHES:
+        monkeypatch.setattr(target, value)
+
+
 run_harness_turn = harness_turn_driver.run_harness_turn
 
 
@@ -271,7 +289,7 @@ def _llm_response(
 
 @pytest.fixture(autouse=True)
 def _llm_planner_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(_ACTION_LLM_FACTORY_PATCH, _MessageMappedActionLLM)
+    _patch_action_llm_factory(monkeypatch, _MessageMappedActionLLM)
 
 
 def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) -> None:
@@ -470,8 +488,8 @@ def test_execute_cli_actions_sets_bare_model_for_active_provider(
 ) -> None:
     reasoning_models: list[str] = []
 
-    monkeypatch.setattr(
-        _ACTION_LLM_FACTORY_PATCH,
+    _patch_action_llm_factory(
+        monkeypatch,
         lambda: FakeActionLLM(
             [
                 _llm_response(
@@ -1309,7 +1327,7 @@ def test_execute_cli_actions_persists_action_agent_llm_unavailable(
     def _raise() -> object:
         raise RuntimeError("action agent unavailable")
 
-    monkeypatch.setattr(_ACTION_LLM_FACTORY_PATCH, _raise)
+    _patch_action_llm_factory(monkeypatch, _raise)
 
     session = Session()
     console, buf = _capture()
@@ -1327,8 +1345,8 @@ def test_execute_cli_actions_persists_action_agent_llm_unavailable(
 def test_execute_cli_actions_executes_matched_clause_ignoring_unhandled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        _ACTION_LLM_FACTORY_PATCH,
+    _patch_action_llm_factory(
+        monkeypatch,
         lambda: FakeActionLLM([_llm_response([_action("slash", "/health")], has_unhandled=True)]),
     )
 
@@ -1391,7 +1409,7 @@ def test_execute_cli_actions_bang_prefix_uses_only_explicit_shell_escape(
         llm_called.append("called")
         raise AssertionError("LLM planner must not be called for !cmd input")
 
-    monkeypatch.setattr(_ACTION_LLM_FACTORY_PATCH, _fail_if_called)
+    _patch_action_llm_factory(monkeypatch, _fail_if_called)
 
     calls: list[tuple[list[str], dict[str, object]]] = []
 
@@ -1431,7 +1449,7 @@ def test_execute_cli_actions_bang_prefix_single_line_dispatches_to_shell(
         llm_called.append("called")
         raise AssertionError("LLM planner must not be called for !cmd input")
 
-    monkeypatch.setattr(_ACTION_LLM_FACTORY_PATCH, _fail_if_called)
+    _patch_action_llm_factory(monkeypatch, _fail_if_called)
 
     calls: list[tuple[list[str], dict[str, object]]] = []
 
@@ -1468,8 +1486,8 @@ def test_execute_cli_actions_handoff_only_plan_falls_through_silently(
     before the real LLM reply ran.  The user saw two assistant headers and internal
     planner reasoning that should have been invisible.
     """
-    monkeypatch.setattr(
-        _ACTION_LLM_FACTORY_PATCH,
+    _patch_action_llm_factory(
+        monkeypatch,
         lambda: FakeActionLLM(
             [
                 _llm_response(

--- a/tests/core/agent/orchestration/test_model_question_misroute.py
+++ b/tests/core/agent/orchestration/test_model_question_misroute.py
@@ -32,7 +32,7 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
     tool_response,
 )
 
-_ACTION_LLM_FACTORY_PATCH = "core.agent_harness.turns.action_driver.default_llm_factory"
+_ACTION_LLM_FACTORY_PATCH = "core.agent_harness.turns.headless_build.default_llm_factory"
 _PROMPT = "which model is being used now?"
 
 

--- a/tests/core/agent_harness/test_action_turn_runner.py
+++ b/tests/core/agent_harness/test_action_turn_runner.py
@@ -14,14 +14,40 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from core.agent_harness.runtime import ActionTurnRunner, TurnBinding
+from core.agent_harness.runtime import ActionTurnRunner, TurnBinding, default_llm_factory
 from core.agent_harness.turns.headless_adapters import BufferOutputSink, NullToolProvider
 from core.agent_harness.turns.headless_agent import HeadlessAgent
 from core.agent_harness.turns.headless_build import InMemoryHeadlessBuild
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+from core.llm_invoke_errors import ProviderFailureKind, classify_llm_provider_failure
 from core.tool.execution import ToolExecutionHooks
 from surfaces.interactive_shell.runtime.turn_seams import bind_injected_stages
 from surfaces.interactive_shell.session import Session
+
+
+def test_action_turn_runner_requires_llm_factory_at_construction() -> None:
+    """Issue #5235: a missing llm_factory must fail loudly at construction
+    (the "composition seam"), not silently mid-turn via a hidden fallback.
+    The error message must classify as NOT_CONFIGURED so existing provider-
+    failure rendering/remediation picks it up correctly."""
+    with pytest.raises(ValueError) as exc_info:
+        ActionTurnRunner(
+            output=BufferOutputSink(),
+            tools=NullToolProvider(),
+            llm_factory=None,  # type: ignore[arg-type]
+        )
+
+    assert classify_llm_provider_failure(str(exc_info.value)) is ProviderFailureKind.NOT_CONFIGURED
+
+
+def test_action_turn_runner_accepts_a_real_default_llm_factory() -> None:
+    """The composition-root default (core.agent_harness.llm_resolution.default_llm_factory)
+    must satisfy the required field without raising at construction."""
+    ActionTurnRunner(
+        output=BufferOutputSink(),
+        tools=NullToolProvider(),
+        llm_factory=default_llm_factory,
+    )
 
 
 def test_action_turn_runner_is_exported_from_runtime_not_the_root() -> None:
@@ -52,9 +78,13 @@ def test_action_turn_runner_run_accepts_confirm_fn(monkeypatch: Any) -> None:
     def _confirm(_prompt: str) -> str:
         return "y"
 
+    def _unused_llm_factory() -> Any:
+        raise AssertionError("llm_factory should not be called; _run_action_turn is mocked")
+
     result = ActionTurnRunner(
         output=BufferOutputSink(),
         tools=NullToolProvider(),
+        llm_factory=_unused_llm_factory,
     ).run("hi", Session(), confirm_fn=_confirm, is_tty=False)
 
     assert result.handled is False

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -136,7 +136,7 @@ def test_agent_exposes_headless_agent_entrypoint(monkeypatch: pytest.MonkeyPatch
             yield "hello from headless"
 
     monkeypatch.setattr(
-        "core.agent_harness.turns.action_driver.default_llm_factory",
+        "core.agent_harness.turns.headless_build.default_llm_factory",
         lambda: FakeLLM(iter([AgentLLMResponse(content="", tool_calls=[], raw_content=None)])),
     )
 
@@ -161,7 +161,7 @@ def test_one_headless_agent_dispatches_multiple_messages(monkeypatch: pytest.Mon
             yield "hello from headless"
 
     monkeypatch.setattr(
-        "core.agent_harness.turns.action_driver.default_llm_factory",
+        "core.agent_harness.turns.headless_build.default_llm_factory",
         lambda: FakeLLM(iter([AgentLLMResponse(content="", tool_calls=[], raw_content=None)])),
     )
     from core.agent_harness.turns.headless_adapters import (

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -2218,7 +2218,7 @@ class TestResumeCommand:
             raise RuntimeError("codex: quota or rate limit exceeded (exit 1)")
 
         with patch(
-            "core.agent_harness.turns.action_driver.default_llm_factory",
+            "surfaces.interactive_shell.runtime.action_turn.default_llm_factory",
             side_effect=_raise,
         ):
             result = run_action_tool_turn("check cpu usage", session, console)

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -316,7 +316,7 @@ def test_run_harness_turn_nitro_prompt_executes_remote_then_investigation(
         call_order.append(f"investigation:{alert_text}")
 
     monkeypatch.setattr(
-        "core.agent_harness.turns.action_driver.default_llm_factory",
+        "core.agent_harness.turns.headless_build.default_llm_factory",
         lambda: FakeActionLLM(
             [
                 AgentLLMResponse(


### PR DESCRIPTION
Fixes #5235

#### Describe the changes you have made in this PR -

The issue describes `action_driver.py`'s fallback to `default_llm_factory` as hiding already-correct wiring at the composition roots ("Composition roots already supply one"). Before implementing, I traced every real call site of `ActionTurnRunner`/`HeadlessAgent` to confirm that premise, and it does not hold: **no** composition root — not gateway's `SessionAgentPool`, not the interactive shell's `build_shell_agent`, not the standalone `run_action_tool_turn` — ever passed an explicit `llm_factory`. The fallback was not a redundant safety net; it was the *only* thing supplying a real LLM to the action turn in production, for both surfaces. A literal "just remove the fallback" would have broken every action turn immediately.

The fix instead **moves** the default from deep inside `action_driver.py` (opaque, per-turn, three call layers down) to the actual composition seam — `headless_build.py`'s module docstring already calls itself "**the single construction seam**":

- `ActionTurnRunner.llm_factory` is now required, validated in `__post_init__` with a message that classifies as `NOT_CONFIGURED` (`core.llm_invoke_errors.classify_llm_provider_failure`), so existing provider-failure rendering/remediation picks it up correctly. A missing factory now fails at construction, never silently mid-turn.
- `HeadlessAgent.llm_factory` is likewise required (mypy forced this once `ActionTurnRunner` tightened, since `_new_action_runner()` constructs it eagerly inside `HeadlessAgent.__init__`).
- `DefaultHeadlessBuild.agent()` / `InMemoryHeadlessBuild.agent()` resolve an unset `llm_factory` to `default_llm_factory` before constructing `HeadlessAgent` — so every current *and future* caller gets a real factory automatically, matching how `tools`/`prompts`/`gather` already default at this exact layer, instead of every caller needing to remember to wire one individually.
- `run_action_tool_turn` (the standalone entry point that builds `ActionTurnRunner` directly, bypassing `HeadlessAgent`) does the same resolution locally.

No `default_llm_factory` import remains in `action_driver.py` (only two docstring/error-message mentions of the name as an example).

### Demo/Screenshot for feature changes and bug fixes -

Before, `ActionTurnRunner(output=..., tools=..., llm_factory=None)` constructed successfully and silently deferred to the global `get_llm` the first time a turn ran:
```python
>>> ActionTurnRunner(output=BufferOutputSink(), tools=NullToolProvider(), llm_factory=None)
<ActionTurnRunner object at ...>  # no error, misconfiguration invisible until a real turn runs
```

After, the same call fails immediately with a classified message:
```python
>>> ActionTurnRunner(output=BufferOutputSink(), tools=NullToolProvider(), llm_factory=None)
ValueError: No LLM provider configured for the action turn: ActionTurnRunner requires an
explicit llm_factory. Wire one at the composition root (e.g.
core.agent_harness.llm_resolution.default_llm_factory).
>>> classify_llm_provider_failure(str(_)) 
ProviderFailureKind.NOT_CONFIGURED
```

Regression test proof: reverted `action_driver.py` alone and reran the two new tests (`test_action_turn_runner_requires_llm_factory_at_construction`, `test_action_turn_runner_accepts_a_real_default_llm_factory`) — the first failed with `Failed: DID NOT RAISE <class 'ValueError'>`, confirming the old code silently accepted `None`. Restored the fix and confirmed green.

Local checks run: `make lint`, `make format-check`, `make typecheck` (all clean, full repo), `uv run mypy` on every touched test file (148 pre-existing errors in `test_agent_actions.py`/`test_action_turn_runner.py`/`test_terminal_runtime_turns.py` confirmed identical before and after my changes — unrelated `monkeypatch: object` typing and `RunActionToolTurn` protocol mismatches, not something this PR touches). Full suite run rather than a narrow slice, since this changes a shared construction seam: `tests/core/agent_harness` (543 passed), `tests/interactive_shell` (1446 passed, 1 skipped), `tests/core/agent/orchestration` (all passed), `tests/core/runtime/test_loop.py` (28 passed), plus the gateway tests that exercise `SessionAgentPool`/`DefaultHeadlessBuild` (`test_package_borders.py`, `test_agent_build_config.py`, `test_turn_handler.py`, `test_session_agents.py`, `test_agent_life_cycle.py`, `test_antartica_slack.py`) — 2291 passed total.

**Test fakes updated** (per the issue's own ask) across three files that patch/construct the old fallback location: most needed a straightforward patch-target update to `core.agent_harness.turns.headless_build.default_llm_factory` (where `DefaultHeadlessBuild`/`InMemoryHeadlessBuild` now resolve it) or `surfaces.interactive_shell.runtime.action_turn.default_llm_factory` (where `run_action_tool_turn` resolves it) depending on which entry point the test exercises. `tests/core/agent/orchestration/test_agent_actions.py` mixes both entry points under one shared `autouse` fixture, so its patch helper now patches both locations rather than one — the unused one is simply never read by whichever path a given test exercises.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Before writing any code, I traced every real (non-test) construction site of `ActionTurnRunner` and `HeadlessAgent` to check the issue's premise that composition roots already supply a factory. They don't — confirmed by grepping every call site and reading `SessionAgentPool.get`, `build_shell_agent`, and `run_action_tool_turn` directly, none of which pass `llm_factory`. This changed the scope from "delete a redundant fallback" to "move the default to the right layer without breaking production." I picked `headless_build.py`'s `.agent()` methods as the resolution point because the module's own docstring identifies itself as "the single construction seam" that every real caller already goes through, and because `tools`/`prompts`/`gather` already default there using the identical `x if x is not None else <default>` pattern — this keeps the fix consistent with the file's existing design rather than introducing a new pattern. `ActionTurnRunner.__post_init__` gives the "fail at composition, not mid-turn" behavior the issue asked for, because it's constructed eagerly inside `HeadlessAgent.__init__` (confirmed by reading `_new_action_runner()`'s call site), not lazily on first turn. For the message text, I read `classify_llm_provider_failure`'s pattern list directly and chose wording containing "no llm provider" so the classification the issue asked for actually holds, rather than guessing. The test updates required tracing each failing test's actual call chain individually (`run_harness_turn` vs `action_turn.run_action_tool_turn` are genuinely different paths with different resolution points now), which is why one file needed a dual-patch helper instead of a single string swap.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.