### PR TITLE
fix(clickhouse): stop excluding failed queries from query activity

### DIFF
--- a/integrations/clickhouse/__init__.py
+++ b/integrations/clickhouse/__init__.py
@@ -166,7 +166,14 @@ def get_query_activity(
 ) -> dict[str, Any]:
     """Retrieve recent query activity from system.query_log.
 
-    Read-only: queries system.query_log for recent completed queries.
+    Read-only: queries system.query_log for recent completed *and* failed
+    queries (``type != 'QueryStart'``: ClickHouse logs a failed query as
+    ``ExceptionBeforeStart``/``ExceptionWhileProcessing``, distinct from the
+    successful ``QueryFinish`` row -- a bare ``type = 'QueryFinish'`` filter
+    silently excludes every failure, which defeats the point of surfacing
+    "recent slow / failed queries" during an incident). ``QueryStart`` rows
+    are excluded since they precede the query's own duration/result being
+    known and would otherwise duplicate its later QueryFinish/Exception row.
     Results capped at config.max_results.
     """
     if not config.is_configured:
@@ -188,7 +195,7 @@ def get_query_activity(
                 "  memory_usage, "
                 "  event_time "
                 "FROM system.query_log "
-                "WHERE type = 'QueryFinish' "
+                "WHERE type != 'QueryStart' "
                 "ORDER BY event_time DESC "
                 "LIMIT %(limit)s",
                 parameters={"limit": effective_limit},

--- a/integrations/clickhouse/__init__.py
+++ b/integrations/clickhouse/__init__.py
@@ -166,15 +166,9 @@ def get_query_activity(
 ) -> dict[str, Any]:
     """Retrieve recent query activity from system.query_log.
 
-    Read-only: queries system.query_log for recent completed *and* failed
-    queries (``type != 'QueryStart'``: ClickHouse logs a failed query as
-    ``ExceptionBeforeStart``/``ExceptionWhileProcessing``, distinct from the
-    successful ``QueryFinish`` row -- a bare ``type = 'QueryFinish'`` filter
-    silently excludes every failure, which defeats the point of surfacing
-    "recent slow / failed queries" during an incident). ``QueryStart`` rows
-    are excluded since they precede the query's own duration/result being
-    known and would otherwise duplicate its later QueryFinish/Exception row.
-    Results capped at config.max_results.
+    Read-only: queries system.query_log for recent completed and failed
+    queries, excluding QueryStart records whose duration and result are not
+    yet known. Results capped at config.max_results.
     """
     if not config.is_configured:
         return tool_unavailable("clickhouse", "Not configured.")

--- a/integrations/clickhouse/tools/clickhouse_query_activity_tool/__init__.py
+++ b/integrations/clickhouse/tools/clickhouse_query_activity_tool/__init__.py
@@ -14,7 +14,7 @@ from integrations.clickhouse import (
 
 @tool(
     name="get_clickhouse_query_activity",
-    description="Retrieve recent query activity from a ClickHouse instance, including query duration, rows read, and memory usage.",
+    description="Retrieve recent query activity (including failed queries) from a ClickHouse instance, with query duration, rows read, and memory usage.",
     source="clickhouse",
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     use_cases=[

--- a/tests/integrations/test_clickhouse.py
+++ b/tests/integrations/test_clickhouse.py
@@ -1,10 +1,13 @@
 """Unit tests for the ClickHouse integration module."""
 
+from unittest.mock import MagicMock, patch
+
 from integrations.clickhouse import (
     ClickHouseConfig,
     ClickHouseValidationResult,
     build_clickhouse_config,
     clickhouse_config_from_env,
+    get_query_activity,
 )
 
 
@@ -144,3 +147,49 @@ class TestClickHouseValidationResult:
         result = ClickHouseValidationResult(ok=False, detail="Connection refused.")
         assert result.ok is False
         assert result.detail == "Connection refused."
+
+
+class TestGetQueryActivityIncludesFailedQueries:
+    """Regression: WHERE type = 'QueryFinish' silently excluded every failed
+    query (ClickHouse logs those as ExceptionBeforeStart/
+    ExceptionWhileProcessing, never QueryFinish), even though the tool is
+    documented to surface "recent slow / failed queries" -- confirmed live
+    against a real ClickHouse instance, where a failing query never appeared
+    in the results no matter the limit."""
+
+    def test_where_clause_does_not_filter_to_query_finish_only(self) -> None:
+        mock_client = MagicMock()
+        mock_client.query.return_value = MagicMock(named_results=lambda: iter([]))
+        with patch("integrations.clickhouse._get_client", return_value=mock_client):
+            config = ClickHouseConfig(host="ch.example.com")
+            get_query_activity(config, limit=10)
+
+        sql = mock_client.query.call_args.args[0]
+        assert "type = 'QueryFinish'" not in sql
+        assert "type != 'QueryStart'" in sql
+
+    def test_returns_a_real_exception_before_start_row(self) -> None:
+        mock_client = MagicMock()
+        mock_client.query.return_value = MagicMock(
+            named_results=lambda: iter(
+                [
+                    {
+                        "query_id": "q1",
+                        "type": "ExceptionBeforeStart",
+                        "query": "SELECT * FROM missing_table",
+                        "query_duration_ms": 0,
+                        "read_rows": 0,
+                        "read_bytes": 0,
+                        "result_rows": 0,
+                        "memory_usage": 0,
+                        "event_time": "2026-01-01 00:00:00",
+                    }
+                ]
+            )
+        )
+        with patch("integrations.clickhouse._get_client", return_value=mock_client):
+            config = ClickHouseConfig(host="ch.example.com")
+            result = get_query_activity(config, limit=10)
+
+        assert result["available"] is True
+        assert result["queries"][0]["type"] == "ExceptionBeforeStart"


### PR DESCRIPTION
Part of #5111 (found while live-verifying ClickHouse's 2 registered tools)

#### Describe the changes you have made in this PR -

Found while live-verifying \`get_clickhouse_query_activity\` against a real ClickHouse instance. The underlying \`get_query_activity\` queried \`system.query_log\` with \`WHERE type = 'QueryFinish'\`, which only matches successful completions. ClickHouse logs a failed query as \`ExceptionBeforeStart\` or \`ExceptionWhileProcessing\` — never \`QueryFinish\` — so the tool could never surface a failed query, no matter how recent or how large the \`limit\`. \`docs/clickhouse.mdx\` documents the tool as returning "recent slow / failed queries," and its own \`use_cases\` say "Identifying slow or resource-heavy queries during an incident" — the exact scenario where seeing a failure matters most was structurally unreachable.

Reproduced live: ran \`SELECT * FROM nonexistent_table_verify_test\` against a real ClickHouse container, flushed logs, and called the tool directly — the failed query never appeared at any limit. Confirmed the actual logged \`type\` via \`system.query_log\` directly: \`ExceptionBeforeStart\`.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix, direct call against the real instance after the failing query ran:
```
types seen: {'QueryFinish'}
failed query present: False
```

After the fix, same instance, same failed query still in the log:
```
types seen: {'ExceptionBeforeStart', 'QueryFinish'}
failed query present: True
```

Regression test proof: reverted the fix locally and reran the new test — failed with `assert "type = 'QueryFinish'" not in sql` showing the old literal string still present, then restored the fix and confirmed green.

Local checks run: `make lint`, `make format-check`, `make typecheck` (all clean), `tests/integrations/test_clickhouse.py` + `tests/tools/test_clickhouse_query_activity_tool.py` + `tests/tools/test_clickhouse_system_health_tool.py` (46 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Found this by exercising both ClickHouse tools against a real, seeded ClickHouse instance rather than trusting the existing mocked tests, which mock `get_query_activity` entirely and never touch the actual SQL string — exactly why this bug had no coverage. I confirmed the real `type` value ClickHouse assigns to a failed query by querying `system.query_log` directly with `curl`, rather than guessing at ClickHouse's schema. The fix changes the filter from an allowlist of one success type to a denylist of the one row kind that should genuinely be excluded (`QueryStart`, which precedes the query's own duration/result being known), which is also more future-proof against ClickHouse adding further terminal-state types later.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.