### PR TITLE
fix(rabbitmq): use the current health-checks API path for alarm status

### DIFF
--- a/integrations/rabbitmq/__init__.py
+++ b/integrations/rabbitmq/__init__.py
@@ -368,11 +368,16 @@ def get_broker_overview(config: RabbitMQConfig) -> dict[str, Any]:
             msg_stats = overview.get("message_stats") or {}
             object_totals = overview.get("object_totals") or {}
 
-            # /api/healthchecks/alarms returns HTTP 503 (not 200) when alarms
+            # /api/health/checks/alarms returns HTTP 503 (not 200) when alarms
             # are active, so we can't use _http_get which treats >=400 as error.
+            # This is the modern Health Checks API path (RabbitMQ 3.9+, the
+            # project's documented minimum is 3.12+); the older one-word
+            # /api/healthchecks/alarms path was removed and 404s on every
+            # broker version this integration targets - confirmed live
+            # against RabbitMQ 3.13.7, where the old path never worked.
             alarm_payload: dict[str, Any] = {"ok": False, "detail": "unknown"}
             try:
-                alarm_resp = client.get("/api/healthchecks/alarms")
+                alarm_resp = client.get("/api/health/checks/alarms")
             except httpx.RequestError as exc:
                 alarm_payload = {"ok": False, "detail": str(exc)}
             else:

--- a/tests/integrations/test_rabbitmq.py
+++ b/tests/integrations/test_rabbitmq.py
@@ -432,7 +432,7 @@ class TestGetBrokerOverview:
                         "channels": 1,
                     },
                 },
-                "/api/healthchecks/alarms": {"status": "ok"},
+                "/api/health/checks/alarms": {"status": "ok"},
             }
         )
         result = get_broker_overview(CONFIGURED)
@@ -452,7 +452,7 @@ class TestGetBrokerOverview:
                     "object_totals": {},
                     "message_stats": {},
                 },
-                "/api/healthchecks/alarms": httpx.Response(
+                "/api/health/checks/alarms": httpx.Response(
                     503,
                     json={
                         "status": "failed",


### PR DESCRIPTION
Part of #5148 (found while live-verifying RabbitMQ's 5 registered tools)

#### Describe the changes you have made in this PR -

Found while live-verifying \`get_rabbitmq_broker_overview\` against a real RabbitMQ 3.13.7 broker. The code queried \`/api/healthchecks/alarms\` (one word) for alarm status. That path was the pre-3.9 Health Checks API and has since been removed; the current API is \`/api/health/checks/alarms\`. Confirmed live: the old path 404s on this broker, the new one returns \`200 {"status":"ok"}\`. \`docs/rabbitmq.mdx\` documents this integration's minimum supported version as 3.12+ (3.13 recommended), so the old path never worked on any version this integration actually targets.

The 404 branch's existing fallback then reported \`"alarm endpoint not available on this broker version"\` — a misleading message, since the endpoint genuinely exists on every version this integration supports, just under a different path.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix, real broker, real call:
```
alarms: {'ok': None, 'detail': 'alarm endpoint not available on this broker version'}
```

After the fix, same broker:
```
alarms: {'ok': True, 'detail': 'ok'}
```

Regression test proof: the two existing tests (\`test_includes_alarms\`, \`test_alarm_failure_surfaces_detail\`) already mocked the correct-shape 200/503 responses; they just mocked them under the old path. Updated their mocked path to the new one and reverted the source fix to confirm they fail cleanly (\`assert None is True\`) against the old code, then restored the fix and confirmed green.

Local checks run: \`make lint\`, \`make format-check\`, \`make typecheck\` (all clean), \`tests/integrations/test_rabbitmq.py\` + \`tests/tools/test_rabbitmq_broker_overview_tool.py\` + \`tests/tools/test_rabbitmq_connection_stats_tool.py\` + \`tests/tools/test_rabbitmq_consumer_health_tool.py\` (64 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Found this by exercising all 5 RabbitMQ tools against a real, seeded broker rather than trusting the mocked test suite. The broker overview's alarms field looked suspicious ("not available on this broker version" against a broker that is exactly the recommended version), so I curled the endpoint directly and confirmed the real API path had moved. I checked \`docs/rabbitmq.mdx\`'s stated minimum supported version (3.12+) before concluding this affects every deployment this integration targets, not just an edge case. The fix is a one-line path change since the existing 200/503 response handling already matches the new endpoint's shape exactly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.