### PR TITLE
refactor(harness): type the gather PersistToolCalls tuple as (ToolCall, Any)

### DIFF
--- a/core/agent_harness/turns/gather_phase.py
+++ b/core/agent_harness/turns/gather_phase.py
@@ -11,9 +11,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from core.agent_harness.ports import ToolEventObserver
+from core.llm.types import ToolCall
 
 #: Persists the tool calls a gather pass made: ``[(tool_call, result), ...]``.
-PersistToolCalls = Callable[[list[tuple[Any, Any]]], None]
+PersistToolCalls = Callable[[list[tuple[ToolCall, Any]]], None]
 
 #: Loop budget for headless metric reports (PostHog / digests): schema discovery plus
 #: one query per metric needs more than the chat default; passed as ``max_iterations``.


### PR DESCRIPTION
## Goal

Update `PersistToolCalls` type signature in `core/agent_harness/turns/gather_phase.py` to `(ToolCall, Any)` matching `AgentActionResult.executed` and tool persistence consumers.

## Context & Rationale

Issue #5242 originally mentioned `(str, Mapping[str, object])`. However, runtime inspection of `AgentActionResult.executed` confirms that gather tool calls pass `(ToolCall, Any)` (where `ToolCall` comes from `core.llm.types`).

## Proposed Changes

- Import `ToolCall` from `core.llm.types` in `core/agent_harness/turns/gather_phase.py`.
- Retype `PersistToolCalls` to `Callable[[list[tuple[ToolCall, Any]]], None]`.

## Verification

- `uv run mypy core/agent_harness/turns/gather_phase.py`
- `uv run pytest tests/core -q` (All tests passing)

FIxes #5242
