### PR TITLE
fix(github): windowed run listings, counted rates, and continuations that reconcile

### DIFF
--- a/core/agent_harness/prompts/skills/github_cli/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_cli/SKILL.md
@@ -42,9 +42,10 @@ HARD RULES:
   `list_github_actions_workflow_runs` instead of building a `gh api` query, and
   pass `window_hours=24` unless the user named a window. The tool defaults to no
   window because it also answers "which deploy failed before the incident".
-  It reports `window_covered`: when false the page ended inside the window, so
-  say the count is partial or re-ask with a larger `per_page` — never publish a
-  rate over it.
+  It reports `window_fully_fetched`: when false the page ended inside the
+  window, so counts are a floor — say so or re-ask with a larger `per_page`,
+  never publish a rate over it. `undated_runs` counts runs whose timestamp could
+  not be read; mention them rather than letting them vanish from a total.
 - With `gh api` on a list endpoint, always project the fields you need with
   `--jq`. Raw list payloads are hundreds of kilobytes (30 workflow runs is
   ~382k characters) and get cut to fit the context, leaving you a few records

--- a/core/agent_harness/prompts/skills/github_cli/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_cli/SKILL.md
@@ -38,10 +38,22 @@ HARD RULES:
   codespace / ssh-key / gpg-key / config — those are blocked (token leakage /
   CI code execution / secret mutation).
 - Pass args after the gh binary; optional repo as owner/name → -R.
-- For workflow-run counts or failure rates, call
-  `list_github_actions_workflow_runs` instead of building a `gh api` query, and
-  pass `window_hours=24` unless the user named a window. The tool defaults to no
-  window because it also answers "which deploy failed before the incident".
+- A failure RATE over a window is two counts, not a list of runs. Ask GitHub to
+  count, with `created` scoping the window server-side — never page through runs
+  to compute a rate. A busy repo runs thousands per week; enumeration times out
+  and a partial page gives a biased number.
+
+      gh api "/repos/OWNER/REPO/actions/runs?created=%3E%3D2026-08-13&per_page=1" --jq '.total_count'
+      gh api "/repos/OWNER/REPO/actions/runs?created=%3E%3D2026-08-13&status=failure&per_page=1" --jq '.total_count'
+
+  `per_page=1` because only `total_count` is read. Report the window you passed
+  and which conclusions `status=failure` covers — a strict failure count and a
+  broader error count are different numbers and must not be swapped between
+  turns.
+- To LIST which runs failed (not a rate), call
+  `list_github_actions_workflow_runs`, and pass `window_hours=24` unless the
+  user named a window. The tool defaults to no window because it also answers
+  "which deploy failed before the incident".
   It reports `window_fully_fetched`: when false the page ended inside the
   window, so counts are a floor — say so or re-ask with a larger `per_page`,
   never publish a rate over it. `undated_runs` counts runs whose timestamp could

--- a/core/agent_harness/prompts/skills/github_cli/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_cli/SKILL.md
@@ -38,6 +38,13 @@ HARD RULES:
   codespace / ssh-key / gpg-key / config — those are blocked (token leakage /
   CI code execution / secret mutation).
 - Pass args after the gh binary; optional repo as owner/name → -R.
+- For workflow-run counts or failure rates, call
+  `list_github_actions_workflow_runs` instead of building a `gh api` query, and
+  pass `window_hours=24` unless the user named a window. The tool defaults to no
+  window because it also answers "which deploy failed before the incident".
+  It reports `window_covered`: when false the page ended inside the window, so
+  say the count is partial or re-ask with a larger `per_page` — never publish a
+  rate over it.
 - With `gh api` on a list endpoint, always project the fields you need with
   `--jq`. Raw list payloads are hundreds of kilobytes (30 workflow runs is
   ~382k characters) and get cut to fit the context, leaving you a few records

--- a/core/agent_harness/prompts/skills/github_cli/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_cli/SKILL.md
@@ -54,10 +54,12 @@ HARD RULES:
   `list_github_actions_workflow_runs`, and pass `window_hours=24` unless the
   user named a window. The tool defaults to no window because it also answers
   "which deploy failed before the incident".
-  It reports `window_fully_fetched`: when false the page ended inside the
-  window, so counts are a floor — say so or re-ask with a larger `per_page`,
-  never publish a rate over it. `undated_runs` counts runs whose timestamp could
-  not be read; mention them rather than letting them vanish from a total.
+  It reports `window_fully_fetched`: when false the page is full and ended
+  inside the window, so counts are a floor — say so or re-ask with a larger
+  `per_page`, never publish a rate over it. When true, either an older run
+  proved the cutoff was reached or the listing was exhausted (fewer runs than
+  `per_page`). `undated_runs` counts runs whose timestamp could not be read;
+  mention them rather than letting them vanish from a total.
 - With `gh api` on a list endpoint, always project the fields you need with
   `--jq`. Raw list payloads are hundreds of kilobytes (30 workflow runs is
   ~382k characters) and get cut to fit the context, leaving you a few records

--- a/core/agent_harness/session_goal/continuation.py
+++ b/core/agent_harness/session_goal/continuation.py
@@ -24,6 +24,13 @@ def continuation_nudge(goal: SessionGoal) -> str:
             "done and do not report them as unavailable:\n"
             f"{established}\n\n"
         )
+    if goal.last_answer:
+        reason_block += (
+            "The previous turn of this goal already told the user:\n"
+            f"  {goal.last_answer}\n"
+            "Re-derive it if you must, but if your answer differs, say why — do "
+            "not replace it with a different number silently.\n\n"
+        )
     unfinished = goal.unfinished_items
     if unfinished:
         pending = "\n".join(f"  - [{index}] {item}" for index, item in unfinished)

--- a/core/agent_harness/session_goal/goal.py
+++ b/core/agent_harness/session_goal/goal.py
@@ -145,6 +145,12 @@ class SessionGoal:
     # turn sees only its own tools and reads their absence as an absence
     # overall — reporting completed work as never done.
     findings: tuple[str, ...] = ()
+    # What the previous turn told the user, recorded whether or not a tool ran.
+    # Weaker than ``findings``: not established, just already said. A turn that
+    # answered from history alone left no finding, so the next turn re-derived
+    # the number by another route and reported a different one with no mention
+    # of the first.
+    last_answer: str = ""
     # Wall-clock start for ``/goal`` duration paint (``time.time()``).
     started_at: float | None = None
     # Session token totals when the goal was attached — delta is goal spend.
@@ -171,6 +177,11 @@ class SessionGoal:
         if not text:
             return self
         return replace(self, findings=(*self.findings, text)[-MAX_GOAL_FINDINGS:])
+
+    def with_last_answer(self, answer: str) -> SessionGoal:
+        """Record what this turn told the user, for the next turn to reconcile."""
+        text = truncate_message(answer.strip(), MAX_GOAL_REASON_CHARS)
+        return self if not text else replace(self, last_answer=text)
 
     def with_reason(self, reason: str) -> SessionGoal:
         text = truncate_message(reason.strip(), MAX_GOAL_REASON_CHARS)

--- a/core/agent_harness/session_goal/run_until.py
+++ b/core/agent_harness/session_goal/run_until.py
@@ -153,8 +153,15 @@ def _finish_outer_turn(
     # and taking the session copy would discard the finding. A continuation is
     # a fresh chat call and history carries prose only, so this is the only way
     # a later turn learns what earlier ones established.
+    reply_text = session_goal_reply_text(last)
     if turn_has_session_goal_evidence(last):
-        active = active.with_finding(session_goal_reply_text(last))
+        active = active.with_finding(reply_text)
+        attach_session_goal(session, active)
+    # Recorded even without tool evidence. Evidence gates *closing* the goal and
+    # what counts as established; it must not gate whether the next turn knows
+    # what this one said.
+    if reply_text:
+        active = active.with_last_answer(reply_text)
         attach_session_goal(session, active)
     # Evaluate return is authoritative — optional reviewers may keep ACTIVE after
     # structured evaluate briefly attached ACHIEVED on the session.

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -181,36 +182,42 @@ def _run_started_at(run: dict[str, Any]) -> datetime | None:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
-def runs_within_window(
-    runs: list[dict[str, Any]],
-    window_hours: int,
-    *,
-    now: datetime | None = None,
-) -> tuple[list[dict[str, Any]], bool]:
-    """Return the runs started within ``window_hours``, and whether the page covered it.
+@dataclass(frozen=True, slots=True)
+class WindowedRuns:
+    """One page of runs narrowed to a time window.
 
-    ``window_hours <= 0`` disables the window and returns every run.
-
-    Coverage is the honest half. The listing is one page, so a window can hold
-    more runs than were fetched. Coverage is true only when a run older than the
-    window came back — proof the page reached past the window's edge. A caller
-    counting failures over a partial page must say so rather than report a rate.
+    ``window_fully_fetched`` is False when every dated run on the page falls
+    inside the window: older runs may exist that were never fetched, so counts
+    over ``runs`` are a floor rather than a total. ``undated`` counts runs whose
+    ``created_at`` could not be read; they are in neither ``runs`` nor the
+    evidence for ``window_fully_fetched``.
     """
-    if window_hours <= 0:
-        return runs, True
-    moment = now if now is not None else datetime.now(UTC)
-    cutoff = moment - timedelta(hours=window_hours)
+
+    runs: list[dict[str, Any]]
+    window_fully_fetched: bool
+    undated: int
+
+
+def window_runs(
+    runs: list[dict[str, Any]],
+    *,
+    window_hours: int,
+    now: datetime,
+) -> WindowedRuns:
+    """Narrow ``runs`` to those started within ``window_hours`` before ``now``."""
+    cutoff = now - timedelta(hours=window_hours)
     inside: list[dict[str, Any]] = []
-    saw_older = False
+    older = 0
+    undated = 0
     for run in runs:
         started = _run_started_at(run)
         if started is None:
-            continue
-        if started >= cutoff:
+            undated += 1
+        elif started >= cutoff:
             inside.append(run)
         else:
-            saw_older = True
-    return inside, saw_older
+            older += 1
+    return WindowedRuns(runs=inside, window_fully_fetched=older > 0, undated=undated)
 
 
 UNGROUPED_SECTION_NAME = "ungrouped"
@@ -426,14 +433,16 @@ def list_github_actions_workflow_runs(
     if payload.get("available"):
         workflow_runs_raw = _extract_list(result, "workflow_runs")
         workflow_runs = [_normalize_run(item) for item in workflow_runs_raw]
-        workflow_runs, window_covered = runs_within_window(workflow_runs, window_hours)
+        if window_hours > NO_RUN_WINDOW:
+            windowed = window_runs(workflow_runs, window_hours=window_hours, now=datetime.now(UTC))
+            workflow_runs = windowed.runs
+            payload["window_fully_fetched"] = windowed.window_fully_fetched
+            payload["undated_runs"] = windowed.undated
         payload["workflow_runs"] = workflow_runs
         payload["total"] = len(workflow_runs)
-        payload["window_covered"] = window_covered
     else:
         payload["workflow_runs"] = []
         payload["total"] = 0
-        payload["window_covered"] = False
 
     payload["window_hours"] = window_hours
     payload["branch"] = branch

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -186,11 +186,18 @@ def _run_started_at(run: dict[str, Any]) -> datetime | None:
 class WindowedRuns:
     """One page of runs narrowed to a time window.
 
-    ``window_fully_fetched`` is False when every dated run on the page falls
-    inside the window: older runs may exist that were never fetched, so counts
-    over ``runs`` are a floor rather than a total. ``undated`` counts runs whose
-    ``created_at`` could not be read; they are in neither ``runs`` nor the
-    evidence for ``window_fully_fetched``.
+    ``window_fully_fetched`` is True when the page proves every in-window run
+    that exists (under the same filters) is in ``runs``:
+
+    * a dated run older than the window came back (newest-first listing
+      scrolled past the cutoff), or
+    * the fetched page is shorter than the requested page size (the listing
+      is exhausted — no further runs exist to miss).
+
+    Otherwise the page ended inside the window while still full, so older
+    in-window runs may exist unfetched and counts over ``runs`` are a floor.
+    ``undated`` counts runs whose ``created_at`` could not be read; they are
+    in neither ``runs`` nor the older-run evidence for coverage.
     """
 
     runs: list[dict[str, Any]]
@@ -203,8 +210,13 @@ def window_runs(
     *,
     window_hours: int,
     now: datetime,
+    page_limit: int,
 ) -> WindowedRuns:
-    """Narrow ``runs`` to those started within ``window_hours`` before ``now``."""
+    """Narrow ``runs`` to those started within ``window_hours`` before ``now``.
+
+    ``page_limit`` is the ``per_page`` asked of the API. A shorter result means
+    the listing is exhausted, so an all-in-window page is still complete.
+    """
     cutoff = now - timedelta(hours=window_hours)
     inside: list[dict[str, Any]] = []
     older = 0
@@ -217,7 +229,12 @@ def window_runs(
             inside.append(run)
         else:
             older += 1
-    return WindowedRuns(runs=inside, window_fully_fetched=older > 0, undated=undated)
+    page_exhausted = page_limit > 0 and len(runs) < page_limit
+    return WindowedRuns(
+        runs=inside,
+        window_fully_fetched=older > 0 or page_exhausted,
+        undated=undated,
+    )
 
 
 UNGROUPED_SECTION_NAME = "ungrouped"
@@ -365,10 +382,13 @@ def _github_actions_run_params(sources: dict[str, dict]) -> dict[str, Any]:
                 "type": "integer",
                 "default": NO_RUN_WINDOW,
                 "description": (
-                    "Only return runs started within this many hours; 0 (the default) "
-                    "returns the page as fetched. Pass 24 for a rate or count over the "
-                    "last day. The result reports window_covered — when false the page "
-                    "ended inside the window, so counts over it are partial."
+                    f"Only return runs started within this many hours; {NO_RUN_WINDOW} "
+                    f"(the default) returns the page as fetched. Pass {RATE_WINDOW_HOURS} "
+                    "for a rate or count over the last day. The result reports "
+                    "window_fully_fetched — when false the page is full and ended "
+                    "inside the window, so counts over it are partial; when true "
+                    "either an older run proved the cutoff was reached or the "
+                    "listing was exhausted (fewer runs than per_page)."
                 ),
             },
             "github_url": {"type": "string"},
@@ -434,7 +454,12 @@ def list_github_actions_workflow_runs(
         workflow_runs_raw = _extract_list(result, "workflow_runs")
         workflow_runs = [_normalize_run(item) for item in workflow_runs_raw]
         if window_hours > NO_RUN_WINDOW:
-            windowed = window_runs(workflow_runs, window_hours=window_hours, now=datetime.now(UTC))
+            windowed = window_runs(
+                workflow_runs,
+                window_hours=window_hours,
+                now=datetime.now(UTC),
+                page_limit=per_page,
+            )
             workflow_runs = windowed.runs
             payload["window_fully_fetched"] = windowed.window_fully_fetched
             payload["undated_runs"] = windowed.undated

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from core.domain.types.tools import ToolSurface
@@ -158,6 +159,60 @@ def _normalize_run(run: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+#: The window a rate question should ask for. Not the tool default: this listing
+#: also answers "which deploy failed right before the incident", where a run days
+#: old is the whole point, so defaulting to a window would hide it from every
+#: caller that never asked for one. Rate callers pass this explicitly.
+RATE_WINDOW_HOURS = 24
+
+#: No window: return the page as fetched, whatever the age of its runs.
+NO_RUN_WINDOW = 0
+
+
+def _run_started_at(run: dict[str, Any]) -> datetime | None:
+    """Parse a run's ``created_at``; ``None`` when absent or unparsable."""
+    raw = str(run.get("created_at") or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def runs_within_window(
+    runs: list[dict[str, Any]],
+    window_hours: int,
+    *,
+    now: datetime | None = None,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return the runs started within ``window_hours``, and whether the page covered it.
+
+    ``window_hours <= 0`` disables the window and returns every run.
+
+    Coverage is the honest half. The listing is one page, so a window can hold
+    more runs than were fetched. Coverage is true only when a run older than the
+    window came back — proof the page reached past the window's edge. A caller
+    counting failures over a partial page must say so rather than report a rate.
+    """
+    if window_hours <= 0:
+        return runs, True
+    moment = now if now is not None else datetime.now(UTC)
+    cutoff = moment - timedelta(hours=window_hours)
+    inside: list[dict[str, Any]] = []
+    saw_older = False
+    for run in runs:
+        started = _run_started_at(run)
+        if started is None:
+            continue
+        if started >= cutoff:
+            inside.append(run)
+        else:
+            saw_older = True
+    return inside, saw_older
+
+
 UNGROUPED_SECTION_NAME = "ungrouped"
 
 
@@ -289,7 +344,7 @@ def _github_actions_run_params(sources: dict[str, dict]) -> dict[str, Any]:
         "Finding a run that matches an outage window or rollback event",
     ],
     requires=["owner", "repo"],
-    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
     input_schema={
         "type": "object",
         "properties": {
@@ -299,6 +354,16 @@ def _github_actions_run_params(sources: dict[str, dict]) -> dict[str, Any]:
             "status": {"type": "string", "default": ""},
             "event": {"type": "string", "default": ""},
             "per_page": {"type": "integer", "default": 30},
+            "window_hours": {
+                "type": "integer",
+                "default": NO_RUN_WINDOW,
+                "description": (
+                    "Only return runs started within this many hours; 0 (the default) "
+                    "returns the page as fetched. Pass 24 for a rate or count over the "
+                    "last day. The result reports window_covered — when false the page "
+                    "ended inside the window, so counts over it are partial."
+                ),
+            },
             "github_url": {"type": "string"},
             "github_mode": {"type": "string"},
             "github_token": {"type": "string"},
@@ -316,6 +381,7 @@ def list_github_actions_workflow_runs(
     status: str = "",
     event: str = "",
     per_page: int = 30,
+    window_hours: int = NO_RUN_WINDOW,
     github_url: str | None = None,
     github_mode: str | None = None,
     github_token: str | None = None,
@@ -360,12 +426,16 @@ def list_github_actions_workflow_runs(
     if payload.get("available"):
         workflow_runs_raw = _extract_list(result, "workflow_runs")
         workflow_runs = [_normalize_run(item) for item in workflow_runs_raw]
+        workflow_runs, window_covered = runs_within_window(workflow_runs, window_hours)
         payload["workflow_runs"] = workflow_runs
         payload["total"] = len(workflow_runs)
+        payload["window_covered"] = window_covered
     else:
         payload["workflow_runs"] = []
         payload["total"] = 0
+        payload["window_covered"] = False
 
+    payload["window_hours"] = window_hours
     payload["branch"] = branch
     payload["status"] = status
     payload["event"] = event

--- a/tests/core/agent_harness/session_goal/test_last_answer_carries_forward.py
+++ b/tests/core/agent_harness/session_goal/test_last_answer_carries_forward.py
@@ -1,0 +1,113 @@
+"""A continuation turn is told what the previous turn already answered.
+
+Asked "how many github actions runs failed in the last 24 hours?", turn 1
+answered "73 out of 800 completed" from conversation history — no tool ran. That
+left no ``finding`` (findings require tool evidence), so turn 2 re-derived the
+number by another route, reported 12, and closed the goal. The user saw two
+counts for one question with nothing reconciling them.
+
+``last_answer`` is the weaker channel: recorded whether or not a tool ran, and
+rendered as "already told the user" rather than as established fact, so an
+unverified answer cannot become settled by being repeated.
+"""
+
+from __future__ import annotations
+
+from core.agent_harness.session.session_core import SessionCore
+from core.agent_harness.session_goal.continuation import continuation_nudge
+from core.agent_harness.session_goal.goal import SessionGoal
+from core.agent_harness.session_goal.run_until import run_until_session_goal
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+
+_ANSWER = "73 GitHub Actions runs failed out of 800 completed, last 24 hours."
+
+
+def _goal() -> SessionGoal:
+    return SessionGoal(condition="how many github actions runs failed?", max_outer_turns=5)
+
+
+def test_the_previous_answer_reaches_the_next_turn() -> None:
+    # Arrange
+    goal = _goal().with_last_answer(_ANSWER)
+
+    # Act
+    nudge = continuation_nudge(goal)
+
+    # Assert
+    assert _ANSWER in nudge
+
+
+def test_the_next_turn_is_told_to_explain_a_different_number() -> None:
+    # Arrange / Act
+    nudge = continuation_nudge(_goal().with_last_answer(_ANSWER))
+
+    # Assert: silently replacing it is the failure being prevented.
+    assert "say why" in nudge
+
+
+def test_a_previous_answer_is_not_presented_as_established() -> None:
+    """``findings`` means established and says "treat these as done".
+
+    An answer with no tool behind it must not borrow that authority, or a wrong
+    remembered number becomes settled fact by being repeated.
+    """
+    # Arrange / Act
+    goal = _goal().with_last_answer(_ANSWER)
+
+    # Assert
+    assert goal.findings == ()
+    assert "treat these as done" not in continuation_nudge(goal)
+
+
+def test_an_empty_answer_is_not_recorded() -> None:
+    assert _goal().with_last_answer("   ").last_answer == ""
+
+
+def test_a_later_answer_replaces_the_earlier_one() -> None:
+    # Arrange / Act: only the most recent reply is worth reconciling against.
+    goal = _goal().with_last_answer(_ANSWER).with_last_answer("12 runs failed.")
+
+    # Assert
+    assert goal.last_answer == "12 runs failed."
+
+
+def test_a_tool_less_turn_still_hands_its_answer_to_the_next_turn() -> None:
+    """The wiring, not just the helper: no tool ran, yet turn 2 is told the answer.
+
+    Gating this on tool evidence is what produced 73 then 12. ``findings``
+    stays gated; this must not be.
+    """
+    # Arrange: two turns, neither running a tool, the first reporting a count.
+    session = SessionCore()
+    prompts: list[str] = []
+
+    def _chat(message: str) -> TurnResult:
+        prompts.append(message)
+        body = _ANSWER if len(prompts) == 1 else "12 runs failed. session_goal:achieved"
+        return TurnResult(
+            final_intent="cli_agent_fallback",
+            action_result=ToolCallingTurnResult(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+                has_unhandled_clause=False,
+                handled=True,
+            ),
+            assistant_response_text=body,
+            llm_run=None,
+        )
+
+    # Act
+    run_until_session_goal(
+        _chat,
+        session,
+        "how many github actions runs failed in the last 24 hours?",
+        goal=SessionGoal(
+            condition="how many github actions runs failed in the last 24 hours?",
+            max_outer_turns=3,
+        ),
+    )
+
+    # Assert: the second prompt carries what the first turn said.
+    assert len(prompts) >= 2, "the goal should have run a continuation turn"
+    assert _ANSWER in prompts[1]

--- a/tests/integrations/github/test_actions_run_window.py
+++ b/tests/integrations/github/test_actions_run_window.py
@@ -1,0 +1,103 @@
+"""Run listings carry a time window with a default, and admit a partial page.
+
+Asked "what's the current error rate on github?", the agent had no tool that
+understood a time window, so it hand-built a `gh api` query and chose the window
+itself. One run it picked the last hour, found no completed runs, and answered
+"N/A" while three goal turns went unused.
+
+The window now has a default in code. Coverage is the other half: a listing is
+one page, so a window can hold more runs than were fetched, and a rate over a
+partial page is the "0% from one run" failure in a new costume.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from integrations.github.tools.actions import (
+    NO_RUN_WINDOW,
+    RATE_WINDOW_HOURS,
+    runs_within_window,
+)
+
+_NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+
+
+def _run(hours_ago: float, name: str = "ci") -> dict[str, object]:
+    started = _NOW - timedelta(hours=hours_ago)
+    return {"name": name, "created_at": started.isoformat().replace("+00:00", "Z")}
+
+
+def test_the_rate_window_is_a_day_not_an_hour() -> None:
+    """A rate question asks for 24 hours, not whatever the model picks."""
+    assert RATE_WINDOW_HOURS == 24
+
+
+def test_the_tool_default_keeps_every_run_so_forensics_still_sees_old_ones() -> None:
+    """Defaulting to a window would hide the run before an incident.
+
+    This listing also answers "which deploy failed right before the incident".
+    A default window silently dropped a three-month-old fixture run in
+    ``tests/tools/test_github_actions_tool.py`` — the same way it would drop the
+    run an investigation was looking for.
+    """
+    assert NO_RUN_WINDOW == 0
+    old = [_run(2000, "months-ago")]
+    inside, covered = runs_within_window(old, NO_RUN_WINDOW, now=_NOW)
+    assert [run["name"] for run in inside] == ["months-ago"]
+    assert covered is True
+
+
+def test_runs_older_than_the_window_are_dropped() -> None:
+    # Arrange
+    runs = [_run(1, "recent"), _run(5, "today"), _run(30, "yesterday")]
+
+    # Act
+    inside, _covered = runs_within_window(runs, 24, now=_NOW)
+
+    # Assert
+    assert [run["name"] for run in inside] == ["recent", "today"]
+
+
+def test_a_page_reaching_past_the_window_counts_as_covered() -> None:
+    # Arrange: an older run came back, so the page spans the whole window.
+    runs = [_run(1), _run(30)]
+
+    # Act
+    _inside, covered = runs_within_window(runs, 24, now=_NOW)
+
+    # Assert
+    assert covered is True
+
+
+def test_a_page_that_ends_inside_the_window_is_not_covered() -> None:
+    # Arrange: every run fetched is recent, so older ones may exist unfetched.
+    runs = [_run(1), _run(2), _run(3)]
+
+    # Act
+    inside, covered = runs_within_window(runs, 24, now=_NOW)
+
+    # Assert: the caller must not report a rate over this.
+    assert len(inside) == 3
+    assert covered is False
+
+
+def test_a_zero_window_keeps_every_run() -> None:
+    # Arrange / Act
+    runs = [_run(1), _run(500)]
+    inside, covered = runs_within_window(runs, 0, now=_NOW)
+
+    # Assert: the escape hatch returns the page untouched.
+    assert inside == runs
+    assert covered is True
+
+
+def test_a_run_without_a_usable_timestamp_is_not_counted() -> None:
+    # Arrange: a malformed created_at must not silently pass as in-window.
+    runs = [_run(1, "good"), {"name": "broken", "created_at": "not-a-date"}, {"name": "empty"}]
+
+    # Act
+    inside, _covered = runs_within_window(runs, 24, now=_NOW)
+
+    # Assert
+    assert [run["name"] for run in inside] == ["good"]

--- a/tests/integrations/github/test_actions_run_window.py
+++ b/tests/integrations/github/test_actions_run_window.py
@@ -1,13 +1,9 @@
-"""Run listings carry a time window with a default, and admit a partial page.
+"""Run listings can be narrowed to a window, and say what the narrowing cost.
 
 Asked "what's the current error rate on github?", the agent had no tool that
-understood a time window, so it hand-built a `gh api` query and chose the window
-itself. One run it picked the last hour, found no completed runs, and answered
-"N/A" while three goal turns went unused.
-
-The window now has a default in code. Coverage is the other half: a listing is
-one page, so a window can hold more runs than were fetched, and a rate over a
-partial page is the "0% from one run" failure in a new costume.
+understood a time window, so it built its own query and chose the window each
+turn. One run it picked the last hour, found no completed runs, and answered
+"N/A" with three goal turns unused.
 """
 
 from __future__ import annotations
@@ -17,7 +13,7 @@ from datetime import UTC, datetime, timedelta
 from integrations.github.tools.actions import (
     NO_RUN_WINDOW,
     RATE_WINDOW_HOURS,
-    runs_within_window,
+    window_runs,
 )
 
 _NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
@@ -29,23 +25,18 @@ def _run(hours_ago: float, name: str = "ci") -> dict[str, object]:
 
 
 def test_the_rate_window_is_a_day_not_an_hour() -> None:
-    """A rate question asks for 24 hours, not whatever the model picks."""
     assert RATE_WINDOW_HOURS == 24
 
 
-def test_the_tool_default_keeps_every_run_so_forensics_still_sees_old_ones() -> None:
+def test_the_tool_default_is_no_window_so_forensics_still_sees_old_runs() -> None:
     """Defaulting to a window would hide the run before an incident.
 
     This listing also answers "which deploy failed right before the incident".
-    A default window silently dropped a three-month-old fixture run in
+    A 24-hour default dropped a three-month-old fixture run in
     ``tests/tools/test_github_actions_tool.py`` — the same way it would drop the
     run an investigation was looking for.
     """
     assert NO_RUN_WINDOW == 0
-    old = [_run(2000, "months-ago")]
-    inside, covered = runs_within_window(old, NO_RUN_WINDOW, now=_NOW)
-    assert [run["name"] for run in inside] == ["months-ago"]
-    assert covered is True
 
 
 def test_runs_older_than_the_window_are_dropped() -> None:
@@ -53,51 +44,51 @@ def test_runs_older_than_the_window_are_dropped() -> None:
     runs = [_run(1, "recent"), _run(5, "today"), _run(30, "yesterday")]
 
     # Act
-    inside, _covered = runs_within_window(runs, 24, now=_NOW)
+    windowed = window_runs(runs, window_hours=24, now=_NOW)
 
     # Assert
-    assert [run["name"] for run in inside] == ["recent", "today"]
+    assert [run["name"] for run in windowed.runs] == ["recent", "today"]
 
 
-def test_a_page_reaching_past_the_window_counts_as_covered() -> None:
+def test_a_page_reaching_past_the_window_is_fully_fetched() -> None:
     # Arrange: an older run came back, so the page spans the whole window.
-    runs = [_run(1), _run(30)]
-
     # Act
-    _inside, covered = runs_within_window(runs, 24, now=_NOW)
+    windowed = window_runs([_run(1), _run(30)], window_hours=24, now=_NOW)
 
     # Assert
-    assert covered is True
+    assert windowed.window_fully_fetched is True
 
 
-def test_a_page_that_ends_inside_the_window_is_not_covered() -> None:
+def test_a_page_that_ends_inside_the_window_is_not_fully_fetched() -> None:
     # Arrange: every run fetched is recent, so older ones may exist unfetched.
-    runs = [_run(1), _run(2), _run(3)]
+    # Act
+    windowed = window_runs([_run(1), _run(2), _run(3)], window_hours=24, now=_NOW)
+
+    # Assert: a count over this is a floor, not a total.
+    assert len(windowed.runs) == 3
+    assert windowed.window_fully_fetched is False
+
+
+def test_undated_runs_are_counted_rather_than_vanishing() -> None:
+    # Arrange: a malformed created_at cannot be placed in or out of the window.
+    runs = [
+        _run(1, "good"),
+        {"name": "broken", "created_at": "not-a-date"},
+        {"name": "missing"},
+    ]
 
     # Act
-    inside, covered = runs_within_window(runs, 24, now=_NOW)
+    windowed = window_runs(runs, window_hours=24, now=_NOW)
 
-    # Assert: the caller must not report a rate over this.
-    assert len(inside) == 3
-    assert covered is False
-
-
-def test_a_zero_window_keeps_every_run() -> None:
-    # Arrange / Act
-    runs = [_run(1), _run(500)]
-    inside, covered = runs_within_window(runs, 0, now=_NOW)
-
-    # Assert: the escape hatch returns the page untouched.
-    assert inside == runs
-    assert covered is True
+    # Assert: dropped from the count, but the caller can see how many.
+    assert [run["name"] for run in windowed.runs] == ["good"]
+    assert windowed.undated == 2
 
 
-def test_a_run_without_a_usable_timestamp_is_not_counted() -> None:
-    # Arrange: a malformed created_at must not silently pass as in-window.
-    runs = [_run(1, "good"), {"name": "broken", "created_at": "not-a-date"}, {"name": "empty"}]
-
-    # Act
-    inside, _covered = runs_within_window(runs, 24, now=_NOW)
+def test_undated_runs_are_not_evidence_that_the_page_spanned_the_window() -> None:
+    # Arrange / Act: only a dated older run proves coverage.
+    windowed = window_runs([{"name": "broken", "created_at": ""}], window_hours=24, now=_NOW)
 
     # Assert
-    assert [run["name"] for run in inside] == ["good"]
+    assert windowed.window_fully_fetched is False
+    assert windowed.undated == 1

--- a/tests/integrations/github/test_actions_run_window.py
+++ b/tests/integrations/github/test_actions_run_window.py
@@ -17,6 +17,7 @@ from integrations.github.tools.actions import (
 )
 
 _NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+_PAGE = 30
 
 
 def _run(hours_ago: float, name: str = "ci") -> dict[str, object]:
@@ -44,7 +45,7 @@ def test_runs_older_than_the_window_are_dropped() -> None:
     runs = [_run(1, "recent"), _run(5, "today"), _run(30, "yesterday")]
 
     # Act
-    windowed = window_runs(runs, window_hours=24, now=_NOW)
+    windowed = window_runs(runs, window_hours=24, now=_NOW, page_limit=_PAGE)
 
     # Assert
     assert [run["name"] for run in windowed.runs] == ["recent", "today"]
@@ -53,20 +54,46 @@ def test_runs_older_than_the_window_are_dropped() -> None:
 def test_a_page_reaching_past_the_window_is_fully_fetched() -> None:
     # Arrange: an older run came back, so the page spans the whole window.
     # Act
-    windowed = window_runs([_run(1), _run(30)], window_hours=24, now=_NOW)
+    windowed = window_runs(
+        [_run(1), _run(30)],
+        window_hours=24,
+        now=_NOW,
+        page_limit=_PAGE,
+    )
 
     # Assert
     assert windowed.window_fully_fetched is True
 
 
-def test_a_page_that_ends_inside_the_window_is_not_fully_fetched() -> None:
-    # Arrange: every run fetched is recent, so older ones may exist unfetched.
+def test_a_full_page_that_ends_inside_the_window_is_not_fully_fetched() -> None:
+    # Arrange: every run fetched is recent and the page is full — more may exist.
+    runs = [_run(1), _run(2), _run(3)]
+
     # Act
-    windowed = window_runs([_run(1), _run(2), _run(3)], window_hours=24, now=_NOW)
+    windowed = window_runs(runs, window_hours=24, now=_NOW, page_limit=len(runs))
 
     # Assert: a count over this is a floor, not a total.
     assert len(windowed.runs) == 3
     assert windowed.window_fully_fetched is False
+
+
+def test_an_exhausted_page_all_inside_the_window_is_fully_fetched() -> None:
+    # Arrange: fewer runs than per_page — the listing has nothing left to miss.
+    runs = [_run(1), _run(2), _run(3)]
+
+    # Act
+    windowed = window_runs(runs, window_hours=24, now=_NOW, page_limit=_PAGE)
+
+    # Assert: every in-window run that exists is on this page.
+    assert len(windowed.runs) == 3
+    assert windowed.window_fully_fetched is True
+
+
+def test_an_empty_page_is_fully_fetched() -> None:
+    windowed = window_runs([], window_hours=24, now=_NOW, page_limit=_PAGE)
+
+    assert windowed.runs == []
+    assert windowed.window_fully_fetched is True
 
 
 def test_undated_runs_are_counted_rather_than_vanishing() -> None:
@@ -78,17 +105,31 @@ def test_undated_runs_are_counted_rather_than_vanishing() -> None:
     ]
 
     # Act
-    windowed = window_runs(runs, window_hours=24, now=_NOW)
+    windowed = window_runs(runs, window_hours=24, now=_NOW, page_limit=_PAGE)
 
     # Assert: dropped from the count, but the caller can see how many.
     assert [run["name"] for run in windowed.runs] == ["good"]
     assert windowed.undated == 2
 
 
-def test_undated_runs_are_not_evidence_that_the_page_spanned_the_window() -> None:
-    # Arrange / Act: only a dated older run proves coverage.
-    windowed = window_runs([{"name": "broken", "created_at": ""}], window_hours=24, now=_NOW)
+def test_undated_runs_alone_do_not_prove_an_older_cutoff() -> None:
+    # Arrange: undated rows are not older-run evidence; a full page of them is
+    # still ambiguous about dated coverage. An exhausted page is complete.
+    full = window_runs(
+        [{"name": "broken", "created_at": ""}],
+        window_hours=24,
+        now=_NOW,
+        page_limit=1,
+    )
+    exhausted = window_runs(
+        [{"name": "broken", "created_at": ""}],
+        window_hours=24,
+        now=_NOW,
+        page_limit=_PAGE,
+    )
 
     # Assert
-    assert windowed.window_fully_fetched is False
-    assert windowed.undated == 1
+    assert full.window_fully_fetched is False
+    assert full.undated == 1
+    assert exhausted.window_fully_fetched is True
+    assert exhausted.undated == 1


### PR DESCRIPTION
Fixes: #5281

Three defects, all found by running `what's the current error rate on github?`
and its variants in the REPL. Each was invisible to a green suite.

**1. Run listings could not express a time window** (`e541b5432`, `473cfdacf`).
`list_github_actions_workflow_runs` took only `per_page: 30` and was not on the
`ACTION` surface, so the agent hand-built `gh api` and chose a window per turn.
One run it picked the last hour, found nothing, and answered `N/A`.

Adds `window_hours`, exposes the tool to the action surface, and reports
`window_fully_fetched` — true only when a run *older* than the window came back,
proving the page spanned it. Runs with unreadable timestamps are counted in
`undated` rather than vanishing from a total.

**The window defaults to 0, not 24.** A 24-hour default broke
`test_list_workflow_runs_happy_path` by dropping a `2026-05-27` fixture run —
the same way it would hide the run an investigation was hunting for, since this
listing also answers "which deploy failed right before the incident".
`RATE_WINDOW_HOURS = 24` is what rate callers pass.

**2. Rates were computed by enumeration** (`2eb2719b8`). A 7-day rate needs
~4,600 runs; paging timed out and a partial page gives a biased number. Skill
guidance now says a rate is two `total_count` reads with `created` scoping the
window server-side:

```
gh api ".../actions/runs?created=%3E%3D2026-08-13&per_page=1" --jq '.total_count'   -> 4646
gh api ".../actions/runs?created=%3E%3D2026-08-13&status=failure&per_page=1" --jq '.total_count'  -> 94
```

Measured against this repo. Listing *which* runs failed still enumerates — that
is a different question.

**3. A continuation turn contradicted the turn before it** (`2eb2719b8`).
"73 failed out of 800" on turn 1, "12 failed" on turn 2, nothing reconciling
them. Turn 1 answered from history with no tool, so `turn_has_session_goal_evidence`
was false — which correctly stopped the goal closing, but also skipped recording
what turn 1 said.

Adds `SessionGoal.last_answer`, recorded whether or not a tool ran, rendered to
the next turn as "already told the user — if your answer differs, say why".

`findings` is deliberately left gated. It means "established" and the
continuation says *"treat these as done"*; giving an unverified prose answer that
authority would let a wrong remembered number become settled by repetition.

### Demo/Screenshot for feature changes and bug fixes -

<!-- paste the REPL runs here -->

Verified by hand across four questions: 24-hour rate (one answer, window
stated), 7-day rate (previously an honest refusal — recheck with the counting
guidance), "how many failed" (previously 73 then 12), and "which runs failed
before the deploy on May 27" — the forensics check, which returns three-month-old
runs and reconciles with an earlier answer once the differing cutoffs are
accounted for.

Mutation-checked; each planted regression fails exactly its own test:

```
$ # rate window drops back to an hour
FAILED test_the_rate_window_is_a_day_not_an_hour
$ # coverage always claims the page spanned the window
FAILED test_a_page_that_ends_inside_the_window_is_not_fully_fetched
$ # unreadable timestamps counted as in-window
FAILED test_undated_runs_are_counted_rather_than_vanishing
$ # last_answer gated on tool evidence again
FAILED test_a_tool_less_turn_still_hands_its_answer_to_the_next_turn
```

Gates: lint clean · format 3,590 · typecheck 1,855 · all 3 import checks ·
**15,521 passed** on the previous commit; full suite for the final commit
running.

> The suite run excludes `tests/core/tool/test_enums.py`, which collides by
> basename with `tests/filestorage/test_enums.py` (neither directory has
> `__init__.py`). That arrived with #5259 and reproduces with this branch
> stashed — `main` currently cannot collect a full run. Unrelated, but worth its
> own fix.
