### PR TITLE
test: use real run info in session goal progress tests

### DIFF
--- a/tests/core/agent_harness/session_goal/test_progress.py
+++ b/tests/core/agent_harness/session_goal/test_progress.py
@@ -17,6 +17,23 @@ from core.agent_harness.session_goal.goal import (
 from core.agent_harness.session_goal.run_until import run_until_session_goal
 from core.agent_harness.turns.assistant_handoff import AssistantHandoff
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from tests.shared.harness_turn_driver import fake_llm_run
+
+
+def _turn_with_answer(response_text: str) -> TurnResult:
+    """A completed answer turn carrying the same text in its run record."""
+    return TurnResult(
+        final_intent="cli_agent_fallback",
+        action_result=ToolCallingTurnResult(
+            planned_count=0,
+            executed_count=0,
+            executed_success_count=0,
+            has_unhandled_clause=False,
+            handled=True,
+        ),
+        assistant_response_text=response_text,
+        llm_run=fake_llm_run(response_text=response_text),
+    )
 
 
 def test_checklist_items_from_structured_handoff_tags() -> None:
@@ -65,7 +82,7 @@ def test_done_tags_mark_checklist_items_and_achieve_when_complete() -> None:
     assert (
         default_evaluate_session_goal(
             after_one,
-            type("R", (), {"assistant_response_text": "session_goal:done=0"})(),
+            _turn_with_answer("session_goal:done=0"),
         )
         == SessionGoalStatus.ACTIVE
     )
@@ -78,7 +95,7 @@ def test_done_tags_mark_checklist_items_and_achieve_when_complete() -> None:
     assert (
         default_evaluate_session_goal(
             after_all,
-            type("R", (), {"assistant_response_text": "session_goal:done=1,2"})(),
+            _turn_with_answer("session_goal:done=1,2"),
         )
         == SessionGoalStatus.ACHIEVED
     )


### PR DESCRIPTION
Fixes #5199

#### Describe the changes you have made in this PR -

Replaced the two anonymous evaluator result objects in `test_progress.py` with the shared `fake_llm_run` helper, so the tests now exercise a real `LlmRunInfo` and will track future contract changes.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run python -m pytest tests/core/agent_harness/session_goal/test_progress.py
19 passed, 1 warning in 7.38s
```

Additional validation:

```text
make lint         # passed
make format-check # passed (3598 files already formatted)
make typecheck    # passed (1860 source files)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The tests previously constructed anonymous objects exposing only `assistant_response_text`, which could stay green if the production result contract changed. I reused the shared `fake_llm_run` helper added for turn-stage tests; it returns the real `LlmRunInfo` while preserving the exact response text and assertions. Keeping local anonymous objects or introducing another helper would retain the contract drift or duplicate the shared test utility.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
