### PR TITLE
test: honor turn-seam contracts in conversation memory follow-up

### DIFF
--- a/tests/core/agent_harness/prompts/test_conversation_memory_follow_up.py
+++ b/tests/core/agent_harness/prompts/test_conversation_memory_follow_up.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from core.agent_harness.ports import AnswerRequest
 from core.agent_harness.prompts.memory.conversation import expand_affirmative_follow_up
+from core.agent_harness.spi.accounting import LlmRunInfo
 from core.agent_harness.turns.headless_adapters import InMemorySessionState, NoopTurnAccounting
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+from tests.shared.harness_turn_driver import no_evidence
+
+
+def no_answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
+    """A StreamAnswerFn that produces no answer."""
+    return None
 
 
 def test_expands_yes_after_roster_want_me_to_offer() -> None:
@@ -128,8 +136,8 @@ def test_run_turn_expands_yes_before_execute_actions() -> None:
         "[Slack channel_id=C1]\nyes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
 


### PR DESCRIPTION
Fixes #5198

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Replaced the permissive variadic answer lambda with a named, typed no-answer stub that matches `StreamAnswerFn`.
- Reused the shared `no_evidence` gather helper so future Protocol signature changes are caught by type checking.
- Preserved the test's existing no-op answer and evidence behavior.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ make lint
All checks passed!

$ make format-check
3598 files already formatted

$ make typecheck
Success: no issues found in 1860 source files

$ uv run mypy tests/core/agent_harness/prompts/test_conversation_memory_follow_up.py
Success: no issues found in 1 source file

$ uv run pytest tests/core/agent_harness/prompts/test_conversation_memory_follow_up.py
10 passed in 0.99s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The test previously injected variadic lambdas that accepted any future call shape, so interface drift would not be caught by static checking. I replaced the answer lambda with a typed function whose parameter names and types match the callable Protocol and reused the shared `no_evidence` helper introduced by #5187 for the gather seam. I considered passing `answer=None`, but that selects the real answer stage and changes the test's intent, so an explicit no-op answer implementation is retained.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (N/A: this is a test-only contract-hardening change)
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
