### PR TITLE
refactor(tool): measure the tool-tier import border and shrink it through one door

### DIFF
--- a/core/tool_framework/utils/__init__.py
+++ b/core/tool_framework/utils/__init__.py
@@ -1,8 +1,23 @@
-"""Tool utilities — code-host helpers, data validation, and database warnings."""
+"""Tool utilities — the one door consumers import these helpers through.
+
+Schema builders, MCP payload readers, code-host and availability envelopes, and
+database-warning wrappers. Importing the submodules directly still works inside
+this package; everything above the tool tier comes through here so the split
+below can change without a sweep across ``integrations/`` and ``tools/``.
+"""
 
 from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
 from core.tool_framework.utils.data_validation import validate_host_metrics
 from core.tool_framework.utils.db_warnings import default_db_warning
+from core.tool_framework.utils.mcp_bridge import unavailable_response
+from core.tool_framework.utils.mcp_params import first_list, first_string
+from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from core.tool_framework.utils.schema import (
+    object_schema,
+    string_array_property,
+    string_property,
+)
+from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
 from core.tool_framework.utils.tool_availability import (
     envelope_source_id,
     is_tool_unavailable_envelope,
@@ -10,10 +25,18 @@ from core.tool_framework.utils.tool_availability import (
 )
 
 __all__ = [
+    "build_mcp_tool_listing",
+    "call_db_tool_with_default_db_warning",
     "code_host_unavailable_payload",
     "default_db_warning",
     "envelope_source_id",
+    "first_list",
+    "first_string",
     "is_tool_unavailable_envelope",
+    "object_schema",
+    "string_array_property",
+    "string_property",
     "tool_unavailable",
+    "unavailable_response",
     "validate_host_metrics",
 ]

--- a/integrations/_relational.py
+++ b/integrations/_relational.py
@@ -11,7 +11,7 @@ from typing import Any, Protocol
 from pydantic import field_validator
 
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_validation_failure
 
 _TRUE_ENV_VALUES = frozenset({"true", "1", "yes"})

--- a/integrations/alertmanager/tools/__init__.py
+++ b/integrations/alertmanager/tools/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.alertmanager.client import make_alertmanager_client
 
 _FIRING_STATES = {"active", "unprocessed"}

--- a/integrations/argocd/tools/__init__.py
+++ b/integrations/argocd/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.argocd.client import make_argocd_client
 
 

--- a/integrations/azure/tools/azure_monitor_logs_tool/__init__.py
+++ b/integrations/azure/tools/azure_monitor_logs_tool/__init__.py
@@ -14,7 +14,7 @@ from config.constants.azure import (
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 
 
 def _bounded_limit(limit: int, max_results: int) -> int:

--- a/integrations/azure_sql/__init__.py
+++ b/integrations/azure_sql/__init__.py
@@ -34,7 +34,7 @@ from config.constants.azure_sql import (
 )
 from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from platform.text.truncation import truncate
 

--- a/integrations/azure_sql/tools/azure_sql_current_queries_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_current_queries_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.azure_sql import (
     azure_sql_extract_params,
     azure_sql_is_available,

--- a/integrations/azure_sql/tools/azure_sql_slow_queries_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_slow_queries_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.azure_sql import (
     azure_sql_extract_params,
     azure_sql_is_available,

--- a/integrations/betterstack/__init__.py
+++ b/integrations/betterstack/__init__.py
@@ -35,7 +35,7 @@ from config.constants.betterstack import (
     BETTERSTACK_USERNAME_ENV,
 )
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)

--- a/integrations/bitbucket/client.py
+++ b/integrations/bitbucket/client.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_validation_failure
 from integrations.bitbucket.config import BitbucketConfig
 

--- a/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.bitbucket.client import list_commits
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend
 from integrations.bitbucket.tools.bitbucket_search_code_tool import (

--- a/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.bitbucket.client import get_file_contents
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend
 from integrations.bitbucket.tools.bitbucket_search_code_tool import (

--- a/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.bitbucket.client import search_code
 from integrations.bitbucket.config import (
     BitbucketConfig,

--- a/integrations/clickhouse/__init__.py
+++ b/integrations/clickhouse/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_validation_failure
 
 logger = logging.getLogger(__name__)

--- a/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
+++ b/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.cloudtrail import (
     DEFAULT_CLOUDTRAIL_REGION,

--- a/integrations/coralogix/tools/__init__.py
+++ b/integrations/coralogix/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.config_models import CoralogixIntegrationConfig
 from integrations.coralogix.client import (
     CoralogixClient,

--- a/integrations/datadog/_client.py
+++ b/integrations/datadog/_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.datadog.client import DatadogAsyncClient, DatadogClient, DatadogConfig
 
 _DEFAULT_SITE = "datadoghq.com"

--- a/integrations/datadog/tools/__init__.py
+++ b/integrations/datadog/tools/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from core.tool.contracts import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.datadog._client import make_async_client
 from platform.evidence.evidence_compaction import compact_logs, summarize_counts
 

--- a/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
+++ b/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
@@ -11,7 +11,7 @@ import logging
 from typing import Any, cast
 
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.aws.topology_helper import (

--- a/integrations/eks/tools/__init__.py
+++ b/integrations/eks/tools/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from core.tool.contracts import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.eks.eks_k8s_client import build_k8s_clients
 
 logger = logging.getLogger(__name__)

--- a/integrations/elasticsearch/_client.py
+++ b/integrations/elasticsearch/_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.elasticsearch.client import ElasticsearchClient, ElasticsearchConfig
 
 

--- a/integrations/elb/tools/elb_target_health_tool/__init__.py
+++ b/integrations/elb/tools/elb_target_health_tool/__init__.py
@@ -12,7 +12,7 @@ import logging
 from typing import Any, cast
 
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.aws.topology_helper import (

--- a/integrations/github/helpers.py
+++ b/integrations/github/helpers.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.mcp import (
     DEFAULT_GITHUB_MCP_MODE,
     GitHubMCPConfig,

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/commits.py
+++ b/integrations/github/tools/commits.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/file_contents.py
+++ b/integrations/github/tools/file_contents.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/git_deploy_timeline_tool/__init__.py
+++ b/integrations/github/tools/git_deploy_timeline_tool/__init__.py
@@ -25,7 +25,7 @@ from typing import Any
 from core.domain.types.incident_window import IncidentWindow
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/issues.py
+++ b/integrations/github/tools/issues.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/repository.py
+++ b/integrations/github/tools/repository.py
@@ -8,7 +8,7 @@ from core.domain.types.tools import ToolSurface
 from core.tool.contracts import SideEffectLevel
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/repository_tree.py
+++ b/integrations/github/tools/repository_tree.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/search_code.py
+++ b/integrations/github/tools/search_code.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/stargazers.py
+++ b/integrations/github/tools/stargazers.py
@@ -11,7 +11,7 @@ from core.domain.types.tools import ToolSurface
 from core.tool.contracts import SideEffectLevel
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, cast
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.gitlab import (
     GitlabConfig,
     build_gitlab_config,

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -7,8 +7,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import code_host_unavailable_payload, tool_unavailable
 from integrations.gitlab import (
     get_gitlab_file,
 )

--- a/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.gitlab import (
     get_gitlab_mrs,
 )

--- a/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.code_host_unavailable import code_host_unavailable_payload
+from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.gitlab import (
     get_gitlab_pipelines,
 )

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from core.tool.contracts import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 
 _GRAFANA_RUNTIME_PARAMS = (
     "grafana_endpoint",

--- a/integrations/groundcover/helpers.py
+++ b/integrations/groundcover/helpers.py
@@ -21,7 +21,7 @@ from typing import Any, cast
 
 from pydantic import ValidationError
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_validation_failure
 from integrations.groundcover.client import (
     GroundcoverClient,

--- a/integrations/groundcover/tools/__init__.py
+++ b/integrations/groundcover/tools/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.groundcover.availability import groundcover_available_or_backend
 from integrations.groundcover.client import GroundcoverClient
 from integrations.groundcover.helpers import (

--- a/integrations/helm/helpers.py
+++ b/integrations/helm/helpers.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.config_models import HelmIntegrationConfig
 from integrations.helm.client import HelmClient
 

--- a/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 
 
 def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:

--- a/integrations/honeycomb/tools/__init__.py
+++ b/integrations/honeycomb/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.honeycomb.client import HoneycombClient
 from integrations.honeycomb.config import HoneycombIntegrationConfig
 

--- a/integrations/incident_io/tools/__init__.py
+++ b/integrations/incident_io/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.incident_io.client import make_incident_io_client
 
 

--- a/integrations/jenkins/tools/__init__.py
+++ b/integrations/jenkins/tools/__init__.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.jenkins import jenkins_config_from_env
 from integrations.jenkins.client import JenkinsClient, make_jenkins_client
 

--- a/integrations/jira/tools/__init__.py
+++ b/integrations/jira/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.jira.client import make_jira_client
 
 

--- a/integrations/kafka/__init__.py
+++ b/integrations/kafka/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_validation_failure
 
 logger = logging.getLogger(__name__)

--- a/integrations/kubernetes/tools/__init__.py
+++ b/integrations/kubernetes/tools/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.config_models import KubernetesIntegrationConfig
 from integrations.kubernetes.client import _RESOURCE_DISPATCH, KubernetesClient
 

--- a/integrations/mariadb/__init__.py
+++ b/integrations/mariadb/__init__.py
@@ -22,7 +22,7 @@ from config.constants.mariadb import (
     MARIADB_USERNAME_ENV,
 )
 from config.llm_credentials import resolve_env_credential
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._relational import RelationalConfigBase, env_bool, env_str
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from platform.text.coercion import safe_int

--- a/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,
     get_innodb_status,

--- a/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,
     get_process_list,

--- a/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,
     get_replication_status,

--- a/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,
     get_slow_queries,

--- a/integrations/mariadb/tools/mariadb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_status_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,
     get_global_status,

--- a/integrations/mongodb/__init__.py
+++ b/integrations/mongodb/__init__.py
@@ -22,7 +22,7 @@ from config.constants.mongodb import (
 )
 from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)

--- a/integrations/mongodb_atlas/__init__.py
+++ b/integrations/mongodb_atlas/__init__.py
@@ -25,7 +25,7 @@ from config.constants.mongodb_atlas import (
     MONGODB_ATLAS_PUBLIC_KEY_ENV,
 )
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 
 logger = logging.getLogger(__name__)

--- a/integrations/mysql/tools/mysql_current_processes_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_current_processes_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_current_processes,
     mysql_extract_params,

--- a/integrations/mysql/tools/mysql_replication_status_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_replication_status_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_replication_status,
     mysql_extract_params,

--- a/integrations/mysql/tools/mysql_server_status_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_server_status_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_server_status,
     mysql_extract_params,

--- a/integrations/mysql/tools/mysql_slow_queries_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_slow_queries_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_slow_queries,
     mysql_extract_params,

--- a/integrations/mysql/tools/mysql_table_stats_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_table_stats_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_table_stats,
     mysql_extract_params,

--- a/integrations/new_relic/tools/new_relic_alerts_tool/tool.py
+++ b/integrations/new_relic/tools/new_relic_alerts_tool/tool.py
@@ -10,7 +10,7 @@ from config.constants.new_relic import (
 )
 from core.tool.contracts import BaseTool, EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.new_relic.client import NewRelicClient
 from integrations.new_relic.config import NewRelicIntegrationConfig
 from integrations.new_relic.tools.new_relic_alerts_tool.results import parse_incident_rows

--- a/integrations/new_relic/tools/new_relic_metrics_tool/tool.py
+++ b/integrations/new_relic/tools/new_relic_metrics_tool/tool.py
@@ -10,7 +10,7 @@ from config.constants.new_relic import (
 )
 from core.tool.contracts import BaseTool, EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.new_relic.client import NewRelicClient
 from integrations.new_relic.config import NewRelicIntegrationConfig
 from integrations.new_relic.tools.new_relic_metrics_tool.validation import (

--- a/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from core.tool_framework.utils import build_mcp_tool_listing
 from integrations.openclaw import (
     OpenClawConfig,
     build_openclaw_config,

--- a/integrations/openclaw/tools/openclaw_mcp_tool/params.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/params.py
@@ -6,7 +6,7 @@ pure dict reads over the ``openclaw`` source, with no bridge traffic.
 
 from __future__ import annotations
 
-from core.tool_framework.utils.mcp_params import first_list, first_string
+from core.tool_framework.utils import first_list, first_string
 from integrations.openclaw.tools.openclaw_mcp_tool.models import OpenClawParams
 
 __all__ = [

--- a/integrations/openclaw/tools/openclaw_mcp_tool/results.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/results.py
@@ -6,7 +6,7 @@ agent sees. Nothing here talks to the bridge — dispatch lives in ``__init__``.
 
 from __future__ import annotations
 
-from core.tool_framework.utils.mcp_bridge import unavailable_response
+from core.tool_framework.utils import unavailable_response
 from integrations.openclaw import OpenClawToolCallResult
 from integrations.openclaw.tools.openclaw_mcp_tool.models import (
     OpenClawBridgeResponse,

--- a/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
+++ b/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
@@ -11,7 +11,7 @@ import httpx
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 
 _DEFAULT_MAX_RESULTS = 100
 _MAX_HARD_LIMIT = 200

--- a/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
+++ b/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.elasticsearch.client import ElasticsearchClient, ElasticsearchConfig
 
 _DEFAULT_MAX_RESULTS = 100

--- a/integrations/opsgenie/tools/__init__.py
+++ b/integrations/opsgenie/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.opsgenie.client import make_opsgenie_client
 
 

--- a/integrations/pagerduty/tools/__init__.py
+++ b/integrations/pagerduty/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.pagerduty.client import make_pagerduty_client
 
 

--- a/integrations/postgresql/__init__.py
+++ b/integrations/postgresql/__init__.py
@@ -22,7 +22,7 @@ from config.constants.postgresql import (
     POSTGRESQL_SSL_MODE_ENV,
     POSTGRESQL_USERNAME_ENV,
 )
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._relational import (
     RelationalConfigBase,
     env_int,

--- a/integrations/postgresql/tools/postgresql_current_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_current_queries_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_current_queries,
     postgresql_extract_params,

--- a/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
@@ -5,7 +5,7 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_lock_status,
     postgresql_extract_params,

--- a/integrations/postgresql/tools/postgresql_replication_status_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_replication_status_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_replication_status,
     postgresql_extract_params,

--- a/integrations/postgresql/tools/postgresql_server_status_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_server_status_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_server_status,
     postgresql_extract_params,

--- a/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_slow_queries,
     postgresql_extract_params,

--- a/integrations/postgresql/tools/postgresql_table_stats_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_table_stats_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.sql_wrapper import call_db_tool_with_default_db_warning
+from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_table_stats,
     postgresql_extract_params,

--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
@@ -16,9 +16,12 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.mcp_bridge import unavailable_response
-from core.tool_framework.utils.mcp_params import first_list, first_string
-from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from core.tool_framework.utils import (
+    build_mcp_tool_listing,
+    first_list,
+    first_string,
+    unavailable_response,
+)
 from integrations.mcp_transport import McpTransportMode
 from integrations.posthog_mcp import (
     PostHogMCPConfig,

--- a/integrations/prefect/tools/__init__.py
+++ b/integrations/prefect/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.prefect.client import make_prefect_client
 
 _ERROR_KEYWORDS = ("error", "failed", "exception", "fatal", "crash", "traceback", "exitcode")

--- a/integrations/rabbitmq/__init__.py
+++ b/integrations/rabbitmq/__init__.py
@@ -28,7 +28,7 @@ import httpx
 from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from platform.text.coercion import safe_int
 

--- a/integrations/rds/tools/rds_describe_instance_tool/__init__.py
+++ b/integrations/rds/tools/rds_describe_instance_tool/__init__.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 
 from core.tool.contracts import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.rds import (
     DEFAULT_RDS_REGION,

--- a/integrations/rds/tools/rds_events_tool/__init__.py
+++ b/integrations/rds/tools/rds_events_tool/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, cast
 
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.rds import (
     DEFAULT_RDS_REGION,

--- a/integrations/redis/__init__.py
+++ b/integrations/redis/__init__.py
@@ -25,7 +25,7 @@ from config.constants.redis import (
 )
 from config.llm_credentials import resolve_env_credential
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_classify_failure, report_validation_failure
 from integrations.config_models import RedisIntegrationConfig
 from platform.text.coercion import safe_int

--- a/integrations/sentry/tools/sentry_issue_details_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_issue_details_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.sentry import get_sentry_issue
 from integrations.sentry.tools.sentry_search_issues_tool import (
     _resolve_config,

--- a/integrations/sentry/tools/sentry_issue_events_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_issue_events_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.sentry import list_sentry_issue_events as sentry_list_issue_events
 from integrations.sentry.tools.sentry_search_issues_tool import (
     _resolve_config,

--- a/integrations/sentry/tools/sentry_search_issues_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_search_issues_tool/__init__.py
@@ -9,7 +9,7 @@ import httpx
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.sentry import (
     DEFAULT_SENTRY_ISSUE_LIMIT,
     SentryConfig,

--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.mcp_bridge import unavailable_response
-from core.tool_framework.utils.mcp_params import first_list, first_string
-from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from core.tool_framework.utils import (
+    build_mcp_tool_listing,
+    first_list,
+    first_string,
+    unavailable_response,
+)
 from integrations.sentry_mcp import (
     SentryMCPConfig,
     SentryMCPToolCallResult,

--- a/integrations/signoz/client.py
+++ b/integrations/signoz/client.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 import httpx
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.signoz import SigNozConfig
 
 logger = logging.getLogger(__name__)

--- a/integrations/signoz/tools/__init__.py
+++ b/integrations/signoz/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.signoz import SigNozConfig, signoz_extract_params
 from integrations.signoz.availability import signoz_available_or_backend
 from integrations.signoz.client import SigNozClient

--- a/integrations/slack/tools/slack_join_channel_tool/tool.py
+++ b/integrations/slack/tools/slack_join_channel_tool/tool.py
@@ -7,7 +7,7 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id
 from integrations.slack.web_client import (

--- a/integrations/slack/tools/slack_list_members_tool/tool.py
+++ b/integrations/slack/tools/slack_list_members_tool/tool.py
@@ -8,7 +8,7 @@ from core.domain.types.tools import ToolSurface
 from core.tool.contracts import BaseTool, SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.web_client import (
     bot_token_configured,

--- a/integrations/slack/tools/slack_read_list_tool/tool.py
+++ b/integrations/slack/tools/slack_read_list_tool/tool.py
@@ -9,7 +9,7 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_list_tool.constants import (
     DEFAULT_ITEM_LIMIT,
     MAX_ITEM_LIMIT,

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -8,7 +8,7 @@ from core.domain.types.tools import ToolSurface
 from core.tool.contracts import BaseTool, SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.web_client import bot_token_configured, resolve_bot_token, search_messages
 

--- a/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
+++ b/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
@@ -9,7 +9,7 @@ import httpx
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 
 _DEFAULT_MAX_RESULTS = 50
 _MAX_HARD_LIMIT = 200

--- a/integrations/splunk/_client.py
+++ b/integrations/splunk/_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.splunk.client import SplunkClient, SplunkConfig
 
 

--- a/integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py
+++ b/integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.sqs import (
     DEFAULT_SQS_MAX_QUEUES,

--- a/integrations/supabase/__init__.py
+++ b/integrations/supabase/__init__.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 from pydantic import Field, field_validator
 
 from config.strict_config import StrictConfigModel
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations._validation_helpers import report_classify_failure
 
 logger = logging.getLogger(__name__)

--- a/integrations/tempo/client.py
+++ b/integrations/tempo/client.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import httpx
 
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.tempo import TempoConfig
 from platform.observability.otlp_parser import parse_otlp_trace
 

--- a/integrations/tempo/tools/__init__.py
+++ b/integrations/tempo/tools/__init__.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from typing import Any
 
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.tempo import TempoConfig, tempo_extract_params
 from integrations.tempo.availability import tempo_available_or_backend
 from integrations.tempo.client import TempoClient

--- a/integrations/temporal/tools/__init__.py
+++ b/integrations/temporal/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.temporal.client import TemporalClient, TemporalConfig
 
 

--- a/integrations/twilio/tools/twilio_notify_tool/__init__.py
+++ b/integrations/twilio/tools/twilio_notify_tool/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.twilio.delivery import send_twilio_sms_report
 
 

--- a/integrations/vercel/tools/__init__.py
+++ b/integrations/vercel/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.vercel.client import make_vercel_client
 
 _ERROR_STATES = {"ERROR", "CANCELED"}

--- a/integrations/victoria_logs/tools/__init__.py
+++ b/integrations/victoria_logs/tools/__init__.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import BaseTool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.victoria_logs.client import make_victoria_logs_client
 
 

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 from core.domain.types.tools import ToolSurface
 from core.tool.execution import report_run_error
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.mcp_bridge import unavailable_response
-from core.tool_framework.utils.mcp_params import first_list, first_string
-from core.tool_framework.utils.mcp_tool_listing import build_mcp_tool_listing
+from core.tool_framework.utils import (
+    build_mcp_tool_listing,
+    first_list,
+    first_string,
+    unavailable_response,
+)
 from integrations.mcp_transport import McpTransportMode
 from integrations.x_mcp import (
     XMCPConfig,

--- a/integrations/yandex_cloud/tools/yc_instances_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_instances_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,
     client_from_params,

--- a/integrations/yandex_cloud/tools/yc_lb_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_lb_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, Final
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,
     client_from_params,

--- a/integrations/yandex_cloud/tools/yc_logs_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_logs_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,
     config_from_params,

--- a/integrations/yandex_cloud/tools/yc_metrics_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_metrics_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,
     client_from_params,

--- a/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool_framework.tool_decorator import tool
-from core.tool_framework.utils.tool_availability import tool_unavailable
+from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.api_index import known_services, lookup
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,

--- a/surfaces/interactive_shell/command_registry/slash_catalog.py
+++ b/surfaces/interactive_shell/command_registry/slash_catalog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from core.tool_framework.utils.schema import object_schema, string_array_property, string_property
+from core.tool_framework.utils import object_schema, string_array_property, string_property
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from tools.interactive_shell.shared.slash_catalog import MCP_BY_COMMAND
 

--- a/tests/shared/api_border.py
+++ b/tests/shared/api_border.py
@@ -1,0 +1,146 @@
+"""Scan a package's consumers for imports that bypass its API modules.
+
+A tier is imported through a fixed set of API modules; everything else inside it
+is internal. This scanner reports the internal imports a consumer makes, so a
+border test can hold that set to an allowlist that only shrinks.
+
+Parameterised by tier because the rule is the same for each: ``core.agent_harness``
+(see :mod:`tests.shared.harness_api`) and the tool tier
+(:mod:`tests.shared.tool_api`) both bind to it rather than carrying a copy.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import importlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from tests.shared.product_sources import is_vendored
+
+_DYNAMIC_IMPORT_FUNCTIONS = frozenset({"import_module", "__import__"})
+
+
+def python_sources(root: Path, *, exclude_parts: frozenset[str] = frozenset()) -> list[Path]:
+    """Return the shipped Python files under ``root``, excluding ``exclude_parts``.
+
+    Vendored trees are skipped via :func:`tests.shared.product_sources.is_vendored`:
+    a virtualenv created inside a package (``config/.venv`` has happened) holds
+    third-party sources this scanner must not read, some of which the current
+    interpreter cannot even parse.
+    """
+    return [
+        path
+        for path in sorted(root.rglob("*.py"))
+        if not is_vendored(path.relative_to(root)) and not (exclude_parts & set(path.parts))
+    ]
+
+
+def _called_function_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+@functools.cache
+def _exported_names(module: str) -> frozenset[str]:
+    """The names an API module exports in ``__all__``; empty when it exports none."""
+    return frozenset(getattr(importlib.import_module(module), "__all__", ()))
+
+
+@dataclass(frozen=True, slots=True)
+class ApiBorder:
+    """One tier: the packages it spans and the modules it may be imported through."""
+
+    #: Package roots that belong to the tier, e.g. ``("core.tool", "core.tool_framework")``.
+    packages: tuple[str, ...]
+    #: Modules a consumer may import. Exact names, so a new submodule under an
+    #: API package does not join the API by accident.
+    api_modules: frozenset[str]
+
+    def owns(self, module: str) -> bool:
+        """True when ``module`` is one of the tier's packages or lives inside one."""
+        return any(module == pkg or module.startswith(pkg + ".") for pkg in self.packages)
+
+    def is_api_module(self, module: str) -> bool:
+        return module in self.api_modules
+
+    def internal_imports(self, tree: ast.AST) -> set[str]:
+        """Return the tier modules ``tree`` imports that are not API modules.
+
+        Covers ``import x``, ``from x import y`` and dynamic imports
+        (``import_module("x")``). For ``from <api module> import y``, a name the
+        API module does not export in ``__all__`` is treated as an import of the
+        internal submodule ``<api module>.y``.
+        """
+        internal: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                internal.update(
+                    alias.name
+                    for alias in node.names
+                    if self.owns(alias.name) and not self.is_api_module(alias.name)
+                )
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if node.level != 0 or not self.owns(module):
+                    continue
+                if not self.is_api_module(module):
+                    internal.add(module)
+                    continue
+                exported = _exported_names(module)
+                internal.update(
+                    f"{module}.{alias.name}" for alias in node.names if alias.name not in exported
+                )
+            elif (
+                isinstance(node, ast.Call)
+                and _called_function_name(node) in _DYNAMIC_IMPORT_FUNCTIONS
+            ):
+                for argument in node.args[:1]:
+                    if (
+                        isinstance(argument, ast.Constant)
+                        and isinstance(argument.value, str)
+                        and self.owns(argument.value)
+                        and not self.is_api_module(argument.value)
+                    ):
+                        internal.add(argument.value)
+        return internal
+
+    def internal_imports_under(
+        self, *roots: Path, exclude_parts: frozenset[str] = frozenset()
+    ) -> set[str]:
+        """Return every internal import of this tier across the sources under ``roots``."""
+        imported: set[str] = set()
+        for root in roots:
+            for path in python_sources(root, exclude_parts=exclude_parts):
+                source = path.read_text(encoding="utf-8")
+                imported |= self.internal_imports(ast.parse(source, filename=str(path)))
+        return imported
+
+    def assert_matches_allowlist(
+        self, imported: set[str], allowlist: frozenset[str], *, consumer: str
+    ) -> None:
+        """Assert ``imported`` equals ``allowlist`` exactly.
+
+        A module not on the allowlist is a new internal dependency and fails; a
+        module on the allowlist that is no longer imported must be removed, so
+        the allowlist can only shrink.
+        """
+        added = sorted(imported - allowlist)
+        assert added == [], (
+            f"{consumer} imports internals not on the allowlist: {added}. "
+            f"Import through an API module ({', '.join(sorted(self.api_modules))}) "
+            "or export the name from the appropriate one."
+        )
+        stale = sorted(allowlist - imported)
+        assert stale == [], (
+            f"{consumer} no longer imports {stale}; remove them from the allowlist "
+            "so it keeps shrinking."
+        )
+
+
+__all__ = ["ApiBorder", "python_sources"]

--- a/tests/shared/harness_api.py
+++ b/tests/shared/harness_api.py
@@ -9,9 +9,9 @@ modules and no others) and by ``tests/core/agent_harness/test_harness_api.py``
 from __future__ import annotations
 
 import ast
-import functools
-import importlib
 from pathlib import Path
+
+from tests.shared.api_border import ApiBorder, python_sources
 
 HARNESS_PACKAGE = "core.agent_harness"
 
@@ -43,112 +43,37 @@ API_MODULES: frozenset[str] = frozenset(
     | {f"{HARNESS_PACKAGE}.spi.{role}" for role in SPI_ROLES}
 )
 
-_DYNAMIC_IMPORT_FUNCTIONS = frozenset({"import_module", "__import__"})
+#: The harness tier: one package, a fixed set of API modules.
+_BORDER = ApiBorder(packages=(HARNESS_PACKAGE,), api_modules=API_MODULES)
 
 
 def is_api_module(module: str) -> bool:
     """Return True when ``module`` is one of the harness API modules."""
-    return module in API_MODULES
+    return _BORDER.is_api_module(module)
 
 
 def is_harness_module(module: str) -> bool:
     """Return True when ``module`` is the harness package or any module inside it."""
-    return module == HARNESS_PACKAGE or module.startswith(HARNESS_PACKAGE + ".")
-
-
-def python_sources(root: Path, *, exclude_parts: frozenset[str] = frozenset()) -> list[Path]:
-    """Return the Python files under ``root``, excluding ``__pycache__`` and ``exclude_parts``."""
-    excluded = exclude_parts | {"__pycache__"}
-    return [path for path in sorted(root.rglob("*.py")) if not (excluded & set(path.parts))]
-
-
-def _called_function_name(node: ast.Call) -> str:
-    func = node.func
-    if isinstance(func, ast.Attribute):
-        return func.attr
-    if isinstance(func, ast.Name):
-        return func.id
-    return ""
-
-
-@functools.cache
-def _exported_names(module: str) -> frozenset[str]:
-    """The names an API module exports in ``__all__``."""
-    return frozenset(importlib.import_module(module).__all__)
+    return _BORDER.owns(module)
 
 
 def internal_harness_imports(tree: ast.AST) -> set[str]:
-    """Return the harness modules ``tree`` imports that are not API modules.
-
-    Covers ``import x``, ``from x import y`` and dynamic imports
-    (``import_module("x")``). For ``from <api module> import y``, a name that
-    the API module does not export in ``__all__`` is treated as an import of
-    the internal submodule ``<api module>.y``.
-    """
-    internal: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            internal.update(
-                alias.name
-                for alias in node.names
-                if is_harness_module(alias.name) and not is_api_module(alias.name)
-            )
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            if node.level != 0 or not is_harness_module(module):
-                continue
-            if not is_api_module(module):
-                internal.add(module)
-                continue
-            exported = _exported_names(module)
-            internal.update(
-                f"{module}.{alias.name}" for alias in node.names if alias.name not in exported
-            )
-        elif (
-            isinstance(node, ast.Call) and _called_function_name(node) in _DYNAMIC_IMPORT_FUNCTIONS
-        ):
-            for argument in node.args[:1]:
-                if (
-                    isinstance(argument, ast.Constant)
-                    and isinstance(argument.value, str)
-                    and is_harness_module(argument.value)
-                    and not is_api_module(argument.value)
-                ):
-                    internal.add(argument.value)
-    return internal
+    """Return the harness modules ``tree`` imports that are not API modules."""
+    return _BORDER.internal_imports(tree)
 
 
 def internal_harness_imports_under(
     *roots: Path, exclude_parts: frozenset[str] = frozenset()
 ) -> set[str]:
     """Return every internal harness import across the Python sources under ``roots``."""
-    imported: set[str] = set()
-    for root in roots:
-        for path in python_sources(root, exclude_parts=exclude_parts):
-            source = path.read_text(encoding="utf-8")
-            imported |= internal_harness_imports(ast.parse(source, filename=str(path)))
-    return imported
+    return _BORDER.internal_imports_under(*roots, exclude_parts=exclude_parts)
 
 
 def assert_internal_imports_match_allowlist(
     imported: set[str], allowlist: frozenset[str], *, package: str
 ) -> None:
-    """Assert ``imported`` equals ``allowlist`` exactly.
-
-    A module not on the allowlist is a new internal dependency and fails; a
-    module on the allowlist that is no longer imported must be removed from it,
-    so the allowlist can only shrink.
-    """
-    added = sorted(imported - allowlist)
-    assert added == [], (
-        f"{package} imports harness internals not on the allowlist: {added}. "
-        f"Import through an API module ({', '.join(sorted(API_MODULES))}) "
-        "or export the name from the appropriate one."
-    )
-    stale = sorted(allowlist - imported)
-    assert stale == [], (
-        f"{package} no longer imports {stale}; remove them from the allowlist so it keeps shrinking."
-    )
+    """Assert ``imported`` equals ``allowlist`` exactly; the allowlist may only shrink."""
+    _BORDER.assert_matches_allowlist(imported, allowlist, consumer=package)
 
 
 __all__ = [

--- a/tests/shared/test_tool_api_border.py
+++ b/tests/shared/test_tool_api_border.py
@@ -1,0 +1,78 @@
+"""Consumers import the tool tier through its API, and the surface only shrinks.
+
+``core/tool/`` (contract, execution, registry port) and ``core/tool_framework/``
+(``@tool``, skill guidance, payload utilities) are one tier to everything above
+them. ``core.tool_framework.utils`` is already a door — it curates ``__all__``
+over nine helper submodules — so an import of it is not internal. The package
+roots export nothing yet; everything reaching past them is listed below, and
+these allowlists are the measurement of the seam.
+
+Each allowlist is compared exactly in both directions: a new internal import
+fails immediately, and an entry no longer imported must be removed. Widening a
+door and moving callers onto it is how these get shorter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.shared.tool_api import TOOL_BORDER
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Internal tool-tier modules each consumer still imports directly.
+_ALLOWED: dict[str, frozenset[str]] = {
+    "tools": frozenset(
+        {
+            "core.tool.contracts",
+            "core.tool.execution",
+            "core.tool.registry",
+            "core.tool_framework.skill_guidance",
+            "core.tool_framework.tags",
+            "core.tool_framework.tool_decorator",
+        }
+    ),
+    "integrations": frozenset(
+        {
+            "core.tool.contracts",
+            "core.tool.execution",
+            "core.tool_framework.tags",
+            "core.tool_framework.tool_decorator",
+        }
+    ),
+    "gateway": frozenset({"core.tool.execution"}),
+    "surfaces": frozenset(
+        {
+            "core.tool.contracts",
+            "core.tool.execution",
+        }
+    ),
+    "platform": frozenset(
+        {
+            "core.tool.contracts",
+            "core.tool.registry",
+        }
+    ),
+}
+
+
+@pytest.mark.parametrize("consumer", sorted(_ALLOWED))
+def test_consumer_tool_tier_imports_match_the_allowlist(consumer: str) -> None:
+    # Arrange / Act
+    imported = TOOL_BORDER.internal_imports_under(
+        REPO_ROOT / consumer, exclude_parts=frozenset({"tests"})
+    )
+
+    # Assert
+    TOOL_BORDER.assert_matches_allowlist(imported, _ALLOWED[consumer], consumer=f"{consumer}/")
+
+
+def test_bootstrap_reaches_the_tool_tier_only_through_its_api() -> None:
+    """The composition root wires tools together; it must not open the tier up."""
+    # Arrange / Act
+    imported = TOOL_BORDER.internal_imports_under(REPO_ROOT / "bootstrap")
+
+    # Assert
+    assert imported == set()

--- a/tests/shared/tool_api.py
+++ b/tests/shared/tool_api.py
@@ -1,0 +1,26 @@
+"""The tool tier's packages and the modules it may be imported through.
+
+``core/tool/`` owns the tool contract, execution and the registry port;
+``core/tool_framework/`` holds the authoring helpers (``@tool``, skill guidance,
+shared payload utilities). Together they are one tier to their consumers.
+
+Neither root exports anything yet, so every import below is internal and the
+border test's allowlists record exactly that. Introducing an API module is the
+next step; the allowlists are how it gets measured.
+"""
+
+from __future__ import annotations
+
+from tests.shared.api_border import ApiBorder
+
+TOOL_PACKAGES: tuple[str, ...] = ("core.tool", "core.tool_framework")
+
+#: Modules a consumer may import the tier through. Listed by exact name so a new
+#: submodule never joins the API by accident. ``utils`` is a door in its own
+#: right: it curates ``__all__`` over the helper submodules below it, so callers
+#: name one module instead of nine.
+API_MODULES: frozenset[str] = frozenset({*TOOL_PACKAGES, "core.tool_framework.utils"})
+
+TOOL_BORDER = ApiBorder(packages=TOOL_PACKAGES, api_modules=API_MODULES)
+
+__all__ = ["API_MODULES", "TOOL_BORDER", "TOOL_PACKAGES"]

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -21,7 +21,7 @@ from core.agent_harness.spi.session_state import (
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_array_property, string_property
+from core.tool_framework.utils import object_schema, string_array_property, string_property
 
 _MIN_OPTIONS = 2
 _MAX_OPTIONS = 8

--- a/tools/interactive_shell/actions/assistant_handoff.py
+++ b/tools/interactive_shell/actions/assistant_handoff.py
@@ -12,7 +12,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_array_property, string_property
+from core.tool_framework.utils import object_schema, string_array_property, string_property
 
 
 def execute_assistant_handoff_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:

--- a/tools/interactive_shell/actions/cli_command.py
+++ b/tools/interactive_shell/actions/cli_command.py
@@ -11,7 +11,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.cli import run_opensre_cli_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 

--- a/tools/interactive_shell/actions/implementation.py
+++ b/tools/interactive_shell/actions/implementation.py
@@ -11,7 +11,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.implementation.claude_code_executor import (
     run_claude_code_implementation,
 )

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -14,7 +14,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from platform.scheduling.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (
     InvestigationLaunchPorts,

--- a/tools/interactive_shell/actions/llm_provider.py
+++ b/tools/interactive_shell/actions/llm_provider.py
@@ -14,7 +14,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema
+from core.tool_framework.utils import object_schema
 from tools.interactive_shell.shared import allow_tool
 
 

--- a/tools/interactive_shell/actions/propose_scheduled_delivery.py
+++ b/tools/interactive_shell/actions/propose_scheduled_delivery.py
@@ -11,7 +11,7 @@ from core.agent_harness.spi.session_state import (
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from platform.scheduling.scheduler.credentials import requires_explicit_chat_id
 from platform.scheduling.scheduler.types import Provider, TaskKind
 

--- a/tools/interactive_shell/actions/sample_alert.py
+++ b/tools/interactive_shell/actions/sample_alert.py
@@ -14,7 +14,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from platform.scheduling.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (
     InvestigationLaunchPorts,

--- a/tools/interactive_shell/actions/sentry_fix.py
+++ b/tools/interactive_shell/actions/sentry_fix.py
@@ -16,7 +16,7 @@ from typing import Any
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from tools.cross_vendor.fix_sentry_issue import fix_sentry_issue
 from tools.cross_vendor.fix_sentry_issue.runner import is_issue_fix_enabled
 

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -11,7 +11,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.shell.runner import run_shell_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 

--- a/tools/interactive_shell/actions/skill_view.py
+++ b/tools/interactive_shell/actions/skill_view.py
@@ -8,7 +8,7 @@ from core.agent_harness.spi.grounding import list_action_skills, load_skill_body
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 
 
 def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolContext) -> dict[str, Any]:

--- a/tools/interactive_shell/actions/synthetic.py
+++ b/tools/interactive_shell/actions/synthetic.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema, string_property
+from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 from tools.interactive_shell.synthetic.runner import run_synthetic_test
 

--- a/tools/interactive_shell/actions/task_cancel.py
+++ b/tools/interactive_shell/actions/task_cancel.py
@@ -14,7 +14,7 @@ from core.agent_harness.tools import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool, SideEffectLevel
-from core.tool_framework.utils.schema import object_schema
+from core.tool_framework.utils import object_schema
 from platform.scheduling.task_types import TaskKind, TaskStatus
 from tools.interactive_shell.shared import plan_foreground_tool
 

--- a/tools/interactive_shell/shared/slash_catalog.py
+++ b/tools/interactive_shell/shared/slash_catalog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from core.tool_framework.utils.schema import object_schema, string_array_property, string_property
+from core.tool_framework.utils import object_schema, string_array_property, string_property
 
 _MAX_COMPACT_DESC_CHARS = 120
 


### PR DESCRIPTION
**The measurement.** `core/tool/` and `core/tool_framework/` are one tier to
everything above them, and nothing held their border. Consumers reached into
**24 internal paths** across five packages.

`tests/shared/api_border.py` is the scanner, extracted from `harness_api.py` and
parameterised on (packages, API modules). That file was 150 lines of exactly this
logic bound to one tier; duplicating it for a second tier would have been the
wrong move. `harness_api` keeps its constants and public function names and now
delegates — its **21 border tests pass unchanged**, before and after.

Allowlists are compared exactly in both directions, so they can only shrink: a
new internal import fails, and an entry no longer imported must be removed.

**The shrink.** `core/tool_framework/utils/__init__.py` was *already* a door,
curating `__all__` over its submodules — just six names wide, so callers reached
past it to nine modules. Widened to fourteen and moved 124 files onto it.

| Consumer | Before | After |
|---|---|---|
| integrations | 11 | **4** |
| tools | 7 | **6** |
| surfaces | 3 | **2** |
| platform | 2 | 2 |
| gateway | 1 | 1 |
| **total** | **24** | **15** |

No file moved and no symbol was renamed. Of 129 changed files, five are
substantive; the other 124 are single import lines.

Direction verified before widening: `core.tool_framework` depends on `core.tool`
and never the reverse, and the pulled-in submodules only reach sideways to
`tool_availability` and `db_warnings`, both already exported. No cycle —
`AGENTS.md` is explicit that CodeQL counts even a `TYPE_CHECKING` import as part
of one.

