### PR TITLE
fix(github): ignore pull requests during issue dedup

### DIFF
--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -583,7 +583,11 @@ def _recent_issues_with_marker(
     if not isinstance(result, list):
         return []
     return [
-        item for item in result if isinstance(item, dict) and marker in str(item.get("body") or "")
+        item
+        for item in result
+        if isinstance(item, dict)
+        and "pull_request" not in item
+        and marker in str(item.get("body") or "")
     ]
 
 

--- a/tests/tools/test_github_workflow_tools.py
+++ b/tests/tools/test_github_workflow_tools.py
@@ -295,6 +295,38 @@ def test_execute_create_returns_existing_issue_for_idempotency_marker() -> None:
     assert result["side_effect"] == "existing_github_issue"
 
 
+def test_execute_create_ignores_pull_request_with_idempotency_marker() -> None:
+    proposal = propose_github_issue_mutation_from_slack(
+        owner="o",
+        repo="r",
+        operation="create",
+        slack_text="ship this",
+        slack_url="https://slack.example/archives/C/p1",
+    )["proposal"]
+    marker = proposal["idempotency_marker"]
+
+    def fake_request(self: GitHubRestClient, method: str, path: str, **_kwargs: Any) -> Any:
+        if path == "/repos/o/r/issues" and method == "GET":
+            return [
+                {
+                    "number": 12,
+                    "body": f"...\n{marker}\n...",
+                    "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/12"},
+                }
+            ]
+        if path == "/repos/o/r/issues" and method == "POST":
+            return {"number": 99, "html_url": "https://github.com/o/r/issues/99"}
+        raise AssertionError((method, path))
+
+    with patch.object(GitHubRestClient, "request", fake_request):
+        result = execute_github_issue_mutation(
+            owner="o", repo="r", proposal=proposal, github_token="tok"
+        )
+
+    assert result["executed"] is True
+    assert result["side_effect"] == "created_github_issue"
+
+
 def test_execute_update_adds_comment_and_preserves_body() -> None:
     proposal = propose_github_issue_mutation_from_slack(
         owner="o",


### PR DESCRIPTION
Fixes #5283

#### Describe the changes you have made in this PR -

The recent repository-issues scan used by GitHub issue-mutation idempotency can return pull requests as well as issues. This change ignores entries with GitHub's `pull_request` key before matching the proposal marker, preserving the former `is:issue` behavior.

A regression test proves that a matching pull request does not suppress creation of the intended issue.

### Demo/Screenshot for feature changes and bug fixes -

`uv run pytest tests/tools/test_github_workflow_tools.py` — 51 passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The smallest safe correction is to preserve the semantic distinction from the previous GitHub search query: only issue results qualify for issue-creation deduplication. The API marks pull requests with `pull_request`, so the filter is local, deterministic, and does not add another request. The regression test provides a pull request containing the marker and asserts the tool continues to create the issue.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.