### PR TITLE
Fix : replace swallow all lambdas with named AnswerShellQuestion stub

### DIFF
--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -20,6 +20,8 @@ import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 import surfaces.interactive_shell.runtime.subprocess_runner as subprocess_runner
 import tests.shared.harness_turn_driver as harness_turn_driver
 import tools.interactive_shell.shell.execution as shell_execution
+from core.agent_harness.accounting.token_accounting import LlmRunInfo
+from core.agent_harness.ports import AnswerRequest, OutputSink
 from core.llm.types import AgentLLMResponse, ToolCall
 from platform.scheduling.task_types import TaskKind, TaskStatus
 from surfaces.interactive_shell.session import Session
@@ -34,8 +36,6 @@ from tools.interactive_shell.action_names import (
     TOOL_KIND_TO_NAME,
     ToolKind,
 )
-from core.agent_harness.ports import AnswerRequest, OutputSink
-from core.agent_harness.accounting.token_accounting import LlmRunInfo
 
 _ACTION_LLM_FACTORY_PATCH = "core.agent_harness.turns.action_driver.default_llm_factory"
 run_harness_turn = harness_turn_driver.run_harness_turn
@@ -46,14 +46,14 @@ def _capture() -> tuple[Console, io.StringIO]:
     return Console(file=buf, force_terminal=False, highlight=False), buf
 
 
-def _no_answer_agent (
-    message : str,
-    session : Session,
-    console : Console,
+def _no_answer_agent(
+    message: str,
+    session: Session,
+    console: Console,
     *,
-    request : AnswerRequest,
-    output : OutputSink | None = None
-) -> LlmRunInfo | None :
+    request: AnswerRequest,
+    output: OutputSink | None = None,
+) -> LlmRunInfo | None:
     return None
 
 
@@ -1304,7 +1304,7 @@ def test_execute_cli_actions_counts_planned_and_executed(monkeypatch: object) ->
         session,
         console,
         recorder=None,
-        answer_agent = _no_answer_agent,
+        answer_agent=_no_answer_agent,
     )
 
     action_result = result.action_result
@@ -1380,7 +1380,7 @@ def test_execute_cli_actions_executes_matched_clause_ignoring_unhandled(
         session,
         console,
         recorder=None,
-        answer_agent = _no_answer_agent,
+        answer_agent=_no_answer_agent,
     )
 
     # The unhandled flag no longer denies the turn: the matched /health runs.

--- a/tests/core/agent/orchestration/test_agent_actions.py
+++ b/tests/core/agent/orchestration/test_agent_actions.py
@@ -34,6 +34,8 @@ from tools.interactive_shell.action_names import (
     TOOL_KIND_TO_NAME,
     ToolKind,
 )
+from core.agent_harness.ports import AnswerRequest, OutputSink
+from core.agent_harness.accounting.token_accounting import LlmRunInfo
 
 _ACTION_LLM_FACTORY_PATCH = "core.agent_harness.turns.action_driver.default_llm_factory"
 run_harness_turn = harness_turn_driver.run_harness_turn
@@ -42,6 +44,17 @@ run_harness_turn = harness_turn_driver.run_harness_turn
 def _capture() -> tuple[Console, io.StringIO]:
     buf = io.StringIO()
     return Console(file=buf, force_terminal=False, highlight=False), buf
+
+
+def _no_answer_agent (
+    message : str,
+    session : Session,
+    console : Console,
+    *,
+    request : AnswerRequest,
+    output : OutputSink | None = None
+) -> LlmRunInfo | None :
+    return None
 
 
 def _action(
@@ -1291,7 +1304,7 @@ def test_execute_cli_actions_counts_planned_and_executed(monkeypatch: object) ->
         session,
         console,
         recorder=None,
-        answer_agent=lambda *_a, **_k: None,
+        answer_agent = _no_answer_agent,
     )
 
     action_result = result.action_result
@@ -1367,7 +1380,7 @@ def test_execute_cli_actions_executes_matched_clause_ignoring_unhandled(
         session,
         console,
         recorder=None,
-        answer_agent=lambda *_a, **_k: None,
+        answer_agent = _no_answer_agent,
     )
 
     # The unhandled flag no longer denies the turn: the matched /health runs.


### PR DESCRIPTION
Fixes #5203

#### Changes made in this PR  -
Replaced the swallow-all `lambda *_a, **_k: None` stubs for `answer_agent` with a explicit helper `_no_answer_agent` in `test_agent_actions.py`. The new helper strictly matches the `AnswerShellQuestion` protocol signature so tests won't silently pass if the underlying protocol changes in the future.

### Screenshot of tests passed - 
<img width="1196" height="165" alt="image" src="https://github.com/user-attachments/assets/a34eec17-ae03-4903-bd30-a10ade2b1862" />

Ran all 36 tests locally and they pass cleanly.


## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The old `lambda *_a, **_k: None` accepted any arguments without checking them. If someone modified the `AnswerShellQuestion` contract then the test would still pass secretly without any warning. 

To fix this I added `_no_answer_agent` which expects the exact arguments from `AnswerShellQuestion`: `message`, `session`, `console`, `request` and `output`. Then replaced the 2 inline lambdas with `_no_answer_agent`.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions