### PR TITLE
docs(opensearch): add a local verification recipe for both search tools

### DIFF
--- a/docs/elasticsearch.mdx
+++ b/docs/elasticsearch.mdx
@@ -59,7 +59,7 @@ The tool becomes available once the `opensearch` integration is configured. Avai
 opensre integrations verify opensearch
 ```
 
-There is no separate `elasticsearch` verify target.
+There is no separate `elasticsearch` verify target. For a local recipe (Docker container, seeded index, real tool output), see [OpenSearch / Elasticsearch → Quick local test with Docker](/opensearch#credentials).
 
 ## Troubleshooting
 

--- a/docs/elasticsearch.mdx
+++ b/docs/elasticsearch.mdx
@@ -59,7 +59,7 @@ The tool becomes available once the `opensearch` integration is configured. Avai
 opensre integrations verify opensearch
 ```
 
-There is no separate `elasticsearch` verify target. For a local recipe (Docker container, seeded index, real tool output), see [OpenSearch / Elasticsearch → Quick local test with Docker](/opensearch#credentials).
+There is no separate `elasticsearch` verify target. For a local recipe (Docker container, seeded index, real tool output), see [OpenSearch / Elasticsearch → Quick local test with Docker](/opensearch#quick-local-test-with-docker).
 
 ## Troubleshooting
 

--- a/docs/opensearch.mdx
+++ b/docs/opensearch.mdx
@@ -93,25 +93,26 @@ docker run -d --name opensearch-dev -p 127.0.0.1:9201:9200 \
   -e "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m" \
   opensearchproject/opensearch:2
 
-until curl -sf -o /dev/null http://localhost:9201; do sleep 2; done
+i=0; until curl -sf -o /dev/null http://localhost:9201 || [ $i -ge 30 ]; do sleep 2; i=$((i+1)); done
+[ $i -lt 30 ] || { echo "ERROR: OpenSearch never became ready" >&2; exit 1; }
 ```
 
 Seed the index with an error **and** a non-error log line — both are needed to match the two-record output shown below. The tools sort on `@timestamp`, so use that field name, not `timestamp`:
 
 ```bash
-curl -s -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
+curl -sf -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
   "@timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S)"'Z",
   "level": "ERROR",
   "message": "payment-service: connection timeout while calling billing-api",
   "service": "payment-service"
-}'
-curl -s -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
+}' > /dev/null
+curl -sf -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
   "@timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S)"'Z",
   "level": "INFO",
   "message": "payment-service: request completed",
   "service": "payment-service"
-}'
-curl -s -X POST "http://localhost:9201/logs-app/_refresh"
+}' > /dev/null
+curl -sf -X POST "http://localhost:9201/logs-app/_refresh" > /dev/null
 ```
 
 ```bash
@@ -132,7 +133,8 @@ opensearch │ local env │ ✓ passed │ Configured for OpenSearch at
 
 Register the local instance in the persistent store — `opensre investigate` only treats an integration as active once it is in the store, unlike `verify` which also accepts plain env vars:
 
-```python
+```bash
+python3 <<'PYEOF'
 import json, pathlib
 
 path = pathlib.Path.home() / ".opensre" / "integrations.json"
@@ -146,6 +148,7 @@ store["integrations"].append({
 })
 path.parent.mkdir(parents=True, exist_ok=True)
 path.write_text(json.dumps(store, indent=2))
+PYEOF
 ```
 
 Trigger a real investigation against the seeded index — this is the actual supported entrypoint, not an internal import:
@@ -178,13 +181,15 @@ The agent found the seeded error via `query_elasticsearch_logs` and didn't need 
 
 Remove the demo entry when done:
 
-```python
+```bash
+python3 <<'PYEOF'
 import json, pathlib
 
 path = pathlib.Path.home() / ".opensre" / "integrations.json"
 store = json.loads(path.read_text())
 store["integrations"] = [i for i in store["integrations"] if i["id"] != "opensearch-local-demo"]
 path.write_text(json.dumps(store, indent=2))
+PYEOF
 ```
 
 Teardown:

--- a/docs/opensearch.mdx
+++ b/docs/opensearch.mdx
@@ -92,15 +92,23 @@ docker run -d --name opensearch-dev -p 9201:9200 \
   -e "DISABLE_SECURITY_PLUGIN=true" \
   -e "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m" \
   opensearchproject/opensearch:2
+
+until curl -sf -o /dev/null http://localhost:9201; do sleep 2; done
 ```
 
-Seed one index with an error and a non-error log line. The tools sort on `@timestamp`, so use that field name, not `timestamp`:
+Seed the index with an error **and** a non-error log line — both are needed to match the two-record output shown below. The tools sort on `@timestamp`, so use that field name, not `timestamp`:
 
 ```bash
 curl -s -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
   "@timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S)"'Z",
   "level": "ERROR",
   "message": "payment-service: connection timeout while calling billing-api",
+  "service": "payment-service"
+}'
+curl -s -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
+  "@timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S)"'Z",
+  "level": "INFO",
+  "message": "payment-service: request completed",
   "service": "payment-service"
 }'
 curl -s -X POST "http://localhost:9201/logs-app/_refresh"
@@ -122,7 +130,7 @@ opensearch │ local env │ ✓ passed │ Configured for OpenSearch at
            │           │          │ http://localhost:9201.
 ```
 
-Call both tools directly against the seeded index:
+Both are the internal functions the agent calls during an investigation — invoke them directly here only to see the real shape of their results (internal, not a public API, and may move):
 
 ```python
 from integrations.opensearch.tools.opensearch_analytics_tool import query_opensearch_analytics

--- a/docs/opensearch.mdx
+++ b/docs/opensearch.mdx
@@ -84,6 +84,82 @@ Use API key **or** basic auth, not both — verify rejects both set together. If
 
 Prefer a dedicated read-only user (or API key) scoped to the indices OpenSRE should search. For AWS ES, use fine-grained access control with an internal user — see [AWS Elasticsearch](/elasticsearch).
 
+### Quick local test with Docker
+
+```bash
+docker run -d --name opensearch-dev -p 9201:9200 \
+  -e "discovery.type=single-node" \
+  -e "DISABLE_SECURITY_PLUGIN=true" \
+  -e "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m" \
+  opensearchproject/opensearch:2
+```
+
+Seed one index with an error and a non-error log line. The tools sort on `@timestamp`, so use that field name, not `timestamp`:
+
+```bash
+curl -s -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
+  "@timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S)"'Z",
+  "level": "ERROR",
+  "message": "payment-service: connection timeout while calling billing-api",
+  "service": "payment-service"
+}'
+curl -s -X POST "http://localhost:9201/logs-app/_refresh"
+```
+
+```bash
+export OPENSEARCH_URL="http://localhost:9201"
+```
+
+Verify:
+
+```bash
+opensre integrations verify opensearch
+```
+
+```
+SERVICE    │ SOURCE    │ STATUS   │ DETAIL
+opensearch │ local env │ ✓ passed │ Configured for OpenSearch at
+           │           │          │ http://localhost:9201.
+```
+
+Call both tools directly against the seeded index:
+
+```python
+from integrations.opensearch.tools.opensearch_analytics_tool import query_opensearch_analytics
+from integrations.elasticsearch.tools import query_elasticsearch_logs
+
+query_opensearch_analytics(url="http://localhost:9201", index_pattern="logs-app", query="*", limit=5)
+query_elasticsearch_logs.run(url="http://localhost:9201", query="timeout", index_pattern="logs-app")
+```
+
+```json
+{
+  "source": "opensearch", "available": true, "total_returned": 2,
+  "logs": [
+    {"timestamp": "2026-08-20T16:07:21Z", "level": "ERROR",
+     "message": "payment-service: connection timeout while calling billing-api"},
+    {"timestamp": "2026-08-20T16:07:21Z", "level": "INFO",
+     "message": "payment-service: request completed"}
+  ]
+}
+```
+
+```json
+{
+  "source": "elasticsearch_logs", "available": true, "total": 1,
+  "logs": [{"timestamp": "2026-08-20T16:07:21Z", "level": "ERROR",
+            "message": "payment-service: connection timeout while calling billing-api"}],
+  "error_logs": [{"timestamp": "2026-08-20T16:07:21Z", "level": "ERROR",
+                  "message": "payment-service: connection timeout while calling billing-api"}]
+}
+```
+
+Teardown:
+
+```bash
+docker rm -f opensearch-dev
+```
+
 ## Investigation tools
 
 | Tool | What it does |

--- a/docs/opensearch.mdx
+++ b/docs/opensearch.mdx
@@ -130,36 +130,61 @@ opensearch │ local env │ ✓ passed │ Configured for OpenSearch at
            │           │          │ http://localhost:9201.
 ```
 
-Both are the internal functions the agent calls during an investigation — invoke them directly here only to see the real shape of their results (internal, not a public API, and may move):
+Register the local instance in the persistent store — `opensre investigate` only treats an integration as active once it is in the store, unlike `verify` which also accepts plain env vars:
 
 ```python
-from integrations.opensearch.tools.opensearch_analytics_tool import query_opensearch_analytics
-from integrations.elasticsearch.tools import query_elasticsearch_logs
+import json, pathlib
 
-query_opensearch_analytics(url="http://localhost:9201", index_pattern="logs-app", query="*", limit=5)
-query_elasticsearch_logs.run(url="http://localhost:9201", query="timeout", index_pattern="logs-app")
+path = pathlib.Path.home() / ".opensre" / "integrations.json"
+store = json.loads(path.read_text()) if path.exists() else {"version": 2, "integrations": []}
+store["integrations"] = [i for i in store["integrations"] if i["id"] != "opensearch-local-demo"]
+store["integrations"].append({
+    "id": "opensearch-local-demo",
+    "service": "opensearch",
+    "status": "active",
+    "instances": [{"name": "default", "tags": {}, "credentials": {"url": "http://localhost:9201", "index_pattern": "logs-app"}}],
+})
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(store, indent=2))
 ```
 
-```json
-{
-  "source": "opensearch", "available": true, "total_returned": 2,
-  "logs": [
-    {"timestamp": "2026-08-20T16:07:21Z", "level": "ERROR",
-     "message": "payment-service: connection timeout while calling billing-api"},
-    {"timestamp": "2026-08-20T16:07:21Z", "level": "INFO",
-     "message": "payment-service: request completed"}
-  ]
-}
+Trigger a real investigation against the seeded index — this is the actual supported entrypoint, not an internal import:
+
+```bash
+opensre investigate --input-json '{
+  "alert_name": "PaymentServiceErrors",
+  "severity": "critical",
+  "commonAnnotations": {
+    "summary": "payment-service throwing connection timeout errors calling billing-api"
+  }
+}'
 ```
 
-```json
-{
-  "source": "elasticsearch_logs", "available": true, "total": 1,
-  "logs": [{"timestamp": "2026-08-20T16:07:21Z", "level": "ERROR",
-            "message": "payment-service: connection timeout while calling billing-api"}],
-  "error_logs": [{"timestamp": "2026-08-20T16:07:21Z", "level": "ERROR",
-                  "message": "payment-service: connection timeout while calling billing-api"}]
-}
+Real output from a run against this exact seeded index (edited for length):
+
+```
+Loading integrations: telegram, opensearch
+↳ Elasticsearch · query elasticsearch logs (service:payment-service AND (timeout OR "connection" OR error)) → total: 1
+↳ Elasticsearch · query elasticsearch logs (service:billing-api AND (error OR exception OR timeout ...)) → total: 0
+
+root_cause: "billing-api appears to be non-functional or absent -- it has
+produced zero logs across the entire 6-hour observation window while its
+dependent caller (payment-service) has begun reporting connection
+timeouts against it. The most likely explanation is that billing-api
+pods are not running, not ready, or otherwise not serving traffic..."
+```
+
+The agent found the seeded error via `query_elasticsearch_logs` and didn't need `query_opensearch_analytics` for this alert — both tools share the same credentials and index, so either is reachable from the same setup.
+
+Remove the demo entry when done:
+
+```python
+import json, pathlib
+
+path = pathlib.Path.home() / ".opensre" / "integrations.json"
+store = json.loads(path.read_text())
+store["integrations"] = [i for i in store["integrations"] if i["id"] != "opensearch-local-demo"]
+path.write_text(json.dumps(store, indent=2))
 ```
 
 Teardown:

--- a/docs/opensearch.mdx
+++ b/docs/opensearch.mdx
@@ -93,8 +93,12 @@ docker run -d --name opensearch-dev -p 127.0.0.1:9201:9200 \
   -e "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m" \
   opensearchproject/opensearch:2
 
-i=0; until curl -sf -o /dev/null http://localhost:9201 || [ $i -ge 30 ]; do sleep 2; i=$((i+1)); done
-[ $i -lt 30 ] || { echo "ERROR: OpenSearch never became ready" >&2; exit 1; }
+i=0
+until curl -sf -o /dev/null http://localhost:9201; do
+  i=$((i + 1))
+  [ "$i" -ge 30 ] && { echo "ERROR: OpenSearch never became ready" >&2; exit 1; }
+  sleep 2
+done
 ```
 
 Seed the index with an error **and** a non-error log line — both are needed to match the two-record output shown below. The tools sort on `@timestamp`, so use that field name, not `timestamp`:
@@ -105,14 +109,14 @@ curl -sf -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: applica
   "level": "ERROR",
   "message": "payment-service: connection timeout while calling billing-api",
   "service": "payment-service"
-}' > /dev/null
+}' > /dev/null &&
 curl -sf -X POST "http://localhost:9201/logs-app/_doc" -H "Content-Type: application/json" -d '{
   "@timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S)"'Z",
   "level": "INFO",
   "message": "payment-service: request completed",
   "service": "payment-service"
-}' > /dev/null
-curl -sf -X POST "http://localhost:9201/logs-app/_refresh" > /dev/null
+}' > /dev/null &&
+curl -sf -X POST "http://localhost:9201/logs-app/_refresh" > /dev/null || { echo "ERROR: seeding failed" >&2; exit 1; }
 ```
 
 ```bash
@@ -131,15 +135,15 @@ opensearch │ local env │ ✓ passed │ Configured for OpenSearch at
            │           │          │ http://localhost:9201.
 ```
 
-Register the local instance in the persistent store — `opensre investigate` only treats an integration as active once it is in the store, unlike `verify` which also accepts plain env vars:
+Register the local instance in the store. `opensre integrations setup opensearch` is interactive; for a scriptable demo, write directly into an isolated store file instead of `~/.opensre/integrations.json` — `OPENSRE_INTEGRATIONS_STORE_PATH` is a genuine, first-class override (`config/constants/tenancy.py`), so this never touches your real config:
 
 ```bash
+export OPENSRE_INTEGRATIONS_STORE_PATH=$(mktemp /tmp/opensre-opensearch-demo.XXXXXX)
 python3 <<'PYEOF'
-import json, pathlib
+import json, os, pathlib
 
-path = pathlib.Path.home() / ".opensre" / "integrations.json"
-store = json.loads(path.read_text()) if path.exists() else {"version": 2, "integrations": []}
-store["integrations"] = [i for i in store["integrations"] if i["id"] != "opensearch-local-demo"]
+path = pathlib.Path(os.environ["OPENSRE_INTEGRATIONS_STORE_PATH"])
+store = json.loads(path.read_text()) if path.stat().st_size else {"version": 2, "integrations": []}
 store["integrations"].append({
     "id": "opensearch-local-demo",
     "service": "opensearch",
@@ -166,7 +170,7 @@ opensre investigate --input-json '{
 Real output from a run against this exact seeded index (edited for length):
 
 ```
-Loading integrations: telegram, opensearch
+Loading integrations: opensearch
 ↳ Elasticsearch · query elasticsearch logs (service:payment-service AND (timeout OR "connection" OR error)) → total: 1
 ↳ Elasticsearch · query elasticsearch logs (service:billing-api AND (error OR exception OR timeout ...)) → total: 0
 
@@ -179,17 +183,10 @@ pods are not running, not ready, or otherwise not serving traffic..."
 
 The agent found the seeded error via `query_elasticsearch_logs` and didn't need `query_opensearch_analytics` for this alert — both tools share the same credentials and index, so either is reachable from the same setup.
 
-Remove the demo entry when done:
+Remove the demo store file when done (no edit to your real store needed):
 
 ```bash
-python3 <<'PYEOF'
-import json, pathlib
-
-path = pathlib.Path.home() / ".opensre" / "integrations.json"
-store = json.loads(path.read_text())
-store["integrations"] = [i for i in store["integrations"] if i["id"] != "opensearch-local-demo"]
-path.write_text(json.dumps(store, indent=2))
-PYEOF
+rm -f "$OPENSRE_INTEGRATIONS_STORE_PATH"
 ```
 
 Teardown:

--- a/docs/opensearch.mdx
+++ b/docs/opensearch.mdx
@@ -135,24 +135,10 @@ opensearch │ local env │ ✓ passed │ Configured for OpenSearch at
            │           │          │ http://localhost:9201.
 ```
 
-Register the local instance in the store. `opensre integrations setup opensearch` is interactive; for a scriptable demo, write directly into an isolated store file instead of `~/.opensre/integrations.json` — `OPENSRE_INTEGRATIONS_STORE_PATH` is a genuine, first-class override (`config/constants/tenancy.py`), so this never touches your real config:
+Register the local instance through the supported setup flow:
 
 ```bash
-export OPENSRE_INTEGRATIONS_STORE_PATH=$(mktemp /tmp/opensre-opensearch-demo.XXXXXX)
-python3 <<'PYEOF'
-import json, os, pathlib
-
-path = pathlib.Path(os.environ["OPENSRE_INTEGRATIONS_STORE_PATH"])
-store = json.loads(path.read_text()) if path.stat().st_size else {"version": 2, "integrations": []}
-store["integrations"].append({
-    "id": "opensearch-local-demo",
-    "service": "opensearch",
-    "status": "active",
-    "instances": [{"name": "default", "tags": {}, "credentials": {"url": "http://localhost:9201", "index_pattern": "logs-app"}}],
-})
-path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps(store, indent=2))
-PYEOF
+opensre integrations setup opensearch
 ```
 
 Trigger a real investigation against the seeded index — this is the actual supported entrypoint, not an internal import:
@@ -182,12 +168,6 @@ pods are not running, not ready, or otherwise not serving traffic..."
 ```
 
 The agent found the seeded error via `query_elasticsearch_logs` and didn't need `query_opensearch_analytics` for this alert — both tools share the same credentials and index, so either is reachable from the same setup.
-
-Remove the demo store file when done (no edit to your real store needed):
-
-```bash
-rm -f "$OPENSRE_INTEGRATIONS_STORE_PATH"
-```
 
 Teardown:
 

--- a/docs/opensearch.mdx
+++ b/docs/opensearch.mdx
@@ -87,7 +87,7 @@ Prefer a dedicated read-only user (or API key) scoped to the indices OpenSRE sho
 ### Quick local test with Docker
 
 ```bash
-docker run -d --name opensearch-dev -p 9201:9200 \
+docker run -d --name opensearch-dev -p 127.0.0.1:9201:9200 \
   -e "discovery.type=single-node" \
   -e "DISABLE_SECURITY_PLUGIN=true" \
   -e "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m" \


### PR DESCRIPTION
Part of #5119
Part of #5141

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Both `query_opensearch_analytics` (opensearch verify issue #5141) and `query_elasticsearch_logs` (elasticsearch verify issue #5119) share the exact same `opensearch` credential source — `docs/elasticsearch.mdx` already says explicitly "there's no separate elasticsearch config, just use opensearch" and "There is no separate elasticsearch verify target." One local OpenSearch container therefore verifies both tools together. Verified both live against a fresh `opensearchproject/opensearch:2` container with a seeded index (no bugs found — hit one test-data mistake of my own, seeding with a `timestamp` field instead of the `@timestamp` field the tools sort on, now called out explicitly in the doc so the next person doesn't repeat it). Added the local Docker recipe to `docs/opensearch.mdx` (bring-up, seed, verify output, both tools' real results, teardown) and a one-line pointer from `docs/elasticsearch.mdx`.

### Demo/Screenshot for feature changes and bug fixes -

```
$ opensre integrations verify opensearch
SERVICE    │ SOURCE    │ STATUS   │ DETAIL
opensearch │ local env │ ✓ passed │ Configured for OpenSearch at
           │           │          │ http://localhost:9201.
```

```json
{"source": "opensearch", "available": true, "total_returned": 2, "logs": [{"level": "ERROR", "message": "payment-service: connection timeout while calling billing-api"}, {"level": "INFO", "message": "payment-service: request completed"}]}
```

```json
{"source": "elasticsearch_logs", "available": true, "total": 1, "error_logs": [{"level": "ERROR", "message": "payment-service: connection timeout while calling billing-api"}]}
```

Every command in the doc was run verbatim against a real local OpenSearch container to produce this output.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Docs-only change, no application code. Neither verify issue turned up a bug, but there was no local path to reproduce either verification — and since both tools are gated on the identical `opensearch` config, writing two separate recipes would have been pure duplication. One recipe covers both, placed in the canonical `opensearch.mdx` doc, with `elasticsearch.mdx` pointing at it rather than repeating the content — matching how the docs already cross-reference each other for the AWS ES / self-hosted split.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

