### PR TITLE
docs(mysql): fix the read-only user grants and add a local recipe

### DIFF
--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -106,12 +106,11 @@ Wait for it to become healthy, then create the read-only user and a table to ins
 
 ```bash
 i=0
-until docker exec mysql-dev mysqladmin ping -uroot -prootpass --silent 2>/dev/null; do
+until docker logs mysql-dev 2>&1 | grep -q "ready for connections.*port: 3306"; do
   i=$((i + 1))
   [ "$i" -ge 30 ] && { echo "ERROR: MySQL never became ready" >&2; exit 1; }
   sleep 2
 done
-[ $i -lt 30 ] || { echo "ERROR: MySQL never became ready" >&2; exit 1; }
 ```
 
 ```bash
@@ -148,28 +147,14 @@ mysql   │ local env │ ✓ passed │ Connected to MySQL 8.0.46
         │           │          │ target database: app_db.
 ```
 
-Register the local instance in the store. `opensre integrations setup mysql` is interactive; for a scriptable demo, write directly into an isolated store file instead of `~/.opensre/integrations.json` — `OPENSRE_INTEGRATIONS_STORE_PATH` is a genuine, first-class override (`config/constants/tenancy.py`), so this never touches your real config or exposes the demo password there:
+`opensre investigate` only treats an integration as active once the store resolution has *something* to fall through to env vars with -- an untouched `~/.opensre/integrations.json` with an unrelated integration in it blocks env-var fallback entirely. Point `OPENSRE_INTEGRATIONS_STORE_PATH` at an empty, valid store instead, so your real config is never read or written and the exported `MYSQL_*` vars above are the only source of credentials:
 
 ```bash
 export OPENSRE_INTEGRATIONS_STORE_PATH=$(mktemp /tmp/opensre-mysql-demo.XXXXXX)
-python3 <<'PYEOF'
-import json, os, pathlib
-
-path = pathlib.Path(os.environ["OPENSRE_INTEGRATIONS_STORE_PATH"])
-store = json.loads(path.read_text()) if path.stat().st_size else {"version": 2, "integrations": []}
-store["integrations"].append({
-    "id": "mysql-local-demo",
-    "service": "mysql",
-    "status": "active",
-    "instances": [{"name": "default", "tags": {}, "credentials": {
-        "host": "127.0.0.1", "port": 3307, "database": "app_db",
-        "username": "opensre_readonly", "password": "secure-password", "ssl_mode": "disabled",
-    }}],
-})
-path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps(store, indent=2))
-PYEOF
+echo '{"version": 2, "integrations": []}' > "$OPENSRE_INTEGRATIONS_STORE_PATH"
 ```
+
+A literal zero-byte file does not work here -- the store loader expects valid JSON and raises on an empty read, so this writes an explicitly empty (but valid) store rather than just creating the file with `mktemp` alone.
 
 Kick off a long-running query so there is something real to investigate, then trigger a real investigation — this is the actual supported entrypoint, not an internal import:
 
@@ -185,10 +170,10 @@ opensre investigate --input-json '{
 }'
 ```
 
-Real output from a run against this exact local instance (edited for length):
+Real output from a run against this exact local instance (edited for length). An empty store makes `opensre investigate` fall through to env-var resolution for *every* integration, not just MySQL -- if your shell or machine already resolves another integration from its own env vars, it rides along too (harmless; it just means extra unrelated tool availability, not incorrect MySQL results). Here `telegram` appears because this environment happens to resolve it:
 
 ```
-Loading integrations: mysql
+Loading integrations: telegram, mysql
 ↳ MySQL · get mysql current processes
 ↳ MySQL · get mysql server status
 ↳ MySQL · get mysql slow queries
@@ -203,15 +188,14 @@ indicating no real workload impact -- this is a synthetic/manual probe,
 not a real incident."
 ```
 
-All 5 registered tools were exercised in this single turn, and the agent correctly identified the exact synthetic probe query. Remove the demo store file when done (no edit to your real store needed):
+All 5 registered tools were exercised in this single turn, and the agent correctly identified the exact synthetic probe query.
+
+Teardown -- remove the demo store file and unset every demo variable, so nothing lingers in the shell to affect a later command:
 
 ```bash
 rm -f "$OPENSRE_INTEGRATIONS_STORE_PATH"
-```
-
-Teardown:
-
-```bash
+unset OPENSRE_INTEGRATIONS_STORE_PATH
+unset MYSQL_HOST MYSQL_PORT MYSQL_DATABASE MYSQL_USERNAME MYSQL_PASSWORD MYSQL_SSL_MODE
 docker rm -f mysql-dev
 ```
 

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -96,13 +96,17 @@ Three notes on these grants, each confirmed against a real server:
 ### Quick local test with Docker
 
 ```bash
-docker run -d --name mysql-dev -p 3307:3306 \
+docker run -d --name mysql-dev -p 127.0.0.1:3307:3306 \
   -e MYSQL_ROOT_PASSWORD=rootpass \
   -e MYSQL_DATABASE=app_db \
   mysql:8.0
 ```
 
 Wait for it to become healthy, then create the read-only user and a table to inspect:
+
+```bash
+until docker exec mysql-dev mysqladmin ping -uroot -prootpass --silent 2>/dev/null; do sleep 2; done
+```
 
 ```bash
 docker exec mysql-dev mysql -uroot -prootpass -e "

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -71,18 +71,23 @@ MYSQL_SSL_MODE=preferred   # preferred, required, or disabled
 ```sql
 CREATE USER 'opensre_readonly'@'%' IDENTIFIED BY 'secure-password';
 GRANT PROCESS ON *.* TO 'opensre_readonly'@'%';
+GRANT REPLICATION CLIENT ON *.* TO 'opensre_readonly'@'%';
 GRANT SELECT ON performance_schema.* TO 'opensre_readonly'@'%';
 GRANT SELECT ON your_database.* TO 'opensre_readonly'@'%';
 FLUSH PRIVILEGES;
 ```
 
-`information_schema` needs no explicit grant — MySQL exposes it automatically based on a
-user's other privileges, and `GRANT SELECT ON information_schema.*` is rejected outright
-(`ERROR 1044`). Reproduced live: that line aborts the script before the `performance_schema`
-grant runs, silently leaving slow-query data unavailable. The grant on the **target
-database** (`MYSQL_DATABASE`) is also required — the connector selects it as the default
-schema on connect, and without at least `SELECT` there, every tool call fails with
-`Access denied ... to database`, even though the user is otherwise fully configured.
+Three notes on these grants, each confirmed against a real server:
+
+- `information_schema` needs no explicit grant — MySQL exposes it automatically based on a
+  user's other privileges. `GRANT SELECT ON information_schema.*` is rejected outright
+  (`ERROR 1044`) and aborts the script before later grants run.
+- The grant on the **target database** (`MYSQL_DATABASE`) is required — the connector
+  selects it as the default schema on connect, and without it every tool call fails with
+  `Access denied ... to database`.
+- `REPLICATION CLIENT` is required for `get_mysql_replication_status` (`SHOW REPLICA STATUS`
+  / `SHOW SLAVE STATUS`) — without it, that one tool returns an access-denied error even
+  though `integrations verify mysql` and the other four tools pass.
 
 <Info>
 `performance_schema` is enabled by default in MySQL 5.7+. Slow query data will not be available if it has been explicitly disabled in `my.cnf`.
@@ -103,6 +108,7 @@ Wait for it to become healthy, then create the read-only user and a table to ins
 docker exec mysql-dev mysql -uroot -prootpass -e "
 CREATE USER 'opensre_readonly'@'%' IDENTIFIED BY 'secure-password';
 GRANT PROCESS ON *.* TO 'opensre_readonly'@'%';
+GRANT REPLICATION CLIENT ON *.* TO 'opensre_readonly'@'%';
 GRANT SELECT ON performance_schema.* TO 'opensre_readonly'@'%';
 GRANT SELECT ON app_db.* TO 'opensre_readonly'@'%';
 FLUSH PRIVILEGES;
@@ -132,7 +138,7 @@ mysql   │ local env │ ✓ passed │ Connected to MySQL 8.0.46
         │           │          │ target database: app_db.
 ```
 
-Call `get_mysql_table_stats` directly:
+`get_mysql_table_stats` is what the agent calls internally during an investigation — call it directly here only to see the real shape of its result (internal, not a public API, and may move):
 
 ```python
 from integrations.mysql.tools.mysql_table_stats_tool import get_mysql_table_stats

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -142,28 +142,68 @@ mysql   │ local env │ ✓ passed │ Connected to MySQL 8.0.46
         │           │          │ target database: app_db.
 ```
 
-`get_mysql_table_stats` is what the agent calls internally during an investigation — call it directly here only to see the real shape of its result (internal, not a public API, and may move):
+Register the local instance in the persistent store — `opensre investigate` only treats an integration as active once it is in the store, unlike `verify` which also accepts plain env vars:
 
 ```python
-from integrations.mysql.tools.mysql_table_stats_tool import get_mysql_table_stats
-get_mysql_table_stats(host="127.0.0.1", database="app_db", port=3307)
+import json, pathlib
+
+path = pathlib.Path.home() / ".opensre" / "integrations.json"
+store = json.loads(path.read_text()) if path.exists() else {"version": 2, "integrations": []}
+store["integrations"] = [i for i in store["integrations"] if i["id"] != "mysql-local-demo"]
+store["integrations"].append({
+    "id": "mysql-local-demo",
+    "service": "mysql",
+    "status": "active",
+    "instances": [{"name": "default", "tags": {}, "credentials": {
+        "host": "127.0.0.1", "port": 3307, "database": "app_db",
+        "username": "opensre_readonly", "password": "secure-password", "ssl_mode": "disabled",
+    }}],
+})
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(store, indent=2))
 ```
 
-```json
-{
-  "source": "mysql",
-  "available": true,
-  "database": "app_db",
-  "total_tables": 1,
-  "tables": [
-    {
-      "table_name": "orders",
-      "engine": "InnoDB",
-      "row_count_estimate": 2,
-      "size": {"data_mb": 0.016, "index_mb": 0.0, "total_mb": 0.016}
-    }
-  ]
-}
+Kick off a long-running query so there is something real to investigate, then trigger a real investigation — this is the actual supported entrypoint, not an internal import:
+
+```bash
+docker exec -d mysql-dev mysql -uroot -prootpass -e "SELECT SLEEP(30);"
+
+opensre investigate --input-json '{
+  "alert_name": "MySQLLongRunningQuery",
+  "severity": "warning",
+  "commonAnnotations": {
+    "summary": "app_db MySQL instance has a long-running query blocking other connections"
+  }
+}'
+```
+
+Real output from a run against this exact local instance (edited for length):
+
+```
+Loading integrations: telegram, mysql
+↳ MySQL · get mysql current processes
+↳ MySQL · get mysql server status
+↳ MySQL · get mysql slow queries
+↳ MySQL · get mysql table stats
+↳ MySQL · get mysql replication status
+
+root_cause: "A single SELECT SLEEP(30) was executed by root@localhost on
+a freshly started MySQL 8.0.46 instance (uptime 32s), which tripped the
+long-running-query alert. All other health signals (connections, locks,
+buffer pool, slow queries, replication, table sizes) are clean,
+indicating no real workload impact -- this is a synthetic/manual probe,
+not a real incident."
+```
+
+All 5 registered tools were exercised in this single turn, and the agent correctly identified the exact synthetic probe query. Remove the demo entry when done:
+
+```python
+import json, pathlib
+
+path = pathlib.Path.home() / ".opensre" / "integrations.json"
+store = json.loads(path.read_text())
+store["integrations"] = [i for i in store["integrations"] if i["id"] != "mysql-local-demo"]
+path.write_text(json.dumps(store, indent=2))
 ```
 
 Teardown:

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -105,7 +105,12 @@ docker run -d --name mysql-dev -p 127.0.0.1:3307:3306 \
 Wait for it to become healthy, then create the read-only user and a table to inspect:
 
 ```bash
-i=0; until docker exec mysql-dev mysqladmin ping -uroot -prootpass --silent 2>/dev/null || [ $i -ge 30 ]; do sleep 2; i=$((i+1)); done
+i=0
+until docker exec mysql-dev mysqladmin ping -uroot -prootpass --silent 2>/dev/null; do
+  i=$((i + 1))
+  [ "$i" -ge 30 ] && { echo "ERROR: MySQL never became ready" >&2; exit 1; }
+  sleep 2
+done
 [ $i -lt 30 ] || { echo "ERROR: MySQL never became ready" >&2; exit 1; }
 ```
 
@@ -143,15 +148,15 @@ mysql   │ local env │ ✓ passed │ Connected to MySQL 8.0.46
         │           │          │ target database: app_db.
 ```
 
-Register the local instance in the persistent store — `opensre investigate` only treats an integration as active once it is in the store, unlike `verify` which also accepts plain env vars:
+Register the local instance in the store. `opensre integrations setup mysql` is interactive; for a scriptable demo, write directly into an isolated store file instead of `~/.opensre/integrations.json` — `OPENSRE_INTEGRATIONS_STORE_PATH` is a genuine, first-class override (`config/constants/tenancy.py`), so this never touches your real config or exposes the demo password there:
 
 ```bash
+export OPENSRE_INTEGRATIONS_STORE_PATH=$(mktemp /tmp/opensre-mysql-demo.XXXXXX)
 python3 <<'PYEOF'
-import json, pathlib
+import json, os, pathlib
 
-path = pathlib.Path.home() / ".opensre" / "integrations.json"
-store = json.loads(path.read_text()) if path.exists() else {"version": 2, "integrations": []}
-store["integrations"] = [i for i in store["integrations"] if i["id"] != "mysql-local-demo"]
+path = pathlib.Path(os.environ["OPENSRE_INTEGRATIONS_STORE_PATH"])
+store = json.loads(path.read_text()) if path.stat().st_size else {"version": 2, "integrations": []}
 store["integrations"].append({
     "id": "mysql-local-demo",
     "service": "mysql",
@@ -183,7 +188,7 @@ opensre investigate --input-json '{
 Real output from a run against this exact local instance (edited for length):
 
 ```
-Loading integrations: telegram, mysql
+Loading integrations: mysql
 ↳ MySQL · get mysql current processes
 ↳ MySQL · get mysql server status
 ↳ MySQL · get mysql slow queries
@@ -198,17 +203,10 @@ indicating no real workload impact -- this is a synthetic/manual probe,
 not a real incident."
 ```
 
-All 5 registered tools were exercised in this single turn, and the agent correctly identified the exact synthetic probe query. Remove the demo entry when done:
+All 5 registered tools were exercised in this single turn, and the agent correctly identified the exact synthetic probe query. Remove the demo store file when done (no edit to your real store needed):
 
 ```bash
-python3 <<'PYEOF'
-import json, pathlib
-
-path = pathlib.Path.home() / ".opensre" / "integrations.json"
-store = json.loads(path.read_text())
-store["integrations"] = [i for i in store["integrations"] if i["id"] != "mysql-local-demo"]
-path.write_text(json.dumps(store, indent=2))
-PYEOF
+rm -f "$OPENSRE_INTEGRATIONS_STORE_PATH"
 ```
 
 Teardown:

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -105,7 +105,8 @@ docker run -d --name mysql-dev -p 127.0.0.1:3307:3306 \
 Wait for it to become healthy, then create the read-only user and a table to inspect:
 
 ```bash
-until docker exec mysql-dev mysqladmin ping -uroot -prootpass --silent 2>/dev/null; do sleep 2; done
+i=0; until docker exec mysql-dev mysqladmin ping -uroot -prootpass --silent 2>/dev/null || [ $i -ge 30 ]; do sleep 2; i=$((i+1)); done
+[ $i -lt 30 ] || { echo "ERROR: MySQL never became ready" >&2; exit 1; }
 ```
 
 ```bash
@@ -144,7 +145,8 @@ mysql   │ local env │ ✓ passed │ Connected to MySQL 8.0.46
 
 Register the local instance in the persistent store — `opensre investigate` only treats an integration as active once it is in the store, unlike `verify` which also accepts plain env vars:
 
-```python
+```bash
+python3 <<'PYEOF'
 import json, pathlib
 
 path = pathlib.Path.home() / ".opensre" / "integrations.json"
@@ -161,6 +163,7 @@ store["integrations"].append({
 })
 path.parent.mkdir(parents=True, exist_ok=True)
 path.write_text(json.dumps(store, indent=2))
+PYEOF
 ```
 
 Kick off a long-running query so there is something real to investigate, then trigger a real investigation — this is the actual supported entrypoint, not an internal import:
@@ -197,13 +200,15 @@ not a real incident."
 
 All 5 registered tools were exercised in this single turn, and the agent correctly identified the exact synthetic probe query. Remove the demo entry when done:
 
-```python
+```bash
+python3 <<'PYEOF'
 import json, pathlib
 
 path = pathlib.Path.home() / ".opensre" / "integrations.json"
 store = json.loads(path.read_text())
 store["integrations"] = [i for i in store["integrations"] if i["id"] != "mysql-local-demo"]
 path.write_text(json.dumps(store, indent=2))
+PYEOF
 ```
 
 Teardown:

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -71,14 +71,96 @@ MYSQL_SSL_MODE=preferred   # preferred, required, or disabled
 ```sql
 CREATE USER 'opensre_readonly'@'%' IDENTIFIED BY 'secure-password';
 GRANT PROCESS ON *.* TO 'opensre_readonly'@'%';
-GRANT SELECT ON information_schema.* TO 'opensre_readonly'@'%';
 GRANT SELECT ON performance_schema.* TO 'opensre_readonly'@'%';
+GRANT SELECT ON your_database.* TO 'opensre_readonly'@'%';
 FLUSH PRIVILEGES;
 ```
+
+`information_schema` needs no explicit grant — MySQL exposes it automatically based on a
+user's other privileges, and `GRANT SELECT ON information_schema.*` is rejected outright
+(`ERROR 1044`). Reproduced live: that line aborts the script before the `performance_schema`
+grant runs, silently leaving slow-query data unavailable. The grant on the **target
+database** (`MYSQL_DATABASE`) is also required — the connector selects it as the default
+schema on connect, and without at least `SELECT` there, every tool call fails with
+`Access denied ... to database`, even though the user is otherwise fully configured.
 
 <Info>
 `performance_schema` is enabled by default in MySQL 5.7+. Slow query data will not be available if it has been explicitly disabled in `my.cnf`.
 </Info>
+
+### Quick local test with Docker
+
+```bash
+docker run -d --name mysql-dev -p 3307:3306 \
+  -e MYSQL_ROOT_PASSWORD=rootpass \
+  -e MYSQL_DATABASE=app_db \
+  mysql:8.0
+```
+
+Wait for it to become healthy, then create the read-only user and a table to inspect:
+
+```bash
+docker exec mysql-dev mysql -uroot -prootpass -e "
+CREATE USER 'opensre_readonly'@'%' IDENTIFIED BY 'secure-password';
+GRANT PROCESS ON *.* TO 'opensre_readonly'@'%';
+GRANT SELECT ON performance_schema.* TO 'opensre_readonly'@'%';
+GRANT SELECT ON app_db.* TO 'opensre_readonly'@'%';
+FLUSH PRIVILEGES;
+CREATE TABLE app_db.orders (id INT PRIMARY KEY, amount DECIMAL(10,2));
+INSERT INTO app_db.orders VALUES (1, 42.50), (2, 17.00);
+"
+```
+
+```bash
+export MYSQL_HOST=127.0.0.1
+export MYSQL_PORT=3307
+export MYSQL_DATABASE=app_db
+export MYSQL_USERNAME=opensre_readonly
+export MYSQL_PASSWORD=secure-password
+export MYSQL_SSL_MODE=disabled
+```
+
+Verify:
+
+```bash
+opensre integrations verify mysql
+```
+
+```
+SERVICE │ SOURCE    │ STATUS   │ DETAIL
+mysql   │ local env │ ✓ passed │ Connected to MySQL 8.0.46
+        │           │          │ target database: app_db.
+```
+
+Call `get_mysql_table_stats` directly:
+
+```python
+from integrations.mysql.tools.mysql_table_stats_tool import get_mysql_table_stats
+get_mysql_table_stats(host="127.0.0.1", database="app_db", port=3307)
+```
+
+```json
+{
+  "source": "mysql",
+  "available": true,
+  "database": "app_db",
+  "total_tables": 1,
+  "tables": [
+    {
+      "table_name": "orders",
+      "engine": "InnoDB",
+      "row_count_estimate": 2,
+      "size": {"data_mb": 0.016, "index_mb": 0.0, "total_mb": 0.016}
+    }
+  ]
+}
+```
+
+Teardown:
+
+```bash
+docker rm -f mysql-dev
+```
 
 ## Investigation tools
 
@@ -112,6 +194,7 @@ Detail: Connected to MySQL 8.0.32; target database: application_db
 | **Authentication failed** | Confirm user host (`'user'@'%'` or specific IP) |
 | **SSL error** | Try `MYSQL_SSL_MODE=disabled` or `required` |
 | **Access denied on performance_schema** | Grant `SELECT ON performance_schema.*` |
+| **Access denied to database** on verify/tool calls | Grant `SELECT ON <your_database>.*` — the connector selects `MYSQL_DATABASE` as its default schema on connect |
 | **Slow query data empty** | Confirm `performance_schema=ON` and restart MySQL |
 | **Replication shows empty** | Expected on primary — other tools still work |
 


### PR DESCRIPTION
Part of #5137

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Verified the 5 registered MySQL tools live against a fresh `mysql:8.0` container. The tools themselves have no bug, but the documented "Creating a read-only user" SQL does: `GRANT SELECT ON information_schema.*` is invalid in MySQL 8 (`ERROR 1044`) and aborts the script before the `performance_schema` grant on the next line runs — reproduced live, following the doc verbatim silently leaves slow-query data unavailable. Separately, the target database (`MYSQL_DATABASE`) also needs an explicit `SELECT` grant since the connector selects it as the default schema on connect; without it every tool call fails with `Access denied ... to database`, also reproduced live. Fixed both in the SQL block, added a troubleshooting row, and added a local Docker recipe with real verify + tool output.

### Demo/Screenshot for feature changes and bug fixes -

```
$ opensre integrations verify mysql
SERVICE │ SOURCE    │ STATUS   │ DETAIL
mysql   │ local env │ ✓ passed │ Connected to MySQL 8.0.46
        │           │          │ target database: app_db.
```

```json
{"source": "mysql", "available": true, "database": "app_db", "total_tables": 1, "tables": [{"table_name": "orders", "engine": "InnoDB", "row_count_estimate": 2}]}
```

Every command in the doc was run verbatim against a real local MySQL container, including reproducing both grant failures before fixing them.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Docs-only change, no application code. Set out to add a local recipe for a "no bug" verify issue, and hit two real failures following the doc's own credential SQL verbatim: an invalid `information_schema` grant that silently skips the following grant statement, and a missing grant on the target database that breaks every tool call. Both are genuine documentation defects independent of the recipe — fixed the SQL, explained why in prose (not just a diff), and added a troubleshooting row so the next person doesn't have to rediscover it by trial and error.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

