### PR TITLE
refactor(tool): a contract door, and a Protocol that ends the LLM↔tool cycle

### DIFF
--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -50,7 +50,7 @@ from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.agent_harness.turns.wal_recorder import with_wal_recording
 from core.events import runtime_event_callback_from_observer
 from core.llm.failure_classification import is_context_length_overflow
-from core.llm.types import AgentLLMResponse, ToolCall
+from core.llm.types import AgentLLMResponse, SchemaDescribedTool, ToolCall
 from core.llm_invoke_errors import remediate_missing_llm_credentials
 from core.tool.execution import (
     BeforeToolCallResult,
@@ -250,7 +250,7 @@ class _StaticToolCallLLM:
         self._tool_calls = tool_calls
         self._used = False
 
-    def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+    def tool_schemas(self, _tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
         return []
 
     def invoke(

--- a/core/llm/shared/tool_schema_normalize.py
+++ b/core/llm/shared/tool_schema_normalize.py
@@ -6,7 +6,10 @@ Provider adapters choose which keys to strip (e.g. Bedrock Converse rejects
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
+
+from core.llm.types import SchemaDescribedTool
 
 # Keys rejected or unresolvable by strict HTTP tool-schema APIs.
 COMMON_UNSUPPORTED_SCHEMA_KEYS = frozenset(
@@ -207,6 +210,6 @@ def _openai_tool_schema(tool: Any) -> dict[str, Any]:
     }
 
 
-def build_openai_tool_specs(tools: list[Any]) -> list[dict[str, Any]]:
+def build_openai_tool_specs(tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
     """Build OpenAI chat ``tools`` entries from registered tool objects."""
     return [_openai_tool_schema(t) for t in tools]

--- a/core/llm/transports/litellm/clients.py
+++ b/core/llm/transports/litellm/clients.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from typing import Any
 
 from core.llm.transports.litellm.frozen_tiktoken_bootstrap import (
@@ -32,7 +32,12 @@ from core.llm.shared.openai_chat_completions import (  # noqa: E402
 )
 from core.llm.shared.structured_output import StructuredOutputClient  # noqa: E402
 from core.llm.shared.tool_schema_normalize import build_openai_tool_specs  # noqa: E402
-from core.llm.types import AgentLLMResponse, LLMResponse, ToolCall  # noqa: E402
+from core.llm.types import (  # noqa: E402
+    AgentLLMResponse,
+    LLMResponse,
+    SchemaDescribedTool,
+    ToolCall,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +82,7 @@ class LiteLLMAgentClient:
     def model_id(self) -> str | None:
         return self._litellm_model
 
-    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+    def tool_schemas(self, tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
         return build_openai_tool_specs(tools)
 
     def _completion(self, **kwargs: Any) -> Any:

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -10,7 +10,7 @@ import logging
 import os
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from core.context_budget import strip_internal_message_markers
@@ -50,7 +50,7 @@ from core.llm.transports.sdk.anthropic_cache import (
 from core.llm.transports.sdk.anthropic_cache import (
     tools_with_cache as _anthropic_tools_with_cache,
 )
-from core.llm.types import AgentLLMResponse, ModelType, ToolCall
+from core.llm.types import AgentLLMResponse, ModelType, SchemaDescribedTool, ToolCall
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ class AnthropicAgentClient:
     def model_id(self) -> str | None:
         return self._model
 
-    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+    def tool_schemas(self, tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
         return [_anthropic_tool_schema(t) for t in tools]
 
     def describe_image(
@@ -408,7 +408,7 @@ class BedrockConverseAgentClient:
     def model_id(self) -> str | None:
         return self._model
 
-    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+    def tool_schemas(self, tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
         from core.llm.transports.sdk.bedrock_converse import build_converse_tool_specs
 
         return build_converse_tool_specs(tools)
@@ -578,7 +578,7 @@ class OpenAIAgentClient:
             return override
         return api_key_env.removesuffix("_API_KEY").replace("_", " ").title()
 
-    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+    def tool_schemas(self, tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
         return build_openai_tool_specs(tools)
 
     def describe_image(
@@ -808,10 +808,13 @@ class CLIBackedAgentClient:
     def model_id(self) -> str | None:
         return self._model
 
-    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
-        # Return the same dicts — used only to pass back into invoke() below.
+    def tool_schemas(self, tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
+        # ``public_input_schema``, not ``input_schema``: injected parameters
+        # (credentials, endpoints) are pruned from what the model is shown. The
+        # other clients already did this; this one did not, so on a CLI-backed
+        # model a tool advertised its own ``github_token`` as fillable.
         return [
-            {"name": t.name, "description": t.description, "input_schema": t.input_schema}
+            {"name": t.name, "description": t.description, "input_schema": t.public_input_schema}
             for t in tools
         ]
 

--- a/core/llm/transports/sdk/bedrock_converse.py
+++ b/core/llm/transports/sdk/bedrock_converse.py
@@ -6,12 +6,14 @@ import json
 import logging
 import os
 import secrets
+from collections.abc import Sequence
 from typing import Any
 
 from core.llm.shared.tool_schema_normalize import (
     BEDROCK_UNSUPPORTED_SCHEMA_KEYS,
     normalize_object_tool_input_schema,
 )
+from core.llm.types import SchemaDescribedTool
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +39,7 @@ def normalize_tool_input_schema(schema: dict[str, Any] | None) -> dict[str, Any]
     )
 
 
-def build_converse_tool_specs(tools: list[Any]) -> list[dict[str, Any]]:
+def build_converse_tool_specs(tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
     """Build ``toolConfig.tools`` entries from registered tool objects."""
     specs: list[dict[str, Any]] = []
     for tool in tools:

--- a/core/llm/types.py
+++ b/core/llm/types.py
@@ -2,14 +2,37 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Protocol, TypeAlias, runtime_checkable
 
-from core.tool.contracts import RuntimeTool
-
 ResolvedIntegrations: TypeAlias = dict[str, Any]  # noqa: UP040
+
+
+@runtime_checkable
+class SchemaDescribedTool(Protocol):
+    """The three attributes a provider reads to build a tool-schema payload.
+
+    Stated here rather than imported from the tool tier. Naming the tool union
+    put ``core.llm`` on a path back into ``core.tool``, which closed a package
+    cycle the moment ``core/tool/__init__`` grew imports — and it bought nothing:
+    every provider client widened the parameter to ``list[Any]`` anyway. This is
+    what ``_anthropic_tool_schema`` and ``build_converse_tool_specs`` actually
+    read.
+    """
+
+    @property
+    def name(self) -> str:
+        """Identifier the provider and the model see."""
+
+    @property
+    def description(self) -> str:
+        """One-line description sent to the model."""
+
+    @property
+    def public_input_schema(self) -> dict[str, Any]:
+        """JSON Schema for the arguments, with internal parameters removed."""
 
 
 class ModelType(StrEnum):
@@ -93,9 +116,7 @@ class AgentLLMClient(Protocol):
     def model_id(self) -> str | None:
         """The provider model identifier, used for context-budget sizing (may be None)."""
 
-    def tool_schemas[RuntimeToolT: RuntimeTool](
-        self, tools: list[RuntimeToolT]
-    ) -> list[dict[str, Any]]:
+    def tool_schemas(self, tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
         """Translate runtime tools into the provider's tool-schema payloads."""
 
     def invoke(

--- a/core/tool/__init__.py
+++ b/core/tool/__init__.py
@@ -1,0 +1,40 @@
+"""The tool contract: what a tool is, how it runs, and where it is registered."""
+
+from core.tool.contracts import (
+    REGISTERED_TOOL_ATTR,
+    AgentToolContext,
+    BaseTool,
+    EvidenceType,
+    RegisteredTool,
+    RuntimeTool,
+    SideEffectLevel,
+    ToolSurface,
+)
+from core.tool.execution import (
+    BeforeToolCallResult,
+    ToolExecutionHooks,
+    ToolExecutionRequest,
+    ToolExecutionResult,
+    availability_view,
+    report_run_error,
+)
+from core.tool.registry import ToolRegistry, normalize_surfaces
+
+__all__ = [
+    "REGISTERED_TOOL_ATTR",
+    "AgentToolContext",
+    "BaseTool",
+    "BeforeToolCallResult",
+    "EvidenceType",
+    "RegisteredTool",
+    "RuntimeTool",
+    "SideEffectLevel",
+    "ToolExecutionHooks",
+    "ToolExecutionRequest",
+    "ToolExecutionResult",
+    "ToolRegistry",
+    "ToolSurface",
+    "availability_view",
+    "normalize_surfaces",
+    "report_run_error",
+]

--- a/gateway/core/middleware/approvals.py
+++ b/gateway/core/middleware/approvals.py
@@ -22,7 +22,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from core.tool.execution import BeforeToolCallResult, ToolExecutionHooks, ToolExecutionRequest
+from core.tool import BeforeToolCallResult, ToolExecutionHooks, ToolExecutionRequest
 from gateway.core.storage.security_audit import audit_security_action
 
 APPROVE_ACTION_ID = "opensre_approval_approve"

--- a/gateway/tests/main/test_antartica_slack.py
+++ b/gateway/tests/main/test_antartica_slack.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Sequence
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -23,7 +24,7 @@ from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.tools.action_tools import action_tool_names
 from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import ActionTurnRunner
-from core.llm.types import AgentLLMResponse, ToolCall
+from core.llm.types import AgentLLMResponse, SchemaDescribedTool, ToolCall
 from tools.interactive_shell.subprocess_presenter import (
     headless_subprocess_presenter_factory,
 )
@@ -61,7 +62,7 @@ class _ComputeThenSlackLLM:
         self.review_calls = 0
         self.sent_slack_message: str | None = None
 
-    def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+    def tool_schemas(self, _tools: Sequence[SchemaDescribedTool]) -> list[dict[str, Any]]:
         return []
 
     def invoke(

--- a/gateway/transports/slack/delivery/turn_output.py
+++ b/gateway/transports/slack/delivery/turn_output.py
@@ -16,7 +16,7 @@ import threading
 import time
 from collections.abc import Iterable
 
-from core.tool.execution import ToolExecutionHooks
+from core.tool import ToolExecutionHooks
 from gateway.transports.slack.client import (
     SLACK_MAX_MARKDOWN_BLOCK_CHARS,
     SLACK_MAX_MESSAGE_CHARS,

--- a/integrations/alertmanager/tools/__init__.py
+++ b/integrations/alertmanager/tools/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.alertmanager.client import make_alertmanager_client
 
@@ -179,7 +179,7 @@ Useful for understanding whether an alert was intentionally suppressed
 """
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class AlertmanagerSilencesTool(BaseTool):

--- a/integrations/argocd/tools/__init__.py
+++ b/integrations/argocd/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.argocd.client import make_argocd_client
 
@@ -140,7 +140,7 @@ argocd_application_diff = ArgoCDApplicationDiffTool()
 """Argo CD application status investigation tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class ArgoCDApplicationStatusTool(BaseTool):

--- a/integrations/azure/tools/azure_monitor_logs_tool/__init__.py
+++ b/integrations/azure/tools/azure_monitor_logs_tool/__init__.py
@@ -12,7 +12,7 @@ from config.constants.azure import (
     AZURE_MAX_RESULTS_HARD_LIMIT,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 

--- a/integrations/buzz/tools/buzz_send_message_tool/tool.py
+++ b/integrations/buzz/tools/buzz_send_message_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.buzz.tools.buzz_send_message_tool.constants import SOURCE
 from integrations.buzz.tools.buzz_send_message_tool.delivery import (

--- a/integrations/cloudwatch/tools/cloudwatch_batch_metrics_tool/__init__.py
+++ b/integrations/cloudwatch/tools/cloudwatch_batch_metrics_tool/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from integrations.aws.cloudwatch_client import get_metric_statistics
 from integrations.cloudwatch.availability import cloudwatch_is_available

--- a/integrations/cloudwatch/tools/cloudwatch_logs_tool/__init__.py
+++ b/integrations/cloudwatch/tools/cloudwatch_logs_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import boto3
 
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 
 

--- a/integrations/coralogix/tools/__init__.py
+++ b/integrations/coralogix/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.config_models import CoralogixIntegrationConfig
 from integrations.coralogix.client import (

--- a/integrations/datadog/tools/__init__.py
+++ b/integrations/datadog/tools/__init__.py
@@ -9,7 +9,7 @@ import concurrent.futures
 import re
 from typing import Any
 
-from core.tool.contracts import EvidenceType, SideEffectLevel
+from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.datadog._client import make_async_client

--- a/integrations/eks/tools/__init__.py
+++ b/integrations/eks/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from core.tool.contracts import EvidenceType, SideEffectLevel
+from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.eks_k8s_client import build_k8s_clients
@@ -112,7 +112,7 @@ def get_eks_deployment_status(
 
 from botocore.exceptions import ClientError
 
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from integrations.eks.eks_client import EKSClient
 

--- a/integrations/elasticsearch/tools/__init__.py
+++ b/integrations/elasticsearch/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from integrations.elasticsearch._client import make_client, unavailable
 from platform.evidence.evidence_compaction import compact_logs, summarize_counts
 

--- a/integrations/github/tools/architecture_issue_tool/tool.py
+++ b/integrations/github/tools/architecture_issue_tool/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.agent_harness.tools import action_context_from_agent_context
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.tools.architecture_issue_tool.repo_workspace import (
     WorkspaceError,

--- a/integrations/github/tools/ci_fix/tool.py
+++ b/integrations/github/tools/ci_fix/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.agent_harness.tools import action_context_from_agent_context
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token

--- a/integrations/github/tools/github_cli/tool.py
+++ b/integrations/github/tools/github_cli/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.tools.github_cli.credentials import (
     GITHUB_CLI_INJECTED_PARAMS,

--- a/integrations/github/tools/repository.py
+++ b/integrations/github/tools/repository.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
-from core.tool.execution import report_run_error
+from core.tool import SideEffectLevel, report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token

--- a/integrations/github/tools/security_fix/tool.py
+++ b/integrations/github/tools/security_fix/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.agent_harness.tools import action_context_from_agent_context
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (

--- a/integrations/github/tools/stargazers.py
+++ b/integrations/github/tools/stargazers.py
@@ -8,8 +8,7 @@ from math import ceil
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
-from core.tool.execution import report_run_error
+from core.tool import SideEffectLevel, report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token

--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -6,7 +6,7 @@ import math
 from typing import Any, Literal, cast
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token

--- a/integrations/github/tools/work_status_report_tool/__init__.py
+++ b/integrations/github/tools/work_status_report_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (

--- a/integrations/google_docs/tools/__init__.py
+++ b/integrations/google_docs/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from integrations.config_models import GoogleDocsIntegrationConfig
 from integrations.google_docs.client import GoogleDocsClient

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import EvidenceType, SideEffectLevel
+from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 

--- a/integrations/helm/tools/__init__.py
+++ b/integrations/helm/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from integrations.helm.helpers import helm_base_unavailable, helm_client_for_run
 
 

--- a/integrations/honeycomb/tools/__init__.py
+++ b/integrations/honeycomb/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.honeycomb.client import HoneycombClient
 from integrations.honeycomb.config import HoneycombIntegrationConfig

--- a/integrations/incident_io/tools/__init__.py
+++ b/integrations/incident_io/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.incident_io.client import make_incident_io_client
 

--- a/integrations/jira/tools/__init__.py
+++ b/integrations/jira/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.jira.client import make_jira_client
 
@@ -105,7 +105,7 @@ jira_add_comment = JiraAddCommentTool()
 """Jira issue creation tool for investigation workflows."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class JiraCreateIssueTool(BaseTool):
@@ -234,7 +234,7 @@ jira_create_issue = JiraCreateIssueTool()
 """Jira issue detail tool for investigation workflows."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class JiraIssueDetailTool(BaseTool):
@@ -333,7 +333,7 @@ jira_issue_detail = JiraIssueDetailTool()
 """Jira issue search tool for investigation workflows."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class JiraSearchIssuesTool(BaseTool):

--- a/integrations/kubernetes/tools/__init__.py
+++ b/integrations/kubernetes/tools/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.config_models import KubernetesIntegrationConfig
 from integrations.kubernetes.client import _RESOURCE_DISPATCH, KubernetesClient

--- a/integrations/new_relic/tools/new_relic_alerts_tool/tool.py
+++ b/integrations/new_relic/tools/new_relic_alerts_tool/tool.py
@@ -8,7 +8,7 @@ from config.constants.new_relic import (
     NEW_RELIC_DEFAULT_INCIDENT_LIMIT,
     NEW_RELIC_DEFAULT_WINDOW_MINUTES,
 )
-from core.tool.contracts import BaseTool, EvidenceType, SideEffectLevel
+from core.tool import BaseTool, EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.new_relic.client import NewRelicClient

--- a/integrations/new_relic/tools/new_relic_metrics_tool/tool.py
+++ b/integrations/new_relic/tools/new_relic_metrics_tool/tool.py
@@ -8,7 +8,7 @@ from config.constants.new_relic import (
     NEW_RELIC_DEFAULT_INCIDENT_LIMIT,
     NEW_RELIC_DEFAULT_WINDOW_MINUTES,
 )
-from core.tool.contracts import BaseTool, EvidenceType, SideEffectLevel
+from core.tool import BaseTool, EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.new_relic.client import NewRelicClient

--- a/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
@@ -15,7 +15,7 @@ Package layout (separation of concerns):
 from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import build_mcp_tool_listing
 from integrations.openclaw import (

--- a/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
+++ b/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 import httpx
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 

--- a/integrations/opsgenie/tools/__init__.py
+++ b/integrations/opsgenie/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.opsgenie.client import make_opsgenie_client
 
@@ -128,7 +128,7 @@ opsgenie_alert_detail = OpsGenieAlertDetailTool()
 """OpsGenie alert listing and search investigation tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 _OPEN_STATUSES = {"open"}
 

--- a/integrations/pagerduty/tools/__init__.py
+++ b/integrations/pagerduty/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.pagerduty.client import make_pagerduty_client
 
@@ -131,7 +131,7 @@ pagerduty_incident_detail = PagerDutyIncidentDetailTool()
 """PagerDuty incident listing and search investigation tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 _ACTIVE_STATUSES = {"triggered", "acknowledged"}
 
@@ -280,7 +280,7 @@ pagerduty_incidents = PagerDutyIncidentsTool()
 """PagerDuty on-call schedule investigation tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class PagerDutyOnCallTool(BaseTool):
@@ -382,7 +382,7 @@ pagerduty_oncall = PagerDutyOnCallTool()
 """PagerDuty services and escalation policies investigation tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class PagerDutyServicesTool(BaseTool):

--- a/integrations/pi/tools/pi_coding_tool/__init__.py
+++ b/integrations/pi/tools/pi_coding_tool/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from integrations.pi import is_pi_coding_enabled
 from integrations.pi.tools.pi_coding_tool.errors import PiCodingError
 from integrations.pi.tools.pi_coding_tool.runner import (

--- a/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import EvidenceType, SideEffectLevel
+from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (

--- a/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import EvidenceType, SideEffectLevel
+from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (

--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
@@ -14,7 +14,7 @@ import re
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import (
     build_mcp_tool_listing,

--- a/integrations/prefect/tools/__init__.py
+++ b/integrations/prefect/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.prefect.client import make_prefect_client
 
@@ -206,7 +206,7 @@ prefect_flow_runs = PrefectFlowRunsTool()
 """Prefect worker and work pool health investigation tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 _UNHEALTHY_WORKER_STATUSES = {"OFFLINE", "UNHEALTHY"}
 _UNHEALTHY_POOL_STATUSES = {"NOT_READY", "PAUSED"}

--- a/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
+++ b/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar
 
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.config_models import RailwayIntegrationConfig
 from integrations.railway.client import (

--- a/integrations/railway/tools/railway_deployment_tool/redeploy_tool.py
+++ b/integrations/railway/tools/railway_deployment_tool/redeploy_tool.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar
 
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.config_models import RailwayIntegrationConfig
 from integrations.railway.client import (

--- a/integrations/rds/tools/rds_describe_instance_tool/__init__.py
+++ b/integrations/rds/tools/rds_describe_instance_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
-from core.tool.contracts import EvidenceType, SideEffectLevel
+from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call

--- a/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
+++ b/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.rocketchat.tools.rocketchat_send_message_tool.constants import SOURCE
 from integrations.rocketchat.tools.rocketchat_send_message_tool.delivery import (

--- a/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from integrations.sentry import (
     SentryConfig,

--- a/integrations/sentry/tools/sentry_search_issues_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_search_issues_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 import httpx
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.sentry import (

--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -10,7 +10,7 @@ individual MCP-side tools.
 from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import (
     build_mcp_tool_listing,

--- a/integrations/slack/tools/slack_add_reaction_tool/tool.py
+++ b/integrations/slack/tools/slack_add_reaction_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id

--- a/integrations/slack/tools/slack_join_channel_tool/tool.py
+++ b/integrations/slack/tools/slack_join_channel_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE

--- a/integrations/slack/tools/slack_list_members_tool/tool.py
+++ b/integrations/slack/tools/slack_list_members_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable

--- a/integrations/slack/tools/slack_read_list_tool/tool.py
+++ b/integrations/slack/tools/slack_read_list_tool/tool.py
@@ -7,7 +7,7 @@ import re
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_list_tool.constants import (

--- a/integrations/slack/tools/slack_read_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_read_messages_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import (

--- a/integrations/slack/tools/slack_reply_message_tool/tool.py
+++ b/integrations/slack/tools/slack_reply_message_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable

--- a/integrations/slack/tools/slack_send_message_tool/tool.py
+++ b/integrations/slack/tools/slack_send_message_tool/tool.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from config.constants.slack import SLACK_WEBHOOK_URL_ENV
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.tools.slack_send_message_tool.constants import SOURCE
 from integrations.slack.tools.slack_send_message_tool.delivery import (

--- a/integrations/slack/tools/slack_thread_replay_tool/tool.py
+++ b/integrations/slack/tools/slack_thread_replay_tool/tool.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar
 
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.slack.thread_client import fetch_thread, parse_thread_ref
 from integrations.slack.web_client import bot_token_configured

--- a/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
+++ b/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 import httpx
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
 

--- a/integrations/splunk/tools/__init__.py
+++ b/integrations/splunk/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from integrations.splunk._client import make_client, unavailable
 from platform.evidence.evidence_compaction import compact_logs, summarize_counts
 

--- a/integrations/telegram/tools/telegram_send_message_tool/tool.py
+++ b/integrations/telegram/tools/telegram_send_message_tool/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from integrations.telegram.tools.telegram_send_message_tool.constants import SOURCE
 from integrations.telegram.tools.telegram_send_message_tool.delivery import (

--- a/integrations/temporal/tools/__init__.py
+++ b/integrations/temporal/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.temporal.client import TemporalClient, TemporalConfig
 
@@ -110,7 +110,7 @@ temporal_namespace_info = TemporalNamespaceInfoTool()
 """Temporal task queue description tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class TemporalTaskQueueTool(BaseTool):
@@ -236,7 +236,7 @@ temporal_task_queue = TemporalTaskQueueTool()
 """Temporal workflow execution history tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class TemporalWorkflowHistoryTool(BaseTool):
@@ -374,7 +374,7 @@ temporal_workflow_history = TemporalWorkflowHistoryTool()
 """Temporal workflow executions listing tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 
 class TemporalWorkflowsTool(BaseTool):

--- a/integrations/twilio/tools/twilio_notify_tool/__init__.py
+++ b/integrations/twilio/tools/twilio_notify_tool/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.twilio.delivery import send_twilio_sms_report
 

--- a/integrations/vercel/tools/__init__.py
+++ b/integrations/vercel/tools/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.vercel.client import make_vercel_client
 
@@ -123,7 +123,7 @@ vercel_deployment_status = VercelDeploymentStatusTool()
 """Vercel deployment logs investigation tool."""
 
 
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 
 _ERROR_KEYWORDS = ("error", "failed", "exception", "fatal", "crash", "panic", "unhandled")
 

--- a/integrations/victoria_logs/tools/__init__.py
+++ b/integrations/victoria_logs/tools/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool
+from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.victoria_logs.client import make_victoria_logs_client
 

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -10,7 +10,7 @@ X adds or renames individual MCP-side tools.
 from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
-from core.tool.execution import report_run_error
+from core.tool import report_run_error
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import (
     build_mcp_tool_listing,

--- a/platform/harness_ports.py
+++ b/platform/harness_ports.py
@@ -21,11 +21,11 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from config.strict_config import StrictConfigModel
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool import RegisteredTool
 
 if TYPE_CHECKING:
     from core.agent_harness.ports import SubprocessPresenterFactory
-    from core.tool.registry import ToolRegistry
+    from core.tool import ToolRegistry
 
 logger = logging.getLogger(__name__)
 

--- a/surfaces/cli/ask/approval.py
+++ b/surfaces/cli/ask/approval.py
@@ -6,8 +6,13 @@ import threading
 from collections.abc import Iterable
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RuntimeTool, SideEffectLevel
-from core.tool.execution import BeforeToolCallResult, ToolExecutionHooks, ToolExecutionRequest
+from core.tool import (
+    BeforeToolCallResult,
+    RuntimeTool,
+    SideEffectLevel,
+    ToolExecutionHooks,
+    ToolExecutionRequest,
+)
 from platform.harness_ports import get_surface_tool_map
 
 _GATED_SIDE_EFFECTS = frozenset({SideEffectLevel.MUTATING, SideEffectLevel.EXTERNAL})

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -23,7 +23,7 @@ from core.agent_harness.runtime import (
     HeadlessAgent,
 )
 from core.agent_harness.spi.cancel import ensure_turn_cancel
-from core.tool.execution import ToolExecutionHooks
+from core.tool import ToolExecutionHooks
 from platform.errors import OpenSREError
 from surfaces.cli.ask.approval import ApprovalTracker, build_approval_hooks
 

--- a/surfaces/interactive_shell/runtime/action_turn.py
+++ b/surfaces/interactive_shell/runtime/action_turn.py
@@ -15,7 +15,7 @@ from core.agent_harness import OutputSink, ToolCallingTurnResult
 from core.agent_harness.ports import LlmFactory
 from core.agent_harness.runtime import ActionTurnRunner, TurnPlan, default_llm_factory
 from core.agent_harness.spi.defaults import DefaultErrorReporter
-from core.tool.execution import ToolExecutionHooks
+from core.tool import ToolExecutionHooks
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.suggestions import resolve_literal_slash_typo
 from surfaces.interactive_shell.runtime.agent_harness_adapters import resolve_output_sink

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -20,7 +20,7 @@ from core.agent_harness.spi.session_goal import (
     SessionGoal,
     format_session_goal_progress,
 )
-from core.tool.execution import ToolExecutionHooks
+from core.tool import ToolExecutionHooks
 from platform.turn_host.turn_handler import TurnHandler
 from platform.turn_host.turn_output import TurnOutput
 from surfaces.interactive_shell.runtime.agent_harness_adapters import ShellOutputSink

--- a/surfaces/interactive_shell/runtime/turn_seams.py
+++ b/surfaces/interactive_shell/runtime/turn_seams.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from core.agent_harness import OutputSink, ToolCallingTurnResult
 from core.agent_harness.ports import AnswerRequest, GatheredEvidence
 from core.agent_harness.runtime import HeadlessAgent, TurnPlan
-from core.tool.execution import ToolExecutionHooks
+from core.tool import ToolExecutionHooks
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.utils.telemetry import LlmRunInfo
 

--- a/surfaces/shared/terminal/tables/tool_catalog.py
+++ b/surfaces/shared/terminal/tables/tool_catalog.py
@@ -36,7 +36,7 @@ from typing import Any
 
 from config.constants.paths import REPO_ROOT
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool import RegisteredTool
 from tools.registry import get_registered_tools
 
 # Cap one-line schema summaries so wide registries don't break terminal

--- a/tests/core/llm/test_tool_schemas_hide_injected_params.py
+++ b/tests/core/llm/test_tool_schemas_hide_injected_params.py
@@ -1,0 +1,74 @@
+"""No provider advertises a tool's injected parameters to the model.
+
+``RegisteredTool`` prunes injected parameters — credentials, endpoints, mode
+flags — into ``public_input_schema``. ``input_schema`` keeps them, because the
+harness fills them at call time.
+
+The CLI-backed client read ``input_schema``, so on that backend a GitHub tool
+offered the model its own ``github_token`` as a fillable argument, while the
+Anthropic, OpenAI and Bedrock clients pruned it. Nothing caught the divergence:
+every client typed the parameter ``list[Any]``, so no contract said which schema
+was meant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.llm.shared.tool_schema_normalize import build_openai_tool_specs
+from core.llm.transports.sdk.bedrock_converse import build_converse_tool_specs
+
+_INJECTED = ("github_token", "github_url")
+
+
+class _ToolWithACredential:
+    """A tool whose schema carries an injected credential the model must not see."""
+
+    name = "github_issue_create"
+    description = "Create a GitHub issue."
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "github_token": {"type": "string"},
+                "github_url": {"type": "string"},
+            },
+            "required": ["title", "github_token"],
+        }
+
+    @property
+    def public_input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+        }
+
+
+def _mentions_a_credential(payload: object) -> bool:
+    return any(name in repr(payload) for name in _INJECTED)
+
+
+def test_the_tool_fixture_would_leak_if_the_raw_schema_were_used() -> None:
+    """Guard the guard: the raw schema really does carry the credential."""
+    assert _mentions_a_credential(_ToolWithACredential().input_schema)
+    assert not _mentions_a_credential(_ToolWithACredential().public_input_schema)
+
+
+def test_openai_specs_hide_injected_params() -> None:
+    # Arrange / Act
+    specs = build_openai_tool_specs([_ToolWithACredential()])
+
+    # Assert
+    assert not _mentions_a_credential(specs)
+
+
+def test_converse_specs_hide_injected_params() -> None:
+    # Arrange / Act
+    specs = build_converse_tool_specs([_ToolWithACredential()])
+
+    # Assert
+    assert not _mentions_a_credential(specs)

--- a/tests/shared/test_tool_api_border.py
+++ b/tests/shared/test_tool_api_border.py
@@ -2,10 +2,14 @@
 
 ``core/tool/`` (contract, execution, registry port) and ``core/tool_framework/``
 (``@tool``, skill guidance, payload utilities) are one tier to everything above
-them. ``core.tool_framework.utils`` is already a door — it curates ``__all__``
-over nine helper submodules — so an import of it is not internal. The package
-roots export nothing yet; everything reaching past them is listed below, and
-these allowlists are the measurement of the seam.
+them. Three doors are open: ``core.tool`` (the contract — what a tool is, how
+it runs, where it is registered), ``core.tool_framework.utils`` (schema builders,
+MCP readers, availability envelopes), and the ``core.tool_framework`` root, which
+exports nothing yet. Everything reaching past a door is listed below, and these
+allowlists are the measurement of the seam.
+
+``gateway``, ``surfaces`` and ``platform`` are at zero: they use the contract and
+nothing behind it.
 
 Each allowlist is compared exactly in both directions: a new internal import
 fails immediately, and an entry no longer imported must be removed. Widening a
@@ -14,6 +18,8 @@ door and moving callers onto it is how these get shorter.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -26,9 +32,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 _ALLOWED: dict[str, frozenset[str]] = {
     "tools": frozenset(
         {
-            "core.tool.contracts",
-            "core.tool.execution",
-            "core.tool.registry",
             "core.tool_framework.skill_guidance",
             "core.tool_framework.tags",
             "core.tool_framework.tool_decorator",
@@ -36,25 +39,13 @@ _ALLOWED: dict[str, frozenset[str]] = {
     ),
     "integrations": frozenset(
         {
-            "core.tool.contracts",
-            "core.tool.execution",
             "core.tool_framework.tags",
             "core.tool_framework.tool_decorator",
         }
     ),
-    "gateway": frozenset({"core.tool.execution"}),
-    "surfaces": frozenset(
-        {
-            "core.tool.contracts",
-            "core.tool.execution",
-        }
-    ),
-    "platform": frozenset(
-        {
-            "core.tool.contracts",
-            "core.tool.registry",
-        }
-    ),
+    "gateway": frozenset(),
+    "surfaces": frozenset(),
+    "platform": frozenset(),
 }
 
 
@@ -76,3 +67,30 @@ def test_bootstrap_reaches_the_tool_tier_only_through_its_api() -> None:
 
     # Assert
     assert imported == set()
+
+
+def test_the_contract_door_survives_being_imported_second() -> None:
+    """``import core.llm.types`` must not re-enter a half-built ``core.tool``.
+
+    ``core.tool.execution`` needs ``ToolCall`` from ``core.llm.types``, which in
+    turn names ``RuntimeTool`` as a PEP 695 bound. Once ``core/tool/__init__``
+    imports execution, a runtime import of that bound makes importing
+    ``core.llm.types`` first fail with ``cannot import name 'ToolCall' from
+    partially initialized module``. The bound is lazy, so the import stays under
+    ``TYPE_CHECKING`` — and this test is what says so out loud.
+    """
+    # Arrange: a fresh interpreter, importing the risky order first.
+    script = "import core.llm.types, core.tool; print(len(core.tool.__all__))"
+
+    # Act
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    # Assert
+    assert proc.returncode == 0, proc.stderr.strip()[-400:]
+    assert proc.stdout.strip() == "16"

--- a/tools/cross_vendor/fix_sentry_issue/__init__.py
+++ b/tools/cross_vendor/fix_sentry_issue/__init__.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from tools.cross_vendor.fix_sentry_issue.context import gather_issue_context
 from tools.cross_vendor.fix_sentry_issue.errors import FixIssueError
 from tools.cross_vendor.fix_sentry_issue.runner import (

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -20,7 +20,7 @@ from core.agent_harness.spi.session_state import (
 )
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_array_property, string_property
 
 _MIN_OPTIONS = 2

--- a/tools/interactive_shell/actions/assistant_handoff.py
+++ b/tools/interactive_shell/actions/assistant_handoff.py
@@ -11,7 +11,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_array_property, string_property
 
 

--- a/tools/interactive_shell/actions/cli_command.py
+++ b/tools/interactive_shell/actions/cli_command.py
@@ -10,7 +10,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.cli import run_opensre_cli_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter

--- a/tools/interactive_shell/actions/implementation.py
+++ b/tools/interactive_shell/actions/implementation.py
@@ -10,7 +10,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.implementation.claude_code_executor import (
     run_claude_code_implementation,

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from platform.scheduling.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (

--- a/tools/interactive_shell/actions/llm_provider.py
+++ b/tools/interactive_shell/actions/llm_provider.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema
 from tools.interactive_shell.shared import allow_tool
 

--- a/tools/interactive_shell/actions/propose_scheduled_delivery.py
+++ b/tools/interactive_shell/actions/propose_scheduled_delivery.py
@@ -10,7 +10,7 @@ from core.agent_harness.spi.session_state import (
 )
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from platform.scheduling.scheduler.credentials import requires_explicit_chat_id
 from platform.scheduling.scheduler.types import Provider, TaskKind

--- a/tools/interactive_shell/actions/sample_alert.py
+++ b/tools/interactive_shell/actions/sample_alert.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from platform.scheduling.task_types import TaskRecord
 from tools.interactive_shell.shared.investigation_launch import (

--- a/tools/interactive_shell/actions/sentry_fix.py
+++ b/tools/interactive_shell/actions/sentry_fix.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from tools.cross_vendor.fix_sentry_issue import fix_sentry_issue
 from tools.cross_vendor.fix_sentry_issue.runner import is_issue_fix_enabled

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -10,7 +10,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.shell.runner import run_shell_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter

--- a/tools/interactive_shell/actions/skill_view.py
+++ b/tools/interactive_shell/actions/skill_view.py
@@ -7,7 +7,7 @@ from typing import Any
 from core.agent_harness.spi.grounding import list_action_skills, load_skill_body
 from core.agent_harness.tools import ActionToolContext, execute_with_action_context
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 
 

--- a/tools/interactive_shell/actions/slash.py
+++ b/tools/interactive_shell/actions/slash.py
@@ -18,7 +18,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from tools.interactive_shell.shared import plan_foreground_tool
 from tools.interactive_shell.shared.slash_catalog import (
     slash_invoke_input_schema,

--- a/tools/interactive_shell/actions/synthetic.py
+++ b/tools/interactive_shell/actions/synthetic.py
@@ -12,7 +12,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 from tools.interactive_shell.synthetic.runner import run_synthetic_test

--- a/tools/interactive_shell/actions/task_cancel.py
+++ b/tools/interactive_shell/actions/task_cancel.py
@@ -13,7 +13,7 @@ from core.agent_harness.tools import (
     execute_with_action_context,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool, SideEffectLevel
+from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema
 from platform.scheduling.task_types import TaskKind, TaskStatus
 from tools.interactive_shell.shared import plan_foreground_tool

--- a/tools/investigation/__init__.py
+++ b/tools/investigation/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from tools.investigation.capability import (
     astream_investigation,

--- a/tools/investigation/stages/gather_evidence/agent.py
+++ b/tools/investigation/stages/gather_evidence/agent.py
@@ -28,7 +28,7 @@ from core.messages import MessageMapper, RuntimeMessage, ToolResultRuntimeMessag
 from core.provider import ProviderHooks, ProviderRequest
 from core.state import InvestigationState
 from core.state.evidence import EvidenceEntry
-from core.tool.contracts import RegisteredTool, RuntimeTool
+from core.tool import RegisteredTool, RuntimeTool
 from platform.observability import debug_print
 from platform.observability import get_progress_tracker as get_tracker
 from platform.observability.trace.redaction import (

--- a/tools/investigation/stages/gather_evidence/loop.py
+++ b/tools/investigation/stages/gather_evidence/loop.py
@@ -17,7 +17,7 @@ from config.constants.investigation import (
 from core.llm.types import ToolCall
 from core.llm_invoke_errors import LLMInvokeFailure
 from core.state.evidence import EvidenceEntry
-from core.tool.execution import (
+from core.tool import (
     BeforeToolCallResult,
     ToolExecutionHooks,
     ToolExecutionRequest,

--- a/tools/investigation/stages/gather_evidence/tools.py
+++ b/tools/investigation/stages/gather_evidence/tools.py
@@ -13,8 +13,7 @@ from core.domain.alerts.alert_source import (
 )
 from core.domain.types.tools import ToolSurface
 from core.llm.types import ToolCall
-from core.tool.contracts import RegisteredTool
-from core.tool.execution import availability_view
+from core.tool import RegisteredTool, availability_view
 from platform.observability.trace.redaction import RedactedToolView, redact_tool_view
 from tools.registry import get_registered_tools
 

--- a/tools/investigation/stages/plan_evidence/node.py
+++ b/tools/investigation/stages/plan_evidence/node.py
@@ -13,7 +13,7 @@ from core.domain.types.planning import PlannedInvestigationAction
 from core.domain.types.retrieval import RetrievalControlsMap, RetrievalIntent, TimeBounds
 from core.domain.types.tools import ToolSurface
 from core.state import InvestigationState
-from core.tool.contracts import RegisteredTool
+from core.tool import RegisteredTool
 from tools.investigation.stages.gather_evidence.tools import (
     availability_view,
     build_connected_tool_context,

--- a/tools/investigation_registry/actions.py
+++ b/tools/investigation_registry/actions.py
@@ -1,7 +1,7 @@
 """Registry of all available investigation actions."""
 
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import RegisteredTool
+from core.tool import RegisteredTool
 from tools.registry import get_registered_tools
 
 

--- a/tools/investigation_registry/models.py
+++ b/tools/investigation_registry/models.py
@@ -1,6 +1,6 @@
 """Investigation action type — RegisteredTool is the canonical representation."""
 
-from core.tool.contracts import RegisteredTool
+from core.tool import RegisteredTool
 
 # InvestigationAction is now an alias for RegisteredTool.
 # All callers that import InvestigationAction continue to work unchanged.

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -17,7 +17,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 import tools as tools_package
-from core.tool.contracts import RegisteredTool, ToolSurface
+from core.tool import RegisteredTool, ToolSurface
 from tools.registry_discovery import (
     INTEGRATION_TOOL_PACKAGES,
     collect_registered_tools_from_module,

--- a/tools/registry_discovery.py
+++ b/tools/registry_discovery.py
@@ -16,7 +16,7 @@ import pkgutil
 from dataclasses import replace
 from types import ModuleType
 
-from core.tool.contracts import REGISTERED_TOOL_ATTR, BaseTool, RegisteredTool
+from core.tool import REGISTERED_TOOL_ATTR, BaseTool, RegisteredTool
 
 logger = logging.getLogger(__name__)
 

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from config.constants.paths import REPO_ROOT
 from core.domain.types.tools import ToolSurface
-from core.tool.registry import normalize_surfaces
+from core.tool import normalize_surfaces
 from tools.registry_discovery import INTEGRATION_TOOL_PACKAGES
 
 _SKIP_FILE_SUFFIXES = ("_test.py",)

--- a/tools/registry_skill_guidance.py
+++ b/tools/registry_skill_guidance.py
@@ -12,7 +12,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from config.constants.paths import REPO_ROOT
-from core.tool.contracts import RegisteredTool
+from core.tool import RegisteredTool
 from core.tool_framework.skill_guidance import format_tool_skill_guidance, load_tool_skill_guidance
 
 logger = logging.getLogger(__name__)

--- a/tools/system/agent_memory/tool.py
+++ b/tools/system/agent_memory/tool.py
@@ -18,7 +18,7 @@ from core.domain.memory import (
     search_memories,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import SideEffectLevel
+from core.tool import SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from tools.system.agent_memory.results import (
     deleted_result,

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -10,7 +10,7 @@ from config.runtime_metadata import (
     STATIC_FACT_KEYS,
 )
 from core.domain.types.tools import ToolSurface
-from core.tool.contracts import BaseTool, SideEffectLevel
+from core.tool import BaseTool, SideEffectLevel
 from platform.observability.trace.spans import component_span
 from tools.system.python_execution_tool.credentials import execution_env, github_extract_params
 from tools.system.python_execution_tool.runner import run_python_execution

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -25,7 +25,7 @@ from core.domain.work_items import (
     update_work_item,
     work_items_path,
 )
-from core.tool.contracts import AgentToolContext, SideEffectLevel
+from core.tool import AgentToolContext, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from platform.scheduling.scheduler.store import add_task as add_scheduled_task
 from platform.scheduling.scheduler.store import list_tasks, update_task


### PR DESCRIPTION
*The door.** `core/tool/__init__.py` exports the 16 names consumers use from
`contracts`, `execution` and `registry`. 98 files now import the door instead of
reaching past it. No file moved, no symbol was renamed.

| Consumer | #5284 | Here |
|---|---|---|
| integrations | 4 | **2** |
| tools | 6 | **3** |
| surfaces | 2 | **0** |
| platform | 2 | **0** |
| gateway | 1 | **0** |
| **total** | 15 | **6** |

**The cycle it exposed.** Populating the package init broke a common import
order:

```
import core.llm.types
  → core.tool.contracts
    → runs core/tool/__init__
      → core.tool.execution
        → core.llm.types   (partially initialised)
ImportError: cannot import name 'ToolCall'
```

Importing `core.tool` first worked fine, which is what makes this the kind of
fault that ships and then surfaces somewhere unrelated.

The first fix was a `TYPE_CHECKING` guard. That is a workaround, and `AGENTS.md`
is explicit that CodeQL counts `TYPE_CHECKING` imports as part of a cycle
anyway — so it would not even have satisfied CI.

**The design fix.** `core/llm/types.py` named `RuntimeTool` — a `TypeAlias`
union of `AgentTool | RegisteredTool` — as a PEP 695 bound:

```python
def tool_schemas[RuntimeToolT: RuntimeTool](self, tools: list[RuntimeToolT])
def tool_schemas(self, tools: list[Any])       # every implementer
```

**No implementation honoured the bound.** All four clients widened to
`list[Any]`, so the import that closed the cycle bought nothing.

Replaced with a structural Protocol owned by the consumer:

```python
@runtime_checkable
class SchemaDescribedTool(Protocol):
    @property
    def name(self) -> str: ...
    @property
    def description(self) -> str: ...
    @property
    def public_input_schema(self) -> dict[str, Any]: ...
```

Those are the three attributes `_anthropic_tool_schema` and
`build_converse_tool_specs` actually read — checked, not assumed. `Sequence`
rather than `list` gives the covariance the generic was there for.
`core/llm/types.py` now imports nothing from `core.tool`: the dependency is
one-way, and both import orders work because there is no loop, not because one
side is lazy.

**What the contract found.** Typing the four implementers off `Any` produced:

```
agent_clients.py:814: "SchemaDescribedTool" has no attribute "input_schema";
                      maybe "public_input_schema"?
```

The CLI-backed client read the **raw** schema. `public_input_schema` exists to
prune injected parameters, and `GITHUB_INJECTED_PARAMS` contains
**`github_token`** — so on that backend, GitHub tools offered the model their own
credential as a fillable argument. The other three clients pruned it. Nothing
caught it because `list[Any]` meant no contract said which schema was meant.

### Demo/Screenshot for feature changes and bug fixes -

Refactor plus one defect fix; the evidence is the measurement and the guards.

The credential leak is now unrepresentable, not merely tested — reintroducing
`t.input_schema` fails typecheck:

```
$ # CLI client reads the raw schema again
core/llm/transports/sdk/agent_clients.py: 2 mypy errors
```

Behavioural cover as well, including a guard-the-guard test so the other two
cannot pass vacuously:

```
tests/core/llm/test_tool_schemas_hide_injected_params.py  3 passed
```

Import order pinned by a test that spawns a fresh interpreter:

```
$ # TYPE_CHECKING guard removed / bound imported at runtime
FAILED test_the_contract_door_survives_being_imported_second
```

Gates: lint clean · format 3,604 · typecheck 1,860 · all 3 import checks ·
**15,590 passed** on the contract door; the run including the Protocol change is
finishing and will be confirmed before merge.

> The suite run excludes `tests/core/tool/test_enums.py`, which collides by
> basename with `tests/filestorage/test_enums.py` (neither directory has
> `__init__.py`). That arrived with #5259 and reproduces on a clean `main` —
> unrelated, but `main` currently cannot collect a full run.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

The door itself is the same move as the utils door in #5284 — widen an existing
boundary, move callers onto it, shrink the allowlist.

The interesting part was refusing to keep the first fix. A `TYPE_CHECKING` guard
made the tests pass and the import orders work, and it was wrong: it hid a
dependency rather than removing one, and CodeQL would have counted it anyway. The
question worth asking was why the LLM tier needed the tool tier at all — and the
answer was that it did not. It named a union of concrete types where it needed
three attributes, and no implementation had honoured that bound in the first
place.

Which is the argument for structural contracts over `Any` generally: the moment
the shape was written down, mypy pointed straight at the one client that read a
different attribute. That defect had been live across every CLI-backed model and
no test covered it, because there was nothing to test against.

Worth flagging for review: `SchemaDescribedTool` is deliberately minimal. If a
future provider needs a fourth attribute, it belongs on the Protocol — not as a
widening back to `Any`.