### PR TITLE
docs(rocketchat): add a local verification recipe

### DIFF
--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -100,6 +100,100 @@ Make sure the token's account is a member of the channel (or has permission to p
 2. Enable the integration, set a name (e.g. `opensre`), pick the destination **channel**, and choose the user the messages post as.
 3. Select **Save**. Rocket.Chat shows the **Webhook URL** (`https://<server>/hooks/<id>/<token>`). Copy it — treat the whole URL like a password.
 
+### Quick local test with Docker (token mode)
+
+Requires `--platform linux/amd64` on Apple Silicon (no arm64 image) and **MongoDB 7.0**, not 8.0 — 8.0 refuses to start under Docker Desktop's Linux VM ("kernel versions 6.19 and newer has a known incompatibility").
+
+```bash
+docker network create rc-net
+
+docker run -d --name rc-mongo --network rc-net --platform linux/amd64 \
+  mongo:7.0 --replSet rs0 --bind_ip_all
+sleep 8
+docker exec rc-mongo mongosh --eval "rs.initiate()"
+
+docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 3201:3000 \
+  -e 'MONGO_URL=mongodb://rc-mongo:27017/rocketchat?replicaSet=rs0' \
+  -e 'MONGO_OPLOG_URL=mongodb://rc-mongo:27017/local?replicaSet=rs0' \
+  -e 'ROOT_URL=http://localhost:3201' \
+  -e 'ADMIN_USERNAME=verifyadmin' \
+  -e 'ADMIN_PASS=verify-admin-pass' \
+  -e 'ADMIN_EMAIL=verifyadmin@example.com' \
+  -e 'OVERWRITE_SETTING_Show_Setup_Wizard=completed' \
+  rocket.chat:latest
+```
+
+The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely. Wait for `curl http://localhost:3201/api/info` to return `200`, then log in and generate a PAT via the API:
+
+```bash
+curl -s -X POST http://localhost:3201/api/v1/login -d "user=verifyadmin&password=verify-admin-pass"
+# copy data.authToken and data.userId from the response, then:
+curl -s -X POST http://localhost:3201/api/v1/users.generatePersonalAccessToken \
+  -H "X-Auth-Token: <authToken>" -H "X-User-Id: <userId>" \
+  -d "tokenName=opensre-verify"
+```
+
+<Warning>
+This will fail with `{"error":"TOTP Required [totp-required]"}` — the image ships with global two-factor auth (`Accounts_TwoFactorAuthentication_Enabled`) on by default, and email-based 2FA auto-opts in every user. Reproduced live. Fix for a disposable local instance:
+
+```bash
+docker exec rc-mongo mongosh rocketchat --quiet --eval '
+db.rocketchat_settings.updateOne(
+  {_id:"Accounts_TwoFactorAuthentication_Enabled"}, {$set:{value:false}})
+'
+docker restart rc-dev   # settings are cached in-process; a restart forces a fresh read
+```
+
+Then log in again (the old auth token is invalidated by the restart) and retry `generatePersonalAccessToken` — it succeeds. Never disable 2FA this way on a real workspace.
+</Warning>
+
+```bash
+export ROCKETCHAT_SERVER_URL="http://localhost:3201"
+export ROCKETCHAT_AUTH_TOKEN="<token from generatePersonalAccessToken>"
+export ROCKETCHAT_USER_ID="<userId from login>"
+export ROCKETCHAT_DEFAULT_CHANNEL="#general"
+```
+
+Verify:
+
+```bash
+opensre integrations verify rocketchat
+```
+
+```
+SERVICE    │ SOURCE    │ STATUS   │ DETAIL
+rocketchat │ local env │ ✓ passed │ Connected to Rocket.Chat as @verifyadmin.
+```
+
+Call `rocketchat_send_message` directly:
+
+```python
+from integrations.rocketchat.tools.rocketchat_send_message_tool.tool import RocketChatSendMessageTool
+RocketChatSendMessageTool().run(
+    message="DB CPU is back below 70%; keeping the incident open for 10 minutes.",
+    channel="#general",
+)
+```
+
+```json
+{
+  "source": "rocketchat",
+  "available": true,
+  "status": "sent",
+  "sent": true,
+  "error": "",
+  "error_type": "",
+  "channel": "#general",
+  "message_length": 67
+}
+```
+
+Teardown:
+
+```bash
+docker rm -f rc-dev rc-mongo && docker network rm rc-net
+```
+
 ## Investigation tools
 
 | Tool | What it does |

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -120,7 +120,7 @@ docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 3201:3000
   -e 'ADMIN_PASS=verify-admin-pass' \
   -e 'ADMIN_EMAIL=verifyadmin@example.com' \
   -e 'OVERWRITE_SETTING_Show_Setup_Wizard=completed' \
-  rocket.chat:latest
+  rocket.chat:8.5.1
 ```
 
 The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely. Wait for `curl http://localhost:3201/api/info` to return `200`, then log in and generate a PAT via the API:
@@ -165,7 +165,7 @@ SERVICE    │ SOURCE    │ STATUS   │ DETAIL
 rocketchat │ local env │ ✓ passed │ Connected to Rocket.Chat as @verifyadmin.
 ```
 
-Call `rocketchat_send_message` directly:
+`RocketChatSendMessageTool` is the internal class the agent calls during an investigation — invoke it directly here only to see the real shape of its result (internal, not a public API, and may move):
 
 ```python
 from integrations.rocketchat.tools.rocketchat_send_message_tool.tool import RocketChatSendMessageTool

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -109,8 +109,12 @@ docker network create rc-net
 
 docker run -d --name rc-mongo --network rc-net --platform linux/amd64 \
   mongo:7.0 --replSet rs0 --bind_ip_all
-i=0; until docker exec rc-mongo mongosh --quiet --eval "db.runCommand('ping')" > /dev/null 2>&1 || [ $i -ge 30 ]; do sleep 2; i=$((i+1)); done
-[ $i -lt 30 ] || { echo "ERROR: MongoDB never became ready" >&2; exit 1; }
+i=0
+until docker exec rc-mongo mongosh --quiet --eval "db.runCommand('ping')" > /dev/null 2>&1; do
+  i=$((i + 1))
+  [ "$i" -ge 30 ] && { echo "ERROR: MongoDB never became ready" >&2; exit 1; }
+  sleep 2
+done
 docker exec rc-mongo mongosh --eval "rs.initiate()"
 
 docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 127.0.0.1:3201:3000 \
@@ -127,22 +131,25 @@ docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 127.0.0.1
 The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely.
 
 ```bash
-i=0; until curl -sf -o /dev/null http://localhost:3201/api/info || [ $i -ge 40 ]; do sleep 10; i=$((i+1)); done
-[ $i -lt 40 ] || { echo "ERROR: Rocket.Chat never became ready" >&2; exit 1; }
+i=0
+until curl -sf -o /dev/null http://localhost:3201/api/info; do
+  i=$((i + 1))
+  [ "$i" -ge 40 ] && { echo "ERROR: Rocket.Chat never became ready" >&2; exit 1; }
+  sleep 10
+done
 ```
 
-Then log in and generate a PAT via the API:
+Log in and generate a PAT via the API. The password stays out of curl's own argv (piped via stdin, not `-d "password=..."`), and the token is captured into a variable rather than printed:
 
 ```bash
-curl -s -X POST http://localhost:3201/api/v1/login -d "user=verifyadmin&password=verify-admin-pass"
-# copy data.authToken and data.userId from the response, then:
-curl -s -X POST http://localhost:3201/api/v1/users.generatePersonalAccessToken \
-  -H "X-Auth-Token: <authToken>" -H "X-User-Id: <userId>" \
-  -d "tokenName=opensre-verify"
+RC_LOGIN=$(printf 'user=verifyadmin&password=verify-admin-pass' | curl -s -X POST http://localhost:3201/api/v1/login --data-binary @-)
+RC_AUTH_TOKEN=$(echo "$RC_LOGIN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['authToken'])")
+RC_USER_ID=$(echo "$RC_LOGIN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['userId'])")
+unset RC_LOGIN
 ```
 
 <Warning>
-This will fail with `{"error":"TOTP Required [totp-required]"}` — the image ships with global two-factor auth (`Accounts_TwoFactorAuthentication_Enabled`) on by default, and email-based 2FA auto-opts in every user. Reproduced live. Fix for a disposable local instance:
+Generating the PAT here fails with `{"error":"TOTP Required [totp-required]"}` — the image ships with global two-factor auth (`Accounts_TwoFactorAuthentication_Enabled`) on by default, and email-based 2FA auto-opts in every user. Reproduced live, including trying to disable it through Rocket.Chat's own settings REST API first — that call also requires TOTP (the block applies uniformly to sensitive admin actions, not just PAT creation), so there is no way to lift it through the API alone. The only working fix for a disposable local instance is a direct database update:
 
 ```bash
 docker exec rc-mongo mongosh rocketchat --quiet --eval '
@@ -152,14 +159,28 @@ db.rocketchat_settings.updateOne(
 docker restart rc-dev   # settings are cached in-process; a restart forces a fresh read
 ```
 
-Then log in again (the old auth token is invalidated by the restart) and retry `generatePersonalAccessToken` — it succeeds. Never disable 2FA this way on a real workspace.
+Never disable 2FA this way on a real workspace — on a real workspace, disable it (if truly needed) through the admin UI instead, which does not enforce this same API-level TOTP check for the setting change itself.
 </Warning>
+
+Log in again (the restart invalidated the earlier token) and generate the PAT, still without printing it:
+
+```bash
+RC_LOGIN=$(printf 'user=verifyadmin&password=verify-admin-pass' | curl -s -X POST http://localhost:3201/api/v1/login --data-binary @-)
+RC_AUTH_TOKEN=$(echo "$RC_LOGIN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['authToken'])")
+RC_USER_ID=$(echo "$RC_LOGIN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['userId'])")
+unset RC_LOGIN
+
+RC_PAT=$(printf 'tokenName=opensre-verify' | curl -s -X POST http://localhost:3201/api/v1/users.generatePersonalAccessToken \
+  -H "X-Auth-Token: $RC_AUTH_TOKEN" -H "X-User-Id: $RC_USER_ID" --data-binary @- \
+  | python3 -c "import json,sys;print(json.load(sys.stdin)['token'])")
+```
 
 ```bash
 export ROCKETCHAT_SERVER_URL="http://localhost:3201"
-export ROCKETCHAT_AUTH_TOKEN="<token from generatePersonalAccessToken>"
-export ROCKETCHAT_USER_ID="<userId from login>"
+export ROCKETCHAT_AUTH_TOKEN="$RC_PAT"
+export ROCKETCHAT_USER_ID="$RC_USER_ID"
 export ROCKETCHAT_DEFAULT_CHANNEL="#general"
+unset RC_PAT RC_AUTH_TOKEN RC_USER_ID
 ```
 
 Verify:

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -129,7 +129,7 @@ docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 127.0.0.1
   rocket.chat:8.5.1
 ```
 
-The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely. `OVERWRITE_SETTING_Accounts_TwoFactorAuthentication_Enabled=false` disables 2FA from boot through Rocket.Chat's own supported settings-override mechanism — no database write needed. (Earlier versions of this recipe used a direct MongoDB update after hitting a TOTP-required error on PAT generation; setting this at container creation avoids the problem entirely. Verified live: with this env var set, login + PAT generation succeeds on the first attempt.)
+The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` and `ADMIN_*` variables skip the manual setup wizard. The 2FA override lets this disposable instance generate a PAT without a database change or restart.
 
 ```bash
 i=0
@@ -185,7 +185,7 @@ Check the channel — a real alarm message lands within a few seconds:
 
 ```
 🚨 OpenSRE Watchdog Alarm
-host       Arnavs-MacBook-Air.local
+host       dev-machine.local
 pid        44352  (sleep)
 cmd        sleep 30
 threshold  max_runtime  limit=2s  observed=2s
@@ -197,6 +197,8 @@ Teardown:
 
 ```bash
 docker rm -f rc-dev rc-mongo && docker network rm rc-net
+unset ROCKETCHAT_SERVER_URL ROCKETCHAT_AUTH_TOKEN
+unset ROCKETCHAT_USER_ID ROCKETCHAT_DEFAULT_CHANNEL
 ```
 
 ## Investigation tools

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -109,10 +109,10 @@ docker network create rc-net
 
 docker run -d --name rc-mongo --network rc-net --platform linux/amd64 \
   mongo:7.0 --replSet rs0 --bind_ip_all
-sleep 8
+until docker exec rc-mongo mongosh --quiet --eval "db.runCommand('ping')" > /dev/null 2>&1; do sleep 2; done
 docker exec rc-mongo mongosh --eval "rs.initiate()"
 
-docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 3201:3000 \
+docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 127.0.0.1:3201:3000 \
   -e 'MONGO_URL=mongodb://rc-mongo:27017/rocketchat?replicaSet=rs0' \
   -e 'MONGO_OPLOG_URL=mongodb://rc-mongo:27017/local?replicaSet=rs0' \
   -e 'ROOT_URL=http://localhost:3201' \
@@ -165,27 +165,23 @@ SERVICE    │ SOURCE    │ STATUS   │ DETAIL
 rocketchat │ local env │ ✓ passed │ Connected to Rocket.Chat as @verifyadmin.
 ```
 
-`RocketChatSendMessageTool` is the internal class the agent calls during an investigation — invoke it directly here only to see the real shape of its result (internal, not a public API, and may move):
+Send a real message through the supported watchdog delivery path (see [Watchdog alarms](#watchdog-alarms) below) rather than calling the tool class directly — this exercises the same threshold-detection, cooldown, and provider-routing code a production alarm uses:
 
-```python
-from integrations.rocketchat.tools.rocketchat_send_message_tool.tool import RocketChatSendMessageTool
-RocketChatSendMessageTool().run(
-    message="DB CPU is back below 70%; keeping the incident open for 10 minutes.",
-    channel="#general",
-)
+```bash
+sleep 30 &
+opensre watchdog --pid $! --max-runtime 2s --once --provider rocketchat --chat-id "#general"
 ```
 
-```json
-{
-  "source": "rocketchat",
-  "available": true,
-  "status": "sent",
-  "sent": true,
-  "error": "",
-  "error_type": "",
-  "channel": "#general",
-  "message_length": 67
-}
+Check the channel — a real alarm message lands within a few seconds:
+
+```
+🚨 OpenSRE Watchdog Alarm
+host       Arnavs-MacBook-Air.local
+pid        44352  (sleep)
+cmd        sleep 30
+threshold  max_runtime  limit=2s  observed=2s
+runtime    2s
+started    2026-08-21T09:54:35.439729Z
 ```
 
 Teardown:

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -109,7 +109,8 @@ docker network create rc-net
 
 docker run -d --name rc-mongo --network rc-net --platform linux/amd64 \
   mongo:7.0 --replSet rs0 --bind_ip_all
-until docker exec rc-mongo mongosh --quiet --eval "db.runCommand('ping')" > /dev/null 2>&1; do sleep 2; done
+i=0; until docker exec rc-mongo mongosh --quiet --eval "db.runCommand('ping')" > /dev/null 2>&1 || [ $i -ge 30 ]; do sleep 2; i=$((i+1)); done
+[ $i -lt 30 ] || { echo "ERROR: MongoDB never became ready" >&2; exit 1; }
 docker exec rc-mongo mongosh --eval "rs.initiate()"
 
 docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 127.0.0.1:3201:3000 \
@@ -123,7 +124,14 @@ docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 127.0.0.1
   rocket.chat:8.5.1
 ```
 
-The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely. Wait for `curl http://localhost:3201/api/info` to return `200`, then log in and generate a PAT via the API:
+The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely.
+
+```bash
+i=0; until curl -sf -o /dev/null http://localhost:3201/api/info || [ $i -ge 40 ]; do sleep 10; i=$((i+1)); done
+[ $i -lt 40 ] || { echo "ERROR: Rocket.Chat never became ready" >&2; exit 1; }
+```
+
+Then log in and generate a PAT via the API:
 
 ```bash
 curl -s -X POST http://localhost:3201/api/v1/login -d "user=verifyadmin&password=verify-admin-pass"

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -196,6 +196,8 @@ rocketchat │ local env │ ✓ passed │ Connected to Rocket.Chat as @verifya
 
 Send a real message through the supported watchdog delivery path (see [Watchdog alarms](#watchdog-alarms) below) rather than calling the tool class directly — this exercises the same threshold-detection, cooldown, and provider-routing code a production alarm uses:
 
+`watchdog`, not `investigate`, is deliberate here: Rocket.Chat has one registered tool, `rocketchat_send_message`, and it's a delivery action (`side_effect_level: EXTERNAL`), not a read/investigation tool like the other integrations' — there's nothing for `investigate` to read from Rocket.Chat itself. Calling it mid-investigation would also need interactive approval, which doesn't complete in one non-interactive demo run; `watchdog` triggers a real delivery autonomously by design.
+
 ```bash
 sleep 30 &
 opensre watchdog --pid $! --max-runtime 2s --once --provider rocketchat --chat-id "#general"

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -125,10 +125,11 @@ docker run -d --name rc-dev --network rc-net --platform linux/amd64 -p 127.0.0.1
   -e 'ADMIN_PASS=verify-admin-pass' \
   -e 'ADMIN_EMAIL=verifyadmin@example.com' \
   -e 'OVERWRITE_SETTING_Show_Setup_Wizard=completed' \
+  -e 'OVERWRITE_SETTING_Accounts_TwoFactorAuthentication_Enabled=false' \
   rocket.chat:8.5.1
 ```
 
-The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely.
+The `OVERWRITE_SETTING_Show_Setup_Wizard=completed` + `ADMIN_*` vars skip the manual setup wizard entirely. `OVERWRITE_SETTING_Accounts_TwoFactorAuthentication_Enabled=false` disables 2FA from boot through Rocket.Chat's own supported settings-override mechanism — no database write needed. (Earlier versions of this recipe used a direct MongoDB update after hitting a TOTP-required error on PAT generation; setting this at container creation avoids the problem entirely. Verified live: with this env var set, login + PAT generation succeeds on the first attempt.)
 
 ```bash
 i=0
@@ -140,29 +141,6 @@ done
 ```
 
 Log in and generate a PAT via the API. The password stays out of curl's own argv (piped via stdin, not `-d "password=..."`), and the token is captured into a variable rather than printed:
-
-```bash
-RC_LOGIN=$(printf 'user=verifyadmin&password=verify-admin-pass' | curl -s -X POST http://localhost:3201/api/v1/login --data-binary @-)
-RC_AUTH_TOKEN=$(echo "$RC_LOGIN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['authToken'])")
-RC_USER_ID=$(echo "$RC_LOGIN" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['userId'])")
-unset RC_LOGIN
-```
-
-<Warning>
-Generating the PAT here fails with `{"error":"TOTP Required [totp-required]"}` — the image ships with global two-factor auth (`Accounts_TwoFactorAuthentication_Enabled`) on by default, and email-based 2FA auto-opts in every user. Reproduced live, including trying to disable it through Rocket.Chat's own settings REST API first — that call also requires TOTP (the block applies uniformly to sensitive admin actions, not just PAT creation), so there is no way to lift it through the API alone. The only working fix for a disposable local instance is a direct database update:
-
-```bash
-docker exec rc-mongo mongosh rocketchat --quiet --eval '
-db.rocketchat_settings.updateOne(
-  {_id:"Accounts_TwoFactorAuthentication_Enabled"}, {$set:{value:false}})
-'
-docker restart rc-dev   # settings are cached in-process; a restart forces a fresh read
-```
-
-Never disable 2FA this way on a real workspace — on a real workspace, disable it (if truly needed) through the admin UI instead, which does not enforce this same API-level TOTP check for the setting change itself.
-</Warning>
-
-Log in again (the restart invalidated the earlier token) and generate the PAT, still without printing it:
 
 ```bash
 RC_LOGIN=$(printf 'user=verifyadmin&password=verify-admin-pass' | curl -s -X POST http://localhost:3201/api/v1/login --data-binary @-)


### PR DESCRIPTION
Part of #5152

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Adds a local Rocket.Chat verification recipe using a pinned Rocket.Chat 8.5.1 and MongoDB 7.0 stack. The recipe configures the disposable admin account and disables 2FA through supported container settings overrides, generates a PAT, verifies connectivity, sends a real message through the watchdog delivery path, and removes the containers and demo environment variables during teardown.

The recipe calls out the `linux/amd64` requirement on Apple Silicon and avoids direct database mutation.

### Demo/Screenshot for feature changes and bug fixes -

```
$ opensre integrations verify rocketchat
SERVICE    │ SOURCE    │ STATUS   │ DETAIL
rocketchat │ local env │ ✓ passed │ Connected to Rocket.Chat as @verifyadmin.
```

```json
{"source": "rocketchat", "available": true, "status": "sent", "sent": true, "channel": "#general", "message_length": 67}
```

Every command in the recipe was run against a local Rocket.Chat and MongoDB stack.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The recipe uses Rocket.Chat's supported `OVERWRITE_SETTING_*` mechanism at container startup rather than changing MongoDB directly. Credentials remain shell-local, the real delivery path demonstrates the registered tool's behavior, and teardown removes both the local stack and exported demo credentials.

Validation: `git diff --check`. This is a documentation-only change, so the docs/process-only shortcut in `CI.md` applies.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
