### PR TITLE
fix(interactive-shell): treat naive received_at as UTC in time_ago

### DIFF
--- a/surfaces/interactive_shell/ui/alerts/__init__.py
+++ b/surfaces/interactive_shell/ui/alerts/__init__.py
@@ -32,6 +32,11 @@ def time_ago(then: datetime | None) -> str:
     if then is None:
         return "unknown"
 
+    # POST /alerts accepts sender-supplied timestamps, so ``received_at`` may be
+    # offset-naive; treat it as UTC like format_repl_timestamp does.
+    if then.tzinfo is None:
+        then = then.replace(tzinfo=UTC)
+
     now = datetime.now(UTC)
     delta = now - then
     seconds = int(delta.total_seconds())

--- a/tests/interactive_shell/ui/test_incoming_alerts.py
+++ b/tests/interactive_shell/ui/test_incoming_alerts.py
@@ -52,6 +52,13 @@ class TestTimeAgo:
         result = time_ago(None)
         assert result == "unknown"
 
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        # POST /alerts keeps sender-supplied timestamps, so an offset-less ISO
+        # string arrives here as a naive datetime; it must not raise.
+        then = datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=3)
+        result = time_ago(then)
+        assert "3m ago" in result
+
 
 class TestFormatIncomingAlert:
     """Test format_incoming_alert rendering."""


### PR DESCRIPTION
Fixes #5298

#### Describe the changes you have made in this PR -

`time_ago()` computed `datetime.now(UTC) - then` with an always-aware `now`, but `POST /alerts` keeps sender-supplied timestamps, so an offset-less ISO string (`"2026-08-20T10:00:00"`) reaches it as a **naive** datetime and the subtraction raises `TypeError`. Because `drain_and_render_incoming()` pops all queued alerts before rendering, the first bad alert silently drops every alert behind it in the batch and kills the `_alert_watcher` task for the rest of the session; `/status` breaks the same way.

The fix mirrors the guard the codebase already uses in `format_repl_timestamp` (`surfaces/shared/terminal/components/time_format.py`): if `then.tzinfo is None`, treat it as UTC. Added a regression test alongside the existing `TestTimeAgo` cases.

### Demo/Screenshot for feature changes and bug fixes -

Before (main):

```
$ uv run python -c "
from core.domain.alerts.inbox import IncomingAlert
from surfaces.interactive_shell.ui.alerts import time_ago
alert = IncomingAlert.model_validate({'text': 'disk full', 'received_at': '2026-08-20T10:00:00'})
print(time_ago(alert.received_at))
"
TypeError: can't subtract offset-naive and offset-aware datetimes
```

After (this branch):

```
parsed tzinfo: None
renders as: received 8h ago
```

Focused tests + baseline checks (per CI.md):

```
uv run python -m pytest tests/interactive_shell/ui/test_incoming_alerts.py -q   # 26 passed
make lint          # All checks passed!
make format-check  # 3604 files already formatted
make typecheck     # Success: no issues found in 1860 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a missing naive-datetime guard on one of the sibling time-formatting paths: `format_repl_timestamp` normalizes naive datetimes to UTC before doing timezone math, but `time_ago` does not, and `received_at` is the one datetime field that can legitimately arrive naive (the gateway only fills it in when the sender omits it). I considered normalizing at the model boundary (a pydantic validator on `IncomingAlert.received_at`) but chose the renderer-side guard because it matches the existing in-repo precedent, keeps the stored value faithful to what the sender supplied, and also covers the `/status` path. The regression test constructs a naive datetime three minutes in the past and asserts the rendered relative time instead of asserting "does not raise".

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
