### PR TITLE
fix(interactive-shell): escape the /theme argument in the unknown-theme error

### DIFF
--- a/surfaces/interactive_shell/command_registry/theme.py
+++ b/surfaces/interactive_shell/command_registry/theme.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 
 from rich.console import Console
+from rich.markup import escape
 
 from platform.terminal import theme as ui_theme
 from platform.terminal.theme import (
@@ -61,7 +62,9 @@ def _cmd_theme(session: Session, console: Console, args: list[str]) -> bool:
         selected = args[0].strip().lower()
         if selected not in list_theme_names():
             supported = ", ".join(list_theme_names())
-            console.print(f"[{ui_theme.ERROR}]unknown theme:[/] {selected}  (choose: {supported})")
+            console.print(
+                f"[{ui_theme.ERROR}]unknown theme:[/] {escape(selected)}  (choose: {supported})"
+            )
             return True
         _persist_and_report_theme(session, console, selected)
         return True

--- a/tests/interactive_shell/test_theme_command.py
+++ b/tests/interactive_shell/test_theme_command.py
@@ -1,0 +1,27 @@
+"""Tests for the /theme slash command."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from surfaces.interactive_shell.command_registry import dispatch_slash
+from surfaces.interactive_shell.runtime import Session
+
+
+def _capture() -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    return Console(file=buf, force_terminal=False, highlight=False, width=120), buf
+
+
+class TestThemeUnknownArgument:
+    def test_markup_like_argument_renders_error_literally(self) -> None:
+        session = Session()
+        console, buf = _capture()
+
+        assert dispatch_slash("/theme [/]", session, console, policy_precleared=True) is True
+
+        out = buf.getvalue()
+        assert "unknown theme:" in out
+        assert "[/]" in out


### PR DESCRIPTION
Fixes #5300

#### Describe the changes you have made in this PR -

`_cmd_theme` echoed the user's raw argument into a Rich markup string in the "unknown theme" error, so a markup-like argument (`/theme [/]`, `/theme [bold`) raised `rich.errors.MarkupError` out of `dispatch_slash` instead of printing the error message. Every sibling slash command that echoes user input already escapes it (`rca_cmds.py`, `watch_cmds.py`, `work_cmds.py`) — `/theme` (added in #2977 after the #1398 hardening pass) was the one call site missing the guard, same defect class as #5016/#5017.

One-line fix: wrap `selected` in `rich.markup.escape` (`supported` is the static theme-name list and needs no escaping). Added a regression test that dispatches `/theme [/]` and asserts the literal error line renders.

### Demo/Screenshot for feature changes and bug fixes -

Before (main):

```
$ uv run python -c "... dispatch_slash('/theme [/]', ...)"
rich.errors.MarkupError: closing tag '[/]' at position 27 has nothing to close
```

After (this branch):

```
unknown theme: [/]  (choose: green, blue, amber, mono, red, pink, purple, orange, teal, lime, nord, dracula, solarized,
gruvbox, webflux, sunset)
```

Focused tests + baseline checks (per CI.md):

```
uv run python -m pytest tests/interactive_shell/test_theme_command.py -q   # 1 passed
make lint          # All checks passed!
make format-check  # 3605 files already formatted
make typecheck     # Success: no issues found in 1860 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The dispatcher has no `except` around `cmd.handler(...)`, so any handler exception escapes the REPL turn — the right place to fix this is at the interpolation site, not by adding a blanket guard to `dispatch_slash` (which would mask real handler bugs). I matched the exact pattern the sibling commands use (`escape(user_value)` inside the themed f-string) rather than switching the print to `markup=False`, which would strip the intended error styling. The test drives the real `dispatch_slash` path with a recording console rather than calling `_cmd_theme` directly, so the regression pins the user-visible behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
