### PR TITLE
fix(yandex-cloud): drop the stray pageSize from the NLB target-state read

### DIFF
--- a/integrations/yandex_cloud/tools/yc_lb_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_lb_tool/__init__.py
@@ -101,6 +101,7 @@ def _network_target_states(
             _NLB_SERVICE,
             f"{_NLB_PATH}/{balancer_id}:getTargetStates",
             {"targetGroupId": group_id},
+            page_size=None,
         )
         if not states.get("success"):
             errors.append(f"{group_id}: {states.get('error', '')}")

--- a/tests/integrations/test_yc_network.py
+++ b/tests/integrations/test_yc_network.py
@@ -117,6 +117,39 @@ class TestLoadBalancers:
         assert [t["address"] for t in result["unhealthy_targets"]] == ["10.0.0.2"]
         assert result["unhealthy_targets"][0]["target_group"] == "tg-sick"
 
+    def test_network_target_state_read_sends_no_page_size(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Yandex answers a target-state read that carries a stray pageSize with a bare 404."""
+        state_queries: list[dict[str, Any]] = []
+
+        def _request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+            params = dict(kwargs.get("params") or {})
+            if ":getTargetStates" in url:
+                state_queries.append(params)
+                return httpx.Response(HTTPStatus.OK, json={"targetStates": []})
+            if "/load-balancer/v1/networkLoadBalancers" in url:
+                return httpx.Response(
+                    HTTPStatus.OK,
+                    json={
+                        "loadBalancers": [
+                            {
+                                "id": "nlb-1",
+                                "name": "edge",
+                                "status": "ACTIVE",
+                                "attachedTargetGroups": [{"targetGroupId": "tg-1"}],
+                            }
+                        ]
+                    },
+                )
+            return httpx.Response(HTTPStatus.OK, json={"loadBalancers": []})
+
+        monkeypatch.setattr("integrations.yandex_cloud.rest_client.send_request", _request)
+
+        get_yc_lb_health(**_CREDENTIALS)
+
+        assert state_queries == [{"targetGroupId": "tg-1"}]
+
     def test_one_balancer_type_can_be_requested(self, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: list[str] = []
 


### PR DESCRIPTION
Fixes #5302

#### Describe the changes you have made in this PR -

`_network_target_states` was the one single-resource read in the yandex_cloud package that didn't pass `page_size=None`, so `YandexCloudClient.get`'s default added `pageSize=100` to `networkLoadBalancers/{id}:getTargetStates`. Per the Yandex API reference the only query parameter on that call is `targetGroupId` (https://yandex.cloud/en/docs/network-load-balancer/api-ref/NetworkLoadBalancer/getTargetStates), and the integration's own docstrings warn that "Yandex answers a target-state or backend-group read that carries a stray pageSize with a bare 404" — the guard applied by the ALB targetStates/backendGroups reads in the same file and the instance reads in `yc_instances_tool`, but omitted here. The 404 landed in `target_states_error` on every call, so `get_yc_lb_health` could never report an unhealthy NLB target.

One-line fix (`page_size=None`) plus a regression test that pins the exact wire query for the target-state read, closing the gap that let this slip through (the existing fakes route on URL substring and ignored stray query params). Also unblocks the NLB-health part of #5170.

### Demo/Screenshot for feature changes and bug fixes -

Wire query captured via a monkeypatched `send_request`, before (main):

```
GET .../networkLoadBalancers/nlb-1:getTargetStates
  params: {'targetGroupId': 'tg-1', 'pageSize': 100}   <-- documented bare-404 shape
```

After (this branch):

```
GET .../networkLoadBalancers/nlb-1:getTargetStates
  params: {'targetGroupId': 'tg-1'}
```

Regression test verified to fail on unfixed code:

```
git stash push integrations/yandex_cloud/tools/yc_lb_tool/__init__.py
uv run python -m pytest tests/integrations/test_yc_network.py -k no_page_size -q   # 1 failed
git stash pop
uv run python -m pytest tests/integrations/test_yc_network.py -k no_page_size -q   # 1 passed
```

Focused tests + baseline checks (per CI.md):

```
uv run python -m pytest tests/integrations/test_yc_network.py -q   # 20 passed
make lint          # All checks passed!
make format-check  # 3604 files already formatted
make typecheck     # Success: no issues found in 1860 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The client centralizes pagination defaults (`page_size=DEFAULT_PAGE_SIZE` with `query.setdefault`), and callers opt out per request with `page_size=None` on endpoints that reject pagination params. I kept that convention rather than special-casing `:getTargetStates` inside the client (e.g. suppressing pageSize for non-collection paths there), because the client already exposes the opt-out and all sibling call sites use it — a client-side heuristic would change behavior for every caller and is a larger design decision than this fix needs. The regression test asserts the exact captured query dict (`== [{"targetGroupId": "tg-1"}]`) rather than just "no pageSize", so any future stray param on this read also trips it.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
