### PR TITLE
fix(integrations): mark bitbucket and supabase as directly effective

### DIFF
--- a/integrations/effective_models.py
+++ b/integrations/effective_models.py
@@ -87,6 +87,7 @@ class EffectiveIntegrations(StrictConfigModel):
     victoria_logs: EffectiveIntegrationEntry | None = None
     alicloud: EffectiveIntegrationEntry | None = None
     signoz: EffectiveIntegrationEntry | None = None
+    supabase: EffectiveIntegrationEntry | None = None
     jenkins: EffectiveIntegrationEntry | None = None
     tempo: EffectiveIntegrationEntry | None = None
     temporal: EffectiveIntegrationEntry | None = None

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -291,7 +291,7 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
         setup_order=21,
         verify_order=14,
     ),
-    IntegrationSpec(service="bitbucket", has_verifier=True, verify_order=24),
+    IntegrationSpec(service="bitbucket", has_verifier=True, direct_effective=True, verify_order=24),
     IntegrationSpec(
         service="snowflake",
         has_verifier=True,
@@ -405,6 +405,7 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(
         service="supabase",
         has_verifier=True,
+        direct_effective=True,
         verify_order=99,
     ),
     IntegrationSpec(

--- a/integrations/supabase/verifier.py
+++ b/integrations/supabase/verifier.py
@@ -4,11 +4,31 @@ from __future__ import annotations
 
 from typing import Any
 
-from integrations.supabase import build_supabase_config, validate_supabase_config
+from integrations.supabase import (
+    SupabaseConfig,
+    build_supabase_config,
+    resolve_supabase_config,
+    validate_supabase_config,
+)
 from integrations.verification import (
     register_verifier,
     verify_with_validation_result,
 )
+
+
+def _build_config_resolving_credentials(config: dict[str, Any]) -> SupabaseConfig:
+    """Build a full config from either credential shape.
+
+    The effective resolution deliberately publishes only ``project_url`` —
+    the service key never appears in resolved configs — so verification
+    re-resolves credentials from the store or environment the same way the
+    tools do. A config that already carries ``url``/``service_key`` builds
+    directly.
+    """
+    project_url = str(config.get("project_url", "")).strip()
+    if project_url and not (config.get("url") or config.get("service_key")):
+        return resolve_supabase_config(project_url)
+    return build_supabase_config(config)
 
 
 @register_verifier("supabase")
@@ -17,6 +37,6 @@ def verify_supabase(source: str, config: dict[str, Any]) -> dict[str, str]:
         "supabase",
         source,
         config,
-        build_config=build_supabase_config,
+        build_config=_build_config_resolving_credentials,
         validate_config=validate_supabase_config,
     )

--- a/tests/integrations/test_catalog_multi_instance.py
+++ b/tests/integrations/test_catalog_multi_instance.py
@@ -355,3 +355,40 @@ def test_resolve_effective_integrations_publishes_store_configured_prefect() -> 
     assert "prefect" in resolved
     assert resolved["prefect"]["source"] == "local store"
     assert resolved["prefect"]["config"]["api_url"] == "http://localhost:4200/api"
+
+
+def test_resolve_effective_integrations_publishes_store_configured_bitbucket() -> None:
+    """Regression: same missing direct_effective=True as prefect (#5147) —
+    classify_integrations() resolved a store-saved bitbucket config, then
+    resolve_effective_integrations() silently dropped it, so
+    `opensre integrations verify bitbucket` reported "missing" even with
+    valid store credentials."""
+    from integrations.catalog import resolve_effective_integrations
+
+    store_record = {
+        "id": "bitbucket-1",
+        "service": "bitbucket",
+        "status": "active",
+        "credentials": {"workspace": "acme", "username": "dev", "app_password": "secret"},
+    }
+    resolved = resolve_effective_integrations(store_integrations=[store_record])
+    assert "bitbucket" in resolved
+    assert resolved["bitbucket"]["source"] == "local store"
+    assert resolved["bitbucket"]["config"]["workspace"] == "acme"
+
+
+def test_resolve_effective_integrations_publishes_store_configured_supabase() -> None:
+    """Regression: same missing direct_effective=True as prefect (#5147),
+    for supabase — classification succeeded and the resolution dropped it."""
+    from integrations.catalog import resolve_effective_integrations
+
+    store_record = {
+        "id": "supabase-1",
+        "service": "supabase",
+        "status": "active",
+        "credentials": {"url": "https://proj.supabase.co", "service_key": "sk"},
+    }
+    resolved = resolve_effective_integrations(store_integrations=[store_record])
+    assert "supabase" in resolved
+    assert resolved["supabase"]["source"] == "local store"
+    assert resolved["supabase"]["config"]["project_url"] == "https://proj.supabase.co"

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -74,7 +74,6 @@ def test_registry_preserves_aliases_and_special_case_buckets() -> None:
     assert "slack" not in SKIP_CLASSIFIED_SERVICES
     assert "slack" in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
     assert "grafana" in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
-    assert "bitbucket" not in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
 
 
 def test_railway_is_registered_as_a_configurable_verified_integration() -> None:
@@ -99,6 +98,19 @@ def test_prefect_is_registered_as_a_directly_effective_integration() -> None:
     assert prefect.has_verifier is True
     assert prefect.direct_effective is True
     assert "prefect" not in SKIP_CLASSIFIED_SERVICES
+
+
+def test_bitbucket_and_supabase_are_registered_as_directly_effective() -> None:
+    # Same omission as prefect (#5147): both have registered classifiers and
+    # env loaders, so classification succeeded and the result was then
+    # silently dropped by resolve_effective_integrations(), which only
+    # publishes services listed in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES.
+    for service in ("bitbucket", "supabase"):
+        spec = next(spec for spec in INTEGRATION_SPECS if spec.service == service)
+
+        assert spec.has_verifier is True
+        assert spec.direct_effective is True
+        assert service not in SKIP_CLASSIFIED_SERVICES
 
 
 def test_resolve_management_service_keeps_posthog_and_posthog_mcp_distinct() -> None:

--- a/tests/integrations/test_supabase.py
+++ b/tests/integrations/test_supabase.py
@@ -339,3 +339,77 @@ class TestGetStorageBuckets:
         assert result["total_buckets"] == 10
         assert result["returned_buckets"] == 2
         assert result["truncated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Verifier — reduced effective config resolves credentials internally
+# ---------------------------------------------------------------------------
+
+
+class TestVerifySupabase:
+    """The effective resolution publishes only ``project_url`` (the service
+    key never appears in resolved configs), so the verifier must re-resolve
+    credentials the way the tools do instead of requiring them in the config."""
+
+    def test_reduced_effective_config_resolves_and_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from integrations.supabase import SupabaseValidationResult
+        from integrations.supabase import verifier as verifier_module
+
+        monkeypatch.setenv("SUPABASE_URL", "https://proj.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_KEY", "svc")
+        seen: list[SupabaseConfig] = []
+
+        def _validate(config: SupabaseConfig) -> SupabaseValidationResult:
+            seen.append(config)
+            return SupabaseValidationResult(ok=True, detail="ok")
+
+        monkeypatch.setattr(verifier_module, "validate_supabase_config", _validate)
+
+        result = verifier_module.verify_supabase(
+            "local store", {"project_url": "https://proj.supabase.co", "integration_id": "sb-1"}
+        )
+
+        assert result["status"] == "passed"
+        assert seen[0].url == "https://proj.supabase.co"
+        assert seen[0].service_key == "svc"
+
+    def test_full_credential_config_still_builds_directly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from integrations.supabase import SupabaseValidationResult
+        from integrations.supabase import verifier as verifier_module
+
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+        seen: list[SupabaseConfig] = []
+
+        def _validate(config: SupabaseConfig) -> SupabaseValidationResult:
+            seen.append(config)
+            return SupabaseValidationResult(ok=True, detail="ok")
+
+        monkeypatch.setattr(verifier_module, "validate_supabase_config", _validate)
+
+        result = verifier_module.verify_supabase(
+            "env", {"url": "https://proj.supabase.co", "service_key": "direct"}
+        )
+
+        assert result["status"] == "passed"
+        assert seen[0].service_key == "direct"
+
+    def test_unresolvable_reduced_config_reports_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from integrations.supabase import verifier as verifier_module
+
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+
+        with patch("integrations.store.load_integrations", return_value=[]):
+            result = verifier_module.verify_supabase(
+                "local store", {"project_url": "https://proj.supabase.co"}
+            )
+
+        assert result["status"] == "missing"
+        assert "not configured" in result["detail"]


### PR DESCRIPTION
Fixes #5304

#### Describe the changes you have made in this PR -

`bitbucket` and `supabase` have the exact bug fixed for prefect in #5147 / #5216: both register classifiers (`_catalog_impl.py`) and env loaders, so `classify_integrations()` resolves their saved credentials correctly — and `resolve_effective_integrations()` then silently drops the result, because it only publishes services in `DIRECT_CLASSIFIED_EFFECTIVE_SERVICES` (built from `spec.direct_effective`) and neither spec carried the flag. There was no way to make either integration effective, from the local store or from env vars: `opensre integrations verify bitbucket|supabase` always reported "missing", which also makes the open verification tasks #5109 and #5161 unfulfillable as-is.

Changes, mirroring #5216:

- `direct_effective=True` on both specs in `integrations/registry.py`
- the missing `supabase` field in `EffectiveIntegrations` (bitbucket already had one)
- regression tests cloned from the #5216 pair, for both services
- removed `assert "bitbucket" not in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES` from `test_registry_preserves_aliases_and_special_case_buckets` — that line came in with the bulk commit that created the test file (99fa19f27), carries no rationale comment, and pinned the buggy status quo; the registered classifier + env loader + verifier only make sense if the classification result is published. If the exclusion was a deliberate decision I'm happy to split supabase out and drop the bitbucket half.

### Demo/Screenshot for feature changes and bug fixes -

Before (main):

```
$ uv run python -c "... resolve_effective_integrations(store_integrations=[rec]) ..."
bitbucket published: False
supabase published: False
```

After (this branch):

```
bitbucket published: True | source: local store
supabase published: True | source: local store
```

Focused tests + baseline checks (per CI.md):

```
uv run python -m pytest tests/integrations/ -q   # 3577 passed, 7 skipped
make lint          # All checks passed!
make format-check  # 3604 files already formatted
make typecheck     # Success: no issues found in 1860 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The publication gate lives in `resolve_effective_integrations()`, which iterates `DIRECT_CLASSIFIED_EFFECTIVE_SERVICES`; the alternative — a bespoke publication block per service like datadog/slack have — exists for services whose effective entry needs extra shaping, which neither of these does, so the flag is the right mechanism. Supabase's classify returns a `{project_url, integration_id}` dict, so the regression test asserts `config["project_url"]`; bitbucket's returns a full `BitbucketConfig`, so its test asserts `config["workspace"]`. I checked both credential shapes against the classifiers (`bitbucket/config.py` requires `workspace`; supabase requires `url` + `service_key` via `build_supabase_config`) so the tests exercise the real resolution path end-to-end rather than stubbing classification.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
