### PR TITLE
refactor(agent_harness): type builder parameters in agent_build_confi…

### DIFF
--- a/core/agent_harness/agent_build_config.py
+++ b/core/agent_harness/agent_build_config.py
@@ -31,10 +31,10 @@ class BuildTools(Protocol):
 
     def __call__(
         self,
-        session: SessionState,
+        session: Any,
         console: Any,
         logger: logging.Logger,
-        observer: ToolEventObserver,
+        observer: ToolEventObserver | None,
         /,
     ) -> ToolProvider:
         """Return the tools for this session."""
@@ -43,14 +43,14 @@ class BuildTools(Protocol):
 class BuildPrompts(Protocol):
     """``(session) -> PromptContextProvider``."""
 
-    def __call__(self, session: SessionState, /) -> PromptContextProvider:
+    def __call__(self, session: Any, /) -> PromptContextProvider:
         """Return the prompt context for this session."""
 
 
 class BuildGather(Protocol):
     """``(session, console) -> GatherPhase``."""
 
-    def __call__(self, session: SessionState, console: Any, /) -> GatherPhase:
+    def __call__(self, session: Any, console: Any, /) -> GatherPhase:
         """Return how this host runs the gather phase."""
 
 
@@ -68,7 +68,7 @@ class DescribeTool(Protocol):
 class ApplyCapabilityPolicy(Protocol):
     """``(session) -> None``. ``None`` on the config field means do not call."""
 
-    def __call__(self, session: SessionState, /) -> None:
+    def __call__(self, session: Any, /) -> None:
         """Mutate ``session`` capabilities, or do nothing."""
 
 

--- a/core/agent_harness/agent_build_config.py
+++ b/core/agent_harness/agent_build_config.py
@@ -13,7 +13,6 @@ from typing import Any, Protocol
 from core.agent_harness.ports import (
     ErrorReporter,
     PromptContextProvider,
-    SessionState,
     SubprocessPresenterFactory,
     ToolEventObserver,
     ToolProvider,

--- a/core/agent_harness/agent_build_config.py
+++ b/core/agent_harness/agent_build_config.py
@@ -13,7 +13,9 @@ from typing import Any, Protocol
 from core.agent_harness.ports import (
     ErrorReporter,
     PromptContextProvider,
+    SessionState,
     SubprocessPresenterFactory,
+    ToolEventObserver,
     ToolProvider,
 )
 from core.agent_harness.turns.gather_phase import GatherPhase
@@ -29,10 +31,10 @@ class BuildTools(Protocol):
 
     def __call__(
         self,
-        session: Any,
+        session: SessionState,
         console: Any,
         logger: logging.Logger,
-        observer: Any,
+        observer: ToolEventObserver,
         /,
     ) -> ToolProvider:
         """Return the tools for this session."""
@@ -41,14 +43,14 @@ class BuildTools(Protocol):
 class BuildPrompts(Protocol):
     """``(session) -> PromptContextProvider``."""
 
-    def __call__(self, session: Any, /) -> PromptContextProvider:
+    def __call__(self, session: SessionState, /) -> PromptContextProvider:
         """Return the prompt context for this session."""
 
 
 class BuildGather(Protocol):
     """``(session, console) -> GatherPhase``."""
 
-    def __call__(self, session: Any, console: Any, /) -> GatherPhase:
+    def __call__(self, session: SessionState, console: Any, /) -> GatherPhase:
         """Return how this host runs the gather phase."""
 
 
@@ -66,7 +68,7 @@ class DescribeTool(Protocol):
 class ApplyCapabilityPolicy(Protocol):
     """``(session) -> None``. ``None`` on the config field means do not call."""
 
-    def __call__(self, session: Any, /) -> None:
+    def __call__(self, session: SessionState, /) -> None:
         """Mutate ``session`` capabilities, or do nothing."""
 
 


### PR DESCRIPTION
Fixes #5250

#### Describe the changes you have made in this PR -
Replaced the `Any` type hints in the builder protocols inside `core/agent_harness/agent_build_config.py` with the concrete types `SessionState` and `ToolEventObserver` from `core.agent_harness.ports`. I left `console` as `Any` since the sibling issue is handling that specific Protocol.

### Demo/Screenshot for feature changes and bug fixes - 
N/A (Code refactoring / typing update only, no UI/UX changes).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

 

**Explain your implementation approach:**
The implementation simply replaces the `Any` parameters in the `BuildTools`, `BuildPrompts`, `BuildGather`, and `ApplyCapabilityPolicy` protocols in `agent_build_config.py` with `SessionState` and `ToolEventObserver` after importing them from the `ports` module. I verified that no runtime changes occur and that type hints match the instructions detailed in the issue. The goal was to strictly type the signatures while adhering to the repo's structure.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions