### PR TITLE
fix(terminal): round the validity percent instead of truncating

### DIFF
--- a/surfaces/shared/terminal/stream_renderer/formatting.py
+++ b/surfaces/shared/terminal/stream_renderer/formatting.py
@@ -64,4 +64,5 @@ def _validity_score_percent(score: Any) -> str | None:
     if not math.isfinite(v):
         return None
     v = max(0.0, min(1.0, v))
-    return f"{int(v * 100)}%"
+    # round, not int: 0.29 * 100 is 28.999... in IEEE-754 and int() truncates.
+    return f"{round(v * 100)}%"

--- a/tests/shared/terminal/stream_renderer/test_renderer.py
+++ b/tests/shared/terminal/stream_renderer/test_renderer.py
@@ -221,6 +221,15 @@ class TestStreamRendererUpdatesMode:
         assert "92%" in msg
 
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
+    def test_node_message_for_diagnose_rounds_validity(self) -> None:
+        # 0.29 * 100 is 28.999... in IEEE-754; int() truncated it to "28%".
+        renderer = StreamRenderer()
+        renderer._final_state = {"validity_score": 0.29}
+        msg = renderer._build_node_message("diagnose_root_cause")
+        assert msg is not None
+        assert "29%" in msg
+
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
     def test_node_message_for_diagnose_skips_non_numeric_validity(self) -> None:
         renderer = StreamRenderer()
         renderer._final_state = {"validity_score": "0.9"}


### PR DESCRIPTION
Fixes #5310

#### Describe the changes you have made in this PR -

`_validity_score_percent` formatted the diagnose validity score with `int(v * 100)`, which truncates — and in IEEE-754, `0.29 * 100 == 28.999999999999996`, so any score whose ×100 product lands just below an integer displayed one point low (`0.29` → `28%`, `0.57` → `56%`) on the diagnose resolution line. One-line fix to `round(v * 100)` plus a regression test through `_build_node_message`, alongside the existing diagnose-validity cases. Same round-before-display class as #5178/#5179.

### Demo/Screenshot for feature changes and bug fixes -

Before (main):

```
$ uv run python -c "from surfaces.shared.terminal.stream_renderer.formatting import _validity_score_percent
for s in (0.29, 0.57, 0.58): print(s, '->', _validity_score_percent(s))"
0.29 -> 28%
0.57 -> 56%
0.58 -> 57%
```

After (this branch):

```
0.29 -> 29%
0.57 -> 57%
0.58 -> 58%
```

Focused tests + baseline checks (per CI.md):

```
uv run python -m pytest tests/shared/terminal/stream_renderer/ -q   # 80 passed
make lint          # All checks passed!
make format-check  # 3618 files already formatted
make typecheck     # Success: no issues found in 1872 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The clamp above the format line already bounds `v` to [0, 1], so `round` cannot push the display past 100% — `round(1.0 * 100) == 100`. I considered formatting with `f"{v:.0%}"` (which also rounds) but kept the explicit `* 100` shape so the diff is one token and the clamp stays visibly separate. The regression test drives the public `_build_node_message` path rather than the private helper, pinning what the user actually sees.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
