### PR TITLE
chore(tests): update pytest configuration to use importlib mode for better file handling

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,9 @@ testpaths =
 python_files = test_*.py *_test.py
 norecursedirs = tests/e2e .git __pycache__ .pytest_cache .venv node_modules *.egg .tox
 python_functions = test_*
-addopts = -v --tb=short --durations=20
+# importlib avoids "import file mismatch" when two test files share a basename
+# (pytest's default prepend mode would import both as top-level test_enums).
+addopts = -v --tb=short --durations=20 --import-mode=importlib
 filterwarnings =
     ignore::DeprecationWarning
     ignore:.*threading\.Lock.*:UserWarning

--- a/tests/quality/test_pytest_duplicate_module_collection.py
+++ b/tests/quality/test_pytest_duplicate_module_collection.py
@@ -1,0 +1,48 @@
+"""Duplicate test basenames must collect in one non-xdist session.
+
+pytest's default prepend import mode imports files as the basename module, so
+``tests/filestorage/test_enums.py`` and ``tests/core/tool/test_enums.py`` both
+become ``test_enums`` and collection fails with ``import file mismatch``.
+``pytest.ini`` sets ``--import-mode=importlib`` so each file loads uniquely
+(issue #5325).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTEST_INI = _REPO_ROOT / "pytest.ini"
+_COLLIDING_ENUM_TESTS = (
+    "tests/filestorage/test_enums.py",
+    "tests/core/tool/test_enums.py",
+)
+
+
+def test_pytest_ini_uses_importlib_import_mode() -> None:
+    text = _PYTEST_INI.read_text(encoding="utf-8")
+    assert "--import-mode=importlib" in text
+
+
+def test_duplicate_test_enums_modules_collect_together() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *_COLLIDING_ENUM_TESTS,
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:xdist",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = f"{result.stdout}{result.stderr}"
+    assert result.returncode == 0, combined
+    assert "import file mismatch" not in combined


### PR DESCRIPTION
/fix #5325 
This pull request addresses issues with pytest module collection when multiple test files share the same basename. The main change is to configure pytest to use `importlib` import mode, ensuring unique imports and preventing "import file mismatch" errors. Additionally, tests are added to verify this behavior.

**Pytest configuration improvements:**

* Updated `pytest.ini` to add `--import-mode=importlib` to `addopts`, which ensures test files with the same basename are imported uniquely and prevents collection errors.

**Test coverage enhancements:**

* Added `tests/quality/test_pytest_duplicate_module_collection.py` to verify that `pytest.ini` uses `--import-mode=importlib` and to test that duplicate-named test modules (e.g., `test_enums.py` in different directories) are collected together without import errors.

<img width="696" height="222" alt="Screenshot 2026-08-21 at 5 02 32 PM" src="https://github.com/user-attachments/assets/ac34cd9a-9fdc-4263-8f05-428787484a70" />
