### PR TITLE
refactor(scheduler): invert vendor delivery behind a delivery-adapter bundle (#5330)

### DIFF
--- a/.importlinter.strict
+++ b/.importlinter.strict
@@ -34,11 +34,6 @@ ignore_imports =
     infrastructure.analytics.cli -> integrations.github.identity
     infrastructure.observability.errors.sentry -> integrations.llm_cli.errors
     infrastructure.scheduling.scheduler.credentials -> integrations.catalog
-    infrastructure.scheduling.scheduler.executor -> integrations.discord.delivery
-    infrastructure.scheduling.scheduler.executor -> integrations.rocketchat.delivery
-    infrastructure.scheduling.scheduler.executor -> integrations.slack.delivery
-    infrastructure.scheduling.scheduler.executor -> integrations.telegram.delivery
-    infrastructure.scheduling.scheduler.executor -> integrations.telegram.formatting
     # surfaces -> gateway (cli + repl gateway commands)
     surfaces.cli.commands.gateway -> gateway.core.process
     surfaces.gateway_entry -> gateway.core.lifecycle.controller

--- a/bootstrap/adapters.py
+++ b/bootstrap/adapters.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from infrastructure.scheduling.scheduler.delivery_bundle import ScheduledDeliveryAdapters
     from infrastructure.scheduling.scheduler.runners import SchedulerRunners
 
 
@@ -112,10 +113,44 @@ def install_scheduler_runners() -> None:
     scheduler_runners().install()
 
 
+def scheduled_delivery_adapters() -> ScheduledDeliveryAdapters:
+    """Assemble the per-provider adapters scheduled delivery dispatches through.
+
+    The only layer that may see both ``integrations`` and ``infrastructure``, so
+    the vendor adapters are bundled here and handed to whichever host installs it.
+    """
+    from infrastructure.scheduling.scheduler.delivery_bundle import ScheduledDeliveryAdapters
+    from infrastructure.scheduling.scheduler.interactive_shell_delivery import (
+        InteractiveShellScheduledDelivery,
+    )
+    from infrastructure.scheduling.scheduler.types import Provider
+    from integrations.discord.scheduled_delivery import DiscordScheduledDelivery
+    from integrations.rocketchat.scheduled_delivery import RocketChatScheduledDelivery
+    from integrations.slack.scheduled_delivery import SlackScheduledDelivery
+    from integrations.telegram.scheduled_delivery import TelegramScheduledDelivery
+
+    return ScheduledDeliveryAdapters(
+        {
+            Provider.TELEGRAM: TelegramScheduledDelivery(),
+            Provider.SLACK: SlackScheduledDelivery(),
+            Provider.DISCORD: DiscordScheduledDelivery(),
+            Provider.ROCKETCHAT: RocketChatScheduledDelivery(),
+            Provider.INTERACTIVE_SHELL: InteractiveShellScheduledDelivery(),
+        }
+    )
+
+
+def install_scheduled_delivery_adapters() -> None:
+    """Bind the scheduled-delivery adapters (worker and CLI hosts)."""
+    scheduled_delivery_adapters().install()
+
+
 __all__ = [
     "install_harness_adapters",
     "install_investigation_api",
     "install_notification_adapters",
     "scheduler_runners",
     "install_scheduler_runners",
+    "scheduled_delivery_adapters",
+    "install_scheduled_delivery_adapters",
 ]

--- a/bootstrap/process.py
+++ b/bootstrap/process.py
@@ -21,7 +21,11 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Final
 
-from bootstrap.adapters import install_harness_adapters, install_scheduler_runners
+from bootstrap.adapters import (
+    install_harness_adapters,
+    install_scheduled_delivery_adapters,
+    install_scheduler_runners,
+)
 from config.local_env import bootstrap_opensre_env_once
 
 _LOG = logging.getLogger(__name__)
@@ -144,6 +148,7 @@ def _run_harness_adapters(_profile: ProcessProfile, _log: logging.Logger) -> Non
 
 def _run_scheduler_runners(_profile: ProcessProfile, _log: logging.Logger) -> None:
     install_scheduler_runners()
+    install_scheduled_delivery_adapters()
 
 
 def _run_capability_warnings(profile: ProcessProfile, log: logging.Logger) -> None:

--- a/core/domain/background_investigations.py
+++ b/core/domain/background_investigations.py
@@ -1,4 +1,4 @@
-"""Background-investigation value types shared across surfaces."""
+"""Background-investigation record: the domain contract for a detached investigation."""
 
 from __future__ import annotations
 

--- a/gateway/core/lifecycle/controller.py
+++ b/gateway/core/lifecycle/controller.py
@@ -129,7 +129,7 @@ class GatewayController:
         :func:`request_scheduler_reload`; this process only installs gated
         runners and starts :func:`start_background_scheduler`.
         """
-        from bootstrap.adapters import scheduler_runners
+        from bootstrap.adapters import install_scheduled_delivery_adapters, scheduler_runners
         from infrastructure.scheduling.scheduler.reload_signal import (
             consume_scheduler_reload_request,
         )
@@ -139,6 +139,7 @@ class GatewayController:
         # A scheduled run costs a turn, so both take the same capacity gate chat
         # turns take — stated here, once, rather than rewritten in afterwards.
         scheduler_runners().gated(self.turn_gate).install()
+        install_scheduled_delivery_adapters()
         # Drop any reload request queued before this process owned the scheduler.
         consume_scheduler_reload_request()
         scheduler, task_count = start_background_scheduler()

--- a/gateway/tests/runtime/test_slash_routing.py
+++ b/gateway/tests/runtime/test_slash_routing.py
@@ -265,11 +265,11 @@ _BOX_DRAWING = set("─│┃━╭╮╰╯┏┓┗┛┿┼┤├┬┴┌┐
 
 
 def _seed_record(**overrides: Any) -> str:
-    from infrastructure.scheduling.background_investigations.store import (
-        background_investigation_store,
-    )
-    from infrastructure.scheduling.background_investigations.types import (
+    from core.domain.background_investigations import (
         BackgroundInvestigationRecord,
+    )
+    from infrastructure.scheduling.background_investigations.store import (
+        open_record_store,
     )
 
     fields: dict[str, Any] = {
@@ -282,7 +282,7 @@ def _seed_record(**overrides: Any) -> str:
     }
     fields.update(overrides)
     record = BackgroundInvestigationRecord(**fields)
-    background_investigation_store().save(record)
+    open_record_store().save(record)
     return record.task_id
 
 

--- a/infrastructure/delivery/notifications/outbound_dispatch.py
+++ b/infrastructure/delivery/notifications/outbound_dispatch.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 import logging
 
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from infrastructure.delivery.notifications.outbound_registry import (
     BACKGROUND_RCA,
     get_outbound_adapter,
 )
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
 logger = logging.getLogger(__name__)
 

--- a/infrastructure/delivery/notifications/outbound_registry.py
+++ b/infrastructure/delivery/notifications/outbound_registry.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
+from core.domain.background_investigations import BackgroundInvestigationRecord
 
 ChannelName = str
 

--- a/infrastructure/delivery/notifications/rca_summary.py
+++ b/infrastructure/delivery/notifications/rca_summary.py
@@ -12,7 +12,7 @@ point the reader at ``/background show`` for the rest.
 
 from __future__ import annotations
 
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
+from core.domain.background_investigations import BackgroundInvestigationRecord
 
 _COMMAND_CHARS = 200
 _ROOT_CAUSE_CHARS = 1000

--- a/infrastructure/scheduling/background_investigations/store.py
+++ b/infrastructure/scheduling/background_investigations/store.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import tempfile
-import threading
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
@@ -20,7 +19,7 @@ from typing import Any
 
 from filelock import FileLock, Timeout
 
-from infrastructure.scheduling.background_investigations.types import (
+from core.domain.background_investigations import (
     BackgroundInvestigationRecord,
     coerce_timestamp,
 )
@@ -41,11 +40,11 @@ _CHANNELS_KEY = "notify_channels"
 _STORE_DIRNAME = "background"
 
 
-class BackgroundInvestigationStoreLockTimeout(TimeoutError):
+class StoreLockTimeout(TimeoutError):
     """Raised when the investigations file cannot be locked in time."""
 
 
-class UnreadableBackgroundInvestigationsError(RuntimeError):
+class UnreadableStoreError(RuntimeError):
     """Raised when the investigations file exists but cannot be parsed."""
 
 
@@ -56,7 +55,7 @@ def _default_path() -> Path:
     return deployment_home() / _STORE_DIRNAME / _STORE_FILENAME
 
 
-class BackgroundInvestigationStore:
+class RecordStore:
     """Background investigation records in one JSON document per principal."""
 
     def __init__(
@@ -152,11 +151,11 @@ class BackgroundInvestigationStore:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
-            raise UnreadableBackgroundInvestigationsError(
+            raise UnreadableStoreError(
                 f"background investigations file is unreadable: {path}"
             ) from exc
         if not isinstance(data, dict) or not isinstance(data.get("records"), list):
-            raise UnreadableBackgroundInvestigationsError(
+            raise UnreadableStoreError(
                 f"background investigations file has an unexpected shape: {path}"
             )
         return data
@@ -208,27 +207,22 @@ class BackgroundInvestigationStore:
             with lock:
                 yield
         except Timeout as exc:
-            raise BackgroundInvestigationStoreLockTimeout(
-                f"background investigations file is locked: {path}"
-            ) from exc
+            raise StoreLockTimeout(f"background investigations file is locked: {path}") from exc
 
 
-_default_store: BackgroundInvestigationStore | None = None
-_default_store_lock = threading.Lock()
+def open_record_store() -> RecordStore:
+    """Open the background-investigations store.
 
-
-def background_investigation_store() -> BackgroundInvestigationStore:
-    """Return the process-wide store, resolving its scope on each operation."""
-    global _default_store
-    with _default_store_lock:
-        if _default_store is None:
-            _default_store = BackgroundInvestigationStore()
-        return _default_store
+    Returns a fresh handle each call: the store resolves its file path per
+    operation and holds no in-memory state, so there is nothing to cache and no
+    process-wide singleton to keep.
+    """
+    return RecordStore()
 
 
 __all__ = [
-    "BackgroundInvestigationStore",
-    "BackgroundInvestigationStoreLockTimeout",
-    "UnreadableBackgroundInvestigationsError",
-    "background_investigation_store",
+    "RecordStore",
+    "StoreLockTimeout",
+    "UnreadableStoreError",
+    "open_record_store",
 ]

--- a/infrastructure/scheduling/scheduler/delivery.py
+++ b/infrastructure/scheduling/scheduler/delivery.py
@@ -7,6 +7,7 @@ package so integrations depend downward on it instead of on each other.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -16,11 +17,39 @@ from rich.console import Console
 from infrastructure.scheduling.scheduler.credentials import (
     resolve_rocketchat_credentials,
     resolve_slack_credentials,
+    resolve_slack_default_chat_id,
     resolve_telegram_credentials,
 )
-from infrastructure.scheduling.scheduler.types import Provider
+from infrastructure.scheduling.scheduler.loop_constants import LOOP_SLACK_CHAT_ID_PARAM
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask
 
 _console = Console()
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def strip_html(text: str) -> str:
+    """Strip HTML tags for providers that use plain text or Markdown."""
+    return _HTML_TAG_RE.sub("", text)
+
+
+def resolve_slack_delivery_chat_id(task: ScheduledTask, *, webhook_url: str) -> str:
+    """Resolve the Slack ``chat_id`` for scheduled delivery.
+
+    A configured webhook is channel-bound, so an implicit default channel must
+    not be applied on top of it — that would force the bot-token path while
+    credentials resolve to webhook-only. Implicit bot-token defaults come from
+    :func:`resolve_slack_default_chat_id`, which pairs the channel with the same
+    credential source as the token.
+    """
+    explicit = task.params.get(LOOP_SLACK_CHAT_ID_PARAM, "").strip() or (
+        (task.chat_id or "").strip() if task.provider == Provider.SLACK else ""
+    )
+    if explicit:
+        return explicit
+    if webhook_url.strip():
+        return ""
+    return resolve_slack_default_chat_id(task.params)
 
 
 def telegram_delivery_ready() -> bool:

--- a/infrastructure/scheduling/scheduler/delivery_bundle.py
+++ b/infrastructure/scheduling/scheduler/delivery_bundle.py
@@ -1,0 +1,68 @@
+"""The per-provider scheduled-delivery adapters, assembled once at boot.
+
+The executor resolves a ``Provider`` to its delivery adapter through this bundle
+instead of importing vendor modules, so a new delivery vendor is added by
+extending the bundle at the composition root (``bootstrap.adapters``) — the
+scheduler stays vendor-agnostic and imports no ``integrations`` package.
+
+The bundle is an immutable value assembled at a composition root and installed
+once (mirrors :class:`infrastructure.scheduling.scheduler.runners.SchedulerRunners`),
+so there is no mutable per-provider registry to read-modify-write.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask
+
+
+@runtime_checkable
+class ScheduledDeliveryAdapter(Protocol):
+    """Delivers one built message to a provider for a scheduled task."""
+
+    def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        """Deliver ``message`` for ``task``; return ``(success, error, message_id)``."""
+
+
+@dataclass(frozen=True)
+class ScheduledDeliveryAdapters:
+    """Immutable provider -> adapter mapping, installed once at boot."""
+
+    adapters: Mapping[Provider, ScheduledDeliveryAdapter]
+
+    def get(self, provider: Provider) -> ScheduledDeliveryAdapter | None:
+        """Return the adapter for ``provider``, or ``None`` if none is bundled."""
+        return self.adapters.get(provider)
+
+    def providers(self) -> frozenset[Provider]:
+        """Return the providers this bundle can deliver to."""
+        return frozenset(self.adapters)
+
+    def install(self) -> None:
+        """Bind this bundle as the process-wide delivery adapters."""
+        global _installed
+        _installed = self
+
+
+_installed: ScheduledDeliveryAdapters | None = None
+
+
+def resolve_delivery_adapter(provider: Provider) -> ScheduledDeliveryAdapter | None:
+    """Return the installed adapter for ``provider``, or ``None`` if unbundled."""
+    return _installed.get(provider) if _installed is not None else None
+
+
+def installed_delivery_providers() -> frozenset[Provider]:
+    """Return the providers the installed bundle can deliver to (empty if none)."""
+    return _installed.providers() if _installed is not None else frozenset()
+
+
+__all__ = [
+    "ScheduledDeliveryAdapter",
+    "ScheduledDeliveryAdapters",
+    "installed_delivery_providers",
+    "resolve_delivery_adapter",
+]

--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -4,21 +4,16 @@ from __future__ import annotations
 
 import json
 import logging
-import re
-from http import HTTPStatus
 
 from infrastructure.scheduling.scheduler.claim_store import complete_run, try_claim
 from infrastructure.scheduling.scheduler.credentials import (
-    resolve_discord_credentials,
-    resolve_rocketchat_credentials,
     resolve_slack_credentials,
-    resolve_slack_default_chat_id,
-    resolve_telegram_credentials,
     resolve_telegram_default_chat_id,
 )
+from infrastructure.scheduling.scheduler.delivery import resolve_slack_delivery_chat_id
+from infrastructure.scheduling.scheduler.delivery_bundle import resolve_delivery_adapter
 from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_CHANNELS_PARAM,
-    LOOP_SLACK_CHAT_ID_PARAM,
     LOOP_TELEGRAM_CHAT_ID_PARAM,
 )
 from infrastructure.scheduling.scheduler.operation_log import record_scheduler_execution_operation
@@ -26,9 +21,6 @@ from infrastructure.scheduling.scheduler.tasks import build_message
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind, TaskStatus
 
 logger = logging.getLogger(__name__)
-
-# Strip HTML tags for providers that don't support them
-_HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
 def execute_task(
@@ -190,19 +182,11 @@ def _deliver(
 
 
 def _deliver_single(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
-    """Deliver one message to ``task.provider``."""
-    if task.provider == Provider.TELEGRAM:
-        return _deliver_telegram(task, message)
-    elif task.provider == Provider.SLACK:
-        return _deliver_slack(task, message)
-    elif task.provider == Provider.DISCORD:
-        return _deliver_discord(task, message)
-    elif task.provider == Provider.ROCKETCHAT:
-        return _deliver_rocketchat(task, message)
-    elif task.provider == Provider.INTERACTIVE_SHELL:
-        return _deliver_interactive_shell(task, message)
-    else:
+    """Deliver one message to ``task.provider`` via its installed adapter."""
+    adapter = resolve_delivery_adapter(task.provider)
+    if adapter is None:
         return False, f"Unsupported provider: {task.provider}", ""
+    return adapter.deliver(task, message)
 
 
 def _deliver_all(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
@@ -326,29 +310,6 @@ def _deliver_to_providers(
     return False, "; ".join(errors), ""
 
 
-def _resolve_slack_delivery_chat_id(
-    task: ScheduledTask,
-    *,
-    webhook_url: str,
-) -> str:
-    """Resolve Slack ``chat_id`` for scheduled delivery.
-
-    When a webhook is configured it is channel-bound, so an implicit default
-    channel must not be applied on top — that would force the bot-token path
-    while credentials resolve to webhook-only. Implicit bot-token defaults
-    come from :func:`resolve_slack_default_chat_id`, which pairs the channel
-    with the same credential source as the token.
-    """
-    explicit = task.params.get(LOOP_SLACK_CHAT_ID_PARAM, "").strip() or (
-        (task.chat_id or "").strip() if task.provider == Provider.SLACK else ""
-    )
-    if explicit:
-        return explicit
-    if webhook_url.strip():
-        return ""
-    return resolve_slack_default_chat_id(task.params)
-
-
 def _task_for_delivery_provider(task: ScheduledTask, provider: Provider) -> ScheduledTask:
     """Return a task-shaped view carrying the destination for ``provider``."""
     chat_id = task.chat_id
@@ -360,7 +321,7 @@ def _task_for_delivery_provider(task: ScheduledTask, provider: Provider) -> Sche
         )
     elif provider == Provider.SLACK:
         slack_creds = resolve_slack_credentials(task.params)
-        chat_id = _resolve_slack_delivery_chat_id(
+        chat_id = resolve_slack_delivery_chat_id(
             task,
             webhook_url=str(slack_creds.get("webhook_url") or ""),
         )
@@ -373,174 +334,6 @@ def _run_provider_label(task: ScheduledTask) -> str:
     """Return the provider label persisted with run history."""
     channels = task.params.get(LOOP_CHANNELS_PARAM, "").strip()
     return channels or task.provider.value
-
-
-def _strip_html(text: str) -> str:
-    """Strip HTML tags for providers that use plain text or Markdown."""
-    return _HTML_TAG_RE.sub("", text)
-
-
-def _deliver_telegram(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
-    """Deliver via Telegram using the truncation helper then posting directly.
-
-    Uses truncate_for_telegram_html to respect the 4096-char limit, then
-    posts via post_telegram_message (no reply_to — new top-level message).
-    """
-    creds = resolve_telegram_credentials(task.params)
-    bot_token = creds.get("bot_token", "")
-    if not bot_token or not task.chat_id:
-        return False, "Missing bot_token or chat_id for Telegram", ""
-
-    from integrations.telegram.delivery import (
-        post_telegram_message,
-        truncate_for_telegram_html,
-    )
-    from integrations.telegram.formatting import markdown_to_telegram_html
-
-    html_message = markdown_to_telegram_html(message)
-    truncated = truncate_for_telegram_html(html_message, 4096, suffix="…")
-    ok, error, msg_id = post_telegram_message(task.chat_id, truncated, bot_token, parse_mode="HTML")
-    if ok:
-        return True, "", msg_id
-    return False, error, ""
-
-
-def _deliver_slack(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
-    """Deliver via Slack using the shared Slack delivery helper when possible."""
-    from infrastructure.scheduling.scheduler.delivery import slack_can_deliver
-
-    creds = resolve_slack_credentials(task.params)
-    access_token = str(creds.get("access_token") or "").strip()
-    webhook_url = str(creds.get("webhook_url") or "").strip()
-    chat_id = _resolve_slack_delivery_chat_id(task, webhook_url=webhook_url)
-
-    # Same policy as readiness: chat_id → bot token; empty chat_id → webhook OK.
-    if not slack_can_deliver(creds, chat_id=chat_id):
-        if chat_id and webhook_url and not access_token:
-            return (
-                False,
-                "Slack bot token required when chat_id is set (a webhook alone "
-                "cannot target an explicit chat_id)",
-                "",
-            )
-        if not chat_id:
-            return False, "Missing chat_id or webhook_url for Slack delivery", ""
-        return False, "Scheduled tasks require Slack bot access_token for chat_id delivery", ""
-
-    # Strip HTML tags — Slack uses mrkdwn, not HTML
-    plain_message = _strip_html(message)
-
-    if access_token and chat_id:
-        # Direct API post as a new top-level message
-        from infrastructure.delivery.notifications.delivery_transport import post_json
-
-        headers = {
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json; charset=utf-8",
-        }
-        payload = {
-            "channel": chat_id,
-            "text": plain_message,
-        }
-        response = post_json(
-            url="https://slack.com/api/chat.postMessage",
-            payload=payload,
-            headers=headers,
-        )
-        if not response.ok:
-            return False, f"Slack API error: {response.error}", ""
-        if not HTTPStatus.OK <= response.status_code < HTTPStatus.MULTIPLE_CHOICES:
-            error_text = response.text[:200] if response.text else f"HTTP {response.status_code}"
-            return False, f"Slack HTTP error: {error_text}", ""
-        if response.data.get("ok") is not True:
-            error = response.data.get("error", "unknown")
-            return False, f"Slack error: {error}", ""
-        msg_ts = str(response.data.get("ts", ""))
-        return True, "", msg_ts
-
-    # Channel-bound webhook path (no explicit chat_id).
-    from integrations.slack.delivery import send_slack_webhook_message
-
-    ok, error = send_slack_webhook_message(
-        plain_message,
-        webhook_url=webhook_url,
-    )
-    return ok, error, ""
-
-
-def _deliver_discord(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
-    """Deliver via Discord using the existing report helper (handles embed truncation)."""
-    creds = resolve_discord_credentials(task.params)
-    bot_token = creds.get("bot_token", "")
-    if not bot_token or not task.chat_id:
-        return False, "Missing bot_token or channel_id for Discord", ""
-
-    from integrations.discord.delivery import send_discord_report
-
-    # Strip HTML tags — Discord uses embeds, not HTML
-    plain_message = _strip_html(message)
-
-    discord_ctx = {
-        "channel_id": task.chat_id,
-        "bot_token": bot_token,
-        # No thread_id — scheduled deliveries post to the channel directly
-    }
-    ok, error = send_discord_report(plain_message, discord_ctx)
-    return ok, error, ""
-
-
-def _deliver_rocketchat(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
-    """Deliver via Rocket.Chat's REST API to the task's channel.
-
-    Requires token credentials (server_url + auth_token + user_id): scheduled
-    tasks carry an explicit ``chat_id`` destination, which an incoming
-    webhook's fixed destination cannot honor — so the webhook mode is
-    deliberately not used here (same rule as the rocketchat_send_message
-    tool).
-    """
-    creds = resolve_rocketchat_credentials(task.params)
-    server_url = creds.get("server_url", "")
-    auth_token = creds.get("auth_token", "")
-    user_id = creds.get("user_id", "")
-    if not (server_url and auth_token and user_id):
-        if creds.get("webhook_url"):
-            return (
-                False,
-                "Rocket.Chat scheduled delivery targets an explicit channel, which "
-                "needs token credentials (server_url, auth_token, user_id); the "
-                "incoming webhook's destination is fixed and cannot honor chat_id",
-                "",
-            )
-        return False, "Missing server_url, auth_token, or user_id for Rocket.Chat", ""
-    if not task.chat_id:
-        return False, "Missing chat_id (channel) for Rocket.Chat", ""
-
-    from infrastructure.delivery.notifications.limits import MAX_MESSAGE_SIZE
-    from infrastructure.text.truncation import truncate
-    from integrations.rocketchat.delivery import post_rocketchat_message
-
-    # Strip HTML tags — Rocket.Chat uses Markdown, not HTML
-    plain_message = truncate(_strip_html(message), MAX_MESSAGE_SIZE, suffix="…")
-    ok, error, msg_id = post_rocketchat_message(
-        server_url,
-        task.chat_id,
-        plain_message,
-        auth_token,
-        user_id,
-    )
-    return (True, "", msg_id) if ok else (False, error, "")
-
-
-def _deliver_interactive_shell(task: ScheduledTask, message: str) -> tuple[bool, str, str]:
-    """Persist loop output to the local interactive-shell inbox."""
-    try:
-        from infrastructure.scheduling.scheduler.local_delivery import record_loop_message
-
-        message_id = record_loop_message(task, _strip_html(message))
-        return True, "", message_id
-    except Exception as exc:
-        logger.warning("Interactive-shell loop delivery failed for task %s: %s", task.id, exc)
-        return False, f"Interactive-shell delivery error: {type(exc).__name__}", ""
 
 
 def _record_failure(

--- a/infrastructure/scheduling/scheduler/interactive_shell_delivery.py
+++ b/infrastructure/scheduling/scheduler/interactive_shell_delivery.py
@@ -1,0 +1,27 @@
+"""Scheduled-delivery adapter: persist a scheduled task's message to the shell inbox.
+
+Local delivery (no vendor), so this adapter lives in ``infrastructure`` rather
+than an ``integrations`` package.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from infrastructure.scheduling.scheduler.delivery import strip_html
+from infrastructure.scheduling.scheduler.local_delivery import record_loop_message
+from infrastructure.scheduling.scheduler.types import ScheduledTask
+
+logger = logging.getLogger(__name__)
+
+
+class InteractiveShellScheduledDelivery:
+    """Persist a scheduled task's loop output to the local interactive-shell inbox."""
+
+    def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        try:
+            message_id = record_loop_message(task, strip_html(message))
+            return True, "", message_id
+        except Exception as exc:
+            logger.warning("Interactive-shell loop delivery failed for task %s: %s", task.id, exc)
+            return False, f"Interactive-shell delivery error: {type(exc).__name__}", ""

--- a/integrations/buzz/background_adapter.py
+++ b/integrations/buzz/background_adapter.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from infrastructure.delivery.notifications.outbound_registry import (
     BACKGROUND_RCA,
     register_outbound_adapter,
 )
 from infrastructure.delivery.notifications.rca_summary import summary_sections
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
 
 def deliver_buzz_notification(record: BackgroundInvestigationRecord) -> str:

--- a/integrations/discord/scheduled_delivery.py
+++ b/integrations/discord/scheduled_delivery.py
@@ -1,0 +1,29 @@
+"""Scheduled-delivery adapter: post a scheduled task's message to Discord."""
+
+from __future__ import annotations
+
+from infrastructure.scheduling.scheduler.credentials import resolve_discord_credentials
+from infrastructure.scheduling.scheduler.delivery import strip_html
+from infrastructure.scheduling.scheduler.types import ScheduledTask
+from integrations.discord.delivery import send_discord_report
+
+
+class DiscordScheduledDelivery:
+    """Deliver a scheduled task's message via the Discord report helper.
+
+    Posts to the channel directly (no thread_id); the report helper handles
+    embed truncation. Discord uses embeds, not HTML, so tags are stripped.
+    """
+
+    def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        creds = resolve_discord_credentials(task.params)
+        bot_token = creds.get("bot_token", "")
+        if not bot_token or not task.chat_id:
+            return False, "Missing bot_token or channel_id for Discord", ""
+
+        discord_ctx = {
+            "channel_id": task.chat_id,
+            "bot_token": bot_token,
+        }
+        ok, error = send_discord_report(strip_html(message), discord_ctx)
+        return ok, error, ""

--- a/integrations/rocketchat/background_adapter.py
+++ b/integrations/rocketchat/background_adapter.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from infrastructure.delivery.notifications.outbound_registry import (
     BACKGROUND_RCA,
     register_outbound_adapter,
 )
 from infrastructure.delivery.notifications.rca_summary import summary_sections
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
 
 def deliver_rocketchat_notification(record: BackgroundInvestigationRecord) -> str:

--- a/integrations/rocketchat/scheduled_delivery.py
+++ b/integrations/rocketchat/scheduled_delivery.py
@@ -1,0 +1,48 @@
+"""Scheduled-delivery adapter: post a scheduled task's message to Rocket.Chat."""
+
+from __future__ import annotations
+
+from infrastructure.delivery.notifications.limits import MAX_MESSAGE_SIZE
+from infrastructure.scheduling.scheduler.credentials import resolve_rocketchat_credentials
+from infrastructure.scheduling.scheduler.delivery import strip_html
+from infrastructure.scheduling.scheduler.types import ScheduledTask
+from infrastructure.text.truncation import truncate
+from integrations.rocketchat.delivery import post_rocketchat_message
+
+
+class RocketChatScheduledDelivery:
+    """Deliver a scheduled task's message via Rocket.Chat's REST API.
+
+    Requires token credentials (server_url + auth_token + user_id): scheduled
+    tasks carry an explicit ``chat_id``, which an incoming webhook's fixed
+    destination cannot honor, so webhook mode is deliberately refused (same rule
+    as the rocketchat_send_message tool). Rocket.Chat uses Markdown, not HTML.
+    """
+
+    def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        creds = resolve_rocketchat_credentials(task.params)
+        server_url = creds.get("server_url", "")
+        auth_token = creds.get("auth_token", "")
+        user_id = creds.get("user_id", "")
+        if not (server_url and auth_token and user_id):
+            if creds.get("webhook_url"):
+                return (
+                    False,
+                    "Rocket.Chat scheduled delivery targets an explicit channel, which "
+                    "needs token credentials (server_url, auth_token, user_id); the "
+                    "incoming webhook's destination is fixed and cannot honor chat_id",
+                    "",
+                )
+            return False, "Missing server_url, auth_token, or user_id for Rocket.Chat", ""
+        if not task.chat_id:
+            return False, "Missing chat_id (channel) for Rocket.Chat", ""
+
+        plain_message = truncate(strip_html(message), MAX_MESSAGE_SIZE, suffix="…")
+        ok, error, msg_id = post_rocketchat_message(
+            server_url,
+            task.chat_id,
+            plain_message,
+            auth_token,
+            user_id,
+        )
+        return (True, "", msg_id) if ok else (False, error, "")

--- a/integrations/slack/scheduled_delivery.py
+++ b/integrations/slack/scheduled_delivery.py
@@ -1,0 +1,71 @@
+"""Scheduled-delivery adapter: post a scheduled task's message to Slack."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from infrastructure.delivery.notifications.delivery_transport import post_json
+from infrastructure.scheduling.scheduler.credentials import resolve_slack_credentials
+from infrastructure.scheduling.scheduler.delivery import (
+    resolve_slack_delivery_chat_id,
+    slack_can_deliver,
+    strip_html,
+)
+from infrastructure.scheduling.scheduler.types import ScheduledTask
+from integrations.slack.delivery import send_slack_webhook_message
+
+
+class SlackScheduledDelivery:
+    """Deliver a scheduled task's message via Slack.
+
+    A resolved ``chat_id`` uses the bot-token ``chat.postMessage`` API (new
+    top-level message); an empty ``chat_id`` uses the channel-bound incoming
+    webhook. Slack uses mrkdwn, not HTML, so tags are stripped.
+    """
+
+    def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        creds = resolve_slack_credentials(task.params)
+        access_token = str(creds.get("access_token") or "").strip()
+        webhook_url = str(creds.get("webhook_url") or "").strip()
+        chat_id = resolve_slack_delivery_chat_id(task, webhook_url=webhook_url)
+
+        # Same policy as readiness: chat_id → bot token; empty chat_id → webhook OK.
+        if not slack_can_deliver(creds, chat_id=chat_id):
+            if chat_id and webhook_url and not access_token:
+                return (
+                    False,
+                    "Slack bot token required when chat_id is set (a webhook alone "
+                    "cannot target an explicit chat_id)",
+                    "",
+                )
+            if not chat_id:
+                return False, "Missing chat_id or webhook_url for Slack delivery", ""
+            return False, "Scheduled tasks require Slack bot access_token for chat_id delivery", ""
+
+        plain_message = strip_html(message)
+
+        if access_token and chat_id:
+            headers = {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json; charset=utf-8",
+            }
+            payload = {"channel": chat_id, "text": plain_message}
+            response = post_json(
+                url="https://slack.com/api/chat.postMessage",
+                payload=payload,
+                headers=headers,
+            )
+            if not response.ok:
+                return False, f"Slack API error: {response.error}", ""
+            if not HTTPStatus.OK <= response.status_code < HTTPStatus.MULTIPLE_CHOICES:
+                error_text = (
+                    response.text[:200] if response.text else f"HTTP {response.status_code}"
+                )
+                return False, f"Slack HTTP error: {error_text}", ""
+            if response.data.get("ok") is not True:
+                error = response.data.get("error", "unknown")
+                return False, f"Slack error: {error}", ""
+            return True, "", str(response.data.get("ts", ""))
+
+        ok, error = send_slack_webhook_message(plain_message, webhook_url=webhook_url)
+        return ok, error, ""

--- a/integrations/smtp/background_adapter.py
+++ b/integrations/smtp/background_adapter.py
@@ -11,11 +11,11 @@ Email keeps the full report. The chat channels carry the bounded summary from
 
 from __future__ import annotations
 
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from infrastructure.delivery.notifications.outbound_registry import (
     BACKGROUND_RCA,
     register_outbound_adapter,
 )
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
 
 def deliver_email_notification(record: BackgroundInvestigationRecord) -> str:

--- a/integrations/telegram/background_adapter.py
+++ b/integrations/telegram/background_adapter.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from infrastructure.delivery.notifications.outbound_registry import (
     BACKGROUND_RCA,
     register_outbound_adapter,
 )
 from infrastructure.delivery.notifications.rca_summary import summary_sections
 from infrastructure.errors import OpenSREError
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
 
 def deliver_telegram_notification(record: BackgroundInvestigationRecord) -> str:

--- a/integrations/telegram/scheduled_delivery.py
+++ b/integrations/telegram/scheduled_delivery.py
@@ -1,0 +1,29 @@
+"""Scheduled-delivery adapter: post a scheduled task's message to Telegram."""
+
+from __future__ import annotations
+
+from infrastructure.scheduling.scheduler.credentials import resolve_telegram_credentials
+from infrastructure.scheduling.scheduler.types import ScheduledTask
+from integrations.telegram.delivery import post_telegram_message, truncate_for_telegram_html
+from integrations.telegram.formatting import markdown_to_telegram_html
+
+
+class TelegramScheduledDelivery:
+    """Deliver a scheduled task's message via the Telegram Bot API.
+
+    Renders Markdown as Telegram HTML, truncates to the 4096-char limit, and
+    posts a new top-level message (no reply_to).
+    """
+
+    def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        creds = resolve_telegram_credentials(task.params)
+        bot_token = creds.get("bot_token", "")
+        if not bot_token or not task.chat_id:
+            return False, "Missing bot_token or chat_id for Telegram", ""
+
+        html_message = markdown_to_telegram_html(message)
+        truncated = truncate_for_telegram_html(html_message, 4096, suffix="…")
+        ok, error, msg_id = post_telegram_message(
+            task.chat_id, truncated, bot_token, parse_mode="HTML"
+        )
+        return (True, "", msg_id) if ok else (False, error, "")

--- a/surfaces/cli/commands/sentry_digest.py
+++ b/surfaces/cli/commands/sentry_digest.py
@@ -159,6 +159,7 @@ def sentry_uptime_watch_add(
     if params:
         _console.print(f"  Project: {params['project_slug']}")
 
+    from bootstrap.adapters import install_scheduled_delivery_adapters
     from infrastructure.scheduling.scheduler.executor import deliver_scheduled_message
     from integrations.sentry.uptime import format_uptime_watch_active_message
 
@@ -168,6 +169,9 @@ def sentry_uptime_watch_add(
         timezone=added.timezone,
         project_slug=params.get("project_slug", ""),
     )
+    # This command boots no scheduler profile, so bind the delivery adapters the
+    # activation notice resolves through before sending it.
+    install_scheduled_delivery_adapters()
     ok, error, _message_id = deliver_scheduled_message(added, active_message)
     if ok:
         _console.print("[green]Activation notice sent to chat.[/green]")

--- a/surfaces/interactive_shell/command_registry/background_cmds.py
+++ b/surfaces/interactive_shell/command_registry/background_cmds.py
@@ -15,7 +15,7 @@ from core.agent_harness.spi.session_state import (
     background_notification_channels,
     session_terminal,
 )
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui import (
@@ -84,10 +84,10 @@ def _tracked_records(
     records: dict[str, BackgroundInvestigationRecord] = dict(background_investigations(session))
     try:
         from infrastructure.scheduling.background_investigations.store import (
-            background_investigation_store,
+            open_record_store,
         )
 
-        stored = background_investigation_store().list_recent(limit=None)
+        stored = open_record_store().list_recent(limit=None)
     except Exception as exc:  # noqa: BLE001
         report_exception(exc, context="surfaces.interactive_shell.background_read")
         console.print(
@@ -111,10 +111,10 @@ def _notify_channels(session: Session) -> tuple[str, ...]:
         return channels
     try:
         from infrastructure.scheduling.background_investigations.store import (
-            background_investigation_store,
+            open_record_store,
         )
 
-        return background_investigation_store().notify_channels()
+        return open_record_store().notify_channels()
     except Exception:  # noqa: BLE001
         return ()
 
@@ -128,10 +128,10 @@ def _persist_notify_channels(console: Console, channels: tuple[str, ...]) -> Non
     """
     try:
         from infrastructure.scheduling.background_investigations.store import (
-            background_investigation_store,
+            open_record_store,
         )
 
-        background_investigation_store().set_notify_channels(channels)
+        open_record_store().set_notify_channels(channels)
     except Exception as exc:  # noqa: BLE001
         report_exception(exc, context="surfaces.interactive_shell.background_notify_persist")
         console.print(

--- a/surfaces/interactive_shell/runtime/background/notifications.py
+++ b/surfaces/interactive_shell/runtime/background/notifications.py
@@ -7,7 +7,7 @@ above it. Imports stay function-local so the REPL boot path pays for none of it.
 
 from __future__ import annotations
 
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
+from core.domain.background_investigations import BackgroundInvestigationRecord
 
 
 def deliver_background_notifications(

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -42,12 +42,12 @@ def _persist_record(session: Session, record: BackgroundInvestigationRecord) -> 
     configures no logging and a lost record is otherwise invisible.
     """
     from infrastructure.scheduling.background_investigations.store import (
-        UnreadableBackgroundInvestigationsError,
-        background_investigation_store,
+        UnreadableStoreError,
+        open_record_store,
     )
 
     try:
-        background_investigation_store().save(record)
+        open_record_store().save(record)
     except Exception as exc:  # noqa: BLE001
         report_exception(exc, context="surfaces.interactive_shell.background_persist")
         # A damaged document fails every later save too, so name it rather than
@@ -55,7 +55,7 @@ def _persist_record(session: Session, record: BackgroundInvestigationRecord) -> 
         # already carries the path, and the local terminal is not an external sink.
         detail = (
             escape(str(exc))
-            if isinstance(exc, UnreadableBackgroundInvestigationsError)
+            if isinstance(exc, UnreadableStoreError)
             else escape(type(exc).__name__)
         )
         session.terminal.enqueue_background_notice(

--- a/surfaces/interactive_shell/session/background_investigations.py
+++ b/surfaces/interactive_shell/session/background_investigations.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
+from core.domain.background_investigations import BackgroundInvestigationRecord
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +43,11 @@ class BackgroundNotificationPreferences:
         empty default they had before preferences were durable.
         """
         from infrastructure.scheduling.background_investigations.store import (
-            background_investigation_store,
+            open_record_store,
         )
 
         try:
-            return cls(channels=background_investigation_store().notify_channels())
+            return cls(channels=open_record_store().notify_channels())
         except Exception:  # noqa: BLE001
             logger.debug("[background] could not load notify channels", exc_info=True)
             return cls()

--- a/tests/cli/test_sentry_digest.py
+++ b/tests/cli/test_sentry_digest.py
@@ -45,6 +45,11 @@ def test_schedule_add_requires_delivery_provider(monkeypatch) -> None:
 
 
 def test_uptime_watch_add_sends_activation_notice(monkeypatch, tmp_path) -> None:
+    import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
+
+    # Start with no bundle so this pins that the command installs it before it
+    # delivers, rather than resolving one another test happened to leave behind.
+    monkeypatch.setattr(delivery_bundle, "_installed", None)
     runner = CliRunner()
     monkeypatch.setattr(
         "integrations.sentry.digest_prerequisites.configured_integration_services",
@@ -58,15 +63,22 @@ def test_uptime_watch_add_sends_activation_notice(monkeypatch, tmp_path) -> None
         "infrastructure.scheduling.scheduler.store._default_store_path",
         lambda: tmp_path / "tasks.json",
     )
+    # Exercise the real delivery path (bundle -> Telegram adapter), stubbing only
+    # the vendor transport. The command must install the adapter bundle first —
+    # without it this resolves no adapter and the notice fails "Unsupported provider".
+    monkeypatch.setattr(
+        "integrations.telegram.scheduled_delivery.resolve_telegram_credentials",
+        lambda _params: {"bot_token": "x"},
+    )
     delivered: list[str] = []
 
-    def _fake_deliver(task, message: str):
-        delivered.append(message)
+    def _fake_post(chat_id, text, bot_token, parse_mode="", **_kwargs):
+        delivered.append(text)
         return True, "", "1"
 
     monkeypatch.setattr(
-        "infrastructure.scheduling.scheduler.executor.deliver_scheduled_message",
-        _fake_deliver,
+        "integrations.telegram.scheduled_delivery.post_telegram_message",
+        _fake_post,
     )
 
     result = runner.invoke(

--- a/tests/infrastructure/delivery/notifications/test_outbound_registry.py
+++ b/tests/infrastructure/delivery/notifications/test_outbound_registry.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 
 import pytest
 
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from infrastructure.delivery.notifications.outbound_dispatch import (
     dispatch_background_notifications,
 )
@@ -17,7 +18,6 @@ from infrastructure.delivery.notifications.outbound_registry import (
     register_outbound_adapter,
     registered_outbound_adapter_names,
 )
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
 
 @pytest.fixture(autouse=True)

--- a/tests/infrastructure/scheduling/background_investigations/test_store.py
+++ b/tests/infrastructure/scheduling/background_investigations/test_store.py
@@ -12,15 +12,15 @@ from typing import Any
 
 import pytest
 
+from core.domain.background_investigations import BackgroundInvestigationRecord
 from infrastructure.scheduling.background_investigations.store import (
-    BackgroundInvestigationStore,
-    UnreadableBackgroundInvestigationsError,
+    RecordStore,
+    UnreadableStoreError,
 )
-from infrastructure.scheduling.background_investigations.types import BackgroundInvestigationRecord
 
 
-def _store(tmp_path: Path, **kwargs: Any) -> BackgroundInvestigationStore:
-    return BackgroundInvestigationStore(tmp_path / "background" / "investigations.json", **kwargs)
+def _store(tmp_path: Path, **kwargs: Any) -> RecordStore:
+    return RecordStore(tmp_path / "background" / "investigations.json", **kwargs)
 
 
 def _record(task_id: str = "bg-1", status: str = "completed") -> BackgroundInvestigationRecord:
@@ -38,8 +38,8 @@ def _record(task_id: str = "bg-1", status: str = "completed") -> BackgroundInves
 
 _WRITER = (
     "from infrastructure.scheduling.background_investigations.store import "
-    "background_investigation_store as s;"
-    "from infrastructure.scheduling.background_investigations.types import "
+    "open_record_store as s;"
+    "from core.domain.background_investigations import "
     "BackgroundInvestigationRecord as R;"
     "s().save(R(task_id='bg-xproc', status='completed', command='/investigate generic',"
     "root_cause='pool saturation'));"
@@ -47,7 +47,7 @@ _WRITER = (
 )
 _READER = (
     "from infrastructure.scheduling.background_investigations.store import "
-    "background_investigation_store as s;"
+    "open_record_store as s;"
     "r = s().get('bg-xproc');"
     "assert r is not None, 'record not visible from a second process';"
     "assert r.status == 'completed', r.status;"
@@ -204,7 +204,7 @@ def test_unreadable_document_raises_rather_than_reading_as_empty(tmp_path: Path)
     path.write_text("{not json", encoding="utf-8")
     store = _store(tmp_path)
 
-    with pytest.raises(UnreadableBackgroundInvestigationsError):
+    with pytest.raises(UnreadableStoreError):
         store.list_recent()
 
 
@@ -213,7 +213,7 @@ def test_document_with_an_unexpected_shape_raises(tmp_path: Path) -> None:
     path.parent.mkdir(parents=True)
     path.write_text(json.dumps({"version": 1, "records": "nope"}), encoding="utf-8")
 
-    with pytest.raises(UnreadableBackgroundInvestigationsError):
+    with pytest.raises(UnreadableStoreError):
         _store(tmp_path).list_recent()
 
 
@@ -284,7 +284,7 @@ def test_the_home_directory_is_not_resolved_at_construction(monkeypatch) -> None
         "infrastructure.scheduling.background_investigations.store._default_path", _explode
     )
 
-    store = BackgroundInvestigationStore()
+    store = RecordStore()
 
     assert calls == []
     with pytest.raises(RuntimeError):
@@ -429,12 +429,12 @@ def test_the_shell_and_a_chat_turn_share_one_document(
     monkeypatch.setenv(ORGANIZATION_ID_ENV, "org_acme")
 
     # The shell writes with nothing bound.
-    BackgroundInvestigationStore().save(_record(task_id="bg-shell"))
+    RecordStore().save(_record(task_id="bg-shell"))
 
     # A Telegram turn reads with the organization bound.
     scope = StorageScope(principal=Principal.org("org_acme"), actor=Actor(id="U_ALICE"))
     with bound_storage_scope(scope):
-        found = BackgroundInvestigationStore().get("bg-shell")
+        found = RecordStore().get("bg-shell")
 
     assert found is not None
     assert found.root_cause == "pool saturation"
@@ -452,7 +452,7 @@ def test_a_machine_with_no_organization_keeps_the_plain_layout(
     monkeypatch.delenv(paths.CONTEXT_ROOT_ENV, raising=False)
     monkeypatch.delenv(ORGANIZATION_ID_ENV, raising=False)
 
-    BackgroundInvestigationStore().save(_record(task_id="bg-laptop"))
+    RecordStore().save(_record(task_id="bg-laptop"))
 
     assert (tmp_path / "background" / "investigations.json").is_file()
     assert not (tmp_path / "orgs").exists()

--- a/tests/interactive_shell/runtime/test_background_runner.py
+++ b/tests/interactive_shell/runtime/test_background_runner.py
@@ -10,8 +10,8 @@ import pytest
 from rich.console import Console
 
 from infrastructure.scheduling.background_investigations.store import (
-    BackgroundInvestigationStore,
-    BackgroundInvestigationStoreLockTimeout,
+    RecordStore,
+    StoreLockTimeout,
 )
 from surfaces.interactive_shell.command_registry import dispatch_slash
 from surfaces.interactive_shell.runtime.background.runner import (
@@ -20,9 +20,7 @@ from surfaces.interactive_shell.runtime.background.runner import (
 )
 from surfaces.interactive_shell.session import Session
 
-_STORE_FACTORY = (
-    "infrastructure.scheduling.background_investigations.store.background_investigation_store"
-)
+_STORE_FACTORY = "infrastructure.scheduling.background_investigations.store.open_record_store"
 
 
 def _noop_tracker(**_kwargs: Any) -> Any:
@@ -129,7 +127,7 @@ class _RaisingStore:
     def save(self, record: Any) -> None:
         _ = record
         self.attempts += 1
-        raise BackgroundInvestigationStoreLockTimeout("locked")
+        raise StoreLockTimeout("locked")
 
 
 def test_a_completed_investigation_is_readable_from_another_store_instance(
@@ -138,12 +136,12 @@ def test_a_completed_investigation_is_readable_from_another_store_instance(
     """ "Readable across processes" is only true once the record reaches the file.
     A second instance over the same path is the closest in-process proxy."""
     path = tmp_path / "background" / "investigations.json"
-    monkeypatch.setattr(_STORE_FACTORY, lambda: BackgroundInvestigationStore(path))
+    monkeypatch.setattr(_STORE_FACTORY, lambda: RecordStore(path))
     session = Session()
 
     task_id = _run_to_completion(session, monkeypatch)
 
-    stored = BackgroundInvestigationStore(path).get(task_id)
+    stored = RecordStore(path).get(task_id)
     assert stored is not None
     assert stored.status == "completed"
     assert stored.root_cause == "pool saturation"
@@ -193,7 +191,7 @@ def test_a_raising_notification_channel_does_not_fail_the_investigation(
     )
 
     path = tmp_path / "background" / "investigations.json"
-    monkeypatch.setattr(_STORE_FACTORY, lambda: BackgroundInvestigationStore(path))
+    monkeypatch.setattr(_STORE_FACTORY, lambda: RecordStore(path))
     monkeypatch.setattr("bootstrap.adapters.install_notification_adapters", lambda: ("telegram",))
     clear_outbound_adapters()
     register_outbound_adapter(_ExplodingAdapter())
@@ -203,7 +201,7 @@ def test_a_raising_notification_channel_does_not_fail_the_investigation(
     task_id = _run_to_completion(session, monkeypatch)
     clear_outbound_adapters()
 
-    stored = BackgroundInvestigationStore(path).get(task_id)
+    stored = RecordStore(path).get(task_id)
     assert stored is not None
     assert stored.status == "completed"
     assert stored.root_cause == "pool saturation"
@@ -216,14 +214,14 @@ def test_new_resets_the_session_without_deleting_durable_records(
     """#4426's scoping asks that /new reset the interactive session but leave the
     durable records and the notification preferences alone."""
     path = tmp_path / "background" / "investigations.json"
-    monkeypatch.setattr(_STORE_FACTORY, lambda: BackgroundInvestigationStore(path))
+    monkeypatch.setattr(_STORE_FACTORY, lambda: RecordStore(path))
     session = Session()
     task_id = _run_to_completion(session, monkeypatch)
     session.terminal.background_notification_preferences.set_channels(["telegram"])
 
     dispatch_slash("/new", session, Console(file=io.StringIO(), force_terminal=False))
 
-    assert BackgroundInvestigationStore(path).get(task_id) is not None
+    assert RecordStore(path).get(task_id) is not None
     assert session.terminal.background_investigations == {}
     assert session.terminal.background_notification_preferences.channels == ("telegram",)
 

--- a/tests/scheduler/test_delivery_bundle.py
+++ b/tests/scheduler/test_delivery_bundle.py
@@ -11,10 +11,6 @@ from __future__ import annotations
 import pytest
 
 import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
-from infrastructure.scheduling.scheduler.delivery_bundle import (
-    ScheduledDeliveryAdapters,
-    resolve_delivery_adapter,
-)
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask
 
 
@@ -30,30 +26,32 @@ def _reset_installed_bundle() -> None:
 
 
 def test_resolve_returns_none_before_any_bundle_is_installed() -> None:
-    assert resolve_delivery_adapter(Provider.TELEGRAM) is None
+    assert delivery_bundle.resolve_delivery_adapter(Provider.TELEGRAM) is None
 
 
 def test_installed_bundle_resolves_only_its_providers() -> None:
     adapter = _Adapter()
 
-    ScheduledDeliveryAdapters({Provider.TELEGRAM: adapter}).install()
+    delivery_bundle.ScheduledDeliveryAdapters({Provider.TELEGRAM: adapter}).install()
 
-    assert resolve_delivery_adapter(Provider.TELEGRAM) is adapter
-    assert resolve_delivery_adapter(Provider.SLACK) is None
+    assert delivery_bundle.resolve_delivery_adapter(Provider.TELEGRAM) is adapter
+    assert delivery_bundle.resolve_delivery_adapter(Provider.SLACK) is None
 
 
 def test_install_atomically_replaces_the_previous_bundle() -> None:
     first, second = _Adapter(), _Adapter()
 
-    ScheduledDeliveryAdapters({Provider.TELEGRAM: first}).install()
-    ScheduledDeliveryAdapters({Provider.SLACK: second}).install()
+    delivery_bundle.ScheduledDeliveryAdapters({Provider.TELEGRAM: first}).install()
+    delivery_bundle.ScheduledDeliveryAdapters({Provider.SLACK: second}).install()
 
     # The whole mapping is replaced, not merged — no residue of the first bundle.
-    assert resolve_delivery_adapter(Provider.TELEGRAM) is None
-    assert resolve_delivery_adapter(Provider.SLACK) is second
+    assert delivery_bundle.resolve_delivery_adapter(Provider.TELEGRAM) is None
+    assert delivery_bundle.resolve_delivery_adapter(Provider.SLACK) is second
 
 
 def test_providers_reports_the_bundled_set() -> None:
-    bundle = ScheduledDeliveryAdapters({Provider.TELEGRAM: _Adapter(), Provider.SLACK: _Adapter()})
+    bundle = delivery_bundle.ScheduledDeliveryAdapters(
+        {Provider.TELEGRAM: _Adapter(), Provider.SLACK: _Adapter()}
+    )
 
     assert bundle.providers() == frozenset({Provider.TELEGRAM, Provider.SLACK})

--- a/tests/scheduler/test_delivery_bundle.py
+++ b/tests/scheduler/test_delivery_bundle.py
@@ -1,0 +1,59 @@
+"""The scheduled-delivery adapter bundle: assemble once, resolve by provider.
+
+Pins the install-once / resolve semantics — in particular that installing a new
+bundle atomically *replaces* the previous mapping rather than merging into it,
+which is the property that made an immutable bundle preferable to a mutable
+per-provider registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
+from infrastructure.scheduling.scheduler.delivery_bundle import (
+    ScheduledDeliveryAdapters,
+    resolve_delivery_adapter,
+)
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask
+
+
+class _Adapter:
+    def deliver(self, _task: ScheduledTask, _message: str) -> tuple[bool, str, str]:
+        return True, "", "id"
+
+
+@pytest.fixture(autouse=True)
+def _reset_installed_bundle() -> None:
+    yield
+    delivery_bundle._installed = None
+
+
+def test_resolve_returns_none_before_any_bundle_is_installed() -> None:
+    assert resolve_delivery_adapter(Provider.TELEGRAM) is None
+
+
+def test_installed_bundle_resolves_only_its_providers() -> None:
+    adapter = _Adapter()
+
+    ScheduledDeliveryAdapters({Provider.TELEGRAM: adapter}).install()
+
+    assert resolve_delivery_adapter(Provider.TELEGRAM) is adapter
+    assert resolve_delivery_adapter(Provider.SLACK) is None
+
+
+def test_install_atomically_replaces_the_previous_bundle() -> None:
+    first, second = _Adapter(), _Adapter()
+
+    ScheduledDeliveryAdapters({Provider.TELEGRAM: first}).install()
+    ScheduledDeliveryAdapters({Provider.SLACK: second}).install()
+
+    # The whole mapping is replaced, not merged — no residue of the first bundle.
+    assert resolve_delivery_adapter(Provider.TELEGRAM) is None
+    assert resolve_delivery_adapter(Provider.SLACK) is second
+
+
+def test_providers_reports_the_bundled_set() -> None:
+    bundle = ScheduledDeliveryAdapters({Provider.TELEGRAM: _Adapter(), Provider.SLACK: _Adapter()})
+
+    assert bundle.providers() == frozenset({Provider.TELEGRAM, Provider.SLACK})

--- a/tests/scheduler/test_delivery_conformance.py
+++ b/tests/scheduler/test_delivery_conformance.py
@@ -17,7 +17,7 @@ import ast
 import inspect
 import textwrap
 
-from infrastructure.scheduling.scheduler import delivery, executor
+from infrastructure.scheduling.scheduler import delivery
 from infrastructure.scheduling.scheduler.types import Provider
 from tools.system.watch_dog import runner
 from tools.system.watch_dog.config import WATCHDOG_SUPPORTED_PROVIDERS
@@ -25,8 +25,8 @@ from tools.system.watch_dog.config import WATCHDOG_SUPPORTED_PROVIDERS
 #: Every member the vocabulary offers a caller.
 ALL_PROVIDERS = frozenset(Provider)
 
-#: What ``executor._deliver_single`` has an explicit branch for. Anything else
-#: reaches the ``else`` and fails the task with "Unsupported provider".
+#: What the installed delivery bundle has an adapter for. Anything else resolves
+#: to no adapter and fails the task with "Unsupported provider".
 EXECUTOR_DELIVERS = frozenset(
     {
         Provider.TELEGRAM,
@@ -70,9 +70,11 @@ def _providers_branched_on(function: object) -> frozenset[Provider]:
 
 
 def test_the_executor_delivers_to_exactly_these_providers() -> None:
-    """The send path's branches are the real answer to "can this be delivered?"."""
-    # Arrange / Act
-    reachable = _providers_branched_on(executor._deliver_single)
+    """The installed adapter bundle is the real answer to "can this be delivered?"."""
+    # Arrange / Act: the composition root assembles exactly the deliverable set.
+    from bootstrap.adapters import scheduled_delivery_adapters
+
+    reachable = scheduled_delivery_adapters().providers()
 
     # Assert
     assert reachable == EXECUTOR_DELIVERS

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -17,7 +17,6 @@ import pytest
 import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
 from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
 from infrastructure.observability.operations_log import read_operations
-from infrastructure.scheduling.scheduler.delivery_bundle import ScheduledDeliveryAdapters
 from infrastructure.scheduling.scheduler.executor import execute_task
 from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
 from infrastructure.scheduling.scheduler.loop_constants import LOOP_CHANNELS_PARAM
@@ -47,7 +46,7 @@ class _FakeAdapter:
 def _install_fake_bundle() -> dict[Provider, _FakeAdapter]:
     """Install a fake adapter for every provider; return them to configure/inspect."""
     adapters = {provider: _FakeAdapter() for provider in _DELIVERY_PROVIDERS}
-    ScheduledDeliveryAdapters(adapters).install()
+    delivery_bundle.ScheduledDeliveryAdapters(adapters).install()
     return adapters
 
 

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -1,4 +1,10 @@
-"""Tests for the task executor with isolated stores."""
+"""Tests for the task executor with isolated stores.
+
+Delivery is inverted behind a per-provider adapter bundle. Routing/orchestration
+tests install a fake bundle and configure each provider's outcome; adapter
+behavior (creds resolution, the vendor transport call) is exercised by installing
+the real bundle and patching that vendor's ``scheduled_delivery`` adapter.
+"""
 
 from __future__ import annotations
 
@@ -8,12 +14,55 @@ from unittest.mock import patch
 
 import pytest
 
+import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
 from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
 from infrastructure.observability.operations_log import read_operations
+from infrastructure.scheduling.scheduler.delivery_bundle import ScheduledDeliveryAdapters
 from infrastructure.scheduling.scheduler.executor import execute_task
 from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
 from infrastructure.scheduling.scheduler.loop_constants import LOOP_CHANNELS_PARAM
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+
+_DELIVERY_PROVIDERS = (
+    Provider.TELEGRAM,
+    Provider.SLACK,
+    Provider.DISCORD,
+    Provider.ROCKETCHAT,
+    Provider.INTERACTIVE_SHELL,
+)
+
+
+class _FakeAdapter:
+    """Records the (task, message) it is handed and returns a fixed outcome."""
+
+    def __init__(self) -> None:
+        self.result: tuple[bool, str, str] = (True, "", "msg")
+        self.calls: list[tuple[ScheduledTask, str]] = []
+
+    def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        self.calls.append((task, message))
+        return self.result
+
+
+def _install_fake_bundle() -> dict[Provider, _FakeAdapter]:
+    """Install a fake adapter for every provider; return them to configure/inspect."""
+    adapters = {provider: _FakeAdapter() for provider in _DELIVERY_PROVIDERS}
+    ScheduledDeliveryAdapters(adapters).install()
+    return adapters
+
+
+def _install_real_bundle() -> None:
+    """Install the production adapter bundle (exercises the real vendor adapters)."""
+    from bootstrap.adapters import scheduled_delivery_adapters
+
+    scheduled_delivery_adapters().install()
+
+
+@pytest.fixture(autouse=True)
+def _reset_delivery_bundle() -> None:
+    """Drop the installed bundle after each test so it cannot leak across tests."""
+    yield
+    delivery_bundle._installed = None
 
 
 @pytest.fixture()
@@ -32,6 +81,8 @@ def _tmp_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.usefixtures("_tmp_stores")
 class TestExecutor:
     def test_telegram_delivery_success(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.TELEGRAM].result = (True, "", "msg_42")
         task = ScheduledTask(
             id="test_tg_01",
             kind=TaskKind.DAILY_SUMMARY,
@@ -40,25 +91,17 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch(
-                "infrastructure.scheduling.scheduler.executor.resolve_telegram_credentials"
-            ) as mock_creds,
-            patch("infrastructure.scheduling.scheduler.executor._deliver_telegram") as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_creds.return_value = {"bot_token": "fake_token"}
-            mock_deliver.return_value = (True, "", "msg_42")
-
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
-        mock_deliver.assert_called_once()
+        assert len(adapters[Provider.TELEGRAM].calls) == 1
 
     def test_telegram_missing_credentials(self) -> None:
+        _install_real_bundle()
         task = ScheduledTask(
             id="test_tg_02",
             kind=TaskKind.DAILY_SUMMARY,
@@ -73,15 +116,17 @@ class TestExecutor:
                 return_value="Scheduled report",
             ),
             patch(
-                "infrastructure.scheduling.scheduler.executor.resolve_telegram_credentials"
-            ) as mock_creds,
+                "integrations.telegram.scheduled_delivery.resolve_telegram_credentials",
+                return_value={},
+            ),
         ):
-            mock_creds.return_value = {}
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is False
 
     def test_slack_delivery_success(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.SLACK].result = (True, "", "ts_123")
         task = ScheduledTask(
             id="test_sl_01",
             kind=TaskKind.DAILY_SUMMARY,
@@ -90,20 +135,18 @@ class TestExecutor:
             chat_id="C123456",
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_deliver.return_value = (True, "", "ts_123")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
-        mock_deliver.assert_called_once()
+        assert len(adapters[Provider.SLACK].calls) == 1
 
     def test_discord_delivery_success(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.DISCORD].result = (True, "", "msg_99")
         task = ScheduledTask(
             id="test_dc_01",
             kind=TaskKind.DAILY_SUMMARY,
@@ -112,20 +155,18 @@ class TestExecutor:
             chat_id="123456789",
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_discord") as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_deliver.return_value = (True, "", "msg_99")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
-        mock_deliver.assert_called_once()
+        assert len(adapters[Provider.DISCORD].calls) == 1
 
     def test_rocketchat_delivery_success(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.ROCKETCHAT].result = (True, "", "msg_rc")
         task = ScheduledTask(
             id="test_rc_01",
             kind=TaskKind.DAILY_SUMMARY,
@@ -134,22 +175,17 @@ class TestExecutor:
             chat_id="#ops",
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch(
-                "infrastructure.scheduling.scheduler.executor._deliver_rocketchat"
-            ) as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_deliver.return_value = (True, "", "msg_rc")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
-        mock_deliver.assert_called_once()
+        assert len(adapters[Provider.ROCKETCHAT].calls) == 1
 
     def test_interactive_shell_delivery_success(self, tmp_path: Path) -> None:
+        _install_real_bundle()
         inbox_path = tmp_path / "loop_messages.jsonl"
         task = ScheduledTask(
             id="test_shell_01",
@@ -182,6 +218,8 @@ class TestExecutor:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.INTERACTIVE_SHELL].result = (True, "", "local:1")
         log_path = tmp_path / "operations.jsonl"
         monkeypatch.setenv(OPENSRE_OPERATIONS_LOG_PATH_ENV, str(log_path))
         task = ScheduledTask(
@@ -192,16 +230,10 @@ class TestExecutor:
             provider=Provider.INTERACTIVE_SHELL,
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Sensitive scheduled report body",
-            ),
-            patch(
-                "infrastructure.scheduling.scheduler.executor._deliver_interactive_shell"
-            ) as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Sensitive scheduled report body",
         ):
-            mock_deliver.return_value = (True, "", "local:1")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
@@ -220,6 +252,9 @@ class TestExecutor:
         assert "Sensitive scheduled report body" not in json.dumps(records)
 
     def test_loop_fanout_builds_message_once(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.INTERACTIVE_SHELL].result = (True, "", "local:1")
+        adapters[Provider.SLACK].result = (True, "", "ts_123")
         task = ScheduledTask(
             id="test_fanout",
             kind=TaskKind.DAILY_SUMMARY,
@@ -228,29 +263,24 @@ class TestExecutor:
             params={LOOP_CHANNELS_PARAM: "interactive_shell,slack"},
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ) as mock_build,
-            patch(
-                "infrastructure.scheduling.scheduler.executor._deliver_interactive_shell"
-            ) as mock_shell,
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_slack,
-        ):
-            mock_shell.return_value = (True, "", "local:1")
-            mock_slack.return_value = (True, "", "ts_123")
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
+        ) as mock_build:
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
         mock_build.assert_called_once_with(task)
-        mock_shell.assert_called_once()
-        mock_slack.assert_called_once()
+        assert len(adapters[Provider.INTERACTIVE_SHELL].calls) == 1
+        assert len(adapters[Provider.SLACK].calls) == 1
 
     def test_loop_fanout_partial_success_completes_claim(self) -> None:
         """One channel failing must not leave an unrecoverable failed claim."""
         from infrastructure.scheduling.scheduler.claim_store import get_runs
 
+        adapters = _install_fake_bundle()
+        adapters[Provider.INTERACTIVE_SHELL].result = (True, "", "local:1")
+        adapters[Provider.SLACK].result = (False, "webhook missing", "")
         task = ScheduledTask(
             id="test_fanout_partial",
             kind=TaskKind.DAILY_SUMMARY,
@@ -259,18 +289,10 @@ class TestExecutor:
             params={LOOP_CHANNELS_PARAM: "interactive_shell,slack"},
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch(
-                "infrastructure.scheduling.scheduler.executor._deliver_interactive_shell"
-            ) as mock_shell,
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_slack,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_shell.return_value = (True, "", "local:1")
-            mock_slack.return_value = (False, "webhook missing", "")
             result = execute_task(task, "2026-01-01T09:05")
 
         assert result is True
@@ -281,11 +303,12 @@ class TestExecutor:
         assert "partial delivery" in runs[0].error
         assert "slack" in runs[0].error
         # First attempt + two retries for the failed slack destination.
-        assert mock_slack.call_count == 3
-        assert mock_shell.call_count == 1
+        assert len(adapters[Provider.SLACK].calls) == 3
+        assert len(adapters[Provider.INTERACTIVE_SHELL].calls) == 1
 
     def test_loop_fanout_slack_uses_default_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Loop fan-out must resolve Slack chat_id when primary is interactive_shell."""
+        adapters = _install_fake_bundle()
         task = ScheduledTask(
             id="test_fanout_slack_default",
             kind=TaskKind.DAILY_SUMMARY,
@@ -294,7 +317,7 @@ class TestExecutor:
             params={LOOP_CHANNELS_PARAM: "interactive_shell,slack"},
         )
         monkeypatch.setattr(
-            "infrastructure.scheduling.scheduler.executor.resolve_slack_default_chat_id",
+            "infrastructure.scheduling.scheduler.delivery.resolve_slack_default_chat_id",
             lambda _params: "C0123ABCD",
         )
         monkeypatch.setattr(
@@ -302,27 +325,20 @@ class TestExecutor:
             lambda _params: {"access_token": "xoxb-test"},
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch(
-                "infrastructure.scheduling.scheduler.executor._deliver_interactive_shell"
-            ) as mock_shell,
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_slack,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_shell.return_value = (True, "", "local:1")
-            mock_slack.return_value = (True, "", "ts_123")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
-        slack_task = mock_slack.call_args[0][0]
+        slack_task = adapters[Provider.SLACK].calls[-1][0]
         assert slack_task.chat_id == "C0123ABCD"
 
     def test_loop_fanout_slack_skips_default_when_webhook_configured(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        adapters = _install_fake_bundle()
         task = ScheduledTask(
             id="test_fanout_slack_webhook",
             kind=TaskKind.CUSTOM_INVESTIGATION,
@@ -331,7 +347,7 @@ class TestExecutor:
             params={LOOP_CHANNELS_PARAM: "slack"},
         )
         monkeypatch.setattr(
-            "infrastructure.scheduling.scheduler.executor.resolve_slack_default_chat_id",
+            "infrastructure.scheduling.scheduler.delivery.resolve_slack_default_chat_id",
             lambda _params: "C0123ABCD",
         )
         monkeypatch.setattr(
@@ -339,24 +355,21 @@ class TestExecutor:
             lambda _params: {"webhook_url": "https://hooks.slack.com/x"},
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Loop report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_slack,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Loop report",
         ):
-            mock_slack.return_value = (True, "", "ts_webhook")
             result = execute_task(task, "2026-01-01T10:00")
 
         assert result is True
-        slack_task = mock_slack.call_args[0][0]
+        slack_task = adapters[Provider.SLACK].calls[-1][0]
         assert slack_task.chat_id == ""
 
     def test_loop_fanout_slack_ignores_non_slack_task_chat_id(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A Telegram chat id on an inbox-primary loop must not become Slack's channel."""
+        adapters = _install_fake_bundle()
         task = ScheduledTask(
             id="test_fanout_slack_ignore_foreign_chat",
             kind=TaskKind.CUSTOM_INVESTIGATION,
@@ -366,7 +379,7 @@ class TestExecutor:
             params={LOOP_CHANNELS_PARAM: "slack"},
         )
         monkeypatch.setattr(
-            "infrastructure.scheduling.scheduler.executor.resolve_slack_default_chat_id",
+            "infrastructure.scheduling.scheduler.delivery.resolve_slack_default_chat_id",
             lambda _params: "C0123ABCD",
         )
         monkeypatch.setattr(
@@ -374,21 +387,18 @@ class TestExecutor:
             lambda _params: {"access_token": "xoxb-test"},
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Loop report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_slack,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Loop report",
         ):
-            mock_slack.return_value = (True, "", "ts_123")
             result = execute_task(task, "2026-01-01T11:00")
 
         assert result is True
-        slack_task = mock_slack.call_args[0][0]
+        slack_task = adapters[Provider.SLACK].calls[-1][0]
         assert slack_task.chat_id == "C0123ABCD"
 
     def test_rocketchat_delivery_posts_to_channel(self) -> None:
+        _install_real_bundle()
         task = ScheduledTask(
             id="test_rc_02",
             kind=TaskKind.DAILY_SUMMARY,
@@ -403,14 +413,16 @@ class TestExecutor:
                 return_value="<b>Scheduled</b> report",
             ),
             patch(
-                "infrastructure.scheduling.scheduler.executor.resolve_rocketchat_credentials",
+                "integrations.rocketchat.scheduled_delivery.resolve_rocketchat_credentials",
                 return_value={
                     "server_url": "https://chat.example.com",
                     "auth_token": "tok",
                     "user_id": "u1",
                 },
             ),
-            patch("integrations.rocketchat.delivery.post_rocketchat_message") as mock_post,
+            patch(
+                "integrations.rocketchat.scheduled_delivery.post_rocketchat_message"
+            ) as mock_post,
         ):
             mock_post.return_value = (True, "", "msg_rc")
             result = execute_task(task, "2026-01-01T09:00")
@@ -426,6 +438,7 @@ class TestExecutor:
 
     def test_slack_delivery_fails_with_webhook_when_chat_id_set(self) -> None:
         """Webhook ignores chat_id — must not silently deliver to the wrong channel."""
+        _install_real_bundle()
         task = ScheduledTask(
             id="test_sl_webhook_chat",
             kind=TaskKind.DAILY_SUMMARY,
@@ -440,10 +453,10 @@ class TestExecutor:
                 return_value="Scheduled report",
             ),
             patch(
-                "infrastructure.scheduling.scheduler.executor.resolve_slack_credentials",
+                "integrations.slack.scheduled_delivery.resolve_slack_credentials",
                 return_value={"webhook_url": "https://hooks.slack.com/services/T/B/x"},
             ),
-            patch("integrations.slack.delivery.send_slack_webhook_message") as mock_hook,
+            patch("integrations.slack.scheduled_delivery.send_slack_webhook_message") as mock_hook,
         ):
             result = execute_task(task, "2026-01-01T09:00")
 
@@ -451,6 +464,7 @@ class TestExecutor:
         mock_hook.assert_not_called()
 
     def test_rocketchat_delivery_fails_without_token_credentials(self) -> None:
+        _install_real_bundle()
         task = ScheduledTask(
             id="test_rc_03",
             kind=TaskKind.DAILY_SUMMARY,
@@ -465,7 +479,7 @@ class TestExecutor:
                 return_value="Scheduled report",
             ),
             patch(
-                "infrastructure.scheduling.scheduler.executor.resolve_rocketchat_credentials",
+                "integrations.rocketchat.scheduled_delivery.resolve_rocketchat_credentials",
                 return_value={"webhook_url": "https://chat.example.com/hooks/a/b"},
             ),
         ):
@@ -475,6 +489,8 @@ class TestExecutor:
         assert result is False
 
     def test_claim_dedup_prevents_double_execution(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.TELEGRAM].result = (True, "", "msg_1")
         task = ScheduledTask(
             id="test_dedup",
             kind=TaskKind.DAILY_SUMMARY,
@@ -483,15 +499,10 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_telegram") as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_deliver.return_value = (True, "", "msg_1")
-
             # First execution succeeds
             result1 = execute_task(task, "2026-01-01T09:00")
             # Second execution with same fire_time is deduped
@@ -500,7 +511,7 @@ class TestExecutor:
         assert result1 is True
         assert result2 is False
         # Only called once due to dedup
-        assert mock_deliver.call_count == 1
+        assert len(adapters[Provider.TELEGRAM].calls) == 1
 
     def test_message_build_failure_records_error(self) -> None:
         task = ScheduledTask(
@@ -518,6 +529,8 @@ class TestExecutor:
         assert result is False
 
     def test_delivery_failure_records_error(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.TELEGRAM].result = (False, "Connection refused", "")
         task = ScheduledTask(
             id="test_del_fail",
             kind=TaskKind.DAILY_SUMMARY,
@@ -526,20 +539,19 @@ class TestExecutor:
             chat_id="-100123",
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_telegram") as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_deliver.return_value = (False, "Connection refused", "")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is False
-        mock_deliver.assert_called_once()
+        assert len(adapters[Provider.TELEGRAM].calls) == 1
 
     def test_delivery_targets_fan_out_same_message(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.SLACK].result = (True, "", "ts_123")
+        adapters[Provider.TELEGRAM].result = (True, "", "msg_42")
         task = ScheduledTask(
             id="test_fanout",
             kind=TaskKind.WORK_ITEM_CHECKIN,
@@ -556,27 +568,24 @@ class TestExecutor:
             },
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_slack,
-            patch(
-                "infrastructure.scheduling.scheduler.executor._deliver_telegram"
-            ) as mock_telegram,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_slack.return_value = (True, "", "ts_123")
-            mock_telegram.return_value = (True, "", "msg_42")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
-        assert mock_slack.call_args.args[0].chat_id == "C123"
-        assert mock_telegram.call_args.args[0].chat_id == "-100123"
-        assert mock_slack.call_args.args[1] == "Scheduled report"
-        assert mock_telegram.call_args.args[1] == "Scheduled report"
+        slack_call = adapters[Provider.SLACK].calls[-1]
+        telegram_call = adapters[Provider.TELEGRAM].calls[-1]
+        assert slack_call[0].chat_id == "C123"
+        assert telegram_call[0].chat_id == "-100123"
+        assert slack_call[1] == "Scheduled report"
+        assert telegram_call[1] == "Scheduled report"
 
     def test_delivery_targets_report_partial_failure(self) -> None:
+        adapters = _install_fake_bundle()
+        adapters[Provider.SLACK].result = (True, "", "ts_123")
+        adapters[Provider.TELEGRAM].result = (False, "missing token", "")
         task = ScheduledTask(
             id="test_fanout_fail",
             kind=TaskKind.WORK_ITEM_CHECKIN,
@@ -593,25 +602,18 @@ class TestExecutor:
             },
         )
 
-        with (
-            patch(
-                "infrastructure.scheduling.scheduler.executor.build_message",
-                return_value="Scheduled report",
-            ),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_slack,
-            patch(
-                "infrastructure.scheduling.scheduler.executor._deliver_telegram"
-            ) as mock_telegram,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
         ):
-            mock_slack.return_value = (True, "", "ts_123")
-            mock_telegram.return_value = (False, "missing token", "")
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is False
-        mock_slack.assert_called_once()
-        mock_telegram.assert_called_once()
+        assert len(adapters[Provider.SLACK].calls) == 1
+        assert len(adapters[Provider.TELEGRAM].calls) == 1
 
     def test_empty_message_skips_delivery(self) -> None:
+        adapters = _install_fake_bundle()
         task = ScheduledTask(
             id="test_quiet_uptime",
             kind=TaskKind.SENTRY_UPTIME_WATCH,
@@ -620,11 +622,11 @@ class TestExecutor:
             chat_id="C123",
         )
 
-        with (
-            patch("infrastructure.scheduling.scheduler.executor.build_message", return_value=""),
-            patch("infrastructure.scheduling.scheduler.executor._deliver_slack") as mock_deliver,
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="",
         ):
             result = execute_task(task, "2026-01-01T09:00")
 
         assert result is True
-        mock_deliver.assert_not_called()
+        assert adapters[Provider.SLACK].calls == []


### PR DESCRIPTION
## What

Removes the scheduler executor's five hard dependencies on concrete vendor
delivery modules by inverting them behind a per-provider adapter port. The
executor now resolves a `Provider` to a `ScheduledDeliveryAdapter` through an
immutable bundle instead of importing `integrations.<vendor>.delivery`.

## Why

`.importlinter.strict` carried seven `infrastructure -> integrations` debt
edges; five were `scheduler.executor` reaching up into vendor delivery:

    scheduler.executor -> integrations.{discord,rocketchat,slack,telegram}.delivery
    scheduler.executor -> integrations.telegram.formatting

Infrastructure (tier 4) importing integrations (tier 3) is an upward edge, and
the executor knew four vendors by name — a fifth delivery vendor meant editing
the scheduler. This collapses all five edges and makes the scheduler
vendor-agnostic.

## How

- New `ScheduledDeliveryAdapter` (Protocol) + `ScheduledDeliveryAdapters`, an
  immutable value assembled at a composition root and installed once. This
  mirrors the existing `runners.py:SchedulerRunners` pattern rather than adding
  a mutable registry (see the note below).
- Each `_deliver_<vendor>` body moves into a vendor adapter in
  `integrations/<vendor>/scheduled_delivery.py`, where importing that vendor's
  delivery is a local (not cross-tier) import. `interactive_shell` — which uses
  no vendor — becomes an `infrastructure` adapter.
- `executor._deliver_single` becomes a bundle lookup; the five `_deliver_*`
  functions and every `integrations` import are gone from the executor. Shared
  helpers (`strip_html`, `resolve_slack_delivery_chat_id`) were extracted to
  `scheduler/delivery.py` so both the executor's fan-out routing and the Slack
  adapter use them.
- Composition root: `bootstrap.adapters.scheduled_delivery_adapters()` builds
  the bundle (the only layer allowed to see both tiers);
  `install_scheduled_delivery_adapters()` binds it. It runs in the
  `SCHEDULER_RUNNERS` boot step (scheduler-worker + all CLI scheduled commands +
  sentry-digest) and in the gateway controller, which installs the runners
  imperatively rather than through the boot step.
- Removed the five `.importlinter.strict` entries.

## A note on the DI mechanism

The scheduler layer wires seams through module-level installers
(`SchedulerRunners`, `agent_runner`, `outbound_registry`), which sits in tension
with the "inject via constructor/parameter" preference. Of the register-at-boot
options, this uses the **immutable, set-once bundle** (`SchedulerRunners`-style)
rather than a mutable per-provider registry: installing a new bundle atomically
replaces the mapping, so there is no read-modify-write module state. The strict
alternative — threading a `Mapping[Provider, adapter]` through `runner.py` and
both `execute_task` call sites — was set aside as inconsistent with the four
sibling seams and higher blast radius.