### PR TITLE
fix(harness): type RunRecordFactory.build and StreamAnswerFn returns …

### DIFF
--- a/core/agent_harness/accounting/run_record.py
+++ b/core/agent_harness/accounting/run_record.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness.accounting.token_accounting import build_llm_run_info
+from core.agent_harness.accounting.token_accounting import LlmRunInfo, build_llm_run_info
+from core.llm.types import StreamingReasoningClient
 
 
 class DefaultRunRecordFactory:
@@ -17,7 +18,14 @@ class DefaultRunRecordFactory:
         """Point run records at a freshly resolved session (gateway reuse)."""
         self._session = session
 
-    def build(self, *, client: Any, prompt: str, response_text: str, started: float) -> Any:
+    def build(
+        self,
+        *,
+        client: StreamingReasoningClient | None,
+        prompt: str,
+        response_text: str,
+        started: float,
+    ) -> LlmRunInfo:
         return build_llm_run_info(
             session=self._session,
             prompt=prompt,

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 from config.llm_reasoning_effort import ReasoningEffortChoice
+from core.agent_harness.accounting.token_accounting import LlmRunInfo
 from core.agent_harness.turns.gather_observation import GatheredEvidence
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from core.llm.types import AgentLLMClient, StreamingReasoningClient
@@ -229,8 +230,15 @@ class ReasoningClientProvider(Protocol):
 class RunRecordFactory(Protocol):
     """Builds the opaque per-answer LLM-run record (telemetry) from raw inputs."""
 
-    def build(self, *, client: Any, prompt: str, response_text: str, started: float) -> Any:
-        raise NotImplementedError
+    def build(
+        self,
+        *,
+        client: StreamingReasoningClient | None,
+        prompt: str,
+        response_text: str,
+        started: float,
+    ) -> LlmRunInfo:
+        """Build the run record for one streamed answer."""
 
 
 @dataclass(frozen=True)
@@ -257,7 +265,7 @@ class AnswerRequest:
 class StreamAnswerFn(Protocol):
     """Bound direct-answer callable (no tools) handed to ``run_turn``."""
 
-    def __call__(self, text: str, request: AnswerRequest) -> Any:
+    def __call__(self, text: str, request: AnswerRequest) -> LlmRunInfo | None:
         """Stream one grounded answer; return the LLM-run record or None."""
 
 

--- a/core/agent_harness/turns/headless_adapters.py
+++ b/core/agent_harness/turns/headless_adapters.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from core.agent_harness.accounting.token_accounting import LlmRunInfo
 from core.agent_harness.ports import (
     ConfirmFn,
     ToolEventObserver,
@@ -201,27 +202,23 @@ class NoopErrorReporter:
         _ = (exc, context, expected)
 
 
-@dataclass
-class SimpleRunRecord:
-    """Opaque conversational-LLM run record for headless runs."""
-
-    response_text: str
-    prompt: str = ""
-    started: float = 0.0
-
-
 class SimpleRunRecordFactory:
-    """Builds :class:`SimpleRunRecord` values."""
+    """Builds :class:`LlmRunInfo` values for headless runs."""
 
     def bind_session(self, session: Any) -> None:
         """Records are ephemeral — no session handle to update."""
         _ = session
 
     def build(
-        self, *, client: Any, prompt: str, response_text: str, started: float
-    ) -> SimpleRunRecord:
-        _ = client
-        return SimpleRunRecord(response_text=response_text, prompt=prompt, started=started)
+        self,
+        *,
+        client: StreamingReasoningClient | None,
+        prompt: str,
+        response_text: str,
+        started: float,
+    ) -> LlmRunInfo:
+        _ = (client, prompt, started)
+        return LlmRunInfo(response_text=response_text)
 
 
 @dataclass

--- a/core/agent_harness/turns/headless_agent.py
+++ b/core/agent_harness/turns/headless_agent.py
@@ -21,6 +21,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import replace
 
+from core.agent_harness.accounting.token_accounting import LlmRunInfo
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.ports import (
     AnswerRequest,
@@ -276,7 +277,7 @@ class HeadlessAgent:
             confirm_fn=confirm_fn,
         )
 
-    def _answer(self, text: str, request: AnswerRequest) -> object:
+    def _answer(self, text: str, request: AnswerRequest) -> LlmRunInfo | None:
         return stream_answer(
             text,
             self._session,


### PR DESCRIPTION
fix(harness): type RunRecordFactory.build and StreamAnswerFn returns (#5249)

Type client as StreamingReasoningClient | None and returns as LlmRunInfo / LlmRunInfo | None in core/agent_harness/ports.py. Update DefaultRunRecordFactory and SimpleRunRecordFactory to match and retire SimpleRunRecord (no compat alias). Update HeadlessAgent._answer return type.

Fixes #5249 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
This PR fixes loose typing in core/agent_harness/ports.py. RunRecordFactory.build and StreamAnswerFn were typed as Any, now they use the real types — client is StreamingReasoningClient | None and the return is LlmRunInfo / LlmRunInfo | None. I updated DefaultRunRecordFactory and SimpleRunRecordFactory to match and removed the old SimpleRunRecord class that is no longer needed.
### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---
<img width="3331" height="1416" alt="Screenshot (203)" src="https://github.com/user-attachments/assets/a3aa08cb-ec69-44b8-92d0-9cbf7728a0fb" />
<img width="3358" height="1322" alt="Screenshot (204)" src="https://github.com/user-attachments/assets/ab86fad5-f002-48d5-a7e2-e4ca44297baf" />
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The run record is the opaque per-answer telemetry object built by `run_factory.build` in `orchestrator._stream_response` and returned by `stream_answer` via `StreamAnswerFn` — `TurnAccounting` and `PromptRecorder` read `.model/.provider/.latency_ms/.input_tokens/.output_tokens/.response_text` off it. Existing implementations already produce `LlmRunInfo` (`build_llm_run_info`), but the Protocols said `Any`, so mypy gave no safety and the `client` param was untyped. I chose the existing `LlmRunInfo` ( `token_accounting.py:25` ) over introducing a new small dataclass — it's the real type `DefaultRunRecordFactory` already builds, and `headless_adapters`' minimal `SimpleRunRecord` is now redundant, so I retired it. Alternative was a new narrow `Protocol` with just `response_text`, but that would be less useful for accounting. `client` is the reasoning client (`reasoning.get() -> StreamingReasoningClient | None`), so `StreamingReasoningClient | None` mirrors `build_llm_run_info` which allows `None`. Verified `typecheck` clean + `test_agent_shapes / test_harness_api / test_token_accounting` etc. green; checked before/after with `get_type_hints` and `git stash`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
