### PR TITLE
fix(mongodb): restore configured diagnostic calls

### DIFF
--- a/docs/mongodb.mdx
+++ b/docs/mongodb.mdx
@@ -119,6 +119,75 @@ Status: passed
 Detail: Connected to MongoDB 6.0.5; target database: production
 ```
 
+### Local Docker verification
+
+Start a disposable single-node replica set without external credentials:
+
+```bash
+docker run --rm --detach --name opensre-mongodb \
+  --publish 127.0.0.1:27018:27018 \
+  mongo:7 --replSet rs0 --bind_ip_all --port 27018
+until docker exec opensre-mongodb mongosh --port 27018 --quiet \
+  --eval 'db.adminCommand({ping:1}).ok' | grep --quiet 1; do sleep 1; done
+docker exec opensre-mongodb mongosh --port 27018 --quiet \
+  --eval 'rs.initiate({_id:"rs0",members:[{_id:0,host:"localhost:27018"}]})'
+until docker exec opensre-mongodb mongosh --port 27018 --quiet \
+  --eval 'db.hello().isWritablePrimary' | grep --quiet true; do sleep 1; done
+```
+
+Seed a collection, enable profiling, complete one slow query for profiler data,
+and leave another running for current-operation data:
+
+```bash
+docker exec opensre-mongodb mongosh --port 27018 --quiet opensre_verify --eval '
+  db.setProfilingLevel(2);
+  db.metrics.insertMany(Array.from({length:1000}, (_,i) => ({service:"checkout", value:i, ts:new Date()})));
+  db.metrics.createIndex({service:1});
+  db.slow.insertOne({name:"profile-seed"});
+  db.slow.find({$where:"sleep(2000); return true"}).toArray();
+'
+docker exec --detach opensre-mongodb mongosh --port 27018 --quiet \
+  opensre_verify --eval 'db.slow.find({$where:"sleep(60000); return true"}).toArray()'
+```
+
+From a source checkout, run `uv run opensre integrations setup mongodb` and use
+these answers:
+
+| Prompt | Answer |
+| --- | --- |
+| Connection string | `mongodb://127.0.0.1:27018/?directConnection=true` |
+| Database name | `opensre_verify` |
+| Auth source | `admin` |
+| TLS enabled | `false` |
+
+Verify the connection:
+
+```bash
+uv run opensre integrations verify mongodb
+```
+
+The verifier should report MongoDB 7 and the `opensre_verify` database. While
+the slow query is still running, exercise `get_mongodb_current_ops` through an
+agent turn:
+
+```bash
+uv run opensre ask \
+  --allowed-tool get_mongodb_current_ops \
+  "Use get_mongodb_current_ops with threshold_ms 1000 now. Report every operation above the threshold."
+```
+
+The result should include the running `COLLSCAN` on `opensre_verify.slow`.
+The other MongoDB tools can now read the seeded collection, profiler entries,
+single healthy primary member, and server status. Stop the disposable instance
+when finished:
+
+```bash
+docker stop opensre-mongodb
+```
+
+This instance has no authentication or TLS. It binds only to loopback and is
+for local verification only.
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/integrations/mongodb/__init__.py
+++ b/integrations/mongodb/__init__.py
@@ -232,7 +232,10 @@ def get_current_ops(
         client = _get_client(config)
         try:
             result = client.admin.command(
-                "currentOp", {"microsecs_running": {"$gte": threshold_microsecs}}
+                {
+                    "currentOp": 1,
+                    "microsecs_running": {"$gte": threshold_microsecs},
+                }
             )
             ops = result.get("inprog", [])
             # Cap results and strip potentially sensitive fields

--- a/integrations/mongodb/tools/mongodb_current_ops_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_current_ops_tool/__init__.py
@@ -26,6 +26,7 @@ def get_mongodb_current_ops(
     threshold_ms: int = 1000,
     auth_source: str = "admin",
     tls: bool = True,
+    **_kwargs: Any,
 ) -> dict[str, Any]:
     """Fetch currently running operations above the threshold (default 1000ms)."""
     config = MongoDBConfig(

--- a/integrations/mongodb/tools/mongodb_replica_status_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_replica_status_tool/__init__.py
@@ -25,6 +25,7 @@ def get_mongodb_replica_status(
     connection_string: str,
     auth_source: str = "admin",
     tls: bool = True,
+    **_kwargs: Any,
 ) -> dict[str, Any]:
     """Fetch status of all members in the MongoDB replica set."""
     config = MongoDBConfig(

--- a/integrations/mongodb/tools/mongodb_server_status_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_server_status_tool/__init__.py
@@ -25,6 +25,7 @@ def get_mongodb_server_status(
     connection_string: str,
     auth_source: str = "admin",
     tls: bool = True,
+    **_kwargs: Any,
 ) -> dict[str, Any]:
     """Fetch server status metrics from a MongoDB instance."""
     config = MongoDBConfig(

--- a/tests/integrations/test_mongodb_integration.py
+++ b/tests/integrations/test_mongodb_integration.py
@@ -110,6 +110,25 @@ class TestMongoDBValidation:
         assert "Conn error" in result.detail
 
 
+class TestMongoDBCurrentOps:
+    @patch("integrations.mongodb._get_client")
+    def test_duration_filter_is_sent_as_a_command_field(self, mock_get_client):
+        mock_get_client.return_value.admin.command.return_value = {"inprog": []}
+
+        result = get_current_ops(
+            MongoDBConfig(connection_string="mongodb://host"),
+            threshold_ms=1000,
+        )
+
+        assert result["operations"] == []
+        mock_get_client.return_value.admin.command.assert_called_once_with(
+            {
+                "currentOp": 1,
+                "microsecs_running": {"$gte": 1_000_000},
+            }
+        )
+
+
 class TestMongoDBAdminUnauthorized:
     """Admin commands should return graceful errors without Sentry reports when unauthorized."""
 

--- a/tests/tools/test_mongodb_shared_params.py
+++ b/tests/tools/test_mongodb_shared_params.py
@@ -1,0 +1,35 @@
+"""Regression coverage for shared MongoDB integration parameters."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from integrations.mongodb.tools.mongodb_current_ops_tool import get_mongodb_current_ops
+from integrations.mongodb.tools.mongodb_replica_status_tool import get_mongodb_replica_status
+from integrations.mongodb.tools.mongodb_server_status_tool import get_mongodb_server_status
+
+
+def test_admin_tools_ignore_database_injected_by_shared_config() -> None:
+    """Admin tools accept the database value injected for database-scoped tools."""
+    shared_params = {
+        "connection_string": "mongodb://localhost:27017",
+        "database": "opensre_verify",
+    }
+
+    with (
+        patch(
+            "integrations.mongodb.tools.mongodb_current_ops_tool.get_current_ops",
+            return_value={"available": True},
+        ),
+        patch(
+            "integrations.mongodb.tools.mongodb_replica_status_tool.get_rs_status",
+            return_value={"available": True},
+        ),
+        patch(
+            "integrations.mongodb.tools.mongodb_server_status_tool.get_server_status",
+            return_value={"available": True},
+        ),
+    ):
+        assert get_mongodb_current_ops(**shared_params)["available"] is True
+        assert get_mongodb_replica_status(**shared_params)["available"] is True
+        assert get_mongodb_server_status(**shared_params)["available"] is True


### PR DESCRIPTION
Supports #5135

#### Describe the changes you have made in this PR -

- Allow MongoDB admin-scoped tool wrappers to ignore the database value injected by the shared integration config.
- Send `microsecs_running` as a top-level `currentOp` command filter so sub-threshold operations are excluded.
- Add regression coverage for both failures discovered through a real agent turn.
- Add a reproducible single-node replica-set Docker recipe covering collection, profiler, current-op, replication, and server data.

### Demo/Screenshot for feature changes and bug fixes -

Before:

```text
[tool:get_mongodb_current_ops] failed: unexpected keyword argument 'database'
[tool:get_mongodb_replica_status] failed: unexpected keyword argument 'database'
[tool:get_mongodb_server_status] failed: unexpected keyword argument 'database'
```

After, in a DeepSeek agent turn:

```text
MongoDB 7.0.40
rs0 localhost:27018 PRIMARY, health 1.0
opensre_verify.metrics: 1,000 documents, 2 indexes
current ops: COLLSCAN on opensre_verify.slow above 1,000 ms
profiler: completed COLLSCAN entries above 100 ms
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The shared MongoDB extractor supplies database-scoped and connection-scoped values to every tool. Database and profiler tools consumed the complete mapping, but the three admin tools rejected `database` before reaching MongoDB. Those wrappers now follow the established tool pattern of accepting unused injected values.

The live verification also showed that `currentOp` returned sub-threshold operations. PyMongo interpreted the second positional mapping as the value of `currentOp`, not as command filter fields. Passing one command document preserves the intended server-side filter.

A single-member replica set is the smallest local topology that gives every registered diagnostic meaningful data. Profiling plus one completed and one in-flight slow query exercises the profiler and current-op paths without external credentials.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest -q tests/integrations/test_mongodb_integration.py tests/tools/test_mongodb_shared_params.py tests/tools/test_mongodb_collection_stats_tool.py tests/tools/test_mongodb_current_ops_tool.py tests/tools/test_mongodb_profiler_tool.py tests/tools/test_mongodb_replica_status_tool.py tests/tools/test_mongodb_server_status_tool.py` (61 passed)
- `git diff --check`
- Manual MongoDB 7 Docker replica-set startup, seed, setup, verifier, direct registered-tool assertions, DeepSeek agent calls, and teardown

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
