### PR TITLE
fix(tempo): resolve optional setup fields

### DIFF
--- a/docs/tempo.mdx
+++ b/docs/tempo.mdx
@@ -145,6 +145,52 @@ Status:  passed
 Detail:  Connected to Grafana Tempo HTTP API (/api/search/tags).
 ```
 
+### Local Docker verification
+
+Start a disposable all-in-one Tempo using the repository's local configuration:
+
+```bash
+docker run --rm --detach --name opensre-tempo \
+  --publish 127.0.0.1:3200:3200 \
+  --publish 127.0.0.1:4318:4318 \
+  --volume "$PWD/tests/e2e/tempo/tempo-local.yaml:/etc/tempo.yaml:ro" \
+  grafana/tempo:2.7.2 -config.file=/etc/tempo.yaml
+until curl --fail --silent http://127.0.0.1:3200/ready; do sleep 1; done
+```
+
+Seed a recent two-second checkout error trace through OTLP/HTTP:
+
+```bash
+uv run python -m tests.e2e.tempo.local_seed
+```
+
+From a source checkout, run `uv run opensre integrations setup tempo`. Enter
+`http://127.0.0.1:3200` as the URL and leave the bearer token, username,
+password, and tenant prompts blank. Then verify the connection:
+
+```bash
+uv run opensre integrations verify tempo
+```
+
+The verifier should report a successful connection to the search API. Exercise
+the search, tag-listing, and trace-fetch actions through one agent turn:
+
+```bash
+uv run opensre ask --allowed-tool query_tempo \
+  "Use query_tempo to list services, list span names, search the last 60 minutes for checkout-service, and fetch the full trace returned by the search. Report the trace ID, root span, duration, HTTP status, and span status."
+```
+
+The result should report `checkout-service`, `POST /checkout`, a two-second
+duration, HTTP status `500`, and an error span. Stop the disposable instance
+when finished:
+
+```bash
+docker stop opensre-tempo
+```
+
+This instance has no authentication or TLS. Both ports bind only to loopback,
+and all trace data is discarded with the container.
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/integrations/tempo/__init__.py
+++ b/integrations/tempo/__init__.py
@@ -150,11 +150,11 @@ def tempo_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     """
     tempo = sources.get("tempo", {})
     return {
-        "url": str(tempo.get("url", "")).strip(),
-        "api_key": str(tempo.get("api_key", "")).strip(),
-        "username": str(tempo.get("username", "")).strip(),
-        "password": str(tempo.get("password", "")).strip(),
-        "org_id": str(tempo.get("org_id", "")).strip(),
+        "url": str(tempo.get("url") or "").strip(),
+        "api_key": str(tempo.get("api_key") or "").strip(),
+        "username": str(tempo.get("username") or "").strip(),
+        "password": str(tempo.get("password") or "").strip(),
+        "org_id": str(tempo.get("org_id") or "").strip(),
     }
 
 
@@ -162,11 +162,11 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[TempoConfig |
     try:
         cfg = build_tempo_config(
             {
-                "url": credentials.get("url", ""),
-                "api_key": credentials.get("api_key", ""),
-                "username": credentials.get("username", ""),
-                "password": credentials.get("password", ""),
-                "org_id": credentials.get("org_id", ""),
+                "url": credentials.get("url") or "",
+                "api_key": credentials.get("api_key") or "",
+                "username": credentials.get("username") or "",
+                "password": credentials.get("password") or "",
+                "org_id": credentials.get("org_id") or "",
                 "integration_id": record_id,
             }
         )

--- a/tests/e2e/tempo/__init__.py
+++ b/tests/e2e/tempo/__init__.py
@@ -1,0 +1,1 @@
+"""Local Grafana Tempo verification support."""

--- a/tests/e2e/tempo/local_seed.py
+++ b/tests/e2e/tempo/local_seed.py
@@ -1,0 +1,75 @@
+"""Seed one deterministic trace into the local Grafana Tempo container."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from urllib.request import Request, urlopen
+
+_OTLP_HTTP_TRACES_URL = "http://127.0.0.1:4318/v1/traces"
+TRACE_ID = "0123456789abcdef0123456789abcdef"
+
+
+def _trace_payload(end_time_unix_nano: int) -> dict[str, Any]:
+    """Build an OTLP/HTTP trace payload ending at the supplied time."""
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {
+                            "key": "service.name",
+                            "value": {"stringValue": "checkout-service"},
+                        },
+                        {
+                            "key": "deployment.environment",
+                            "value": {"stringValue": "local"},
+                        },
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "opensre.local-verification"},
+                        "spans": [
+                            {
+                                "traceId": TRACE_ID,
+                                "spanId": "0123456789abcdef",
+                                "name": "POST /checkout",
+                                "kind": 2,
+                                "startTimeUnixNano": str(end_time_unix_nano - 2_000_000_000),
+                                "endTimeUnixNano": str(end_time_unix_nano),
+                                "attributes": [
+                                    {
+                                        "key": "http.response.status_code",
+                                        "value": {"intValue": "500"},
+                                    }
+                                ],
+                                "status": {
+                                    "code": 2,
+                                    "message": "seeded failure",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def main() -> None:
+    """Send one recent checkout error trace to the local OTLP endpoint."""
+    request = Request(
+        _OTLP_HTTP_TRACES_URL,
+        data=json.dumps(_trace_payload(time.time_ns())).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(request, timeout=10) as response:
+        response.read()
+    print(f"Seeded checkout-service trace {TRACE_ID}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/tempo/tempo-local.yaml
+++ b/tests/e2e/tempo/tempo-local.yaml
@@ -1,0 +1,24 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_duration: 1m
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /tmp/tempo/wal
+    local:
+      path: /tmp/tempo/blocks

--- a/tests/e2e/tempo/test_local_seed.py
+++ b/tests/e2e/tempo/test_local_seed.py
@@ -16,3 +16,9 @@ def test_trace_payload_contains_searchable_error_span() -> None:
     assert span["name"] == "POST /checkout"
     assert int(span["endTimeUnixNano"]) - int(span["startTimeUnixNano"]) == 2_000_000_000
     assert span["status"]["code"] == 2
+    http_status = next(
+        attribute["value"]["intValue"]
+        for attribute in span["attributes"]
+        if attribute["key"] == "http.response.status_code"
+    )
+    assert http_status == "500"

--- a/tests/e2e/tempo/test_local_seed.py
+++ b/tests/e2e/tempo/test_local_seed.py
@@ -1,0 +1,18 @@
+"""Tests for the local Grafana Tempo trace seed."""
+
+from tests.e2e.tempo.local_seed import TRACE_ID, _trace_payload
+
+
+def test_trace_payload_contains_searchable_error_span() -> None:
+    end_time = 3_000_000_000
+
+    payload = _trace_payload(end_time)
+
+    resource_span = payload["resourceSpans"][0]
+    resource_attributes = resource_span["resource"]["attributes"]
+    span = resource_span["scopeSpans"][0]["spans"][0]
+    assert resource_attributes[0]["value"]["stringValue"] == "checkout-service"
+    assert span["traceId"] == TRACE_ID
+    assert span["name"] == "POST /checkout"
+    assert int(span["endTimeUnixNano"]) - int(span["startTimeUnixNano"]) == 2_000_000_000
+    assert span["status"]["code"] == 2

--- a/tests/integrations/test_tempo.py
+++ b/tests/integrations/test_tempo.py
@@ -4,6 +4,7 @@ from integrations.catalog import load_env_integrations
 from integrations.tempo import (
     TempoConfig,
     build_tempo_config,
+    classify,
     tempo_config_from_env,
     tempo_extract_params,
     validate_tempo_config,
@@ -122,6 +123,26 @@ class TestTempoExtractParams:
         params = tempo_extract_params({})
         assert params["url"] == ""
         assert params["api_key"] == ""
+
+    def test_normalizes_optional_null_credentials_from_setup(self) -> None:
+        credentials = {
+            "url": "http://localhost:3200",
+            "api_key": None,
+            "username": None,
+            "password": None,
+            "org_id": None,
+        }
+
+        config, source = classify(credentials, "tempo-local")
+        params = tempo_extract_params({"tempo": credentials})
+
+        assert source == "tempo"
+        assert config is not None
+        assert config.api_key == ""
+        assert params["api_key"] == ""
+        assert params["username"] == ""
+        assert params["password"] == ""
+        assert params["org_id"] == ""
 
 
 class TestTempoEnvCatalogLoading:


### PR DESCRIPTION
Supports #5163

#### Describe the changes you have made in this PR -

- Normalize optional Tempo setup fields persisted as `null`, so unauthenticated setup resolves from the local store after validation.
- Add regression coverage for the setup-store representation and extracted tool parameters.
- Add a minimal all-in-one Tempo configuration and deterministic OTLP/HTTP trace seed.
- Document Docker startup, setup, verification, all query actions, expected data, and teardown.

### Demo/Screenshot for feature changes and bug fixes -

Before setup completed validation but the immediate verifier failed:

```text
✓ Saved → None
classify_failed: integration=tempo
TempoConfig validation failed
status: missing
```

After:

```text
tempo │ local store │ ✓ passed │ Connected to Grafana Tempo HTTP API (/api/search/tags).
service: checkout-service
span: POST /checkout
trace duration: 2000 ms
HTTP status: 500
span status: STATUS_CODE_ERROR — seeded failure
```

A DeepSeek agent turn used `query_tempo` to list services and span names, search the seeded trace, and fetch its full span data.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Tempo's setup flow validates blank optional prompts as strings, then persists them as null values. `TempoConfig` correctly keeps strict string fields, so the integration boundary now normalizes absent optional credentials before model validation and tool extraction. This matches how an unauthenticated Tempo deployment is represented without weakening the config type.

The local recipe uses one official all-in-one Tempo container. A repository-owned configuration enables only the HTTP API, OTLP/HTTP receiver, and ephemeral local trace storage. The seed emits one recent deterministic checkout error span so search, tag listing, and trace fetching all have meaningful data.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest -q tests/integrations/test_tempo.py tests/tools/test_tempo_tools.py tests/e2e/tempo/test_local_seed.py` (30 passed)
- `git diff --check`
- Manual Tempo 2.7.2 Docker startup/readiness, OTLP seed, setup, verifier, four direct tool actions, DeepSeek agent turn, and teardown

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
