### PR TITLE
fix: Replace json.dumps in tool_call_signature with hashable fingerprint (#5086)

### DIFF
--- a/tests/benchmarks/investigation/__init__.py
+++ b/tests/benchmarks/investigation/__init__.py
@@ -1,0 +1,1 @@
+"""Microbenchmarks for investigation runtime mechanics."""

--- a/tests/benchmarks/investigation/tool_call_signature_benchmark.py
+++ b/tests/benchmarks/investigation/tool_call_signature_benchmark.py
@@ -1,0 +1,103 @@
+"""Compare the investigation tool-call cache identity paths.
+
+Run locally:
+
+    uv run python -m tests.benchmarks.investigation.tool_call_signature_benchmark
+
+This benchmark intentionally has no timing assertion: it records the evidence
+for a performance-sensitive refactor without making CI depend on host speed.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import timeit
+from collections.abc import Callable
+from typing import Any
+
+from core.llm.types import ToolCall
+from tools.investigation.stages.gather_evidence.loop import tool_call_signature
+
+_ITERATIONS = 50_000
+_REPEATS = 7
+_RESULT = {"traces": 12}
+
+# Mirrors the nested arguments accepted by integrations.tempo.tools.query_tempo.
+_TOOL_CALL = ToolCall(
+    id="benchmark",
+    name="query_tempo",
+    input={
+        "action": "search",
+        "service": "checkout-api",
+        "span_name": "POST /checkout",
+        "min_duration_ms": 500.0,
+        "max_duration_ms": 5_000.0,
+        "tags": {
+            "resource.cluster": "prod-eu",
+            "http.status_code": "500",
+        },
+        "time_range_minutes": 60,
+        "limit": 20,
+    },
+)
+
+
+def _legacy_signature(tool_call: ToolCall) -> str:
+    """Return the pre-refactor JSON identity for comparison only."""
+    try:
+        args = json.dumps(tool_call.input, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        args = repr(tool_call.input)
+    return f"{tool_call.name}::{args}"
+
+
+def _legacy_fresh_path() -> None:
+    cache: dict[str, Any] = {}
+    cache.get(_legacy_signature(_TOOL_CALL))
+    cache.setdefault(_legacy_signature(_TOOL_CALL), _RESULT)
+
+
+def _fingerprint_fresh_path() -> None:
+    cache: dict[tuple[str, Any], Any] = {}
+    signature = tool_call_signature(_TOOL_CALL)
+    cache.get(signature)
+    cache.setdefault(signature, _RESULT)
+
+
+_LEGACY_DUPLICATE_CACHE = {_legacy_signature(_TOOL_CALL): _RESULT}
+_FINGERPRINT_DUPLICATE_CACHE = {tool_call_signature(_TOOL_CALL): _RESULT}
+
+
+def _legacy_duplicate_lookup() -> None:
+    _LEGACY_DUPLICATE_CACHE.get(_legacy_signature(_TOOL_CALL))
+
+
+def _fingerprint_duplicate_lookup() -> None:
+    _FINGERPRINT_DUPLICATE_CACHE.get(tool_call_signature(_TOOL_CALL))
+
+
+def _median_us(fn: Callable[[], object]) -> float:
+    for _ in range(1_000):
+        fn()
+    samples = timeit.repeat(fn, number=_ITERATIONS, repeat=_REPEATS)
+    return statistics.median(samples) * 1_000_000 / _ITERATIONS
+
+
+def _report(label: str, legacy: Callable[[], object], fingerprint: Callable[[], object]) -> None:
+    legacy_us = _median_us(legacy)
+    fingerprint_us = _median_us(fingerprint)
+    ratio = legacy_us / fingerprint_us
+    print(
+        f"{label}: legacy={legacy_us:.3f} us  fingerprint={fingerprint_us:.3f} us  "
+        f"speedup={ratio:.2f}x"
+    )
+
+
+def main() -> None:
+    _report("fresh lookup + store", _legacy_fresh_path, _fingerprint_fresh_path)
+    _report("duplicate lookup", _legacy_duplicate_lookup, _fingerprint_duplicate_lookup)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tools/investigation/stages/gather_evidence/test_loop.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_loop.py
@@ -1,0 +1,52 @@
+from core.llm.types import ToolCall
+from tools.investigation.stages.gather_evidence.loop import tool_call_signature
+
+
+class Unhashable:
+    __hash__ = None  # type: ignore
+
+    def __init__(self, val):
+        self.val = val
+
+    def __str__(self):
+        return f"Unhashable({self.val})"
+
+
+def test_tool_call_signature_same_args():
+    tc1 = ToolCall(id="1", name="my_tool", input={"a": 1, "b": 2})
+    tc2 = ToolCall(id="2", name="my_tool", input={"b": 2, "a": 1})
+    assert tool_call_signature(tc1) == tool_call_signature(tc2)
+
+
+def test_tool_call_signature_different_nested_values():
+    tc1 = ToolCall(id="1", name="my_tool", input={"a": {"c": 3}})
+    tc2 = ToolCall(id="2", name="my_tool", input={"a": {"c": 4}})
+    assert tool_call_signature(tc1) != tool_call_signature(tc2)
+
+
+def test_tool_call_signature_nested_dict():
+    tc1 = ToolCall(id="1", name="my_tool", input={"a": {"z": 1, "y": 2}})
+    tc2 = ToolCall(id="2", name="my_tool", input={"a": {"y": 2, "z": 1}})
+    assert tool_call_signature(tc1) == tool_call_signature(tc2)
+
+
+def test_tool_call_signature_list():
+    tc1 = ToolCall(id="1", name="my_tool", input={"a": [1, 2, 3]})
+    tc2 = ToolCall(id="2", name="my_tool", input={"a": [1, 2, 3]})
+    tc3 = ToolCall(id="3", name="my_tool", input={"a": [1, 3, 2]})
+    assert tool_call_signature(tc1) == tool_call_signature(tc2)
+    assert tool_call_signature(tc1) != tool_call_signature(tc3)
+
+
+def test_tool_call_signature_unhashable_leaves():
+    obj1 = Unhashable(1)
+    tc1 = ToolCall(id="1", name="my_tool", input={"a": obj1})
+    tc2 = ToolCall(id="2", name="my_tool", input={"a": obj1})
+    assert tool_call_signature(tc1) == tool_call_signature(tc2)
+    assert str(obj1) in str(tool_call_signature(tc1))
+
+
+def test_tool_call_signature_container_collision():
+    tc1 = ToolCall(id="1", name="my_tool", input={"filter": {}})
+    tc2 = ToolCall(id="2", name="my_tool", input={"filter": []})
+    assert tool_call_signature(tc1) != tool_call_signature(tc2)

--- a/tests/tools/investigation/stages/gather_evidence/test_loop.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_loop.py
@@ -1,15 +1,29 @@
+from dataclasses import dataclass
+
 from core.llm.types import ToolCall
-from tools.investigation.stages.gather_evidence.loop import tool_call_signature
+from tools.investigation.stages.gather_evidence.loop import (
+    InvestigationLoopController,
+    InvestigationToolCallCache,
+    tool_call_signature,
+)
 
 
+@dataclass
 class Unhashable:
-    __hash__ = None  # type: ignore
+    val: int
 
-    def __init__(self, val):
-        self.val = val
-
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Unhashable({self.val})"
+
+
+class CountingFallback:
+    def __init__(self, val: int) -> None:
+        self.val = val
+        self.str_calls = 0
+
+    def __str__(self) -> str:
+        self.str_calls += 1
+        return f"CountingFallback({self.val})"
 
 
 def test_tool_call_signature_same_args():
@@ -38,15 +52,67 @@ def test_tool_call_signature_list():
     assert tool_call_signature(tc1) != tool_call_signature(tc3)
 
 
-def test_tool_call_signature_unhashable_leaves():
+def test_tool_call_signature_unhashable_leaves() -> None:
     obj1 = Unhashable(1)
+    obj2 = Unhashable(1)
     tc1 = ToolCall(id="1", name="my_tool", input={"a": obj1})
-    tc2 = ToolCall(id="2", name="my_tool", input={"a": obj1})
+    tc2 = ToolCall(id="2", name="my_tool", input={"a": obj2})
     assert tool_call_signature(tc1) == tool_call_signature(tc2)
-    assert str(obj1) in str(tool_call_signature(tc1))
+    _ = hash(tool_call_signature(tc1))
 
 
-def test_tool_call_signature_container_collision():
+def test_tool_call_signature_container_collision() -> None:
     tc1 = ToolCall(id="1", name="my_tool", input={"filter": {}})
     tc2 = ToolCall(id="2", name="my_tool", input={"filter": []})
-    assert tool_call_signature(tc1) != tool_call_signature(tc2)
+    cache = InvestigationToolCallCache()
+    cache.store(tool_call_signature(tc1), {"shape": "object"}, loop_iteration=0)
+
+    assert cache.lookup(tool_call_signature(tc2)) is None
+
+
+def test_tool_call_signature_distinguishes_signed_zero() -> None:
+    positive = ToolCall(id="1", name="my_tool", input={"value": 0.0})
+    negative = ToolCall(id="2", name="my_tool", input={"value": -0.0})
+    cache = InvestigationToolCallCache()
+    cache.store(tool_call_signature(positive), {"sign": "positive"}, loop_iteration=0)
+
+    assert cache.lookup(tool_call_signature(negative)) is None
+
+
+def test_tool_call_signature_normalizes_non_finite_floats() -> None:
+    nan_1 = ToolCall(id="1", name="my_tool", input={"value": float("nan")})
+    nan_2 = ToolCall(id="2", name="my_tool", input={"value": float("nan")})
+    positive_inf = ToolCall(id="3", name="my_tool", input={"value": float("inf")})
+    negative_inf = ToolCall(id="4", name="my_tool", input={"value": float("-inf")})
+
+    assert tool_call_signature(nan_1) == tool_call_signature(nan_2)
+    assert tool_call_signature(positive_inf) != tool_call_signature(negative_inf)
+
+
+def test_tool_call_signature_preserves_scalar_types() -> None:
+    signatures = {
+        tool_call_signature(ToolCall(id="1", name="my_tool", input={"value": True})),
+        tool_call_signature(ToolCall(id="2", name="my_tool", input={"value": 1})),
+        tool_call_signature(ToolCall(id="3", name="my_tool", input={"value": 1.0})),
+    }
+
+    assert len(signatures) == 3
+
+
+def test_controller_reuses_the_classified_signature_when_storing() -> None:
+    leaf = CountingFallback(1)
+    tool_call = ToolCall(id="call-1", name="my_tool", input={"value": leaf})
+    controller = InvestigationLoopController(
+        stagnation_nudge="try something else",
+        checkpoint_nudge="checkpoint",
+        max_stagnant_iterations=2,
+    )
+
+    controller.prepare_batch([tool_call], iteration=0)
+    controller.record_runtime_result(
+        iteration=0,
+        tool_call_id=tool_call.id,
+        result={"ok": True},
+    )
+
+    assert leaf.str_calls == 1

--- a/tools/investigation/stages/gather_evidence/loop.py
+++ b/tools/investigation/stages/gather_evidence/loop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Hashable, Sequence
 from dataclasses import dataclass
 from threading import Lock
 from typing import Any
@@ -28,26 +28,45 @@ from infrastructure.text.truncation import truncate
 _MAX_CACHED_RESULT_CHARS = 8_000
 
 
-def _canonicalize_args(value: Any) -> Any:
+_ToolCallSignature = tuple[str, Hashable]
+
+
+def _canonicalize_args(value: Any) -> Hashable:
     """Recursively convert a value into a hashable fingerprint."""
-    if isinstance(value, dict):
-        return ("dict", tuple(sorted((str(k), _canonicalize_args(v)) for k, v in value.items())))
-    if isinstance(value, (list, tuple)):
-        return ("list", tuple(_canonicalize_args(v) for v in value))
-    if isinstance(value, bool):
-        return ("bool", value)
-    if isinstance(value, int):
-        return ("int", value)
-    if isinstance(value, float):
-        return ("float", value)
-    if isinstance(value, str):
-        return ("str", value)
+    value_type = type(value)
+    if value_type is dict:
+        return frozenset((str(key), _canonicalize_args(item)) for key, item in value.items())
+    if value_type is list or value_type is tuple:
+        return tuple(_canonicalize_args(item) for item in value)
+    if value_type is str:
+        return str.__str__(value)
     if value is None:
-        return ("none", None)
-    return ("str", str(value))
+        return None
+    if value_type is bool:
+        return (bool, value)
+    if value_type is int:
+        return (int, value)
+    if value_type is float:
+        return (float, float.hex(value))
+
+    # Provider-decoded arguments use exact JSON scalar/container types. Keep
+    # programmatic seed calls compatible without paying these checks normally.
+    if isinstance(value, dict):
+        return frozenset((str(key), _canonicalize_args(item)) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return tuple(_canonicalize_args(item) for item in value)
+    if isinstance(value, bool):
+        return (bool, bool(value))
+    if isinstance(value, int):
+        return (int, int.__index__(value))
+    if isinstance(value, float):
+        return (float, float.hex(value))
+    if isinstance(value, str):
+        return str.__str__(value)
+    return str(value)
 
 
-def tool_call_signature(tool_call: ToolCall) -> tuple[Any, ...]:
+def tool_call_signature(tool_call: ToolCall) -> _ToolCallSignature:
     """Stable identity for a tool call: ``name`` + canonicalised arguments."""
     args_fingerprint = _canonicalize_args(tool_call.input)
     return (tool_call.name, args_fingerprint)
@@ -62,6 +81,7 @@ class CachedToolResult:
 @dataclass(frozen=True)
 class _CallOccurrence:
     tool_call: ToolCall
+    signature: _ToolCallSignature
     iteration: int
     order: int
     cached: CachedToolResult | None
@@ -94,11 +114,11 @@ class InvestigationToolCallCache:
             raise ValueError("max_total_chars must be >= 1")
         self._max_entries = max_entries
         self._max_total_chars = max_total_chars
-        self._entries: OrderedDict[tuple[Any, ...], CachedToolResult] = OrderedDict()
-        self._entry_chars: dict[tuple[Any, ...], int] = {}
+        self._entries: OrderedDict[_ToolCallSignature, CachedToolResult] = OrderedDict()
+        self._entry_chars: dict[_ToolCallSignature, int] = {}
         self._total_chars = 0
 
-    def store(self, signature: tuple[Any, ...], result: Any, *, loop_iteration: int) -> None:
+    def store(self, signature: _ToolCallSignature, result: Any, *, loop_iteration: int) -> None:
         if signature in self._entries:
             return
         stored = result
@@ -128,7 +148,7 @@ class InvestigationToolCallCache:
         self._entry_chars[signature] = size
         self._total_chars += size
 
-    def lookup(self, signature: tuple[Any, ...]) -> CachedToolResult | None:
+    def lookup(self, signature: _ToolCallSignature) -> CachedToolResult | None:
         cached = self._entries.get(signature)
         if cached is not None:
             self._entries.move_to_end(signature)
@@ -245,9 +265,11 @@ class InvestigationLoopController:
         fresh_names: list[str] = []
         duplicate_count = 0
         for tool_call in tool_calls:
-            cached = self._cache.lookup(tool_call_signature(tool_call))
+            signature = tool_call_signature(tool_call)
+            cached = self._cache.lookup(signature)
             occurrence = _CallOccurrence(
                 tool_call=tool_call,
+                signature=signature,
                 iteration=call_iteration,
                 order=self._next_call_order,
                 cached=cached,
@@ -349,7 +371,7 @@ class InvestigationLoopController:
                 return
             self._recorded_occurrences.add(occurrence_key)
             self._cache.store(
-                tool_call_signature(occurrence.tool_call),
+                occurrence.signature,
                 payload,
                 loop_iteration=occurrence.iteration,
             )

--- a/tools/investigation/stages/gather_evidence/loop.py
+++ b/tools/investigation/stages/gather_evidence/loop.py
@@ -28,13 +28,29 @@ from infrastructure.text.truncation import truncate
 _MAX_CACHED_RESULT_CHARS = 8_000
 
 
-def tool_call_signature(tool_call: ToolCall) -> str:
+def _canonicalize_args(value: Any) -> Any:
+    """Recursively convert a value into a hashable fingerprint."""
+    if isinstance(value, dict):
+        return ("dict", tuple(sorted((str(k), _canonicalize_args(v)) for k, v in value.items())))
+    if isinstance(value, (list, tuple)):
+        return ("list", tuple(_canonicalize_args(v) for v in value))
+    if isinstance(value, bool):
+        return ("bool", value)
+    if isinstance(value, int):
+        return ("int", value)
+    if isinstance(value, float):
+        return ("float", value)
+    if isinstance(value, str):
+        return ("str", value)
+    if value is None:
+        return ("none", None)
+    return ("str", str(value))
+
+
+def tool_call_signature(tool_call: ToolCall) -> tuple[Any, ...]:
     """Stable identity for a tool call: ``name`` + canonicalised arguments."""
-    try:
-        args = json.dumps(tool_call.input, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        args = repr(tool_call.input)
-    return f"{tool_call.name}::{args}"
+    args_fingerprint = _canonicalize_args(tool_call.input)
+    return (tool_call.name, args_fingerprint)
 
 
 @dataclass(frozen=True)
@@ -78,11 +94,11 @@ class InvestigationToolCallCache:
             raise ValueError("max_total_chars must be >= 1")
         self._max_entries = max_entries
         self._max_total_chars = max_total_chars
-        self._entries: OrderedDict[str, CachedToolResult] = OrderedDict()
-        self._entry_chars: dict[str, int] = {}
+        self._entries: OrderedDict[tuple[Any, ...], CachedToolResult] = OrderedDict()
+        self._entry_chars: dict[tuple[Any, ...], int] = {}
         self._total_chars = 0
 
-    def store(self, signature: str, result: Any, *, loop_iteration: int) -> None:
+    def store(self, signature: tuple[Any, ...], result: Any, *, loop_iteration: int) -> None:
         if signature in self._entries:
             return
         stored = result
@@ -112,7 +128,7 @@ class InvestigationToolCallCache:
         self._entry_chars[signature] = size
         self._total_chars += size
 
-    def lookup(self, signature: str) -> CachedToolResult | None:
+    def lookup(self, signature: tuple[Any, ...]) -> CachedToolResult | None:
         cached = self._entries.get(signature)
         if cached is not None:
             self._entries.move_to_end(signature)


### PR DESCRIPTION
Fixes #5086

#### Describe the changes you have made in this PR -
- Replaces `json.dumps` on the investigation tool-call identity path with a typed, hashable structural fingerprint.
- Preserves mapping order independence, container and scalar types, signed-zero identity, and stable non-finite float behavior.
- Computes each fresh-call signature once and reuses it when storing the result.
- Adds cache-level regressions for container collisions, scalar types, floats, unhashable fallback values, and signature reuse.
- Retains a representative nested-payload benchmark under `tests/benchmarks/investigation/`.

### Demo/Screenshot for feature changes and bug fixes -
N/A — this is a backend performance refactor covered by tests and a retained microbenchmark.

### Validation
- `make lint` — passed
- `make format-check` — passed
- `make typecheck` — passed (1,896 source files)
- `pytest tests/tools/investigation tests/agent/test_investigation.py -q` — 126 passed
- `uv run python -m tests.benchmarks.investigation.tool_call_signature_benchmark`
  - fresh lookup + store: 2.51x faster locally
  - duplicate lookup: 1.15x faster locally

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Investigation tool payloads are open-ended JSON-like dictionaries, so the cache key recursively freezes mappings, sequences, and scalars into a typed hashable value. Exact provider-decoded JSON types take a fast path; programmatic non-JSON leaves preserve the previous `str()` fallback behavior. The controller stores the classified signature with each call occurrence so a fresh call is not canonicalized twice.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
