### PR TITLE
fix(cli): round diagnose validity percent instead of truncating

### DIFF
--- a/surfaces/shared/terminal/stream_renderer/formatting.py
+++ b/surfaces/shared/terminal/stream_renderer/formatting.py
@@ -64,4 +64,4 @@ def _validity_score_percent(score: Any) -> str | None:
     if not math.isfinite(v):
         return None
     v = max(0.0, min(1.0, v))
-    return f"{int(v * 100)}%"
+    return f"{round(v * 100)}%"

--- a/tests/shared/terminal/stream_renderer/test_renderer.py
+++ b/tests/shared/terminal/stream_renderer/test_renderer.py
@@ -221,6 +221,14 @@ class TestStreamRendererUpdatesMode:
         assert "92%" in msg
 
     @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
+    def test_node_message_for_diagnose_rounds_float_percent(self) -> None:
+        """0.29 * 100 is 28.999… in IEEE-754; display must round, not truncate."""
+        renderer = StreamRenderer()
+        renderer._final_state = {"validity_score": 0.29}
+        msg = renderer._build_node_message("diagnose_root_cause")
+        assert msg == "validity:29%"
+
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
     def test_node_message_for_diagnose_skips_non_numeric_validity(self) -> None:
         renderer = StreamRenderer()
         renderer._final_state = {"validity_score": "0.9"}


### PR DESCRIPTION
IEEE-754 makes 0.29*100 land just below 29, so int() displayed 28%. Round before formatting.

Fixes #5310 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

### Demo/Screenshot for feature changes and bug fixes - 
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/3788ea2f-a311-4458-b6f3-2cc4c2daebff" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [ ✅] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ✅] I have reviewed every single line of the AI-generated code
- [ ✅] I can explain the purpose and logic of each function/component I added
- [ ✅] I have tested edge cases and understand how the code handles them
- [✅ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The diagnose line shows a 0–1 validity score as a percent. _validity_score_percent already validates, rejects non-finite values, and clamps to [0, 1]. Display used int(v * 100), which truncates. For values like 0.29, IEEE-754 makes 0.29 * 100 equal 28.999…, so int() printed 28% instead of 29%.

Approach: keep that helper as the only formatter, and round after clamp:

return f"{round(v * 100)}%"
StreamRenderer._build_node_message still does validity:{pct} for diagnose / diagnose_root_cause. No renderer or pipeline change.

Why not the alternatives

Decimal / string rounding — heavier than a display helper needs; the score is already a float.
math.ceil / format(..., '.0f') — ceil would inflate scores; :.0f also rounds, but round() is the same class of fix as #5178/#5179 and stays a one-token change.
Changing callers — every diagnose percent goes through this helper, so one site is enough.
Test: test_node_message_for_diagnose_rounds_float_percent drives _build_node_message with validity_score=0.29 and asserts validity:29%. That is the user-visible line, not only the private helper. Existing diagnose tests still cover 0.92, non-numeric, and NaN.



---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [ ] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
