### PR TITLE
refactor(notifications): register outbound adapters only from bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
             shard: integrations-and-misc
             pytest_paths: >-
               tests/integrations
+              tests/bootstrap
               tests/benchmarks
               tests/chaos_engineering
               tests/shared

--- a/bootstrap/adapters.py
+++ b/bootstrap/adapters.py
@@ -68,10 +68,11 @@ def install_notification_adapters() -> tuple[str, ...]:
     its vendor transport, because each keeps its client import inside the
     delivery function.
 
-    Registers the adapter objects rather than relying on the import side effect
-    alone. Imports are cached, so a re-import after
-    ``clear_outbound_adapters()`` runs no module body and would leave the
-    registry empty while this function reported success.
+    The adapter modules only define their adapter; this step is the one place
+    that registers one. Nothing registers at import time, so a module imported
+    on its own (a tool reaching for ``deliver_email_notification``, say) leaves
+    the registry untouched, and this step still repopulates a registry a test
+    cleared, because it registers objects rather than replaying a cached import.
     """
     from infrastructure.delivery.notifications.outbound_registry import (
         register_outbound_adapter,

--- a/infrastructure/delivery/notifications/outbound_registry.py
+++ b/infrastructure/delivery/notifications/outbound_registry.py
@@ -12,9 +12,10 @@ chose, and ``/background show`` renders the result mapping in that order, so
 resolving by name keeps the caller's ordering authoritative.
 
 Mutation is an unsynchronised module dict, matching the report registry. The sole
-caller runs on a daemon thread, but dict writes are atomic under the GIL and
-CPython's per-module import lock serialises the adapter imports, so the race is
-benign.
+registrar is ``bootstrap.adapters.install_notification_adapters``, which a daemon
+thread may run concurrently with a ``/background notify set`` on the REPL thread,
+but every call writes the same names to the same adapter objects and dict writes
+are atomic under the GIL, so the race is benign.
 """
 
 from __future__ import annotations

--- a/integrations/buzz/background_adapter.py
+++ b/integrations/buzz/background_adapter.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from core.domain.background_investigations import BackgroundInvestigationRecord
-from infrastructure.delivery.notifications.outbound_registry import (
-    BACKGROUND_RCA,
-    register_outbound_adapter,
-)
+from infrastructure.delivery.notifications.outbound_registry import BACKGROUND_RCA
 from infrastructure.delivery.notifications.rca_summary import summary_sections
 
 
@@ -70,4 +67,3 @@ class _BuzzBackgroundAdapter:
 
 
 buzz_background_adapter = _BuzzBackgroundAdapter()
-register_outbound_adapter(buzz_background_adapter)

--- a/integrations/rocketchat/background_adapter.py
+++ b/integrations/rocketchat/background_adapter.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from core.domain.background_investigations import BackgroundInvestigationRecord
-from infrastructure.delivery.notifications.outbound_registry import (
-    BACKGROUND_RCA,
-    register_outbound_adapter,
-)
+from infrastructure.delivery.notifications.outbound_registry import BACKGROUND_RCA
 from infrastructure.delivery.notifications.rca_summary import summary_sections
 
 
@@ -92,4 +89,3 @@ class _RocketChatBackgroundAdapter:
 
 
 rocketchat_background_adapter = _RocketChatBackgroundAdapter()
-register_outbound_adapter(rocketchat_background_adapter)

--- a/integrations/smtp/background_adapter.py
+++ b/integrations/smtp/background_adapter.py
@@ -12,10 +12,7 @@ Email keeps the full report. The chat channels carry the bounded summary from
 from __future__ import annotations
 
 from core.domain.background_investigations import BackgroundInvestigationRecord
-from infrastructure.delivery.notifications.outbound_registry import (
-    BACKGROUND_RCA,
-    register_outbound_adapter,
-)
+from infrastructure.delivery.notifications.outbound_registry import BACKGROUND_RCA
 
 
 def deliver_email_notification(record: BackgroundInvestigationRecord) -> str:
@@ -59,4 +56,3 @@ class _EmailBackgroundAdapter:
 
 
 email_background_adapter = _EmailBackgroundAdapter()
-register_outbound_adapter(email_background_adapter)

--- a/integrations/telegram/background_adapter.py
+++ b/integrations/telegram/background_adapter.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from core.domain.background_investigations import BackgroundInvestigationRecord
-from infrastructure.delivery.notifications.outbound_registry import (
-    BACKGROUND_RCA,
-    register_outbound_adapter,
-)
+from infrastructure.delivery.notifications.outbound_registry import BACKGROUND_RCA
 from infrastructure.delivery.notifications.rca_summary import summary_sections
 from infrastructure.errors import OpenSREError
 
@@ -58,4 +55,3 @@ class _TelegramBackgroundAdapter:
 
 
 telegram_background_adapter = _TelegramBackgroundAdapter()
-register_outbound_adapter(telegram_background_adapter)

--- a/tests/bootstrap/test_notification_adapters.py
+++ b/tests/bootstrap/test_notification_adapters.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import ast
 import pathlib
+import subprocess
+import sys
 
 from bootstrap.adapters import install_notification_adapters
 from infrastructure.delivery.notifications.outbound_registry import (
@@ -39,10 +41,11 @@ def test_step_is_idempotent() -> None:
 def test_step_repopulates_a_cleared_registry() -> None:
     """Calling it twice proves nothing on its own: the second call is a no-op
     against an already-full registry either way. Registration has to survive a
-    clear, because the step registers adapter objects rather than relying on the
-    module import side effect, and imports are cached. Relying on the import
-    alone leaves the registry empty here while the step reports success, which
-    would make ``/background notify set email`` reject its own shipped channel."""
+    clear, because the step registers adapter objects and the adapter modules
+    themselves register nothing — an import is cached, so a step that leaned on
+    the module body would leave the registry empty here while reporting success,
+    which would make ``/background notify set email`` reject its own shipped
+    channel."""
     clear_outbound_adapters()
 
     names = install_notification_adapters()
@@ -94,3 +97,33 @@ def test_only_the_composition_root_registers_notification_adapters() -> None:
 
     # Assert
     assert definers == ["bootstrap/adapters.py::install_notification_adapters"], definers
+
+
+# Importing an adapter module must define its adapter and register nothing: the
+# registry's contents are then a fact about who called the bootstrap step, not
+# about which module some unrelated import happened to pull in first.
+_IMPORT_ONLY_PROBE = (
+    "import integrations.buzz.background_adapter; "
+    "import integrations.rocketchat.background_adapter; "
+    "import integrations.smtp.background_adapter; "
+    "import integrations.telegram.background_adapter; "
+    "import infrastructure.delivery.notifications.outbound_registry as registry; "
+    "names = registry.registered_outbound_adapter_names(); "
+    "assert names == (), names; "
+    "print('OK: import registers nothing')"
+)
+
+
+def test_importing_an_adapter_module_registers_nothing() -> None:
+    """A fresh interpreter, because ``sys.modules`` is process-global: by the
+    time this test runs, another test has already imported every adapter module
+    and filled the registry, so an in-process import would pass vacuously."""
+    completed = subprocess.run(
+        [sys.executable, "-c", _IMPORT_ONLY_PROBE],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "OK: import registers nothing" in completed.stdout

--- a/tests/scheduler/test_delivery_bundle.py
+++ b/tests/scheduler/test_delivery_bundle.py
@@ -21,6 +21,10 @@ class _Adapter:
 
 @pytest.fixture(autouse=True)
 def _reset_installed_bundle() -> None:
+    # Reset on the way in as well as out: a bundle installed by an earlier test
+    # module (booting a real process profile installs one) otherwise survives
+    # into the "before any bundle is installed" case.
+    delivery_bundle._installed = None
     yield
     delivery_bundle._installed = None
 


### PR DESCRIPTION
Fixes #5240 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

The four background-notification adapters (smtp, telegram, rocketchat, buzz) called
register_outbound_adapter() in their module bodies, so which channels ended up registered
depended on who imported what. Removed those calls — the adapter modules now only define,
and bootstrap.adapters.install_notification_adapters() is the sole registrar. Added a test
that imports all four in a fresh interpreter and asserts the registry stays empty.


### Demo/Screenshot for feature changes and bug fixes - 

<img width="1237" height="287" alt="Pasted image (83)" src="https://github.com/user-attachments/assets/c5174c65-ff94-4c0f-89c9-5f5baf652d88" />
Before

<img width="1237" height="287" alt="Pasted image (84)" src="https://github.com/user-attachments/assets/1ffdeb1b-9955-4c2f-83c7-69d72e704997" />
After

<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem was ordering-dependent wiring: with registration in the module body, the
registry's contents depended on import order, and an unregistered channel doesn't raise —
it just reports "unsupported", which looks exactly like a channel-name typo to the user.

The alternative was to drop the explicit registrations in install_notification_adapters()
and let its imports do the work. I rejected it — imports are cached, so after
clear_outbound_adapters() a re-import runs no module body and leaves the registry empty
while the step reports success. Registering the adapter objects is the only version that
survives that, and it keeps registration in the composition root where ARCHITECTURE.md
says it belongs.

The new test runs in a subprocess because sys.modules is process-global: by the time it
runs, sibling tests have already imported every adapter, so an in-process import would
pass vacuously. I checked it actually fails by re-adding the telegram call, then reverted.


<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
