### PR TITLE
test(agent_harness): use AgentLLMResponse in session goal evaluator tests

### DIFF
--- a/tests/core/agent_harness/session_goal/test_evaluate.py
+++ b/tests/core/agent_harness/session_goal/test_evaluate.py
@@ -16,6 +16,7 @@ from core.agent_harness.session_goal.goal import (
 )
 from core.agent_harness.session_goal.run_until import run_until_session_goal
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from core.llm.types import AgentLLMResponse
 
 
 def _result(
@@ -685,7 +686,7 @@ def test_llm_evaluator_rejects_soft_achieve() -> None:
 
         def invoke(self, messages, *, system=None, tools=None):  # noqa: ANN001
             _ = (messages, system, tools)
-            return type("R", (), {"content": '{"verdict": "NOT_REACHED"}'})()
+            return AgentLLMResponse(content='{"verdict": "NOT_REACHED"}')
 
         def tool_schemas(self, tools):  # noqa: ANN001
             _ = tools
@@ -715,7 +716,7 @@ def test_llm_reject_survives_outer_loop_session_reread() -> None:
 
         def invoke(self, messages, *, system=None, tools=None):  # noqa: ANN001
             _ = (messages, system, tools)
-            return type("R", (), {"content": '{"verdict": "NOT_REACHED"}'})()
+            return AgentLLMResponse(content='{"verdict": "NOT_REACHED"}')
 
         def tool_schemas(self, tools):  # noqa: ANN001
             _ = tools
@@ -770,7 +771,7 @@ def test_llm_evaluator_confirms_soft_achieve() -> None:
 
         def invoke(self, messages, *, system=None, tools=None):  # noqa: ANN001
             _ = (messages, system, tools)
-            return type("R", (), {"content": '{"verdict": "GOAL_REACHED"}'})()
+            return AgentLLMResponse(content='{"verdict": "GOAL_REACHED"}')
 
         def tool_schemas(self, tools):  # noqa: ANN001
             _ = tools
@@ -792,7 +793,7 @@ def test_llm_evaluator_fails_closed_on_free_text_verdict() -> None:
 
         def invoke(self, messages, *, system=None, tools=None):  # noqa: ANN001
             _ = (messages, system, tools)
-            return type("R", (), {"content": "GOAL_REACHED — looks done to me"})()
+            return AgentLLMResponse(content="GOAL_REACHED — looks done to me")
 
         def tool_schemas(self, tools):  # noqa: ANN001
             _ = tools


### PR DESCRIPTION
Fixes #5194

#### Describe the changes you have made in this PR -

- Replaced ad-hoc fake LLM response objects in session goal evaluator tests with the production `AgentLLMResponse` type.
- Updated evaluator tests to follow the `AgentLLMClient.invoke()` response contract by returning `AgentLLMResponse(content=...)`.
- Removed anonymous response mocks (`type("R", (), {...})`) that only partially represented the real LLM response object.
- Kept the change scoped to `test_evaluate.py` because this test path consumes `AgentLLMResponse.content` through the structured output flow.

### Demo/Screenshot for feature changes and bug fixes -

Tested with:

```bash
uv run pytest tests/core/agent_harness/session_goal/test_evaluate.py -v
````

All tests passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [ ] No, I wrote all the code myself
* [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The goal of this change is to make the session goal evaluator tests use the same response type as the production LLM client contract.

Previously, these tests created anonymous objects with a `content` attribute using `type("R", (), {...})()`. While this worked because the evaluator only accessed `.content`, it did not accurately represent the object returned by `AgentLLMClient.invoke()`.

The implementation replaces these anonymous objects with `AgentLLMResponse`, which is the actual response type consumed by the structured output layer.

I considered reusing existing helpers from `tests/shared`, but the available helpers target different test boundaries (for example, turn accounting with `LlmRunInfo`). Since this code path validates the LLM invocation contract, using `AgentLLMResponse` directly keeps the test aligned with production behavior.

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] **I can explain the purpose of every function, class, and logic block I added**
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [x] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.