### PR TITLE
docs(grafana): fix the broken ServiceMonitor patch and complete the local lab

### DIFF
--- a/docs/grafana.mdx
+++ b/docs/grafana.mdx
@@ -201,9 +201,24 @@ Use this lab to run Grafana, Prometheus, and a sample app locally, then connect 
    ```bash
    kubectl patch prometheus kube-stack-kube-prometheus-prometheus \
    -n monitoring \
-   --type=merge \
-   -p '{"spec":{"serviceMonitorSelector":{},"serviceMonitorNamespaceSelector":{}}}'
+   --type=json \
+   -p '[{"op":"replace","path":"/spec/serviceMonitorSelector","value":{}}]'
+   kubectl patch prometheus kube-stack-kube-prometheus-prometheus \
+   -n monitoring \
+   --type=json \
+   -p '[{"op":"replace","path":"/spec/serviceMonitorNamespaceSelector","value":{}}]'
    ```
+
+   <Warning>
+   A JSON **merge** patch (`--type=merge`) with `{}` for a nested object field is a
+   no-op, not a replacement -- RFC 7396 merge-patch semantics only remove keys set to
+   `null`; an empty object leaves the existing `matchLabels: {release: kube-stack}`
+   in place, so podinfo's ServiceMonitor (which carries no such label) never gets
+   scraped and this step silently does nothing. Confirmed live: `kubectl patch
+   --type=merge` here reports `"patched (no change)"`, and `podinfo` never appears
+   in `http://localhost:9090/api/v1/targets` until switched to `--type=json` with an
+   explicit `replace` operation.
+   </Warning>
 
 #### Grafana credentials
 
@@ -308,3 +323,229 @@ The alert fires after about 30 seconds of elevated errors. Check [http://localho
    <Frame>
      ![Successful Grafana Integration with OpenSRE](/images/successful-grafana-opensre-integration.png)
    </Frame>
+
+### Add Loki and Tempo for full tool coverage
+
+The steps above give OpenSRE a working `query_grafana_metrics` and (once a rule/annotation
+exists) `query_grafana_alert_rules` / `query_grafana_annotations`, but `query_grafana_logs`,
+`query_grafana_service_names`, and `query_grafana_traces` need Loki and Tempo datasources,
+which this lab doesn't install by default. Verified live: without them, those three tools
+return `"Loki datasource not found"` / `"Tempo datasource not found"`, not real data.
+
+1. Add the Grafana chart repo and install Loki (bundled with Promtail) and Tempo:
+
+   ```bash
+   helm repo add grafana https://grafana.github.io/helm-charts
+   helm repo update
+   helm install loki grafana/loki-stack -n monitoring --set promtail.enabled=true
+   helm install tempo grafana/tempo -n monitoring
+   kubectl -n monitoring wait --for=condition=Ready pods -l "app=loki" --timeout=180s
+   kubectl -n monitoring wait --for=condition=Ready pods -l "app.kubernetes.io/name=tempo" --timeout=180s
+   ```
+
+2. Register both as Grafana datasources (the chart doesn't auto-provision them):
+
+   ```bash
+   GRAFANA_PW=$(kubectl get secret kube-stack-grafana --namespace monitoring \
+     -o jsonpath="{.data.admin-password}" | base64 --decode)
+
+   curl -s -X POST -H "Content-Type: application/json" \
+     -d '{"name":"Loki","type":"loki","access":"proxy","url":"http://loki.monitoring:3100"}' \
+     "http://admin:${GRAFANA_PW}@localhost:3000/api/datasources"
+
+   curl -s -X POST -H "Content-Type: application/json" \
+     -d '{"name":"Tempo","type":"tempo","access":"proxy","url":"http://tempo.monitoring:3200"}' \
+     "http://admin:${GRAFANA_PW}@localhost:3000/api/datasources"
+   ```
+
+<Warning>
+Promtail's default relabeling produces `job`/`namespace`/`pod`/`app` labels on log
+streams, and the ServiceMonitor stack's default metric labels are `job`/`service` --
+neither includes a `service_name` label. `query_grafana_logs` and
+`query_grafana_service_names` query Loki's `service_name` label specifically, and
+`query_grafana_metrics` filters on the same label when a `service_name` argument is
+passed, so all three return empty against an unmodified stack even though the
+underlying log/metric data is present. Confirmed live: `query_loki_label_values` and a
+`service_name="podinfo"` Mimir query both returned nothing until the two relabelings
+below were added; a real user's own services will hit the same gap unless they already
+emit or relabel a `service_name` label.
+</Warning>
+
+3. Add a `service_name` relabel to Promtail (derived from the pod's
+   `app.kubernetes.io/name` label) by upgrading the release with an extra
+   relabel config alongside Promtail's defaults:
+
+   ```bash
+cat > /tmp/promtail-values.yaml << 'EOF'
+promtail:
+  config:
+    snippets:
+      common:
+        - action: replace
+          source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node_name
+        - action: replace
+          source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+        - action: replace
+          replacement: $1
+          separator: /
+          source_labels: [namespace, app]
+          target_label: job
+        - action: replace
+          source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod
+        - action: replace
+          source_labels: [__meta_kubernetes_pod_container_name]
+          target_label: container
+        - action: replace
+          source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+          target_label: service_name
+        - action: replace
+          replacement: /var/log/pods/*$1/*.log
+          separator: /
+          source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+          target_label: __path__
+EOF
+helm upgrade loki grafana/loki-stack -n monitoring -f /tmp/promtail-values.yaml \
+  --set promtail.enabled=true --reuse-values
+   ```
+
+   <Warning>
+   Keep the heredoc terminator (`EOF`) flush against the left margin, not indented to
+   match this list item -- `<<'EOF'` requires an exact, unindented match to end the
+   here-document. An indented closing line is swallowed as YAML content instead of
+   ending the file, and the `helm upgrade` line after it gets swallowed too, silently
+   turning into dead text inside the values file instead of running. Confirmed live
+   by copy-pasting an indented version of this exact block.
+   </Warning>
+
+4. Enable request tracing on podinfo -- it ships an OpenTelemetry exporter but keeps
+   it disabled until both `--otel-service-name` and an OTLP endpoint are set (the
+   chart's `extraEnvs` alone is not enough; confirmed via `podinfo --help`, which
+   states tracing is disabled unless `--otel-service-name` is set):
+
+   ```bash
+cat > /tmp/podinfo-tracing-values.yaml << 'EOF'
+serviceMonitor:
+  enabled: true
+extraArgs:
+  - "--otel-service-name=podinfo"
+extraEnvs:
+  - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    value: "http://tempo.monitoring:4317"
+EOF
+helm upgrade podinfo podinfo/podinfo -n podinfo -f /tmp/podinfo-tracing-values.yaml
+kubectl -n podinfo wait --for=condition=Ready pods --all --timeout=60s
+   ```
+
+   The upgrade replaces the podinfo pod, so re-run the port-forward from
+   [Steps](#steps) (step 6) if it's still attached to the old pod.
+
+5. Add the same `service_name` relabel to the podinfo ServiceMonitor for metrics
+   (`kubectl patch` here, since the podinfo chart doesn't expose `metricRelabelings`
+   as a values key):
+
+   ```bash
+   kubectl patch servicemonitor podinfo -n podinfo --type=json -p '[{
+     "op": "add",
+     "path": "/spec/endpoints/0/metricRelabelings",
+     "value": [{"sourceLabels": ["job"], "targetLabel": "service_name"}]
+   }]'
+   ```
+
+   <Warning>
+   Do this **after** the tracing upgrade above, not before. `helm upgrade` re-applies
+   the ServiceMonitor via server-side apply; if `kubectl patch` already owns
+   `.spec.endpoints` from a prior patch, a later `helm upgrade podinfo` fails with
+   `Apply failed with 1 conflict: conflict with "kubectl-patch"`. Confirmed live by
+   running these two steps in the opposite order.
+   </Warning>
+
+6. Generate some traffic so there's real data for every tool, then confirm each
+   datasource actually has it:
+
+   ```bash
+   for i in $(seq 1 10); do curl -s http://localhost:8080/ >/dev/null; done
+   for i in $(seq 1 5); do curl -s http://localhost:8080/status/500 >/dev/null; done
+   ```
+
+### Run a real investigation
+
+```bash
+opensre integrations verify grafana
+```
+
+```
+SERVICE │ SOURCE    │ STATUS   │ DETAIL
+grafana │ local env │ ✓ passed │ Connected to http://localhost:3000 and
+        │           │          │ discovered loki, prometheus, tempo datasources.
+```
+
+Trigger a real investigation against the firing `PodinfoHighErrorRate` alert from
+[Steps](#steps) -- this is the actual supported entrypoint, not an internal import:
+
+```bash
+opensre investigate --input-json '{
+  "alert_name": "PodinfoHighErrorRate",
+  "severity": "critical",
+  "commonAnnotations": {
+    "summary": "Podinfo error rate is high",
+    "service_name": "podinfo"
+  }
+}'
+```
+
+All 6 registered tools return real data against this lab once the datasources and
+relabelings above are in place -- confirmed by calling each tool function directly:
+`query_grafana_metrics` (real `http_requests_total` series, `service_name="podinfo"`),
+`query_grafana_logs` (real podinfo log lines), `query_grafana_traces` (real spans like
+`GET /status/{code:[0-9]+}` from the generated load), `query_grafana_service_names`
+(`["podinfo", ...]`), `query_grafana_alert_rules` (the rule created via
+`/api/v1/provisioning/alert-rules` below), and `query_grafana_annotations` (an
+annotation created via `/api/annotations`).
+
+<Info>
+`query_grafana_alert_rules` and `query_grafana_annotations` query Grafana's own
+alerting/annotation APIs, not the raw `PrometheusRule` CRD from
+[Prometheus alert for high error rate](#prometheus-alert-for-high-error-rate) -- that
+CRD is evaluated by Prometheus itself and never becomes a Grafana-managed rule.
+To exercise these two tools with real data, create a rule and annotation through
+Grafana directly, for example:
+
+```bash
+GRAFANA_PW=$(kubectl get secret kube-stack-grafana --namespace monitoring \
+  -o jsonpath="{.data.admin-password}" | base64 --decode)
+
+FOLDER_UID=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"title":"podinfo-alerts"}' \
+  "http://admin:${GRAFANA_PW}@localhost:3000/api/folders" | python3 -c 'import json,sys; print(json.load(sys.stdin)["uid"])')
+
+curl -s -X POST -H "Content-Type: application/json" \
+  -d "{
+    \"title\": \"PodinfoHighErrorRateGrafana\", \"ruleGroup\": \"podinfo-group\",
+    \"folderUID\": \"${FOLDER_UID}\", \"condition\": \"B\", \"noDataState\": \"NoData\",
+    \"execErrState\": \"Error\", \"for\": \"30s\",
+    \"data\": [
+      {\"refId\": \"A\", \"relativeTimeRange\": {\"from\": 300, \"to\": 0}, \"datasourceUid\": \"prometheus\",
+       \"model\": {\"expr\": \"increase(http_requests_total{status=\\\"500\\\"}[5m])\", \"refId\": \"A\", \"instant\": true}},
+      {\"refId\": \"B\", \"relativeTimeRange\": {\"from\": 0, \"to\": 0}, \"datasourceUid\": \"__expr__\",
+       \"model\": {\"type\": \"threshold\", \"expression\": \"A\", \"conditions\": [{\"evaluator\": {\"type\": \"gt\", \"params\": [5]}}], \"refId\": \"B\"}}
+    ]
+  }" \
+  "http://admin:${GRAFANA_PW}@localhost:3000/api/v1/provisioning/alert-rules"
+
+curl -s -X POST -H "Content-Type: application/json" \
+  -d "{\"text\":\"podinfo v6.14.1 deployed with tracing enabled\",\"tags\":[\"deployment\",\"podinfo\"],\"time\":$(($(date +%s) * 1000))}" \
+  "http://admin:${GRAFANA_PW}@localhost:3000/api/annotations"
+```
+</Info>
+
+### Teardown
+
+```bash
+kind delete cluster --name grafana-lab   # or: minikube delete
+```
+
+If you started separate port-forward terminals per [Steps](#steps), `Ctrl-C` each one
+first (deleting the cluster also kills them, but not always cleanly on every platform).

--- a/docs/grafana.mdx
+++ b/docs/grafana.mdx
@@ -326,11 +326,11 @@ The alert fires after about 30 seconds of elevated errors. Check [http://localho
 
 ### Add Loki and Tempo for full tool coverage
 
-The steps above give OpenSRE a working `query_grafana_metrics` and (once a rule/annotation
-exists) `query_grafana_alert_rules` / `query_grafana_annotations`, but `query_grafana_logs`,
-`query_grafana_service_names`, and `query_grafana_traces` need Loki and Tempo datasources,
-which this lab doesn't install by default. Verified live: without them, those three tools
-return `"Loki datasource not found"` / `"Tempo datasource not found"`, not real data.
+The steps above give OpenSRE working metrics querying and (once a rule/annotation
+exists) alert-rule and annotation querying, but log search, service-name discovery, and
+trace querying need Loki and Tempo datasources, which this lab doesn't install by default.
+Verified live: without them, those three capabilities return
+`"Loki datasource not found"` / `"Tempo datasource not found"`, not real data.
 
 1. Add the Grafana chart repo and install Loki (bundled with Promtail) and Tempo:
 
@@ -361,11 +361,10 @@ return `"Loki datasource not found"` / `"Tempo datasource not found"`, not real 
 <Warning>
 Promtail's default relabeling produces `job`/`namespace`/`pod`/`app` labels on log
 streams, and the ServiceMonitor stack's default metric labels are `job`/`service` --
-neither includes a `service_name` label. `query_grafana_logs` and
-`query_grafana_service_names` query Loki's `service_name` label specifically, and
-`query_grafana_metrics` filters on the same label when a `service_name` argument is
-passed, so all three return empty against an unmodified stack even though the
-underlying log/metric data is present. Confirmed live: `query_loki_label_values` and a
+neither includes a `service_name` label. Log search and service-name discovery both
+query Loki's `service_name` label specifically, and metrics querying filters on the same
+label when a service name is passed, so all three return empty against an unmodified
+stack even though the underlying log/metric data is present. Confirmed live: a Loki label query and a
 `service_name="podinfo"` Mimir query both returned nothing until the two relabelings
 below were added; a real user's own services will hit the same gap unless they already
 emit or relabel a `service_name` label.
@@ -497,16 +496,15 @@ opensre investigate --input-json '{
 ```
 
 All 6 registered tools return real data against this lab once the datasources and
-relabelings above are in place -- confirmed by calling each tool function directly:
-`query_grafana_metrics` (real `http_requests_total` series, `service_name="podinfo"`),
-`query_grafana_logs` (real podinfo log lines), `query_grafana_traces` (real spans like
-`GET /status/{code:[0-9]+}` from the generated load), `query_grafana_service_names`
-(`["podinfo", ...]`), `query_grafana_alert_rules` (the rule created via
-`/api/v1/provisioning/alert-rules` below), and `query_grafana_annotations` (an
+relabelings above are in place -- confirmed by direct calls to each tool: metrics
+querying (real `http_requests_total` series, `service_name="podinfo"`), log search (real
+podinfo log lines), trace querying (real spans like `GET /status/{code:[0-9]+}` from the
+generated load), service-name discovery (`["podinfo", ...]`), alert-rule querying (the
+rule created via `/api/v1/provisioning/alert-rules` below), and annotation querying (an
 annotation created via `/api/annotations`).
 
 <Info>
-`query_grafana_alert_rules` and `query_grafana_annotations` query Grafana's own
+Alert-rule and annotation querying use Grafana's own
 alerting/annotation APIs, not the raw `PrometheusRule` CRD from
 [Prometheus alert for high error rate](#prometheus-alert-for-high-error-rate) -- that
 CRD is evaluated by Prometheus itself and never becomes a Grafana-managed rule.


### PR DESCRIPTION
Part of #5124 (found while live-verifying Grafana's 6 registered tools)

#### Describe the changes you have made in this PR -

The doc already had a fairly complete local Minikube lab (Prometheus + podinfo + Grafana), but it had never actually been proven end-to-end — it stopped at "Connect OpenSRE to the lab Grafana" with no real `opensre investigate` output, and only 1 of the 6 registered tools (`query_grafana_metrics`) had any real datasource behind it. Verifying it live (via `kind`, a lighter local equivalent to Minikube available in my environment) surfaced two real, reproducible bugs and closed the tool-coverage gap:

1. **Broken `kubectl patch`** — the documented `--type=merge -p '{"spec":{"serviceMonitorSelector":{}}}'` is a no-op. JSON merge-patch semantics (RFC 7396) treat an empty object as "no change" to a nested field, not "replace with empty" — so podinfo's ServiceMonitor never actually got scraped, even though the command reports `"patched (no change)"` with no visible error. Fixed with `--type=json` and explicit `replace` operations, confirmed live: `podinfo` only appears in Prometheus's `/api/v1/targets` after the fix.
2. **Missing `service_name` label everywhere** — `query_grafana_logs`, `query_grafana_service_names`, and `query_grafana_metrics` (when filtered by service) all query a `service_name` label specifically. Neither Promtail's default relabeling (`job`/`namespace`/`pod`/`app`) nor the ServiceMonitor's default metric labels (`job`/`service`) produce it — a real user's own services will hit the exact same gap. Added the relabeling both places need.
3. **podinfo's tracing needs a flag, not just an env var** — `podinfo --help` states tracing and log export are disabled unless `--otel-service-name` is set; the chart's `extraEnvs` alone (setting `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) silently does nothing without it.
4. **A step-ordering bug in my own draft**, caught before it shipped — patching the ServiceMonitor before the podinfo tracing `helm upgrade` causes a Kubernetes field-ownership conflict on the later upgrade (`Apply failed with 1 conflict: conflict with "kubectl-patch"`). Reordered so the upgrade runs first.

Added Loki+Promtail and Tempo to the lab (neither was previously installed), wired podinfo's OpenTelemetry tracing to Tempo, and added a `Run a real investigation` section with real `opensre integrations verify` output and an `opensre investigate` call against the lab's own `PodinfoHighErrorRate` alert. Also added a `Teardown` section — there wasn't one before.

### Demo/Screenshot for feature changes and bug fixes -

```
$ opensre integrations verify grafana
SERVICE │ SOURCE    │ STATUS   │ DETAIL
grafana │ local env │ ✓ passed │ Connected to http://localhost:3000 and
        │           │          │ discovered loki, prometheus, tempo datasources.
```

All 6 registered tools confirmed against real data by direct invocation against the live lab:
- `query_grafana_metrics` — real `http_requests_total` series filtered by `service_name="podinfo"`
- `query_grafana_logs` — real podinfo log lines from Loki
- `query_grafana_traces` — real spans (e.g. `GET /status/{code:[0-9]+}`) from the generated load, via Tempo
- `query_grafana_service_names` — `["podinfo", ...]`
- `query_grafana_alert_rules` — a real Grafana-native rule (the tool queries Grafana's own alerting API, not raw `PrometheusRule` CRDs, which is documented as a gotcha since the lab's existing Prometheus alert doesn't satisfy it)
- `query_grafana_annotations` — a real annotation created via `/api/annotations`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Docs-only change, no application code. Brought up the existing documented lab exactly as written first (via `kind` in place of Minikube, since only `minikube start` is Minikube-specific — the rest is plain `kubectl`/`helm`), which is how the merge-patch bug and the tool-coverage gap were found. Every fix and addition was verified against the real running stack before being written into the doc, including a heredoc-indentation bug in my own first draft (caught by copy-pasting the exact rendered block, not just conceptually reviewing it) and the ServiceMonitor field-ownership ordering issue.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.