### PR TITLE
Refactor headless-agent construction: collapse `ask` onto AgentSession, own the build-config expansion

### DIFF
--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from core.agent_harness.session_goal.run_until import SessionGoalRunResult
     from core.agent_harness.turns.gather_phase import GatherPhase
     from core.agent_harness.turns.turn_results import TurnResult
+    from core.tool.execution import ToolExecutionHooks
 
 
 class ChatDispatcher(Protocol):
@@ -125,6 +126,7 @@ class AgentSession:
         logger: logging.Logger | None = None,
         surface: str | None = None,
         is_tty: bool | None = None,
+        tool_hooks: ToolExecutionHooks | None = None,
     ) -> AgentSession:
         """Return a session that is ready to :meth:`chat`.
 
@@ -147,8 +149,9 @@ class AgentSession:
         and before the agent is built. ``console``, ``logger`` and ``surface``
         are the :class:`~core.agent_harness.turns.headless_build.DefaultHeadlessBuild`
         fields; ``tools`` and ``gather`` the ports its ``agent()`` takes;
-        ``is_tty`` is bound on the first turn. A host that needs more (its own
-        sink, prompts, error reporter, an action ``llm_factory``) builds through
+        ``is_tty`` and ``tool_hooks`` (the turn's approval hooks) are bound on
+        the first turn. A host that needs more (its own sink, prompts, error
+        reporter, an action ``llm_factory``) builds through
         :class:`DefaultHeadlessBuild` itself and calls :meth:`attach_agent`.
         """
         from core.agent_harness.turns.headless_adapters import BufferOutputSink
@@ -168,6 +171,7 @@ class AgentSession:
             logger=logger,
             surface=surface,
             is_tty=is_tty,
+            tool_hooks=tool_hooks,
         )
         return agent_session
 
@@ -219,6 +223,11 @@ class AgentSession:
     def attach_agent(self, agent: ChatDispatcher) -> None:
         """Bind a chat dispatcher for :meth:`chat` reuse."""
         self._agent = agent
+
+    @property
+    def bound_session(self) -> SessionCore | None:
+        """The session created by :meth:`start`, for host-side lifecycle (e.g. close)."""
+        return self._bound_session
 
     @property
     def agent(self) -> ChatDispatcher | None:
@@ -319,6 +328,7 @@ class AgentSession:
         logger: logging.Logger | None = None,
         surface: str | None = None,
         is_tty: bool | None = None,
+        tool_hooks: ToolExecutionHooks | None = None,
     ) -> None:
         """Attach the agent built on the default port family (one construction recipe).
 
@@ -332,7 +342,7 @@ class AgentSession:
         agent = DefaultHeadlessBuild(
             session=session, output=output, console=console, logger=logger, surface=surface
         ).agent(tools=tools, prompts=prompts, gather=gather)
-        agent.bind_turn(TurnBinding(is_tty=is_tty))
+        agent.bind_turn(TurnBinding(is_tty=is_tty, tool_hooks=tool_hooks))
         self.attach_agent(agent)
 
     def _resolve_env_variables(self) -> None:

--- a/core/agent_harness/runtime.py
+++ b/core/agent_harness/runtime.py
@@ -24,7 +24,11 @@ from core.agent_harness.tools.tool_provider import DefaultToolProvider
 from core.agent_harness.turns.action_driver import ActionTurnRunner
 from core.agent_harness.turns.gather_phase import MAX_REPORT_GATHER_ITERATIONS, GatherPhase
 from core.agent_harness.turns.headless_agent import AgentBusyError, HeadlessAgent
-from core.agent_harness.turns.headless_build import DefaultHeadlessBuild, InMemoryHeadlessBuild
+from core.agent_harness.turns.headless_build import (
+    DefaultHeadlessBuild,
+    InMemoryHeadlessBuild,
+    resolve_agent_ports,
+)
 from core.agent_harness.turns.turn_plan import TurnPlan
 
 __all__ = [
@@ -45,4 +49,5 @@ __all__ = [
     "build_agent",
     "default_llm_factory",
     "default_reasoning_llm_factory",
+    "resolve_agent_ports",
 ]

--- a/core/agent_harness/turns/headless_build.py
+++ b/core/agent_harness/turns/headless_build.py
@@ -15,6 +15,7 @@ Per-message values are bound on the agent with :meth:`HeadlessAgent.handle`
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
 from io import StringIO
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from rich.console import Console
 
 from core.agent_harness.accounting.run_record import DefaultRunRecordFactory
+from core.agent_harness.agent_build_config import AgentBuildConfig
 from core.agent_harness.error_reporting import DefaultErrorReporter
 from core.agent_harness.llm_resolution import default_llm_factory
 from core.agent_harness.ports import (
@@ -33,6 +35,7 @@ from core.agent_harness.ports import (
     ReasoningClientProvider,
     RunRecordFactory,
     SessionState,
+    ToolEventObserver,
     ToolProvider,
 )
 from core.agent_harness.prompts.grounding import (
@@ -200,4 +203,39 @@ class DefaultHeadlessBuild:
         )
 
 
-__all__ = ["DefaultHeadlessBuild", "InMemoryHeadlessBuild"]
+def resolve_agent_ports(
+    config: AgentBuildConfig,
+    *,
+    session: Any,
+    console: Any,
+    logger: logging.Logger,
+    observer: ToolEventObserver | None = None,
+    default_tools: Callable[[], ToolProvider] | None = None,
+    default_gather: GatherPhase | None = None,
+) -> tuple[ToolProvider | None, PromptContextProvider | None, GatherPhase | None]:
+    """Resolve ``(tools, prompts, gather)`` from a host's :class:`AgentBuildConfig`.
+
+    The single expansion of ``build_tools`` / ``build_prompts`` / ``build_gather``,
+    each falling back to ``default_tools`` / ``None`` / ``default_gather`` when
+    the hook is omitted. Callers pass the result to
+    ``DefaultHeadlessBuild(...).agent(...)``. The gateway pool and the shell
+    builder share this so both expand a config the same way.
+
+    ``config.apply_capability_policy`` is the caller's to run, not this
+    function's: the pool applies it every turn (the session is re-resolved even
+    on a cached agent), so binding it here would skip it on cache hits.
+    """
+    if config.build_tools is not None:
+        tools: ToolProvider | None = config.build_tools(session, console, logger, observer)
+    elif default_tools is not None:
+        tools = default_tools()
+    else:
+        tools = None
+    prompts = config.build_prompts(session) if config.build_prompts is not None else None
+    gather = (
+        config.build_gather(session, console) if config.build_gather is not None else default_gather
+    )
+    return tools, prompts, gather
+
+
+__all__ = ["DefaultHeadlessBuild", "InMemoryHeadlessBuild", "resolve_agent_ports"]

--- a/infrastructure/turn_host/session_agents.py
+++ b/infrastructure/turn_host/session_agents.py
@@ -24,6 +24,7 @@ from core.agent_harness.runtime import (
     DescribeTool,
     GatherPhase,
     HeadlessAgent,
+    resolve_agent_ports,
 )
 from infrastructure.turn_host.bindable_output import BindableOutput
 from infrastructure.turn_host.capability_policy import ensure_gateway_capability_policy
@@ -158,10 +159,9 @@ class SessionAgentPool:
 
         build = self._build
         observer = _ToolStatusObserver(session_output, build.describe_tool)
-        if build.build_tools is not None:
-            tools = build.build_tools(session, self._console, logger, observer)
-        else:
-            tools = DefaultToolProvider(
+
+        def default_tools() -> DefaultToolProvider:
+            return DefaultToolProvider(
                 session,
                 self._console,
                 tool_action_logger=logger,
@@ -169,11 +169,15 @@ class SessionAgentPool:
                 subprocess_presenter_factory=build.subprocess_presenter_factory,
                 slash_ports_factory=self._slash_ports_factory,
             )
-        prompts = build.build_prompts(session) if build.build_prompts is not None else None
-        gather = (
-            build.build_gather(session, self._console)
-            if build.build_gather is not None
-            else GatherPhase()
+
+        tools, prompts, gather = resolve_agent_ports(
+            build,
+            session=session,
+            console=self._console,
+            logger=logger,
+            observer=observer,
+            default_tools=default_tools,
+            default_gather=GatherPhase(),
         )
         agent = DefaultHeadlessBuild(
             session=session,
@@ -182,11 +186,7 @@ class SessionAgentPool:
             logger=logger,
             surface="gateway",
             error_reporter=build.error_reporter,
-        ).agent(
-            tools=tools,
-            prompts=prompts,
-            gather=gather,
-        )
+        ).agent(tools=tools, prompts=prompts, gather=gather)
         if session_id:
             self._agents[session_id] = agent
         return agent

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -176,7 +176,10 @@ def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
                 tool_hooks=hooks,
             )
             session = agent_session.bound_session
-            return agent_session.chat(prompt)
+            # chat_until_goal, not chat: a multi-step ask can attach a session
+            # goal via an assistant_handoff, and it must run to completion rather
+            # than stop after the first turn.
+            return agent_session.chat_until_goal(prompt).last_result
     finally:
         if session is not None:
             manager.close(session, extract_memory=False)

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -14,18 +14,22 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness import AgentSession, SessionConfig, SessionManager, TurnResult
-from core.agent_harness.ports import TurnBinding
-from core.agent_harness.runtime import (
-    DefaultHeadlessBuild,
-    DefaultToolProvider,
-    GatherPhase,
-    HeadlessAgent,
+from core.agent_harness import (
+    AgentSession,
+    SessionConfig,
+    SessionCore,
+    SessionManager,
+    TurnResult,
 )
+from core.agent_harness.runtime import GatherPhase
 from core.agent_harness.spi.cancel import ensure_turn_cancel
 from core.tool import ToolExecutionHooks
 from infrastructure.errors import OpenSREError
 from surfaces.cli.ask.approval import ApprovalTracker, build_approval_hooks
+
+#: Capabilities the one-shot ``ask`` agent must not reach — it answers or runs a
+#: bounded action, not investigations, slash commands, or task cancellation.
+_ASK_DISABLED_CAPABILITIES = ("investigation", "llm_provider", "slash_commands", "task_cancel")
 
 
 class AskStatus(StrEnum):
@@ -121,16 +125,6 @@ class _AskOutputSink:
         _ = answer
 
 
-@dataclass(frozen=True, slots=True)
-class _BoundDispatcher:
-    agent: HeadlessAgent
-    binding: TurnBinding
-
-    def dispatch(self, message: str) -> TurnResult:
-        """Run one message through the shared host entrypoint."""
-        return self.agent.handle(message, self.binding)
-
-
 @contextmanager
 def ask_signal_scope(cancel_event: threading.Event | None = None) -> Iterator[None]:
     """Map process termination signals to ``AskSignal`` within one CLI scope."""
@@ -151,56 +145,37 @@ def ask_signal_scope(cancel_event: threading.Event | None = None) -> Iterator[No
             signal.signal(sig, handler)
 
 
+def _restrict_ask_capabilities(session: SessionCore) -> None:
+    """Zero the capabilities the one-shot ask agent must not use."""
+    for capability in _ASK_DISABLED_CAPABILITIES:
+        session.available_capabilities[capability] = ()
+
+
 def _run_agent_turn(prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
     manager = SessionManager()
-    agent_session = AgentSession(
-        SessionConfig(
-            load_env=True,
-            hydrate_integrations=True,
-            warm_integrations=True,
-            persistent_tasks=False,
-            open_store=False,
-            session_manager=manager,
-        )
-    )
     output = _AskOutputSink()
     cancel_event = ensure_turn_cancel(output)
     console = _CancellableConsole(cancel_event)
-    session = None
+    session: SessionCore | None = None
     try:
         with ask_signal_scope(cancel_event):
-            startup = agent_session.startup()
-            session = startup.session
-            for capability in (
-                "investigation",
-                "llm_provider",
-                "slash_commands",
-                "task_cancel",
-            ):
-                session.available_capabilities[capability] = ()
-
-            tools = DefaultToolProvider(session, console)
-            agent = DefaultHeadlessBuild(
-                session=session,
+            agent_session = AgentSession.start(
+                SessionConfig(
+                    load_env=True,
+                    hydrate_integrations=True,
+                    warm_integrations=True,
+                    persistent_tasks=False,
+                    open_store=False,
+                    session_manager=manager,
+                ),
                 output=output,
-                console=console,
-            ).agent(
-                tools=tools,
-                prompts=startup.prompts,
+                prepare_session=_restrict_ask_capabilities,
                 gather=GatherPhase(),
+                console=console,
+                is_tty=False,
+                tool_hooks=hooks,
             )
-            agent_session.attach_agent(
-                _BoundDispatcher(
-                    agent=agent,
-                    binding=TurnBinding(
-                        session=session,
-                        output=output,
-                        tool_hooks=hooks,
-                        console=console,
-                        is_tty=False,
-                    ),
-                )
-            )
+            session = agent_session.bound_session
             return agent_session.chat(prompt)
     finally:
         if session is not None:

--- a/surfaces/interactive_shell/runtime/shell_agent.py
+++ b/surfaces/interactive_shell/runtime/shell_agent.py
@@ -21,6 +21,7 @@ from core.agent_harness.runtime import (
     DefaultHeadlessBuild,
     DefaultToolProvider,
     HeadlessAgent,
+    resolve_agent_ports,
 )
 from surfaces.interactive_shell.grounding.cli_reference import shell_prompt_context_provider
 from surfaces.interactive_shell.runtime.agent_harness_adapters import (
@@ -124,28 +125,21 @@ def build_shell_agent(
 ) -> HeadlessAgent:
     """One shell agent from :func:`shell_agent_build_config`; per-turn values via ``bind_turn``."""
     config = shell_agent_build_config(request_exit=request_exit)
-    policy = config.apply_capability_policy
-    if policy is not None:
-        policy(session)
-    logger = logging.getLogger("opensre.interactive_shell")
-    tools = (
-        config.build_tools(session, console, logger, None)
-        if config.build_tools is not None
-        else None
+    if config.apply_capability_policy is not None:
+        config.apply_capability_policy(session)
+    tools, prompts, gather = resolve_agent_ports(
+        config,
+        session=session,
+        console=console,
+        logger=logging.getLogger("opensre.interactive_shell"),
     )
-    prompts = config.build_prompts(session) if config.build_prompts is not None else None
-    gather = config.build_gather(session, console) if config.build_gather is not None else None
     return DefaultHeadlessBuild(
         session=session,
         output=resolve_output_sink(console, output),
         console=console,
         surface="interactive_shell",
         error_reporter=config.error_reporter,
-    ).agent(
-        tools=tools,
-        prompts=prompts,
-        gather=gather,
-    )
+    ).agent(tools=tools, prompts=prompts, gather=gather)
 
 
 __all__ = [

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -67,29 +67,19 @@ class _FakeSession:
 class _FakeAgentSession:
     session = _FakeSession()
 
-    def __init__(self, _config: object) -> None:
-        self.attached: object | None = None
+    @classmethod
+    def start(cls, _config: object, **kwargs: object) -> _FakeAgentSession:
+        prepare = kwargs.get("prepare_session")
+        if callable(prepare):
+            prepare(cls.session)
+        return cls()
 
-    def startup(self) -> object:
-        return type(
-            "Startup",
-            (),
-            {"session": self.session, "prompts": object()},
-        )()
-
-    def attach_agent(self, agent: object) -> None:
-        self.attached = agent
+    @property
+    def bound_session(self) -> _FakeSession:
+        return type(self).session
 
     def chat(self, _prompt: str) -> TurnResult:
         raise RuntimeError("turn failed")
-
-
-class _FakeHeadlessBuild:
-    def __init__(self, **_kwargs: object) -> None:
-        pass
-
-    def agent(self, **_kwargs: object) -> object:
-        return object()
 
 
 def test_run_ask_returns_success(monkeypatch) -> None:
@@ -103,21 +93,63 @@ def test_run_ask_returns_success(monkeypatch) -> None:
 
 
 def test_agent_turn_closes_ephemeral_session_after_failure(monkeypatch) -> None:
+    # Arrange: the built session fails its turn; the ephemeral session must
+    # still be closed (extract_memory=False) via the finally block.
     manager = _FakeSessionManager()
     _FakeAgentSession.session = _FakeSession()
     monkeypatch.setattr(service, "SessionManager", lambda: manager)
     monkeypatch.setattr(service, "AgentSession", _FakeAgentSession)
-    monkeypatch.setattr(service, "DefaultHeadlessBuild", _FakeHeadlessBuild)
-    monkeypatch.setattr(
-        service,
-        "DefaultToolProvider",
-        lambda *_args, **_kwargs: object(),
-    )
 
+    # Act / Assert
     with pytest.raises(RuntimeError, match="turn failed"):
         service._run_agent_turn("prompt", ToolExecutionHooks())
 
     assert manager.closed == [(_FakeAgentSession.session, False)]
+
+
+def test_agent_turn_binds_hooks_and_restricts_capabilities_via_start(monkeypatch) -> None:
+    """The collapse onto AgentSession.start must still bind the approval hooks
+    and strip the one-shot ask agent's forbidden capabilities."""
+    # Arrange: record what ask hands AgentSession.start, and let its
+    # prepare_session run against a session carrying a forbidden capability.
+    manager = _FakeSessionManager()
+    session = _FakeSession()
+    session.available_capabilities = {"investigation": ("live",), "shell": ("keep",)}
+    recorded: dict[str, object] = {}
+    hooks = ToolExecutionHooks()
+
+    class _RecordingAgentSession:
+        @classmethod
+        def start(cls, _config: object, **kwargs: object) -> _RecordingAgentSession:
+            recorded.update(kwargs)
+            prepare = kwargs["prepare_session"]
+            assert callable(prepare)
+            prepare(session)
+            return cls()
+
+        @property
+        def bound_session(self) -> _FakeSession:
+            return session
+
+        def chat(self, prompt: str) -> TurnResult:
+            recorded["prompt"] = prompt
+            return _turn()
+
+    monkeypatch.setattr(service, "SessionManager", lambda: manager)
+    monkeypatch.setattr(service, "AgentSession", _RecordingAgentSession)
+
+    # Act
+    result = service._run_agent_turn("hello", hooks)
+
+    # Assert: hooks bound, forbidden capability zeroed (unrelated kept), one-shot
+    # dispatched, ephemeral session closed without memory extraction.
+    assert recorded["tool_hooks"] is hooks
+    assert recorded["is_tty"] is False
+    assert session.available_capabilities["investigation"] == ()
+    assert session.available_capabilities["shell"] == ("keep",)
+    assert recorded["prompt"] == "hello"
+    assert result.primary_response_text == "answer"
+    assert manager.closed == [(session, False)]
 
 
 def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -78,8 +78,15 @@ class _FakeAgentSession:
     def bound_session(self) -> _FakeSession:
         return type(self).session
 
-    def chat(self, _prompt: str) -> TurnResult:
+    def chat_until_goal(self, _prompt: str) -> object:
         raise RuntimeError("turn failed")
+
+
+class _GoalRun:
+    """Stand-in for SessionGoalRunResult: only ``last_result`` is read."""
+
+    def __init__(self, last_result: TurnResult) -> None:
+        self.last_result = last_result
 
 
 def test_run_ask_returns_success(monkeypatch) -> None:
@@ -131,9 +138,11 @@ def test_agent_turn_binds_hooks_and_restricts_capabilities_via_start(monkeypatch
         def bound_session(self) -> _FakeSession:
             return session
 
-        def chat(self, prompt: str) -> TurnResult:
+        def chat_until_goal(self, prompt: str) -> _GoalRun:
+            # chat_until_goal, not chat: ask must run the session-goal loop so a
+            # multi-step turn completes instead of stopping after the first.
             recorded["prompt"] = prompt
-            return _turn()
+            return _GoalRun(_turn())
 
     monkeypatch.setattr(service, "SessionManager", lambda: manager)
     monkeypatch.setattr(service, "AgentSession", _RecordingAgentSession)

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -174,6 +174,7 @@ RUNTIME = frozenset(
         "build_agent",
         "default_llm_factory",
         "default_reasoning_llm_factory",
+        "resolve_agent_ports",
     }
 )
 

--- a/tests/core/agent_harness/test_headless_build.py
+++ b/tests/core/agent_harness/test_headless_build.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from io import StringIO
 from types import SimpleNamespace
 
@@ -179,3 +180,59 @@ def test_a_stage_override_replaces_only_that_stage() -> None:
     assert isinstance(result, TurnResult)
     assert agent._answer_override is None  # noqa: SLF001
     assert agent._gather_override is None  # noqa: SLF001
+
+
+def test_resolve_agent_ports_uses_hooks_when_present() -> None:
+    """Each provided build hook is called with the session/console and returned."""
+    # Arrange
+    from core.agent_harness.agent_build_config import AgentBuildConfig
+    from core.agent_harness.turns.gather_phase import GatherPhase
+    from core.agent_harness.turns.headless_build import resolve_agent_ports
+
+    tools_obj, prompts_obj, gather_obj = object(), object(), GatherPhase()
+    console = object()
+    seen: dict[str, object] = {}
+
+    def build_tools(session, console_, _logger, observer):  # noqa: ANN001, ANN202
+        seen["tools_args"] = (session, console_, observer)
+        return tools_obj
+
+    config = AgentBuildConfig(
+        build_tools=build_tools,
+        build_prompts=lambda _session: prompts_obj,
+        build_gather=lambda _session, _console: gather_obj,
+    )
+
+    # Act
+    tools, prompts, gather = resolve_agent_ports(
+        config, session="S", console=console, logger=logging.getLogger("t")
+    )
+
+    # Assert
+    assert (tools, prompts, gather) == (tools_obj, prompts_obj, gather_obj)
+    assert seen["tools_args"] == ("S", console, None)
+
+
+def test_resolve_agent_ports_falls_back_when_hooks_omitted() -> None:
+    """An empty config yields the caller's default tools/gather and no prompts."""
+    # Arrange
+    from core.agent_harness.agent_build_config import AgentBuildConfig
+    from core.agent_harness.turns.gather_phase import GatherPhase
+    from core.agent_harness.turns.headless_build import resolve_agent_ports
+
+    default_tools_obj, default_gather = object(), GatherPhase()
+
+    # Act
+    tools, prompts, gather = resolve_agent_ports(
+        AgentBuildConfig(),
+        session="S",
+        console=object(),
+        logger=logging.getLogger("t"),
+        default_tools=lambda: default_tools_obj,
+        default_gather=default_gather,
+    )
+
+    # Assert
+    assert tools is default_tools_obj
+    assert prompts is None
+    assert gather is default_gather


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Two related cleanups of how headless agents are constructed, both toward one
clear narrative for building an agent. No behavior change.

**1. Collapse the CLI `ask` path onto `AgentSession`.**
`ask` was hand-rolling the whole build: a private `_BoundDispatcher`, a manual
`startup()`, a manual capability-stripping loop, its own `DefaultToolProvider` +
`DefaultHeadlessBuild(...).agent(...)`, and a hand-assembled `TurnBinding` — the
exact recipe `AgentSession` documents that hosts must not re-copy.
`AgentSession.start` gained a `tool_hooks` parameter (the per-turn approval
hooks, bound on the first turn alongside `is_tty`) and a `bound_session`
accessor. `ask` now reads: `AgentSession.start(config, output=…,
prepare_session=_restrict_ask_capabilities, gather=…, console=…, is_tty=False,
tool_hooks=hooks)` then `chat_until_goal(prompt)`. The inline capability loop
became a named `_restrict_ask_capabilities` passed as `prepare_session`.

`chat_until_goal` (not `chat`) preserves the previous behavior exactly: a
multi-step `ask` can attach a session goal via an `assistant_handoff`, and it
must run the session-goal loop to completion rather than stop after the first
turn. This is `AgentSession`'s public goal-loop verb, wrapping the same
`run_until_session_goal` the old hand-rolled dispatcher reached through
`HeadlessAgent.handle`.

**2. One owner for the AgentBuildConfig expansion.**
The gateway pool and the shell builder each hand-copied the same "resolve
`build_tools` / `build_prompts` / `build_gather`, falling back to defaults"
logic. Extracted `resolve_agent_ports(config, …) -> (tools, prompts, gather)` in
`headless_build.py`; both call it, then pass the result to
`DefaultHeadlessBuild(...).agent(...)`. Capability policy stays with the callers
on purpose: the pool applies it every turn (the session is re-resolved even on a
cached agent), so folding it into the shared expander would skip it on cache
hits — the docstring records this.

### Demo/Screenshot for feature changes and bug fixes -

Single-turn `ask` end-to-end:
$ LLM_PROVIDER=claude-code uv run opensre --json ask "reply with exactly PONG"
{"status": "success", "response": "PONG", "denied_tools": [], "error": null}



Full suite: `15440 passed, 66 skipped, 1 xfailed` (`pytest -n auto`, CI-parity
ignores). `make check-imports` green (new `headless_build → agent_build_config`
edge, no cycle). ruff lint + `ruff format --check` + mypy all clean.

### Behavior preservation notes

- Multi-step `ask` still completes its session goal (guarded by a test that
  fails if the dispatch verb is reverted to single-turn `chat`).
- The gateway pool and shell build agents exactly as before — `DefaultHeadlessBuild`
  stays at both call sites, so no construction-seam test infra changed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Both changes remove duplication of the agent-construction recipe without changing
what gets built. For `ask`, the private dispatcher and hand-rolled build existed
only to bind approval hooks and run the session-goal loop; giving
`AgentSession.start` a `tool_hooks` parameter let it collapse onto the public API,
the capability policy moved to the `prepare_session` hook that already runs at the
right moment, and `chat_until_goal` restores the goal-loop semantics through a
documented verb. For the expansion I first over-reached and had the shared helper
build the whole agent — that moved `DefaultHeadlessBuild` out of the call sites and
broke the ~30 tests that stub that construction seam, so I corrected to a
`(tools, prompts, gather)` producer (the milestone's actual spec), which keeps
`DefaultHeadlessBuild` at both call sites. The subtle correctness point is that
capability policy cannot live in the shared expander: the pool must apply it every
turn, including cache hits, and the expander only runs on a cache miss.

Key pieces: `AgentSession.start(tool_hooks=…)` / `bound_session`
(`core/agent_harness/harness.py`), `_restrict_ask_capabilities` +
`AgentSession.start` / `chat_until_goal` usage (`surfaces/cli/ask/service.py`), and
`resolve_agent_ports` (`core/agent_harness/turns/headless_build.py`) with its two
callers (`infrastructure/turn_host/session_agents.py`,
`surfaces/interactive_shell/runtime/shell_agent.py`). New tests pin the
security-relevant `ask` wiring (hooks bound + capabilities stripped), that `ask`
runs the goal loop, and the `resolve_agent_ports` fallback contract.