### PR TITLE
Install the subprocess presenter as a frozen provider instead of a mutable global

### DIFF
--- a/bootstrap/adapters.py
+++ b/bootstrap/adapters.py
@@ -48,7 +48,7 @@ def install_harness_adapters() -> None:
 
     register_integrations()
     register_tools()
-    harness_providers.set_subprocess_presenter_factory(headless_subprocess_presenter_factory)
+    harness_providers.SubprocessPresenterProvider(headless_subprocess_presenter_factory).install()
     # Shell / REPL / gateway slash surface: CTA must name a runnable command.
     harness_providers.set_integration_setup_command(
         lambda service_id: f"/integrations setup {service_id}"

--- a/core/agent_harness/turns/headless_build.py
+++ b/core/agent_harness/turns/headless_build.py
@@ -54,7 +54,7 @@ from core.agent_harness.turns.headless_adapters import (
     StaticReasoningClientProvider,
 )
 from core.agent_harness.turns.headless_agent import HeadlessAgent
-from infrastructure.harness_providers import get_subprocess_presenter_factory
+from infrastructure.harness_providers import resolve_subprocess_presenter
 
 if TYPE_CHECKING:
     from core.agent_harness.session.session_core import SessionCore
@@ -160,7 +160,7 @@ class DefaultHeadlessBuild:
             self.session,
             self._console,
             tool_action_logger=self._logger,
-            subprocess_presenter_factory=get_subprocess_presenter_factory(),
+            subprocess_presenter_factory=resolve_subprocess_presenter(),
         )
 
     def prompts(self) -> PromptContextProvider:

--- a/infrastructure/harness_providers/__init__.py
+++ b/infrastructure/harness_providers/__init__.py
@@ -96,8 +96,8 @@ from infrastructure.harness_providers.repo_scope import (
 )
 from infrastructure.harness_providers.repo_scope import reset as _reset_repo_scope
 from infrastructure.harness_providers.subprocess_presenter import (
-    get_subprocess_presenter_factory,
-    set_subprocess_presenter_factory,
+    SubprocessPresenterProvider,
+    resolve_subprocess_presenter,
 )
 from infrastructure.harness_providers.subprocess_presenter import (
     reset as _reset_subprocess_presenter,
@@ -172,6 +172,7 @@ __all__ = [
     "PromptFragmentFn",
     "RemoteIntegrationsFetcher",
     "SetupableIntegrationServicesFn",
+    "SubprocessPresenterProvider",
     "VcsRepoScopeProvider",
     "WebappVaultFetcherFn",
     "action_prompt_vendor_fragments",
@@ -193,7 +194,6 @@ __all__ = [
     "gateway_persona_fragments",
     "gather_prompt_vendor_fragments",
     "get_investigation_tools",
-    "get_subprocess_presenter_factory",
     "get_surface_tool_map",
     "get_surface_tools",
     "integration_setup_command",
@@ -217,13 +217,13 @@ __all__ = [
     "reset_harness_providers",
     "resolve_integrations",
     "resolve_integrations_with_metadata",
+    "resolve_subprocess_presenter",
     "set_cli_llm_adapters",
     "set_integration_resolution_adapters",
     "set_integration_setup_command",
     "set_investigation_tools_adapter",
     "set_remote_integrations_fetcher",
     "set_setupable_integration_services",
-    "set_subprocess_presenter_factory",
     "set_tool_registry",
     "setupable_integration_services",
     "strip_message_context_prefix",

--- a/infrastructure/harness_providers/subprocess_presenter.py
+++ b/infrastructure/harness_providers/subprocess_presenter.py
@@ -2,34 +2,49 @@
 
 Streaming shell/CLI output needs a presenter that lives in ``tools`` (its
 process helpers) and is therefore invisible to ``core.agent_harness``.
-Registering it here lets the default agent execute shell tools instead of
+Installing it here lets the default agent execute shell tools instead of
 refusing them, without core importing tools or gateway.
+
+The presenter is an immutable value installed once at the composition root
+(``bootstrap.adapters``) and read through :func:`resolve_subprocess_presenter`,
+mirroring
+:class:`infrastructure.scheduling.scheduler.delivery_bundle.ScheduledDeliveryAdapters`.
+There is no setter — nothing rewrites it after boot.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from core.agent_harness.ports import SubprocessPresenterFactory
 
-_subprocess_presenter_factory: SubprocessPresenterFactory | None = None
+
+@dataclass(frozen=True)
+class SubprocessPresenterProvider:
+    """The presenter factory the default agent gives shell tools, installed once."""
+
+    factory: SubprocessPresenterFactory
+
+    def install(self) -> None:
+        """Bind this provider as the process-wide subprocess presenter."""
+        global _installed
+        _installed = self
 
 
-def set_subprocess_presenter_factory(factory: SubprocessPresenterFactory | None) -> None:
-    """Register (or clear) the presenter the default agent gives shell tools."""
-    global _subprocess_presenter_factory
-    _subprocess_presenter_factory = factory
+_installed: SubprocessPresenterProvider | None = None
 
 
-def get_subprocess_presenter_factory() -> SubprocessPresenterFactory | None:
-    """Return the registered presenter factory, or ``None`` before boot."""
-    return _subprocess_presenter_factory
+def resolve_subprocess_presenter() -> SubprocessPresenterFactory | None:
+    """Return the installed presenter factory, or ``None`` before boot."""
+    return _installed.factory if _installed is not None else None
 
 
 def reset() -> None:
-    """Restore the presenter to its unset default (tests)."""
-    set_subprocess_presenter_factory(None)
+    """Clear the installed presenter (tests)."""
+    global _installed
+    _installed = None
 
 
-__all__ = ["get_subprocess_presenter_factory", "set_subprocess_presenter_factory"]
+__all__ = ["SubprocessPresenterProvider", "resolve_subprocess_presenter"]

--- a/tests/bootstrap/test_subprocess_presenter.py
+++ b/tests/bootstrap/test_subprocess_presenter.py
@@ -3,12 +3,13 @@
 ``AgentSession.start()`` is the documented Python entry point. With no
 subprocess presenter, ``shell_run`` refuses every call ("subprocess presenter
 is required for this action tool") and the agent silently degrades to writing
-a plan it cannot execute — which reads as a reasoning failure but is a wiring
-gap. Observed live: the 5-step goal prompt returned PLANNED=4 / EXECUTED=0.
+a plan it cannot execute — which reads as a reasoning failure but is a
+registration gap. Observed live: the 5-step goal prompt returned PLANNED=4 /
+EXECUTED=0.
 
 The presenter cannot be a core default: it lives in ``tools`` (its process
 helpers) and ``core.agent_harness`` may import neither ``tools`` nor
-``gateway``. It is registered on this port at process boot instead.
+``gateway``. It is installed as an immutable provider at process boot instead.
 """
 
 from __future__ import annotations
@@ -18,20 +19,21 @@ from collections.abc import Iterator
 import pytest
 
 import infrastructure.harness_providers as harness_providers
+from infrastructure.harness_providers import subprocess_presenter
 
 
 @pytest.fixture(autouse=True)
-def _restore_port() -> Iterator[None]:
-    """Keep this module's writes out of every other test in the process."""
-    previous = harness_providers.get_subprocess_presenter_factory()
+def _restore_presenter() -> Iterator[None]:
+    """Keep this module's installs out of every other test in the process."""
+    previous = subprocess_presenter._installed  # noqa: SLF001
     yield
-    harness_providers.set_subprocess_presenter_factory(previous)
+    subprocess_presenter._installed = previous  # noqa: SLF001
 
 
 def test_process_boot_installs_a_subprocess_presenter_for_the_default_agent() -> None:
-    """Boot leaves a presenter registered so the default port stack can execute."""
+    """Boot leaves a presenter installed so the default port stack can execute."""
     # Arrange.
-    harness_providers.set_subprocess_presenter_factory(None)
+    subprocess_presenter.reset()
 
     # Act.
     from bootstrap.adapters import install_harness_adapters
@@ -39,37 +41,37 @@ def test_process_boot_installs_a_subprocess_presenter_for_the_default_agent() ->
     install_harness_adapters()
 
     # Assert.
-    assert harness_providers.get_subprocess_presenter_factory() is not None
+    assert harness_providers.resolve_subprocess_presenter() is not None
 
 
 def test_resetting_the_harness_providers_clears_the_presenter() -> None:
-    """A booted presenter must not leak into tests that reset the ports.
+    """A booted presenter must not leak into tests that reset the providers.
 
-    ``reset_harness_providers`` is the suite's "back to noop defaults" call; a port
-    it forgets stays registered for the rest of the process.
+    ``reset_harness_providers`` is the suite's "back to noop defaults" call; a
+    provider it forgets stays installed for the rest of the process.
     """
 
-    # Arrange: something registered, as after boot.
+    # Arrange: something installed, as after boot.
     def _presenter(*_args: object, **_kwargs: object) -> object:
         return object()
 
-    harness_providers.set_subprocess_presenter_factory(_presenter)
+    harness_providers.SubprocessPresenterProvider(_presenter).install()
 
     # Act.
     harness_providers.reset_harness_providers()
 
     # Assert.
-    assert harness_providers.get_subprocess_presenter_factory() is None
+    assert harness_providers.resolve_subprocess_presenter() is None
 
 
-def test_default_headless_build_injects_the_registered_presenter() -> None:
-    """The default port stack takes the boot-registered factory at construction.
+def test_default_headless_build_injects_the_installed_presenter() -> None:
+    """The default port stack takes the boot-installed factory at construction.
 
     Hosts that pass their own ``DefaultToolProvider`` keep that factory. The
     family's bare default is what ``AgentSession.start()`` uses, so it must
-    receive the registered presenter or ``shell_run`` refuses every call. The
+    receive the installed presenter or ``shell_run`` refuses every call. The
     provider itself must not look the factory up — a missing constructor arg
-    stays missing even when one is registered.
+    stays missing even when one is installed.
     """
     # Arrange.
     from core.agent_harness.session import SessionCore
@@ -78,13 +80,13 @@ def test_default_headless_build_injects_the_registered_presenter() -> None:
     from core.agent_harness.turns.headless_adapters import BufferOutputSink
     from core.agent_harness.turns.headless_build import DefaultHeadlessBuild
 
-    def _registered(*_args: object, **_kwargs: object) -> object:
+    def _installed(*_args: object, **_kwargs: object) -> object:
         return object()
 
     def _explicit(*_args: object, **_kwargs: object) -> object:
         return object()
 
-    harness_providers.set_subprocess_presenter_factory(_registered)
+    harness_providers.SubprocessPresenterProvider(_installed).install()
     with_explicit = DefaultToolProvider(object(), object(), subprocess_presenter_factory=_explicit)
     without = DefaultToolProvider(object(), object())
     default_tools = DefaultHeadlessBuild(
@@ -96,4 +98,4 @@ def test_default_headless_build_injects_the_registered_presenter() -> None:
     assert with_explicit._subprocess_presenter_factory is _explicit  # noqa: SLF001
     assert without._subprocess_presenter_factory is None  # noqa: SLF001
     assert isinstance(default_tools, DefaultToolProvider)
-    assert default_tools._subprocess_presenter_factory is _registered  # noqa: SLF001
+    assert default_tools._subprocess_presenter_factory is _installed  # noqa: SLF001


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

The subprocess-presenter provider in `infrastructure/harness_providers/` used a
mutable `set_`/`get_` global — any caller could overwrite it at any time (a
read-modify-write global, which the house rules discourage). This converts it to
the frozen-installed-once pattern already used for `cli_auth` and scheduler
delivery. Behavior is identical; the write surface is what shrinks.

Before — a slot anyone can overwrite, anytime:
```python
_factory = None
def set_subprocess_presenter_factory(f): global _factory; _factory = f
def get_subprocess_presenter_factory(): return _factory
After — an immutable value installed once at the composition root, read-only:


@dataclass(frozen=True)
class SubprocessPresenterProvider:
    factory: SubprocessPresenterFactory
    def install(self) -> None: global _installed; _installed = self

def resolve_subprocess_presenter() -> SubprocessPresenterFactory | None:
    return _installed.factory if _installed is not None else None
Call-site changes:

Composition root (bootstrap/adapters.py): set_...factory(f) becomes SubprocessPresenterProvider(f).install().
Reader (core/agent_harness/turns/headless_build.py): get_...factory() becomes resolve_subprocess_presenter().
The package no longer exports a setter — there is one install site, at boot.
The test is rewritten against the new API (and leftover "port"/"wiring" wording in its docstrings is cleaned up).
The other three single-value providers (tool registry, integration resolution,
cli-llm) follow the same pattern in later PRs. The append-only registries (prompt
fragments, evidence sources, metric drafts) are left as-is — they are filled once
at boot and never rewritten.

Demo/Screenshot for feature changes and bug fixes -
Install-then-resolve at real boot, and a real shell-tool run through the presenter:


before boot: None
after boot : installed   (SubprocessPresenterProvider, frozen)

$ LLM_PROVIDER=claude-code uv run opensre --json ask \
    --dangerously-bypass-approvals "run the shell command: echo solution2ok"
{"status": "success", "response": "solution2ok", "denied_tools": [], "error": null}
make check-imports green (no cycle); ruff + mypy clean; 5752 tests pass across
agent_harness / bootstrap / cli / integrations / gateway. The one failure in the
suite — tests/cli/test_main.py::test_root_main_propagates_the_cli_exit_code — is
pre-existing and unrelated (an import main path issue that fails on a clean tree
too).

Explain your implementation approach:

The one thing that changes is who may write the slot and when. A mutable
set_/get_ global lets any code overwrite the presenter at any point; the
frozen provider is assembled once at the composition root, frozen so it cannot be
mutated, and installed once — readers only resolve it, and no setter is exported.
That removes the read-modify-write global while keeping behavior identical, which
the tests and a real shell-tool run confirm. I deliberately scoped this to the
one provider so it is a small, obvious pattern-setter; the other single-value
providers get the same treatment in their own PRs, and the append-only registries
are intentionally left alone because they are never rewritten after boot.

Key pieces: SubprocessPresenterProvider / resolve_subprocess_presenter in
infrastructure/harness_providers/subprocess_presenter.py, and the two call-site
updates in bootstrap/adapters.py and core/agent_harness/turns/headless_build.py.