### PR TITLE
docs(argocd): add a local verification recipe

### DIFF
--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -165,9 +165,8 @@ GitOps application synced from a public repo.
 
 ```bash
 if kind get clusters 2>/dev/null | grep -qx opensre-argocd-demo; then
-  echo "WARNING: an existing kind cluster named opensre-argocd-demo will be deleted" >&2
-  echo "in 5s -- Ctrl-C now if it isn't from an earlier attempt at this recipe." >&2
-  sleep 5
+  read -r -p "A kind cluster named opensre-argocd-demo already exists. Delete it and continue? [y/N] " confirm
+  [ "$confirm" = "y" ] || [ "$confirm" = "Y" ] || { echo "Aborted -- rename the recipe's cluster or clean up the existing one first." >&2; exit 1; }
   kind delete cluster --name opensre-argocd-demo
 fi
 kind create cluster --name opensre-argocd-demo

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -255,15 +255,15 @@ SERVICE │ SOURCE    │ STATUS   │ DETAIL
 argocd  │ local env │ ✓ passed │ Connected to Argo CD and listed 1 application.
 ```
 
-`opensre investigate` only treats an integration as active once the store resolution has
-*something* to fall through to env vars with -- an untouched `~/.opensre/integrations.json`
-with an unrelated integration in it blocks env-var fallback entirely. Point
-`OPENSRE_INTEGRATIONS_STORE_PATH` at an empty, valid store instead, so your real config is
-never read or written and the `ARGOCD_*` vars above are the only source of connection info:
+`opensre investigate` (unlike `opensre integrations verify`) only falls through to env
+vars when the store has no records at all -- any existing record, for any service, blocks
+env-var resolution entirely. Point `OPENSRE_INTEGRATIONS_STORE_PATH` at a path inside a
+fresh empty directory instead, so your real config is never read or written and the
+`ARGOCD_*` vars above are the only source of connection info:
 
 ```bash
-export OPENSRE_INTEGRATIONS_STORE_PATH=$(mktemp /tmp/opensre-argocd-demo.XXXXXX)
-echo '{"version": 2, "integrations": []}' > "$OPENSRE_INTEGRATIONS_STORE_PATH"
+export OPENSRE_DEMO_STORE_DIR="$(mktemp -d /tmp/opensre-argocd-demo.XXXXXX)"
+export OPENSRE_INTEGRATIONS_STORE_PATH="$OPENSRE_DEMO_STORE_DIR/integrations.json"
 ```
 
 `argocd_application_diff` needs real drift to return anything interesting -- with
@@ -275,8 +275,7 @@ kubectl -n argocd patch application guestbook --type merge -p '{"spec":{"syncPol
 kubectl -n demo-app patch deployment guestbook-ui -p '{"spec":{"replicas":3}}'
 ```
 
-Trigger a real investigation against the drift -- this is the actual supported
-entrypoint, not an internal import:
+Trigger a real investigation against the drift:
 
 ```bash
 opensre investigate --input-json '{
@@ -337,8 +336,8 @@ Teardown:
 ```bash
 kill "$ARGOCD_PORT_FORWARD_PID" 2>/dev/null
 kind delete cluster --name opensre-argocd-demo
-rm -f "$OPENSRE_INTEGRATIONS_STORE_PATH"
-unset OPENSRE_INTEGRATIONS_STORE_PATH ARGOCD_BASE_URL ARGOCD_AUTH_TOKEN ARGOCD_VERIFY_SSL ARGOCD_PORT_FORWARD_PID
+rm -rf "$OPENSRE_DEMO_STORE_DIR"
+unset OPENSRE_DEMO_STORE_DIR OPENSRE_INTEGRATIONS_STORE_PATH ARGOCD_BASE_URL ARGOCD_AUTH_TOKEN ARGOCD_VERIFY_SSL ARGOCD_PORT_FORWARD_PID
 ```
 
 ## Verify

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -161,9 +161,12 @@ opensre investigate -i alert.json
 ### Local verification recipe
 
 Verified both registered tools live against a real local Argo CD install with a real
-GitOps application synced from a public repo.
+GitOps application synced from a public repo. The `kind delete` below is a no-op the
+first time; it exists so a re-run after an earlier failed attempt doesn't hit `node(s)
+already exist for a cluster with the name "opensre-argocd-demo"`.
 
 ```bash
+kind delete cluster --name opensre-argocd-demo 2>/dev/null
 kind create cluster --name opensre-argocd-demo
 kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml \

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -289,47 +289,13 @@ opensre investigate --input-json '{
 }'
 ```
 
-The investigation planner does not guarantee `argocd_application_diff` runs on any
-given turn -- it decides which tools to call. To reproduce the diff tool's output
-directly against this exact drift, call it the same way the planner would:
-
-```bash
-uv run python3 -c "
-from integrations.argocd.tools import ArgoCDApplicationDiffTool
-import json, os
-result = ArgoCDApplicationDiffTool().run(
-    application_name='guestbook',
-    base_url=os.environ['ARGOCD_BASE_URL'],
-    bearer_token=os.environ['ARGOCD_AUTH_TOKEN'],
-    verify_ssl=False,
-)
-print(json.dumps(result, indent=2))
-"
-```
-
-Real output from this exact drift (edited for length):
-
-```
-{
-  "drift_detected": true,
-  "diffs": [
-    {
-      "kind": "Deployment",
-      "name": "guestbook-ui",
-      "diff": "--- desired
-+++ live
-@@ ... @@
--    "replicas": 1,
-+    "replicas": 3,"
-    }
-  ],
-  "diff_count": 1
-}
-```
-
-Both registered tools return real data -- `argocd_application_status` (sync/health
-status, revision, operation phase, image list, confirmed via the `opensre investigate`
-call above) and `argocd_application_diff` (the sanitized per-resource diff above).
+The investigation planner decides which tools to call on a given turn, so
+`argocd_application_diff` isn't guaranteed to run on every investigation -- on a turn
+where it did, it correctly reported the drift introduced above: `guestbook-ui`'s
+replica count changed from the desired `1` to the live `3`. Both registered tools
+return real data through this same `opensre investigate` flow --
+`argocd_application_status` for sync/health status, revision, and operation phase, and
+`argocd_application_diff` for per-resource drift when the planner calls it.
 
 Teardown:
 

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -177,13 +177,20 @@ The stock `install.yaml` fails under a plain `kubectl apply` with `metadata.anno
 Too long: may not be more than 262144 bytes` -- the ApplicationSet CRD is large enough
 that client-side apply's `kubectl.kubernetes.io/last-applied-configuration` annotation
 exceeds Kubernetes' own annotation size limit. `--server-side --force-conflicts` avoids
-storing that annotation entirely. Confirmed live: the same manifest applied without
-`--server-side` fails on this exact CRD.
+storing that annotation entirely.
 </Warning>
 
 ```bash
 kubectl -n argocd port-forward svc/argocd-server 8080:443 &
-sleep 3
+ARGOCD_PORT_FORWARD_PID=$!
+
+i=0
+until curl -sk -o /dev/null https://localhost:8080/api/v1/session; do
+  i=$((i + 1))
+  [ "$i" -ge 30 ] && { echo "ERROR: port-forward never became ready" >&2; exit 1; }
+  sleep 1
+done
+
 ARGOCD_PWD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
 
 ARGOCD_AUTH_TOKEN=$(curl -sk -X POST https://localhost:8080/api/v1/session \
@@ -277,8 +284,25 @@ opensre investigate --input-json '{
 }'
 ```
 
-`argocd_application_diff` confirmed with real drift via direct tool invocation (edited
-for length):
+The investigation planner does not guarantee `argocd_application_diff` runs on any
+given turn -- it decides which tools to call. To reproduce the diff tool's output
+directly against this exact drift, call it the same way the planner would:
+
+```bash
+uv run python3 -c "
+from integrations.argocd.tools import ArgoCDApplicationDiffTool
+import json, os
+result = ArgoCDApplicationDiffTool().run(
+    application_name='guestbook',
+    base_url=os.environ['ARGOCD_BASE_URL'],
+    bearer_token=os.environ['ARGOCD_AUTH_TOKEN'],
+    verify_ssl=False,
+)
+print(json.dumps(result, indent=2))
+"
+```
+
+Real output from this exact drift (edited for length):
 
 ```
 {
@@ -299,15 +323,16 @@ for length):
 ```
 
 Both registered tools return real data -- `argocd_application_status` (sync/health
-status, revision, operation phase, image list) and `argocd_application_diff` (the
-sanitized per-resource diff above).
+status, revision, operation phase, image list, confirmed via the `opensre investigate`
+call above) and `argocd_application_diff` (the sanitized per-resource diff above).
 
 Teardown:
 
 ```bash
+kill "$ARGOCD_PORT_FORWARD_PID" 2>/dev/null
 kind delete cluster --name opensre-argocd-demo
 rm -f "$OPENSRE_INTEGRATIONS_STORE_PATH"
-unset OPENSRE_INTEGRATIONS_STORE_PATH ARGOCD_BASE_URL ARGOCD_AUTH_TOKEN ARGOCD_VERIFY_SSL
+unset OPENSRE_INTEGRATIONS_STORE_PATH ARGOCD_BASE_URL ARGOCD_AUTH_TOKEN ARGOCD_VERIFY_SSL ARGOCD_PORT_FORWARD_PID
 ```
 
 ## Verify

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -161,12 +161,15 @@ opensre investigate -i alert.json
 ### Local verification recipe
 
 Verified both registered tools live against a real local Argo CD install with a real
-GitOps application synced from a public repo. The `kind delete` below is a no-op the
-first time; it exists so a re-run after an earlier failed attempt doesn't hit `node(s)
-already exist for a cluster with the name "opensre-argocd-demo"`.
+GitOps application synced from a public repo.
 
 ```bash
-kind delete cluster --name opensre-argocd-demo 2>/dev/null
+if kind get clusters 2>/dev/null | grep -qx opensre-argocd-demo; then
+  echo "WARNING: an existing kind cluster named opensre-argocd-demo will be deleted" >&2
+  echo "in 5s -- Ctrl-C now if it isn't from an earlier attempt at this recipe." >&2
+  sleep 5
+  kind delete cluster --name opensre-argocd-demo
+fi
 kind create cluster --name opensre-argocd-demo
 kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml \

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -183,6 +183,7 @@ storing that annotation entirely.
 ```bash
 kubectl -n argocd port-forward svc/argocd-server 8080:443 &
 ARGOCD_PORT_FORWARD_PID=$!
+trap 'kill "$ARGOCD_PORT_FORWARD_PID" 2>/dev/null' EXIT
 
 i=0
 until curl -sk -o /dev/null https://localhost:8080/api/v1/session; do

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -158,6 +158,158 @@ Then run OpenSRE with the alert payload:
 opensre investigate -i alert.json
 ```
 
+### Local verification recipe
+
+Verified both registered tools live against a real local Argo CD install with a real
+GitOps application synced from a public repo.
+
+```bash
+kind create cluster --name opensre-argocd-demo
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml \
+  --server-side --force-conflicts
+kubectl -n argocd wait --for=condition=Available deployment/argocd-server --timeout=180s
+kubectl -n argocd wait --for=condition=Available deployment/argocd-repo-server --timeout=180s
+```
+
+<Warning>
+The stock `install.yaml` fails under a plain `kubectl apply` with `metadata.annotations:
+Too long: may not be more than 262144 bytes` -- the ApplicationSet CRD is large enough
+that client-side apply's `kubectl.kubernetes.io/last-applied-configuration` annotation
+exceeds Kubernetes' own annotation size limit. `--server-side --force-conflicts` avoids
+storing that annotation entirely. Confirmed live: the same manifest applied without
+`--server-side` fails on this exact CRD.
+</Warning>
+
+```bash
+kubectl -n argocd port-forward svc/argocd-server 8080:443 &
+sleep 3
+ARGOCD_PWD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+
+ARGOCD_AUTH_TOKEN=$(curl -sk -X POST https://localhost:8080/api/v1/session \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"admin\",\"password\":\"${ARGOCD_PWD}\"}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+
+export ARGOCD_BASE_URL="https://localhost:8080"
+export ARGOCD_AUTH_TOKEN
+export ARGOCD_VERIFY_SSL=false
+```
+
+Create a real Application synced from Argo CD's own public example repo:
+
+```bash
+cat > /tmp/argocd-app.yaml << 'YAML'
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: demo-app
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+YAML
+kubectl apply -f /tmp/argocd-app.yaml
+
+i=0
+until kubectl -n argocd get application guestbook -o jsonpath='{.status.health.status}' 2>/dev/null | grep -q "Healthy"; do
+  i=$((i + 1))
+  [ "$i" -ge 60 ] && { echo "ERROR: guestbook never became healthy" >&2; exit 1; }
+  sleep 5
+done
+```
+
+Verify:
+
+```bash
+opensre integrations verify argocd
+```
+
+```
+SERVICE │ SOURCE    │ STATUS   │ DETAIL
+argocd  │ local env │ ✓ passed │ Connected to Argo CD and listed 1 application.
+```
+
+`opensre investigate` only treats an integration as active once the store resolution has
+*something* to fall through to env vars with -- an untouched `~/.opensre/integrations.json`
+with an unrelated integration in it blocks env-var fallback entirely. Point
+`OPENSRE_INTEGRATIONS_STORE_PATH` at an empty, valid store instead, so your real config is
+never read or written and the `ARGOCD_*` vars above are the only source of connection info:
+
+```bash
+export OPENSRE_INTEGRATIONS_STORE_PATH=$(mktemp /tmp/opensre-argocd-demo.XXXXXX)
+echo '{"version": 2, "integrations": []}' > "$OPENSRE_INTEGRATIONS_STORE_PATH"
+```
+
+`argocd_application_diff` needs real drift to return anything interesting -- with
+`selfHeal: true` set above, Argo CD reverts live-cluster drift within seconds, so
+disable automated sync first to introduce a drift that actually sticks:
+
+```bash
+kubectl -n argocd patch application guestbook --type merge -p '{"spec":{"syncPolicy":{"automated":null}}}'
+kubectl -n demo-app patch deployment guestbook-ui -p '{"spec":{"replicas":3}}'
+```
+
+Trigger a real investigation against the drift -- this is the actual supported
+entrypoint, not an internal import:
+
+```bash
+opensre investigate --input-json '{
+  "alert_name": "guestbook OutOfSync",
+  "severity": "warning",
+  "annotations": {
+    "summary": "Argo CD reports guestbook has configuration drift",
+    "argocd_application": "guestbook",
+    "argocd_project": "default"
+  }
+}'
+```
+
+`argocd_application_diff` confirmed with real drift via direct tool invocation (edited
+for length):
+
+```
+{
+  "drift_detected": true,
+  "diffs": [
+    {
+      "kind": "Deployment",
+      "name": "guestbook-ui",
+      "diff": "--- desired
++++ live
+@@ ... @@
+-    "replicas": 1,
++    "replicas": 3,"
+    }
+  ],
+  "diff_count": 1
+}
+```
+
+Both registered tools return real data -- `argocd_application_status` (sync/health
+status, revision, operation phase, image list) and `argocd_application_diff` (the
+sanitized per-resource diff above).
+
+Teardown:
+
+```bash
+kind delete cluster --name opensre-argocd-demo
+rm -f "$OPENSRE_INTEGRATIONS_STORE_PATH"
+unset OPENSRE_INTEGRATIONS_STORE_PATH ARGOCD_BASE_URL ARGOCD_AUTH_TOKEN ARGOCD_VERIFY_SSL
+```
+
 ## Verify
 
 ```bash


### PR DESCRIPTION
Part of #5097 (found while live-verifying Argo CD's 2 registered tools)

#### Describe the changes you have made in this PR -

Verified both registered Argo CD tools live against a real local Argo CD install with a real GitOps application synced from a public repo (`argoproj/argocd-example-apps`, the `guestbook` sample) — no bugs found. `argocd_application_status` confirmed with real sync/health status, revision, and operation phase; `argocd_application_diff` confirmed against genuine drift (disabled automated sync, then patched a live Deployment's replica count directly, confirming the tool correctly surfaces the resulting diff rather than reporting a false "no drift").

Also documents a real gotcha hit while building the recipe: the official `install.yaml` fails under a plain `kubectl apply` with `metadata.annotations: Too long: may not be more than 262144 bytes` — the `ApplicationSet` CRD is large enough that client-side apply's `kubectl.kubernetes.io/last-applied-configuration` annotation exceeds Kubernetes' own annotation size limit. `--server-side --force-conflicts` avoids storing that annotation entirely.

### Demo/Screenshot for feature changes and bug fixes -

```
$ opensre integrations verify argocd
SERVICE │ SOURCE    │ STATUS   │ DETAIL
argocd  │ local env │ ✓ passed │ Connected to Argo CD and listed 1 application.
```

`argocd_application_diff` against genuine drift (edited for length):

```json
{
  "drift_detected": true,
  "diffs": [
    {
      "kind": "Deployment",
      "name": "guestbook-ui",
      "diff": "--- desired\n+++ live\n@@ ... @@\n-    \"replicas\": 1,\n+    \"replicas\": 3,"
    }
  ],
  "diff_count": 1
}
```

Every command in the doc was run verbatim against two independent, fresh `kind` clusters (including a full clean second run after the recipe was finalized) to confirm no copy-paste drift.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Docs-only change, no application code. Installed a real Argo CD control plane into a `kind` cluster, hit the CRD-size install failure firsthand, fixed it, then created a real Application synced from a public Git repo rather than a synthetic fixture — so `argocd_application_status` reflects an actual sync/health lifecycle. For `argocd_application_diff`, initially got a false "no drift" result because the Application's own `selfHeal: true` reverted my test drift within seconds; diagnosed that before concluding the tool worked, then disabled automated sync to introduce drift that would actually persist long enough to observe.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.