### PR TITLE
refactor(eks): rename utils.py to aws_credentials.py

### DIFF
--- a/integrations/eks/aws_credentials.py
+++ b/integrations/eks/aws_credentials.py
@@ -1,7 +1,7 @@
-"""EKS helper utilities.
+"""Normalize stored AWS credentials for botocore.
 
-Provides shared logic to normalize internal AWS credential structures (which use
-snake_case keys) into botocore-compatible formats (which use PascalCase keys).
+Maps internal snake_case credential keys to the PascalCase dict botocore
+clients expect.
 """
 
 from __future__ import annotations

--- a/integrations/eks/eks_client.py
+++ b/integrations/eks/eks_client.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import boto3
 
-from integrations.eks.utils import stored_credentials_to_aws_creds
+from integrations.eks.aws_credentials import stored_credentials_to_aws_creds
 
 
 class EKSClient:

--- a/integrations/eks/eks_k8s_client.py
+++ b/integrations/eks/eks_k8s_client.py
@@ -20,7 +20,7 @@ import botocore.session
 from kubernetes import client as k8s_client
 
 from config.constants import OPENSRE_TMP_DIR, ensure_opensre_tmp_dir
-from integrations.eks.utils import stored_credentials_to_aws_creds
+from integrations.eks.aws_credentials import stored_credentials_to_aws_creds
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integrations/eks/test_client.py
+++ b/tests/integrations/eks/test_client.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from integrations.eks.aws_credentials import stored_credentials_to_aws_creds
 from integrations.eks.eks_client import EKSClient
-from integrations.eks.utils import stored_credentials_to_aws_creds
 
 # ---------------------------------------------------------------------------
 # stored_credentials_to_aws_creds


### PR DESCRIPTION
Fixes #5372

#### Describe the changes you have made in this PR -

`integrations/eks/utils.py` only maps stored AWS credentials to botocore's PascalCase shape. Rename it to `aws_credentials.py` for that role, update callers/tests, and delete the `utils.py` grab-bag. No behavior change.

### Demo/Screenshot for feature changes and bug fixes -
No UI change. Local proof:
uv run pytest tests/integrations/eks/test_client.py -q
12 passed


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
`utils.py` was a category name, not a role. The module has one function, `stored_credentials_to_aws_creds`, used by both `eks_client.py` and `eks_k8s_client.py`, so it cannot live next to a single caller.

I moved it to `integrations/eks/aws_credentials.py` (the file now names the credential-normalization role), updated imports, and deleted `utils.py`. I did not add a compatibility shim. Function logic is unchanged; existing tests in `tests/integrations/eks/test_client.py` still cover full triplets, empty/missing session tokens, missing keys, and `None`/empty input.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.