### PR TITLE
test(quality): ban new untyped Callable[..., Any] under harness ports and shell runtime (#5228)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
               tests/packaging
               tests/scheduler
               gateway/tests
+              tests/quality
           # install/ + quickstart/ are opt-in live (CDN/brew/LLM); not PR CI.
           - os: ubuntu-latest
             shard: e2e-general

--- a/tests/quality/test_no_new_callable_any.py
+++ b/tests/quality/test_no_new_callable_any.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.shared.product_sources import product_python_files
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Relative paths to check under the repository root
@@ -82,7 +84,7 @@ def _collect_python_files(rel_path: str) -> list[Path]:
     if full_path.is_file() and full_path.suffix == ".py":
         return [full_path]
     if full_path.is_dir():
-        return sorted(p for p in full_path.rglob("*.py") if not p.name.startswith("test_"))
+        return [p for p in product_python_files(full_path) if not p.name.startswith("test_")]
     return []
 
 

--- a/tests/quality/test_no_new_callable_any.py
+++ b/tests/quality/test_no_new_callable_any.py
@@ -32,9 +32,12 @@ def _is_untyped_callable_any(node: ast.AST) -> bool:
         return False
 
     value = node.value
-    if isinstance(value, ast.Name) and value.id == "Callable":
-        pass
-    elif isinstance(value, ast.Attribute) and value.attr == "Callable":
+    if (
+        isinstance(value, ast.Name)
+        and value.id == "Callable"
+        or isinstance(value, ast.Attribute)
+        and value.attr == "Callable"
+    ):
         pass
     else:
         return False

--- a/tests/quality/test_no_new_callable_any.py
+++ b/tests/quality/test_no_new_callable_any.py
@@ -1,0 +1,110 @@
+"""Quality gate: prevent untyped ``Callable[..., Any]`` seams.
+
+Untyped callable seams reduce type safety across core agent harness ports,
+harness providers, and interactive shell runtime modules. This test pins
+the maximum allowed count of ``Callable[..., Any]`` occurrences under those
+paths so new untyped seams fail in CI.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Relative paths to check under the repository root
+_TARGET_PATHS = (
+    "core/agent_harness/ports.py",
+    "infrastructure/harness_providers",
+    "surfaces/interactive_shell/runtime",
+)
+
+# Baseline allowed count of untyped Callable[..., Any] occurrences
+_BASELINE_ALLOWED_COUNT = 0
+
+
+def _is_untyped_callable_any(node: ast.AST) -> bool:
+    """Return True if node represents Callable[..., Any]."""
+    if not isinstance(node, ast.Subscript):
+        return False
+
+    value = node.value
+    if isinstance(value, ast.Name) and value.id == "Callable":
+        pass
+    elif isinstance(value, ast.Attribute) and value.attr == "Callable":
+        pass
+    else:
+        return False
+
+    slice_node = node.slice
+    if isinstance(slice_node, ast.Tuple):
+        elts = slice_node.elts
+    else:
+        elts = [slice_node]
+
+    if len(elts) < 2:
+        return False
+
+    args_part, return_part = elts[0], elts[1]
+
+    # Check first argument is Ellipsis (...)
+    is_ellipsis = isinstance(args_part, ast.Constant) and args_part.value is Ellipsis
+
+    # Check return type is Any
+    is_any = (isinstance(return_part, ast.Name) and return_part.id == "Any") or (
+        isinstance(return_part, ast.Attribute) and return_part.attr == "Any"
+    )
+
+    return is_ellipsis and is_any
+
+
+def _find_callable_any_offenses(tree: ast.AST) -> list[tuple[int, str]]:
+    hits: list[tuple[int, str]] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Subscript(self, node: ast.Subscript) -> None:
+            if _is_untyped_callable_any(node):
+                hits.append((node.lineno, "Callable[..., Any]"))
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return hits
+
+
+def _collect_python_files(rel_path: str) -> list[Path]:
+    full_path = _REPO_ROOT / rel_path
+    if full_path.is_file() and full_path.suffix == ".py":
+        return [full_path]
+    if full_path.is_dir():
+        return sorted(p for p in full_path.rglob("*.py") if not p.name.startswith("test_"))
+    return []
+
+
+@pytest.mark.parametrize("target_path", _TARGET_PATHS)
+def test_no_untyped_callable_any_seams(target_path: str) -> None:
+    files = _collect_python_files(target_path)
+    if not files:
+        pytest.skip(f"Target path {target_path} not found")
+
+    offenders: list[str] = []
+    for path in files:
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            offenders.append(f"{path.relative_to(_REPO_ROOT)}: syntax error: {exc}")
+            continue
+
+        for lineno, msg in _find_callable_any_offenses(tree):
+            rel_file = path.relative_to(_REPO_ROOT)
+            offenders.append(f"{rel_file}:{lineno}: untyped seam `{msg}`")
+
+    count = len(offenders)
+    assert count <= _BASELINE_ALLOWED_COUNT, (
+        f"Found {count} untyped `Callable[..., Any]` occurrences under {target_path} "
+        f"(baseline limit is {_BASELINE_ALLOWED_COUNT}). Type the seam or define a Protocol:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/quality/test_no_new_callable_any.py
+++ b/tests/quality/test_no_new_callable_any.py
@@ -86,8 +86,7 @@ def _collect_python_files(rel_path: str) -> list[Path]:
 @pytest.mark.parametrize("target_path", _TARGET_PATHS)
 def test_no_untyped_callable_any_seams(target_path: str) -> None:
     files = _collect_python_files(target_path)
-    if not files:
-        pytest.skip(f"Target path {target_path} not found")
+    assert files, f"Target path {target_path} not found or contains no Python files"
 
     offenders: list[str] = []
     for path in files:
@@ -95,11 +94,11 @@ def test_no_untyped_callable_any_seams(target_path: str) -> None:
         try:
             tree = ast.parse(source, filename=str(path))
         except SyntaxError as exc:
-            offenders.append(f"{path.relative_to(_REPO_ROOT)}: syntax error: {exc}")
+            offenders.append(f"{path.relative_to(_REPO_ROOT).as_posix()}: syntax error: {exc}")
             continue
 
         for lineno, msg in _find_callable_any_offenses(tree):
-            rel_file = path.relative_to(_REPO_ROOT)
+            rel_file = path.relative_to(_REPO_ROOT).as_posix()
             offenders.append(f"{rel_file}:{lineno}: untyped seam `{msg}`")
 
     count = len(offenders)


### PR DESCRIPTION
Fixes #5228

Describe the changes you have made in this PR -
- Added a new quality gate test `tests/quality/test_no_new_callable_any.py` that counts untyped `Callable[..., Any]` occurrences under `core/agent_harness/ports.py`, `infrastructure/harness_providers`, and `surfaces/interactive_shell/runtime`.
- Enforces baseline limit of 0 untyped `Callable[..., Any]` seams under these paths to prevent untyped callable seams from reappearing in future PRs.
- Verified test passes on clean main and fails when an untyped seam is added under the target paths.

Demo/Screenshot for feature changes and bug fixes -
N/A — Test-only quality gate addition. Verified via `uv run pytest tests/quality/test_no_new_callable_any.py` and `uv run mypy tests/quality/test_no_new_callable_any.py`.

Code Understanding and AI Usage
Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

If you used AI assistance:
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

Explain your implementation approach:
Added AST-based quality gate in `tests/quality/test_no_new_callable_any.py` following precedent `tests/quality/test_no_constant_condition_toggles.py`. Walks python files under target paths, checks AST subscript nodes for `Callable[..., Any]`, and asserts occurrences stay <= baseline 0.

Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and how I tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions