### PR TITLE
refactor(helm): split helpers.py into role-named modules

### DIFF
--- a/integrations/helm/client_factory.py
+++ b/integrations/helm/client_factory.py
@@ -1,5 +1,4 @@
-"""Build a ``HelmClient`` from raw tool params, or a standard unavailable
-response when Helm can't run for this call.
+"""Build a ``HelmClient`` from raw tool params for one Helm tool call.
 
 Helm tools call ``helm_client_for_run`` first; if it returns ``None`` they
 return ``helm_base_unavailable(...)`` instead of invoking the client.
@@ -8,11 +7,9 @@ return ``helm_base_unavailable(...)`` instead of invoking the client.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from pydantic import ValidationError
 
-from core.tool_framework.utils import tool_unavailable
 from integrations.config_models import HelmIntegrationConfig
 from integrations.helm.client import HelmClient
 
@@ -64,18 +61,3 @@ def helm_client_for_run(
         logger.debug("helm_client_for_run failed unexpectedly", exc_info=True)
         return None
     return HelmClient(cfg)
-
-
-def helm_base_unavailable(error: str) -> dict[str, Any]:
-    """Build the standard Helm "unavailable" tool response.
-
-    Args:
-        error: Human-readable reason the Helm tool can't run right now
-            (e.g. why ``helm_client_for_run`` returned ``None``).
-
-    Returns:
-        ``{"source": "helm", "available": False, "error": error}``, the
-        envelope Helm tools return directly as their result instead of
-        calling into a ``HelmClient``.
-    """
-    return tool_unavailable("helm", error)

--- a/integrations/helm/tools/__init__.py
+++ b/integrations/helm/tools/__init__.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool import BaseTool
-from integrations.helm.helpers import helm_base_unavailable, helm_client_for_run
+from integrations.helm.client_factory import helm_client_for_run
+from integrations.helm.unavailable import helm_base_unavailable
 
 
 class HelmListReleasesTool(BaseTool):

--- a/integrations/helm/unavailable.py
+++ b/integrations/helm/unavailable.py
@@ -1,0 +1,26 @@
+"""Standard Helm unavailable tool response.
+
+Helm tools return ``helm_base_unavailable(...)`` when ``helm_client_for_run``
+returns ``None`` or the Helm binary is missing, instead of invoking the client.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.tool_framework.utils import tool_unavailable
+
+
+def helm_base_unavailable(error: str) -> dict[str, Any]:
+    """Build the standard Helm "unavailable" tool response.
+
+    Args:
+        error: Human-readable reason the Helm tool can't run right now
+            (e.g. why ``helm_client_for_run`` returned ``None``).
+
+    Returns:
+        ``{"source": "helm", "available": False, "error": error}``, the
+        envelope Helm tools return directly as their result instead of
+        calling into a ``HelmClient``.
+    """
+    return tool_unavailable("helm", error)

--- a/tests/integrations/helm/test_client_factory.py
+++ b/tests/integrations/helm/test_client_factory.py
@@ -1,4 +1,4 @@
-"""Tests for shared Helm integration helpers."""
+"""Tests for Helm client construction from raw tool params."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from integrations.config_models import HelmIntegrationConfig
-from integrations.helm import helpers
+from integrations.helm import client_factory
 from integrations.helm.client import HelmClient
 
 
@@ -19,7 +19,7 @@ def _helm_validation_error() -> ValidationError:
 
 
 def test_helm_client_for_run_builds_client_for_valid_config() -> None:
-    client = helpers.helm_client_for_run(integration_id="helm-test")
+    client = client_factory.helm_client_for_run(integration_id="helm-test")
 
     assert isinstance(client, HelmClient)
 
@@ -29,10 +29,10 @@ def test_helm_client_for_run_returns_none_for_validation_error(
 ) -> None:
     validate = MagicMock(side_effect=_helm_validation_error())
     debug_log = MagicMock()
-    monkeypatch.setattr(helpers.HelmIntegrationConfig, "model_validate", validate)
-    monkeypatch.setattr(helpers.logger, "debug", debug_log)
+    monkeypatch.setattr(client_factory.HelmIntegrationConfig, "model_validate", validate)
+    monkeypatch.setattr(client_factory.logger, "debug", debug_log)
 
-    assert helpers.helm_client_for_run() is None
+    assert client_factory.helm_client_for_run() is None
     debug_log.assert_not_called()
 
 
@@ -42,10 +42,10 @@ def test_helm_client_for_run_logs_unexpected_validation_failure(
     error = RuntimeError("unexpected validation failure")
     validate = MagicMock(side_effect=error)
     debug_log = MagicMock()
-    monkeypatch.setattr(helpers.HelmIntegrationConfig, "model_validate", validate)
-    monkeypatch.setattr(helpers.logger, "debug", debug_log)
+    monkeypatch.setattr(client_factory.HelmIntegrationConfig, "model_validate", validate)
+    monkeypatch.setattr(client_factory.logger, "debug", debug_log)
 
-    assert helpers.helm_client_for_run() is None
+    assert client_factory.helm_client_for_run() is None
     debug_log.assert_called_once_with(
         "helm_client_for_run failed unexpectedly",
         exc_info=True,


### PR DESCRIPTION
Fixes #5371

#### Describe the changes you have made in this PR -

`integrations/helm/helpers.py` mixed two concerns: building a `HelmClient` from raw tool params, and returning the standard Helm unavailable envelope. Split them into role-named modules, update callers/tests, and delete the `helpers.py` grab-bag. No behavior change.

- `integrations/helm/client_factory.py` — `helm_client_for_run`
- `integrations/helm/unavailable.py` — `helm_base_unavailable`

### Demo/Screenshot for feature changes and bug fixes -

No UI change. Local proof:

```text
uv run python -m pytest tests/integrations/helm/ tests/tools/test_helm_tools.py -q
20 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`helpers.py` was a category name, not a role. It held two unrelated functions used by the Helm tools: `helm_client_for_run` validates raw tool params and constructs a `HelmClient`, and `helm_base_unavailable` builds the standard `{source, available, error}` envelope when Helm cannot run.

I followed the same split as the groundcover/github helpers work: one file per concern, named for the role it plays. Client construction went to `client_factory.py`; the unavailable envelope went to `unavailable.py`. Callers in `integrations/helm/tools/__init__.py` and the existing helper tests were updated to the new paths. I did not add a compatibility shim.

Function logic is unchanged. Existing tests still cover a valid client build, `ValidationError` returning `None` without a debug log, and unexpected validation failures logging at debug. Tool tests continue to patch `integrations.helm.tools.helm_client_for_run` where the name is bound.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.