### PR TITLE
refactor: rename ActionToolContext and AgentToolContext to *Scope (#5382)

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -63,8 +63,8 @@ _EXPORT_MODULES = {
     "ProviderRequest": "core.provider",
     "resolve_llm_api_key": "core.provider",
     "AgentTool": "core.tool.contracts",
-    "AgentToolContext": "core.tool.contracts",
     "AgentToolExecutor": "core.tool.contracts",
+    "AgentToolScope": "core.tool.contracts",
     "RuntimeTool": "core.tool.contracts",
     "ToolParallelism": "core.tool.contracts",
 }

--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -364,7 +364,7 @@ SubprocessPresenterFactory = Callable[
 # Protocols here would mean ``core`` importing ``tools``.
 #
 # The return is ``object``, not ``Any``: ``core`` calls the factory and hands the
-# result to ``ActionToolContext`` without reading a single attribute, and
+# result to ``ActionToolScope`` without reading a single attribute, and
 # ``object`` is the type that says so. ``Any`` would silence a typo here as
 # readily as it silences the import ``core`` is avoiding.
 InvestigationPortsFactory = Callable[[], object]

--- a/core/agent_harness/tools/__init__.py
+++ b/core/agent_harness/tools/__init__.py
@@ -1,6 +1,6 @@
 """What an action tool implements and calls: the harness API for tool authors.
 
-An action tool receives an :class:`ActionToolContext`, runs its body under it
+An action tool receives an :class:`ActionToolScope`, runs its body under it
 with :func:`execute_with_action_context`, and may ask whether a capability is
 available. The handoff and evidence shapes are what a tool hands back to the
 engine. Import-cheap: nothing here loads the agent loop.
@@ -13,7 +13,7 @@ role), :mod:`core.agent_harness.runtime` (build and run the agent).
 from __future__ import annotations
 
 from core.agent_harness.tools.tool_context import (
-    ActionToolContext,
+    ActionToolScope,
     action_context_from_agent_context,
     capability_available_from_sources,
     execute_with_action_context,
@@ -24,7 +24,7 @@ from core.agent_harness.turns.handoff_keys import HandoffField
 
 __all__ = [
     "EVIDENCE_KIND_VALUES",
-    "ActionToolContext",
+    "ActionToolScope",
     "HandoffField",
     "action_context_from_agent_context",
     "capability_available_from_sources",

--- a/core/agent_harness/tools/tool_context.py
+++ b/core/agent_harness/tools/tool_context.py
@@ -6,16 +6,16 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from core.tool.contracts import AgentToolContext
+from core.tool.contracts import AgentToolScope
 
 ToolExecutionPayload = bool | dict[str, Any]
-ToolExecutor = Callable[[dict[str, Any], "ActionToolContext"], ToolExecutionPayload]
+ToolExecutor = Callable[[dict[str, Any], "ActionToolScope"], ToolExecutionPayload]
 ACTION_TOOL_CONTEXT_RESOURCE_KEY = "action_tool_context"
 _ACTION_SESSION_SOURCE = "_action_session"
 
 
 @dataclass(frozen=True)
-class ActionToolContext:
+class ActionToolScope:
     """Per-turn resources exposed to action-surface tools."""
 
     session: Any
@@ -39,16 +39,16 @@ class ActionToolContext:
     slash_ports: Any = None
 
 
-def action_context_from_agent_context(context: AgentToolContext) -> ActionToolContext:
+def action_context_from_agent_context(context: AgentToolScope) -> ActionToolScope:
     action_context = context.resources.get(ACTION_TOOL_CONTEXT_RESOURCE_KEY)
-    if not isinstance(action_context, ActionToolContext):
+    if not isinstance(action_context, ActionToolScope):
         raise RuntimeError("action tool requires action runtime context")
     return action_context
 
 
 def execute_with_action_context(
     args: dict[str, Any],
-    context: AgentToolContext,
+    context: AgentToolScope,
     execute: ToolExecutor,
 ) -> dict[str, Any]:
     action_context = action_context_from_agent_context(context)
@@ -89,7 +89,7 @@ def capability_not_explicitly_disabled(session: Any, capability_name: str) -> bo
 
 __all__ = [
     "ACTION_TOOL_CONTEXT_RESOURCE_KEY",
-    "ActionToolContext",
+    "ActionToolScope",
     "ToolExecutor",
     "ToolExecutionPayload",
     "action_context_from_agent_context",

--- a/core/agent_harness/tools/tool_provider.py
+++ b/core/agent_harness/tools/tool_provider.py
@@ -18,7 +18,7 @@ from core.agent_harness.ports import (
 from core.agent_harness.tools.action_tools import get_action_tools_from_integrations_context
 from core.agent_harness.tools.tool_context import (
     ACTION_TOOL_CONTEXT_RESOURCE_KEY,
-    ActionToolContext,
+    ActionToolScope,
 )
 
 ActionObserverFactory = Callable[[str], ToolEventObserver]
@@ -64,7 +64,7 @@ class DefaultToolProvider:
         self._llm_provider_ports_factory = llm_provider_ports_factory
         self._task_cancel_ports_factory = task_cancel_ports_factory
         self._slash_ports_factory = slash_ports_factory
-        self._tool_context: ActionToolContext | None = None
+        self._tool_context: ActionToolScope | None = None
 
     def bind_session(self, session: Any) -> None:
         """Point this provider at a freshly resolved session (gateway reuse)."""
@@ -110,7 +110,7 @@ class DefaultToolProvider:
         if self._slash_ports_factory is not None:
             slash_ports = self._slash_ports_factory()
 
-        ctx = ActionToolContext(
+        ctx = ActionToolScope(
             session=self._session,
             console=self._console,
             confirm_fn=confirm_fn,

--- a/core/agent_harness/turns/host_cancel.py
+++ b/core/agent_harness/turns/host_cancel.py
@@ -70,7 +70,7 @@ class CancelProbeConsole:
 
 @dataclass(frozen=True, slots=True)
 class CancelProbeContext:
-    """Stand-in ``ActionToolContext`` carrying only the cancel console."""
+    """Stand-in ``ActionToolScope`` carrying only the cancel console."""
 
     console: CancelProbeConsole
 

--- a/core/tool/__init__.py
+++ b/core/tool/__init__.py
@@ -2,7 +2,7 @@
 
 from core.tool.contracts import (
     REGISTERED_TOOL_ATTR,
-    AgentToolContext,
+    AgentToolScope,
     BaseTool,
     EvidenceType,
     RegisteredTool,
@@ -22,7 +22,7 @@ from core.tool.registry import ToolRegistry, normalize_surfaces
 
 __all__ = [
     "REGISTERED_TOOL_ATTR",
-    "AgentToolContext",
+    "AgentToolScope",
     "BaseTool",
     "BeforeToolCallResult",
     "EvidenceType",

--- a/core/tool/contracts.py
+++ b/core/tool/contracts.py
@@ -121,7 +121,7 @@ def _json_type_matches(value: Any, schema_type: str) -> bool:
     if schema_type == "integer":
         return isinstance(value, int) and not isinstance(value, bool)
     if schema_type == "number":
-        return isinstance(value, (int, float)) and not isinstance(value, bool)
+        return isinstance(value, int | float) and not isinstance(value, bool)
     if schema_type == "boolean":
         return isinstance(value, bool)
     if schema_type == "array":
@@ -700,7 +700,7 @@ class RegisteredTool:
 
 
 @dataclass(frozen=True)
-class AgentToolContext:
+class AgentToolScope:
     """Resources available while a first-class agent tool executes."""
 
     resolved_integrations: dict[str, Any]
@@ -719,7 +719,7 @@ class AgentToolContext:
 
 
 # CodeQL currently misses PEP 695 ``type`` aliases in ``__all__`` export checks.
-AgentToolExecutor: TypeAlias = Callable[[dict[str, Any], AgentToolContext], Any]  # noqa: UP040
+AgentToolExecutor: TypeAlias = Callable[[dict[str, Any], AgentToolScope], Any]  # noqa: UP040
 
 
 class ToolParallelism(StrEnum):
@@ -797,8 +797,8 @@ RuntimeTool: TypeAlias = AgentTool | RegisteredTool  # noqa: UP040
 
 __all__ = [
     "AgentTool",
-    "AgentToolContext",
     "AgentToolExecutor",
+    "AgentToolScope",
     "BaseTool",
     "EvidenceType",
     "REGISTERED_TOOL_ATTR",

--- a/core/tool/execution.py
+++ b/core/tool/execution.py
@@ -12,7 +12,7 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 from core.llm.types import ToolCall
-from core.tool.contracts import AgentTool, AgentToolContext, RuntimeTool
+from core.tool.contracts import AgentTool, AgentToolScope, RuntimeTool
 from infrastructure.observability.errors.boundary import report_exception
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.observability.trace.spans import mark_span_outcome, tool_span
@@ -437,7 +437,7 @@ def _invoke_runtime_tool(
 ) -> Any:
     """Dispatch to AgentTool.execute or RegisteredTool.run."""
     if isinstance(tool, AgentTool):
-        context = AgentToolContext(
+        context = AgentToolScope(
             resolved_integrations=resolved_integrations,
             resources=runtime_resources,
             _emit_update=lambda update: _run_update_hook(hooks, request, update),
@@ -453,7 +453,7 @@ def _invoke_runtime_tool(
         if key in protected and value not in (None, "", []):
             kwargs[key] = value
     if getattr(tool, "accepts_runtime_context", False):
-        context = AgentToolContext(
+        context = AgentToolScope(
             resolved_integrations=resolved_integrations,
             resources=runtime_resources,
             _emit_update=lambda update: _run_update_hook(hooks, request, update),

--- a/docs/hosting-the-agent.mdx
+++ b/docs/hosting-the-agent.mdx
@@ -21,7 +21,7 @@ harness API. Nothing else under `core.agent_harness` is part of it.
 | **Embed** | run turns with the standard ports | `core.agent_harness` — `AgentSession`, `SessionConfig`, `SessionCore`, `SessionManager`, `TurnResult`, `ToolCallingTurnResult`, `OutputSink` |
 | **Host** | build one agent from your ports, handle it per message | `core.agent_harness.runtime` — `DefaultHeadlessBuild`, `InMemoryHeadlessBuild`, `HeadlessAgent`, `TurnBinding`, `GatherPhase`, `DefaultToolProvider`, `ActionTurnRunner`; also the ReAct engine the investigation pipeline shares (`AgentConfig`, `build_agent`, the default LLM factories) |
 | **Host** | call helpers around a turn | `core.agent_harness.spi.<role>` — `session_goal`, `session_state`, `cancel`, `accounting`, `prompt_chrome`, `integrations`, `grounding`, `defaults` |
-| **Write a tool** | implement an action tool | `core.agent_harness.tools` — `ActionToolContext`, `execute_with_action_context`, `capability_available_from_sources`, `HandoffField`, `EVIDENCE_KIND_VALUES` |
+| **Write a tool** | implement an action tool | `core.agent_harness.tools` — `ActionToolScope`, `execute_with_action_context`, `capability_available_from_sources`, `HandoffField`, `EVIDENCE_KIND_VALUES` |
 | **Implement** | satisfy a protocol the harness calls | `core.agent_harness.ports` — `OutputSink`, `ToolProvider`, `PromptContextProvider`, `ReasoningClientProvider`, `RunRecordFactory`, `ErrorReporter`, `TurnAccounting`, `SessionState`, and the rebind mix-ins `ConsoleBindable` / `OutputBindable` / `SessionBindable` |
 
 ## The host loop

--- a/tests/core/agent/orchestration/test_ask_choice_tool.py
+++ b/tests/core/agent/orchestration/test_ask_choice_tool.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from rich.console import Console
 
-from core.agent_harness.tools.tool_context import ActionToolContext
+from core.agent_harness.tools.tool_context import ActionToolScope
 from core.agent_harness.turns.headless_adapters import InMemorySessionState
 from surfaces.interactive_shell.session import Session
 from tools.interactive_shell.actions.ask_choice import (
@@ -45,9 +45,9 @@ def _ctx(
     session: Any | None = None,
     ports: _Ports | None = None,
     is_tty: bool | None = None,
-) -> ActionToolContext:
+) -> ActionToolScope:
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
-    return ActionToolContext(
+    return ActionToolScope(
         session=session if session is not None else Session(),
         console=console,
         slash_ports=ports if ports is not None else _Ports(),

--- a/tests/core/agent/orchestration/test_slash_tool.py
+++ b/tests/core/agent/orchestration/test_slash_tool.py
@@ -16,7 +16,7 @@ import pytest
 from rich.console import Console
 
 import tools.interactive_shell.actions.slash as slash_tool
-from core.agent_harness.tools.tool_context import ActionToolContext
+from core.agent_harness.tools.tool_context import ActionToolScope
 from surfaces.interactive_shell.session import Session
 
 
@@ -60,14 +60,14 @@ def _ctx(
     *,
     ports: FakeSlashPorts | None = None,
     request_exit: Any = None,
-) -> tuple[ActionToolContext, io.StringIO, Session, FakeSlashPorts]:
+) -> tuple[ActionToolScope, io.StringIO, Session, FakeSlashPorts]:
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False, highlight=False)
     session = Session()
     resolved_ports = ports or FakeSlashPorts()
 
     return (
-        ActionToolContext(
+        ActionToolScope(
             session=session,
             console=console,
             request_exit=request_exit,
@@ -353,7 +353,7 @@ def test_failed_rows_from_earlier_turns_are_not_evidence() -> None:
     session = Session()
     session.record("slash", "/health", ok=False, response_text="old failure")
     ports = FakeSlashPorts(tty=True)
-    ctx = ActionToolContext(
+    ctx = ActionToolScope(
         session=session,
         console=console,
         slash_ports=ports,
@@ -387,7 +387,7 @@ def test_cron_list_output_reaches_the_model(monkeypatch: pytest.MonkeyPatch) -> 
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False, highlight=False)
     session = Session()
-    ctx = ActionToolContext(
+    ctx = ActionToolScope(
         session=session,
         console=console,
         is_tty=True,
@@ -421,7 +421,7 @@ def test_cron_remove_missing_task_id_regression(monkeypatch: pytest.MonkeyPatch)
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False, highlight=False)
     session = Session()
-    ctx = ActionToolContext(
+    ctx = ActionToolScope(
         session=session,
         console=console,
         is_tty=True,

--- a/tests/core/agent/test_tool_registry.py
+++ b/tests/core/agent/test_tool_registry.py
@@ -11,7 +11,7 @@ from core.agent_harness.tools.action_tools import (
     get_action_tools_from_integrations_context,
 )
 from core.agent_harness.tools.tool_context import (
-    ActionToolContext,
+    ActionToolScope,
 )
 from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.session import Session
@@ -24,7 +24,7 @@ def _action_tools(
     *,
     resolved_integrations: dict[str, dict[str, str]] | None = None,
 ) -> list[object]:
-    ctx = ActionToolContext(session=session, console=Console(force_terminal=False))
+    ctx = ActionToolScope(session=session, console=Console(force_terminal=False))
     return get_action_tools_from_integrations_context(
         ctx, resolved_integrations=resolved_integrations
     )
@@ -220,7 +220,7 @@ def test_llm_set_provider_offered_by_default() -> None:
 
 def test_registry_agent_tools_exclude_unavailable_tool() -> None:
     session = Session(available_capabilities={"slash_commands": ()})
-    ctx = ActionToolContext(session=session, console=Console(force_terminal=False))
+    ctx = ActionToolScope(session=session, console=Console(force_terminal=False))
     names = {tool.name for tool in get_action_tools_from_integrations_context(ctx)}
     assert "slash_invoke" not in names
 

--- a/tests/core/agent/test_turn_scenarios.py
+++ b/tests/core/agent/test_turn_scenarios.py
@@ -11,13 +11,13 @@ from typing import Any, NotRequired, TypedDict, cast
 import pytest
 from rich.console import Console
 
-from core import Agent, AgentTool, AgentToolContext
+from core import Agent, AgentTool, AgentToolScope
 from core.agent_harness.prompts import (
     build_action_system_prompt,
     build_action_user_message,
 )
 from core.agent_harness.tools.action_tools import get_action_tools_from_integrations_context
-from core.agent_harness.tools.tool_context import ActionToolContext
+from core.agent_harness.tools.tool_context import ActionToolScope
 from core.agent_harness.turns.action_driver import _MAX_TOOL_CALLING_ITERATIONS
 from core.llm.shared.llm_retry import LLMCreditExhaustedError
 from core.llm.types import ToolCall
@@ -219,7 +219,7 @@ def _build_actual_action(action: ToolCall) -> ExpectedAction:
 def _planning_probe_tool(tool: AgentTool) -> AgentTool:
     """Return an inert copy of an action tool for live planning assertions."""
 
-    def _execute(args: dict[str, Any], _ctx: AgentToolContext) -> dict[str, Any]:
+    def _execute(args: dict[str, Any], _ctx: AgentToolScope) -> dict[str, Any]:
         if tool.name == "slash_invoke":
             command = str(args.get("command", "")).strip()
             raw_args = args.get("args")
@@ -630,7 +630,7 @@ def _assert_live_action_planning_once(case: ScenarioCase) -> None:
         _assert_planned_actions_match(actual_actions, expected_actions)
         return
 
-    ctx = ActionToolContext(
+    ctx = ActionToolScope(
         session=session, console=Console(file=io.StringIO(), force_terminal=False)
     )
     tools = get_action_tools_from_integrations_context(ctx, resolved_integrations=resolved_override)

--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -6,7 +6,7 @@ import pytest
 
 from core.agent_harness.prompts.memory.conversation import expand_affirmative_follow_up
 from core.agent_harness.session.pending_offer import PendingScheduleOffer
-from core.agent_harness.tools.tool_context import ActionToolContext
+from core.agent_harness.tools.tool_context import ActionToolScope
 from core.agent_harness.turns.headless_adapters import InMemorySessionState, NoopTurnAccounting
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
@@ -65,7 +65,7 @@ def test_propose_tool_sets_session_pending_offer() -> None:
         ok=True,
         response_text="Some headline",
     )
-    ctx = ActionToolContext(session=session, console=object())
+    ctx = ActionToolScope(session=session, console=object())
     briefing = (
         "Good morning! Here is your briefing.\n"
         "Weather — Amsterdam: ☀️ +20°C\n"
@@ -94,7 +94,7 @@ def test_propose_tool_sets_session_pending_offer() -> None:
 def test_propose_alone_without_briefing_work_is_rejected() -> None:
     """User symptom: 'give me a morning report' → only Want me to, no weather."""
     session = InMemorySessionState()
-    ctx = ActionToolContext(session=session, console=object())
+    ctx = ActionToolScope(session=session, console=object())
     result = execute_propose_scheduled_delivery_tool(
         {
             "kind": "daily_summary",
@@ -231,10 +231,10 @@ def test_slash_tool_rebuild_keeps_cron_expression_for_dispatch() -> None:
     dispatched: list[str] = []
     from rich.console import Console
 
-    from core.agent_harness.tools.tool_context import ActionToolContext
+    from core.agent_harness.tools.tool_context import ActionToolScope
     from core.agent_harness.turns.headless_adapters import InMemorySessionState
 
-    ctx = ActionToolContext(
+    ctx = ActionToolScope(
         session=InMemorySessionState(),
         console=Console(force_terminal=False, highlight=False),
         slash_ports=_Ports(),
@@ -400,7 +400,7 @@ def test_a_stale_fetch_from_an_earlier_turn_does_not_unlock_the_offer() -> None:
     reached through a different door.
     """
     # Arrange
-    from core.agent_harness.tools.tool_context import ActionToolContext
+    from core.agent_harness.tools.tool_context import ActionToolScope
     from core.agent_harness.turns.headless_adapters import InMemorySessionState
     from tools.interactive_shell.actions.propose_scheduled_delivery import (
         execute_propose_scheduled_delivery_tool,
@@ -411,7 +411,7 @@ def test_a_stale_fetch_from_an_earlier_turn_does_not_unlock_the_offer() -> None:
     session.record("shell", "curl -s 'wttr.in/Amsterdam?format=3'", ok=True)
     session.record("shell", "curl -s 'https://feeds.bbci.co.uk/news/rss.xml'", ok=True)
     # This turn starts here and fetches nothing.
-    ctx = ActionToolContext(session=session, console=object(), history_start=len(session.history))
+    ctx = ActionToolScope(session=session, console=object(), history_start=len(session.history))
 
     # Act
     result = execute_propose_scheduled_delivery_tool(

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -181,7 +181,7 @@ RUNTIME = frozenset(
 TOOLS = frozenset(
     {
         "EVIDENCE_KIND_VALUES",
-        "ActionToolContext",
+        "ActionToolScope",
         "HandoffField",
         "action_context_from_agent_context",
         "capability_available_from_sources",

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -24,7 +24,7 @@ from core.messages import (
     UserRuntimeMessage,
 )
 from core.provider import ProviderHooks
-from core.tool.contracts import AgentTool, AgentToolContext, RegisteredTool
+from core.tool.contracts import AgentTool, AgentToolScope, RegisteredTool
 
 
 class FakeLLM:
@@ -546,7 +546,7 @@ def test_follow_up_runs_after_an_accepted_final_answer() -> None:
 
 
 def test_agent_tool_context_update_emits_tool_execution_update() -> None:
-    def execute(_payload: dict[str, Any], context: AgentToolContext) -> dict[str, Any]:
+    def execute(_payload: dict[str, Any], context: AgentToolScope) -> dict[str, Any]:
         assert context.on_update is not None
         context.on_update({"status": "halfway"})
         return {"ok": True}

--- a/tests/core/tool/test_execution.py
+++ b/tests/core/tool/test_execution.py
@@ -9,7 +9,7 @@ import pytest
 from core.agent import Agent
 from core.llm.types import AgentLLMResponse, ToolCall
 from core.provider import ProviderHooks, ProviderRequest
-from core.tool.contracts import AgentTool, AgentToolContext, RegisteredTool
+from core.tool.contracts import AgentTool, AgentToolScope, RegisteredTool
 from core.tool.execution import (
     BeforeToolCallResult,
     ToolExecutionHooks,
@@ -58,7 +58,7 @@ def _call(name: str = "echo", value: str = "ok") -> ToolCall:
 def test_execute_tool_calls_validates_arguments_before_execution() -> None:
     called = False
 
-    def execute(_args: dict[str, Any], _ctx: AgentToolContext) -> dict[str, Any]:
+    def execute(_args: dict[str, Any], _ctx: AgentToolScope) -> dict[str, Any]:
         nonlocal called
         called = True
         return {"ok": True}
@@ -215,7 +215,7 @@ def test_after_hook_runs_when_tool_raises() -> None:
     """Raised exceptions become error results and still notify after_tool_call."""
     seen: list[str] = []
 
-    def execute(_args: dict[str, Any], _ctx: AgentToolContext) -> dict[str, Any]:
+    def execute(_args: dict[str, Any], _ctx: AgentToolScope) -> dict[str, Any]:
         raise ConnectionError("Connection to 172.29.15.185 timed out. (connect timeout=10)")
 
     def after(request: ToolExecutionRequest, result: ToolExecutionResult) -> None:
@@ -237,7 +237,7 @@ def test_after_hook_runs_when_tool_raises() -> None:
 def test_partial_tool_update_events_are_forwarded() -> None:
     updates: list[tuple[str, Any]] = []
 
-    def execute(args: dict[str, Any], ctx: AgentToolContext) -> dict[str, Any]:
+    def execute(args: dict[str, Any], ctx: AgentToolScope) -> dict[str, Any]:
         ctx.emit_update({"seen": args["value"]})
         return {"done": True}
 
@@ -257,7 +257,7 @@ def test_partial_tool_update_events_are_forwarded() -> None:
 def test_registered_tool_receives_runtime_context_only_when_opted_in() -> None:
     seen: dict[str, Any] = {}
 
-    def run(value: str, context: AgentToolContext) -> dict[str, Any]:
+    def run(value: str, context: AgentToolScope) -> dict[str, Any]:
         seen["value"] = value
         seen["resource"] = context.resources["marker"]
         return {"ok": True}
@@ -792,10 +792,10 @@ def test_execute_tool_calls_span_marks_tool_error_and_exception(
     session_id = "sess-tool-err"
     path = _activate_tool_trace(tmp_path, monkeypatch, session_id)
 
-    def soft_fail(_args: dict[str, Any], _ctx: AgentToolContext) -> dict[str, Any]:
+    def soft_fail(_args: dict[str, Any], _ctx: AgentToolScope) -> dict[str, Any]:
         return {"error": "soft fail"}
 
-    def hard_fail(_args: dict[str, Any], _ctx: AgentToolContext) -> dict[str, Any]:
+    def hard_fail(_args: dict[str, Any], _ctx: AgentToolScope) -> dict[str, Any]:
         raise RuntimeError("hard fail")
 
     try:

--- a/tests/tools/test_architecture_issue_tool.py
+++ b/tests/tools/test_architecture_issue_tool.py
@@ -196,19 +196,19 @@ def test_architecture_save_observations_tool_reads_session_from_context(
 ) -> None:
     from core.agent_harness.tools.tool_context import (
         ACTION_TOOL_CONTEXT_RESOURCE_KEY,
-        ActionToolContext,
+        ActionToolScope,
     )
-    from core.tool.contracts import AgentToolContext
+    from core.tool.contracts import AgentToolScope
 
     monkeypatch.setattr(
         "integrations.github.tools.architecture_issue_tool.tool.save_architecture_observations",
         partial(save_architecture_observations, home_dir=tmp_path),
     )
     session = SimpleNamespace(session_id="ctx-session-id")
-    context = AgentToolContext(
+    context = AgentToolScope(
         resolved_integrations={},
         resources={
-            ACTION_TOOL_CONTEXT_RESOURCE_KEY: ActionToolContext(
+            ACTION_TOOL_CONTEXT_RESOURCE_KEY: ActionToolScope(
                 session=session,
                 console=SimpleNamespace(),
             )

--- a/tests/tools/test_github_ci_fix.py
+++ b/tests/tools/test_github_ci_fix.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock, patch
 
 from core.agent_harness.tools.tool_context import (
     ACTION_TOOL_CONTEXT_RESOURCE_KEY,
-    ActionToolContext,
+    ActionToolScope,
 )
-from core.tool.contracts import AgentToolContext, RegisteredTool
+from core.tool.contracts import AgentToolScope, RegisteredTool
 from integrations.coding_agent import CodingResult
 from integrations.github.tools.ci_fix.context import (
     CiFixContext,
@@ -450,10 +450,10 @@ def test_tool_passes_shell_confirmation_function() -> None:
     def confirm(_prompt: str) -> str:
         return "y"
 
-    agent_context = AgentToolContext(
+    agent_context = AgentToolScope(
         resolved_integrations={},
         resources={
-            ACTION_TOOL_CONTEXT_RESOURCE_KEY: ActionToolContext(
+            ACTION_TOOL_CONTEXT_RESOURCE_KEY: ActionToolScope(
                 session=object(),
                 console=SimpleNamespace(),
                 confirm_fn=confirm,

--- a/tests/tools/test_github_security_fix.py
+++ b/tests/tools/test_github_security_fix.py
@@ -10,9 +10,9 @@ from unittest.mock import MagicMock, patch
 
 from core.agent_harness.tools.tool_context import (
     ACTION_TOOL_CONTEXT_RESOURCE_KEY,
-    ActionToolContext,
+    ActionToolScope,
 )
-from core.tool.contracts import AgentToolContext, RegisteredTool
+from core.tool.contracts import AgentToolScope, RegisteredTool
 from integrations.coding_agent import CodingResult
 from integrations.github.client import GitHubRestClient
 from integrations.github.pull_requests import PullRequest
@@ -769,10 +769,10 @@ def test_tool_passes_repl_confirmation_function() -> None:
     def confirm(_prompt: str) -> str:
         return "y"
 
-    agent_context = AgentToolContext(
+    agent_context = AgentToolScope(
         resolved_integrations={},
         resources={
-            ACTION_TOOL_CONTEXT_RESOURCE_KEY: ActionToolContext(
+            ACTION_TOOL_CONTEXT_RESOURCE_KEY: ActionToolScope(
                 session=object(),
                 console=SimpleNamespace(),
                 confirm_fn=confirm,

--- a/tests/tools/test_sentry_fix_action.py
+++ b/tests/tools/test_sentry_fix_action.py
@@ -16,18 +16,18 @@ from rich.console import Console
 import tools.interactive_shell.actions.sentry_fix as sentry_fix
 from core.agent_harness.tools.tool_context import (
     ACTION_TOOL_CONTEXT_RESOURCE_KEY,
-    ActionToolContext,
+    ActionToolScope,
 )
-from core.tool.contracts import AgentToolContext
+from core.tool.contracts import AgentToolScope
 
 _TOOL_RUN = "tools.interactive_shell.actions.sentry_fix.fix_sentry_issue.run"
 _URL = "https://acme.sentry.io/issues/12345/"
 
 
-def _ctx() -> tuple[ActionToolContext, io.StringIO]:
+def _ctx() -> tuple[ActionToolScope, io.StringIO]:
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False, highlight=False, width=200)
-    return ActionToolContext(session=MagicMock(), console=console), buf
+    return ActionToolScope(session=MagicMock(), console=console), buf
 
 
 # --------------------------------------------------------------------------- #
@@ -155,7 +155,7 @@ def test_renders_pr_failed_recovery_says_already_pushed(mock_run: MagicMock) -> 
 @patch(_TOOL_RUN, return_value={"success": True, "issue_id": "1", "pr_url": None})
 def test_run_sentry_fix_uses_action_context(mock_run: MagicMock) -> None:
     action_ctx, _ = _ctx()
-    agent_ctx = AgentToolContext(
+    agent_ctx = AgentToolScope(
         resolved_integrations={},
         resources={ACTION_TOOL_CONTEXT_RESOURCE_KEY: action_ctx},
     )

--- a/tools/interactive_shell/AGENTS.md
+++ b/tools/interactive_shell/AGENTS.md
@@ -34,7 +34,7 @@ Subprocess runners must stay split into two layers:
    no `execution_confirm`.
 2. **REPL presentation** under `surfaces/interactive_shell/runtime/subprocess_runner/`
    — `ReplSubprocessPresenter` implements `SubprocessPresenter` and is injected
-   through `ActionToolContext.subprocess_presenter` from `action_turn.py`.
+   through `ActionToolScope.subprocess_presenter` from `action_turn.py`.
 
 Shared stdlib-only helpers live in `tools/interactive_shell/subprocess.py`.
 Rich stream relay stays in `surfaces/.../subprocess_runner/task_streaming.py`.

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -18,7 +18,7 @@ from core.agent_harness.spi.session_state import (
     session_terminal,
     set_auto_command,
 )
-from core.agent_harness.tools import ActionToolContext, execute_with_action_context
+from core.agent_harness.tools import ActionToolScope, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_array_property, string_property
@@ -40,7 +40,7 @@ _QUEUED_INSTRUCTION = (
 )
 
 
-def _menu_available(ctx: ActionToolContext) -> bool:
+def _menu_available(ctx: ActionToolScope) -> bool:
     """True when the REPL can render the deferred ``/choose`` picker.
 
     Mirrors ``_slash_drives_interactive_picker``: gateway/headless sessions have
@@ -53,7 +53,7 @@ def _menu_available(ctx: ActionToolContext) -> bool:
     return ports is not None and bool(ports.tty_interactive())
 
 
-def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolContext) -> dict[str, Any]:
+def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
     title = str(args.get("title", "")).strip()
     raw_options = args.get("options")
     options: list[str] = []

--- a/tools/interactive_shell/actions/assistant_handoff.py
+++ b/tools/interactive_shell/actions/assistant_handoff.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.agent_harness.tools import (
     EVIDENCE_KIND_VALUES,
-    ActionToolContext,
+    ActionToolScope,
     HandoffField,
     execute_with_action_context,
 )
@@ -15,7 +15,7 @@ from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_array_property, string_property
 
 
-def execute_assistant_handoff_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_assistant_handoff_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     _ = args
     _ = ctx
     # Handoffs are informational planning outputs and intentionally

--- a/tools/interactive_shell/actions/cli_command.py
+++ b/tools/interactive_shell/actions/cli_command.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -16,7 +16,7 @@ from tools.interactive_shell.cli import run_opensre_cli_command
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 
 
-def execute_cli_command_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_cli_command_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     payload = str(args.get("payload", "")).strip()
     if not payload:
         return False

--- a/tools/interactive_shell/actions/implementation.py
+++ b/tools/interactive_shell/actions/implementation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -18,7 +18,7 @@ from tools.interactive_shell.implementation.claude_code_executor import (
 from tools.interactive_shell.subprocess import require_subprocess_presenter
 
 
-def execute_implementation_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_implementation_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     task = str(args.get("task", "")).strip()
     if not task:
         return False

--- a/tools/interactive_shell/actions/investigation.py
+++ b/tools/interactive_shell/actions/investigation.py
@@ -8,7 +8,7 @@ from typing import Any
 from rich.console import Console
 
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -90,7 +90,7 @@ def run_text_investigation(
     )
 
 
-def execute_investigation_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_investigation_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     alert_text = normalize_investigation_alert_text(str(args.get("alert_text", "")))
     if not alert_text:
         return False

--- a/tools/interactive_shell/actions/llm_provider.py
+++ b/tools/interactive_shell/actions/llm_provider.py
@@ -8,7 +8,7 @@ from rich.markup import escape
 
 from config.llm_auth.provider_catalog import PROVIDER_BY_VALUE
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -38,13 +38,13 @@ def _target_property_schema() -> dict[str, Any]:
     }
 
 
-def _apply_model_set_target(target: str, ctx: ActionToolContext) -> bool:
+def _apply_model_set_target(target: str, ctx: ActionToolScope) -> bool:
     if ctx.llm_provider_ports is None:
         raise RuntimeError("LLM provider tool requires provider runtime ports")
     return bool(ctx.llm_provider_ports.apply_target(target, ctx.console))
 
 
-def execute_llm_provider_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_llm_provider_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     target = str(args.get("target", args.get("provider", ""))).strip()
     if not target:
         return False

--- a/tools/interactive_shell/actions/propose_scheduled_delivery.py
+++ b/tools/interactive_shell/actions/propose_scheduled_delivery.py
@@ -8,7 +8,7 @@ from core.agent_harness.spi.session_state import (
     PendingScheduleOffer,
     clear_competing_pending_offers,
 )
-from core.agent_harness.tools import ActionToolContext, execute_with_action_context
+from core.agent_harness.tools import ActionToolScope, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
@@ -68,7 +68,7 @@ def _briefing_looks_real(text: str) -> bool:
 
 
 def execute_propose_scheduled_delivery_tool(
-    args: dict[str, Any], ctx: ActionToolContext
+    args: dict[str, Any], ctx: ActionToolScope
 ) -> dict[str, Any]:
     kind = str(args.get("kind", "")).strip().lower()
     cron = " ".join(str(args.get("cron", "")).split())

--- a/tools/interactive_shell/actions/sample_alert.py
+++ b/tools/interactive_shell/actions/sample_alert.py
@@ -8,7 +8,7 @@ from typing import Any
 from rich.console import Console
 
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -70,7 +70,7 @@ def run_sample_alert(
     )
 
 
-def execute_sample_alert_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_sample_alert_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     template = str(args.get("template", "")).strip()
     if not template:
         return False

--- a/tools/interactive_shell/actions/sentry_fix.py
+++ b/tools/interactive_shell/actions/sentry_fix.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness.tools import ActionToolContext, execute_with_action_context
+from core.agent_harness.tools import ActionToolScope, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
@@ -69,7 +69,7 @@ def _render_result(console: Any, out: dict[str, Any]) -> None:
         console.print("[dim]Diff left in your working tree (no PR requested).[/]")
 
 
-def execute_sentry_fix_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_sentry_fix_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     sentry_url = str(args.get("sentry_url", "")).strip()
     if not sentry_url:
         return False

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -24,7 +24,7 @@ def _coerce_quiet(value: Any) -> bool:
     return bool(value)
 
 
-def execute_shell_tool(args: dict[str, Any], ctx: ActionToolContext) -> dict[str, Any]:
+def execute_shell_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
     command = str(args.get("command", "")).strip()
     if not command:
         return {"ok": False, "command": "", "response_text": "missing shell command"}

--- a/tools/interactive_shell/actions/skill_view.py
+++ b/tools/interactive_shell/actions/skill_view.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.spi.grounding import list_action_skills, load_skill_body
-from core.agent_harness.tools import ActionToolContext, execute_with_action_context
+from core.agent_harness.tools import ActionToolScope, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 
 
-def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolContext) -> dict[str, Any]:
+def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
     _ = ctx
     name = str(args.get("name", "")).strip()
     if not name:

--- a/tools/interactive_shell/actions/slash.py
+++ b/tools/interactive_shell/actions/slash.py
@@ -12,8 +12,8 @@ from core.agent_harness.spi.session_state import (
     session_terminal,
     set_auto_command,
 )
-from core.agent_harness.tools import (
-    ActionToolContext,
+from core.agent_harness.tools.tool_context import (
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -82,7 +82,7 @@ _MAX_OBSERVED_OUTPUT_CHARS = 2000
 
 
 def _dispatch_and_translate_exit(
-    command: str, ctx: ActionToolContext, **kwargs: Any
+    command: str, ctx: ActionToolScope, **kwargs: Any
 ) -> bool | dict[str, Any]:
     should_continue = ctx.slash_ports.dispatch(
         command,
@@ -97,7 +97,7 @@ def _dispatch_and_translate_exit(
     return _slash_observation(ctx, command)
 
 
-def _slash_observation(ctx: ActionToolContext, command: str) -> bool | dict[str, Any]:
+def _slash_observation(ctx: ActionToolScope, command: str) -> bool | dict[str, Any]:
     """Build the model-facing result from the slash row this dispatch recorded.
 
     ``dispatch_slash`` records a history row for the command with an outcome
@@ -178,7 +178,7 @@ def _slash_line_parts(stripped: str) -> list[str]:
         return stripped.split()
 
 
-def execute_slash_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool | dict[str, Any]:
+def execute_slash_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool | dict[str, Any]:
     if ctx.slash_ports is None:
         raise RuntimeError("slash tool requires slash runtime ports")
     command = str(args.get("command", "")).strip()

--- a/tools/interactive_shell/actions/synthetic.py
+++ b/tools/interactive_shell/actions/synthetic.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from config.constants.paths import SYNTHETIC_SCENARIOS_DIR
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -35,7 +35,7 @@ def list_rds_postgres_scenarios() -> tuple[str, ...]:
     )
 
 
-def execute_synthetic_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_synthetic_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     suite = str(args.get("suite", "")).strip()
     scenario = str(args.get("scenario", "")).strip()
     if not suite or not scenario:

--- a/tools/interactive_shell/actions/task_cancel.py
+++ b/tools/interactive_shell/actions/task_cancel.py
@@ -8,7 +8,7 @@ from typing import Any
 from rich.markup import escape
 
 from core.agent_harness.tools import (
-    ActionToolContext,
+    ActionToolScope,
     capability_available_from_sources,
     execute_with_action_context,
 )
@@ -19,7 +19,7 @@ from infrastructure.scheduling.task_types import TaskKind, TaskStatus
 from tools.interactive_shell.shared import plan_foreground_tool
 
 
-def _running_task_matches(ctx: ActionToolContext, target: str) -> Sequence[object]:
+def _running_task_matches(ctx: ActionToolScope, target: str) -> Sequence[object]:
     running = [
         task
         for task in ctx.session.task_registry.list_recent(n=50)
@@ -32,7 +32,7 @@ def _running_task_matches(ctx: ActionToolContext, target: str) -> Sequence[objec
     return []
 
 
-def _resolve_task_cancel_target(ctx: ActionToolContext, target: str) -> str | None:
+def _resolve_task_cancel_target(ctx: ActionToolScope, target: str) -> str | None:
     if target in {"synthetic_test", "task"}:
         matches = _running_task_matches(ctx, target)
         if not matches:
@@ -66,7 +66,7 @@ def _resolve_task_cancel_target(ctx: ActionToolContext, target: str) -> str | No
     return str(candidates[0].task_id)
 
 
-def execute_task_cancel_tool(args: dict[str, Any], ctx: ActionToolContext) -> bool:
+def execute_task_cancel_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     target = str(args.get("target", "")).strip()
     if not target:
         return False

--- a/tools/interactive_shell/subprocess.py
+++ b/tools/interactive_shell/subprocess.py
@@ -12,7 +12,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
-from core.agent_harness.tools import ActionToolContext
+from core.agent_harness.tools import ActionToolScope
 from tools.interactive_shell.shared import ExecutionPolicyResult
 
 # --- constants ---
@@ -198,7 +198,7 @@ class SubprocessPresenter(Protocol):
         """Launch a background opensre CLI subprocess with streamed output."""
 
 
-def require_subprocess_presenter(ctx: ActionToolContext) -> SubprocessPresenter:
+def require_subprocess_presenter(ctx: ActionToolScope) -> SubprocessPresenter:
     presenter = ctx.subprocess_presenter
     if not isinstance(presenter, SubprocessPresenter):
         raise RuntimeError("subprocess presenter is required for this action tool")

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -25,7 +25,7 @@ from core.domain.work_items import (
     update_work_item,
     work_items_path,
 )
-from core.tool import AgentToolContext, SideEffectLevel
+from core.tool import AgentToolScope, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from infrastructure.scheduling.scheduler.store import add_task as add_scheduled_task
 from infrastructure.scheduling.scheduler.store import list_tasks, update_task
@@ -55,7 +55,7 @@ def _work_items_available(_sources: dict[str, dict[str, Any]]) -> bool:
     return True
 
 
-def _gateway_delivery_context(context: AgentToolContext | None) -> tuple[str, str]:
+def _gateway_delivery_context(context: AgentToolScope | None) -> tuple[str, str]:
     if context is None:
         return "", ""
     try:
@@ -76,7 +76,7 @@ def _delivery_targets(
     chat_id: str,
     item: WorkItem | None = None,
     channel_targets: list[dict[str, str]] | None = None,
-    context: AgentToolContext | None = None,
+    context: AgentToolScope | None = None,
 ) -> list[WorkItemChannelTarget]:
     default_provider, default_chat_id = _gateway_delivery_context(context)
     targets: list[WorkItemChannelTarget] = []
@@ -269,7 +269,7 @@ def work_task_add(
     channel_id: str = "",
     channel_targets: list[dict[str, str]] | None = None,
     timezone: str = "UTC",
-    context: AgentToolContext | None = None,
+    context: AgentToolScope | None = None,
 ) -> dict[str, Any]:
     if not str(title or "").strip():
         return {"error": "empty_title", "detail": "title must be a non-empty string"}
@@ -464,7 +464,7 @@ def work_task_update(
     channel_id: str = "",
     channel_targets: list[dict[str, str]] | None = None,
     timezone: str = "UTC",
-    context: AgentToolContext | None = None,
+    context: AgentToolScope | None = None,
 ) -> dict[str, Any]:
     changes: WorkItemUpdates = {}
     if status:
@@ -659,7 +659,7 @@ def work_task_schedule_checkin(
     channel_targets: list[dict[str, str]] | None = None,
     project: str = "",
     limit: int = DEFAULT_PRIORITY_LIMIT,
-    context: AgentToolContext | None = None,
+    context: AgentToolScope | None = None,
 ) -> dict[str, Any]:
     parts = cron.split()
     if len(parts) != 5:


### PR DESCRIPTION
Closes #5382

### Summary of Changes
- Renamed `ActionToolContext` -> `ActionToolScope` in `core/agent_harness/tools/tool_context.py` and downstream tools/tests.
- Renamed `AgentToolContext` -> `AgentToolScope` in `core/types.py`, `core/__init__.py`, `core/execution.py`, and downstream tools/tests.
- Updated all action tool executors, harness adapters, and test fixtures.
- Zero backwards-compatibility re-exports retained per `AGENTS.md`.

### Verification
- `uv run pytest <affected test suites>` -> 208 passed
- `uv run python .github/ci/check_imports.py` -> 3/3 import checks passed
- `uv run ruff check` & `uv run ruff format --check` -> Clean
