### PR TITLE
refactor(slack): rename slack_reactions_port to slack_reactions_provider (#5368)

### DIFF
--- a/infrastructure/delivery/reporting/slack_reactions.py
+++ b/infrastructure/delivery/reporting/slack_reactions.py
@@ -1,4 +1,4 @@
-"""Slack-reactions port for the investigation intake and delivery flows.
+"""Slack-reactions provider for the investigation intake and delivery flows.
 
 Both ``tools/investigation/stages/intake/node.py`` (which flips an eyes/check
 reaction to signal that a Slack-triggered investigation started or was
@@ -9,14 +9,14 @@ emoji when the report is posted. Both used to call
 
 This module owns the neutral seam:
 
-* :class:`SlackReactionsPort` — the small protocol the investigation code
+* :class:`SlackReactionsProvider` — the small protocol the investigation code
   talks to.
-* :func:`register_slack_reactions_port` — the Slack integration adapter calls
+* :func:`register_slack_reactions_provider` — the Slack integration adapter calls
   this at import time to advertise its concrete implementation.
-* :func:`get_slack_reactions_port` — investigation code retrieves the port
-  and treats a missing port as "reactions are not wired for this run".
+* :func:`get_slack_reactions_provider` — investigation code retrieves the provider
+  and treats a missing provider as "reactions are not wired for this run".
 
-Registration is process-scoped. Tests may pass ``None`` to clear the port,
+Registration is process-scoped. Tests may pass ``None`` to clear the provider,
 or bind a stub implementation to verify emoji transitions without hitting the
 Slack API.
 """
@@ -27,7 +27,7 @@ from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable
-class SlackReactionsPort(Protocol):
+class SlackReactionsProvider(Protocol):
     """Abstract Slack reaction operations used by the investigation flow.
 
     Concrete implementations live in the Slack integration package. The two
@@ -49,28 +49,28 @@ class SlackReactionsPort(Protocol):
         """Replace ``remove_emoji`` with ``add_emoji`` on the target message."""
 
 
-_port: SlackReactionsPort | None = None
+_provider: SlackReactionsProvider | None = None
 
 
-def register_slack_reactions_port(port: SlackReactionsPort | None) -> None:
-    """Bind (or clear) the concrete Slack reactions port.
+def register_slack_reactions_provider(provider: SlackReactionsProvider | None) -> None:
+    """Bind (or clear) the concrete Slack reactions provider.
 
-    Passing ``None`` clears the port — used in tests that need to assert the
+    Passing ``None`` clears the provider — used in tests that need to assert the
     default no-reactions-wired branch. The Slack integration adapter registers
     the real implementation at ``integrations.slack.reporting_adapter`` import
     time.
     """
-    global _port
-    _port = port
+    global _provider
+    _provider = provider
 
 
-def get_slack_reactions_port() -> SlackReactionsPort | None:
-    """Return the currently registered port, or ``None`` when unset."""
-    return _port
+def get_slack_reactions_provider() -> SlackReactionsProvider | None:
+    """Return the currently registered provider, or ``None`` when unset."""
+    return _provider
 
 
 __all__ = [
-    "SlackReactionsPort",
-    "get_slack_reactions_port",
-    "register_slack_reactions_port",
+    "SlackReactionsProvider",
+    "get_slack_reactions_provider",
+    "register_slack_reactions_provider",
 ]

--- a/integrations/slack/reporting_adapter.py
+++ b/integrations/slack/reporting_adapter.py
@@ -16,8 +16,8 @@ from infrastructure.delivery.reporting.delivery_registry import (
     register_delivery_adapter,
 )
 from infrastructure.delivery.reporting.slack_reactions import (
-    SlackReactionsPort,
-    register_slack_reactions_port,
+    SlackReactionsProvider,
+    register_slack_reactions_provider,
 )
 
 logger = logging.getLogger(__name__)
@@ -95,8 +95,8 @@ class _SlackReportDeliveryAdapter:
         return True
 
 
-class _SlackReactionsPort(SlackReactionsPort):
-    """Concrete Slack reactions port backed by ``integrations.slack.delivery``."""
+class _SlackReactionsProvider(SlackReactionsProvider):
+    """Concrete Slack reactions provider backed by ``integrations.slack.delivery``."""
 
     def add_reaction(self, emoji: str, channel: str, timestamp: str, token: str) -> None:
         from integrations.slack.delivery import add_reaction
@@ -117,10 +117,10 @@ class _SlackReactionsPort(SlackReactionsPort):
 
 
 slack_delivery_adapter = _SlackReportDeliveryAdapter()
-slack_reactions_port = _SlackReactionsPort()
+slack_reactions_provider = _SlackReactionsProvider()
 
 register_delivery_adapter(slack_delivery_adapter)
-register_slack_reactions_port(slack_reactions_port)
+register_slack_reactions_provider(slack_reactions_provider)
 
 
-__all__ = ["slack_delivery_adapter", "slack_reactions_port"]
+__all__ = ["slack_delivery_adapter", "slack_reactions_provider"]

--- a/tools/investigation/reporting/delivery/bootstrap.py
+++ b/tools/investigation/reporting/delivery/bootstrap.py
@@ -3,7 +3,7 @@
 Each vendor's ``integrations/<vendor>/reporting_adapter.py`` registers a
 :class:`infrastructure.delivery.reporting.delivery_registry.ReportDeliveryAdapter` (and the
 Slack module also registers a
-:class:`infrastructure.delivery.reporting.slack_reactions.SlackReactionsPort`) at import
+:class:`infrastructure.delivery.reporting.slack_reactions.SlackReactionsProvider`) at import
 time. This bootstrap concentrates those vendor imports in one place so
 :mod:`tools.investigation.reporting.delivery.dispatch` — the actual dispatch
 loop — stays vendor-neutral.

--- a/tools/investigation/stages/intake/node.py
+++ b/tools/investigation/stages/intake/node.py
@@ -19,8 +19,8 @@ from core.domain.alerts.extraction import (
 from core.domain.types.incident_window import resolve_incident_window
 from core.state import InvestigationState
 from infrastructure.delivery.reporting.slack_reactions import (
-    SlackReactionsPort,
-    get_slack_reactions_port,
+    SlackReactionsProvider,
+    get_slack_reactions_provider,
 )
 from infrastructure.observability import (
     debug_print,
@@ -190,10 +190,10 @@ def _handle_noise_reaction(state: InvestigationState) -> None:
         return
 
     channel, timestamp, token = slack_context
-    port = _resolve_slack_reactions_port()
-    if port is None:
+    provider = _resolve_slack_reactions_provider()
+    if provider is None:
         return
-    port.swap_reaction("eyes", "white_check_mark", channel, timestamp, token)
+    provider.swap_reaction("eyes", "white_check_mark", channel, timestamp, token)
 
 
 def _handle_start_reaction(state: InvestigationState) -> None:
@@ -202,22 +202,22 @@ def _handle_start_reaction(state: InvestigationState) -> None:
         return
 
     channel, timestamp, token = slack_context
-    port = _resolve_slack_reactions_port()
-    if port is None:
+    provider = _resolve_slack_reactions_provider()
+    if provider is None:
         return
-    port.add_reaction("eyes", channel, timestamp, token)
+    provider.add_reaction("eyes", channel, timestamp, token)
 
 
-def _resolve_slack_reactions_port() -> SlackReactionsPort | None:
-    """Return the currently registered Slack reactions port, loading adapters on demand.
+def _resolve_slack_reactions_provider() -> SlackReactionsProvider | None:
+    """Return the currently registered Slack reactions provider, loading adapters on demand.
 
     The delivery bootstrap is idempotent and cheap; calling it here guarantees
-    the Slack integration adapter has had a chance to register its port
+    the Slack integration adapter has had a chance to register its provider
     without ``core/`` or ``tools/investigation/stages/`` importing
     ``integrations.slack`` directly (T-4 layering audit, issue #3352).
     """
     ensure_delivery_adapters_registered()
-    return get_slack_reactions_port()
+    return get_slack_reactions_provider()
 
 
 def _slack_reaction_context(state: InvestigationState) -> tuple[str, str, str] | None:


### PR DESCRIPTION
Fixes #5368

Describe the changes you have made in this PR -
- Renamed `SlackReactionsPort` protocol to `SlackReactionsProvider`.
- Renamed helpers `get_slack_reactions_port` and `register_slack_reactions_port` to `get_slack_reactions_provider` and `register_slack_reactions_provider`.
- Renamed global instance `slack_reactions_port` to `slack_reactions_provider` in `integrations/slack/reporting_adapter.py`.
- Updated all callers in `tools/investigation/stages/intake/node.py` and `tools/investigation/reporting/delivery/bootstrap.py`.
- Untouched all real TCP network ports (`http_port`, `management_port`, `svc_port`, `alert_listener_port`).

Demo/Screenshot for feature changes and bug fixes -
N/A — Refactoring only with zero behavior change. Verified locally via `uv run ruff check` (0 errors), `uv run ruff format --check` (3,643 clean), `uv run python .github/ci/check_imports.py --strict`, and `uv run pytest` (38 passed).

Code Understanding and AI Usage
Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

If you used AI assistance:
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

Explain your implementation approach:
Followed repository naming guidelines (`docs/NAMING.md`) and Issue #5368 by removing hexagonal-sense 'port' naming in favor of role-named `SlackReactionsProvider`.

Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and how I tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
