### PR TITLE
fix: Type SessionState.reasoning_effort as ReasoningEffortChoice | None

### DIFF
--- a/tests/core/agent_harness/test_chat_api.py
+++ b/tests/core/agent_harness/test_chat_api.py
@@ -136,6 +136,6 @@ def test_only_chat_api_module_defines_dispatch_chat_turn() -> None:
             continue
         for node in ast.walk(tree):
             if isinstance(node, ast.FunctionDef) and node.name == "dispatch_chat_turn":
-                definers.append(str(path.relative_to(root)))
+                definers.append(path.relative_to(root).as_posix())
 
     assert definers == ["core/agent_harness/turns/chat_api.py"], definers

--- a/tests/core/agent_harness/test_host_capability_ports.py
+++ b/tests/core/agent_harness/test_host_capability_ports.py
@@ -78,7 +78,7 @@ def _protocols_declaring_the_gate() -> set[str]:
                 and _is_protocol_class(node)
                 and _declares_the_wide_gate(node)
             ):
-                found.add(f"{path.relative_to(REPO_ROOT)}::{node.name}")
+                found.add(f"{path.relative_to(REPO_ROOT).as_posix()}::{node.name}")
     return found
 
 
@@ -148,7 +148,7 @@ def test_no_tier_redeclares_a_host_port_factory_alias() -> None:
     # Act
     offenders: dict[str, list[str]] = {}
     for path in _python_sources():
-        relative = str(path.relative_to(REPO_ROOT))
+        relative = path.relative_to(REPO_ROOT).as_posix()
         if relative == _ALIAS_HOME:
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))


### PR DESCRIPTION
Fixes #5225 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
The changes were made in files:
- `tests/core/agent_harness/test_chat_api.py`
- `tests/core/agent_harness/test_host_capability_ports.py`

Normalize Path.relative_to(...) with .as_posix() so comparisons use / on Windows as well as Unix.

Demo/Screenshot for feature changes and bug fixes - 
N/A. Ran all the tests using `uv run pytest tests/core/agent_harness -q`. All the tests passed.
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Normalize Path.relative_to(...) with .as_posix() so comparisons use / on Windows as well as Unix.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
