### PR TITLE
Install tool sources as a frozen ToolSources bundle instead of two mutable setters

### DIFF
--- a/core/agent_harness/tools/action_tools.py
+++ b/core/agent_harness/tools/action_tools.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import RegisteredTool
 from core.tool.execution import availability_view
-from infrastructure.harness_providers import get_surface_tool_map, get_surface_tools
+from infrastructure.harness_providers import resolve_surface_tool_map, resolve_surface_tools
 from infrastructure.observability.trace.redaction import redact_sensitive
 
 _ACTION_SESSION_SOURCE = "_action_session"
@@ -53,7 +53,7 @@ def get_action_tools_from_integrations_context(
     """Return canonical registered tools available to the action agent."""
     sources = _sources_for_context(ctx, resolved_integrations)
     tools: list[RegisteredTool] = []
-    for candidate in get_surface_tools(ToolSurface.ACTION):
+    for candidate in resolve_surface_tools(ToolSurface.ACTION):
         try:
             if not candidate.is_available(sources):
                 continue
@@ -68,7 +68,7 @@ def get_action_tools_from_integrations_context(
 
 def get_action_tool(name: str) -> RegisteredTool | None:
     """Return a registered action tool by name."""
-    return get_surface_tool_map(ToolSurface.ACTION).get(name)
+    return resolve_surface_tool_map(ToolSurface.ACTION).get(name)
 
 
 def action_tool_names(tools: Iterable[RegisteredTool]) -> tuple[str, ...]:

--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -305,7 +305,7 @@ def gather_tool_evidence(
         # Tool discovery, integration resolution, and LLM load run inside this
         # helper, within the ``_safe_execute`` fallback boundary.
         from core.agent_harness.turns.host_cancel import cancel_tool_resources
-        from infrastructure.harness_providers import get_investigation_tools
+        from infrastructure.harness_providers import resolve_investigation_tools
 
         if is_cancelled is not None and is_cancelled():
             log.debug("gather_evidence skip: host cancelled")
@@ -313,7 +313,7 @@ def gather_tool_evidence(
         resolved = _resolve_gather_integrations(
             session, message, resolved_integrations=resolved_integrations
         )
-        gather_tools = list(get_investigation_tools(resolved))
+        gather_tools = list(resolve_investigation_tools(resolved))
         if not _has_usable_gather_tools(gather_tools):
             log.debug("gather_evidence skip: no usable tools")
             return None

--- a/infrastructure/harness_providers/__init__.py
+++ b/infrastructure/harness_providers/__init__.py
@@ -104,11 +104,10 @@ from infrastructure.harness_providers.subprocess_presenter import (
 )
 from infrastructure.harness_providers.tool_registry import (
     InvestigationToolsFn,
-    get_investigation_tools,
-    get_surface_tool_map,
-    get_surface_tools,
-    set_investigation_tools_adapter,
-    set_tool_registry,
+    ToolSources,
+    resolve_investigation_tools,
+    resolve_surface_tool_map,
+    resolve_surface_tools,
 )
 from infrastructure.harness_providers.tool_registry import reset as _reset_tool_registry
 
@@ -173,6 +172,7 @@ __all__ = [
     "RemoteIntegrationsFetcher",
     "SetupableIntegrationServicesFn",
     "SubprocessPresenterProvider",
+    "ToolSources",
     "VcsRepoScopeProvider",
     "WebappVaultFetcherFn",
     "action_prompt_vendor_fragments",
@@ -193,9 +193,6 @@ __all__ = [
     "flatten_cli_messages_to_prompt",
     "gateway_persona_fragments",
     "gather_prompt_vendor_fragments",
-    "get_investigation_tools",
-    "get_surface_tool_map",
-    "get_surface_tools",
     "integration_setup_command",
     "metric_cohort_resolved_for",
     "metric_query_draft_for",
@@ -217,14 +214,15 @@ __all__ = [
     "reset_harness_providers",
     "resolve_integrations",
     "resolve_integrations_with_metadata",
+    "resolve_investigation_tools",
     "resolve_subprocess_presenter",
+    "resolve_surface_tool_map",
+    "resolve_surface_tools",
     "set_cli_llm_adapters",
     "set_integration_resolution_adapters",
     "set_integration_setup_command",
-    "set_investigation_tools_adapter",
     "set_remote_integrations_fetcher",
     "set_setupable_integration_services",
-    "set_tool_registry",
     "setupable_integration_services",
     "strip_message_context_prefix",
 ]

--- a/infrastructure/harness_providers/tool_registry.py
+++ b/infrastructure/harness_providers/tool_registry.py
@@ -1,13 +1,15 @@
 """Tool registry and investigation-tool resolution.
 
 Core resolves the tools for a surface and the investigation tool list without
-importing the tool packages: ``tools/harness_adapters.py`` injects a real
-registry at boot.
+importing the tool packages: ``tools/harness_adapters.py`` installs the real
+sources once at boot, read afterwards through ``resolve_*``. There is no
+setter — nothing rewrites the sources after boot.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from core.domain.types.tools import ToolSurface
@@ -20,7 +22,7 @@ InvestigationToolsFn = Callable[[dict[str, Any]], list[RegisteredTool]]
 
 
 class _EmptyToolRegistry:
-    """Default tool registry that resolves nothing until one is injected."""
+    """Default tool registry that resolves nothing until one is installed."""
 
     def tools_for_surface(self, _surface: ToolSurface) -> list[RegisteredTool]:
         return []
@@ -33,46 +35,50 @@ def _default_investigation_tools(_resolved: dict[str, Any]) -> list[RegisteredTo
     return []
 
 
-_tool_registry: ToolRegistry = _EmptyToolRegistry()
-_get_investigation_tools: InvestigationToolsFn = _default_investigation_tools
+_EMPTY_REGISTRY: ToolRegistry = _EmptyToolRegistry()
 
 
-def get_surface_tools(surface: ToolSurface) -> list[RegisteredTool]:
-    return _tool_registry.tools_for_surface(surface)
+@dataclass(frozen=True)
+class ToolSources:
+    """The tool registry and investigation-tool resolver, installed once at boot."""
+
+    registry: ToolRegistry = _EMPTY_REGISTRY
+    investigation_tools: InvestigationToolsFn = _default_investigation_tools
+
+    def install(self) -> None:
+        """Bind these as the process-wide tool sources."""
+        global _installed
+        _installed = self
 
 
-def get_surface_tool_map(surface: ToolSurface) -> dict[str, RegisteredTool]:
-    return _tool_registry.tool_map_for_surface(surface)
+_installed: ToolSources | None = None
 
 
-def get_investigation_tools(resolved_integrations: dict[str, Any]) -> list[RegisteredTool]:
-    return _get_investigation_tools(resolved_integrations)
+def resolve_surface_tools(surface: ToolSurface) -> list[RegisteredTool]:
+    """Return the installed registry's tools for ``surface`` (empty before boot)."""
+    return _installed.registry.tools_for_surface(surface) if _installed is not None else []
 
 
-def set_tool_registry(registry: ToolRegistry) -> None:
-    global _tool_registry
-    _tool_registry = registry
+def resolve_surface_tool_map(surface: ToolSurface) -> dict[str, RegisteredTool]:
+    """Return the installed registry's name→tool map for ``surface`` (empty before boot)."""
+    return _installed.registry.tool_map_for_surface(surface) if _installed is not None else {}
 
 
-def set_investigation_tools_adapter(
-    get_investigation_tools: InvestigationToolsFn | None = None,
-) -> None:
-    global _get_investigation_tools
-    if get_investigation_tools is not None:
-        _get_investigation_tools = get_investigation_tools
+def resolve_investigation_tools(resolved_integrations: dict[str, Any]) -> list[RegisteredTool]:
+    """Return the investigation tools for ``resolved_integrations`` (empty before boot)."""
+    return _installed.investigation_tools(resolved_integrations) if _installed is not None else []
 
 
 def reset() -> None:
-    """Restore the empty registry and noop investigation tools (tests)."""
-    set_tool_registry(_EmptyToolRegistry())
-    set_investigation_tools_adapter(get_investigation_tools=_default_investigation_tools)
+    """Clear the installed tool sources (tests)."""
+    global _installed
+    _installed = None
 
 
 __all__ = [
     "InvestigationToolsFn",
-    "get_investigation_tools",
-    "get_surface_tool_map",
-    "get_surface_tools",
-    "set_investigation_tools_adapter",
-    "set_tool_registry",
+    "ToolSources",
+    "resolve_investigation_tools",
+    "resolve_surface_tool_map",
+    "resolve_surface_tools",
 ]

--- a/surfaces/cli/ask/approval.py
+++ b/surfaces/cli/ask/approval.py
@@ -13,7 +13,7 @@ from core.tool import (
     ToolExecutionHooks,
     ToolExecutionRequest,
 )
-from infrastructure.harness_providers import get_surface_tool_map
+from infrastructure.harness_providers import resolve_surface_tool_map
 
 _GATED_SIDE_EFFECTS = frozenset({SideEffectLevel.MUTATING, SideEffectLevel.EXTERNAL})
 
@@ -51,7 +51,7 @@ def registered_ask_tool_names() -> frozenset[str]:
     """Return every registered tool name the ask action or gather phases can reach."""
     names: set[str] = set()
     for surface in (ToolSurface.ACTION, ToolSurface.INVESTIGATION):
-        names.update(get_surface_tool_map(surface))
+        names.update(resolve_surface_tool_map(surface))
     return frozenset(names)
 
 

--- a/tests/bootstrap/test_embedded_session.py
+++ b/tests/bootstrap/test_embedded_session.py
@@ -62,9 +62,9 @@ def test_embedded_session_boots_adapters_so_integrations_resolve() -> None:
     """
     from bootstrap.process import reset_process_runtime_for_tests
     from infrastructure.harness_providers import (
-        get_investigation_tools,
         reset_harness_providers,
         resolve_integrations,
+        resolve_investigation_tools,
     )
 
     reset_harness_providers()
@@ -76,6 +76,6 @@ def test_embedded_session_boots_adapters_so_integrations_resolve() -> None:
     )
 
     grafana_tools = list(
-        get_investigation_tools({"grafana": {"endpoint": "http://g", "connection_verified": True}})
+        resolve_investigation_tools({"grafana": {"endpoint": "http://g", "connection_verified": True}})
     )
     assert any(t.name.startswith("query_grafana") for t in grafana_tools)

--- a/tests/bootstrap/test_embedded_session.py
+++ b/tests/bootstrap/test_embedded_session.py
@@ -76,6 +76,8 @@ def test_embedded_session_boots_adapters_so_integrations_resolve() -> None:
     )
 
     grafana_tools = list(
-        resolve_investigation_tools({"grafana": {"endpoint": "http://g", "connection_verified": True}})
+        resolve_investigation_tools(
+            {"grafana": {"endpoint": "http://g", "connection_verified": True}}
+        )
     )
     assert any(t.name.startswith("query_grafana") for t in grafana_tools)

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -263,9 +263,9 @@ def wire_tool_registry(monkeypatch: Any, tools: list[RegisteredTool]) -> None:
             del surface
             return dict(by_name)
 
-    from infrastructure.harness_providers import set_tool_registry
+    from infrastructure.harness_providers import ToolSources
 
-    set_tool_registry(_FixedToolRegistry())
+    ToolSources(registry=_FixedToolRegistry()).install()
 
     from core.agent_harness.tools.action_tools import _sources_for_context
 

--- a/tests/core/agent_harness/test_agent_session_api.py
+++ b/tests/core/agent_harness/test_agent_session_api.py
@@ -106,7 +106,9 @@ def test_start_registers_harness_adapters_so_integrations_resolve() -> None:
 
     # Tool registry is populated even when the local store is empty (CI).
     grafana_tools = list(
-        resolve_investigation_tools({"grafana": {"endpoint": "http://g", "connection_verified": True}})
+        resolve_investigation_tools(
+            {"grafana": {"endpoint": "http://g", "connection_verified": True}}
+        )
     )
     assert any(t.name.startswith("query_grafana") for t in grafana_tools)
 

--- a/tests/core/agent_harness/test_agent_session_api.py
+++ b/tests/core/agent_harness/test_agent_session_api.py
@@ -84,16 +84,16 @@ def test_start_registers_harness_adapters_so_integrations_resolve() -> None:
     )
     from infrastructure.harness_providers import (
         configured_integration_services,
-        get_investigation_tools,
         reset_harness_providers,
         resolve_integrations,
+        resolve_investigation_tools,
     )
 
     reset_harness_providers()
     reset_process_runtime_for_tests()
     assert configured_integration_services() == ()
     assert resolve_integrations() == {}
-    assert list(get_investigation_tools({"grafana": {"connection_verified": True}})) == []
+    assert list(resolve_investigation_tools({"grafana": {"connection_verified": True}})) == []
 
     AgentSession.start(
         SessionConfig(
@@ -106,7 +106,7 @@ def test_start_registers_harness_adapters_so_integrations_resolve() -> None:
 
     # Tool registry is populated even when the local store is empty (CI).
     grafana_tools = list(
-        get_investigation_tools({"grafana": {"endpoint": "http://g", "connection_verified": True}})
+        resolve_investigation_tools({"grafana": {"endpoint": "http://g", "connection_verified": True}})
     )
     assert any(t.name.startswith("query_grafana") for t in grafana_tools)
 

--- a/tests/core/agent_harness/test_evidence_agent.py
+++ b/tests/core/agent_harness/test_evidence_agent.py
@@ -33,7 +33,7 @@ def test_tool_discovery_raise_is_swallowed(monkeypatch: Any) -> None:
     def _boom(_resolved: dict[str, Any]) -> Any:
         raise RuntimeError("tool registry import blew up")
 
-    monkeypatch.setattr(harness_providers, "get_investigation_tools", _boom)
+    monkeypatch.setattr(harness_providers, "resolve_investigation_tools", _boom)
 
     reporter = _RecordingReporter()
     result = evidence_agent.gather_tool_evidence(
@@ -71,7 +71,7 @@ def test_no_error_reporter_still_swallows(monkeypatch: Any) -> None:
     def _boom(_resolved: dict[str, Any]) -> Any:
         raise RuntimeError("tool registry import blew up")
 
-    monkeypatch.setattr(harness_providers, "get_investigation_tools", _boom)
+    monkeypatch.setattr(harness_providers, "resolve_investigation_tools", _boom)
 
     assert evidence_agent.gather_tool_evidence("why?", _session()) is None
 
@@ -82,7 +82,7 @@ def test_empty_tools_returns_none(monkeypatch: Any) -> None:
         "_resolve_gather_integrations",
         lambda *_args, **_kwargs: {"datadog": {}},
     )
-    monkeypatch.setattr(harness_providers, "get_investigation_tools", lambda _resolved: [])
+    monkeypatch.setattr(harness_providers, "resolve_investigation_tools", lambda _resolved: [])
 
     assert evidence_agent.gather_tool_evidence("status?", _session()) is None
 

--- a/tests/integrations/test_harness_providers_install.py
+++ b/tests/integrations/test_harness_providers_install.py
@@ -93,7 +93,7 @@ def test_install_harness_providers_wires_catalog_and_registry() -> None:
         harness_providers.integration_resolution._load_integrations
         is not harness_providers.integration_resolution._default_load_integrations
     )
-    assert isinstance(harness_providers.get_surface_tools("action"), list)
+    assert isinstance(harness_providers.resolve_surface_tools("action"), list)
 
 
 def test_install_harness_providers_wires_cli_llm_adapters() -> None:

--- a/tests/interactive_shell/tools/test_tool_gathering.py
+++ b/tests/interactive_shell/tools/test_tool_gathering.py
@@ -79,7 +79,7 @@ def test_no_tools_available_returns_none(monkeypatch: Any) -> None:
     session = Session()
     session.resolved_integrations_cache = {}
 
-    monkeypatch.setattr(harness_providers, "get_investigation_tools", lambda _resolved: [])
+    monkeypatch.setattr(harness_providers, "resolve_investigation_tools", lambda _resolved: [])
 
     assert gather_shell_evidence("any question", session, _console()) is None
 
@@ -90,7 +90,7 @@ def test_secondary_only_tools_return_none(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(
         harness_providers,
-        "get_investigation_tools",
+        "resolve_investigation_tools",
         lambda _resolved: [_DummyTool("get_sre_guidance", source="knowledge")],
     )
 
@@ -108,7 +108,7 @@ def test_executed_results_return_formatted_observation(monkeypatch: Any) -> None
 
     monkeypatch.setattr(
         harness_providers,
-        "get_investigation_tools",
+        "resolve_investigation_tools",
         lambda _resolved: [_DummyTool("search_github_issues")],
     )
     monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: object())
@@ -147,7 +147,7 @@ def test_no_executed_returns_none(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(
         harness_providers,
-        "get_investigation_tools",
+        "resolve_investigation_tools",
         lambda _resolved: [_DummyTool("search_github_issues")],
     )
     monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: object())
@@ -174,7 +174,7 @@ def test_exception_path_returns_none(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(
         harness_providers,
-        "get_investigation_tools",
+        "resolve_investigation_tools",
         lambda _resolved: [_DummyTool("search_github_issues")],
     )
 
@@ -234,7 +234,7 @@ def test_gathering_progress_lines_print_on_tool_start(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(
         harness_providers,
-        "get_investigation_tools",
+        "resolve_investigation_tools",
         lambda _resolved: [_DummyTool("query_grafana_metrics", source="grafana")],
     )
     monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: object())
@@ -413,7 +413,7 @@ def test_gather_enriches_github_before_selecting_tools(monkeypatch: Any) -> None
             return [_DummyTool("search_github_issues")]
         return []
 
-    monkeypatch.setattr(harness_providers, "get_investigation_tools", _capture_tools)
+    monkeypatch.setattr(harness_providers, "resolve_investigation_tools", _capture_tools)
     monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: object())
 
     def _fake_run(
@@ -447,7 +447,7 @@ def test_gather_enriches_gitlab_before_selecting_tools(monkeypatch: Any) -> None
             return [_DummyTool("get_gitlab_file", source="gitlab")]
         return []
 
-    monkeypatch.setattr(harness_providers, "get_investigation_tools", _capture_tools)
+    monkeypatch.setattr(harness_providers, "resolve_investigation_tools", _capture_tools)
     monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: object())
 
     def _fake_run(
@@ -475,7 +475,7 @@ def test_gather_user_message_includes_recent_conversation(monkeypatch: Any) -> N
 
     monkeypatch.setattr(
         harness_providers,
-        "get_investigation_tools",
+        "resolve_investigation_tools",
         lambda _resolved: [_DummyTool("search_github_issues")],
     )
     monkeypatch.setattr("core.llm.factory.get_llm", lambda _role: object())

--- a/tools/harness_adapters.py
+++ b/tools/harness_adapters.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 
 def register_harness_adapters() -> None:
-    from infrastructure.harness_providers import set_investigation_tools_adapter, set_tool_registry
+    from infrastructure.harness_providers import ToolSources
     from tools.investigation.stages.gather_evidence.tools import get_available_tools
     from tools.registry import RegisteredToolRegistry
 
-    set_tool_registry(RegisteredToolRegistry())
-    set_investigation_tools_adapter(get_investigation_tools=get_available_tools)
+    ToolSources(
+        registry=RegisteredToolRegistry(),
+        investigation_tools=get_available_tools,
+    ).install()


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Third slice of the F3 cleanup (after the subprocess presenter). The tool registry
in `infrastructure/harness_providers/` exposed two mutable setters —
`set_tool_registry` and `set_investigation_tools_adapter` — each a read-modify-write
global anyone could call at any time. This bundles both values into one frozen
`ToolSources` installed once at boot, read through `resolve_*`. Behavior is
identical; the write surface shrinks to a single install site.

This is the two-value case: where the subprocess presenter carried one value, the
tool registry carries two (the surface registry and the investigation-tools
resolver), so they bundle into one frozen dataclass rather than one bare value.

Before — two setters, two mutable globals:
```python
def set_tool_registry(r): global _tool_registry; _tool_registry = r
def set_investigation_tools_adapter(get_investigation_tools=None): ...
def get_surface_tools(surface): return _tool_registry.tools_for_surface(surface)
def get_investigation_tools(resolved): return _get_investigation_tools(resolved)

After — one frozen bundle installed once, read-only resolvers:


@dataclass(frozen=True)
class ToolSources:
    registry: ToolRegistry = _EMPTY_REGISTRY
    investigation_tools: InvestigationToolsFn = _default_investigation_tools
    def install(self) -> None: global _installed; _installed = self

def resolve_surface_tools(surface): ...       # empty before boot
def resolve_surface_tool_map(surface): ...
def resolve_investigation_tools(resolved): ...
Call-site changes:

```

Composition root (tools/harness_adapters.py): the two set_... calls become one ToolSources(registry=…, investigation_tools=…).install().
Readers: get_surface_tools / get_surface_tool_map / get_investigation_tools become resolve_surface_tools / resolve_surface_tool_map / resolve_investigation_tools in core/agent_harness/tools/action_tools.py, core/agent_harness/turns/evidence_driver.py, and surfaces/cli/ask/approval.py.
The package no longer exports any setter; it re-exports ToolSources and the three resolve_*.
Tests migrated, including a registry-only install (ToolSources(registry=…).install()) — the bundle's field defaults make partial installs clean.

The other two providers (integration resolution, cli-llm) follow the same pattern
in later PRs; the append-only registries are left as-is.

Demo/Screenshot for feature changes and bug fixes -
Boot installs the sources, and a real ask executes an action tool resolved through
ToolSources:


before boot: action tools = 0
after boot : action tools = 51   (registry installed)

$ LLM_PROVIDER=claude-code uv run opensre --json ask \
    --dangerously-bypass-approvals "run the shell command: echo toolregistry_ok"
{"status": "success", "response": "toolregistry_ok", "denied_tools": [], "error": null}
make check-imports green (no cycle); ruff + mypy clean; 831 tests pass on the
directly-affected suites and 2194 across tests/core. One suite failure —
tests/core/agent/test_turn_scenarios.py::test_live_turn_execution_oracle[...local-llama-fail-closed]
— is a pre-existing cross-suite ordering flake (a live-LLM fail-closed test that is
skipped in isolation, passes identically with and without this change at the file
level, and only surfaces in a specific four-directory run); it is unrelated to this
change.

