### PR TITLE
Install CLI-LLM adapters as a frozen CliLlmAdapters bundle instead of a mutable setter

### DIFF
--- a/infrastructure/harness_providers/__init__.py
+++ b/infrastructure/harness_providers/__init__.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 
 from infrastructure.harness_providers.cli_llm import (
     BuildCliClientFn,
+    CliLlmAdapters,
     CliProviderRegistrationFn,
     FlattenCliMessagesFn,
     build_cli_client,
     cli_provider_registration,
     flatten_cli_messages_to_prompt,
-    set_cli_llm_adapters,
 )
 from infrastructure.harness_providers.cli_llm import reset as _reset_cli_llm
 from infrastructure.harness_providers.evidence_sources import (
@@ -153,6 +153,7 @@ def reset_harness_providers() -> None:
 
 __all__ = [
     "BuildCliClientFn",
+    "CliLlmAdapters",
     "ClassifyIntegrationsFn",
     "CliProviderRegistrationFn",
     "ConfiguredIntegrationServicesFn",
@@ -218,7 +219,6 @@ __all__ = [
     "resolve_subprocess_presenter",
     "resolve_surface_tool_map",
     "resolve_surface_tools",
-    "set_cli_llm_adapters",
     "set_integration_resolution_adapters",
     "set_integration_setup_command",
     "set_remote_integrations_fetcher",

--- a/infrastructure/harness_providers/cli_llm.py
+++ b/infrastructure/harness_providers/cli_llm.py
@@ -1,13 +1,15 @@
 """CLI-backed LLM adapters (``integrations.llm_cli``).
 
 Core's LLM factory and transports build CLI-backed clients without importing the
-``integrations.llm_cli`` package: it injects the registration lookup, the client
-builder, and the message-flattening helper at boot.
+``integrations.llm_cli`` package: the adapters are assembled once at boot and
+installed as an immutable :class:`CliLlmAdapters`, read through the module
+functions. There is no setter — nothing rewrites them after boot.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 from core.llm.types import CliLLMClient, ModelType
@@ -42,13 +44,26 @@ def _cli_llm_backend_unavailable(*_args: Any, **_kwargs: Any) -> Any:
     )
 
 
-_cli_provider_registration_fn: CliProviderRegistrationFn = _default_cli_provider_registration
-_build_cli_client_fn: BuildCliClientFn = _cli_llm_backend_unavailable
-_flatten_cli_messages_fn: FlattenCliMessagesFn = _cli_llm_backend_unavailable
+@dataclass(frozen=True)
+class CliLlmAdapters:
+    """The CLI-LLM adapters, installed once at boot."""
+
+    cli_provider_registration: CliProviderRegistrationFn = _default_cli_provider_registration
+    build_cli_client: BuildCliClientFn = _cli_llm_backend_unavailable
+    flatten_cli_messages: FlattenCliMessagesFn = _cli_llm_backend_unavailable
+
+    def install(self) -> None:
+        """Bind these as the process-wide CLI-LLM adapters."""
+        global _installed
+        _installed = self
+
+
+_installed: CliLlmAdapters | None = None
 
 
 def cli_provider_registration(provider: str) -> Any:
-    return _cli_provider_registration_fn(provider)
+    fn = _installed.cli_provider_registration if _installed is not None else None
+    return fn(provider) if fn is not None else None
 
 
 def build_cli_client(
@@ -58,43 +73,27 @@ def build_cli_client(
     max_tokens: int | None = None,
     model_type: ModelType | None = None,
 ) -> CliLLMClient:
-    return _build_cli_client_fn(adapter, model=model, max_tokens=max_tokens, model_type=model_type)
+    fn = _installed.build_cli_client if _installed is not None else _cli_llm_backend_unavailable
+    return fn(adapter, model=model, max_tokens=max_tokens, model_type=model_type)
 
 
 def flatten_cli_messages_to_prompt(messages: list[dict[str, Any]]) -> str:
-    return _flatten_cli_messages_fn(messages)
-
-
-def set_cli_llm_adapters(
-    *,
-    cli_provider_registration: CliProviderRegistrationFn | None = None,
-    build_cli_client: BuildCliClientFn | None = None,
-    flatten_cli_messages: FlattenCliMessagesFn | None = None,
-) -> None:
-    global _cli_provider_registration_fn, _build_cli_client_fn, _flatten_cli_messages_fn
-    if cli_provider_registration is not None:
-        _cli_provider_registration_fn = cli_provider_registration
-    if build_cli_client is not None:
-        _build_cli_client_fn = build_cli_client
-    if flatten_cli_messages is not None:
-        _flatten_cli_messages_fn = flatten_cli_messages
+    fn = _installed.flatten_cli_messages if _installed is not None else _cli_llm_backend_unavailable
+    return fn(messages)
 
 
 def reset() -> None:
-    """Restore the unavailable-backend defaults (tests)."""
-    set_cli_llm_adapters(
-        cli_provider_registration=_default_cli_provider_registration,
-        build_cli_client=_cli_llm_backend_unavailable,
-        flatten_cli_messages=_cli_llm_backend_unavailable,
-    )
+    """Clear the installed CLI-LLM adapters (tests)."""
+    global _installed
+    _installed = None
 
 
 __all__ = [
     "BuildCliClientFn",
+    "CliLlmAdapters",
     "CliProviderRegistrationFn",
     "FlattenCliMessagesFn",
     "build_cli_client",
     "cli_provider_registration",
     "flatten_cli_messages_to_prompt",
-    "set_cli_llm_adapters",
 ]

--- a/integrations/harness_adapters.py
+++ b/integrations/harness_adapters.py
@@ -225,7 +225,7 @@ def _register_cli_llm_adapters() -> None:
     from typing import Any
 
     from core.llm.types import CliLLMClient, ModelType
-    from infrastructure.harness_providers import set_cli_llm_adapters
+    from infrastructure.harness_providers import CliLlmAdapters
     from integrations.llm_cli.registry import get_cli_provider_registration
     from integrations.llm_cli.runner import CLIBackedLLMClient
     from integrations.llm_cli.text import flatten_messages_to_prompt
@@ -244,8 +244,8 @@ def _register_cli_llm_adapters() -> None:
             kwargs["model_type"] = model_type
         return CLIBackedLLMClient(adapter, **kwargs)
 
-    set_cli_llm_adapters(
+    CliLlmAdapters(
         cli_provider_registration=get_cli_provider_registration,
         build_cli_client=_build_cli_client,
         flatten_cli_messages=flatten_messages_to_prompt,
-    )
+    ).install()

--- a/tests/integrations/test_harness_providers_install.py
+++ b/tests/integrations/test_harness_providers_install.py
@@ -104,17 +104,15 @@ def test_install_harness_providers_wires_cli_llm_adapters() -> None:
 
     output_boundary.install_harness_providers()
 
+    installed = harness_providers.cli_llm._installed
+    assert installed is not None
     assert (
-        harness_providers.cli_llm._cli_provider_registration_fn
+        installed.cli_provider_registration
         is not harness_providers.cli_llm._default_cli_provider_registration
     )
+    assert installed.build_cli_client is not harness_providers.cli_llm._cli_llm_backend_unavailable
     assert (
-        harness_providers.cli_llm._build_cli_client_fn
-        is not harness_providers.cli_llm._cli_llm_backend_unavailable
-    )
-    assert (
-        harness_providers.cli_llm._flatten_cli_messages_fn
-        is not harness_providers.cli_llm._cli_llm_backend_unavailable
+        installed.flatten_cli_messages is not harness_providers.cli_llm._cli_llm_backend_unavailable
     )
 
 


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

The CLI-LLM provider in `infrastructure/harness_providers/` exposed a mutable `set_cli_llm_adapters`
setter over three module globals — a read-modify-write group anyone could overwrite. This bundles the three adapters into one frozen `CliLlmAdapters` installed once at boot. Behavior is identical; the write surface collapses to a single install site.

The three readers keep their domain names (`cli_provider_registration`, `build_cli_client`, `flatten_cli_messages_to_prompt`) — their 15 call sites in `core/llm` are untouched; only their internals change to read the installed bundle.

Before — one setter, three mutable globals:
```python
_cli_provider_registration_fn = _default_cli_provider_registration
_build_cli_client_fn = _cli_llm_backend_unavailable
_flatten_cli_messages_fn = _cli_llm_backend_unavailable
def set_cli_llm_adapters(cli_provider_registration=None, build_cli_client=None, flatten_cli_messages=None): ...
```

After — one frozen bundle installed once, read-only functions:
```python
@dataclass(frozen=True)
class CliLlmAdapters:
    cli_provider_registration: CliProviderRegistrationFn = _default_cli_provider_registration
    build_cli_client: BuildCliClientFn = _cli_llm_backend_unavailable
    flatten_cli_messages: FlattenCliMessagesFn = _cli_llm_backend_unavailable
    def install(self) -> None: global _installed; _installed = self
```

Call-site changes:

Composition root (integrations/harness_adapters.py): set_cli_llm_adapters(...) becomes CliLlmAdapters(...).install().
The package no longer exports a setter; it re-exports CliLlmAdapters and the three reader functions.
One test's private-global assertions updated to the new _installed bundle.
Pre-boot behavior is preserved: cli_provider_registration returns None and
build_cli_client / flatten_cli_messages_to_prompt raise "not registered"
until the bundle is installed.

This is the last of the single-value / small-bundle providers. integration_resolution
(the multi-site, eleven-value one) is tracked separately; the append-only
registries are left as-is.

Demo/Screenshot for feature changes and bug fixes -
Direct wiring proof (independent of the external CLI):

before boot: provider reg = None
before boot: build_cli_client raises "not registered"
after boot : provider reg = installed
after boot : build_cli_client -> CLIBackedLLMClient
make check-imports green (no cycle); ruff + mypy clean; 573 tests pass across
core/llm, the harness-providers install test, and agent_harness.


Explain your implementation approach:

Same inversion as the subprocess presenter and tool registry: the three CLI-LLM
adapters, previously three mutable globals behind one setter, bundle into a frozen
CliLlmAdapters assembled at the composition root and installed once. The reader
functions keep their names because they are already domain verbs, and they fall
back to the module's default functions before the bundle is installed, preserving
the exact pre-boot behavior (returns None / raises "not registered"). One thing I
checked deliberately: a function stored as a dataclass instance attribute is not
a bound method, so installed.build_cli_client(adapter, …) calls the function
without a phantom self — verified directly.

Key pieces: CliLlmAdapters and the three reader functions in
infrastructure/harness_providers/cli_llm.py, and the single install in
integrations/harness_adapters.py.
