### PR TITLE
refactor(background): type BackgroundRunFn contract

### DIFF
--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import contextvars
 import threading
-from collections.abc import Callable
+from collections.abc import Mapping
 from contextlib import nullcontext
-from typing import Any
+from typing import Any, Protocol, TypedDict, cast
 from uuid import uuid4
 
 from prompt_toolkit.patch_stdout import patch_stdout
@@ -27,7 +27,28 @@ from surfaces.interactive_shell.runtime.background.notifications import (
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING
 from surfaces.shared.error_handling.exception_reporting import report_exception
 
-BackgroundRunFn = Callable[..., dict[str, Any]]
+
+class BackgroundRunResult(TypedDict, total=False):
+    """Fields consumed from a background investigation result."""
+
+    root_cause: str
+    validated_claims: list[dict[str, Any]]
+    remediation_steps: list[str]
+    evidence_entries: list[Any]
+    investigation_loop_count: int
+    validity_score: float
+
+
+class BackgroundRunFn(Protocol):
+    """Callable contract for running a background investigation."""
+
+    def __call__(
+        self,
+        *,
+        cancel_requested: threading.Event,
+        **kwargs: Any,
+    ) -> BackgroundRunResult:
+        """Run an investigation with cooperative cancellation support."""
 
 
 def _persist_record(session: Session, record: BackgroundInvestigationRecord) -> None:
@@ -91,7 +112,7 @@ def _build_record(
     )
 
 
-def _top_analysis(final_state: dict[str, Any]) -> tuple[str, ...]:
+def _top_analysis(final_state: Mapping[str, Any]) -> tuple[str, ...]:
     claims = final_state.get("validated_claims", [])
     if not isinstance(claims, list):
         return ()
@@ -107,7 +128,7 @@ def _top_analysis(final_state: dict[str, Any]) -> tuple[str, ...]:
     return tuple(lines)
 
 
-def _next_steps(final_state: dict[str, Any]) -> tuple[str, ...]:
+def _next_steps(final_state: Mapping[str, Any]) -> tuple[str, ...]:
     steps = final_state.get("remediation_steps", [])
     if not isinstance(steps, list):
         return ()
@@ -119,7 +140,7 @@ def _next_steps(final_state: dict[str, Any]) -> tuple[str, ...]:
     return tuple(values)
 
 
-def _stats(final_state: dict[str, Any]) -> dict[str, Any]:
+def _stats(final_state: Mapping[str, Any]) -> dict[str, Any]:
     tool_calls = final_state.get("evidence_entries", [])
     loops = final_state.get("investigation_loop_count", 0)
     validity = final_state.get("validity_score", 0.0)
@@ -255,7 +276,7 @@ def start_background_text_investigation(
         session=session,
         console=console,
         display_command=display_command,
-        run_fn=run_investigation_for_session_background,
+        run_fn=cast(BackgroundRunFn, run_investigation_for_session_background),
         kwargs={
             "alert_text": alert_text,
             "context_overrides": session.accumulated_context or None,
@@ -281,7 +302,7 @@ def start_background_template_investigation(
         session=session,
         console=console,
         display_command=display_command,
-        run_fn=run_sample_alert_for_session_background,
+        run_fn=cast(BackgroundRunFn, run_sample_alert_for_session_background),
         kwargs={
             "template_name": template_name,
             "context_overrides": session.accumulated_context or None,

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -46,9 +46,8 @@ class BackgroundRunFn(Protocol):
         self,
         *,
         cancel_requested: threading.Event,
-        **kwargs: Any,
     ) -> BackgroundRunResult:
-        """Run an investigation with cooperative cancellation support."""
+        """Run a background investigation with cooperative cancellation support."""
 
 
 def _persist_record(session: Session, record: BackgroundInvestigationRecord) -> None:
@@ -157,7 +156,6 @@ def _start_background_investigation(
     console: Console,
     display_command: str,
     run_fn: BackgroundRunFn,
-    kwargs: dict[str, Any],
     investigation_target: str = "",
     input_path: str | None = None,
 ) -> str:
@@ -189,7 +187,7 @@ def _start_background_investigation(
                     investigation_target=investigation_target or None,
                     session=session,
                 ) as tracker:
-                    final_state = run_fn(cancel_requested=task.cancel_requested, **kwargs)
+                    final_state = run_fn(cancel_requested=task.cancel_requested)
                     tracker.record_loop_metrics_from_state(final_state)
                 root = str(final_state.get("root_cause") or "")
                 record.status = "completed"
@@ -272,15 +270,21 @@ def start_background_text_investigation(
         run_investigation_for_session_background,
     )
 
+    def _run(*, cancel_requested: threading.Event) -> BackgroundRunResult:
+        return cast(
+            BackgroundRunResult,
+            run_investigation_for_session_background(
+                alert_text=alert_text,
+                context_overrides=session.accumulated_context or None,
+                cancel_requested=cancel_requested,
+            ),
+        )
+
     return _start_background_investigation(
         session=session,
         console=console,
         display_command=display_command,
-        run_fn=cast(BackgroundRunFn, run_investigation_for_session_background),
-        kwargs={
-            "alert_text": alert_text,
-            "context_overrides": session.accumulated_context or None,
-        },
+        run_fn=_run,
         investigation_target=investigation_target,
         input_path=display_command,
     )
@@ -298,15 +302,21 @@ def start_background_template_investigation(
         run_sample_alert_for_session_background,
     )
 
+    def _run(*, cancel_requested: threading.Event) -> BackgroundRunResult:
+        return cast(
+            BackgroundRunResult,
+            run_sample_alert_for_session_background(
+                template_name=template_name,
+                context_overrides=session.accumulated_context or None,
+                cancel_requested=cancel_requested,
+            ),
+        )
+
     return _start_background_investigation(
         session=session,
         console=console,
         display_command=display_command,
-        run_fn=cast(BackgroundRunFn, run_sample_alert_for_session_background),
-        kwargs={
-            "template_name": template_name,
-            "context_overrides": session.accumulated_context or None,
-        },
+        run_fn=_run,
         investigation_target=investigation_target,
         input_path=f"template:{template_name}",
     )

--- a/surfaces/interactive_shell/runtime/background/runner.py
+++ b/surfaces/interactive_shell/runtime/background/runner.py
@@ -270,12 +270,14 @@ def start_background_text_investigation(
         run_investigation_for_session_background,
     )
 
+    context_overrides = dict(session.accumulated_context) or None
+
     def _run(*, cancel_requested: threading.Event) -> BackgroundRunResult:
         return cast(
             BackgroundRunResult,
             run_investigation_for_session_background(
                 alert_text=alert_text,
-                context_overrides=session.accumulated_context or None,
+                context_overrides=context_overrides,
                 cancel_requested=cancel_requested,
             ),
         )
@@ -302,12 +304,14 @@ def start_background_template_investigation(
         run_sample_alert_for_session_background,
     )
 
+    context_overrides = dict(session.accumulated_context) or None
+
     def _run(*, cancel_requested: threading.Event) -> BackgroundRunResult:
         return cast(
             BackgroundRunResult,
             run_sample_alert_for_session_background(
                 template_name=template_name,
-                context_overrides=session.accumulated_context or None,
+                context_overrides=context_overrides,
                 cancel_requested=cancel_requested,
             ),
         )

--- a/tests/interactive_shell/runtime/test_background_notifications_e2e.py
+++ b/tests/interactive_shell/runtime/test_background_notifications_e2e.py
@@ -54,7 +54,7 @@ def _run_investigation_to_completion(
         lambda exc, **_kwargs: caught.setdefault("exc", exc),
     )
 
-    def _fake_run(*, cancel_requested, **_kwargs: object) -> dict[str, object]:
+    def _fake_run(*, cancel_requested) -> dict[str, object]:
         _ = cancel_requested
         return dict(final_state)
 
@@ -64,7 +64,6 @@ def _run_investigation_to_completion(
         console=console,
         display_command="/investigate checkout-latency",
         run_fn=_fake_run,
-        kwargs={},
     )
     # Join the real daemon worker so the completion hook has run to
     # completion before we inspect the record.

--- a/tests/interactive_shell/runtime/test_background_notifications_e2e.py
+++ b/tests/interactive_shell/runtime/test_background_notifications_e2e.py
@@ -20,7 +20,10 @@ from rich.console import Console
 
 from surfaces.interactive_shell.command_registry import dispatch_slash
 from surfaces.interactive_shell.runtime.background import runner as runner_mod
-from surfaces.interactive_shell.runtime.background.runner import _start_background_investigation
+from surfaces.interactive_shell.runtime.background.runner import (
+    BackgroundRunResult,
+    _start_background_investigation,
+)
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.session.background_investigations import (
     BackgroundInvestigationRecord,
@@ -30,7 +33,7 @@ from surfaces.interactive_shell.session.background_investigations import (
 def _run_investigation_to_completion(
     session: Session,
     monkeypatch: pytest.MonkeyPatch,
-    final_state: dict[str, object],
+    final_state: BackgroundRunResult,
 ) -> tuple[str, BackgroundInvestigationRecord]:
     """Drive the REAL runner completion hook (runner.py `_worker`) to completion.
 
@@ -54,9 +57,9 @@ def _run_investigation_to_completion(
         lambda exc, **_kwargs: caught.setdefault("exc", exc),
     )
 
-    def _fake_run(*, cancel_requested) -> dict[str, object]:
+    def _fake_run(*, cancel_requested: threading.Event) -> BackgroundRunResult:
         _ = cancel_requested
-        return dict(final_state)
+        return final_state.copy()
 
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
     task_id = _start_background_investigation(
@@ -133,7 +136,7 @@ def test_e2e_happy_path_full_chain(
 
     # (2) REAL runner completes a synthetic investigation and fires the real
     # completion hook, which fans out to the real dispatcher.
-    final_state = {
+    final_state: BackgroundRunResult = {
         "root_cause": "ROOTSENTINEL postgres connection pool saturation",
         "validated_claims": [{"claim": "TOPCLAIM rds cpu spike to 98%"}],
         "remediation_steps": ["NEXTSTEP raise pool max to 40"],
@@ -194,7 +197,7 @@ def test_e2e_failure_400_renders_in_background_show(monkeypatch: pytest.MonkeyPa
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
     assert dispatch_slash("/background notify set telegram", session, console) is True
 
-    final_state: dict[str, object] = {
+    final_state: BackgroundRunResult = {
         "root_cause": "kafka rebalance storm",
         "remediation_steps": ["pin partitions"],
     }
@@ -210,8 +213,9 @@ def test_e2e_failure_400_renders_in_background_show(monkeypatch: pytest.MonkeyPa
     assert "parse_mode" not in payload
 
     # REAL `/background show` renders the failed row.
-    show_console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    show_output = io.StringIO()
+    show_console = Console(file=show_output, force_terminal=False, highlight=False)
     assert dispatch_slash(f"/background show {task_id}", session, show_console) is True
-    out = show_console.file.getvalue()
+    out = show_output.getvalue()
     assert "telegram:failed: Bad Request: chat not found" in out
     assert "MarkupError" not in out

--- a/tests/interactive_shell/runtime/test_background_runner.py
+++ b/tests/interactive_shell/runtime/test_background_runner.py
@@ -14,9 +14,12 @@ from infrastructure.scheduling.background_investigations.store import (
     StoreLockTimeout,
 )
 from surfaces.interactive_shell.command_registry import dispatch_slash
+from surfaces.interactive_shell.runtime.background import runner as runner_mod
 from surfaces.interactive_shell.runtime.background.runner import (
+    BackgroundRunFn,
     drain_background_notices,
     start_background_template_investigation,
+    start_background_text_investigation,
 )
 from surfaces.interactive_shell.session import Session
 
@@ -60,18 +63,82 @@ def _run_to_completion(session: Session, monkeypatch: pytest.MonkeyPatch) -> str
 
 
 def test_enqueue_and_drain_background_notices() -> None:
-    import io
-
-    from rich.console import Console
-
     session = Session()
     session.terminal.enqueue_background_notice("[bold]done[/bold]")
-    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    output = io.StringIO()
+    console = Console(file=output, force_terminal=False, highlight=False)
 
     drain_background_notices(session, console)
 
     assert session.terminal.drain_background_notices() == []
-    assert "done" in console.file.getvalue()
+    assert "done" in output.getvalue()
+
+
+@pytest.mark.parametrize("mode", ["text", "template"])
+def test_background_launcher_snapshots_context_before_worker_starts(
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_runs: list[BackgroundRunFn] = []
+    seen_contexts: list[dict[str, Any] | None] = []
+
+    def _capture_start(*, run_fn: BackgroundRunFn, **_kwargs: Any) -> str:
+        captured_runs.append(run_fn)
+        return "task-id"
+
+    def _fake_text_run(
+        *,
+        alert_text: str,
+        context_overrides: dict[str, Any] | None,
+        cancel_requested: threading.Event | None,
+    ) -> dict[str, Any]:
+        _ = (alert_text, cancel_requested)
+        seen_contexts.append(context_overrides)
+        return {"root_cause": "done"}
+
+    def _fake_template_run(
+        *,
+        template_name: str,
+        context_overrides: dict[str, Any] | None,
+        cancel_requested: threading.Event | None,
+    ) -> dict[str, Any]:
+        _ = (template_name, cancel_requested)
+        seen_contexts.append(context_overrides)
+        return {"root_cause": "done"}
+
+    monkeypatch.setattr(runner_mod, "_start_background_investigation", _capture_start)
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.investigation_adapter"
+        ".run_investigation_for_session_background",
+        _fake_text_run,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.investigation_adapter"
+        ".run_sample_alert_for_session_background",
+        _fake_template_run,
+    )
+
+    session = Session()
+    session.accumulated_context = {"service": "launch-context"}
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    if mode == "text":
+        start_background_text_investigation(
+            alert_text="checkout latency",
+            session=session,
+            console=console,
+        )
+    else:
+        start_background_template_investigation(
+            template_name="generic",
+            session=session,
+            console=console,
+            display_command="/investigate generic",
+        )
+
+    session.accumulated_context["service"] = "later-context"
+    captured_runs[0](cancel_requested=threading.Event())
+
+    assert seen_contexts == [{"service": "launch-context"}]
 
 
 def test_start_background_template_investigation_assigns_fresh_investigation_id(


### PR DESCRIPTION
Fixes #5232

Supersedes #5425, which could not be reopened after its source branch was deleted. This replacement preserves @CaiusLuo's original implementation commits and adds the follow-up fixes found during maintainer validation.

#### Describe the changes you have made in this PR -

- Introduce the typed `BackgroundRunFn` protocol and `BackgroundRunResult` contract.
- Narrow background callbacks so launchers close over their operation-specific arguments instead of forwarding a broad `**kwargs` mapping.
- Snapshot `session.accumulated_context` before worker startup so a delayed background run cannot observe later session mutations.
- Type the touched notification test helpers and add a regression test covering both text and template launchers.

### Demo/Screenshot for feature changes and bug fixes -

Focused runtime validation:

```text
tests/interactive_shell: 1453 passed, 1 skipped
focused background tests: 36 passed
touched-test mypy: Success: no issues found in 2 source files
source mypy: Success: no issues found in 1892 source files
ruff: All checks passed
ruff format: 3643 files already formatted
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The callback contract now describes the actual background-run payload instead of accepting arbitrary keyword arguments. Each launcher closes over its own arguments, while shared orchestration receives a single typed callable. The accumulated context is copied synchronously at launch time; copying is required because capturing the mutable dictionary by reference would still allow later foreground changes to leak into the background job. A parameterized regression test intercepts worker startup, mutates the live session context, and verifies that both launch paths retain the original snapshot.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
