### PR TITLE
Type console binding with a cancel-capable Protocol

### DIFF
--- a/core/agent_harness/ports.py
+++ b/core/agent_harness/ports.py
@@ -111,6 +111,18 @@ class SessionBindable(Protocol):
 
 
 @runtime_checkable
+class CancelCapableConsole(Protocol):
+    """Console capabilities required by the agent harness."""
+
+    @property
+    def cancel_requested(self) -> bool:
+        """Whether cancellation has been requested."""
+
+    def print(self, message: str = "") -> None:
+        """Print a message to the console."""
+
+
+@runtime_checkable
 class ConsoleBindable(Protocol):
     """Tool port that can retarget the turn console (cancel / TTY observers).
 
@@ -118,7 +130,7 @@ class ConsoleBindable(Protocol):
     the shared ``sink.turn_cancel`` Event for that message.
     """
 
-    def bind_console(self, console: Any) -> None:
+    def bind_console(self, console: CancelCapableConsole) -> None:
         """Point tool UI / cancel probes at ``console`` for this turn."""
 
 
@@ -314,7 +326,7 @@ class TurnBinding:
     output: OutputSink | None = None
     accounting: TurnAccounting | None = None
     tool_hooks: ToolExecutionHooks | None = None
-    console: Any | None = None
+    console: CancelCapableConsole | None = None
     confirm_fn: ConfirmFn | None = None
     is_tty: bool | None = None
 
@@ -323,6 +335,7 @@ __all__ = [
     "AnswerRequest",
     "StreamAnswerFn",
     "ConfirmFn",
+    "CancelCapableConsole",
     "ConsoleBindable",
     "ErrorReporter",
     "EvidenceGatherer",


### PR DESCRIPTION
## Summary

I Introduced a narrow `CancelCapableConsole` Protocol for the agent harness and use it for console binding.

This replaces the previous `Any` typing on `ConsoleBindable.bind_console()` and `TurnBinding.console` with the console capabilities the harness actually uses:

- `cancel_requested`
- `print()`

Fixes #5230

## Validation

- `uv run mypy bootstrap config core gateway integrations infrastructure surfaces tools` ✅
- `uv run ruff check core/agent_harness/ports.py` ✅
- `uv run ruff format --check core/agent_harness/ports.py` ✅
- `uv run pytest tests/core/agent_harness/test_session_bindable_ports.py -q` ✅ 8 passed
- `uv run pytest tests/core/agent_harness/test_host_cancel_turn.py tests/core/agent_harness/test_host_capability_ports.py tests/core/agent_harness/test_host_seam_types.py -q`
  - 8 passed
  - 2 unrelated failures in `test_host_capability_ports.py` caused by existing Windows path-separator / alias checks