### PR TITLE
Session-store cross-process lock + horizontal scale-out guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -771,6 +771,13 @@ ENV=development
 # profile or task resources — raise concurrency on the same task. A non-positive
 # or unparseable value is ignored and the size-profile default applies.
 # OPENSRE_MAX_CONCURRENT_TURNS=2
+#
+# OPENSRE_SESSION_FILE_LOCK serializes writes to a session's file with an OS lock
+# so several gateway tasks (horizontal scale-out) can share one session on the
+# mount without corrupting it. Off by default — a single-task deployment cannot
+# hit the race and should not pay the per-write lock cost. Turn on only when
+# running more than one gateway task against a shared session store.
+# OPENSRE_SESSION_FILE_LOCK=1
 
 # Reversible masking before external LLM calls. Off by default.
 OPENSRE_MASK_ENABLED=false

--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -328,6 +328,7 @@ from config.constants.servicenow import (
     SERVICENOW_PASSWORD_ENV,
     SERVICENOW_USERNAME_ENV,
 )
+from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
 from config.constants.signoz import SIGNOZ_API_KEY_ENV, SIGNOZ_URL_ENV
 from config.constants.slack import (
     SLACK_APP_TOKEN_ENV,
@@ -601,6 +602,7 @@ __all__ = [
     "OPENSRE_MEMORY_DIR_ENV",
     "OPENSRE_MEMORY_DISABLED_ENV",
     "OPENSRE_MEMORY_GATEWAY_ENABLED_ENV",
+    "OPENSRE_SESSION_FILE_LOCK_ENV",
     "OPENSRE_SIZE_PROFILE_ENV",
     "OPENSRE_WORK_ITEMS_DIR_ENV",
     "OPENSRE_TMP_DIR",

--- a/config/constants/session_store.py
+++ b/config/constants/session_store.py
@@ -1,0 +1,11 @@
+"""Session-store environment variable names."""
+
+from __future__ import annotations
+
+# Serialize writes to a session's JSONL file with an OS file lock so several
+# gateway tasks (horizontal scale-out) can share one session on the mount
+# without corrupting it. Off by default: a single-task deployment cannot hit the
+# hazard and should not pay the per-write lock cost. Turn on when running N tasks.
+OPENSRE_SESSION_FILE_LOCK_ENV = "OPENSRE_SESSION_FILE_LOCK"
+
+__all__ = ["OPENSRE_SESSION_FILE_LOCK_ENV"]

--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -4,15 +4,33 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
+import threading
 import uuid
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from filelock import FileLock, Timeout
+
+from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
 from config.version import get_opensre_version
 from core.agent_harness.session.persistence.contracts import CHAT_KINDS, SessionPersistenceSource
 from core.agent_harness.session.persistence.paths import session_path
+
+logger = logging.getLogger(__name__)
+
+# Seconds to wait for the cross-process session lock before giving up. Generous:
+# same-session turns are already serialized in-process, so real contention here
+# is only two tasks racing one session — rare, and pathological beyond this.
+_SESSION_LOCK_TIMEOUT_SECONDS = 10
+
+
+def _session_file_lock_enabled() -> bool:
+    """Whether to serialize session writes across processes (scale-out; off by default)."""
+    return os.getenv(OPENSRE_SESSION_FILE_LOCK_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 _TRIGGER_MAX_CHARS = 200
 # Cold tip scan keeps at most this many trailing bytes resident (then grows by the
@@ -63,24 +81,61 @@ class JsonlSessionStore:
         self._leaf_ids: dict[tuple[str, str], str | None] = {}
         # (session_id, path) → (mtime_ns, size) when the tip was last trusted.
         self._leaf_file_sig: dict[tuple[str, str], tuple[int, int]] = {}
+        # Cross-process write serialization for horizontal scale-out. Off unless
+        # OPENSRE_SESSION_FILE_LOCK is set; one cached FileLock per path so
+        # flush's inner appends re-enter the same lock instead of deadlocking.
+        self._file_lock_enabled = _session_file_lock_enabled()
+        self._write_locks: dict[str, FileLock] = {}
+        self._write_locks_guard = threading.Lock()
+
+    @contextlib.contextmanager
+    def _locked(self, path: Path) -> Iterator[None]:
+        """Serialize writes to one session file across processes (reentrant).
+
+        A no-op unless the file lock is enabled. Same-instance reentrancy lets
+        ``flush`` hold the lock across its whole read-modify-append while inner
+        appends re-enter cheaply; a per-path lock means different sessions never
+        contend. On timeout the caller's best-effort ``suppress`` skips the write
+        after a warning.
+        """
+        if not self._file_lock_enabled:
+            yield
+            return
+        key = str(path)
+        with self._write_locks_guard:
+            lock = self._write_locks.get(key)
+            if lock is None:
+                lock = FileLock(f"{key}.lock", timeout=_SESSION_LOCK_TIMEOUT_SECONDS)
+                self._write_locks[key] = lock
+        try:
+            with lock:
+                yield
+        except Timeout:
+            logger.warning("session file lock timed out; skipping write: %s", path)
+            raise
+        finally:
+            with self._write_locks_guard:
+                if not lock.is_locked:
+                    self._write_locks.pop(key, None)
 
     def open_session(self, session: SessionPersistenceSource) -> None:
         with contextlib.suppress(Exception):
             path = session_path(session.session_id)
-            path.parent.mkdir(parents=True, exist_ok=True)
-            record = {
-                "type": "session",
-                "version": 2,
-                "id": session.session_id,
-                "created_at": datetime.fromtimestamp(session.started_at, tz=UTC).isoformat(),
-                "cwd": str(Path.cwd()),
-                "opensre_version": get_opensre_version(),
-            }
-            with path.open("w", encoding="utf-8") as fh:
-                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
-            key = (session.session_id, str(path))
-            self._leaf_ids[key] = None
-            self._leaf_file_sig[key] = self._file_sig(path)
+            with self._locked(path):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                record = {
+                    "type": "session",
+                    "version": 2,
+                    "id": session.session_id,
+                    "created_at": datetime.fromtimestamp(session.started_at, tz=UTC).isoformat(),
+                    "cwd": str(Path.cwd()),
+                    "opensre_version": get_opensre_version(),
+                }
+                with path.open("w", encoding="utf-8") as fh:
+                    fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+                key = (session.session_id, str(path))
+                self._leaf_ids[key] = None
+                self._leaf_file_sig[key] = self._file_sig(path)
 
     def append_turn(self, session: SessionPersistenceSource, kind: str, text: str) -> None:
         self._append_entry(
@@ -339,72 +394,82 @@ class JsonlSessionStore:
             path = session_path(session.session_id)
             if not path.exists():
                 return
-            records = self._read_records(path)
-            if not records:
-                return
-            trailing_leaf = records[-1].get("type") == "leaf"
-            if not trailing_leaf and not self._has_turns(records):
-                path.unlink(missing_ok=True)
-                return
-            # Trailing ``leaf``: still append changed session-goal state so
-            # mid-session ``/goal pause`` survives the next ``resolve``. Do not
-            # write another leaf (end-of-session flush stays idempotent).
-            # ``records`` is not re-read after the appends below. The counts in
-            # the leaf entry only match ``custom_message``/``turn_stub`` records,
-            # and the guard below only looks for ``message`` records — neither
-            # append can produce either, so a re-parse would return the same
-            # answers for the cost of a full pass over the whole transcript.
-            if session.accumulated_context and not trailing_leaf:
+            with self._locked(path):
+                self._flush_locked(session, path)
+
+    def _flush_locked(self, session: SessionPersistenceSource, path: Path) -> None:
+        """Read-modify-append leaf / goal / message records; runs under the write lock.
+
+        Held whole so the record read and the appends it decides on cannot
+        interleave with another writer (see :meth:`_locked`); inner appends
+        re-enter the same lock.
+        """
+        records = self._read_records(path)
+        if not records:
+            return
+        trailing_leaf = records[-1].get("type") == "leaf"
+        if not trailing_leaf and not self._has_turns(records):
+            path.unlink(missing_ok=True)
+            return
+        # Trailing ``leaf``: still append changed session-goal state so
+        # mid-session ``/goal pause`` survives the next ``resolve``. Do not
+        # write another leaf (end-of-session flush stays idempotent).
+        # ``records`` is not re-read after the appends below. The counts in
+        # the leaf entry only match ``custom_message``/``turn_stub`` records,
+        # and the guard below only looks for ``message`` records — neither
+        # append can produce either, so a re-parse would return the same
+        # answers for the cost of a full pass over the whole transcript.
+        if session.accumulated_context and not trailing_leaf:
+            self.append_custom_message(
+                session.session_id,
+                custom_type="accumulated_context",
+                content=dict(session.accumulated_context),
+                display=False,
+            )
+        if hasattr(session, "session_goal"):
+            from core.agent_harness.session_goal.persist import (
+                SESSION_GOAL_STATE_CUSTOM_TYPE,
+                session_goal_state_snapshot,
+                should_persist_session_goal_state,
+            )
+
+            goal_state = session_goal_state_snapshot(session)
+            if should_persist_session_goal_state(goal_state, prior_records=records):
                 self.append_custom_message(
                     session.session_id,
-                    custom_type="accumulated_context",
-                    content=dict(session.accumulated_context),
+                    custom_type=SESSION_GOAL_STATE_CUSTOM_TYPE,
+                    content=goal_state,
                     display=False,
                 )
-            if hasattr(session, "session_goal"):
-                from core.agent_harness.session_goal.persist import (
-                    SESSION_GOAL_STATE_CUSTOM_TYPE,
-                    session_goal_state_snapshot,
-                    should_persist_session_goal_state,
+        if trailing_leaf:
+            return
+        if session.agent.messages and not any(rec.get("type") == "message" for rec in records):
+            for role, content in session.agent.messages:
+                self.append_message(
+                    session.session_id,
+                    role=role,
+                    content=content,
+                    metadata={"kind": "chat"},
                 )
-
-                goal_state = session_goal_state_snapshot(session)
-                if should_persist_session_goal_state(goal_state, prior_records=records):
-                    self.append_custom_message(
-                        session.session_id,
-                        custom_type=SESSION_GOAL_STATE_CUSTOM_TYPE,
-                        content=goal_state,
-                        display=False,
-                    )
-            if trailing_leaf:
-                return
-            if session.agent.messages and not any(rec.get("type") == "message" for rec in records):
-                for role, content in session.agent.messages:
-                    self.append_message(
-                        session.session_id,
-                        role=role,
-                        content=content,
-                        metadata={"kind": "chat"},
-                    )
-            duration_secs = max(
-                0,
-                int(
-                    (
-                        datetime.now(UTC) - datetime.fromtimestamp(session.started_at, tz=UTC)
-                    ).total_seconds()
-                ),
-            )
-            self._append_entry(
-                session.session_id,
-                "leaf",
-                {
-                    "duration_secs": duration_secs,
-                    "total_turns": self._count_turns(records),
-                    "chat_turns": self._count_chat_turns(records),
-                    "investigation_turns": self._count_investigation_turns(records),
-                    "ended_at": _now(),
-                },
-            )
+        duration_secs = max(
+            0,
+            int(
+                (
+                    datetime.now(UTC) - datetime.fromtimestamp(session.started_at, tz=UTC)
+                ).total_seconds()
+            ),
+        )
+        self._append_entry(
+            session.session_id,
+            "leaf",
+            {
+                "duration_secs": duration_secs,
+                "total_turns": self._count_turns(records),
+                "chat_turns": self._count_chat_turns(records),
+                "investigation_turns": self._count_investigation_turns(records),
+                "ended_at": _now(),
+            },
+        )
 
     def reopen_session(self, session_id: str) -> None:
         # V2 session files are append-only; drop the tip cache so the next
@@ -445,35 +510,36 @@ class JsonlSessionStore:
             path = session_path(session_id)
             if not path.exists():
                 return ""
-            entry_id = _new_id()
-            parent = parent_id
-            if parent is None and resolve_parent and not sidecar:
-                parent = self._current_leaf_id(session_id, path)
-            record = {
-                "id": entry_id,
-                "parent_id": parent,
-                "timestamp": _now(),
-                "type": entry_type,
-                **({"sidecar": True} if sidecar else {}),
-                **{key: value for key, value in payload.items() if value is not None},
-            }
-            with path.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
-                if durable:
-                    fh.flush()
-                    os.fsync(fh.fileno())
-            if not sidecar:
-                self._remember_leaf(
-                    session_id,
-                    path,
-                    entry_type,
-                    entry_id,
-                    parent=parent,
-                )
-            # Refresh the sig even for sidecars: the tip is unchanged but the
-            # file grew, and a stale sig would force a cold rescan next append.
-            self._leaf_file_sig[(session_id, str(path))] = self._file_sig(path)
-            return entry_id
+            with self._locked(path):
+                entry_id = _new_id()
+                parent = parent_id
+                if parent is None and resolve_parent and not sidecar:
+                    parent = self._current_leaf_id(session_id, path)
+                record = {
+                    "id": entry_id,
+                    "parent_id": parent,
+                    "timestamp": _now(),
+                    "type": entry_type,
+                    **({"sidecar": True} if sidecar else {}),
+                    **{key: value for key, value in payload.items() if value is not None},
+                }
+                with path.open("a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+                    if durable:
+                        fh.flush()
+                        os.fsync(fh.fileno())
+                if not sidecar:
+                    self._remember_leaf(
+                        session_id,
+                        path,
+                        entry_type,
+                        entry_id,
+                        parent=parent,
+                    )
+                # Refresh the sig even for sidecars: the tip is unchanged but the
+                # file grew, and a stale sig would force a cold rescan next append.
+                self._leaf_file_sig[(session_id, str(path))] = self._file_sig(path)
+                return entry_id
         return ""
 
     def _remember_leaf(

--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -30,7 +30,13 @@ _SESSION_LOCK_TIMEOUT_SECONDS = 10
 
 def _session_file_lock_enabled() -> bool:
     """Whether to serialize session writes across processes (scale-out; off by default)."""
-    return os.getenv(OPENSRE_SESSION_FILE_LOCK_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+    return os.getenv(OPENSRE_SESSION_FILE_LOCK_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
 
 _TRIGGER_MAX_CHARS = 200
 # Cold tip scan keeps at most this many trailing bytes resident (then grows by the

--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -99,3 +99,51 @@ Complete route reference: [HTTP API](/api).
    strings.
 3. Optionally set `OPENSRE_DEPLOYMENT_METHOD=railway` for telemetry labeling.
 4. Deploy the service through your Railway project.
+
+## Horizontal scale-out
+
+Run more than one gateway task to serve more concurrent conversations.
+
+### Required: a shared, locked session store
+
+All tasks must use the same session store — a shared mount such as an S3 Files or
+EFS volume. Turn on the cross-process lock so two tasks never corrupt one
+session's file:
+
+```bash
+OPENSRE_SESSION_FILE_LOCK=1
+```
+
+Without it, two tasks handling turns for the same conversation at the same moment
+can interleave writes and lose turns. A single-task deployment does not need it
+and should leave it off.
+
+### Concurrency per task
+
+Each task runs a bounded number of turns at once (default 1). Turns are I/O-bound
+— mostly waiting on the model — so a small task can run several; the limit is the
+task's memory, since each concurrent turn holds its context resident. Raise it
+without changing the task size:
+
+```bash
+OPENSRE_MAX_CONCURRENT_TURNS=2
+```
+
+Read the `gateway_turn_memory` debug lines (`delta_mb`, `peak_mb`) from a real run
+to size this against the task's memory limit before raising it.
+
+### Optional: conversation affinity
+
+The lock keeps N tasks correct. Affinity — routing a conversation to the same
+task each time — is a performance option: it keeps that conversation's warm agent
+in one task's memory instead of cold-rebuilding when a turn lands elsewhere.
+
+Affinity is a routing concern, not an app setting:
+
+- Behind an HTTP load balancer (Slack Events API), enable consistent hashing on
+  the conversation (Slack channel and thread) so a thread sticks to one task.
+- With the pull transports (Slack Socket Mode, Telegram, Discord), each task
+  connects independently and the provider spreads events across tasks, so there
+  is no built-in affinity. The lock keeps this correct; affinity would need an
+  external dispatcher and is worth adding only when warm-agent reuse measurably
+  helps.

--- a/tests/core/agent_harness/session/test_jsonl_store_lock.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock.py
@@ -1,0 +1,97 @@
+"""Cross-process write lock on the session JSONL store (horizontal scale-out).
+
+The lock serializes writes to one session file across tasks. It is opt-in via
+``OPENSRE_SESSION_FILE_LOCK`` so a single-task deployment pays nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from core.agent_harness.session.persistence import jsonl_store
+from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
+from core.agent_harness.session.persistence.paths import session_path
+
+
+@pytest.fixture
+def storage_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point session storage at a temp home so nothing touches ~/.opensre."""
+    monkeypatch.setenv("OPENSRE_HOME", str(tmp_path))
+    from config.constants import paths as paths_constants
+
+    monkeypatch.setattr(paths_constants, "OPENSRE_HOME_DIR", tmp_path, raising=False)
+    return tmp_path
+
+
+def _session(session_id: str) -> Any:
+    return SimpleNamespace(
+        session_id=session_id,
+        started_at=0.0,
+        agent=SimpleNamespace(messages=[]),
+        accumulated_context={},
+    )
+
+
+def test_writes_take_no_lock_by_default(storage_home: Path) -> None:
+    # Arrange: default (flag unset) — single-task behavior, no lock file.
+    session = _session("sess-nolock")
+    store = JsonlSessionStore()
+
+    # Act.
+    store.open_session(session)
+    store.append_turn(session, "chat", "one")
+
+    # Assert: the turn is written and no .lock file was ever created.
+    path = session_path(session.session_id)
+    assert "one" in path.read_text(encoding="utf-8")
+    assert not Path(f"{path}.lock").exists()
+
+
+def test_enabled_lock_skips_a_write_another_holder_is_blocking(
+    storage_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange: enable the lock with a short timeout, and open a session.
+    from filelock import FileLock
+
+    monkeypatch.setenv("OPENSRE_SESSION_FILE_LOCK", "1")
+    monkeypatch.setattr(jsonl_store, "_SESSION_LOCK_TIMEOUT_SECONDS", 0.2)
+    session = _session("sess-lock")
+    store = JsonlSessionStore()
+    store.open_session(session)
+    path = session_path(session.session_id)
+    before = path.read_text(encoding="utf-8")
+
+    # Act: another task holds the write lock while this store tries to append.
+    held = FileLock(f"{path}.lock", timeout=0.2)
+    held.acquire()
+    try:
+        store.append_turn(session, "chat", "blocked")
+    finally:
+        held.release()
+
+    # Assert: the contended write was skipped (best-effort), never interleaved.
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_flush_completes_with_the_lock_enabled(
+    storage_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The lock is reentrant: flush holds it across its inner appends (leaf, goal,
+    # messages) without deadlocking on its own OS lock.
+    import json
+
+    monkeypatch.setenv("OPENSRE_SESSION_FILE_LOCK", "1")
+    monkeypatch.setattr(jsonl_store, "_SESSION_LOCK_TIMEOUT_SECONDS", 1.0)
+    session = _session("sess-flush-locked")
+    store = JsonlSessionStore()
+    store.open_session(session)
+    store.append_turn(session, "chat", "one")
+
+    store.flush(session)
+
+    lines = session_path(session.session_id).read_text(encoding="utf-8").splitlines()
+    assert any(json.loads(line).get("type") == "leaf" for line in lines)

--- a/tests/core/agent_harness/session/test_jsonl_store_lock.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
 from core.agent_harness.session.persistence import jsonl_store
 from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
 from core.agent_harness.session.persistence.paths import session_path
@@ -57,7 +58,7 @@ def test_enabled_lock_skips_a_write_another_holder_is_blocking(
     # Arrange: enable the lock with a short timeout, and open a session.
     from filelock import FileLock
 
-    monkeypatch.setenv("OPENSRE_SESSION_FILE_LOCK", "1")
+    monkeypatch.setenv(OPENSRE_SESSION_FILE_LOCK_ENV, "1")
     monkeypatch.setattr(jsonl_store, "_SESSION_LOCK_TIMEOUT_SECONDS", 0.2)
     session = _session("sess-lock")
     store = JsonlSessionStore()
@@ -84,7 +85,7 @@ def test_flush_completes_with_the_lock_enabled(
     # messages) without deadlocking on its own OS lock.
     import json
 
-    monkeypatch.setenv("OPENSRE_SESSION_FILE_LOCK", "1")
+    monkeypatch.setenv(OPENSRE_SESSION_FILE_LOCK_ENV, "1")
     monkeypatch.setattr(jsonl_store, "_SESSION_LOCK_TIMEOUT_SECONDS", 1.0)
     session = _session("sess-flush-locked")
     store = JsonlSessionStore()


### PR DESCRIPTION
Fixes #5434

**Task A — cross-process session lock (code).** The conversation state (one JSONL per session) had no cross process write guard, so two tasks handling turns for the same conversation could interleave writes and lose turns — all same-session serialization was in-process only. Added a per-path `FileLock` (reusing the binding store's proven pattern) around `open_session` / `flush` / append, held reentrantly so flush spans its inner appends. Opt-in via
`OPENSRE_SESSION_FILE_LOCK`, default off: single-task deployments are byte-identical and pay no per-write lock cost. Env name in `config/constants/session_store.py`, documented in `.env.example`.

**Task B — affinity (docs).** Affinity keeps a conversation's warm agent on one task; with the lock in place it is a performance option, not a correctness need. It cannot be safe in-process code — each transport delivers an event to one task, so a filter would drop messages — so it is a routing/deployment concern. Documented the scale-out model (shared locked store, per-task concurrency, affinity via LB consistent-hashing or a dispatcher) in `docs/deployment.mdx`.

#### Testing
- New tests: default takes no lock; a write blocked by another holder is skipped,
  not interleaved; flush completes with the lock on (reentrancy).
- `make typecheck` clean (1895 files); ruff + `make check-imports` green; the
  existing 116 session-persistence tests pass.

## Code Understanding and AI Usage
- [x] Yes, I used AI assistance
- [x] I have reviewed every single line of the AI-generated code
- [x] I have modified the AI output to follow this project's coding standards and conventions