### PR TITLE
refactor(twilio): give verifier a typed validation result (#5439)

### DIFF
--- a/integrations/twilio/verifier.py
+++ b/integrations/twilio/verifier.py
@@ -8,21 +8,42 @@ standalone ``whatsapp`` integration.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 import requests
 
+from integrations.probes import ProbeStatus
 from integrations.verification import register_verifier, result
 
 
-@register_verifier("twilio")
-def verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
+@dataclass(frozen=True)
+class TwilioValidationResult:
+    """Outcome of validating Twilio credentials and SMS channel readiness.
+
+    ``status`` is the discriminator: a missing credential (``MISSING``) is
+    distinct from an API or SMS-channel failure (``FAILED``) without parsing
+    ``detail``. ``ok`` is the posthog-style pass/fail view derived from it,
+    so callers that only need "did it pass" read ``ok`` exactly like
+    :class:`integrations.posthog.verifier.PostHogValidationResult`.
+    """
+
+    status: ProbeStatus
+    detail: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status is ProbeStatus.PASSED
+
+
+def validate_twilio_config(config: dict[str, Any]) -> TwilioValidationResult:
+    """Authenticate the Twilio account and confirm the SMS channel is ready."""
     account_sid = str(config.get("account_sid", "")).strip()
     auth_token = str(config.get("auth_token", "")).strip()
     if not account_sid:
-        return result("twilio", source, "missing", "Missing account_sid.")
+        return TwilioValidationResult(status=ProbeStatus.MISSING, detail="Missing account_sid.")
     if not auth_token:
-        return result("twilio", source, "missing", "Missing auth_token.")
+        return TwilioValidationResult(status=ProbeStatus.MISSING, detail="Missing auth_token.")
 
     try:
         response = requests.get(
@@ -33,7 +54,9 @@ def verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
-        return result("twilio", source, "failed", f"Twilio API check failed: {exc}")
+        return TwilioValidationResult(
+            status=ProbeStatus.FAILED, detail=f"Twilio API check failed: {exc}"
+        )
 
     friendly_name = str(payload.get("friendly_name", "")).strip() or account_sid
 
@@ -44,19 +67,27 @@ def verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
     )
 
     if not sms_ready:
-        return result(
-            "twilio",
-            source,
-            "failed",
-            (
+        return TwilioValidationResult(
+            status=ProbeStatus.FAILED,
+            detail=(
                 f"Connected to Twilio account {friendly_name} but the SMS channel "
                 "is not ready. Enable SMS and set a from_number or messaging_service_sid."
             ),
         )
 
-    return result(
-        "twilio",
-        source,
-        "passed",
-        f"Connected to Twilio account {friendly_name}; SMS channel ready.",
+    return TwilioValidationResult(
+        status=ProbeStatus.PASSED,
+        detail=f"Connected to Twilio account {friendly_name}; SMS channel ready.",
     )
+
+
+@register_verifier("twilio")
+def verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
+    """Edge adapter: run the typed validation and convert at the registry boundary.
+
+    The registry contract is ``dict[str, str]`` (shared by all 64 verifiers);
+    the typed :class:`TwilioValidationResult` is an internal detail converted
+    here so the contract stays unchanged for everyone else.
+    """
+    validation = validate_twilio_config(config)
+    return result("twilio", source, validation.status.value, validation.detail)

--- a/tests/integrations/test_twilio.py
+++ b/tests/integrations/test_twilio.py
@@ -11,9 +11,7 @@ from integrations.probes import ProbeStatus
 from integrations.twilio.verifier import (
     TwilioValidationResult,
     validate_twilio_config,
-)
-from integrations.twilio.verifier import (
-    verify_twilio as _verify_twilio,
+    verify_twilio,
 )
 
 
@@ -87,7 +85,7 @@ def test_config_rejects_blank_auth_token() -> None:
         )
 
 
-# ---- _verify_twilio -----------------------------------------------------------
+# ---- verify_twilio ------------------------------------------------------------
 
 
 def test_validate_distinguishes_missing_from_api_failure(
@@ -132,13 +130,13 @@ def test_validate_passed_carries_ok_when_sms_ready(
 
 
 def test_verify_missing_account_sid() -> None:
-    result = _verify_twilio("env", {"auth_token": "tok"})
+    result = verify_twilio("env", {"auth_token": "tok"})
     assert result["status"] == "missing"
     assert "account_sid" in result["detail"].lower()
 
 
 def test_verify_missing_auth_token() -> None:
-    result = _verify_twilio("env", {"account_sid": "AC1"})
+    result = verify_twilio("env", {"account_sid": "AC1"})
     assert result["status"] == "missing"
     assert "auth_token" in result["detail"].lower()
 
@@ -149,7 +147,7 @@ def test_verify_passed_when_sms_ready(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda *_a, **_kw: _FakeResponse({"friendly_name": "Demo"}),
     )
 
-    result = _verify_twilio(
+    result = verify_twilio(
         "env",
         {
             "account_sid": "AC1",
@@ -168,7 +166,7 @@ def test_verify_passed_with_messaging_service_sid(monkeypatch: pytest.MonkeyPatc
         lambda *_a, **_kw: _FakeResponse({"friendly_name": "Demo"}),
     )
 
-    result = _verify_twilio(
+    result = verify_twilio(
         "env",
         {
             "account_sid": "AC1",
@@ -186,7 +184,7 @@ def test_verify_failed_when_sms_not_ready(monkeypatch: pytest.MonkeyPatch) -> No
         lambda *_a, **_kw: _FakeResponse({"friendly_name": "Demo"}),
     )
 
-    result = _verify_twilio(
+    result = verify_twilio(
         "env",
         {
             "account_sid": "AC1",
@@ -205,7 +203,7 @@ def test_verify_failed_when_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("integrations.twilio.verifier.requests.get", _raise)
 
-    result = _verify_twilio("env", {"account_sid": "AC1", "auth_token": "tok"})
+    result = verify_twilio("env", {"account_sid": "AC1", "auth_token": "tok"})
 
     assert result["status"] == "failed"
     assert "Connection timeout" in result["detail"]

--- a/tests/integrations/test_twilio.py
+++ b/tests/integrations/test_twilio.py
@@ -7,7 +7,14 @@ from typing import Any
 import pytest
 
 from integrations.config_models import TwilioIntegrationConfig, TwilioSMSChannelConfig
-from integrations.twilio.verifier import verify_twilio as _verify_twilio
+from integrations.probes import ProbeStatus
+from integrations.twilio.verifier import (
+    TwilioValidationResult,
+    validate_twilio_config,
+)
+from integrations.twilio.verifier import (
+    verify_twilio as _verify_twilio,
+)
 
 
 class _FakeResponse:
@@ -81,6 +88,47 @@ def test_config_rejects_blank_auth_token() -> None:
 
 
 # ---- _verify_twilio -----------------------------------------------------------
+
+
+def test_validate_distinguishes_missing_from_api_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The typed result tells missing-credential from API-failure by status, not detail text."""
+    missing = validate_twilio_config({"auth_token": "tok"})
+    assert missing.status is ProbeStatus.MISSING
+    assert missing.ok is False
+
+    def _raise(*_a: Any, **_kw: Any) -> Any:
+        raise Exception("Connection timeout")
+
+    monkeypatch.setattr("integrations.twilio.verifier.requests.get", _raise)
+    failed = validate_twilio_config({"account_sid": "AC1", "auth_token": "tok"})
+
+    assert failed.status is ProbeStatus.FAILED
+    assert failed.ok is False
+    # Same ok=False, but the status field tells them apart without parsing detail.
+    assert missing.status is not failed.status
+    assert isinstance(missing, TwilioValidationResult)
+
+
+def test_validate_passed_carries_ok_when_sms_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "integrations.twilio.verifier.requests.get",
+        lambda *_a, **_kw: _FakeResponse({"friendly_name": "Demo"}),
+    )
+
+    validation = validate_twilio_config(
+        {
+            "account_sid": "AC1",
+            "auth_token": "tok",
+            "sms": {"enabled": True, "from_number": "+14155551111"},
+        }
+    )
+
+    assert validation.status is ProbeStatus.PASSED
+    assert validation.ok is True
 
 
 def test_verify_missing_account_sid() -> None:


### PR DESCRIPTION
Fixes #5439

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Convert `verify_twilio` from a free-form `dict[str, str]` built by `result(...)` to a typed `TwilioValidationResult` (ok/detail split like `PostHogValidationResult`, plus a `ProbeStatus` discriminator so missing-credential and API-failure paths are distinguishable without parsing the detail string). The registry boundary contract stays `dict[str, str]`: `verify_twilio` is now a thin edge adapter that runs `validate_twilio_config` and converts via `status.value`, so the other 63 verifiers and the CLI output are unchanged. Add tests pinning the missing-vs-failed distinguishability and the `ok=True` passed path.

### Demo/Screenshot for feature changes and bug fixes -

Confirmed `uv run opensre integrations verify twilio` output unchanged for both paths by invoking the boundary function (`verify_twilio`) directly and comparing against the pre-change dict:

Missing credential →
```json
{
  "service": "twilio",
  "source": "env",
  "status": "missing",
  "detail": "Missing account_sid."
}
```

Bad credential (API failure) →
```json
{
  "service": "twilio",
  "source": "env",
  "status": "failed",
  "detail": "Twilio API check failed: 401 Client Error: Unauthorized for url: https://api.twilio.com/2010-04-01/Accounts/ACbad.json"
}
```

Both `status` and `detail` match the pre-change output verbatim, so the CLI rendering (which keys off `status`/`detail`) is identical.

The typed result now lets a caller tell the two apart by `status` instead of string-matching:
```python
>>> validate_twilio_config({"auth_token": "tok"}).status
<ProbeStatus.MISSING: 'missing'>
>>> validate_twilio_config({"account_sid": "ACbad", "auth_token": "tok"}).status
<ProbeStatus.FAILED: 'failed'>
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **Problem:** `verify_twilio` returned a free-form `dict[str, str]`, so callers could not tell a missing credential from an API failure without matching on the `detail` message string. Issue #5439 asks to convert it to a typed result, following the posthog/servicenow/trello precedent.
- **Alternative considered:** Using the shared `register_validation_verifier` helper (like posthog does). Rejected because its `verify_with_validation_result` collapses every `ok=False` into `"failed"`, which would drop twilio's `"missing"` state. The CLI (`integrations/verify.py`) gives `"missing"` and `"failed"` different glyphs/colours and different exit-code semantics, so collapsing them would change user-visible output and break the issue's "same user-facing outcome" acceptance criterion.
- **Chosen implementation:** Added a frozen `TwilioValidationResult` dataclass with `status: ProbeStatus` + `detail: str` and a derived `ok` property (mirrors `integrations.probes.ProbeResult`'s status/detail/ok shape, DRY against the existing canonical type). `validate_twilio_config` holds all the logic and returns the typed result; `verify_twilio` stays registered via `@register_verifier("twilio")` and is now a thin edge adapter that converts `status.value` + `detail` back to the `dict[str, str]` the registry contract expects.
- **Key components:**
  - `TwilioValidationResult` — typed outcome; `status` discriminates missing/failed/passed, `ok` gives the posthog-style pass/fail view.
  - `validate_twilio_config` — pure validation logic, returns the typed result (missing → `MISSING`, API/SMS failure → `FAILED`, success → `PASSED`); detail text preserved verbatim from the old implementation.
  - `verify_twilio` — edge adapter, preserves the `dict[str, str]` contract for the other 63 verifiers and the CLI.
- **Why it works:** The boundary conversion means `setup.py` and `verify.py` are unchanged and keep reading the same dict; the typed result is an internal detail. No shared base class or registration-contract change (out of scope per the issue).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
````