### PR TITLE
test(quality): add umbrella-name naming guard (issue #5363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,7 @@ jobs:
               tests/quality
               tests/packaging
               tests/scheduler
+              tests/quality
               gateway/tests
           # install/ + quickstart/ are opt-in live (CDN/brew/LLM); not PR CI.
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,7 +511,6 @@ jobs:
               tests/quality
               tests/packaging
               tests/scheduler
-              tests/quality
               gateway/tests
           # install/ + quickstart/ are opt-in live (CDN/brew/LLM); not PR CI.
           - os: ubuntu-latest

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -105,17 +105,22 @@ def _umbrella_offenses(path: Path, tree: ast.AST) -> list[tuple[str, str]]:
         module_name = path.stem
 
     offending_word = _offending_word(_split_module_name(module_name))
-
     if offending_word is not None:
         hits.append(("module", module_name))
 
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.ClassDef):
+    class _Visitor(ast.NodeVisitor):
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
             offending_word = _offending_word(_split_class_name(node.name))
-
             if offending_word is not None:
                 hits.append(("class", node.name))
 
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            pass
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            pass
+
+    _Visitor().visit(tree)
     return hits
 
 
@@ -232,3 +237,51 @@ def test_hexagonal_port_still_flagged() -> None:
     hits = _umbrella_offenses(Path("infrastructure/storage/storage_port.py"), tree)
 
     assert hits == [("module", "storage_port"), ("class", "StoragePort")]
+
+
+def test_class_inside_if_block_is_detected() -> None:
+    tree = ast.parse("if True:\n    class RequestManager:\n        pass\n")
+    hits = _umbrella_offenses(Path("core/x.py"), tree)
+
+    assert ("class", "RequestManager") in hits
+
+
+def test_class_inside_module_level_except_importerror_is_detected() -> None:
+    tree = ast.parse(
+        "try:\n"
+        "    from botocore.exceptions import ClientError\n"
+        "except ImportError:\n"
+        "    class FallbackHandler(Exception):\n"
+        "        pass\n"
+    )
+    hits = _umbrella_offenses(Path("integrations/aws/example_client.py"), tree)
+
+    assert ("class", "FallbackHandler") in hits
+
+
+def test_class_inside_for_loop_is_detected() -> None:
+    tree = ast.parse("for _ in range(1):\n    class BazEngine:\n        pass\n")
+    hits = _umbrella_offenses(Path("core/z.py"), tree)
+
+    assert ("class", "BazEngine") in hits
+
+
+def test_class_inside_with_block_is_detected() -> None:
+    tree = ast.parse("with suppress(Exception):\n    class QueueCoordinator:\n        pass\n")
+    hits = _umbrella_offenses(Path("core/w.py"), tree)
+
+    assert ("class", "QueueCoordinator") in hits
+
+
+def test_class_inside_function_is_not_detected() -> None:
+    tree = ast.parse("def build():\n    class TempManager:\n        pass\n    return TempManager\n")
+    hits = _umbrella_offenses(Path("core/v.py"), tree)
+
+    assert hits == []
+
+
+def test_nested_class_inside_classdef_is_not_detected() -> None:
+    tree = ast.parse("class Outer:\n    class InnerManager:\n        pass\n")
+    hits = _umbrella_offenses(Path("core/u.py"), tree)
+
+    assert hits == []

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -117,17 +117,8 @@ def _offending_word(words: list[str], is_hexagonal_port: bool = False) -> str | 
     return None
 
 
-def _umbrella_offenses(path: Path, tree: ast.AST) -> list[tuple[str, str]]:
+def _class_name_offenses(tree: ast.AST) -> list[tuple[str, str]]:
     hits: list[tuple[str, str]] = []
-
-    if path.stem == "__init__":
-        module_name = path.parent.stem
-    else:
-        module_name = path.stem
-
-    offending_word = _offending_word(_split_module_name(module_name))
-    if offending_word is not None:
-        hits.append(("module", module_name))
 
     hexagonal_port_base_names: frozenset[str] = _hexagonal_port_base_names(tree)
 
@@ -149,12 +140,44 @@ def _umbrella_offenses(path: Path, tree: ast.AST) -> list[tuple[str, str]]:
     return hits
 
 
+def _package_directories(root: Path, files: list[Path]) -> set[Path]:
+    dirs: set[Path] = set()
+    for file in files:
+        for rel_parent in file.relative_to(root).parents:
+            if rel_parent == Path("."):
+                continue
+            dirs.add(rel_parent)
+    return dirs
+
+
+def _module_name_offenses(root: Path, files: list[Path]) -> set[tuple[str, str, str]]:
+    hits: set[tuple[str, str, str]] = set()
+
+    for package_dir in _package_directories(root, files):
+        offending_word = _offending_word(_split_module_name(package_dir.name))
+        if offending_word is not None:
+            # Namespace packages have no __init__.py on disk, so append __init__.py
+            # for reporting. Add it to the allowlist path too when allowlisting.
+            report_path = (package_dir / "__init__.py").as_posix()
+            hits.add((report_path, "module", package_dir.name))
+
+    for file in files:
+        offending_word = _offending_word(_split_module_name(file.stem))
+        if offending_word is not None:
+            relpath = file.relative_to(root).as_posix()
+            hits.add((relpath, "module", file.stem))
+
+    return hits
+
+
 def _scan_offenders(root: Path) -> set[tuple[str, str, str]]:
     offenders: set[tuple[str, str, str]] = set()
+    files: list[Path] = []
 
     for path in product_python_files(root):
         if _is_test_path(path):
             continue
+        files.append(path)
         source = path.read_text(encoding="utf-8")
         try:
             tree = ast.parse(source, filename=str(path))
@@ -162,8 +185,12 @@ def _scan_offenders(root: Path) -> set[tuple[str, str, str]]:
             continue
 
         relpath = path.relative_to(_REPO_ROOT).as_posix()
-        for kind, name in _umbrella_offenses(path, tree):
+        for kind, name in _class_name_offenses(tree):
             offenders.add((relpath, kind, name))
+
+    package = root.relative_to(_REPO_ROOT).as_posix()
+    for rel_from_root, kind, name in _module_name_offenses(root, files):
+        offenders.add((f"{package}/{rel_from_root}", kind, name))
 
     return offenders
 
@@ -176,9 +203,11 @@ def test_product_packages_have_no_umbrella_names(package: str) -> None:
 
     offenders: list[str] = []
     allowlist: set[tuple[str, str, str]] = _load_allowlist()
+    files: list[Path] = []
     for path in product_python_files(root):
         if _is_test_path(path):
             continue
+        files.append(path)
         source = path.read_text(encoding="utf-8")
         try:
             tree = ast.parse(source, filename=str(path))
@@ -187,11 +216,18 @@ def test_product_packages_have_no_umbrella_names(package: str) -> None:
             continue
 
         relpath = path.relative_to(_REPO_ROOT).as_posix()
-        for kind, name in _umbrella_offenses(path, tree):
+        for kind, name in _class_name_offenses(tree):
             if (relpath, kind, name) in allowlist:
                 continue
 
             offenders.append(f"{relpath}:{kind}: {name}")
+
+    for rel_from_root, kind, name in _module_name_offenses(root, files):
+        relpath = f"{package}/{rel_from_root}"
+        if (relpath, kind, name) in allowlist:
+            continue
+
+        offenders.append(f"{relpath}:{kind}: {name}")
 
     assert offenders == [], (
         "New umbrella name introduced (see docs/NAMING.md for the vocabulary to use "
@@ -218,31 +254,23 @@ def test_umbrella_allowlist_has_no_stale_entries() -> None:
     )
 
 
-def test_offending_package_dunder_init_uses_parent_dir_name(tmp_path):
+def test_offending_package_dunder_init_uses_parent_dir_name(tmp_path: Path) -> None:
     offending_package_dir = tmp_path / "prompt_manager"
     offending_package_dir.mkdir()
 
     init_file = offending_package_dir / "__init__.py"
     init_file.write_text("")
 
-    tree = ast.parse("", filename=str(init_file))
-    hits = _umbrella_offenses(init_file, tree)
+    hits = _module_name_offenses(tmp_path, [init_file])
 
-    assert ("module", "prompt_manager") in hits
+    assert ("prompt_manager/__init__.py", "module", "prompt_manager") in hits
 
 
 def test_network_port_module_name_is_exempt() -> None:
-    tree = ast.parse("")
-    hits = _umbrella_offenses(Path("infrastructure/network/http_port.py"), tree)
+    path = Path("infrastructure/network/http_port.py")
+    hits = _module_name_offenses(path.parent, [path])
 
-    assert hits == []
-
-
-def test_network_port_class_name_is_exempt() -> None:
-    tree = ast.parse("class HttpPort:\n    pass\n")
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
-
-    assert hits == []
+    assert hits == set()
 
 
 def test_network_port_package_dunder_init_is_exempt(tmp_path: Path) -> None:
@@ -251,22 +279,71 @@ def test_network_port_package_dunder_init_is_exempt(tmp_path: Path) -> None:
     init_file = package_dir / "__init__.py"
     init_file.write_text("")
 
-    tree = ast.parse("", filename=str(init_file))
-    hits = _umbrella_offenses(init_file, tree)
+    hits = _module_name_offenses(tmp_path, [init_file])
+
+    assert hits == set()
+
+
+def test_namespace_package_without_init_is_detected(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "prompt_manager"
+    pkg_dir.mkdir()
+    (pkg_dir / "service.py").write_text("")
+
+    hits = _module_name_offenses(tmp_path, [pkg_dir / "service.py"])
+
+    assert ("prompt_manager/__init__.py", "module", "prompt_manager") in hits
+
+
+def test_nested_namespace_package_all_ancestor_levels_are_detected(tmp_path: Path) -> None:
+    deep = tmp_path / "prompt_manager" / "sub"
+    deep.mkdir(parents=True)
+    (deep / "service.py").write_text("")
+
+    hits = _module_name_offenses(tmp_path, [deep / "service.py"])
+
+    assert any(name == "prompt_manager" for _, _, name in hits)
+
+
+def test_namespace_package_non_offending_name_is_not_detected(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "grounding"
+    pkg_dir.mkdir()
+    (pkg_dir / "provider.py").write_text("")
+
+    hits = _module_name_offenses(tmp_path, [pkg_dir / "provider.py"])
+
+    assert hits == set()
+
+
+def test_syntax_error_file_name_is_still_detected(tmp_path: Path) -> None:
+    bad_file = tmp_path / "session_manager.py"
+    bad_file.write_text("def broken(:\n")
+
+    hits = _module_name_offenses(tmp_path, [bad_file])
+
+    assert ("session_manager.py", "module", "session_manager") in hits
+
+
+def test_hexagonal_port_still_flagged() -> None:
+    path = Path("infrastructure/storage/storage_port.py")
+    tree = ast.parse("class StoragePort:\n    pass\n")
+
+    class_hits = _class_name_offenses(tree)
+    module_hits = _module_name_offenses(path.parent, [path])
+
+    assert class_hits == [("class", "StoragePort")]
+    assert ("storage_port.py", "module", "storage_port") in module_hits
+
+
+def test_network_port_class_name_is_exempt() -> None:
+    tree = ast.parse("class HttpPort:\n    pass\n")
+    hits = _class_name_offenses(tree)
 
     assert hits == []
 
 
-def test_hexagonal_port_still_flagged() -> None:
-    tree = ast.parse("class StoragePort:\n    pass\n")
-    hits = _umbrella_offenses(Path("infrastructure/storage/storage_port.py"), tree)
-
-    assert hits == [("module", "storage_port"), ("class", "StoragePort")]
-
-
 def test_class_inside_if_block_is_detected() -> None:
     tree = ast.parse("if True:\n    class RequestManager:\n        pass\n")
-    hits = _umbrella_offenses(Path("core/x.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "RequestManager") in hits
 
@@ -279,70 +356,70 @@ def test_class_inside_module_level_except_importerror_is_detected() -> None:
         "    class FallbackHandler(Exception):\n"
         "        pass\n"
     )
-    hits = _umbrella_offenses(Path("integrations/aws/example_client.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "FallbackHandler") in hits
 
 
 def test_class_inside_for_loop_is_detected() -> None:
     tree = ast.parse("for _ in range(1):\n    class BazEngine:\n        pass\n")
-    hits = _umbrella_offenses(Path("core/z.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "BazEngine") in hits
 
 
 def test_class_inside_with_block_is_detected() -> None:
     tree = ast.parse("with suppress(Exception):\n    class QueueCoordinator:\n        pass\n")
-    hits = _umbrella_offenses(Path("core/w.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "QueueCoordinator") in hits
 
 
 def test_class_inside_function_is_not_detected() -> None:
     tree = ast.parse("def build():\n    class TempManager:\n        pass\n    return TempManager\n")
-    hits = _umbrella_offenses(Path("core/v.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert hits == []
 
 
 def test_nested_class_inside_classdef_is_not_detected() -> None:
     tree = ast.parse("class Outer:\n    class InnerManager:\n        pass\n")
-    hits = _umbrella_offenses(Path("core/u.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert hits == []
 
 
 def test_protocol_http_port_acronym_class_is_detected() -> None:
     tree = ast.parse("class HTTPPort(Protocol):\n    pass\n")
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "HTTPPort") in hits
 
 
 def test_http_port_acronym_class_name_is_exempt() -> None:
     tree = ast.parse("class HTTPPort:\n    pass\n")
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert hits == []
 
 
 def test_tcp_port_acronym_class_name_is_exempt() -> None:
     tree = ast.parse("class TCPPort:\n    pass\n")
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert hits == []
 
 
 def test_abc_http_port_class_is_detected() -> None:
     tree = ast.parse("class HttpPort(ABC):\n    pass\n")
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "HttpPort") in hits
 
 
 def test_protocol_as_second_base_class_is_still_detected() -> None:
     tree = ast.parse("class HttpPort(ExecutionGate, Protocol):\n    pass\n")
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "HttpPort") in hits
 
@@ -351,7 +428,7 @@ def test_aliased_protocol_import_is_still_detected() -> None:
     tree = ast.parse(
         "from typing import Protocol as _Protocol\n\n\nclass HttpPort(_Protocol):\n    pass\n"
     )
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+    hits = _class_name_offenses(tree)
 
     assert ("class", "HttpPort") in hits
 
@@ -365,6 +442,5 @@ def test_generic_protocol_port_class_is_detected() -> None:
         "class HttpPort(Protocol[T]):\n"
         "    pass\n"
     )
-    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
-
+    hits = _class_name_offenses(tree)
     assert ("class", "HttpPort") in hits

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -410,6 +410,10 @@ def test_tcp_port_acronym_class_name_is_exempt() -> None:
     assert hits == []
 
 
+def test_split_class_name_keeps_acronym_with_digit_together() -> None:
+    assert _split_class_name("S3Client") == ["s3", "client"]
+
+
 def test_abc_http_port_class_is_detected() -> None:
     tree = ast.parse("class HttpPort(ABC):\n    pass\n")
     hits = _class_name_offenses(tree)

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -88,7 +88,11 @@ def _offending_word(words: list[str]) -> str | None:
 
 def _umbrella_offenses(path: Path, tree: ast.AST) -> list[tuple[str, str]]:
     hits: list[tuple[str, str]] = []
-    module_name = path.stem
+
+    if path.stem == "__init__":
+        module_name = path.parent.stem
+    else:
+        module_name = path.stem
 
     offending_word = _offending_word(_split_module_name(module_name))
 
@@ -172,3 +176,16 @@ def test_umbrella_allowlist_has_no_stale_entries() -> None:
         "current offender (already renamed, or never existed). Remove them:\n"
         + "\n".join(sorted(f"{path}|{kind}|{name}" for path, kind, name in stale_entries))
     )
+
+
+def test_offending_package_dunder_init_uses_parent_dir_name(tmp_path):
+    offending_package_dir = tmp_path / "prompt_manager"
+    offending_package_dir.mkdir()
+
+    init_file = offending_package_dir / "__init__.py"
+    init_file.write_text("")
+
+    tree = ast.parse("", filename=str(init_file))
+    hits = _umbrella_offenses(init_file, tree)
+
+    assert ("module", "prompt_manager") in hits

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -45,6 +45,9 @@ _UMBRELLA_WORDS = frozenset(
         "context",
     }
 )
+_NETWORK_PORT_PREFIXES = frozenset(
+    {"http", "https", "tcp", "udp", "grpc", "ws", "wss", "ssh", "ftp", "smtp", "dns", "ip"}
+)
 _BARE_UMBRELLA_WORDS = frozenset({"utils", "helpers", "common", "misc"})
 _ALLOWLIST_PATH = Path(__file__).resolve().parent / "umbrella_names_allowlist.txt"
 _CLASS_NAME_PART_REGEX = re.compile(r"[A-Z][a-z0-9]*|[a-z0-9]+")
@@ -68,6 +71,10 @@ def _is_test_path(path: Path) -> bool:
     return "tests" in path.parts or path.name.startswith("test_")
 
 
+def _is_network_port(word: str, previous_word: str) -> bool:
+    return word == "port" and previous_word in _NETWORK_PORT_PREFIXES
+
+
 def _split_module_name(name: str) -> list[str]:
     return [part for part in name.strip("_").lower().split("_") if part]
 
@@ -80,9 +87,12 @@ def _offending_word(words: list[str]) -> str | None:
     if len(words) == 1 and words[0] in _BARE_UMBRELLA_WORDS:
         return words[0]
 
+    previous_word: str = ""
     for word in words:
-        if word in _UMBRELLA_WORDS:
+        if word in _UMBRELLA_WORDS and not _is_network_port(word, previous_word):
             return word
+
+        previous_word = word
     return None
 
 
@@ -189,3 +199,36 @@ def test_offending_package_dunder_init_uses_parent_dir_name(tmp_path):
     hits = _umbrella_offenses(init_file, tree)
 
     assert ("module", "prompt_manager") in hits
+
+
+def test_network_port_module_name_is_exempt() -> None:
+    tree = ast.parse("")
+    hits = _umbrella_offenses(Path("infrastructure/network/http_port.py"), tree)
+
+    assert hits == []
+
+
+def test_network_port_class_name_is_exempt() -> None:
+    tree = ast.parse("class HttpPort:\n    pass\n")
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert hits == []
+
+
+def test_network_port_package_dunder_init_is_exempt(tmp_path: Path) -> None:
+    package_dir = tmp_path / "http_port"
+    package_dir.mkdir()
+    init_file = package_dir / "__init__.py"
+    init_file.write_text("")
+
+    tree = ast.parse("", filename=str(init_file))
+    hits = _umbrella_offenses(init_file, tree)
+
+    assert hits == []
+
+
+def test_hexagonal_port_still_flagged() -> None:
+    tree = ast.parse("class StoragePort:\n    pass\n")
+    hits = _umbrella_offenses(Path("infrastructure/storage/storage_port.py"), tree)
+
+    assert hits == [("module", "storage_port"), ("class", "StoragePort")]

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -46,12 +46,28 @@ _UMBRELLA_WORDS = frozenset(
     }
 )
 _NETWORK_PORT_PREFIXES = frozenset(
-    {"http", "https", "tcp", "udp", "grpc", "ws", "wss", "ssh", "ftp", "smtp", "dns", "ip"}
+    {
+        "http",
+        "https",
+        "tcp",
+        "udp",
+        "grpc",
+        "ws",
+        "wss",
+        "ssh",
+        "ftp",
+        "smtp",
+        "dns",
+        "ip",
+        "ipv",
+    }
 )
+_NETWORK_PORT_QUALIFIERS = frozenset({"listener", "server", "socket"})
 _HEXAGONAL_PORT_BASE_NAMES = frozenset({"Protocol", "ABC"})
 _BARE_UMBRELLA_WORDS = frozenset({"utils", "helpers", "common", "misc"})
 _ALLOWLIST_PATH = Path(__file__).resolve().parent / "umbrella_names_allowlist.txt"
 _CLASS_NAME_PART_REGEX = re.compile(r"[A-Z]+[0-9]*(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+_VERSION_WORD_REGEX = re.compile(r"v?[0-9]+")
 
 
 def _load_allowlist() -> set[tuple[str, str, str]]:
@@ -72,14 +88,64 @@ def _is_test_path(path: Path) -> bool:
     return "tests" in path.parts or path.name.startswith("test_")
 
 
-def _is_network_port(word: str, previous_word: str, is_hexagonal_port: bool) -> bool:
-    return word == "port" and previous_word in _NETWORK_PORT_PREFIXES and not is_hexagonal_port
+def _without_trailing_digits(word: str) -> str:
+    return word.rstrip("0123456789")
+
+
+def _umbrella_word(word: str) -> str | None:
+    normalized = _without_trailing_digits(word)
+    if normalized in _UMBRELLA_WORDS:
+        return normalized
+    if normalized.endswith("s") and normalized[:-1] in _UMBRELLA_WORDS:
+        return normalized[:-1]
+    return None
+
+
+def _bare_umbrella_word(words: list[str]) -> str | None:
+    if len(words) == 2 and _VERSION_WORD_REGEX.fullmatch(words[1]) is None:
+        return None
+    if len(words) not in (1, 2):
+        return None
+    word = _without_trailing_digits(words[0])
+    return word if word in _BARE_UMBRELLA_WORDS else None
+
+
+def _is_network_prefix(word: str) -> bool:
+    return _without_trailing_digits(word) in _NETWORK_PORT_PREFIXES
+
+
+def _network_prefix_ends_at(words: list[str]) -> bool:
+    if not words:
+        return False
+    if _is_network_prefix(words[-1]):
+        return True
+    return len(words) >= 2 and _is_network_prefix("".join(words[-2:]))
+
+
+def _is_network_port(
+    word: str,
+    preceding_words: list[str],
+    is_hexagonal_port: bool,
+) -> bool:
+    if word != "port" or is_hexagonal_port:
+        return False
+    if _network_prefix_ends_at(preceding_words):
+        return True
+    return bool(
+        preceding_words
+        and preceding_words[-1] in _NETWORK_PORT_QUALIFIERS
+        and _network_prefix_ends_at(preceding_words[:-1])
+    )
 
 
 def _hexagonal_port_base_names(tree: ast.AST) -> frozenset[str]:
     names = set(_HEXAGONAL_PORT_BASE_NAMES)
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module in ("typing", "abc"):
+        if isinstance(node, ast.ImportFrom) and node.module in (
+            "typing",
+            "typing_extensions",
+            "abc",
+        ):
             for alias in node.names:
                 if alias.name in _HEXAGONAL_PORT_BASE_NAMES and alias.asname:
                     names.add(alias.asname)
@@ -97,7 +163,11 @@ def _is_hexagonal_port_class(node: ast.ClassDef, base_names: frozenset[str]) -> 
 
 
 def _split_module_name(name: str) -> list[str]:
-    return [part for part in name.strip("_").lower().split("_") if part]
+    return [
+        match.group(0).lower()
+        for component in name.strip("_").split("_")
+        for match in _CLASS_NAME_PART_REGEX.finditer(component)
+    ]
 
 
 def _split_class_name(name: str) -> list[str]:
@@ -105,15 +175,18 @@ def _split_class_name(name: str) -> list[str]:
 
 
 def _offending_word(words: list[str], is_hexagonal_port: bool = False) -> str | None:
-    if len(words) == 1 and words[0] in _BARE_UMBRELLA_WORDS:
-        return words[0]
+    bare_word = _bare_umbrella_word(words)
+    if bare_word is not None:
+        return bare_word
 
-    previous_word: str = ""
-    for word in words:
-        if word in _UMBRELLA_WORDS and not _is_network_port(word, previous_word, is_hexagonal_port):
-            return word
-
-        previous_word = word
+    for index, word in enumerate(words):
+        offending_word = _umbrella_word(word)
+        if offending_word is not None and not _is_network_port(
+            offending_word,
+            words[:index],
+            is_hexagonal_port,
+        ):
+            return offending_word
     return None
 
 
@@ -341,6 +414,75 @@ def test_network_port_class_name_is_exempt() -> None:
     assert hits == []
 
 
+def test_banned_word_suffixes_do_not_bypass_guard() -> None:
+    for class_name in (
+        "RequestManager2",
+        "RequestManagers",
+        "StoragePorts",
+        "Utils2",
+        "UtilsV2",
+    ):
+        tree = ast.parse(f"class {class_name}:\n    pass\n")
+        assert _class_name_offenses(tree) == [("class", class_name)]
+
+    for module_name in (
+        "request_manager2.py",
+        "request_managers.py",
+        "storage_ports.py",
+        "utils_2.py",
+        "utils_v2.py",
+    ):
+        path = Path("core") / module_name
+        assert (module_name, "module", path.stem) in _module_name_offenses(path.parent, [path])
+
+    assert _class_name_offenses(ast.parse("class CommonConfig2:\n    pass\n")) == []
+
+
+def test_camel_case_module_name_does_not_bypass_guard() -> None:
+    path = Path("core/PromptManager.py")
+
+    assert ("PromptManager.py", "module", "PromptManager") in _module_name_offenses(
+        path.parent, [path]
+    )
+
+
+def test_versioned_network_port_names_are_exempt() -> None:
+    for class_name, module_name in (
+        ("HTTP2Port", "http2_port.py"),
+        ("HTTP2Ports", "http2_ports.py"),
+        ("IPv6Port", "ipv6_port.py"),
+    ):
+        tree = ast.parse(f"class {class_name}:\n    pass\n")
+        path = Path("infrastructure/network") / module_name
+
+        assert _class_name_offenses(tree) == []
+        assert _module_name_offenses(path.parent, [path]) == set()
+
+
+def test_compound_network_port_names_are_exempt() -> None:
+    tree = ast.parse("class HTTPServerPort:\n    pass\n")
+    path = Path("infrastructure/network/http_server_port.py")
+
+    assert _class_name_offenses(tree) == []
+    assert _module_name_offenses(path.parent, [path]) == set()
+
+
+def test_domain_word_between_network_prefix_and_port_is_not_exempt() -> None:
+    tree = ast.parse("class HttpServicePort:\n    pass\n")
+    path = Path("infrastructure/service/http_service_port.py")
+
+    assert _class_name_offenses(tree) == [("class", "HttpServicePort")]
+    assert ("http_service_port.py", "module", "http_service_port") in _module_name_offenses(
+        path.parent, [path]
+    )
+
+
+def test_versioned_network_port_protocol_is_detected() -> None:
+    tree = ast.parse("class HTTP2Ports(Protocol):\n    pass\n")
+
+    assert _class_name_offenses(tree) == [("class", "HTTP2Ports")]
+
+
 def test_class_inside_if_block_is_detected() -> None:
     tree = ast.parse("if True:\n    class RequestManager:\n        pass\n")
     hits = _class_name_offenses(tree)
@@ -430,11 +572,21 @@ def test_protocol_as_second_base_class_is_still_detected() -> None:
 
 def test_aliased_protocol_import_is_still_detected() -> None:
     tree = ast.parse(
-        "from typing import Protocol as _Protocol\n\n\nclass HttpPort(_Protocol):\n    pass\n"
+        "from typing import Protocol as _Protocol\n"
+        "from typing_extensions import Protocol as _ExtensionsProtocol\n"
+        "\n"
+        "\n"
+        "class HttpPort(_Protocol):\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        "class HTTP2Port(_ExtensionsProtocol):\n"
+        "    pass\n"
     )
     hits = _class_name_offenses(tree)
 
     assert ("class", "HttpPort") in hits
+    assert ("class", "HTTP2Port") in hits
 
 
 def test_generic_protocol_port_class_is_detected() -> None:

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -1,0 +1,137 @@
+"""Ban umbrella words in new first-party module and top-level class names.
+
+Names like ``manager``, ``handler``, ``context``, or bare ``utils`` say
+nothing about what a file or class actually does, so responsibilities pile
+up under them with nothing pushing back. See docs/NAMING.md for the
+vocabulary to use instead (State, Snapshot, Slice, Host, ...).
+
+This guard is shrink-only: today's offenders are recorded in
+tests/quality/umbrella_names_allowlist.txt so this test passes as of the
+PR that introduced it. Do not add a new entry to silence a new offender —
+rename it instead.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.shared.product_sources import product_python_files
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PRODUCT_ROOTS = (
+    "bootstrap",
+    "config",
+    "core",
+    "gateway",
+    "integrations",
+    "infrastructure",
+    "surfaces",
+    "tools",
+)
+_UMBRELLA_WORDS = frozenset(
+    {
+        "port",
+        "wiring",
+        "manager",
+        "handler",
+        "processor",
+        "engine",
+        "wrapper",
+        "coordinator",
+        "context",
+    }
+)
+_BARE_UMBRELLA_WORDS = frozenset({"utils", "helpers", "common", "misc"})
+_ALLOWLIST_PATH = Path(__file__).resolve().parent / "umbrella_names_allowlist.txt"
+_CLASS_NAME_PART_REGEX = re.compile(r"[A-Z][a-z0-9]*|[a-z0-9]+")
+
+
+def _load_allowlist() -> set[tuple[str, str, str]]:
+    allowlist: set[tuple[str, str, str]] = set()
+
+    for line in _ALLOWLIST_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+
+        if not line or line.startswith("#"):
+            continue
+
+        path, kind, name = line.split("|", 2)
+        allowlist.add((path, kind, name))
+    return allowlist
+
+
+def _is_test_path(path: Path) -> bool:
+    return "tests" in path.parts or path.name.startswith("test_")
+
+
+def _split_module_name(name: str) -> list[str]:
+    return [part for part in name.strip("_").lower().split("_") if part]
+
+
+def _split_class_name(name: str) -> list[str]:
+    return [match.group(0).lower() for match in _CLASS_NAME_PART_REGEX.finditer(name.strip("_"))]
+
+
+def _offending_word(words: list[str]) -> str | None:
+    if len(words) == 1 and words[0] in _BARE_UMBRELLA_WORDS:
+        return words[0]
+
+    for word in words:
+        if word in _UMBRELLA_WORDS:
+            return word
+    return None
+
+
+def _umbrella_offenses(path: Path, tree: ast.AST) -> list[tuple[str, str]]:
+    hits: list[tuple[str, str]] = []
+    module_name = path.stem
+
+    offending_word = _offending_word(_split_module_name(module_name))
+
+    if offending_word is not None:
+        hits.append(("module", module_name))
+
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef):
+            offending_word = _offending_word(_split_class_name(node.name))
+
+            if offending_word is not None:
+                hits.append(("class", node.name))
+
+    return hits
+
+
+@pytest.mark.parametrize("package", _PRODUCT_ROOTS)
+def test_product_packages_have_no_umbrella_names(package: str) -> None:
+    root = _REPO_ROOT / package
+    if not root.is_dir():
+        pytest.skip(f"{package}/ missing")
+
+    offenders: list[str] = []
+    allowlist: set[tuple[str, str, str]] = _load_allowlist()
+    for path in product_python_files(root):
+        if _is_test_path(path):
+            continue
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            offenders.append(f"{path.relative_to(_REPO_ROOT)}: syntax error: {exc}")
+            continue
+
+        relpath = path.relative_to(_REPO_ROOT).as_posix()
+        for kind, name in _umbrella_offenses(path, tree):
+            if (relpath, kind, name) in allowlist:
+                continue
+
+            offenders.append(f"{relpath}:{kind}: {name}")
+
+    assert offenders == [], (
+        "New umbrella name introduced (see docs/NAMING.md for the vocabulary to use "
+        "instead). Rename it — do not add it to "
+        "tests/quality/umbrella_names_allowlist.txt to silence this:\n" + "\n".join(offenders)
+    )

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -105,6 +105,25 @@ def _umbrella_offenses(path: Path, tree: ast.AST) -> list[tuple[str, str]]:
     return hits
 
 
+def _scan_offenders(root: Path) -> set[tuple[str, str, str]]:
+    offenders: set[tuple[str, str, str]] = set()
+
+    for path in product_python_files(root):
+        if _is_test_path(path):
+            continue
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+
+        relpath = path.relative_to(_REPO_ROOT).as_posix()
+        for kind, name in _umbrella_offenses(path, tree):
+            offenders.add((relpath, kind, name))
+
+    return offenders
+
+
 @pytest.mark.parametrize("package", _PRODUCT_ROOTS)
 def test_product_packages_have_no_umbrella_names(package: str) -> None:
     root = _REPO_ROOT / package
@@ -134,4 +153,22 @@ def test_product_packages_have_no_umbrella_names(package: str) -> None:
         "New umbrella name introduced (see docs/NAMING.md for the vocabulary to use "
         "instead). Rename it — do not add it to "
         "tests/quality/umbrella_names_allowlist.txt to silence this:\n" + "\n".join(offenders)
+    )
+
+
+def test_umbrella_allowlist_has_no_stale_entries() -> None:
+    allowlist: set[tuple[str, str, str]] = _load_allowlist()
+
+    offenders: set[tuple[str, str, str]] = set()
+    for package in _PRODUCT_ROOTS:
+        root = _REPO_ROOT / package
+        if not root.is_dir():
+            continue
+        offenders |= _scan_offenders(root)
+
+    stale_entries: set[tuple[str, str, str]] = allowlist - offenders
+    assert stale_entries == set(), (
+        "umbrella_names_allowlist.txt has entries that no longer match a real, "
+        "current offender (already renamed, or never existed). Remove them:\n"
+        + "\n".join(sorted(f"{path}|{kind}|{name}" for path, kind, name in stale_entries))
     )

--- a/tests/quality/test_no_umbrella_names.py
+++ b/tests/quality/test_no_umbrella_names.py
@@ -48,9 +48,10 @@ _UMBRELLA_WORDS = frozenset(
 _NETWORK_PORT_PREFIXES = frozenset(
     {"http", "https", "tcp", "udp", "grpc", "ws", "wss", "ssh", "ftp", "smtp", "dns", "ip"}
 )
+_HEXAGONAL_PORT_BASE_NAMES = frozenset({"Protocol", "ABC"})
 _BARE_UMBRELLA_WORDS = frozenset({"utils", "helpers", "common", "misc"})
 _ALLOWLIST_PATH = Path(__file__).resolve().parent / "umbrella_names_allowlist.txt"
-_CLASS_NAME_PART_REGEX = re.compile(r"[A-Z][a-z0-9]*|[a-z0-9]+")
+_CLASS_NAME_PART_REGEX = re.compile(r"[A-Z]+[0-9]*(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
 
 
 def _load_allowlist() -> set[tuple[str, str, str]]:
@@ -71,8 +72,28 @@ def _is_test_path(path: Path) -> bool:
     return "tests" in path.parts or path.name.startswith("test_")
 
 
-def _is_network_port(word: str, previous_word: str) -> bool:
-    return word == "port" and previous_word in _NETWORK_PORT_PREFIXES
+def _is_network_port(word: str, previous_word: str, is_hexagonal_port: bool) -> bool:
+    return word == "port" and previous_word in _NETWORK_PORT_PREFIXES and not is_hexagonal_port
+
+
+def _hexagonal_port_base_names(tree: ast.AST) -> frozenset[str]:
+    names = set(_HEXAGONAL_PORT_BASE_NAMES)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in ("typing", "abc"):
+            for alias in node.names:
+                if alias.name in _HEXAGONAL_PORT_BASE_NAMES and alias.asname:
+                    names.add(alias.asname)
+    return frozenset(names)
+
+
+def _is_hexagonal_port_class(node: ast.ClassDef, base_names: frozenset[str]) -> bool:
+    for base in node.bases:
+        if isinstance(base, ast.Subscript):
+            base = base.value
+        name = base.id if isinstance(base, ast.Name) else getattr(base, "attr", None)
+        if name in base_names:
+            return True
+    return False
 
 
 def _split_module_name(name: str) -> list[str]:
@@ -83,13 +104,13 @@ def _split_class_name(name: str) -> list[str]:
     return [match.group(0).lower() for match in _CLASS_NAME_PART_REGEX.finditer(name.strip("_"))]
 
 
-def _offending_word(words: list[str]) -> str | None:
+def _offending_word(words: list[str], is_hexagonal_port: bool = False) -> str | None:
     if len(words) == 1 and words[0] in _BARE_UMBRELLA_WORDS:
         return words[0]
 
     previous_word: str = ""
     for word in words:
-        if word in _UMBRELLA_WORDS and not _is_network_port(word, previous_word):
+        if word in _UMBRELLA_WORDS and not _is_network_port(word, previous_word, is_hexagonal_port):
             return word
 
         previous_word = word
@@ -108,9 +129,13 @@ def _umbrella_offenses(path: Path, tree: ast.AST) -> list[tuple[str, str]]:
     if offending_word is not None:
         hits.append(("module", module_name))
 
+    hexagonal_port_base_names: frozenset[str] = _hexagonal_port_base_names(tree)
+
     class _Visitor(ast.NodeVisitor):
         def visit_ClassDef(self, node: ast.ClassDef) -> None:
-            offending_word = _offending_word(_split_class_name(node.name))
+            is_hexagonal_port = _is_hexagonal_port_class(node, hexagonal_port_base_names)
+            offending_word = _offending_word(_split_class_name(node.name), is_hexagonal_port)
+
             if offending_word is not None:
                 hits.append(("class", node.name))
 
@@ -285,3 +310,61 @@ def test_nested_class_inside_classdef_is_not_detected() -> None:
     hits = _umbrella_offenses(Path("core/u.py"), tree)
 
     assert hits == []
+
+
+def test_protocol_http_port_acronym_class_is_detected() -> None:
+    tree = ast.parse("class HTTPPort(Protocol):\n    pass\n")
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert ("class", "HTTPPort") in hits
+
+
+def test_http_port_acronym_class_name_is_exempt() -> None:
+    tree = ast.parse("class HTTPPort:\n    pass\n")
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert hits == []
+
+
+def test_tcp_port_acronym_class_name_is_exempt() -> None:
+    tree = ast.parse("class TCPPort:\n    pass\n")
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert hits == []
+
+
+def test_abc_http_port_class_is_detected() -> None:
+    tree = ast.parse("class HttpPort(ABC):\n    pass\n")
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert ("class", "HttpPort") in hits
+
+
+def test_protocol_as_second_base_class_is_still_detected() -> None:
+    tree = ast.parse("class HttpPort(ExecutionGate, Protocol):\n    pass\n")
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert ("class", "HttpPort") in hits
+
+
+def test_aliased_protocol_import_is_still_detected() -> None:
+    tree = ast.parse(
+        "from typing import Protocol as _Protocol\n\n\nclass HttpPort(_Protocol):\n    pass\n"
+    )
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert ("class", "HttpPort") in hits
+
+
+def test_generic_protocol_port_class_is_detected() -> None:
+    tree = ast.parse(
+        "from typing import Protocol, TypeVar\n"
+        "T = TypeVar('T')\n"
+        "\n"
+        "\n"
+        "class HttpPort(Protocol[T]):\n"
+        "    pass\n"
+    )
+    hits = _umbrella_offenses(Path("infrastructure/network/transport.py"), tree)
+
+    assert ("class", "HttpPort") in hits

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -8,8 +8,6 @@
 
 # bare utils/helpers/common/misc
 integrations/github/helpers.py|module|helpers
-surfaces/interactive_shell/runtime/utils/__init__.py|module|utils
-surfaces/interactive_shell/utils/__init__.py|module|utils
 
 # engine
 infrastructure/filestorage/engine.py|module|engine
@@ -61,6 +59,7 @@ integrations/github/tools/security_fix/context.py|module|context
 integrations/slack/message_context.py|module|message_context
 surfaces/interactive_shell/grounding/cli_reference.py|class|ShellPromptContextProvider
 surfaces/interactive_shell/runtime/context.py|module|context
+surfaces/shared/terminal/feedback/context_display.py|module|context_display
 tools/cross_vendor/fix_sentry_issue/context.py|class|IssueContext
 tools/cross_vendor/fix_sentry_issue/context.py|module|context
 tools/investigation/reporting/context/schema.py|class|ReportContext

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -9,6 +9,8 @@
 # bare utils/helpers/common/misc
 integrations/github/helpers.py|module|helpers
 integrations/helm/helpers.py|module|helpers
+surfaces/interactive_shell/runtime/utils/__init__.py|module|utils
+surfaces/interactive_shell/utils/__init__.py|module|utils
 
 # engine
 infrastructure/filestorage/engine.py|module|engine
@@ -48,6 +50,7 @@ core/context_budget.py|module|context_budget
 core/state/channel_context.py|module|channel_context
 core/state/runtime_slices.py|class|DeliveryContextSlice
 core/tool/contracts.py|class|AgentToolContext
+core/tool_framework/utils/__init__.py|module|utils
 gateway/core/session/gateway_chat_context.py|module|gateway_chat_context
 infrastructure/analytics/repl_context.py|module|repl_context
 infrastructure/analytics/usage_context.py|module|usage_context
@@ -62,3 +65,4 @@ surfaces/interactive_shell/runtime/context.py|module|context
 tools/cross_vendor/fix_sentry_issue/context.py|class|IssueContext
 tools/cross_vendor/fix_sentry_issue/context.py|module|context
 tools/investigation/reporting/context/schema.py|class|ReportContext
+tools/investigation/reporting/context/__init__.py|module|context

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -21,7 +21,6 @@ gateway/transports/buzz/inbound_handler.py|module|inbound_handler
 gateway/transports/telegram/inbound_handler.py|module|inbound_handler
 infrastructure/logging/shell_handler.py|class|ShellLogHandler
 infrastructure/logging/shell_handler.py|module|shell_handler
-integrations/llm_cli/codex_oauth.py|class|_CallbackHandler
 
 # wrapper
 core/tool_framework/utils/sql_wrapper.py|module|sql_wrapper
@@ -36,7 +35,6 @@ config/scope_context.py|module|scope_context
 core/agent_harness/grounding/context.py|class|GroundingContext
 core/agent_harness/grounding/context.py|module|context
 core/agent_harness/ports.py|class|PromptContextProvider
-core/agent_harness/prompts/assistant/turn.py|class|AssistantPromptContextProvider
 core/agent_harness/prompts/grounding/provider.py|class|DefaultPromptContextProvider
 core/agent_harness/tools/action_tools.py|class|IntegrationsContext
 core/agent_harness/tools/action_tools.py|class|_IntegrationContextSession

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -46,6 +46,7 @@ core/state/channel_context.py|module|channel_context
 core/state/runtime_slices.py|class|DeliveryContextSlice
 core/tool/contracts.py|class|AgentToolContext
 core/tool_framework/utils/__init__.py|module|utils
+core/agent_harness/session/persistence/contracts.py|class|RestoreContextKey
 gateway/core/session/gateway_chat_context.py|module|gateway_chat_context
 infrastructure/analytics/repl_context.py|module|repl_context
 infrastructure/analytics/usage_context.py|module|usage_context

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -27,7 +27,17 @@ infrastructure/logging/shell_handler.py|module|shell_handler
 core/tool_framework/utils/sql_wrapper.py|module|sql_wrapper
 
 # port (hexagonal sense — not network ports)
+core/agent_harness/ports.py|module|ports
 integrations/hermes/sinks.py|class|AlarmDispatcherPort
+surfaces/interactive_shell/runtime/investigation_adapter.py|class|ReplInvestigationLaunchPorts
+surfaces/interactive_shell/runtime/llm_provider_adapter.py|class|LlmProviderPorts
+surfaces/interactive_shell/runtime/llm_provider_adapter.py|class|ReplLlmProviderPorts
+surfaces/interactive_shell/runtime/slash_adapter.py|class|HeadlessSlashPorts
+surfaces/interactive_shell/runtime/slash_adapter.py|class|ReplSlashPorts
+surfaces/interactive_shell/runtime/slash_adapter.py|class|SlashPorts
+surfaces/interactive_shell/runtime/task_cancel_adapter.py|class|ReplTaskCancelPorts
+surfaces/interactive_shell/runtime/task_cancel_adapter.py|class|TaskCancelPorts
+tools/interactive_shell/shared/investigation_launch.py|class|InvestigationLaunchPorts
 tools/system/watch_dog/monitor.py|class|AlarmDispatcherPort
 
 # context

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -8,23 +8,16 @@
 
 # bare utils/helpers/common/misc
 integrations/github/helpers.py|module|helpers
-integrations/groundcover/helpers.py|module|helpers
 integrations/helm/helpers.py|module|helpers
 
 # engine
 infrastructure/filestorage/engine.py|module|engine
-infrastructure/safety/guardrails/engine.py|class|GuardrailEngine
-infrastructure/safety/guardrails/engine.py|module|engine
 
 # manager
 core/agent_harness/session/lifecycle.py|class|SessionManager
 gateway/core/lifecycle/credential_hydration.py|class|SecretsManagerClient
-surfaces/interactive_shell/runtime/background/workers.py|class|BackgroundTaskManager
-surfaces/interactive_shell/runtime/core/prompt_manager.py|class|PromptManager
-surfaces/interactive_shell/runtime/core/prompt_manager.py|module|prompt_manager
 
 # handler
-core/agent/handle_conclusion.py|class|ConclusionHandler
 gateway/transports/buzz/inbound_handler.py|module|inbound_handler
 gateway/transports/telegram/inbound_handler.py|module|inbound_handler
 infrastructure/logging/shell_handler.py|class|ShellLogHandler
@@ -35,9 +28,7 @@ integrations/llm_cli/codex_oauth.py|class|_CallbackHandler
 core/tool_framework/utils/sql_wrapper.py|module|sql_wrapper
 
 # port (hexagonal sense — not network ports)
-infrastructure/delivery/reporting/slack_reactions.py|class|SlackReactionsPort
 integrations/hermes/sinks.py|class|AlarmDispatcherPort
-integrations/slack/reporting_adapter.py|class|_SlackReactionsPort
 tools/system/watch_dog/monitor.py|class|AlarmDispatcherPort
 
 # context
@@ -50,7 +41,6 @@ core/agent_harness/prompts/assistant/turn.py|class|AssistantPromptContextProvide
 core/agent_harness/prompts/grounding/provider.py|class|DefaultPromptContextProvider
 core/agent_harness/tools/action_tools.py|class|IntegrationsContext
 core/agent_harness/tools/action_tools.py|class|_IntegrationContextSession
-core/agent_harness/tools/tool_context.py|class|ActionToolContext
 core/agent_harness/tools/tool_context.py|module|tool_context
 core/agent_harness/turns/headless_adapters.py|class|EmptyPromptContextProvider
 core/agent_harness/turns/host_cancel.py|class|CancelProbeContext
@@ -60,19 +50,14 @@ core/state/runtime_slices.py|class|DeliveryContextSlice
 core/tool/contracts.py|class|AgentToolContext
 gateway/core/session/gateway_chat_context.py|module|gateway_chat_context
 infrastructure/analytics/repl_context.py|module|repl_context
-infrastructure/analytics/runtime_context.py|class|RuntimeContext
-infrastructure/analytics/runtime_context.py|module|runtime_context
 infrastructure/analytics/usage_context.py|module|usage_context
 infrastructure/harness_providers/message_context.py|module|message_context
-infrastructure/safety/masking/context.py|class|MaskingContext
-infrastructure/safety/masking/context.py|module|context
 integrations/github/tools/ci_fix/context.py|class|CiFixContext
 integrations/github/tools/ci_fix/context.py|module|context
 integrations/github/tools/security_fix/context.py|class|SecurityAlertContext
 integrations/github/tools/security_fix/context.py|module|context
 integrations/slack/message_context.py|module|message_context
 surfaces/interactive_shell/grounding/cli_reference.py|class|ShellPromptContextProvider
-surfaces/interactive_shell/runtime/context.py|class|ReplRuntimeContext
 surfaces/interactive_shell/runtime/context.py|module|context
 tools/cross_vendor/fix_sentry_issue/context.py|class|IssueContext
 tools/cross_vendor/fix_sentry_issue/context.py|module|context

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -8,6 +8,7 @@
 
 # bare utils/helpers/common/misc
 integrations/github/helpers.py|module|helpers
+integrations/grafana/tools/_helpers.py|module|_helpers
 
 # engine
 infrastructure/filestorage/engine.py|module|engine
@@ -36,8 +37,6 @@ core/agent_harness/grounding/context.py|class|GroundingContext
 core/agent_harness/grounding/context.py|module|context
 core/agent_harness/ports.py|class|PromptContextProvider
 core/agent_harness/prompts/grounding/provider.py|class|DefaultPromptContextProvider
-core/agent_harness/tools/action_tools.py|class|IntegrationsContext
-core/agent_harness/tools/action_tools.py|class|_IntegrationContextSession
 core/agent_harness/tools/tool_context.py|module|tool_context
 core/agent_harness/turns/headless_adapters.py|class|EmptyPromptContextProvider
 core/agent_harness/turns/host_cancel.py|class|CancelProbeContext

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -8,7 +8,6 @@
 
 # bare utils/helpers/common/misc
 integrations/github/helpers.py|module|helpers
-integrations/helm/helpers.py|module|helpers
 surfaces/interactive_shell/runtime/utils/__init__.py|module|utils
 surfaces/interactive_shell/utils/__init__.py|module|utils
 

--- a/tests/quality/umbrella_names_allowlist.txt
+++ b/tests/quality/umbrella_names_allowlist.txt
@@ -1,0 +1,79 @@
+# Shrink-only allowlist for tests/quality/test_no_umbrella_names.py.
+#
+# Format: <repo-relative path>|<module|class>|<offending name>
+#
+# One line per known umbrella-name offender as of the PR that added this
+# guard. Remove a line once the file/class is renamed away from the banned
+# word — do not add a new line to silence a new offender, rename it instead.
+
+# bare utils/helpers/common/misc
+integrations/github/helpers.py|module|helpers
+integrations/groundcover/helpers.py|module|helpers
+integrations/helm/helpers.py|module|helpers
+
+# engine
+infrastructure/filestorage/engine.py|module|engine
+infrastructure/safety/guardrails/engine.py|class|GuardrailEngine
+infrastructure/safety/guardrails/engine.py|module|engine
+
+# manager
+core/agent_harness/session/lifecycle.py|class|SessionManager
+gateway/core/lifecycle/credential_hydration.py|class|SecretsManagerClient
+surfaces/interactive_shell/runtime/background/workers.py|class|BackgroundTaskManager
+surfaces/interactive_shell/runtime/core/prompt_manager.py|class|PromptManager
+surfaces/interactive_shell/runtime/core/prompt_manager.py|module|prompt_manager
+
+# handler
+core/agent/handle_conclusion.py|class|ConclusionHandler
+gateway/transports/buzz/inbound_handler.py|module|inbound_handler
+gateway/transports/telegram/inbound_handler.py|module|inbound_handler
+infrastructure/logging/shell_handler.py|class|ShellLogHandler
+infrastructure/logging/shell_handler.py|module|shell_handler
+integrations/llm_cli/codex_oauth.py|class|_CallbackHandler
+
+# wrapper
+core/tool_framework/utils/sql_wrapper.py|module|sql_wrapper
+
+# port (hexagonal sense — not network ports)
+infrastructure/delivery/reporting/slack_reactions.py|class|SlackReactionsPort
+integrations/hermes/sinks.py|class|AlarmDispatcherPort
+integrations/slack/reporting_adapter.py|class|_SlackReactionsPort
+tools/system/watch_dog/monitor.py|class|AlarmDispatcherPort
+
+# context
+config/constants/paths.py|class|ContextRootOwnerMismatchError
+config/scope_context.py|module|scope_context
+core/agent_harness/grounding/context.py|class|GroundingContext
+core/agent_harness/grounding/context.py|module|context
+core/agent_harness/ports.py|class|PromptContextProvider
+core/agent_harness/prompts/assistant/turn.py|class|AssistantPromptContextProvider
+core/agent_harness/prompts/grounding/provider.py|class|DefaultPromptContextProvider
+core/agent_harness/tools/action_tools.py|class|IntegrationsContext
+core/agent_harness/tools/action_tools.py|class|_IntegrationContextSession
+core/agent_harness/tools/tool_context.py|class|ActionToolContext
+core/agent_harness/tools/tool_context.py|module|tool_context
+core/agent_harness/turns/headless_adapters.py|class|EmptyPromptContextProvider
+core/agent_harness/turns/host_cancel.py|class|CancelProbeContext
+core/context_budget.py|module|context_budget
+core/state/channel_context.py|module|channel_context
+core/state/runtime_slices.py|class|DeliveryContextSlice
+core/tool/contracts.py|class|AgentToolContext
+gateway/core/session/gateway_chat_context.py|module|gateway_chat_context
+infrastructure/analytics/repl_context.py|module|repl_context
+infrastructure/analytics/runtime_context.py|class|RuntimeContext
+infrastructure/analytics/runtime_context.py|module|runtime_context
+infrastructure/analytics/usage_context.py|module|usage_context
+infrastructure/harness_providers/message_context.py|module|message_context
+infrastructure/safety/masking/context.py|class|MaskingContext
+infrastructure/safety/masking/context.py|module|context
+integrations/github/tools/ci_fix/context.py|class|CiFixContext
+integrations/github/tools/ci_fix/context.py|module|context
+integrations/github/tools/security_fix/context.py|class|SecurityAlertContext
+integrations/github/tools/security_fix/context.py|module|context
+integrations/slack/message_context.py|module|message_context
+surfaces/interactive_shell/grounding/cli_reference.py|class|ShellPromptContextProvider
+surfaces/interactive_shell/runtime/context.py|class|ReplRuntimeContext
+surfaces/interactive_shell/runtime/context.py|module|context
+tools/cross_vendor/fix_sentry_issue/context.py|class|IssueContext
+tools/cross_vendor/fix_sentry_issue/context.py|module|context
+tools/investigation/reporting/context/schema.py|class|ReportContext


### PR DESCRIPTION

Fixes #5363

#### Describe the changes you have made in this PR -

Ban umbrella words (manager, handler, context, engine, bare utils/helpers,
hexagonal port, ...) in new first-party module and top-level class names,
with a shrink-only allowlist of today's existing offenders.

### Demo/Screenshot for feature changes and bug fixes - 

- test pass

```bash
uv run pytest tests/quality/test_no_umbrella_names.py -q
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/ryo_kasai/opensre
configfile: pytest.ini
plugins: anyio-4.13.0, cov-7.1.0, asyncio-1.3.0, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 8 items                                                                                                                                                                                              

tests/quality/test_no_umbrella_names.py ........                                                                                                                                                         [100%]

============================================================================================= slowest 20 durations =============================================================================================
1.03s setup    tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[bootstrap]
0.40s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[integrations]
0.18s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[core]
0.15s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[surfaces]
0.12s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[infrastructure]
0.12s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[tools]
0.06s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[gateway]
0.03s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[config]

(12 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================================================== 8 passed in 2.13s ===============================================================================================
```

- test faile

```bash
uv run pytest tests/quality/test_no_umbrella_names.py -q
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/ryo_kasai/opensre
configfile: pytest.ini
plugins: anyio-4.13.0, cov-7.1.0, asyncio-1.3.0, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 8 items                                                                                                                                                                                              

tests/quality/test_no_umbrella_names.py ....F...                                                                                                                                                         [100%]

=================================================================================================== FAILURES ===================================================================================================
__________________________________________________________________________ test_product_packages_have_no_umbrella_names[integrations] __________________________________________________________________________
tests/quality/test_no_umbrella_names.py:133: in test_product_packages_have_no_umbrella_names
    assert offenders == [], (
E   AssertionError: New umbrella name introduced (see docs/NAMING.md for the vocabulary to use instead). Rename it — do not add it to tests/quality/umbrella_names_allowlist.txt to silence this:
E     integrations/github/helpers.py:module: helpers
E   assert ['integration...ule: helpers'] == []
E     
E     Left contains one more item: 'integrations/github/helpers.py:module: helpers'
E     Use -v to get more diff
============================================================================================= slowest 20 durations =============================================================================================
0.87s setup    tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[bootstrap]
0.37s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[integrations]
0.17s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[surfaces]
0.16s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[core]
0.12s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[infrastructure]
0.08s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[tools]
0.05s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[gateway]
0.03s call     tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[config]

(12 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================================================================================== short test summary info ============================================================================================
FAILED tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[integrations] - AssertionError: New umbrella name introduced (see docs/NAMING.md for the vocabulary to use instead). Rename it — do not add it to tests/quality/umbrella_names_allowlist.txt to silence this:
========================================================================================= 1 failed, 7 passed in 1.93s ==========================================================================================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**What problem does your code solve**

The goal is to detect "umbrella words"—vague terms prone to becoming catch-alls—during CI test execution (with enforcement starting after merging) in order to ensure the quality of production code.

We believe that eliminating umbrella words will lead to:

- Separation of concerns
- Improved code readability

...thereby boosting team productivity.

**What alternative approaches did you consider**

- We considered several alternatives for the allowlist file format (e.g., YAML, JSON).

- We chose the .txt format for the following reasons:
  - .importlinter.strict was a plain text file.
  - Formats other than plain text would introduce unnecessary dependencies.
  - It allows for parsing using only `line.split`, resulting in simpler code.


**Why did you choose this specific implementation?**

- I implemented the solution based on the reference to `tests/quality/test_no_constant_condition_toggles.py` found in the issue description.

- For the allowlist, I am using a grouped text file, modeled after the `ignore_imports` configuration in `.importlinter.strict`.

- Regarding the implementation `_CLASS_NAME_PART_REGEX = re.compile(r"[A-Z][a-z0-9]*|[a-z0-9]+")`: while this would technically not trigger a violation for a name like `UTILSClass`, I have not accounted for this scenario as it violates standard Python naming conventions.

**What are the key functions/components and what do they do?**

`test_product_packages_have_no_umbrella_names`
  - Core test logic.
  - Retrieves a list of actual Python files and detects those that violate the rule.
  - Entries included in a pre-defined allowlist are excluded (exclusions apply based on exact matches for the path relative to the project root, type, and filename).

`_umbrella_offenses`
  - Core logic for detecting inappropriate terms.
  - It first checks the module name, then sequentially traverses code elements extracted from the Abstract Syntax Tree (AST) to inspect for inappropriate words, particularly within class names.
  - Implemented in alignment with the logic found in `tests/quality/test_no_constant_condition_toggles.py`.

`test_umbrella_allowlist_has_no_stale_entries`
- This test detects stale or renamed entries in the allowlist.
- It verifies that there are no discrepancies between the list of entries in the allowlist and the set of current violations (obtained via `_scan_offenders`).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
---

### Maintainer follow-up validation

- Closed plural, numeric/version-suffix, and CamelCase naming bypasses.
- Kept network-port exemptions narrow while covering HTTP/2, IPv6, and reviewed server/listener/socket forms; Protocol/ABC contracts remain blocked.
- Refreshed the initial baseline with the ten pre-existing plural `Port(s)` offenders exposed by the stricter matcher.
- Validation: `make lint`, `make format-check`, `make typecheck`, and `uv run python -m pytest tests/quality/test_no_umbrella_names.py -q` (`38 passed`).
