### PR TITLE
refactor(wizard): give _ui.py public names and extract the render block

### DIFF
--- a/surfaces/cli/wizard/_integration_configurators.py
+++ b/surfaces/cli/wizard/_integration_configurators.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from infrastructure.terminal.theme import SECONDARY, WARNING
-from surfaces.cli.wizard._ui import _choose, _console, _step
+from surfaces.cli.wizard.components import choose, console, step
 from surfaces.cli.wizard.configurators.alerting import (
     _configure_alertmanager,
     _configure_betterstack,
@@ -66,12 +66,12 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
     configured: list[str] = []
     last_env_path: str | None = None
 
-    _console.print(
+    console.print(
         f"[{SECONDARY}]Pick one integration to wire up now, or skip this step "
         f"and come back later.[/]"
     )
     integration_choices = list(ONBOARD_INTEGRATION_CHOICES)
-    selected_service = _choose(
+    selected_service = choose(
         "Choose an integration to configure",
         integration_choices,
         default="grafana_local",
@@ -152,9 +152,9 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         "tempo": "grafana tempo",
     }
 
-    _step(f"Service · {_SERVICE_LABELS.get(selected_service, selected_service)}")
+    step(f"Service · {_SERVICE_LABELS.get(selected_service, selected_service)}")
     if selected_service == "vercel":
-        _console.print(
+        console.print(
             f"[{SECONDARY}]Note: Vercel's runtime-log API may omit or delay lines compared to the "
             "dashboard. Deployment and build checks still apply; there is no CLI incident browser.[/]"
         )
@@ -163,7 +163,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         configured.append(label)
         last_env_path = env_path
     except KeyboardInterrupt:
-        _console.print(
+        console.print(
             f"[{WARNING}]{_SERVICE_LABELS.get(selected_service, selected_service)} setup skipped.[/]"
         )
 

--- a/surfaces/cli/wizard/azure_openai.py
+++ b/surfaces/cli/wizard/azure_openai.py
@@ -12,15 +12,15 @@ from core.llm.providers.azure_openai import (
     resolve_azure_openai_api_version,
 )
 from infrastructure.terminal.theme import ERROR, WARNING
-from surfaces.cli.wizard._ui import (
-    _CUSTOM_MODEL_SENTINEL,
+from surfaces.cli.wizard.components import (
+    CUSTOM_MODEL_SENTINEL,
     Choice,
     WizardBack,
-    _choose,
-    _choose_model,
-    _console,
-    _prompt_value,
-    _step,
+    choose,
+    choose_model,
+    console,
+    prompt_value,
+    step,
 )
 
 if TYPE_CHECKING:
@@ -40,9 +40,9 @@ def prompt_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
     if not provider.endpoint_env or not provider.api_version_env:
         return {}
 
-    _step("Azure endpoint")
+    step("Azure endpoint")
     try:
-        base_url = _prompt_value(
+        base_url = prompt_value(
             f"Azure OpenAI resource URL ({provider.endpoint_env})",
             default=os.getenv(provider.endpoint_env, provider.credential_default),
             secret=False,
@@ -53,7 +53,7 @@ def prompt_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
 
     normalized_base = normalize_azure_openai_base_url(base_url)
     if not normalized_base:
-        _console.print(f"[{ERROR}]Azure OpenAI resource URL is required.[/]")
+        console.print(f"[{ERROR}]Azure OpenAI resource URL is required.[/]")
         return None
     return {
         provider.endpoint_env: normalized_base,
@@ -79,16 +79,16 @@ def choose_azure_deployment(
     back_on_cancel: bool = False,
 ) -> str:
     """Prompt for an Azure OpenAI deployment name from the user's resource."""
-    _step("Deployment")
+    step("Deployment")
 
     resolved_default = (default or "").strip()
     deployments = discover_azure_openai_deployments_from_env()
     if not deployments:
-        _console.print(
+        console.print(
             f"[{WARNING}]Could not list deployments from your Azure resource. "
             "Enter the deployment name from the Azure portal.[/]"
         )
-        return _prompt_value(
+        return prompt_value(
             f"Azure OpenAI deployment name ({model_env})",
             default=resolved_default,
             allow_empty=False,
@@ -103,7 +103,7 @@ def choose_azure_deployment(
         extra_choices.append(Choice(value=resolved_default, label=resolved_default, hint="current"))
 
     custom_choice = Choice(
-        value=_CUSTOM_MODEL_SENTINEL,
+        value=CUSTOM_MODEL_SENTINEL,
         label="Enter custom deployment name",
         hint="type deployment name from Azure portal",
     )
@@ -112,16 +112,16 @@ def choose_azure_deployment(
     if default_value and not any(choice.value == default_value for choice in choices):
         default_value = deployments[0]
 
-    selection = _choose(
+    selection = choose(
         "Choose Azure OpenAI deployment",
         choices,
         default=default_value or None,
         back_on_cancel=back_on_cancel,
     )
-    if selection != _CUSTOM_MODEL_SENTINEL:
+    if selection != CUSTOM_MODEL_SENTINEL:
         return selection
 
-    return _prompt_value(
+    return prompt_value(
         f"Custom Azure OpenAI deployment name ({model_env})",
         default=resolved_default,
         allow_empty=False,
@@ -144,7 +144,7 @@ def choose_provider_model(
             model_env=model_provider.model_env,
             back_on_cancel=back_on_cancel,
         )
-    return _choose_model(
+    return choose_model(
         model_provider,
         default=default,
         prompt_label=prompt_label,

--- a/surfaces/cli/wizard/components.py
+++ b/surfaces/cli/wizard/components.py
@@ -1,11 +1,20 @@
-"""UI primitives and rendering helpers for the wizard onboarding flow."""
+"""Shared UI components for the wizard onboarding flow.
+
+This is the wizard's interaction layer: the ``Choice`` type and ``WizardBack``
+control-flow exception, the shared ``console``, step headers, and the
+choice/value/confirm/model prompts that compose wizard steps. It sits above
+:mod:`surfaces.cli.wizard.prompts`, which builds the raw prompt-toolkit
+select/checkbox widgets — ``prompts`` renders a list control, this module
+orchestrates it into a wizard step. Rendered output screens (splash, saved
+summary, integration result, next steps) live in
+:mod:`surfaces.cli.wizard.summaries`.
+"""
 
 from __future__ import annotations
 
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import cast
 
 import questionary
 from rich.console import Console
@@ -22,14 +31,12 @@ from config.llm_auth.credentials import has_llm_api_key, save_api_key
 from config.llm_auth.provider_catalog import API_KEY_PROVIDER_ENVS
 from config.llm_credentials import get_keyring_setup_instructions, save_keyring_secret
 from config.setup_store import get_store_path, load_local_config
-from config.version import get_opensre_version
 from infrastructure.terminal.theme import (
     BG,
     BRAND,
     DIM,
     ERROR,
     GLYPH_ERROR,
-    GLYPH_SUCCESS,
     GLYPH_WARNING,
     HIGHLIGHT,
     SECONDARY,
@@ -37,7 +44,6 @@ from infrastructure.terminal.theme import (
     WARNING,
 )
 from integrations.store import get_integration
-from surfaces.cli.wizard.integration_health import IntegrationHealthResult
 from surfaces.cli.wizard.probes import ProbeResult
 from surfaces.cli.wizard.prompts import select as select_prompt
 from surfaces.shared.llm_setup.catalog import (
@@ -47,7 +53,7 @@ from surfaces.shared.llm_setup.catalog import (
 )
 from surfaces.shared.llm_setup.persist import AuthSetupError, persist_api_key_secret
 
-_console = Console(
+console = Console(
     highlight=False, force_terminal=True, color_system="truecolor", legacy_windows=False
 )
 
@@ -76,7 +82,7 @@ def _questionary_style() -> questionary.Style:
     )
 
 
-def _group_header_label(group: str) -> str:
+def group_header_label(group: str) -> str:
     """Format a category label for grouped wizard pickers."""
     return f"── {group} ──"
 
@@ -99,11 +105,11 @@ def _as_mapping(value: object) -> Mapping[str, object]:
     return value if isinstance(value, Mapping) else {}
 
 
-def _string_value(value: object, fallback: str = "") -> str:
+def string_value(value: object, fallback: str = "") -> str:
     return value if isinstance(value, str) else fallback
 
 
-def _joined_values(value: object, *, separator: str, fallback: str) -> str:
+def joined_values(value: object, *, separator: str, fallback: str) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, list) and all(isinstance(item, str) for item in value):
@@ -111,18 +117,18 @@ def _joined_values(value: object, *, separator: str, fallback: str) -> str:
     return fallback
 
 
-def _local_defaults() -> dict[str, str | bool | None]:
+def local_defaults() -> dict[str, str | bool | None]:
     stored = load_local_config(get_store_path())
     wizard = _as_mapping(stored.get("wizard"))
     targets = _as_mapping(stored.get("targets"))
     local = _as_mapping(targets.get("local"))
     raw_provider = local.get("provider")
-    raw_provider_value = _string_value(raw_provider) if raw_provider else ""
+    raw_provider_value = string_value(raw_provider) if raw_provider else ""
     provider_value = canonical_llm_provider(raw_provider_value) if raw_provider_value else ""
     provider = PROVIDER_BY_VALUE.get(provider_value) if provider_value else None
     raw_provider_option = PROVIDER_BY_VALUE.get(raw_provider_value) if raw_provider_value else None
     api_key_provider = raw_provider_option or provider
-    api_key_env = _string_value(
+    api_key_env = string_value(
         local.get("api_key_env"), api_key_provider.api_key_env if api_key_provider else ""
     )
     is_cli = bool(
@@ -136,18 +142,18 @@ def _local_defaults() -> dict[str, str | bool | None]:
     auth_method = (
         normalize_llm_auth_method(raw_auth_method if isinstance(raw_auth_method, str) else None)
         if raw_auth_method
-        else get_configured_llm_auth_method(_string_value(raw_provider))
+        else get_configured_llm_auth_method(string_value(raw_provider))
     )
     if is_oauth_backend:
         auth_method = OAUTH_AUTH_METHOD
-    wizard_mode = _string_value(wizard.get("mode"), "quickstart")
+    wizard_mode = string_value(wizard.get("mode"), "quickstart")
     if wizard_mode in {"aha", "focused"}:
         wizard_mode = "quickstart"
     return {
         "wizard_mode": wizard_mode,
         "provider": provider_value if raw_provider_value else None,
         "auth_method": auth_method,
-        "model": _string_value(local.get("model")),
+        "model": string_value(local.get("model")),
         "api_key_env": api_key_env,
         # A ``host`` credential (e.g. the Ollama host) is only real when the
         # runtime can see it — the environment — never the keyring.
@@ -158,25 +164,25 @@ def _local_defaults() -> dict[str, str | bool | None]:
             if is_host
             else bool(api_key_env and has_llm_api_key(api_key_env))
         ),
-        "legacy_api_key": _string_value(local.get("api_key")),
+        "legacy_api_key": string_value(local.get("api_key")),
     }
 
 
-def _integration_defaults(service: str) -> tuple[Mapping[str, object], Mapping[str, object]]:
+def integration_defaults(service: str) -> tuple[Mapping[str, object], Mapping[str, object]]:
     entry = _as_mapping(get_integration(service))
     return entry, _as_mapping(entry.get("credentials"))
 
 
-def _step(title: str) -> None:
-    _console.print()
+def step(title: str) -> None:
+    console.print()
     t = Text()
     t.append("  ")
     t.append(title, style=f"bold {HIGHLIGHT}")
-    _console.print(t)
-    _console.print(Rule(style=DIM))
+    console.print(t)
+    console.print(Rule(style=DIM))
 
 
-def _step_header(n: int, total: int, title: str) -> None:
+def step_header(n: int, total: int, title: str) -> None:
     """Print a numbered wizard stage header.
 
     Rendered output (colour roles):
@@ -185,16 +191,16 @@ def _step_header(n: int, total: int, title: str) -> None:
       ─────────────────────────────────────────  [DIM rule]
     """
     dots = "●" * n + "○" * (total - n)
-    _console.print()
-    _console.print(Rule(style=DIM))
+    console.print()
+    console.print(Rule(style=DIM))
     header = Text()
     header.append("  ")
     header.append(dots, style=f"bold {BRAND}")
     header.append("  ", style=DIM)
     header.append(title, style=f"bold {TEXT}")
     header.append(f"  {n}/{total}", style=SECONDARY)
-    _console.print(header)
-    _console.print(Rule(style=DIM))
+    console.print(header)
+    console.print(Rule(style=DIM))
 
 
 def _choice_title(choice: Choice) -> str:
@@ -215,7 +221,7 @@ def _questionary_choice(choice: Choice) -> questionary.Choice:
     )
 
 
-def _grouped_questionary_choices(
+def grouped_questionary_choices(
     choices: list[Choice],
     *,
     group_order: tuple[str, ...],
@@ -236,11 +242,11 @@ def _grouped_questionary_choices(
         group_choices = grouped[group]
         if not group_choices:
             continue
-        rendered.append(questionary.Separator(_group_header_label(group)))
+        rendered.append(questionary.Separator(group_header_label(group)))
         rendered.extend(_questionary_choice(choice) for choice in group_choices)
 
     if ungrouped:
-        rendered.append(questionary.Separator(_group_header_label("Other")))
+        rendered.append(questionary.Separator(group_header_label("Other")))
         rendered.extend(_questionary_choice(choice) for choice in ungrouped)
 
     if trailing_choices:
@@ -250,7 +256,7 @@ def _grouped_questionary_choices(
     return rendered
 
 
-_CUSTOM_MODEL_SENTINEL = "__custom__"
+CUSTOM_MODEL_SENTINEL = "__custom__"
 
 
 def _provider_model_prompt_label(provider: ProviderOption) -> str:
@@ -261,7 +267,7 @@ def _provider_model_prompt_label(provider: ProviderOption) -> str:
     return provider.label
 
 
-def _choose_model(
+def choose_model(
     provider: ProviderOption,
     *,
     default: str | None,
@@ -282,8 +288,8 @@ def _choose_model(
         # OpenAI-/Anthropic-compatible gateways) must still be asked for a model
         # ID rather than silently returning an empty default.
         if provider.allow_custom_models:
-            _step("Model")
-            return _prompt_value(
+            step("Model")
+            return prompt_value(
                 f"{_provider_model_prompt_label(provider)} model ID ({provider.model_env})",
                 default=resolved_default or provider.default_model,
                 allow_empty=False,
@@ -291,7 +297,7 @@ def _choose_model(
             )
         return resolved_default or provider.default_model
 
-    _step("Model")
+    step("Model")
 
     curated_values = {option.value for option in models}
     curated_choices: list[Choice] = [
@@ -303,7 +309,7 @@ def _choose_model(
         extra_choices.append(Choice(value=resolved_default, label=resolved_default, hint="current"))
 
     custom_choice = Choice(
-        value=_CUSTOM_MODEL_SENTINEL,
+        value=CUSTOM_MODEL_SENTINEL,
         label="Enter custom model ID",
         hint="type any model identifier",
     )
@@ -311,20 +317,20 @@ def _choose_model(
     choices = curated_choices + extra_choices + [custom_choice]
     default_value = resolved_default or provider.default_model
     if default_value and not any(c.value == default_value for c in choices):
-        default_value = curated_choices[0].value if curated_choices else _CUSTOM_MODEL_SENTINEL
+        default_value = curated_choices[0].value if curated_choices else CUSTOM_MODEL_SENTINEL
 
     provider_label = prompt_label or _provider_model_prompt_label(provider)
-    selection = _choose(
+    selection = choose(
         f"Choose {provider_label} model",
         choices,
         default=default_value or None,
         back_on_cancel=back_on_cancel,
     )
 
-    if selection != _CUSTOM_MODEL_SENTINEL:
+    if selection != CUSTOM_MODEL_SENTINEL:
         return selection
 
-    return _prompt_value(
+    return prompt_value(
         f"Custom {provider_label} model ID ({provider.model_env})",
         default=resolved_default,
         allow_empty=False,
@@ -332,7 +338,7 @@ def _choose_model(
     )
 
 
-def _choose(
+def choose(
     prompt: str,
     choices: list[Choice],
     *,
@@ -342,7 +348,7 @@ def _choose(
     back_on_cancel: bool = False,
 ) -> str:
     if group_order is not None:
-        q_choices = _grouped_questionary_choices(
+        q_choices = grouped_questionary_choices(
             choices,
             group_order=group_order,
             trailing_choices=trailing_choices,
@@ -368,14 +374,14 @@ def _choose(
     return str(result)
 
 
-def _confirm(prompt: str, *, default: bool = True) -> bool:
+def confirm(prompt: str, *, default: bool = True) -> bool:
     result = questionary.confirm(prompt, default=default, style=_questionary_style()).ask()
     if result is None:
         raise KeyboardInterrupt
     return bool(result)
 
 
-def _prompt_value(
+def prompt_value(
     label: str,
     *,
     default: str = "",
@@ -412,10 +418,10 @@ def _prompt_value(
             return default
         if allow_empty:
             return ""
-        _console.print(f"[{ERROR}]  {GLYPH_ERROR}  Required.[/]")
+        console.print(f"[{ERROR}]  {GLYPH_ERROR}  Required.[/]")
 
 
-def _persist_llm_api_key(env_var: str, value: str) -> bool:
+def persist_llm_api_key(env_var: str, value: str) -> bool:
     try:
         provider = next(
             (
@@ -431,35 +437,35 @@ def _persist_llm_api_key(env_var: str, value: str) -> bool:
             result = persist_api_key_secret(env_var, value, save_secret=save_keyring_secret)
         detail = result.detail if result.used_fallback else ""
     except (AuthSetupError, RuntimeError, ValueError) as exc:
-        _console.print(f"[{ERROR}]  {GLYPH_ERROR}  {exc}[/]")
-        _console.print(
+        console.print(f"[{ERROR}]  {GLYPH_ERROR}  {exc}[/]")
+        console.print(
             f"[{WARNING}]  {GLYPH_WARNING}  OpenSRE could not save your API key to secure local storage.[/]"
         )
         for line in get_keyring_setup_instructions(env_var):
-            _console.print(f"[{SECONDARY}]    {line}[/]")
+            console.print(f"[{SECONDARY}]    {line}[/]")
         return False
     if detail:
         # Saved, but not where we would have preferred — say so rather than
         # letting a silent downgrade to on-disk storage look like a keychain write.
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+        console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
     return True
 
 
-def _parse_csv_values(raw_value: str) -> list[str]:
+def parse_csv_values(raw_value: str) -> list[str]:
     return [part.strip() for part in raw_value.split(",") if part.strip()]
 
 
 def _display_probe(result: ProbeResult) -> None:
     status = f"[{HIGHLIGHT}]reachable[/]" if result.reachable else f"[{ERROR}]unreachable[/]"
-    _console.print(f"{result.target}: {status} [{SECONDARY}]({result.detail})[/]")
+    console.print(f"{result.target}: {status} [{SECONDARY}]({result.detail})[/]")
 
 
-def _select_target_for_advanced(local_probe: ProbeResult, remote_probe: ProbeResult) -> str | None:
-    _console.print(f"\n[{SECONDARY}]reachability[/]")
+def select_target_for_advanced(local_probe: ProbeResult, remote_probe: ProbeResult) -> str | None:
+    console.print(f"\n[{SECONDARY}]reachability[/]")
     _display_probe(local_probe)
     _display_probe(remote_probe)
 
-    target = _choose(
+    target = choose(
         "Choose a configuration target:",
         [
             Choice(value="local", label="Local machine"),
@@ -470,194 +476,8 @@ def _select_target_for_advanced(local_probe: ProbeResult, remote_probe: ProbeRes
     if target == "local":
         return "local"
 
-    _console.print(f"\n[{WARNING}]Remote setup is not available yet.[/]")
-    if _confirm("Use local setup instead?", default=True):
+    console.print(f"\n[{WARNING}]Remote setup is not available yet.[/]")
+    if confirm("Use local setup instead?", default=True):
         return "local"
-    _console.print(f"[{WARNING}]Setup cancelled.[/]")
+    console.print(f"[{WARNING}]Setup cancelled.[/]")
     return None
-
-
-def _render_header() -> None:
-    """Print the onboarding splash using the design-system palette.
-
-    Rendered output (colour roles):
-      ─────────────────────────────────────────  [DIM rule]
-        ___                    ____  ____  _____ [HIGHLIGHT art]
-       / _ \\ ...
-      opensre  ·  v<version>                     [SECONDARY name] [DIM ·] [BRAND version]
-      open-source SRE agent for automated …      [SECONDARY description]
-      ─────────────────────────────────────────  [DIM rule]
-      Setup — Configure your local AI stack …    [SECONDARY subtitle]
-    """
-    from surfaces.shared.terminal.components.banner_art import render_art
-
-    art = render_art()
-    version = get_opensre_version()
-
-    _console.print()
-    _console.print(Rule(style=DIM))
-    _console.print()
-
-    for line in art.splitlines():
-        t = Text()
-        t.append("  ")
-        t.append(line, style=f"bold {HIGHLIGHT}")
-        _console.print(t)
-
-    _console.print()
-
-    subtitle = Text()
-    subtitle.append("  ")
-    subtitle.append("opensre", style=SECONDARY)
-    subtitle.append("  ·  ", style=DIM)
-    subtitle.append(f"v{version}", style=BRAND)
-    _console.print(subtitle)
-
-    desc = Text()
-    desc.append(
-        "  open-source SRE agent for automated incident investigation and root cause analysis",
-        style=SECONDARY,
-    )
-    _console.print(desc)
-    _console.print()
-    _console.print(Rule(style=DIM))
-    _console.print()
-
-    setup_line = Text()
-    setup_line.append("  Setup", style=f"bold {TEXT}")
-    setup_line.append(
-        "  —  Configure your local AI stack and optional integrations.", style=SECONDARY
-    )
-    _console.print(setup_line)
-    _console.print()
-
-
-def _render_saved_summary(
-    *,
-    provider_label: str,
-    model: str,
-    saved_path: str,
-    env_path: str,
-    configured_integrations: list[str],
-    credential_line: str = "system keychain",
-) -> None:
-    """Print the post-onboarding success screen.
-
-    Rendered output (colour roles):
-      ─────────────────────────────────────────  [DIM rule]
-      ✓  Done.                                   [HIGHLIGHT ✓ + text]
-      ─────────────────────────────────────────  [DIM rule]
-                                                 [blank]
-        provider    Anthropic                    [SECONDARY key] [TEXT value]
-        model       claude-opus-4-5              [SECONDARY key] [TEXT value]
-        services    grafana · datadog            [SECONDARY key] [TEXT value]
-        config      ~/.opensre/opensre.json      [SECONDARY key] [BRAND path]
-        env         .env                         [SECONDARY key] [BRAND path]
-        credentials system keychain              [SECONDARY key] [TEXT value]
-        store       ~/.opensre/store.json        [SECONDARY key] [BRAND path]
-    """
-    from integrations.store import STORE_PATH
-
-    integrations_str = "  ·  ".join(configured_integrations) if configured_integrations else "none"
-
-    _console.print()
-    _console.print(Rule(style=DIM))
-
-    done = Text()
-    done.append(f"  {GLYPH_SUCCESS}  ", style=f"bold {HIGHLIGHT}")
-    done.append("Done.", style=f"bold {TEXT}")
-    _console.print(done)
-
-    _console.print(Rule(style=DIM))
-    _console.print()
-
-    key_col = 14
-
-    def _kv(key: str, value: str, value_style: str = TEXT) -> None:
-        row = Text()
-        row.append(f"    {key:<{key_col}}", style=SECONDARY)
-        row.append(value, style=value_style)
-        _console.print(row)
-
-    _kv("provider", provider_label)
-    _kv("model", model)
-    _kv("services", integrations_str)
-    _kv("config", saved_path, BRAND)
-    _kv("env", env_path, BRAND)
-    _kv("credentials", credential_line)
-    _kv("store", str(STORE_PATH), BRAND)
-    _console.print()
-
-
-def _render_integration_result(
-    service_label: str,
-    result: IntegrationHealthResult,
-    *,
-    github_display_level: str | None = None,
-) -> None:
-    if result.github_mcp is not None:
-        from integrations.github.mcp import (
-            GitHubMcpDisplayDetailLevel,
-            print_github_mcp_validation_report,
-        )
-
-        print_github_mcp_validation_report(
-            result.github_mcp,
-            console=_console,
-            detail_level=cast(
-                GitHubMcpDisplayDetailLevel,
-                github_display_level or "standard",
-            ),
-        )
-        return
-    ok = bool(result.ok)
-    detail = str(result.detail)
-    glyph = GLYPH_SUCCESS if ok else GLYPH_ERROR
-    glyph_style = f"bold {HIGHLIGHT}" if ok else f"bold {ERROR}"
-    prefix = "Connected" if ok else "Failed"
-
-    status_line = Text()
-    status_line.append(f"  {glyph}  ", style=glyph_style)
-    status_line.append(f"{service_label}", style=f"bold {TEXT}")
-    status_line.append("  ·  ", style=DIM)
-    status_line.append(prefix, style=TEXT)
-    _console.print(status_line)
-
-    for raw_line in detail.splitlines():
-        line = raw_line.strip()
-        if line:
-            detail_text = Text()
-            detail_text.append(f"     {line}", style=SECONDARY)
-            _console.print(detail_text)
-
-
-def _render_next_steps() -> None:
-    """Print suggested commands after onboarding."""
-    _console.print(Rule(style=DIM))
-
-    section = Text()
-    section.append("  What's next", style=SECONDARY)
-    _console.print(section)
-
-    _console.print(Rule(style=DIM))
-    _console.print()
-
-    next_steps: tuple[tuple[str, str], ...] = (
-        ("opensre", "Start the interactive agent and run /loops"),
-        (
-            "opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json",
-            "Run root-cause analysis on a sample alert",
-        ),
-        ("opensre doctor", "Verify your full environment setup"),
-        ("opensre onboard", "Re-run this setup at any time"),
-    )
-
-    for cmd, description in next_steps:
-        cmd_line = Text()
-        cmd_line.append(f"  {cmd}", style=f"bold {BRAND}")
-        _console.print(cmd_line)
-        desc_line = Text()
-        desc_line.append(f"    {description}", style=SECONDARY)
-        _console.print(desc_line)
-
-    _console.print()

--- a/surfaces/cli/wizard/configurators/alerting.py
+++ b/surfaces/cli/wizard/configurators/alerting.py
@@ -9,17 +9,17 @@ from integrations.betterstack.setup import BETTERSTACK_SETUP
 from integrations.incident_io.setup import INCIDENT_IO_SETUP
 from integrations.pagerduty.setup import PAGERDUTY_SETUP
 from integrations.store import upsert_integration
-from surfaces.cli.wizard._ui import (
-    _console,
-    _integration_defaults,
-    _prompt_value,
-    _render_integration_result,
-    _string_value,
+from surfaces.cli.wizard.components import (
+    console,
+    integration_defaults,
+    prompt_value,
+    string_value,
 )
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 from surfaces.cli.wizard.integration_health import (
     validate_opsgenie_integration,
 )
+from surfaces.cli.wizard.summaries import render_integration_result
 
 
 def _configure_betterstack() -> tuple[str, str]:
@@ -31,20 +31,20 @@ def _configure_alertmanager() -> tuple[str, str]:
 
 
 def _configure_opsgenie() -> tuple[str, str]:
-    _, credentials = _integration_defaults("opsgenie")
+    _, credentials = integration_defaults("opsgenie")
     while True:
-        api_key = _prompt_value(
+        api_key = prompt_value(
             "OpsGenie API key (Settings > API key management)",
-            default=_string_value(credentials.get("api_key")),
+            default=string_value(credentials.get("api_key")),
             secret=True,
         )
-        region = _prompt_value(
+        region = prompt_value(
             "OpsGenie region (us or eu)",
-            default=_string_value(credentials.get("region"), "us"),
+            default=string_value(credentials.get("region"), "us"),
         )
-        with _console.status("Validating OpsGenie integration...", spinner="dots"):
+        with console.status("Validating OpsGenie integration...", spinner="dots"):
             result = validate_opsgenie_integration(api_key=api_key, region=region)
-        _render_integration_result("OpsGenie", result)
+        render_integration_result("OpsGenie", result)
         if result.ok:
             upsert_integration(
                 "opsgenie",
@@ -52,7 +52,7 @@ def _configure_opsgenie() -> tuple[str, str]:
             )
             env_path = sync_env_values({})
             return "OpsGenie", str(env_path)
-        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
 def _configure_pagerduty() -> tuple[str, str]:

--- a/surfaces/cli/wizard/configurators/aws.py
+++ b/surfaces/cli/wizard/configurators/aws.py
@@ -18,13 +18,13 @@ from integrations.aws.role_mode_gate import (
     gate_role_mode,
 )
 from integrations.aws.setup import AWS_SETUP
-from surfaces.cli.wizard._ui import Choice, WizardBack, _choose, _console
+from surfaces.cli.wizard.components import Choice, WizardBack, choose, console
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 
 
 def _ask_gate() -> RoleGateChoice | None:
-    _console.print(f"[{WARNING}]{NO_AMBIENT_CREDENTIALS_NOTICE}[/]")
-    picked = _choose(
+    console.print(f"[{WARNING}]{NO_AMBIENT_CREDENTIALS_NOTICE}[/]")
+    picked = choose(
         GATE_QUESTION,
         [Choice(value=str(o.value), label=o.label, hint=o.hint) for o in GATE_OPTIONS],
         default=str(RoleGateChoice.USE_KEYS),
@@ -36,7 +36,7 @@ def _gate_aws_mode(mode: str) -> str:
     try:
         return gate_role_mode(mode, ask=_ask_gate)
     except ConfigureCredentialsFirst:
-        _console.print(f"[{SECONDARY}]{CONFIGURE_FIRST_INSTRUCTION}[/]")
+        console.print(f"[{SECONDARY}]{CONFIGURE_FIRST_INSTRUCTION}[/]")
         # The wizard reports the service as skipped and moves on.
         raise WizardBack from None
 

--- a/surfaces/cli/wizard/configurators/github.py
+++ b/surfaces/cli/wizard/configurators/github.py
@@ -13,19 +13,19 @@ from infrastructure.terminal.theme import DEVICE_CODE, SECONDARY
 from integrations.github.mcp import DEFAULT_GITHUB_MCP_MODE, DEFAULT_GITHUB_MCP_URL
 from integrations.github.setup import GITHUB_SETUP
 from integrations.setup_flow import apply_setup
-from surfaces.cli.wizard._ui import (
+from surfaces.cli.wizard.components import (
     Choice,
-    _choose,
-    _console,
-    _integration_defaults,
-    _joined_values,
-    _parse_csv_values,
-    _prompt_value,
-    _render_integration_result,
-    _string_value,
+    choose,
+    console,
+    integration_defaults,
+    joined_values,
+    parse_csv_values,
+    prompt_value,
+    string_value,
 )
 from surfaces.cli.wizard.integration_health import validate_github_mcp_integration
 from surfaces.cli.wizard.integration_validators.shared import IntegrationHealthResult
+from surfaces.cli.wizard.summaries import render_integration_result
 
 
 def _github_wizard_browser_authorize() -> str | None:
@@ -40,28 +40,28 @@ def _github_wizard_browser_authorize() -> str | None:
 
     def _show(code: GitHubDeviceCode) -> None:
         user_code = escape(code.user_code)
-        _console.print()
-        _console.print(f"  1. Your browser will open [bold]{code.verification_uri}[/]")
-        _console.print(f"     [{SECONDARY}](if it doesn't open, visit that URL yourself).[/]")
-        _console.print(
+        console.print()
+        console.print(f"  1. Your browser will open [bold]{code.verification_uri}[/]")
+        console.print(f"     [{SECONDARY}](if it doesn't open, visit that URL yourself).[/]")
+        console.print(
             f"  2. Enter this one-time code when GitHub asks: [{DEVICE_CODE}]{user_code}[/]"
         )
-        _console.print("  3. Approve the request for OpenSRE.")
-        _console.print()
-        _console.print(f"  [{SECONDARY}]Waiting for you to approve in the browser…[/]")
+        console.print("  3. Approve the request for OpenSRE.")
+        console.print()
+        console.print(f"  [{SECONDARY}]Waiting for you to approve in the browser…[/]")
 
-    _console.print()
-    _console.print("Sign in to GitHub in your browser (device authorization):")
-    _console.print(f"[{SECONDARY}]Requesting a one-time code from GitHub…[/]")
+    console.print()
+    console.print("Sign in to GitHub in your browser (device authorization):")
+    console.print(f"[{SECONDARY}]Requesting a one-time code from GitHub…[/]")
     try:
         token = authorize_github_via_device_flow(on_prompt=_show)
     except GitHubDeviceFlowError as err:
-        _console.print(f"Browser authorization unavailable: {err}")
+        console.print(f"Browser authorization unavailable: {err}")
         return None
     except Exception as err:  # network/transport issues
-        _console.print(f"Browser authorization failed: {err}")
+        console.print(f"Browser authorization failed: {err}")
         return None
-    _console.print("[bold]Authorized.[/] Saved a GitHub token from the browser sign-in.")
+    console.print("[bold]Authorized.[/] Saved a GitHub token from the browser sign-in.")
     return token.access_token
 
 
@@ -70,16 +70,16 @@ def _github_wizard_auth_token(mode: str, credentials: object) -> str:
     from collections.abc import Mapping
 
     creds = credentials if isinstance(credentials, Mapping) else {}
-    existing = _string_value(creds.get("auth_token"))
+    existing = string_value(creds.get("auth_token"))
     if mode == "stdio":
-        return _prompt_value(
+        return prompt_value(
             "GitHub PAT / auth token (optional if the server already authenticates upstream)",
             default=existing,
             secret=True,
             allow_empty=True,
         )
 
-    method = _choose(
+    method = choose(
         "How do you want to connect OpenSRE to GitHub?",
         [
             Choice(
@@ -97,8 +97,8 @@ def _github_wizard_auth_token(mode: str, credentials: object) -> str:
         token = _github_wizard_browser_authorize()
         if token:
             return token
-        _console.print("Falling back to manual token entry.")
-    return _prompt_value(
+        console.print("Falling back to manual token entry.")
+    return prompt_value(
         "GitHub PAT / auth token",
         default=existing,
         secret=True,
@@ -107,21 +107,21 @@ def _github_wizard_auth_token(mode: str, credentials: object) -> str:
 
 
 def _configure_github_mcp() -> tuple[str, str]:
-    _, credentials = _integration_defaults("github")
+    _, credentials = integration_defaults("github")
     # Transport is fixed to Streamable HTTP — the only mode anyone selects in practice,
     # and SSE/stdio are deprecated for the hosted GitHub MCP server. The transport
     # prompt was removed on purpose — do NOT reintroduce a transport selection here.
     mode = DEFAULT_GITHUB_MCP_MODE
 
     while True:
-        url = _prompt_value(
+        url = prompt_value(
             "GitHub MCP URL",
-            default=_string_value(credentials.get("url"), DEFAULT_GITHUB_MCP_URL),
+            default=string_value(credentials.get("url"), DEFAULT_GITHUB_MCP_URL),
         )
-        toolsets = _parse_csv_values(
-            _prompt_value(
+        toolsets = parse_csv_values(
+            prompt_value(
                 "GitHub MCP toolsets (comma-separated)",
-                default=_joined_values(
+                default=joined_values(
                     credentials.get("toolsets"),
                     separator=",",
                     fallback="repos,issues,pull_requests,actions,search",
@@ -130,7 +130,7 @@ def _configure_github_mcp() -> tuple[str, str]:
         )
         auth_token = _github_wizard_auth_token(mode, credentials)
 
-        repo_view = _choose(
+        repo_view = choose(
             "Which repository view should we use to verify access?",
             [
                 Choice(value="auto", label="Auto (recommended)"),
@@ -140,7 +140,7 @@ def _configure_github_mcp() -> tuple[str, str]:
             ],
             default="auto",
         )
-        repo_visibility = _choose(
+        repo_visibility = choose(
             "Filter repositories by visibility (best-effort)",
             [
                 Choice(value="any", label="Any (recommended)"),
@@ -150,7 +150,7 @@ def _configure_github_mcp() -> tuple[str, str]:
             default="any",
         )
 
-        with _console.status("Validating GitHub MCP integration...", spinner="dots"):
+        with console.status("Validating GitHub MCP integration...", spinner="dots"):
             result = validate_github_mcp_integration(
                 url=url,
                 mode=mode,
@@ -163,7 +163,7 @@ def _configure_github_mcp() -> tuple[str, str]:
             )
         display_level = "standard"
         if result.ok:
-            display_level = _choose(
+            display_level = choose(
                 "How should we show repository access?",
                 [
                     Choice(value="summary", label="Brief (recommended) — no repo names"),
@@ -178,7 +178,7 @@ def _configure_github_mcp() -> tuple[str, str]:
                 ],
                 default="summary",
             )
-        _render_integration_result(
+        render_integration_result(
             "GitHub MCP",
             result,
             github_display_level=display_level,
@@ -199,7 +199,7 @@ def _configure_github_mcp() -> tuple[str, str]:
                     "username": authenticated_user,
                 },
             )
-            _render_integration_result(
+            render_integration_result(
                 "GitHub MCP",
                 IntegrationHealthResult(ok=outcome.ok, detail=outcome.detail),
             )
@@ -208,4 +208,4 @@ def _configure_github_mcp() -> tuple[str, str]:
                     "apply_setup returned ok=True without an env_path"
                 )
                 return "GitHub MCP", str(outcome.env_path)
-        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")

--- a/surfaces/cli/wizard/configurators/observability.py
+++ b/surfaces/cli/wizard/configurators/observability.py
@@ -12,18 +12,18 @@ from integrations.new_relic.setup import NEW_RELIC_SETUP
 from integrations.opensearch.setup import OPENSEARCH_SETUP
 from integrations.store import remove_integration, upsert_integration
 from integrations.tempo.setup import TEMPO_SETUP
-from surfaces.cli.wizard._ui import (
-    _confirm,
-    _console,
-    _integration_defaults,
-    _prompt_value,
-    _render_integration_result,
-    _string_value,
+from surfaces.cli.wizard.components import (
+    confirm,
+    console,
+    integration_defaults,
+    prompt_value,
+    string_value,
 )
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 from surfaces.cli.wizard.integration_health import (
     validate_splunk_integration,
 )
+from surfaces.cli.wizard.summaries import render_integration_result
 
 
 def _configure_grafana() -> tuple[str, str]:
@@ -36,8 +36,8 @@ def _configure_grafana_local() -> tuple[str, str]:
     from pathlib import Path
 
     if not shutil.which("docker"):
-        _console.print(f"[{ERROR}]Docker not found.[/]")
-        _console.print(f"[{SECONDARY}]Install Docker Desktop and retry.[/]")
+        console.print(f"[{ERROR}]Docker not found.[/]")
+        console.print(f"[{SECONDARY}]Install Docker Desktop and retry.[/]")
         return "Grafana Local (skipped)", ""
 
     # Check Docker daemon is actually running
@@ -49,14 +49,14 @@ def _configure_grafana_local() -> tuple[str, str]:
         errors="replace",
     )
     if ping.returncode != 0:
-        _console.print(f"[{ERROR}]Docker is not running.[/]")
-        _console.print(
+        console.print(f"[{ERROR}]Docker is not running.[/]")
+        console.print(
             f"[{SECONDARY}]Start Docker Desktop, then run [bold]opensre onboard[/bold] again.[/]"
         )
         return "Grafana Local (skipped)", ""
 
     compose_file = str(Path(__file__).parent.parent / "local_grafana_stack/docker-compose.yml")
-    with _console.status("Starting Grafana + Loki (docker compose up -d)...", spinner="dots"):
+    with console.status("Starting Grafana + Loki (docker compose up -d)...", spinner="dots"):
         result = subprocess.run(
             ["docker", "compose", "-f", compose_file, "up", "-d"],
             capture_output=True,
@@ -65,17 +65,17 @@ def _configure_grafana_local() -> tuple[str, str]:
             errors="replace",
         )
     if result.returncode != 0:
-        _console.print(f"[{ERROR}]Docker compose failed.[/]")
-        _console.print(result.stderr or result.stdout)
+        console.print(f"[{ERROR}]Docker compose failed.[/]")
+        console.print(result.stderr or result.stdout)
         return "Grafana Local (skipped)", ""
 
-    with _console.status("Waiting for Loki to be ready and seeding logs...", spinner="dots"):
+    with console.status("Waiting for Loki to be ready and seeding logs...", spinner="dots"):
         try:
             from surfaces.cli.wizard.grafana_seed import seed_logs
 
             seed_logs()
         except (SystemExit, Exception) as exc:
-            _console.print(f"[{ERROR}]Loki seed failed: {exc}[/]")
+            console.print(f"[{ERROR}]Loki seed failed: {exc}[/]")
             return "Grafana Local (skipped)", ""
 
     endpoint = "http://localhost:3000"
@@ -83,11 +83,11 @@ def _configure_grafana_local() -> tuple[str, str]:
     remove_integration("grafana")  # clean up any stale grafana record pointing to localhost
     upsert_integration("grafana_local", {"credentials": {"endpoint": endpoint, "api_key": api_key}})
     env_path = sync_env_values({"GRAFANA_INSTANCE_URL": endpoint})
-    _console.print(f"[{HIGHLIGHT}]Grafana Local · ready[/]")
-    _console.print(f"[{SECONDARY}]UI: {endpoint}[/]")
-    _console.print(f"[{SECONDARY}]Loki seeded with events_fact pipeline failure logs.[/]")
-    _console.print(f"[{SECONDARY}]Run RCA:[/]")
-    _console.print("[bold]  opensre investigate -i tests/fixtures/grafana_local_alert.json[/]")
+    console.print(f"[{HIGHLIGHT}]Grafana Local · ready[/]")
+    console.print(f"[{SECONDARY}]UI: {endpoint}[/]")
+    console.print(f"[{SECONDARY}]Loki seeded with events_fact pipeline failure logs.[/]")
+    console.print(f"[{SECONDARY}]Run RCA:[/]")
+    console.print("[bold]  opensre investigate -i tests/fixtures/grafana_local_alert.json[/]")
     return "Grafana Local", str(env_path)
 
 
@@ -118,33 +118,33 @@ def _configure_tempo() -> tuple[str, str]:
 
 
 def _configure_splunk() -> tuple[str, str]:
-    _, credentials = _integration_defaults("splunk")
+    _, credentials = integration_defaults("splunk")
     while True:
-        base_url = _prompt_value(
+        base_url = prompt_value(
             "Splunk REST API base URL (e.g. https://splunk.corp.com:8089)",
-            default=_string_value(credentials.get("base_url")),
+            default=string_value(credentials.get("base_url")),
         )
-        token = _prompt_value(
+        token = prompt_value(
             "Splunk API bearer token",
-            default=_string_value(credentials.get("token")),
+            default=string_value(credentials.get("token")),
             secret=True,
         )
-        index = _prompt_value(
+        index = prompt_value(
             "Default Splunk index to search",
-            default=_string_value(credentials.get("index"), "main"),
+            default=string_value(credentials.get("index"), "main"),
         )
-        verify_ssl = _confirm(
+        verify_ssl = confirm(
             "Verify SSL certificate?",
             default=bool(credentials.get("verify_ssl", True)),
         )
         ca_bundle = ""
         if verify_ssl:
-            ca_bundle = _prompt_value(
+            ca_bundle = prompt_value(
                 "Path to CA bundle for SSL verification (leave empty to use system defaults)",
-                default=_string_value(credentials.get("ca_bundle")),
+                default=string_value(credentials.get("ca_bundle")),
                 allow_empty=True,
             )
-        with _console.status("Validating Splunk integration...", spinner="dots"):
+        with console.status("Validating Splunk integration...", spinner="dots"):
             result = validate_splunk_integration(
                 base_url=base_url,
                 token=token,
@@ -152,7 +152,7 @@ def _configure_splunk() -> tuple[str, str]:
                 verify_ssl=verify_ssl,
                 ca_bundle=ca_bundle,
             )
-        _render_integration_result("Splunk", result)
+        render_integration_result("Splunk", result)
         if result.ok:
             upsert_integration(
                 "splunk",
@@ -176,7 +176,7 @@ def _configure_splunk() -> tuple[str, str]:
                 env_values["SPLUNK_CA_BUNDLE"] = ca_bundle
             env_path = sync_env_values(env_values)
             return "Splunk", str(env_path)
-        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
 def _configure_opensearch() -> tuple[str, str]:

--- a/surfaces/cli/wizard/configurators/productivity.py
+++ b/surfaces/cli/wizard/configurators/productivity.py
@@ -6,12 +6,11 @@ from config.env_file import sync_env_values
 from infrastructure.terminal.theme import SECONDARY
 from integrations.servicenow.setup import SERVICENOW_SETUP
 from integrations.store import upsert_integration
-from surfaces.cli.wizard._ui import (
-    _console,
-    _integration_defaults,
-    _prompt_value,
-    _render_integration_result,
-    _string_value,
+from surfaces.cli.wizard.components import (
+    console,
+    integration_defaults,
+    prompt_value,
+    string_value,
 )
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 from surfaces.cli.wizard.integration_health import (
@@ -19,21 +18,22 @@ from surfaces.cli.wizard.integration_health import (
     validate_jira_integration,
     validate_notion_integration,
 )
+from surfaces.cli.wizard.summaries import render_integration_result
 
 
 def _configure_notion() -> tuple[str, str]:
-    _, credentials = _integration_defaults("notion")
-    _console.print("\n[bold]Notion Integration[/bold]")
-    _console.print("Create an internal integration at https://www.notion.so/my-integrations")
-    _console.print("then share your target database with the integration.\n")
+    _, credentials = integration_defaults("notion")
+    console.print("\n[bold]Notion Integration[/bold]")
+    console.print("Create an internal integration at https://www.notion.so/my-integrations")
+    console.print("then share your target database with the integration.\n")
 
     while True:
-        api_key = _prompt_value("Notion API key (secret_...)", secret=True)
-        database_id = _prompt_value("Notion database ID")
+        api_key = prompt_value("Notion API key (secret_...)", secret=True)
+        database_id = prompt_value("Notion database ID")
 
-        with _console.status("Validating Notion connection...", spinner="dots"):
+        with console.status("Validating Notion connection...", spinner="dots"):
             result = validate_notion_integration(api_key=api_key, database_id=database_id)
-        _render_integration_result("Notion", result)
+        render_integration_result("Notion", result)
 
         if result.ok:
             upsert_integration(
@@ -41,30 +41,30 @@ def _configure_notion() -> tuple[str, str]:
             )
             env_path = sync_env_values({"NOTION_DATABASE_ID": database_id})
             return "Notion", str(env_path)
-        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
 def _configure_jira() -> tuple[str, str]:
-    _, credentials = _integration_defaults("jira")
-    _console.print("\n[bold]Jira Integration[/bold]")
-    _console.print(
+    _, credentials = integration_defaults("jira")
+    console.print("\n[bold]Jira Integration[/bold]")
+    console.print(
         "Create an API token at https://id.atlassian.com/manage-profile/security/api-tokens\n"
     )
 
     while True:
-        base_url = _prompt_value("Jira base URL (e.g. https://myteam.atlassian.net)")
-        email = _prompt_value("Jira account email")
-        api_token = _prompt_value("Jira API token", secret=True)
-        project_key = _prompt_value("Jira project key (e.g. OPS)")
+        base_url = prompt_value("Jira base URL (e.g. https://myteam.atlassian.net)")
+        email = prompt_value("Jira account email")
+        api_token = prompt_value("Jira API token", secret=True)
+        project_key = prompt_value("Jira project key (e.g. OPS)")
 
-        with _console.status("Validating Jira connection...", spinner="dots"):
+        with console.status("Validating Jira connection...", spinner="dots"):
             result = validate_jira_integration(
                 base_url=base_url,
                 email=email,
                 api_token=api_token,
                 project_key=project_key,
             )
-        _render_integration_result("Jira", result)
+        render_integration_result("Jira", result)
 
         if result.ok:
             upsert_integration(
@@ -80,7 +80,7 @@ def _configure_jira() -> tuple[str, str]:
             )
             env_path = sync_env_values({})
             return "Jira", str(env_path)
-        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
 def _configure_servicenow() -> tuple[str, str]:
@@ -96,22 +96,22 @@ def _configure_servicenow() -> tuple[str, str]:
 
 
 def _configure_google_docs() -> tuple[str, str]:
-    _, credentials = _integration_defaults("google_docs")
+    _, credentials = integration_defaults("google_docs")
     while True:
-        credentials_file = _prompt_value(
+        credentials_file = prompt_value(
             "Path to Google service account credentials JSON file",
-            default=_string_value(credentials.get("credentials_file")),
+            default=string_value(credentials.get("credentials_file")),
         )
-        folder_id = _prompt_value(
+        folder_id = prompt_value(
             "Google Drive folder ID for incident reports",
-            default=_string_value(credentials.get("folder_id")),
+            default=string_value(credentials.get("folder_id")),
         )
-        with _console.status("Validating Google Docs integration...", spinner="dots"):
+        with console.status("Validating Google Docs integration...", spinner="dots"):
             result = validate_google_docs_integration(
                 credentials_file=credentials_file,
                 folder_id=folder_id,
             )
-        _render_integration_result("Google Docs", result)
+        render_integration_result("Google Docs", result)
         if result.ok:
             upsert_integration(
                 "google_docs",
@@ -129,4 +129,4 @@ def _configure_google_docs() -> tuple[str, str]:
                 }
             )
             return "Google Docs", str(env_path)
-        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")

--- a/surfaces/cli/wizard/configurators/spec_configurator.py
+++ b/surfaces/cli/wizard/configurators/spec_configurator.py
@@ -19,17 +19,17 @@ from collections.abc import Callable
 
 from infrastructure.terminal.theme import SECONDARY
 from integrations.setup_flow import IntegrationSetupSpec, apply_setup
-from surfaces.cli.wizard._ui import (
+from surfaces.cli.wizard.components import (
     Choice,
-    _choose,
-    _console,
-    _integration_defaults,
-    _joined_values,
-    _prompt_value,
-    _render_integration_result,
-    _string_value,
+    choose,
+    console,
+    integration_defaults,
+    joined_values,
+    prompt_value,
+    string_value,
 )
 from surfaces.cli.wizard.integration_validators.shared import IntegrationHealthResult
+from surfaces.cli.wizard.summaries import render_integration_result
 
 #: Vendor hook run after the mode picker and before its fields are prompted.
 #: Returns the mode to continue with — the same one, or a different one when
@@ -51,13 +51,13 @@ def configure_from_spec(
     steer to another mode. Returns the pair the wizard's configurator table
     expects: the display name and the ``.env`` path that was written.
     """
-    _, credentials = _integration_defaults(spec.service)
+    _, credentials = integration_defaults(spec.service)
     if intro:
-        _console.print(intro)
+        console.print(intro)
     while True:
         mode: str | None = None
         if spec.mode_prompt:
-            mode = _choose(
+            mode = choose(
                 spec.mode_prompt,
                 [Choice(value=m.value, label=m.label) for m in spec.modes],
                 default=spec.modes[0].value,
@@ -77,31 +77,31 @@ def configure_from_spec(
                 continue
             stored = credentials.get(field.name)
             # Prefer a joined list when the store still has a sequence (e.g. Better
-            # Stack ``sources`` from the pre-spec wizard). ``_string_value`` alone
+            # Stack ``sources`` from the pre-spec wizard). ``string_value`` alone
             # would drop the list and prefill blank, so Enter would clear it.
-            default = _joined_values(
-                stored, separator=",", fallback=_string_value(stored, field.default)
+            default = joined_values(
+                stored, separator=",", fallback=string_value(stored, field.default)
             )
             while True:
-                answer = _prompt_value(
+                answer = prompt_value(
                     field.question,
                     # A stored value wins over the spec's default, so re-running
                     # onboarding is a series of enters rather than a retype.
                     default=default,
                     secret=field.secret,
                     # Only reached when the field has no default to fall back on:
-                    # _prompt_value substitutes the default before it consults this,
+                    # prompt_value substitutes the default before it consults this,
                     # so a defaulted field never re-prompts and never returns blank.
                     allow_empty=not spec.is_required(field, mode),
                 )
                 problem = field.validate(answer) if answer and field.validate else None
                 if problem is None:
                     break
-                _console.print(f"[{SECONDARY}]{problem}[/]")
+                console.print(f"[{SECONDARY}]{problem}[/]")
             values[field.name] = answer
-        with _console.status(f"Validating {title} credentials...", spinner="dots"):
+        with console.status(f"Validating {title} credentials...", spinner="dots"):
             outcome = apply_setup(spec, values)
-        _render_integration_result(
+        render_integration_result(
             title, IntegrationHealthResult(ok=outcome.ok, detail=outcome.detail)
         )
         if outcome.ok:
@@ -110,4 +110,4 @@ def configure_from_spec(
             # stops doing so.
             assert outcome.env_path is not None, "apply_setup returned ok=True without an env_path"
             return title, str(outcome.env_path)
-        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")

--- a/surfaces/cli/wizard/custom_endpoints.py
+++ b/surfaces/cli/wizard/custom_endpoints.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from surfaces.cli.wizard._ui import Choice
+    from surfaces.cli.wizard.components import Choice
     from surfaces.shared.llm_setup.catalog import ProviderOption
 
 CUSTOM_ENDPOINT_SELECTION = "__custom-api-endpoint__"
@@ -22,7 +22,7 @@ _CUSTOM_PROVIDER_VALUES = frozenset(("custom-openai", "custom-anthropic"))
 
 def onboarding_provider_choices(choices: list[Choice]) -> list[Choice]:
     """Collapse both custom protocols into one discoverable onboarding choice."""
-    from surfaces.cli.wizard._ui import Choice
+    from surfaces.cli.wizard.components import Choice
 
     custom = Choice(
         value=CUSTOM_ENDPOINT_SELECTION,
@@ -44,10 +44,10 @@ def resolve_onboarding_provider(selection: str, *, default: str | None) -> str:
     if selection != CUSTOM_ENDPOINT_SELECTION:
         return selection
 
-    from surfaces.cli.wizard._ui import Choice, _choose, _step
+    from surfaces.cli.wizard.components import Choice, choose, step
 
-    _step("Custom API Endpoint")
-    return _choose(
+    step("Custom API Endpoint")
+    return choose(
         "Choose endpoint compatibility",
         [
             Choice(
@@ -101,12 +101,12 @@ def ensure_endpoint_settings(provider: ProviderOption) -> dict[str, str] | None:
 
 def _prompt_endpoint(provider: ProviderOption) -> dict[str, str] | None:
     from infrastructure.terminal.theme import ERROR
-    from surfaces.cli.wizard._ui import WizardBack, _console, _prompt_value, _step
+    from surfaces.cli.wizard.components import WizardBack, console, prompt_value, step
 
     normalize = _base_url_normalizer(provider)
-    _step("Endpoint")
+    step("Endpoint")
     try:
-        raw = _prompt_value(
+        raw = prompt_value(
             f"Base URL ({provider.endpoint_env})",
             default=os.getenv(provider.endpoint_env, provider.credential_default),
             secret=False,
@@ -116,6 +116,6 @@ def _prompt_endpoint(provider: ProviderOption) -> dict[str, str] | None:
         return None
     normalized = normalize(raw)
     if not normalized:
-        _console.print(f"[{ERROR}]A base URL is required for this provider.[/]")
+        console.print(f"[{ERROR}]A base URL is required for this provider.[/]")
         return None
     return {provider.endpoint_env: normalized}

--- a/surfaces/cli/wizard/flow.py
+++ b/surfaces/cli/wizard/flow.py
@@ -38,22 +38,19 @@ from infrastructure.terminal.theme import (
 )
 from integrations.llm_cli.binary_resolver import diagnose_binary_path
 from integrations.llm_cli.codex_oauth import CodexOAuthError, run_codex_oauth_login
-from surfaces.cli.wizard._ui import (
-    Choice,
-    WizardBack,
-    _choose,
-    _confirm,
-    _console,
-    _local_defaults,
-    _prompt_value,
-    _render_header,
-    _render_next_steps,
-    _render_saved_summary,
-    _select_target_for_advanced,
-    _step_header,
-)
 from surfaces.cli.wizard.azure_openai import (
     choose_provider_model,
+)
+from surfaces.cli.wizard.components import (
+    Choice,
+    WizardBack,
+    choose,
+    confirm,
+    console,
+    local_defaults,
+    prompt_value,
+    select_target_for_advanced,
+    step_header,
 )
 from surfaces.cli.wizard.configurators.github import (
     DEFAULT_GITHUB_MCP_MODE,
@@ -82,6 +79,11 @@ from surfaces.cli.wizard.llm_credential import (
     _provider_choice_label,
 )
 from surfaces.cli.wizard.probes import ProbeResult, probe_local_target, probe_remote_target
+from surfaces.cli.wizard.summaries import (
+    render_header,
+    render_next_steps,
+    render_saved_summary,
+)
 from surfaces.shared.llm_setup.catalog import (
     PROVIDER_BY_VALUE,
     SUPPORTED_PROVIDERS,
@@ -188,7 +190,7 @@ def _choose_auth_method(
         return OAUTH_AUTH_METHOD
     if not supports_oauth_auth_method(provider.value):
         return API_KEY_AUTH_METHOD
-    method = _choose(
+    method = choose(
         f"Choose {provider.label.removesuffix(' API key')} auth method",
         [
             Choice(
@@ -394,14 +396,14 @@ def _run_subscription_login(
 ) -> _SubscriptionLoginResult:
     """Launch the provider CLI login flow and report whether it exited cleanly."""
     if provider.value == "codex":
-        _console.print(
+        console.print(
             f"[{SECONDARY}]Starting OpenSRE Codex OAuth server on http://localhost:1455[/]"
         )
         try:
             oauth_result = run_codex_oauth_login()
         except CodexOAuthError as exc:
             detail = str(exc)
-            _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+            console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
             return _SubscriptionLoginResult(ok=False, detail=detail)
         save_provider_auth_record(
             provider="codex",
@@ -410,14 +412,14 @@ def _run_subscription_login(
             source="codex-oauth",
             detail=oauth_result.detail,
         )
-        _console.print(f"[{SECONDARY}]{oauth_result.detail}[/]")
+        console.print(f"[{SECONDARY}]{oauth_result.detail}[/]")
         return _SubscriptionLoginResult(ok=True, detail=oauth_result.detail)
 
     command = _subscription_login_command(provider, binary_path)
     if command is None:
         auth_hint = provider.adapter_factory().auth_hint if provider.adapter_factory else ""
         detail = f"No browser login command is registered for {provider.label}. {auth_hint}"
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+        console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
         return _SubscriptionLoginResult(ok=False, detail=detail)
 
     preflight_command = _subscription_login_preflight_command(provider, binary_path)
@@ -426,26 +428,26 @@ def _run_subscription_login(
             preflight_result = _run_login_preflight_process(preflight_command)
         except OSError as exc:
             detail = f"Could not check login config: {exc}"
-            _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+            console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
             return _SubscriptionLoginResult(ok=False, detail=detail)
         if preflight_result.returncode != 0:
             login_result = _subscription_login_error(provider, preflight_result)
-            _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {login_result.detail}[/]")
+            console.print(f"[{WARNING}]  {GLYPH_WARNING}  {login_result.detail}[/]")
             return login_result
 
-    _console.print(f"[{SECONDARY}]Launching {shlex.join(command)} for browser login…[/]")
+    console.print(f"[{SECONDARY}]Launching {shlex.join(command)} for browser login…[/]")
     try:
         result = _run_interactive_login_process(command)
     except KeyboardInterrupt:
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Login cancelled.[/]")
+        console.print(f"[{WARNING}]  {GLYPH_WARNING}  Login cancelled.[/]")
         return _SubscriptionLoginResult(ok=False, detail="Login cancelled.")
     except OSError as exc:
         detail = f"Could not launch login: {exc}"
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
+        console.print(f"[{WARNING}]  {GLYPH_WARNING}  {detail}[/]")
         return _SubscriptionLoginResult(ok=False, detail=detail)
     if result.returncode != 0:
         login_result = _subscription_login_error(provider, result)
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {login_result.detail}[/]")
+        console.print(f"[{WARNING}]  {GLYPH_WARNING}  {login_result.detail}[/]")
         return login_result
     return _SubscriptionLoginResult(ok=True)
 
@@ -487,7 +489,7 @@ def _recover_subscription_config_error(
             ),
         ]
     )
-    recovery = _choose(
+    recovery = choose(
         f"{provider_label} OAuth could not start. What next?",
         choices,
         default="repair" if repair_hint is not None else "retry",
@@ -502,10 +504,10 @@ def _recover_subscription_config_error(
         detail=login_result.config_error_detail,
     )
     if not repair_result.ok:
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {repair_result.detail}[/]")
+        console.print(f"[{WARNING}]  {GLYPH_WARNING}  {repair_result.detail}[/]")
         return "continue"
 
-    _console.print(f"[{SECONDARY}]  Updated Codex config: {repair_result.detail}.[/]")
+    console.print(f"[{SECONDARY}]  Updated Codex config: {repair_result.detail}.[/]")
     retry_result = _run_subscription_login(provider, binary_path)
     if retry_result.ok:
         return "ok"
@@ -518,7 +520,7 @@ def _run_cli_llm_onboarding(
     """Probe CLI binary + auth; recovery menu when missing. ``repick`` = choose another LLM."""
     factory = provider.adapter_factory
     if factory is None:
-        _console.print(
+        console.print(
             f"[{ERROR}]  {GLYPH_ERROR}  Internal error: CLI provider missing adapter factory.[/]"
         )
         return "abort"
@@ -531,10 +533,10 @@ def _run_cli_llm_onboarding(
     for _attempt in range(10):
         probe = adapter.detect()
         if probe.installed and probe.logged_in is True:
-            _console.print(f"[{SECONDARY}]{probe.detail}[/]")
+            console.print(f"[{SECONDARY}]{probe.detail}[/]")
             return "ok"
         if probe.installed and probe.logged_in is not True:
-            _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {probe.detail}[/]")
+            console.print(f"[{WARNING}]  {GLYPH_WARNING}  {probe.detail}[/]")
             status_prompt = (
                 f"{provider_label} requires login. What next?"
                 if probe.logged_in is False
@@ -563,7 +565,7 @@ def _run_cli_llm_onboarding(
                     ),
                 ]
             )
-            action = _choose(
+            action = choose(
                 status_prompt,
                 choices,
                 default="login" if choices and choices[0].value == "login" else "retry",
@@ -587,8 +589,8 @@ def _run_cli_llm_onboarding(
                         return "repick"
                 continue
             continue
-        _console.print(f"[{WARNING}]  {GLYPH_WARNING}  {probe.detail}[/]")
-        action = _choose(
+        console.print(f"[{WARNING}]  {GLYPH_WARNING}  {probe.detail}[/]")
+        action = choose(
             f"{provider_label} not found. What next?",
             [
                 Choice(
@@ -612,23 +614,23 @@ def _run_cli_llm_onboarding(
         if action == "repick":
             return "repick"
         if action == "path":
-            path = _prompt_value(f"Full path to {name} binary")
+            path = prompt_value(f"Full path to {name} binary")
             reason = diagnose_binary_path(path)
             if reason:
-                _console.print(f"[{WARNING}]{reason} Try again.[/]")
+                console.print(f"[{WARNING}]{reason} Try again.[/]")
                 continue
             sync_env_values({env_key: path})
             os.environ[env_key] = path
             continue
-        _console.print(f"[{SECONDARY}]    Hint: {install_hint}[/]")
-    _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Too many retry attempts. Aborting setup.[/]")
+        console.print(f"[{SECONDARY}]    Hint: {install_hint}[/]")
+    console.print(f"[{WARNING}]  {GLYPH_WARNING}  Too many retry attempts. Aborting setup.[/]")
     return "abort"
 
 
 def run_wizard(_argv: list[str] | None = None) -> int:
     """Run the interactive wizard."""
-    _render_header()
-    defaults = _local_defaults()
+    render_header()
+    defaults = local_defaults()
     saved_provider_value = defaults["provider"] if isinstance(defaults["provider"], str) else None
     saved_model_value = defaults["model"] if isinstance(defaults["model"], str) else ""
     default_wizard_mode = (
@@ -648,8 +650,8 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         else provider_options[0].value
     )
 
-    _step_header(1, WIZARD_TOTAL_STEPS, "Setup Mode")
-    wizard_mode = _choose(
+    step_header(1, WIZARD_TOTAL_STEPS, "Setup Mode")
+    wizard_mode = choose(
         "How do you want to get started?",
         [
             Choice(
@@ -676,7 +678,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
 
     if wizard_mode == "advanced":
         remote_probe = probe_remote_target()
-        target = _select_target_for_advanced(local_probe, remote_probe)
+        target = select_target_for_advanced(local_probe, remote_probe)
         if target is None:
             return 1
     else:
@@ -699,7 +701,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
     while True:
         credential_state = OK
         session_env_sink = {}
-        _step_header(2, WIZARD_TOTAL_STEPS, "LLM Provider")
+        step_header(2, WIZARD_TOTAL_STEPS, "LLM Provider")
         saved_provider = (
             PROVIDER_BY_VALUE.get(saved_provider_value) if saved_provider_value else None
         )
@@ -711,17 +713,17 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 if supports_oauth_auth_method(saved_provider.value)
                 else ""
             )
-            _console.print(
+            console.print(
                 f"[{SECONDARY}]current provider  {_provider_choice_label(saved_provider)}{auth_segment}  ·  {current_model}[/]"
             )
-            change_provider = _confirm("Change provider?", default=False)
+            change_provider = confirm("Change provider?", default=False)
         else:
             change_provider = True
         force_repick = False
 
         if change_provider:
             try:
-                provider_selection = _choose(
+                provider_selection = choose(
                     "Choose your LLM provider",
                     onboarding_provider_choices(
                         [
@@ -783,8 +785,8 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                     continue
         elif model_provider.models:
             current_display = model or "CLI default"
-            _console.print(f"[{SECONDARY}]current model  {current_display}[/]")
-            if _confirm("Change model?", default=False):
+            console.print(f"[{SECONDARY}]current model  {current_display}[/]")
+            if confirm("Change model?", default=False):
                 model = choose_provider_model(
                     provider,
                     model_provider,
@@ -936,7 +938,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         # saving", where re-applying it to os.environ is exactly what is wanted.
         os.environ.update(session_env_sink)
 
-    _step_header(3, WIZARD_TOTAL_STEPS, "Integrations")
+    step_header(3, WIZARD_TOTAL_STEPS, "Integrations")
     try:
         configured_integrations, integration_env_path = (
             _integration_configurators_module._configure_selected_integrations()
@@ -945,15 +947,15 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         cancelled = Text()
         cancelled.append(f"\n  {GLYPH_WARNING}  ", style=f"bold {WARNING}")
         cancelled.append("Integration setup cancelled. AI config was kept.", style=TEXT)
-        _console.print(cancelled)
+        console.print(cancelled)
         configured_integrations = []
         integration_env_path = None
 
     summary_env_path = integration_env_path or str(env_path)
     _seed_onboarding_loops()
 
-    _step_header(4, WIZARD_TOTAL_STEPS, "Summary")
-    _render_saved_summary(
+    step_header(4, WIZARD_TOTAL_STEPS, "Summary")
+    render_saved_summary(
         provider_label=_provider_label_for_saved_summary(provider, persisted_auth_method),
         model=model,
         saved_path=str(saved_path),
@@ -963,5 +965,5 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             provider, persisted_auth_method, credential_state=credential_state
         ),
     )
-    _render_next_steps()
+    render_next_steps()
     return 0

--- a/surfaces/cli/wizard/llm_credential.py
+++ b/surfaces/cli/wizard/llm_credential.py
@@ -4,7 +4,7 @@ Extracted from ``surfaces/cli/wizard/flow.py`` so the wizard's top-level control
 flow (``run_wizard``) stays readable and this credential-specific logic lives in one
 place (#4055 review). ``run_wizard`` imports the public helpers from here — this
 module must never import ``flow`` (that would be a cycle); it depends only on the
-same lower-level sources ``flow`` uses: ``_ui``, ``validation``, ``env_sync``,
+same lower-level sources ``flow`` uses: ``components``, ``validation``, ``env_sync``,
 ``config``, and the shared theme.
 """
 
@@ -29,17 +29,17 @@ from infrastructure.terminal.theme import (
     TEXT,
     WARNING,
 )
-from surfaces.cli.wizard._ui import (
-    Choice,
-    WizardBack,
-    _choose,
-    _console,
-    _persist_llm_api_key,
-    _prompt_value,
-    _step,
-)
 from surfaces.cli.wizard.azure_openai import (
     choose_provider_model,
+)
+from surfaces.cli.wizard.components import (
+    Choice,
+    WizardBack,
+    choose,
+    console,
+    persist_llm_api_key,
+    prompt_value,
+    step,
 )
 from surfaces.cli.wizard.endpoint_prompt import (
     ensure_endpoint_settings as ensure_provider_endpoint_settings,
@@ -59,9 +59,9 @@ CredentialState = Literal["ok", "unverified", "unsaved", "deferred"]
 CredentialOutcome = Literal["ok", "unverified", "unsaved", "deferred", "repick", "cancel"]
 
 # Recovery/outcome vocabulary. These are the byte-identical string values the wizard
-# menus, ``_choose`` defaults, and ``run_wizard`` branches all resolve against; named
+# menus, ``choose`` defaults, and ``run_wizard`` branches all resolve against; named
 # constants keep the vocabulary spelled in exactly one place (#4055 review). The string
-# values must never change — tests assert against them and ``_choose(default=...)``
+# values must never change — tests assert against them and ``choose(default=...)``
 # resolves ``default`` against ``Choice.value``.
 RETRY: Final = "retry"
 REPICK: Final = "repick"
@@ -162,14 +162,14 @@ def _persist_llm_credential(provider: ProviderOption, value: str) -> bool:
             # Same remediation style the keyring branch uses: a WARNING line naming the
             # target and the error, then return False so the caller shows the shared
             # recovery menu instead of letting the write error escape (#3591).
-            _console.print(
+            console.print(
                 f"[{WARNING}]  {GLYPH_WARNING}  "
                 f"Could not write {provider.api_key_env} to {PROJECT_ENV_PATH}: {exc}[/]"
             )
             return False
         os.environ[provider.api_key_env] = value
         return True
-    return _persist_llm_api_key(provider.api_key_env, value)
+    return persist_llm_api_key(provider.api_key_env, value)
 
 
 def _recovery_action(*, prompt: str, retry_label: str, retry_hint: str, escape: Choice) -> str:
@@ -179,15 +179,15 @@ def _recovery_action(*, prompt: str, retry_label: str, retry_hint: str, escape: 
     hatch, then repick. Returns ``"retry"``, ``escape.value``, ``"repick"`` or
     ``"cancel"``.
 
-    ``_choose`` is called without ``back_on_cancel``, so ESCAPE here raises a bare
+    ``choose`` is called without ``back_on_cancel``, so ESCAPE here raises a bare
     ``KeyboardInterrupt`` and never ``WizardBack`` — there is no back-navigation arm
     to catch.
     """
     try:
-        return _choose(
+        return choose(
             prompt,
             [
-                # ``RETRY`` must stay row 1's value: _choose resolves ``default`` against
+                # ``RETRY`` must stay row 1's value: choose resolves ``default`` against
                 # Choice.value and raises ValueError when it matches no row.
                 Choice(value=RETRY, label=retry_label, hint=retry_hint),
                 escape,
@@ -196,7 +196,7 @@ def _recovery_action(*, prompt: str, retry_label: str, retry_hint: str, escape: 
             default=RETRY,
         )
     except KeyboardInterrupt:
-        _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
+        console.print(f"\n[{WARNING}]Setup cancelled.[/]")
         return CANCEL
 
 
@@ -217,7 +217,7 @@ def _render_credential_validation(label: str, model: str, result: ValidationResu
     status_line.append(model, style=BRAND)
     status_line.append("  ·  ", style=DIM)
     status_line.append("Connected" if ok else "Failed", style=TEXT)
-    _console.print(status_line)
+    console.print(status_line)
 
     # The validator's detail is rendered verbatim, never reworded and never branched
     # on: only its auth path says "rejected", so an offline user is never accused of
@@ -228,11 +228,11 @@ def _render_credential_validation(label: str, model: str, result: ValidationResu
             continue
         detail_text = Text()
         detail_text.append(f"     {line}", style=SECONDARY)
-        _console.print(detail_text)
+        console.print(detail_text)
     if result.sample_response:
         reply = Text()
         reply.append(f"     Test reply: {result.sample_response}", style=SECONDARY)
-        _console.print(reply)
+        console.print(reply)
 
 
 def _validate_llm_credential(
@@ -241,7 +241,7 @@ def _validate_llm_credential(
     """Run the live provider probe behind a spinner, converting any escape into a result."""
     label = _credential_prompt_label(provider)
     try:
-        with _console.status(f"Validating {label} {provider.credential_label}...", spinner="dots"):
+        with console.status(f"Validating {label} {provider.credential_label}...", spinner="dots"):
             return validate_provider_credentials(provider=provider, api_key=value, model=model)
     except Exception as err:  # mirror the validator's own catch-all conversion
         return ValidationResult(ok=False, detail=f"Validation request failed: {err}")
@@ -293,11 +293,11 @@ def _persist_llm_credential_with_recovery(
             os.environ[env_key] = api_key
             if session_env_sink is not None:
                 session_env_sink[env_key] = api_key
-            _console.print(
+            console.print(
                 f"[{WARNING}]  {GLYPH_WARNING}  "
                 f"Using {env_key} for this session only — it was not saved.[/]"
             )
-            _console.print(
+            console.print(
                 f"[{SECONDARY}]     Re-enter it next run, "
                 f"or fix the keychain with the steps above.[/]"
             )
@@ -305,7 +305,7 @@ def _persist_llm_credential_with_recovery(
         if action == REPICK:
             return REPICK
         return CANCEL  # ESCAPE, or defensively: the menu offers no other values
-    _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Too many retry attempts. Aborting setup.[/]")
+    console.print(f"[{WARNING}]  {GLYPH_WARNING}  Too many retry attempts. Aborting setup.[/]")
     return CANCEL
 
 
@@ -349,7 +349,7 @@ def _prompt_validated_llm_credential(
     ``session_env_sink`` is forwarded to ``_persist_llm_credential_with_recovery`` so a
     ``continue_unsaved`` export survives the post-wizard ``sync_provider_env`` (#3591).
     """
-    _step(provider.credential_label.title())
+    step(provider.credential_label.title())
     label = _credential_prompt_label(provider)
     credential_display = f"{label} {provider.credential_label}"
     env_key = provider.api_key_env
@@ -362,9 +362,9 @@ def _prompt_validated_llm_credential(
     needs_endpoint = is_azure or is_custom_provider(provider.value)
     for _attempt in range(_LLM_CREDENTIAL_MAX_ATTEMPTS):
         try:
-            value = _prompt_value(
+            value = prompt_value(
                 f"{credential_display} ({env_key}) — leave blank to set up later",
-                # Only a ``host`` credential may be pre-filled. _prompt_value returns the
+                # Only a ``host`` credential may be pre-filled. prompt_value returns the
                 # default on empty input, and a secret provider's credential_default is a
                 # placeholder (Azure's is an endpoint URL) — offering it would let a bare
                 # Enter persist a URL as the API key.
@@ -382,7 +382,7 @@ def _prompt_validated_llm_credential(
         except WizardBack:  # must precede KeyboardInterrupt: WizardBack subclasses it
             return REPICK, model
         except KeyboardInterrupt:
-            _console.print(f"\n[{WARNING}]Setup cancelled.[/]")
+            console.print(f"\n[{WARNING}]Setup cancelled.[/]")
             return CANCEL, model
 
         azure_env = ensure_provider_endpoint_settings(provider)
@@ -457,14 +457,14 @@ def _prompt_validated_llm_credential(
         if not validation.ok:
             # Printed only after the write succeeded, so it never claims a save that
             # did not happen.
-            _console.print(
+            console.print(
                 f"[{WARNING}]  {GLYPH_WARNING}  Saved {env_key} without validating it.[/]"
             )
-            _console.print(
+            console.print(
                 f"[{SECONDARY}]     If OpenSRE cannot reach {label}, "
                 f"rerun `opensre onboard` and re-enter it.[/]"
             )
             return UNVERIFIED, model
         return OK, model
-    _console.print(f"[{WARNING}]  {GLYPH_WARNING}  Too many retry attempts. Aborting setup.[/]")
+    console.print(f"[{WARNING}]  {GLYPH_WARNING}  Too many retry attempts. Aborting setup.[/]")
     return CANCEL, model

--- a/surfaces/cli/wizard/onboard_integrations.py
+++ b/surfaces/cli/wizard/onboard_integrations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from surfaces.cli.wizard._ui import Choice
+from surfaces.cli.wizard.components import Choice
 
 ONBOARD_INTEGRATION_GROUP_ORDER: tuple[str, ...] = (
     "Observability",

--- a/surfaces/cli/wizard/summaries.py
+++ b/surfaces/cli/wizard/summaries.py
@@ -1,0 +1,215 @@
+"""Rendered summary screens for the wizard onboarding flow.
+
+One job: print the wizard's non-interactive output sections — the opening
+splash header, the post-onboarding saved-configuration summary, the per-step
+integration result card, and the closing next-steps list. These are pure
+renders against the shared ``console`` (from
+:mod:`surfaces.cli.wizard.components`); they hold no prompt or state logic.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from rich.rule import Rule
+from rich.text import Text
+
+from config.version import get_opensre_version
+from infrastructure.terminal.theme import (
+    BRAND,
+    DIM,
+    ERROR,
+    GLYPH_ERROR,
+    GLYPH_SUCCESS,
+    HIGHLIGHT,
+    SECONDARY,
+    TEXT,
+)
+from surfaces.cli.wizard.components import console
+from surfaces.cli.wizard.integration_health import IntegrationHealthResult
+
+
+def render_header() -> None:
+    """Print the onboarding splash using the design-system palette.
+
+    Rendered output (colour roles):
+      ─────────────────────────────────────────  [DIM rule]
+        ___                    ____  ____  _____ [HIGHLIGHT art]
+       / _ \\ ...
+      opensre  ·  v<version>                     [SECONDARY name] [DIM ·] [BRAND version]
+      open-source SRE agent for automated …      [SECONDARY description]
+      ─────────────────────────────────────────  [DIM rule]
+      Setup — Configure your local AI stack …    [SECONDARY subtitle]
+    """
+    from surfaces.shared.terminal.components.banner_art import render_art
+
+    art = render_art()
+    version = get_opensre_version()
+
+    console.print()
+    console.print(Rule(style=DIM))
+    console.print()
+
+    for line in art.splitlines():
+        t = Text()
+        t.append("  ")
+        t.append(line, style=f"bold {HIGHLIGHT}")
+        console.print(t)
+
+    console.print()
+
+    subtitle = Text()
+    subtitle.append("  ")
+    subtitle.append("opensre", style=SECONDARY)
+    subtitle.append("  ·  ", style=DIM)
+    subtitle.append(f"v{version}", style=BRAND)
+    console.print(subtitle)
+
+    desc = Text()
+    desc.append(
+        "  open-source SRE agent for automated incident investigation and root cause analysis",
+        style=SECONDARY,
+    )
+    console.print(desc)
+    console.print()
+    console.print(Rule(style=DIM))
+    console.print()
+
+    setup_line = Text()
+    setup_line.append("  Setup", style=f"bold {TEXT}")
+    setup_line.append(
+        "  —  Configure your local AI stack and optional integrations.", style=SECONDARY
+    )
+    console.print(setup_line)
+    console.print()
+
+
+def render_saved_summary(
+    *,
+    provider_label: str,
+    model: str,
+    saved_path: str,
+    env_path: str,
+    configured_integrations: list[str],
+    credential_line: str = "system keychain",
+) -> None:
+    """Print the post-onboarding success screen.
+
+    Rendered output (colour roles):
+      ─────────────────────────────────────────  [DIM rule]
+      ✓  Done.                                   [HIGHLIGHT ✓ + text]
+      ─────────────────────────────────────────  [DIM rule]
+                                                  [blank]
+        provider    Anthropic                    [SECONDARY key] [TEXT value]
+        model       claude-opus-4-5              [SECONDARY key] [TEXT value]
+        services    grafana · datadog            [SECONDARY key] [TEXT value]
+        config      ~/.opensre/opensre.json      [SECONDARY key] [BRAND path]
+        env         .env                         [SECONDARY key] [BRAND path]
+        credentials system keychain              [SECONDARY key] [TEXT value]
+        store       ~/.opensre/store.json        [SECONDARY key] [BRAND path]
+    """
+    from integrations.store import STORE_PATH
+
+    integrations_str = "  ·  ".join(configured_integrations) if configured_integrations else "none"
+
+    console.print()
+    console.print(Rule(style=DIM))
+
+    done = Text()
+    done.append(f"  {GLYPH_SUCCESS}  ", style=f"bold {HIGHLIGHT}")
+    done.append("Done.", style=f"bold {TEXT}")
+    console.print(done)
+
+    console.print(Rule(style=DIM))
+    console.print()
+
+    key_col = 14
+
+    def _kv(key: str, value: str, value_style: str = TEXT) -> None:
+        row = Text()
+        row.append(f"    {key:<{key_col}}", style=SECONDARY)
+        row.append(value, style=value_style)
+        console.print(row)
+
+    _kv("provider", provider_label)
+    _kv("model", model)
+    _kv("services", integrations_str)
+    _kv("config", saved_path, BRAND)
+    _kv("env", env_path, BRAND)
+    _kv("credentials", credential_line)
+    _kv("store", str(STORE_PATH), BRAND)
+    console.print()
+
+
+def render_integration_result(
+    service_label: str,
+    result: IntegrationHealthResult,
+    *,
+    github_display_level: str | None = None,
+) -> None:
+    if result.github_mcp is not None:
+        from integrations.github.mcp import (
+            GitHubMcpDisplayDetailLevel,
+            print_github_mcp_validation_report,
+        )
+
+        print_github_mcp_validation_report(
+            result.github_mcp,
+            console=console,
+            detail_level=cast(
+                GitHubMcpDisplayDetailLevel,
+                github_display_level or "standard",
+            ),
+        )
+        return
+    ok = bool(result.ok)
+    detail = str(result.detail)
+    glyph = GLYPH_SUCCESS if ok else GLYPH_ERROR
+    glyph_style = f"bold {HIGHLIGHT}" if ok else f"bold {ERROR}"
+    prefix = "Connected" if ok else "Failed"
+
+    status_line = Text()
+    status_line.append(f"  {glyph}  ", style=glyph_style)
+    status_line.append(f"{service_label}", style=f"bold {TEXT}")
+    status_line.append("  ·  ", style=DIM)
+    status_line.append(prefix, style=TEXT)
+    console.print(status_line)
+
+    for raw_line in detail.splitlines():
+        line = raw_line.strip()
+        if line:
+            detail_text = Text()
+            detail_text.append(f"     {line}", style=SECONDARY)
+            console.print(detail_text)
+
+
+def render_next_steps() -> None:
+    """Print suggested commands after onboarding."""
+    console.print(Rule(style=DIM))
+
+    section = Text()
+    section.append("  What's next", style=SECONDARY)
+    console.print(section)
+
+    console.print(Rule(style=DIM))
+    console.print()
+
+    next_steps: tuple[tuple[str, str], ...] = (
+        ("opensre", "Start the interactive agent and run /loops"),
+        (
+            "opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json",
+            "Run root-cause analysis on a sample alert",
+        ),
+        ("opensre doctor", "Verify your full environment setup"),
+        ("opensre onboard", "Re-run this setup at any time"),
+    )
+
+    for cmd, description in next_steps:
+        cmd_line = Text()
+        cmd_line.append(f"  {cmd}", style=f"bold {BRAND}")
+        console.print(cmd_line)
+        desc_line = Text()
+        desc_line.append(f"    {description}", style=SECONDARY)
+        console.print(desc_line)
+
+    console.print()

--- a/tests/cli/wizard/test_azure_openai_wizard.py
+++ b/tests/cli/wizard/test_azure_openai_wizard.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from surfaces.cli.wizard import _ui, azure_openai
+from surfaces.cli.wizard import azure_openai, components
 
 
 def test_choose_azure_deployment_lists_resource_deployments(
@@ -27,13 +27,13 @@ def test_choose_azure_deployment_lists_resource_deployments(
         m.ask.return_value = "gpt-4.1"
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
 
     deployment = azure_openai.choose_azure_deployment(default="")
 
     assert deployment == "gpt-4.1"
     assert captured["values"][:2] == ["gpt-4.1", "my-custom-deployment"]
-    assert captured["values"][-1] == _ui._CUSTOM_MODEL_SENTINEL
+    assert captured["values"][-1] == components.CUSTOM_MODEL_SENTINEL
 
 
 def test_choose_azure_deployment_prompts_manual_entry_when_discovery_fails(
@@ -42,7 +42,7 @@ def test_choose_azure_deployment_prompts_manual_entry_when_discovery_fails(
     monkeypatch.setattr(azure_openai, "discover_azure_openai_deployments_from_env", lambda: [])
     monkeypatch.setattr(
         azure_openai,
-        "_prompt_value",
+        "prompt_value",
         lambda *_args, **_kwargs: "manual-deployment",
     )
 

--- a/tests/cli/wizard/test_configurator_aws.py
+++ b/tests/cli/wizard/test_configurator_aws.py
@@ -12,14 +12,14 @@ import pytest
 
 import surfaces.cli.wizard.configurators.aws as aws_configurator
 from integrations.aws import role_mode_gate as gate
-from surfaces.cli.wizard._ui import WizardBack
+from surfaces.cli.wizard.components import WizardBack
 
 
 @pytest.fixture
 def quiet_console(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     printed: list[str] = []
     monkeypatch.setattr(
-        aws_configurator._console, "print", lambda *args, **_kw: printed.append(str(args[0]))
+        aws_configurator.console, "print", lambda *args, **_kw: printed.append(str(args[0]))
     )
     return printed
 
@@ -32,7 +32,7 @@ def _pick(monkeypatch: pytest.MonkeyPatch, value: str) -> list[dict[str, Any]]:
         offered.append({"prompt": prompt, "values": [c.value for c in choices], **kwargs})
         return value
 
-    monkeypatch.setattr(aws_configurator, "_choose", _fake_choose)
+    monkeypatch.setattr(aws_configurator, "choose", _fake_choose)
     return offered
 
 

--- a/tests/cli/wizard/test_configurators_chat_notifications.py
+++ b/tests/cli/wizard/test_configurators_chat_notifications.py
@@ -104,10 +104,10 @@ def wizard(monkeypatch: pytest.MonkeyPatch) -> _Wizard:
             note="Delivering to Acme Alerts (channel).",
         )
 
-    monkeypatch.setattr(spec_configurator, "_console", run.console)
-    monkeypatch.setattr(spec_configurator, "_integration_defaults", lambda _s: ({}, {}))
-    monkeypatch.setattr(spec_configurator, "_prompt_value", _fake_prompt)
-    monkeypatch.setattr(spec_configurator, "_render_integration_result", lambda *_a: None)
+    monkeypatch.setattr(spec_configurator, "console", run.console)
+    monkeypatch.setattr(spec_configurator, "integration_defaults", lambda _s: ({}, {}))
+    monkeypatch.setattr(spec_configurator, "prompt_value", _fake_prompt)
+    monkeypatch.setattr(spec_configurator, "render_integration_result", lambda *_a: None)
     monkeypatch.setattr(
         chat_notifications,
         "TELEGRAM_SETUP",

--- a/tests/cli/wizard/test_custom_endpoints.py
+++ b/tests/cli/wizard/test_custom_endpoints.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-import surfaces.cli.wizard._ui as ui
+import surfaces.cli.wizard.components as ui
 from surfaces.cli.wizard.custom_endpoints import (
     CUSTOM_ENDPOINT_SELECTION,
     ensure_endpoint_settings,
@@ -34,7 +34,7 @@ def test_configured_custom_anthropic_strips_trailing_v1(monkeypatch: Any) -> Non
 def test_unset_endpoint_prompts(monkeypatch: Any) -> None:
     # When the endpoint env is unset the module prompts; stub the prompt to a value.
     monkeypatch.delenv("CUSTOM_OPENAI_BASE_URL", raising=False)
-    monkeypatch.setattr(ui, "_prompt_value", lambda *_a, **_k: "http://gw.internal:8000/v1")
+    monkeypatch.setattr(ui, "prompt_value", lambda *_a, **_k: "http://gw.internal:8000/v1")
     result = ensure_endpoint_settings(PROVIDER_BY_VALUE["custom-openai"])
     assert result == {"CUSTOM_OPENAI_BASE_URL": "http://gw.internal:8000/v1"}
 
@@ -43,7 +43,7 @@ def test_unset_endpoint_prompts(monkeypatch: Any) -> None:
 def test_blank_prompt_is_rejected(monkeypatch: Any, slug: str) -> None:
     endpoint_env = PROVIDER_BY_VALUE[slug].endpoint_env
     monkeypatch.delenv(endpoint_env, raising=False)
-    monkeypatch.setattr(ui, "_prompt_value", lambda *_a, **_k: "")
+    monkeypatch.setattr(ui, "prompt_value", lambda *_a, **_k: "")
     assert ensure_endpoint_settings(PROVIDER_BY_VALUE[slug]) is None
 
 
@@ -78,7 +78,7 @@ def test_custom_choice_opens_compatibility_dropdown(monkeypatch: Any) -> None:
         captured["default"] = kwargs["default"]
         return "custom-anthropic"
 
-    monkeypatch.setattr("surfaces.cli.wizard._ui._choose", _choose_compatibility)
+    monkeypatch.setattr("surfaces.cli.wizard.components.choose", _choose_compatibility)
 
     result = resolve_onboarding_provider(
         CUSTOM_ENDPOINT_SELECTION,

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -11,7 +11,7 @@ import integrations.setup_flow as _setup_flow
 from config import setup_store as wizard_store
 from config.secrets.store import SecretSaveResult
 from integrations.llm_cli.codex_oauth import CodexOAuthResult
-from surfaces.cli.wizard import _ui, azure_openai, flow, llm_credential
+from surfaces.cli.wizard import azure_openai, components, flow, llm_credential
 from surfaces.cli.wizard.configurators import chat_notifications as _chat_notifications_configurator
 from surfaces.cli.wizard.configurators import dagster as _dagster_configurator
 from surfaces.cli.wizard.configurators import github as _github_configurator
@@ -70,7 +70,7 @@ def _stub_dagster_setup(monkeypatch: pytest.MonkeyPatch, verify) -> None:
 @pytest.fixture(autouse=True)
 def _stub_managed_llm_secret_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
     """Wizard flow tests should not touch the developer's real keychain."""
-    monkeypatch.setattr(_ui, "save_api_key", _stub_save)
+    monkeypatch.setattr(components, "save_api_key", _stub_save)
 
 
 @pytest.fixture(autouse=True)
@@ -123,10 +123,10 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     saved_llm_keys: list[tuple[str, str]] = []
     seeded_loops: list[bool] = []
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         flow, "probe_remote_target", lambda: ProbeResult("remote", True, "remote ok")
@@ -140,7 +140,7 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(flow, "_seed_onboarding_loops", lambda: seeded_loops.append(True) or 3)
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -162,16 +162,16 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     assert output.index("Summary") < output.index("Done.")
 
 
-def test_prompt_value_can_signal_wizard_back(monkeypatch) -> None:
+def testprompt_value_can_signal_wizard_back(monkeypatch) -> None:
     def _mock_password(*_args, **_kwargs):
         m = MagicMock()
         m.ask.return_value = None
         return m
 
-    monkeypatch.setattr(_ui.questionary, "password", _mock_password)
+    monkeypatch.setattr(components.questionary, "password", _mock_password)
 
-    with pytest.raises(_ui.WizardBack):
-        _ui._prompt_value("OpenAI API key", secret=True, back_on_cancel=True)
+    with pytest.raises(components.WizardBack):
+        components.prompt_value("OpenAI API key", secret=True, back_on_cancel=True)
 
 
 def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> None:
@@ -188,13 +188,13 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
         m.ask.return_value = "secret-key"
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     exit_code = flow.run_wizard()
     assert exit_code == 0
@@ -217,19 +217,19 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
         m.ask.return_value = "secret-key"
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             RuntimeError("Secure local credential storage is unavailable on this machine.")
         ),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: (
             "Current keyring backend: keyring.backends.fail.Keyring.",
@@ -278,10 +278,10 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -293,7 +293,7 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -360,10 +360,10 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -375,7 +375,7 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -445,10 +445,10 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -460,7 +460,7 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -526,10 +526,10 @@ def test_run_wizard_configures_new_relic(monkeypatch, tmp_path) -> None:
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -541,7 +541,7 @@ def test_run_wizard_configures_new_relic(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -604,17 +604,17 @@ def test_run_wizard_configures_dagster(monkeypatch, tmp_path) -> None:
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     _stub_dagster_setup(
         monkeypatch, lambda _source, _config: {"status": "passed", "detail": "Dagster ok"}
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -673,17 +673,17 @@ def test_run_wizard_configures_dagster_oss_skips_secret(monkeypatch, tmp_path) -
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     _stub_dagster_setup(
         monkeypatch, lambda _source, _config: {"status": "passed", "detail": "Dagster ok"}
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
     monkeypatch.setattr(
         _setup_flow,
         "sync_env_values",
@@ -739,10 +739,10 @@ def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> 
         m.ask.return_value = ""
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _chat_notifications_configurator,
@@ -754,7 +754,7 @@ def test_run_wizard_configures_slack_persists_webhook(monkeypatch, tmp_path) -> 
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -832,15 +832,15 @@ def test_run_wizard_dagster_retries_on_validation_failure(monkeypatch, tmp_path)
             return {"status": "failed", "detail": "Dagster GraphQL probe failed: HTTP 401"}
         return {"status": "passed", "detail": "Dagster ok"}
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     _stub_dagster_setup(monkeypatch, _validate_dagster)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -923,10 +923,10 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _github_configurator,
@@ -935,7 +935,7 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1008,11 +1008,11 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
         m.ask.return_value = False
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -1027,7 +1027,7 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
         },
     )
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: False)
 
     def _save_local_config(**kwargs):
         saved.update(kwargs)
@@ -1036,7 +1036,7 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
     monkeypatch.setattr(flow, "save_local_config", _save_local_config)
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -1084,11 +1084,11 @@ def test_run_wizard_changes_model_when_user_keeps_provider(monkeypatch, tmp_path
             m.ask.return_value = False
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -1103,7 +1103,7 @@ def test_run_wizard_changes_model_when_user_keeps_provider(monkeypatch, tmp_path
         },
     )
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: True)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: True)
 
     def _save_local_config(**kwargs):
         saved.update(kwargs)
@@ -1137,9 +1137,9 @@ def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path
     store_path = tmp_path / "opensre.json"
     env_path = tmp_path / ".env"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(components, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         flow,
@@ -1152,7 +1152,7 @@ def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -1192,8 +1192,8 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
     store_path = tmp_path / "opensre.json"
     env_path = tmp_path / ".env"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
     monkeypatch.setattr(
@@ -1207,7 +1207,7 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -1247,8 +1247,8 @@ def test_run_wizard_openai_oauth_is_onboarding_auth_method(monkeypatch, tmp_path
     store_path = tmp_path / "opensre.json"
     env_path = tmp_path / ".env"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
     monkeypatch.setattr(
@@ -1262,13 +1262,11 @@ def test_run_wizard_openai_oauth_is_onboarding_auth_method(monkeypatch, tmp_path
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
-    monkeypatch.setattr(
-        flow, "_render_saved_summary", lambda **kwargs: saved_summary.update(kwargs)
-    )
+    monkeypatch.setattr(flow, "render_saved_summary", lambda **kwargs: saved_summary.update(kwargs))
 
     exit_code = flow.run_wizard()
 
@@ -1308,8 +1306,8 @@ def test_run_wizard_anthropic_oauth_is_onboarding_auth_method(monkeypatch, tmp_p
     store_path = tmp_path / "opensre.json"
     env_path = tmp_path / ".env"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
     monkeypatch.setattr(
@@ -1358,8 +1356,8 @@ def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
     store_path = tmp_path / "opensre.json"
     env_path = tmp_path / ".env"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
     monkeypatch.setattr(
@@ -1373,7 +1371,7 @@ def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -1410,8 +1408,8 @@ def test_run_wizard_gemini_cli_skips_api_key_and_runs_cli_onboarding(monkeypatch
     store_path = tmp_path / "opensre.json"
     env_path = tmp_path / ".env"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
     monkeypatch.setattr(
@@ -1425,7 +1423,7 @@ def test_run_wizard_gemini_cli_skips_api_key_and_runs_cli_onboarding(monkeypatch
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -1480,7 +1478,7 @@ def test_run_cli_llm_onboarding_repick_when_not_logged_in(monkeypatch) -> None:
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "repick")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "repick")
     result = flow._run_cli_llm_onboarding(provider)
     assert result == "repick"
 
@@ -1508,7 +1506,7 @@ def test_run_cli_llm_onboarding_ok_after_login_retry(monkeypatch) -> None:
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "retry")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "retry")
     result = flow._run_cli_llm_onboarding(provider)
     assert result == "ok"
     assert len(detect_calls) == 2
@@ -1548,7 +1546,7 @@ def test_run_cli_llm_onboarding_launches_managed_codex_oauth(monkeypatch, tmp_pa
             detail="OpenAI OAuth tokens stored for Codex.",
         )
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "login")
     monkeypatch.setattr(flow, "run_codex_oauth_login", _fake_codex_oauth_login)
     monkeypatch.setenv("OPENSRE_LLM_AUTH_METADATA_PATH", str(tmp_path / "llm-auth.json"))
 
@@ -1581,7 +1579,7 @@ def test_run_cli_llm_onboarding_surfaces_managed_codex_oauth_error(monkeypatch) 
     def _choose(*_args, **_kwargs):
         return choices.pop(0)
 
-    monkeypatch.setattr(flow, "_choose", _choose)
+    monkeypatch.setattr(flow, "choose", _choose)
     monkeypatch.setattr(
         flow,
         "run_codex_oauth_login",
@@ -1625,7 +1623,7 @@ def test_run_cli_llm_onboarding_launches_claude_browser_login(monkeypatch) -> No
         login_commands.append(command)
         return flow._LoginProcessResult(returncode=0)
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "login")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "login")
     monkeypatch.setattr(flow, "_run_interactive_login_process", _fake_login)
 
     result = flow._run_cli_llm_onboarding(provider)
@@ -1650,7 +1648,7 @@ def test_run_cli_llm_onboarding_repick_when_auth_status_unclear(monkeypatch) -> 
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "repick")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "repick")
     result = flow._run_cli_llm_onboarding(provider)
     assert result == "repick"
 
@@ -1678,7 +1676,7 @@ def test_run_cli_llm_onboarding_ok_after_unclear_auth_retry(monkeypatch) -> None
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "retry")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "retry")
     result = flow._run_cli_llm_onboarding(provider)
     assert result == "ok"
     assert len(detect_calls) == 2
@@ -1699,7 +1697,7 @@ def test_run_cli_llm_onboarding_repick_when_user_chooses_repick(monkeypatch) -> 
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "repick")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "repick")
     result = flow._run_cli_llm_onboarding(provider)
     assert result == "repick"
 
@@ -1726,8 +1724,8 @@ def test_run_cli_llm_onboarding_path_override_then_ok(monkeypatch, tmp_path) -> 
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "path")
-    monkeypatch.setattr(flow, "_prompt_value", lambda *_args, **_kwargs: str(fake_bin))
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "path")
+    monkeypatch.setattr(flow, "prompt_value", lambda *_args, **_kwargs: str(fake_bin))
     monkeypatch.setattr(flow, "sync_env_values", lambda *_args, **_kwargs: None)
 
     original_codex_bin = os.environ.get("CODEX_BIN")
@@ -1761,7 +1759,7 @@ def test_run_cli_llm_onboarding_abort_after_max_retries(monkeypatch) -> None:
     provider.label = "OpenAI Codex CLI"
     provider.adapter_factory = lambda: adapter
 
-    monkeypatch.setattr(flow, "_choose", lambda *_args, **_kwargs: "retry")
+    monkeypatch.setattr(flow, "choose", lambda *_args, **_kwargs: "retry")
     result = flow._run_cli_llm_onboarding(provider)
     assert result == "abort"
     assert adapter.detect.call_count == 10
@@ -1855,10 +1853,10 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _gitlab_configurator,
@@ -1870,7 +1868,7 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -1948,10 +1946,10 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
             return {"status": "failed", "detail": "Unauthorized"}
         return {"status": "passed", "detail": "GitLab ok"}
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _gitlab_configurator,
@@ -1960,7 +1958,7 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2044,10 +2042,10 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(components, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         flow,
@@ -2060,7 +2058,7 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
         lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -2112,10 +2110,10 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -2127,7 +2125,7 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2217,10 +2215,10 @@ def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_pa
             return {"status": "failed", "detail": "HTTP 401: unauthorized"}
         return {"status": "passed", "detail": "OpenSearch ok"}
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -2231,7 +2229,7 @@ def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_pa
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_args, **_kwargs: None)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
@@ -2308,10 +2306,10 @@ def test_run_wizard_opensearch_allows_url_only_when_auth_blank(monkeypatch, tmp_
             return {"status": "failed", "detail": "Provide both username and password."}
         return {"status": "passed", "detail": "OpenSearch ok"}
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -2322,7 +2320,7 @@ def test_run_wizard_opensearch_allows_url_only_when_auth_blank(monkeypatch, tmp_
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env")
     monkeypatch.setattr(
@@ -2407,10 +2405,10 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
             return {"status": "failed", "detail": "Provide both username and password."}
         return {"status": "passed", "detail": "OpenSearch ok"}
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(
         _observability_configurator,
@@ -2421,7 +2419,7 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(_setup_flow, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env")
     monkeypatch.setattr(
@@ -2478,10 +2476,10 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
         m.ask.return_value = next(text_responses)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     _stub_telegram_setup(
         monkeypatch,
@@ -2492,7 +2490,7 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     )
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
 
     def _sync_env_values(values: dict[str, str], **_kwargs):
         synced_env_values.append(values)
@@ -2556,15 +2554,15 @@ def test_run_wizard_telegram_retries_on_validation_failure(monkeypatch, tmp_path
             return {"status": "failed", "detail": "Telegram API check failed."}
         return {"status": "passed", "detail": "Connected to Telegram bot @bot."}
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     _stub_telegram_setup(monkeypatch, _validate)
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_keyring_secret", _stub_save)
+    monkeypatch.setattr(components, "save_keyring_secret", _stub_save)
     monkeypatch.setattr(_setup_flow, "sync_env_values", lambda *_a, **_kw: tmp_path / ".env")
     monkeypatch.setattr(_setup_flow, "sync_env_secret", lambda *_a, **_kw: None)
     monkeypatch.setattr(
@@ -2592,7 +2590,7 @@ def test_persist_llm_credential_host_kind_writes_env_not_keyring(monkeypatch, tm
     keyring_calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
         llm_credential,
-        "_persist_llm_api_key",
+        "persist_llm_api_key",
         lambda env, val: keyring_calls.append((env, val)) or True,
     )
     monkeypatch.setenv("OLLAMA_HOST", "sentinel-before")
@@ -2615,7 +2613,7 @@ def test_persist_llm_credential_secret_kind_keeps_keyring(monkeypatch, tmp_path)
     keyring_calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
         llm_credential,
-        "_persist_llm_api_key",
+        "persist_llm_api_key",
         lambda env, val: keyring_calls.append((env, val)) or True,
     )
 
@@ -2624,19 +2622,19 @@ def test_persist_llm_credential_secret_kind_keeps_keyring(monkeypatch, tmp_path)
     assert keyring_calls == [("ANTHROPIC_API_KEY", "sk-test")]
 
 
-def test_local_defaults_host_kind_ignores_stale_keyring_entry(monkeypatch, tmp_path) -> None:
+def testlocal_defaults_host_kind_ignores_stale_keyring_entry(monkeypatch, tmp_path) -> None:
     """#3291 trap half: a keyring-only host must NOT read as configured — the runtime
     cannot see it, so the wizard must re-prompt instead of skipping."""
     store = tmp_path / "opensre.json"
     store.write_text(json.dumps({"targets": {"local": {"provider": "ollama"}}}))
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store)
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: True)  # stale keyring entry
+    monkeypatch.setattr(components, "get_store_path", lambda: store)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: True)  # stale keyring entry
 
     monkeypatch.delenv("OLLAMA_HOST", raising=False)
-    assert _ui._local_defaults()["has_api_key"] is False
+    assert components.local_defaults()["has_api_key"] is False
 
     monkeypatch.setenv("OLLAMA_HOST", "http://10.0.0.5:11434")
-    assert _ui._local_defaults()["has_api_key"] is True
+    assert components.local_defaults()["has_api_key"] is True
 
 
 def test_run_wizard_host_kind_does_not_migrate_legacy_api_key(monkeypatch, tmp_path) -> None:
@@ -2659,7 +2657,7 @@ def test_run_wizard_host_kind_does_not_migrate_legacy_api_key(monkeypatch, tmp_p
             }
         )
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: store)
+    monkeypatch.setattr(components, "get_store_path", lambda: store)
     monkeypatch.setattr(flow, "get_store_path", lambda: store)
     monkeypatch.delenv("OLLAMA_HOST", raising=False)
     monkeypatch.setattr(flow, "probe_local_target", lambda _p: ProbeResult("local", True, "ok"))
@@ -2674,7 +2672,7 @@ def test_run_wizard_host_kind_does_not_migrate_legacy_api_key(monkeypatch, tmp_p
         m.ask.return_value = False
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
 
     prompted: list[str] = []
@@ -2683,7 +2681,7 @@ def test_run_wizard_host_kind_does_not_migrate_legacy_api_key(monkeypatch, tmp_p
         prompted.append(label)
         return "http://10.0.0.9:11434"  # the host the user actually enters
 
-    monkeypatch.setattr(llm_credential, "_prompt_value", _fake_prompt)
+    monkeypatch.setattr(llm_credential, "prompt_value", _fake_prompt)
 
     persisted: list[tuple[str, str]] = []
 
@@ -2750,14 +2748,14 @@ def test_run_wizard_llm_key_retries_on_validation_failure(monkeypatch, tmp_path,
         call_order.append(f"persist:{value}")
         return _KEYRING_SAVE
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
 
     exit_code = flow.run_wizard()
 
@@ -2810,13 +2808,13 @@ def test_run_wizard_saved_provider_missing_key_validates_on_reentry(monkeypatch,
             return ValidationResult(ok=False, detail="OpenAI rejected the API key.")
         return ValidationResult(ok=True, detail="OpenAI API key validated.")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -2832,12 +2830,12 @@ def test_run_wizard_saved_provider_missing_key_validates_on_reentry(monkeypatch,
             },
         },
     )
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: False)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -2887,15 +2885,15 @@ def test_run_wizard_llm_key_save_anyway_persists_unvalidated_key(
         validation_call_count += 1
         return ValidationResult(ok=False, detail="Validation request failed: network unreachable")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -2948,10 +2946,10 @@ def test_run_wizard_llm_key_repick_returns_to_provider_menu(monkeypatch, tmp_pat
             return ValidationResult(ok=False, detail="Anthropic rejected the API key.")
         return ValidationResult(ok=True, detail="OpenAI API key validated.")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
@@ -2961,7 +2959,7 @@ def test_run_wizard_llm_key_repick_returns_to_provider_menu(monkeypatch, tmp_pat
         lambda values, **_kwargs: synced_env_values.append(values) or (tmp_path / ".env"),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3001,14 +2999,14 @@ def test_run_wizard_llm_key_valid_first_try_validates_once(monkeypatch, tmp_path
         call_order.append(f"persist:{value}")
         return _KEYRING_SAVE
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
 
     exit_code = flow.run_wizard()
 
@@ -3074,16 +3072,16 @@ def test_run_wizard_azure_llm_key_validation_runs_after_endpoint_prompt(
     monkeypatch.setattr(
         azure_openai, "discover_azure_openai_deployments_from_env", lambda: ["gpt-5.4-mini"]
     )
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", _sync_provider_env)
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3142,16 +3140,16 @@ def test_run_wizard_cli_provider_skips_llm_key_validation(monkeypatch, tmp_path)
         cli_onboarding_providers.append(provider.value)
         return "ok"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3219,11 +3217,11 @@ def test_run_wizard_ollama_host_is_validated_then_persisted_to_dotenv(
             return ValidationResult(ok=True, detail=f"Ollama reachable. Model '{model}' is ready.")
         return ValidationResult(ok=False, detail="Anthropic rejected the API key.")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
@@ -3233,7 +3231,7 @@ def test_run_wizard_ollama_host_is_validated_then_persisted_to_dotenv(
         lambda values, **_kwargs: synced_env_values.append(values) or (tmp_path / ".env"),
     )
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3300,15 +3298,15 @@ def test_run_wizard_ollama_host_env_write_failure_offers_recovery_menu(
         # Simulate a real .env write failure: no write permission / read-only fs / full disk.
         raise OSError("[Errno 13] Permission denied: '.env'")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(llm_credential, "sync_env_values", _raise_env_write)
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3349,13 +3347,13 @@ def test_run_wizard_saved_provider_with_stored_key_skips_validation(monkeypatch,
     def _validate(**_kwargs):
         raise AssertionError("validator must not be called for a stored key")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate, raising=False)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -3369,12 +3367,12 @@ def test_run_wizard_saved_provider_with_stored_key_skips_validation(monkeypatch,
             },
         },
     )
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: True)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: True)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3411,13 +3409,13 @@ def test_run_wizard_legacy_key_migration_does_not_validate(monkeypatch, tmp_path
     def _validate(**_kwargs):
         raise AssertionError("validator must not be called for a legacy migration")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate, raising=False)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -3432,12 +3430,12 @@ def test_run_wizard_legacy_key_migration_does_not_validate(monkeypatch, tmp_path
             },
         },
     )
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: False)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3492,16 +3490,16 @@ def test_run_wizard_llm_key_persist_failure_offers_recovery_menu(
             raise RuntimeError("keychain locked")
         return _KEYRING_SAVE
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: ("Current keyring backend: keyring.backends.fail.Keyring.",),
     )
@@ -3562,16 +3560,16 @@ def test_run_wizard_llm_key_persist_failure_repick_returns_to_provider_menu(
             raise RuntimeError("keychain locked")
         return _KEYRING_SAVE
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: ("Current keyring backend: keyring.backends.fail.Keyring.",),
     )
@@ -3618,20 +3616,20 @@ def test_run_wizard_llm_key_persist_failure_abort_exits_nonzero(
         persist_attempts.append((provider, value))
         raise RuntimeError("keychain locked")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(
         llm_credential,
         "validate_provider_credentials",
         lambda **_kwargs: ValidationResult(ok=True, detail="Anthropic API key validated."),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: ("Current keyring backend: keyring.backends.fail.Keyring.",),
     )
@@ -3685,15 +3683,15 @@ def test_run_wizard_llm_key_back_at_reprompt_returns_to_provider_menu(
             return ValidationResult(ok=False, detail="Anthropic rejected the API key.")
         return ValidationResult(ok=True, detail="OpenAI API key validated.")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3736,19 +3734,19 @@ def test_run_wizard_llm_key_ctrl_c_at_retry_menu_cancels_setup(
         m.ask.return_value = "sk-bad"
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(
         llm_credential,
         "validate_provider_credentials",
         lambda **_kwargs: ValidationResult(ok=False, detail="Anthropic rejected the API key."),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3802,15 +3800,15 @@ def test_run_wizard_llm_key_validator_exception_treated_as_failure(
             raise RuntimeError("boom")
         return ValidationResult(ok=True, detail="OpenAI API key validated.")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3871,15 +3869,15 @@ def test_run_wizard_llm_key_validation_failure_output_masks_secret(
         validation_call_count += 1
         return ValidationResult(ok=False, detail="Anthropic rejected the API key.")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -3901,7 +3899,7 @@ def test_run_wizard_llm_key_validation_failure_output_masks_secret(
 # ---------------------------------------------------------------------------
 # DELTA 3 — validation must probe the model the user actually picked.
 #
-# Today `run_wizard` prompts for + validates the credential BEFORE `_choose_model`
+# Today `run_wizard` prompts for + validates the credential BEFORE `choose_model`
 # runs (flow.py: credential block ~920-974, model selection ~976-1003), so the
 # validator is handed `model_provider.default_model` (change-provider branch) or
 # the *stale* saved model (saved-provider branch) instead of the model that is
@@ -3951,14 +3949,14 @@ def test_run_wizard_validates_the_model_the_user_picked_change_provider(
         saved.update(kwargs)
         return tmp_path / "opensre.json"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", _save_local_config)
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _stub_save)
+    monkeypatch.setattr(components, "save_api_key", _stub_save)
 
     exit_code = flow.run_wizard()
 
@@ -4012,13 +4010,13 @@ def test_run_wizard_validates_the_model_the_user_picked_saved_provider(
         saved.update(kwargs)
         return tmp_path / "opensre.json"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -4032,11 +4030,11 @@ def test_run_wizard_validates_the_model_the_user_picked_saved_provider(
             },
         },
     )
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: False)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", _save_local_config)
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _stub_save)
+    monkeypatch.setattr(components, "save_api_key", _stub_save)
 
     exit_code = flow.run_wizard()
 
@@ -4094,10 +4092,10 @@ def test_run_wizard_ollama_validates_the_selected_model_not_the_default(
         saved.update(kwargs)
         return tmp_path / "opensre.json"
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", _save_local_config)
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
@@ -4127,7 +4125,7 @@ def test_run_wizard_ollama_validates_the_selected_model_not_the_default(
 def test_recovery_action_renders_three_rows_with_retry_as_the_default(monkeypatch) -> None:
     """The shared menu: 3 rows in a fixed order, row 1 is "retry" AND is the default.
 
-    ``_choose(default=...)`` matches by ``Choice.value`` and raises ``ValueError``
+    ``choose(default=...)`` matches by ``Choice.value`` and raises ``ValueError``
     when it matches nothing, so ``default`` and ``choices[0].value`` must both be
     the literal string ``"retry"`` — this is a crash gate, not a cosmetic one.
     """
@@ -4139,7 +4137,7 @@ def test_recovery_action_renders_three_rows_with_retry_as_the_default(monkeypatc
         recorded["kwargs"] = kwargs
         return "retry"
 
-    monkeypatch.setattr(llm_credential, "_choose", _fake_choose)
+    monkeypatch.setattr(llm_credential, "choose", _fake_choose)
 
     escape = flow.Choice(
         value="save_anyway",
@@ -4166,7 +4164,7 @@ def test_recovery_action_renders_three_rows_with_retry_as_the_default(monkeypatc
     assert kwargs["default"] == "retry"
     # The literal "retry" must be row 1's value or questionary raises ValueError.
     assert kwargs["default"] == choices[0].value
-    # The WizardBack arm is dead code by contract: _choose must not be asked to
+    # The WizardBack arm is dead code by contract: choose must not be asked to
     # raise WizardBack here (it only does so when back_on_cancel=True).
     assert kwargs.get("back_on_cancel", False) is False
 
@@ -4183,14 +4181,14 @@ def test_recovery_action_escape_returns_cancel_and_prints_setup_cancelled(
 ) -> None:
     """ESCAPE at either menu -> "cancel" -> "Setup cancelled." (X1).
 
-    ESCAPE — not Ctrl-C — is the production trigger: ``_choose`` is called without
+    ESCAPE — not Ctrl-C — is the production trigger: ``choose`` is called without
     ``back_on_cancel``, so an escaped select raises a BARE ``KeyboardInterrupt``.
     """
 
     def _fake_choose(*_args, **_kwargs):
         raise KeyboardInterrupt
 
-    monkeypatch.setattr(llm_credential, "_choose", _fake_choose)
+    monkeypatch.setattr(llm_credential, "choose", _fake_choose)
 
     action = llm_credential._recovery_action(
         prompt="ANTHROPIC_API_KEY could not be saved. What next?",
@@ -4249,14 +4247,14 @@ def test_run_wizard_keyring_failure_continue_unsaved_exports_env_and_never_write
         persist_attempts.append((provider, value))
         raise RuntimeError("keychain locked")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(
         llm_credential,
         "validate_provider_credentials",
         lambda **_kwargs: ValidationResult(ok=True, detail="Anthropic API key validated."),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     # Run the REAL sync against a tmp .env so the assertion below exercises the true
@@ -4272,9 +4270,9 @@ def test_run_wizard_keyring_failure_continue_unsaved_exports_env_and_never_write
         "sync_env_values",
         lambda values, **_kw: synced_env_values.append(dict(values)) or (tmp_path / ".env"),
     )
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: ("Current keyring backend: keyring.backends.fail.Keyring.",),
     )
@@ -4338,7 +4336,7 @@ def test_run_wizard_keyring_failure_at_saved_provider_site_reaches_the_shared_me
             raise RuntimeError("keychain locked")
         return _KEYRING_SAVE
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(
@@ -4346,9 +4344,9 @@ def test_run_wizard_keyring_failure_at_saved_provider_site_reaches_the_shared_me
         "validate_provider_credentials",
         lambda **_kwargs: ValidationResult(ok=True, detail="Anthropic API key validated."),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -4362,13 +4360,13 @@ def test_run_wizard_keyring_failure_at_saved_provider_site_reaches_the_shared_me
             },
         },
     )
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: False)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: ("Current keyring backend: keyring.backends.fail.Keyring.",),
     )
@@ -4424,7 +4422,7 @@ def test_run_wizard_keyring_failure_at_legacy_migration_site_reaches_the_shared_
             raise RuntimeError("keychain locked")
         return _KEYRING_SAVE
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(
@@ -4432,9 +4430,9 @@ def test_run_wizard_keyring_failure_at_legacy_migration_site_reaches_the_shared_
         "validate_provider_credentials",
         lambda **_kwargs: ValidationResult(ok=True, detail="stubbed"),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {
             "wizard": {"mode": "quickstart"},
@@ -4449,13 +4447,13 @@ def test_run_wizard_keyring_failure_at_legacy_migration_site_reaches_the_shared_
             },
         },
     )
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: False)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: ("Current keyring backend: keyring.backends.fail.Keyring.",),
     )
@@ -4473,7 +4471,7 @@ def test_run_wizard_keyring_failure_at_legacy_migration_site_reaches_the_shared_
 #
 # The key prompt passes `default=provider.credential_default`. For azure-openai
 # that default is the ENDPOINT placeholder "https://your-resource.openai.azure.com",
-# and `_prompt_value` RETURNS THE DEFAULT ON EMPTY INPUT (_ui.py) — so a bare Enter
+# and `prompt_value` RETURNS THE DEFAULT ON EMPTY INPUT (components.py) — so a bare Enter
 # silently persists a URL as the API key. Ollama's host default must survive.
 # ---------------------------------------------------------------------------
 
@@ -4531,16 +4529,16 @@ def test_run_wizard_azure_empty_key_input_never_persists_the_endpoint_placeholde
     monkeypatch.setattr(
         azure_openai, "discover_azure_openai_deployments_from_env", lambda: ["gpt-5.4-mini"]
     )
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -4589,14 +4587,14 @@ def test_run_wizard_ollama_host_prompt_keeps_its_localhost_default(monkeypatch, 
         m.ask.return_value = ""  # bare Enter -> must fall back to the offered default
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(
         llm_credential,
         "validate_provider_credentials",
         lambda **_kwargs: ValidationResult(ok=True, detail="Ollama host URL validated."),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
@@ -4623,15 +4621,15 @@ def test_run_wizard_ollama_host_prompt_keeps_its_localhost_default(monkeypatch, 
 
 
 def _summary_kwargs_spy(monkeypatch) -> dict[str, object]:
-    """Record the kwargs `_render_saved_summary` is called with, then render for real."""
+    """Record the kwargs `render_saved_summary` is called with, then render for real."""
     recorded: dict[str, object] = {}
-    real = flow._render_saved_summary
+    real = flow.render_saved_summary
 
     def _spy(**kwargs):
         recorded.update(kwargs)
         return real(**kwargs)
 
-    monkeypatch.setattr(flow, "_render_saved_summary", _spy)
+    monkeypatch.setattr(flow, "render_saved_summary", _spy)
     return recorded
 
 
@@ -4666,20 +4664,20 @@ def test_run_wizard_summary_credential_line_after_continue_unsaved(monkeypatch, 
     def _save_api_key(_provider, _value, **_kwargs):
         raise RuntimeError("keychain locked")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(
         llm_credential,
         "validate_provider_credentials",
         lambda **_kwargs: ValidationResult(ok=True, detail="Anthropic API key validated."),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _save_api_key)
+    monkeypatch.setattr(components, "save_api_key", _save_api_key)
     monkeypatch.setattr(
-        _ui,
+        components,
         "get_keyring_setup_instructions",
         lambda _env_var: ("Current keyring backend: keyring.backends.fail.Keyring.",),
     )
@@ -4717,7 +4715,7 @@ def test_run_wizard_summary_credential_line_after_save_anyway(monkeypatch, tmp_p
         m.ask.return_value = "sk-offline"
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(
         llm_credential,
@@ -4726,11 +4724,11 @@ def test_run_wizard_summary_credential_line_after_save_anyway(monkeypatch, tmp_p
             ok=False, detail="Validation request failed: Connection error."
         ),
     )
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
-    monkeypatch.setattr(_ui, "save_api_key", _stub_save)
+    monkeypatch.setattr(components, "save_api_key", _stub_save)
 
     exit_code = flow.run_wizard()
 
@@ -4748,7 +4746,7 @@ def test_prompt_validated_llm_credential_wizard_back_precedes_keyboard_interrupt
 ) -> None:
     """EXCEPT-ORDER GATE. This test exists to go RED if the two arms are inverted.
 
-    ``WizardBack`` SUBCLASSES ``KeyboardInterrupt`` (_ui.py), so an
+    ``WizardBack`` SUBCLASSES ``KeyboardInterrupt`` (components.py), so an
     ``except KeyboardInterrupt`` arm placed FIRST silently swallows back-navigation
     and turns it into "Setup cancelled." Back-out at the key prompt must return
     "repick" (-> the provider picker) and must print nothing about cancelling.
@@ -4846,16 +4844,16 @@ def test_run_wizard_azure_endpoint_reprompted_on_retry_after_validation_failure(
     monkeypatch.setattr(
         azure_openai, "discover_azure_openai_deployments_from_env", lambda: ["gpt-5.4-mini"]
     )
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -4947,16 +4945,16 @@ def test_run_wizard_azure_endpoint_reprompted_on_repick_then_reselect(
     monkeypatch.setattr(
         azure_openai, "discover_azure_openai_deployments_from_env", lambda: ["gpt-5.4-mini"]
     )
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -5024,7 +5022,7 @@ def test_run_wizard_falls_back_when_saved_mode_is_not_offered(monkeypatch, stale
     # Arrange
     monkeypatch.setattr(
         flow,
-        "_local_defaults",
+        "local_defaults",
         lambda: {"provider": None, "model": "", "wizard_mode": stale_mode, "auth_method": None},
     )
     seen: dict[str, object] = {}
@@ -5033,9 +5031,9 @@ def test_run_wizard_falls_back_when_saved_mode_is_not_offered(monkeypatch, stale
         seen["default"] = default
         raise KeyboardInterrupt  # stop the wizard once the default is known
 
-    monkeypatch.setattr(flow, "_choose", _capture_choose)
-    monkeypatch.setattr(flow, "_render_header", lambda: None)
-    monkeypatch.setattr(flow, "_step_header", lambda *_a, **_k: None)
+    monkeypatch.setattr(flow, "choose", _capture_choose)
+    monkeypatch.setattr(flow, "render_header", lambda: None)
+    monkeypatch.setattr(flow, "step_header", lambda *_a, **_k: None)
 
     # Act
     with pytest.raises(KeyboardInterrupt):
@@ -5083,15 +5081,15 @@ def test_run_wizard_blank_llm_key_defers_setup_instead_of_ending(monkeypatch, tm
         validator_calls.append((provider.value, api_key))
         return ValidationResult(ok=True, detail="unexpected")
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(llm_credential, "validate_provider_credentials", _validate)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )
@@ -5145,17 +5143,17 @@ def test_run_wizard_blank_key_on_kept_provider_reports_deferred_not_keychain(
             },
         }
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
-    monkeypatch.setattr(_ui, "load_local_config", _load_saved_openai)
-    monkeypatch.setattr(_ui, "has_llm_api_key", lambda _env: False)
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(components, "load_local_config", _load_saved_openai)
+    monkeypatch.setattr(components, "has_llm_api_key", lambda _env: False)
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(
-        _ui,
+        components,
         "save_api_key",
         lambda provider, value, **_kwargs: _stub_save_recording(saved_llm_keys, provider, value),
     )

--- a/tests/cli/wizard/test_integration_configurators.py
+++ b/tests/cli/wizard/test_integration_configurators.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from surfaces.cli.wizard import _integration_configurators as configurators
-from surfaces.cli.wizard import _ui
+from surfaces.cli.wizard import components
 
 
 @pytest.mark.parametrize("legacy_mode", ["aha", "focused"])
@@ -16,13 +16,13 @@ def test_local_defaults_maps_legacy_mode_to_quickstart(
     tmp_path: Any,
     legacy_mode: str,
 ) -> None:
-    monkeypatch.setattr(_ui, "get_store_path", lambda: tmp_path / "store.json")
+    monkeypatch.setattr(components, "get_store_path", lambda: tmp_path / "store.json")
     monkeypatch.setattr(
-        _ui,
+        components,
         "load_local_config",
         lambda _path: {"wizard": {"mode": legacy_mode}, "targets": {"local": {}}},
     )
-    assert _ui._local_defaults()["wizard_mode"] == "quickstart"
+    assert components.local_defaults()["wizard_mode"] == "quickstart"
 
 
 def test_configure_selected_integrations_default_prompt(
@@ -30,11 +30,11 @@ def test_configure_selected_integrations_default_prompt(
 ) -> None:
     printed: list[str] = []
     monkeypatch.setattr(
-        configurators._console,
+        configurators.console,
         "print",
         lambda msg, **_kwargs: printed.append(str(msg)),
     )
-    monkeypatch.setattr(configurators, "_choose", lambda *_args, **_kwargs: "skip")
+    monkeypatch.setattr(configurators, "choose", lambda *_args, **_kwargs: "skip")
 
     configurators._configure_selected_integrations()
 
@@ -45,9 +45,9 @@ def test_configure_selected_integrations_runs_one_handler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
-    monkeypatch.setattr(configurators._console, "print", lambda *_a, **_k: None)
-    monkeypatch.setattr(configurators, "_step", lambda *_a, **_k: None)
-    monkeypatch.setattr(configurators, "_choose", lambda *_args, **_kwargs: "datadog")
+    monkeypatch.setattr(configurators.console, "print", lambda *_a, **_k: None)
+    monkeypatch.setattr(configurators, "step", lambda *_a, **_k: None)
+    monkeypatch.setattr(configurators, "choose", lambda *_args, **_kwargs: "datadog")
     monkeypatch.setattr(
         configurators,
         "_configure_datadog",

--- a/tests/cli/wizard/test_model_selection.py
+++ b/tests/cli/wizard/test_model_selection.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from surfaces.cli.wizard import _ui, flow
+from surfaces.cli.wizard import components, flow
 from surfaces.shared.llm_setup.catalog import PROVIDER_BY_VALUE
 
 
@@ -29,7 +29,7 @@ def _wire_prompts(
         m.ask.return_value = next(text_iter)
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
     monkeypatch.setattr(flow.questionary, "text", _mock_text)
 
 
@@ -37,7 +37,7 @@ def test_choose_model_returns_curated_default(monkeypatch: pytest.MonkeyPatch) -
     provider = PROVIDER_BY_VALUE["anthropic"]
     _wire_prompts(monkeypatch, select_values=[provider.default_model])
 
-    model = _ui._choose_model(provider, default=provider.default_model)
+    model = components.choose_model(provider, default=provider.default_model)
 
     assert model == provider.default_model
 
@@ -53,13 +53,13 @@ def test_choose_model_offers_full_curated_list(monkeypatch: pytest.MonkeyPatch) 
         m.ask.return_value = provider.default_model
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
 
-    _ui._choose_model(provider, default="")
+    components.choose_model(provider, default="")
 
     expected_curated = [opt.value for opt in provider.models]
     assert captured["values"][:-1] == expected_curated
-    assert captured["values"][-1] == _ui._CUSTOM_MODEL_SENTINEL
+    assert captured["values"][-1] == components.CUSTOM_MODEL_SENTINEL
 
 
 def test_choose_model_preserves_saved_model_not_in_curated(
@@ -75,9 +75,9 @@ def test_choose_model_preserves_saved_model_not_in_curated(
         m.ask.return_value = "my-tuned-gpt"
         return m
 
-    monkeypatch.setattr(_ui, "select_prompt", _mock_select)
+    monkeypatch.setattr(components, "select_prompt", _mock_select)
 
-    model = _ui._choose_model(provider, default="my-tuned-gpt")
+    model = components.choose_model(provider, default="my-tuned-gpt")
 
     assert model == "my-tuned-gpt"
     assert "my-tuned-gpt" in captured["values"]
@@ -87,11 +87,11 @@ def test_choose_model_accepts_custom_entry(monkeypatch: pytest.MonkeyPatch) -> N
     provider = PROVIDER_BY_VALUE["anthropic"]
     _wire_prompts(
         monkeypatch,
-        select_values=[_ui._CUSTOM_MODEL_SENTINEL],
+        select_values=[components.CUSTOM_MODEL_SENTINEL],
         text_values=["claude-future-preview"],
     )
 
-    model = _ui._choose_model(provider, default=provider.default_model)
+    model = components.choose_model(provider, default=provider.default_model)
 
     assert model == "claude-future-preview"
 
@@ -101,7 +101,7 @@ def test_choose_model_works_for_cli_provider(monkeypatch: pytest.MonkeyPatch) ->
     provider = PROVIDER_BY_VALUE["codex"]
     _wire_prompts(monkeypatch, select_values=["gpt-5.4"])
 
-    model = _ui._choose_model(provider, default="")
+    model = components.choose_model(provider, default="")
 
     assert model == "gpt-5.4"
 
@@ -142,4 +142,4 @@ class TestGpt56CatalogPresence:
         provider = PROVIDER_BY_VALUE["openai"]
         _wire_prompts(monkeypatch, select_values=["gpt-5.6-sol"])
 
-        assert _ui._choose_model(provider, default="") == "gpt-5.6-sol"
+        assert components.choose_model(provider, default="") == "gpt-5.6-sol"

--- a/tests/cli/wizard/test_onboard_integrations.py
+++ b/tests/cli/wizard/test_onboard_integrations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import questionary
 
-from surfaces.cli.wizard._ui import Choice, _group_header_label, _grouped_questionary_choices
+from surfaces.cli.wizard.components import Choice, group_header_label, grouped_questionary_choices
 from surfaces.cli.wizard.onboard_integrations import (
     ONBOARD_INTEGRATION_CHOICES,
     ONBOARD_INTEGRATION_GROUP_ORDER,
@@ -14,13 +14,13 @@ from surfaces.cli.wizard.prompts import _SelectControl
 
 
 def test_group_header_label_formats_category_title() -> None:
-    assert _group_header_label("Observability") == "── Observability ──"
+    assert group_header_label("Observability") == "── Observability ──"
 
 
 def test_select_control_renders_group_headers_with_highlight_style() -> None:
     ic = _SelectControl(
         [
-            questionary.Separator(_group_header_label("Observability")),
+            questionary.Separator(group_header_label("Observability")),
             questionary.Choice("Datadog", value="datadog"),
         ],
         None,
@@ -49,7 +49,7 @@ def _expected_grouped_choice_values(
     group_order: tuple[str, ...],
     trailing_choices: list[Choice] | None = None,
 ) -> list[str]:
-    """Build selectable values in the same order as ``_grouped_questionary_choices``."""
+    """Build selectable values in the same order as ``grouped_questionary_choices``."""
     grouped_values: dict[str, list[str]] = {group: [] for group in group_order}
     for choice in choices:
         if choice.group in grouped_values:
@@ -64,7 +64,7 @@ def _expected_grouped_choice_values(
 
 
 def test_grouped_questionary_choices_renders_category_separators() -> None:
-    rendered = _grouped_questionary_choices(
+    rendered = grouped_questionary_choices(
         list(ONBOARD_INTEGRATION_CHOICES),
         group_order=ONBOARD_INTEGRATION_GROUP_ORDER,
         trailing_choices=[ONBOARD_SKIP_CHOICE],
@@ -72,7 +72,7 @@ def test_grouped_questionary_choices_renders_category_separators() -> None:
 
     separator_titles = [item.title for item in rendered if isinstance(item, questionary.Separator)]
     assert separator_titles[: len(ONBOARD_INTEGRATION_GROUP_ORDER)] == [
-        _group_header_label(group) for group in ONBOARD_INTEGRATION_GROUP_ORDER
+        group_header_label(group) for group in ONBOARD_INTEGRATION_GROUP_ORDER
     ]
     assert len(separator_titles) == len(ONBOARD_INTEGRATION_GROUP_ORDER) + 1
 
@@ -89,7 +89,7 @@ def test_grouped_questionary_choices_renders_category_separators() -> None:
 
 
 def test_grouped_questionary_choices_labels_unknown_groups_as_other() -> None:
-    rendered = _grouped_questionary_choices(
+    rendered = grouped_questionary_choices(
         [
             Choice(value="datadog", label="Datadog", group="Observability"),
             Choice(value="custom", label="Custom", group="Unknown"),
@@ -99,8 +99,8 @@ def test_grouped_questionary_choices_labels_unknown_groups_as_other() -> None:
 
     separator_titles = [item.title for item in rendered if isinstance(item, questionary.Separator)]
     assert separator_titles == [
-        _group_header_label("Observability"),
-        _group_header_label("Other"),
+        group_header_label("Observability"),
+        group_header_label("Other"),
     ]
     selectable_values = [
         item.value

--- a/tests/cli/wizard/test_spec_configurator.py
+++ b/tests/cli/wizard/test_spec_configurator.py
@@ -59,12 +59,12 @@ def run(monkeypatch: pytest.MonkeyPatch) -> _Run:
         state.asked.append(
             {"label": label, "default": default, "secret": secret, "allow_empty": allow_empty}
         )
-        # Mirror the real _prompt_value: a blank answer falls back to the default.
+        # Mirror the real prompt_value: a blank answer falls back to the default.
         return state.answers.get(label, "") or default
 
-    monkeypatch.setattr(spec_configurator, "_prompt_value", _fake_prompt_value)
-    monkeypatch.setattr(spec_configurator, "_integration_defaults", lambda _s: ({}, state.stored))
-    monkeypatch.setattr(spec_configurator, "_render_integration_result", lambda *_a: None)
+    monkeypatch.setattr(spec_configurator, "prompt_value", _fake_prompt_value)
+    monkeypatch.setattr(spec_configurator, "integration_defaults", lambda _s: ({}, state.stored))
+    monkeypatch.setattr(spec_configurator, "render_integration_result", lambda *_a: None)
     monkeypatch.setattr(setup_flow, "upsert_integration", lambda *_a: None)
     monkeypatch.setattr(setup_flow, "sync_env_secret", lambda *_a: None)
     monkeypatch.setattr(setup_flow, "sync_env_values", lambda *_a, **_kw: _ENV_PATH)
@@ -181,7 +181,7 @@ def test_mode_gate_can_steer_to_a_different_mode_before_fields_are_asked(
 ) -> None:
     """A vendor may swap the picked mode when its prerequisite is missing."""
     # Arrange — user picks "token"; the gate finds it unusable and steers to "basic"
-    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "token")
+    monkeypatch.setattr(spec_configurator, "choose", lambda *_a, **_k: "token")
     gated_with: list[str] = []
 
     def steer_to_basic(mode: str) -> str:
@@ -203,7 +203,7 @@ def test_without_a_mode_gate_the_picked_mode_is_used_unchanged(
     run: _Run, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Arrange
-    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "token")
+    monkeypatch.setattr(spec_configurator, "choose", lambda *_a, **_k: "token")
     run.answers = {"Demo token": "t"}
 
     # Act
@@ -222,7 +222,7 @@ def test_a_field_required_by_the_chosen_mode_may_not_be_left_empty(
     config-model "requires either role_arn or credentials" validation error.
     """
     # Arrange — user picks "token"; the spec says token is required in that mode
-    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "token")
+    monkeypatch.setattr(spec_configurator, "choose", lambda *_a, **_k: "token")
     run.answers = {"Demo token": "t"}
 
     # Act
@@ -237,7 +237,7 @@ def test_the_same_field_stays_optional_when_another_mode_is_chosen(
     run: _Run, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Arrange — "basic" is chosen; its fields are optional at every level
-    monkeypatch.setattr(spec_configurator, "_choose", lambda *_a, **_k: "basic")
+    monkeypatch.setattr(spec_configurator, "choose", lambda *_a, **_k: "basic")
     run.answers = {"Demo user": "u", "Demo password": "p"}
 
     # Act

--- a/tests/cli/wizard/test_ui_style.py
+++ b/tests/cli/wizard/test_ui_style.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from infrastructure.terminal.theme import BG, HIGHLIGHT, set_active_theme
-from surfaces.cli.wizard import _ui as wizard_ui
+from surfaces.cli.wizard import components as wizard_ui
 
 
 def test_questionary_highlighted_style_uses_dark_text_on_highlight_background() -> None:


### PR DESCRIPTION
Fixes #5447

#### Describe the changes you have made in this PR -

`surfaces/cli/wizard/_ui.py` was 663 lines where every function was
underscore-private, yet fifteen modules across four wizard packages (plus
tests) imported those "private" names anyway. The leading-underscore
marker was false — this is the wizard's shared UI layer.

Two changes, one file split into three:

1. **Rename `_ui.py` → `components.py`** and drop the leading underscore
   from every name imported across a module boundary:
   `_choose`→`choose`, `_console`→`console`, `_step`→`step`,
   `_step_header`→`step_header`, `_prompt_value`→`prompt_value`,
   `_choose_model`→`choose_model`, `_confirm`→`confirm`,
   `_string_value`→`string_value`, `_joined_values`→`joined_values`,
   `_local_defaults`→`local_defaults`,
   `_integration_defaults`→`integration_defaults`,
   `_persist_llm_api_key`→`persist_llm_api_key`,
   `_parse_csv_values`→`parse_csv_values`,
   `_select_target_for_advanced`→`select_target_for_advanced`,
   `_CUSTOM_MODEL_SENTINEL`→`CUSTOM_MODEL_SENTINEL`,
   `_group_header_label`→`group_header_label`,
   `_grouped_questionary_choices`→`grouped_questionary_choices`.

   Names with a single caller inside the file stayed underscore-private
   (per the issue): `_questionary_style`, `_as_mapping`, `_choice_title`,
   `_choice_description`, `_questionary_choice`,
   `_provider_model_prompt_label`, `_display_probe`.

2. **Extract the `_render_*` block → `summaries.py`** — the four summary
   render functions (`render_header`, `render_saved_summary`,
   `render_integration_result`, `render_next_steps`, ~215 lines) now live
   in a one-job module with no callers outside the wizard. They import the
   shared `console` from `components`, so it is the same instance — no
   behavior change.

**How I read the difference between `components.py` and `prompts.py`:**
`prompts.py` builds the raw prompt-toolkit select/checkbox widgets
(`_SelectControl`, `_CheckboxControl`, `select()`, `checkbox()`).
`components.py` sits above it — it orchestrates those widgets into wizard
steps (`Choice` type, `WizardBack`, step headers, the choose/prompt_value/
confirm/model-picker prompts, default lookups, API-key persistence). They
are different jobs: one renders a list control, the other composes it into
a multi-field onboarding step. `summaries.py` is a third job — pure
non-interactive output rendering. If `components` and `prompts` ever turn
out to be the same job, that is worth knowing before someone merges them
by accident (per the issue).

No function body changed — only symbol renames, the module rename, and the
render-block split. `git diff -M` detects the `_ui.py => components.py`
rename (60% similarity).

### Demo/Screenshot for feature changes and bug fixes -

Refactor with no behavior change — verification is test results and grep
checks, not a UI screenshot.

**Acceptance greps (both print nothing):**
$ grep -rn "wizard\.ui\|ui import" --include='*.py' surfaces tests
(no output)
$ grep -rn "^from surfaces.cli.wizard.* import .\b_a-z" --include='.py' surfaces tests
(no output — only pre-existing configure* / _integration_configurators
imports unrelated to _ui; the new modules export no underscore names)

**`git diff -M` shows the rename:**
surfaces/cli/wizard/{_ui.py => components.py} | 306 ++++++--------------------
surfaces/cli/wizard/summaries.py              | 215 ++++++++++++++++++
2 files changed, 278 insertions(+), 243 deletions(-)

**Tests:**
$ uv run python -m pytest tests/cli/wizard/ -q
178 passed, 5 failed in 5.6s
The 5 failures are all in `test_prompts.py` and **pre-exist on `main**
(verified via `git stash` — they are Windows ProactorEventLoop/PTY
teardown issues in `prompts.py`, which this PR does not touch).

**Lint / format / typecheck:**
$ uv run python -m ruff check ...   → All checks passed
$ uv run python -m ruff format --check ... → 3652 files already formatted
$ uv run python -m mypy ... → Success: no issues found in 43 source files
$ uv run python .github/ci/check_imports.py → All 3 import checks passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `_ui.py` was a 663-line kitchen-sink module where every name
carried a leading underscore (signaling "module-private"), but fifteen
modules across the wizard imported those names anyway. The marker lied.

**What the code solves:** Two issues in one file — (1) false-private names
that should be public, and (2) a file holding unrelated concerns (questionary
style, Choice type, control-flow exception, default lookups, step headers,
choice prompts, model selection, API-key persistence, CSV parsing, and four
render functions).

**Alternative approaches considered:**
- Name it `wizard_prompts` — rejected per the issue; `prompts.py` already
  exists at 405 lines and the two would be indistinguishable.
- Move everything into `prompts.py` — rejected; that would merge two
  different jobs (widget rendering vs. wizard-step orchestration).

**Why this implementation:**
- `components.py` is a role name for the wizard's interaction layer — it
  says what the module *is* (UI components that compose wizard steps),
  not a generic `_ui` placeholder.
- `summaries.py` is the cleanest extraction: ~215 lines, four functions,
  no callers outside the wizard, one clear job (render output screens).
- Private single-caller helpers stayed underscored — the issue explicitly
  named them and said to leave them alone.

**Key components:**
- `components.py`: `Choice` (frozen dataclass), `WizardBack` (control-flow
  exception), `console` (shared Rich Console), `step`/`step_header`
  (visual section markers), `choose`/`confirm`/`prompt_value`/`choose_model`
  (the four prompt primitives), `local_defaults`/`integration_defaults`
  (stored-config lookups), `persist_llm_api_key` (keyring persistence).
- `summaries.py`: `render_header` (splash), `render_saved_summary`
  (post-onboarding success screen), `render_integration_result` (per-step
  validation card), `render_next_steps` (closing command list).

The refactor is mechanically safe: symbol renames + module split, no logic
change. Tests were updated to import paths and renamed symbols only — no
assertions or test logic changed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.