### PR TITLE
docs(tests): clarify test-full excludes e2e

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@
 | Verify all integration configs and clients | `make verify-integrations` | After adding or changing an integration. |
 | Run a live RCA end-to-end test | `make test-rca` | When you need to validate a full investigation against real services. |
 | Run a single RCA fixture | `make test-rca FILE=<name>` | When iterating on one specific alert scenario. |
-| Run the full suite including e2e | `make test-full` | Pre-release or CI; requires live infrastructure. |
+| Run the default pytest collection (`tests/e2e` excluded by pytest configuration) | `make test-full` | Broad local or CI regression run; use `make test-rca` for live RCA end-to-end testing. |
 | Run synthetic scenarios (no live infra) | `make test-synthetic` | When testing scenario logic without external service dependencies. |
 
 ## Layout


### PR DESCRIPTION
Fixes #5645

#### Describe the changes you have made in this PR -

Clarify the `make test-full` entry in `tests/README.md` so it matches the repository's current test configuration:

- `make test-full` runs the default pytest collection.
- `pytest.ini` excludes `tests/e2e` from recursive collection.
- Contributors are directed to `make test-rca` for live RCA end-to-end testing.

This is a one-line documentation-only change. It does not alter test execution or runtime behavior.

### Demo/Screenshot for feature changes and bug fixes -

Before: the table said `make test-full` included E2E and required live infrastructure.

After: the table states that E2E is excluded by pytest configuration and points to `make test-rca` for live RCA E2E runs.

Validation:

- Reviewed the `test-full` target in `Makefile`.
- Reviewed `norecursedirs` in `pytest.ini`.
- Ran `git status --short` and `git diff --check`.
- Code tests were not run because this qualifies for the documentation-only shortcut in `CI.md`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated content
- [x] I can explain the purpose and logic of the change
- [x] I have checked the relevant command and configuration edge case
- [x] I have modified the AI output to follow this project's conventions

**Explain your implementation approach:**

The existing table contradicted the executable configuration: the Make target invokes the default pytest collection, while `pytest.ini` excludes `tests/e2e`. I updated only the inaccurate table row and retained the existing `make test-rca` command as the documented path for live RCA E2E testing. Changing the Make target instead was rejected because that would introduce runtime, credential, and infrastructure impact for what is only a documentation mismatch.

---

## Checklist before requesting a review
- [x] I have added a proper PR title
- [x] I have performed a self-review of my change
- [x] I can explain the purpose of every changed line
- [x] I understand why the change is accurate and have validated it against the repository configuration
- [x] I have considered the distinction between default pytest collection and live E2E execution
- [x] This is not a core feature and requires no new tests
- [x] My change follows the project's style and documentation conventions

---

Note: Maintainer edits are welcome.

