### PR TITLE
test(agent): honour turn-seam contracts in test_agent_actions_harness.py (#5189)

### DIFF
--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -16,6 +16,7 @@ from core.agent_harness.prompts.memory.prior_investigation import (
     PRIOR_INVESTIGATION_RECALL_SECONDS,
 )
 from core.agent_harness.session.pending_offer import first_pending_offer
+from core.agent_harness.spi.accounting import LlmRunInfo
 from core.agent_harness.turns.action_driver import (
     ActionTurnPlan,
     ActionTurnRunner,
@@ -34,6 +35,15 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
     no_tool_response,
     tool_response,
 )
+from tests.shared.harness_turn_driver import fake_llm_run, no_evidence
+
+
+def _ignore_tool_event(_kind: str, _data: dict[str, Any]) -> None:
+    """Ignore one tool event."""
+
+
+def _no_answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
+    """Return no answer for a turn."""
 
 
 class _GenericActionToolProvider:
@@ -1560,7 +1570,7 @@ def test_run_turn_passes_handoff_contents_to_assistant() -> None:
         "please connect to local llama",
         Session(),
         execute_actions=_execute,
-        gather=lambda *_args, **_kwargs: None,
+        gather=no_evidence,
         answer=_answer,
         accounting=DefaultTurnAccounting(Session(), "please connect to local llama"),
     )
@@ -1612,7 +1622,7 @@ def test_run_turn_mixed_action_and_handoff_routes_to_assistant() -> None:
         "check health and connect local llama",
         Session(),
         execute_actions=_execute,
-        gather=lambda *_args, **_kwargs: None,
+        gather=no_evidence,
         answer=_answer,
         accounting=DefaultTurnAccounting(Session(), "check health and connect local llama"),
     )
@@ -1700,15 +1710,15 @@ def test_database_query_handoff_keeps_connect_want_me_to_closer() -> None:
             handoff_contents=("database_query:mysql_active_connections",),
         )
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> Any:
+    def _answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
         assert request.handoff_contents == ("database_query:mysql_active_connections",)
-        return type("Run", (), {"response_text": model_reply})()
+        return fake_llm_run(response_text=model_reply)
 
     result = run_turn(
         prompt,
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "",
+        gather=no_evidence,
         answer=_answer,
         accounting=DefaultTurnAccounting(session, prompt),
     )
@@ -1765,7 +1775,7 @@ def test_follow_up_answer_with_want_me_to_paints_on_non_tty_console() -> None:
         "why did it fail?",
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "should-not-gather",
+        gather=no_evidence,
         answer=_answer,
         accounting=DefaultTurnAccounting(session, "why did it fail?"),
         output=sink,
@@ -2053,7 +2063,7 @@ def test_build_action_agent_returns_action_turn_plan() -> None:
         llm_factory=llm_factory,
         tool_hooks=None,
         tool_resources={},
-        observer=lambda *_args, **_kwargs: None,
+        observer=_ignore_tool_event,
     )
 
     assert isinstance(plan, ActionTurnPlan)
@@ -2087,7 +2097,7 @@ def test_build_action_agent_keeps_conversation_out_of_system() -> None:
         llm_factory=llm_factory,
         tool_hooks=None,
         tool_resources={},
-        observer=lambda *_args, **_kwargs: None,
+        observer=_ignore_tool_event,
     )
 
     system = plan.agent._system
@@ -2121,7 +2131,7 @@ def test_build_action_agent_system_identical_across_conversation_growth() -> Non
             llm_factory=llm_factory,
             tool_hooks=None,
             tool_resources={},
-            observer=lambda *_args, **_kwargs: None,
+            observer=_ignore_tool_event,
         )
 
     first = _plan([("user", "hello")])
@@ -2144,7 +2154,7 @@ def test_bang_shell_bypass_does_not_use_action_envelope() -> None:
         llm_factory=llm_factory,
         tool_hooks=None,
         tool_resources={},
-        observer=lambda *_args, **_kwargs: None,
+        observer=_ignore_tool_event,
     )
     assert plan.agent._system == "Execute the explicit shell_run tool call."
     assert plan.user_message == "!echo hello"
@@ -2210,7 +2220,7 @@ def test_run_turn_skips_gather_for_follow_up_even_when_investigation_is_old() ->
         session,
         execute_actions=_execute,
         gather=_gather,
-        answer=lambda *_a, **_k: None,
+        answer=_no_answer,
         accounting=DefaultTurnAccounting(session, "what happened?"),
     )
 
@@ -2341,7 +2351,7 @@ def test_run_turn_still_gathers_after_actions_when_the_handoff_did_not_opt_out()
         session,
         execute_actions=_execute,
         gather=_gather,
-        answer=lambda *_a, **_k: None,
+        answer=_no_answer,
         accounting=DefaultTurnAccounting(session, "connect local llama"),
     )
 
@@ -2372,7 +2382,7 @@ def test_run_turn_still_gathers_when_the_action_turn_executed_nothing() -> None:
         session,
         execute_actions=_execute,
         gather=_gather,
-        answer=lambda *_a, **_k: None,
+        answer=_no_answer,
         accounting=DefaultTurnAccounting(session, "why is the orders-api slow?"),
     )
 

--- a/tests/core/agent/orchestration/test_agent_actions_harness.py
+++ b/tests/core/agent/orchestration/test_agent_actions_harness.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
-from core.agent_harness.ports import AnswerRequest
+from core.agent_harness.ports import AnswerRequest, ConfirmFn
 from core.agent_harness.prompts.memory.prior_investigation import (
     PRIOR_INVESTIGATION_RECALL_SECONDS,
 )
@@ -1552,7 +1552,13 @@ def test_route_investigation_dispatch_skips_gather_even_with_handoff() -> None:
 def test_run_turn_passes_handoff_contents_to_assistant() -> None:
     captured: list[tuple[str, ...]] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=0,
             executed_count=0,
@@ -1562,7 +1568,7 @@ def test_run_turn_passes_handoff_contents_to_assistant() -> None:
             handoff_contents=("provider:local_llama_connect",),
         )
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+    def _answer(text: str, request: AnswerRequest) -> None:
         captured.append(request.handoff_contents)
         return None
 
@@ -1603,7 +1609,13 @@ def test_run_turn_mixed_action_and_handoff_routes_to_assistant() -> None:
     """Handled action plus handoff tags must not take the handled_without_llm path."""
     captured: list[tuple[str, ...]] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -1614,7 +1626,7 @@ def test_run_turn_mixed_action_and_handoff_routes_to_assistant() -> None:
             handoff_contents=("provider:local_llama_connect",),
         )
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+    def _answer(text: str, request: AnswerRequest) -> None:
         captured.append(request.handoff_contents)
         return None
 
@@ -1641,7 +1653,13 @@ def test_run_turn_skips_gather_for_follow_up_handoff_with_prior_state() -> None:
     gather_calls: list[str] = []
     answer_kwargs: list[dict[str, Any]] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -1651,11 +1669,11 @@ def test_run_turn_skips_gather_for_follow_up_handoff_with_prior_state() -> None:
             handoff_contents=("follow_up:prior_investigation",),
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: search_sentry_issues\nArguments: {}\nResult: should-not-run"
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+    def _answer(text: str, request: AnswerRequest) -> None:
         answer_kwargs.append(
             {
                 "tool_observation": request.tool_observation,
@@ -1700,7 +1718,13 @@ def test_database_query_handoff_keeps_connect_want_me_to_closer() -> None:
         "**Want me to:** walk you through `/mcp connect mysql`?"
     )
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -1739,7 +1763,6 @@ def test_follow_up_answer_with_want_me_to_paints_on_non_tty_console() -> None:
     and the console oracle sees an empty response.
     """
     import io
-    from types import SimpleNamespace
 
     from surfaces.interactive_shell.runtime.agent_harness_adapters import ShellOutputSink
 
@@ -1752,7 +1775,13 @@ def test_follow_up_answer_with_want_me_to_paints_on_non_tty_console() -> None:
         "investigation_started_at": time.monotonic(),
     }
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -1762,14 +1791,14 @@ def test_follow_up_answer_with_want_me_to_paints_on_non_tty_console() -> None:
             handoff_contents=("follow_up:prior_investigation",),
         )
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> Any:
+    def _answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
         body = "The disk was full on orders-api.\n\n**Want me to:** run a full investigation"
         painted = sink.stream(
             label="OpenSRE",
             chunks=[body],
             defer_want_me_to_closer=request.defer_want_me_to_closer,
         )
-        return SimpleNamespace(response_text=painted)
+        return fake_llm_run(response_text=painted)
 
     result = run_turn(
         "why did it fail?",
@@ -1797,7 +1826,13 @@ def test_run_turn_still_gathers_for_non_follow_up_handoff_with_prior_state() -> 
     gather_calls: list[str] = []
     answer_kwargs: list[dict[str, Any]] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -1807,11 +1842,11 @@ def test_run_turn_still_gathers_for_non_follow_up_handoff_with_prior_state() -> 
             handoff_contents=("provider:local_llama_connect",),
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: x\nArguments: {}\nResult: y"
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+    def _answer(text: str, request: AnswerRequest) -> None:
         answer_kwargs.append({"defer_want_me_to_closer": request.defer_want_me_to_closer})
         return None
 
@@ -2201,7 +2236,13 @@ def test_run_turn_skips_gather_for_follow_up_even_when_investigation_is_old() ->
     }
     gather_calls: list[str] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -2211,7 +2252,7 @@ def test_run_turn_skips_gather_for_follow_up_even_when_investigation_is_old() ->
             handoff_contents=("follow_up:prior_investigation",),
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: search_sentry_issues\nArguments: {}\nResult: should-not-run"
 
@@ -2244,7 +2285,13 @@ def test_run_turn_does_not_gather_after_the_action_turn_already_did_the_work() -
     gather_calls: list[str] = []
     answer_kwargs: list[dict[str, Any]] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=2,
             executed_count=2,
@@ -2255,11 +2302,11 @@ def test_run_turn_does_not_gather_after_the_action_turn_already_did_the_work() -
             handoff_requires_gather=False,
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: kubernetes_list_pods\nResult: should-not-run"
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+    def _answer(text: str, request: AnswerRequest) -> None:
         answer_kwargs.append({"handoff_contents": request.handoff_contents})
         return None
 
@@ -2289,7 +2336,13 @@ def test_run_turn_skips_gather_for_stream_only_conversational_handoff() -> None:
     gather_calls: list[str] = []
     answer_calls: list[dict[str, Any]] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -2300,11 +2353,11 @@ def test_run_turn_skips_gather_for_stream_only_conversational_handoff() -> None:
             handoff_requires_gather=False,
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: should_not_run\nResult: unused"
 
-    def _answer(_text: str, request: AnswerRequest, **_kwargs: Any) -> None:
+    def _answer(text: str, request: AnswerRequest) -> None:
         answer_calls.append({"handoff_contents": request.handoff_contents})
         return None
 
@@ -2332,7 +2385,13 @@ def test_run_turn_still_gathers_after_actions_when_the_handoff_did_not_opt_out()
     session = Session()
     gather_calls: list[str] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -2342,7 +2401,7 @@ def test_run_turn_still_gathers_after_actions_when_the_handoff_did_not_opt_out()
             handoff_contents=("provider:local_llama_connect",),
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: x\nArguments: {}\nResult: y"
 
@@ -2363,7 +2422,13 @@ def test_run_turn_still_gathers_when_the_action_turn_executed_nothing() -> None:
     session = Session()
     gather_calls: list[str] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=0,
             executed_count=0,
@@ -2373,7 +2438,7 @@ def test_run_turn_still_gathers_when_the_action_turn_executed_nothing() -> None:
             handoff_contents=("why is the orders-api slow?",),
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: search_sentry_issues\nResult: 3 issues"
 
@@ -2484,7 +2549,13 @@ def test_run_turn_skips_gather_and_answer_when_the_action_turn_was_cancelled() -
     gather_calls: list[str] = []
     answer_calls: list[str] = []
 
-    def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=2,
             executed_count=1,
@@ -2494,7 +2565,7 @@ def test_run_turn_skips_gather_and_answer_when_the_action_turn_was_cancelled() -
             cancelled=True,
         )
 
-    def _gather(text: str, *_args: object, **_kwargs: object) -> str:
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
         gather_calls.append(text)
         return "Tool: kubernetes_list_pods\nResult: should-not-run"
 


### PR DESCRIPTION
Fixes #5189

#### Describe the changes you have made in this PR -

Test-only refactor of `tests/core/agent/orchestration/test_agent_actions_harness.py`: the swallow-all `lambda *_a, **_k` stage injections and anonymous `type("Run", (), {...})()` result fakes are replaced with named `def` stubs that match the exact Protocol signatures in `core/agent_harness/ports.py` (`ExecuteActions`, `EvidenceGatherer`, `StreamAnswerFn`), reusing the shared helpers from `tests/shared/harness_turn_driver.py` introduced by #5215 (`no_evidence`, `fake_llm_run`, `answer_with_text`). Test intent is unchanged: no `answer=None` (real stage) was swapped for a stub or vice versa. No product code touched.

### Demo/Screenshot for feature changes and bug fixes -

Verification run from the repo root:

```
pytest: 57 passed | ruff check: All checks passed! | mypy: no new errors vs main baseline (pre-existing errors in this file left untouched)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: seam stubs written as `lambda *_a, **_k` (or loose `**_kwargs` defs) and anonymous `type(...)` objects keep a test green when the Protocol or result type changes underneath it. The fix follows the pattern already established in `test_upgrade_cta_accept.py`: each stub is a named `def` whose parameters mirror the Protocol's `__call__` exactly (including parameter names — mypy treats a mismatched positional name as Protocol-incompatible), and every faked answer is a real `LlmRunInfo` built by the shared `fake_llm_run`/`answer_with_text` helpers, so the test fails if the type gains a field the product reads. Where a gather seam must return specific evidence text (asserted by the test), a local named stub is used instead of the find-nothing `no_evidence` helper to preserve intent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
