### PR TITLE
test(harness): honour turn-seam contracts in test_pending_investigation_offer.py (#5190)

### DIFF
--- a/tests/core/agent_harness/session/test_pending_investigation_offer.py
+++ b/tests/core/agent_harness/session/test_pending_investigation_offer.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from core.agent_harness.ports import AnswerRequest, EvidenceGatherer
 from core.agent_harness.prompts.memory.conversation import expand_affirmative_follow_up
 from core.agent_harness.session.pending_offer import (
     DispatchablePendingOffer,
@@ -19,10 +22,26 @@ from core.agent_harness.session.pending_offer import (
     synthesize_investigation_alert_text,
 )
 from core.agent_harness.session.want_me_to import offer_from_assistant_content
+from core.agent_harness.spi.accounting import LlmRunInfo
 from core.agent_harness.turns.action_driver import _literal_slash_tool_call
 from core.agent_harness.turns.headless_adapters import InMemorySessionState, NoopTurnAccounting
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+from tests.shared.harness_turn_driver import answer_with_text, no_evidence
+
+
+def no_answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
+    """A StreamAnswerFn that answers nothing — the turn produced no LLM run."""
+    return None
+
+
+def evidence_text(observation: str) -> EvidenceGatherer:
+    """An EvidenceGatherer returning one fixed observation."""
+
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
+        return observation
+
+    return _gather
 
 
 def test_dispatch_message_quotes_alert_text() -> None:
@@ -274,21 +293,20 @@ def test_run_turn_dogfood_dual_menu_yes_still_starts_investigation() -> None:
             investigation_dispatched=True,
         )
 
-    class _Run:
-        # Intentionally broken closer from live dogfood.
-        response_text = (
-            "Checkout 502; Grafana unreachable.\n\n"
-            "**Want me to:**\n"
-            "1. run a full investigation once you paste the alert, or\n"
-            "2. walk you through `/integrations setup grafana`?"
-        )
+    # Intentionally broken closer from live dogfood.
+    broken_closer = (
+        "Checkout 502; Grafana unreachable.\n\n"
+        "**Want me to:**\n"
+        "1. run a full investigation once you paste the alert, or\n"
+        "2. walk you through `/integrations setup grafana`?"
+    )
 
     first = run_turn(
         "why is checkout 502?",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: _Run(),
-        gather=lambda *_a, **_k: "connection refused",
+        answer=answer_with_text(broken_closer),
+        gather=evidence_text("connection refused"),
         accounting=NoopTurnAccounting(),
     )
 
@@ -302,8 +320,8 @@ def test_run_turn_dogfood_dual_menu_yes_still_starts_investigation() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
     assert len(seen) == 1
@@ -328,15 +346,12 @@ def test_run_turn_does_not_arm_investigation_when_capability_disabled() -> None:
             handoff_contents=("diagnostic:checkout_502",),
         )
 
-    class _Run:
-        response_text = "Empty evidence.\n\n**Want me to:** run a full investigation."
-
     first = run_turn(
         "why is checkout 502?",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: _Run(),
-        gather=lambda *_a, **_k: "connection refused",
+        answer=answer_with_text("Empty evidence.\n\n**Want me to:** run a full investigation."),
+        gather=evidence_text("connection refused"),
         accounting=NoopTurnAccounting(),
     )
 
@@ -373,25 +388,14 @@ def test_run_turn_arms_then_yes_dispatches_investigation() -> None:
             investigation_dispatched=True,
         )
 
-    class _Run:
-        response_text = (
-            "Datadog shows elevated DB latency.\n\n**Want me to:** run a full investigation."
-        )
-
-    def answer(text: str, request: object = None) -> _Run:
-        _ = text, request
-        return _Run()
-
-    def gather(text: str, *, turn_plan: object = None) -> str:
-        _ = text, turn_plan
-        return "p95 latency 2.1s on checkout-db"
-
     run_turn(
         "why is the database slow?",
         session,
         execute_actions=execute_actions,
-        answer=answer,
-        gather=gather,
+        answer=answer_with_text(
+            "Datadog shows elevated DB latency.\n\n**Want me to:** run a full investigation."
+        ),
+        gather=evidence_text("p95 latency 2.1s on checkout-db"),
         accounting=NoopTurnAccounting(),
     )
 
@@ -404,8 +408,8 @@ def test_run_turn_arms_then_yes_dispatches_investigation() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
 
@@ -437,8 +441,8 @@ def test_failed_investigation_keeps_pending_offer() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
     assert session.pending_investigation_offer is not None


### PR DESCRIPTION
Fixes #5190

#### Describe the changes you have made in this PR -

Test-only refactor of `tests/core/agent_harness/session/test_pending_investigation_offer.py`: the swallow-all `lambda *_a, **_k` stage injections and anonymous `type("Run", (), {...})()` result fakes are replaced with named `def` stubs that match the exact Protocol signatures in `core/agent_harness/ports.py` (`ExecuteActions`, `EvidenceGatherer`, `StreamAnswerFn`), reusing the shared helpers from `tests/shared/harness_turn_driver.py` introduced by #5215 (`no_evidence`, `fake_llm_run`, `answer_with_text`). Test intent is unchanged: no `answer=None` (real stage) was swapped for a stub or vice versa. No product code touched.

### Demo/Screenshot for feature changes and bug fixes -

Verification run from the repo root:

```
pytest: 22 passed | ruff check: All checks passed! | mypy (touched file): no issues
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: seam stubs written as `lambda *_a, **_k` (or loose `**_kwargs` defs) and anonymous `type(...)` objects keep a test green when the Protocol or result type changes underneath it. The fix follows the pattern already established in `test_upgrade_cta_accept.py`: each stub is a named `def` whose parameters mirror the Protocol's `__call__` exactly (including parameter names — mypy treats a mismatched positional name as Protocol-incompatible), and every faked answer is a real `LlmRunInfo` built by the shared `fake_llm_run`/`answer_with_text` helpers, so the test fails if the type gains a field the product reads. Where a gather seam must return specific evidence text (asserted by the test), a local named stub is used instead of the find-nothing `no_evidence` helper to preserve intent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
