### PR TITLE
test(harness): honour turn-seam contracts in test_upgrade_cta_reoffer.py (#5192)

### DIFF
--- a/tests/core/agent_harness/session/test_upgrade_cta_reoffer.py
+++ b/tests/core/agent_harness/session/test_upgrade_cta_reoffer.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
 from core.agent_harness.session.pending_offer import (
     PendingIntegrationSetupOffer,
@@ -13,9 +16,16 @@ from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from infrastructure.harness_providers import preferred_evidence_sources_for
 from surfaces.interactive_shell.session import Session
+from tests.shared.harness_turn_driver import answer_with_text, no_evidence
 
 
-def _metric_execute(*_a: object, **_k: object) -> ToolCallingTurnResult:
+def _metric_execute(
+    text: str,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    turn_plan: Any = None,
+) -> ToolCallingTurnResult:
     return ToolCallingTurnResult(
         planned_count=0,
         executed_count=0,
@@ -31,8 +41,8 @@ def _run_metric_ask(session: Session, text: str = "how many windows users") -> s
         text,
         session,
         execute_actions=_metric_execute,
-        gather=lambda *_a, **_k: "should-not-run",
-        answer=lambda *_a, **_k: type("Run", (), {"response_text": "Draft outline."})(),
+        gather=no_evidence,
+        answer=answer_with_text("Draft outline."),
         accounting=DefaultTurnAccounting(session, text),
     )
     return result.assistant_response_text or ""
@@ -63,20 +73,29 @@ def test_cta_reoffers_after_user_moves_on_without_accepting() -> None:
     assert "/integrations setup posthog_mcp" in first
     assert isinstance(first_pending_offer(session), PendingIntegrationSetupOffer)
 
-    # Non-confirm turn clears the stale pending offer.
-    run_turn(
-        "tell me about something else entirely",
-        session,
-        execute_actions=lambda *_a, **_k: ToolCallingTurnResult(
+    def _execute_other(
+        text: str,
+        *,
+        confirm_fn: Callable[[str], str] | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(
             planned_count=0,
             executed_count=0,
             executed_success_count=0,
             has_unhandled_clause=True,
             handled=False,
             handoff_contents=("chat:other",),
-        ),
-        gather=lambda *_a, **_k: "",
-        answer=lambda *_a, **_k: type("Run", (), {"response_text": "Sure."})(),
+        )
+
+    # Non-confirm turn clears the stale pending offer.
+    run_turn(
+        "tell me about something else entirely",
+        session,
+        execute_actions=_execute_other,
+        gather=no_evidence,
+        answer=answer_with_text("Sure."),
         accounting=DefaultTurnAccounting(session, "other"),
     )
     assert first_pending_offer(session) is None


### PR DESCRIPTION
Fixes #5192

#### Describe the changes you have made in this PR -

Test-only refactor of `tests/core/agent_harness/session/test_upgrade_cta_reoffer.py`: the swallow-all `lambda *_a, **_k` stage injections and anonymous `type("Run", (), {...})()` result fakes are replaced with named `def` stubs that match the exact Protocol signatures in `core/agent_harness/ports.py` (`ExecuteActions`, `EvidenceGatherer`, `StreamAnswerFn`), reusing the shared helpers from `tests/shared/harness_turn_driver.py` introduced by #5215 (`no_evidence`, `fake_llm_run`, `answer_with_text`). Test intent is unchanged: no `answer=None` (real stage) was swapped for a stub or vice versa. No product code touched.

### Demo/Screenshot for feature changes and bug fixes -

Verification run from the repo root:

```
pytest: 2 passed | ruff check: All checks passed! | mypy: Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: seam stubs written as `lambda *_a, **_k` (or loose `**_kwargs` defs) and anonymous `type(...)` objects keep a test green when the Protocol or result type changes underneath it. The fix follows the pattern already established in `test_upgrade_cta_accept.py`: each stub is a named `def` whose parameters mirror the Protocol's `__call__` exactly (including parameter names — mypy treats a mismatched positional name as Protocol-incompatible), and every faked answer is a real `LlmRunInfo` built by the shared `fake_llm_run`/`answer_with_text` helpers, so the test fails if the type gains a field the product reads. Where a gather seam must return specific evidence text (asserted by the test), a local named stub is used instead of the find-nothing `no_evidence` helper to preserve intent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
