### PR TITLE
test(harness): honour turn-seam contracts in test_pending_offer.py (#5193)

### DIFF
--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -129,7 +129,13 @@ def test_run_turn_consumes_pending_schedule_on_yes() -> None:
     )
     seen: list[str] = []
 
-    def execute_actions(text: str, **_kwargs: object) -> ToolCallingTurnResult:
+    def execute_actions(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: object = None,
+    ) -> ToolCallingTurnResult:
         seen.append(text)
         return ToolCallingTurnResult(
             planned_count=1,

--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -4,15 +4,21 @@ from __future__ import annotations
 
 import pytest
 
+from core.agent_harness.ports import AnswerRequest, ConfirmFn
 from core.agent_harness.prompts.memory.conversation import expand_affirmative_follow_up
 from core.agent_harness.session.pending_offer import PendingScheduleOffer
 from core.agent_harness.tools.tool_context import ActionToolContext
 from core.agent_harness.turns.headless_adapters import InMemorySessionState, NoopTurnAccounting
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+from tests.shared.harness_turn_driver import no_evidence
 from tools.interactive_shell.actions.propose_scheduled_delivery import (
     execute_propose_scheduled_delivery_tool,
 )
+
+
+def no_answer(text: str, request: AnswerRequest) -> None:
+    """A StreamAnswerFn that produces no answer."""
 
 
 def test_pending_offer_to_slash_omits_slack_chat_id() -> None:
@@ -138,8 +144,8 @@ def test_run_turn_consumes_pending_schedule_on_yes() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
 
@@ -329,7 +335,13 @@ def test_a_failed_schedule_keeps_the_offer_for_a_second_try() -> None:
         kind="daily_summary", cron="0 8 * * 1-5", timezone="UTC", provider="slack"
     )
 
-    def _execute_failing(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute_failing(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: object = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -343,8 +355,8 @@ def test_a_failed_schedule_keeps_the_offer_for_a_second_try() -> None:
         "yes",
         session,
         execute_actions=_execute_failing,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: "",
+        answer=no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
 
@@ -367,7 +379,13 @@ def test_a_successful_schedule_consumes_the_offer() -> None:
         kind="daily_summary", cron="0 8 * * 1-5", timezone="UTC", provider="slack"
     )
 
-    def _execute_ok(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+    def _execute_ok(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: object = None,
+    ) -> ToolCallingTurnResult:
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -382,8 +400,8 @@ def test_a_successful_schedule_consumes_the_offer() -> None:
         "yes",
         session,
         execute_actions=_execute_ok,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: "",
+        answer=no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
 


### PR DESCRIPTION
Fixes #5193

#### Describe the changes you have made in this PR -

Test-only refactor of `tests/core/agent_harness/session/test_pending_offer.py`: the swallow-all `lambda *_a, **_k` stage injections and anonymous `type("Run", (), {...})()` result fakes are replaced with named `def` stubs that match the exact Protocol signatures in `core/agent_harness/ports.py` (`ExecuteActions`, `EvidenceGatherer`, `StreamAnswerFn`), reusing the shared helpers from `tests/shared/harness_turn_driver.py` introduced by #5215 (`no_evidence`, `fake_llm_run`, `answer_with_text`). Test intent is unchanged: no `answer=None` (real stage) was swapped for a stub or vice versa. No product code touched.

### Demo/Screenshot for feature changes and bug fixes -

Verification run from the repo root:

```
pytest: 14 passed | ruff check: All checks passed! | mypy: Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: seam stubs written as `lambda *_a, **_k` (or loose `**_kwargs` defs) and anonymous `type(...)` objects keep a test green when the Protocol or result type changes underneath it. The fix follows the pattern already established in `test_upgrade_cta_accept.py`: each stub is a named `def` whose parameters mirror the Protocol's `__call__` exactly (including parameter names — mypy treats a mismatched positional name as Protocol-incompatible), and every faked answer is a real `LlmRunInfo` built by the shared `fake_llm_run`/`answer_with_text` helpers, so the test fails if the type gains a field the product reads. Where a gather seam must return specific evidence text (asserted by the test), a local named stub is used instead of the find-nothing `no_evidence` helper to preserve intent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
