### PR TITLE
Fix: truncate telegram html tag safely after markdown conversion, issue 5316

### DIFF
--- a/gateway/transports/telegram/turn_output.py
+++ b/gateway/transports/telegram/turn_output.py
@@ -11,6 +11,7 @@ from gateway.core.single_message_output import (
 from gateway.transports.telegram.poller.client import TelegramBotClient
 from infrastructure.delivery.notifications.limits import MAX_MESSAGE_SIZE
 from infrastructure.text.truncation import truncate
+from integrations.telegram.delivery import truncate_for_telegram_html
 from integrations.telegram.formatting import markdown_to_telegram_html
 
 logger = logging.getLogger("gateway")
@@ -45,7 +46,9 @@ class _TelegramChannel:
         final = truncate(answer, MAX_MESSAGE_SIZE, suffix="…")
         # Render the answer's Markdown as Telegram HTML, falling back to the plain
         # answer if the API rejects the markup so a message is never lost.
-        html_final = markdown_to_telegram_html(final)
+        html_final = truncate_for_telegram_html(
+            markdown_to_telegram_html(answer), MAX_MESSAGE_SIZE, suffix="…"
+        )
         if message_id and self._edit_final(message_id, html_final, final):
             logger.info("outbound %s text=%r", self.destination, log_preview(final))
             return ""


### PR DESCRIPTION
Fixes #5316

#### Changes made -
- Updated `_TelegramChannel.deliver_final` in `gateway/transports/telegram/turn_output.py` to convert the answer to Telegram HTML first and then truncate it tag safely using `truncate_for_telegram_html(..., MAX_MESSAGE_SIZE, suffix="…")`
- Added import for `truncate_for_telegram_html` from `integrations.telegram.delivery`
- Fixed a bug where Markdown-to-HTML conversion expanded the text past Telegram's 4,096 character limit thuscausing Telegram to reject formatted messages and silently fallback to unformatted plain text (final)

### Demo/Screenshot for feature changes and bug fixes - 
<img width="834" height="317" alt="image" src="https://github.com/user-attachments/assets/d8a51b6f-4d71-4999-9b9f-d487858ca225" />

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions