### PR TITLE
refactor(reporting): make any tool's output citeable via record_evidence_entry

### DIFF
--- a/core/domain/types/evidence.py
+++ b/core/domain/types/evidence.py
@@ -17,3 +17,31 @@ EvidenceSource = str
 #: ``evidence`` in place. Declared per tool (``@tool(evidence_mapper=...)``) so a
 #: vendor's mapping lives with the vendor's tool, never in a shared stage file.
 EvidenceMapper = Callable[[dict[str, Any], dict[str, Any], dict[str, Any]], None]
+
+#: Key under which mappers accumulate citeable report entries in the evidence dict.
+CATALOG_ENTRIES_KEY = "catalog_entries"
+
+
+def record_evidence_entry(
+    evidence: dict[str, Any],
+    *,
+    source: str,
+    label: str,
+    summary: str | None = None,
+    url: str | None = None,
+    snippet: str | None = None,
+) -> None:
+    """Record a citeable report entry from inside an evidence mapper.
+
+    The report's evidence catalog turns each entry into a display id (``E1`` …)
+    the agent can cite. ``source`` is the claim-facing key; the first entry for a
+    given ``source`` wins, and a bespoke catalog reader for the same key takes
+    precedence. Lets a tool's output become citeable without editing the shared
+    catalog builder.
+    """
+    entries = evidence.setdefault(CATALOG_ENTRIES_KEY, [])
+    if not isinstance(entries, list):
+        return
+    entries.append(
+        {"source": source, "label": label, "summary": summary, "url": url, "snippet": snippet}
+    )

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework.tool_decorator import tool
 from core.tool_framework.utils import tool_unavailable
@@ -65,7 +66,15 @@ def _normalize_backend_alert_rules(raw: dict[str, Any]) -> list[dict[str, Any]]:
 def _map_grafana_alert_rules(
     evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
 ) -> None:
-    evidence["grafana_alert_rules"] = output.get("rules", [])
+    rules = output.get("rules", [])
+    evidence["grafana_alert_rules"] = rules
+    if rules:
+        record_evidence_entry(
+            evidence,
+            source="grafana_alert_rules",
+            label="Grafana Alert Rules",
+            summary=f"{len(rules)} rules",
+        )
 
 
 @tool(
@@ -583,7 +592,15 @@ def _map_grafana_metrics(
     metric_results = evidence.setdefault("grafana_metric_results", {})
     if isinstance(metric_results, dict) and metric_name:
         metric_results[metric_name] = output
-    evidence["grafana_metrics"] = output.get("metrics", [])
+    metrics = output.get("metrics", [])
+    evidence["grafana_metrics"] = metrics
+    if metrics:
+        record_evidence_entry(
+            evidence,
+            source="grafana_metrics",
+            label="Grafana Metrics",
+            summary=", ".join(p for p in [metric_name or None, f"{len(metrics)} series"] if p),
+        )
 
 
 @tool(
@@ -683,7 +700,15 @@ def _query_grafana_service_names_available(sources: dict[str, dict]) -> bool:
 def _map_grafana_service_names(
     evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
 ) -> None:
-    evidence["grafana_service_names"] = output.get("service_names", [])
+    service_names = output.get("service_names", [])
+    evidence["grafana_service_names"] = service_names
+    if service_names:
+        record_evidence_entry(
+            evidence,
+            source="grafana_service_names",
+            label="Grafana Service Names",
+            summary=f"{len(service_names)} services",
+        )
 
 
 @tool(
@@ -779,8 +804,16 @@ def _query_grafana_traces_available(sources: dict[str, dict]) -> bool:
 def _map_grafana_traces(
     evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
 ) -> None:
-    evidence["grafana_traces"] = output.get("traces", [])
+    traces = output.get("traces", [])
+    evidence["grafana_traces"] = traces
     evidence["grafana_pipeline_spans"] = output.get("pipeline_spans", [])
+    if traces:
+        record_evidence_entry(
+            evidence,
+            source="grafana_traces",
+            label="Grafana Traces",
+            summary=f"{len(traces)} traces",
+        )
 
 
 @tool(

--- a/tests/delivery/test_report_provenance.py
+++ b/tests/delivery/test_report_provenance.py
@@ -285,6 +285,46 @@ def test_build_report_context_handles_new_relic_alert_with_no_condition_name() -
     assert catalog_entry["snippet"] is None
 
 
+def test_build_report_context_cites_mapper_recorded_entry() -> None:
+    # A tool with no bespoke catalog reader becomes citeable via a recorded entry.
+    state = _make_state()
+    state["evidence"]["catalog_entries"] = [
+        {
+            "source": "postgresql_slow_queries",
+            "label": "PostgreSQL Slow Queries",
+            "summary": "3 queries",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+    ctx = build_report_context(state)
+
+    entry = ctx["evidence_catalog"]["evidence/mapped/postgresql_slow_queries"]
+    assert entry["label"] == "PostgreSQL Slow Queries"
+    assert entry["summary"] == "3 queries"
+    assert entry["display_id"].startswith("E")
+
+
+def test_bespoke_reader_wins_over_mapped_entry_for_same_source() -> None:
+    # _make_state has grafana_logs, which the bespoke reader already catalogs.
+    state = _make_state()
+    state["evidence"]["catalog_entries"] = [
+        {
+            "source": "grafana_logs",
+            "label": "Should be ignored",
+            "summary": None,
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+    ctx = build_report_context(state)
+
+    assert "evidence/grafana/loki" in ctx["evidence_catalog"]
+    assert "evidence/mapped/grafana_logs" not in ctx["evidence_catalog"]
+
+
 def test_build_report_context_drops_empty_provenance_summaries() -> None:
     state = _make_state()
     state["available_sources"]["github"] = {}

--- a/tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py
+++ b/tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py
@@ -124,3 +124,17 @@ class TestGrafanaMappingCharacterization:
         merge_tool_evidence(evidence, "query_grafana_logs", "not-a-dict", {})
         assert evidence["query_grafana_logs"] == "not-a-dict"
         assert "grafana_logs" not in evidence
+
+    def test_mapper_records_citeable_catalog_entry(self) -> None:
+        # A mapper makes its output citeable by recording a catalog entry that
+        # build_evidence_catalog turns into a display id.
+        evidence: dict[str, object] = {}
+        merge_tool_evidence(
+            evidence,
+            "query_grafana_metrics",
+            {"metrics": [{"v": 1}], "metric_name": "cpu"},
+            {},
+        )
+        entries = evidence["catalog_entries"]
+        assert isinstance(entries, list)
+        assert any(e["source"] == "grafana_metrics" for e in entries)

--- a/tools/investigation/reporting/context/evidence_catalog.py
+++ b/tools/investigation/reporting/context/evidence_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import CATALOG_ENTRIES_KEY
 from tools.investigation.reporting.context.normalize import (
     NormalizedState,
     as_snippet,
@@ -415,11 +416,42 @@ def build_evidence_catalog(
     _add_coralogix_logs(ns.evidence, catalog, source_to_id)
     _add_betterstack_logs(ns.evidence, catalog, source_to_id)
     _add_new_relic_alerts(ns.evidence, catalog, source_to_id)
+    _add_mapped_entries(ns.evidence, catalog, source_to_id)
 
     for i, entry in enumerate(catalog.values()):
         entry["display_id"] = f"E{i + 1}"
 
     return catalog, source_to_id
+
+
+def _add_mapped_entries(
+    evidence: dict[str, Any],
+    catalog: dict[str, dict],
+    source_to_id: dict[str, str],
+) -> None:
+    """Add catalog entries recorded by per-tool evidence mappers.
+
+    Lets any tool contribute citeable evidence via ``record_evidence_entry``
+    without a bespoke reader here. A source already claimed by a bespoke reader
+    above is skipped so the richer, hand-written entry wins.
+    """
+    entries = evidence.get(CATALOG_ENTRIES_KEY) or []
+    if not isinstance(entries, list):
+        return
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        source = entry.get("source")
+        if not source or source in source_to_id:
+            continue
+        eid = f"evidence/mapped/{source}"
+        catalog[eid] = {
+            "label": entry.get("label") or source,
+            "url": entry.get("url"),
+            "summary": entry.get("summary"),
+            "snippet": entry.get("snippet"),
+        }
+        source_to_id[source] = eid
 
 
 def attach_evidence_to_claims(


### PR DESCRIPTION
Fixes #5517 

The report's evidence catalog only cited tool output through ~13 hand-written _add_* readers, so most tools' output was never citeable and per-vendor backfill would have forced every contributor to edit the shared catalog builder.

This adds a uniform, additive path:
- `record_evidence_entry(evidence, *, source, label, summary, url, snippet)` in   core (core/domain/types/evidence.py) — a mapper records a citeable entry.
- `build_evidence_catalog` gains `_add_mapped_entries`, which turns recorded   entries into display ids after the existing bespoke readers. A source already  claimed by a bespoke reader is skipped, so current report output is unchanged.
- Migrated the four Grafana mappers that were mapped-but-not-citeable  (metrics/traces/alert_rules/service_names) onto record_evidence_entry as the  reference example for the vendor backfill.