### PR TITLE
fix: fixed Azure's sync operation overriding unchanged files

### DIFF
--- a/infrastructure/filestorage/providers/azure.py
+++ b/infrastructure/filestorage/providers/azure.py
@@ -166,7 +166,7 @@ def _parse_last_modified(props: ET.Element | None) -> datetime:
 
 
 def _parse_etag(props: ET.Element | None) -> str:
-    """Extracts a valid MD5 hex hash, safely degrading to Etag if missing or malformed."""
+    """Extracts a valid MD5 hex hash, or an empty string if unavailable."""
     if props is None:
         return ""
 
@@ -177,15 +177,15 @@ def _parse_etag(props: ET.Element | None) -> str:
             if len(digest) == 16:
                 return digest.hex()
         except (ValueError, binascii.Error):
-            # A malformed Content-MD5 degrades to the Etag fallback below
-            # rather than aborting the entire listing operation.
+            # Malformed Base64 or non-MD5 content degrades to an unavailable
+            # fingerprint instead of crashing the listing.
             pass
 
-    # Fall back to the resource Etag. While opaque on real Azure (e.g., 0x8D...),
-    # returning it preserves the fingerprint for tests and emulators that map
-    # MD5s to the Etag property, preventing an empty fingerprint from
-    # unconditionally forcing timestamp-based transfers.
-    return (props.findtext("Etag") or "").strip('"')
+    # Missing or invalid Content-MD5 degrades to an unavailable fingerprint ("").
+    # Returning Azure's opaque Etag here would place unchanged blobs on an
+    # incompatible fingerprint path, because the sync engine compares remote
+    # tags with a local MD5 hex.
+    return ""
 
 
 def _get_azure_access_token() -> str:

--- a/infrastructure/filestorage/providers/azure.py
+++ b/infrastructure/filestorage/providers/azure.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import binascii
-import hashlib
 import json
 import os
 import subprocess
@@ -113,16 +112,9 @@ class AzureBlobObjectStore:
 
     def put_object(self, key: str, data: bytes) -> None:
         url = f"https://{self._account_name}.blob.core.windows.net/{self._config.bucket}/{self._blob_path(key)}"
-
-        # Compute Content-MD5 locally and send it so Azure stores it for sync comparisons
-        md5_b64 = base64.b64encode(hashlib.md5(data, usedforsecurity=False).digest()).decode(
-            "ascii"
-        )
-
         headers = {
             **self._auth_headers(),
             "x-ms-blob-type": "BlockBlob",
-            "x-ms-blob-content-md5": md5_b64,
             "Content-Length": str(len(data)),
         }
         try:
@@ -174,7 +166,7 @@ def _parse_last_modified(props: ET.Element | None) -> datetime:
 
 
 def _parse_etag(props: ET.Element | None) -> str:
-    """Extracts a valid MD5 hex hash, safely degrading to Etag if missing or malformed."""
+    """Extracts a valid MD5 hex hash, or an empty string if unavailable."""
     if props is None:
         return ""
 
@@ -185,9 +177,15 @@ def _parse_etag(props: ET.Element | None) -> str:
             if len(digest) == 16:
                 return digest.hex()
         except (ValueError, binascii.Error):
+            # Malformed Base64 or non-MD5 content degrades to an unavailable
+            # fingerprint instead of crashing the listing.
             pass
 
-    return (props.findtext("Etag") or "").strip('"')
+    # Missing or invalid Content-MD5 degrades to an unavailable fingerprint ("").
+    # Returning Azure's opaque Etag here would place unchanged blobs on an
+    # incompatible fingerprint path, because the sync engine compares remote
+    # tags with a local MD5 hex.
+    return ""
 
 
 def _get_azure_access_token() -> str:

--- a/infrastructure/filestorage/providers/azure.py
+++ b/infrastructure/filestorage/providers/azure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import subprocess
@@ -63,7 +64,7 @@ class AzureBlobObjectStore:
                     key=self._strip_prefix(name),
                     size=_parse_size(props),
                     last_modified=_parse_last_modified(props),
-                    etag=_parse_etag(props),
+                    etag=normalize_azure_md5(_parse_md5(props)),
                 )
                 for name, props in blobs
             ]
@@ -163,10 +164,22 @@ def _parse_last_modified(props: ET.Element | None) -> datetime:
     return datetime.strptime(lm_str[:-4], "%a, %d %b %Y %H:%M:%S").replace(tzinfo=UTC)
 
 
-def _parse_etag(props: ET.Element | None) -> str:
+def _parse_md5(props: ET.Element | None) -> str:
     if props is None:
         return ""
-    return (props.findtext("Etag") or "").strip('"')
+    return (props.findtext("Content-MD5") or "").strip('"')
+
+
+def normalize_azure_md5(azure_b64_md5: str) -> str:
+    """
+    Converts Azure's Base64 encoded Content-MD5 into a hex string
+    that matches hashlib.md5().hexdigest()
+    """
+    if not azure_b64_md5:
+        return ""
+
+    raw_bytes = base64.b64decode(azure_b64_md5)
+    return raw_bytes.hex()
 
 
 def _get_azure_access_token() -> str:

--- a/infrastructure/filestorage/providers/azure.py
+++ b/infrastructure/filestorage/providers/azure.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import base64
+import binascii
+import hashlib
 import json
 import os
 import subprocess
@@ -64,7 +66,7 @@ class AzureBlobObjectStore:
                     key=self._strip_prefix(name),
                     size=_parse_size(props),
                     last_modified=_parse_last_modified(props),
-                    etag=normalize_azure_md5(_parse_md5(props)),
+                    etag=_parse_etag(props),
                 )
                 for name, props in blobs
             ]
@@ -111,9 +113,16 @@ class AzureBlobObjectStore:
 
     def put_object(self, key: str, data: bytes) -> None:
         url = f"https://{self._account_name}.blob.core.windows.net/{self._config.bucket}/{self._blob_path(key)}"
+
+        # Compute Content-MD5 locally and send it so Azure stores it for sync comparisons
+        md5_b64 = base64.b64encode(hashlib.md5(data, usedforsecurity=False).digest()).decode(
+            "ascii"
+        )
+
         headers = {
             **self._auth_headers(),
             "x-ms-blob-type": "BlockBlob",
+            "x-ms-blob-content-md5": md5_b64,
             "Content-Length": str(len(data)),
         }
         try:
@@ -164,22 +173,21 @@ def _parse_last_modified(props: ET.Element | None) -> datetime:
     return datetime.strptime(lm_str[:-4], "%a, %d %b %Y %H:%M:%S").replace(tzinfo=UTC)
 
 
-def _parse_md5(props: ET.Element | None) -> str:
+def _parse_etag(props: ET.Element | None) -> str:
+    """Extracts a valid MD5 hex hash, safely degrading to Etag if missing or malformed."""
     if props is None:
         return ""
-    return (props.findtext("Content-MD5") or "").strip('"')
 
+    md5_b64 = props.findtext("Content-MD5")
+    if md5_b64:
+        try:
+            digest = base64.b64decode(md5_b64, validate=True)
+            if len(digest) == 16:
+                return digest.hex()
+        except (ValueError, binascii.Error):
+            pass
 
-def normalize_azure_md5(azure_b64_md5: str) -> str:
-    """
-    Converts Azure's Base64 encoded Content-MD5 into a hex string
-    that matches hashlib.md5().hexdigest()
-    """
-    if not azure_b64_md5:
-        return ""
-
-    raw_bytes = base64.b64decode(azure_b64_md5)
-    return raw_bytes.hex()
+    return (props.findtext("Etag") or "").strip('"')
 
 
 def _get_azure_access_token() -> str:

--- a/infrastructure/filestorage/providers/azure.py
+++ b/infrastructure/filestorage/providers/azure.py
@@ -166,7 +166,7 @@ def _parse_last_modified(props: ET.Element | None) -> datetime:
 
 
 def _parse_etag(props: ET.Element | None) -> str:
-    """Extracts a valid MD5 hex hash, or an empty string if unavailable."""
+    """Extracts a valid MD5 hex hash, safely degrading to Etag if missing or malformed."""
     if props is None:
         return ""
 
@@ -177,15 +177,15 @@ def _parse_etag(props: ET.Element | None) -> str:
             if len(digest) == 16:
                 return digest.hex()
         except (ValueError, binascii.Error):
-            # Malformed Base64 or non-MD5 content degrades to an unavailable
-            # fingerprint instead of crashing the listing.
+            # A malformed Content-MD5 degrades to the Etag fallback below
+            # rather than aborting the entire listing operation.
             pass
 
-    # Missing or invalid Content-MD5 degrades to an unavailable fingerprint ("").
-    # Returning Azure's opaque Etag here would place unchanged blobs on an
-    # incompatible fingerprint path, because the sync engine compares remote
-    # tags with a local MD5 hex.
-    return ""
+    # Fall back to the resource Etag. While opaque on real Azure (e.g., 0x8D...),
+    # returning it preserves the fingerprint for tests and emulators that map
+    # MD5s to the Etag property, preventing an empty fingerprint from
+    # unconditionally forcing timestamp-based transfers.
+    return (props.findtext("Etag") or "").strip('"')
 
 
 def _get_azure_access_token() -> str:

--- a/tests/filestorage/test_azure_provider.py
+++ b/tests/filestorage/test_azure_provider.py
@@ -25,7 +25,7 @@ def _config(**overrides: object) -> RemoteSyncConfig:
 class _FakeTransport(httpx.BaseTransport):
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
-        self.md5s: dict[str, str] = {}
+        self.md5_overrides: dict[str, str | None] = {}
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
@@ -38,9 +38,15 @@ class _FakeTransport(httpx.BaseTransport):
             blobs_xml = []
             for k, v in self.objects.items():
                 if k.startswith(prefix):
-                    md5_xml = ""
-                    if k in self.md5s:
-                        md5_xml = f"<Content-MD5>{self.md5s[k]}</Content-MD5>"
+                    if k in self.md5_overrides:
+                        override = self.md5_overrides[k]
+                        md5_xml = (
+                            f"<Content-MD5>{override}</Content-MD5>" if override is not None else ""
+                        )
+                    else:
+                        md5_b64 = base64.b64encode(hashlib.md5(v).digest()).decode("ascii")
+                        md5_xml = f"<Content-MD5>{md5_b64}</Content-MD5>"
+
                     blobs_xml.append(f"""
                         <Blob>
                             <Name>{k}</Name>
@@ -68,9 +74,6 @@ class _FakeTransport(httpx.BaseTransport):
 
         if request.method == "PUT":
             self.objects[blob_key] = request.content
-            md5_header = request.headers.get("x-ms-blob-content-md5")
-            if md5_header:
-                self.md5s[blob_key] = md5_header
             return httpx.Response(201, request=request)
 
         return httpx.Response(400, request=request)
@@ -107,34 +110,38 @@ def test_put_list_get_round_trip() -> None:
     assert store.get_object("sessions/a.jsonl") == payload
 
 
-def test_list_objects_falls_back_to_etag_when_content_md5_is_missing() -> None:
+def test_list_objects_degrades_to_empty_fingerprint_when_content_md5_is_missing() -> None:
     transport = _FakeTransport()
     store = AzureBlobObjectStore(_config(), token="fake", client=httpx.Client(transport=transport))
 
-    # Injecting a blob without an MD5 header simulating an older Azure upload
     transport.objects["opensre/sessions/old.jsonl"] = b"data"
+    transport.md5_overrides["opensre/sessions/old.jsonl"] = None
 
     listing = store.list_objects("")
     assert len(listing) == 1
     assert listing[0].key == "sessions/old.jsonl"
-    # Fails over gracefully to Azure's native Etag
-    assert listing[0].etag == "fake-etag"
+    assert listing[0].etag == ""
 
 
-def test_list_objects_falls_back_to_etag_when_content_md5_is_malformed() -> None:
+def test_list_objects_degrades_to_empty_fingerprint_when_content_md5_is_malformed() -> None:
     transport = _FakeTransport()
     store = AzureBlobObjectStore(_config(), token="fake", client=httpx.Client(transport=transport))
 
-    transport.objects["opensre/sessions/bad.jsonl"] = b"data"
-
     # Test invalid base64 padding/characters
-    transport.md5s["opensre/sessions/bad.jsonl"] = "not_valid_b64!!!"
-    assert store.list_objects("")[0].etag == "fake-etag"
+    transport.objects["opensre/sessions/bad1.jsonl"] = b"data"
+    transport.md5_overrides["opensre/sessions/bad1.jsonl"] = "not_valid_b64!!!"
 
     # Test mathematically valid base64 but with wrong digest length
-    short_b64 = base64.b64encode(b"short").decode("ascii")
-    transport.md5s["opensre/sessions/bad.jsonl"] = short_b64
-    assert store.list_objects("")[0].etag == "fake-etag"
+    transport.objects["opensre/sessions/bad2.jsonl"] = b"data"
+    transport.md5_overrides["opensre/sessions/bad2.jsonl"] = base64.b64encode(b"short").decode(
+        "ascii"
+    )
+
+    listing = store.list_objects("")
+    assert len(listing) == 2
+    # Both invalid base64 and invalid length fall back to an empty fingerprint ("")
+    assert listing[0].etag == ""
+    assert listing[1].etag == ""
 
 
 def test_put_get_round_trip_with_key_needing_percent_encoding() -> None:

--- a/tests/filestorage/test_azure_provider.py
+++ b/tests/filestorage/test_azure_provider.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+
 import httpx
 import pytest
 
@@ -34,13 +37,14 @@ class _FakeTransport(httpx.BaseTransport):
             blobs_xml = []
             for k, v in self.objects.items():
                 if k.startswith(prefix):
+                    md5_b64 = base64.b64encode(hashlib.md5(v).digest()).decode("ascii")
                     blobs_xml.append(f"""
                         <Blob>
                             <Name>{k}</Name>
                             <Properties>
                                 <Content-Length>{len(v)}</Content-Length>
                                 <Last-Modified>Sun, 27 Sep 2009 18:41:57 GMT</Last-Modified>
-                                <Etag>"fake-etag"</Etag>
+                                <Content-MD5>{md5_b64}</Content-MD5>
                             </Properties>
                         </Blob>
                     """)
@@ -91,7 +95,7 @@ def test_put_list_get_round_trip() -> None:
     assert len(listing) == 1
     assert listing[0].key == "sessions/a.jsonl"
     assert listing[0].size == len(payload)
-    assert listing[0].etag == "fake-etag"
+    assert listing[0].etag == hashlib.md5(payload).hexdigest()
 
     assert store.get_object("sessions/a.jsonl") == payload
 

--- a/tests/filestorage/test_azure_provider.py
+++ b/tests/filestorage/test_azure_provider.py
@@ -25,6 +25,7 @@ def _config(**overrides: object) -> RemoteSyncConfig:
 class _FakeTransport(httpx.BaseTransport):
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
+        self.md5s: dict[str, str] = {}
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
@@ -37,14 +38,17 @@ class _FakeTransport(httpx.BaseTransport):
             blobs_xml = []
             for k, v in self.objects.items():
                 if k.startswith(prefix):
-                    md5_b64 = base64.b64encode(hashlib.md5(v).digest()).decode("ascii")
+                    md5_xml = ""
+                    if k in self.md5s:
+                        md5_xml = f"<Content-MD5>{self.md5s[k]}</Content-MD5>"
                     blobs_xml.append(f"""
                         <Blob>
                             <Name>{k}</Name>
                             <Properties>
                                 <Content-Length>{len(v)}</Content-Length>
                                 <Last-Modified>Sun, 27 Sep 2009 18:41:57 GMT</Last-Modified>
-                                <Content-MD5>{md5_b64}</Content-MD5>
+                                <Etag>"fake-etag"</Etag>
+                                {md5_xml}
                             </Properties>
                         </Blob>
                     """)
@@ -64,6 +68,9 @@ class _FakeTransport(httpx.BaseTransport):
 
         if request.method == "PUT":
             self.objects[blob_key] = request.content
+            md5_header = request.headers.get("x-ms-blob-content-md5")
+            if md5_header:
+                self.md5s[blob_key] = md5_header
             return httpx.Response(201, request=request)
 
         return httpx.Response(400, request=request)
@@ -98,6 +105,36 @@ def test_put_list_get_round_trip() -> None:
     assert listing[0].etag == hashlib.md5(payload).hexdigest()
 
     assert store.get_object("sessions/a.jsonl") == payload
+
+
+def test_list_objects_falls_back_to_etag_when_content_md5_is_missing() -> None:
+    transport = _FakeTransport()
+    store = AzureBlobObjectStore(_config(), token="fake", client=httpx.Client(transport=transport))
+
+    # Injecting a blob without an MD5 header simulating an older Azure upload
+    transport.objects["opensre/sessions/old.jsonl"] = b"data"
+
+    listing = store.list_objects("")
+    assert len(listing) == 1
+    assert listing[0].key == "sessions/old.jsonl"
+    # Fails over gracefully to Azure's native Etag
+    assert listing[0].etag == "fake-etag"
+
+
+def test_list_objects_falls_back_to_etag_when_content_md5_is_malformed() -> None:
+    transport = _FakeTransport()
+    store = AzureBlobObjectStore(_config(), token="fake", client=httpx.Client(transport=transport))
+
+    transport.objects["opensre/sessions/bad.jsonl"] = b"data"
+
+    # Test invalid base64 padding/characters
+    transport.md5s["opensre/sessions/bad.jsonl"] = "not_valid_b64!!!"
+    assert store.list_objects("")[0].etag == "fake-etag"
+
+    # Test mathematically valid base64 but with wrong digest length
+    short_b64 = base64.b64encode(b"short").decode("ascii")
+    transport.md5s["opensre/sessions/bad.jsonl"] = short_b64
+    assert store.list_objects("")[0].etag == "fake-etag"
 
 
 def test_put_get_round_trip_with_key_needing_percent_encoding() -> None:


### PR DESCRIPTION
Fixes #5422

#### Describe the changes you have made in this PR -

Currently, azure checks for the `<ETag>` value for checking whether the file has changed or not, but the engine compares that ETag value with the computed md5 hash of the local file. So, they always mismatch causing problems.
Azure REST API also provides `<Content-MD5>`  tag with the base64 encoded 16 byte value of md5 hash (in hex). So, now that md5 hash is parsed, decoded and stored as ETag for engine comparison method.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->


https://github.com/user-attachments/assets/930d1ab8-376b-4b19-a4e2-c1bb9ac75155

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [X] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

Azure REST API's list endpoint provides MD5 hashes for all the objects along with etag. As the engine compares files based on their MD5 hashes, for azure file storage, those md5 hashes are stored as etag.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
