### PR TITLE
refactor(core/tool): core.tool_framework API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ The tool registry auto-discovers modules under `tools/`, so the normal path is t
 
 Steps:
 
-1. Pick the simplest shape that fits the tool. Use a `BaseTool` subclass (from `core.tool.contracts`) for richer behavior; use `@tool(...)` from `core.tool_framework.tool_decorator` for a lightweight function tool.
+1. Pick the simplest shape that fits the tool. Use a `BaseTool` subclass (from `core.tool`) for richer behavior; use `@tool(...)` from `core.tool_framework` for a lightweight function tool. Import through those tier doors, not their internal submodules — the border test in `tests/shared/test_tool_api_border.py` enforces it.
 2. Declare clear metadata: `name`, `description`, `source`, `input_schema`, and any `use_cases`, `requires`, `outputs`, or `retrieval_controls` you need.
 3. Before opening or approving the PR, follow [docs/adding-tools-and-integrations.md](docs/adding-tools-and-integrations.md).
 

--- a/core/tool_framework/__init__.py
+++ b/core/tool_framework/__init__.py
@@ -1,0 +1,21 @@
+"""Tool authoring helpers: the ``@tool`` decorator, planning tags, skill guidance.
+
+The tier's door for consumers above it. Schema and payload utilities live behind
+the sibling ``core.tool_framework.utils`` door; the tool contract itself (what a
+tool is, how it runs, where it is registered) is ``core.tool``.
+"""
+
+from core.tool_framework.skill_guidance import (
+    format_tool_skill_guidance,
+    load_tool_skill_guidance,
+)
+from core.tool_framework.tags import FALLBACK_PLANNING_TAG, SUMMARIZE_OBSERVATION_TAG
+from core.tool_framework.tool_decorator import tool
+
+__all__ = [
+    "FALLBACK_PLANNING_TAG",
+    "SUMMARIZE_OBSERVATION_TAG",
+    "format_tool_skill_guidance",
+    "load_tool_skill_guidance",
+    "tool",
+]

--- a/integrations/aws/tools/aws_operation_tool/__init__.py
+++ b/integrations/aws/tools/aws_operation_tool/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 
 

--- a/integrations/aws_lambda/tools/lambda_config_tool/__init__.py
+++ b/integrations/aws_lambda/tools/lambda_config_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.aws.lambda_client import get_function_configuration
 from integrations.aws_lambda.availability import lambda_available, lambda_name
 

--- a/integrations/aws_lambda/tools/lambda_errors_tool/__init__.py
+++ b/integrations/aws_lambda/tools/lambda_errors_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.aws_lambda.availability import lambda_available, lambda_name
 from integrations.aws_lambda.tools.lambda_invocation_logs_tool import get_lambda_invocation_logs
 

--- a/integrations/aws_lambda/tools/lambda_inspect_tool/__init__.py
+++ b/integrations/aws_lambda/tools/lambda_inspect_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.aws.lambda_client import get_function_code, get_function_configuration
 from integrations.aws_lambda.availability import lambda_available, lambda_name
 

--- a/integrations/aws_lambda/tools/lambda_invocation_logs_tool/__init__.py
+++ b/integrations/aws_lambda/tools/lambda_invocation_logs_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from infrastructure.evidence.evidence_compaction import (
     compact_invocations,
     compact_logs,

--- a/integrations/azure/tools/azure_monitor_logs_tool/__init__.py
+++ b/integrations/azure/tools/azure_monitor_logs_tool/__init__.py
@@ -13,7 +13,7 @@ from config.constants.azure import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 
 

--- a/integrations/azure_sql/tools/azure_sql_current_queries_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_current_queries_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.azure_sql import (
     azure_sql_extract_params,

--- a/integrations/azure_sql/tools/azure_sql_resource_stats_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_resource_stats_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.azure_sql import (
     azure_sql_extract_params,
     azure_sql_is_available,

--- a/integrations/azure_sql/tools/azure_sql_server_status_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_server_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.azure_sql import (
     azure_sql_extract_params,
     azure_sql_is_available,

--- a/integrations/azure_sql/tools/azure_sql_slow_queries_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_slow_queries_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.azure_sql import (
     azure_sql_extract_params,

--- a/integrations/azure_sql/tools/azure_sql_wait_stats_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_wait_stats_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.azure_sql import (
     azure_sql_extract_params,
     azure_sql_is_available,

--- a/integrations/betterstack/tools/betterstack_logs_tool/__init__.py
+++ b/integrations/betterstack/tools/betterstack_logs_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.betterstack import (
     BetterStackConfig,
     betterstack_extract_params,

--- a/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.bitbucket.client import list_commits
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend

--- a/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.bitbucket.client import get_file_contents
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend

--- a/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.bitbucket.client import search_code
 from integrations.bitbucket.config import (

--- a/integrations/buzz/tools/buzz_send_message_tool/tool.py
+++ b/integrations/buzz/tools/buzz_send_message_tool/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.buzz.tools.buzz_send_message_tool.constants import SOURCE
 from integrations.buzz.tools.buzz_send_message_tool.delivery import (
     dispatch_message,

--- a/integrations/clickhouse/tools/clickhouse_query_activity_tool/__init__.py
+++ b/integrations/clickhouse/tools/clickhouse_query_activity_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.clickhouse import (
     ClickHouseConfig,
     clickhouse_extract_params,

--- a/integrations/clickhouse/tools/clickhouse_system_health_tool/__init__.py
+++ b/integrations/clickhouse/tools/clickhouse_system_health_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.clickhouse import (
     ClickHouseConfig,
     clickhouse_extract_params,

--- a/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
+++ b/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
@@ -18,7 +18,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.cloudtrail import (

--- a/integrations/cloudwatch/tools/cloudwatch_batch_metrics_tool/__init__.py
+++ b/integrations/cloudwatch/tools/cloudwatch_batch_metrics_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from infrastructure.evidence.evidence_compaction import truncate_list
 from integrations.aws.cloudwatch_client import get_metric_statistics
 from integrations.cloudwatch.availability import cloudwatch_is_available

--- a/integrations/cloudwatch/tools/cloudwatch_logs_tool/__init__.py
+++ b/integrations/cloudwatch/tools/cloudwatch_logs_tool/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 import boto3
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 
 
 def _cloudwatch_logs_available(sources: dict[str, dict]) -> bool:

--- a/integrations/dagster/tools/__init__.py
+++ b/integrations/dagster/tools/__init__.py
@@ -5,7 +5,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.dagster import (
     DagsterConfig,
     dagster_extract_params,
@@ -39,7 +39,7 @@ def list_dagster_assets(
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.dagster import (
     dagster_extract_params,
     dagster_is_available,
@@ -89,7 +89,7 @@ def get_dagster_run_logs(
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.dagster import (
     dagster_extract_params,
     dagster_is_available,
@@ -134,7 +134,7 @@ def list_dagster_runs(
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.dagster import (
     dagster_extract_params,
     dagster_is_available,
@@ -181,7 +181,7 @@ def list_dagster_schedule_ticks(
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.dagster import (
     dagster_extract_params,
     dagster_is_available,

--- a/integrations/datadog/tools/__init__.py
+++ b/integrations/datadog/tools/__init__.py
@@ -10,7 +10,7 @@ import re
 from typing import Any
 
 from core.tool import EvidenceType, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from infrastructure.evidence.evidence_compaction import compact_logs, summarize_counts
 from integrations.datadog._client import make_async_client
@@ -291,7 +291,7 @@ def fetch_datadog_context(
 """Datadog events query tool."""
 
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.datadog._client import make_client, unavailable
 
 
@@ -366,7 +366,7 @@ def query_datadog_events(
 
 from typing import cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.datadog.availability import datadog_available_or_backend
 
 _ERROR_KEYWORDS = (
@@ -505,7 +505,7 @@ def query_datadog_logs(
 
 from pydantic import BaseModel, Field
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 
 
 class QueryDatadogMetricsInput(BaseModel):
@@ -598,7 +598,7 @@ def query_datadog_metrics(
 """Datadog monitor listing tool."""
 
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 
 
 def _monitors_is_available(sources: dict[str, dict]) -> bool:
@@ -680,7 +680,7 @@ def query_datadog_monitors(
 """Datadog tool: resolve a node IP to the pods running on that node."""
 
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 
 
 def _node_pods_is_available(sources: dict[str, dict]) -> bool:

--- a/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
+++ b/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call

--- a/integrations/eks/tools/eks_deployment_status_tool/__init__.py
+++ b/integrations/eks/tools/eks_deployment_status_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available
 from integrations.eks.eks_k8s_client import build_k8s_clients

--- a/integrations/eks/tools/eks_describe_addon_tool/__init__.py
+++ b/integrations/eks/tools/eks_describe_addon_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 from botocore.exceptions import ClientError
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available
 from integrations.eks.eks_client import EKSClient

--- a/integrations/eks/tools/eks_describe_cluster_tool/__init__.py
+++ b/integrations/eks/tools/eks_describe_cluster_tool/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 from botocore.exceptions import ClientError
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available
 from integrations.eks.eks_client import EKSClient

--- a/integrations/eks/tools/eks_events_tool/__init__.py
+++ b/integrations/eks/tools/eks_events_tool/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, cast
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available_or_backend
 from integrations.eks.eks_k8s_client import build_k8s_clients

--- a/integrations/eks/tools/eks_list_clusters_tool/__init__.py
+++ b/integrations/eks/tools/eks_list_clusters_tool/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 from botocore.exceptions import ClientError
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available
 from integrations.eks.eks_client import EKSClient

--- a/integrations/eks/tools/eks_list_deployments_tool/__init__.py
+++ b/integrations/eks/tools/eks_list_deployments_tool/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, cast
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available_or_backend
 from integrations.eks.eks_k8s_client import build_k8s_clients

--- a/integrations/eks/tools/eks_list_namespaces_tool/__init__.py
+++ b/integrations/eks/tools/eks_list_namespaces_tool/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available
 from integrations.eks.eks_k8s_client import build_k8s_clients

--- a/integrations/eks/tools/eks_list_pods_tool/__init__.py
+++ b/integrations/eks/tools/eks_list_pods_tool/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from pydantic import BaseModel, Field
 
 from core.tool import EvidenceType, SideEffectLevel, report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available_or_backend
 from integrations.eks.eks_k8s_client import build_k8s_clients

--- a/integrations/eks/tools/eks_node_health_tool/__init__.py
+++ b/integrations/eks/tools/eks_node_health_tool/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, cast
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available_or_backend
 from integrations.eks.eks_k8s_client import build_k8s_clients

--- a/integrations/eks/tools/eks_nodegroup_health_tool/__init__.py
+++ b/integrations/eks/tools/eks_nodegroup_health_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 from botocore.exceptions import ClientError
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available
 from integrations.eks.eks_client import EKSClient

--- a/integrations/eks/tools/eks_pod_logs_tool/__init__.py
+++ b/integrations/eks/tools/eks_pod_logs_tool/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, cast
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.eks.availability import eks_available_or_backend
 from integrations.eks.eks_k8s_client import build_k8s_clients

--- a/integrations/elb/tools/elb_target_health_tool/__init__.py
+++ b/integrations/elb/tools/elb_target_health_tool/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/architecture_issue_tool/tool.py
+++ b/integrations/github/tools/architecture_issue_tool/tool.py
@@ -7,7 +7,7 @@ from typing import Any
 from core.agent_harness.tools import action_context_from_agent_context
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.github.tools.architecture_issue_tool.repo_workspace import (
     WorkspaceError,
     architecture_workspace_dir,

--- a/integrations/github/tools/ci_fix/tool.py
+++ b/integrations/github/tools/ci_fix/tool.py
@@ -7,7 +7,7 @@ from typing import Any
 from core.agent_harness.tools import action_context_from_agent_context
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/commits.py
+++ b/integrations/github/tools/commits.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/community_followup_tool/__init__.py
+++ b/integrations/github/tools/community_followup_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (

--- a/integrations/github/tools/file_contents.py
+++ b/integrations/github/tools/file_contents.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/git_deploy_timeline_tool/__init__.py
+++ b/integrations/github/tools/git_deploy_timeline_tool/__init__.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from core.domain.types.incident_window import IncidentWindow
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/github_cli/tool.py
+++ b/integrations/github/tools/github_cli/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.github.tools.github_cli.credentials import (
     GITHUB_CLI_INJECTED_PARAMS,
     github_creds,

--- a/integrations/github/tools/issues.py
+++ b/integrations/github/tools/issues.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/repository.py
+++ b/integrations/github/tools/repository.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel, report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (

--- a/integrations/github/tools/repository_tree.py
+++ b/integrations/github/tools/repository_tree.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/search_code.py
+++ b/integrations/github/tools/search_code.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/security_fix/tool.py
+++ b/integrations/github/tools/security_fix/tool.py
@@ -7,7 +7,7 @@ from typing import Any
 from core.agent_harness.tools import action_context_from_agent_context
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/github/tools/stargazers.py
+++ b/integrations/github/tools/stargazers.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel, report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (

--- a/integrations/github/tools/work_status.py
+++ b/integrations/github/tools/work_status.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, cast
 
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
 from integrations.github.helpers import (

--- a/integrations/github/tools/work_status_report_tool/__init__.py
+++ b/integrations/github/tools/work_status_report_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.github.client import resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,

--- a/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.gitlab import (
     GitlabConfig,

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -6,7 +6,7 @@ import base64
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload, tool_unavailable
 from integrations.gitlab import (
     get_gitlab_file,

--- a/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.gitlab import (
     get_gitlab_mrs,

--- a/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
 from integrations.gitlab import (
     get_gitlab_pipelines,

--- a/integrations/google_docs/tools/__init__.py
+++ b/integrations/google_docs/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.config_models import GoogleDocsIntegrationConfig
 from integrations.google_docs.client import GoogleDocsClient
 

--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from core.domain.types.evidence import record_evidence_entry
 from core.tool import EvidenceType, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 
 _GRAFANA_RUNTIME_PARAMS = (
@@ -154,7 +154,7 @@ def query_grafana_alert_rules(
 import time
 from datetime import UTC, datetime
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.grafana.base import _epoch_ms_to_iso, _map_annotation
 
 
@@ -296,7 +296,7 @@ def query_grafana_annotations(
 """Grafana Loki log query tool — primary owner of Grafana helpers."""
 
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from infrastructure.evidence.evidence_compaction import summarize_counts
 from infrastructure.evidence.log_compaction import build_error_taxonomy, deduplicate_logs
 from integrations.grafana.client import get_grafana_client_from_credentials
@@ -546,7 +546,7 @@ def query_grafana_logs(
 
 from pydantic import BaseModel, Field
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 
 
 class QueryGrafanaMetricsInput(BaseModel):
@@ -682,7 +682,7 @@ def query_grafana_metrics(
 """Grafana Loki service name discovery tool."""
 
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 
 
 def _query_grafana_service_names_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -774,7 +774,7 @@ def query_grafana_service_names(
 
 
 from core.domain.pipeline_spans import extract_pipeline_spans as _extract_pipeline_spans
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from infrastructure.evidence.evidence_compaction import DEFAULT_TRACE_LIMIT, compact_traces
 
 

--- a/integrations/groundcover/tools/__init__.py
+++ b/integrations/groundcover/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.groundcover.availability import groundcover_available_or_backend
 from integrations.groundcover.client import GroundcoverClient
@@ -110,7 +110,7 @@ def query_groundcover_logs(
 
 from typing import cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 
 _QUERY_REF_SOURCE = "groundcover_query_reference"
 
@@ -178,7 +178,7 @@ def get_groundcover_query_reference(
 """groundcover traces query tool (gcQL over query_traces)."""
 
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.groundcover.guidance import (
     DEFAULT_TRACES_QUERY,
     GCQL_GUIDANCE,

--- a/integrations/hermes/tools/hermes_logs_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_logs_tool/__init__.py
@@ -44,7 +44,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.hermes.availability import hermes_available_or_backend
 from integrations.hermes.classifier import IncidentClassifier
 from integrations.hermes.incident import HermesIncident, LogLevel, LogRecord

--- a/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 
 

--- a/integrations/jenkins/tools/__init__.py
+++ b/integrations/jenkins/tools/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.jenkins import jenkins_config_from_env
 from integrations.jenkins.client import JenkinsClient, make_jenkins_client

--- a/integrations/kafka/tools/kafka_consumer_group_tool/__init__.py
+++ b/integrations/kafka/tools/kafka_consumer_group_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.kafka import (
     KafkaConfig,
     get_consumer_group_lag,

--- a/integrations/kafka/tools/kafka_topic_health_tool/__init__.py
+++ b/integrations/kafka/tools/kafka_topic_health_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.kafka import (
     KafkaConfig,
     get_topic_health,

--- a/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,

--- a/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,

--- a/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,

--- a/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,

--- a/integrations/mariadb/tools/mariadb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mariadb import (
     MariaDBConfig,

--- a/integrations/mongodb/tools/mongodb_collection_stats_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_collection_stats_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb import (
     MongoDBConfig,
     get_collection_stats,

--- a/integrations/mongodb/tools/mongodb_current_ops_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_current_ops_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb import (
     MongoDBConfig,
     get_current_ops,

--- a/integrations/mongodb/tools/mongodb_profiler_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_profiler_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb import (
     MongoDBConfig,
     get_profiler_data,

--- a/integrations/mongodb/tools/mongodb_replica_status_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_replica_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb import (
     MongoDBConfig,
     get_rs_status,

--- a/integrations/mongodb/tools/mongodb_server_status_tool/__init__.py
+++ b/integrations/mongodb/tools/mongodb_server_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb import (
     MongoDBConfig,
     get_server_status,

--- a/integrations/mongodb_atlas/tools/mongodb_atlas_alerts_tool/__init__.py
+++ b/integrations/mongodb_atlas/tools/mongodb_atlas_alerts_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb_atlas import (
     MongoDBAtlasConfig,
     atlas_extract_params,

--- a/integrations/mongodb_atlas/tools/mongodb_atlas_clusters_tool/__init__.py
+++ b/integrations/mongodb_atlas/tools/mongodb_atlas_clusters_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb_atlas import (
     MongoDBAtlasConfig,
     atlas_extract_params,

--- a/integrations/mongodb_atlas/tools/mongodb_atlas_events_tool/__init__.py
+++ b/integrations/mongodb_atlas/tools/mongodb_atlas_events_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb_atlas import (
     MongoDBAtlasConfig,
     atlas_extract_params,

--- a/integrations/mongodb_atlas/tools/mongodb_atlas_metrics_tool/__init__.py
+++ b/integrations/mongodb_atlas/tools/mongodb_atlas_metrics_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb_atlas import (
     MongoDBAtlasConfig,
     atlas_extract_params,

--- a/integrations/mongodb_atlas/tools/mongodb_atlas_performance_advisor_tool/__init__.py
+++ b/integrations/mongodb_atlas/tools/mongodb_atlas_performance_advisor_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.mongodb_atlas import (
     MongoDBAtlasConfig,
     atlas_extract_params,

--- a/integrations/mysql/tools/mysql_current_processes_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_current_processes_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_current_processes,

--- a/integrations/mysql/tools/mysql_replication_status_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_replication_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_replication_status,

--- a/integrations/mysql/tools/mysql_server_status_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_server_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_server_status,

--- a/integrations/mysql/tools/mysql_slow_queries_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_slow_queries_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_slow_queries,

--- a/integrations/mysql/tools/mysql_table_stats_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_table_stats_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.mysql import (
     get_table_stats,

--- a/integrations/new_relic/tools/new_relic_alerts_tool/tool.py
+++ b/integrations/new_relic/tools/new_relic_alerts_tool/tool.py
@@ -9,7 +9,7 @@ from config.constants.new_relic import (
     NEW_RELIC_DEFAULT_WINDOW_MINUTES,
 )
 from core.tool import BaseTool, EvidenceType, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.new_relic.client import NewRelicClient
 from integrations.new_relic.config import NewRelicIntegrationConfig

--- a/integrations/new_relic/tools/new_relic_metrics_tool/tool.py
+++ b/integrations/new_relic/tools/new_relic_metrics_tool/tool.py
@@ -9,7 +9,7 @@ from config.constants.new_relic import (
     NEW_RELIC_DEFAULT_WINDOW_MINUTES,
 )
 from core.tool import BaseTool, EvidenceType, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.new_relic.client import NewRelicClient
 from integrations.new_relic.config import NewRelicIntegrationConfig

--- a/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import build_mcp_tool_listing
 from integrations.openclaw import (
     OpenClawConfig,

--- a/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
+++ b/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
@@ -10,7 +10,7 @@ import httpx
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 
 _DEFAULT_MAX_RESULTS = 100

--- a/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
+++ b/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.elasticsearch.client import ElasticsearchClient, ElasticsearchConfig
 

--- a/integrations/postgresql/tools/postgresql_current_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_current_queries_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_current_queries,

--- a/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import EvidenceType, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_lock_status,

--- a/integrations/postgresql/tools/postgresql_replication_status_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_replication_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_replication_status,

--- a/integrations/postgresql/tools/postgresql_server_status_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_server_status_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_server_status,

--- a/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from core.domain.types.tools import ToolSurface
 from core.tool import EvidenceType, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_slow_queries,

--- a/integrations/postgresql/tools/postgresql_table_stats_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_table_stats_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
 from integrations.postgresql import (
     get_table_stats,

--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import (
     build_mcp_tool_listing,
     first_list,

--- a/integrations/rabbitmq/tools/rabbitmq_broker_overview_tool/__init__.py
+++ b/integrations/rabbitmq/tools/rabbitmq_broker_overview_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.rabbitmq import (
     RabbitMQConfig,
     get_broker_overview,

--- a/integrations/rabbitmq/tools/rabbitmq_connection_stats_tool/__init__.py
+++ b/integrations/rabbitmq/tools/rabbitmq_connection_stats_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.rabbitmq import (
     RabbitMQConfig,
     get_connection_stats,

--- a/integrations/rabbitmq/tools/rabbitmq_consumer_health_tool/__init__.py
+++ b/integrations/rabbitmq/tools/rabbitmq_consumer_health_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.rabbitmq import (
     RabbitMQConfig,
     get_consumer_health,

--- a/integrations/rabbitmq/tools/rabbitmq_node_health_tool/__init__.py
+++ b/integrations/rabbitmq/tools/rabbitmq_node_health_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.rabbitmq import (
     RabbitMQConfig,
     get_node_health,

--- a/integrations/rabbitmq/tools/rabbitmq_queue_backlog_tool/__init__.py
+++ b/integrations/rabbitmq/tools/rabbitmq_queue_backlog_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.rabbitmq import (
     RabbitMQConfig,
     get_queue_backlog,

--- a/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
+++ b/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.config_models import RailwayIntegrationConfig
 from integrations.railway.client import (
     RailwayClient,

--- a/integrations/railway/tools/railway_deployment_tool/redeploy_tool.py
+++ b/integrations/railway/tools/railway_deployment_tool/redeploy_tool.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.config_models import RailwayIntegrationConfig
 from integrations.railway.client import (
     RailwayClient,

--- a/integrations/rds/tools/rds_describe_instance_tool/__init__.py
+++ b/integrations/rds/tools/rds_describe_instance_tool/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from pydantic import BaseModel, Field
 
 from core.tool import EvidenceType, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.rds import (

--- a/integrations/rds/tools/rds_events_tool/__init__.py
+++ b/integrations/rds/tools/rds_events_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.rds import (

--- a/integrations/redis/tools/redis_client_list_tool/__init__.py
+++ b/integrations/redis/tools/redis_client_list_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.redis import (
     RedisConfig,
     get_client_list,

--- a/integrations/redis/tools/redis_key_scan_tool/__init__.py
+++ b/integrations/redis/tools/redis_key_scan_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.redis import (
     RedisConfig,
     redis_extract_params,

--- a/integrations/redis/tools/redis_latency_doctor_tool/__init__.py
+++ b/integrations/redis/tools/redis_latency_doctor_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.redis import (
     RedisConfig,
     get_latency_doctor,

--- a/integrations/redis/tools/redis_list_depth_tool/__init__.py
+++ b/integrations/redis/tools/redis_list_depth_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.redis import (
     RedisConfig,
     get_list_depth,

--- a/integrations/redis/tools/redis_replication_tool/__init__.py
+++ b/integrations/redis/tools/redis_replication_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.redis import (
     RedisConfig,
     get_replication,

--- a/integrations/redis/tools/redis_server_info_tool/__init__.py
+++ b/integrations/redis/tools/redis_server_info_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.redis import (
     RedisConfig,
     get_server_info,

--- a/integrations/redis/tools/redis_slowlog_tool/__init__.py
+++ b/integrations/redis/tools/redis_slowlog_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.redis import (
     RedisConfig,
     get_slowlog,

--- a/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
+++ b/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.rocketchat.tools.rocketchat_send_message_tool.constants import SOURCE
 from integrations.rocketchat.tools.rocketchat_send_message_tool.delivery import (
     dispatch_message,

--- a/integrations/s3/tools/s3_get_object_tool/__init__.py
+++ b/integrations/s3/tools/s3_get_object_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.aws.s3_client import get_full_object
 
 

--- a/integrations/s3/tools/s3_inspect_tool/__init__.py
+++ b/integrations/s3/tools/s3_inspect_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from infrastructure.delivery.notifications.limits import MAX_MESSAGE_SIZE
 from integrations.aws.s3_client import get_object_metadata, get_object_sample
 

--- a/integrations/s3/tools/s3_list_tool/__init__.py
+++ b/integrations/s3/tools/s3_list_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.aws.s3_client import list_objects
 
 

--- a/integrations/s3/tools/s3_marker_tool/__init__.py
+++ b/integrations/s3/tools/s3_marker_tool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.aws.s3_client import check_s3_marker_presence
 
 

--- a/integrations/sentry/tools/sentry_issue_details_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_issue_details_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.sentry import get_sentry_issue
 from integrations.sentry.tools.sentry_search_issues_tool import (

--- a/integrations/sentry/tools/sentry_issue_events_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_issue_events_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.sentry import list_sentry_issue_events as sentry_list_issue_events
 from integrations.sentry.tools.sentry_search_issues_tool import (

--- a/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_list_uptime_alerts_tool/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.sentry import (
     SentryConfig,
     build_sentry_config,

--- a/integrations/sentry/tools/sentry_search_issues_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_search_issues_tool/__init__.py
@@ -8,7 +8,7 @@ import httpx
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.sentry import (
     DEFAULT_SENTRY_ISSUE_LIMIT,

--- a/integrations/sentry/tools/sentry_uptime_digest_tool/__init__.py
+++ b/integrations/sentry/tools/sentry_uptime_digest_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.sentry.uptime import (
     UptimeTransitionRecord,
     WatchState,

--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import (
     build_mcp_tool_listing,
     first_list,

--- a/integrations/signoz/tools/query_signoz_logs_tool/tool.py
+++ b/integrations/signoz/tools/query_signoz_logs_tool/tool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from infrastructure.evidence.evidence_compaction import compact_logs, summarize_counts
 from integrations.signoz import SigNozConfig, signoz_extract_params

--- a/integrations/signoz/tools/query_signoz_metrics_tool/tool.py
+++ b/integrations/signoz/tools/query_signoz_metrics_tool/tool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.signoz import SigNozConfig, signoz_extract_params
 from integrations.signoz.availability import signoz_available_or_backend

--- a/integrations/signoz/tools/query_signoz_traces_tool/tool.py
+++ b/integrations/signoz/tools/query_signoz_traces_tool/tool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.signoz import SigNozConfig, signoz_extract_params
 from integrations.signoz.availability import signoz_available_or_backend

--- a/integrations/slack/tools/slack_add_reaction_tool/tool.py
+++ b/integrations/slack/tools/slack_add_reaction_tool/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id
 from integrations.slack.web_client import (

--- a/integrations/slack/tools/slack_join_channel_tool/tool.py
+++ b/integrations/slack/tools/slack_join_channel_tool/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id

--- a/integrations/slack/tools/slack_list_members_tool/tool.py
+++ b/integrations/slack/tools/slack_list_members_tool/tool.py
@@ -6,8 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.web_client import (

--- a/integrations/slack/tools/slack_read_list_tool/tool.py
+++ b/integrations/slack/tools/slack_read_list_tool/tool.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_list_tool.constants import (
     DEFAULT_ITEM_LIMIT,

--- a/integrations/slack/tools/slack_read_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_read_messages_tool/tool.py
@@ -6,8 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
 from integrations.slack.tools.slack_read_messages_tool.constants import (
     DEFAULT_MESSAGE_LIMIT,
     SOURCE,

--- a/integrations/slack/tools/slack_reply_message_tool/tool.py
+++ b/integrations/slack/tools/slack_reply_message_tool/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.tools.slack_read_messages_tool.validation import validate_channel_id
 from integrations.slack.tools.slack_send_message_tool.validation import validate_message

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -6,8 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.web_client import bot_token_configured, resolve_bot_token, search_messages

--- a/integrations/slack/tools/slack_send_message_tool/tool.py
+++ b/integrations/slack/tools/slack_send_message_tool/tool.py
@@ -8,7 +8,7 @@ from typing import Any
 from config.constants.slack import SLACK_WEBHOOK_URL_ENV
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.slack.tools.slack_send_message_tool.constants import SOURCE
 from integrations.slack.tools.slack_send_message_tool.delivery import (
     dispatch_message,

--- a/integrations/slack/tools/slack_thread_replay_tool/tool.py
+++ b/integrations/slack/tools/slack_thread_replay_tool/tool.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar
 from core.domain.types.evidence import EvidenceSource
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.slack.thread_client import fetch_thread, parse_thread_ref
 from integrations.slack.web_client import bot_token_configured
 

--- a/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
+++ b/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
@@ -8,7 +8,7 @@ import httpx
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 
 _DEFAULT_MAX_RESULTS = 50

--- a/integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py
+++ b/integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py
@@ -17,7 +17,7 @@ import logging
 from typing import Any, cast
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.sqs import (

--- a/integrations/supabase/tools/supabase_health_tool/__init__.py
+++ b/integrations/supabase/tools/supabase_health_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.supabase import (
     get_service_health,
     resolve_supabase_config,

--- a/integrations/supabase/tools/supabase_storage_tool/__init__.py
+++ b/integrations/supabase/tools/supabase_storage_tool/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.supabase import (
     get_storage_buckets,
     resolve_supabase_config,

--- a/integrations/telegram/tools/telegram_send_message_tool/tool.py
+++ b/integrations/telegram/tools/telegram_send_message_tool/tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.telegram.tools.telegram_send_message_tool.constants import SOURCE
 from integrations.telegram.tools.telegram_send_message_tool.delivery import (
     dispatch_message,

--- a/integrations/tempo/tools/__init__.py
+++ b/integrations/tempo/tools/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.tempo import TempoConfig, tempo_extract_params
 from integrations.tempo.availability import tempo_available_or_backend

--- a/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
@@ -6,7 +6,7 @@ import os
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.airflow.config import (
     AirflowConfig,
     build_airflow_config,

--- a/integrations/tracer/tools/tracer_airflow_metrics_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_airflow_metrics_tool/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.tracer import get_tracer_web_client
 from integrations.tracer.tools.tracer_failed_jobs_tool import _tracer_available, _tracer_trace_id
 

--- a/integrations/tracer/tools/tracer_batch_statistics_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_batch_statistics_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.tracer import get_tracer_web_client
 from integrations.tracer.tools.tracer_failed_jobs_tool import _tracer_available, _tracer_trace_id
 

--- a/integrations/tracer/tools/tracer_error_logs_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_error_logs_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from infrastructure.evidence.log_compaction import build_error_taxonomy, deduplicate_logs
 from integrations.tracer import get_tracer_web_client
 

--- a/integrations/tracer/tools/tracer_failed_jobs_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_failed_jobs_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.tracer import (
     AWSBatchJobResult,
     get_tracer_client,

--- a/integrations/tracer/tools/tracer_failed_run_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_failed_run_tool/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from config.config import get_tracer_base_url
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.tracer import (
     PipelineRunSummary,
     get_tracer_web_client,

--- a/integrations/tracer/tools/tracer_failed_tools_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_failed_tools_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.tracer import get_tracer_web_client
 from integrations.tracer.tools.tracer_failed_jobs_tool import _tracer_available, _tracer_trace_id
 

--- a/integrations/tracer/tools/tracer_host_metrics_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_host_metrics_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import validate_host_metrics
 from integrations.tracer import get_tracer_web_client
 from integrations.tracer.tools.tracer_failed_jobs_tool import _tracer_available, _tracer_trace_id

--- a/integrations/tracer/tools/tracer_run_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_run_tool/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.tracer import TracerRunResult, get_tracer_client
 
 

--- a/integrations/tracer/tools/tracer_tasks_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_tasks_tool/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.tracer import TracerTaskResult, get_tracer_client
 
 

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import (
     build_mcp_tool_listing,
     first_list,

--- a/integrations/yandex_cloud/tools/yc_api_lookup_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_api_lookup_tool/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from integrations.yandex_cloud.api_index import (
     DEFAULT_LIMIT,
     endpoint_count,

--- a/integrations/yandex_cloud/tools/yc_instances_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_instances_tool/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,

--- a/integrations/yandex_cloud/tools/yc_lb_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_lb_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Final
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,

--- a/integrations/yandex_cloud/tools/yc_logs_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_logs_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,

--- a/integrations/yandex_cloud/tools/yc_metrics_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_metrics_tool/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,

--- a/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.tools import ToolSurface
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.yandex_cloud.api_index import known_services, lookup
 from integrations.yandex_cloud.availability import (

--- a/tests/shared/test_tool_api_border.py
+++ b/tests/shared/test_tool_api_border.py
@@ -3,17 +3,16 @@
 ``core/tool/`` (contract, execution, registry port) and ``core/tool_framework/``
 (``@tool``, skill guidance, payload utilities) are one tier to everything above
 them. Three doors are open: ``core.tool`` (the contract — what a tool is, how
-it runs, where it is registered), ``core.tool_framework.utils`` (schema builders,
-MCP readers, availability envelopes), and the ``core.tool_framework`` root, which
-exports nothing yet. Everything reaching past a door is listed below, and these
-allowlists are the measurement of the seam.
+it runs, where it is registered), ``core.tool_framework`` (the ``@tool``
+decorator, planning tags, skill guidance), and ``core.tool_framework.utils``
+(schema builders, MCP readers, availability envelopes). Everything reaching past
+a door is listed below, and these allowlists are the measurement of the seam.
 
-``gateway``, ``surfaces`` and ``infrastructure`` are at zero: they use the contract and
-nothing behind it.
+Every consumer is now at zero: they use the tier's doors and nothing behind them.
 
 Each allowlist is compared exactly in both directions: a new internal import
-fails immediately, and an entry no longer imported must be removed. Widening a
-door and moving callers onto it is how these get shorter.
+fails immediately, and an entry no longer imported must be removed. The seam is
+closed — keep it closed.
 """
 
 from __future__ import annotations
@@ -30,19 +29,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 #: Internal tool-tier modules each consumer still imports directly.
 _ALLOWED: dict[str, frozenset[str]] = {
-    "tools": frozenset(
-        {
-            "core.tool_framework.skill_guidance",
-            "core.tool_framework.tags",
-            "core.tool_framework.tool_decorator",
-        }
-    ),
-    "integrations": frozenset(
-        {
-            "core.tool_framework.tags",
-            "core.tool_framework.tool_decorator",
-        }
-    ),
+    "tools": frozenset(),
+    "integrations": frozenset(),
     "gateway": frozenset(),
     "surfaces": frozenset(),
     "infrastructure": frozenset(),

--- a/tests/shared/tool_api.py
+++ b/tests/shared/tool_api.py
@@ -4,9 +4,8 @@
 ``core/tool_framework/`` holds the authoring helpers (``@tool``, skill guidance,
 shared payload utilities). Together they are one tier to their consumers.
 
-Neither root exports anything yet, so every import below is internal and the
-border test's allowlists record exactly that. Introducing an API module is the
-next step; the allowlists are how it gets measured.
+Both roots now curate a public surface, so consumers import the tier through
+these modules and the border test's allowlists are empty.
 """
 
 from __future__ import annotations

--- a/tools/investigation/__init__.py
+++ b/tools/investigation/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from tools.investigation.capability import (
     astream_investigation,
     build_investigation_payload,

--- a/tools/registry_skill_guidance.py
+++ b/tools/registry_skill_guidance.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from config.constants.paths import REPO_ROOT
 from core.tool import RegisteredTool
-from core.tool_framework.skill_guidance import format_tool_skill_guidance, load_tool_skill_guidance
+from core.tool_framework import format_tool_skill_guidance, load_tool_skill_guidance
 
 logger = logging.getLogger(__name__)
 

--- a/tools/system/agent_memory/tool.py
+++ b/tools/system/agent_memory/tool.py
@@ -19,7 +19,7 @@ from core.domain.memory import (
 )
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from tools.system.agent_memory.results import (
     deleted_result,
     index_result,

--- a/tools/system/sre_guidance_tool/__init__.py
+++ b/tools/system/sre_guidance_tool/__init__.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.tool_framework.tags import FALLBACK_PLANNING_TAG
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import FALLBACK_PLANNING_TAG, tool
 from tools.system.sre_guidance_tool.knowledge_base import (
     get_sre_guidance as _get_sre_guidance,
 )

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -26,7 +26,7 @@ from core.domain.work_items import (
     work_items_path,
 )
 from core.tool import AgentToolContext, SideEffectLevel
-from core.tool_framework.tool_decorator import tool
+from core.tool_framework import tool
 from infrastructure.scheduling.scheduler.store import add_task as add_scheduled_task
 from infrastructure.scheduling.scheduler.store import list_tasks, update_task
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind


### PR DESCRIPTION
Fixes #5596

The tool tier is reached through API modules held by a shrink-only border test. The core.tool contract interface and core.tool_framework.utils interface were already at zero; the core.tool_framework root exported nothing, so tools/ and integrations/ still imported its internals (tool_decorator, tags, skill_guidance). This closes that last door:

- core/tool_framework/__init__.py now re-exports the authoring surface: `tool`,
  FALLBACK_PLANNING_TAG, SUMMARIZE_OBSERVATION_TAG, format_tool_skill_guidance,
  load_tool_skill_guidance (with __all__).
- 163 files in tools/ + integrations/ migrated from
  `core.tool_framework.<internal>` onto `core.tool_framework` (import-path only).
- All five consumer allowlists in tests/shared/test_tool_api_border.py are now
  frozenset(); the border-test and scanner docstrings are updated to match.

every consumer uses the tier's doors and nothing behind them.
The change is cycle-safe — core/tool never imports core/tool_framework, so the door importing tool_decorator introduces no cycle.