### PR TITLE
test(integrations): add a check that direct vendor imports only decrease

### DIFF
--- a/tests/shared/integrations_api.py
+++ b/tests/shared/integrations_api.py
@@ -1,0 +1,42 @@
+"""Check that code imports each vendor through its main module.
+
+Every ``integrations/<vendor>/`` folder should be used through its main module
+``integrations.<vendor>``, not by importing a file deep inside it. This finds
+imports that reach inside a vendor folder from outside it, so a test can list
+them and require the list to only get shorter over time.
+
+Vendor folders are found on disk, so adding a new ``integrations/<vendor>/``
+folder includes it automatically. The 29 loose ``.py`` files directly under
+``integrations/`` are not vendors and are not checked here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.shared.api_border import ApiBorder
+
+_INTEGRATIONS_DIR = Path(__file__).resolve().parents[2] / "integrations"
+
+
+def vendor_names() -> tuple[str, ...]:
+    """The vendor package names under ``integrations/`` (directories, sorted)."""
+    return tuple(
+        sorted(
+            path.name
+            for path in _INTEGRATIONS_DIR.iterdir()
+            if path.is_dir() and not path.name.startswith("__") and (path / "__init__.py").exists()
+        )
+    )
+
+
+VENDOR_PACKAGES: tuple[str, ...] = tuple(f"integrations.{name}" for name in vendor_names())
+
+#: The main module of every vendor. Importing a file below a vendor folder, or
+#: importing a name the vendor's ``__init__`` does not list in ``__all__``,
+#: counts as reaching inside the vendor from outside it.
+API_MODULES: frozenset[str] = frozenset(VENDOR_PACKAGES)
+
+INTEGRATIONS_BORDER = ApiBorder(packages=VENDOR_PACKAGES, api_modules=API_MODULES)
+
+__all__ = ["API_MODULES", "INTEGRATIONS_BORDER", "VENDOR_PACKAGES", "vendor_names"]

--- a/tests/shared/test_integrations_api_border.py
+++ b/tests/shared/test_integrations_api_border.py
@@ -1,0 +1,185 @@
+"""Each part of the codebase imports vendors through their main module.
+
+Every ``integrations/<vendor>/`` folder should be used through its main module
+``integrations.<vendor>``. Below is the list, per top-level folder, of vendor
+files still imported directly from outside the vendor (plus any name imported
+from a vendor's ``__init__`` that it does not list in ``__all__``). The list can
+only get shorter: adding a new direct import fails the test, and an entry that is
+no longer imported must be deleted from the list.
+
+``core`` and ``config`` already import nothing internal. Imports between vendors
+(one vendor reaching inside another) are handled separately and are not checked
+here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.shared.integrations_api import INTEGRATIONS_BORDER
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Vendor files each top-level folder still imports directly, instead of through
+#: the vendor's main module ``integrations.<vendor>``.
+_ALLOWED: dict[str, frozenset[str]] = {
+    "core": frozenset(),
+    "config": frozenset(),
+    "infrastructure": frozenset(
+        {
+            "integrations.github.identity",
+            "integrations.llm_cli.errors",
+        }
+    ),
+    "gateway": frozenset(
+        {
+            "integrations.buzz.client",
+            "integrations.slack.formatting",
+            "integrations.slack.web_client",
+            "integrations.telegram.formatting",
+        }
+    ),
+    "bootstrap": frozenset(
+        {
+            "integrations.buzz.background_adapter",
+            "integrations.discord.scheduled_delivery",
+            "integrations.llm_cli.auth_check",
+            "integrations.rocketchat.background_adapter",
+            "integrations.rocketchat.scheduled_delivery",
+            "integrations.slack.scheduled_delivery",
+            "integrations.smtp.background_adapter",
+            "integrations.telegram.background_adapter",
+            "integrations.telegram.scheduled_delivery",
+        }
+    ),
+    "tools": frozenset(
+        {
+            "integrations.buzz.alarms",
+            "integrations.buzz.credentials",
+            "integrations.buzz.reporting_adapter",
+            "integrations.datadog.correlation.registration",
+            "integrations.discord.reporting_adapter",
+            "integrations.github.client",
+            "integrations.github.helpers",
+            "integrations.github.pull_requests",
+            "integrations.gitlab.build_gitlab_config",
+            "integrations.gitlab.post_gitlab_mr_note",
+            "integrations.grafana.reporting_adapter",
+            "integrations.llm_cli.claude_code",
+            "integrations.llm_cli.subprocess_env",
+            "integrations.openclaw.reporting_adapter",
+            "integrations.opensre.hf_remote",
+            "integrations.opensre.llm_eval_judge",
+            "integrations.rocketchat.alarms",
+            "integrations.rocketchat.credentials",
+            "integrations.rocketchat.reporting_adapter",
+            "integrations.sentry.SentryConfig",
+            "integrations.sentry.get_sentry_issue",
+            "integrations.sentry.issue_url",
+            "integrations.sentry.sentry_config_from_env",
+            "integrations.slack.reporting_adapter",
+            "integrations.telegram.alarms",
+            "integrations.telegram.credentials",
+            "integrations.telegram.formatting",
+            "integrations.telegram.reporting_adapter",
+            "integrations.twilio.reporting_adapter",
+            "integrations.whatsapp.reporting_adapter",
+        }
+    ),
+    "surfaces": frozenset(
+        {
+            "integrations.alertmanager.client",
+            "integrations.alertmanager.setup",
+            "integrations.aws.role_mode_gate",
+            "integrations.aws.setup",
+            "integrations.betterstack.setup",
+            "integrations.buzz.alarms",
+            "integrations.buzz.client",
+            "integrations.buzz.credentials",
+            "integrations.buzz.setup",
+            "integrations.coralogix.setup",
+            "integrations.dagster.setup",
+            "integrations.datadog.setup",
+            "integrations.discord.setup",
+            "integrations.elasticsearch.client",
+            "integrations.github.identity",
+            "integrations.github.login",
+            "integrations.github.mcp",
+            "integrations.github.mcp_oauth",
+            "integrations.github.setup",
+            "integrations.gitlab.setup",
+            "integrations.google_docs.client",
+            "integrations.grafana.client",
+            "integrations.grafana.setup",
+            "integrations.hermes.agent",
+            "integrations.hermes.correlating_sink",
+            "integrations.hermes.correlator",
+            "integrations.hermes.investigation",
+            "integrations.hermes.sinks",
+            "integrations.honeycomb.setup",
+            "integrations.incident_io.setup",
+            "integrations.jenkins.setup",
+            "integrations.llm_cli.antigravity_cli",
+            "integrations.llm_cli.base",
+            "integrations.llm_cli.binary_resolver",
+            "integrations.llm_cli.claude_code",
+            "integrations.llm_cli.codex",
+            "integrations.llm_cli.codex_oauth",
+            "integrations.llm_cli.copilot",
+            "integrations.llm_cli.cursor",
+            "integrations.llm_cli.errors",
+            "integrations.llm_cli.gemini_cli",
+            "integrations.llm_cli.grok_cli",
+            "integrations.llm_cli.kimi",
+            "integrations.llm_cli.opencode",
+            "integrations.llm_cli.pi_cli",
+            "integrations.new_relic.setup",
+            "integrations.openclaw.build_openclaw_config",
+            "integrations.openclaw.setup",
+            "integrations.openclaw.validate_openclaw_config",
+            "integrations.opensearch.setup",
+            "integrations.opsgenie.client",
+            "integrations.pagerduty.setup",
+            "integrations.posthog.report_prerequisites",
+            "integrations.posthog.setup",
+            "integrations.posthog_mcp.build_posthog_mcp_config",
+            "integrations.posthog_mcp.setup",
+            "integrations.posthog_mcp.validate_posthog_mcp_config",
+            "integrations.rocketchat.alarms",
+            "integrations.rocketchat.credentials",
+            "integrations.rocketchat.setup",
+            "integrations.sentry.digest_prerequisites",
+            "integrations.sentry.get_sentry_auth_recommendations",
+            "integrations.sentry.setup",
+            "integrations.sentry.uptime",
+            "integrations.sentry_mcp.build_sentry_mcp_config",
+            "integrations.sentry_mcp.setup",
+            "integrations.sentry_mcp.validate_sentry_mcp_config",
+            "integrations.servicenow.setup",
+            "integrations.servicenow.verifier",
+            "integrations.slack.setup",
+            "integrations.splunk.client",
+            "integrations.telegram.alarms",
+            "integrations.telegram.credentials",
+            "integrations.telegram.setup",
+            "integrations.tempo.setup",
+            "integrations.tracer.integrations_adapter",
+            "integrations.vercel.setup",
+        }
+    ),
+}
+
+
+@pytest.mark.parametrize("consumer", sorted(_ALLOWED))
+def test_consumer_vendor_imports_match_the_allowlist(consumer: str) -> None:
+    # Arrange / Act
+    imported = INTEGRATIONS_BORDER.internal_imports_under(
+        REPO_ROOT / consumer, exclude_parts=frozenset({"tests"})
+    )
+
+    # Assert
+    INTEGRATIONS_BORDER.assert_matches_allowlist(
+        imported, _ALLOWED[consumer], consumer=f"{consumer}/"
+    )


### PR DESCRIPTION
Fixes #5599

Every vendor lives in integrations/<vendor>/ and should be used through its one main module integrations.<vendor>. Today lots of code imports files buried inside a vendor's folder instead. This PR adds a test that records those direct imports
and makes the count only allowed to go down — it does not move any code.

- tests/shared/integrations_api.py — finds the vendor folders on disk and sets up  the check (each vendor's main module is the one allowed way in).
- tests/shared/test_integrations_api_border.py — for each top-level folder, the  list of vendor inner files still imported directly: core 0, config 0,  infrastructure 2, gateway 4, bootstrap 9, tools 30, surfaces 77. The test fails  if the list grows or if an entry is left in after it stops being imported.

No product code changes. Imports from one vendor into another (115 of them) are a separate follow-up, because the check needs to skip a vendor importing its own files. Later PRs give each vendor a proper main module and move imports onto it,
shrinking these numbers toward zero.