### PR TITLE
fix(batch): record failed jobs as evidence

### DIFF
--- a/integrations/tracer/tools/tracer_failed_jobs_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_failed_jobs_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from integrations.tracer import (
@@ -19,6 +20,20 @@ def _tracer_available(sources: dict[str, dict]) -> bool:
 
 def _tracer_trace_id(sources: dict[str, dict]) -> str:
     return str(sources.get("tracer_web", {}).get("trace_id", ""))
+
+
+def _map_failed_jobs(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    failed_jobs = output.get("failed_jobs", [])
+    if failed_jobs:
+        count = len(failed_jobs)
+        record_evidence_entry(
+            evidence,
+            source="get_failed_jobs",
+            label="Failed AWS Batch Jobs",
+            summary=f"{count} failed {'job' if count == 1 else 'jobs'}",
+        )
 
 
 @tool(
@@ -41,6 +56,7 @@ def _tracer_trace_id(sources: dict[str, dict]) -> str:
     },
     is_available=_tracer_available,
     extract_params=lambda sources: {"trace_id": _tracer_trace_id(sources)},
+    evidence_mapper=_map_failed_jobs,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
 )
 def get_failed_jobs(trace_id: str) -> dict[str, Any]:

--- a/tests/integrations/batch/test_evidence_mapper.py
+++ b/tests/integrations/batch/test_evidence_mapper.py
@@ -1,0 +1,19 @@
+"""Tests for AWS Batch evidence mapping."""
+
+from integrations.tracer.tools.tracer_failed_jobs_tool import _map_failed_jobs
+
+
+def test_failed_jobs_are_recorded_as_evidence() -> None:
+    evidence = {}
+
+    _map_failed_jobs(evidence, {"failed_jobs": [{"job_name": "job-1"}]}, {})
+
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "get_failed_jobs",
+            "label": "Failed AWS Batch Jobs",
+            "summary": "1 failed job",
+            "url": None,
+            "snippet": None,
+        }
+    ]

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -48,7 +48,6 @@ get_eks_nodegroup_health
 get_eks_pod_logs
 get_elb_target_health
 get_error_logs
-get_failed_jobs
 get_failed_tools
 get_git_deploy_timeline
 get_github_actions_step_log


### PR DESCRIPTION
Fixes #5579
Part of #5519

#### Describe the changes you have made in this PR -

Attached an evidence mapper to `get_failed_jobs` so failed AWS Batch job results become citeable report entries, removed the tool from the known-gap baseline, and added focused mapper coverage.

### Demo/Screenshot for feature changes and bug fixes -

Using the same mapper input:

```python
{"failed_jobs": [{"job_name": "job-1"}]}
```

Before — the tool result produced no evidence catalog entry:

```python
{}
```

After — the failed job is recorded as citeable evidence:

```python
{
    "catalog_entries": [
        {
            "source": "get_failed_jobs",
            "label": "Failed AWS Batch Jobs",
            "summary": "1 failed job",
            "url": None,
            "snippet": None,
        }
    ]
}
```

Verification:

- 20 focused tests passed.
- `make lint`, `make format-check`, and `make typecheck` passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The mapper reads the existing `failed_jobs` list returned by the tool and records a catalog entry only when failures are present. This keeps empty/error responses from creating unsupported evidence while preserving the tool's raw output through the existing gather-evidence path. I used the established Grafana mapper pattern instead of changing the shared catalog builder, keeping integration-specific behavior beside the tool that owns it.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (N/A — this is an integration mapper; focused coverage is included)
- [x] My code follows the project's style guidelines and conventions

---

Note: Allow edits from maintainers is enabled on the fork PR.
