### PR TITLE
feat(tempo): make query output citeable evidence

### DIFF
--- a/integrations/tempo/tools/__init__.py
+++ b/integrations/tempo/tools/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.tempo import TempoConfig, tempo_extract_params
@@ -30,6 +31,21 @@ def _tempo_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
 
 
 _VALID_ACTIONS = ("search", "get_trace", "list_services", "list_span_names")
+
+
+def _map_query_tempo(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    for result_key in ("traces", "spans", "services", "span_names"):
+        items = output.get(result_key, [])
+        if items:
+            record_evidence_entry(
+                evidence,
+                source="query_tempo",
+                label="Tempo Query",
+                summary=f"{len(items)} {result_key.replace('_', ' ')}",
+            )
+            return
 
 
 def _dispatch(
@@ -72,6 +88,7 @@ def _dispatch(
     name="query_tempo",
     display_name="Grafana Tempo",
     source="tempo",
+    evidence_mapper=_map_query_tempo,
     tags=("traces", "observability"),
     description=(
         "Query a standalone Grafana Tempo backend for distributed traces. "

--- a/tests/integrations/tempo/test_evidence_mapper.py
+++ b/tests/integrations/tempo/test_evidence_mapper.py
@@ -1,0 +1,31 @@
+import pytest
+
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+
+@pytest.mark.parametrize(
+    ("action", "result_key"),
+    [
+        ("search", "traces"),
+        ("get_trace", "spans"),
+        ("list_services", "services"),
+        ("list_span_names", "span_names"),
+    ],
+)
+def test_query_tempo_records_results_as_evidence(action: str, result_key: str) -> None:
+    evidence: dict = {}
+
+    merge_tool_evidence(
+        evidence,
+        "query_tempo",
+        {"action": action, result_key: ["first", "second"]},
+        {},
+    )
+
+    entry = evidence["catalog_entries"][0]
+    assert entry["source"] == "query_tempo"
+    assert entry["summary"] == f"2 {result_key.replace('_', ' ')}"
+
+    empty: dict = {}
+    merge_tool_evidence(empty, "query_tempo", {"action": action, result_key: []}, {})
+    assert "catalog_entries" not in empty

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -225,7 +225,6 @@ query_signoz_metrics
 query_signoz_traces
 query_snowflake_history
 query_splunk_logs
-query_tempo
 query_yc_metrics
 read_yc_logs
 redeploy_railway_service


### PR DESCRIPTION
Fixes #5593

Part of #5519

#### Describe the changes you have made in this PR -

- Attach an evidence mapper to `query_tempo`.
- Record non-empty trace, span, service, and span-name results as citeable Tempo evidence.
- Remove `query_tempo` from the known mapper gaps and add focused coverage for every action and empty results.

### Demo/Screenshot for feature changes and bug fixes -

```text
$ uv run python -c "... bool(g('query_tempo').evidence_mapper) ..."
{'query_tempo': True}

$ uv run python -c "... merge_tool_evidence(... {'traces': [1, 2]} ...) ..."
[{'source': 'query_tempo', 'label': 'Tempo Query', 'summary': '2 traces', ...}]

$ uv run pytest tests/ -k tempo -q
155 passed, 14937 deselected, 4 warnings in 26.99s

$ uv run pytest tests/integrations/tempo/test_evidence_mapper.py tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
13 passed in 1.26s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`query_tempo` is one action-based read tool whose four actions return useful lists under different keys: `traces`, `spans`, `services`, or `span_names`. `_map_query_tempo` checks those known result fields, records the first non-empty one with `record_evidence_entry`, and returns without creating a misleading entry for empty results. I considered mapping only trace-search output, but that would continue dropping diagnostic output from the other three read actions. Keeping this logic beside the Tempo tool follows the existing vendor-owned mapper design and avoids changing the shared evidence stage.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

Additional validation:

```text
$ make lint && make format-check && make typecheck
All checks passed!
3671 files already formatted
Success: no issues found in 1907 source files
```
