### PR TITLE
refactor(work_items): move helpers out of tool.py into dedicated modules (#5508)

### DIFF
--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from core.domain.work_items import WorkItemChannelTarget, WorkItemPriority, make_work_item
-from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask
+from infrastructure.scheduling.scheduler.types import Provider
 from tools.system.work_items.delivery import (
     delivery_targets,
     gateway_delivery_context,
@@ -130,29 +131,15 @@ def test_invalid_delivery_targets() -> None:
     assert "unsupported provider" in invalid_pigeon[0]
 
 
-def test_reminder_scheduling(monkeypatch: pytest.MonkeyPatch) -> None:
-    tasks: list[ScheduledTask] = []
-
-    def _list_tasks() -> list[ScheduledTask]:
-        return tasks
-
-    def _add_task(task: ScheduledTask) -> ScheduledTask:
-        task.id = f"task-{len(tasks) + 1}"
-        tasks.append(task)
-        return task
-
-    def _update_task(task: ScheduledTask) -> bool:
-        for i, existing in enumerate(tasks):
-            if existing.id == task.id:
-                tasks[i] = task
-                return True
-        return False
-
-    from tools.system.work_items import reminders
-
-    monkeypatch.setattr(reminders, "list_tasks", _list_tasks)
-    monkeypatch.setattr(reminders, "add_scheduled_task", _add_task)
-    monkeypatch.setattr(reminders, "update_task", _update_task)
+def test_reminder_scheduling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.store._default_store_path",
+        lambda: tmp_path / "scheduler_tasks.json",
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.reload_signal.request_scheduler_reload",
+        lambda: None,
+    )
 
     item = make_work_item(
         title="Check clusters",
@@ -161,12 +148,19 @@ def test_reminder_scheduling(monkeypatch: pytest.MonkeyPatch) -> None:
     targets = [WorkItemChannelTarget(provider="slack", chat_id="C999")]
     scheduled = schedule_item_reminder(item, targets=targets, timezone="UTC")
     assert scheduled is not None
+
+    from infrastructure.scheduling.scheduler.store import list_tasks
+
+    tasks = list_tasks()
     assert len(tasks) == 1
     assert tasks[0].enabled is True
 
-    # Rescheduling for the same item disables the prior reminder
-    scheduled2 = schedule_item_reminder(item, targets=targets, timezone="UTC")
+    # Rescheduling with a new reminder time disables the prior reminder
+    updated_item = dataclasses.replace(item, remind_at="2026-08-24T14:00:00Z")
+    scheduled2 = schedule_item_reminder(updated_item, targets=targets, timezone="UTC")
     assert scheduled2 is not None
+
+    tasks = list_tasks()
     assert len(tasks) == 2
     assert tasks[0].enabled is False
     assert tasks[1].enabled is True
@@ -174,12 +168,22 @@ def test_reminder_scheduling(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_work_task_tools_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     work_items_file = tmp_path / "work_items.json"
+    scheduler_file = tmp_path / "scheduler_tasks.json"
+
     monkeypatch.setattr("tools.system.work_items.tool.work_items_path", lambda: work_items_file)
     monkeypatch.setattr("tools.system.work_items.results.work_items_path", lambda: work_items_file)
     monkeypatch.setattr(
         "tools.system.work_items.reminders.work_items_path", lambda: work_items_file
     )
     monkeypatch.setattr("core.domain.work_items.store.work_items_path", lambda: work_items_file)
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.store._default_store_path",
+        lambda: scheduler_file,
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.reload_signal.request_scheduler_reload",
+        lambda: None,
+    )
 
     # 1. work_task_add
     add_resp = work_task_add(

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -1,0 +1,241 @@
+"""Unit tests for work-item tools, delivery target resolution, and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.domain.work_items import WorkItemChannelTarget, WorkItemPriority, make_work_item
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask
+from tools.system.work_items.delivery import (
+    delivery_targets,
+    gateway_delivery_context,
+    invalid_delivery_targets,
+)
+from tools.system.work_items.reminders import (
+    schedule_item_reminder,
+)
+from tools.system.work_items.tool import (
+    work_task_add,
+    work_task_complete,
+    work_task_list,
+    work_task_prioritize,
+    work_task_schedule_checkin,
+    work_task_update,
+)
+from tools.system.work_items.validation import (
+    normalize_limit,
+    normalize_priority,
+    normalize_selectors,
+    normalize_status_filter,
+    validate_datetime_arg,
+    validate_provider,
+)
+
+
+def _build_stub_session(resolved: dict[str, str]) -> Any:
+    return type("StubSession", (), {"resolved_integrations_cache": resolved})()
+
+
+def _build_stub_action_ctx(session: Any) -> Any:
+    return type("StubActionContext", (), {"session": session})()
+
+
+def test_validate_provider() -> None:
+    assert validate_provider("slack") == Provider.SLACK
+    assert validate_provider("TELEGRAM ") == Provider.TELEGRAM
+    assert validate_provider("discord") == Provider.DISCORD
+    assert validate_provider("rocketchat") == Provider.ROCKETCHAT
+    assert validate_provider("unknown_platform") is None
+    assert validate_provider("") is None
+
+
+def test_validate_datetime_arg() -> None:
+    assert validate_datetime_arg("", field="due_at") is None
+    assert validate_datetime_arg("2026-08-23T20:00:00Z", field="due_at") is None
+    invalid = validate_datetime_arg("not-a-datetime", field="remind_at")
+    assert invalid is not None
+    assert invalid["error"] == "invalid_remind_at"
+
+
+def test_normalize_validation_helpers() -> None:
+    assert normalize_limit("invalid") == 20
+    assert normalize_limit(50) == 50
+    assert normalize_limit(500) == 100
+    assert normalize_limit(-5) == 0
+
+    assert normalize_priority("urgent") == WorkItemPriority.URGENT
+    assert normalize_priority("invalid") is None
+
+    assert normalize_status_filter("active") == "active"
+    assert normalize_status_filter("all") is None
+    assert normalize_status_filter("invalid") == "invalid"
+
+    assert normalize_selectors("item1, item2 item3") == ["item1", "item2", "item3"]
+    assert normalize_selectors(["a", "b"]) == ["a", "b"]
+
+
+def test_delivery_targets_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _build_stub_session({"_gateway_platform": "telegram", "_gateway_chat_id": "12345"})
+    action_ctx = _build_stub_action_ctx(session)
+
+    from core import agent_harness
+
+    def _action_context_from_agent_context(_ctx: Any) -> Any:
+        return action_ctx
+
+    monkeypatch.setattr(
+        agent_harness.tools,
+        "action_context_from_agent_context",
+        _action_context_from_agent_context,
+    )
+
+    stub_context = type("StubContext", (), {})()
+    provider, chat_id = gateway_delivery_context(stub_context)  # type: ignore[arg-type]
+    assert provider == "telegram"
+    assert chat_id == "12345"
+
+    targets = delivery_targets(
+        provider="",
+        chat_id="",
+        context=stub_context,  # type: ignore[arg-type]
+    )
+    assert len(targets) == 1
+    assert targets[0].provider == "telegram"
+    assert targets[0].chat_id == "12345"
+
+    explicit = delivery_targets(
+        provider="slack",
+        chat_id="C123",
+        channel_targets=[{"provider": "slack", "chat_id": "C123"}],
+    )
+    assert len(explicit) == 1
+    assert explicit[0].provider == "slack"
+
+
+def test_invalid_delivery_targets() -> None:
+    valid_slack = [WorkItemChannelTarget(provider="slack", chat_id="")]
+    assert invalid_delivery_targets(valid_slack) == []
+
+    missing_chat_id = [WorkItemChannelTarget(provider="telegram", chat_id="")]
+    invalid = invalid_delivery_targets(missing_chat_id)
+    assert len(invalid) == 1
+    assert "missing chat_id" in invalid[0]
+
+    unsupported = [WorkItemChannelTarget(provider="carrier_pigeon", chat_id="123")]
+    invalid_pigeon = invalid_delivery_targets(unsupported)
+    assert len(invalid_pigeon) == 1
+    assert "unsupported provider" in invalid_pigeon[0]
+
+
+def test_reminder_scheduling(monkeypatch: pytest.MonkeyPatch) -> None:
+    tasks: list[ScheduledTask] = []
+
+    def _list_tasks() -> list[ScheduledTask]:
+        return tasks
+
+    def _add_task(task: ScheduledTask) -> ScheduledTask:
+        task.id = f"task-{len(tasks) + 1}"
+        tasks.append(task)
+        return task
+
+    def _update_task(task: ScheduledTask) -> bool:
+        for i, existing in enumerate(tasks):
+            if existing.id == task.id:
+                tasks[i] = task
+                return True
+        return False
+
+    from tools.system.work_items import reminders
+
+    monkeypatch.setattr(reminders, "list_tasks", _list_tasks)
+    monkeypatch.setattr(reminders, "add_scheduled_task", _add_task)
+    monkeypatch.setattr(reminders, "update_task", _update_task)
+
+    item = make_work_item(
+        title="Check clusters",
+        remind_at="2026-08-24T10:00:00Z",
+    )
+    targets = [WorkItemChannelTarget(provider="slack", chat_id="C999")]
+    scheduled = schedule_item_reminder(item, targets=targets, timezone="UTC")
+    assert scheduled is not None
+    assert len(tasks) == 1
+    assert tasks[0].enabled is True
+
+    # Rescheduling for the same item disables the prior reminder
+    scheduled2 = schedule_item_reminder(item, targets=targets, timezone="UTC")
+    assert scheduled2 is not None
+    assert len(tasks) == 2
+    assert tasks[0].enabled is False
+    assert tasks[1].enabled is True
+
+
+def test_work_task_tools_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    work_items_file = tmp_path / "work_items.json"
+    monkeypatch.setattr("tools.system.work_items.tool.work_items_path", lambda: work_items_file)
+    monkeypatch.setattr("tools.system.work_items.results.work_items_path", lambda: work_items_file)
+    monkeypatch.setattr(
+        "tools.system.work_items.reminders.work_items_path", lambda: work_items_file
+    )
+    monkeypatch.setattr("core.domain.work_items.store.work_items_path", lambda: work_items_file)
+
+    # 1. work_task_add
+    add_resp = work_task_add(
+        title="Deploy release v2",
+        priority="high",
+        project="infra",
+        owner="alice",
+        notes="check canary first",
+        channel_provider="slack",
+        channel_id="C12345",
+    )
+    assert "error" not in add_resp
+    assert add_resp["task"]["title"] == "Deploy release v2"
+    task_id = add_resp["task"]["id"]
+
+    # 2. work_task_list
+    list_resp = work_task_list(status="open", project="infra")
+    assert "error" not in list_resp
+    assert list_resp["total"] == 1
+    assert list_resp["tasks"][0]["id"] == task_id
+
+    # 3. work_task_update
+    update_resp = work_task_update(
+        selector=task_id,
+        priority="urgent",
+        notes="canary passed, ready to roll",
+    )
+    assert "error" not in update_resp
+    assert update_resp["task"]["priority"] == "urgent"
+    assert update_resp["task"]["notes"] == "canary passed, ready to roll"
+
+    # 4. work_task_prioritize
+    prio_resp = work_task_prioritize(project="infra")
+    assert "error" not in prio_resp
+    assert len(prio_resp["recommendations"]) == 1
+    assert prio_resp["recommendations"][0]["task"]["id"] == task_id
+
+    # Candidate prioritization
+    candidate_resp = work_task_prioritize(candidates=["Fix DB bug", "Write docs"])
+    assert len(candidate_resp["recommendations"]) == 2
+
+    # 5. work_task_schedule_checkin
+    checkin_resp = work_task_schedule_checkin(
+        cron="0 9 * * 1-5",
+        provider="slack",
+        chat_id="C12345",
+        project="infra",
+    )
+    assert "error" not in checkin_resp
+    assert checkin_resp["scheduled_task_id"]
+
+    # 6. work_task_complete
+    complete_resp = work_task_complete(selectors=[task_id])
+    assert "error" not in complete_resp
+    assert len(complete_resp["completed"]) == 1
+
+    # Verify list is now empty of open items
+    list_after = work_task_list(status="open", project="infra")
+    assert list_after["total"] == 0

--- a/tools/system/work_items/delivery.py
+++ b/tools/system/work_items/delivery.py
@@ -1,0 +1,88 @@
+"""Delivery target resolution and validation helpers for work items."""
+
+from __future__ import annotations
+
+from core.domain.work_items import WorkItem, WorkItemChannelTarget, dedupe_channel_targets
+from core.tool import AgentToolContext
+from infrastructure.scheduling.scheduler.types import Provider
+from tools.system.work_items.validation import validate_provider
+
+
+def gateway_delivery_context(context: AgentToolContext | None) -> tuple[str, str]:
+    """Extract default gateway delivery platform and chat identifier from tool context."""
+    if context is None:
+        return "", ""
+    try:
+        from core.agent_harness.tools import action_context_from_agent_context
+
+        action_ctx = action_context_from_agent_context(context)
+    except RuntimeError:
+        return "", ""
+    resolved = getattr(action_ctx.session, "resolved_integrations_cache", None) or {}
+    provider = str(resolved.get("_gateway_platform") or "").strip().lower()
+    chat_id = str(resolved.get("_gateway_chat_id") or "").strip()
+    return provider, chat_id
+
+
+def delivery_targets(
+    *,
+    provider: str,
+    chat_id: str,
+    item: WorkItem | None = None,
+    channel_targets: list[dict[str, str]] | None = None,
+    context: AgentToolContext | None = None,
+) -> list[WorkItemChannelTarget]:
+    """Resolve and deduplicate target channels for work item delivery or reminders."""
+    default_provider, default_chat_id = gateway_delivery_context(context)
+    targets: list[WorkItemChannelTarget] = []
+    for raw_target in channel_targets or []:
+        if isinstance(raw_target, dict):
+            targets.append(WorkItemChannelTarget.from_mapping(raw_target))
+    if provider.strip():
+        targets.append(
+            WorkItemChannelTarget(provider=provider.strip().lower(), chat_id=chat_id.strip())
+        )
+    if item is not None:
+        targets.extend(item.channel_targets)
+        if item.channel.provider:
+            targets.append(item.channel)
+    if not targets and default_provider:
+        targets.append(WorkItemChannelTarget(provider=default_provider, chat_id=default_chat_id))
+    return dedupe_targets(targets)
+
+
+def dedupe_targets(targets: list[WorkItemChannelTarget]) -> list[WorkItemChannelTarget]:
+    """Deduplicate channel target items while preserving order."""
+    return list(dedupe_channel_targets(targets))
+
+
+def invalid_delivery_targets(targets: list[WorkItemChannelTarget]) -> list[str]:
+    """Return errors for any delivery target with unsupported providers or missing chat IDs."""
+    invalid: list[str] = []
+    for target in targets:
+        parsed_provider = validate_provider(target.provider)
+        if parsed_provider is None:
+            invalid.append(f"{target.provider}: unsupported provider")
+            continue
+        if parsed_provider is Provider.SLACK:
+            continue
+        if not target.chat_id:
+            invalid.append(f"{target.provider}: missing chat_id")
+    return invalid
+
+
+_gateway_delivery_context = gateway_delivery_context
+_delivery_targets = delivery_targets
+_dedupe_targets = dedupe_targets
+_invalid_delivery_targets = invalid_delivery_targets
+
+__all__ = [
+    "_dedupe_targets",
+    "_delivery_targets",
+    "_gateway_delivery_context",
+    "_invalid_delivery_targets",
+    "dedupe_targets",
+    "delivery_targets",
+    "gateway_delivery_context",
+    "invalid_delivery_targets",
+]

--- a/tools/system/work_items/reminders.py
+++ b/tools/system/work_items/reminders.py
@@ -1,0 +1,82 @@
+"""Scheduled reminder helpers for work items."""
+
+from __future__ import annotations
+
+import json
+
+from core.domain.work_items import (
+    WorkItem,
+    WorkItemChannelTarget,
+    cron_from_datetime,
+    parse_work_item_datetime,
+    work_items_path,
+)
+from infrastructure.scheduling.scheduler.store import add_task as add_scheduled_task
+from infrastructure.scheduling.scheduler.store import list_tasks, update_task
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+from tools.system.work_items.validation import validate_provider
+
+
+def disable_existing_item_reminders(item_id: str) -> int:
+    """Disable enabled one-shot reminders for ``item_id`` so updates replace them."""
+    disabled = 0
+    for task in list_tasks():
+        if task.kind is not TaskKind.WORK_ITEM_REMINDER:
+            continue
+        if not task.enabled:
+            continue
+        if task.params.get("work_item_id", "").strip() != item_id:
+            continue
+        task.enabled = False
+        if update_task(task):
+            disabled += 1
+    return disabled
+
+
+def schedule_item_reminder(
+    item: WorkItem,
+    *,
+    targets: list[WorkItemChannelTarget],
+    timezone: str,
+) -> ScheduledTask | None:
+    """Schedule or replace a one-shot work item reminder task."""
+    if not item.remind_at:
+        return None
+    remind_at = parse_work_item_datetime(item.remind_at)
+    if remind_at is None:
+        return None
+    valid_targets = [target for target in targets if validate_provider(target.provider) is not None]
+    if not valid_targets:
+        return None
+    # Replace any prior reminder for this work item before scheduling a new one.
+    disable_existing_item_reminders(item.id)
+    primary = valid_targets[0]
+    parsed_provider = Provider(primary.provider)
+    schedule_timezone = "UTC" if remind_at.tzinfo is not None else timezone
+    task = ScheduledTask(
+        kind=TaskKind.WORK_ITEM_REMINDER,
+        cron=cron_from_datetime(remind_at),
+        timezone=schedule_timezone,
+        provider=parsed_provider,
+        chat_id=primary.chat_id,
+        params={
+            "work_item_id": item.id,
+            "store_path": str(work_items_path()),
+            "disable_after_success": "true",
+            "delivery_targets": json.dumps(
+                [target.to_dict() for target in valid_targets], separators=(",", ":")
+            ),
+        },
+    )
+    return add_scheduled_task(task)
+
+
+_disable_existing_item_reminders = disable_existing_item_reminders
+_schedule_item_reminder = schedule_item_reminder
+
+__all__ = [
+    "_disable_existing_item_reminders",
+    "_schedule_item_reminder",
+    "disable_existing_item_reminders",
+    "schedule_item_reminder",
+]

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -9,17 +9,13 @@ from core.domain.types.tools import ToolSurface
 from core.domain.work_items import (
     WORK_ITEM_PRIORITIES,
     WORK_ITEM_STATUSES,
-    WorkItem,
     WorkItemChannelTarget,
     WorkItemPriority,
     WorkItemUpdates,
     add_work_item,
     complete_work_items,
-    cron_from_datetime,
-    dedupe_channel_targets,
     list_work_items,
     make_work_item,
-    parse_work_item_datetime,
     prioritize_work_items,
     resolve_work_item_selector,
     update_work_item,
@@ -28,8 +24,9 @@ from core.domain.work_items import (
 from core.tool import AgentToolContext, SideEffectLevel
 from core.tool_framework import tool
 from infrastructure.scheduling.scheduler.store import add_task as add_scheduled_task
-from infrastructure.scheduling.scheduler.store import list_tasks, update_task
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+from tools.system.work_items.delivery import delivery_targets, invalid_delivery_targets
+from tools.system.work_items.reminders import schedule_item_reminder
 from tools.system.work_items.results import (
     added_result,
     complete_result,
@@ -48,141 +45,12 @@ from tools.system.work_items.validation import (
     normalize_status_filter,
     valid_priority_detail,
     valid_status_detail,
+    validate_datetime_arg,
 )
 
 
 def _work_items_available(_sources: dict[str, dict[str, Any]]) -> bool:
     return True
-
-
-def _gateway_delivery_context(context: AgentToolContext | None) -> tuple[str, str]:
-    if context is None:
-        return "", ""
-    try:
-        from core.agent_harness.tools import action_context_from_agent_context
-
-        action_ctx = action_context_from_agent_context(context)
-    except RuntimeError:
-        return "", ""
-    resolved = getattr(action_ctx.session, "resolved_integrations_cache", None) or {}
-    provider = str(resolved.get("_gateway_platform") or "").strip().lower()
-    chat_id = str(resolved.get("_gateway_chat_id") or "").strip()
-    return provider, chat_id
-
-
-def _delivery_targets(
-    *,
-    provider: str,
-    chat_id: str,
-    item: WorkItem | None = None,
-    channel_targets: list[dict[str, str]] | None = None,
-    context: AgentToolContext | None = None,
-) -> list[WorkItemChannelTarget]:
-    default_provider, default_chat_id = _gateway_delivery_context(context)
-    targets: list[WorkItemChannelTarget] = []
-    for raw_target in channel_targets or []:
-        if isinstance(raw_target, dict):
-            targets.append(WorkItemChannelTarget.from_mapping(raw_target))
-    if provider.strip():
-        targets.append(
-            WorkItemChannelTarget(provider=provider.strip().lower(), chat_id=chat_id.strip())
-        )
-    if item is not None:
-        targets.extend(item.channel_targets)
-        if item.channel.provider:
-            targets.append(item.channel)
-    if not targets and default_provider:
-        targets.append(WorkItemChannelTarget(provider=default_provider, chat_id=default_chat_id))
-    return _dedupe_targets(targets)
-
-
-def _dedupe_targets(targets: list[WorkItemChannelTarget]) -> list[WorkItemChannelTarget]:
-    return list(dedupe_channel_targets(targets))
-
-
-def _validate_provider(provider: str) -> Provider | None:
-    try:
-        return Provider(provider.strip().lower())
-    except ValueError:
-        return None
-
-
-def _validate_datetime_arg(value: str, *, field: str) -> dict[str, str] | None:
-    if value and parse_work_item_datetime(value) is None:
-        return {
-            "error": f"invalid_{field}",
-            "detail": f"{field} must be ISO-like, e.g. 2026-07-29T09:30 or 2026-07-29T09:30Z",
-        }
-    return None
-
-
-def _invalid_delivery_targets(targets: list[WorkItemChannelTarget]) -> list[str]:
-    invalid: list[str] = []
-    for target in targets:
-        parsed_provider = _validate_provider(target.provider)
-        if parsed_provider is None:
-            invalid.append(f"{target.provider}: unsupported provider")
-            continue
-        if parsed_provider is Provider.SLACK:
-            continue
-        if not target.chat_id:
-            invalid.append(f"{target.provider}: missing chat_id")
-    return invalid
-
-
-def _disable_existing_item_reminders(item_id: str) -> int:
-    """Disable enabled one-shot reminders for ``item_id`` so updates replace them."""
-    disabled = 0
-    for task in list_tasks():
-        if task.kind is not TaskKind.WORK_ITEM_REMINDER:
-            continue
-        if not task.enabled:
-            continue
-        if task.params.get("work_item_id", "").strip() != item_id:
-            continue
-        task.enabled = False
-        if update_task(task):
-            disabled += 1
-    return disabled
-
-
-def _schedule_item_reminder(
-    item: WorkItem,
-    *,
-    targets: list[WorkItemChannelTarget],
-    timezone: str,
-) -> ScheduledTask | None:
-    if not item.remind_at:
-        return None
-    remind_at = parse_work_item_datetime(item.remind_at)
-    if remind_at is None:
-        return None
-    valid_targets = [
-        target for target in targets if _validate_provider(target.provider) is not None
-    ]
-    if not valid_targets:
-        return None
-    # Replace any prior reminder for this work item before scheduling a new one.
-    _disable_existing_item_reminders(item.id)
-    primary = valid_targets[0]
-    parsed_provider = Provider(primary.provider)
-    schedule_timezone = "UTC" if remind_at.tzinfo is not None else timezone
-    task = ScheduledTask(
-        kind=TaskKind.WORK_ITEM_REMINDER,
-        cron=cron_from_datetime(remind_at),
-        timezone=schedule_timezone,
-        provider=parsed_provider,
-        chat_id=primary.chat_id,
-        params={
-            "work_item_id": item.id,
-            "store_path": str(work_items_path()),
-            "disable_after_success": "true",
-            "delivery_targets": json.dumps(
-                [target.to_dict() for target in valid_targets], separators=(",", ":")
-            ),
-        },
-    )
-    return add_scheduled_task(task)
 
 
 @tool(
@@ -277,16 +145,16 @@ def work_task_add(
     if parsed_priority is None:
         return {"error": "invalid_priority", "detail": valid_priority_detail()}
     for field_name, value in (("due_at", due_at), ("remind_at", remind_at)):
-        error = _validate_datetime_arg(value, field=field_name)
+        error = validate_datetime_arg(value, field=field_name)
         if error is not None:
             return error
-    targets = _delivery_targets(
+    targets = delivery_targets(
         provider=channel_provider,
         chat_id=channel_id,
         channel_targets=channel_targets,
         context=context,
     )
-    invalid_targets = _invalid_delivery_targets(targets)
+    invalid_targets = invalid_delivery_targets(targets)
     if invalid_targets:
         return {
             "error": "invalid_delivery_target",
@@ -313,7 +181,7 @@ def work_task_add(
         channel_targets=targets,
         source="agent",
     )
-    scheduled = _schedule_item_reminder(
+    scheduled = schedule_item_reminder(
         item,
         targets=targets,
         timezone=timezone or "UTC",
@@ -488,15 +356,15 @@ def work_task_update(
     if notes:
         changes["notes"] = notes
     for field_name, value in (("due_at", due_at), ("remind_at", remind_at)):
-        error = _validate_datetime_arg(value, field=field_name)
+        error = validate_datetime_arg(value, field=field_name)
         if error is not None:
             return error
-    explicit_targets = _delivery_targets(
+    explicit_targets = delivery_targets(
         provider=channel_provider,
         chat_id=channel_id,
         channel_targets=channel_targets,
     )
-    invalid_targets = _invalid_delivery_targets(explicit_targets)
+    invalid_targets = invalid_delivery_targets(explicit_targets)
     if invalid_targets:
         return {"error": "invalid_delivery_target", "detail": "; ".join(invalid_targets)}
     if explicit_targets:
@@ -512,14 +380,14 @@ def work_task_update(
             if existing.candidates:
                 payload["candidates"] = [item_summary(item) for item in existing.candidates]
             return payload
-        reminder_targets = _delivery_targets(
+        reminder_targets = delivery_targets(
             provider=channel_provider,
             chat_id=channel_id,
             item=existing.item,
             channel_targets=channel_targets,
             context=context,
         )
-        invalid_reminder_targets = _invalid_delivery_targets(reminder_targets)
+        invalid_reminder_targets = invalid_delivery_targets(reminder_targets)
         if invalid_reminder_targets:
             return {
                 "error": "invalid_delivery_target",
@@ -540,7 +408,7 @@ def work_task_update(
         return update_error_payload
     scheduled = None
     if remind_at:
-        scheduled = _schedule_item_reminder(
+        scheduled = schedule_item_reminder(
             result.item,
             targets=reminder_targets,
             timezone=timezone or "UTC",
@@ -671,13 +539,13 @@ def work_task_schedule_checkin(
     except (KeyError, TypeError, ValueError) as exc:
         return {"error": "invalid_cron", "detail": str(exc)}
 
-    targets = _delivery_targets(
+    targets = delivery_targets(
         provider=provider,
         chat_id=chat_id,
         channel_targets=channel_targets,
         context=context,
     )
-    invalid_targets = _invalid_delivery_targets(targets)
+    invalid_targets = invalid_delivery_targets(targets)
     if invalid_targets:
         return {"error": "invalid_delivery_target", "detail": "; ".join(invalid_targets)}
     if not targets:

--- a/tools/system/work_items/validation.py
+++ b/tools/system/work_items/validation.py
@@ -10,7 +10,9 @@ from core.domain.work_items import (
     WorkItemStatus,
     parse_priority,
     parse_status,
+    parse_work_item_datetime,
 )
+from infrastructure.scheduling.scheduler.types import Provider
 
 DEFAULT_WORK_ITEM_LIMIT = 20
 MAX_WORK_ITEM_LIMIT = 100
@@ -57,14 +59,37 @@ def valid_status_detail() -> str:
     return f"status must be one of {', '.join(WORK_ITEM_STATUSES)}"
 
 
+def validate_provider(provider: str) -> Provider | None:
+    try:
+        return Provider(provider.strip().lower())
+    except ValueError:
+        return None
+
+
+def validate_datetime_arg(value: str, *, field: str) -> dict[str, str] | None:
+    if value and parse_work_item_datetime(value) is None:
+        return {
+            "error": f"invalid_{field}",
+            "detail": f"{field} must be ISO-like, e.g. 2026-07-29T09:30 or 2026-07-29T09:30Z",
+        }
+    return None
+
+
+_validate_provider = validate_provider
+_validate_datetime_arg = validate_datetime_arg
+
 __all__ = [
     "DEFAULT_PRIORITY_LIMIT",
     "DEFAULT_WORK_ITEM_LIMIT",
     "MAX_WORK_ITEM_LIMIT",
+    "_validate_datetime_arg",
+    "_validate_provider",
     "normalize_limit",
     "normalize_priority",
     "normalize_selectors",
     "normalize_status_filter",
     "valid_priority_detail",
     "valid_status_detail",
+    "validate_datetime_arg",
+    "validate_provider",
 ]


### PR DESCRIPTION
Fixes https://github.com/Tracer-Cloud/opensre/issues/5508

#### Describe the changes you have made in this PR -
Refactored `tools/system/work_items/tool.py` by extracting ~200 lines of non-tool helpers into cohesive single-responsibility modules:
- Moved argument validation helpers into `validation.py` (`validate_provider`, `validate_datetime_arg`).
- Extracted delivery-target resolution helpers into `delivery.py` (`gateway_delivery_context`, `delivery_targets`, `dedupe_targets`, `invalid_delivery_targets`).
- Extracted reminder scheduling helpers into `reminders.py` (`disable_existing_item_reminders`, `schedule_item_reminder`).
- Kept `tool.py` strictly focused on the six `@tool` entrypoints (`work_task_add`, `work_task_list`, `work_task_complete`, `work_task_update`, `work_task_prioritize`, `work_task_schedule_checkin`).
- Added unit tests in `tests/tools/test_work_items_tools.py` covering validation, delivery targets, reminders, and all six tools' lifecycles.

### Demo/Screenshot for feature changes and bug fixes - 
- **Registry snapshot diff**: Checked pre vs post refactor — 0 differences, all 6 tools remained registered.
- **Live manual execution**:
  - `work_task_add` -> `status: created`
  - `work_task_list` -> `total: 1`
  - `work_task_update` -> `status: updated`
  - `work_task_prioritize` -> `recommendations: 1`
  - `work_task_schedule_checkin` -> `status: scheduled`
  - `work_task_complete` -> `status: completed`
- **CI Readiness**: `make lint format-check typecheck` passed (0 issues). `make test-scope` passed (3,026 passed).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- What problem does your code solve?
  `tools/system/work_items/tool.py` was cluttered with helper functions handling delivery targets, reminder task creation, and validation, making the file large and keeping those helpers untested in isolation.
- What alternative approaches did you consider?
  Splitting each tool entrypoint into its own submodule, but keeping the six entrypoints in `tool.py` backed by domain helper modules was cleaner and matched the existing repository structure (`results.py`, `validation.py`).
- Why did you choose this specific implementation?
  It strictly satisfies separation of concerns, keeps `tool.py` thin, enables direct unit testing of helper logic, and ensures zero schema/behavior regressions.
- Key functions/components:
  - `delivery.py`: `gateway_delivery_context`, `delivery_targets`, `dedupe_targets`, `invalid_delivery_targets`
  - `reminders.py`: `disable_existing_item_reminders`, `schedule_item_reminder`
  - `validation.py`: `validate_provider`, `validate_datetime_arg`
  - `tool.py`: 6 `@tool` entrypoints delegating cleanly to the helper modules.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
