### PR TITLE
feat(elasticsearch): add evidence mapper for query_elasticsearch_logs

### DIFF
--- a/integrations/elasticsearch/tools/__init__.py
+++ b/integrations/elasticsearch/tools/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from infrastructure.evidence.evidence_compaction import compact_logs, summarize_counts
 from integrations.elasticsearch._client import make_client, unavailable
@@ -23,10 +24,31 @@ _ERROR_KEYWORDS = (
 )
 
 
+def _map_elasticsearch_logs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    logs = output.get("logs", [])
+    error_logs = output.get("error_logs", [])
+    evidence["elasticsearch_logs"] = logs
+    evidence["elasticsearch_error_logs"] = error_logs
+    evidence["elasticsearch_logs_query"] = output.get("query") or tool_input.get("query", "")
+    if logs:
+        summary_parts = [f"{len(logs)} logs"]
+        if error_logs:
+            summary_parts.append(f"{len(error_logs)} errors")
+        record_evidence_entry(
+            evidence,
+            source="query_elasticsearch_logs",
+            label="Elasticsearch Logs",
+            summary=", ".join(summary_parts),
+        )
+
+
 class ElasticsearchLogsTool(BaseTool):
     """Search Elasticsearch logs for errors, exceptions, and application events."""
 
     name = "query_elasticsearch_logs"
+    evidence_mapper = _map_elasticsearch_logs
     source = "elasticsearch"
     description = "Search Elasticsearch logs for errors, exceptions, and application events."
     use_cases = [

--- a/tests/integrations/elasticsearch/test_client.py
+++ b/tests/integrations/elasticsearch/test_client.py
@@ -431,3 +431,54 @@ def test_tool_run_returns_logs_on_success() -> None:
     assert result["available"] is True
     assert result["source"] == "elasticsearch_logs"
     assert len(result["logs"]) == 1
+
+
+def test_elasticsearch_evidence_mapper_with_logs_and_errors() -> None:
+    from integrations.elasticsearch.tools import _map_elasticsearch_logs
+
+    evidence: dict[str, object] = {}
+    output = {
+        "logs": [{"message": "hello"}, {"message": "error occurred"}],
+        "error_logs": [{"message": "error occurred"}],
+        "query": "status:500",
+    }
+    _map_elasticsearch_logs(evidence, output, {"query": "status:500"})
+
+    assert evidence["elasticsearch_logs"] == output["logs"]
+    assert evidence["elasticsearch_error_logs"] == output["error_logs"]
+    assert evidence["elasticsearch_logs_query"] == "status:500"
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert len(entries) == 1
+    assert entries[0] == {
+        "source": "query_elasticsearch_logs",
+        "label": "Elasticsearch Logs",
+        "summary": "2 logs, 1 errors",
+        "url": None,
+        "snippet": None,
+    }
+
+
+def test_elasticsearch_evidence_mapper_without_logs() -> None:
+    from integrations.elasticsearch.tools import _map_elasticsearch_logs
+
+    evidence: dict[str, object] = {}
+    output = {
+        "logs": [],
+        "error_logs": [],
+        "query": "status:500",
+    }
+    _map_elasticsearch_logs(evidence, output, {"query": "status:500"})
+
+    assert evidence["elasticsearch_logs"] == []
+    assert evidence["elasticsearch_error_logs"] == []
+    assert evidence["elasticsearch_logs_query"] == "status:500"
+    assert "catalog_entries" not in evidence
+
+
+def test_elasticsearch_tool_carries_evidence_mapper() -> None:
+    from tools.registry import get_registered_tool
+
+    tool = get_registered_tool("query_elasticsearch_logs")
+    assert tool is not None
+    assert tool.evidence_mapper is not None

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -211,7 +211,6 @@ query_datadog_events
 query_datadog_logs
 query_datadog_metrics
 query_datadog_monitors
-query_elasticsearch_logs
 query_grafana_annotations
 query_groundcover_logs
 query_groundcover_traces


### PR DESCRIPTION
Fixes #5583
Tracking Epic: #5519 (part of #1079)

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
- Added `_map_elasticsearch_logs` evidence mapper to `integrations/elasticsearch/tools/__init__.py` and attached it to `ElasticsearchLogsTool`.
- Records citeable report evidence entries (`source="query_elasticsearch_logs"`, `label="Elasticsearch Logs"`, `summary="<N> logs[, <M> errors]"`) when logs are returned.
- Lifts `elasticsearch_logs`, `elasticsearch_error_logs`, and `elasticsearch_logs_query` into the evidence dictionary.
- Removed `query_elasticsearch_logs` from `tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt`.
- Added unit tests in `tests/integrations/elasticsearch/test_client.py` covering mapper behavior with logs, without logs, and verifying that the registered tool carries the mapper.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Problem: Output from query_elasticsearch_logs was previously dropped rather than recorded as citeable evidence in investigation reports.
Approach: Defined _map_elasticsearch_logs using record_evidence_entry to populate canonical evidence keys and catalog entries. Attached evidence_mapper to ElasticsearchLogsTool, removed the tool from the known-gaps baseline, and added unit tests validating data extraction and catalog entry emission.
Key Functions:
_map_elasticsearch_logs: Extracts logs and error counts from tool output and registers citeable catalog entries when logs exist.
test_elasticsearch_evidence_mapper_with_logs_and_errors & test_elasticsearch_evidence_mapper_without_logs: Unit tests asserting evidence dict population and catalog creation rules.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


