### PR TITLE
test(registry): require actionable argument descriptions (#5500)

### DIFF
--- a/tests/tools/property_description_allowlist.py
+++ b/tests/tools/property_description_allowlist.py
@@ -1,0 +1,200 @@
+"""Shrink-only allowlist for pre-existing actionable-description debt (#5500).
+
+Compared exactly in both directions: a new violation fails; a fixed description
+must drop its entry here. Per-source counts at quarantine time:
+
+  github             45
+  hermes             19
+  redis              7
+  bitbucket          6
+  knowledge          6
+  gitlab             5
+  helm               5
+  mongodb_atlas      5
+  yandex_cloud       5
+  airflow            4
+  interactive_shell  4
+  openobserve        4
+  tracer_web         4
+  cloudwatch         3
+  slack              3
+  snowflake          3
+  azure              2
+  betterstack        2
+  clickhouse         2
+  ec2                2
+  grafana            2
+  openclaw           2
+  opensearch         2
+  rds                2
+  sentry             2
+  azure_sql          1
+  coralogix          1
+  dagster            1
+  honeycomb          1
+  incident_io        1
+  kafka              1
+  kubernetes         1
+  tempo              1
+"""
+
+from __future__ import annotations
+
+ACTIONABLE_PROPERTY_DESCRIPTION_ALLOWLIST: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        ("alert_sample", "template", "enum_values"),
+        ("describe_rds_events", "db_instance_identifier", "identifier_kind"),
+        ("describe_rds_events", "duration_minutes", "time_unit_and_format"),
+        ("ec2_instances_by_tag", "instance_ids", "identifier_kind"),
+        ("ec2_instances_by_tag", "vpc_id", "identifier_kind"),
+        ("execute_github_issue_mutation", "owner", "identifier_kind"),
+        ("execute_github_issue_mutation", "repo", "identifier_kind"),
+        ("fix_github_security_alert", "alert_type", "enum_values"),
+        ("generate_work_status_report", "owner", "identifier_kind"),
+        ("generate_work_status_report", "repo", "identifier_kind"),
+        ("get_airflow_dag_runs", "dag_id", "identifier_kind"),
+        ("get_airflow_metrics", "trace_id", "identifier_kind"),
+        ("get_airflow_task_instances", "dag_id", "identifier_kind"),
+        ("get_airflow_task_instances", "dag_run_id", "identifier_kind"),
+        ("get_azure_sql_resource_stats", "minutes", "time_unit_and_format"),
+        ("get_batch_statistics", "trace_id", "identifier_kind"),
+        ("get_bitbucket_file_contents", "integration_id", "identifier_kind"),
+        ("get_bitbucket_file_contents", "username", "identifier_kind"),
+        ("get_clickhouse_query_activity", "username", "identifier_kind"),
+        ("get_clickhouse_system_health", "username", "identifier_kind"),
+        ("get_cloudwatch_batch_metrics", "metric_type", "enum_values"),
+        ("get_dagster_run_logs", "run_id", "identifier_kind"),
+        ("get_error_logs", "trace_id", "identifier_kind"),
+        ("get_failed_tools", "trace_id", "identifier_kind"),
+        ("get_git_deploy_timeline", "owner", "identifier_kind"),
+        ("get_git_deploy_timeline", "repo", "identifier_kind"),
+        ("get_github_actions_step_log", "job_id", "identifier_kind"),
+        ("get_github_actions_step_log", "owner", "identifier_kind"),
+        ("get_github_actions_step_log", "repo", "identifier_kind"),
+        ("get_github_actions_step_log", "run_id", "identifier_kind"),
+        ("get_github_file_contents", "owner", "identifier_kind"),
+        ("get_github_file_contents", "repo", "identifier_kind"),
+        ("get_github_repository", "owner", "identifier_kind"),
+        ("get_github_repository", "repo", "identifier_kind"),
+        ("get_github_repository_tree", "owner", "identifier_kind"),
+        ("get_github_repository_tree", "repo", "identifier_kind"),
+        ("get_gitlab_file", "project_id", "identifier_kind"),
+        ("get_hermes_adapter_catalog", "session_id", "identifier_kind"),
+        ("get_hermes_approval_events", "session_id", "identifier_kind"),
+        ("get_hermes_audit_trail", "session_id", "identifier_kind"),
+        ("get_hermes_config", "session_id", "identifier_kind"),
+        ("get_hermes_credential_state", "session_id", "identifier_kind"),
+        ("get_hermes_cron_state", "session_id", "identifier_kind"),
+        ("get_hermes_filesystem_state", "session_id", "identifier_kind"),
+        ("get_hermes_kv_cache_state", "session_id", "identifier_kind"),
+        ("get_hermes_logs", "levels", "enum_values"),
+        ("get_hermes_memory_state", "session_id", "identifier_kind"),
+        ("get_hermes_message_history", "session_id", "identifier_kind"),
+        ("get_hermes_orchestration_state", "session_id", "identifier_kind"),
+        ("get_hermes_provider_traffic", "session_id", "identifier_kind"),
+        ("get_hermes_rbac_state", "session_id", "identifier_kind"),
+        ("get_hermes_routing_decisions", "session_id", "identifier_kind"),
+        ("get_hermes_runtime_state", "session_id", "identifier_kind"),
+        ("get_hermes_session_log", "session_id", "identifier_kind"),
+        ("get_hermes_session_topology", "session_id", "identifier_kind"),
+        ("get_hermes_workflow_run", "session_id", "identifier_kind"),
+        ("get_host_metrics", "trace_id", "identifier_kind"),
+        ("get_kafka_consumer_group_lag", "group_id", "identifier_kind"),
+        ("get_lambda_invocation_logs", "request_id", "identifier_kind"),
+        ("get_mongodb_atlas_alerts", "project_id", "identifier_kind"),
+        ("get_mongodb_atlas_cluster_events", "project_id", "identifier_kind"),
+        ("get_mongodb_atlas_cluster_metrics", "project_id", "identifier_kind"),
+        ("get_mongodb_atlas_clusters", "project_id", "identifier_kind"),
+        ("get_mongodb_atlas_performance_advisor", "project_id", "identifier_kind"),
+        ("get_openclaw_conversation", "conversation_id", "identifier_kind"),
+        ("get_recent_airflow_failures", "dag_id", "identifier_kind"),
+        ("get_redis_client_list", "username", "identifier_kind"),
+        ("get_redis_latency_doctor", "username", "identifier_kind"),
+        ("get_redis_list_depth", "username", "identifier_kind"),
+        ("get_redis_replication", "username", "identifier_kind"),
+        ("get_redis_server_info", "username", "identifier_kind"),
+        ("get_redis_slowlog", "username", "identifier_kind"),
+        ("get_sentry_issue_details", "issue_id", "identifier_kind"),
+        ("get_yc_lb_health", "type", "enum_values"),
+        ("helm_get_release_manifest", "integration_id", "identifier_kind"),
+        ("helm_get_release_values", "integration_id", "identifier_kind"),
+        ("helm_list_releases", "integration_id", "identifier_kind"),
+        ("helm_release_history", "integration_id", "identifier_kind"),
+        ("helm_release_status", "integration_id", "identifier_kind"),
+        ("incident_io_incidents", "action", "enum_values"),
+        ("kubernetes_get_resource", "resource_type", "enum_values"),
+        ("list_bitbucket_commits", "integration_id", "identifier_kind"),
+        ("list_bitbucket_commits", "username", "identifier_kind"),
+        ("list_github_actions_active_runs", "owner", "identifier_kind"),
+        ("list_github_actions_active_runs", "repo", "identifier_kind"),
+        ("list_github_actions_run_jobs", "owner", "identifier_kind"),
+        ("list_github_actions_run_jobs", "repo", "identifier_kind"),
+        ("list_github_actions_run_jobs", "run_id", "identifier_kind"),
+        ("list_github_actions_workflow_runs", "owner", "identifier_kind"),
+        ("list_github_actions_workflow_runs", "repo", "identifier_kind"),
+        ("list_github_commits", "owner", "identifier_kind"),
+        ("list_github_commits", "repo", "identifier_kind"),
+        ("list_github_security_alerts", "alert_type", "enum_values"),
+        ("list_github_security_alerts", "owner", "identifier_kind"),
+        ("list_github_security_alerts", "repo", "identifier_kind"),
+        ("list_github_work_items", "owner", "identifier_kind"),
+        ("list_github_work_items", "repo", "identifier_kind"),
+        ("list_github_work_items", "state", "enum_values"),
+        ("list_gitlab_commits", "project_id", "identifier_kind"),
+        ("list_gitlab_commits", "since", "time_unit_and_format"),
+        ("list_gitlab_mrs", "project_id", "identifier_kind"),
+        ("list_gitlab_pipelines", "project_id", "identifier_kind"),
+        ("list_sentry_issue_events", "issue_id", "identifier_kind"),
+        ("memory_remember", "type", "enum_values"),
+        ("propose_github_issue_mutation_from_slack", "operation", "enum_values"),
+        ("propose_github_issue_mutation_from_slack", "owner", "identifier_kind"),
+        ("propose_github_issue_mutation_from_slack", "repo", "identifier_kind"),
+        ("query_azure_monitor_logs", "integration_id", "identifier_kind"),
+        ("query_azure_monitor_logs", "timeout_seconds", "time_unit_and_format"),
+        ("query_betterstack_logs", "since", "time_unit_and_format"),
+        ("query_betterstack_logs", "until", "time_unit_and_format"),
+        ("query_coralogix_logs", "trace_id", "identifier_kind"),
+        ("query_grafana_logs", "execution_run_id", "identifier_kind"),
+        ("query_grafana_traces", "execution_run_id", "identifier_kind"),
+        ("query_honeycomb_traces", "trace_id", "identifier_kind"),
+        ("query_openobserve_logs", "integration_id", "identifier_kind"),
+        ("query_openobserve_logs", "org", "identifier_kind"),
+        ("query_openobserve_logs", "timeout_seconds", "time_unit_and_format"),
+        ("query_openobserve_logs", "username", "identifier_kind"),
+        ("query_opensearch_analytics", "integration_id", "identifier_kind"),
+        ("query_opensearch_analytics", "username", "identifier_kind"),
+        ("query_snowflake_history", "integration_id", "identifier_kind"),
+        ("query_snowflake_history", "timeout_seconds", "time_unit_and_format"),
+        ("query_snowflake_history", "user", "identifier_kind"),
+        ("query_tempo", "action", "enum_values"),
+        ("query_yc_metrics", "aggregation", "enum_values"),
+        ("query_yc_metrics", "window_minutes", "time_unit_and_format"),
+        ("read_yc_logs", "levels", "enum_values"),
+        ("read_yc_logs", "window_minutes", "time_unit_and_format"),
+        ("scan_redis_keys", "username", "identifier_kind"),
+        ("search_bitbucket_code", "integration_id", "identifier_kind"),
+        ("search_bitbucket_code", "username", "identifier_kind"),
+        ("search_github_code", "owner", "identifier_kind"),
+        ("search_github_code", "repo", "identifier_kind"),
+        ("search_github_issues", "owner", "identifier_kind"),
+        ("search_github_issues", "repo", "identifier_kind"),
+        ("search_github_issues", "state", "enum_values"),
+        ("send_openclaw_message", "conversation_id", "identifier_kind"),
+        ("slack_add_reaction", "timestamp", "time_unit_and_format"),
+        ("slack_read_messages", "thread_ts", "time_unit_and_format"),
+        ("slack_reply_message", "thread_ts", "time_unit_and_format"),
+        ("slash_invoke", "command", "enum_values"),
+        ("summarize_community_followups", "owner", "identifier_kind"),
+        ("summarize_community_followups", "repo", "identifier_kind"),
+        ("summarize_github_pr_status", "owner", "identifier_kind"),
+        ("summarize_github_pr_status", "repo", "identifier_kind"),
+        ("summarize_github_pr_status", "state", "enum_values"),
+        ("synthetic_run", "scenario", "enum_values"),
+        ("synthetic_run", "suite", "enum_values"),
+        ("work_task_add", "priority", "enum_values"),
+        ("work_task_update", "channel_id", "identifier_kind"),
+        ("work_task_update", "owner", "identifier_kind"),
+        ("work_task_update", "priority", "enum_values"),
+        ("work_task_update", "status", "enum_values"),
+    }
+)

--- a/tests/tools/property_description_rules.py
+++ b/tests/tools/property_description_rules.py
@@ -617,9 +617,7 @@ def _enum_values_are_documented(values: Sequence[str], description: str) -> bool
 
 def _enum_value_in_description(value: str, description: str) -> bool:
     needle = value.lower()
-    if len(needle) <= 2:
-        return re.search(rf"(?<![a-z0-9]){re.escape(needle)}(?![a-z0-9])", description) is not None
-    return needle in description
+    return re.search(rf"(?<![a-z0-9]){re.escape(needle)}(?![a-z0-9])", description) is not None
 
 
 def _is_identifier_field(name: str) -> bool:
@@ -659,22 +657,21 @@ def _exclusive_property_groups(schema: Mapping[str, Any]) -> list[tuple[str, ...
     properties = schema.get("properties")
     names = set(properties) if isinstance(properties, dict) else set()
 
-    for key in ("oneOf", "anyOf"):
-        variants = schema.get(key)
-        if not isinstance(variants, list):
-            continue
+    # JSON Schema ``anyOf`` allows multiple branches to match, so it is not
+    # exclusive. Only ``oneOf`` is a true XOR of required properties.
+    variants = schema.get("oneOf")
+    if isinstance(variants, list):
         required_sets = [
             frozenset(str(item) for item in variant.get("required", []) if isinstance(item, str))
             for variant in variants
             if isinstance(variant, dict)
         ]
         required_sets = [group for group in required_sets if group]
-        if len(required_sets) < 2:
-            continue
-        counts: Counter[str] = Counter(name for group in required_sets for name in group)
-        exclusive = tuple(sorted(name for name, count in counts.items() if count == 1))
-        if len(exclusive) >= 2:
-            groups.append(exclusive)
+        if len(required_sets) >= 2:
+            counts: Counter[str] = Counter(name for group in required_sets for name in group)
+            exclusive = tuple(sorted(name for name, count in counts.items() if count == 1))
+            if len(exclusive) >= 2:
+                groups.append(exclusive)
 
     if not names:
         return groups

--- a/tests/tools/property_description_rules.py
+++ b/tests/tools/property_description_rules.py
@@ -1,0 +1,709 @@
+"""Actionable-description rules for model-facing tool property schemas.
+
+A description that exists but cannot be filled still fails the call. These
+rules infer field shape from the property name plus schema, then require the
+description to carry the missing fill-in detail. Detection is conservative:
+uncertain shapes are skipped rather than flagged.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, NamedTuple
+
+from core.tool import RegisteredTool
+
+RULE_TIME = "time_unit_and_format"
+RULE_ENUM = "enum_values"
+RULE_IDENTIFIER = "identifier_kind"
+RULE_EXCLUSIVE = "mutual_exclusion"
+
+_TIME_EXACT = frozenset(
+    {
+        "since",
+        "until",
+        "duration",
+        "timeout",
+        "interval",
+        "lookback",
+        "ttl",
+        "delay",
+        "timestamp",
+        "datetime",
+        "time",
+        "time_range",
+        "time_window",
+        "time_from",
+        "time_to",
+        "from_time",
+        "to_time",
+        "start_time",
+        "end_time",
+        "start_at",
+        "end_at",
+        "start_timestamp",
+        "end_timestamp",
+        "starttime",
+        "endtime",
+        "hours",
+        "minutes",
+        "seconds",
+        "days",
+        "window_minutes",
+        "window_seconds",
+        "window_hours",
+        "window_days",
+        "lookback_minutes",
+        "lookback_hours",
+        "lookback_seconds",
+        "lookback_days",
+        "period_seconds",
+        "period_ms",
+        "period_milliseconds",
+        "hours_ago",
+        "minutes_ago",
+        "days_ago",
+        "created_at",
+        "updated_at",
+        "modified_at",
+        "deleted_at",
+        "occurred_at",
+        "expires_at",
+        "expired_at",
+        "started_at",
+        "ended_at",
+        "closed_at",
+        "opened_at",
+        "published_at",
+        "last_seen_at",
+        "first_seen_at",
+    }
+)
+_TIME_SUFFIXES = frozenset(
+    {
+        "time",
+        "times",
+        "timestamp",
+        "timestamps",
+        "datetime",
+        "timeout",
+        "interval",
+        "lookback",
+        "duration",
+        "ttl",
+        "delay",
+    }
+)
+_TIME_UNIT_QUALIFIERS = frozenset(
+    {
+        "window",
+        "lookback",
+        "look",
+        "period",
+        "offset",
+        "age",
+        "timeout",
+        "duration",
+        "ttl",
+        "delay",
+        "interval",
+    }
+)
+_TIME_UNIT_WORDS = frozenset(
+    {
+        "minutes",
+        "seconds",
+        "hours",
+        "days",
+        "ms",
+        "millis",
+        "milliseconds",
+    }
+)
+_AT_PREFIXES = frozenset(
+    {
+        "created",
+        "updated",
+        "modified",
+        "deleted",
+        "occurred",
+        "expires",
+        "expired",
+        "started",
+        "ended",
+        "closed",
+        "opened",
+        "published",
+        "last",
+        "first",
+        "seen",
+        "last_seen",
+        "first_seen",
+        "last_seen_at",
+    }
+)
+
+# ISO-8601 / RFC3339 document both the unit (datetime) and the accepted format.
+_TIME_UNIT_AND_FORMAT = (
+    "iso-8601",
+    "iso8601",
+    "iso 8601",
+    "rfc3339",
+    "rfc 3339",
+    "rfc-3339",
+)
+_TIME_UNIT = (
+    "nanosecond",
+    "nanoseconds",
+    "microsecond",
+    "microseconds",
+    "millisecond",
+    "milliseconds",
+    "msec",
+    "millis",
+    "second",
+    "seconds",
+    "sec",
+    "secs",
+    "minute",
+    "minutes",
+    "min",
+    "mins",
+    "hour",
+    "hours",
+    "hr",
+    "hrs",
+    "day",
+    "days",
+    "week",
+    "weeks",
+    "month",
+    "months",
+    "year",
+    "years",
+    "unix",
+    "epoch",
+)
+_TIME_FORMAT = (
+    "iso-8601",
+    "iso8601",
+    "iso 8601",
+    "rfc3339",
+    "rfc 3339",
+    "rfc-3339",
+    "unix",
+    "epoch",
+    "posix",
+    "yyyy-mm-dd",
+    "yyyy-mm-ddthh",
+    "hh:mm",
+    "relative",
+    "duration string",
+    "go duration",
+    "prometheus",
+    "unix timestamp",
+    "unix epoch",
+    "epoch millis",
+    "epoch milliseconds",
+    "epoch seconds",
+    "integer",
+    "int ",
+)
+
+_ID_EXACT = frozenset(
+    {
+        "id",
+        "ids",
+        "name",
+        "owner",
+        "repo",
+        "repository",
+        "org",
+        "organization",
+        "username",
+        "user",
+        "account",
+        "identifier",
+        "selector",
+        "arn",
+        "urn",
+        "uuid",
+        "guid",
+        "slug",
+    }
+)
+_ID_KIND_HINTS = (
+    "numeric",
+    "integer",
+    "uuid",
+    "guid",
+    "slug",
+    "display name",
+    "display-name",
+    "full name",
+    "full-name",
+    "owner/repo",
+    "owner/name",
+    "org/repo",
+    "arn",
+    "url",
+    "uri",
+    "urn",
+    "email",
+    "hostname",
+    "fqdn",
+    "sha256",
+    "sha1",
+    "sha-1",
+    "commit hash",
+    "fingerprint",
+    "hex",
+    "namespace",
+    "fully-qualified",
+    "fully qualified",
+    "qualified name",
+    "username",
+    "login",
+    "handle",
+    "canonical",
+    "snowflake",
+    "ulid",
+    "human-readable",
+    "human readable",
+    "resource name",
+    "resource id",
+    "instance identifier",
+    "cluster name",
+    "login name",
+)
+
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "of",
+        "to",
+        "for",
+        "this",
+        "that",
+        "used",
+        "use",
+        "using",
+        "optional",
+        "required",
+        "parameter",
+        "argument",
+        "value",
+        "field",
+        "param",
+        "given",
+        "specify",
+        "specified",
+        "provided",
+        "provide",
+        "set",
+        "when",
+        "if",
+        "or",
+        "and",
+        "with",
+        "from",
+        "into",
+        "by",
+        "is",
+        "be",
+        "as",
+        "in",
+        "on",
+        "at",
+        "vs",
+        "versus",
+        "id",
+        "ids",
+        "name",
+        "names",
+        "identifier",
+        "identifiers",
+        "selector",
+        "selectors",
+    }
+)
+_SYNONYMS: dict[str, frozenset[str]] = {
+    "repo": frozenset({"repository", "repositories"}),
+    "repository": frozenset({"repo", "repositories"}),
+    "org": frozenset({"organization", "organisation", "orgs"}),
+    "organization": frozenset({"org", "organisation"}),
+    "user": frozenset({"username", "login", "users"}),
+    "username": frozenset({"user", "login"}),
+    "id": frozenset({"identifier", "ids"}),
+    "ids": frozenset({"id", "identifier"}),
+    "identifier": frozenset({"id", "ids"}),
+    "name": frozenset({"names"}),
+    "url": frozenset({"uri", "link", "href"}),
+    "uri": frozenset({"url", "urn"}),
+}
+
+_EXCLUSIVE_HINTS = (
+    "mutually exclusive",
+    "mutually-exclusive",
+    "instead of",
+    "not both",
+    "do not pass both",
+    "don't pass both",
+    "cannot be used with",
+    "cannot be combined",
+    "exclusive with",
+    "xor",
+    "either ",
+    "one of these",
+    "omit if",
+    "if omitted",
+    "when omitted",
+    "is omitted",
+    "conflicts with",
+    "rather than",
+    "as an alternative",
+    "alternative to",
+    "do not set both",
+    "don't set both",
+    "not used with",
+    "cannot both",
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_WORD_RE = re.compile(r"[a-z0-9]+", re.IGNORECASE)
+
+
+class PropertyViolation(NamedTuple):
+    """One property that failed one actionable-description rule."""
+
+    tool_name: str
+    source: str
+    property_name: str
+    rule: str
+    reason: str
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.tool_name, self.property_name, self.rule)
+
+
+def collect_violations(tools: Iterable[RegisteredTool]) -> list[PropertyViolation]:
+    """Return every actionable-description miss on ``tools``' public schemas."""
+    violations: list[PropertyViolation] = []
+    for tool in tools:
+        schema = tool.public_input_schema
+        if not isinstance(schema, dict):
+            continue
+        violations.extend(
+            collect_schema_violations(
+                tool_name=tool.name,
+                source=str(tool.source),
+                schema=schema,
+            )
+        )
+    return violations
+
+
+def collect_schema_violations(
+    *, tool_name: str, source: str, schema: Mapping[str, Any]
+) -> list[PropertyViolation]:
+    """Run every rule against one object schema's top-level properties."""
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return []
+
+    violations: list[PropertyViolation] = []
+    exclusive_groups = _exclusive_property_groups(schema)
+
+    for prop_name, prop_schema in properties.items():
+        if not isinstance(prop_name, str) or not isinstance(prop_schema, dict):
+            continue
+        description = _property_description(prop_schema)
+        lowered = description.lower()
+
+        if _is_time_field(prop_name) and not _time_description_is_actionable(prop_schema, lowered):
+            violations.append(
+                PropertyViolation(
+                    tool_name,
+                    source,
+                    prop_name,
+                    RULE_TIME,
+                    "time/duration/window field must state a unit and an accepted format",
+                )
+            )
+
+        enum_values = _enum_values(prop_schema)
+        if enum_values and not _enum_values_are_documented(enum_values, lowered):
+            violations.append(
+                PropertyViolation(
+                    tool_name,
+                    source,
+                    prop_name,
+                    RULE_ENUM,
+                    "enum property must document its allowed values in the description",
+                )
+            )
+
+        if _is_identifier_field(prop_name) and not _identifier_description_is_actionable(
+            prop_name, lowered
+        ):
+            violations.append(
+                PropertyViolation(
+                    tool_name,
+                    source,
+                    prop_name,
+                    RULE_IDENTIFIER,
+                    "id/name/selector field must say which identifier to send",
+                )
+            )
+
+    for group in exclusive_groups:
+        named = [name for name in group if name in properties]
+        if len(named) < 2:
+            continue
+        for prop_name in named:
+            prop_schema = properties[prop_name]
+            if not isinstance(prop_schema, dict):
+                continue
+            others = [name for name in named if name != prop_name]
+            if not _exclusive_description_names_conflict(
+                _property_description(prop_schema).lower(), others
+            ):
+                violations.append(
+                    PropertyViolation(
+                        tool_name,
+                        source,
+                        prop_name,
+                        RULE_EXCLUSIVE,
+                        "mutually exclusive parameter must say so and name the other field",
+                    )
+                )
+    return violations
+
+
+def violations_by_source(violations: Sequence[PropertyViolation]) -> dict[str, int]:
+    """Return violator counts keyed by tool source (one count per property hit)."""
+    counts: dict[str, int] = defaultdict(int)
+    for violation in violations:
+        counts[violation.source] += 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
+def format_source_counts(counts: Mapping[str, int]) -> str:
+    """Render per-source counts as stable, reviewable lines."""
+    if not counts:
+        return "(none)"
+    width = max(len(source) for source in counts)
+    return "\n".join(f"  {source:<{width}}  {count}" for source, count in counts.items())
+
+
+def _property_description(prop_schema: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    raw = prop_schema.get("description")
+    if isinstance(raw, str) and raw.strip():
+        parts.append(raw)
+    for key in ("allOf", "oneOf", "anyOf"):
+        variants = prop_schema.get(key)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if isinstance(variant, dict):
+                nested = variant.get("description")
+                if isinstance(nested, str) and nested.strip():
+                    parts.append(nested)
+    return " ".join(parts)
+
+
+def _schema_types(prop_schema: Mapping[str, Any]) -> frozenset[str]:
+    declared = prop_schema.get("type")
+    types: set[str] = set()
+    if isinstance(declared, str):
+        types.add(declared)
+    elif isinstance(declared, list):
+        types.update(item for item in declared if isinstance(item, str))
+    for key in ("oneOf", "anyOf"):
+        variants = prop_schema.get(key)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if isinstance(variant, dict):
+                types.update(_schema_types(variant))
+    types.discard("null")
+    return frozenset(types)
+
+
+def _is_time_field(name: str) -> bool:
+    lowered = name.lower()
+    if lowered in _TIME_EXACT:
+        return True
+    if lowered.endswith("_at"):
+        return lowered[: -len("_at")] in _AT_PREFIXES or lowered in _TIME_EXACT
+    if lowered.endswith("_ts") or lowered.endswith("_timestamp"):
+        return True
+    parts = lowered.split("_")
+    if parts[-1] in _TIME_SUFFIXES:
+        return True
+    return parts[-1] in _TIME_UNIT_WORDS and any(part in _TIME_UNIT_QUALIFIERS for part in parts)
+
+
+def _contains_phrase(text: str, phrases: Sequence[str]) -> bool:
+    return any(phrase in text for phrase in phrases)
+
+
+def _has_unit_token(text: str) -> bool:
+    if _contains_phrase(text, _TIME_UNIT_AND_FORMAT):
+        return True
+    if _contains_phrase(text, _TIME_UNIT):
+        return True
+    return bool(re.search(r"\b(?:ns|us|µs|ms|msec|sec|mins?|hrs?)\b", text))
+
+
+def _has_format_token(text: str) -> bool:
+    if _contains_phrase(text, _TIME_UNIT_AND_FORMAT):
+        return True
+    if _contains_phrase(text, _TIME_FORMAT):
+        return True
+    if re.search(r"\b\d{4}-\d{2}-\d{2}", text):
+        return True
+    return bool(re.search(r"\b\d+(?:ns|us|ms|s|m|h|d)\b", text))
+
+
+def _time_description_is_actionable(prop_schema: Mapping[str, Any], description: str) -> bool:
+    if not description.strip():
+        return False
+    types = _schema_types(prop_schema)
+    has_unit = _has_unit_token(description)
+    has_format = _has_format_token(description)
+    if types <= frozenset({"integer", "number"}):
+        # Integer durations are filled as a count of the stated unit.
+        return has_unit
+    return has_unit and has_format
+
+
+def _enum_values(prop_schema: Mapping[str, Any]) -> tuple[str, ...]:
+    values: list[str] = []
+    raw = prop_schema.get("enum")
+    if isinstance(raw, list):
+        values.extend(str(item) for item in raw if item is not None and str(item) != "")
+    items = prop_schema.get("items")
+    if isinstance(items, dict):
+        values.extend(_enum_values(items))
+    for key in ("oneOf", "anyOf", "allOf"):
+        variants = prop_schema.get(key)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if isinstance(variant, dict):
+                values.extend(_enum_values(variant))
+    # Preserve order, drop duplicates.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            unique.append(value)
+    return tuple(unique)
+
+
+def _enum_values_are_documented(values: Sequence[str], description: str) -> bool:
+    if not description.strip() or not values:
+        return False
+    return all(_enum_value_in_description(value, description) for value in values)
+
+
+def _enum_value_in_description(value: str, description: str) -> bool:
+    needle = value.lower()
+    if len(needle) <= 2:
+        return re.search(rf"(?<![a-z0-9]){re.escape(needle)}(?![a-z0-9])", description) is not None
+    return needle in description
+
+
+def _is_identifier_field(name: str) -> bool:
+    lowered = name.lower()
+    if lowered in _ID_EXACT:
+        return True
+    if lowered.endswith("_id") or lowered.endswith("_ids"):
+        return True
+    if lowered.endswith("_identifier") or lowered.endswith("_identifiers"):
+        return True
+    return lowered.endswith("_selector") or lowered.endswith("_selectors")
+
+
+def _identifier_description_is_actionable(prop_name: str, description: str) -> bool:
+    if not description.strip():
+        return False
+    if any(hint in description for hint in _ID_KIND_HINTS):
+        return True
+    return _has_residual_identifier_detail(prop_name, description)
+
+
+def _has_residual_identifier_detail(prop_name: str, description: str) -> bool:
+    """Return True when the description says more than the property name."""
+    strip_tokens = set(prop_name.lower().split("_"))
+    for token in tuple(strip_tokens):
+        strip_tokens.update(_SYNONYMS.get(token, ()))
+    leftover = [
+        token
+        for token in _TOKEN_RE.findall(description.lower())
+        if token not in strip_tokens and token not in _STOPWORDS and len(token) >= 3
+    ]
+    return bool(leftover)
+
+
+def _exclusive_property_groups(schema: Mapping[str, Any]) -> list[tuple[str, ...]]:
+    groups: list[tuple[str, ...]] = []
+    properties = schema.get("properties")
+    names = set(properties) if isinstance(properties, dict) else set()
+
+    for key in ("oneOf", "anyOf"):
+        variants = schema.get(key)
+        if not isinstance(variants, list):
+            continue
+        required_sets = [
+            frozenset(str(item) for item in variant.get("required", []) if isinstance(item, str))
+            for variant in variants
+            if isinstance(variant, dict)
+        ]
+        required_sets = [group for group in required_sets if group]
+        if len(required_sets) < 2:
+            continue
+        counts: Counter[str] = Counter(name for group in required_sets for name in group)
+        exclusive = tuple(sorted(name for name, count in counts.items() if count == 1))
+        if len(exclusive) >= 2:
+            groups.append(exclusive)
+
+    if not names:
+        return groups
+
+    prefixes_with_id = {name[: -len("_id")]: name for name in names if name.endswith("_id")}
+    for prefix, id_name in prefixes_with_id.items():
+        if not prefix:
+            continue
+        for suffix in ("_url", "_key", "_uri"):
+            other = f"{prefix}{suffix}"
+            if other in names:
+                groups.append(tuple(sorted((id_name, other))))
+
+    for left, right in (
+        ("query", "query_file"),
+        ("query", "file_path"),
+        ("content", "file_path"),
+        ("content", "path"),
+        ("sql", "query_file"),
+        ("body", "file_path"),
+    ):
+        if left in names and right in names:
+            groups.append((left, right))
+    return groups
+
+
+def _exclusive_description_names_conflict(description: str, others: Sequence[str]) -> bool:
+    if not description.strip():
+        return False
+    names_other = any(other.lower() in description for other in others)
+    hinted = _contains_phrase(description, _EXCLUSIVE_HINTS)
+    return names_other and hinted

--- a/tests/tools/property_description_rules.py
+++ b/tests/tools/property_description_rules.py
@@ -374,7 +374,6 @@ _EXCLUSIVE_HINTS = (
 )
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
-_WORD_RE = re.compile(r"[a-z0-9]+", re.IGNORECASE)
 
 
 class PropertyViolation(NamedTuple):

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -894,6 +894,49 @@ def test_actionable_property_description_exclusive_rule_catches_missing_hint() -
     assert {violation.property_name for violation in violations} == {"query", "query_file"}
 
 
+def test_actionable_property_description_exclusive_rule_ignores_any_of() -> None:
+    violations = collect_schema_violations(
+        tool_name="throwaway_any_of_not_exclusive",
+        source="knowledge",
+        schema={
+            "type": "object",
+            "properties": {
+                "alpha": {
+                    "type": "string",
+                    "description": "First optional selector.",
+                },
+                "beta": {
+                    "type": "string",
+                    "description": "Second optional selector.",
+                },
+            },
+            "anyOf": [
+                {"required": ["alpha"]},
+                {"required": ["beta"]},
+            ],
+        },
+    )
+    assert violations == []
+
+
+def test_actionable_property_description_enum_rule_requires_token_boundaries() -> None:
+    violations = collect_schema_violations(
+        tool_name="throwaway_enum_token_boundary",
+        source="knowledge",
+        schema={
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": ["open"],
+                    "description": "Issue state filter. Use opened or reopened.",
+                }
+            },
+        },
+    )
+    assert [violation.rule for violation in violations] == [RULE_ENUM]
+
+
 def test_v2_registry_required_fields_are_declared() -> None:
     for tool_def in _v2_tools():
         schema = tool_def.public_input_schema

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -12,6 +12,19 @@ from core.domain.types.retrieval import RetrievalControls
 from core.domain.types.tools import ToolSurface
 from core.tool.contracts import REGISTERED_TOOL_ATTR, BaseTool, RegisteredTool
 from core.tool_framework.tool_decorator import tool
+from tests.tools.property_description_allowlist import (
+    ACTIONABLE_PROPERTY_DESCRIPTION_ALLOWLIST,
+)
+from tests.tools.property_description_rules import (
+    RULE_ENUM,
+    RULE_EXCLUSIVE,
+    RULE_IDENTIFIER,
+    RULE_TIME,
+    collect_schema_violations,
+    collect_violations,
+    format_source_counts,
+    violations_by_source,
+)
 from tools import registry as registry_module
 from tools import registry_discovery
 from tools.investigation_registry.actions import get_available_actions
@@ -749,6 +762,10 @@ def _v2_tools() -> list[RegisteredTool]:
     ]
 
 
+def _deduped_registry_tools() -> list[RegisteredTool]:
+    return list({tool.name: tool for tool in registry_module.get_registered_tools()}.values())
+
+
 def test_v2_registry_tool_contracts_exist() -> None:
     discovered = {tool.name for tool in _v2_tools()}
     assert discovered == _V2_TOOL_CONTRACT_NAMES
@@ -778,6 +795,103 @@ def test_v2_registry_property_schemas_are_typed_and_described() -> None:
             assert str(prop_schema.get("description", "")).strip(), (
                 f"{tool_def.name}.{prop_name} must include description."
             )
+
+    violations = collect_violations(_deduped_registry_tools())
+    by_key = {violation.key: violation for violation in violations}
+    unexpected = sorted(
+        key for key in by_key if key not in ACTIONABLE_PROPERTY_DESCRIPTION_ALLOWLIST
+    )
+    stale = sorted(ACTIONABLE_PROPERTY_DESCRIPTION_ALLOWLIST - set(by_key))
+    assert unexpected == [], (
+        "Property descriptions must be actionable (units, enum values, identifier "
+        "kind, mutual exclusion). Fix the description or, for pre-existing debt, "
+        "add to the shrink-only allowlist in "
+        "tests/tools/property_description_allowlist.py:\n"
+        + "\n".join(f"  - {tool}.{prop} ({rule})" for tool, prop, rule in unexpected)
+        + "\n\nPer-source violator counts (including allowlisted):\n"
+        + format_source_counts(violations_by_source(violations))
+    )
+    assert stale == [], "Remove stale allowlist entries so it keeps shrinking:\n" + "\n".join(
+        f"  - {tool}.{prop} ({rule})" for tool, prop, rule in stale
+    )
+
+
+def test_actionable_property_description_time_rule_catches_missing_unit() -> None:
+    violations = collect_schema_violations(
+        tool_name="throwaway_time_rule",
+        source="knowledge",
+        schema={
+            "type": "object",
+            "properties": {
+                "start_time": {
+                    "type": "string",
+                    "description": "the start",
+                }
+            },
+        },
+    )
+    assert [violation.rule for violation in violations] == [RULE_TIME]
+
+
+def test_actionable_property_description_enum_rule_catches_missing_values() -> None:
+    violations = collect_schema_violations(
+        tool_name="throwaway_enum_rule",
+        source="knowledge",
+        schema={
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed"],
+                    "description": "Issue state filter.",
+                }
+            },
+        },
+    )
+    assert [violation.rule for violation in violations] == [RULE_ENUM]
+
+
+def test_actionable_property_description_identifier_rule_catches_missing_kind() -> None:
+    violations = collect_schema_violations(
+        tool_name="throwaway_identifier_rule",
+        source="knowledge",
+        schema={
+            "type": "object",
+            "properties": {
+                "incident_id": {
+                    "type": "string",
+                    "description": "the incident",
+                }
+            },
+        },
+    )
+    assert [violation.rule for violation in violations] == [RULE_IDENTIFIER]
+
+
+def test_actionable_property_description_exclusive_rule_catches_missing_hint() -> None:
+    violations = collect_schema_violations(
+        tool_name="throwaway_exclusive_rule",
+        source="knowledge",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "SQL query to execute.",
+                },
+                "query_file": {
+                    "type": "string",
+                    "description": "Path to a SQL file on disk.",
+                },
+            },
+            "oneOf": [
+                {"required": ["query"]},
+                {"required": ["query_file"]},
+            ],
+        },
+    )
+    assert {violation.rule for violation in violations} == {RULE_EXCLUSIVE}
+    assert {violation.property_name for violation in violations} == {"query", "query_file"}
 
 
 def test_v2_registry_required_fields_are_declared() -> None:


### PR DESCRIPTION
Fixes #5500

#### Describe the changes you have made in this PR -

Extend `test_v2_registry_property_schemas_are_typed_and_described` so a property description must be fillable, not merely present. The test now applies four conservative field-shape rules (time unit + format, enum values, identifier kind, mutual exclusion), quarantines current violators on a shrink-only allowlist, and reports violator counts per source. Existing tool descriptions are unchanged.

Per-source violator counts at quarantine time (154 total):

| source | count |
| --- | ---: |
| github | 45 |
| hermes | 19 |
| redis | 7 |
| bitbucket | 6 |
| knowledge | 6 |
| gitlab | 5 |
| helm | 5 |
| mongodb_atlas | 5 |
| yandex_cloud | 5 |
| airflow | 4 |
| interactive_shell | 4 |
| openobserve | 4 |
| tracer_web | 4 |
| cloudwatch | 3 |
| slack | 3 |
| snowflake | 3 |
| azure | 2 |
| betterstack | 2 |
| clickhouse | 2 |
| ec2 | 2 |
| grafana | 2 |
| openclaw | 2 |
| opensearch | 2 |
| rds | 2 |
| sentry | 2 |
| azure_sql | 1 |
| coralogix | 1 |
| dagster | 1 |
| honeycomb | 1 |
| incident_io | 1 |
| kafka | 1 |
| kubernetes | 1 |
| tempo | 1 |

### Demo/Screenshot for feature changes and bug fixes -

```bash
uv run python -m pytest tests/tools/test_registry.py -q -k property_schemas
```

```text
============================= test session starts =============================
collected 45 items / 44 deselected / 1 selected

tests\tools\test_registry.py .                                           [100%]

====================== 1 passed, 44 deselected in 3.33s =======================
```

The four rule-firing tests also pass (`-k "property_schemas or actionable_property_description"`): a `start_time` described as `"the start"` is caught by the unit rule; the same pattern is used for one enum, one identifier, and one mutually exclusive pair.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The existing registry test only required a non-empty description. A model can still pick the right tool and fill the argument wrongly (time with no unit, an undocumented enum, an ID of the wrong kind, or two exclusive params at once).

I extended the existing property walk instead of adding a second registry scan. Rules infer field shape from the property name plus schema, then check the description; detection is conservative so uncertain shapes are skipped rather than flagged. Current violators are frozen on a shrink-only allowlist compared exactly in both directions: a new miss fails, a fixed description must drop its entry. Descriptions themselves are out of scope.

Key pieces:
- `tests/tools/property_description_rules.py` — the four rules and helpers that collect violations from public input schemas.
- `tests/tools/property_description_allowlist.py` — shrink-only quarantine of the 154 existing misses, with per-source counts in the module docstring.
- `test_v2_registry_property_schemas_are_typed_and_described` — still checks type + non-empty description, then asserts the live violation set equals the allowlist.
- Four small tests feed throwaway schemas (`start_time` / enum / ID / exclusive pair) to prove each rule fires, without leaving a registered dummy tool in the tree.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.