### PR TITLE
feat(victoria_logs): add citeable query evidence

### DIFF
--- a/integrations/victoria_logs/tools/__init__.py
+++ b/integrations/victoria_logs/tools/__init__.py
@@ -16,12 +16,14 @@ permanently non-functional from the executor path. See
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
+from core.domain.types.evidence import EvidenceMapper
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.victoria_logs.client import make_victoria_logs_client
+from integrations.victoria_logs.tools._evidence import map_victoria_logs_query
 
 
 class VictoriaLogsTool(BaseTool):
@@ -29,6 +31,7 @@ class VictoriaLogsTool(BaseTool):
 
     name = "victoria_logs_query"
     source = "victoria_logs"
+    evidence_mapper: ClassVar[EvidenceMapper | None] = map_victoria_logs_query
     description = (
         "Query structured logs from VictoriaLogs using LogsQL to investigate "
         "application errors, request anomalies, or other log-correlated signals."

--- a/integrations/victoria_logs/tools/_evidence.py
+++ b/integrations/victoria_logs/tools/_evidence.py
@@ -1,0 +1,27 @@
+"""Evidence mapper for VictoriaLogs queries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+
+def map_victoria_logs_query(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Lift a VictoriaLogs query result into citeable report evidence."""
+    rows = output.get("rows", [])
+    if not isinstance(rows, list) or not rows:
+        return
+
+    query = output.get("query") or tool_input.get("query")
+    query_text = str(query).strip() if query else ""
+    row_label = "log entry" if len(rows) == 1 else "log entries"
+    record_evidence_entry(
+        evidence,
+        source="victoria_logs_query",
+        label="VictoriaLogs Logs",
+        summary=f"{len(rows)} {row_label}",
+        snippet=query_text[:200] or None,
+    )

--- a/tests/integrations/victoria_logs/test_evidence_mapper.py
+++ b/tests/integrations/victoria_logs/test_evidence_mapper.py
@@ -1,0 +1,62 @@
+"""Regression coverage for VictoriaLogs report evidence mapping."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import CATALOG_ENTRIES_KEY
+from integrations.victoria_logs.tools._evidence import map_victoria_logs_query
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+from tools.registry import get_registered_tool
+
+
+def test_mapper_records_rows_as_citeable_evidence() -> None:
+    evidence: dict[str, Any] = {}
+    rows = [{"_msg": "boom"}, {"_msg": "retry"}]
+
+    map_victoria_logs_query(
+        evidence,
+        {"rows": rows, "query": "level:error"},
+        {},
+    )
+
+    entries = evidence[CATALOG_ENTRIES_KEY]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "victoria_logs_query"
+    assert entries[0]["label"] == "VictoriaLogs Logs"
+    assert entries[0]["summary"] == "2 log entries"
+    assert entries[0]["snippet"] == "level:error"
+
+
+def test_mapper_skips_empty_rows() -> None:
+    evidence: dict[str, Any] = {}
+
+    map_victoria_logs_query(evidence, {"rows": [], "query": "*"}, {})
+
+    assert CATALOG_ENTRIES_KEY not in evidence
+
+
+def test_registered_tool_carries_evidence_mapper() -> None:
+    tool = get_registered_tool("victoria_logs_query")
+
+    assert tool is not None
+    assert tool.evidence_mapper is not None
+
+
+def test_merge_tool_evidence_uses_victoria_logs_mapper() -> None:
+    evidence: dict[str, Any] = {}
+    output = {"rows": [{"_msg": "boom"}], "query": "level:error"}
+
+    merge_tool_evidence(
+        evidence,
+        "victoria_logs_query",
+        output,
+        {"query": "level:error"},
+    )
+
+    assert evidence["victoria_logs_query"] == output
+    entries = evidence[CATALOG_ENTRIES_KEY]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "victoria_logs_query"
+    assert entries[0]["summary"] == "1 log entry"
+    assert entries[0]["snippet"] == "level:error"

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -166,7 +166,6 @@ summarize_community_followups
 summarize_github_pr_status
 telegram_send_message
 twilio_notify
-victoria_logs_query
 work_task_add
 work_task_complete
 work_task_list


### PR DESCRIPTION
Fixes #5594

Tracking epic: #5519 (part of #1079)

#### Describe the changes you have made in this PR -

`victoria_logs_query` already returns structured log rows, but it had no evidence mapper, so those results could not become citeable report evidence.

This PR:
- adds a VictoriaLogs-owned evidence mapper in `integrations/victoria_logs/tools/_evidence.py` and attaches it through the existing `BaseTool.evidence_mapper` contract
- records a `VictoriaLogs Logs` catalog entry for a non-empty query result, with the row count and a bounded query snippet
- leaves the shared merge/report pipeline and its raw `victoria_logs_query` output untouched
- removes `victoria_logs_query` from the evidence-mapper known-gap baseline
- adds focused mapper, registry, real merge-path, and empty-result regression coverage under `tests/integrations/victoria_logs/`

After review feedback, the mapper is intentionally scoped to the single-call behavior requested by #5594. Repeated-query citation semantics are not changed in this PR.

The mapper implementation is kept in a sibling `_evidence.py` module so the tool package follows the repository's current lightweight-`__init__.py` direction for new evidence-mapper code.

### Behavior comparison

For a successful result containing two rows and query `service:api AND level:error`, the raw `victoria_logs_query` value and the redacted `tool_outputs` entry remain unchanged. The only added evidence-path state is one catalog entry:

```json
{
  "label": "VictoriaLogs Logs",
  "snippet": "service:api AND level:error",
  "source": "victoria_logs_query",
  "summary": "2 log entries",
  "url": null
}
```

That mapped entry becomes a normal catalog item such as:

```text
- E1 — VictoriaLogs Logs — 2 log entries — service:api AND level:error
```

- **What the reader gains:** a report can cite that a VictoriaLogs query returned matching log entries, tied to the query that produced them.
- **Context cost:** one small summary entry, not the log payload. The query snippet is capped at 200 characters.
- **Empty/error behavior:** empty or non-list `rows` record no catalog entry.
- **Duplicate recording:** the mapper adds only report metadata; it does not copy log rows into the catalog.
- **Repeated-query behavior:** unchanged; this PR intentionally maps only the current call and does not alter shared evidence/report semantics.

I did not use live VictoriaLogs credentials for an end-to-end external query.

### Demo/Screenshot for feature changes and bug fixes -

Backend-only change; no UI screenshot applies.

Verification status:
- self-reviewed the refreshed four-file diff against current `main`
- the branch is based directly on current upstream `main` and contains only the VictoriaLogs mapper wiring/module, focused tests, and the baseline removal
- Greptile previously reported 5/5 on the same behavior before the repository's evidence-mapper layout rule changed; re-review has been requested for the refreshed head
- upstream repository workflows currently require approval before they can run on this forked PR

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-assisted code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have considered the empty-result edge case and the review-reported repeated-query interaction
- [x] I have modified the AI output to follow this project's coding standards and reviewer guidance

**Explain your implementation approach:**

The mapper now lives in `integrations/victoria_logs/tools/_evidence.py`, following the repository's current evidence-mapper placement pattern. The existing VictoriaLogs tool imports that mapper and attaches it through `BaseTool.evidence_mapper`; no shared investigation-stage behavior is changed.

When the tool returns a non-empty `rows` list, the mapper records one catalog entry with source `victoria_logs_query`, label `VictoriaLogs Logs`, a row-count summary, and a bounded query snippet. Empty row sets do not create citeable evidence.

The first revision attempted to aggregate repeated VictoriaLogs calls. Review correctly identified that `merge_tool_evidence` owns the raw `evidence["victoria_logs_query"]` key and replaces it before invoking the mapper. That unsupported behavior remains removed; #5594 stays scoped to mapping the current call only.

---

## Checklist before requesting a review
- [x] I have added a proper PR title and linked to the issue
- [x] I have performed a self-review of the refreshed diff
- [x] I can explain the purpose of every function, class, and logic block added
- [x] I have considered potential edge cases and how the code handles them
- [x] Focused regression tests are included
- [x] Behavior-change comparison requested by #5594 is documented above
- [ ] Full repository checks on the refreshed head — upstream workflows currently require maintainer approval

---

**Allow edits from maintainers:** enabled.