### PR TITLE
feat(x-mcp): add evidence mappers for X tools

### DIFF
--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -80,6 +80,20 @@ def _record_catalog_entry_once(
     record_evidence_entry(evidence, source=source, label=label, summary=summary)
 
 
+def _merge_tool_descriptor(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    """Merge repeated tool descriptors without dropping previously seen fields."""
+    merged = dict(existing)
+    for key, value in incoming.items():
+        previous = merged.get(key)
+        if isinstance(previous, dict) and isinstance(value, dict):
+            # MCP schemas can be nested, so merge them recursively to keep metadata
+            # learned from either compact or schema-rich inventory responses.
+            merged[key] = _merge_tool_descriptor(previous, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def _map_x_tool_listing(
     evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
 ) -> None:
@@ -92,7 +106,8 @@ def _map_x_tool_listing(
     if not isinstance(inventory, list):
         return
 
-    # Merge repeated filtered listings by tool name while retaining richer later descriptors.
+    # Merge repeated filtered listings by tool name without making descriptor richness
+    # depend on whether compact or schema-rich inventory responses arrive first.
     positions = {
         str(item.get("name")): index
         for index, item in enumerate(inventory)
@@ -103,7 +118,9 @@ def _map_x_tool_listing(
             continue
         name = str(descriptor["name"])
         if name in positions:
-            inventory[positions[name]] = descriptor
+            existing = inventory[positions[name]]
+            if isinstance(existing, dict):
+                inventory[positions[name]] = _merge_tool_descriptor(existing, descriptor)
         else:
             positions[name] = len(inventory)
             inventory.append(descriptor)

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -62,7 +62,18 @@ def _has_evidence_payload(value: object) -> bool:
     if isinstance(value, (int, float)):
         return True
     if isinstance(value, dict):
-        return any(_has_evidence_payload(item) for item in value.values())
+        # MCP TextContent envelopes carry a type marker even when their visible
+        # text is empty. Only the text field determines whether that envelope
+        # should create a report entry.
+        if value.get("type") == "text" and "text" in value:
+            return _has_evidence_payload(value["text"])
+
+        # Structured boolean fields such as {"exists": false} are meaningful
+        # tool results. Preserve both answers rather than treating false as an
+        # absent payload while still ignoring a standalone boolean value.
+        return any(_has_evidence_payload(item) for item in value.values()) or any(
+            isinstance(item, bool) for item in value.values()
+        )
     if isinstance(value, (list, tuple, set)):
         return any(_has_evidence_payload(item) for item in value)
     return False

--- a/integrations/x_mcp/tools/x_mcp_tool/__init__.py
+++ b/integrations/x_mcp/tools/x_mcp_tool/__init__.py
@@ -9,6 +9,9 @@ X adds or renames individual MCP-side tools.
 
 from __future__ import annotations
 
+from typing import Any
+
+from core.domain.types.evidence import CATALOG_ENTRIES_KEY, record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
 from core.tool_framework import tool
@@ -46,6 +49,104 @@ def _unavailable_response(
 
 
 _KNOWN_X_MCP_MODES = frozenset(McpTransportMode)
+
+
+def _has_evidence_payload(value: object) -> bool:
+    """Return whether an MCP payload value contains reportable data."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, dict):
+        return any(_has_evidence_payload(item) for item in value.values())
+    if isinstance(value, (list, tuple, set)):
+        return any(_has_evidence_payload(item) for item in value)
+    return False
+
+
+def _record_catalog_entry_once(
+    evidence: dict[str, Any], *, source: str, label: str, summary: str
+) -> None:
+    """Record one catalog row for an accumulating canonical evidence key."""
+    entries = evidence.get(CATALOG_ENTRIES_KEY)
+    if isinstance(entries, list) and any(
+        isinstance(entry, dict) and entry.get("source") == source for entry in entries
+    ):
+        return
+    record_evidence_entry(evidence, source=source, label=label, summary=summary)
+
+
+def _map_x_tool_listing(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    """Make a successful X MCP tool inventory citeable in incident reports."""
+    tools = output.get("tools")
+    if output.get("available") is not True or not isinstance(tools, list) or not tools:
+        return
+
+    inventory = evidence.setdefault("x_mcp_tools", [])
+    if not isinstance(inventory, list):
+        return
+
+    # Merge repeated filtered listings by tool name while retaining richer later descriptors.
+    positions = {
+        str(item.get("name")): index
+        for index, item in enumerate(inventory)
+        if isinstance(item, dict) and item.get("name")
+    }
+    for descriptor in tools:
+        if not isinstance(descriptor, dict) or not descriptor.get("name"):
+            continue
+        name = str(descriptor["name"])
+        if name in positions:
+            inventory[positions[name]] = descriptor
+        else:
+            positions[name] = len(inventory)
+            inventory.append(descriptor)
+
+    if not inventory:
+        evidence.pop("x_mcp_tools", None)
+        return
+    _record_catalog_entry_once(
+        evidence,
+        source="x_mcp_tools",
+        label="X MCP Tool Inventory",
+        summary="Available X MCP tools",
+    )
+
+
+def _map_x_tool_result(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    """Make a successful X MCP tool result citeable in incident reports."""
+    payload_fields = ("text", "structured_content", "content")
+    if output.get("available") is not True or not any(
+        _has_evidence_payload(output.get(field)) for field in payload_fields
+    ):
+        return
+
+    results = evidence.setdefault("x_mcp_results", [])
+    if not isinstance(results, list):
+        return
+    # Keep only response data in the canonical report key; raw output remains available
+    # through merge_tool_evidence without duplicating echoed call arguments here.
+    result = {
+        field: output.get(field)
+        for field in ("tool", "text", "structured_content", "content")
+        if field in output
+    }
+    results.append(result)
+
+    _record_catalog_entry_once(
+        evidence,
+        source="x_mcp_results",
+        label="X MCP Results",
+        summary="X MCP tool results",
+    )
 
 
 def _resolve_config(
@@ -128,6 +229,7 @@ def _normalize_tool_result(result: XMCPToolCallResult) -> XMCPResponse:
 @tool(
     name="list_x_tools",
     source="x_mcp",
+    evidence_mapper=_map_x_tool_listing,
     description=(
         "List the tools exposed by the configured X (Twitter) MCP server. Pass "
         "name_filter (e.g. 'search tweet timeline') to narrow the list, and "
@@ -232,6 +334,7 @@ def list_x_tools(
 @tool(
     name="call_x_tool",
     source="x_mcp",
+    evidence_mapper=_map_x_tool_result,
     description=(
         "Call a named tool exposed by the configured X (Twitter) MCP server "
         "(e.g. search tweets, inspect a user's timeline, look up a tweet by ID)."

--- a/tests/integrations/x_mcp/test_evidence_mappers.py
+++ b/tests/integrations/x_mcp/test_evidence_mappers.py
@@ -137,6 +137,35 @@ def test_repeated_x_calls_accumulate_without_duplicate_catalog_rows() -> None:
     assert [entry["source"] for entry in entries] == ["x_mcp_tools", "x_mcp_results"]
 
 
+def test_repeated_x_tool_listing_preserves_rich_descriptor_in_reverse_order() -> None:
+    """A later compact listing must not erase schema metadata already collected."""
+    evidence: dict[str, object] = {}
+    rich_descriptor = {
+        "name": "search-tweets",
+        "description": "Search recent tweets",
+        "input_schema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+    }
+
+    merge_tool_evidence(
+        evidence,
+        "list_x_tools",
+        {"available": True, "tools": [rich_descriptor]},
+        {},
+    )
+    merge_tool_evidence(
+        evidence,
+        "list_x_tools",
+        {"available": True, "tools": [{"name": "search-tweets"}]},
+        {},
+    )
+
+    assert evidence["x_mcp_tools"] == [rich_descriptor]
+    assert len(evidence["catalog_entries"]) == 1
+
+
 @pytest.mark.parametrize(
     ("tool_name", "output"),
     [

--- a/tests/integrations/x_mcp/test_evidence_mappers.py
+++ b/tests/integrations/x_mcp/test_evidence_mappers.py
@@ -1,0 +1,176 @@
+"""Evidence mapper coverage for the X MCP integration."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+
+def test_list_x_tools_records_tool_inventory() -> None:
+    """A non-empty tool listing becomes a citeable inventory entry."""
+    evidence: dict[str, object] = {}
+    tools = [
+        {"name": "search-tweets", "description": "Search recent tweets"},
+        {"name": "get-timeline", "description": "Read a user timeline"},
+    ]
+
+    merge_tool_evidence(
+        evidence,
+        "list_x_tools",
+        {"available": True, "tools": tools, "total_tools": 2},
+        {},
+    )
+
+    assert evidence["x_mcp_tools"] == tools
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "x_mcp_tools",
+            "label": "X MCP Tool Inventory",
+            "summary": "Available X MCP tools",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_call_x_tool_records_structured_result() -> None:
+    """Structured X results survive the real merge path and become citeable."""
+    evidence: dict[str, object] = {}
+    output = {
+        "available": True,
+        "tool": "search-tweets",
+        "text": "2 matching posts",
+        "structured_content": {"tweets": [{"id": "1"}, {"id": "2"}]},
+        "content": [],
+    }
+
+    merge_tool_evidence(
+        evidence,
+        "call_x_tool",
+        output,
+        {"tool_name": "search-tweets", "arguments": {"query": "outage"}},
+    )
+
+    assert evidence["x_mcp_results"] == [
+        {
+            "tool": "search-tweets",
+            "text": "2 matching posts",
+            "structured_content": {"tweets": [{"id": "1"}, {"id": "2"}]},
+            "content": [],
+        }
+    ]
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    assert entries[0]["source"] == "x_mcp_results"
+    assert entries[0]["summary"] == "X MCP tool results"
+
+
+def test_call_x_tool_records_numeric_structured_content() -> None:
+    """Numeric IDs and metrics in structured MCP payloads remain reportable."""
+    evidence: dict[str, object] = {}
+
+    merge_tool_evidence(
+        evidence,
+        "call_x_tool",
+        {
+            "available": True,
+            "tool": "search-tweets",
+            "structured_content": {"tweets": [1, 2]},
+        },
+        {},
+    )
+
+    assert evidence["x_mcp_results"] == [
+        {"tool": "search-tweets", "structured_content": {"tweets": [1, 2]}}
+    ]
+    assert evidence["catalog_entries"]
+
+
+def test_repeated_x_calls_accumulate_without_duplicate_catalog_rows() -> None:
+    """Repeated listings and calls retain evidence behind one catalog source each."""
+    evidence: dict[str, object] = {}
+
+    merge_tool_evidence(
+        evidence,
+        "list_x_tools",
+        {"available": True, "tools": [{"name": "search-tweets"}]},
+        {},
+    )
+    merge_tool_evidence(
+        evidence,
+        "list_x_tools",
+        {
+            "available": True,
+            "tools": [
+                {"name": "search-tweets", "input_schema": {"type": "object"}},
+                {"name": "get-timeline"},
+            ],
+        },
+        {},
+    )
+    for tool_name in ("search-tweets", "get-timeline"):
+        merge_tool_evidence(
+            evidence,
+            "call_x_tool",
+            {
+                "available": True,
+                "tool": tool_name,
+                "text": f"{tool_name} result",
+                "arguments": {"token": "must-not-enter-canonical-evidence"},
+            },
+            {"tool_name": tool_name},
+        )
+
+    assert evidence["x_mcp_tools"] == [
+        {"name": "search-tweets", "input_schema": {"type": "object"}},
+        {"name": "get-timeline"},
+    ]
+    results = evidence["x_mcp_results"]
+    assert isinstance(results, list)
+    assert [result["tool"] for result in results] == ["search-tweets", "get-timeline"]
+    assert all("arguments" not in result for result in results)
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    assert [entry["source"] for entry in entries] == ["x_mcp_tools", "x_mcp_results"]
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "output"),
+    [
+        ("list_x_tools", {"available": True, "tools": []}),
+        (
+            "call_x_tool",
+            {
+                "available": True,
+                "tool": "search-tweets",
+                "text": "",
+                "structured_content": None,
+                "content": [],
+            },
+        ),
+        (
+            "call_x_tool",
+            {
+                "available": True,
+                "text": False,
+                "structured_content": {"items": [{}]},
+                "content": [{}],
+            },
+        ),
+        ("call_x_tool", {"available": False, "error": "permission denied"}),
+    ],
+)
+def test_empty_or_unavailable_x_output_is_not_citeable(
+    tool_name: str, output: dict[str, object]
+) -> None:
+    """Empty and failed MCP responses must not create report evidence."""
+    evidence: dict[str, object] = {}
+
+    merge_tool_evidence(evidence, tool_name, output, {})
+
+    assert "catalog_entries" not in evidence
+    assert "x_mcp_tools" not in evidence
+    assert "x_mcp_results" not in evidence

--- a/tests/integrations/x_mcp/test_evidence_mappers.py
+++ b/tests/integrations/x_mcp/test_evidence_mappers.py
@@ -89,6 +89,47 @@ def test_call_x_tool_records_numeric_structured_content() -> None:
     assert evidence["catalog_entries"]
 
 
+@pytest.mark.parametrize("exists", [False, True])
+def test_call_x_tool_records_boolean_structured_content(exists: bool) -> None:
+    """Boolean structured responses remain citeable for both truth values."""
+    evidence: dict[str, object] = {}
+
+    merge_tool_evidence(
+        evidence,
+        "call_x_tool",
+        {
+            "available": True,
+            "tool": "tweet-exists",
+            "structured_content": {"exists": exists},
+        },
+        {},
+    )
+
+    assert evidence["x_mcp_results"] == [
+        {"tool": "tweet-exists", "structured_content": {"exists": exists}}
+    ]
+    assert evidence["catalog_entries"]
+
+
+def test_call_x_tool_ignores_empty_text_content_envelope() -> None:
+    """A TextContent type marker alone must not create empty report evidence."""
+    evidence: dict[str, object] = {}
+
+    merge_tool_evidence(
+        evidence,
+        "call_x_tool",
+        {
+            "available": True,
+            "tool": "search-tweets",
+            "content": [{"type": "text", "text": ""}],
+        },
+        {},
+    )
+
+    assert "catalog_entries" not in evidence
+    assert "x_mcp_results" not in evidence
+
+
 def test_repeated_x_calls_accumulate_without_duplicate_catalog_rows() -> None:
     """Repeated listings and calls retain evidence behind one catalog source each."""
     evidence: dict[str, object] = {}

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -19,7 +19,6 @@ buzz_send_message
 call_openclaw_tool
 call_posthog_tool
 call_sentry_tool
-call_x_tool
 check_s3_marker
 create_google_docs_incident_report
 describe_eks_addon
@@ -142,7 +141,6 @@ list_openclaw_tools
 list_posthog_tools
 list_s3_objects
 list_sentry_tools
-list_x_tools
 list_yc_instances
 list_yc_log_groups
 list_yc_metrics


### PR DESCRIPTION
Fixes #5576

#### Describe the changes you have made in this PR -

- Add evidence mappers to both `list_x_tools` and `call_x_tool`, making successful X MCP inventories and results citeable in incident reports.
- Accumulate repeated tool listings/results behind stable canonical evidence keys while recording one catalog entry per key.
- Ignore unavailable and empty payloads, retain structured boolean answers, and keep echoed call arguments out of canonical report evidence.
- Remove both tools from the evidence-mapper known-gap baseline and add focused unit/merge-path coverage.

### Demo/Screenshot for feature changes and bug fixes -

```text
{'call_x_tool': True, 'list_x_tools': True}
[{'source': 'x_mcp_results', 'label': 'X MCP Results', 'summary': 'X MCP tool results', 'url': None, 'snippet': None}]
```

Validation after rebasing onto current `main`:

- `make lint` — passed
- `make format-check` — passed (3706 files already formatted)
- `make typecheck` — passed (1938 source files)
- `uv run python -m pytest tests/integrations/x_mcp/ tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py` — 23 passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The two generic X MCP tools already return normalized envelopes, but without an `evidence_mapper` their output remains an opaque tool blob and cannot receive a report evidence ID. The new mappers live beside their owning tools and translate only successful, non-empty response data into canonical `x_mcp_tools` and `x_mcp_results` keys.

For repeated discovery calls, descriptors are merged recursively by tool name so compact listings cannot erase richer nested schema metadata. Call results accumulate, but echoed `arguments` are deliberately not duplicated into the canonical report path. A recursive payload check accepts meaningful text, numeric IDs/metrics, structured objects, and booleans nested in structured payloads while rejecting standalone booleans, recursively empty containers, and metadata-only empty TextContent envelopes. Catalog rows are recorded once per accumulating evidence key.

I considered storing each raw output directly as canonical evidence. I kept the existing raw-output path unchanged and instead normalized the report-facing keys to prevent duplicate call arguments and to make repeated calls deterministic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Allow edits from maintainers is enabled.
