### PR TITLE
fix(integrations): add evidence mapper for execute_aws_operation

### DIFF
--- a/integrations/aws/tools/aws_operation_tool/__init__.py
+++ b/integrations/aws/tools/aws_operation_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework import tool
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 
@@ -13,9 +14,48 @@ def _aws_operation_never_auto_available(_sources: dict[str, dict]) -> bool:
     return False
 
 
+def _summarize_aws_result(result: Any) -> str:
+    """Describe an AWS operation payload by shape only.
+
+    Never echoes payload values: an operation may return role policies or secret
+    metadata, and the summary is rendered into the incident report.
+    """
+    if isinstance(result, dict):
+        if not result:
+            return "empty result"
+        return "1 top-level key" if len(result) == 1 else f"{len(result)} top-level keys"
+    if isinstance(result, list):
+        if not result:
+            return "empty result"
+        return "1 record" if len(result) == 1 else f"{len(result)} records"
+    if result is None:
+        return "empty result"
+    return f"{type(result).__name__} result"
+
+
+def _map_aws_operation(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    if not output.get("found"):
+        return
+
+    service = str(output.get("service") or "")
+    operation = str(output.get("operation") or "")
+    qualified = ".".join(part for part in (service, operation) if part) or "operation"
+    evidence["aws_operation"] = output.get("result")
+
+    record_evidence_entry(
+        evidence,
+        source="execute_aws_operation",
+        label=f"AWS {qualified}",
+        summary=_summarize_aws_result(output.get("result")),
+    )
+
+
 @tool(
     name="execute_aws_operation",
     source="aws_sdk",
+    evidence_mapper=_map_aws_operation,
     description="Execute any read-only AWS SDK operation for investigation.",
     use_cases=[
         "Checking ECS task status and health (ecs.describe_tasks)",

--- a/tests/integrations/aws/test_aws_operation_evidence.py
+++ b/tests/integrations/aws/test_aws_operation_evidence.py
@@ -1,0 +1,120 @@
+"""Evidence mapping for the ``execute_aws_operation`` tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.aws.tools.aws_operation_tool import _map_aws_operation
+from tools.registry import get_registered_tool
+
+
+def test_successful_operation_is_citeable_with_qualified_label() -> None:
+    # Arrange
+    evidence: dict[str, Any] = {}
+    output = {
+        "found": True,
+        "service": "ecs",
+        "operation": "describe_tasks",
+        "result": {"tasks": [], "failures": []},
+    }
+
+    # Act
+    _map_aws_operation(evidence, output, {})
+
+    # Assert: the source must match the tool name so the report can cite it, and
+    # the label carries service.operation to tell two AWS calls apart.
+    entry = evidence["catalog_entries"][0]
+    assert entry["source"] == "execute_aws_operation"
+    assert entry["label"] == "AWS ecs.describe_tasks"
+    assert entry["summary"] == "2 top-level keys"
+
+
+def test_failed_operation_records_no_entry() -> None:
+    # Arrange: the failure branch carries an error and no result, so an entry
+    # here would be citeable noise the agent could mistake for data.
+    evidence: dict[str, Any] = {}
+
+    # Act
+    _map_aws_operation(
+        evidence,
+        {"found": False, "service": "ecs", "operation": "describe_tasks", "error": "denied"},
+        {},
+    )
+
+    # Assert
+    assert evidence == {}
+
+
+def test_missing_result_key_summarizes_as_empty() -> None:
+    # Arrange
+    evidence: dict[str, Any] = {}
+
+    # Act
+    _map_aws_operation(
+        evidence, {"found": True, "service": "rds", "operation": "describe_db_instances"}, {}
+    )
+
+    # Assert
+    assert evidence["catalog_entries"][0]["summary"] == "empty result"
+
+
+def test_empty_result_summarizes_as_empty() -> None:
+    # Arrange
+    evidence: dict[str, Any] = {}
+
+    # Act
+    _map_aws_operation(
+        evidence,
+        {"found": True, "service": "rds", "operation": "describe_db_instances", "result": {}},
+        {},
+    )
+
+    # Assert
+    assert evidence["catalog_entries"][0]["summary"] == "empty result"
+
+
+def test_summary_reports_shape_without_leaking_payload_values() -> None:
+    # Arrange: an operation may return secret metadata or role policies, and the
+    # summary is rendered into the report a human reads.
+    evidence: dict[str, Any] = {}
+
+    # Act
+    _map_aws_operation(
+        evidence,
+        {
+            "found": True,
+            "service": "ec2",
+            "operation": "describe_instances",
+            "result": [{"InstanceId": "i-secret"}, {"InstanceId": "i-also-secret"}],
+        },
+        {},
+    )
+
+    # Assert
+    summary = evidence["catalog_entries"][0]["summary"]
+    assert summary == "2 records"
+    assert "secret" not in summary
+
+
+def test_single_item_result_is_not_pluralized() -> None:
+    # Arrange: the summary reaches a human reader, so "1 records" is a defect.
+    evidence: dict[str, Any] = {}
+
+    # Act
+    _map_aws_operation(
+        evidence,
+        {"found": True, "service": "iam", "operation": "get_role", "result": {"Role": {}}},
+        {},
+    )
+
+    # Assert
+    assert evidence["catalog_entries"][0]["summary"] == "1 top-level key"
+
+
+def test_registered_tool_carries_the_mapper() -> None:
+    # Arrange / Act
+    registered_tool = get_registered_tool("execute_aws_operation")
+
+    # Assert
+    assert registered_tool is not None
+    assert registered_tool.evidence_mapper is _map_aws_operation

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -19,7 +19,6 @@ describe_eks_cluster
 describe_rds_events
 describe_rds_instance
 ec2_instances_by_tag
-execute_aws_operation
 execute_python_code
 execute_yc_operation
 fetch_failed_run


### PR DESCRIPTION
Fixes #5577

#### Describe the changes you have made in this PR -

`execute_aws_operation` had no `evidence_mapper`, so nothing it returned could ever get cited in the incident report, it just sat in `evidence_mapper_baseline.txt` as a known gap. Added `_map_aws_operation` (records the entry, skips the failure branch so errors aren't cited as data) and `_summarize_aws_result` (describes payloads by shape, i.e, record/key counts, never actual values, since `iam.get_role` and `secretsmanager.describe_secret` are both in this tool's use cases and I didn't want secrets leaking into report text). Tests cover the happy path, failure branch, missing/empty/list-shaped results, all 28 tests pass, and ruff/mypy clean.

One deliberate tradeoff: I considered encoding the operation into `source` (e.g. `source="aws_ecs_describe_tasks"`) instead of `label`, which would've fixed a real bug where `_add_mapped_entries` drops every AWS call after the first in one investigation. Didn't do it since the source is the claim-facing key that `attach_evidence_to_claims` resolves through, and the issue's own verification snippet asserts on it. Making it dynamic would've traded claim attribution for report cosmetics, so I kept source constant and just flagged the dedupe limitation instead of quietly shipping a partial fix.

Also: the issue references `integrations/aws_sdk/`, which doesn't exist — `aws_sdk` is just the tool's `source=` label. Real code and tests live under `integrations/aws/tools/aws_operation_tool/` and `tests/integrations/aws/`. Happy to move either if you'd rather split it out.

### Demo/Screenshot for feature changes and bug fixes -

![PR 5577 verification](https://raw.githubusercontent.com/ashthejuan/opensre/pr-assets-5577/pr-5577-verification.png)

The output really becomes report evidence (the issue's verification path):

```
$ uv run python -c "from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence; ev={}; merge_tool_evidence(ev, 'execute_aws_operation', {'found': True, 'service': 'ecs', 'operation': 'describe_tasks', 'result': {'tasks': [], 'failures': []}}, {}); print(ev.get('catalog_entries'))"
[{'source': 'execute_aws_operation', 'label': 'AWS ecs.describe_tasks', 'summary': '2 top-level keys', 'url': None, 'snippet': None}]
```

The tool carries its mapper:

```
$ uv run python -c "from tools.registry import get_registered_tool as g; print({n: bool(g(n).evidence_mapper) for n in ['execute_aws_operation']})"
{'execute_aws_operation': True}
```

Tests, including the tool's existing `BaseToolContract` suite that `make test-scope` targets, plus the evidence-mapper ratchet:

```
$ uv run pytest tests/integrations/aws/test_aws_operation_evidence.py tests/tools/test_aws_operation_tool.py tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q --no-header
28 passed
```

Summary shape across payload types. Before this PR every one of these produced no entry at all:

```
{'Role': {}}                  -> AWS iam.get_role | 1 top-level key
{'tasks': [], 'failures': []} -> AWS iam.get_role | 2 top-level keys
[1, 2]                        -> AWS iam.get_role | 2 records
{}                            -> AWS iam.get_role | empty result
found: False                  -> no catalog entry recorded
```

`ruff check`, `ruff format --check`, and `mypy` pass on both changed files.

I have not run the full `make test-cov` locally. `main` in my checkout has four pre-existing collection errors from missing optional dependencies, plus an unrelated failure in `tests/integrations/datadog/test_async_client.py`, so a full local run is mostly noise I did not cause. I relied on `make test-scope` and am leaving the full suite to CI.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a wiring gap, not a logic bug. The report can only cite what reaches `evidence["catalog_entries"]`, and only a mapper puts things there — `merge_tool_evidence` stores the raw output under `evidence[tool_name]`, then looks up the tool's mapper and calls it. With no mapper, AWS output stayed an opaque blob. So the fix is one mapper attached to one tool, and the interesting decisions are all about what belongs in an entry.

Two functions. `_map_aws_operation` is the mapper: guard on `found`, build the label, write the canonical `evidence["aws_operation"]` key, record the entry. `_summarize_aws_result` is split out because the shape branching had grown past what reads well inline, and separating it gave the shape-only rule a docstring a reviewer will actually see.

Three alternatives I considered and rejected:

Skipping the tool as action-only. The issue invites this for tools that only perform an action, but this one is read-only and returns real diagnostics (ECS task state, RDS config, EC2 state), so skipping would leave the exact gap the issue exists to close. Its `is_available` returning `False` only keeps it out of automatic planning; when the agent calls it explicitly the output should still be citeable.

Encoding the operation into `source` instead of `label`. Covered above — it would have fixed the dedupe limitation, but `source` is the claim-facing key that the issue's verification snippet asserts on and that `attach_evidence_to_claims` resolves through `SOURCE_ALIASES` / `source_to_id`. A dynamic source would break claim attribution to buy a report-cosmetics win.

Putting some of the payload in `summary` for a richer entry. Rejected on security grounds. `iam.get_role` and `secretsmanager.describe_secret` are in the tool's own documented use cases, so anything echoed there can end up in report text a human reads. Counts only.

Edge cases the tests pin: failure branch records nothing; `result` missing entirely behaves like `result: {}`; list payloads count records while dict payloads count top-level keys; single items are not mis-pluralized, since a human reads this string and "1 records" is a defect; and payload values never appear in the summary.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
