### PR TITLE
feat: add Splunk evidence mapper

### DIFF
--- a/integrations/splunk/tools/__init__.py
+++ b/integrations/splunk/tools/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool
 from infrastructure.evidence.evidence_compaction import compact_logs, summarize_counts
@@ -24,11 +25,25 @@ _ERROR_KEYWORDS = (
 )
 
 
+def _map_query_splunk_logs(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    logs = output.get("logs", [])
+    if logs:
+        record_evidence_entry(
+            evidence,
+            source="query_splunk_logs",
+            label="Splunk Logs",
+            summary=f"{len(logs)} logs",
+        )
+
+
 class SplunkSearchTool(BaseTool):
     """Search Splunk logs using SPL for errors, exceptions, and application events."""
 
     name = "query_splunk_logs"
     source = "splunk"
+    evidence_mapper = _map_query_splunk_logs
     description = (
         "Search Splunk using SPL (Search Processing Language) for application errors, "
         "exceptions, and operational events. Returns time-bounded log evidence."

--- a/tests/integrations/splunk/test_evidence_mapper.py
+++ b/tests/integrations/splunk/test_evidence_mapper.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from integrations.splunk.tools import _map_query_splunk_logs
+
+
+def test_query_splunk_logs_records_evidence_entry() -> None:
+    # Arrange
+    evidence: dict[str, Any] = {}
+    output = {
+        "logs": [
+            {"message": "connection failed"},
+            {"message": "request timeout"},
+        ]
+    }
+
+    # Act
+    _map_query_splunk_logs(evidence, output, {})
+
+    # Assert
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    assert any(
+        entry["source"] == "query_splunk_logs"
+        and entry["label"] == "Splunk Logs"
+        and entry["summary"] == "2 logs"
+        for entry in entries
+    )

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -158,7 +158,6 @@ query_datadog_monitors
 query_grafana_annotations
 query_groundcover_logs
 query_groundcover_traces
-query_splunk_logs
 query_yc_metrics
 read_yc_logs
 redeploy_railway_service


### PR DESCRIPTION
Fixes #5591
Part of #5519

#### Describe the changes you have made in this PR -

Adds an evidence mapper for `query_splunk_logs` so successful Splunk log results can be included as citeable evidence in investigation reports.

- Added `_map_query_splunk_logs` using `record_evidence_entry`
- Attached the mapper to the existing `SplunkSearchTool`
- Added a focused mapper unit test under `tests/integrations/splunk/`
- Removed `query_splunk_logs` from the evidence mapper known-gaps baseline

The existing class-based Splunk tool implementation is preserved. No shared report/evidence infrastructure or Splunk query behavior is changed.

### Behavior comparison

I ran the same mocked Splunk response against the PR base commit and this branch.

For a successful response containing 3 logs:

**Before**

```text
"mapper_registered": false,

"success_merge": {
  "catalog_entries": null,
  "tool_outputs_count": 1
}
```

**After**

```text
"mapper_registered": true,

"success_merge": {
  "catalog_entries": [
    {
      "label": "Splunk Logs",
      "snippet": null,
      "source": "query_splunk_logs",
      "summary": "3 logs",
      "url": null
    }
  ],
  "tool_outputs_count": 1
}
```

<details>
<summary>Actual before/after diff</summary>

```diff
- "mapper_registered": false,
+ "mapper_registered": true,

- "catalog_entries": null,
+ "catalog_entries": [
+   {
+     "label": "Splunk Logs",
+     "snippet": null,
+     "source": "query_splunk_logs",
+     "summary": "3 logs",
+     "url": null
+   }
+ ],
```

Empty response:

```text
Before: catalog_entries = null
After:  catalog_entries = null
```

Failed response (`Connection refused`):

```text
Before: catalog_entries = null
After:  catalog_entries = null
```

</details>

#### Behavior impact

- **What the reader gains:** A successful non-empty `query_splunk_logs` result can now appear as a citeable `Splunk Logs` evidence entry instead of only being retained as raw tool output.
- **Context cost:** The measured catalog entry above is 97 characters when compact-JSON serialized, excluding surrounding catalog/list formatting. No Splunk log payload is inlined; only the source, label, and count summary are added.
- **Empty/error results:** Both were tested before and after. Neither creates a catalog entry.
- **Duplicate evidence:** No existing evidence mapper was recording `query_splunk_logs`. The existing raw tool output remains unchanged, and this PR adds one report-facing catalog entry rather than another copy of the log payload.
- **Existing evidence shape:** In the before/after run, the raw Splunk output and `tool_outputs_count` were identical. The only observed evidence-path difference was the new catalog entry for successful non-empty results.

Query execution, error filtering, log compaction, return shape, failure handling, and raw evidence storage were unchanged in the comparison.

### Demo/Screenshot for feature changes and bug fixes -

Verified through the registered tool and real evidence merge path:

```text
{'query_splunk_logs': True}

[{'source': 'query_splunk_logs',
  'label': 'Splunk Logs',
  'summary': '2 logs',
  'url': None,
  'snippet': None}]
```

Validation:

```text
1 passed   tests/integrations/splunk/test_evidence_mapper.py
9 passed   tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py
70 passed  tests/ -k splunk

make lint         -> All checks passed
make format-check -> 3671 files already formatted
make typecheck    -> Success: no issues found in 1907 source files
```

`make test-cov` completed with 15,497 passed and 2 failures. Both failures were unrelated to this change and passed when rerun independently:

```text
tests/config/test_runtime_metadata_perf.py::test_baseline_stability
-> 3 passed

TestEvidenceMapperCoverage::test_no_new_unmapped_tool
-> 1 passed
```

The evidence mapper coverage failure only appeared during the parallel full-suite run with additional globally registered tools; `query_splunk_logs` was not among the reported unmapped tools.

### Report-level verification

The mapper registration and real `merge_tool_evidence` path have been verified above.

A live Splunk-backed `opensre investigate` report check has not been performed locally yet. This does not affect the before/after evidence-path comparison above.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`query_splunk_logs` already returns diagnostic data in its `logs` field, but it did not have an evidence mapper, so that output was not added to the citeable evidence catalog.

The new `_map_query_splunk_logs` mapper reads the `logs` field and records a catalog entry with `query_splunk_logs` as the source when logs are present.

Because the Splunk tool is implemented as a `BaseTool` subclass rather than with the `@tool` decorator, the mapper is attached through the existing `evidence_mapper` class attribute. This preserves the existing tool structure and keeps the change scoped to the issue.

The mapper deliberately records only a short count summary rather than copying the log payload into the catalog. Empty and failure outputs do not create entries.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
