### PR TITLE
fix: parse glued shell operators correctly

### DIFF
--- a/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
+++ b/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Protocol, cast
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework.tool_decorator import tool
 
 # --------------------------------------------------------------------------- #
@@ -265,9 +266,228 @@ def _run_backend(cloudops_backend: Any, method_name: str, **kwargs: Any) -> dict
     return method(**kwargs)
 
 
+def _cloudopsbench_snippet(value: Any) -> str | None:
+    if value in (None, "", [], {}):
+        return None
+    compact = " ".join(str(value).split())
+    compact = compact.replace("{", "").replace("}", "").replace("[", "").replace("]", "")
+    return compact[:140] or None
+
+
+def _record_cloudopsbench_evidence(
+    evidence: dict[str, Any],
+    output: dict[str, Any],
+    tool_input: dict[str, Any],
+    *,
+    source: str,
+    label: str,
+    summary: str,
+) -> None:
+    if not output.get("available", False):
+        return
+    rendered_output = output.get("output")
+    if rendered_output in (None, "", [], {}):
+        return
+    record_evidence_entry(
+        evidence,
+        source=source,
+        label=label,
+        summary=summary,
+        snippet=_cloudopsbench_snippet(rendered_output),
+    )
+
+
+def _cloudopsbench_action_input(
+    output: dict[str, Any], tool_input: dict[str, Any]
+) -> dict[str, Any]:
+    action_input = output.get("action_input")
+    if isinstance(action_input, dict):
+        return action_input
+    return tool_input
+
+
+def _map_get_resources(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    resource_type = str(
+        action_input.get("resource_type") or tool_input.get("resource_type") or _DEFAULT_RESOURCE_TYPE
+    )
+    namespace = action_input.get("namespace") or tool_input.get("namespace") or _DEFAULT_NAMESPACE
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="GetResources",
+        label="Kubernetes Resources",
+        summary=f"{resource_type} in {namespace or 'cluster scope'}",
+    )
+
+
+def _map_describe_resource(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    resource_type = str(
+        action_input.get("resource_type")
+        or tool_input.get("resource_type")
+        or _DEFAULT_DESCRIBE_RESOURCE_TYPE
+    )
+    name = str(
+        action_input.get("name") or tool_input.get("name") or _DEFAULT_SERVICE
+    )
+    namespace = action_input.get("namespace") or tool_input.get("namespace")
+    summary = f"{resource_type} {name}"
+    if namespace:
+        summary = f"{summary} in {namespace}"
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="DescribeResource",
+        label="Kubernetes Resource Details",
+        summary=summary,
+    )
+
+
+def _map_get_cluster_configuration(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="GetClusterConfiguration",
+        label="Cluster Configuration",
+        summary="cluster configuration snapshot",
+    )
+
+
+def _map_get_alerts(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="GetAlerts",
+        label="Cluster Alerts",
+        summary="active alerts snapshot",
+    )
+
+
+def _map_get_error_logs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    service_name = str(
+        action_input.get("service_name") or tool_input.get("service_name") or _DEFAULT_SERVICE
+    )
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="GetErrorLogs",
+        label="Service Error Logs",
+        summary=f"{service_name} error logs",
+    )
+
+
+def _map_get_recent_logs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    service_name = str(
+        action_input.get("service_name") or tool_input.get("service_name") or _DEFAULT_SERVICE
+    )
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="GetRecentLogs",
+        label="Recent Service Logs",
+        summary=f"{service_name} recent logs",
+    )
+
+
+def _map_get_service_dependencies(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    service_name = str(
+        action_input.get("service_name") or tool_input.get("service_name") or _DEFAULT_SERVICE
+    )
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="GetServiceDependencies",
+        label="Service Dependencies",
+        summary=f"{service_name} dependencies",
+    )
+
+
+def _map_get_app_yaml(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    app_name = str(action_input.get("app_name") or tool_input.get("app_name") or _DEFAULT_SERVICE)
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="GetAppYAML",
+        label="Application YAML",
+        summary=f"{app_name} deployment YAML",
+    )
+
+
+def _map_check_service_connectivity(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    service_name = str(
+        action_input.get("service_name") or tool_input.get("service_name") or _DEFAULT_SERVICE
+    )
+    port = action_input.get("port") or tool_input.get("port") or _DEFAULT_HTTP_PORT
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="CheckServiceConnectivity",
+        label="Service Connectivity",
+        summary=f"{service_name}:{port} connectivity",
+    )
+
+
+def _map_check_node_service_status(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    action_input = _cloudopsbench_action_input(output, tool_input)
+    node_name = str(
+        action_input.get("node_name")
+        or tool_input.get("node_name")
+        or _DEFAULT_CONTROL_PLANE_NODE
+    )
+    service_name = str(
+        action_input.get("service_name")
+        or tool_input.get("service_name")
+        or _DEFAULT_CONTROL_PLANE_SERVICE
+    )
+    _record_cloudopsbench_evidence(
+        evidence,
+        output,
+        tool_input,
+        source="CheckNodeServiceStatus",
+        label="Node Service Status",
+        summary=f"{node_name} {service_name} status",
+    )
+
+
 @tool(
     name="GetResources",
     source="eks",
+    evidence_mapper=_map_get_resources,
     description=(
         "List Kubernetes resources in the cluster — pods, deployments, "
         "services, events, nodes, replicasets. Use this FIRST in most "
@@ -312,6 +532,7 @@ def get_resources(
 @tool(
     name="DescribeResource",
     source="eks",
+    evidence_mapper=_map_describe_resource,
     description=(
         "Get detailed configuration for a specific named Kubernetes resource "
         "(pod, deployment, service, statefulset). Use AFTER GetResources "
@@ -348,6 +569,7 @@ def describe_resource(
 @tool(
     name="GetClusterConfiguration",
     source="eks",
+    evidence_mapper=_map_get_cluster_configuration,
     description=(
         "Get cluster-level state: node health, control-plane component "
         "status (kubelet, kube-scheduler, kube-proxy, containerd), and "
@@ -372,6 +594,7 @@ def get_cluster_configuration(cloudops_backend: Any) -> dict[str, Any]:
 @tool(
     name="GetAlerts",
     source="eks",
+    evidence_mapper=_map_get_alerts,
     description=(
         "Get the active alerts that triggered this investigation. Call "
         "this FIRST in every case — the alert message identifies the "
@@ -397,6 +620,7 @@ def get_alerts(cloudops_backend: Any) -> dict[str, Any]:
 @tool(
     name="GetErrorLogs",
     source="eks",
+    evidence_mapper=_map_get_error_logs,
     description=(
         "Get aggregated error-log signals for a specific service: counts "
         "and example messages grouped by error type. Use AFTER finding a "
@@ -432,6 +656,7 @@ def get_error_logs(
 @tool(
     name="GetRecentLogs",
     source="eks",
+    evidence_mapper=_map_get_recent_logs,
     description=(
         "Get the most recent log lines from a service — chronologically "
         "ordered, unfiltered. Use when GetErrorLogs aggregation isn't "
@@ -468,6 +693,7 @@ def get_recent_logs(
 @tool(
     name="GetServiceDependencies",
     source="eks",
+    evidence_mapper=_map_get_service_dependencies,
     description=(
         "Map a service's upstream and downstream dependencies. Use this "
         "to trace cascading failures: if service A is failing, what "
@@ -496,6 +722,7 @@ def get_service_dependencies(cloudops_backend: Any, service_name: str) -> dict[s
 @tool(
     name="GetAppYAML",
     source="eks",
+    evidence_mapper=_map_get_app_yaml,
     description=(
         "Get the full deployment YAML for an application — shows every "
         "secret reference, env var, volume mount, image tag, and resource "
@@ -522,6 +749,7 @@ def get_app_yaml(cloudops_backend: Any, app_name: str) -> dict[str, Any]:
 @tool(
     name="CheckServiceConnectivity",
     source="eks",
+    evidence_mapper=_map_check_service_connectivity,
     description=(
         "Test reachability of a Kubernetes service from inside the "
         "cluster. Use to confirm suspected service-routing failures: "
@@ -558,6 +786,7 @@ def check_service_connectivity(
 @tool(
     name="CheckNodeServiceStatus",
     source="eks",
+    evidence_mapper=_map_check_node_service_status,
     description=(
         "Check the health of a specific Kubernetes control-plane "
         "component (kubelet, kube-scheduler, kube-proxy, containerd) "

--- a/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
+++ b/tests/benchmarks/cloudopsbench/tools/k8s/__init__.py
@@ -311,7 +311,9 @@ def _map_get_resources(
 ) -> None:
     action_input = _cloudopsbench_action_input(output, tool_input)
     resource_type = str(
-        action_input.get("resource_type") or tool_input.get("resource_type") or _DEFAULT_RESOURCE_TYPE
+        action_input.get("resource_type")
+        or tool_input.get("resource_type")
+        or _DEFAULT_RESOURCE_TYPE
     )
     namespace = action_input.get("namespace") or tool_input.get("namespace") or _DEFAULT_NAMESPACE
     _record_cloudopsbench_evidence(
@@ -333,9 +335,7 @@ def _map_describe_resource(
         or tool_input.get("resource_type")
         or _DEFAULT_DESCRIBE_RESOURCE_TYPE
     )
-    name = str(
-        action_input.get("name") or tool_input.get("name") or _DEFAULT_SERVICE
-    )
+    name = str(action_input.get("name") or tool_input.get("name") or _DEFAULT_SERVICE)
     namespace = action_input.get("namespace") or tool_input.get("namespace")
     summary = f"{resource_type} {name}"
     if namespace:
@@ -465,9 +465,7 @@ def _map_check_node_service_status(
 ) -> None:
     action_input = _cloudopsbench_action_input(output, tool_input)
     node_name = str(
-        action_input.get("node_name")
-        or tool_input.get("node_name")
-        or _DEFAULT_CONTROL_PLANE_NODE
+        action_input.get("node_name") or tool_input.get("node_name") or _DEFAULT_CONTROL_PLANE_NODE
     )
     service_name = str(
         action_input.get("service_name")

--- a/tests/benchmarks/cloudopsbench/tools/tests/test_k8s_tools.py
+++ b/tests/benchmarks/cloudopsbench/tools/tests/test_k8s_tools.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-from tests.benchmarks.cloudopsbench.tools.k8s import get_error_logs, get_recent_logs
+import pytest
+
+from tests.benchmarks.cloudopsbench.tools import k8s as k8s_tools
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
 
 
 class _Backend:
@@ -34,9 +37,102 @@ def test_recent_logs_extracts_its_own_service_name() -> None:
     # slot-separation refactor enforces.
     sources = {"eks": {"_bench_backend": backend, "namespace": "boutique"}}
 
-    error_params = _tool_params(get_error_logs, sources)
-    recent_params = _tool_params(get_recent_logs, sources)
+    error_params = _tool_params(k8s_tools.get_error_logs, sources)
+    recent_params = _tool_params(k8s_tools.get_recent_logs, sources)
 
     assert error_params["service_name"] == "frontend"
     assert recent_params["service_name"] == "cartservice"
     assert recent_params["namespace"] == "boutique"
+
+
+@pytest.mark.parametrize(
+    ("tool_func", "tool_input", "rendered_output", "expected_summary"),
+    [
+        (
+            k8s_tools.get_resources,
+            {"resource_type": "pods", "namespace": "boutique"},
+            [{"name": "frontend-abc123"}],
+            "pods in boutique",
+        ),
+        (
+            k8s_tools.describe_resource,
+            {"resource_type": "deployment", "name": "frontend", "namespace": "boutique"},
+            {"kind": "Deployment", "name": "frontend"},
+            "deployment frontend in boutique",
+        ),
+        (
+            k8s_tools.get_cluster_configuration,
+            {},
+            {"nodes": ["node-a"]},
+            "cluster configuration snapshot",
+        ),
+        (
+            k8s_tools.get_alerts,
+            {},
+            "2 active alerts",
+            "active alerts snapshot",
+        ),
+        (
+            k8s_tools.get_error_logs,
+            {"namespace": "boutique", "service_name": "frontend"},
+            "Access denied for user",
+            "frontend error logs",
+        ),
+        (
+            k8s_tools.get_recent_logs,
+            {"namespace": "boutique", "service_name": "cartservice"},
+            ["recent line 1", "recent line 2"],
+            "cartservice recent logs",
+        ),
+        (
+            k8s_tools.get_service_dependencies,
+            {"service_name": "frontend"},
+            {"downstream": ["catalogservice"]},
+            "frontend dependencies",
+        ),
+        (
+            k8s_tools.get_app_yaml,
+            {"app_name": "frontend"},
+            "apiVersion: apps/v1",
+            "frontend deployment YAML",
+        ),
+        (
+            k8s_tools.check_service_connectivity,
+            {"service_name": "frontend", "port": 80, "namespace": "boutique"},
+            "Connection OK",
+            "frontend:80 connectivity",
+        ),
+        (
+            k8s_tools.check_node_service_status,
+            {"node_name": "node-a", "service_name": "kubelet"},
+            {"status": "Running"},
+            "node-a kubelet status",
+        ),
+    ],
+)
+def test_cloudopsbench_k8s_tools_record_citeable_evidence(
+    tool_func: Any,
+    tool_input: dict[str, Any],
+    rendered_output: Any,
+    expected_summary: str,
+) -> None:
+    evidence: dict[str, Any] = {}
+    tool_name = tool_func.__opensre_registered_tool__.name
+    output = {
+        "source": "cloudopsbench",
+        "available": True,
+        "action_name": tool_name,
+        "action_input": tool_input,
+        "output": rendered_output,
+        "cache_key": "cache-key",
+        "cache_hit": True,
+    }
+
+    merge_tool_evidence(evidence, tool_name, output, tool_input)
+
+    assert evidence[tool_name] == output
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    entry = next(item for item in entries if item["source"] == tool_name)
+    assert expected_summary in (entry.get("summary") or "")
+    assert entry.get("label")

--- a/tests/integrations/llm_cli/test_codex_oauth.py
+++ b/tests/integrations/llm_cli/test_codex_oauth.py
@@ -5,6 +5,7 @@ import json
 import socket
 import stat
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -44,6 +45,10 @@ def _free_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def _callback_get(url: str, **kwargs: Any) -> httpx.Response:
+    return httpx.get(url, trust_env=False, **kwargs)
+
+
 def test_build_codex_oauth_request_uses_pkce_and_localhost_callback() -> None:
     request = codex_oauth.build_codex_oauth_request()
 
@@ -67,7 +72,7 @@ def test_wait_for_codex_oauth_callback_writes_tokens_and_redirects_success(
     request = codex_oauth.build_codex_oauth_request()
 
     def _open_browser(_url: str) -> bool:
-        response = httpx.get(
+        response = _callback_get(
             f"http://localhost:{port}/auth/callback",
             params={"code": "auth-code", "state": request.state},
             follow_redirects=False,
@@ -117,7 +122,7 @@ def test_wait_for_codex_oauth_callback_rejects_invalid_callbacks(
     params = {**params, "state": params.get("state", request.state)}
 
     def _open_browser(_url: str) -> bool:
-        response = httpx.get(
+        response = _callback_get(
             f"http://localhost:{port}/auth/callback",
             params=params,
             timeout=5.0,
@@ -150,7 +155,7 @@ def test_wait_for_codex_oauth_callback_stores_success_id_token_callback(
     )
 
     def _open_browser(_url: str) -> bool:
-        response = httpx.get(
+        response = _callback_get(
             f"http://localhost:{port}/success",
             params={"id_token": id_token},
             timeout=5.0,

--- a/tests/interactive_shell/shell/test_shell_parsing.py
+++ b/tests/interactive_shell/shell/test_shell_parsing.py
@@ -83,6 +83,22 @@ def test_background_operator_runs_through_shell() -> None:
     assert parsed.parse_error is None
 
 
+def test_windows_backslash_does_not_escape_operator() -> None:
+    parsed = parse_shell_command(r"echo C:\tmp\& echo done", is_windows=True)
+
+    assert parsed.use_shell is True
+    assert parsed.argv is None
+    assert parsed.parse_error is None
+
+
+def test_posix_backslash_escapes_literal_operator() -> None:
+    parsed = parse_shell_command(r"echo dir\&name", is_windows=False)
+
+    assert parsed.use_shell is False
+    assert parsed.argv == ["echo", "dir&name"]
+    assert parsed.parse_error is None
+
+
 def test_command_substitution_runs_through_shell() -> None:
     parsed = parse_shell_command("echo $(date)", is_windows=False)
 

--- a/tests/interactive_shell/shell/test_shell_parsing.py
+++ b/tests/interactive_shell/shell/test_shell_parsing.py
@@ -51,6 +51,30 @@ def test_operators_run_through_shell_without_block() -> None:
     assert parsed.parse_error is None
 
 
+def test_glued_redirection_runs_through_shell() -> None:
+    parsed = parse_shell_command("echo hello >out.txt 2>&1", is_windows=False)
+
+    assert parsed.use_shell is True
+    assert parsed.argv is None
+    assert parsed.parse_error is None
+
+
+def test_glued_append_redirection_runs_through_shell() -> None:
+    parsed = parse_shell_command("printf hello>>out.txt", is_windows=False)
+
+    assert parsed.use_shell is True
+    assert parsed.argv is None
+    assert parsed.parse_error is None
+
+
+def test_background_operator_runs_through_shell() -> None:
+    parsed = parse_shell_command("sleep 1&", is_windows=False)
+
+    assert parsed.use_shell is True
+    assert parsed.argv is None
+    assert parsed.parse_error is None
+
+
 def test_command_substitution_runs_through_shell() -> None:
     parsed = parse_shell_command("echo $(date)", is_windows=False)
 

--- a/tests/interactive_shell/shell/test_shell_parsing.py
+++ b/tests/interactive_shell/shell/test_shell_parsing.py
@@ -59,6 +59,22 @@ def test_quoted_operator_stays_in_argv_mode() -> None:
     assert parsed.parse_error is None
 
 
+def test_single_quoted_substitution_stays_in_argv_mode() -> None:
+    parsed = parse_shell_command("cd 'dir$(name)'", is_windows=False)
+
+    assert parsed.use_shell is False
+    assert parsed.argv == ["cd", "dir$(name)"]
+    assert parsed.parse_error is None
+
+
+def test_double_quoted_substitution_runs_through_shell() -> None:
+    parsed = parse_shell_command('echo "$(date)"', is_windows=False)
+
+    assert parsed.use_shell is True
+    assert parsed.argv is None
+    assert parsed.parse_error is None
+
+
 def test_glued_redirection_runs_through_shell() -> None:
     parsed = parse_shell_command("echo hello >out.txt 2>&1", is_windows=False)
 
@@ -85,6 +101,14 @@ def test_background_operator_runs_through_shell() -> None:
 
 def test_windows_backslash_does_not_escape_operator() -> None:
     parsed = parse_shell_command(r"echo C:\tmp\& echo done", is_windows=True)
+
+    assert parsed.use_shell is True
+    assert parsed.argv is None
+    assert parsed.parse_error is None
+
+
+def test_windows_apostrophe_does_not_quote_operator() -> None:
+    parsed = parse_shell_command("echo '&'", is_windows=True)
 
     assert parsed.use_shell is True
     assert parsed.argv is None

--- a/tests/interactive_shell/shell/test_shell_parsing.py
+++ b/tests/interactive_shell/shell/test_shell_parsing.py
@@ -51,6 +51,14 @@ def test_operators_run_through_shell_without_block() -> None:
     assert parsed.parse_error is None
 
 
+def test_quoted_operator_stays_in_argv_mode() -> None:
+    parsed = parse_shell_command('cd "dir&name"', is_windows=False)
+
+    assert parsed.use_shell is False
+    assert parsed.argv == ["cd", "dir&name"]
+    assert parsed.parse_error is None
+
+
 def test_glued_redirection_runs_through_shell() -> None:
     parsed = parse_shell_command("echo hello >out.txt 2>&1", is_windows=False)
 
@@ -138,3 +146,11 @@ def test_argv_for_repl_builtin_detection_skips_operator_command() -> None:
     """A leading ``cd`` in an operator command must not be hijacked as a builtin."""
     parsed = parse_shell_command("cd /tmp && ls", is_windows=False)
     assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) is None
+
+
+def test_argv_for_repl_builtin_detection_keeps_quoted_operator_arg() -> None:
+    parsed = parse_shell_command('cd "dir&name"', is_windows=False)
+    assert argv_for_repl_builtin_detection(parsed=parsed, is_windows=False) == [
+        "cd",
+        "dir&name",
+    ]

--- a/tests/interactive_shell/test_cli_foreground.py
+++ b/tests/interactive_shell/test_cli_foreground.py
@@ -1,0 +1,28 @@
+"""Tests for foreground OpenSRE CLI subprocess execution."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import NoReturn
+
+import pytest
+
+from tools.interactive_shell.cli import run_foreground_cli
+
+
+def test_run_foreground_cli_decodes_timeout_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_args: object, **_kwargs: object) -> NoReturn:
+        raise subprocess.TimeoutExpired(
+            cmd=["opensre", "health"],
+            timeout=1,
+            output=b"partial stdout\n",
+            stderr=b"partial stderr\n",
+        )
+
+    monkeypatch.setattr("tools.interactive_shell.cli.subprocess.run", _raise)
+
+    result = run_foreground_cli(["opensre", "health"], timeout_seconds=1)
+
+    assert result.timed_out is True
+    assert result.stdout == "partial stdout\n"
+    assert result.stderr == "partial stderr\n"

--- a/tools/interactive_shell/cli.py
+++ b/tools/interactive_shell/cli.py
@@ -95,6 +95,14 @@ class ForegroundCliResult:
     start_error: str | None = None
 
 
+def _text_from_timeout_stream(raw: str | bytes | None) -> str:
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    return raw.decode("utf-8", errors="replace")
+
+
 def _sys_executable_is_python() -> bool:
     return Path(sys.executable).name.lower().startswith(_PYTHON_EXECUTABLE_PREFIXES)
 
@@ -238,8 +246,8 @@ def run_foreground_cli(
         )
     except subprocess.TimeoutExpired as exc:
         return ForegroundCliResult(
-            stdout=str(exc.output or ""),
-            stderr=str(exc.stderr or ""),
+            stdout=_text_from_timeout_stream(exc.output),
+            stderr=_text_from_timeout_stream(exc.stderr),
             exit_code=None,
             timed_out=True,
             start_failed=False,

--- a/tools/interactive_shell/shell/parsing.py
+++ b/tools/interactive_shell/shell/parsing.py
@@ -29,11 +29,10 @@ import shlex
 from dataclasses import dataclass
 
 _EXPLICIT_SHELL_PREFIX = "!"
-_SHELL_OPERATOR_RE = re.compile(r"(^|\s)(\|\||&&|[|;<>]|>>|<<|2>)(\s|$)")
+_SHELL_OPERATOR_RE = re.compile(r"\|\||&&|[|;&<>]")
 _INLINE_SUBSHELL_RE = re.compile(r"`|\$\(")
-# Heredoc starts such as ``<<'PY'`` or ``<<EOF`` — ``<<`` alone is already covered
-# by ``_SHELL_OPERATOR_RE`` only when followed by whitespace; quoted/unquoted
-# delimiters need an explicit match so ``python3 - <<'PY'`` is not tokenized.
+# Heredoc starts such as ``<<'PY'`` or ``<<EOF``; the explicit pattern preserves
+# that intent even though the broad operator check already catches ``<``.
 _HEREDOC_START_RE = re.compile(r"(^|\s)<<-?\s*(?:'[^'\n]+'|\"[^\"\n]+\"|[^\s\\|;&<>]+)")
 
 

--- a/tools/interactive_shell/shell/parsing.py
+++ b/tools/interactive_shell/shell/parsing.py
@@ -29,11 +29,7 @@ import shlex
 from dataclasses import dataclass
 
 _EXPLICIT_SHELL_PREFIX = "!"
-_SHELL_OPERATOR_RE = re.compile(r"\|\||&&|[|;&<>]")
 _INLINE_SUBSHELL_RE = re.compile(r"`|\$\(")
-# Heredoc starts such as ``<<'PY'`` or ``<<EOF``; the explicit pattern preserves
-# that intent even though the broad operator check already catches ``<``.
-_HEREDOC_START_RE = re.compile(r"(^|\s)<<-?\s*(?:'[^'\n]+'|\"[^\"\n]+\"|[^\s\\|;&<>]+)")
 
 
 @dataclass(frozen=True)
@@ -63,6 +59,48 @@ def _split_argv(command: str, *, is_windows: bool) -> list[str] | None:
             return None
 
 
+def _has_unquoted_shell_operator(command: str) -> bool:
+    """Return True when shell metacharacters appear outside quotes.
+
+    The parser needs to notice glued operators like ``>out.txt`` or ``2>&1``,
+    but a literal ``&`` inside ``cd "dir&name"`` must stay an argument so the
+    REPL builtin path can preserve the working directory.
+    """
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+
+    for ch in command:
+        if escaped:
+            escaped = False
+            continue
+
+        if ch == "\\" and not in_single_quote:
+            escaped = True
+            continue
+
+        if in_single_quote:
+            if ch == "'":
+                in_single_quote = False
+            continue
+
+        if in_double_quote:
+            if ch == '"':
+                in_double_quote = False
+            continue
+
+        if ch == "'":
+            in_single_quote = True
+            continue
+        if ch == '"':
+            in_double_quote = True
+            continue
+        if ch in "|;&<>":
+            return True
+
+    return False
+
+
 def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand:
     """Parse command text into an executable shape (no safety policy applied)."""
     stripped = command.strip()
@@ -84,10 +122,8 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
             use_shell=True,
         )
 
-    if (
-        _SHELL_OPERATOR_RE.search(stripped) is not None
-        or _INLINE_SUBSHELL_RE.search(stripped) is not None
-        or _HEREDOC_START_RE.search(stripped) is not None
+    if _INLINE_SUBSHELL_RE.search(stripped) is not None or _has_unquoted_shell_operator(
+        stripped
     ):
         # Operators / substitution need a real shell; alpha mode runs them.
         return ParsedShellCommand(

--- a/tools/interactive_shell/shell/parsing.py
+++ b/tools/interactive_shell/shell/parsing.py
@@ -122,9 +122,7 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
             use_shell=True,
         )
 
-    if _INLINE_SUBSHELL_RE.search(stripped) is not None or _has_unquoted_shell_operator(
-        stripped
-    ):
+    if _INLINE_SUBSHELL_RE.search(stripped) is not None or _has_unquoted_shell_operator(stripped):
         # Operators / substitution need a real shell; alpha mode runs them.
         return ParsedShellCommand(
             command=stripped,

--- a/tools/interactive_shell/shell/parsing.py
+++ b/tools/interactive_shell/shell/parsing.py
@@ -59,7 +59,7 @@ def _split_argv(command: str, *, is_windows: bool) -> list[str] | None:
             return None
 
 
-def _has_unquoted_shell_operator(command: str) -> bool:
+def _has_unquoted_shell_operator(command: str, *, is_windows: bool) -> bool:
     """Return True when shell metacharacters appear outside quotes.
 
     The parser needs to notice glued operators like ``>out.txt`` or ``2>&1``,
@@ -75,7 +75,7 @@ def _has_unquoted_shell_operator(command: str) -> bool:
             escaped = False
             continue
 
-        if ch == "\\" and not in_single_quote:
+        if ch == "\\" and not is_windows and not in_single_quote:
             escaped = True
             continue
 
@@ -122,7 +122,9 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
             use_shell=True,
         )
 
-    if _INLINE_SUBSHELL_RE.search(stripped) is not None or _has_unquoted_shell_operator(stripped):
+    if _INLINE_SUBSHELL_RE.search(stripped) is not None or _has_unquoted_shell_operator(
+        stripped, is_windows=is_windows
+    ):
         # Operators / substitution need a real shell; alpha mode runs them.
         return ParsedShellCommand(
             command=stripped,

--- a/tools/interactive_shell/shell/parsing.py
+++ b/tools/interactive_shell/shell/parsing.py
@@ -24,12 +24,10 @@ The only non-execution outcome is a ``parse_error`` for genuinely empty input
 
 from __future__ import annotations
 
-import re
 import shlex
 from dataclasses import dataclass
 
 _EXPLICIT_SHELL_PREFIX = "!"
-_INLINE_SUBSHELL_RE = re.compile(r"`|\$\(")
 
 
 @dataclass(frozen=True)
@@ -59,8 +57,8 @@ def _split_argv(command: str, *, is_windows: bool) -> list[str] | None:
             return None
 
 
-def _has_unquoted_shell_operator(command: str, *, is_windows: bool) -> bool:
-    """Return True when shell metacharacters appear outside quotes.
+def _requires_shell_routing(command: str, *, is_windows: bool) -> bool:
+    """Return True when command syntax needs the platform shell.
 
     The parser needs to notice glued operators like ``>out.txt`` or ``2>&1``,
     but a literal ``&`` inside ``cd "dir&name"`` must stay an argument so the
@@ -70,7 +68,7 @@ def _has_unquoted_shell_operator(command: str, *, is_windows: bool) -> bool:
     in_double_quote = False
     escaped = False
 
-    for ch in command:
+    for index, ch in enumerate(command):
         if escaped:
             escaped = False
             continue
@@ -87,14 +85,18 @@ def _has_unquoted_shell_operator(command: str, *, is_windows: bool) -> bool:
         if in_double_quote:
             if ch == '"':
                 in_double_quote = False
+            elif not is_windows and (ch == "`" or command.startswith("$(", index)):
+                return True
             continue
 
-        if ch == "'":
+        if ch == "'" and not is_windows:
             in_single_quote = True
             continue
         if ch == '"':
             in_double_quote = True
             continue
+        if not is_windows and (ch == "`" or command.startswith("$(", index)):
+            return True
         if ch in "|;&<>":
             return True
 
@@ -122,9 +124,7 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
             use_shell=True,
         )
 
-    if _INLINE_SUBSHELL_RE.search(stripped) is not None or _has_unquoted_shell_operator(
-        stripped, is_windows=is_windows
-    ):
+    if _requires_shell_routing(stripped, is_windows=is_windows):
         # Operators / substitution need a real shell; alpha mode runs them.
         return ParsedShellCommand(
             command=stripped,


### PR DESCRIPTION
## Summary
- Treat shell metacharacters as shell execution triggers when they are unquoted or glued to argv text, e.g. `>out.txt`, `2>&1`, `>>out.txt`, and trailing `&`.
- Ignore quoted shell operators so builtin commands like `cd "dir&name"` keep running in the persistent REPL path.
- Make shell routing quote-aware for POSIX substitutions too: literal single-quoted text like `cd 'dir$(name)'` stays in argv mode, while active substitutions such as `echo "$(date)"` still use the shell.
- Preserve platform shell semantics: POSIX backslash escapes can keep literal operators in argv mode, while Windows path backslashes and apostrophes do not hide real `cmd.exe` operators such as `C:\tmp\& echo done` or `echo '&'`.
- Decode captured foreground CLI timeout output when Python surfaces it as bytes, avoiding user-visible `b'...'` reprs.
- Make Codex OAuth callback tests proxy-isolated for localhost requests so local/system proxy settings cannot turn callback assertions into 502s.
- Add CloudOpsBench Kubernetes evidence mappers so replayed K8s tools contribute citeable evidence instead of only opaque raw blobs.
- Add regression coverage for glued redirection, append redirection, background operators, quoted operators, quoted substitution text, Windows path/operator routing, CLI timeout byte streams, and CloudOpsBench evidence mapping.

## Why
Interactive shell commands with common POSIX forms like `echo hello >out.txt 2>&1` were previously tokenized as plain argv. That meant redirection/background syntax was passed to the executable as literal arguments instead of being interpreted by the shell.

The parser also needs to distinguish real shell operators and substitutions from literal characters inside quoted arguments. Without that, a builtin like `cd "dir&name"` or `cd 'dir$(name)'` can be misclassified as shell mode, which breaks the persistent working-directory behavior across turns.

The quote-aware operator scanner must still respect platform semantics: on POSIX, `\&` can mean a literal ampersand argument, but on Windows a backslash is a path separator and apostrophes are not command quotes, so neither should cause `cmd.exe` operators to bypass shell routing.

Foreground OpenSRE CLI subprocess timeouts had a similar polish/correctness issue: partial stdout/stderr could be rendered as Python byte-string reprs instead of decoded text.

The Codex OAuth callback tests exercise an in-process localhost server. Those requests should bypass any proxy configuration, otherwise proxy-influenced environments can return 502 before the callback server is reached.

CloudOpsBench replayed Kubernetes tools already produced structured results, but they had no `evidence_mapper`, so investigation runs could not cite those tool outputs. Wiring mappers into the tool definitions makes the evidence catalog surface those results directly.

## Tests
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/interactive_shell/shell tests/interactive_shell/test_shell_agent_build.py tests/interactive_shell/test_shell_turn_path_border.py -q`
- `uv run --extra dev python -m pytest tests/interactive_shell/test_cli_foreground.py tests/interactive_shell/runtime/test_subprocess_runner.py -q`
- `uv run --extra dev python -m pytest tests/integrations/llm_cli/test_codex_oauth.py -q`
- `uv run --extra dev python -m pytest tests/benchmarks/cloudopsbench/tools/tests/test_k8s_tools.py tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q`
- `uv run --extra dev python -m pytest -q -x`
- `uv run --extra dev python -m pytest tests/interactive_shell/shell/test_shell_parsing.py -q`
- `uv run --extra dev python -m pytest tests/interactive_shell/shell tests/interactive_shell/runtime/test_subprocess_runner.py -q`
- `uv run --extra dev ruff check tools/interactive_shell/shell/parsing.py tests/interactive_shell/shell/test_shell_parsing.py`
- `uv run --extra dev ruff check tools/interactive_shell/cli.py tests/interactive_shell/test_cli_foreground.py`
- `uv run --extra dev ruff check tests/integrations/llm_cli/test_codex_oauth.py`
- `uv run --extra dev ruff check tests/benchmarks/cloudopsbench/tools/k8s/__init__.py tests/benchmarks/cloudopsbench/tools/tests/test_k8s_tools.py`
