### PR TITLE
refactor(github): extract MCP result envelope from helpers

### DIFF
--- a/integrations/github/envelope.py
+++ b/integrations/github/envelope.py
@@ -1,0 +1,57 @@
+"""Response envelope shaping for GitHub MCP tool results."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.tool_framework.utils import tool_unavailable
+
+
+def _structured_content_or_text_fallback(result: dict[str, Any]) -> Any:
+    """Return ``structured_content`` if present, else ``text`` parsed as JSON.
+
+    Returns ``None`` when ``text`` is empty or not valid JSON.
+    """
+    structured = result.get("structured_content")
+    if structured is not None:
+        return structured
+    text = str(result.get("text") or "").strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def normalize_github_tool_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw GitHub MCP tool result into the tool-framework payload.
+
+    ``result`` is the dict returned by ``call_github_mcp_tool``: it carries
+    ``is_error`` (bool), ``text`` (str, root-cause message on error),
+    ``tool`` (str, the MCP tool name), ``arguments`` (dict passed to the tool),
+    ``structured_content`` (parsed JSON or None), and ``content`` (list of MCP
+    content items). When ``is_error`` is truthy, returns the standard
+    ``tool_unavailable("github", ...)`` envelope so the framework surfaces a
+    consistent unavailable-source response. Otherwise returns a dict with
+    ``source="github"``, ``available=True``, and the original ``tool``,
+    ``arguments``, ``text``, ``content`` keys preserved, and
+    ``structured_content`` normalized via :func:`_structured_content_or_text_fallback`.
+    """
+    if result.get("is_error"):
+        return tool_unavailable(
+            "github",
+            result.get("text") or "GitHub MCP tool call failed.",
+            tool=result.get("tool"),
+            arguments=result.get("arguments", {}),
+        )
+    return {
+        "source": "github",
+        "available": True,
+        "tool": result.get("tool"),
+        "arguments": result.get("arguments", {}),
+        "text": result.get("text", ""),
+        "structured_content": _structured_content_or_text_fallback(result),
+        "content": result.get("content", []),
+    }

--- a/integrations/github/helpers.py
+++ b/integrations/github/helpers.py
@@ -1,7 +1,7 @@
 """Helpers shared by GitHub MCP tools.
 
 Each function takes inputs produced by the rest of the runtime
-(integration store entries, MCP tool results, runtime-extracted kwargs)
+(integration store entries, runtime-extracted kwargs)
 and returns the shape the next layer expects. Callers live in
 ``integrations/github/tools/*.py`` and rely on these wrappers so the
 tool files stay thin.
@@ -13,16 +13,12 @@ Exports:
 - ``github_source_available``: predicate on the integration store entry.
 - ``github_creds``: maps classified integration fields to tool kwargs.
 - ``resolve_github_mcp_config``: merges env defaults with explicit overrides.
-- ``normalize_github_tool_result``: turns a raw MCP tool result into the
-  payload shape consumed by the tool framework.
 """
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
-from core.tool_framework.utils import tool_unavailable
 from integrations.github.mcp import (
     DEFAULT_GITHUB_MCP_MODE,
     GitHubMCPConfig,
@@ -120,52 +116,3 @@ def resolve_github_mcp_config(
             "toolsets": env_config.toolsets if env_config else (),
         }
     )
-
-
-def _structured_content_or_text_fallback(result: dict[str, Any]) -> Any:
-    """Return ``structured_content`` if present, else ``text`` parsed as JSON.
-
-    Returns ``None`` when ``text`` is empty or not valid JSON.
-    """
-    structured = result.get("structured_content")
-    if structured is not None:
-        return structured
-    text = str(result.get("text") or "").strip()
-    if not text:
-        return None
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return None
-
-
-def normalize_github_tool_result(result: dict[str, Any]) -> dict[str, Any]:
-    """Normalize a raw GitHub MCP tool result into the tool-framework payload.
-
-    ``result`` is the dict returned by ``call_github_mcp_tool``: it carries
-    ``is_error`` (bool), ``text`` (str, root-cause message on error),
-    ``tool`` (str, the MCP tool name), ``arguments`` (dict passed to the tool),
-    ``structured_content`` (parsed JSON or None), and ``content`` (list of MCP
-    content items). When ``is_error`` is truthy, returns the standard
-    ``tool_unavailable("github", ...)`` envelope so the framework surfaces a
-    consistent unavailable-source response. Otherwise returns a dict with
-    ``source="github"``, ``available=True``, and the original ``tool``,
-    ``arguments``, ``text``, ``content`` keys preserved, and
-    ``structured_content`` normalized via :func:`_structured_content_or_text_fallback`.
-    """
-    if result.get("is_error"):
-        return tool_unavailable(
-            "github",
-            result.get("text") or "GitHub MCP tool call failed.",
-            tool=result.get("tool"),
-            arguments=result.get("arguments", {}),
-        )
-    return {
-        "source": "github",
-        "available": True,
-        "tool": result.get("tool"),
-        "arguments": result.get("arguments", {}),
-        "text": result.get("text", ""),
-        "structured_content": _structured_content_or_text_fallback(result),
-        "content": result.get("content", []),
-    }

--- a/integrations/github/tools/actions.py
+++ b/integrations/github/tools/actions.py
@@ -10,11 +10,11 @@ from typing import Any, cast
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import call_github_mcp_tool

--- a/integrations/github/tools/commits.py
+++ b/integrations/github/tools/commits.py
@@ -7,11 +7,11 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import call_github_mcp_tool

--- a/integrations/github/tools/file_contents.py
+++ b/integrations/github/tools/file_contents.py
@@ -7,11 +7,11 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import call_github_mcp_tool

--- a/integrations/github/tools/git_deploy_timeline_tool/__init__.py
+++ b/integrations/github/tools/git_deploy_timeline_tool/__init__.py
@@ -26,11 +26,11 @@ from core.domain.types.incident_window import IncidentWindow
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import call_github_mcp_tool

--- a/integrations/github/tools/issues.py
+++ b/integrations/github/tools/issues.py
@@ -7,11 +7,11 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import (

--- a/integrations/github/tools/repository_tree.py
+++ b/integrations/github/tools/repository_tree.py
@@ -7,11 +7,11 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import call_github_mcp_tool

--- a/integrations/github/tools/search_code.py
+++ b/integrations/github/tools/search_code.py
@@ -7,11 +7,11 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import (

--- a/tests/tools/test_github_helpers.py
+++ b/tests/tools/test_github_helpers.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from integrations.github.envelope import normalize_github_tool_result
 from integrations.github.helpers import (
     github_creds,
-    normalize_github_tool_result,
     resolve_github_mcp_config,
 )
 from integrations.github.mcp import DEFAULT_GITHUB_MCP_MODE


### PR DESCRIPTION
Fixes #5631

#### Describe the changes you have made in this PR -

Extracted GitHub MCP result-normalization out of `integrations/github/helpers.py` into a dedicated `integrations/github/envelope.py`, matching Groundcover's `envelope.py` role (raw tool result → framework payload).

Moved only this pair:
- `normalize_github_tool_result`
- `_structured_content_or_text_fallback` (private, called only by the function above)

Left in `helpers.py`:
- `github_source_available`
- `github_creds`
- `resolve_github_mcp_config`
- `_has_explicit_github_mcp_overrides`

Updated only the importers of `normalize_github_tool_result` (7 GitHub MCP tools + `tests/tools/test_github_helpers.py`). The other helpers import sites were not touched. There is no compatibility re-export from `helpers.py`.

**Next concern to extract:** MCP config resolution (`resolve_github_mcp_config` + `_has_explicit_github_mcp_overrides`). It is the remaining two-function cluster, has fewer importers than availability/creds, and belongs next to `mcp.py` rather than in a grab-bag `helpers.py`. `github_source_available` → `availability.py` is the Groundcover-named role, but it would touch almost every GitHub tool in one PR.

### Demo/Screenshot for feature changes and bug fixes -

Verification (Windows, `uv run`):

```text
# every normalize_github_tool_result hit points at envelope.py; none at helpers.py
integrations/github/envelope.py:28:def normalize_github_tool_result(...)
integrations/github/tools/{actions,commits,file_contents,issues,search_code,repository_tree,git_deploy_timeline_tool}.py
tests/tools/test_github_helpers.py

# GitHub tools still registered
19 github tools   # identical before and after

# focused tests
261 passed in 5.23s

# live GitHub tool call on this machine (no GitHub MCP env configured)
live_available False
live_error GitHub MCP integration is not configured.
```

Result-normalization behavior is covered by the existing helper tests: JSON-in-`text` fallback, native `structured_content` preferred, and non-JSON `text` left as `None`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`integrations/github/helpers.py` mixed four jobs (availability, credentials, MCP config, result-normalization) under a non-role name, and it is imported from many places. Issue #5631 asked to extract **one** concern and stop, so a full rename of all 63 importers was out of scope.

I compared Groundcover's `envelope.py` (shape a raw tool result into `source` / `available` / payload) with `compaction.py` (row/field truncation). GitHub's `normalize_github_tool_result` is envelope-shaping, not compaction, so the new module is `integrations/github/envelope.py`.

The two functions were moved verbatim — same signatures, docstrings, and error/success payload. Callers now import `normalize_github_tool_result` from `envelope.py` and keep availability/creds/MCP helpers from `helpers.py`. I did not re-export from `helpers.py`, because the issue required every `normalize_github_tool_result` hit to point at the new module.

`normalize_github_tool_result` turns a raw MCP result into the tool-framework payload: `is_error` → `tool_unavailable("github", ...)`; otherwise `source="github"`, `available=True`, with `structured_content` taken from native structured content or JSON parsed from `text`. `_structured_content_or_text_fallback` is private and only used there.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.