### PR TITLE
fix(scheduler): make task-store writes crash-safe

### DIFF
--- a/infrastructure/scheduling/scheduler/store.py
+++ b/infrastructure/scheduling/scheduler/store.py
@@ -31,6 +31,18 @@ def _lock_path(store_path: Path) -> Path:
     return store_path.with_suffix(".lock")
 
 
+def _fsync_parent_dir(path: Path) -> None:
+    """Sync the directory entry after a replacement on Unix."""
+    if os.name == "nt":
+        return
+    with contextlib.suppress(OSError):
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+
 def _read_rows(store_path: Path) -> list[dict[str, object]] | None:
     """Read task rows, or ``None`` when an existing store is not trustworthy."""
     try:
@@ -66,6 +78,7 @@ def _quarantine_unreadable(store_path: Path) -> None:
         os.close(descriptor)
         descriptor = None
         os.replace(store_path, backup_path)
+        _fsync_parent_dir(store_path)
         replaced = True
     except OSError:
         logger.error(
@@ -116,6 +129,7 @@ def _save_raw(store_path: Path, data: list[dict[str, object]]) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temp_path, store_path)
+        _fsync_parent_dir(store_path)
         replaced = True
     finally:
         if descriptor is not None:

--- a/infrastructure/scheduling/scheduler/store.py
+++ b/infrastructure/scheduling/scheduler/store.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -28,24 +31,99 @@ def _lock_path(store_path: Path) -> Path:
     return store_path.with_suffix(".lock")
 
 
-def _load_raw(store_path: Path) -> list[dict[str, object]]:
-    """Load raw task list from disk."""
-    if not store_path.exists():
-        return []
+def _read_rows(store_path: Path) -> list[dict[str, object]] | None:
+    """Read task rows, or ``None`` when an existing store is not trustworthy."""
     try:
         data = json.loads(store_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+    except FileNotFoundError:
+        return []
+    except (json.JSONDecodeError, OSError, UnicodeError) as exc:
         logger.warning("Failed to read scheduler store: %s", exc)
-        return []
+        return None
     if not isinstance(data, list):
-        return []
+        logger.warning("Scheduler store is not a JSON list; treating it as unreadable")
+        return None
     return data  # type: ignore[return-value]
 
 
+def _load_raw(store_path: Path) -> list[dict[str, object]]:
+    """Load task rows for a read-only operation."""
+    rows = _read_rows(store_path)
+    return [] if rows is None else rows
+
+
+def _quarantine_unreadable(store_path: Path) -> None:
+    """Move an unreadable store aside before a mutation can replace it."""
+    descriptor: int | None = None
+    backup_path: Path | None = None
+    replaced = False
+    try:
+        descriptor, backup_name = tempfile.mkstemp(
+            dir=store_path.parent,
+            prefix=f"{store_path.name}.corrupt-",
+        )
+        backup_path = Path(backup_name)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(store_path, backup_path)
+        replaced = True
+    except OSError:
+        logger.error(
+            "Could not preserve unreadable scheduler store at %s; refusing to overwrite it",
+            store_path,
+            exc_info=True,
+        )
+        raise
+    finally:
+        if descriptor is not None:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
+        if not replaced and backup_path is not None:
+            with contextlib.suppress(OSError):
+                backup_path.unlink()
+    logger.error(
+        "Scheduler store at %s was unreadable and has been preserved at %s",
+        store_path,
+        backup_path,
+    )
+
+
+def _load_raw_for_write(store_path: Path) -> list[dict[str, object]]:
+    """Load task rows for a mutation, preserving unreadable existing data."""
+    rows = _read_rows(store_path)
+    if rows is None:
+        _quarantine_unreadable(store_path)
+        return []
+    return rows
+
+
 def _save_raw(store_path: Path, data: list[dict[str, object]]) -> None:
-    """Persist task list to disk."""
+    """Persist task rows with a same-directory atomic replacement."""
     store_path.parent.mkdir(parents=True, exist_ok=True)
-    store_path.write_text(json.dumps(data, indent=2, default=str) + "\n", encoding="utf-8")
+    serialized = json.dumps(data, indent=2, default=str) + "\n"
+    descriptor: int | None = None
+    temp_path: Path | None = None
+    replaced = False
+    try:
+        descriptor, temp_name = tempfile.mkstemp(
+            dir=store_path.parent,
+            prefix=f"{store_path.name}.tmp",
+        )
+        temp_path = Path(temp_name)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = None
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, store_path)
+        replaced = True
+    finally:
+        if descriptor is not None:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
+        if not replaced and temp_path is not None:
+            with contextlib.suppress(OSError):
+                temp_path.unlink()
 
 
 def list_tasks(store_path: Path | None = None) -> list[ScheduledTask]:
@@ -101,7 +179,7 @@ def add_task(task: ScheduledTask, store_path: Path | None = None) -> ScheduledTa
     path = store_path or _default_store_path()
     lock = FileLock(_lock_path(path))
     with lock:
-        raw = _load_raw(path)
+        raw = _load_raw_for_write(path)
         wanted = _schedule_identity(task.model_dump(mode="json"))
         existing = next(
             (entry for entry in raw if _schedule_identity(entry) == wanted),

--- a/infrastructure/scheduling/scheduler/store.py
+++ b/infrastructure/scheduling/scheduler/store.py
@@ -35,12 +35,11 @@ def _fsync_parent_dir(path: Path) -> None:
     """Sync the directory entry after a replacement on Unix."""
     if os.name == "nt":
         return
-    with contextlib.suppress(OSError):
-        directory_fd = os.open(path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
 
 
 def _read_rows(store_path: Path) -> list[dict[str, object]] | None:
@@ -78,8 +77,8 @@ def _quarantine_unreadable(store_path: Path) -> None:
         os.close(descriptor)
         descriptor = None
         os.replace(store_path, backup_path)
-        _fsync_parent_dir(store_path)
         replaced = True
+        _fsync_parent_dir(store_path)
     except OSError:
         logger.error(
             "Could not preserve unreadable scheduler store at %s; refusing to overwrite it",
@@ -129,8 +128,8 @@ def _save_raw(store_path: Path, data: list[dict[str, object]]) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temp_path, store_path)
-        _fsync_parent_dir(store_path)
         replaced = True
+        _fsync_parent_dir(store_path)
     finally:
         if descriptor is not None:
             with contextlib.suppress(OSError):

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -276,6 +277,47 @@ class TestStoreDurability:
         assert [task.name for task in list_tasks(store_path)] == ["digest-7"]
         assert list(store_path.parent.glob(f"{store_path.name}.tmp*")) == []
 
+    def test_parent_directory_sync_failure_is_not_reported_as_success(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        add_task(self._task(7), store_path)
+        fsync_calls = 0
+        real_fsync = os.fsync
+
+        def fail_directory_fsync(file_descriptor: int) -> None:
+            nonlocal fsync_calls
+            fsync_calls += 1
+            if fsync_calls == 2:
+                raise OSError("directory sync failed")
+            real_fsync(file_descriptor)
+
+        monkeypatch.setattr("os.fsync", fail_directory_fsync)
+
+        with pytest.raises(OSError, match="directory sync failed"):
+            add_task(self._task(8), store_path)
+
+        assert fsync_calls == 2
+        assert [task.name for task in list_tasks(store_path)] == ["digest-7", "digest-8"]
+        assert list(store_path.parent.glob(f"{store_path.name}.tmp*")) == []
+
+    def test_temporary_file_sync_failure_preserves_the_previous_store(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        add_task(self._task(7), store_path)
+        before = store_path.read_bytes()
+
+        def fail_temporary_fsync(_file_descriptor: int) -> None:
+            raise OSError("temporary file sync failed")
+
+        monkeypatch.setattr("os.fsync", fail_temporary_fsync)
+
+        with pytest.raises(OSError, match="temporary file sync failed"):
+            add_task(self._task(8), store_path)
+
+        assert store_path.read_bytes() == before
+        assert [task.name for task in list_tasks(store_path)] == ["digest-7"]
+        assert list(store_path.parent.glob(f"{store_path.name}.tmp*")) == []
+
     def test_add_quarantines_an_unreadable_store(
         self, store_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -321,6 +363,26 @@ class TestStoreDurability:
 
         assert store_path.read_bytes() == corrupt_bytes
         assert list(store_path.parent.glob(f"{store_path.name}.corrupt-*")) == []
+
+    def test_quarantine_sync_failure_keeps_the_recovery_copy(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        corrupt_bytes = b"truncated task store"
+        store_path.write_bytes(corrupt_bytes)
+
+        def fail_directory_fsync(_file_descriptor: int) -> None:
+            raise OSError("directory sync failed")
+
+        monkeypatch.setattr("os.fsync", fail_directory_fsync)
+
+        with pytest.raises(OSError, match="directory sync failed"):
+            add_task(self._task(7), store_path)
+
+        recovery_files = list(store_path.parent.glob(f"{store_path.name}.corrupt-*"))
+        assert len(recovery_files) == 1
+        assert recovery_files[0].read_bytes() == corrupt_bytes
+        assert not store_path.exists()
+        assert list(store_path.parent.glob(f"{store_path.name}.tmp*")) == []
 
     def test_repeated_quarantines_keep_distinct_recovery_copies(self, store_path: Path) -> None:
         first_corrupt_bytes = b"first torn write"

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -242,6 +243,110 @@ class TestAddTaskDeduplicates:
 
         # Assert
         assert len(list_tasks(store_path)) == 2
+
+
+class TestStoreDurability:
+    """Task-store failures preserve recoverable data and avoid torn writes."""
+
+    @staticmethod
+    def _task(hour: int) -> ScheduledTask:
+        return ScheduledTask(
+            name=f"digest-{hour}",
+            kind=TaskKind.DAILY_SUMMARY,
+            cron=f"0 {hour} * * *",
+            provider=Provider.TELEGRAM,
+            chat_id="-100",
+        )
+
+    def test_failed_replacement_preserves_the_previous_store(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        add_task(self._task(7), store_path)
+        before = store_path.read_bytes()
+
+        def fail_replace(_source: str, _destination: Path) -> None:
+            raise OSError("replacement failed")
+
+        monkeypatch.setattr("os.replace", fail_replace)
+
+        with pytest.raises(OSError, match="replacement failed"):
+            add_task(self._task(8), store_path)
+
+        assert store_path.read_bytes() == before
+        assert [task.name for task in list_tasks(store_path)] == ["digest-7"]
+        assert list(store_path.parent.glob(f"{store_path.name}.tmp*")) == []
+
+    def test_add_quarantines_an_unreadable_store(
+        self, store_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        corrupt_bytes = b'[{"id": "lost-before-crash"}'
+        store_path.write_bytes(corrupt_bytes)
+
+        with caplog.at_level(logging.ERROR):
+            add_task(self._task(7), store_path)
+
+        recovery_files = list(store_path.parent.glob(f"{store_path.name}.corrupt-*"))
+        assert len(recovery_files) == 1
+        assert recovery_files[0].read_bytes() == corrupt_bytes
+        assert [task.name for task in list_tasks(store_path)] == ["digest-7"]
+        assert any(
+            record.levelno == logging.ERROR and str(recovery_files[0]) in record.message
+            for record in caplog.records
+        )
+
+    def test_wrong_top_level_shape_is_quarantined(self, store_path: Path) -> None:
+        corrupt_bytes = b'{"tasks": []}'
+        store_path.write_bytes(corrupt_bytes)
+
+        add_task(self._task(7), store_path)
+
+        recovery_files = list(store_path.parent.glob(f"{store_path.name}.corrupt-*"))
+        assert len(recovery_files) == 1
+        assert recovery_files[0].read_bytes() == corrupt_bytes
+        assert [task.name for task in list_tasks(store_path)] == ["digest-7"]
+
+    def test_quarantine_failure_leaves_the_corrupt_store_untouched(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        corrupt_bytes = b"truncated task store"
+        store_path.write_bytes(corrupt_bytes)
+
+        def fail_replace(_source: str, _destination: Path) -> None:
+            raise OSError("quarantine failed")
+
+        monkeypatch.setattr("os.replace", fail_replace)
+
+        with pytest.raises(OSError, match="quarantine failed"):
+            add_task(self._task(7), store_path)
+
+        assert store_path.read_bytes() == corrupt_bytes
+        assert list(store_path.parent.glob(f"{store_path.name}.corrupt-*")) == []
+
+    def test_repeated_quarantines_keep_distinct_recovery_copies(self, store_path: Path) -> None:
+        first_corrupt_bytes = b"first torn write"
+        second_corrupt_bytes = b"second torn write"
+
+        store_path.write_bytes(first_corrupt_bytes)
+        add_task(self._task(7), store_path)
+        store_path.write_bytes(second_corrupt_bytes)
+        add_task(self._task(8), store_path)
+
+        recovery_files = sorted(store_path.parent.glob(f"{store_path.name}.corrupt-*"))
+        assert len(recovery_files) == 2
+        assert {path.read_bytes() for path in recovery_files} == {
+            first_corrupt_bytes,
+            second_corrupt_bytes,
+        }
+
+    def test_remove_and_update_do_not_rewrite_an_unreadable_store(self, store_path: Path) -> None:
+        corrupt_bytes = b"not valid json"
+        store_path.write_bytes(corrupt_bytes)
+        task = self._task(7)
+
+        assert remove_task(task.id, store_path) is False
+        assert update_task(task, store_path) is False
+        assert store_path.read_bytes() == corrupt_bytes
+        assert list(store_path.parent.glob(f"{store_path.name}.corrupt-*")) == []
 
 
 class TestReloadSignal:


### PR DESCRIPTION
Fixes #4927

#### Describe the changes you have made in this PR -

### Problem

The scheduler task store was persisted with `Path.write_text`, which truncates the live JSON file before rewriting it. An interrupted write could leave malformed JSON. The loader then treated that unreadable file as an empty task list, so the next `add_task` replaced the recoverable schedules with only the new task.

### Fix

- Serialize task rows before touching the live file, write them to a same-directory temporary file, flush and fsync it, atomically replace the destination with `os.replace`, and fsync the parent directory on Unix.
- Distinguish a missing store from an unreadable store. Read-only listing still returns an empty collection for unreadable data, while `add_task` quarantines the unreadable bytes to a uniquely reserved `scheduler_tasks.json.corrupt-*` path before writing a fresh store.
- If quarantine fails, including a directory-sync failure, the mutation raises and does not create a replacement store. Temporary files are cleaned up when atomic persistence fails, and directory-sync failures are surfaced instead of being reported as durable success.

### Why this approach

Atomic replacement prevents new torn writes, but it does not protect a store that was already damaged. Quarantine preserves that existing data, but it does not prevent a future crash from tearing a new write. These two narrow changes address both loss paths without changing scheduler persistence format, task identity, or introducing a persistence abstraction.

### Demo/Screenshot for feature changes and bug fixes -

Before (upstream `main`):

```text
valid_tasks_before_damage=3
list_after_damage= []
list_after_add= ['digest-10']
recovery_files= []
```

After:

```text
valid_tasks_before_damage=3
list_after_damage= []
list_after_add= ['digest-10']
recovery_files= ['scheduler_tasks.json.corrupt-wnf9g0ch']
recovery_bytes_preserved= True
```

### Tests

- Added filesystem regressions for replacement failure, temporary-file fsync failure and cleanup, parent-directory fsync failure, malformed and wrong-shape stores, quarantine failure fail-closed behavior, repeated quarantine uniqueness, and remove/update preserving unreadable files.
- The five durability tests that expose the original bug failed against unmodified upstream `main`; the existing read-only corrupted-store characterization continued to pass.

Executed locally:

```text
uv run python -m pytest tests/scheduler/test_store.py -q
31 passed

uv run python -m pytest tests/scheduler/ -q
186 passed

make lint
All checks passed

make format-check
3670 files already formatted

make typecheck
Success: no issues found in 1907 source files

make verify-integrations-smoke
32 passed

uv run python .github/ci/run_test_scope.py --base origin/main --dry-run
Running scoped tests: tests/scheduler/test_store.py
```

### Compatibility

The task JSON shape and scheduler API behavior for valid stores are unchanged. Task IDs, deduplication, reload signaling, claim-store cascade deletion, and filesystem locking remain unchanged. No dependency was added.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`_read_rows` returns an empty list only for a missing file and returns `None` for malformed, unreadable, or non-list JSON. `_load_raw` keeps the existing read-only empty-on-error behavior. `_load_raw_for_write`, used by `add_task`, quarantines `None` results before returning an empty in-memory list; the reservation comes from `tempfile.mkstemp` in the store directory, so recovery names cannot collide. A failed quarantine propagates before `_save_raw` can run.

`_save_raw` serializes first, writes and fsyncs a sibling temporary file, replaces the live path only after the complete payload is durable, then fsyncs the parent directory on Unix. `_fsync_parent_dir` propagates directory-sync errors, so callers do not report a metadata durability failure as success. Its `finally` cleanup removes any temporary path when writing or replacement fails, leaving the previous destination untouched whenever replacement has not happened.

### Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines
