### PR TITLE
refactor(session-goal): rename continuation prompt helper

### DIFF
--- a/core/agent_harness/session_goal/continuation.py
+++ b/core/agent_harness/session_goal/continuation.py
@@ -13,7 +13,7 @@ from core.agent_harness.session_goal.goal import (
 )
 
 
-def continuation_nudge(goal: SessionGoal) -> str:
+def continuation_prompt(goal: SessionGoal) -> str:
     """User-visible follow-up message for the next session-goal turn."""
     reason = goal.last_reason.strip() or derive_session_goal_reason(goal)
     reason_block = f"Last progress: {reason}\n\n"
@@ -64,5 +64,5 @@ def continuation_nudge(goal: SessionGoal) -> str:
 
 
 __all__ = [
-    "continuation_nudge",
+    "continuation_prompt",
 ]

--- a/core/agent_harness/session_goal/run_until.py
+++ b/core/agent_harness/session_goal/run_until.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 from core.agent_harness.session.terminal_access import clear_pending_autosubmit
-from core.agent_harness.session_goal.continuation import continuation_nudge
+from core.agent_harness.session_goal.continuation import continuation_prompt
 from core.agent_harness.session_goal.evaluate import (
     default_evaluate_session_goal,
     session_goal_reply_text,
@@ -209,7 +209,7 @@ def run_until_session_goal(
     """Run ``chat`` until the session goal is terminal or the budget is hit.
 
     Always runs the first ``chat(message)`` through the action-agent path.
-    Continues with nudges only when a goal is already active afterward
+    Continues with prompts only when a goal is already active afterward
     (explicit ``goal=`` attach, or ``session_goal:`` handoff from that turn).
     """
     evaluate_fn = evaluate or default_evaluate_session_goal
@@ -278,7 +278,7 @@ def run_until_session_goal(
             break
 
         _announce_working(session, active, on_progress)
-        last = chat(continuation_nudge(active))
+        last = chat(continuation_prompt(active))
         active = active.record_turn()
         attach_session_goal(session, active)
         active, last, stop = _finish_outer_turn(

--- a/tests/core/agent_harness/session_goal/test_last_answer_carries_forward.py
+++ b/tests/core/agent_harness/session_goal/test_last_answer_carries_forward.py
@@ -14,7 +14,7 @@ unverified answer cannot become settled by being repeated.
 from __future__ import annotations
 
 from core.agent_harness.session.session_core import SessionCore
-from core.agent_harness.session_goal.continuation import continuation_nudge
+from core.agent_harness.session_goal.continuation import continuation_prompt
 from core.agent_harness.session_goal.goal import SessionGoal
 from core.agent_harness.session_goal.run_until import run_until_session_goal
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
@@ -31,18 +31,18 @@ def test_the_previous_answer_reaches_the_next_turn() -> None:
     goal = _goal().with_last_answer(_ANSWER)
 
     # Act
-    nudge = continuation_nudge(goal)
+    prompt = continuation_prompt(goal)
 
     # Assert
-    assert _ANSWER in nudge
+    assert _ANSWER in prompt
 
 
 def test_the_next_turn_is_told_to_explain_a_different_number() -> None:
     # Arrange / Act
-    nudge = continuation_nudge(_goal().with_last_answer(_ANSWER))
+    prompt = continuation_prompt(_goal().with_last_answer(_ANSWER))
 
     # Assert: silently replacing it is the failure being prevented.
-    assert "say why" in nudge
+    assert "say why" in prompt
 
 
 def test_a_previous_answer_is_not_presented_as_established() -> None:
@@ -56,7 +56,7 @@ def test_a_previous_answer_is_not_presented_as_established() -> None:
 
     # Assert
     assert goal.findings == ()
-    assert "treat these as done" not in continuation_nudge(goal)
+    assert "treat these as done" not in continuation_prompt(goal)
 
 
 def test_an_empty_answer_is_not_recorded() -> None:

--- a/tests/core/agent_harness/session_goal/test_progress.py
+++ b/tests/core/agent_harness/session_goal/test_progress.py
@@ -226,8 +226,8 @@ def test_outer_loop_achieves_via_checklist_without_achieved_tag() -> None:
     assert outcome.goal.completed == frozenset({0, 1, 2})
 
 
-def test_nudge_lists_unfinished_checklist_items() -> None:
-    from core.agent_harness.session_goal.continuation import continuation_nudge
+def test_prompt_lists_unfinished_checklist_items() -> None:
+    from core.agent_harness.session_goal.continuation import continuation_prompt
 
     goal = SessionGoal(
         condition="x",
@@ -235,14 +235,14 @@ def test_nudge_lists_unfinished_checklist_items() -> None:
         completed=frozenset({0}),
         last_reason="checklist 1/3 done — next: B",
     )
-    nudge = continuation_nudge(goal)
+    prompt = continuation_prompt(goal)
 
-    assert "B" in nudge and "C" in nudge
-    assert "session_goal:done=" in nudge
-    assert "Last progress: checklist 1/3 done — next: B" in nudge
+    assert "B" in prompt and "C" in prompt
+    assert "session_goal:done=" in prompt
+    assert "Last progress: checklist 1/3 done — next: B" in prompt
 
 
-def test_outer_loop_nudge_carries_reason_after_partial_progress() -> None:
+def test_outer_loop_prompt_carries_reason_after_partial_progress() -> None:
     session = SessionCore()
     turns: list[str] = []
     goal = SessionGoal(


### PR DESCRIPTION
Fixes #5627

#### Describe the changes you have made in this PR -

Problem: `continuation_nudge` described implementation intent rather than the user-message prompt returned for the next session-goal turn.

Fix: renamed the first-party helper, export list, call site, imports, and tests to `continuation_prompt`. Updated directly associated test names/locals and the `run_until.py` prose. There is intentionally no compatibility alias. `core/agent/goals.py::Goal.nudge` is explicitly untouched.

Changed files:
- `core/agent_harness/session_goal/continuation.py`
- `core/agent_harness/session_goal/run_until.py`
- `tests/core/agent_harness/session_goal/test_progress.py`
- `tests/core/agent_harness/session_goal/test_last_answer_carries_forward.py`

Behavior is unchanged.

#### Demo/Screenshot for feature changes and bug fixes -

Not applicable for this behavior-preserving symbol rename. The deterministic continuation regression passed and still exercises the second session-goal turn.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This is a direct, behavior-preserving rename. The helper remains in its owning continuation leaf; its `__all__` entry, `run_until_session_goal` import/call, and the tests that exercise the helper now use `continuation_prompt`. No compatibility alias or unrelated naming cleanup was added.

## Validation

- `uv run python -m pytest tests/core/agent_harness/session_goal/ -q` — 110 passed
- deterministic continuation regression — 1 passed
- `make lint` — passed
- `make format-check` — passed
- `make typecheck` — passed (`1907` source files)
- old-name grep — no matches
- `git diff --check` — passed
- Manual `uv run opensre` `/goal` check was not run; the deterministic session-goal regression covers the continuation path without requiring an LLM/API credential.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] My code follows the project's style guidelines

Maintainer edits are enabled by default.