### PR TITLE
feat(snowflake): make query history citeable evidence

### DIFF
--- a/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
+++ b/integrations/snowflake/tools/snowflake_query_history_tool/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import httpx
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
 from core.tool_framework import tool
@@ -93,11 +94,25 @@ def _normalize_rows(response_payload: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
+def _map_query_snowflake_history(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    rows = output.get("rows", [])
+    if output.get("available", True) and isinstance(rows, list) and rows:
+        record_evidence_entry(
+            evidence,
+            source="query_snowflake_history",
+            label="Snowflake Query History",
+            summary=f"{len(rows)} queries",
+        )
+
+
 @tool(
     name="query_snowflake_history",
     description="Query Snowflake query history using a read-only bounded statement.",
     source="snowflake",
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    evidence_mapper=_map_query_snowflake_history,
     requires=["account_identifier"],
     input_schema={
         "type": "object",

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -220,7 +220,6 @@ query_opensearch_analytics
 query_signoz_logs
 query_signoz_metrics
 query_signoz_traces
-query_snowflake_history
 query_splunk_logs
 query_tempo
 query_yc_metrics

--- a/tests/tools/test_snowflake_query_history_evidence.py
+++ b/tests/tools/test_snowflake_query_history_evidence.py
@@ -1,0 +1,73 @@
+"""Evidence mapping tests for Snowflake query history."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+from tools.registry import get_registered_tool
+
+_TOOL_NAME = "query_snowflake_history"
+
+
+def _catalog_entries(evidence: dict[str, Any]) -> list[dict[str, Any]]:
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    return entries
+
+
+def test_mapper_records_non_empty_query_history() -> None:
+    tool = get_registered_tool(_TOOL_NAME)
+    assert tool is not None
+    assert tool.evidence_mapper is not None
+
+    evidence: dict[str, Any] = {}
+    tool.evidence_mapper(
+        evidence,
+        {
+            "available": True,
+            "rows": [{"QUERY_ID": "abc"}, {"QUERY_ID": "def"}],
+            "total_returned": 2,
+        },
+        {},
+    )
+
+    entries = _catalog_entries(evidence)
+    assert len(entries) == 1
+    assert entries[0]["source"] == _TOOL_NAME
+    assert entries[0]["label"] == "Snowflake Query History"
+    assert entries[0]["summary"] == "2 queries"
+
+
+def test_mapper_skips_empty_or_unavailable_query_history() -> None:
+    tool = get_registered_tool(_TOOL_NAME)
+    assert tool is not None
+    assert tool.evidence_mapper is not None
+
+    for output in (
+        {"available": True, "rows": [], "total_returned": 0},
+        {"available": False, "rows": [], "total_returned": 0},
+    ):
+        evidence: dict[str, Any] = {}
+        tool.evidence_mapper(evidence, output, {})
+        assert "catalog_entries" not in evidence
+
+
+def test_query_history_tool_registration_exposes_mapper() -> None:
+    tool = get_registered_tool(_TOOL_NAME)
+
+    assert tool is not None
+    assert tool.evidence_mapper is not None
+
+
+def test_merge_tool_evidence_records_query_history_catalog_entry() -> None:
+    evidence: dict[str, Any] = {}
+    output = {"rows": [{"QUERY_ID": "q1"}, {"QUERY_ID": "q2"}]}
+
+    merge_tool_evidence(evidence, _TOOL_NAME, output, {})
+
+    assert evidence[_TOOL_NAME] == output
+    entries = _catalog_entries(evidence)
+    assert len(entries) == 1
+    assert entries[0]["source"] == _TOOL_NAME
+    assert entries[0]["summary"] == "2 queries"


### PR DESCRIPTION
Fixes #5590

Part of #5519

#### Describe the changes you have made in this PR -

Problem: `query_snowflake_history` returns useful diagnostic rows, but those rows never become citeable report evidence.

Fix: Attach a Snowflake-owned evidence mapper that records non-empty query history as a catalog evidence entry, remove the tool from the mapper-gap baseline, and add focused regression coverage for the mapper, registration, empty/unavailable output, and the real merge path.

Behavior: The Snowflake query, request shaping, authentication, limits, and result normalization are unchanged. Only post-tool evidence extraction is added.

### Demo/Screenshot for feature changes and bug fixes -

Representative merge-path output:

```
[{'source': 'query_snowflake_history', 'label': 'Snowflake Query History', 'summary': '2 queries', 'url': None, 'snippet': None}]
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The mapper lives beside the Snowflake tool and reads its successful `rows` output. It records one `query_snowflake_history` catalog entry labeled `Snowflake Query History` with a count summary such as `2 queries`. It skips empty and unavailable output. The existing merge path continues to retain the raw tool output under the tool name.

I kept the source as `query_snowflake_history` because catalog entries use the claim-facing tool key, and used the existing `record_evidence_entry` contract rather than changing shared evidence infrastructure. The baseline ratchet now removes exactly this handled tool.

## Testing

- `uv run pytest tests/tools/test_snowflake_query_history_evidence.py tests/tools/test_snowflake_query_history_tool.py -q` — 30 passed
- `uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q` — 11 passed
- `uv run pytest tests/ -k snowflake -q` — 37 passed, 15061 deselected (29 pre-existing warnings)
- Registry check — `True`
- Real `merge_tool_evidence` check — catalog entry recorded with source `query_snowflake_history`
- Scoped Snowflake + telemetry tests — 62 passed
- `make lint` — passed
- `make format-check` — passed
- `make typecheck` — passed
- `git diff --check` — passed

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases
- [x] My code follows the project's style guidelines