### PR TITLE
feat(packaging): add infrastructure data entries handling and exclusions

### DIFF
--- a/infrastructure/deployment/packaging/release_manifest.py
+++ b/infrastructure/deployment/packaging/release_manifest.py
@@ -16,6 +16,10 @@ _SKILL_DATA_ROOTS = (Path("integrations"), Path("tools"))
 #: the tool that reads it degrades silently rather than failing to import.
 _RUNTIME_DATA_FILES = (Path("integrations/yandex_cloud/api_index.json"),)
 _RUNTIME_DISCOVERY_EXCLUSIONS = frozenset({"investigation_registry", "registry.py"})
+#: Non-Python trees under ``infrastructure/`` that never run from the frozen
+#: binary (e.g. a Cloudflare Worker deployed separately via ``wrangler``).
+#: Bundling them only adds dead weight to the release artifact.
+_INFRASTRUCTURE_DATA_EXCLUSIONS = (Path("infrastructure/deployment/cloudflare_install_proxy"),)
 
 
 def _module_name(repo_root: Path, source_path: Path) -> str:
@@ -68,4 +72,28 @@ def skill_data_entries(repo_root: Path) -> tuple[tuple[str, str], ...]:
     )
 
 
-__all__ = ["required_skill_files", "runtime_hidden_imports", "skill_data_entries"]
+def infrastructure_data_entries(repo_root: Path) -> tuple[tuple[str, str], ...]:
+    """Return PyInstaller ``datas`` entries for ``infrastructure/``, per-file.
+
+    Walking file-by-file (rather than handing PyInstaller the whole directory)
+    lets us drop ``_INFRASTRUCTURE_DATA_EXCLUSIONS`` trees that hold no code the
+    frozen binary ever imports or executes.
+    """
+    excluded_roots = tuple(repo_root / excluded for excluded in _INFRASTRUCTURE_DATA_EXCLUSIONS)
+    infrastructure_root = repo_root / "infrastructure"
+    entries: list[tuple[str, str]] = []
+    for path in sorted(infrastructure_root.rglob("*")):
+        if not path.is_file() or "__pycache__" in path.parts:
+            continue
+        if any(excluded == path or excluded in path.parents for excluded in excluded_roots):
+            continue
+        entries.append((str(path), str(path.parent.relative_to(repo_root))))
+    return tuple(entries)
+
+
+__all__ = [
+    "infrastructure_data_entries",
+    "required_skill_files",
+    "runtime_hidden_imports",
+    "skill_data_entries",
+]

--- a/opensre.spec
+++ b/opensre.spec
@@ -17,10 +17,9 @@ if MODE not in {"onedir", "onefile"}:
 manifest = runpy.run_path(str(ROOT / "infrastructure/deployment/packaging/release_manifest.py"))
 runtime_hidden_imports = manifest["runtime_hidden_imports"]
 skill_data_entries = manifest["skill_data_entries"]
+infrastructure_data_entries = manifest["infrastructure_data_entries"]
 
-datas = [
-    (str(ROOT / "infrastructure"), "infrastructure"),
-]
+datas = list(infrastructure_data_entries(ROOT))
 datas += collect_data_files("surfaces.cli")
 datas += collect_data_files("surfaces.shared")
 datas += collect_data_files("config")

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from infrastructure.deployment.packaging.release_manifest import (
+    infrastructure_data_entries,
     required_skill_files,
     runtime_hidden_imports,
 )
@@ -82,3 +83,37 @@ def test_release_build_uses_checked_in_spec() -> None:
     assert "OPENSRE_PYINSTALLER_MODE: ${{ matrix.pyinstaller_mode }}" in workflow
     assert "release_manifest.py" in spec
     assert "skill_data_entries(ROOT)" in spec
+
+
+def test_infrastructure_data_excludes_the_cloudflare_worker() -> None:
+    """The Cloudflare install-proxy is a JS Worker deployed via ``wrangler``.
+
+    It never runs from the frozen binary, so bundling it only adds dead,
+    non-Python weight to the release artifact.
+    """
+    relative_paths = {
+        Path(dest) / Path(source).name for source, dest in infrastructure_data_entries(_REPO_ROOT)
+    }
+
+    assert not any("cloudflare_install_proxy" in path.parts for path in relative_paths), (
+        relative_paths
+    )
+
+    assert Path("infrastructure/deployment/cloudflare_install_proxy/README.md").exists()
+    assert Path("infrastructure/deployment/cloudflare_install_proxy/src/index.mjs").exists()
+
+
+def test_infrastructure_data_still_covers_real_infrastructure_code() -> None:
+    relative_paths = {
+        Path(dest) / Path(source).name for source, dest in infrastructure_data_entries(_REPO_ROOT)
+    }
+
+    assert Path("infrastructure/deployment/packaging/release_manifest.py") in relative_paths
+    assert Path("infrastructure/deployment/ec2/telegram_gateway/README.md") in relative_paths
+
+
+def test_spec_bundles_infrastructure_via_the_filtered_helper() -> None:
+    spec = _SPEC_FILE.read_text(encoding="utf-8")
+
+    assert "infrastructure_data_entries(ROOT)" in spec
+    assert '(str(ROOT / "infrastructure"), "infrastructure")' not in spec


### PR DESCRIPTION
/fix #5326 
This pull request refines how infrastructure data files are included in the release artifact by introducing a more selective approach to packaging. The main goal is to avoid bundling unnecessary files—specifically, to exclude non-Python trees like the Cloudflare Worker (which is deployed separately) from the release artifact, thereby reducing its size and avoiding dead weight. The changes also add thorough testing to ensure both the correct exclusion and inclusion of files.

**Packaging improvements:**

* Added `_INFRASTRUCTURE_DATA_EXCLUSIONS` in `release_manifest.py` to specify infrastructure subtrees (like `cloudflare_install_proxy`) that should be excluded from the release artifact, as they are not used by the frozen binary.
* Introduced the `infrastructure_data_entries` function in `release_manifest.py` to generate per-file PyInstaller data entries for the `infrastructure/` directory, filtering out excluded subtrees and unnecessary files.
* Updated the PyInstaller spec file (`opensre.spec`) to use `infrastructure_data_entries` instead of bundling the entire `infrastructure` directory, ensuring only relevant files are included in the release.

**Testing:**

* Added tests in `test_release_manifest.py` to verify that the Cloudflare Worker is excluded, while real infrastructure code is still included, and that the spec file uses the new filtered helper.
* Updated imports in the test file to include the new `infrastructure_data_entries` function.