### PR TITLE
feat(agent_harness): inject reasoning client factory into DefaultReasoningClientProvider

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -165,6 +165,8 @@ subpackage. Default port implementations live with the concern they serve, not i
     and the neutral turn-result models.
   - `default_reasoning_client.py` — `DefaultReasoningClientProvider`, kept with the
     reasoning-client family (`stream_answer`, `StaticReasoningClientProvider`).
+    The client factory is injected at construction; `DefaultHeadlessBuild.reasoning`
+    supplies `default_reasoning_llm_factory`. `get()` swallows factory failures.
 - `tools/` — action-tool wiring over the canonical registry (`action_tools.py`,
   `tool_context.py`) and `tool_provider.py` (`DefaultToolProvider`).
 - `accounting/` — session-scoped token accounting and LLM run metadata, plus the

--- a/core/agent_harness/turns/default_reasoning_client.py
+++ b/core/agent_harness/turns/default_reasoning_client.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Callable
+from typing import Any
 
 from rich.markup import escape
 
@@ -31,10 +32,12 @@ class DefaultReasoningClientProvider:
     def __init__(
         self,
         *,
+        client_factory: Callable[[], StreamingReasoningClient],
         output: OutputSink | None = None,
         error_reporter: ErrorReporter | None = None,
         session: Any | None = None,
     ) -> None:
+        self._client_factory = client_factory
         self._output = output
         self._error_reporter = error_reporter
         self._session = session
@@ -49,21 +52,9 @@ class DefaultReasoningClientProvider:
 
     def get(self) -> StreamingReasoningClient | None:
         try:
-            from core.llm.factory import LLMRole, get_llm
+            return self._client_factory()
         except Exception as exc:
-            self._handle_unavailable(
-                exc, context="core.agent_harness.default_reasoning_client.import"
-            )
-            return None
-        try:
-            # ``get_llm`` stays untyped for this role on purpose: other callers
-            # use the same client for structured output, not streaming. This
-            # provider promises only the streaming contract, so narrow here.
-            return cast(StreamingReasoningClient, get_llm(LLMRole.REASONING))
-        except Exception as exc:
-            self._handle_unavailable(
-                exc, context="core.agent_harness.default_reasoning_client.create"
-            )
+            self._handle_unavailable(exc, context="core.agent_harness.default_reasoning_client.get")
             return None
 
     def _handle_unavailable(self, exc: Exception, *, context: str) -> None:

--- a/core/agent_harness/turns/headless_build.py
+++ b/core/agent_harness/turns/headless_build.py
@@ -26,7 +26,7 @@ from rich.console import Console
 from core.agent_harness.accounting.run_record import DefaultRunRecordFactory
 from core.agent_harness.agent_build_config import AgentBuildConfig
 from core.agent_harness.error_reporting import DefaultErrorReporter
-from core.agent_harness.llm_resolution import default_llm_factory
+from core.agent_harness.llm_resolution import default_llm_factory, default_reasoning_llm_factory
 from core.agent_harness.ports import (
     ErrorReporter,
     LlmFactory,
@@ -170,7 +170,10 @@ class DefaultHeadlessBuild:
 
     def reasoning(self) -> ReasoningClientProvider:
         return DefaultReasoningClientProvider(
-            output=self.output, error_reporter=self._error_reporter, session=self.session
+            client_factory=default_reasoning_llm_factory,
+            output=self.output,
+            error_reporter=self._error_reporter,
+            session=self.session,
         )
 
     def run_factory(self) -> RunRecordFactory:

--- a/tests/core/agent/orchestration/cross_surface_parity_harness.py
+++ b/tests/core/agent/orchestration/cross_surface_parity_harness.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 
 from rich.console import Console
 
+from core.agent_harness.llm_resolution import default_reasoning_llm_factory
 from core.agent_harness.prompts.grounding import DefaultPromptContextProvider
 from core.agent_harness.runtime import TurnBinding
 from core.agent_harness.session import InMemorySessionStore
@@ -309,7 +310,11 @@ def _dispatch_turn(
 ) -> TurnResult:
     output = BufferOutputSink()
     agent = InMemoryHeadlessBuild(
-        session=session, output=output, reasoning=DefaultReasoningClientProvider(output=output)
+        session=session,
+        output=output,
+        reasoning=DefaultReasoningClientProvider(
+            client_factory=default_reasoning_llm_factory, output=output
+        ),
     ).agent(
         tools=DefaultToolProvider(
             session,

--- a/tests/core/agent_harness/test_headless_build.py
+++ b/tests/core/agent_harness/test_headless_build.py
@@ -113,6 +113,26 @@ def test_primary_response_text_prefers_assistant() -> None:
     assert empty_assistant.primary_response_text == "from action"
 
 
+def test_default_headless_build_supplies_the_reasoning_client_factory(monkeypatch) -> None:
+    """The default family injects ``default_reasoning_llm_factory`` into the provider."""
+    sentinel = object()
+
+    def _factory() -> object:
+        return sentinel
+
+    monkeypatch.setattr(
+        "core.agent_harness.turns.headless_build.default_reasoning_llm_factory",
+        _factory,
+    )
+    session = SimpleNamespace(
+        configured_integrations=[],
+        resolved_integrations_cache={},
+        session_id="s1",
+    )
+    provider = DefaultHeadlessBuild(session=session, output=BufferOutputSink()).reasoning()
+    assert provider.get() is sentinel
+
+
 def test_default_headless_build_takes_the_hosts_tool_provider_and_forwards_the_llm_factory() -> (
     None
 ):

--- a/tests/core/agent_harness/test_llm_client_preload_and_errors.py
+++ b/tests/core/agent_harness/test_llm_client_preload_and_errors.py
@@ -7,12 +7,14 @@ the actionable message shown when the reasoning-client import fails.
 from __future__ import annotations
 
 import sys
+from typing import cast
 
 from core.agent_harness.turns.default_reasoning_client import (
     DefaultReasoningClientProvider,
     _llm_client_unavailable_message,
 )
 from core.llm.internal.preload import preload_llm_clients
+from core.llm.types import StreamingReasoningClient
 
 
 def test_preload_imports_the_llm_client_graph() -> None:
@@ -42,17 +44,25 @@ def test_non_import_error_message_is_unchanged() -> None:
     assert "Restart" not in message
 
 
-def test_reasoning_provider_renders_actionable_message_on_import_error(monkeypatch) -> None:
+def test_reasoning_provider_returns_injected_client() -> None:
+    client = cast(StreamingReasoningClient, object())
+    provider = DefaultReasoningClientProvider(client_factory=lambda: client)
+    assert provider.get() is client
+
+
+def test_reasoning_provider_renders_actionable_message_on_import_error() -> None:
     rendered: list[str] = []
 
     class FakeOutput:
         def render_error(self, message: str) -> None:
             rendered.append(message)
 
-    # Force the lazy import inside get() to fail like a stale process would.
-    monkeypatch.setitem(sys.modules, "core.llm.factory", None)
+    def _raise_import_error() -> StreamingReasoningClient:
+        raise ImportError("cannot import name 'x'")
 
-    provider = DefaultReasoningClientProvider(output=FakeOutput())
+    provider = DefaultReasoningClientProvider(
+        client_factory=_raise_import_error, output=FakeOutput()
+    )
     result = provider.get()
 
     assert result is None

--- a/tests/core/agent_harness/test_session_bindable_ports.py
+++ b/tests/core/agent_harness/test_session_bindable_ports.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from typing import Any
+from typing import Any, cast
 
 from core.agent_harness.ports import (
     CancelCapableConsole,
@@ -24,6 +24,7 @@ from core.agent_harness.turns.headless_adapters import (
 )
 from core.agent_harness.turns.headless_build import InMemoryHeadlessBuild
 from core.agent_harness.turns.host_cancel import ensure_turn_cancel
+from core.llm.types import StreamingReasoningClient
 
 
 class _SpyTools:
@@ -96,7 +97,9 @@ def test_headless_agent_bind_turn_console_invokes_console_bindable() -> None:
 def test_default_reasoning_provider_is_output_bindable() -> None:
     first = BufferOutputSink()
     second = BufferOutputSink()
-    reasoning = DefaultReasoningClientProvider(output=first)
+    reasoning = DefaultReasoningClientProvider(
+        client_factory=lambda: cast(StreamingReasoningClient, None), output=first
+    )
     assert isinstance(reasoning, OutputBindable)
     assert isinstance(StaticReasoningClientProvider(), OutputBindable)
     reasoning.bind_output(second)
@@ -108,7 +111,9 @@ def test_default_reasoning_provider_is_output_bindable() -> None:
 def test_headless_agent_bind_turn_output_retargets_reasoning() -> None:
     first = BufferOutputSink()
     second = BufferOutputSink()
-    reasoning = DefaultReasoningClientProvider(output=first)
+    reasoning = DefaultReasoningClientProvider(
+        client_factory=lambda: cast(StreamingReasoningClient, None), output=first
+    )
     agent = InMemoryHeadlessBuild(
         session=InMemorySessionState(), output=first, reasoning=reasoning
     ).agent(tools=NullToolProvider())


### PR DESCRIPTION
/fix #5254 
This pull request refactors how the default reasoning client is constructed and injected throughout the agent harness, making the client factory explicit and improving testability and error handling. The main change is to inject a `client_factory` into `DefaultReasoningClientProvider`, replacing implicit imports and making the dependency explicit. This also requires updates across the codebase and tests to use the new constructor signature.

**Reasoning Client Construction and Injection:**

- `DefaultReasoningClientProvider` now requires a `client_factory` argument at construction, replacing the previous implicit import-based approach. The `get()` method now simply calls this factory and handles any exceptions, improving clarity and testability. [[1]](diffhunk://#diff-c08d99b64e2c303225497d09a195d19279320ce9043f4e096f43602d6a9ec5faR35-R40) [[2]](diffhunk://#diff-c08d99b64e2c303225497d09a195d19279320ce9043f4e096f43602d6a9ec5faL52-R57)
- `DefaultHeadlessBuild.reasoning()` is updated to inject the `default_reasoning_llm_factory` as the `client_factory` when constructing the reasoning provider, ensuring consistent dependency injection. [[1]](diffhunk://#diff-ec75ff85e52a9034025fcbcf7f861c4cc0b7ccbd37726f45d4a93fa8f5f85ff7L173-R176) [[2]](diffhunk://#diff-ec75ff85e52a9034025fcbcf7f861c4cc0b7ccbd37726f45d4a93fa8f5f85ff7L29-R29)
- Documentation in `AGENTS.md` is updated to describe the new injection strategy for the reasoning client factory.

**Test Updates for New Construction Pattern:**

- All tests that instantiate `DefaultReasoningClientProvider` are updated to provide a `client_factory`, often as a lambda or test double. This includes both orchestration and headless build tests, ensuring they work with the new explicit dependency. [[1]](diffhunk://#diff-004e198f954825ce730e0ea14589190e7a65a3574ad76f2e097bb36b6185b8a3L312-R317) [[2]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aL99-R102) [[3]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aL111-R116)
- Added a new test to verify that `DefaultHeadlessBuild` correctly supplies the reasoning client factory and that the provider returns the expected object.
- Additional tests confirm that the provider returns the injected client and that actionable error messages are rendered on import errors, using the new factory-based approach.

**Type and Import Cleanups:**

- Updated imports to bring in `StreamingReasoningClient` and use `cast` where needed for type safety in tests. [[1]](diffhunk://#diff-c08d99b64e2c303225497d09a195d19279320ce9043f4e096f43602d6a9ec5faL5-R6) [[2]](diffhunk://#diff-4192e99d393dd6db6b60b58e660dfe1c08c2823c94bb159d06f1aae53e2d29a0R10-R17) [[3]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aL6-R6) [[4]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aR27)
- Minor refactors in test files to align with the new construction pattern and ensure type correctness. [[1]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aL99-R102) [[2]](diffhunk://#diff-d8ce33336ec2b15b0494d1b155bb54adf43b3c7368f38c94c72481d15ac4189aL111-R116)

These changes collectively improve the clarity, testability, and maintainability of the reasoning client integration in the agent harness.