### PR TITLE
refactor(integrations): give eight more vendors a public API (setup, client)

### DIFF
--- a/integrations/alertmanager/__init__.py
+++ b/integrations/alertmanager/__init__.py
@@ -6,9 +6,14 @@ import logging
 from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
+from integrations.alertmanager.client import make_alertmanager_client
+from integrations.alertmanager.setup import ALERTMANAGER_SETUP
 from integrations.config_models import AlertmanagerIntegrationConfig
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["ALERTMANAGER_SETUP", "classify", "make_alertmanager_client"]
 
 
 def classify(

--- a/integrations/coralogix/__init__.py
+++ b/integrations/coralogix/__init__.py
@@ -7,8 +7,12 @@ from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import CoralogixIntegrationConfig
+from integrations.coralogix.setup import CORALOGIX_SETUP
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["CORALOGIX_SETUP", "classify"]
 
 
 def classify(

--- a/integrations/honeycomb/__init__.py
+++ b/integrations/honeycomb/__init__.py
@@ -7,8 +7,12 @@ from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
 from integrations.honeycomb.config import HoneycombIntegrationConfig
+from integrations.honeycomb.setup import HONEYCOMB_SETUP
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["HONEYCOMB_SETUP", "classify"]
 
 
 def classify(

--- a/integrations/incident_io/__init__.py
+++ b/integrations/incident_io/__init__.py
@@ -7,8 +7,12 @@ from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import IncidentIoIntegrationConfig
+from integrations.incident_io.setup import INCIDENT_IO_SETUP
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["INCIDENT_IO_SETUP", "classify"]
 
 
 def classify(

--- a/integrations/new_relic/__init__.py
+++ b/integrations/new_relic/__init__.py
@@ -7,8 +7,12 @@ from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
 from integrations.new_relic.config import NewRelicIntegrationConfig
+from integrations.new_relic.setup import NEW_RELIC_SETUP
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["NEW_RELIC_SETUP", "classify"]
 
 
 def classify(

--- a/integrations/opensearch/__init__.py
+++ b/integrations/opensearch/__init__.py
@@ -7,8 +7,12 @@ from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import OpenSearchIntegrationConfig
+from integrations.opensearch.setup import OPENSEARCH_SETUP
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["OPENSEARCH_SETUP", "classify"]
 
 
 def classify(

--- a/integrations/pagerduty/__init__.py
+++ b/integrations/pagerduty/__init__.py
@@ -7,8 +7,12 @@ from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
 from integrations.config_models import PagerDutyIntegrationConfig
+from integrations.pagerduty.setup import PAGERDUTY_SETUP
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["PAGERDUTY_SETUP", "classify"]
 
 
 def classify(

--- a/integrations/vercel/__init__.py
+++ b/integrations/vercel/__init__.py
@@ -7,8 +7,12 @@ from typing import Any
 
 from integrations._validation_helpers import report_classify_failure
 from integrations.vercel.client import VercelConfig
+from integrations.vercel.setup import VERCEL_SETUP
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = ["VERCEL_SETUP", "classify"]
 
 
 def classify(credentials: dict[str, Any], record_id: str) -> tuple[VercelConfig | None, str | None]:

--- a/surfaces/cli/wizard/configurators/alerting.py
+++ b/surfaces/cli/wizard/configurators/alerting.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from config.env_file import sync_env_values
 from infrastructure.terminal.theme import SECONDARY
-from integrations.alertmanager.setup import ALERTMANAGER_SETUP
+from integrations.alertmanager import ALERTMANAGER_SETUP
 from integrations.betterstack.setup import BETTERSTACK_SETUP
-from integrations.incident_io.setup import INCIDENT_IO_SETUP
-from integrations.pagerduty.setup import PAGERDUTY_SETUP
+from integrations.incident_io import INCIDENT_IO_SETUP
+from integrations.pagerduty import PAGERDUTY_SETUP
 from integrations.store import upsert_integration
 from surfaces.cli.wizard._ui import (
     _console,

--- a/surfaces/cli/wizard/configurators/observability.py
+++ b/surfaces/cli/wizard/configurators/observability.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from config.env_file import sync_env_values
 from infrastructure.terminal.theme import ERROR, HIGHLIGHT, SECONDARY
-from integrations.coralogix.setup import CORALOGIX_SETUP
+from integrations.coralogix import CORALOGIX_SETUP
 from integrations.datadog.setup import DATADOG_SETUP
 from integrations.grafana.setup import GRAFANA_SETUP
-from integrations.honeycomb.setup import HONEYCOMB_SETUP
-from integrations.new_relic.setup import NEW_RELIC_SETUP
-from integrations.opensearch.setup import OPENSEARCH_SETUP
+from integrations.honeycomb import HONEYCOMB_SETUP
+from integrations.new_relic import NEW_RELIC_SETUP
+from integrations.opensearch import OPENSEARCH_SETUP
 from integrations.store import remove_integration, upsert_integration
 from integrations.tempo.setup import TEMPO_SETUP
 from surfaces.cli.wizard._ui import (

--- a/surfaces/cli/wizard/configurators/vercel.py
+++ b/surfaces/cli/wizard/configurators/vercel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from integrations.vercel.setup import VERCEL_SETUP
+from integrations.vercel import VERCEL_SETUP
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 
 

--- a/surfaces/cli/wizard/integration_validators/alerting.py
+++ b/surfaces/cli/wizard/integration_validators/alerting.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from integrations.alertmanager.client import make_alertmanager_client
+from integrations.alertmanager import make_alertmanager_client
 from integrations.betterstack import build_betterstack_config, validate_betterstack_config
 from integrations.opsgenie import OpsGenieClient, OpsGenieConfig
 

--- a/tests/shared/test_integrations_api_border.py
+++ b/tests/shared/test_integrations_api_border.py
@@ -90,8 +90,6 @@ _ALLOWED: dict[str, frozenset[str]] = {
     ),
     "surfaces": frozenset(
         {
-            "integrations.alertmanager.client",
-            "integrations.alertmanager.setup",
             "integrations.aws.role_mode_gate",
             "integrations.aws.setup",
             "integrations.betterstack.setup",
@@ -99,7 +97,6 @@ _ALLOWED: dict[str, frozenset[str]] = {
             "integrations.buzz.client",
             "integrations.buzz.credentials",
             "integrations.buzz.setup",
-            "integrations.coralogix.setup",
             "integrations.dagster.setup",
             "integrations.datadog.setup",
             "integrations.discord.setup",
@@ -116,8 +113,6 @@ _ALLOWED: dict[str, frozenset[str]] = {
             "integrations.hermes.correlator",
             "integrations.hermes.investigation",
             "integrations.hermes.sinks",
-            "integrations.honeycomb.setup",
-            "integrations.incident_io.setup",
             "integrations.jenkins.setup",
             "integrations.llm_cli.antigravity_cli",
             "integrations.llm_cli.base",
@@ -133,12 +128,9 @@ _ALLOWED: dict[str, frozenset[str]] = {
             "integrations.llm_cli.kimi",
             "integrations.llm_cli.opencode",
             "integrations.llm_cli.pi_cli",
-            "integrations.new_relic.setup",
             "integrations.openclaw.build_openclaw_config",
             "integrations.openclaw.setup",
             "integrations.openclaw.validate_openclaw_config",
-            "integrations.opensearch.setup",
-            "integrations.pagerduty.setup",
             "integrations.posthog.report_prerequisites",
             "integrations.posthog.setup",
             "integrations.posthog_mcp.build_posthog_mcp_config",
@@ -162,7 +154,6 @@ _ALLOWED: dict[str, frozenset[str]] = {
             "integrations.telegram.setup",
             "integrations.tempo.setup",
             "integrations.tracer.integrations_adapter",
-            "integrations.vercel.setup",
         }
     ),
 }


### PR DESCRIPTION
Continues the integrations public-API cleanup. Eight vendors expose their setup
step (and alertmanager its client) through the vendor's main module, and the
setup screens import from there instead of reaching inside the folder.

- alertmanager (client + setup), coralogix, honeycomb, incident_io, new_relic,
  opensearch, pagerduty, vercel: main module re-exports the name(s), __all__ set.
- Four surfaces configurators (+ one validator) import from integrations.<vendor>.
- Nine cleared entries removed from the import check; setup-screen count 73 -> 64.

Not included, on purpose:
- Grafana's reporting_adapter and eight other vendors' side-effect registration
  imports are one cluster covered by #5256 — better done there than per vendor.
- betterstack, dagster, jenkins, tempo have a verifier that imports their own
  main module, so exposing setup there would form an import cycle; they need a
  different approach and are deferred.

No behaviour changes. The setup modules are lightweight (config constants, the
vendor verifier, a shared setup spec), so exposing them through the main module
adds no heavy import and, for these eight, no cycle (verified by importing each).