### PR TITLE
feat(cli): add explicit investigation mode to ask

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,10 @@ opensre
 
 ```bash
 opensre ask "why is checkout-api slow?"
+opensre ask --investigate "checkout-api is returning 502s in us-east-1"
 ```
 
-See **[Headless CLI](https://www.opensre.com/docs/headless-cli)** for stdin prompts, JSON output, and tool approvals.
+See **[Headless CLI](https://www.opensre.com/docs/headless-cli)** for investigation mode, stdin prompts, JSON output, and tool approvals.
 
 **One-shot investigation** — run the agent once against an alert file:
 

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -324,12 +324,14 @@ class AgentSession:
         *,
         opensre_evaluate: bool = False,
         investigation_metadata: tuple[str, str] | None = None,
+        user_requested: bool = False,
     ) -> InvestigationResult:
         """Run an investigation and return a typed result.
 
         Uses the payload runner installed at process boot
         (:func:`core.agent_harness.investigation_api.install_investigation_payload_runner`).
-        Does not require an attached chat agent.
+        Does not require an attached chat agent. Set ``user_requested`` when an
+        explicit user action must bypass automated alert noise filtering.
         """
         from core.agent_harness.investigation_api import run_installed_investigation_payload
 
@@ -337,6 +339,7 @@ class AgentSession:
             raw_alert=alert,
             opensre_evaluate=opensre_evaluate,
             investigation_metadata=investigation_metadata,
+            user_requested=user_requested,
         )
 
     def resolve_integrations(self, session: SessionCore) -> dict[str, Any]:

--- a/core/agent_harness/investigation_api.py
+++ b/core/agent_harness/investigation_api.py
@@ -99,6 +99,7 @@ def run_installed_investigation_payload(
     raw_alert: AlertInput,
     opensre_evaluate: bool = False,
     investigation_metadata: tuple[str, str] | None = None,
+    user_requested: bool = False,
 ) -> InvestigationResult:
     """Run investigation through the installed payload runner."""
     runner = _payload_runner
@@ -109,11 +110,21 @@ def run_installed_investigation_payload(
             "bootstrap.adapters.install_investigation_api() before "
             "AgentSession.investigate."
         )
-    payload = runner(
-        raw_alert=raw_alert,
-        opensre_evaluate=opensre_evaluate,
-        investigation_metadata=investigation_metadata,
-    )
+    if user_requested:
+        payload = runner(
+            raw_alert=raw_alert,
+            opensre_evaluate=opensre_evaluate,
+            investigation_metadata=investigation_metadata,
+            user_requested=True,
+        )
+    else:
+        # Preserve compatibility with installed runners that predate the
+        # explicit-user marker.
+        payload = runner(
+            raw_alert=raw_alert,
+            opensre_evaluate=opensre_evaluate,
+            investigation_metadata=investigation_metadata,
+        )
     return InvestigationResult.from_payload(payload)
 
 

--- a/docs/headless-cli.mdx
+++ b/docs/headless-cli.mdx
@@ -18,7 +18,35 @@ Pass `-` as the prompt to read all of standard input:
 cat incident-notes.txt | opensre ask -
 ```
 
-For a structured alert investigation, use `opensre investigate` instead.
+## Full investigation mode
+
+Normal Ask requests are conversational and do not automatically start the full
+RCA pipeline. Select it explicitly when the prompt describes an incident:
+
+```bash
+opensre ask --investigate "checkout-api is returning 502s in us-east-1"
+```
+
+A literal leading `/investigate` is supported as a compatibility shortcut:
+
+```bash
+opensre ask "/investigate checkout-api is returning 502s in us-east-1"
+```
+
+Only `/investigate` is available through Ask. Open `opensre` to use other slash
+commands. Continue to use `opensre investigate` for alert files, templates,
+evaluation, or the complete structured result.
+
+Integration setup remains an interactive terminal workflow and never opens
+inside Ask. Run it directly, then retry the request:
+
+```bash
+opensre integrations setup grafana
+opensre integrations verify grafana
+```
+
+Do not combine `--investigate` with Ask's tool-approval options. Investigation
+mode uses the same execution contract as `opensre investigate`.
 
 ## Tool approvals
 
@@ -60,7 +88,8 @@ opensre --json ask "summarize current service health"
 
 The command writes one JSON object with `status`, `response`, `denied_tools`,
 and `error`. The `error` value is either `null` or an object with `message` and
-`suggestion`.
+`suggestion`. In a terminal, progress is written to stderr; redirected and JSON
+runs stay quiet until the final result.
 
 | Exit code | Meaning |
 | --- | --- |

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -201,13 +201,13 @@ def _run_investigation(prompt: str) -> dict[str, object]:
     """Run raw incident text through the canonical CLI investigation service."""
     from surfaces.cli.investigation.investigate import run_investigation_cli
 
-    return run_investigation_cli(raw_alert=prompt)
+    return run_investigation_cli(raw_alert=prompt, user_requested=True)
 
 
 def _investigation_response(payload: dict[str, object]) -> str:
     """Render a completed investigation into Ask's stable text response field."""
     root_cause = str(payload.get("root_cause") or "").strip()
-    report = str(payload.get("problem_md") or payload.get("report") or "").strip()
+    report = str(payload.get("report") or payload.get("problem_md") or "").strip()
     sections: list[str] = []
     if root_cause:
         sections.append(f"## Root Cause\n\n{root_cause}")

--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -197,6 +197,25 @@ def _successful_turn(result: TurnResult) -> bool:
     )
 
 
+def _run_investigation(prompt: str) -> dict[str, object]:
+    """Run raw incident text through the canonical CLI investigation service."""
+    from surfaces.cli.investigation.investigate import run_investigation_cli
+
+    return run_investigation_cli(raw_alert=prompt)
+
+
+def _investigation_response(payload: dict[str, object]) -> str:
+    """Render a completed investigation into Ask's stable text response field."""
+    root_cause = str(payload.get("root_cause") or "").strip()
+    report = str(payload.get("problem_md") or payload.get("report") or "").strip()
+    sections: list[str] = []
+    if root_cause:
+        sections.append(f"## Root Cause\n\n{root_cause}")
+    if report:
+        sections.append(f"## Report\n\n{report}")
+    return "\n\n".join(sections)
+
+
 def _approval_denied_outcome(
     tracker: ApprovalTracker,
     *,
@@ -223,13 +242,63 @@ def cancelled_outcome(signum: int) -> AskOutcome:
     )
 
 
+def _failure_outcome(
+    exc: Exception,
+    *,
+    tracker: ApprovalTracker | None = None,
+    context: str,
+) -> AskOutcome:
+    if tracker is not None:
+        denied = _approval_denied_outcome(tracker)
+        if denied is not None:
+            return denied
+    if isinstance(exc, OpenSREError):
+        return AskOutcome(
+            status=AskStatus.ERROR,
+            response="",
+            error=AskError(message=exc.message, suggestion=exc.suggestion),
+            exit_code=AskExitCode.ERROR,
+        )
+
+    from surfaces.cli.telemetry import report_exception
+
+    report_exception(exc, context=context)
+    return AskOutcome(
+        status=AskStatus.ERROR,
+        response="",
+        error=AskError(message=str(exc) or type(exc).__name__),
+        exit_code=AskExitCode.ERROR,
+    )
+
+
+def _run_ask_investigation(prompt: str) -> AskOutcome:
+    try:
+        response = _investigation_response(_run_investigation(prompt))
+    except AskSignal as exc:
+        return cancelled_outcome(exc.signum)
+    except Exception as exc:
+        return _failure_outcome(exc, context="surfaces.cli.ask.investigate")
+    if not response:
+        return AskOutcome(
+            status=AskStatus.ERROR,
+            response="",
+            error=AskError(message="The investigation did not produce a report."),
+            exit_code=AskExitCode.ERROR,
+        )
+    return AskOutcome(status=AskStatus.SUCCESS, response=response)
+
+
 def run_ask(
     prompt: str,
     *,
     allowed_tools: tuple[str, ...],
     bypass_approvals: bool,
+    investigate: bool = False,
 ) -> AskOutcome:
     """Execute one ask turn with invocation-scoped approval authority."""
+    if investigate:
+        return _run_ask_investigation(prompt)
+
     tracker = ApprovalTracker()
     hooks = build_approval_hooks(
         allowed_tools=allowed_tools,
@@ -240,29 +309,8 @@ def run_ask(
         result = _run_agent_turn(prompt, hooks)
     except AskSignal as exc:
         return cancelled_outcome(exc.signum)
-    except OpenSREError as exc:
-        denied = _approval_denied_outcome(tracker)
-        if denied is not None:
-            return denied
-        return AskOutcome(
-            status=AskStatus.ERROR,
-            response="",
-            error=AskError(message=exc.message, suggestion=exc.suggestion),
-            exit_code=AskExitCode.ERROR,
-        )
     except Exception as exc:
-        denied = _approval_denied_outcome(tracker)
-        if denied is not None:
-            return denied
-        from surfaces.cli.telemetry import report_exception
-
-        report_exception(exc, context="surfaces.cli.ask")
-        return AskOutcome(
-            status=AskStatus.ERROR,
-            response="",
-            error=AskError(message=str(exc) or type(exc).__name__),
-            exit_code=AskExitCode.ERROR,
-        )
+        return _failure_outcome(exc, tracker=tracker, context="surfaces.cli.ask")
 
     denied = _approval_denied_outcome(
         tracker,

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import click
+from rich.console import Console
 
 from infrastructure.process.runtime_flags import is_json_output
 from surfaces.cli.ask.approval import unknown_allowed_tools
@@ -18,6 +21,8 @@ from surfaces.cli.ask.service import (
     run_ask,
 )
 
+_INVESTIGATE_COMMAND = "/investigate"
+
 
 def _resolve_prompt(value: str) -> str:
     prompt = sys.stdin.read() if value == "-" else value
@@ -25,6 +30,38 @@ def _resolve_prompt(value: str) -> str:
     if not prompt:
         raise click.UsageError("PROMPT must not be empty.")
     return prompt
+
+
+def _resolve_mode(prompt: str, *, investigate: bool) -> tuple[str, bool]:
+    """Resolve explicit Ask mode selectors without inferring prose intent."""
+    if prompt == _INVESTIGATE_COMMAND:
+        raise click.UsageError("/investigate requires incident text.")
+    if prompt.startswith(_INVESTIGATE_COMMAND) and prompt[len(_INVESTIGATE_COMMAND)].isspace():
+        if investigate:
+            raise click.UsageError("Specify investigation mode only once.")
+        incident = prompt.removeprefix(_INVESTIGATE_COMMAND).strip()
+        return incident, True
+    if prompt.startswith("/"):
+        if prompt.startswith("/integrations "):
+            direct_command = f"opensre {prompt.removeprefix('/')}"
+            raise click.UsageError(
+                f"Ask only supports /investigate. Run `{direct_command}` directly."
+            )
+        raise click.UsageError(
+            "Ask only supports /investigate. Open `opensre` for slash commands "
+            "or run the equivalent `opensre` subcommand directly."
+        )
+    return prompt, investigate
+
+
+@contextmanager
+def _progress(label: str) -> Iterator[None]:
+    """Show TTY-only progress on stderr without contaminating automation output."""
+    if is_json_output() or not sys.stderr.isatty():
+        yield
+        return
+    with Console(stderr=True).status(label):
+        yield
 
 
 def _render_outcome(outcome: AskOutcome) -> None:
@@ -45,6 +82,11 @@ def _render_outcome(outcome: AskOutcome) -> None:
 @click.command(name="ask")
 @click.argument("prompt")
 @click.option(
+    "--investigate",
+    is_flag=True,
+    help="Run the prompt through the full incident investigation pipeline.",
+)
+@click.option(
     "--allowed-tool",
     "allowed_tools",
     multiple=True,
@@ -58,28 +100,40 @@ def _render_outcome(outcome: AskOutcome) -> None:
 )
 def ask_command(
     prompt: str,
+    investigate: bool,
     allowed_tools: tuple[str, ...],
     dangerously_bypass_approvals: bool,
 ) -> None:
     """Run one configured OpenSRE agent request and exit."""
-    if allowed_tools and dangerously_bypass_approvals:
-        raise click.UsageError(
-            "--allowed-tool cannot be combined with --dangerously-bypass-approvals."
-        )
-    unknown = unknown_allowed_tools(allowed_tools)
-    if unknown:
-        names = ", ".join(unknown)
-        raise click.BadParameter(
-            f"unknown registered tool name(s): {names}",
-            param_hint="--allowed-tool",
-        )
     try:
         with ask_signal_scope():
-            outcome = run_ask(
-                _resolve_prompt(prompt),
-                allowed_tools=allowed_tools,
-                bypass_approvals=dangerously_bypass_approvals,
+            resolved_prompt, investigate = _resolve_mode(
+                _resolve_prompt(prompt), investigate=investigate
             )
+            if investigate and (allowed_tools or dangerously_bypass_approvals):
+                raise click.UsageError(
+                    "--allowed-tool and --dangerously-bypass-approvals cannot be combined "
+                    "with --investigate."
+                )
+            if allowed_tools and dangerously_bypass_approvals:
+                raise click.UsageError(
+                    "--allowed-tool cannot be combined with --dangerously-bypass-approvals."
+                )
+            unknown = unknown_allowed_tools(allowed_tools)
+            if unknown:
+                names = ", ".join(unknown)
+                raise click.BadParameter(
+                    f"unknown registered tool name(s): {names}",
+                    param_hint="--allowed-tool",
+                )
+            label = "Investigating…" if investigate else "Working…"
+            with _progress(label):
+                outcome = run_ask(
+                    resolved_prompt,
+                    allowed_tools=allowed_tools,
+                    bypass_approvals=dangerously_bypass_approvals,
+                    investigate=investigate,
+                )
     except AskSignal as exc:
         outcome = cancelled_outcome(exc.signum)
     _render_outcome(outcome)

--- a/surfaces/cli/investigation/investigate.py
+++ b/surfaces/cli/investigation/investigate.py
@@ -34,7 +34,7 @@ def _reraise_cli_investigation_failure(exc: BaseException) -> NoReturn:
 @traceable(name="investigation")
 def run_investigation_cli(
     *,
-    raw_alert: dict[str, Any],
+    raw_alert: str | dict[str, Any],
     opensre_evaluate: bool = False,
     investigation_metadata: tuple[str, str] | None = None,
 ) -> dict[str, Any]:

--- a/surfaces/cli/investigation/investigate.py
+++ b/surfaces/cli/investigation/investigate.py
@@ -37,6 +37,7 @@ def run_investigation_cli(
     raw_alert: str | dict[str, Any],
     opensre_evaluate: bool = False,
     investigation_metadata: tuple[str, str] | None = None,
+    user_requested: bool = False,
 ) -> dict[str, Any]:
     """Run the investigation and return the CLI-facing JSON payload.
 
@@ -46,6 +47,7 @@ def run_investigation_cli(
     the shared session API so every surface uses the same entry.
 
     ``investigation_metadata`` is an optional ``(alert_name, severity)`` tuple.
+    ``user_requested`` bypasses automated alert noise filtering.
     """
     check_llm_settings()
     from bootstrap.adapters import install_investigation_api
@@ -60,6 +62,7 @@ def run_investigation_cli(
                 raw_alert,
                 opensre_evaluate=opensre_evaluate,
                 investigation_metadata=investigation_metadata,
+                user_requested=user_requested,
             )
             .as_dict()
         )

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -41,6 +41,7 @@ def test_ask_passes_prompt_and_invocation_authority(monkeypatch) -> None:
         "prompt": "check latency",
         "allowed_tools": ("grafana_query",),
         "bypass_approvals": False,
+        "investigate": False,
     }
 
 
@@ -74,6 +75,107 @@ def test_ask_reads_prompt_from_stdin(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert seen == ["from stdin"]
+
+
+def test_ask_investigate_flag_selects_investigation_mode(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(prompt: str, **kwargs: object) -> AskOutcome:
+        captured.update(prompt=prompt, **kwargs)
+        return _success("Root Cause\n\nupstream timeout")
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(
+        ask_command,
+        ["--investigate", "checkout-api is returning 502s"],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "prompt": "checkout-api is returning 502s",
+        "allowed_tools": (),
+        "bypass_approvals": False,
+        "investigate": True,
+    }
+
+
+def test_ask_literal_investigate_alias_preserves_full_prompt(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(prompt: str, **kwargs: object) -> AskOutcome:
+        captured.update(prompt=prompt, **kwargs)
+        return _success()
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(
+        ask_command,
+        ["/investigate checkout-api is returning 502s in us-east-1"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["prompt"] == "checkout-api is returning 502s in us-east-1"
+    assert captured["investigate"] is True
+
+
+def test_ask_does_not_infer_investigation_from_prose(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(prompt: str, **kwargs: object) -> AskOutcome:
+        captured.update(prompt=prompt, **kwargs)
+        return _success()
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(ask_command, ["investigate how the RCA pipeline works"])
+
+    assert result.exit_code == 0
+    assert captured["investigate"] is False
+
+
+def test_ask_rejects_other_literal_slash_commands_before_execution(monkeypatch) -> None:
+    called = False
+
+    def fake_run(*_args: object, **_kwargs: object) -> AskOutcome:
+        nonlocal called
+        called = True
+        return _success()
+
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", fake_run)
+
+    result = CliRunner().invoke(ask_command, ["/integrations setup grafana"])
+
+    assert result.exit_code == 2
+    assert "opensre integrations setup grafana" in result.output
+    assert called is False
+
+
+def test_ask_rejects_empty_or_duplicate_investigation_selectors(monkeypatch) -> None:
+    monkeypatch.setattr("surfaces.cli.commands.ask.run_ask", lambda *_a, **_kw: _success())
+
+    empty = CliRunner().invoke(ask_command, ["/investigate"])
+    duplicate = CliRunner().invoke(
+        ask_command,
+        ["--investigate", "/investigate checkout is slow"],
+    )
+
+    assert empty.exit_code == 2
+    assert "requires incident text" in empty.output
+    assert duplicate.exit_code == 2
+    assert "only once" in duplicate.output
+
+
+def test_ask_investigation_rejects_approval_options(monkeypatch) -> None:
+    monkeypatch.setattr("surfaces.cli.commands.ask.unknown_allowed_tools", lambda _v: ())
+
+    result = CliRunner().invoke(
+        ask_command,
+        ["--investigate", "checkout is slow", "--allowed-tool", "shell_run"],
+    )
+
+    assert result.exit_code == 2
+    assert "cannot be combined with --investigate" in result.output
 
 
 def test_ask_interrupt_while_reading_stdin_returns_signal_exit(monkeypatch) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -107,7 +107,7 @@ def test_run_ask_investigation_reuses_cli_investigation_service(monkeypatch) -> 
         return {
             "root_cause": "The upstream timed out.",
             "problem_md": "Retry saturation caused the 502s.",
-            "report": "Fallback summary",
+            "report": "Restart the exhausted upstream connection pool.",
         }
 
     monkeypatch.setattr(service, "_run_investigation", fake_investigation)
@@ -122,7 +122,8 @@ def test_run_ask_investigation_reuses_cli_investigation_service(monkeypatch) -> 
     assert seen == ["checkout-api is returning 502s"]
     assert outcome.status is AskStatus.SUCCESS
     assert outcome.response == (
-        "## Root Cause\n\nThe upstream timed out.\n\n## Report\n\nRetry saturation caused the 502s."
+        "## Root Cause\n\nThe upstream timed out.\n\n## Report\n\n"
+        "Restart the exhausted upstream connection pool."
     )
 
 

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -99,6 +99,52 @@ def test_run_ask_returns_success(monkeypatch) -> None:
     assert outcome.exit_code is AskExitCode.SUCCESS
 
 
+def test_run_ask_investigation_reuses_cli_investigation_service(monkeypatch) -> None:
+    seen: list[str] = []
+
+    def fake_investigation(prompt: str) -> dict[str, object]:
+        seen.append(prompt)
+        return {
+            "root_cause": "The upstream timed out.",
+            "problem_md": "Retry saturation caused the 502s.",
+            "report": "Fallback summary",
+        }
+
+    monkeypatch.setattr(service, "_run_investigation", fake_investigation)
+
+    outcome = service.run_ask(
+        "checkout-api is returning 502s",
+        allowed_tools=(),
+        bypass_approvals=False,
+        investigate=True,
+    )
+
+    assert seen == ["checkout-api is returning 502s"]
+    assert outcome.status is AskStatus.SUCCESS
+    assert outcome.response == (
+        "## Root Cause\n\nThe upstream timed out.\n\n## Report\n\nRetry saturation caused the 502s."
+    )
+
+
+def test_run_ask_investigation_maps_runtime_failure(monkeypatch) -> None:
+    def fail(_prompt: str) -> dict[str, object]:
+        raise RuntimeError("pipeline failed")
+
+    monkeypatch.setattr(service, "_run_investigation", fail)
+    monkeypatch.setattr("surfaces.cli.telemetry.report_exception", lambda *_a, **_kw: None)
+
+    outcome = service.run_ask(
+        "checkout is slow",
+        allowed_tools=(),
+        bypass_approvals=False,
+        investigate=True,
+    )
+
+    assert outcome.status is AskStatus.ERROR
+    assert outcome.error is not None
+    assert outcome.error.message == "pipeline failed"
+
+
 def test_agent_turn_closes_ephemeral_session_after_failure(monkeypatch) -> None:
     # Arrange: the built session fails its turn; the ephemeral session must
     # still be closed (extract_memory=False) via the finally block.

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -71,6 +71,27 @@ def test_run_investigation_cli_passes_investigation_metadata_to_runner(
     }
 
 
+def test_run_investigation_cli_accepts_raw_incident_text(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_call(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "report": "r",
+            "problem_md": "p",
+            "root_cause": "c",
+            "is_noise": False,
+            "validity_score": 0.0,
+        }
+
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
+    monkeypatch.setattr("tools.investigation.capability.run_investigation_payload", fake_call)
+
+    run_investigation_cli(raw_alert="checkout-api is returning 502s")
+
+    assert captured["raw_alert"] == "checkout-api is returning 502s"
+
+
 def test_run_investigation_cli_shapes_agent_state(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -92,6 +92,27 @@ def test_run_investigation_cli_accepts_raw_incident_text(monkeypatch) -> None:
     assert captured["raw_alert"] == "checkout-api is returning 502s"
 
 
+def test_run_investigation_cli_marks_explicit_user_request(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_call(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "report": "r",
+            "problem_md": "p",
+            "root_cause": "c",
+            "is_noise": False,
+            "validity_score": 0.0,
+        }
+
+    monkeypatch.setattr("surfaces.cli.investigation.investigate.check_llm_settings", lambda: None)
+    monkeypatch.setattr("tools.investigation.capability.run_investigation_payload", fake_call)
+
+    run_investigation_cli(raw_alert="checkout-api is returning 502s", user_requested=True)
+
+    assert captured["user_requested"] is True
+
+
 def test_run_investigation_cli_shapes_agent_state(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -121,6 +142,7 @@ def test_run_investigation_cli_shapes_agent_state(monkeypatch) -> None:
         "raw_alert": {"alert_name": "PayloadAlert"},
         "opensre_evaluate": False,
         "investigation_metadata": None,
+        "user_requested": False,
     }
     assert result == {
         "report": "report body",

--- a/tests/core/agent_harness/test_agent_session_api.py
+++ b/tests/core/agent_harness/test_agent_session_api.py
@@ -182,6 +182,29 @@ def test_investigate_fails_closed_without_runner() -> None:
         AgentSession().investigate("spike")
 
 
+def test_investigate_forwards_explicit_user_request() -> None:
+    reset_investigation_payload_runner_for_tests()
+    captured: dict[str, Any] = {}
+
+    def _fake_runner(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "report": "done",
+            "problem_md": "p",
+            "root_cause": "r",
+            "is_noise": False,
+            "validity_score": 0.9,
+        }
+
+    install_investigation_payload_runner(_fake_runner)
+    try:
+        AgentSession().investigate("spike", user_requested=True)
+    finally:
+        reset_investigation_payload_runner_for_tests()
+
+    assert captured["user_requested"] is True
+
+
 def test_investigation_result_round_trips_optional_fields() -> None:
     payload = {
         "report": "r",

--- a/tests/tools/investigation/test_runners_sentry.py
+++ b/tests/tools/investigation/test_runners_sentry.py
@@ -32,6 +32,25 @@ def test_run_investigation_initializes_sentry_and_captures_unhandled_errors(
     assert captured_errors == [expected_error]
 
 
+def test_run_investigation_marks_explicit_user_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def capture_state(state: dict[str, object], **_kwargs: object) -> dict[str, object]:
+        captured.update(state)
+        return state
+
+    import tools.investigation.lifecycle as pipeline_module
+
+    monkeypatch.setattr(runners, "init_sentry", lambda **_kw: None)
+    monkeypatch.setattr(pipeline_module, "run_connected_investigation", capture_state)
+
+    runners.run_investigation("cpu high on api", user_requested=True)
+
+    assert captured["user_requested"] is True
+
+
 def test_traced_node_exception_is_captured_once_with_node_tag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tools/investigation/capability.py
+++ b/tools/investigation/capability.py
@@ -87,6 +87,7 @@ def run_investigation(
     openclaw_context: dict[str, Any] | None = None,
     opensre_evaluate: bool = False,
     investigation_metadata: tuple[str, str] | None = None,
+    user_requested: bool = False,
     agent_class: type[ConnectedInvestigationAgent] | None = None,
 ) -> AgentState:
     """Run the investigation from a raw alert payload. Pure function: inputs in, state out.
@@ -97,6 +98,7 @@ def run_investigation(
             integration resolution is skipped — useful for synthetic testing where a
             FixtureGrafanaBackend should be injected without real credential resolution.
         investigation_metadata: Optional ``(alert_name, severity)`` for AgentState.
+        user_requested: Whether an explicit user action initiated the investigation.
         agent_class: Optional override for the investigation agent class. Defaults
             to ``ConnectedInvestigationAgent``. Callers that need a custom
             termination policy, structured-stage progression, or other
@@ -109,6 +111,7 @@ def run_investigation(
         raw_alert=raw_alert,
         opensre_evaluate=opensre_evaluate,
         investigation_metadata=investigation_metadata,
+        user_requested=user_requested,
     )
     if resolved_integrations is not None:
         cast(dict[str, Any], initial)["resolved_integrations"] = resolved_integrations
@@ -205,6 +208,7 @@ def run_investigation_payload(
     raw_alert: str | dict[str, Any],
     opensre_evaluate: bool = False,
     investigation_metadata: tuple[str, str] | None = None,
+    user_requested: bool = False,
 ) -> dict[str, Any]:
     """Run an investigation and return the serializable result payload.
 
@@ -214,11 +218,13 @@ def run_investigation_payload(
     to reach up into ``cli.investigation`` to run an investigation.
 
     ``investigation_metadata`` is an optional ``(alert_name, severity)`` tuple.
+    ``user_requested`` bypasses automated alert noise filtering.
     """
     state = run_investigation(
         raw_alert,
         opensre_evaluate=opensre_evaluate,
         investigation_metadata=investigation_metadata,
+        user_requested=user_requested,
     )
     return build_investigation_payload(state, opensre_evaluate=opensre_evaluate)
 


### PR DESCRIPTION
Fixes #5652

Related context: #5028 and #5273

#### Describe the changes you have made in this PR -

- Add `opensre ask --investigate PROMPT` as an explicit full-RCA mode.
- Accept a literal leading `/investigate` as a compatibility alias while leaving ordinary natural-language Ask routing unchanged.
- Delegate raw incident text to the existing `run_investigation_cli` / `AgentSession.investigate` pipeline instead of adding investigation prompts or a second runtime. Explicit Ask runs carry the pipeline's existing `user_requested` marker so the automated-alert noise gate does not override the user's choice.
- Reject empty, duplicate, and unsupported slash selectors before LLM execution; `/integrations setup …` points to the direct CLI command rather than opening interactive credential UI.
- Keep Ask's existing JSON fields, exit codes, approval behavior, and signal handling; the completed investigation report is projected into the existing text `response` field.
- Document when to use Ask investigation mode versus structured `opensre investigate` and direct integration setup.

### Demo/Screenshot for feature changes and bug fixes - 

```console
$ uv run opensre ask --help
Usage: opensre ask [OPTIONS] PROMPT

Options:
  --investigate                   Run the prompt through the full incident
                                  investigation pipeline.
  --allowed-tool TOOL             Authorize a registered tool for this
                                  invocation. Repeat as needed.
  --dangerously-bypass-approvals  Authorize every approval-gated tool for this
                                  invocation.
  -h, --help                      Show this message and exit.

$ uv run opensre ask '/integrations setup grafana'
Error: Ask only supports /investigate. Run `opensre integrations setup grafana` directly.
```

Local validation:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/cli/test_ask_approval.py tests/cli/test_ask_command.py tests/cli/test_ask_service.py tests/cli/test_investigate.py -q` (49 passed)
- `uv run python -m pytest tests/cli/test_ask_approval.py tests/cli/test_ask_command.py tests/cli/test_ask_service.py tests/cli/test_investigate.py tests/core/agent_harness/test_agent_session_api.py tests/tools/investigation/test_runners_sentry.py tests/tools/investigation/stages/intake/test_intake_noise_gate.py -q` (66 passed after review fixes)
- `uv run python -m pytest tests/cli/` (826 passed, 3 skipped; one unrelated existing PTY smoke failure in the OpenCode provider picker, reproduced in isolation—the test navigates to GitHub Copilot instead of OpenCode)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The Click boundary recognizes only explicit investigation selectors: the boolean flag or a literal leading `/investigate`. It deliberately does not infer intent from ordinary prose. Investigation mode calls the existing CLI investigation service with raw incident text and the pipeline's existing explicit-user marker; that service installs and invokes the canonical `AgentSession.investigate` runner, so all existing RCA stages, prompts, tools, noise-gate semantics, and final report shaping remain authoritative. The result is formatted into Ask's existing response envelope so current automation consumers keep the same schema. I considered installing the interactive-shell slash adapter, but rejected it because its menus, background tasks, and session-history behavior do not belong in a one-shot headless command.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

