### PR TITLE
feat(slack): add error hint for not allowed token type in API and update search messages tool documentation

### DIFF
--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -9,7 +9,7 @@ from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
-from integrations.slack.web_client import bot_token_configured, resolve_bot_token, search_messages
+from integrations.slack.web_client import resolve_bot_token, search_messages
 
 
 class SlackSearchMessagesTool(BaseTool):
@@ -18,10 +18,12 @@ class SlackSearchMessagesTool(BaseTool):
     name = "slack_search_messages"
     source = SOURCE
     description = (
-        "Search Slack *messages* workspace-wide (search.messages) using the bot token. "
-        "Use Slack search syntax (e.g. 'in:#incidents timeout', 'from:@user error'). "
-        "Requires the search:read bot scope. Not for workspace roster — use "
-        "slack_list_team_members for who is on the team / member IDs."
+        "Search Slack *messages* workspace-wide (search.messages). Slack only allows "
+        "this method with a user token (xoxp-…); it rejects bot tokens (xoxb-…) "
+        "outright with not_allowed_token_type, regardless of scopes granted. This "
+        "integration configures a bot token only, so this tool cannot currently "
+        "return results — use slack_read_messages for one known channel/thread or "
+        "slack_list_team_members for the workspace roster instead."
     )
     use_cases = [
         "Finding prior discussion of an incident keyword",
@@ -59,8 +61,15 @@ class SlackSearchMessagesTool(BaseTool):
         "error_type": "validation_error, configuration_error, or api_error",
     }
 
-    def is_available(self, sources: dict[str, Any]) -> bool:
-        return bot_token_configured(sources)
+    def is_available(self, _sources: dict[str, Any]) -> bool:
+        """Always unavailable: search.messages needs a user token this integration never has.
+
+        No bot scope makes ``search.messages`` work — Slack rejects bot tokens for
+        this method with ``not_allowed_token_type`` regardless of scopes, and
+        ``integrations/slack/setup.py`` only collects a bot token. Advertising this
+        as available would offer a capability that fails on every call.
+        """
+        return False
 
     def run(self, query: str, count: int = 20, **_kwargs: Any) -> dict[str, Any]:
         target, resolution_error = resolve_bot_token()

--- a/integrations/slack/web_client.py
+++ b/integrations/slack/web_client.py
@@ -152,6 +152,11 @@ def _api_error_hint(error: str, *, context: str) -> str:
             "The Slack app is missing a required OAuth scope. Reinstall after adding scopes.",
         ),
         "thread_not_found": "No thread with this parent ts was found in the channel.",
+        "not_allowed_token_type": (
+            "This Slack API method does not accept a bot token (xoxb-…) — it only "
+            "accepts a user token (xoxp-…), which this integration does not "
+            "configure. No added scope or reinstall enables it with a bot token."
+        ),
     }
     return hints.get(error, f"Slack API error: {error}")
 

--- a/tests/tools/test_slack_coworker_tools.py
+++ b/tests/tools/test_slack_coworker_tools.py
@@ -9,6 +9,7 @@ import pytest
 import integrations.slack.web_client as web_client
 from integrations.slack.tools.slack_join_channel_tool import slack_join_channel
 from integrations.slack.tools.slack_search_messages_tool import slack_search_messages
+from integrations.slack.tools.slack_search_messages_tool.tool import SlackSearchMessagesTool
 
 
 class _FakeResponse:
@@ -93,6 +94,29 @@ def test_add_reaction_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_search_tool_requires_query() -> None:
     result = slack_search_messages.run(query="  ")
     assert result["status"] == "failed"
+
+
+def test_search_tool_is_never_available() -> None:
+    """search.messages rejects bot tokens outright; this integration has no user
+    token, so the tool must stay hidden rather than advertise a capability that
+    always fails with not_allowed_token_type (see issue #5660).
+    """
+    assert SlackSearchMessagesTool().is_available({"slack": {"bot_token": "xoxb-x"}}) is False
+
+
+def test_search_messages_maps_not_allowed_token_type_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_client(
+        monkeypatch,
+        lambda **_kw: _FakeResponse({"ok": False, "error": "not_allowed_token_type"}),
+    )
+    matches, error = web_client.search_messages(
+        web_client.SlackBotTarget(bot_token="xoxb-x"), query="boom"
+    )
+    assert matches is None
+    assert "user token" in error
+    assert "bot token" in error
 
 
 def test_join_tool_metadata() -> None:


### PR DESCRIPTION
/fix #5660 
- Introduced a new error hint for the Slack API indicating that certain methods require a user token instead of a bot token.
- Updated the SlackSearchMessagesTool to clarify that it cannot function with a bot token and is always unavailable.
- Added tests to ensure the new error handling and availability logic are correctly implemented.