### PR TITLE
fix(tools): sibling confusion audit for s3 (#5499)

### DIFF
--- a/integrations/s3/tools/s3_get_object_tool/__init__.py
+++ b/integrations/s3/tools/s3_get_object_tool/__init__.py
@@ -29,7 +29,12 @@ def _extract_get_s3_object_params(sources: dict[str, dict]) -> dict:
     name="get_s3_object",
     display_name="S3 audit",
     source="storage",
-    description="Get full S3 object content — audit payloads, configs, lineage data.",
+    description=(
+        "Get full S3 object content (audit payloads, configs, lineage data up to 1MB). "
+        "Use this when you need complete file contents for inspection or analysis. "
+        "Use inspect_s3_object instead when you only need metadata, headers, or a small "
+        "content preview."
+    ),
     use_cases=[
         "Retrieving audit payloads when audit_key found in S3 metadata",
         "Tracing external vendor interactions that caused failures",

--- a/integrations/s3/tools/s3_inspect_tool/__init__.py
+++ b/integrations/s3/tools/s3_inspect_tool/__init__.py
@@ -22,7 +22,12 @@ def _extract_inspect_s3_params(sources: dict[str, dict]) -> dict:
     name="inspect_s3_object",
     display_name="S3",
     source="storage",
-    description="Inspect an S3 object's metadata and sample content.",
+    description=(
+        "Inspect S3 object metadata (size, content type, etag) and sample preview content. "
+        "Use this when diagnosing schemas, lineage, or checking object headers without loading "
+        "large payloads. Use get_s3_object instead when you need the complete file content "
+        "(such as full configs, manifests, or audit payloads up to 1MB)."
+    ),
     use_cases=[
         "Tracing data lineage upstream to find root cause",
         "Identifying schema changes in input data",
@@ -42,7 +47,7 @@ def _extract_inspect_s3_params(sources: dict[str, dict]) -> dict:
     extract_params=_extract_inspect_s3_params,
 )
 def inspect_s3_object(bucket: str, key: str) -> dict:
-    """Inspect an S3 object's metadata and sample content."""
+    """Inspect S3 object metadata and sample preview content."""
     if not bucket or not key:
         return {"error": "bucket and key are required"}
 

--- a/integrations/s3/tools/s3_list_tool/__init__.py
+++ b/integrations/s3/tools/s3_list_tool/__init__.py
@@ -21,7 +21,12 @@ def _extract_list_s3_params(sources: dict[str, dict]) -> dict:
 @tool(
     name="list_s3_objects",
     source="storage",
-    description="List objects in an S3 bucket with optional prefix filter.",
+    description=(
+        "List objects in an S3 bucket with optional prefix filter. "
+        "Use this when exploring bucket hierarchy or enumerating keys under a prefix. "
+        "Use check_s3_marker instead when verifying if a pipeline run completed by "
+        "checking for a _SUCCESS marker file."
+    ),
     use_cases=[
         "Exploring S3 bucket contents and finding relevant data files",
         "Verifying which files are present in a pipeline output location",

--- a/integrations/s3/tools/s3_marker_tool/__init__.py
+++ b/integrations/s3/tools/s3_marker_tool/__init__.py
@@ -28,7 +28,12 @@ def _extract_check_s3_marker_params(sources: dict[str, dict]) -> dict:
 @tool(
     name="check_s3_marker",
     source="storage",
-    description="Check if a _SUCCESS marker exists in S3 storage to verify pipeline completion.",
+    description=(
+        "Check if a _SUCCESS marker exists in S3 storage to verify pipeline completion. "
+        "Use this when checking pipeline completion status or marker presence. "
+        "Use list_s3_objects instead when exploring, searching, or enumerating general files "
+        "and keys under a prefix."
+    ),
     use_cases=[
         "Verifying if a data pipeline run completed successfully",
         "Checking for presence of a _SUCCESS marker file",

--- a/scripts/cluster_similarity.py
+++ b/scripts/cluster_similarity.py
@@ -1,0 +1,209 @@
+"""Cluster and rank tool pairs within an integration by description similarity.
+
+Used for identifying confusable sibling tool pairs that require explicit
+disambiguation in their descriptions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import itertools
+import json
+import pkgutil
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ToolInfo:
+    name: str
+    description: str
+    module_path: str
+    source: str
+
+
+@dataclass(frozen=True)
+class PairSimilarity:
+    tool_a: str
+    tool_b: str
+    shared_tokens: list[str]
+    shared_token_count: int
+    jaccard_similarity: float
+    description_a: str
+    description_b: str
+
+
+def tokenize(text: str) -> set[str]:
+    """Extract normalized alphanumeric word tokens from text, ignoring common stop words."""
+    stopwords = {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "this",
+        "to",
+        "was",
+        "what",
+        "when",
+        "where",
+        "which",
+        "with",
+    }
+    words = re.findall(r"[a-zA-Z0-9_]+", text.lower())
+    return {w for w in words if len(w) > 1 and w not in stopwords}
+
+
+def compute_jaccard(tokens_a: set[str], tokens_b: set[str]) -> float:
+    """Compute Jaccard similarity coefficient between two token sets."""
+    if not tokens_a and not tokens_b:
+        return 0.0
+    union = tokens_a | tokens_b
+    if not union:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(union)
+
+
+def discover_integration_tools(integration_name: str) -> list[ToolInfo]:
+    """Discover all registered tools under integrations/<integration_name>/tools."""
+    tools_dir = Path("integrations") / integration_name / "tools"
+    if not tools_dir.exists() or not tools_dir.is_dir():
+        print(f"Directory not found: {tools_dir}", file=sys.stderr)
+        return []
+
+    tools: list[ToolInfo] = []
+    package_path = f"integrations.{integration_name}.tools"
+
+    # Walk subpackages/modules in the tools directory
+    for _, mod_name, _ in pkgutil.iter_modules([str(tools_dir)]):
+        full_mod_path = f"{package_path}.{mod_name}"
+        try:
+            mod = importlib.import_module(full_mod_path)
+        except Exception as err:
+            print(f"Warning: could not import {full_mod_path}: {err}", file=sys.stderr)
+            continue
+
+        # Look for registered tools or BaseTool instances in module
+        for attr_name in dir(mod):
+            attr = getattr(mod, attr_name)
+            reg_tool: Any = getattr(attr, "__opensre_registered_tool__", None)
+            if reg_tool is not None:
+                tools.append(
+                    ToolInfo(
+                        name=reg_tool.name,
+                        description=reg_tool.description,
+                        module_path=full_mod_path,
+                        source=getattr(reg_tool, "source", integration_name),
+                    )
+                )
+            elif hasattr(attr, "name") and hasattr(attr, "description") and hasattr(attr, "run"):
+                # BaseTool-like instance or class
+                if isinstance(attr, type):
+                    continue
+                tools.append(
+                    ToolInfo(
+                        name=attr.name,
+                        description=attr.description,
+                        module_path=full_mod_path,
+                        source=getattr(attr, "source", integration_name),
+                    )
+                )
+
+    # Deduplicate by name
+    unique_tools: dict[str, ToolInfo] = {}
+    for t in tools:
+        if t.name not in unique_tools:
+            unique_tools[t.name] = t
+
+    return list(unique_tools.values())
+
+
+def analyze_integration_similarity(
+    tools: list[ToolInfo],
+) -> list[PairSimilarity]:
+    """Rank all pairwise combinations of tools by token overlap and Jaccard similarity."""
+    pairs: list[PairSimilarity] = []
+
+    for tool_a, tool_b in itertools.combinations(tools, 2):
+        tokens_a = tokenize(tool_a.description)
+        tokens_b = tokenize(tool_b.description)
+        shared = sorted(tokens_a & tokens_b)
+        jaccard = compute_jaccard(tokens_a, tokens_b)
+        pairs.append(
+            PairSimilarity(
+                tool_a=tool_a.name,
+                tool_b=tool_b.name,
+                shared_tokens=shared,
+                shared_token_count=len(shared),
+                jaccard_similarity=round(jaccard, 4),
+                description_a=tool_a.description,
+                description_b=tool_b.description,
+            )
+        )
+
+    # Sort primarily by Jaccard similarity, secondarily by shared token count
+    pairs.sort(key=lambda p: (p.jaccard_similarity, p.shared_token_count), reverse=True)
+    return pairs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute tool description similarity clusters for an integration."
+    )
+    parser.add_argument(
+        "--integration",
+        default="s3",
+        help="Integration name under integrations/ (default: s3)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output raw JSON results",
+    )
+    args = parser.parse_args()
+
+    tools = discover_integration_tools(args.integration)
+    if not tools:
+        print(f"No tools discovered for integration '{args.integration}'")
+        sys.exit(1)
+
+    print(f"Discovered {len(tools)} tools for integration '{args.integration}':")
+    for t in tools:
+        print(f"  - {t.name}: {t.description}")
+    print()
+
+    pairs = analyze_integration_similarity(tools)
+
+    if args.json:
+        print(json.dumps([asdict(p) for p in pairs], indent=2))
+        return
+
+    print("=== Pairwise Similarity Ranking (Jaccard + Shared Tokens) ===")
+    for rank, p in enumerate(pairs, 1):
+        print(f"#{rank} {p.tool_a} <-> {p.tool_b}")
+        print(f"   Jaccard Similarity: {p.jaccard_similarity:.4f}")
+        print(f"   Shared Tokens ({p.shared_token_count}): {', '.join(p.shared_tokens)}")
+        print(f"   Tool A description: {p.description_a}")
+        print(f"   Tool B description: {p.description_b}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/sibling_pairs.json
+++ b/tests/fixtures/sibling_pairs.json
@@ -1,0 +1,51 @@
+{
+  "integration": "s3",
+  "pairs": [
+    {
+      "tool_a": "inspect_s3_object",
+      "tool_b": "get_s3_object",
+      "confusion_reason": "Both tools operate on a specific S3 object (bucket and key). inspect_s3_object retrieves metadata, headers, and a preview sample without full download, whereas get_s3_object retrieves full object contents up to 1MB.",
+      "tool_a_disambiguation": {
+        "use_when": "diagnosing schemas, lineage, or checking object headers without loading large payloads",
+        "use_sibling_instead_when": "you need the complete file content (such as full configs, manifests, or audit payloads up to 1MB)"
+      },
+      "tool_b_disambiguation": {
+        "use_when": "you need complete file contents for inspection or analysis",
+        "use_sibling_instead_when": "you only need metadata, headers, or a small content preview"
+      },
+      "required_in_a": [
+        "get_s3_object",
+        "Use this when",
+        "instead"
+      ],
+      "required_in_b": [
+        "inspect_s3_object",
+        "Use this when",
+        "instead"
+      ]
+    },
+    {
+      "tool_a": "list_s3_objects",
+      "tool_b": "check_s3_marker",
+      "confusion_reason": "Both tools operate on a bucket and prefix. list_s3_objects general-purpose enumerates objects matching a prefix filter, whereas check_s3_marker specifically tests for pipeline completion via _SUCCESS marker file existence.",
+      "tool_a_disambiguation": {
+        "use_when": "exploring bucket hierarchy or enumerating keys under a prefix",
+        "use_sibling_instead_when": "verifying if a pipeline run completed by checking for a _SUCCESS marker file"
+      },
+      "tool_b_disambiguation": {
+        "use_when": "checking pipeline completion status or marker presence",
+        "use_sibling_instead_when": "exploring, searching, or enumerating general files and keys under a prefix"
+      },
+      "required_in_a": [
+        "check_s3_marker",
+        "Use this when",
+        "instead"
+      ],
+      "required_in_b": [
+        "list_s3_objects",
+        "Use this when",
+        "instead"
+      ]
+    }
+  ]
+}

--- a/tests/tools/test_sibling_confusion.py
+++ b/tests/tools/test_sibling_confusion.py
@@ -1,0 +1,75 @@
+"""Static tests locking sibling tool disambiguation in descriptions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from integrations.s3.tools.s3_get_object_tool import get_s3_object
+from integrations.s3.tools.s3_inspect_tool import inspect_s3_object
+from integrations.s3.tools.s3_list_tool import list_s3_objects
+from integrations.s3.tools.s3_marker_tool import check_s3_marker
+
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "sibling_pairs.json"
+
+TOOL_REGISTRY: dict[str, Any] = {
+    "get_s3_object": getattr(get_s3_object, "__opensre_registered_tool__"),
+    "inspect_s3_object": getattr(inspect_s3_object, "__opensre_registered_tool__"),
+    "list_s3_objects": getattr(list_s3_objects, "__opensre_registered_tool__"),
+    "check_s3_marker": getattr(check_s3_marker, "__opensre_registered_tool__"),
+}
+
+
+def _load_sibling_pairs() -> list[dict[str, Any]]:
+    with open(FIXTURE_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+    pairs = data.get("pairs", [])
+    return cast(list[dict[str, Any]], pairs)
+
+
+@pytest.fixture
+def sibling_pairs() -> list[dict[str, Any]]:
+    return _load_sibling_pairs()
+
+
+def test_sibling_pairs_fixture_validity(sibling_pairs: list[dict[str, Any]]) -> None:
+    """Ensure fixture records valid non-empty sibling pairs."""
+    assert len(sibling_pairs) > 0
+    for pair in sibling_pairs:
+        assert pair["tool_a"] in TOOL_REGISTRY
+        assert pair["tool_b"] in TOOL_REGISTRY
+        assert pair["tool_a"] != pair["tool_b"]
+        assert len(pair["required_in_a"]) > 0
+        assert len(pair["required_in_b"]) > 0
+
+
+@pytest.mark.parametrize(
+    "pair_data",
+    _load_sibling_pairs(),
+    ids=lambda p: f"{p['tool_a']}_vs_{p['tool_b']}",
+)
+def test_sibling_tool_disambiguation(pair_data: dict[str, Any]) -> None:
+    """Assert that confusable sibling tool descriptions explicitly cross-reference each other."""
+    tool_a_name = pair_data["tool_a"]
+    tool_b_name = pair_data["tool_b"]
+
+    tool_a = TOOL_REGISTRY[tool_a_name]
+    tool_b = TOOL_REGISTRY[tool_b_name]
+
+    desc_a = tool_a.description
+    desc_b = tool_b.description
+
+    for required_phrase in pair_data["required_in_a"]:
+        assert required_phrase.lower() in desc_a.lower(), (
+            f"Tool '{tool_a_name}' description must contain '{required_phrase}' to disambiguate "
+            f"against sibling '{tool_b_name}'. Actual description: {desc_a}"
+        )
+
+    for required_phrase in pair_data["required_in_b"]:
+        assert required_phrase.lower() in desc_b.lower(), (
+            f"Tool '{tool_b_name}' description must contain '{required_phrase}' to disambiguate "
+            f"against sibling '{tool_a_name}'. Actual description: {desc_b}"
+        )

--- a/tests/tools/test_sibling_confusion.py
+++ b/tests/tools/test_sibling_confusion.py
@@ -16,10 +16,10 @@ from integrations.s3.tools.s3_marker_tool import check_s3_marker
 FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "sibling_pairs.json"
 
 TOOL_REGISTRY: dict[str, Any] = {
-    "get_s3_object": getattr(get_s3_object, "__opensre_registered_tool__"),
-    "inspect_s3_object": getattr(inspect_s3_object, "__opensre_registered_tool__"),
-    "list_s3_objects": getattr(list_s3_objects, "__opensre_registered_tool__"),
-    "check_s3_marker": getattr(check_s3_marker, "__opensre_registered_tool__"),
+    "get_s3_object": get_s3_object.__opensre_registered_tool__,  # type: ignore[attr-defined]
+    "inspect_s3_object": inspect_s3_object.__opensre_registered_tool__,  # type: ignore[attr-defined]
+    "list_s3_objects": list_s3_objects.__opensre_registered_tool__,  # type: ignore[attr-defined]
+    "check_s3_marker": check_s3_marker.__opensre_registered_tool__,  # type: ignore[attr-defined]
 }
 
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Fixes #5499</h1><h4>Describe the changes you have made in this PR -</h4><p>Audited the <strong><code inline="">s3</code> integration</strong> for sibling tool confusion and added regression coverage for the identified confusable tool pairs.</p><h3>Changes made</h3><ul><li><p>Analyzed the S3 tools using shared-token/wording overlap to identify potentially similar tool pairs.</p></li><li><p>Manually reviewed the highest-overlap candidates to determine which pairs could realistically be confused by an LLM or developer.</p></li><li><p>Identified and addressed two confusable sibling pairs:</p><ul><li><p><code inline="">s3_get_object</code> ↔ <code inline="">s3_inspect</code></p></li><li><p><code inline="">s3_list</code> ↔ <code inline="">s3_marker</code></p></li></ul></li><li><p>Updated both tool descriptions in each pair to clearly explain <strong>when to use the tool</strong> and <strong>when to use its sibling instead</strong>.</p></li><li><p>Added <code inline="">scripts/cluster_similarity.py</code> to make the similarity-ranking step reproducible.</p></li><li><p>Added the identified pairs and their required differentiating phrases to <code inline="">tests/fixtures/sibling_pairs.json</code>.</p></li><li><p>Added fixture-driven regression tests in <code inline="">tests/tools/test_sibling_confusion.py</code>.</p></li><li><p>Verified the regression lock by temporarily reverting the differentiating wording and confirming that the corresponding test fails.</p></li></ul><h3>Confusable pairs</h3>
Tool | Sibling | Distinction
-- | -- | --
s3_get_object | s3_inspect | s3_get_object retrieves complete object content, while s3_inspect is intended for metadata and preview/inspection.
s3_list | s3_marker | s3_list performs general object/prefix enumeration, while s3_marker is intended for checking pipeline-completion markers such as _SUCCESS.

<h3>Before → After</h3><h4><code inline="">s3_get_object</code> ↔ <code inline="">s3_inspect</code></h4><p><strong>Before:</strong><br>The descriptions had overlapping object-related terminology without explicitly making the retrieval-versus-inspection distinction clear.</p><p><strong>After:</strong><br>The descriptions now explicitly distinguish <strong>full object retrieval</strong> from <strong>metadata/preview inspection</strong>, and each tool indicates when the sibling should be used instead.</p><h4><code inline="">s3_list</code> ↔ <code inline="">s3_marker</code></h4><p><strong>Before:</strong><br>The descriptions did not clearly distinguish general S3 enumeration from checking for pipeline-completion markers.</p><p><strong>After:</strong><br>The descriptions now explicitly distinguish <strong>general object listing</strong> from <strong>completion-marker checks</strong>, and direct the user to the sibling tool when the other operation is required.</p><h3>Demo/Screenshot for feature changes and bug fixes -</h3><p>Ran the sibling-confusion regression tests with:</p><pre><code class="language-text">uv run python -m pytest tests/tools/ -q -k sibling
</code></pre><p>Result:</p><pre><code class="language-text">5 passed, 3031 deselected in 13.40s
</code></pre><p>The attached terminal screenshot shows the regression tests passing, including the tests covering the identified S3 sibling pairs.</p><hr><h2>Code Understanding and AI Usage</h2><p><strong>Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?</strong></p><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" disabled=""> No, I wrote all the code myself</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Yes, I used AI assistance (continue below)</p></li></ul><p><strong>If you used AI assistance:</strong></p><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have reviewed every single line of the AI-generated code</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I can explain the purpose and logic of each function/component I added</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have tested edge cases and understand how the code handles them</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have modified the AI output to follow this project's coding standards and conventions</p></li></ul><p><strong>Explain your implementation approach:</strong></p><p>The goal of this change is to reduce incorrect tool selection between sibling S3 tools with overlapping terminology or similar responsibilities.</p><p>I limited the audit to the <code inline="">s3</code> integration, as required by the issue. I first used shared-token/wording overlap to rank potentially similar tool descriptions and then manually reviewed the highest-overlap candidates to identify pairs that could realistically be confused.</p><p>For each confirmed pair, I updated both tool descriptions to make their intended usage explicit. Each description now explains when the tool should be selected and when its sibling should be used instead.</p><p>I also added a reusable similarity-ranking script to make the initial analysis reproducible, recorded the confirmed pairs in a fixture, and added regression tests that verify the required differentiating language remains present.</p><p>Finally, I temporarily reverted the differentiating wording to verify that the regression test fails when the distinction is removed.</p><h3>Alternative approach considered</h3><p>Embedding-based similarity could be used to identify potentially similar tools, but shared-token/wording overlap was sufficient for this audit and provides a lightweight, reproducible approach. Manual review was used for the final determination of whether a pair was genuinely confusable.</p><h3>Key implementation areas</h3><ul><li><p><strong><code inline="">scripts/cluster_similarity.py</code></strong> — ranks potentially similar tool descriptions using shared-token/wording overlap.</p></li><li><p><strong><code inline="">tests/fixtures/sibling_pairs.json</code></strong> — records the confirmed confusable pairs and required differentiating phrases.</p></li><li><p><strong><code inline="">tests/tools/test_sibling_confusion.py</code></strong> — verifies that the required sibling-selection guidance remains present.</p></li><li><p><strong>S3 tool descriptions</strong> — clarify the intended use of each tool and when its sibling should be used instead.
<img width="1507" height="937" alt="Screenshot 2026-08-24 175210" src="https://github.com/user-attachments/assets/89177840-a238-4063-91e0-38c0ab8bae2f" />



</p></li></ul><hr><h2>Checklist before requesting a review</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have added proper PR title and linked to the issue</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have performed a self-review of my code</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> <strong>I can explain the purpose of every function, class, and logic block I added</strong></p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I understand why my changes work and have tested them thoroughly</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have considered potential edge cases and how my changes handle them</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> If it is a core feature, I have added thorough tests</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> My code follows the project's style guidelines and conventions</p></li></ul><hr></body></html><!--EndFragment-->
</body>
</html>