### PR TITLE
feat(supabase): add evidence mappers for service health and storage buckets

### DIFF
--- a/integrations/supabase/tools/supabase_health_tool/__init__.py
+++ b/integrations/supabase/tools/supabase_health_tool/__init__.py
@@ -2,7 +2,9 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
+from core.tool import EvidenceType
 from core.tool_framework import tool
 from integrations.supabase import (
     get_service_health,
@@ -10,6 +12,26 @@ from integrations.supabase import (
     supabase_extract_params,
     supabase_is_available,
 )
+
+
+def _map_get_supabase_service_health(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    services = output.get("services", {})
+    if not services:
+        return
+    degraded = output.get("degraded_services", [])
+    summary = f"{len(services)} services checked"
+    if degraded:
+        summary += f", degraded: {', '.join(degraded)}"
+    else:
+        summary += ", all healthy"
+    record_evidence_entry(
+        evidence,
+        source="get_supabase_service_health",
+        label="Supabase Service Health",
+        summary=summary,
+    )
 
 
 @tool(
@@ -25,6 +47,8 @@ from integrations.supabase import (
     is_available=supabase_is_available,
     injected_params=("project_url",),
     extract_params=supabase_extract_params,
+    evidence_type=EvidenceType.OTHER,
+    evidence_mapper=_map_get_supabase_service_health,
 )
 def get_supabase_service_health(
     project_url: str,

--- a/integrations/supabase/tools/supabase_storage_tool/__init__.py
+++ b/integrations/supabase/tools/supabase_storage_tool/__init__.py
@@ -2,7 +2,9 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
+from core.tool import EvidenceType
 from core.tool_framework import tool
 from integrations.supabase import (
     get_storage_buckets,
@@ -10,6 +12,27 @@ from integrations.supabase import (
     supabase_extract_params,
     supabase_is_available,
 )
+
+
+def _map_get_supabase_storage_buckets(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    buckets = output.get("buckets", [])
+    if not buckets:
+        return
+    total = output.get("total_buckets", len(buckets))
+    summary = f"{len(buckets)} buckets"
+    if output.get("truncated"):
+        summary += f" (of {total})"
+    public = [b.get("name", "") for b in buckets if b.get("public")]
+    if public:
+        summary += f", public: {', '.join(n for n in public if n)}"
+    record_evidence_entry(
+        evidence,
+        source="get_supabase_storage_buckets",
+        label="Supabase Storage Buckets",
+        summary=summary,
+    )
 
 
 @tool(
@@ -25,6 +48,8 @@ from integrations.supabase import (
     is_available=supabase_is_available,
     injected_params=("project_url",),
     extract_params=supabase_extract_params,
+    evidence_type=EvidenceType.OTHER,
+    evidence_mapper=_map_get_supabase_storage_buckets,
 )
 def get_supabase_storage_buckets(
     project_url: str,

--- a/tests/integrations/supabase/test_evidence_mappers.py
+++ b/tests/integrations/supabase/test_evidence_mappers.py
@@ -1,5 +1,7 @@
 """Evidence mapper tests for the Supabase tools."""
 
+from http import HTTPStatus
+
 from integrations.supabase.tools.supabase_health_tool import (
     _map_get_supabase_service_health,
 )
@@ -12,9 +14,9 @@ def test_service_health_mapper_records_entry_when_all_healthy() -> None:
     evidence: dict[str, object] = {}
     output = {
         "services": {
-            "postgrest": {"healthy": True, "status_code": 200},
-            "auth": {"healthy": True, "status_code": 200},
-            "storage": {"healthy": True, "status_code": 200},
+            "postgrest": {"healthy": True, "status_code": HTTPStatus.OK},
+            "auth": {"healthy": True, "status_code": HTTPStatus.OK},
+            "storage": {"healthy": True, "status_code": HTTPStatus.OK},
         },
         "degraded_services": [],
         "overall_healthy": True,
@@ -40,7 +42,7 @@ def test_service_health_mapper_names_the_degraded_services() -> None:
     output = {
         "services": {
             "postgrest": {"healthy": True},
-            "auth": {"healthy": False, "status_code": 503},
+            "auth": {"healthy": False, "status_code": HTTPStatus.SERVICE_UNAVAILABLE},
             "storage": {"healthy": False, "error": "timeout"},
         },
         "degraded_services": ["auth", "storage"],

--- a/tests/integrations/supabase/test_evidence_mappers.py
+++ b/tests/integrations/supabase/test_evidence_mappers.py
@@ -1,0 +1,113 @@
+"""Evidence mapper tests for the Supabase tools."""
+
+from integrations.supabase.tools.supabase_health_tool import (
+    _map_get_supabase_service_health,
+)
+from integrations.supabase.tools.supabase_storage_tool import (
+    _map_get_supabase_storage_buckets,
+)
+
+
+def test_service_health_mapper_records_entry_when_all_healthy() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "services": {
+            "postgrest": {"healthy": True, "status_code": 200},
+            "auth": {"healthy": True, "status_code": 200},
+            "storage": {"healthy": True, "status_code": 200},
+        },
+        "degraded_services": [],
+        "overall_healthy": True,
+    }
+
+    _map_get_supabase_service_health(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_supabase_service_health",
+            "label": "Supabase Service Health",
+            "summary": "3 services checked, all healthy",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_service_health_mapper_names_the_degraded_services() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "services": {
+            "postgrest": {"healthy": True},
+            "auth": {"healthy": False, "status_code": 503},
+            "storage": {"healthy": False, "error": "timeout"},
+        },
+        "degraded_services": ["auth", "storage"],
+        "overall_healthy": False,
+    }
+
+    _map_get_supabase_service_health(evidence, output, {})
+
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    assert entries[0]["summary"] == "3 services checked, degraded: auth, storage"
+
+
+def test_service_health_mapper_records_nothing_without_services() -> None:
+    evidence: dict[str, object] = {}
+
+    _map_get_supabase_service_health(evidence, {"available": False}, {})
+
+    assert "catalog_entries" not in evidence
+
+
+def test_storage_buckets_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "total_buckets": 2,
+        "returned_buckets": 2,
+        "truncated": False,
+        "buckets": [
+            {"id": "a", "name": "avatars", "public": True},
+            {"id": "b", "name": "backups", "public": False},
+        ],
+    }
+
+    _map_get_supabase_storage_buckets(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_supabase_storage_buckets",
+            "label": "Supabase Storage Buckets",
+            "summary": "2 buckets, public: avatars",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_storage_buckets_mapper_notes_truncation() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "total_buckets": 10,
+        "returned_buckets": 1,
+        "truncated": True,
+        "buckets": [{"id": "a", "name": "avatars", "public": False}],
+    }
+
+    _map_get_supabase_storage_buckets(evidence, output, {})
+
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    assert entries[0]["summary"] == "1 buckets (of 10)"
+
+
+def test_storage_buckets_mapper_records_nothing_without_buckets() -> None:
+    evidence: dict[str, object] = {}
+
+    _map_get_supabase_storage_buckets(evidence, {"buckets": []}, {})
+
+    assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -138,8 +138,6 @@ get_s3_object
 get_sentry_issue_details
 get_sqs_queue_attributes
 get_sre_guidance
-get_supabase_service_health
-get_supabase_storage_buckets
 get_tracer_run
 get_tracer_tasks
 get_yc_instance_diagnostics


### PR DESCRIPTION
Fixes #5574

#### Describe the changes you have made in this PR -

`get_supabase_service_health` and `get_supabase_storage_buckets` already returned useful diagnostic data, but it never became evidence in the incident report — the output was dropped. This adds an evidence mapper for each and attaches it to the tool.

- `integrations/supabase/tools/supabase_health_tool/__init__.py` — `_map_get_supabase_service_health` records one entry summarising how many services were checked and naming any degraded ones.
- `integrations/supabase/tools/supabase_storage_tool/__init__.py` — `_map_get_supabase_storage_buckets` records one entry with the bucket count, a `(of N)` note when the result was truncated, and the names of any public buckets.
- Both names removed from `tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt`.
- Tests added under `tests/integrations/supabase/`.

Both mappers follow the shipped Grafana example and return early when the relevant field is absent, so an unconfigured or failed call records nothing.

### Demo/Screenshot for feature changes and bug fixes -

Verification steps from the issue, in order:

**1. Unit tests**
```
$ uv run pytest tests/integrations/supabase/ -q
6 passed in 5.21s
```

**2. The tools carry their mapper**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; print({n: bool(g(n).evidence_mapper) for n in ['get_supabase_service_health','get_supabase_storage_buckets']})"
{'get_supabase_service_health': True, 'get_supabase_storage_buckets': True}
```

**3. Output really becomes report evidence**
```
$ uv run python -c "from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence; ev={}; merge_tool_evidence(ev,'get_supabase_service_health',{'services':{'auth':{'healthy':False}},'degraded_services':['auth']},{}); print(ev.get('catalog_entries'))"
[{'source': 'get_supabase_service_health', 'label': 'Supabase Service Health', 'summary': '1 services checked, degraded: auth', 'url': None, 'snippet': None}]

$ ... merge_tool_evidence(ev2,'get_supabase_storage_buckets',{'buckets':[{'name':'avatars','public':True}],'total_buckets':1},{})
[{'source': 'get_supabase_storage_buckets', 'label': 'Supabase Storage Buckets', 'summary': '1 buckets, public: avatars', 'url': None, 'snippet': None}]
```

**4. Nothing else broke**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py
11 passed in 1.16s

$ uv run pytest tests/ -k supabase -q
47 passed, 15086 deselected in 22.29s

$ make lint          -> All checks passed!
$ make format-check  -> 3685 files already formatted
$ make typecheck     -> Success: no issues found in 1916 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is that two Supabase tools produce diagnostic output that the report never cites, so the agent's conclusions about Supabase have nothing visible behind them.

Each mapper takes the tool's output dict and calls `record_evidence_entry` once, which is what makes the result citeable. For health, the meaningful field is `services` (a per-service dict) plus `degraded_services`, so the summary reports the count and names whatever is degraded — that is the part a reader of the report actually needs. For storage, the field is `buckets`; the summary carries the count, and I added the public-bucket names because a bucket unexpectedly being public is the kind of thing a storage incident turns on.

An alternative was to also copy the raw output onto the evidence dict under a namespaced key, which is what the Grafana metrics mapper does (`evidence["grafana_metrics"] = metrics`). I left that out because nothing downstream reads a `supabase_*` key today, and adding unread state seemed worse than keeping the mappers to the one thing the issue asks for. Happy to add it if you would rather these match Grafana exactly.

Both mappers return early when their field is missing or empty, so a `tool_unavailable` response or an empty bucket list records no entry rather than an entry saying "0 items" — covered by two of the tests.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

