### PR TITLE
feat(session): instrument the session file lock

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import threading
+import time
 import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime
@@ -19,6 +20,7 @@ from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
 from config.version import get_opensre_version
 from core.agent_harness.session.persistence.contracts import CHAT_KINDS, SessionPersistenceSource
 from core.agent_harness.session.persistence.paths import session_path
+from infrastructure.observability.operations_log import record_operation
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +48,10 @@ _TAIL_SCAN_CHUNK_BYTES = 64 * 1024
 # (e.g. a full script body) never bloats the session log.
 _INTENT_ARGS_MAX_CHARS = 2_000
 _INTENT_USER_TEXT_MAX_CHARS = 200
+
+
+def _elapsed_ms(started: float) -> int:
+    return round((time.monotonic() - started) * 1000)
 
 
 def _now() -> str:
@@ -98,11 +104,17 @@ class JsonlSessionStore:
     def _locked(self, path: Path) -> Iterator[None]:
         """Serialize writes to one session file across processes (reentrant).
 
-        A no-op unless the file lock is enabled. Same-instance reentrancy lets
-        ``flush`` hold the lock across its whole read-modify-append while inner
-        appends re-enter cheaply; a per-path lock means different sessions never
-        contend. On timeout the caller's best-effort ``suppress`` skips the write
-        after a warning.
+        A no-op unless the file lock is enabled — the early return above keeps
+        the default (single-task) path free of the timing/recording below. Same-
+        instance reentrancy lets ``flush`` hold the lock across its whole
+        read-modify-append while inner appends re-enter cheaply; a per-path lock
+        means different sessions never contend. On timeout the caller's
+        best-effort ``suppress`` skips the write after a warning.
+
+        Every acquire (successful or not) records its wait time via the
+        operations log, and a timeout is recorded under its own event —
+        distinct from a generic failure, since it is a write that did not
+        happen rather than an error mid-write.
         """
         if not self._file_lock_enabled:
             yield
@@ -113,10 +125,19 @@ class JsonlSessionStore:
             if lock is None:
                 lock = FileLock(f"{key}.lock", timeout=_SESSION_LOCK_TIMEOUT_SECONDS)
                 self._write_locks[key] = lock
+        started = time.monotonic()
         try:
             with lock:
+                record_operation(
+                    "session_file_lock_wait",
+                    {"wait_ms": _elapsed_ms(started), "path": str(path)},
+                )
                 yield
         except Timeout:
+            record_operation(
+                "session_file_lock_timeout",
+                {"wait_ms": _elapsed_ms(started), "path": str(path)},
+            )
             logger.warning("session file lock timed out; skipping write: %s", path)
             raise
         finally:
@@ -569,11 +590,20 @@ class JsonlSessionStore:
         self._leaf_ids[key] = entry_id
 
     @staticmethod
-    def _loads_record(line: str) -> dict[str, Any] | None:
-        """Parse one JSONL line into a record dict, or ``None`` if unusable."""
+    def _loads_record(line: str, *, path: Path | None = None) -> dict[str, Any] | None:
+        """Parse one JSONL line into a record dict, or ``None`` if unusable.
+
+        A decode failure here is a torn tail or truncation on the read side —
+        recorded distinctly from a write-side lock timeout, since the two catch
+        different failure modes on either end of the same file.
+        """
         try:
             rec = json.loads(line)
         except json.JSONDecodeError:
+            record_operation(
+                "session_jsonl_decode_failed",
+                {"line_chars": len(line), "path": str(path) if path else ""},
+            )
             return None
         return rec if isinstance(rec, dict) else None
 
@@ -581,7 +611,7 @@ class JsonlSessionStore:
     def _read_records(path: Path) -> list[dict[str, Any]]:
         records: list[dict[str, Any]] = []
         for line in path.read_text(encoding="utf-8").splitlines():
-            rec = JsonlSessionStore._loads_record(line)
+            rec = JsonlSessionStore._loads_record(line, path=path)
             if rec is not None:
                 records.append(rec)
         return records
@@ -664,7 +694,7 @@ class JsonlSessionStore:
                     for line in reversed(region.decode("utf-8").splitlines()):
                         if not line.strip():
                             continue
-                        rec = self._loads_record(line)
+                        rec = self._loads_record(line, path=path)
                         if rec is None:
                             continue
                         resolved, tip = self._tip_id_from_record(rec)

--- a/tests/core/agent_harness/session/test_jsonl_store_lock.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock.py
@@ -12,10 +12,12 @@ from typing import Any
 
 import pytest
 
+from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
 from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
 from core.agent_harness.session.persistence import jsonl_store
 from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
 from core.agent_harness.session.persistence.paths import session_path
+from infrastructure.observability.operations_log import read_operations
 
 
 @pytest.fixture
@@ -96,3 +98,95 @@ def test_flush_completes_with_the_lock_enabled(
 
     lines = session_path(session.session_id).read_text(encoding="utf-8").splitlines()
     assert any(json.loads(line).get("type") == "leaf" for line in lines)
+
+
+def test_lock_disabled_records_no_lock_metrics(
+    storage_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default (lock-off) path never touches the operations log for the lock."""
+    log_path = storage_home / "operations.jsonl"
+    monkeypatch.setenv(OPENSRE_OPERATIONS_LOG_PATH_ENV, str(log_path))
+    session = _session("sess-nolock-metrics")
+    store = JsonlSessionStore()
+
+    store.open_session(session)
+    for i in range(5):
+        store.append_turn(session, "chat", f"msg-{i}")
+
+    records = read_operations(path=log_path, limit=1000)
+    lock_events = [r for r in records if r["event"].startswith("session_file_lock")]
+    assert lock_events == []
+
+
+def test_soak_contending_writers_record_plausible_wait_and_timeout_metrics(
+    storage_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two writers contending on one session file produce plausible lock metrics.
+
+    Uncontended writes seed real (near-zero) wait samples for the max/p50
+    signal; a second writer holding the lock externally then forces a
+    deterministic timeout, matching the issue's own verification recipe
+    without relying on real thread-timing races to produce contention.
+    """
+    from filelock import FileLock
+
+    log_path = storage_home / "operations.jsonl"
+    monkeypatch.setenv(OPENSRE_OPERATIONS_LOG_PATH_ENV, str(log_path))
+    monkeypatch.setenv(OPENSRE_SESSION_FILE_LOCK_ENV, "1")
+    monkeypatch.setattr(jsonl_store, "_SESSION_LOCK_TIMEOUT_SECONDS", 0.2)
+    session = _session("sess-soak")
+    store = JsonlSessionStore()
+    store.open_session(session)
+
+    # Writer A: a run of uncontended appends, seeding wait-time samples.
+    for i in range(10):
+        store.append_turn(session, "chat", f"msg-{i}")
+
+    # Writer B: another holder blocks the file lock, forcing this store's next
+    # write to time out rather than interleave.
+    path = session_path(session.session_id)
+    held = FileLock(f"{path}.lock", timeout=0.2)
+    held.acquire()
+    try:
+        store.append_turn(session, "chat", "blocked")
+    finally:
+        held.release()
+
+    records = read_operations(path=log_path, limit=1000)
+    waits = [r["data"]["wait_ms"] for r in records if r["event"] == "session_file_lock_wait"]
+    timeouts = [r for r in records if r["event"] == "session_file_lock_timeout"]
+
+    assert waits, "expected recorded wait times from the uncontended writer"
+    assert all(isinstance(w, int) and w >= 0 for w in waits)
+    p50 = sorted(waits)[len(waits) // 2]
+    assert 0 <= p50 <= max(waits)
+
+    assert len(timeouts) == 1
+    assert timeouts[0]["data"]["wait_ms"] >= 100  # close to the 200ms configured timeout
+
+
+def test_torn_tail_decode_failure_is_recorded(
+    storage_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A corrupted trailing line is counted separately from a lock timeout."""
+    log_path = storage_home / "operations.jsonl"
+    monkeypatch.setenv(OPENSRE_OPERATIONS_LOG_PATH_ENV, str(log_path))
+    session = _session("sess-torn-tail")
+    store = JsonlSessionStore()
+    store.open_session(session)
+    store.append_turn(session, "chat", "one")
+
+    path = session_path(session.session_id)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('{"id": "torn", "type": "message", "content": \n')
+
+    store.flush(session)
+
+    # The out-of-band write below invalidates the in-memory tip cache, so the
+    # flush's own read and the subsequent tip re-scan both independently hit
+    # the same corrupted line — at least one decode failure is the invariant,
+    # not an exact count tied to how many internal passes read the file.
+    records = read_operations(path=log_path, limit=1000)
+    decode_failures = [r for r in records if r["event"] == "session_jsonl_decode_failed"]
+    assert decode_failures
+    assert all(rec["data"]["line_chars"] > 0 for rec in decode_failures)


### PR DESCRIPTION
Closes #5484

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Instruments `_locked` and `_loads_record` in
`core/agent_harness/session/persistence/jsonl_store.py` so the cross-process
session file lock (`OPENSRE_SESSION_FILE_LOCK`, off by default) emits the three
signals the issue asks for, routed through the existing local operations log
(`infrastructure/observability/operations_log.py`) rather than a new counter:

- **`session_file_lock_wait`** — recorded on every successful acquire, with
  `wait_ms`. Enough samples over time give the max/p50 the issue wants; the log
  itself is the existing "operational lifecycle event" sink (same one
  `infrastructure/scheduling/scheduler/operation_log.py` already uses), not
  something new.
- **`session_file_lock_timeout`** — recorded in the existing `except Timeout:`
  branch, separate from the wait event, so a dropped write is countable on its
  own rather than folded into "other failures."
- **`session_jsonl_decode_failed`** — recorded in `_loads_record` on a
  `JSONDecodeError` (torn tail / truncation), now carrying the session path
  from both call sites (`_read_records`'s linear flush scan and
  `_scan_leaf_id`'s cold-tail tip resolve).

**Why not the session trace-span helpers** (`infrastructure/observability/trace/spans.py`,
the other "tracing helpers" the issue points at): I checked them first, since
they're the more obvious "existing observability layer" candidate. They're
wrong for this specific case — the REPL's `SessionTraceStore` is
`JsonlSessionTraceStore`, which writes `trace_span` records back through
`JsonlSessionStore.append_trace_span` → `_append_entry` → `_locked` on the
*same* session file the lock protects. Emitting a span from inside `_locked`
would recurse back into the very code path being timed. I also checked
`infrastructure/analytics/` (PostHog `Analytics.capture`) — wrong shape too:
it's a queued, network-backed, opt-out-able event pipeline meant for product
telemetry, not a synchronous local counter with a read-back path a test can
query. `operations_log.py`'s `record_operation`/`read_operations()` is the one
that's local, synchronous, JSONL-backed, and already has a direct precedent
for exactly this "lifecycle event with numeric payload, queryable in tests"
shape.

**Lock-off path stays free**: `_locked`'s early return
(`if not self._file_lock_enabled: yield; return`) sits before the new
`time.monotonic()` call and every `record_operation` call, so the default
(single-task) path runs exactly the code it ran before — no timer, no log
lookup, nothing.

Also added three tests to `tests/core/agent_harness/session/test_jsonl_store_lock.py`:
`test_lock_disabled_records_no_lock_metrics` (inert when off),
`test_soak_contending_writers_record_plausible_wait_and_timeout_metrics` (real
contention produces plausible wait/timeout data), and
`test_torn_tail_decode_failure_is_recorded` (decode failures counted
separately from lock failures).

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run python -m pytest tests/core/agent_harness/session/test_jsonl_store_lock.py -v
test_writes_take_no_lock_by_default PASSED
test_enabled_lock_skips_a_write_another_holder_is_blocking PASSED
test_flush_completes_with_the_lock_enabled PASSED
test_lock_disabled_records_no_lock_metrics PASSED
test_soak_contending_writers_record_plausible_wait_and_timeout_metrics PASSED
test_torn_tail_decode_failure_is_recorded PASSED
6 passed in 2.95s
```

The soak test's actual recorded data from one run (10 uncontended appends +
one write forced to time out against an externally held lock, 200ms
timeout configured):
```
waits (ms):    10 samples, all >= 0, p50 well under the timeout
timeouts:      1 record, wait_ms >= 100 (close to the configured 200ms)
```

**One note on the issue's own verification command** — I ran it and it does
not pass as literally written:
```
$ OPENSRE_SESSION_FILE_LOCK=1 uv run python -m pytest \
    tests/core/agent_harness/session/ -q -k "lock or soak"
2 failed, 6 passed, 86 deselected
```
The two failures are `test_writes_take_no_lock_by_default` (pre-existing, not
touched by this PR) and my new `test_lock_disabled_records_no_lock_metrics` —
both specifically test the lock-*disabled* path, and both fail for the same
reason: the command sets `OPENSRE_SESSION_FILE_LOCK=1` as a **process-level**
env var, which overrides every test in the file, including the ones that
exist to prove the default-off behavior. I confirmed this is pre-existing by
stashing this change and running the same command against unmodified `main` —
`test_writes_take_no_lock_by_default` fails there too, identically. Each
test in the file controls the lock state itself via
`monkeypatch.setenv(OPENSRE_SESSION_FILE_LOCK_ENV, ...)`, which is what
actually exercises both branches correctly in one full run of the file (see
the un-prefixed run above, 6/6 passed) — the outer env var in the issue's
verification command clobbers that per-test control. Left the recipe as
written in the issue rather than "fixing" it, since it's describing an
operator sanity-check, not a CI gate.

Full quality gates:
```
$ uv run python -m pytest tests/core/agent_harness/session/ -q
94 passed

$ uv run python -m pytest tests/core/agent_harness -q
565 passed

$ make lint
All checks passed!

$ make format && make format-check
3689 files already formatted

$ make typecheck
Success: no issues found in 1920 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue's hardest constraint was "route through the existing observability
layer rather than inventing a counter," so before writing anything I read all
three candidates it names: the session trace-span helpers, the analytics
(PostHog) module, and `infrastructure/observability/` generally. The trace
spans turned out to be actively wrong for this — they write back into the same
session JSONL file the lock guards, so timing the lock by emitting a span from
inside it would be timing-through-recursion. PostHog analytics is a queued,
network, opt-out pipeline built for product events, not a local synchronous
counter. `operations_log.py`'s `record_operation`/`read_operations()` matched
what the issue actually wants (a local, queryable, "operational lifecycle
event" sink) and had a direct precedent in the scheduler's use of the same
module, which is what settled the choice. For "wait time (max, p50)" I
recorded the raw per-acquire sample rather than maintaining an in-process
histogram, since aggregation from raw samples is exactly what
`read_operations()` already supports and keeps me from building a second,
bespoke counter alongside the log the issue told me not to invent. I verified
the lock-off path pays nothing by placing all new code after the existing
early-return guard, and verified contention produces real (not synthetic)
numbers by writing a deterministic two-writer test — an externally held
`FileLock` forcing an actual timeout — rather than relying on a real thread
race, since a race-based test would be flaky on slower CI machines. I ran the
issue's own literal verification command and found it conflicts with a
pre-existing test; I verified that conflict predates this PR before writing
it into the description rather than silently working around it.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
