### PR TITLE
refactor(agent_harness): inject the investigation runner instead of a module global

### DIFF
--- a/bootstrap/adapters.py
+++ b/bootstrap/adapters.py
@@ -18,24 +18,11 @@ if TYPE_CHECKING:
     from infrastructure.scheduling.scheduler.runners import SchedulerRunners
 
 
-def install_investigation_api() -> None:
-    """Wire :meth:`AgentSession.investigate` to the canonical payload runner.
-
-    ``agent_harness`` must not import ``tools``; this composition-root step
-    installs the callable the session API dispatches through.
-    """
-    from core.agent_harness.investigation_api import install_investigation_payload_runner
-    from tools.investigation.capability import run_investigation_payload
-
-    install_investigation_payload_runner(run_investigation_payload)
-
-
 def install_harness_adapters() -> None:
     """Register the integration and tool adapters the harness resolves through.
 
     Without this a harness starts but no tool is available — the ports report
-    nothing until both registries have been installed. Also installs the
-    investigation payload runner used by :meth:`AgentSession.investigate`.
+    nothing until both registries have been installed.
     """
     import infrastructure.harness_providers as harness_providers
     from integrations.harness_adapters import (
@@ -53,7 +40,6 @@ def install_harness_adapters() -> None:
     harness_providers.IntegrationSetupCommand(
         lambda service_id: f"/integrations setup {service_id}"
     ).install()
-    install_investigation_api()
 
 
 def install_notification_adapters() -> tuple[str, ...]:
@@ -159,7 +145,6 @@ def install_cli_auth_checker() -> None:
 
 __all__ = [
     "install_harness_adapters",
-    "install_investigation_api",
     "install_notification_adapters",
     "scheduler_runners",
     "scheduled_delivery_adapters",

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -322,12 +322,17 @@ a headless agent on every message for the same logical session.
 
 ```python
 from bootstrap.embedded import start_embedded_session
+from tools.investigation.capability import run_investigation_payload
 
 session = start_embedded_session()    # EMBEDDED_PROFILE + default agent
 result = session.chat("…")            # turn 1
 result = session.chat("…")            # turn 2 — same attached agent
-report = session.investigate({…})     # investigation pipeline (separate stage machine)
+report = session.investigate({…}, runner=run_investigation_payload)  # investigation pipeline
 ```
+
+``investigate`` takes its payload runner as an argument because ``core`` may not
+import ``tools``; the caller (a surface, the gateway, or an embedder) supplies
+``run_investigation_payload``.
 
 ``AgentSession.start`` must not import ``bootstrap`` (layer contract). Surfaces
 that already ran another process profile call ``startup()`` (or pass an

--- a/core/agent_harness/harness.py
+++ b/core/agent_harness/harness.py
@@ -5,7 +5,7 @@ Create the session, attach an agent, run turns::
     session = AgentSession.start(config)  # builds the default agent
     result = session.chat("…")            # turn 1
     follow = session.chat("…")            # turn 2 — same attached agent
-    report = session.investigate({…})     # needs no attached chat agent
+    report = session.investigate({…}, runner=run)  # needs no attached chat agent
 
 Embedded scripts that need local adapters use
 ``bootstrap.embedded.start_embedded_session``. Scheduled one-shots may use
@@ -33,7 +33,11 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from core.agent_harness.session import SessionManager
 
 if TYPE_CHECKING:
-    from core.agent_harness.investigation_api import AlertInput, InvestigationResult
+    from core.agent_harness.investigation_api import (
+        AlertInput,
+        InvestigationPayloadRunner,
+        InvestigationResult,
+    )
     from core.agent_harness.ports import (
         OutputSink,
         PromptContextProvider,
@@ -322,22 +326,25 @@ class AgentSession:
         self,
         alert: AlertInput,
         *,
+        runner: InvestigationPayloadRunner,
         opensre_evaluate: bool = False,
         investigation_metadata: tuple[str, str] | None = None,
     ) -> InvestigationResult:
-        """Run an investigation and return a typed result.
+        """Run an investigation through ``runner`` and return a typed result.
 
-        Uses the payload runner installed at process boot
-        (:func:`core.agent_harness.investigation_api.install_investigation_payload_runner`).
-        Does not require an attached chat agent.
+        ``agent_harness`` must not import ``tools``, so the caller (a surface or
+        the gateway) supplies the payload callable — normally
+        :func:`tools.investigation.capability.run_investigation_payload`. Does
+        not require an attached chat agent.
         """
-        from core.agent_harness.investigation_api import run_installed_investigation_payload
+        from core.agent_harness.investigation_api import InvestigationResult
 
-        return run_installed_investigation_payload(
+        payload = runner(
             raw_alert=alert,
             opensre_evaluate=opensre_evaluate,
             investigation_metadata=investigation_metadata,
         )
+        return InvestigationResult.from_payload(payload)
 
     def resolve_integrations(self, session: SessionCore) -> dict[str, Any]:
         """Return resolved integration configs for ``session``."""

--- a/core/agent_harness/investigation_api.py
+++ b/core/agent_harness/investigation_api.py
@@ -1,9 +1,9 @@
-"""Public investigation result + installable payload runner port.
+"""Public investigation result + payload runner type.
 
-``agent_harness`` must not import ``tools`` (import-boundary tests). Process
-boot installs the canonical runner via :func:`install_investigation_payload_runner`
-from :mod:`bootstrap.adapters`. Surfaces and embedders call
-:meth:`AgentSession.investigate`, which uses the installed runner.
+``agent_harness`` must not import ``tools`` (import-boundary tests), so callers
+supply the payload callable when they invoke :meth:`AgentSession.investigate`
+rather than the harness reaching for it. The canonical callable is
+:func:`tools.investigation.capability.run_investigation_payload`.
 """
 
 from __future__ import annotations
@@ -14,8 +14,6 @@ from typing import Any
 
 AlertInput = str | dict[str, Any]
 InvestigationPayloadRunner = Callable[..., dict[str, Any]]
-
-_payload_runner: InvestigationPayloadRunner | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,52 +75,8 @@ class InvestigationResult:
         return out
 
 
-def install_investigation_payload_runner(runner: InvestigationPayloadRunner) -> None:
-    """Bind the payload investigation callable used by :meth:`AgentSession.investigate`."""
-    global _payload_runner
-    _payload_runner = runner
-
-
-def reset_investigation_payload_runner_for_tests() -> None:
-    """Clear the installed runner (tests only)."""
-    global _payload_runner
-    _payload_runner = None
-
-
-def get_investigation_payload_runner() -> InvestigationPayloadRunner | None:
-    """Return the installed runner, or ``None`` if process boot has not wired it."""
-    return _payload_runner
-
-
-def run_installed_investigation_payload(
-    *,
-    raw_alert: AlertInput,
-    opensre_evaluate: bool = False,
-    investigation_metadata: tuple[str, str] | None = None,
-) -> InvestigationResult:
-    """Run investigation through the installed payload runner."""
-    runner = _payload_runner
-    if runner is None:
-        raise RuntimeError(
-            "Investigation payload runner is not installed. Call "
-            "configure_process(...) (harness adapters) or "
-            "bootstrap.adapters.install_investigation_api() before "
-            "AgentSession.investigate."
-        )
-    payload = runner(
-        raw_alert=raw_alert,
-        opensre_evaluate=opensre_evaluate,
-        investigation_metadata=investigation_metadata,
-    )
-    return InvestigationResult.from_payload(payload)
-
-
 __all__ = [
     "AlertInput",
     "InvestigationPayloadRunner",
     "InvestigationResult",
-    "get_investigation_payload_runner",
-    "install_investigation_payload_runner",
-    "reset_investigation_payload_runner_for_tests",
-    "run_installed_investigation_payload",
 ]

--- a/docs/python-api.mdx
+++ b/docs/python-api.mdx
@@ -79,6 +79,7 @@ webhook, or monitoring system directly into OpenSRE's investigation pipeline:
 ```python
 from bootstrap.process import EMBEDDED_PROFILE, configure_process
 from core.agent_harness import AgentSession
+from tools.investigation.capability import run_investigation_payload
 
 # 1. Register tools and investigation adapters
 configure_process(EMBEDDED_PROFILE)
@@ -94,7 +95,7 @@ alert_payload = {
     "description": "p99 latency exceeded 1200ms in us-east-1",
 }
 
-report = session.investigate(alert_payload)
+report = session.investigate(alert_payload, runner=run_investigation_payload)
 print(report.report)
 ```
 
@@ -105,6 +106,7 @@ Every surface uses the same two verbs:
 ```python
 from bootstrap.process import EMBEDDED_PROFILE, configure_process
 from core.agent_harness import AgentSession
+from tools.investigation.capability import run_investigation_payload
 
 configure_process(EMBEDDED_PROFILE)
 
@@ -118,7 +120,10 @@ action_ok = (
 if (result.answered or action_ok) and not result.cancelled:
     print(result.primary_response_text)
 
-report = session.investigate({"alert_name": "HighLatency", "severity": "warning"})
+report = session.investigate(
+    {"alert_name": "HighLatency", "severity": "warning"},
+    runner=run_investigation_payload,
+)
 print(report.report)
 ```
 
@@ -135,7 +140,8 @@ an agent with the standard ports — the same tools and prompts the interactive
 shell uses. It does **not** register adapters (``core`` may not import
 ``bootstrap``); call ``configure_process`` first or use
 ``start_embedded_session``. `investigate` does not require an attached chat
-agent; it uses the payload runner installed by `configure_process`.
+agent; pass it the `run_investigation_payload` runner as shown above (``core``
+may not import ``tools``, so the caller supplies it).
 
 Always verify turn success before trusting chat text:
 - For conversational questions and digests, the agent synthesizes an answer (`result.answered`).
@@ -145,8 +151,8 @@ Always verify turn success before trusting chat text:
 ### Internal seams (not for hosts)
 
 Chat hosts terminate at `dispatch_chat_turn` → `run_turn`. Investigation
-terminates at the installed payload runner (`run_investigation_payload`). Do not
-invent parallel public entrypoints.
+terminates at the payload runner the caller passes to `investigate`
+(`run_investigation_payload`). Do not invent parallel public entrypoints.
 
 ## Unattended daily delivery and background loops
 

--- a/gateway/tests/web/test_webapp_investigate.py
+++ b/gateway/tests/web/test_webapp_investigate.py
@@ -9,10 +9,6 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-from core.agent_harness.investigation_api import (
-    install_investigation_payload_runner,
-    reset_investigation_payload_runner_for_tests,
-)
 from gateway.web import webapp
 
 _LOOPBACK = ("127.0.0.1", 40000)
@@ -25,16 +21,14 @@ def _no_token(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     yield
 
 
-@pytest.fixture(autouse=True)
-def _reset_investigation_runner() -> Iterator[None]:
-    reset_investigation_payload_runner_for_tests()
-    yield
-    reset_investigation_payload_runner_for_tests()
-
-
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(webapp.app, client=_LOOPBACK)
+
+
+def _use_runner(monkeypatch: pytest.MonkeyPatch, runner: Any) -> None:
+    """Substitute the payload runner the endpoint injects into ``investigate``."""
+    monkeypatch.setattr(webapp, "run_investigation_payload", runner)
 
 
 def _fake_payload() -> dict[str, Any]:
@@ -51,7 +45,6 @@ def _fake_payload() -> dict[str, Any]:
 def test_investigate_runs_pipeline_and_returns_report(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    del monkeypatch  # fixture reserved for env overrides elsewhere
     captured: dict[str, Any] = {}
 
     def _fake_run(
@@ -61,7 +54,7 @@ def test_investigate_runs_pipeline_and_returns_report(
         captured["investigation_metadata"] = investigation_metadata
         return _fake_payload()
 
-    install_investigation_payload_runner(_fake_run)
+    _use_runner(monkeypatch, _fake_run)
 
     resp = client.post(
         "/investigate",
@@ -85,7 +78,7 @@ def test_investigate_runs_pipeline_and_returns_report(
 
 
 def test_investigate_resolves_metadata_from_raw_alert_when_overrides_missing(
-    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
     captured: dict[str, Any] = {}
 
@@ -93,7 +86,7 @@ def test_investigate_resolves_metadata_from_raw_alert_when_overrides_missing(
         captured["investigation_metadata"] = investigation_metadata
         return _fake_payload()
 
-    install_investigation_payload_runner(_fake_run)
+    _use_runner(monkeypatch, _fake_run)
 
     resp = client.post(
         "/investigate",
@@ -110,12 +103,12 @@ def test_investigate_missing_raw_alert_returns_422(client: TestClient) -> None:
 
 
 def test_investigate_pipeline_failure_returns_503_without_leaking_exception_text(
-    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
     def _boom(**_: Any) -> dict[str, Any]:
         raise RuntimeError("llm unavailable at s3://internal-bucket/creds.json")
 
-    install_investigation_payload_runner(_boom)
+    _use_runner(monkeypatch, _boom)
 
     resp = client.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
 
@@ -126,13 +119,15 @@ def test_investigate_pipeline_failure_returns_503_without_leaking_exception_text
     assert "s3://internal-bucket" not in body["error"]
 
 
-def test_investigate_malformed_pipeline_result_returns_503(client: TestClient) -> None:
+def test_investigate_malformed_pipeline_result_returns_503(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
     """A result dict that fails InvestigateResponse validation is caught too."""
 
     def _malformed(**_: Any) -> dict[str, Any]:
         return {"report": None, "problem_md": "p", "root_cause": "c"}
 
-    install_investigation_payload_runner(_malformed)
+    _use_runner(monkeypatch, _malformed)
 
     resp = client.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
 
@@ -140,8 +135,10 @@ def test_investigate_malformed_pipeline_result_returns_503(client: TestClient) -
     assert resp.json()["error"] == "investigation failed: ValidationError"
 
 
-def test_investigate_non_loopback_without_token_returns_403() -> None:
-    install_investigation_payload_runner(lambda **_: _fake_payload())
+def test_investigate_non_loopback_without_token_returns_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_runner(monkeypatch, lambda **_: _fake_payload())
     remote = TestClient(webapp.app, client=_REMOTE)
 
     resp = remote.post("/investigate", json={"raw_alert": {"alert_name": "x"}})
@@ -151,7 +148,7 @@ def test_investigate_non_loopback_without_token_returns_403() -> None:
 
 def test_investigate_token_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENSRE_ALERT_LISTENER_TOKEN", "sekret")
-    install_investigation_payload_runner(lambda **_: _fake_payload())
+    _use_runner(monkeypatch, lambda **_: _fake_payload())
     remote = TestClient(webapp.app, client=_REMOTE)
 
     assert (
@@ -168,14 +165,16 @@ def test_investigate_token_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_investigate_at_capacity_returns_503(client: TestClient) -> None:
+def test_investigate_at_capacity_returns_503(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
     from infrastructure.turn_host.concurrency import (
         TurnConcurrencyGate,
         reset_process_turn_gate_for_tests,
         set_process_turn_gate,
     )
 
-    install_investigation_payload_runner(lambda **_: _fake_payload())
+    _use_runner(monkeypatch, lambda **_: _fake_payload())
     gate = TurnConcurrencyGate(1)
     assert gate.try_acquire() is True  # occupy the only slot
     set_process_turn_gate(gate)

--- a/gateway/web/webapp.py
+++ b/gateway/web/webapp.py
@@ -33,7 +33,7 @@ from infrastructure.alert_intake import (
 from infrastructure.alert_intake import router as alert_router
 from infrastructure.observability.errors.sentry import capture_exception
 from infrastructure.process.turn_capacity import turn_slot
-from tools.investigation.capability import resolve_investigation_context
+from tools.investigation.capability import resolve_investigation_context, run_investigation_payload
 
 # Standalone uvicorn and in-process gateway both need adapters for /investigate.
 configure_process(WEB_PROFILE)  # env → sentry → adapters
@@ -142,6 +142,7 @@ def _run_investigation(req: InvestigateRequest) -> InvestigateResponse | JSONRes
     try:
         result = AgentSession().investigate(
             req.raw_alert,
+            runner=run_investigation_payload,
             investigation_metadata=investigation_metadata,
         )
         return InvestigateResponse(**result.as_dict())

--- a/gateway/web/worker.py
+++ b/gateway/web/worker.py
@@ -26,7 +26,10 @@ InvestigationRunner = Callable[[dict[str, Any]], dict[str, Any]]
 
 def _run_pipeline(trigger: dict[str, Any]) -> dict[str, Any]:
     from core.agent_harness import AgentSession
-    from tools.investigation.capability import resolve_investigation_context
+    from tools.investigation.capability import (
+        resolve_investigation_context,
+        run_investigation_payload,
+    )
 
     raw_alert = trigger.get("raw_alert") or {}
     investigation_metadata = resolve_investigation_context(
@@ -38,6 +41,7 @@ def _run_pipeline(trigger: dict[str, Any]) -> dict[str, Any]:
         AgentSession()
         .investigate(
             raw_alert,
+            runner=run_investigation_payload,
             investigation_metadata=investigation_metadata,
         )
         .as_dict()

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ Driving the agent from Python instead of the CLI::
 
     from bootstrap.process import EMBEDDED_PROFILE, configure_process
     from core.agent_harness import AgentSession
+    from tools.investigation.capability import run_investigation_payload
 
     configure_process(EMBEDDED_PROFILE)
 
@@ -28,14 +29,17 @@ Driving the agent from Python instead of the CLI::
         print(result.primary_response_text)
     follow = session.chat("what should we check next?")  # same agent, next turn
 
-    report = session.investigate({"alert_name": "HighLatency"})
+    report = session.investigate(
+        {"alert_name": "HighLatency"}, runner=run_investigation_payload
+    )
     print(report.report)
 
 ``configure_process`` comes first and is what registers the harness adapters
-tools resolve through (and the investigation payload runner);
-``AgentSession.start()`` only loads the environment, so on its own the agent
-starts but no tool is available. It cannot self-bootstrap — ``core`` sits below
-``bootstrap`` in the layer contract, so the caller wires it.
+tools resolve through; ``AgentSession.start()`` only loads the environment, so
+on its own the agent starts but no tool is available. It cannot self-bootstrap —
+``core`` sits below ``bootstrap`` in the layer contract, so the caller wires it.
+``investigate`` takes its payload runner as an argument (``core`` must not import
+``tools``); embedders pass ``run_investigation_payload`` as shown.
 ``EMBEDDED_PROFILE`` deliberately leaves Sentry and LLM preloading to the host
 process.
 

--- a/surfaces/cli/investigation/investigate.py
+++ b/surfaces/cli/investigation/investigate.py
@@ -48,16 +48,15 @@ def run_investigation_cli(
     ``investigation_metadata`` is an optional ``(alert_name, severity)`` tuple.
     """
     check_llm_settings()
-    from bootstrap.adapters import install_investigation_api
     from core.agent_harness import AgentSession
+    from tools.investigation.capability import run_investigation_payload
 
-    # CLI_PROFILE boots env only; install the payload runner before investigate.
-    install_investigation_api()
     try:
         return (
             AgentSession()
             .investigate(
                 raw_alert,
+                runner=run_investigation_payload,
                 opensre_evaluate=opensre_evaluate,
                 investigation_metadata=investigation_metadata,
             )

--- a/tests/bootstrap/test_adapters.py
+++ b/tests/bootstrap/test_adapters.py
@@ -38,10 +38,6 @@ def registration_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
     for target, name in _REGISTRARS.items():
         monkeypatch.setattr(target, _recorder(name))
-    monkeypatch.setattr(
-        "bootstrap.adapters.install_investigation_api",
-        _recorder("investigation_api"),
-    )
     return calls
 
 
@@ -49,9 +45,8 @@ def test_harness_adapters_registers_both_registries(registration_calls: list[str
     # Arrange / Act
     adapters.install_harness_adapters()
 
-    # Assert: adapters include the AgentSession.investigate payload runner;
-    # they must not silently pull in scheduler runners.
-    assert registration_calls == ["integrations", "tools", "investigation_api"]
+    # Assert: both registries install; they must not silently pull in scheduler runners.
+    assert registration_calls == ["integrations", "tools"]
 
 
 def test_only_the_composition_root_defines_the_steps() -> None:

--- a/tests/core/agent_harness/test_agent_session_api.py
+++ b/tests/core/agent_harness/test_agent_session_api.py
@@ -5,14 +5,8 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
-import pytest
-
 from core.agent_harness.harness import AgentSession, SessionConfig
-from core.agent_harness.investigation_api import (
-    InvestigationResult,
-    install_investigation_payload_runner,
-    reset_investigation_payload_runner_for_tests,
-)
+from core.agent_harness.investigation_api import InvestigationResult
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 
 
@@ -142,9 +136,8 @@ def test_chat_is_the_public_verb(monkeypatch: Any) -> None:
     assert captured == ["why is checkout-api slow?", "follow-up"]
 
 
-def test_investigate_uses_installed_runner() -> None:
-    reset_investigation_payload_runner_for_tests()
-
+def test_investigate_runs_through_the_injected_runner() -> None:
+    # Arrange: a runner the caller supplies, asserting it receives the alert verbatim.
     def _fake_runner(
         *,
         raw_alert: Any,
@@ -162,24 +155,18 @@ def test_investigate_uses_installed_runner() -> None:
             "validity_score": 0.9,
         }
 
-    install_investigation_payload_runner(_fake_runner)
-    try:
-        result = AgentSession().investigate(
-            {"alert_name": "HighLatency"},
-            investigation_metadata=("HighLatency", "warning"),
-        )
-        assert isinstance(result, InvestigationResult)
-        assert result.report == "done"
-        assert result.root_cause == "r"
-        assert result.as_dict()["report"] == "done"
-    finally:
-        reset_investigation_payload_runner_for_tests()
+    # Act: investigate through the injected runner.
+    result = AgentSession().investigate(
+        {"alert_name": "HighLatency"},
+        runner=_fake_runner,
+        investigation_metadata=("HighLatency", "warning"),
+    )
 
-
-def test_investigate_fails_closed_without_runner() -> None:
-    reset_investigation_payload_runner_for_tests()
-    with pytest.raises(RuntimeError, match="Investigation payload runner is not installed"):
-        AgentSession().investigate("spike")
+    # Assert: the payload is wrapped into the typed public result.
+    assert isinstance(result, InvestigationResult)
+    assert result.report == "done"
+    assert result.root_cause == "r"
+    assert result.as_dict()["report"] == "done"
 
 
 def test_investigation_result_round_trips_optional_fields() -> None:


### PR DESCRIPTION
What: AgentSession.investigate() receives its payload runner as a parameter; the module-global runner + its install/get/reset helpers and the install_investigation_api boot step are deleted.
Why: removes hidden mutable global state and the "install before you call" ordering footgun; makes the dependency explicit at each call site. Same pattern as the scheduler-runner injection (#5681).