### PR TITLE
feat(rds): add a DescribeDBInstances verifier for integrations verify rds

### DIFF
--- a/docs/aws.mdx
+++ b/docs/aws.mdx
@@ -169,7 +169,7 @@ Status: passed
 Detail: Connected to AWS STS via static-creds in us-east-1; caller identity account=123456789012 arn=arn:aws:iam::123456789012:user/opensre.
 ```
 
-Inside the REPL: `/integrations verify aws` or `/verify aws`. Aliases such as `eks` also map to this check.
+Inside the REPL: `/integrations verify aws` or `/verify aws`. Aliases such as `eks` also map to this check. CloudWatch, CloudTrail, EC2, ELB, S3, SQS, and Lambda have no separate verify target; they share this AWS check. RDS has its own verifier — see [RDS](/rds).
 
 ## Troubleshooting
 

--- a/docs/rds.mdx
+++ b/docs/rds.mdx
@@ -112,7 +112,21 @@ opensre investigate
 
 ## Verify
 
-There is no dedicated `opensre integrations verify rds` target today. Confirm AWS credentials work (see [AWS](/aws)) and that tools can describe your instance during an investigation.
+RDS has its own verifier. It calls `DescribeDBInstances` for the configured identifier — a passing AWS STS check does not prove RDS access.
+
+```bash
+opensre integrations verify rds
+```
+
+Expected output:
+
+```
+Service: rds
+Status: passed
+Detail: Reached RDS instance prod-orders-db in us-east-1; status=available engine=postgres.
+```
+
+CloudWatch, CloudTrail, EC2, EKS, ELB, S3, SQS, and Lambda have no separate setup identity and keep verifying through [`opensre integrations verify aws`](/aws).
 
 ## Troubleshooting
 

--- a/integrations/effective_models.py
+++ b/integrations/effective_models.py
@@ -93,3 +93,4 @@ class EffectiveIntegrations(StrictConfigModel):
     kubernetes: EffectiveIntegrationEntry | None = None
     new_relic: EffectiveIntegrationEntry | None = None
     yandex_cloud: EffectiveIntegrationEntry | None = None
+    rds: EffectiveIntegrationEntry | None = None

--- a/integrations/rds/client.py
+++ b/integrations/rds/client.py
@@ -1,0 +1,53 @@
+"""RDS Describe API client used by verification."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.aws.aws_sdk_client import execute_aws_sdk_call
+from integrations.probes import ProbeResult
+from integrations.rds import RDSConfig
+
+
+class RDSClient:
+    """Read-only RDS client. Verification probes ``DescribeDBInstances``."""
+
+    def __init__(self, config: RDSConfig) -> None:
+        self.config = config
+
+    def probe_access(self) -> ProbeResult:
+        """Confirm the configured instance is reachable with current AWS credentials."""
+        if not self.config.is_configured:
+            return ProbeResult.missing("Missing RDS DB instance identifier.")
+
+        identifier = self.config.db_instance_identifier
+        region = self.config.region
+        result = execute_aws_sdk_call(
+            service_name="rds",
+            operation_name="describe_db_instances",
+            parameters={"DBInstanceIdentifier": identifier},
+            region=region,
+        )
+        if not result.get("success"):
+            error = str(result.get("error") or "unknown error")
+            return ProbeResult.failed(f"RDS DescribeDBInstances failed: {error}")
+
+        instances = _db_instances(result.get("data"))
+        if not instances:
+            return ProbeResult.failed(f"No RDS instance named {identifier} in {region}.")
+
+        instance = instances[0]
+        status = str(instance.get("DBInstanceStatus") or "unknown")
+        engine = str(instance.get("Engine") or "unknown")
+        return ProbeResult.passed(
+            f"Reached RDS instance {identifier} in {region}; status={status} engine={engine}."
+        )
+
+
+def _db_instances(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    raw = payload.get("DBInstances") or []
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]

--- a/integrations/rds/setup.py
+++ b/integrations/rds/setup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from config.constants.rds import RDS_DB_INSTANCE_IDENTIFIER_ENV, RDS_REGION_ENV
 from integrations.rds import DEFAULT_RDS_REGION
+from integrations.rds.verifier import verify_rds
 from integrations.setup_flow import IntegrationSetupSpec, SetupField
 
 DB_INSTANCE_IDENTIFIER_FIELD = "db_instance_identifier"
@@ -31,7 +32,7 @@ RDS_SETUP = IntegrationSetupSpec(
             default=DEFAULT_RDS_REGION,
         ),
     ),
-    verify=None,
+    verify=verify_rds,
 )
 
 __all__ = [

--- a/integrations/rds/verifier.py
+++ b/integrations/rds/verifier.py
@@ -1,0 +1,13 @@
+"""RDS integration verifier."""
+
+from __future__ import annotations
+
+from integrations.rds import RDSConfig
+from integrations.rds.client import RDSClient
+from integrations.verification import register_probe_verifier
+
+verify_rds = register_probe_verifier(
+    "rds",
+    config=RDSConfig.model_validate,
+    client=RDSClient,
+)

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -401,7 +401,13 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
         verify_order=54,
     ),
     IntegrationSpec(service="trello"),
-    IntegrationSpec(service="rds", setup_order=11),
+    IntegrationSpec(
+        service="rds",
+        has_verifier=True,
+        direct_effective=True,
+        setup_order=11,
+        verify_order=60,
+    ),
     IntegrationSpec(
         service="supabase",
         has_verifier=True,

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -289,6 +289,24 @@ def test_integrations_setup_accepts_smtp() -> None:
     mock_verify.assert_called_once_with("smtp")
 
 
+def test_integrations_setup_accepts_rds() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("surfaces.cli.commands.integrations.capture_integration_setup_started"),
+        patch("surfaces.cli.commands.integrations.capture_integration_setup_completed"),
+        patch("surfaces.cli.commands.integrations.capture_integration_verified"),
+        patch("integrations.cli.cmd_setup") as mock_setup,
+        patch("integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        mock_setup.return_value = "rds"
+        result = runner.invoke(cli, ["integrations", "setup", "rds"])
+
+    assert result.exit_code == 0
+    mock_setup.assert_called_once_with("rds")
+    mock_verify.assert_called_once_with("rds")
+
+
 def test_integrations_setup_skips_auto_verify_for_unverifiable_service() -> None:
     runner = CliRunner()
 
@@ -298,11 +316,15 @@ def test_integrations_setup_skips_auto_verify_for_unverifiable_service() -> None
         patch("surfaces.cli.commands.integrations.capture_integration_verified"),
         patch("integrations.cli.cmd_setup") as mock_setup,
         patch("integrations.cli.cmd_verify") as mock_verify,
+        # No shipped setup service is currently unverifiable. Pin the skip
+        # path by excluding the chosen service from VERIFY_SERVICES rather
+        # than depending on a shrinking real-world leftover (opensearch, then
+        # rds, each broke this test when they gained a verifier).
+        patch(
+            "surfaces.cli.commands.integrations.constants.VERIFY_SERVICES",
+            ("github", "datadog"),
+        ),
     ):
-        # rds is registered in SETUP_SERVICES but intentionally absent from
-        # VERIFY_SERVICES, so it exercises the auto-verify-skip path.
-        # (opensearch was used here previously but moved into VERIFY_SERVICES
-        # by PR #1143, which is why this assertion was updated.)
         mock_setup.return_value = "rds"
         result = runner.invoke(cli, ["integrations", "setup", "rds"])
 

--- a/tests/integrations/test_rds.py
+++ b/tests/integrations/test_rds.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 from unittest.mock import patch
 
 from integrations.rds import (
@@ -13,6 +14,10 @@ from integrations.rds import (
     rds_extract_params,
     rds_is_available,
 )
+from integrations.rds.client import RDSClient
+from integrations.rds.verifier import verify_rds
+from integrations.registry import DIRECT_CLASSIFIED_EFFECTIVE_SERVICES, INTEGRATION_SPECS
+from integrations.verification import list_verifiers
 
 
 def test_build_rds_config_with_data() -> None:
@@ -170,3 +175,125 @@ def test_classify_service_instance_rds_skips_when_db_id_missing() -> None:
     )
 
     assert flat is None and resolved_key is None
+
+
+def _rds_client(identifier: str = "prod-orders-db", region: str = "us-east-1") -> RDSClient:
+    return RDSClient(RDSConfig(db_instance_identifier=identifier, region=region))
+
+
+def test_rds_spec_is_a_directly_effective_verified_integration() -> None:
+    spec = next(item for item in INTEGRATION_SPECS if item.service == "rds")
+    assert spec.has_verifier is True
+    assert spec.direct_effective is True
+    assert "rds" in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
+    assert "rds" in list_verifiers()
+
+
+def test_resolve_effective_integrations_publishes_store_configured_rds() -> None:
+    from integrations.catalog import resolve_effective_integrations
+
+    store_record = {
+        "id": "rds-1",
+        "service": "rds",
+        "status": "active",
+        "credentials": {
+            "db_instance_identifier": "prod-orders-db",
+            "region": "us-east-1",
+        },
+    }
+    resolved = resolve_effective_integrations(store_integrations=[store_record])
+    assert "rds" in resolved
+    assert resolved["rds"]["source"] == "local store"
+    assert resolved["rds"]["config"]["db_instance_identifier"] == "prod-orders-db"
+
+
+def test_probe_access_missing_identifier() -> None:
+    result = RDSClient(RDSConfig(db_instance_identifier="", region="us-east-1")).probe_access()
+    assert result.status == "missing"
+    assert "identifier" in result.detail.lower()
+
+
+def test_probe_access_success() -> None:
+    payload = {
+        "success": True,
+        "data": {
+            "DBInstances": [
+                {
+                    "DBInstanceIdentifier": "prod-orders-db",
+                    "DBInstanceStatus": "available",
+                    "Engine": "postgres",
+                }
+            ]
+        },
+        "error": None,
+    }
+    with patch(
+        "integrations.rds.client.execute_aws_sdk_call",
+        return_value=payload,
+    ) as mocked:
+        result = _rds_client().probe_access()
+
+    assert result.status == "passed"
+    assert "prod-orders-db" in result.detail
+    assert "available" in result.detail
+    mocked.assert_called_once_with(
+        service_name="rds",
+        operation_name="describe_db_instances",
+        parameters={"DBInstanceIdentifier": "prod-orders-db"},
+        region="us-east-1",
+    )
+
+
+def test_probe_access_reports_api_error() -> None:
+    with patch(
+        "integrations.rds.client.execute_aws_sdk_call",
+        return_value={
+            "success": False,
+            "error": "AWS API error (AccessDenied): not allowed",
+            "data": None,
+        },
+    ):
+        result = _rds_client().probe_access()
+
+    assert result.status == "failed"
+    assert "AccessDenied" in result.detail
+
+
+def test_probe_access_reports_missing_instance() -> None:
+    with patch(
+        "integrations.rds.client.execute_aws_sdk_call",
+        return_value={"success": True, "data": {"DBInstances": []}, "error": None},
+    ):
+        result = _rds_client().probe_access()
+
+    assert result.status == "failed"
+    assert "No RDS instance" in result.detail
+
+
+def test_verify_rds_passed_on_describe_success() -> None:
+    payload: dict[str, Any] = {
+        "success": True,
+        "data": {
+            "DBInstances": [
+                {"DBInstanceStatus": "available", "Engine": "postgres"},
+            ]
+        },
+        "error": None,
+    }
+    with patch(
+        "integrations.rds.client.execute_aws_sdk_call",
+        return_value=payload,
+    ):
+        result = verify_rds(
+            "local env",
+            {"db_instance_identifier": "prod-orders-db", "region": "eu-west-1"},
+        )
+
+    assert result["service"] == "rds"
+    assert result["status"] == "passed"
+    assert "eu-west-1" in result["detail"]
+
+
+def test_verify_rds_missing_when_identifier_blank() -> None:
+    result = verify_rds("local store", {"db_instance_identifier": "", "region": "us-east-1"})
+    assert result["status"] == "missing"


### PR DESCRIPTION
Fixes #5093

#### Describe the changes you have made in this PR -

RDS already had setup and tools, but `opensre integrations verify rds` was not a real target. This adds an RDS-owned verifier that probes `DescribeDBInstances` for the configured identifier, instead of treating STS success on `verify aws` as enough.

Same decision for the other AWS satellites: CloudWatch, CloudTrail, EC2, EKS, ELB, S3, SQS, and Lambda have no separate setup identity, so they keep verifying through `opensre integrations verify aws`. That answer is recorded on the RDS and AWS docs pages rather than opening eight issues.

`rds` is also marked `direct_effective` and added to `EffectiveIntegrations`, otherwise a configured RDS record was classified and then dropped before verify could see it.

### Demo/Screenshot for feature changes and bug fixes -

`opensre integrations verify rds` is now a supported target. On this machine RDS is not configured, so it reports missing instead of rejecting the service:

```
SERVICE │ SOURCE │ STATUS    │ DETAIL
━━━━━━━━┿━━━━━━━━┿━━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
rds     │ -      │ ⚠ missing │ Not configured in local store or environment
        │        │           │ variables.
```

With a configured identifier, the probe calls `DescribeDBInstances` and reports instance status and engine (covered by unit tests with a fixture payload).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is that `verify rds` either was unsupported or could not see a configured RDS record. Folding RDS under `verify aws` would still not check `rds:DescribeDBInstances` or the stored instance identifier, which is the whole point of RDS setup.

I followed the PagerDuty probe-verifier shape: `RDSConfig.model_validate` plus `RDSClient.probe_access()`. The probe reuses `execute_aws_sdk_call` so it stays on the same read-only allowlist as the investigation tools. Registry `has_verifier` / `direct_effective` plus an `EffectiveIntegrations.rds` field are what make the CLI actually dispatch and keep the resolved config.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

## Test plan
- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`
- [x] `uv run python -m pytest tests/integrations/test_rds.py tests/integrations/test_registry.py tests/tools/test_rds_tools.py tests/integrations/test_cli_spec_setup.py -k rds tests/integrations/test_setup_spec_env_round_trip.py tests/integrations/test_verification_registry.py tests/integrations/test_verify.py tests/integrations/test_external_registration.py`
- [x] `uv run opensre integrations verify rds` (missing when unconfigured; no longer an unknown service)

Made with [Cursor](https://cursor.com)