### PR TITLE
refactor(gitlab): declare the integration's public API with __all__

### DIFF
--- a/integrations/gitlab/__init__.py
+++ b/integrations/gitlab/__init__.py
@@ -270,3 +270,20 @@ def classify(credentials: dict[str, Any], record_id: str) -> tuple[GitlabConfig 
         report_classify_failure(exc, logger=logger, integration="gitlab", record_id=record_id)
         return None, None
     return cfg, "gitlab"
+
+
+__all__ = [
+    "DEFAULT_GITLAB_BASE_URL",
+    "GitlabConfig",
+    "GitlabValidationResult",
+    "build_gitlab_config",
+    "classify",
+    "get_gitlab_commits",
+    "get_gitlab_file",
+    "get_gitlab_mrs",
+    "get_gitlab_pipelines",
+    "gitlab_config_from_env",
+    "post_gitlab_mr_note",
+    "validate_gitlab_config",
+    "validate_gitlab_connection",
+]

--- a/tests/shared/test_integrations_api_border.py
+++ b/tests/shared/test_integrations_api_border.py
@@ -61,8 +61,6 @@ _ALLOWED: dict[str, frozenset[str]] = {
             "integrations.github.client",
             "integrations.github.helpers",
             "integrations.github.pull_requests",
-            "integrations.gitlab.build_gitlab_config",
-            "integrations.gitlab.post_gitlab_mr_note",
             "integrations.grafana.reporting_adapter",
             "integrations.llm_cli.claude_code",
             "integrations.llm_cli.subprocess_env",


### PR DESCRIPTION
refactor(gitlab): declare the integration's public API with __all__