### PR TITLE
fix(gateway): deny pending approvals at telegram shutdown

### DIFF
--- a/gateway/core/middleware/approvals.py
+++ b/gateway/core/middleware/approvals.py
@@ -50,6 +50,7 @@ class ApprovalBroker:
     def __init__(self) -> None:
         self._pending: dict[str, _PendingApproval] = {}
         self._lock = threading.Lock()
+        self._closed = False
 
     def create(
         self,
@@ -99,9 +100,14 @@ class ApprovalBroker:
         """Block for a decision; expiry counts as deny. Returns (approved, decided_by)."""
         with self._lock:
             pending = self._pending.get(approval_id)
+            closed = self._closed
         if pending is None:
             return (False, "")
-        decided = pending.event.wait(timeout)
+        # A closed broker can never receive a decision, so blocking would only
+        # hold this thread for the full timeout. Poll once instead: an approval
+        # ``close`` already denied reports that denial, and one created after it
+        # expires immediately.
+        decided = pending.event.wait(0 if closed else timeout)
         with self._lock:
             self._pending.pop(approval_id, None)
         if not decided:
@@ -115,6 +121,21 @@ class ApprovalBroker:
             )
             return (False, "")
         return (pending.approved, pending.decided_by)
+
+    def close(self) -> int:
+        """Deny every outstanding approval and refuse new ones; returns how many were pending.
+
+        Shutdown hook. Once a transport stops polling, no click or reply can
+        reach :meth:`resolve` any more, so a waiter would hold its executor
+        thread until ``MAX_APPROVAL_WAIT_SECONDS``. Denying returns those turns
+        to the loop at once, in time to post the outcome they owe the chat.
+        """
+        with self._lock:
+            self._closed = True
+            approval_ids = list(self._pending)
+        return sum(
+            self.resolve(approval_id, approved=False, decided_by="") for approval_id in approval_ids
+        )
 
 
 class ApprovalPrompter(Protocol):

--- a/gateway/tests/runtime/test_approval_broker_close.py
+++ b/gateway/tests/runtime/test_approval_broker_close.py
@@ -1,0 +1,29 @@
+"""A closed approval broker must never park a turn on a decision that cannot arrive."""
+
+from __future__ import annotations
+
+import time
+
+from gateway.core.middleware.approvals import MAX_APPROVAL_WAIT_SECONDS, ApprovalBroker
+
+
+def test_approval_requested_after_close_fails_closed_without_waiting() -> None:
+    """The turn a shutdown denial releases can ask again; that ask must not block.
+
+    ``close()`` unblocks the waiters it can see, but the released turn runs on
+    to its next tool call. Without the closed guard that second approval waits
+    the full expiry and holds the executor thread shutdown is trying to join.
+    """
+    # Arrange
+    broker = ApprovalBroker()
+    broker.close()
+
+    # Act
+    approval_id = broker.create(platform="telegram", chat_id="chat-1")
+    started = time.monotonic()
+    approved, decided_by = broker.wait(approval_id, timeout=MAX_APPROVAL_WAIT_SECONDS)
+    elapsed = time.monotonic() - started
+
+    # Assert
+    assert (approved, decided_by) == (False, "")
+    assert elapsed < 1.0, "closed broker still blocked on a decision that cannot arrive"

--- a/gateway/tests/telegram/test_background.py
+++ b/gateway/tests/telegram/test_background.py
@@ -4,12 +4,13 @@ import asyncio
 import logging
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from gateway.core.middleware.active_turns import ActiveTurnRegistry
-from gateway.core.middleware.approvals import ApprovalBroker
+from gateway.core.middleware.approvals import MAX_APPROVAL_WAIT_SECONDS, ApprovalBroker
 from gateway.transports.telegram import background
 from gateway.transports.telegram.background import start_telegram_gateway_background
 from gateway.transports.telegram.poller.poller import TelegramPollResult
@@ -281,3 +282,59 @@ async def test_stop_in_same_batch_cancels_the_turn_dispatched_before_it() -> Non
     # and the turn itself observed the cancellation.
     assert resources.client.send_message.call_args_list == []
     assert cancel_seen == [True]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_releases_a_turn_blocked_on_an_approval() -> None:
+    """A turn parked in ``ApprovalBroker.wait`` must be denied, not left to expire.
+
+    Setting the cancel Event does not reach a thread already blocked inside
+    ``wait``: polling has stopped, so no click can arrive, and the executor
+    thread would sit there for ``MAX_APPROVAL_WAIT_SECONDS`` while
+    ``executor.shutdown(wait=True)`` blocks far past the stop budget.
+    """
+    # Arrange — a real executor and a real broker; an asyncio-level fake turn
+    # would not hold the thread that the bug leaks.
+    poller = _FakePoller([TelegramPollResult(messages=[_message()])])
+    resources = _resources()
+    executor = ThreadPoolExecutor(max_workers=1)
+    resources.executor = executor
+    waiting = threading.Event()
+    decisions: list[tuple[bool, str]] = []
+
+    def _block_on_approval(broker: ApprovalBroker) -> None:
+        approval_id = broker.create(platform="telegram", chat_id="chat-1")
+        waiting.set()
+        decisions.append(broker.wait(approval_id, timeout=MAX_APPROVAL_WAIT_SECONDS))
+
+    async def _turn_awaiting_approval(_event, *, approvals, loop, **_kwargs) -> None:
+        await loop.run_in_executor(executor, _block_on_approval, approvals)
+
+    stop_event = threading.Event()
+
+    try:
+        with (
+            patch.object(background, "TelegramPoller", lambda _token: poller),
+            patch.object(
+                background, "handle_polled_inbound_telegram_message", _turn_awaiting_approval
+            ),
+        ):
+            loop_task = _run_loop(
+                resources=resources, stop_event=stop_event, shutdown_drain_seconds=2.0
+            )
+            await _wait_until(waiting.is_set)
+
+            # Act — shut down while the turn is blocked on the approval.
+            stop_event.set()
+            await asyncio.wait_for(loop_task, timeout=5.0)
+            # Snapshot before the teardown below, which would otherwise hand
+            # the waiter the very denial this test is asserting the drain sent.
+            decided_during_shutdown = list(decisions)
+    finally:
+        # Release the thread even if the drain left it blocked, so a failure
+        # reports in seconds instead of hanging the suite for the full expiry.
+        resources.approvals.close()
+        executor.shutdown(wait=False)
+
+    # Assert — the turn came back with a denial it can report, inside the drain.
+    assert decided_during_shutdown == [(False, "")]

--- a/gateway/transports/telegram/background.py
+++ b/gateway/transports/telegram/background.py
@@ -124,7 +124,7 @@ async def _poll_telegram_until_stopped(
             logger.error("Error while polling Telegram updates", exc_info=True)
             await asyncio.to_thread(stop_event.wait, 2)
 
-    await _drain_active_turns(pending_turns, settings=settings, logger=logger)
+    await _drain_active_turns(pending_turns, resources=resources, settings=settings, logger=logger)
 
 
 async def _dispatch_turn(
@@ -172,17 +172,29 @@ async def _dispatch_turn(
 async def _drain_active_turns(
     pending_turns: dict[asyncio.Task[None], threading.Event],
     *,
+    resources: TelegramPollingRuntime,
     settings: GatewaySettings,
     logger: logging.Logger,
 ) -> None:
     """Let in-flight turns finish before ``asyncio.run`` closes the loop.
 
-    Bounded: polling has stopped, so no click can resolve an approval wait any
-    more. Whatever misses ``shutdown_drain_seconds`` has its cancel Event set
+    Outstanding approvals are denied first: polling has stopped, so no click
+    can resolve one, and the waiting turn holds an executor thread that
+    ``executor.shutdown(wait=True)`` would then block on well past the stop
+    budget. Denying hands those turns back to the loop in time to tell the
+    chat the action was skipped.
+
+    Whatever still misses ``shutdown_drain_seconds`` has its cancel Event set
     before its task is cancelled — the turn body runs on the executor, which
-    cancelling the awaiting task does not reach, so only the Event stops it in
-    time for ``executor.shutdown(wait=True)``.
+    cancelling the awaiting task does not reach.
     """
+    denied = resources.approvals.close()
+    if denied:
+        logger.warning(
+            "[telegram-gateway] denied %d approval(s) still waiting at shutdown",
+            denied,
+        )
+
     if not pending_turns:
         return
 


### PR DESCRIPTION
Follow-up to #5218. The P1 Greptile left on it was never addressed before that PR merged.

#### Describe the changes you have made in this PR -

A turn parked in `ApprovalBroker.wait` is blocked on a decision that only a button click delivers. By the time the drain runs, polling has stopped, so that click can never arrive. Setting `turn_cancel` and cancelling the asyncio task do not reach the blocked thread, because the turn body runs on the executor.

Telegram is the one transport that shuts its executor down with `wait=True`. So that thread pinned the worker for up to `MAX_APPROVAL_WAIT_SECONDS` (180s) against an 8s stop budget, `stop()` reported failure, and the user never heard that their action had been skipped.

`ApprovalBroker.close()` denies everything still outstanding and refuses new requests, so the released turn's next approval fails closed instead of parking again. The Telegram drain calls it before it waits. Buzz already does this through its own pending-approval registry; this puts the same guarantee on the broker, where any transport can reach it.

The drain docstring claimed the cancel Event stopped the turn body in time. It does not in this case, so I rewrote it.

### Demo/Screenshot for feature changes and bug fixes -

One turn parked on an approval, then an operator stops the gateway. Same script both ways.

Before:

```
[telegram-gateway] shutting down with 1 unfinished turn(s)
turn is parked on an approval; operator now stops the gateway

gateway.stop() returned : False
took                    : 8.01s (budget 8.00s)
turn outcome            : never came back
```

After:

```
[telegram-gateway] denied 1 approval(s) still waiting at shutdown
turn is parked on an approval; operator now stops the gateway

gateway.stop() returned : True
took                    : 0.05s (budget 8.00s)
turn outcome            : ['denied -> told the chat it was skipped']
```

Checks: ruff, format, mypy (1925 files), gateway suite 804 passed, and the full `integrations-and-misc` shard that carries `gateway/tests` at 5844 passed / 24 skipped.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a lock ordering problem in disguise. `wait()` blocks on one thing, the approval's `threading.Event`, and only `resolve()` sets it. `resolve()` is reachable only from a callback delivered by the poll loop. Shutdown stops the poll loop first, so from that moment the waiter is unreachable and its 180s timeout is the only exit.

I considered passing `turn_cancel` down into the prompter and waiting on both events. I did not do that: the prompter is per transport and there are four of them, so the fix would have to be repeated, and it would leave `wait()` still able to block on a broker nobody can reach. Denying at the broker fixes it once for every transport.

`close()` does two things, and the second matters more than it looks. It denies what is currently pending, which unblocks the waiters. It also sets `_closed`, so an approval created *after* the sweep resolves immediately instead of parking for another 180s. That case is real: a denied turn goes back to the agent loop and can reach another write tool before the drain window ends.

`wait()` polls with `wait(0)` rather than skipping the wait outright, so an approval that `close()` already denied reports that denial instead of logging a second audit row as an expiry.

The two tests cover the two distinct failure modes. The background test uses a real executor and a real broker, because the existing shutdown test fakes the turn at the asyncio level and that is exactly why this survived review. It snapshots the decision at drain completion, since the teardown that releases a stuck thread would otherwise hand the waiter the very denial the test asserts. The broker test covers the second approval, which the background test cannot reach.

I checked the other transports. Buzz and Discord shut down with `wait=False` and Slack bounds the join with a timer thread, so Telegram was the only one that could hang. I left Buzz alone rather than rewrite a working sibling in a fix PR.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
