### PR TITLE
refactor(session-goal): rename progress paint symbols (#5628)

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -39,9 +39,9 @@ complete via `done=` indices; condition-only handoff goals need
 `session_goal:achieved` **with tool evidence** (bare `achieved` ignored);
 **host-owned** (`/goal set`) condition-only goals may achieve on the tag alone
 (explicit slash-path rule). Host reason strings live in `SessionGoalReason` —
-never embed `session_goal:…` tag grammar in painted reasons. Reason derive:
-`session_goal.goal.derive_session_goal_reason`. Paint (presentation only):
-`session_goal/progress.py` (`SESSION_GOAL_PAINT_MARK`). Continuation prompts:
+never embed `session_goal:…` tag grammar in progress reasons. Reason derive:
+`session_goal.goal.derive_session_goal_reason`. Progress (presentation only):
+`session_goal/progress.py` (`SESSION_GOAL_PROGRESS_MARK`). Continuation prompts:
 `session_goal/continuation.py`. Flush/restore: `session_goal/persist.py`. Optional LLM
 confirm for the tool-evidence path: `build_session_goal_llm_evaluator` in
 `session_goal/confirm.py` (pass as `evaluate=` to the session-goal loop) —

--- a/core/agent_harness/session_goal/AGENTS.md
+++ b/core/agent_harness/session_goal/AGENTS.md
@@ -10,7 +10,7 @@ Host-scoped completion across many `chat` turns. **Not** the ReAct
 | `goal.py` | `SessionGoal`, statuses/reasons, attach/clear, reason derive |
 | `evaluate.py` | Structured host completion (claim ≠ proof) |
 | `confirm.py` | Optional LLM confirm after tool-evidence achieve |
-| `progress.py` | `SESSION_GOAL_PAINT_MARK` + progress / status-line formatting |
+| `progress.py` | `SESSION_GOAL_PROGRESS_MARK` + progress / status-line formatting |
 | `continuation.py` | Session-goal continuation prompts |
 | `persist.py` | Flush / restore payload |
 | `run_until.py` | `run_until_session_goal` |

--- a/core/agent_harness/session_goal/__init__.py
+++ b/core/agent_harness/session_goal/__init__.py
@@ -40,7 +40,7 @@ from core.agent_harness.session_goal.goal import (
     strip_shell_prompt_chrome,
 )
 from core.agent_harness.session_goal.progress import (
-    SESSION_GOAL_PAINT_MARK,
+    SESSION_GOAL_PROGRESS_MARK,
     SESSION_GOAL_USER_WORD,
     format_session_goal_progress,
     format_session_goal_status_line,
@@ -50,7 +50,7 @@ from core.agent_harness.session_goal.run_until import SessionGoalRunResult, run_
 __all__ = [
     "MAX_GOAL_CONDITION_CHARS",
     "MAX_GOAL_REASON_CHARS",
-    "SESSION_GOAL_PAINT_MARK",
+    "SESSION_GOAL_PROGRESS_MARK",
     "SESSION_GOAL_USER_WORD",
     "SessionGoal",
     "SessionGoalReason",

--- a/core/agent_harness/session_goal/evaluate.py
+++ b/core/agent_harness/session_goal/evaluate.py
@@ -47,7 +47,7 @@ from core.agent_harness.session_goal.goal import (
     apply_session_goal_progress,
     attach_session_goal,
 )
-from core.agent_harness.session_goal.progress import is_session_goal_progress_paint
+from core.agent_harness.session_goal.progress import is_session_goal_progress_text
 from core.agent_harness.turns.cohort_identity import (
     goal_needs_cohort_identity,
     reply_reports_cohort_unverified,
@@ -57,7 +57,7 @@ from core.agent_harness.turns.cohort_identity import (
 _ACHIEVED_CLAIM = re.compile(r"session_goal:achieved")
 
 # Pre-fix host reasons embedded the tag grammar; neutralize before scanning so
-# old painted status text cannot look like a claim.
+# old progress status text cannot look like a claim.
 _LEGACY_WAITING_WITH_TAG = (
     "waiting for session_goal:achieved with tool evidence",
     "waiting for session_goal:achieved",
@@ -87,7 +87,7 @@ def reply_claims_session_goal_achieved(text: str) -> bool:
     """True when ``text`` contains a real ``session_goal:achieved`` progress tag.
 
     Host status reasons never embed tag grammar (:class:`SessionGoalReason`).
-    Legacy painted phrases that did are stripped before the token scan.
+    Legacy progress phrases that did are stripped before the token scan.
     """
     if not text:
         return False
@@ -156,9 +156,9 @@ def _same_turn_completable(goal: SessionGoal) -> bool:
     return len(goal.checklist) <= _SAME_TURN_CHECKLIST_MAX_ITEMS
 
 
-def _reply_is_nonempty_and_not_progress_paint(text: str) -> bool:
+def _reply_is_nonempty_and_not_progress_text(text: str) -> bool:
     """True when the assistant reply is real content, not ``/goal`` status chrome."""
-    return bool(text.strip()) and not is_session_goal_progress_paint(text)
+    return bool(text.strip()) and not is_session_goal_progress_text(text)
 
 
 def _short_checklist_has_achieved_claim_and_tool_evidence(
@@ -209,7 +209,7 @@ def _host_owned_goal_has_unverified_cohort_reply(goal: SessionGoal, text: str) -
     """
     return (
         goal.host_owned
-        and _reply_is_nonempty_and_not_progress_paint(text)
+        and _reply_is_nonempty_and_not_progress_text(text)
         and goal_needs_cohort_identity(goal.condition)
         and reply_reports_cohort_unverified(text)
     )
@@ -226,7 +226,7 @@ def _host_owned_goal_has_tool_evidence_and_answer_reply(
     Do not wait for ``session_goal:achieved`` — that tag is scrubbed from the
     visible reply and models often omit it.
     """
-    return goal.host_owned and has_evidence and _reply_is_nonempty_and_not_progress_paint(text)
+    return goal.host_owned and has_evidence and _reply_is_nonempty_and_not_progress_text(text)
 
 
 def evaluate_session_goal(

--- a/core/agent_harness/session_goal/goal.py
+++ b/core/agent_harness/session_goal/goal.py
@@ -48,10 +48,10 @@ class SessionGoalStatus:
 
 
 class SessionGoalReason:
-    """Stable host reason strings for evaluate, paint, and LLM confirm.
+    """Stable host reason strings for evaluate and LLM confirm.
 
     Call sites compare with ``==`` / helpers — do not invent parallel phrases.
-    Never embed ``session_goal:…`` tag grammar here: painted reasons can land in
+    Never embed ``session_goal:…`` tag grammar here: progress reasons can land in
     captured reply text and must not look like progress claims.
     """
 
@@ -138,7 +138,7 @@ class SessionGoal:
     step_count: int | None = None
     checklist: tuple[str, ...] = ()
     completed: frozenset[int] = frozenset()
-    # Last host/evaluator reason shown in progress paint and continuation nudges.
+    # Last host/evaluator reason shown in progress output and continuation nudges.
     last_reason: str = ""
     # What earlier turns established, oldest first. Continuations are fresh
     # ``chat`` calls and history carries prose only, so without this a later
@@ -151,7 +151,7 @@ class SessionGoal:
     # the number by another route and reported a different one with no mention
     # of the first.
     last_answer: str = ""
-    # Wall-clock start for ``/goal`` duration paint (``time.time()``).
+    # Wall-clock start for ``/goal`` duration progress (``time.time()``).
     started_at: float | None = None
     # Session token totals when the goal was attached — delta is goal spend.
     token_baseline_input: int = 0
@@ -518,7 +518,7 @@ def strip_shell_prompt_chrome(text: str) -> str:
 def derive_session_goal_reason(goal: SessionGoal) -> str:
     """Structured reason from goal state (no LLM).
 
-    Used by evaluate/paint/nudge so hosts stay honest and cheap. Returns a
+    Used by evaluate/progress/nudge so hosts stay honest and cheap. Returns a
     :class:`SessionGoalReason` string — never tag grammar.
     """
     if goal.status == SessionGoalStatus.ACHIEVED:

--- a/core/agent_harness/session_goal/progress.py
+++ b/core/agent_harness/session_goal/progress.py
@@ -21,8 +21,8 @@ from core.agent_harness.session_goal.goal import (
 from infrastructure.evidence.evidence_compaction import truncate_message
 
 # Leading mark for user-visible ``/goal`` progress lines (REPL + gateway).
-SESSION_GOAL_PAINT_MARK = "◎"
-# User-facing slash name — paint never says ``SessionGoal``.
+SESSION_GOAL_PROGRESS_MARK = "◎"
+# User-facing slash name — progress text never says ``SessionGoal``.
 SESSION_GOAL_USER_WORD = "/goal"
 
 # Status-line condition shares a Slack/Telegram timeline row with status,
@@ -79,7 +79,7 @@ def _progress_headline_active_or_paused(
         output_tokens=output_tokens,
     )
     token_text = format_token_count_compact(tokens)
-    mark = SESSION_GOAL_PAINT_MARK
+    mark = SESSION_GOAL_PROGRESS_MARK
     word = SESSION_GOAL_USER_WORD
     if label == "active" and SessionGoalReason.is_working(reason):
         return (
@@ -100,7 +100,7 @@ def format_session_goal_progress(
     input_tokens: int | None = None,
     output_tokens: int | None = None,
 ) -> str:
-    """Multi-line progress paint for REPL mid-loop updates and ``/goal show``."""
+    """Multi-line progress text for REPL mid-loop updates and ``/goal show``."""
     reason = goal.last_reason.strip() or derive_session_goal_reason(goal)
     status = goal.status
     if status == SessionGoalStatus.ACTIVE:
@@ -125,7 +125,7 @@ def format_session_goal_progress(
         )
     else:
         headline = (
-            f"{SESSION_GOAL_PAINT_MARK} {SESSION_GOAL_USER_WORD} {status} · "
+            f"{SESSION_GOAL_PROGRESS_MARK} {SESSION_GOAL_USER_WORD} {status} · "
             f"turn {goal.turns_used}/{goal.max_outer_turns}"
         )
     lines = [
@@ -156,7 +156,7 @@ def format_session_goal_status_line(
     reason = goal.last_reason.strip() or derive_session_goal_reason(goal)
     condition = goal.condition.strip()
     condition = truncate_message(condition, _MAX_STATUS_LINE_CONDITION_CHARS)
-    mark = SESSION_GOAL_PAINT_MARK
+    mark = SESSION_GOAL_PROGRESS_MARK
     word = SESSION_GOAL_USER_WORD
     if goal.status == SessionGoalStatus.ACTIVE:
         elapsed = session_goal_elapsed_seconds(goal, now=now)
@@ -180,11 +180,11 @@ def format_session_goal_status_line(
     )
 
 
-def is_session_goal_progress_paint(text: str) -> bool:
+def is_session_goal_progress_text(text: str) -> bool:
     """True when ``text`` is ``/goal`` status chrome, not an assistant answer.
 
     The ``/goal set`` attach turn may run ``slash_invoke`` (counts as tool
-    evidence) and capture the painted status block as the turn "reply". Host
+    evidence) and capture the progress status block as the turn "reply". Host
     evaluate must not treat that as a completed answer.
     """
     stripped = text.strip()
@@ -192,16 +192,16 @@ def is_session_goal_progress_paint(text: str) -> bool:
         return False
     if SessionGoalReason.WAITING_HOST_SIGNAL in stripped:
         return True
-    paint_lead = f"{SESSION_GOAL_PAINT_MARK} {SESSION_GOAL_USER_WORD}"
-    return paint_lead in stripped
+    progress_lead = f"{SESSION_GOAL_PROGRESS_MARK} {SESSION_GOAL_USER_WORD}"
+    return progress_lead in stripped
 
 
 __all__ = [
-    "SESSION_GOAL_PAINT_MARK",
+    "SESSION_GOAL_PROGRESS_MARK",
     "SESSION_GOAL_USER_WORD",
     "format_duration_compact",
     "format_session_goal_progress",
     "format_session_goal_status_line",
     "format_token_count_compact",
-    "is_session_goal_progress_paint",
+    "is_session_goal_progress_text",
 ]

--- a/surfaces/interactive_shell/command_registry/session_cmds/goal.py
+++ b/surfaces/interactive_shell/command_registry/session_cmds/goal.py
@@ -1,8 +1,8 @@
 """/goal slash command: show|set|pause|resume|edit|clear.
 
 ``/goal set`` attaches a completion condition and immediately queues that
-condition as the next turn (autosubmit). Status shows the paint progress line
-(``SESSION_GOAL_PAINT_MARK`` + ``/goal active``) with duration, turn budget,
+condition as the next turn (autosubmit). Status shows the progress line
+(``SESSION_GOAL_PROGRESS_MARK`` + ``/goal active``) with duration, turn budget,
 and token delta. User-facing copy never says ``SessionGoal`` — only ``/goal``.
 """
 

--- a/tests/core/agent_harness/session_goal/test_evaluate.py
+++ b/tests/core/agent_harness/session_goal/test_evaluate.py
@@ -72,7 +72,7 @@ def test_waiting_for_reason_is_not_an_achieved_claim() -> None:
         )
         is False
     )
-    # Legacy painted reasons that embedded the tag literal.
+    # Legacy progress reasons that embedded the tag literal.
     assert reply_claims_session_goal_achieved("waiting for session_goal:achieved") is False
     assert (
         reply_claims_session_goal_achieved(
@@ -85,7 +85,7 @@ def test_waiting_for_reason_is_not_an_achieved_claim() -> None:
 def test_slash_capture_waiting_reason_does_not_achieve_host_goal() -> None:
     """Regression: /goal set turn captured status text and falsely achieved."""
     from core.agent_harness.session_goal.progress import (
-        SESSION_GOAL_PAINT_MARK,
+        SESSION_GOAL_PROGRESS_MARK,
         SESSION_GOAL_USER_WORD,
     )
 
@@ -96,14 +96,14 @@ def test_slash_capture_waiting_reason_does_not_achieve_host_goal() -> None:
         host_owned=True,
     )
     attach_session_goal(session, goal)
-    paint = (
-        f"{SESSION_GOAL_PAINT_MARK} {SESSION_GOAL_USER_WORD} active · 0s · turn 0/4 · +0 tokens\n"
+    progress_text = (
+        f"{SESSION_GOAL_PROGRESS_MARK} {SESSION_GOAL_USER_WORD} active · 0s · turn 0/4 · +0 tokens\n"
         "  condition: How many Windows users?\n"
         f"  reason: {SessionGoalReason.WAITING_HOST_SIGNAL}"
     )
     verdict = evaluate_session_goal(
         goal,
-        _result(paint, executed=1, success=1),
+        _result(progress_text, executed=1, success=1),
         session=session,
     )
     assert verdict.status == SessionGoalStatus.ACTIVE
@@ -723,7 +723,7 @@ def test_llm_reject_survives_outer_loop_session_reread() -> None:
             return []
 
     session = SessionCore()
-    paints: list[str] = []
+    progress_updates: list[str] = []
 
     def _chat(message: str) -> TurnResult:
         _ = message
@@ -735,18 +735,18 @@ def test_llm_reject_survives_outer_loop_session_reread() -> None:
         "go",
         goal=SessionGoal(condition="finish migration", max_outer_turns=2),
         evaluate=build_session_goal_llm_evaluator(_LLM()),  # type: ignore[arg-type]
-        on_progress=lambda g: paints.append(g.status),
+        on_progress=lambda g: progress_updates.append(g.status),
     )
 
     assert outcome.goal.status == SessionGoalStatus.BUDGET_EXHAUSTED
-    assert SessionGoalStatus.ACHIEVED not in paints
+    assert SessionGoalStatus.ACHIEVED not in progress_updates
     assert session.session_goal is not None
     assert session.session_goal.status == SessionGoalStatus.BUDGET_EXHAUSTED
 
 
-def test_budget_exhaustion_paints_once() -> None:
+def test_budget_exhaustion_reports_progress_once() -> None:
     session = SessionCore()
-    paints: list[str] = []
+    progress_updates: list[str] = []
 
     def _chat(message: str) -> TurnResult:
         _ = message
@@ -757,12 +757,14 @@ def test_budget_exhaustion_paints_once() -> None:
         session,
         "go",
         goal=SessionGoal(condition="never done", max_outer_turns=1, host_owned=True),
-        on_progress=lambda g: paints.append(f"{g.status}:{g.last_reason}"),
+        on_progress=lambda g: progress_updates.append(f"{g.status}:{g.last_reason}"),
     )
 
     assert outcome.goal.status == SessionGoalStatus.BUDGET_EXHAUSTED
-    budget_paints = [p for p in paints if p.startswith(SessionGoalStatus.BUDGET_EXHAUSTED)]
-    assert len(budget_paints) == 1
+    budget_updates = [
+        p for p in progress_updates if p.startswith(SessionGoalStatus.BUDGET_EXHAUSTED)
+    ]
+    assert len(budget_updates) == 1
 
 
 def test_llm_evaluator_confirms_soft_achieve() -> None:

--- a/tests/core/agent_harness/session_goal/test_evaluate_predicates.py
+++ b/tests/core/agent_harness/session_goal/test_evaluate_predicates.py
@@ -8,7 +8,7 @@ from core.agent_harness.session_goal.evaluate import (
     _host_owned_achieved_claim_lacks_tool_evidence,
     _host_owned_goal_has_tool_evidence_and_answer_reply,
     _host_owned_goal_has_unverified_cohort_reply,
-    _reply_is_nonempty_and_not_progress_paint,
+    _reply_is_nonempty_and_not_progress_text,
     _short_checklist_has_achieved_claim_and_tool_evidence,
     _short_checklist_has_no_prior_progress_and_tool_answer,
 )
@@ -31,12 +31,12 @@ def _goal(
     )
 
 
-def test_reply_is_nonempty_and_not_progress_paint() -> None:
-    assert _reply_is_nonempty_and_not_progress_paint("D7 retention is unavailable.") is True
-    assert _reply_is_nonempty_and_not_progress_paint("   ") is False
-    assert _reply_is_nonempty_and_not_progress_paint("") is False
-    paint = "◎ /goal active\n  reason: waiting for host signal"
-    assert _reply_is_nonempty_and_not_progress_paint(paint) is False
+def test_reply_is_nonempty_and_not_progress_text() -> None:
+    assert _reply_is_nonempty_and_not_progress_text("D7 retention is unavailable.") is True
+    assert _reply_is_nonempty_and_not_progress_text("   ") is False
+    assert _reply_is_nonempty_and_not_progress_text("") is False
+    progress_text = "◎ /goal active\n  reason: waiting for host signal"
+    assert _reply_is_nonempty_and_not_progress_text(progress_text) is False
 
 
 def test_host_owned_goal_has_unverified_cohort_reply_requires_all_parts() -> None:

--- a/tests/core/agent_harness/session_goal/test_progress.py
+++ b/tests/core/agent_harness/session_goal/test_progress.py
@@ -330,18 +330,18 @@ def test_attach_session_goal_strips_prompt_chrome_from_condition() -> None:
     assert attached.condition == ("what windows users number did open opensre during last 7 days?")
 
 
-def test_is_session_goal_progress_paint_uses_paint_constants() -> None:
+def test_is_session_goal_progress_text_uses_progress_constants() -> None:
     from core.agent_harness.session_goal.goal import SessionGoalReason
     from core.agent_harness.session_goal.progress import (
-        SESSION_GOAL_PAINT_MARK,
+        SESSION_GOAL_PROGRESS_MARK,
         SESSION_GOAL_USER_WORD,
-        is_session_goal_progress_paint,
+        is_session_goal_progress_text,
     )
 
-    paint = (
-        f"{SESSION_GOAL_PAINT_MARK} {SESSION_GOAL_USER_WORD} active · 0s · turn 0/4\n"
+    progress_text = (
+        f"{SESSION_GOAL_PROGRESS_MARK} {SESSION_GOAL_USER_WORD} active · 0s · turn 0/4\n"
         f"  reason: {SessionGoalReason.WAITING_HOST_SIGNAL}"
     )
-    assert is_session_goal_progress_paint(paint) is True
-    assert is_session_goal_progress_paint(SessionGoalReason.WAITING_HOST_SIGNAL) is True
-    assert is_session_goal_progress_paint("272 Windows users last 7 days.") is False
+    assert is_session_goal_progress_text(progress_text) is True
+    assert is_session_goal_progress_text(SessionGoalReason.WAITING_HOST_SIGNAL) is True
+    assert is_session_goal_progress_text("272 Windows users last 7 days.") is False


### PR DESCRIPTION
Fixes #5628

#### Describe the changes you have made in this PR -

This PR renames the SessionGoal progress-related "paint" terminology to "progress" terminology for better consistency and clarity.

Changes made:
- Renamed `SESSION_GOAL_PAINT_MARK` to `SESSION_GOAL_PROGRESS_MARK`.
- Renamed `is_session_goal_progress_paint` to `is_session_goal_progress_text`.
- Renamed `_reply_is_nonempty_and_not_progress_paint` to `_reply_is_nonempty_and_not_progress_text`.
- Updated all related imports, exports, usages, tests, and documentation references.
- Updated contributor documentation to remove outdated terminology.

No behavior changes were introduced. The user-facing progress mark (`◎`) remains unchanged.

### Demo/Screenshot for feature changes and bug fixes -

Test result:

```text
uv run pytest tests/core/agent_harness/session_goal/ -q

110 passed in 1.03s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [x] Yes, I used AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code
* [ ] No, I wrote all the code myself

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This change is a terminology refactor without changing runtime behavior.

The implementation approach was:

1. Identify all public symbols and internal references related to SessionGoal progress paint terminology.
2. Rename the symbols to use "progress" terminology:

   * `SESSION_GOAL_PROGRESS_MARK`
   * `is_session_goal_progress_text`
   * `_reply_is_nonempty_and_not_progress_text`
3. Update all imports, exports, call sites, tests, and documentation references.
4. Keep the existing output format unchanged, including the `◎` progress marker.

The main components affected are:

* `progress.py`: owns SessionGoal progress formatting and detection logic.
* `evaluate.py`: determines whether assistant replies contain real content or SessionGoal progress output.
* Related tests: verify the renamed APIs continue to preserve existing behavior.

The alternative approach considered was keeping backward-compatible aliases for the old names, but this would preserve the outdated terminology and was unnecessary because this is an internal rename.

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] I can explain the purpose of every function, class, and logic block I added
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [x] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.