### PR TITLE
test(tools): assert description contract for every registered tool

### DIFF
--- a/tests/tools/test_description_contract.py
+++ b/tests/tools/test_description_contract.py
@@ -1,0 +1,241 @@
+"""Description contract for every registered tool.
+
+A tool's description is the model's primary signal for choosing it among the
+~290 tools offered together. This suite pins a minimum quality bar so a tool
+cannot enter the registry with an unusable description.
+
+Existing violators are quarantined in a shrink-only allowlist (issue #5498).
+The allowlist is compared exactly against the live violator set: a tool that
+gets fixed MUST be removed (the ratchet test fails on a stale entry), and a
+new violator fails immediately. Rewriting descriptions is explicitly out of
+scope — the allowlist is the measured backlog.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import pytest
+
+from core.tool import RegisteredTool
+from tools import registry as registry_module
+
+# Mirrors tools/registry_skill_guidance.py:_MAX_TOOL_SKILL_GUIDANCE_CHARS.
+_MAX_TOOL_SKILL_GUIDANCE_CHARS = 2400
+
+# A description shorter than this gives the model too little signal to pick the
+# tool among ~290 siblings. The shortest live description is 31 chars, so this
+# floor catches only genuinely stub descriptions.
+_MIN_DESCRIPTION_CHARS = 20
+
+# Placeholders a developer leaves when the real description is not yet written.
+# Anchored at the start so legitimate mid-sentence uses (e.g. "a todo list
+# tool", "placeholder quoted text") are not false-flagged.
+_PLACEHOLDER_RE = re.compile(
+    r"^(TODO|TBD|FIXME|description here|placeholder|lorem ipsum)\b",
+    re.IGNORECASE,
+)
+
+# Credential shapes that must never ship in a tool description (visible to the
+# model and to transcript readers). Only high-confidence token shapes are
+# matched so a legitimate description is not blocked by a short lookalike.
+_SECRET_RE = re.compile(
+    r"(sk-[A-Za-z0-9]{20,}"
+    r"|AKIA[0-9A-Z]{16}"
+    r"|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"
+    r"|gh[pousr]_[A-Za-z0-9]{36,})",
+    re.IGNORECASE,
+)
+
+# Today's production tool count. Discovery swallows import errors, so a silently
+# short registry would make every per-tool check pass by testing nothing. This
+# floor fails loud when the registry shrinks; raise it when the registry grows.
+_MIN_REGISTRY_SIZE = 290
+
+#: Tools that currently violate at least one description-contract rule.
+#: Compared exactly against the live violator set — a fixed tool MUST be removed
+#: (the ratchet test fails on a stale entry), and a new violator MUST be fixed,
+#: never appended. Each entry is per-integration backlog work tracked under
+#: issue #5498; rewriting descriptions is out of scope for that issue.
+_DESCRIPTION_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "alert_sample",
+        "assistant_handoff",
+        "cli_exec",
+        "code_implement",
+        "fix_sentry_issue_start",
+        "get_dagster_run_logs",
+        "get_mariadb_global_status",
+        "get_mariadb_innodb_status",
+        "get_mariadb_process_list",
+        "get_mariadb_replication_status",
+        "get_mariadb_slow_queries",
+        "get_mongodb_atlas_alerts",
+        "get_mongodb_atlas_cluster_events",
+        "get_mongodb_atlas_cluster_metrics",
+        "get_mongodb_atlas_clusters",
+        "get_mongodb_atlas_performance_advisor",
+        "get_mongodb_collection_stats",
+        "get_mongodb_current_ops",
+        "get_mongodb_profiler_data",
+        "get_mongodb_replica_status",
+        "get_mongodb_server_status",
+        "inspect_railway_deployment",
+        "investigation_start",
+        "list_dagster_assets",
+        "list_dagster_runs",
+        "list_dagster_schedule_ticks",
+        "list_dagster_sensor_ticks",
+        "llm_set_provider",
+        "memory_forget",
+        "memory_recall",
+        "redeploy_railway_service",
+        "replay_slack_thread_locally",
+        "run_investigation",
+        "shell_run",
+        "skill_view",
+        "slash_invoke",
+        "synthetic_run",
+        "task_cancel",
+        "work_task_complete",
+        "work_task_list",
+        "work_task_prioritize",
+        "work_task_update",
+    }
+)
+
+
+def _production_tool_names() -> tuple[str, ...]:
+    """Every tool name in the production registry (external packages excluded).
+
+    Other tests register bench/external tool packages as a side effect; those
+    extra tools would inflate the parametrize set and break the ratchet. Snapshot
+    the production registry in isolation so the IDs cannot go stale.
+    """
+    saved = list(registry_module._external_tool_packages)
+    registry_module._external_tool_packages.clear()
+    registry_module.clear_tool_registry_cache()
+    try:
+        return tuple(tool.name for tool in registry_module._load_registry_snapshot())
+    finally:
+        registry_module._external_tool_packages[:] = saved
+        registry_module.clear_tool_registry_cache()
+
+
+@pytest.fixture(autouse=True)
+def _clean_production_registry() -> Iterator[None]:
+    """Pin a production-only registry around each check.
+
+    Bench and external tool packages registered by other tests would widen the
+    violator set (breaking the ratchet) or shift the floor count. Each check
+    reads a production-only snapshot so the result is stable regardless of test
+    run order.
+    """
+    saved = list(registry_module._external_tool_packages)
+    registry_module._external_tool_packages.clear()
+    registry_module.clear_tool_registry_cache()
+    yield
+    registry_module._external_tool_packages[:] = saved
+    registry_module.clear_tool_registry_cache()
+
+
+def _sources_with_siblings(tools: tuple[RegisteredTool, ...]) -> frozenset[str]:
+    """Source values that back more than one tool — those tools are siblings.
+
+    When a source has siblings the model needs ``use_cases`` to disambiguate
+    which one to pick, so a single-tool source is exempt from that rule.
+    """
+    counts: dict[str, int] = {}
+    for tool in tools:
+        counts[str(tool.source)] = counts.get(str(tool.source), 0) + 1
+    return frozenset(src for src, count in counts.items() if count > 1)
+
+
+def _description_contract_violations(
+    tool: RegisteredTool,
+    *,
+    sibling_sources: frozenset[str],
+) -> list[str]:
+    """Human-readable rule violations for one tool; empty list means clean."""
+    reasons: list[str] = []
+    description = (tool.description or "").strip()
+
+    if not description:
+        reasons.append("description is empty")
+    elif len(description) < _MIN_DESCRIPTION_CHARS:
+        reasons.append(
+            f"description is only {len(description)} chars (minimum {_MIN_DESCRIPTION_CHARS})"
+        )
+
+    if _PLACEHOLDER_RE.search(description):
+        reasons.append("description starts with placeholder text (TODO/TBD/FIXME)")
+
+    if _SECRET_RE.search(description):
+        reasons.append("description may contain a secret or credential")
+
+    if str(tool.source) in sibling_sources and not tool.use_cases:
+        reasons.append("use_cases is empty despite siblings in the same source")
+
+    guidance = tool.skill_guidance or ""
+    if len(guidance) > _MAX_TOOL_SKILL_GUIDANCE_CHARS:
+        reasons.append(
+            f"skill_guidance is {len(guidance)} chars (budget {_MAX_TOOL_SKILL_GUIDANCE_CHARS})"
+        )
+
+    return reasons
+
+
+def test_description_contract_registry_floor() -> None:
+    snapshot = registry_module._load_registry_snapshot()
+    assert len(snapshot) >= _MIN_REGISTRY_SIZE, (
+        f"registry has {len(snapshot)} tools, expected at least "
+        f"{_MIN_REGISTRY_SIZE}. Discovery swallows import errors, so a short "
+        f"registry makes the per-tool checks pass by testing nothing."
+    )
+
+
+@pytest.mark.parametrize("tool_name", _production_tool_names())
+def test_description_contract(tool_name: str) -> None:
+    snapshot = registry_module._load_registry_snapshot()
+    tools_by_name = {tool.name: tool for tool in snapshot}
+    tool = tools_by_name[tool_name]
+    sibling_sources = _sources_with_siblings(snapshot)
+    violations = _description_contract_violations(tool, sibling_sources=sibling_sources)
+
+    if not violations:
+        return  # clean
+
+    if tool.name in _DESCRIPTION_CONTRACT_ALLOWLIST:
+        pytest.skip(f"{tool.name} quarantined under #5498: {'; '.join(violations)}")
+
+    pytest.fail(
+        f"{tool.name} violates the description contract: "
+        f"{'; '.join(violations)}. Fix the description, or quarantine the tool "
+        f"in _DESCRIPTION_CONTRACT_ALLOWLIST with a tracking ticket."
+    )
+
+
+def test_description_contract_allowlist_ratchets() -> None:
+    snapshot = registry_module._load_registry_snapshot()
+    sibling_sources = _sources_with_siblings(snapshot)
+    violators = {
+        tool.name
+        for tool in snapshot
+        if _description_contract_violations(tool, sibling_sources=sibling_sources)
+    }
+
+    allowlist = _DESCRIPTION_CONTRACT_ALLOWLIST
+    new_violators = sorted(violators - allowlist)
+    stale_entries = sorted(allowlist - violators)
+
+    assert not new_violators, (
+        f"new description-contract violators not in the allowlist: "
+        f"{new_violators}. Fix the description, or quarantine the tool in "
+        f"_DESCRIPTION_CONTRACT_ALLOWLIST with a tracking ticket."
+    )
+    assert not stale_entries, (
+        f"allowlist entries that no longer violate (stale — remove them so the "
+        f"allowlist keeps shrinking): {stale_entries}."
+    )


### PR DESCRIPTION
Parametrize over the live registry (issue #5498) so a tool cannot enter it with an unusable description. Each of the 290 tools is checked against five rules: non-empty and minimum-length description, no placeholder text, no secrets, non-empty use_cases when the tool has siblings in the same source, and skill guidance within the 2400-char budget.

One test case per tool so a failure names the offender. A floor test guards against a silently short registry. Existing violators (42, all failing the use_cases rule) are quarantined in a shrink-only allowlist compared exactly against the live violator set: a fixed tool must be removed and a new violator fails immediately. Rewriting descriptions is out of scope; the allowlist is the measured backlog.

Fixes #5498

#### Describe the changes you have made in this PR -

Added `tests/tools/test_description_contract.py`, a parametrized description-contract suite that asserts a quality bar for every registered tool's description — the model's primary signal for choosing among the ~290 tools offered together.

**Three test functions (all matched by `-k description_contract`):**

- `test_description_contract_registry_floor` — asserts the live registry holds at least 290 tools. Discovery swallows import errors, so a silently short registry would make the per-tool checks pass by testing nothing; this floor fails loud.
- `test_description_contract[tool_name]` — parametrized over `_production_tool_names()` (one case per tool). Each tool is checked against five rules. Clean tools pass; allowlisted violators are `pytest.skip`'d (counted and visible); a new, unallowlisted violator `pytest.fail`s naming the tool and the broken rule(s).
- `test_description_contract_allowlist_ratchets` — computes the live violator set and asserts it exactly equals `_DESCRIPTION_CONTRACT_ALLOWLIST`. Catches both directions: a new violator not in the allowlist (`violators - allowlist`) and a stale entry that was fixed but not removed (`allowlist - violators`). The allowlist can only shrink.

**The five rules** (in `_description_contract_violations`):

1. **Non-empty, minimum-length description** — stripped description must be non-empty and ≥20 chars. The shortest live description is 31 chars, so the floor catches only genuinely stub descriptions.
2. **No placeholder text** — regex anchored at start `^(TODO|TBD|FIXME|description here|placeholder|lorem ipsum)\b` so legitimate mid-sentence uses (e.g. "a todo list tool", "placeholder quoted text") are not false-flagged.
3. **No secrets or credentials** — high-confidence token shapes only (AWS `AKIA…`, OpenAI `sk-…`, Slack `xox…`, GitHub `gh[pousr]_…`, `-----BEGIN … PRIVATE KEY-----`) so a legitimate description is never blocked by a short lookalike.
4. **Non-empty `use_cases` when the tool has siblings in the same `source`** — `_sources_with_siblings` groups tools by `source`; a source backing more than one tool means the model needs `use_cases` to disambiguate. Single-tool sources are exempt.
5. **Skill guidance within the 2400-char budget** — mirrors `tools/registry_skill_guidance.py:_MAX_TOOL_SKILL_GUIDANCE_CHARS`; the truncation in `apply_skill_guidance` enforces it at load, this test pins the invariant defensively.

**Allowlist:** 42 tools, all failing the `use_cases` rule. Each entry is per-integration backlog work tracked under #5498; rewriting descriptions is explicitly out of scope for this issue. The allowlist is compared exactly so it can only shrink — a tool that gets fixed must be removed (ratchet test fails on a stale entry), and a new violator cannot enter unnoticed (per-tool test + ratchet test both fail).

**Test isolation:** an autouse fixture `_clean_production_registry` saves/clears/restores `_external_tool_packages` and the registry cache around each check, so bench tools registered as a side effect by other tests can't widen the violator set or shift the floor. `_production_tool_names()` snapshots the production registry in isolation for the parametrize IDs.

### Demo/Screenshot for feature changes and bug fixes -

Terminal output of the verification command from the issue:

$ uv run python -m pytest tests/tools/ -q -k description_contract
collected 3325 items / 3033 deselected / 292 selected
...
============== 250 passed, 42 skipped, 3033 deselected in 35.63s ==============

**Demonstration 1 — catches a new violator.** Registered a throwaway tool `zzz_throwaway_contract_demo` with description `"TBD"`:

$ uv run python -m pytest tests/tools/test_description_contract.py -q -k "description_contract[zzz_throwaway"
FAILED tests/tools/test_description_contract.py::test_description_contractzzz_throwaway_contract_demo
E   Failed: zzz_throwaway_contract_demo violates the description contract:
    description is only 3 chars (minimum 20); description starts with
    placeholder text (TODO/TBD/FIXME). Fix the description, or quarantine
    the tool in _DESCRIPTION_CONTRACT_ALLOWLIST with a tracking ticket.

The ratchet test also caught it:

$ uv run python -m pytest tests/tools/test_description_contract.py::test_description_contract_allowlist_ratchets -q
E   AssertionError: new description-contract violators not in the allowlist:
    'zzz_throwaway_contract_demo'. Fix the description, or quarantine the
    tool in _DESCRIPTION_CONTRACT_ALLOWLIST with a tracking ticket.

Tool removed after the demonstration.

**Demonstration 2 — the allowlist ratchets.** Removed `alert_sample` from `_DESCRIPTION_CONTRACT_ALLOWLIST` without fixing the tool:

$ uv run python -m pytest tests/tools/test_description_contract.py -q -k "description_contract[alert_sample"
FAILED tests/tools/test_description_contract.py::test_description_contractalert_sample
E   Failed: alert_sample violates the description contract: use_cases is
    empty despite siblings in the same source. Fix the description, or
    quarantine the tool in _DESCRIPTION_CONTRACT_ALLOWLIST with a tracking ticket.

The ratchet test also failed:

$ uv run python -m pytest tests/tools/test_description_contract.py::test_description_contract_allowlist_ratchets -q
E   AssertionError: new description-contract violators not in the allowlist:
    'alert_sample'. Fix the description, or quarantine the tool in
    _DESCRIPTION_CONTRACT_ALLOWLIST with a tracking ticket.

Allowlist entry restored after the demonstration; suite back to green (250 passed, 42 skipped).

**Violator count reported: 42** — this number is the backlog.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** `tests/tools/test_registry.py` asserts a lot about tool *schemas* (closed objects, typed/described properties, required fields) but nothing about the tool's own *description* — the model's primary signal for choosing among 290 tools offered together. A tool could ship with placeholder text and every existing test passed.

**Alternative approaches considered:**
- *One test over a loop* — rejected: it reports one failure for twenty bad tools. The issue explicitly requires one test case per tool so each is reported separately.
- *Fixing the violators in this PR* — rejected: the issue says "Quarantine, do not fix" and "Rewriting descriptions is separate work, and mixing it in makes the PR unreviewable."
- *Per-rule allowlists* — rejected in favour of a single tool-name allowlist. A tool is a "violator" if it fails any rule; the allowlist tracks tool identity, not per-rule state. This keeps the ratchet simple (one exact-set comparison) and matches the idiom in `gateway/tests/test_harness_behaviour_border.py`.
- *Mocking the registry* — rejected: the issue says to parametrize over the live registry via `tools.registry._load_registry_snapshot()` so the test "needs no fixture and cannot go stale."

**Why this implementation:**
- `@pytest.mark.parametrize` over `_production_tool_names()` generates one test ID per tool at collection time, so pytest reports each offender by name.
- An autouse fixture (`_clean_production_registry`) pins a production-only registry around each check, because other tests register bench/external tool packages as a side effect (e.g. `tests.benchmarks.cloudopsbench`) which would inflate the parametrize set and break the ratchet. This mirrors the save/clear/restore pattern already used in `test_registry.py::test_real_registry_does_not_emit_duplicate_tool_warnings`.
- The allowlist is a `frozenset[str]` of tool names compared exactly (`violators == allowlist`) — the same shrink-only idiom as `gateway/tests/test_harness_behaviour_border.py::_OUTSIDE_HOST_LAYER`.
- Allowlisted violators use `pytest.skip` (not silent pass) so the 42 are counted and visible in every run, satisfying "Existing violators are counted and visible rather than invisible."

**Key functions:**
- `_production_tool_names()` — returns every tool name from the production registry (external packages excluded) for parametrize IDs.
- `_sources_with_siblings(tools)` — groups tools by `source`, returns the source values backing more than one tool; only those tools must have non-empty `use_cases`.
- `_description_contract_violations(tool, *, sibling_sources)` — returns a human-readable list of broken rules for one tool (empty = clean).
- `test_description_contract_registry_floor` — guards against a silently short registry.
- `test_description_contract[tool_name]` — per-tool check; skip if allowlisted, fail if not.
- `test_description_contract_allowlist_ratchets` — exact-set ratchet; fails on both new violators and stale entries.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
