### PR TITLE
test(gateway): assert capacity sentence is uniform across transports

### DIFF
--- a/gateway/tests/test_multi_actor_concurrency.py
+++ b/gateway/tests/test_multi_actor_concurrency.py
@@ -382,11 +382,14 @@ _FANOUT_TRANSPORTS = ("slack", "telegram", "discord")
 
 
 class _TransportSink:
-    """Stub chat-transport output: records the finalized reply for one actor.
+    """Stub chat-transport output that exercises each transport's real text rendering.
 
-    Each transport renders its own delivery, but the at-capacity sentence must
-    be the one the gate hands it via ``finalize`` — this stub records exactly
-    that call so the test can assert it verbatim against the imported constant.
+    Instead of recording the ``finalize`` argument verbatim, each sink runs the
+    answer through the same text-formatting functions the production transport
+    output uses (Slack mrkdwn + truncation, Discord markdown tightening + split,
+    Telegram HTML + truncation) before recording the user-visible text. A
+    transport-specific formatter that altered the capacity sentence would fail
+    the verbatim assertion, not just a missing one.
     """
 
     def __init__(self, *, transport: str, actor: str) -> None:
@@ -421,7 +424,44 @@ class _TransportSink:
         pass
 
     def finalize(self, answer: str) -> None:
-        self.finalized = answer
+        self.finalized = self._render(answer)
+
+    def _render(self, answer: str) -> str:
+        """Apply the transport's real ``finalize`` text formatting and return it."""
+        if self.transport == "slack":
+            return self._render_slack(answer)
+        if self.transport == "discord":
+            return self._render_discord(answer)
+        if self.transport == "telegram":
+            return self._render_telegram(answer)
+        return answer
+
+    @staticmethod
+    def _render_slack(answer: str) -> str:
+        from gateway.transports.slack.client import SLACK_MAX_MESSAGE_CHARS
+        from infrastructure.text.truncation import truncate
+        from integrations.slack import markdown_to_slack_mrkdwn
+
+        return truncate(markdown_to_slack_mrkdwn(answer), SLACK_MAX_MESSAGE_CHARS, suffix="…")
+
+    @staticmethod
+    def _render_discord(answer: str) -> str:
+        from gateway.transports.discord.client import split_discord_content
+        from infrastructure.text.markdown import tighten_markdown_emphasis
+
+        body = tighten_markdown_emphasis((answer or "").strip())
+        return "".join(split_discord_content(body))
+
+    @staticmethod
+    def _render_telegram(answer: str) -> str:
+        from infrastructure.delivery.notifications.limits import MAX_MESSAGE_SIZE
+        from infrastructure.text.truncation import truncate
+        from integrations.telegram.delivery import truncate_for_telegram_html
+        from integrations.telegram.formatting import markdown_to_telegram_html
+
+        return truncate_for_telegram_html(
+            markdown_to_telegram_html(answer), MAX_MESSAGE_SIZE, suffix="…"
+        ) or truncate(answer, MAX_MESSAGE_SIZE, suffix="…")
 
 
 @dataclass
@@ -431,7 +471,6 @@ class _ActorSpec:
     chat_id: str
     session_id: str
     sink: _TransportSink
-    session: SessionCore
     message: str
 
 
@@ -443,8 +482,9 @@ def test_fanout_three_transports_one_capacity_sentence_and_bindings_survive(
 
     The process gate owns the at-capacity sentence: every transport rejected
     under load must receive ``AT_CAPACITY_MESSAGE`` verbatim (imported, never
-    retyped), saturation must not corrupt the actor-to-session mapping, and one
-    actor's reply must never land in another transport's sink.
+    retyped) through the transport's real text rendering, saturation must not
+    corrupt the actor-to-session mapping, and one actor's reply must never land
+    in another transport's sink.
     """
     import sys
     import types
@@ -465,7 +505,10 @@ def test_fanout_three_transports_one_capacity_sentence_and_bindings_survive(
     n_actors = 12
     limit = 4
 
-    # Arrange: 4 actors per transport, each pre-bound to its own session.
+    # Arrange: 4 actors per transport, each pre-bound to its own session. The
+    # worker resolves the session from the binding store at turn time (as a
+    # transport dispatcher does), not from a pre-built object, so concurrent
+    # resolution under saturation is exercised — not just pre/post reads.
     actors: list[_ActorSpec] = []
     for i in range(n_actors):
         transport = _FANOUT_TRANSPORTS[i // 4]
@@ -486,7 +529,6 @@ def test_fanout_three_transports_one_capacity_sentence_and_bindings_survive(
                 chat_id=chat_id,
                 session_id=session_id,
                 sink=_TransportSink(transport=transport, actor=actor_id),
-                session=SessionCore(store=InMemorySessionStore(), session_id=session_id),
                 message=f"hello-{actor_id}",
             )
         )
@@ -547,11 +589,35 @@ def test_fanout_three_transports_one_capacity_sentence_and_bindings_survive(
 
     def _worker(spec: _ActorSpec) -> None:
         try:
+            # Resolve the session from the binding store the way a transport
+            # dispatcher does — concurrently with every other worker — so a
+            # binding misroute or store corruption under saturation surfaces
+            # here, not only in the post-turn check.
+            resolved = store.get_session_id(
+                platform=spec.transport,
+                chat_id=spec.chat_id,
+                principal=ACME,
+                actor=spec.actor_id,
+            )
+            assert resolved == spec.session_id, (
+                f"pre-turn resolution mismatch for {spec.transport}/{spec.actor_id}: {resolved!r}"
+            )
+            session = SessionCore(store=InMemorySessionStore(), session_id=resolved)
             runner(
                 spec.message,
-                spec.session,
+                session,
                 spec.sink,
                 logging.getLogger("test.fanout"),
+            )
+            # Post-turn: the binding must still resolve to the same session.
+            post = store.get_session_id(
+                platform=spec.transport,
+                chat_id=spec.chat_id,
+                principal=ACME,
+                actor=spec.actor_id,
+            )
+            assert post == spec.session_id, (
+                f"post-turn binding lost for {spec.transport}/{spec.actor_id}: {post!r}"
             )
         except Exception as exc:
             errors.append(exc)
@@ -574,15 +640,15 @@ def test_fanout_three_transports_one_capacity_sentence_and_bindings_survive(
     assert not errors, [repr(e) for e in errors]
     assert peak == limit, f"expected {limit} turns in flight at the peak, got {peak}"
 
-    # Every rejected actor received AT_CAPACITY_MESSAGE verbatim — the imported
-    # constant, never a retyped sentence.
+    # Every rejected actor received AT_CAPACITY_MESSAGE verbatim through the
+    # transport's real text rendering — the imported constant, never retyped.
     ran = [a for a in actors if a.sink.finalized and a.sink.finalized != AT_CAPACITY_MESSAGE]
     rejected = [a for a in actors if a.sink.finalized == AT_CAPACITY_MESSAGE]
     assert len(ran) == limit
     assert len(rejected) == n_actors - limit
     for a in rejected:
         assert a.sink.finalized == AT_CAPACITY_MESSAGE, (
-            f"{a.transport}/{a.actor_id} got a different capacity sentence"
+            f"{a.transport}/{a.actor_id} rendered a different capacity sentence"
         )
 
     # No binding lost: every actor still resolves to its own session.

--- a/gateway/tests/test_multi_actor_concurrency.py
+++ b/gateway/tests/test_multi_actor_concurrency.py
@@ -14,20 +14,31 @@ for lost rows, unreadable JSON, and cross-actor session bleed.
 from __future__ import annotations
 
 import json
+import logging
 import multiprocessing
 import threading
 import time
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pytest
+from rich.console import Console
 
 from config.constants import paths
 from config.constants.billing import ORGANIZATION_ID_ENV
 from config.principal import Actor, Principal, StorageScope
 from config.scope_context import bound_storage_scope
+from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
+from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.session.persistence.paths import session_path, sessions_dir
+from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
 from gateway.core.storage.session.file_bindings import FileBindingStore
+from infrastructure.turn_host.concurrency import AT_CAPACITY_MESSAGE, TurnConcurrencyGate
+from tests.shared.default_headless_build_stub import default_headless_build_stub
+from tests.shared.fake_agent import fake_agent
 
 ACME = Principal.org("org_acme")
 ALICE = "U_ALICE"
@@ -362,3 +373,234 @@ def test_same_session_concurrent_appends_remain_line_parseable() -> None:
     assert len(messages) == 80
     contents = {r.get("content") for r in messages}
     assert {f"a-{i}" for i in range(40)} | {f"b-{i}" for i in range(40)} <= contents
+
+
+# ── Transport fan-out capacity ────────────────────────────────────────────────
+
+
+_FANOUT_TRANSPORTS = ("slack", "telegram", "discord")
+
+
+class _TransportSink:
+    """Stub chat-transport output: records the finalized reply for one actor.
+
+    Each transport renders its own delivery, but the at-capacity sentence must
+    be the one the gate hands it via ``finalize`` — this stub records exactly
+    that call so the test can assert it verbatim against the imported constant.
+    """
+
+    def __init__(self, *, transport: str, actor: str) -> None:
+        self.transport = transport
+        self.actor = actor
+        self.finalized: str | None = None
+        # ``TurnRunner`` reads ``tool_hooks`` onto the turn binding; ``None`` is
+        # the chat default (no approval gate).
+        self.tool_hooks = None
+
+    def print(self, message: str = "") -> None:
+        pass
+
+    def render_response_header(self, label: str) -> None:
+        pass
+
+    def render_error(self, message: str) -> None:
+        pass
+
+    def stream(
+        self,
+        *,
+        label: str,
+        chunks: Iterable[str],
+        suppress_if_starts_with: str | None = None,
+        defer_want_me_to_closer: bool = False,
+    ) -> str:
+        _ = (label, suppress_if_starts_with, defer_want_me_to_closer)
+        return "".join(str(chunk) for chunk in chunks)
+
+    def set_tool_status(self, status: str) -> None:
+        pass
+
+    def finalize(self, answer: str) -> None:
+        self.finalized = answer
+
+
+@dataclass
+class _ActorSpec:
+    transport: str
+    actor_id: str
+    chat_id: str
+    session_id: str
+    sink: _TransportSink
+    session: SessionCore
+    message: str
+
+
+def test_fanout_three_transports_one_capacity_sentence_and_bindings_survive(
+    bindings_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """12 actors across Slack/Telegram/Discord, limit 4: one capacity sentence, no binding lost, no bleed.
+
+    The process gate owns the at-capacity sentence: every transport rejected
+    under load must receive ``AT_CAPACITY_MESSAGE`` verbatim (imported, never
+    retyped), saturation must not corrupt the actor-to-session mapping, and one
+    actor's reply must never land in another transport's sink.
+    """
+    import sys
+    import types
+
+    # ``turn_memory`` imports the Unix-only ``resource`` module unconditionally;
+    # stub it on Windows so the gate path can be exercised locally. On Linux the
+    # real module is already imported and this is a no-op.
+    if sys.platform == "win32" and "resource" not in sys.modules:
+        _resource_stub = types.ModuleType("resource")
+        _resource_stub.RUSAGE_SELF = 0
+        _resource_stub.getrusage = lambda _who: types.SimpleNamespace(ru_maxrss=0)
+        _resource_stub.getpagesize = lambda: 4096
+        monkeypatch.setitem(sys.modules, "resource", _resource_stub)
+
+    from infrastructure.turn_host.turn_runner import TurnRunner
+
+    store = FileBindingStore(bindings_path)
+    n_actors = 12
+    limit = 4
+
+    # Arrange: 4 actors per transport, each pre-bound to its own session.
+    actors: list[_ActorSpec] = []
+    for i in range(n_actors):
+        transport = _FANOUT_TRANSPORTS[i // 4]
+        actor_id = f"U_{i:03d}"
+        chat_id = f"{transport}:chat:{i:03d}"
+        session_id = f"sess-{i:03d}"
+        store.bind(
+            platform=transport,
+            chat_id=chat_id,
+            session_id=session_id,
+            principal=ACME,
+            actor=actor_id,
+        )
+        actors.append(
+            _ActorSpec(
+                transport=transport,
+                actor_id=actor_id,
+                chat_id=chat_id,
+                session_id=session_id,
+                sink=_TransportSink(transport=transport, actor=actor_id),
+                session=SessionCore(store=InMemorySessionStore(), session_id=session_id),
+                message=f"hello-{actor_id}",
+            )
+        )
+
+    # Barrier-controlled stub LLM: the 4 admitted turns block in dispatch so
+    # the peak is deterministic; the 8 rejected never reach it.
+    peak_barrier = threading.Barrier(limit + 1)
+    release = threading.Event()
+    inflight = {"count": 0}
+    inflight_lock = threading.Lock()
+
+    def _stub_dispatch(message: str) -> TurnResult:
+        with inflight_lock:
+            inflight["count"] += 1
+        try:
+            peak_barrier.wait(timeout=30)
+            release.wait(timeout=30)
+        finally:
+            with inflight_lock:
+                inflight["count"] -= 1
+        return TurnResult(
+            final_intent="cli_agent_handled",
+            action_result=ToolCallingTurnResult(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+                has_unhandled_clause=False,
+                handled=True,
+                response_text=f"reply-{message}",
+            ),
+        )
+
+    def _build(**_kwargs: Any) -> Any:
+        agent = fake_agent()
+        agent.dispatch.side_effect = _stub_dispatch
+        return agent
+
+    monkeypatch.setattr(
+        "infrastructure.turn_host.session_agents.DefaultHeadlessBuild",
+        default_headless_build_stub(_build),
+    )
+    monkeypatch.setattr(
+        "infrastructure.turn_host.turn_runner.capture_gateway_turn_started", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "infrastructure.turn_host.turn_runner.capture_gateway_turn_completed", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "infrastructure.turn_host.turn_runner.capture_gateway_turn_failed", lambda **_: None
+    )
+
+    runner = TurnRunner(
+        console=Console(force_terminal=False),
+        gate=TurnConcurrencyGate(limit),
+    )
+
+    errors: list[Exception] = []
+
+    def _worker(spec: _ActorSpec) -> None:
+        try:
+            runner(
+                spec.message,
+                spec.session,
+                spec.sink,
+                logging.getLogger("test.fanout"),
+            )
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=_worker, args=(spec,), name=f"fanout-{spec.actor_id}")
+        for spec in actors
+    ]
+    for t in threads:
+        t.start()
+
+    # The barrier opens once the 4 admitted turns are in dispatch plus the main
+    # thread — that moment is the peak.
+    peak_barrier.wait(timeout=30)
+    with inflight_lock:
+        peak = inflight["count"]
+    release.set()
+    _join(threads)
+
+    assert not errors, [repr(e) for e in errors]
+    assert peak == limit, f"expected {limit} turns in flight at the peak, got {peak}"
+
+    # Every rejected actor received AT_CAPACITY_MESSAGE verbatim — the imported
+    # constant, never a retyped sentence.
+    ran = [a for a in actors if a.sink.finalized and a.sink.finalized != AT_CAPACITY_MESSAGE]
+    rejected = [a for a in actors if a.sink.finalized == AT_CAPACITY_MESSAGE]
+    assert len(ran) == limit
+    assert len(rejected) == n_actors - limit
+    for a in rejected:
+        assert a.sink.finalized == AT_CAPACITY_MESSAGE, (
+            f"{a.transport}/{a.actor_id} got a different capacity sentence"
+        )
+
+    # No binding lost: every actor still resolves to its own session.
+    for a in actors:
+        got = store.get_session_id(
+            platform=a.transport, chat_id=a.chat_id, principal=ACME, actor=a.actor_id
+        )
+        assert got == a.session_id, f"binding lost for {a.transport}/{a.actor_id}: got {got!r}"
+
+    # No cross-actor bleed: no sink holds another actor's reply or message.
+    for a in actors:
+        text = a.sink.finalized or ""
+        for other in actors:
+            if other is a:
+                continue
+            assert other.message not in text, (
+                f"bleed: {other.actor_id}'s message in {a.actor_id}'s sink ({a.transport})"
+            )
+            assert f"reply-{other.message}" not in text, (
+                f"bleed: {other.actor_id}'s reply in {a.actor_id}'s sink ({a.transport})"
+            )


### PR DESCRIPTION
Fixes #5494

#### Describe the changes you have made in this PR -

Adds a single fan-out concurrency test to `gateway/tests/test_multi_actor_concurrency.py` that proves the capacity path is uniform across all chat transports and that saturation does not corrupt the actor-to-session mapping.

The test (`test_fanout_three_transports_one_capacity_sentence_and_bindings_survive`) builds:

- **12 actors** across **Slack, Telegram, and Discord** (4 per transport), each pre-bound to its own session via `FileBindingStore`.
- **One `TurnRunner`** with a `TurnConcurrencyGate(4)` — the shared process gate.
- A **barrier-controlled stub LLM**: the 4 admitted turns block inside `dispatch` on a `threading.Barrier(5)` (4 dispatch + main thread) so the peak is deterministic; the 8 rejected turns never reach dispatch.

It then asserts:

| Assertion | How |
|-----------|-----|
| Exactly 4 turns in flight at the peak | `assert peak == limit` — read from an `inflight` counter after the barrier opens |
| Every rejected actor received `AT_CAPACITY_MESSAGE` verbatim | `assert a.sink.finalized == AT_CAPACITY_MESSAGE` — the constant is imported from `infrastructure.turn_host.concurrency`, never retyped |
| No binding lost | Each of the 12 actors' `store.get_session_id(...)` still resolves to its own session afterwards |
| No cross-actor bleed | No sink holds another actor's reply marker (`reply-hello-U_xxx`) or raw message |

Supporting change: the `TurnRunner` import is lazy (inside the test function) because `turn_memory.py` unconditionally imports the Unix-only `resource` module. On Windows a minimal `resource` stub is injected via `monkeypatch.setitem` (rolled back after the test); on Linux the real module is used. This keeps the module collectable on all platforms without touching production code.

### Demo/Screenshot for feature changes and bug fixes -

Terminal output — 5 consecutive runs all pass:

```
=== Run 1 ===  1 passed in 2.80s
=== Run 2 ===  1 passed in 2.76s
=== Run 3 ===  1 passed in 2.76s
=== Run 4 ===  1 passed in 2.82s
=== Run 5 ===  1 passed in 2.78s
```

Wording assertion proven real — temporarily set `busy_message="Custom capacity message."` and the test fails:

```
FAILED ...::test_fanout_three_transports_one_capacity_sentence_and_bindings_survive
AssertionError: assert 12 == 4
```

grep verification (no transport hardcodes the capacity text):

```powershell
Select-String -Path "gateway\**\*.py" -Pattern "at capacity" | Where-Object { $_.Line -notmatch 'AT_CAPACITY_MESSAGE' }
# (no output)
```

Lint / format / typecheck:

```
ruff check   — All checks passed!
ruff format  — 1 file already formatted
mypy         — 3 pre-existing errors in original code (lines 85, 289, 342); 0 in new code
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `AT_CAPACITY_MESSAGE` is a single sentence defined in `infrastructure/turn_host/concurrency.py:104`. Nothing asserted that every chat transport uses that exact sentence under load, or that a transport under load does not lose an actor binding. This PR adds one test that pins all three guarantees.

**What the code solves:** it proves that (1) the capacity sentence is uniform across Slack/Telegram/Discord, (2) saturation does not corrupt the actor-to-session mapping in `FileBindingStore`, and (3) one actor's reply never lands in another transport's sink.

**Alternative approaches considered:**
- *Mock the gate instead of using the real `TurnRunner`* — rejected: the test must exercise the real capacity path (`turn_slot` → `try_acquire` → `output.finalize(self._busy_message)`) to prove the sentence comes from the gate, not a stub.
- *Use the process gate singleton (`process_turn_gate()`)* — rejected: it carries global state across tests and depends on the `OPENSRE_MAX_CONCURRENT_TURNS` env var. Constructing `TurnConcurrencyGate(4)` directly and passing it as `gate=` is deterministic and self-contained (matches the pattern in `test_run_returns_none_and_says_at_capacity_when_the_gate_refuses`).
- *Use a start barrier so all 12 hit the gate simultaneously* — rejected as unnecessary: `BoundedSemaphore` is thread-safe, exactly 4 acquire and 8 are rejected regardless of arrival order. The peak barrier (inside dispatch) is what makes the peak deterministic.

**Why this implementation:** the barrier-controlled stub is the key. `_stub_dispatch` increments an `inflight` counter, waits at a `threading.Barrier(5)` (4 admitted + main), then blocks on a `release` event. The main thread synchronizes at the same barrier — when it opens, exactly 4 turns are in flight and the peak is observable. Releasing lets the 4 finish; the 8 rejected already returned with `AT_CAPACITY_MESSAGE` finalized on their sinks.

**Key components:**
- `_TransportSink` — a `TurnOutput`-protocol stub that records `finalize(answer)` for one actor. Implements all `OutputSink`/`TurnOutput` methods so it is mypy-clean.
- `_ActorSpec` — dataclass bundling each actor's transport, ids, sink, session, and unique message marker.
- `_stub_dispatch` — the barrier-controlled fake LLM turn; returns a `TurnResult` with `response_text=f"reply-{message}"` so no-bleed is assertable per actor.
- `_build` — patches `DefaultHeadlessBuild` (via `default_headless_build_stub`) so `SessionAgentPool` returns the fake agent.

**Edge cases handled:**
- The 4 admitted actors each have a distinct session, so no two share a pooled agent or per-session lock — no false `AgentBusyError`.
- The `resource` stub is Windows-only and scoped via `monkeypatch.setitem` (auto-cleanup); on Linux it is a no-op.
- The no-bleed assertion checks both the raw message (`hello-U_xxx`) and the reply marker (`reply-hello-U_xxx`) so a sink cannot accidentally match a substring of another actor's text.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
