### PR TITLE
fix(core): resolve LLM model via public model_id for litellm clients

### DIFF
--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -96,7 +96,8 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         self._msg_formatter = MessageMapper(self._llm)
         self._runtime_tools = list(host._filter_tools(run_input.tools))
         self._tool_schemas = self._llm.tool_schemas(self._runtime_tools)
-        self._ceiling = context_budget_ceiling_for_model(getattr(self._llm, "_model", None))
+        model_id = getattr(self._llm, "model_id", None) or getattr(self._llm, "_model", None)
+        self._ceiling = context_budget_ceiling_for_model(model_id)
         # System prompt and tool schemas are fixed for the run; serialize once.
         self._fixed_overhead_tokens = system_and_tools_overhead(self._system, self._tool_schemas)
         self._executed: list[tuple[ToolCall, Any]] = []

--- a/core/agent_harness/accounting/token_accounting.py
+++ b/core/agent_harness/accounting/token_accounting.py
@@ -57,11 +57,13 @@ def estimate_tokens(text: str) -> int:
 def resolve_model_name(client: object) -> str | None:
     """Best-effort read of an LLM client's model name.
 
-    Reads the private ``_model`` attribute off ``client``. Returns the
-    value only if it's a non-empty ``str``; returns ``None`` if the
-    attribute is missing, empty, or not a string (no exceptions raised).
+    Prefers the public ``model_id`` attribute (the litellm transport client
+    exposes only this and has no ``_model``); falls back to the private
+    ``_model`` used by the SDK clients. Returns the value only if it's a
+    non-empty ``str``; returns ``None`` if neither yields a usable string
+    (no exceptions raised).
     """
-    value = getattr(client, "_model", None)
+    value = getattr(client, "model_id", None) or getattr(client, "_model", None)
     return value if isinstance(value, str) and value else None
 
 

--- a/tests/core/test_model_id_context_resolution.py
+++ b/tests/core/test_model_id_context_resolution.py
@@ -1,0 +1,81 @@
+"""Model identity for context sizing and analytics must read the public ``model_id``.
+
+The litellm transport client (``OPENSRE_LLM_TRANSPORT=litellm``) exposes its model
+name only through the public ``model_id`` property; it has no private ``_model``
+attribute. Two call sites used to read ``_model`` directly, so every litellm-routed
+turn silently fell back to the conservative default context window and reported an
+``unknown`` model to analytics. Both sites now prefer ``model_id`` and keep the
+private ``_model`` as a fallback, matching the resolution already used elsewhere in
+``react_loop``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent import Agent
+from core.agent.react_loop import ReactLoop
+from core.agent.run_io import AgentRunInput
+from core.agent_harness.accounting.token_accounting import resolve_model_name
+from core.context_budget import context_budget_ceiling_for_model
+
+_CLAUDE_MODEL = "anthropic/claude-sonnet-4-5"
+_CLAUDE_CEILING = context_budget_ceiling_for_model(_CLAUDE_MODEL)
+_DEFAULT_CEILING = context_budget_ceiling_for_model(None)
+
+
+class _LiteLLMStyleClient:
+    """Fake litellm transport client: public ``model_id`` only, no ``_model``."""
+
+    def __init__(self, model: str) -> None:
+        self._litellm_model = model
+
+    @property
+    def model_id(self) -> str | None:
+        return self._litellm_model
+
+    def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+        return []
+
+
+class _DirectStyleClient:
+    """Fake SDK transport client that exposes only the private ``_model``."""
+
+    def __init__(self, model: str) -> None:
+        self._model = model
+
+    def tool_schemas(self, _tools: list[Any]) -> list[dict[str, Any]]:
+        return []
+
+
+def _build_loop(client: Any) -> ReactLoop[Any]:
+    agent: Agent[Any] = Agent(llm=client, system="sys", tools=[], max_iterations=1)
+    run_input = AgentRunInput[Any].from_messages(
+        [{"role": "user", "content": "hi"}],
+        llm=client,
+        system="sys",
+        tools=[],
+        resolved=None,
+        tool_resources={},
+        max_iterations=1,
+    )
+    return ReactLoop(run_input, agent)
+
+
+def test_react_loop_sizes_context_from_litellm_model_id() -> None:
+    loop = _build_loop(_LiteLLMStyleClient(_CLAUDE_MODEL))
+    assert loop._ceiling == _CLAUDE_CEILING
+    assert loop._ceiling != _DEFAULT_CEILING
+
+
+def test_react_loop_still_sizes_context_from_direct_model() -> None:
+    loop = _build_loop(_DirectStyleClient(_CLAUDE_MODEL))
+    assert loop._ceiling == _CLAUDE_CEILING
+
+
+def test_resolve_model_name_reads_litellm_model_id() -> None:
+    assert resolve_model_name(_LiteLLMStyleClient(_CLAUDE_MODEL)) == _CLAUDE_MODEL
+
+
+def test_resolve_model_name_falls_back_to_direct_model() -> None:
+    assert resolve_model_name(_DirectStyleClient(_CLAUDE_MODEL)) == _CLAUDE_MODEL


### PR DESCRIPTION
Fixes #5700

#### Describe the changes you have made in this PR -

The litellm transport client (`OPENSRE_LLM_TRANSPORT=litellm`, `core/llm/transports/litellm/clients.py`) exposes its model name only through the public `model_id` property and has **no** private `_model` attribute (that lives on the SDK clients). Two sites read `_model` directly off the client:

1. `core/agent/react_loop.py:99` — `ReactLoop.__init__` sized the context budget from `getattr(self._llm, "_model", None)`. For every litellm-routed turn that returned `None`, so `context_budget_ceiling_for_model` fell back to the conservative 128k default (112000 after response headroom) instead of the model's real window (200k / 184000 for Claude). The loop then evicted tool exchanges and truncated evidence ~72000 tokens earlier than necessary.
2. `core/agent_harness/accounting/token_accounting.py:64` — `resolve_model_name` returned `None`, so `$ai_model` analytics was silently `unknown` for every litellm turn.

Both now prefer the public `model_id` and fall back to `_model`, matching the resolution already used one method over in `react_loop._operation_base` (`getattr(self._llm, "model_id", None) or getattr(self._llm, "_model", None)`) and the `AgentLLMClient` Protocol contract in `core/llm/types.py`, whose `model_id` docstring says it is "used for context-budget sizing". SDK/direct clients are unaffected (they expose both). This is a correctness bug, not a crash.

### Demo/Screenshot for feature changes and bug fixes -

Before/after against a litellm-style Claude client (`model_id="anthropic/claude-sonnet-4-5"`, no `_model`):

```
litellm claude client (model_id='anthropic/claude-sonnet-4-5', _model=None)
BEFORE  context ceiling: 112000 | resolve_model_name ->  None
AFTER   context ceiling: 184000 | resolve_model_name ->  anthropic/claude-sonnet-4-5
reclaimed tokens: 72000
```

New regression suite (`tests/core/test_model_id_context_resolution.py`):

```
tests/core/test_model_id_context_resolution.py::test_react_loop_sizes_context_from_litellm_model_id PASSED
tests/core/test_model_id_context_resolution.py::test_react_loop_still_sizes_context_from_direct_model PASSED
tests/core/test_model_id_context_resolution.py::test_resolve_model_name_reads_litellm_model_id PASSED
tests/core/test_model_id_context_resolution.py::test_resolve_model_name_falls_back_to_direct_model PASSED
4 passed
```
On unmodified `main` the first and third fail (112000 != 184000; `None` != the model), confirming the tests catch the bug.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem is a transport-abstraction leak: the ReAct loop and the token-accounting helper identified the active model by reaching for the SDK clients' private `_model`, but the litellm client only publishes `model_id`. So on the litellm transport the context-budget ceiling silently collapsed to the conservative default and analytics lost the model name. I traced both transports (`transports/sdk/agent_clients.py` sets `_model` and returns it from `model_id`; `transports/litellm/clients.py` sets `_litellm_model` and returns it from `model_id`, with no `_model`) and confirmed the `AgentLLMClient` Protocol only guarantees the public `model_id`. Rather than invent a new resolver, I mirrored the exact `model_id or _model` fallback that `react_loop._operation_base` already uses — it reads the public identifier first and still works for any client that exposes only `_model`, so both transports resolve correctly and the direct-client path is unchanged. I considered dropping the `_model` fallback entirely, but kept it to preserve behavior for any client exposing only the private field. The tests use named-`def` fakes (per the repo's test-fake convention, no Mock): a litellm-style fake with `model_id` and no `_model`, and a direct-style fake with only `_model`, asserting the real ceiling (184000, not 112000) at the ReactLoop site and that `resolve_model_name` returns the id.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
