### PR TITLE
fix(slack): update search_messages to require user token for search.messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -460,6 +460,8 @@ SLACK_APP_TOKEN=
 # NOTE: to restrict access later (e.g. a paid/prod team), add SLACK_ALLOWED_USERS
 # as a comma-separated list of member IDs (U…). An allowlist takes precedence over
 # open-workspace, so leave it unset while everyone in the channel should have access.
+# Slack user token (xoxp-…) with search:read. Only slack_search_messages needs
+# it — Slack rejects bot tokens for workspace search. Unset hides that tool.
 # SLACK_ACCESS_TOKEN=
 
 # --- Additional RCA integrations -------------------------------------------

--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -337,11 +337,13 @@ from config.constants.servicenow import (
 from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
 from config.constants.signoz import SIGNOZ_API_KEY_ENV, SIGNOZ_URL_ENV
 from config.constants.slack import (
+    SLACK_ACCESS_TOKEN_ENV,
     SLACK_APP_TOKEN_ENV,
     SLACK_BOT_TOKEN_ENV,
     SLACK_DEFAULT_CHAT_ID_ENV,
     SLACK_FILE_HOST_SUFFIXES,
     SLACK_HEARTBEAT_STOP_TIMEOUT_SECONDS,
+    SLACK_USER_TOKEN_PREFIXES,
     SLACK_WEBHOOK_URL_ENV,
 )
 from config.constants.slash_commands import (
@@ -673,9 +675,11 @@ __all__ = [
     "SERVICENOW_USERNAME_ENV",
     "SIGNOZ_API_KEY_ENV",
     "SIGNOZ_URL_ENV",
+    "SLACK_ACCESS_TOKEN_ENV",
     "SLACK_APP_TOKEN_ENV",
     "SLACK_BOT_TOKEN_ENV",
     "SLACK_DEFAULT_CHAT_ID_ENV",
+    "SLACK_USER_TOKEN_PREFIXES",
     "SLACK_WEBHOOK_URL_ENV",
     "SLACK_FILE_HOST_SUFFIXES",
     "SLACK_HEARTBEAT_STOP_TIMEOUT_SECONDS",

--- a/config/constants/slack.py
+++ b/config/constants/slack.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 SLACK_BOT_TOKEN_ENV = "SLACK_BOT_TOKEN"
 SLACK_APP_TOKEN_ENV = "SLACK_APP_TOKEN"
+SLACK_ACCESS_TOKEN_ENV = "SLACK_ACCESS_TOKEN"
 SLACK_DEFAULT_CHAT_ID_ENV = "SLACK_DEFAULT_CHAT_ID"
 SLACK_WEBHOOK_URL_ENV = "SLACK_WEBHOOK_URL"
 SLACK_GITHUB_ISSUES_WEBHOOK_URL_ENV = "SLACK_GITHUB_ISSUES_WEBHOOK_URL"
@@ -12,6 +13,11 @@ SLACK_GITHUB_ISSUES_WEBHOOK_URL_ENV = "SLACK_GITHUB_ISSUES_WEBHOOK_URL"
 # of being silently attributed to the silo org (and its stored credentials).
 # Unset preserves the permissive dogfood behaviour (with a warning).
 SLACK_SILO_TEAM_IDS_ENV = "OPENSRE_SILO_TEAM_IDS"
+
+# Slack user ("access") token prefixes. ``search.messages`` is user-token only,
+# so callers must tell the two apart. Rotation-enabled user tokens arrive as
+# ``xoxe.xoxp-``, which is why this is a tuple and not a single prefix.
+SLACK_USER_TOKEN_PREFIXES: tuple[str, ...] = ("xoxp-", "xoxe.xoxp-")
 
 # Socket Mode liveness ticker join during worker stop. Keep this small so
 # in-flight Slack turns keep the rest of the SIGTERM budget.
@@ -28,6 +34,7 @@ SLACK_FILE_HOST_SUFFIXES: tuple[str, ...] = (
 )
 
 __all__ = [
+    "SLACK_ACCESS_TOKEN_ENV",
     "SLACK_APP_TOKEN_ENV",
     "SLACK_BOT_TOKEN_ENV",
     "SLACK_DEFAULT_CHAT_ID_ENV",
@@ -35,5 +42,6 @@ __all__ = [
     "SLACK_GITHUB_ISSUES_WEBHOOK_URL_ENV",
     "SLACK_HEARTBEAT_STOP_TIMEOUT_SECONDS",
     "SLACK_SILO_TEAM_IDS_ENV",
+    "SLACK_USER_TOKEN_PREFIXES",
     "SLACK_WEBHOOK_URL_ENV",
 ]

--- a/docs/messaging/slack.mdx
+++ b/docs/messaging/slack.mdx
@@ -51,6 +51,7 @@ SLACK_ALLOWED_USERS=U0123ABCD
 | `SLACK_BOT_TOKEN` | Bot token (`xoxb-…`) for the two-way Slack bot. Env or integration store. |
 | `SLACK_DEFAULT_CHAT_ID` | Default channel (`C…`) for scheduled delivery when using a bot token. Env or integration store; pair it with the same source as the bot token. |
 | `SLACK_APP_TOKEN` | App-level token (`xapp-…`) for Socket Mode. Env or integration store. |
+| `SLACK_ACCESS_TOKEN` | User token (`xoxp-…`) with `search:read`. Required only for `slack_search_messages` — Slack rejects bot tokens there. |
 | `SLACK_ALLOWED_USERS` | Comma-separated Slack user IDs allowed to talk to the bot (required unless open workspace). |
 | `SLACK_ALLOW_OPEN_WORKSPACE` | Set to `1` to allow any workspace member (dogfood escape hatch). |
 | `SLACK_TEAM_TASKS_LIST_ID` | Optional Slack List id (`F…`) for `slack_read_list` without a name search. |
@@ -103,12 +104,6 @@ Treat this URL like a password — anyone holding it can post to your channel. I
 | `files:read` | Inbound file-attachment downloads + discover Slack Lists (`files.list`) |
 | `files:write` | Upload files as the bot |
 | `lists:read` | `slack_read_list` — read Slack List rows (`slackLists.items.list`) |
-| `search:read.public` | `slack_search_messages` in public channels |
-| `search:read.private` | Search private channels |
-| `search:read.im` | Search DMs |
-| `search:read.mpim` | Search group DMs |
-| `search:read.files` | Search files |
-| `search:read.users` | Search users |
 | `usergroups:read` | View workspace user groups |
 | `users.profile:read` | Speaker profile details |
 | `users:read` | `slack_list_team_members` + user lookup |
@@ -118,6 +113,10 @@ Add these only if you use the feature — they are not in the current app config
 </Note>
 
 Reinstall the app after adding scopes so the bot token picks them up. Invite the bot (`/invite @OpenSRE`) to private channels it should read or post in.
+
+<Note>
+`slack_search_messages` is the one tool a bot token can never run — Slack refuses bot tokens for workspace message search, no matter which scopes you grant. To enable search, add `search:read` under **OAuth & Permissions → User Token Scopes**, reinstall, and set `SLACK_ACCESS_TOKEN` to the resulting user token (`xoxp-…`). Leave it unset and search simply stays hidden from the agent; every other Slack tool works on the bot token alone.
+</Note>
 
 ### Allow your Slack user
 
@@ -158,7 +157,7 @@ Teammate tools (bot token) plus webhook blast. Credentials resolve inside the to
 | `slack_send_message` | Post to the webhook's fixed channel | `SLACK_WEBHOOK_URL` | Yes |
 | `slack_reply_message` | Post to any channel/thread (`C…` or `#name`) | bot token, `chat:write` | Yes |
 | `slack_read_messages` | Read channel history or a thread (`thread_ts`) | bot token, history + list scopes | No |
-| `slack_search_messages` | Workspace message search | bot token, `search:read` | No |
+| `slack_search_messages` | Workspace message search | **user** token (`SLACK_ACCESS_TOKEN`), `search:read` | No |
 | `slack_list_team_members` | List workspace members | bot token, `users:read` | No |
 | `slack_join_channel` | Join a public channel | bot token, `channels:join` | Yes |
 | `slack_add_reaction` | React to a message ts | bot token, `reactions:write` | No |

--- a/infrastructure/scheduling/scheduler/credentials.py
+++ b/infrastructure/scheduling/scheduler/credentials.py
@@ -27,6 +27,7 @@ from config.constants.rocketchat import (
     ROCKETCHAT_USER_ID_ENV,
 )
 from config.constants.slack import (
+    SLACK_ACCESS_TOKEN_ENV,
     SLACK_BOT_TOKEN_ENV,
     SLACK_DEFAULT_CHAT_ID_ENV,
     SLACK_WEBHOOK_URL_ENV,
@@ -130,7 +131,7 @@ def _resolve_slack_with_source(task_params: dict[str, str]) -> tuple[dict[str, s
     if store_token:
         return {"access_token": store_token}, "store"
 
-    for env_var in (SLACK_BOT_TOKEN_ENV, "SLACK_ACCESS_TOKEN"):
+    for env_var in (SLACK_BOT_TOKEN_ENV, SLACK_ACCESS_TOKEN_ENV):
         value = resolve_env_credential(env_var).strip()
         if value:
             return {"access_token": value}, "env"

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -9,7 +9,7 @@ from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
-from integrations.slack.web_client import bot_token_configured, resolve_bot_token, search_messages
+from integrations.slack.web_client import resolve_user_token, search_messages, user_token_configured
 
 
 class SlackSearchMessagesTool(BaseTool):
@@ -20,7 +20,8 @@ class SlackSearchMessagesTool(BaseTool):
     description = (
         "Search Slack *messages* workspace-wide (search.messages). "
         "Use Slack search syntax (e.g. 'in:#incidents timeout', 'from:@user error'). "
-        "Requires a user token (xoxp-…) with search:read; bot tokens are rejected. "
+        "Needs a Slack user token (SLACK_ACCESS_TOKEN, xoxp-…) with search:read — "
+        "Slack refuses bot tokens for this endpoint. "
         "Not for workspace roster — use slack_list_team_members for who is on the team / member IDs."
     )
     use_cases = [
@@ -59,11 +60,13 @@ class SlackSearchMessagesTool(BaseTool):
         "error_type": "validation_error, configuration_error, or api_error",
     }
 
-    def is_available(self, sources: dict[str, Any]) -> bool:
-        return bot_token_configured(sources)
+    def is_available(self, _sources: dict[str, Any]) -> bool:
+        # A bot token does not make this tool usable, so the resolved-integration
+        # map is not consulted: only a user token counts.
+        return user_token_configured()
 
     def run(self, query: str, count: int = 20, **_kwargs: Any) -> dict[str, Any]:
-        target, resolution_error = resolve_bot_token()
+        target, resolution_error = resolve_user_token()
         if target is None:
             return tool_unavailable(
                 SOURCE,

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -18,10 +18,10 @@ class SlackSearchMessagesTool(BaseTool):
     name = "slack_search_messages"
     source = SOURCE
     description = (
-        "Search Slack *messages* workspace-wide (search.messages) using the bot token. "
+        "Search Slack *messages* workspace-wide (search.messages). "
         "Use Slack search syntax (e.g. 'in:#incidents timeout', 'from:@user error'). "
-        "Requires the search:read bot scope. Not for workspace roster — use "
-        "slack_list_team_members for who is on the team / member IDs."
+        "Requires a user token (xoxp-…) with search:read; bot tokens are rejected. "
+        "Not for workspace roster — use slack_list_team_members for who is on the team / member IDs."
     )
     use_cases = [
         "Finding prior discussion of an incident keyword",

--- a/integrations/slack/web_client.py
+++ b/integrations/slack/web_client.py
@@ -152,6 +152,10 @@ def _api_error_hint(error: str, *, context: str) -> str:
             "The Slack app is missing a required OAuth scope. Reinstall after adding scopes.",
         ),
         "thread_not_found": "No thread with this parent ts was found in the channel.",
+        "not_allowed_token_type": (
+            "search.messages requires a user token (xoxp-…); bot tokens are rejected. "
+            "Use slack_read_messages on a known channel instead."
+        ),
     }
     return hints.get(error, f"Slack API error: {error}")
 
@@ -686,6 +690,8 @@ def search_messages(
     q = str(query or "").strip()
     if not q:
         return None, "query cannot be empty."
+    if not target.bot_token.startswith("xoxp-"):
+        return None, _api_error_hint("not_allowed_token_type", context="search")
     limit = max(1, min(int(count), 100))
     payload, req_err = _request_json(
         "GET",

--- a/integrations/slack/web_client.py
+++ b/integrations/slack/web_client.py
@@ -15,7 +15,11 @@ from typing import Any
 
 import httpx
 
-from config.constants.slack import SLACK_BOT_TOKEN_ENV
+from config.constants.slack import (
+    SLACK_ACCESS_TOKEN_ENV,
+    SLACK_BOT_TOKEN_ENV,
+    SLACK_USER_TOKEN_PREFIXES,
+)
 from config.llm_credentials import resolve_env_credential
 
 _API_BASE = "https://slack.com/api"
@@ -108,6 +112,43 @@ def bot_token_configured(sources: dict[str, Any] | None = None) -> bool:
     return target is not None
 
 
+_SEARCH_NEEDS_USER_TOKEN = (
+    "Slack search needs a user token: search.messages rejects bot tokens "
+    f"(not_allowed_token_type). Set {SLACK_ACCESS_TOKEN_ENV} to a user token "
+    "(xoxp-…) holding search:read, or read a known channel with "
+    "slack_read_messages instead."
+)
+
+
+def is_user_token(token: str) -> bool:
+    """True when *token* is a Slack user token (``xoxp-``, or rotating ``xoxe.xoxp-``)."""
+    return token.strip().startswith(SLACK_USER_TOKEN_PREFIXES)
+
+
+def resolve_user_token() -> tuple[SlackBotTarget | None, str]:
+    """Resolve a Slack **user** token for ``search.messages``.
+
+    ``SLACK_ACCESS_TOKEN`` first, then the bot-token path when the value found
+    there is itself a user token (a workspace may have only ever configured one
+    Slack credential). A bot token is never returned: Slack refuses it for
+    search, so returning one would guarantee a failed call.
+    """
+    env_token = resolve_env_credential(SLACK_ACCESS_TOKEN_ENV).strip()
+    if is_user_token(env_token):
+        return SlackBotTarget(bot_token=env_token), ""
+
+    target, _error = resolve_bot_token()
+    if target is not None and is_user_token(target.bot_token):
+        return target, ""
+    return None, _SEARCH_NEEDS_USER_TOKEN
+
+
+def user_token_configured() -> bool:
+    """True when a Slack user token is available, so search can actually run."""
+    target, _error = resolve_user_token()
+    return target is not None
+
+
 def _bearer_headers(token: str) -> dict[str, str]:
     # Match delivery.py: Slack wants charset=utf-8 on JSON bodies.
     return {
@@ -152,10 +193,7 @@ def _api_error_hint(error: str, *, context: str) -> str:
             "The Slack app is missing a required OAuth scope. Reinstall after adding scopes.",
         ),
         "thread_not_found": "No thread with this parent ts was found in the channel.",
-        "not_allowed_token_type": (
-            "search.messages requires a user token (xoxp-…); bot tokens are rejected. "
-            "Use slack_read_messages on a known channel instead."
-        ),
+        "not_allowed_token_type": _SEARCH_NEEDS_USER_TOKEN,
     }
     return hints.get(error, f"Slack API error: {error}")
 
@@ -690,8 +728,8 @@ def search_messages(
     q = str(query or "").strip()
     if not q:
         return None, "query cannot be empty."
-    if not target.bot_token.startswith("xoxp-"):
-        return None, _api_error_hint("not_allowed_token_type", context="search")
+    if not is_user_token(target.bot_token):
+        return None, _SEARCH_NEEDS_USER_TOKEN
     limit = max(1, min(int(count), 100))
     payload, req_err = _request_json(
         "GET",

--- a/tests/tools/test_slack_coworker_tools.py
+++ b/tests/tools/test_slack_coworker_tools.py
@@ -71,7 +71,7 @@ def test_search_messages_maps_matches(monkeypatch: pytest.MonkeyPatch) -> None:
     }
     _install_fake_client(monkeypatch, lambda **_kw: _FakeResponse(payload))
     matches, error = web_client.search_messages(
-        web_client.SlackBotTarget(bot_token="xoxb-x"), query="boom"
+        web_client.SlackBotTarget(bot_token="xoxp-user"), query="boom"
     )
     assert error == ""
     assert matches is not None

--- a/tests/tools/test_slack_search_messages_tool.py
+++ b/tests/tools/test_slack_search_messages_tool.py
@@ -1,0 +1,27 @@
+"""Pins #5660: search.messages rejects bot tokens; hint instead of opaque error."""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations.slack.tools.slack_search_messages_tool.tool import SlackSearchMessagesTool
+from integrations.slack.web_client import SlackBotTarget, _api_error_hint, search_messages
+
+
+def test_description_does_not_claim_a_bot_search_scope() -> None:
+    assert "bot scope" not in SlackSearchMessagesTool().description
+    assert "xoxp-" in SlackSearchMessagesTool().description
+
+
+def test_bot_token_is_rejected_with_a_clear_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-x")
+    matches, error = search_messages(SlackBotTarget(bot_token="xoxb-x"), query="timeout")
+    assert matches is None
+    assert "user token" in error
+    result = SlackSearchMessagesTool().run(query="timeout")
+    assert result["status"] == "failed"
+    assert result["error"] == error
+
+
+def test_not_allowed_token_type_maps_to_the_same_hint() -> None:
+    assert "user token" in _api_error_hint("not_allowed_token_type", context="search")

--- a/tests/tools/test_slack_search_messages_tool.py
+++ b/tests/tools/test_slack_search_messages_tool.py
@@ -1,27 +1,159 @@
-"""Pins #5660: search.messages rejects bot tokens; hint instead of opaque error."""
+"""Pins #5660: ``search.messages`` is user-token only.
+
+A bot token can never search, so the tool must resolve ``SLACK_ACCESS_TOKEN``,
+hide itself when no user token exists, and refuse a bot token without spending
+a request. Rotating user tokens (``xoxe.xoxp-``) count as user tokens.
+"""
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+import integrations.slack.web_client as web_client
 from integrations.slack.tools.slack_search_messages_tool.tool import SlackSearchMessagesTool
-from integrations.slack.web_client import SlackBotTarget, _api_error_hint, search_messages
+
+_SEARCH_PAYLOAD = {
+    "ok": True,
+    "messages": {
+        "matches": [
+            {
+                "text": "boom",
+                "user": "U1",
+                "ts": "1.0",
+                "permalink": "https://example",
+                "channel": {"id": "C01234567"},
+            }
+        ]
+    },
+}
 
 
-def test_description_does_not_claim_a_bot_search_scope() -> None:
-    assert "bot scope" not in SlackSearchMessagesTool().description
-    assert "xoxp-" in SlackSearchMessagesTool().description
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.status_code = 200
+        self.headers: dict[str, str] = {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
 
 
-def test_bot_token_is_rejected_with_a_clear_hint(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-x")
-    matches, error = search_messages(SlackBotTarget(bot_token="xoxb-x"), query="timeout")
+class _ExplodingClient:
+    """Fails the test if any request is issued."""
+
+    def get(self, _path: str, **_kw: Any) -> _FakeResponse:
+        raise AssertionError("search.messages must not be called with a bot token")
+
+    def post(self, _path: str, **_kw: Any) -> _FakeResponse:
+        raise AssertionError("search.messages must not be called with a bot token")
+
+
+class _RecordingClient:
+    """Captures the token every call carried so tests can assert on it."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.tokens: list[str] = []
+
+    def _respond(self, **kw: Any) -> _FakeResponse:
+        headers = kw.get("headers") or {}
+        self.tokens.append(str(headers.get("Authorization", "")))
+        return _FakeResponse(self._payload)
+
+    def get(self, _path: str, **kw: Any) -> _FakeResponse:
+        return self._respond(**kw)
+
+    def post(self, _path: str, **kw: Any) -> _FakeResponse:
+        return self._respond(**kw)
+
+
+@pytest.fixture
+def slack_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Isolate token resolution from the developer's env, keyring, and store."""
+    values: dict[str, str] = {}
+
+    def resolve(name: str, **_kwargs: Any) -> str:
+        return values.get(name, "")
+
+    monkeypatch.setattr(web_client, "resolve_env_credential", resolve)
+    monkeypatch.setattr("integrations.catalog.resolve_effective_integrations", dict)
+    return values
+
+
+def _install_client(monkeypatch: pytest.MonkeyPatch, client: Any) -> None:
+    monkeypatch.setattr(web_client, "_shared_client", lambda: client)
+    monkeypatch.setattr(web_client.time, "sleep", lambda _s: None)
+
+
+def test_description_does_not_promise_a_bot_search_scope() -> None:
+    description = SlackSearchMessagesTool().description
+    assert "bot scope" not in description
+    assert "SLACK_ACCESS_TOKEN" in description
+
+
+def test_bot_token_is_refused_without_calling_slack(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_client(monkeypatch, _ExplodingClient())
+    matches, error = web_client.search_messages(
+        web_client.SlackBotTarget(bot_token="xoxb-x"), query="timeout"
+    )
     assert matches is None
-    assert "user token" in error
-    result = SlackSearchMessagesTool().run(query="timeout")
+    assert "SLACK_ACCESS_TOKEN" in error
+
+
+def test_rotating_user_token_is_treated_as_a_user_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _RecordingClient(_SEARCH_PAYLOAD)
+    _install_client(monkeypatch, client)
+    matches, error = web_client.search_messages(
+        web_client.SlackBotTarget(bot_token="xoxe.xoxp-rotating"), query="boom"
+    )
+    assert error == ""
+    assert matches is not None
+    assert client.tokens == ["Bearer xoxe.xoxp-rotating"]
+
+
+def test_is_available_ignores_a_bot_token(slack_env: dict[str, str]) -> None:
+    slack_env["SLACK_BOT_TOKEN"] = "xoxb-x"
+    assert SlackSearchMessagesTool().is_available({"slack": {"bot_token": "xoxb-x"}}) is False
+
+    slack_env["SLACK_ACCESS_TOKEN"] = "xoxp-user"
+    assert SlackSearchMessagesTool().is_available({}) is True
+
+
+def test_run_searches_with_the_configured_user_token(
+    monkeypatch: pytest.MonkeyPatch, slack_env: dict[str, str]
+) -> None:
+    slack_env["SLACK_BOT_TOKEN"] = "xoxb-x"
+    slack_env["SLACK_ACCESS_TOKEN"] = "xoxp-user"
+    client = _RecordingClient(_SEARCH_PAYLOAD)
+    _install_client(monkeypatch, client)
+
+    result = SlackSearchMessagesTool().run(query="boom")
+
+    assert result["status"] == "read"
+    assert result["match_count"] == 1
+    assert client.tokens == ["Bearer xoxp-user"]
+
+
+def test_run_without_a_user_token_reports_configuration(slack_env: dict[str, str]) -> None:
+    slack_env["SLACK_BOT_TOKEN"] = "xoxb-x"
+    result = SlackSearchMessagesTool().run(query="boom")
     assert result["status"] == "failed"
-    assert result["error"] == error
+    assert result["error_type"] == "configuration_error"
+    assert "SLACK_ACCESS_TOKEN" in result["error"]
 
 
-def test_not_allowed_token_type_maps_to_the_same_hint() -> None:
-    assert "user token" in _api_error_hint("not_allowed_token_type", context="search")
+def test_slack_rejection_maps_to_the_same_actionable_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user token Slack still refuses must not surface the raw error code."""
+    _install_client(monkeypatch, _RecordingClient({"ok": False, "error": "not_allowed_token_type"}))
+    matches, error = web_client.search_messages(
+        web_client.SlackBotTarget(bot_token="xoxp-user"), query="boom"
+    )
+    assert matches is None
+    assert "SLACK_ACCESS_TOKEN" in error


### PR DESCRIPTION
/fix #5660 
This pull request updates the Slack integration to correctly require and handle a Slack user token (`SLACK_ACCESS_TOKEN`) for workspace message search (`search.messages`). It ensures that bot tokens are never used for this endpoint, improves error messaging, updates documentation, and adds comprehensive tests to enforce the new behavior.

**Slack user token requirement for message search:**

- Updated the `slack_search_messages` tool and underlying logic to require a Slack user token (`SLACK_ACCESS_TOKEN`, `xoxp-…` or `xoxe.xoxp-…`) for workspace message search, since Slack rejects bot tokens for this endpoint. The tool now refuses to run or hides itself if only a bot token is available, and provides actionable error messages when misconfigured. [[1]](diffhunk://#diff-254bea2f4c45a3e5390265fb44318c54b1c4f3b5c7df75de42c612de19dfe0f2L12-R12) [[2]](diffhunk://#diff-254bea2f4c45a3e5390265fb44318c54b1c4f3b5c7df75de42c612de19dfe0f2L21-R25) [[3]](diffhunk://#diff-254bea2f4c45a3e5390265fb44318c54b1c4f3b5c7df75de42c612de19dfe0f2L62-R69) [[4]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3R115-R151) [[5]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3R731-R732)

- Added logic to distinguish user tokens from bot tokens via the prefixes `xoxp-` and `xoxe.xoxp-`, and updated token resolution functions accordingly. [[1]](diffhunk://#diff-820ddb4c79059c232aae7180cb7e337c13b06738882f70e4189bba438e3d9d4bR17-R21) [[2]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3L18-R22)

**Documentation and configuration updates:**

- Updated documentation (`docs/messaging/slack.mdx`, `.env.example`) to clarify that `SLACK_ACCESS_TOKEN` is required for message search, explain how to obtain it, and remove misleading references to bot token scopes for search. [[1]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafR54) [[2]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafL106-L111) [[3]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafR117-R120) [[4]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafL161-R160) [[5]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR463-R464)

- Added new constants and updated exports to support the new configuration, such as `SLACK_ACCESS_TOKEN_ENV` and `SLACK_USER_TOKEN_PREFIXES`. [[1]](diffhunk://#diff-820ddb4c79059c232aae7180cb7e337c13b06738882f70e4189bba438e3d9d4bR7) [[2]](diffhunk://#diff-820ddb4c79059c232aae7180cb7e337c13b06738882f70e4189bba438e3d9d4bR37-R45) [[3]](diffhunk://#diff-750cacca527c2a3807b0c9342c54cf6b74d4ddcc2b889578b9bf417a54889b51R340-R346) [[4]](diffhunk://#diff-750cacca527c2a3807b0c9342c54cf6b74d4ddcc2b889578b9bf417a54889b51R678-R682) [[5]](diffhunk://#diff-4959cd677dc6e574255be84667b2258e3e5044463223d479cc2efc6469323dc9R30)

**Improved error handling:**

- Enhanced error messages to provide clear, actionable feedback when a user token is missing or misconfigured, including mapping Slack's `not_allowed_token_type` error to a helpful hint. [[1]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3R115-R151) [[2]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3R196)

**Testing:**

- Added a new test suite (`test_slack_search_messages_tool.py`) to verify that only user tokens are accepted for search, bot tokens are refused without making Slack API calls, and error handling is robust.

- Updated existing tests to use user tokens for search where appropriate.

**Token resolution improvements:**

- Updated credential resolution logic to check for `SLACK_ACCESS_TOKEN` using the new constant, and to ensure only user tokens are used for search.

---

**References:**  
[[1]](diffhunk://#diff-254bea2f4c45a3e5390265fb44318c54b1c4f3b5c7df75de42c612de19dfe0f2L12-R12) [[2]](diffhunk://#diff-254bea2f4c45a3e5390265fb44318c54b1c4f3b5c7df75de42c612de19dfe0f2L21-R25) [[3]](diffhunk://#diff-254bea2f4c45a3e5390265fb44318c54b1c4f3b5c7df75de42c612de19dfe0f2L62-R69) [[4]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3R115-R151) [[5]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3R731-R732) [[6]](diffhunk://#diff-820ddb4c79059c232aae7180cb7e337c13b06738882f70e4189bba438e3d9d4bR17-R21) [[7]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3L18-R22) [[8]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafR54) [[9]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafL106-L111) [[10]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafR117-R120) [[11]](diffhunk://#diff-5de87b952116d9a48441195dd43e3abe727d3df2922379a75cdd1c63a7671cafL161-R160) [[12]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR463-R464) [[13]](diffhunk://#diff-820ddb4c79059c232aae7180cb7e337c13b06738882f70e4189bba438e3d9d4bR7) [[14]](diffhunk://#diff-820ddb4c79059c232aae7180cb7e337c13b06738882f70e4189bba438e3d9d4bR37-R45) [[15]](diffhunk://#diff-750cacca527c2a3807b0c9342c54cf6b74d4ddcc2b889578b9bf417a54889b51R340-R346) [[16]](diffhunk://#diff-750cacca527c2a3807b0c9342c54cf6b74d4ddcc2b889578b9bf417a54889b51R678-R682) [[17]](diffhunk://#diff-4959cd677dc6e574255be84667b2258e3e5044463223d479cc2efc6469323dc9R30) [[18]](diffhunk://#diff-8be118214e2cf7105b6799fbd2add138ccb9af4bef400b290719b17674e980a3R196) [[19]](diffhunk://#diff-9499bafac536fb5c7d476b3df884556ee5ad87b1593e7647ae505e800c2678c5R1-R159) [[20]](diffhunk://#diff-ba83f451778dbcd3d72a712408ec48334de1e4009702e0850187532a0dd673d6L74-R74) [[21]](diffhunk://#diff-4959cd677dc6e574255be84667b2258e3e5044463223d479cc2efc6469323dc9L133-R134)