### PR TITLE
Docs: add AWS CloudWatch integration page

### DIFF
--- a/docs/cloudwatch.mdx
+++ b/docs/cloudwatch.mdx
@@ -1,0 +1,85 @@
+---
+title: "AWS CloudWatch"
+description: "Pull AWS Batch job metrics and CloudWatch Logs events during incidents"
+---
+
+## Overview
+
+OpenSRE uses AWS CloudWatch to pull CPU and memory metrics for AWS Batch jobs and search CloudWatch Logs groups for error events and tracebacks during an investigation.
+
+CloudWatch alarms (via SNS or EventBridge) can also trigger an investigation directly — OpenSRE recognizes the alarm payload and extracts details like the log group from it automatically.
+
+All CloudWatch API calls are read-only.
+
+## Prerequisites
+
+- AWS credentials configured per the [AWS integration](/aws) (role ARN recommended)
+- An AWS Batch job queue and/or a CloudWatch Logs log group you want OpenSRE to investigate
+- IAM permissions for the actions listed below
+
+## Setup
+
+CloudWatch has no setup wizard or environment variables of its own — it reuses the credentials and region configured for the [AWS integration](/aws):
+
+```bash
+opensre integrations setup aws
+```
+
+Region comes from `AWS_REGION` (default `us-east-1`), same as every other AWS tool.
+
+Unlike RDS or Kafka, there's nothing CloudWatch-specific to preset ahead of time: the job queue, log group, and correlation ID each tool needs come from the alert being investigated (or are filled in by the LLM), not from a config file.
+
+## Credentials
+
+The integration only needs four read-only actions on the same IAM role or user used for the [AWS integration](/aws):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "logs:FilterLogEvents",
+        "logs:GetLogEvents",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+If you already use the AWS managed `ReadOnlyAccess` policy, all four actions are covered.
+
+## Investigation tools
+
+| Tool | AWS API call | What it returns |
+| --- | --- | --- |
+| `get_cloudwatch_batch_metrics` | `cloudwatch:GetMetricStatistics` | CPU or memory utilization datapoints for one AWS Batch job queue (`AWS/Batch` namespace) |
+| `get_cloudwatch_logs` | `logs:FilterLogEvents` / `logs:GetLogEvents` / `logs:DescribeLogStreams` | Recent log events from one CloudWatch Logs group — by filter pattern/correlation ID, a named stream, or the most-recently-active stream |
+
+`get_cloudwatch_batch_metrics` needs a `job_queue` (from the alert or the investigating LLM) and errors without one. `get_cloudwatch_logs` only becomes available once `log_group` is present in the resolved sources.
+
+### Use cases
+
+- Proving a CPU or memory resource-constraint hypothesis behind a stuck or slow AWS Batch job
+- Pulling error tracebacks from a known CloudWatch Logs group
+- Searching a log group by correlation ID or error pattern to trace a failure
+
+## Verify
+
+There is no dedicated `opensre integrations verify cloudwatch` target. Confirm AWS credentials work (see [AWS](/aws)) — CloudWatch tools activate automatically during an investigation once a job queue or log group shows up in the alert.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **`get_cloudwatch_logs` with `filter_pattern` finds nothing** | Pattern search only looks back 2 hours from now (hardcoded, not configurable) — for an older incident, call it with an explicit `log_stream` instead, which isn't time-bounded (just capped at `limit` events, default 100) |
+
+## Security
+
+- Use read-only IAM (`Get*`, `Filter*`, `Describe*` only — no `Put*` or `Delete*`).
+- Prefer role ARN / least privilege over long-lived keys, same as the AWS integration.
+- Store log group names and credentials out of source control.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -190,6 +190,7 @@
                   "aws",
                   "aws_lambda",
                   "cloudtrail_events",
+                  "cloudwatch",
                   "ec2",
                   "elb",
                   "helm",


### PR DESCRIPTION
Fixes #4269

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Adds `docs/cloudwatch.mdx` (AWS CloudWatch integration page: overview, prerequisites, setup, a least-privilege IAM policy built from the actual boto3 calls in `integrations/cloudwatch/`, the two real registered tools with their AWS API calls, a verify section, one genuine gotcha, and a security note) and wires it into `docs/docs.json`'s navigation (alphabetically between `cloudtrail_events` and `ec2`, matching that section's existing ordering) — without the nav entry the page is unreachable from the sidebar per this repo's Mintlify setup. Follows the shape of `docs/rds.mdx` / `docs/kafka.mdx` as instructed.

**Two things found while writing this that are outside this PR's scope, flagging for visibility:**
1. `get_cloudwatch_batch_metrics` never passes `start_time`/`end_time` to `get_metric_statistics()`, so both default to `None` and get forwarded to boto3 as `StartTime=None, EndTime=None` — both are required parameters for that AWS API call and this would very likely raise a client-side `ParamValidationError` in real (non-mocked) use. All existing unit tests mock `get_metric_statistics` itself, so this path isn't exercised. Not fixed here since it's a product bug, not a docs gap, and outside what #4269 asked for — but worth a maintainer's eyes.
2. `docs/aws.mdx`'s existing least-privilege IAM policy lists `cloudwatch:GetMetricData` / `cloudwatch:ListMetrics`, but the real code only ever calls `get_metric_statistics` (-> `cloudwatch:GetMetricStatistics`) and is missing `logs:DescribeLogStreams` (needed for `get_cloudwatch_logs`'s stream auto-discovery). `docs/cloudwatch.mdx`'s own policy in this PR is written from the real calls, not copied from the stale one in `aws.mdx`. Didn't touch `aws.mdx` itself since that's a separate pre-existing inconsistency, not part of this issue.

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Docs-only change (`docs/cloudwatch.mdx`, `docs/docs.json` both qualify for CI.md's docs-only shortcut). `git status --short` confirms only those two files touched; `docs/docs.json` parses as valid JSON post-edit with `cloudwatch` correctly inserted into the nav array.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours. Please specifically verify the tool descriptions and IAM policy in cloudwatch.mdx against integrations/cloudwatch/ yourself — the two findings noted above should make you want to double check the factual claims here particularly carefully.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: the change is implemented and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff, per this repo's AI-Assisted PR policy — not something to check automatically. Will mark ready for review once confirmed.
