### PR TITLE
Fix: redact bot token from gateway Telegram poller errors

### DIFF
--- a/gateway/tests/telegram/test_telegram_client.py
+++ b/gateway/tests/telegram/test_telegram_client.py
@@ -33,3 +33,26 @@ def test_send_message_success_with_mapping_proxy_data(mock_post: MagicMock) -> N
     assert ok is True
     assert error == ""
     assert message_id == "42"
+
+
+@patch("gateway.transports.telegram.poller.client.post_json")
+def test_send_message_redacts_bot_token_from_transport_exception(
+    mock_post: MagicMock, caplog: object
+) -> None:
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="gateway.transports.telegram.poller.client")
+    mock_post.return_value = DeliveryResponse(
+        ok=False,
+        error="Connection refused for url: https://api.telegram.org/botSECRET/sendMessage",
+        exc_type="ConnectError",
+    )
+    client = TelegramBotClient("SECRET")
+    ok, error, message_id = client.send_message("123", "hello")
+    assert ok is False
+    assert message_id == ""
+    assert "/botSECRET/" not in error
+    assert "SECRET" not in error
+    assert "ConnectError" in error
+    log_messages = [record.message for record in caplog.records]
+    assert not any("/botSECRET/" in message or "SECRET" in message for message in log_messages)

--- a/gateway/tests/telegram/test_telegram_poller.py
+++ b/gateway/tests/telegram/test_telegram_poller.py
@@ -53,6 +53,27 @@ def test_poll_once_conflict_is_debug_not_warning(
 
 @patch("gateway.transports.telegram.poller.poller.time.sleep")
 @patch("gateway.transports.telegram.poller.poller.httpx.get")
+def test_poll_once_redacts_bot_token_from_exception_log(
+    mock_get: MagicMock,
+    mock_sleep: MagicMock,
+    caplog: object,
+) -> None:
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="gateway.transports.telegram.poller.poller")
+    mock_get.side_effect = httpx.ConnectError(
+        "Connection refused for url: https://api.telegram.org/botSECRET/getUpdates"
+    )
+    poller = TelegramPoller("SECRET")
+    assert poller.poll_once() == TelegramPollResult()
+    mock_sleep.assert_called_once_with(2.0)
+    messages = [record.message for record in caplog.records]
+    assert not any("/botSECRET/" in message or "SECRET" in message for message in messages)
+    assert any("ConnectError" in message for message in messages)
+
+
+@patch("gateway.transports.telegram.poller.poller.time.sleep")
+@patch("gateway.transports.telegram.poller.poller.httpx.get")
 def test_poll_once_success_resets_conflict_backoff(
     mock_get: MagicMock, _mock_sleep: MagicMock
 ) -> None:

--- a/gateway/transports/telegram/poller/client.py
+++ b/gateway/transports/telegram/poller/client.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 from typing import Any
 
 from infrastructure.delivery.notifications.delivery_transport import post_json
+from infrastructure.delivery.notifications.redaction import redact_token
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,8 @@ class TelegramBotClient:
             payload=payload,
         )
         if not response.ok:
-            return False, {}, response.error
+            safe_error = redact_token(response.error, self._token)
+            return False, {}, f"{response.exc_type}: {safe_error}"
         if response.status_code != HTTPStatus.OK or not isinstance(response.data, Mapping):
             return False, {}, response.text or f"HTTP {response.status_code}"
         if not response.data.get("ok"):

--- a/gateway/transports/telegram/poller/poller.py
+++ b/gateway/transports/telegram/poller/poller.py
@@ -18,6 +18,7 @@ from gateway.transports.telegram.settings import (
     TelegramCallbackQuery,
     TelegramInboundMessage,
 )
+from infrastructure.delivery.notifications.redaction import redact_token
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,12 @@ class TelegramPoller:
         try:
             response = httpx.get(url, params=params, timeout=float(self._timeout + 5))
         except Exception as exc:
-            self._log_transient("[telegram-gateway] getUpdates failed: %s", exc)
+            safe_error = redact_token(str(exc), self._token)
+            self._log_transient(
+                "[telegram-gateway] getUpdates failed (%s): %s",
+                type(exc).__name__,
+                safe_error,
+            )
             time.sleep(_DEFAULT_RETRY_SECONDS)
             return TelegramPollResult()
 


### PR DESCRIPTION
Fixes #4769

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

The gateway's Telegram poller could leak a live bot token into logs or caller-visible error strings on a transient HTTP failure, because it logged/returned raw exception text that embeds the `.../bot{token}/...` URL. This PR applies the same `redact_token` pattern already used by `integrations/telegram/verifier.py` to the two leak points named in the issue:

- `gateway/transports/telegram/poller/poller.py` — `TelegramPoller.poll_once()`'s exception handler now logs `type(exc).__name__` plus a redacted message, instead of the raw exception.
- `gateway/transports/telegram/poller/client.py` — `TelegramBotClient._call()`'s `not response.ok` branch now redacts `response.error` before returning it, prefixed with `response.exc_type`. This single fix point covers every caller (`send_message`, `edit_message_text`, `answer_callback_query`) since they all just log or propagate whatever `_call` returns.

Two new regression tests force an exception containing `/botSECRET/` through each path and assert the token never appears in any log record or returned string.

**One design choice worth your attention:** in `client.py` I combined `response.exc_type` with the redacted message (`f"{response.exc_type}: {safe_error}"`) rather than the simpler `redact_token(response.error, token)`-only pattern used in the sibling `integrations/telegram/delivery.py`. I did this because the issue explicitly calls `exc_type` "a ready building block" and asks to "prefer logging `type(exc).__name__` + a redacted message over raw exc" — and `exc_type` is guaranteed non-empty whenever `response.ok` is `False`. But most sibling delivery modules (Discord, WhatsApp, RocketChat, Twilio, same-vendor Telegram delivery) don't include `exc_type` in their returned string, so this is a slight departure from the majority pattern — please double check it's what you'd want.

Left untouched, deliberately: `_handle_poll_error` in `poller.py` and the two non-exception branches in `client.py._call` (`response.text`, `response.data.get("description")`) — those carry Telegram's own JSON/text response body from a completed HTTP round trip, not exception text, so they can't contain the request URL/token. The issue's "Actual" section names exactly the two leak points fixed here.

Also note: the issue text's file paths (`platform/notifications/redaction.py`, `platform/notifications/delivery_transport.py`) are stale — real paths are `infrastructure/delivery/notifications/redaction.py` and `infrastructure/delivery/notifications/delivery_transport.py` (confirmed via the imports already used by `integrations/telegram/verifier.py`).

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

No live bot token was available to reproduce end-to-end (the issue's own manual repro steps say so too — the regression tests are the intended verification path). Local verification output:

```
make lint            -> All checks passed!
make format-check    -> 3703 files already formatted
make typecheck       -> Success: no issues found in 1925 source files
make test-scope      -> 806 passed, 0 failed, including both new regression tests:
  test_poll_once_redacts_bot_token_from_exception_log
  test_send_message_redacts_bot_token_from_transport_exception
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft. Given this is a security-relevant fix, please give it a genuinely careful read rather than a skim.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours. The exc_type design choice flagged above is the one thing here that most needs your own judgment, not just a readthrough.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (2 new regression tests, both asserting the token is absent from logs/returned strings)
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: the change is implemented, tested, and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff, per this repo's AI-Assisted PR policy — not something to check automatically, especially for a security-relevant change like this one. Will mark ready for review once confirmed.
