### PR TITLE
feat(gitlab): add evidence mappers (#5552)

### DIFF
--- a/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
@@ -74,9 +75,24 @@ def _list_gitlab_commits_available(sources: dict[str, dict]) -> bool:
     return bool(_gitlab_available(sources) and gl.get("project_id"))
 
 
+def _map_list_gitlab_commits(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record recent GitLab commits as citeable evidence."""
+    commits = output.get("commits", [])
+    if commits:
+        record_evidence_entry(
+            evidence,
+            source="list_gitlab_commits",
+            label="GitLab Commits",
+            summary=f"{len(commits)} recent commits",
+        )
+
+
 @tool(
     name="list_gitlab_commits",
     source="gitlab",
+    evidence_mapper=_map_list_gitlab_commits,
     description="List recent commits for a gitlab repository.",
     use_cases=[
         "Checking whether a recent change could explain a failure",

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -41,7 +41,7 @@ def _map_get_gitlab_file(
     file = output.get("file") or {}
     content = file.get("content", "")
     if content:
-        lines = content.count("\n") + 1
+        lines = len(content.splitlines())
         record_evidence_entry(
             evidence,
             source="get_gitlab_file",

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload, tool_unavailable
@@ -33,9 +34,26 @@ def _get_gitlab_file_available(sources: dict[str, dict]) -> bool:
     return bool(_gitlab_available(sources) and gl.get("project_id") and gl.get("file_path"))
 
 
+def _map_get_gitlab_file(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record a fetched GitLab file as citeable evidence (identity only, not contents)."""
+    file = output.get("file") or {}
+    content = file.get("content", "")
+    if content:
+        lines = content.count("\n") + 1
+        record_evidence_entry(
+            evidence,
+            source="get_gitlab_file",
+            label="GitLab File",
+            summary=f"{file.get('file_path') or 'file'} ({lines} lines, {len(content)} chars)",
+        )
+
+
 @tool(
     name="get_gitlab_file",
     source="gitlab",
+    evidence_mapper=_map_get_gitlab_file,
     description="Read the contents of a specific file from a GitLab repository.",
     use_cases=[
         "Reading a config file that may explain a misconfiguration causing the incident",

--- a/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
@@ -33,9 +34,24 @@ def _list_gitlab_mrs_available(sources: dict[str, dict]) -> bool:
     return bool(_gitlab_available(sources) and gl.get("project_id"))
 
 
+def _map_list_gitlab_mrs(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record recent GitLab merge requests as citeable evidence."""
+    mrs = output.get("mrs", [])
+    if mrs:
+        record_evidence_entry(
+            evidence,
+            source="list_gitlab_mrs",
+            label="GitLab Merge Requests",
+            summary=f"{len(mrs)} recent merge requests",
+        )
+
+
 @tool(
     name="list_gitlab_mrs",
     source="gitlab",
+    evidence_mapper=_map_list_gitlab_mrs,
     description="List recent merge requests for a GitLab project.",
     use_cases=[
         "Checking whether a recently merged MR introduced a failure",

--- a/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
@@ -34,9 +35,24 @@ def _list_gitlab_pipelines_available(sources: dict[str, dict]) -> bool:
     return bool(_gitlab_available(sources) and gl.get("project_id"))
 
 
+def _map_list_gitlab_pipelines(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record recent GitLab CI/CD pipelines as citeable evidence."""
+    pipelines = output.get("pipelines", [])
+    if pipelines:
+        record_evidence_entry(
+            evidence,
+            source="list_gitlab_pipelines",
+            label="GitLab Pipelines",
+            summary=f"{len(pipelines)} recent pipelines",
+        )
+
+
 @tool(
     name="list_gitlab_pipelines",
     source="gitlab",
+    evidence_mapper=_map_list_gitlab_pipelines,
     description="List recent CI/CD pipelines for a GitLab project.",
     use_cases=[
         "Checking whether a failed pipeline caused or coincided with the incident",

--- a/tests/integrations/gitlab/test_evidence_mapper.py
+++ b/tests/integrations/gitlab/test_evidence_mapper.py
@@ -50,6 +50,20 @@ def test_get_gitlab_file_records_identity_not_contents() -> None:
     assert "a: 1" not in entry["summary"]
 
 
+def test_get_gitlab_file_line_count_ignores_trailing_newline() -> None:
+    evidence: dict[str, Any] = {}
+
+    merge_tool_evidence(
+        evidence,
+        "get_gitlab_file",
+        {"file": {"file_path": "config/app.yaml", "content": "a\nb\nc\n"}},
+        {},
+    )
+
+    # A newline-terminated file has 3 lines, not 4.
+    assert evidence["catalog_entries"][0]["summary"] == "config/app.yaml (3 lines, 6 chars)"
+
+
 def test_get_gitlab_file_records_nothing_when_empty_or_unavailable() -> None:
     payloads: tuple[dict[str, Any], ...] = (
         {"file": {}},

--- a/tests/integrations/gitlab/test_evidence_mapper.py
+++ b/tests/integrations/gitlab/test_evidence_mapper.py
@@ -1,5 +1,7 @@
 """GitLab tools must surface their diagnostic output as citeable evidence."""
 
+from typing import Any
+
 import pytest
 
 from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
@@ -16,7 +18,7 @@ from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
 def test_gitlab_list_tools_record_counts_as_evidence(
     tool_name: str, result_key: str, label: str, noun: str
 ) -> None:
-    evidence: dict = {}
+    evidence: dict[str, Any] = {}
 
     merge_tool_evidence(evidence, tool_name, {result_key: [{"id": 1}, {"id": 2}]}, {})
 
@@ -25,13 +27,13 @@ def test_gitlab_list_tools_record_counts_as_evidence(
     assert entry["label"] == label
     assert entry["summary"] == f"2 {noun}"
 
-    empty: dict = {}
+    empty: dict[str, Any] = {}
     merge_tool_evidence(empty, tool_name, {result_key: []}, {})
     assert "catalog_entries" not in empty
 
 
 def test_get_gitlab_file_records_identity_not_contents() -> None:
-    evidence: dict = {}
+    evidence: dict[str, Any] = {}
 
     merge_tool_evidence(
         evidence,
@@ -49,7 +51,12 @@ def test_get_gitlab_file_records_identity_not_contents() -> None:
 
 
 def test_get_gitlab_file_records_nothing_when_empty_or_unavailable() -> None:
-    for payload in ({"file": {}}, {"file": {"content": ""}}, {"available": False}):
-        evidence: dict = {}
+    payloads: tuple[dict[str, Any], ...] = (
+        {"file": {}},
+        {"file": {"content": ""}},
+        {"available": False},
+    )
+    for payload in payloads:
+        evidence: dict[str, Any] = {}
         merge_tool_evidence(evidence, "get_gitlab_file", payload, {})
         assert "catalog_entries" not in evidence

--- a/tests/integrations/gitlab/test_evidence_mapper.py
+++ b/tests/integrations/gitlab/test_evidence_mapper.py
@@ -1,0 +1,55 @@
+"""GitLab tools must surface their diagnostic output as citeable evidence."""
+
+import pytest
+
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "result_key", "label", "noun"),
+    [
+        ("list_gitlab_commits", "commits", "GitLab Commits", "recent commits"),
+        ("list_gitlab_mrs", "mrs", "GitLab Merge Requests", "recent merge requests"),
+        ("list_gitlab_pipelines", "pipelines", "GitLab Pipelines", "recent pipelines"),
+    ],
+)
+def test_gitlab_list_tools_record_counts_as_evidence(
+    tool_name: str, result_key: str, label: str, noun: str
+) -> None:
+    evidence: dict = {}
+
+    merge_tool_evidence(evidence, tool_name, {result_key: [{"id": 1}, {"id": 2}]}, {})
+
+    entry = evidence["catalog_entries"][0]
+    assert entry["source"] == tool_name
+    assert entry["label"] == label
+    assert entry["summary"] == f"2 {noun}"
+
+    empty: dict = {}
+    merge_tool_evidence(empty, tool_name, {result_key: []}, {})
+    assert "catalog_entries" not in empty
+
+
+def test_get_gitlab_file_records_identity_not_contents() -> None:
+    evidence: dict = {}
+
+    merge_tool_evidence(
+        evidence,
+        "get_gitlab_file",
+        {"file": {"file_path": "config/app.yaml", "content": "a: 1\nb: 2\nc: 3"}},
+        {},
+    )
+
+    entry = evidence["catalog_entries"][0]
+    assert entry["source"] == "get_gitlab_file"
+    assert entry["label"] == "GitLab File"
+    assert entry["summary"] == "config/app.yaml (3 lines, 14 chars)"
+    # The file body must not be dumped into the citeable summary.
+    assert "a: 1" not in entry["summary"]
+
+
+def test_get_gitlab_file_records_nothing_when_empty_or_unavailable() -> None:
+    for payload in ({"file": {}}, {"file": {"content": ""}}, {"available": False}):
+        evidence: dict = {}
+        merge_tool_evidence(evidence, "get_gitlab_file", payload, {})
+        assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -65,7 +65,6 @@ get_github_file_contents
 get_github_repository
 get_github_repository_tree
 get_github_star_history
-get_gitlab_file
 get_groundcover_query_reference
 get_hermes_adapter_catalog
 get_hermes_approval_events
@@ -180,9 +179,6 @@ list_github_actions_workflow_runs
 list_github_commits
 list_github_security_alerts
 list_github_work_items
-list_gitlab_commits
-list_gitlab_mrs
-list_gitlab_pipelines
 list_jenkins_builds
 list_jenkins_jobs
 list_jenkins_running_builds


### PR DESCRIPTION
Fixes #5552 (part of epic #5519)

Wire the four read-only GitLab tools to `record_evidence_entry` so their output becomes citeable report evidence instead of being dropped:

| Tool | Records | Gate |
| --- | --- | --- |
| `list_gitlab_commits` | `"N recent commits"` | `commits` non-empty |
| `list_gitlab_mrs` | `"N recent merge requests"` | `mrs` non-empty |
| `list_gitlab_pipelines` | `"N recent pipelines"` | `pipelines` non-empty |
| `get_gitlab_file` | `"<path> (N lines, M chars)"` | nested `file.content` non-empty |

Removes the four tools from `evidence_mapper_baseline.txt` and adds unit tests. All four return diagnostic data; no action/notification tools touched.

### Demo — actual before/after

Real `merge_tool_evidence` output, `main` vs this branch. "before" = the summary recorded on `main` (these tools had no mapper, so their output was dropped); "after" = the summary this branch records. Reproduced by feeding each payload through `merge_tool_evidence` and reading `catalog_entries[0]["summary"]`:

```
tool                    input                                    before (main)  ->  after (this branch)
list_gitlab_commits     {"commits": [ {id:1}, {id:2}, {id:3} ]}  (dropped)      ->  3 recent commits
list_gitlab_mrs         {"mrs": [ {id:1}, {id:2} ]}              (dropped)      ->  2 recent merge requests
list_gitlab_pipelines   {"pipelines": [ {id:1} ]}                (dropped)      ->  1 recent pipelines
get_gitlab_file         {"file": {file_path: "config/app.yaml",  (dropped)      ->  config/app.yaml (3 lines, 15 chars)
                          content: "a: 1\nb: 2\nc: 3\n"}}
list_gitlab_commits     {"commits": []}                          (nothing)      ->  (nothing)   # no "0 items" noise
get_gitlab_file         {"available": False}                     (nothing)      ->  (nothing)
```

`get_gitlab_file` records path + size only — the file body is never dumped into the summary (context budget). Empty/unavailable/too-large/binary all record nothing.

Line counts use `len(content.splitlines())`, so a newline-terminated file (`a\nb\nc\n`) reports 3 lines, not 4 (review feedback — was `count("\n") + 1`).

Verification: `pytest -k gitlab` 160 passed · new mapper tests 6 passed (incl. trailing-newline regression) · ruff + mypy clean.

---

## Checklist
- [x] Proper PR title and linked issue
- [x] Self-review performed
- [x] I can explain every block I added
- [x] Tested thoroughly, edge cases considered
- [x] Added tests
- [x] Follows project style guidelines
