### PR TITLE
refactor(gitlab): break the setup/verifier import cycle via a client leaf

### DIFF
--- a/integrations/gitlab/__init__.py
+++ b/integrations/gitlab/__init__.py
@@ -1,279 +1,47 @@
-"""Shared gitlab integration helpers."""
+"""GitLab integration package — the public API other tiers import.
+
+The config/HTTP core lives in the ``client`` leaf; ``GITLAB_SETUP`` is
+re-exported lazily so importing the package does not pull the setup/verifier
+chain (and so the root does not import ``setup`` eagerly, keeping the graph
+acyclic).
+"""
 
 from __future__ import annotations
 
-import logging
-import os
-from dataclasses import dataclass
-from typing import Any
-from urllib.parse import quote, urlsplit
+import importlib
+from typing import TYPE_CHECKING
 
-import httpx
-from pydantic import Field, field_validator
-
-from config.constants.gitlab import GITLAB_AUTH_TOKEN_ENV, GITLAB_BASE_URL_ENV
-from config.llm_credentials import resolve_env_credential
-from config.strict_config import StrictConfigModel
-from integrations._validation_helpers import report_classify_failure, report_validation_failure
-
-logger = logging.getLogger(__name__)
-
-DEFAULT_GITLAB_BASE_URL = "https://gitlab.com/api/v4"
-
-
-def _normalize_gitlab_base_url(value: Any) -> str:
-    normalized = str(value or DEFAULT_GITLAB_BASE_URL).strip().rstrip("/")
-    if not normalized:
-        return DEFAULT_GITLAB_BASE_URL
-
-    parsed = urlsplit(normalized)
-    if parsed.scheme and parsed.netloc and parsed.path == "":
-        return f"{normalized}/api/v4"
-    return normalized
+from integrations.gitlab.client import (
+    DEFAULT_GITLAB_BASE_URL,
+    GitlabConfig,
+    GitlabValidationResult,
+    build_gitlab_config,
+    classify,
+    get_gitlab_commits,
+    get_gitlab_file,
+    get_gitlab_mrs,
+    get_gitlab_pipelines,
+    gitlab_config_from_env,
+    post_gitlab_mr_note,
+    validate_gitlab_config,
+    validate_gitlab_connection,
+)
 
 
-class GitlabConfig(StrictConfigModel):
-    """Normalized Gitlab connection settings."""
-
-    base_url: str = DEFAULT_GITLAB_BASE_URL
-    auth_token: str = ""
-    timeout_seconds: float = Field(default=15.0, gt=0)
-
-    @field_validator("base_url", mode="before")
-    @classmethod
-    def _normalize_base_url(cls, value: Any) -> str:
-        return _normalize_gitlab_base_url(value)
-
-    @property
-    def api_base_url(self) -> str:
-        return self.base_url.rstrip("/")
-
-    @property
-    def auth_headers(self) -> dict[str, str]:
-        headers = {"Accept": "application/json"}
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
-        return headers
+def __getattr__(name: str) -> object:
+    """Lazily re-export ``GITLAB_SETUP`` from the setup submodule (PEP 562)."""
+    if name == "GITLAB_SETUP":
+        return importlib.import_module("integrations.gitlab.setup").GITLAB_SETUP
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-@dataclass(frozen=True)
-class GitlabValidationResult:
-    """Result of validating a Gitlab integration."""
-
-    ok: bool
-    detail: str
-
-
-def build_gitlab_config(raw: dict[str, Any] | None) -> GitlabConfig:
-    """Build a normalized Gitlab config object from env/store data."""
-    return GitlabConfig.model_validate(raw or {})
-
-
-def gitlab_config_from_env() -> GitlabConfig | None:
-    """Load a Gitlab config from env vars."""
-    auth_token = resolve_env_credential(GITLAB_AUTH_TOKEN_ENV)
-    if not auth_token:
-        return None
-    return build_gitlab_config(
-        {
-            "base_url": os.getenv(GITLAB_BASE_URL_ENV, DEFAULT_GITLAB_BASE_URL).strip()
-            or DEFAULT_GITLAB_BASE_URL,
-            "auth_token": auth_token,
-        }
-    )
-
-
-def _request_json(
-    config: GitlabConfig,
-    method: str,
-    path: str,
-    *,
-    params: list[tuple[str, str | int | float | bool | None]] | None = None,
-    json: dict | None = None,
-) -> Any:
-    url = f"{config.api_base_url}{path}"
-    response = httpx.request(
-        method,
-        url,
-        json=json,
-        headers=config.auth_headers,
-        params=params,
-        timeout=config.timeout_seconds,
-    )
-    response.raise_for_status()
-    return response.json()
-
-
-def validate_gitlab_config(config: GitlabConfig) -> GitlabValidationResult:
-    """Validate gitlab connectivity with a lightweight user query."""
-
-    if not config.auth_token:
-        return GitlabValidationResult(ok=False, detail="Gitlab auth token is required.")
-
-    try:
-        user = validate_gitlab_connection(config=config)
-        username = user.get("username", "unknown")
-        return GitlabValidationResult(
-            ok=True, detail=f"GitLab connectivity successful. Authenticated as @{username}"
-        )
-    except httpx.HTTPStatusError as err:
-        detail = err.response.text.strip() or str(err)
-        return GitlabValidationResult(ok=False, detail=f"Gitlab validation failed: {detail}")
-    except Exception as err:
-        report_validation_failure(
-            err,
-            logger=logger,
-            integration="gitlab",
-            method="validate_gitlab_config",
-        )
-        return GitlabValidationResult(ok=False, detail=f"Gitlab validation failed: {err}")
-
-
-def validate_gitlab_connection(
-    *,
-    config: GitlabConfig,
-) -> dict[str, Any]:
-    """Validate gitlab connection."""
-
-    payload = _request_json(
-        config,
-        "GET",
-        "/user",
-    )
-    return payload if isinstance(payload, dict) else {}
-
-
-def get_gitlab_commits(
-    *, config: GitlabConfig, project_id: str, ref_name="main", since: str, per_page: int = 10
-) -> list[dict[str, Any]]:
-    """Fetch gitlab commits for project."""
-
-    encoded_project_id = quote(project_id, safe="")
-    params: list[tuple[str, str | int | float | bool | None]] = [
-        ("ref_name", ref_name),
-        ("per_page", per_page),
-    ]
-    if since:
-        params.append(("since", since))
-    payload = _request_json(
-        config,
-        "GET",
-        f"/projects/{encoded_project_id}/repository/commits",
-        params=params,
-    )
-    return payload if isinstance(payload, list) else []
-
-
-def get_gitlab_mrs(
-    *,
-    config: GitlabConfig,
-    project_id: str,
-    state: str = "merged",
-    target_branch: str = "main",
-    updated_after: str,
-    per_page: int = 10,
-) -> list[dict[str, Any]]:
-    """Fetch gitlab Merge requests for project."""
-
-    encoded_project_id = quote(project_id, safe="")
-    params: list[tuple[str, str | int | float | bool | None]] = [
-        ("state", state),
-        ("target_branch", target_branch),
-        ("per_page", per_page),
-    ]
-    if updated_after:
-        params.append(("updated_after", updated_after))
-    payload = _request_json(
-        config,
-        "GET",
-        f"/projects/{encoded_project_id}/merge_requests",
-        params=params,
-    )
-    return payload if isinstance(payload, list) else []
-
-
-def get_gitlab_pipelines(
-    *,
-    config: GitlabConfig,
-    project_id: str,
-    ref: str = "main",
-    status: str = "failed",
-    updated_after: str,
-    per_page: int = 5,
-) -> list[dict[str, Any]]:
-    """Fetch gitlab pipelines for project."""
-
-    encoded_project_id = quote(project_id, safe="")
-    params: list[tuple[str, str | int | float | bool | None]] = [
-        ("status", status),
-        ("ref", ref),
-        ("per_page", per_page),
-    ]
-    if updated_after:
-        params.append(("updated_after", updated_after))
-    payload = _request_json(
-        config,
-        "GET",
-        f"/projects/{encoded_project_id}/pipelines",
-        params=params,
-    )
-    return payload if isinstance(payload, list) else []
-
-
-def get_gitlab_file(
-    *,
-    config: GitlabConfig,
-    project_id: str,
-    ref: str = "main",
-    file_path: str,
-) -> dict[str, Any]:
-    """Fetch particular gitlab file"""
-
-    encoded_project_id = quote(project_id, safe="")
-    encoded_path = quote(file_path, safe="")
-    payload = _request_json(
-        config,
-        "GET",
-        f"/projects/{encoded_project_id}/repository/files/{encoded_path}",
-        params=[
-            ("ref", ref),
-        ],
-    )
-    return payload if isinstance(payload, dict) else {}
-
-
-def post_gitlab_mr_note(
-    *, config: GitlabConfig, project_id: str, mr_iid: str, body: str
-) -> dict[str, Any]:
-    """Post findings back on mr as comment"""
-
-    encoded_project_id = quote(project_id, safe="")
-    json_body = {"body": body}
-    payload = _request_json(
-        config,
-        "POST",
-        f"/projects/{encoded_project_id}/merge_requests/{mr_iid}/notes",
-        json=json_body,
-    )
-    return payload if isinstance(payload, dict) else {}
-
-
-def classify(credentials: dict[str, Any], record_id: str) -> tuple[GitlabConfig | None, str | None]:
-    try:
-        cfg = build_gitlab_config(
-            {
-                "base_url": credentials.get("base_url", ""),
-                "auth_token": credentials.get("auth_token", ""),
-            }
-        )
-    except Exception as exc:
-        report_classify_failure(exc, logger=logger, integration="gitlab", record_id=record_id)
-        return None, None
-    return cfg, "gitlab"
+if TYPE_CHECKING:
+    from integrations.gitlab.setup import GITLAB_SETUP
 
 
 __all__ = [
     "DEFAULT_GITLAB_BASE_URL",
+    "GITLAB_SETUP",
     "GitlabConfig",
     "GitlabValidationResult",
     "build_gitlab_config",

--- a/integrations/gitlab/client.py
+++ b/integrations/gitlab/client.py
@@ -1,0 +1,295 @@
+"""GitLab config, HTTP client, and validation — the vendor's leaf core.
+
+Kept below the package root so ``setup.py`` and ``verifier.py`` import their
+config/validation helpers from here rather than from ``integrations.gitlab``.
+That lets the root re-export ``GITLAB_SETUP`` without a ``root -> setup ->
+verifier -> root`` import cycle. The public API is re-exported from the root.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, urlsplit
+
+import httpx
+from pydantic import Field, field_validator
+
+from config.constants.gitlab import GITLAB_AUTH_TOKEN_ENV, GITLAB_BASE_URL_ENV
+from config.llm_credentials import resolve_env_credential
+from config.strict_config import StrictConfigModel
+from integrations._validation_helpers import report_classify_failure, report_validation_failure
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GITLAB_BASE_URL = "https://gitlab.com/api/v4"
+
+
+def _normalize_gitlab_base_url(value: Any) -> str:
+    normalized = str(value or DEFAULT_GITLAB_BASE_URL).strip().rstrip("/")
+    if not normalized:
+        return DEFAULT_GITLAB_BASE_URL
+
+    parsed = urlsplit(normalized)
+    if parsed.scheme and parsed.netloc and parsed.path == "":
+        return f"{normalized}/api/v4"
+    return normalized
+
+
+class GitlabConfig(StrictConfigModel):
+    """Normalized Gitlab connection settings."""
+
+    base_url: str = DEFAULT_GITLAB_BASE_URL
+    auth_token: str = ""
+    timeout_seconds: float = Field(default=15.0, gt=0)
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _normalize_base_url(cls, value: Any) -> str:
+        return _normalize_gitlab_base_url(value)
+
+    @property
+    def api_base_url(self) -> str:
+        return self.base_url.rstrip("/")
+
+    @property
+    def auth_headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        return headers
+
+
+@dataclass(frozen=True)
+class GitlabValidationResult:
+    """Result of validating a Gitlab integration."""
+
+    ok: bool
+    detail: str
+
+
+def build_gitlab_config(raw: dict[str, Any] | None) -> GitlabConfig:
+    """Build a normalized Gitlab config object from env/store data."""
+    return GitlabConfig.model_validate(raw or {})
+
+
+def gitlab_config_from_env() -> GitlabConfig | None:
+    """Load a Gitlab config from env vars."""
+    auth_token = resolve_env_credential(GITLAB_AUTH_TOKEN_ENV)
+    if not auth_token:
+        return None
+    return build_gitlab_config(
+        {
+            "base_url": os.getenv(GITLAB_BASE_URL_ENV, DEFAULT_GITLAB_BASE_URL).strip()
+            or DEFAULT_GITLAB_BASE_URL,
+            "auth_token": auth_token,
+        }
+    )
+
+
+def _request_json(
+    config: GitlabConfig,
+    method: str,
+    path: str,
+    *,
+    params: list[tuple[str, str | int | float | bool | None]] | None = None,
+    json: dict | None = None,
+) -> Any:
+    url = f"{config.api_base_url}{path}"
+    response = httpx.request(
+        method,
+        url,
+        json=json,
+        headers=config.auth_headers,
+        params=params,
+        timeout=config.timeout_seconds,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def validate_gitlab_config(config: GitlabConfig) -> GitlabValidationResult:
+    """Validate gitlab connectivity with a lightweight user query."""
+
+    if not config.auth_token:
+        return GitlabValidationResult(ok=False, detail="Gitlab auth token is required.")
+
+    try:
+        user = validate_gitlab_connection(config=config)
+        username = user.get("username", "unknown")
+        return GitlabValidationResult(
+            ok=True, detail=f"GitLab connectivity successful. Authenticated as @{username}"
+        )
+    except httpx.HTTPStatusError as err:
+        detail = err.response.text.strip() or str(err)
+        return GitlabValidationResult(ok=False, detail=f"Gitlab validation failed: {detail}")
+    except Exception as err:
+        report_validation_failure(
+            err,
+            logger=logger,
+            integration="gitlab",
+            method="validate_gitlab_config",
+        )
+        return GitlabValidationResult(ok=False, detail=f"Gitlab validation failed: {err}")
+
+
+def validate_gitlab_connection(
+    *,
+    config: GitlabConfig,
+) -> dict[str, Any]:
+    """Validate gitlab connection."""
+
+    payload = _request_json(
+        config,
+        "GET",
+        "/user",
+    )
+    return payload if isinstance(payload, dict) else {}
+
+
+def get_gitlab_commits(
+    *, config: GitlabConfig, project_id: str, ref_name="main", since: str, per_page: int = 10
+) -> list[dict[str, Any]]:
+    """Fetch gitlab commits for project."""
+
+    encoded_project_id = quote(project_id, safe="")
+    params: list[tuple[str, str | int | float | bool | None]] = [
+        ("ref_name", ref_name),
+        ("per_page", per_page),
+    ]
+    if since:
+        params.append(("since", since))
+    payload = _request_json(
+        config,
+        "GET",
+        f"/projects/{encoded_project_id}/repository/commits",
+        params=params,
+    )
+    return payload if isinstance(payload, list) else []
+
+
+def get_gitlab_mrs(
+    *,
+    config: GitlabConfig,
+    project_id: str,
+    state: str = "merged",
+    target_branch: str = "main",
+    updated_after: str,
+    per_page: int = 10,
+) -> list[dict[str, Any]]:
+    """Fetch gitlab Merge requests for project."""
+
+    encoded_project_id = quote(project_id, safe="")
+    params: list[tuple[str, str | int | float | bool | None]] = [
+        ("state", state),
+        ("target_branch", target_branch),
+        ("per_page", per_page),
+    ]
+    if updated_after:
+        params.append(("updated_after", updated_after))
+    payload = _request_json(
+        config,
+        "GET",
+        f"/projects/{encoded_project_id}/merge_requests",
+        params=params,
+    )
+    return payload if isinstance(payload, list) else []
+
+
+def get_gitlab_pipelines(
+    *,
+    config: GitlabConfig,
+    project_id: str,
+    ref: str = "main",
+    status: str = "failed",
+    updated_after: str,
+    per_page: int = 5,
+) -> list[dict[str, Any]]:
+    """Fetch gitlab pipelines for project."""
+
+    encoded_project_id = quote(project_id, safe="")
+    params: list[tuple[str, str | int | float | bool | None]] = [
+        ("status", status),
+        ("ref", ref),
+        ("per_page", per_page),
+    ]
+    if updated_after:
+        params.append(("updated_after", updated_after))
+    payload = _request_json(
+        config,
+        "GET",
+        f"/projects/{encoded_project_id}/pipelines",
+        params=params,
+    )
+    return payload if isinstance(payload, list) else []
+
+
+def get_gitlab_file(
+    *,
+    config: GitlabConfig,
+    project_id: str,
+    ref: str = "main",
+    file_path: str,
+) -> dict[str, Any]:
+    """Fetch particular gitlab file"""
+
+    encoded_project_id = quote(project_id, safe="")
+    encoded_path = quote(file_path, safe="")
+    payload = _request_json(
+        config,
+        "GET",
+        f"/projects/{encoded_project_id}/repository/files/{encoded_path}",
+        params=[
+            ("ref", ref),
+        ],
+    )
+    return payload if isinstance(payload, dict) else {}
+
+
+def post_gitlab_mr_note(
+    *, config: GitlabConfig, project_id: str, mr_iid: str, body: str
+) -> dict[str, Any]:
+    """Post findings back on mr as comment"""
+
+    encoded_project_id = quote(project_id, safe="")
+    json_body = {"body": body}
+    payload = _request_json(
+        config,
+        "POST",
+        f"/projects/{encoded_project_id}/merge_requests/{mr_iid}/notes",
+        json=json_body,
+    )
+    return payload if isinstance(payload, dict) else {}
+
+
+def classify(credentials: dict[str, Any], record_id: str) -> tuple[GitlabConfig | None, str | None]:
+    try:
+        cfg = build_gitlab_config(
+            {
+                "base_url": credentials.get("base_url", ""),
+                "auth_token": credentials.get("auth_token", ""),
+            }
+        )
+    except Exception as exc:
+        report_classify_failure(exc, logger=logger, integration="gitlab", record_id=record_id)
+        return None, None
+    return cfg, "gitlab"
+
+
+__all__ = [
+    "DEFAULT_GITLAB_BASE_URL",
+    "GitlabConfig",
+    "GitlabValidationResult",
+    "build_gitlab_config",
+    "classify",
+    "get_gitlab_commits",
+    "get_gitlab_file",
+    "get_gitlab_mrs",
+    "get_gitlab_pipelines",
+    "gitlab_config_from_env",
+    "post_gitlab_mr_note",
+    "validate_gitlab_config",
+    "validate_gitlab_connection",
+]

--- a/integrations/gitlab/setup.py
+++ b/integrations/gitlab/setup.py
@@ -8,7 +8,7 @@ and stored an integration that could not authenticate.
 from __future__ import annotations
 
 from config.constants.gitlab import GITLAB_AUTH_TOKEN_ENV, GITLAB_BASE_URL_ENV
-from integrations.gitlab import DEFAULT_GITLAB_BASE_URL
+from integrations.gitlab.client import DEFAULT_GITLAB_BASE_URL
 from integrations.gitlab.verifier import verify_gitlab
 from integrations.setup_flow import IntegrationSetupSpec, SetupField
 

--- a/integrations/gitlab/verifier.py
+++ b/integrations/gitlab/verifier.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from integrations.gitlab import build_gitlab_config, validate_gitlab_config
+from integrations.gitlab.client import build_gitlab_config, validate_gitlab_config
 from integrations.verification import register_validation_verifier
 
 verify_gitlab = register_validation_verifier(

--- a/surfaces/cli/wizard/configurators/gitlab.py
+++ b/surfaces/cli/wizard/configurators/gitlab.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from integrations.gitlab.setup import GITLAB_SETUP
+from integrations.gitlab import GITLAB_SETUP
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 
 

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -101,7 +101,7 @@ _CLASSIFY_PATCH_TARGETS: list[tuple[str, str, str]] = [
     ("new_relic", "integrations.new_relic", "NewRelicIntegrationConfig"),
     ("github", "integrations.github.mcp", "build_github_mcp_config"),
     ("sentry", "integrations.sentry", "build_sentry_config"),
-    ("gitlab", "integrations.gitlab", "build_gitlab_config"),
+    ("gitlab", "integrations.gitlab.client", "build_gitlab_config"),
     ("mongodb", "integrations.mongodb", "build_mongodb_config"),
     ("postgresql", "integrations.postgresql", "build_postgresql_config"),
     ("mongodb_atlas", "integrations.mongodb_atlas", "build_mongodb_atlas_config"),

--- a/tests/integrations/test_gitlab.py
+++ b/tests/integrations/test_gitlab.py
@@ -184,7 +184,7 @@ def test_validate_gitlab_config_returns_ok_on_success(
         return {"username": "gl-user"}
 
     monkeypatch.setattr(
-        "integrations.gitlab.validate_gitlab_connection",
+        "integrations.gitlab.client.validate_gitlab_connection",
         _ok,
     )
 
@@ -206,7 +206,7 @@ def test_validate_gitlab_config_handles_http_error(
             response=response,
         )
 
-    monkeypatch.setattr("integrations.gitlab.validate_gitlab_connection", _raise)
+    monkeypatch.setattr("integrations.gitlab.client.validate_gitlab_connection", _raise)
 
     result = validate_gitlab_config(_make_config())
 
@@ -222,7 +222,7 @@ def test_validate_gitlab_config_handles_generic_exception(
         raise RuntimeError("connection refused")
 
     monkeypatch.setattr(
-        "integrations.gitlab.validate_gitlab_connection",
+        "integrations.gitlab.client.validate_gitlab_connection",
         _boom,
     )
 
@@ -237,7 +237,7 @@ def test_verify_gitlab_wraps_validation_result(monkeypatch: pytest.MonkeyPatch) 
         del config
         return {"username": "gl-user"}
 
-    monkeypatch.setattr("integrations.gitlab.validate_gitlab_connection", _ok)
+    monkeypatch.setattr("integrations.gitlab.client.validate_gitlab_connection", _ok)
 
     result = verify_gitlab("local store", {"auth_token": "test-token"})
 
@@ -258,7 +258,7 @@ def test_validate_gitlab_connection_returns_user_dict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse({"id": 1, "username": "gl-user"}),
     )
 
@@ -271,7 +271,7 @@ def test_validate_gitlab_connection_returns_empty_dict_for_non_dict_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse(["unexpected", "list"]),
     )
 
@@ -288,7 +288,7 @@ def test_validate_gitlab_connection_returns_empty_dict_for_non_dict_response(
 def test_get_gitlab_commits_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
     commits = [{"id": "abc123", "title": "Fix bug"}]
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse(commits),
     )
 
@@ -310,7 +310,7 @@ def test_get_gitlab_commits_url_encodes_project_id(
         captured["url"] = url
         return _FakeResponse([])
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     get_gitlab_commits(
         config=_make_config(),
@@ -325,7 +325,7 @@ def test_get_gitlab_commits_returns_empty_list_for_non_list_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse({"error": "not found"}),
     )
 
@@ -347,7 +347,7 @@ def test_get_gitlab_commits_includes_since_param_when_provided(
         captured["params"] = kw.get("params", [])
         return _FakeResponse([])
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     get_gitlab_commits(
         config=_make_config(),
@@ -367,7 +367,7 @@ def test_get_gitlab_commits_includes_since_param_when_provided(
 def test_get_gitlab_mrs_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
     mrs = [{"iid": 1, "title": "Add feature"}]
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse(mrs),
     )
 
@@ -387,7 +387,7 @@ def test_get_gitlab_mrs_url_encodes_project_id(monkeypatch: pytest.MonkeyPatch) 
         captured["url"] = url
         return _FakeResponse([])
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     get_gitlab_mrs(
         config=_make_config(),
@@ -402,7 +402,7 @@ def test_get_gitlab_mrs_returns_empty_list_for_non_list_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse({}),
     )
 
@@ -423,7 +423,7 @@ def test_get_gitlab_mrs_returns_empty_list_for_non_list_response(
 def test_get_gitlab_pipelines_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
     pipelines = [{"id": 99, "status": "failed"}]
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse(pipelines),
     )
 
@@ -445,7 +445,7 @@ def test_get_gitlab_pipelines_url_encodes_project_id(
         captured["url"] = url
         return _FakeResponse([])
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     get_gitlab_pipelines(
         config=_make_config(),
@@ -460,7 +460,7 @@ def test_get_gitlab_pipelines_returns_empty_list_for_non_list_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse({"unexpected": "dict"}),
     )
 
@@ -481,7 +481,7 @@ def test_get_gitlab_pipelines_returns_empty_list_for_non_list_response(
 def test_get_gitlab_file_returns_dict(monkeypatch: pytest.MonkeyPatch) -> None:
     file_data = {"file_name": "README.md", "content": "SGVsbG8="}
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse(file_data),
     )
 
@@ -503,7 +503,7 @@ def test_get_gitlab_file_url_encodes_project_id_and_path(
         captured["url"] = url
         return _FakeResponse({})
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     get_gitlab_file(
         config=_make_config(),
@@ -519,7 +519,7 @@ def test_get_gitlab_file_returns_empty_dict_for_non_dict_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse(["not", "a", "dict"]),
     )
 
@@ -544,7 +544,7 @@ def test_post_gitlab_mr_note_uses_post_method(monkeypatch: pytest.MonkeyPatch) -
         captured["method"] = method
         return _FakeResponse({"id": 1, "body": "RCA Finding"})
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     post_gitlab_mr_note(
         config=_make_config(), project_id="my-org/my-repo", mr_iid="42", body="RCA Finding"
@@ -560,7 +560,7 @@ def test_post_gitlab_mr_note_url_encodes_project_id(monkeypatch: pytest.MonkeyPa
         captured["url"] = url
         return _FakeResponse({"id": 1})
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     post_gitlab_mr_note(config=_make_config(), project_id="my-org/my-repo", mr_iid="7", body="note")
 
@@ -575,7 +575,7 @@ def test_post_gitlab_mr_note_sends_body_in_json(monkeypatch: pytest.MonkeyPatch)
         captured["json"] = kw.get("json")
         return _FakeResponse({"id": 1})
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     post_gitlab_mr_note(
         config=_make_config(), project_id="proj", mr_iid="3", body="root cause is X"
@@ -588,7 +588,7 @@ def test_post_gitlab_mr_note_returns_empty_dict_for_non_dict_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse([{"unexpected": "list"}]),
     )
 
@@ -600,7 +600,7 @@ def test_post_gitlab_mr_note_returns_empty_dict_for_non_dict_response(
 def test_post_gitlab_mr_note_returns_created_note_dict(monkeypatch: pytest.MonkeyPatch) -> None:
     note = {"id": 42, "body": "RCA: deployment caused the spike", "author": {"username": "bot"}}
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse(note),
     )
 
@@ -617,7 +617,7 @@ def test_post_gitlab_mr_note_returns_created_note_dict(monkeypatch: pytest.Monke
 
 def test_post_gitlab_mr_note_raises_on_403(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse({}, status_code=403),
     )
 
@@ -627,7 +627,7 @@ def test_post_gitlab_mr_note_raises_on_403(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_post_gitlab_mr_note_raises_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "integrations.gitlab.httpx.request",
+        "integrations.gitlab.client.httpx.request",
         lambda *_, **__: _FakeResponse({}, status_code=404),
     )
 
@@ -642,7 +642,7 @@ def test_post_gitlab_mr_note_mr_iid_in_url_path(monkeypatch: pytest.MonkeyPatch)
         captured["url"] = url
         return _FakeResponse({"id": 1})
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     post_gitlab_mr_note(config=_make_config(), project_id="proj", mr_iid="123", body="note")
 
@@ -657,7 +657,7 @@ def test_post_gitlab_mr_note_sends_multiline_body(monkeypatch: pytest.MonkeyPatc
         captured["json"] = kw.get("json")
         return _FakeResponse({"id": 1})
 
-    monkeypatch.setattr("integrations.gitlab.httpx.request", _fake_request)
+    monkeypatch.setattr("integrations.gitlab.client.httpx.request", _fake_request)
 
     post_gitlab_mr_note(config=_make_config(), project_id="proj", mr_iid="1", body=multiline)
 

--- a/tests/integrations/test_validator_sentry_capture.py
+++ b/tests/integrations/test_validator_sentry_capture.py
@@ -143,7 +143,10 @@ CASES: tuple[MigrationCase, ...] = (
     MigrationCase("integrations/betterstack.py", "query_logs", "betterstack", "query_logs"),
     # gitlab
     MigrationCase(
-        "integrations/gitlab.py", "validate_gitlab_config", "gitlab", "validate_gitlab_config"
+        "integrations/gitlab/client.py",
+        "validate_gitlab_config",
+        "gitlab",
+        "validate_gitlab_config",
     ),
     # bitbucket
     MigrationCase(

--- a/tests/shared/test_integrations_api_border.py
+++ b/tests/shared/test_integrations_api_border.py
@@ -81,7 +81,6 @@ _ALLOWED: dict[str, frozenset[str]] = {
             "integrations.github.mcp",
             "integrations.github.mcp_oauth",
             "integrations.github.setup",
-            "integrations.gitlab.setup",
             "integrations.jenkins.setup",
             "integrations.llm_cli.binary_resolver",
             "integrations.llm_cli.codex_oauth",


### PR DESCRIPTION
setup.py and verifier.py imported config/validation helpers from the package root, so re-exporting GITLAB_SETUP at the root would form a root -> setup -> verifier -> root cycle. Move the config/HTTP core into a new integrations/gitlab/client.py leaf; the root __init__ re-exports it (and GITLAB_SETUP lazily). setup.py and verifier.py now import from the leaf, so the
graph is acyclic and GITLAB_SETUP is reachable from the root. Migrate the one boundary caller and drop the allowlist entry. Repoint tests that patched the moved functions to the client module.