### PR TITLE
fix(correlation): score sustained elevation as a single spike

### DIFF
--- a/core/domain/correlation/scoring.py
+++ b/core/domain/correlation/scoring.py
@@ -144,7 +144,13 @@ def score_periodic_spikes(
     values: tuple[float, ...],
     spike_threshold: float,
 ) -> PeriodicityScore:
-    repeated_spikes = sum(1 for value in values if value >= spike_threshold)
+    # Count upward threshold crossings so a sustained elevation scores as one
+    # spike, not one per elevated sample.
+    repeated_spikes = sum(
+        1
+        for previous, value in zip(values, values[1:])
+        if previous < spike_threshold and value >= spike_threshold
+    )
 
     if repeated_spikes <= 1:
         score = 0.0

--- a/tests/synthetic/rds_postgres/correlation/test_periodicity.py
+++ b/tests/synthetic/rds_postgres/correlation/test_periodicity.py
@@ -21,3 +21,14 @@ def test_periodic_spikes_score_low_when_not_repeated() -> None:
 
     assert result.repeated_spikes == 1
     assert result.score == 0.0
+
+
+def test_periodic_spikes_sustained_elevation_is_one_spike() -> None:
+    result = score_periodic_spikes(
+        signal_name="upstream_cpu",
+        values=(20.0, 90.0, 90.0, 90.0, 20.0),
+        spike_threshold=80.0,
+    )
+
+    assert result.repeated_spikes == 1
+    assert result.score == 0.0


### PR DESCRIPTION
Fixes #4249

#### Describe the changes you have made in this PR -

`score_periodic_spikes` counted every sample at or above `spike_threshold`, so a single sustained spike scored as a repeated pattern. A signal like `(20, 90, 90, 90, 20)` with threshold 80 returned `repeated_spikes=3, score=1.0` when it crosses the threshold once.

The count is now upward threshold crossings: a sample at or above the threshold whose predecessor was below it. Sustained elevation counts as one spike, alternating spikes still count individually, and a fully elevated series counts zero crossings. The existing alternating-series tests pass unchanged; added a sustained-elevation case that fails on main.

### Demo/Screenshot for feature changes and bug fixes -

Before, on main:

```
FAILED tests/synthetic/rds_postgres/correlation/test_periodicity.py::test_periodic_spikes_sustained_elevation_is_one_spike
AssertionError: assert 3 == 1
```

After:

```
6 passed in 0.64s
```

`make lint`, `make format-check`, `make typecheck` all green.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The reported symptom is a counting bug: elevated samples were treated as independent spikes. Periodicity implies repetition, so the right unit is a below-to-above transition, which a `zip(values, values[1:])` pairwise scan counts directly. I considered also counting a series that starts elevated as one spike, but a leading plateau has no crossing and calling it periodic would reintroduce the false positive the issue is about, so it counts zero. Edge cases: empty or single-sample input yields zero crossings, and a fully elevated series scores 0.0.
