### PR TITLE
fix(packaging): bundle prompts and validate PR binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,14 @@
 name: Release
 
 on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "tests/**"
+      - "*.md"
+      - "*.mdx"
+      - ".claude/**"
   push:
     branches: [main]
     paths-ignore:
@@ -30,11 +38,11 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 concurrency:
-  group: release-${{ github.event_name == 'push' && 'main' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'main' && 'main') || 'stable' }}
+  group: release-${{ github.event_name == 'pull_request' && github.event.pull_request.number || (github.event_name == 'push' && 'main') || (github.event_name == 'workflow_dispatch' && inputs.channel == 'main' && 'main') || 'stable' }}
   cancel-in-progress: true
 
 jobs:
@@ -62,6 +70,18 @@ jobs:
           set -euo pipefail
 
           channel="release"
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            short_sha="${GITHUB_SHA:0:7}"
+            year="$(date -u +%Y)"
+            month="$(date -u +%-m)"
+            day="$(date -u +%-d)"
+
+            echo "channel=pr" >> "$GITHUB_OUTPUT"
+            echo "tag_name=pr-build" >> "$GITHUB_OUTPUT"
+            echo "version_name=0.1.${year}.${month}.${day}+pr.${short_sha}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ "$EVENT_NAME" = "push" ]; then
             channel="main"
@@ -469,8 +489,10 @@ jobs:
           set -euo pipefail
           if [ "$RELEASE_CHANNEL" = "release" ]; then
             ASSET_BASENAME="opensre_${TAG_NAME#v}_${{ matrix.target }}"
-          else
+          elif [ "$RELEASE_CHANNEL" = "main" ]; then
             ASSET_BASENAME="opensre_main_${{ matrix.target }}"
+          else
+            ASSET_BASENAME="opensre_pr_${{ matrix.target }}"
           fi
           tar -C dist -czf "${ASSET_BASENAME}.tar.gz" "${{ matrix.binary_name }}"
           shasum -a 256 "${ASSET_BASENAME}.tar.gz" > "${ASSET_BASENAME}.tar.gz.sha256"
@@ -491,7 +513,7 @@ jobs:
       - name: Upload binary archive
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.RELEASE_CHANNEL == 'main' && 'main-' || '' }}release-${{ matrix.target }}
+          name: ${{ env.RELEASE_CHANNEL == 'pr' && 'pr-' || env.RELEASE_CHANNEL == 'main' && 'main-' || '' }}release-${{ matrix.target }}
           path: |
             opensre_*_${{ matrix.target }}.${{ matrix.archive_ext }}
             opensre_*_${{ matrix.target }}.${{ matrix.archive_ext }}.sha256
@@ -500,6 +522,9 @@ jobs:
   publish-release:
     if: needs.prepare.outputs.channel == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
     needs:
       - prepare
       - build-python-dist
@@ -702,6 +727,9 @@ jobs:
   publish-main-release:
     if: always() && needs.prepare.outputs.channel == 'main' && needs.build-binaries.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
     needs:
       - prepare
       - build-binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,8 +503,10 @@ jobs:
         run: |
           if ($env:RELEASE_CHANNEL -eq "release") {
             $assetBaseName = "opensre_$($env:TAG_NAME.TrimStart('v'))_${{ matrix.target }}"
-          } else {
+          } elseif ($env:RELEASE_CHANNEL -eq "main") {
             $assetBaseName = "opensre_main_${{ matrix.target }}"
+          } else {
+            $assetBaseName = "opensre_pr_${{ matrix.target }}"
           }
           Compress-Archive -Path "dist\${{ matrix.binary_name }}" -DestinationPath "${assetBaseName}.zip"
           $hash = (Get-FileHash -Algorithm SHA256 "${assetBaseName}.zip").Hash.ToLowerInvariant()

--- a/opensre.spec
+++ b/opensre.spec
@@ -20,6 +20,7 @@ skill_data_entries = manifest["skill_data_entries"]
 infrastructure_data_entries = manifest["infrastructure_data_entries"]
 
 datas = list(infrastructure_data_entries(ROOT))
+datas += collect_data_files("core.agent_harness.prompts.action")
 datas += collect_data_files("surfaces.cli")
 datas += collect_data_files("surfaces.shared")
 datas += collect_data_files("config")

--- a/tests/packaging/test_frozen_entrypoint.py
+++ b/tests/packaging/test_frozen_entrypoint.py
@@ -58,3 +58,11 @@ def test_frozen_bundle_ships_the_shared_surface_data() -> None:
     # Act / Assert
     assert 'collect_data_files("surfaces.shared")' in spec
     assert (REPO_ROOT / "surfaces/shared/sample_alerts/alert.json").is_file()
+
+
+def test_frozen_bundle_ships_the_action_system_prompt() -> None:
+    """The action prompt loader reads its Markdown file at runtime."""
+    spec = (REPO_ROOT / "opensre.spec").read_text(encoding="utf-8")
+
+    assert 'collect_data_files("core.agent_harness.prompts.action")' in spec
+    assert (REPO_ROOT / "core/agent_harness/prompts/action/opensre_system_prompt.md").is_file()

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -85,6 +85,15 @@ def test_release_build_uses_checked_in_spec() -> None:
     assert "skill_data_entries(ROOT)" in spec
 
 
+def test_pull_requests_build_release_binaries_without_publishing() -> None:
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "  pull_request:\n    branches: [main]" in workflow
+    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in workflow
+    assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' in workflow
+    assert "if: needs.prepare.outputs.channel == 'release'" in workflow
+
+
 def test_infrastructure_data_excludes_the_cloudflare_worker() -> None:
     """The Cloudflare install-proxy is a JS Worker deployed via ``wrangler``.
 

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -91,6 +91,8 @@ def test_pull_requests_build_release_binaries_without_publishing() -> None:
     assert "  pull_request:\n    branches: [main]" in workflow
     assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in workflow
     assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' in workflow
+    assert workflow.count('ASSET_BASENAME="opensre_pr_${{ matrix.target }}"') == 1
+    assert workflow.count('$assetBaseName = "opensre_pr_${{ matrix.target }}"') == 1
     assert "if: needs.prepare.outputs.channel == 'release'" in workflow
 
 


### PR DESCRIPTION
Related to #5732

#### Describe the changes you have made in this PR -

- Bundle `core.agent_harness.prompts.action` data in PyInstaller artifacts so the Markdown-backed system prompt is available at runtime.
- Run the release binary matrix for runtime pull requests using a non-publishing `pr` channel.
- Isolate PR concurrency and artifact names from rolling-main and stable releases.
- Limit write permissions to the two publishing jobs; PR build jobs receive read-only contents access.
- Add packaging contracts for the prompt data and PR release-workflow path.

The post-merge Release run failed on Linux x64 and arm64 because the frozen executable could not read `opensre_system_prompt.md`: https://github.com/Tracer-Cloud/opensre/actions/runs/32860944224/job/97844581315

### Demo/Screenshot for feature changes and bug fixes -

Local PyInstaller onedir build and the same smoke commands used by Release CI:

```text
Build complete! The results are available in: .../dist
opensre, version 0.1
{"action_skills": 6, "integration_verifiers": 62, "registered_tools": 290, "status": "ok"}
```

Validation:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/packaging/test_frozen_entrypoint.py tests/packaging/test_release_manifest.py` (15 passed)
- `OPENSRE_PYINSTALLER_MODE=onedir uv run pyinstaller opensre.spec --clean --noconfirm`
- `./dist/opensre/opensre --version`
- `./dist/opensre/opensre -h`
- `./dist/opensre/opensre _package-smoke`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The Python wheel already declares the action Markdown as package data, but PyInstaller has a separate data manifest. The smallest root-cause fix is therefore to collect that owning action-prompt package in `opensre.spec`, matching the existing package-specific data collection pattern.

The failure was invisible before merge because Release only ran on `main`, schedules, and manual dispatches. The workflow now handles `pull_request` as a distinct `pr` channel: verification and all binary smoke builds run, while Python distribution publishing, stable publishing, and rolling-main publishing remain gated to their existing channels. PR runs also receive a PR-specific concurrency group and artifact prefix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
