### PR TITLE
Test: type pending-investigation-offer turn-seam stubs to their real Protocols

### DIFF
--- a/tests/core/agent_harness/session/test_pending_investigation_offer.py
+++ b/tests/core/agent_harness/session/test_pending_investigation_offer.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from core.agent_harness.ports import AnswerRequest
 from core.agent_harness.prompts.memory.conversation import expand_affirmative_follow_up
 from core.agent_harness.session.pending_offer import (
     DispatchablePendingOffer,
@@ -19,10 +22,22 @@ from core.agent_harness.session.pending_offer import (
     synthesize_investigation_alert_text,
 )
 from core.agent_harness.session.want_me_to import offer_from_assistant_content
+from core.agent_harness.spi.accounting import LlmRunInfo
 from core.agent_harness.turns.action_driver import _literal_slash_tool_call
 from core.agent_harness.turns.headless_adapters import InMemorySessionState, NoopTurnAccounting
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+from tests.shared.harness_turn_driver import answer_with_text, no_evidence
+
+
+def _no_answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
+    """A StreamAnswerFn that produces no answer."""
+    return None
+
+
+def _gather_connection_refused(text: str, *, turn_plan: Any = None) -> str:
+    """An EvidenceGatherer that fails to reach the source."""
+    return "connection refused"
 
 
 def test_dispatch_message_quotes_alert_text() -> None:
@@ -274,21 +289,18 @@ def test_run_turn_dogfood_dual_menu_yes_still_starts_investigation() -> None:
             investigation_dispatched=True,
         )
 
-    class _Run:
-        # Intentionally broken closer from live dogfood.
-        response_text = (
-            "Checkout 502; Grafana unreachable.\n\n"
-            "**Want me to:**\n"
-            "1. run a full investigation once you paste the alert, or\n"
-            "2. walk you through `/integrations setup grafana`?"
-        )
-
     first = run_turn(
         "why is checkout 502?",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: _Run(),
-        gather=lambda *_a, **_k: "connection refused",
+        # Intentionally broken closer from live dogfood.
+        answer=answer_with_text(
+            "Checkout 502; Grafana unreachable.\n\n"
+            "**Want me to:**\n"
+            "1. run a full investigation once you paste the alert, or\n"
+            "2. walk you through `/integrations setup grafana`?"
+        ),
+        gather=_gather_connection_refused,
         accounting=NoopTurnAccounting(),
     )
 
@@ -302,8 +314,8 @@ def test_run_turn_dogfood_dual_menu_yes_still_starts_investigation() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=_no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
     assert len(seen) == 1
@@ -328,15 +340,12 @@ def test_run_turn_does_not_arm_investigation_when_capability_disabled() -> None:
             handoff_contents=("diagnostic:checkout_502",),
         )
 
-    class _Run:
-        response_text = "Empty evidence.\n\n**Want me to:** run a full investigation."
-
     first = run_turn(
         "why is checkout 502?",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: _Run(),
-        gather=lambda *_a, **_k: "connection refused",
+        answer=answer_with_text("Empty evidence.\n\n**Want me to:** run a full investigation."),
+        gather=_gather_connection_refused,
         accounting=NoopTurnAccounting(),
     )
 
@@ -373,15 +382,6 @@ def test_run_turn_arms_then_yes_dispatches_investigation() -> None:
             investigation_dispatched=True,
         )
 
-    class _Run:
-        response_text = (
-            "Datadog shows elevated DB latency.\n\n**Want me to:** run a full investigation."
-        )
-
-    def answer(text: str, request: object = None) -> _Run:
-        _ = text, request
-        return _Run()
-
     def gather(text: str, *, turn_plan: object = None) -> str:
         _ = text, turn_plan
         return "p95 latency 2.1s on checkout-db"
@@ -390,7 +390,9 @@ def test_run_turn_arms_then_yes_dispatches_investigation() -> None:
         "why is the database slow?",
         session,
         execute_actions=execute_actions,
-        answer=answer,
+        answer=answer_with_text(
+            "Datadog shows elevated DB latency.\n\n**Want me to:** run a full investigation."
+        ),
         gather=gather,
         accounting=NoopTurnAccounting(),
     )
@@ -404,8 +406,8 @@ def test_run_turn_arms_then_yes_dispatches_investigation() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=_no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
 
@@ -437,8 +439,8 @@ def test_failed_investigation_keeps_pending_offer() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=_no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
     assert session.pending_investigation_offer is not None


### PR DESCRIPTION
Fixes #5190

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Replaces all swallow-all `lambda *_a, **_k:` stage injections and `type("Run", ...)`/ad hoc `_Run`-class result fakes in `tests/core/agent_harness/session/test_pending_investigation_offer.py` with named functions typed to their real Protocol (`core/agent_harness/ports.py`), reusing the shared `no_evidence`/`answer_with_text` helpers from `tests/shared/harness_turn_driver.py` where the original behavior matched, and adding two small file-local stubs (`_no_answer`, `_gather_connection_refused`) where it didn't (the originals returned specific non-`None` values, e.g. `"connection refused"`, which the shared helpers don't produce). Also removed 3 now-redundant ad hoc `_Run` classes/wrapper functions the lambdas were built on.

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Test-only change. Verification:

```
make lint / format-check / typecheck -> all pass
pytest tests/core/agent_harness/session/test_pending_investigation_offer.py -v -> 22 passed (same count as before)
make test-scope -> 22 passed
```

Deliberate-break round trip: stripped the `turn_plan` keyword from `_gather_connection_refused` — exactly the 2 tests that actually invoke it failed with `TypeError`, the other 20 stayed green. Reverted, re-confirmed 22/22.

Also ran a second honesty check: stripped the `request` parameter from `_no_answer` — all 22 tests still passed, because `_no_answer` turns out to be unreachable at all 3 of its call sites (the action result is always `handled=True` before the answer stage would run). This is pre-existing test structure — the original `lambda *_a, **_k: None` at those same sites was equally unreached — not something introduced here, but flagged for visibility.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours. Worth your attention: the `_no_answer` stub is currently dead code at all 3 call sites (explained above) — pre-existing, not a regression, but worth knowing.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: implemented, tested, and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff. Will mark ready for review once confirmed.
