### PR TITLE
Test: type goal-and-run-until turn-seam stubs to their real Protocols

### DIFF
--- a/tests/core/agent_harness/session_goal/test_goal_and_run_until.py
+++ b/tests/core/agent_harness/session_goal/test_goal_and_run_until.py
@@ -17,6 +17,7 @@ from core.agent_harness.session_goal.run_until import run_until_session_goal
 from core.agent_harness.turns.assistant_handoff import AssistantHandoff
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from tests.shared.harness_turn_driver import answer_with_text
 
 _FIVE_STEP_ASK = (
     "Do this 5-step sequential process without asking whether to continue: "
@@ -83,16 +84,15 @@ def test_want_me_to_suppressed_while_session_goal_active() -> None:
             handoff_contents=("Continue the multi-step process.",),
         )
 
+    def _gather(text: str, *_a: object, **_k: object) -> str:
+        return "evidence"
+
     result = run_turn(
         _FIVE_STEP_ASK,
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "evidence",
-        answer=lambda *_a, **_k: type(
-            "Run",
-            (),
-            {"response_text": "Step 1 done."},
-        )(),
+        gather=_gather,
+        answer=answer_with_text("Step 1 done."),
         accounting=DefaultTurnAccounting(session, _FIVE_STEP_ASK),
     )
 
@@ -113,12 +113,15 @@ def test_action_handoff_attaches_session_goal() -> None:
             handoff_contents=("session_goal:max_turns=5;steps=5", "Start the checklist."),
         )
 
+    def _gather(text: str, *_a: object, **_k: object) -> str:
+        return "evidence"
+
     run_turn(
         _FIVE_STEP_ASK,
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "evidence",
-        answer=lambda *_a, **_k: type("Run", (), {"response_text": "Step 1."})(),
+        gather=_gather,
+        answer=answer_with_text("Step 1."),
         accounting=DefaultTurnAccounting(session, _FIVE_STEP_ASK),
     )
 
@@ -160,12 +163,15 @@ def test_typed_assistant_handoff_attaches_session_goal_without_content_tags() ->
             assistant_handoffs=(typed,),
         )
 
+    def _gather(text: str, *_a: object, **_k: object) -> str:
+        return "evidence"
+
     run_turn(
         _FIVE_STEP_ASK,
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "evidence",
-        answer=lambda *_a, **_k: type("Run", (), {"response_text": "Step 1."})(),
+        gather=_gather,
+        answer=answer_with_text("Step 1."),
         accounting=DefaultTurnAccounting(session, _FIVE_STEP_ASK),
     )
 
@@ -298,16 +304,15 @@ def test_metric_read_handoff_without_session_goal_flag_continues_outer_loop() ->
             assistant_handoffs=(typed,),
         )
 
+    def _gather(text: str, *_a: object, **_k: object) -> str:
+        return "schema only"
+
     run_turn(
         ask,
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "schema only",
-        answer=lambda *_a, **_k: type(
-            "Run",
-            (),
-            {"response_text": "Schema found; no count yet."},
-        )(),
+        gather=_gather,
+        answer=answer_with_text("Schema found; no count yet."),
         accounting=DefaultTurnAccounting(session, ask),
     )
     assert session_goal_is_active(session)


### PR DESCRIPTION
Fixes #5191

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Replaces every swallow-all `lambda *_a, **_k:` stage injection and `type("Run", ...)` result fake in `tests/core/agent_harness/session_goal/test_goal_and_run_until.py` with named functions. Found 8 lambda stubs and 4 anonymous result objects — 2 more of the latter than the issue itself listed, since its line-based scan missed two multi-line `type(...)` calls. `answer=` fakes now use the shared `answer_with_text()` helper (exact match, already used identically in the merged sibling file `test_upgrade_cta_accept.py`); `gather=` fakes needed small local named stubs since the tests require specific literal strings (`"evidence"`, `"schema only"`) that the shared `no_evidence()` helper (which only returns `None`) doesn't produce.

One lambda (`evaluate=lambda *_a, **_k: SessionGoalStatus.ACTIVE`) was deliberately left untouched — it's passed to a different, non-Protocol callable alias (`EvaluateFn = Callable[..., str]`), not one of the three `run_turn` stage Protocols this issue is about, matching the issue's own "not a stage injection" carve-out.

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Test-only change. Verification:

```
make lint / format-check / typecheck -> all pass
pytest tests/core/agent_harness/session_goal/test_goal_and_run_until.py -v -> 11 passed (same count as before)
make test-scope -> 11 passed
```

Deliberate-break round trip: added a required extra positional argument to one `_gather` stub — exactly the one test using it failed with `TypeError`, raised from the real call site in `orchestrator.py`; the other 10 stayed green. Reverted, re-confirmed 11/11. The old swallow-all lambda would have silently accepted any call shape and never caught this.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: implemented, tested, and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff. Will mark ready for review once confirmed.
