### PR TITLE
Test: type pending-offer turn-seam stubs to their real Protocols

### DIFF
--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -2,17 +2,32 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+from core.agent_harness.ports import AnswerRequest
 from core.agent_harness.prompts.memory.conversation import expand_affirmative_follow_up
 from core.agent_harness.session.pending_offer import PendingScheduleOffer
+from core.agent_harness.spi.accounting import LlmRunInfo
 from core.agent_harness.tools.tool_context import ActionToolScope
 from core.agent_harness.turns.headless_adapters import InMemorySessionState, NoopTurnAccounting
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+from tests.shared.harness_turn_driver import no_evidence
 from tools.interactive_shell.actions.propose_scheduled_delivery import (
     execute_propose_scheduled_delivery_tool,
 )
+
+
+def _no_answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
+    """A StreamAnswerFn that produces no answer."""
+    return None
+
+
+def _empty_evidence(text: str, *, turn_plan: Any = None) -> str:
+    """An EvidenceGatherer that gathers an empty observation string."""
+    return ""
 
 
 def test_pending_offer_to_slash_omits_slack_chat_id() -> None:
@@ -138,8 +153,8 @@ def test_run_turn_consumes_pending_schedule_on_yes() -> None:
         "yes",
         session,
         execute_actions=execute_actions,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: None,
+        answer=_no_answer,
+        gather=no_evidence,
         accounting=NoopTurnAccounting(),
     )
 
@@ -343,8 +358,8 @@ def test_a_failed_schedule_keeps_the_offer_for_a_second_try() -> None:
         "yes",
         session,
         execute_actions=_execute_failing,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: "",
+        answer=_no_answer,
+        gather=_empty_evidence,
         accounting=NoopTurnAccounting(),
     )
 
@@ -382,8 +397,8 @@ def test_a_successful_schedule_consumes_the_offer() -> None:
         "yes",
         session,
         execute_actions=_execute_ok,
-        answer=lambda *_a, **_k: None,
-        gather=lambda *_a, **_k: "",
+        answer=_no_answer,
+        gather=_empty_evidence,
         accounting=NoopTurnAccounting(),
     )
 


### PR DESCRIPTION
Fixes #5193

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Replaces all 6 swallow-all `lambda *_a, **_k:` stage injections in `tests/core/agent_harness/session/test_pending_offer.py` with named functions typed to their real Protocol. `answer=` sites all use a new local `_no_answer` stub. `gather=` sites needed two different replacements since the originals return different literal values: the shared `no_evidence()` helper (returns `None`) for the one site that originally returned `None`, and a new local `_empty_evidence` stub (returns `""`) for the two sites that originally returned `""` — deliberately not collapsed into one, to preserve the exact original return values. No `type("Run", ...)` fakes exist in this file (confirmed — only in the sibling `test_pending_investigation_offer.py`, out of scope here).

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Test-only change. Verification:

```
make lint / format-check / typecheck -> all pass
pytest tests/core/agent_harness/session/test_pending_offer.py -v -> 14 passed (same count as before)
make test-scope -> 14 passed
```

Deliberate-break round trip: stripped the `turn_plan` keyword from `_empty_evidence` — exactly the one test that actually invokes it failed with `TypeError` raised from the real orchestrator call; the other 13 (including a sibling test using the same stub in a path that doesn't reach it) stayed green. Reverted, re-confirmed 14/14. Also confirmed via a mypy diff-against-stash comparison that the 2 pre-existing mypy findings in this file (on the untouched `execute_actions=` fakes) are unrelated pre-existing debt, not something this change introduced.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: implemented, tested, and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff. Will mark ready for review once confirmed.
