### PR TITLE
Test: type metric-l0-degradation turn-seam stubs to their real Protocols

### DIFF
--- a/tests/core/agent_harness/test_metric_l0_degradation.py
+++ b/tests/core/agent_harness/test_metric_l0_degradation.py
@@ -9,16 +9,18 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
-from core.agent_harness.ports import AnswerRequest
+from core.agent_harness.ports import AnswerRequest, ConfirmFn
 from core.agent_harness.session.pending_offer import (
     PendingIntegrationSetupOffer,
     first_pending_offer,
 )
+from core.agent_harness.spi.accounting import LlmRunInfo
 from core.agent_harness.turns.assistant_handoff import AssistantHandoff
 from core.agent_harness.turns.evidence_need import EvidenceKind
 from core.agent_harness.turns.orchestrator import run_turn
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from surfaces.interactive_shell.session import Session
+from tests.shared.harness_turn_driver import answer_with_text, fake_llm_run
 
 _WINDOWS_USERS_ASK = "how many windows users did we have in the last 7 days"
 
@@ -68,18 +70,14 @@ def test_before_after_metric_ask_skips_gather_and_adds_cta_without_investigate_o
         gather_calls.append(text)
         return "Tool: list_posthog_tools\nResult: (discovery only — should not run)"
 
-    def _answer(text: str, request: AnswerRequest, **_kwargs: Any) -> Any:
+    def _answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
         answer_calls.append(text)
-        return type(
-            "Run",
-            (),
-            {
-                "response_text": (
-                    "Without live analytics I can outline a count query, "
-                    "but I cannot return the real number yet."
-                )
-            },
-        )()
+        return fake_llm_run(
+            response_text=(
+                "Without live analytics I can outline a count query, "
+                "but I cannot return the real number yet."
+            )
+        )
 
     result = run_turn(
         _WINDOWS_USERS_ASK,
@@ -115,12 +113,15 @@ def test_metric_ask_with_source_connected_still_gathers() -> None:
         gather_calls.append(text)
         return "Tool: execute-sql\nResult: windows_users=42"
 
+    def _answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
+        return None
+
     run_turn(
         _WINDOWS_USERS_ASK,
         session,
         execute_actions=_execute,
         gather=_gather,
-        answer=lambda *_a, **_k: None,
+        answer=_answer,
         accounting=DefaultTurnAccounting(session, _WINDOWS_USERS_ASK),
     )
 
@@ -134,6 +135,15 @@ def test_connected_source_auth_failure_gathers_then_appends_reconnect_cta() -> N
     gather_calls: list[str] = []
     answer_handoffs: list[tuple[str, ...]] = []
 
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
+        return _action_metric_handoff()
+
     def _gather(text: str, *_args: object, **_kwargs: object) -> str:
         gather_calls.append(text)
         # Typed tool_unavailable envelope (Python repr — how gather often
@@ -143,23 +153,18 @@ def test_connected_source_auth_failure_gathers_then_appends_reconnect_cta() -> N
             "Result: {'available': False, 'error': '401 Unauthorized — invalid api key'}"
         )
 
-    def _answer(text: str, request: AnswerRequest, **_kwargs: Any) -> Any:
+    def _answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
         answer_handoffs.append(tuple(request.handoff_contents or ()))
-        return type(
-            "Run",
-            (),
-            {
-                "response_text": (
-                    "PostHog returned 401 — credentials look wrong. "
-                    "Draft HogQL once reconnect works."
-                )
-            },
-        )()
+        return fake_llm_run(
+            response_text=(
+                "PostHog returned 401 — credentials look wrong. Draft HogQL once reconnect works."
+            )
+        )
 
     result = run_turn(
         _WINDOWS_USERS_ASK,
         session,
-        execute_actions=lambda *_a, **_k: _action_metric_handoff(),
+        execute_actions=_execute,
         gather=_gather,
         answer=_answer,
         accounting=DefaultTurnAccounting(session, _WINDOWS_USERS_ASK),
@@ -185,6 +190,15 @@ def test_connected_source_hogql_failure_gathers_without_cta() -> None:
     session.resolved_integrations_cache = {"posthog_mcp": {"url": "https://mcp.example"}}
     gather_calls: list[str] = []
 
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
+        return _action_metric_handoff()
+
     def _gather(text: str, *_args: object, **_kwargs: object) -> str:
         gather_calls.append(text)
         return "Tool: posthog_mcp\nResult: HogQL syntax error near WHERE"
@@ -192,13 +206,9 @@ def test_connected_source_hogql_failure_gathers_without_cta() -> None:
     result = run_turn(
         _WINDOWS_USERS_ASK,
         session,
-        execute_actions=lambda *_a, **_k: _action_metric_handoff(),
+        execute_actions=_execute,
         gather=_gather,
-        answer=lambda *_a, **_k: type(
-            "Run",
-            (),
-            {"response_text": "The HogQL query failed; try a simpler property."},
-        )(),
+        answer=answer_with_text("The HogQL query failed; try a simpler property."),
         accounting=DefaultTurnAccounting(session, _WINDOWS_USERS_ASK),
     )
 
@@ -214,6 +224,15 @@ def test_connected_source_without_a_live_query_still_drafts_hogql_and_setup() ->
     session.resolved_integrations_cache = {"posthog_mcp": {"configured": True}}
     answer_handoffs: list[tuple[str, ...]] = []
 
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
+        return _action_metric_handoff()
+
     def _gather(text: str, *_args: object, **_kwargs: object) -> str:
         return (
             "Tool: list_posthog_tools\nArguments: {}\nResult: []\n\n"
@@ -222,18 +241,16 @@ def test_connected_source_without_a_live_query_still_drafts_hogql_and_setup() ->
             "Result: []"
         )
 
-    def _answer(text: str, request: AnswerRequest, **_kwargs: Any) -> Any:
+    def _answer(text: str, request: AnswerRequest) -> LlmRunInfo | None:
         answer_handoffs.append(tuple(request.handoff_contents or ()))
-        return type(
-            "Run",
-            (),
-            {"response_text": ("I could not identify a signup event, so I cannot return a count.")},
-        )()
+        return fake_llm_run(
+            response_text="I could not identify a signup event, so I cannot return a count."
+        )
 
     result = run_turn(
         "How many Windows users signed up in the last 7 days?",
         session,
-        execute_actions=lambda *_a, **_k: _action_metric_handoff(),
+        execute_actions=_execute,
         gather=_gather,
         answer=_answer,
         accounting=DefaultTurnAccounting(
@@ -265,12 +282,16 @@ def test_without_evidence_kind_handoff_does_not_skip_gather() -> None:
             handoff_contents=("Look up the Windows user count in product analytics.",),
         )
 
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
+        gather_calls.append(text)
+        return "evidence"
+
     run_turn(
         _WINDOWS_USERS_ASK,
         session,
         execute_actions=_execute,
-        gather=lambda text, *_a, **_k: gather_calls.append(text) or "evidence",
-        answer=lambda *_a, **_k: type("Run", (), {"response_text": "ok"})(),
+        gather=_gather,
+        answer=answer_with_text("ok"),
         accounting=DefaultTurnAccounting(session, _WINDOWS_USERS_ASK),
     )
 
@@ -283,12 +304,25 @@ def test_typed_evidence_kind_schema_field_skips_gather_like_content_tag() -> Non
     session.resolved_integrations_cache = {}
     gather_calls: list[str] = []
 
+    def _execute(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
+        return _action_metric_handoff_typed()
+
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
+        gather_calls.append(text)
+        return "should-not-run"
+
     run_turn(
         _WINDOWS_USERS_ASK,
         session,
-        execute_actions=lambda *_a, **_k: _action_metric_handoff_typed(),
-        gather=lambda text, *_a, **_k: gather_calls.append(text) or "should-not-run",
-        answer=lambda *_a, **_k: type("Run", (), {"response_text": "Connect PostHog."})(),
+        execute_actions=_execute,
+        gather=_gather,
+        answer=answer_with_text("Connect PostHog."),
         accounting=DefaultTurnAccounting(session, _WINDOWS_USERS_ASK),
     )
 
@@ -311,14 +345,16 @@ def test_upgrade_cta_reoffers_when_user_asks_again() -> None:
     def _execute(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
         return _action_metric_handoff()
 
-    def _answer(*_args: object, **_kwargs: Any) -> Any:
-        return type("Run", (), {"response_text": "Draft query outline."})()
+    def _gather(text: str, *, turn_plan: Any = None) -> str:
+        return "should-not-run"
+
+    _answer = answer_with_text("Draft query outline.")
 
     first = run_turn(
         _WINDOWS_USERS_ASK,
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "should-not-run",
+        gather=_gather,
         answer=_answer,
         accounting=DefaultTurnAccounting(session, _WINDOWS_USERS_ASK),
     )
@@ -326,7 +362,7 @@ def test_upgrade_cta_reoffers_when_user_asks_again() -> None:
         _WINDOWS_USERS_ASK,
         session,
         execute_actions=_execute,
-        gather=lambda *_a, **_k: "should-not-run",
+        gather=_gather,
         answer=_answer,
         accounting=DefaultTurnAccounting(session, _WINDOWS_USERS_ASK),
     )


### PR DESCRIPTION
Fixes #5188

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Replaces every swallow-all `lambda *_a, **_k:` stage injection and `type("Run", ...)` anonymous result fake in `tests/core/agent_harness/test_metric_l0_degradation.py` with named functions typed to their real Protocol (`ExecuteActions`, `EvidenceGatherer`, or `StreamAnswerFn`). Reused the shared `answer_with_text`/`fake_llm_run` helpers wherever a stub had no side effect and a fixed return value; kept small locally-scoped named functions where a stub had a side effect (e.g. appending to a call-tracking list) or returned a distinctive sentinel string (`"should-not-run"`) the shared helpers don't produce. `no_evidence` was not used anywhere in this file — none of its `gather` lambdas were a pure no-op matching it exactly.

Note: the issue text names the file as `tests/core/agent_harness/session/test_metric_l0_degradation.py`; the real path (confirmed on disk and via the issue tracker) is `tests/core/agent_harness/test_metric_l0_degradation.py`, no `session/` segment — used the real path throughout.

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Test-only change. Verification:

```
make lint / format-check -> pass
mypy (targeted, --cache-dir=/dev/null) -> Success: no issues found in 1 source file
pytest tests/core/agent_harness/test_metric_l0_degradation.py -v -> 8 passed (same count as before)
```

The deliberate-break/revert round trip could not be completed live due to a disk-space emergency on the local machine partway through this session (unrelated to the repo, confirmed independently by three other PRs in this batch). Reasoned instead from reading `core/agent_harness/turns/orchestrator.py` directly: `run_turn` unconditionally calls `execute_actions(text, confirm_fn=confirm_fn, is_tty=is_tty, turn_plan=turn_plan)`, so any of the new `_execute` stubs missing the `turn_plan` parameter would raise `TypeError` immediately when its test runs — a certainty from Python's calling convention, not a guess. Flagging this as **not empirically verified**, worth a maintainer or reviewer spending 30 seconds to actually run it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours. The un-executed deliberate-break check noted above is the one thing here that most needs independent confirmation, not just a readthrough.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: implemented and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff. Will mark ready for review once confirmed.
