### PR TITLE
Feat: wire evidence mappers for MariaDB tools

### DIFF
--- a/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,10 +14,24 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_innodb_status(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    status_text = output.get("innodb_status", "")
+    if status_text:
+        record_evidence_entry(
+            evidence,
+            source="get_mariadb_innodb_status",
+            label="MariaDB InnoDB Status",
+            summary=f"{len(status_text)} chars",
+        )
+
+
 @tool(
     name="get_mariadb_innodb_status",
     description="Retrieve InnoDB engine internals including deadlocks, buffer pool state, and I/O activity from SHOW ENGINE INNODB STATUS.",
     source="mariadb",
+    evidence_mapper=_map_get_mariadb_innodb_status,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),

--- a/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,6 +14,19 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_process_list(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    processes = output.get("processes", [])
+    if processes:
+        record_evidence_entry(
+            evidence,
+            source="get_mariadb_process_list",
+            label="MariaDB Process List",
+            summary=f"{len(processes)} active processes",
+        )
+
+
 @tool(
     name="get_mariadb_process_list",
     description=(
@@ -20,6 +34,7 @@ from integrations.mariadb import (
         " information_schema.PROCESSLIST, excluding idle connections."
     ),
     source="mariadb",
+    evidence_mapper=_map_get_mariadb_process_list,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),

--- a/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,10 +14,24 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_replication_status(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    channels = output.get("channels", [])
+    if channels:
+        record_evidence_entry(
+            evidence,
+            source="get_mariadb_replication_status",
+            label="MariaDB Replication Status",
+            summary=f"{len(channels)} replication channels",
+        )
+
+
 @tool(
     name="get_mariadb_replication_status",
     description="Retrieve MariaDB replication status including I/O and SQL thread state, lag, and errors from SHOW ALL SLAVES STATUS.",
     source="mariadb",
+    evidence_mapper=_map_get_mariadb_replication_status,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),

--- a/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,10 +14,24 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_slow_queries(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    queries = output.get("queries", [])
+    if queries:
+        record_evidence_entry(
+            evidence,
+            source="get_mariadb_slow_queries",
+            label="MariaDB Slow Queries",
+            summary=f"{len(queries)} slow queries",
+        )
+
+
 @tool(
     name="get_mariadb_slow_queries",
     description="Retrieve top MariaDB queries by average execution time from performance_schema.events_statements_summary_by_digest.",
     source="mariadb",
+    evidence_mapper=_map_get_mariadb_slow_queries,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),

--- a/integrations/mariadb/tools/mariadb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,10 +14,24 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_global_status(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    metrics = output.get("metrics", {})
+    if metrics:
+        record_evidence_entry(
+            evidence,
+            source="get_mariadb_global_status",
+            label="MariaDB Global Status",
+            summary=f"{len(metrics)} metrics",
+        )
+
+
 @tool(
     name="get_mariadb_global_status",
     description="Retrieve key MariaDB server metrics including connections, threads, slow queries, InnoDB buffer pool stats, and uptime from SHOW GLOBAL STATUS.",
     source="mariadb",
+    evidence_mapper=_map_get_mariadb_global_status,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),

--- a/tests/integrations/mariadb/test_evidence_mappers.py
+++ b/tests/integrations/mariadb/test_evidence_mappers.py
@@ -1,0 +1,288 @@
+"""Evidence mapper tests for the MariaDB tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from integrations.mariadb.tools.mariadb_innodb_status_tool import (
+    _map_get_mariadb_innodb_status,
+)
+from integrations.mariadb.tools.mariadb_process_list_tool import (
+    _map_get_mariadb_process_list,
+)
+from integrations.mariadb.tools.mariadb_replication_tool import (
+    _map_get_mariadb_replication_status,
+)
+from integrations.mariadb.tools.mariadb_slow_queries_tool import (
+    _map_get_mariadb_slow_queries,
+)
+from integrations.mariadb.tools.mariadb_status_tool import (
+    _map_get_mariadb_global_status,
+)
+from tools.registry import get_registered_tool
+
+
+def test_global_status_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "mariadb",
+        "available": True,
+        "metrics": {
+            "Threads_connected": "10",
+            "Threads_running": "2",
+            "Uptime": "86400",
+        },
+    }
+
+    _map_get_mariadb_global_status(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_mariadb_global_status",
+            "label": "MariaDB Global Status",
+            "summary": "3 metrics",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_global_status_mapper_records_nothing_on_error() -> None:
+    evidence: dict[str, object] = {}
+
+    _map_get_mariadb_global_status(
+        evidence,
+        {"source": "mariadb", "available": False, "error": "connection timeout"},
+        {},
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+def test_innodb_status_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    status_text = (
+        "=====================================\n"
+        "BUFFER POOL AND MEMORY\n"
+        "Total memory allocated 137428992\n"
+        "====================================="
+    )
+    output = {"source": "mariadb", "available": True, "innodb_status": status_text}
+
+    _map_get_mariadb_innodb_status(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_mariadb_innodb_status",
+            "label": "MariaDB InnoDB Status",
+            "summary": f"{len(status_text)} chars",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_innodb_status_mapper_records_nothing_on_error() -> None:
+    evidence: dict[str, object] = {}
+
+    _map_get_mariadb_innodb_status(
+        evidence,
+        {"source": "mariadb", "available": False, "error": "connection timeout"},
+        {},
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+def test_process_list_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "mariadb",
+        "available": True,
+        "total_processes": 2,
+        "processes": [
+            {
+                "id": 12,
+                "user": "app",
+                "host": "10.0.0.5:51820",
+                "database": "orders",
+                "command": "Query",
+                "time_secs": 42,
+                "state": "Sending data",
+                "query": "SELECT * FROM orders WHERE customer_id = 881",
+            },
+            {
+                "id": 13,
+                "user": "app",
+                "host": "10.0.0.6:51821",
+                "database": "orders",
+                "command": "Query",
+                "time_secs": 5,
+                "state": "executing",
+                "query": "UPDATE orders SET status = 'shipped' WHERE id = 42",
+            },
+        ],
+    }
+
+    _map_get_mariadb_process_list(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_mariadb_process_list",
+            "label": "MariaDB Process List",
+            "summary": "2 active processes",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_process_list_mapper_records_nothing_when_idle() -> None:
+    evidence: dict[str, object] = {}
+
+    _map_get_mariadb_process_list(
+        evidence,
+        {"source": "mariadb", "available": True, "total_processes": 0, "processes": []},
+        {},
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+def test_replication_status_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "mariadb",
+        "available": True,
+        "channels": [
+            {
+                "Slave_IO_Running": "Yes",
+                "Slave_SQL_Running": "Yes",
+                "Seconds_Behind_Master": 0,
+                "Master_Host": "db-primary.internal",
+                "Connection_name": "",
+            },
+            {
+                "Slave_IO_Running": "No",
+                "Slave_SQL_Running": "Yes",
+                "Seconds_Behind_Master": None,
+                "Last_Error": "Could not execute Update_rows_v1 event",
+                "Master_Host": "db-secondary.internal",
+                "Connection_name": "analytics",
+            },
+        ],
+    }
+
+    _map_get_mariadb_replication_status(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_mariadb_replication_status",
+            "label": "MariaDB Replication Status",
+            "summary": "2 replication channels",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_replication_status_mapper_records_nothing_when_not_a_replica() -> None:
+    evidence: dict[str, object] = {}
+
+    _map_get_mariadb_replication_status(
+        evidence,
+        {
+            "source": "mariadb",
+            "available": True,
+            "note": "This server is not configured as a replica.",
+            "channels": [],
+        },
+        {},
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+def test_slow_queries_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "mariadb",
+        "available": True,
+        "total_queries": 2,
+        "queries": [
+            {
+                "digest_text": "SELECT * FROM orders WHERE customer_id = ?",
+                "count": 542,
+                "avg_time_ms": 812.4,
+                "total_time_ms": 440320.8,
+                "rows_examined": 100000,
+                "rows_sent": 542,
+            },
+            {
+                "digest_text": "UPDATE orders SET status = ? WHERE id = ?",
+                "count": 12,
+                "avg_time_ms": 45.2,
+                "total_time_ms": 542.4,
+                "rows_examined": 12,
+                "rows_sent": 12,
+            },
+        ],
+    }
+
+    _map_get_mariadb_slow_queries(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_mariadb_slow_queries",
+            "label": "MariaDB Slow Queries",
+            "summary": "2 slow queries",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_slow_queries_mapper_records_nothing_when_performance_schema_disabled() -> None:
+    evidence: dict[str, object] = {}
+
+    _map_get_mariadb_slow_queries(
+        evidence,
+        {
+            "source": "mariadb",
+            "available": True,
+            "note": "performance_schema is disabled. Enable it in my.cnf to collect slow query data.",
+            "queries": [],
+        },
+        {},
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "mapper"),
+    [
+        ("get_mariadb_global_status", _map_get_mariadb_global_status),
+        ("get_mariadb_innodb_status", _map_get_mariadb_innodb_status),
+        ("get_mariadb_process_list", _map_get_mariadb_process_list),
+        ("get_mariadb_replication_status", _map_get_mariadb_replication_status),
+        ("get_mariadb_slow_queries", _map_get_mariadb_slow_queries),
+    ],
+)
+def test_registered_tool_carries_the_mapper(tool_name: str, mapper: Any) -> None:
+    registered_tool = get_registered_tool(tool_name)
+
+    assert registered_tool is not None
+    assert registered_tool.evidence_mapper is mapper

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -94,11 +94,6 @@ get_kafka_topic_health
 get_lambda_configuration
 get_lambda_errors
 get_lambda_invocation_logs
-get_mariadb_global_status
-get_mariadb_innodb_status
-get_mariadb_process_list
-get_mariadb_replication_status
-get_mariadb_slow_queries
 get_mongodb_atlas_alerts
 get_mongodb_atlas_cluster_events
 get_mongodb_atlas_cluster_metrics


### PR DESCRIPTION
Fixes #5546

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires `evidence_mapper` functions onto all 5 MariaDB tools named in the issue — `get_mariadb_global_status`, `get_mariadb_innodb_status`, `get_mariadb_process_list`, `get_mariadb_replication_status`, `get_mariadb_slow_queries` — so their real output becomes a citeable, numbered entry in the investigation report instead of being silently dropped. All 5 are genuine read/diagnostic tools (each runs a `SHOW`/`information_schema`/`performance_schema` query); none were action-only, so none were skipped. Each mapper follows the shipped Grafana precedent (`_map_grafana_metrics`) and reads the tool's real output field (verified from the actual implementation in `integrations/mariadb/__init__.py`, not guessed from the issue's placeholder template): `metrics`, `innodb_status` (raw text, summarized by character count rather than echoed), `processes`, `channels`, `queries`. Removed all 5 tool names from `evidence_mapper_baseline.txt`. Added `tests/integrations/mariadb/test_evidence_mappers.py` (15 tests: happy-path + records-nothing per mapper, using each tool's real empty/error shape, plus a registry-wiring check).

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```
Registered-mapper check: {'get_mariadb_global_status': True, 'get_mariadb_innodb_status': True,
  'get_mariadb_process_list': True, 'get_mariadb_replication_status': True, 'get_mariadb_slow_queries': True}

merge_tool_evidence('get_mariadb_global_status', {realistic 18-key status dict}, {}) ->
  catalog_entries = [{'source': 'get_mariadb_global_status', 'label': 'MariaDB Global Status',
    'summary': '18 metrics', 'url': None, 'snippet': None}]

make lint / format-check / typecheck -> all pass (both a full repo run and independently re-confirmed
  with a targeted mypy pass over integrations/ — 775 source files, 0 issues)
pytest tests/ -k mariadb -> 179 passed
```

**Check 5 (evidence reaches a live report) — attempted, not completed:** `uv run opensre integrations verify mariadb` reports "Not configured" in this environment — no MariaDB credentials available, which the issue explicitly calls a normal, non-blocking outcome. Checks 1–4 stand on their own; this one is left for a reviewer with a real MariaDB target to finish.

## Behaviour comparison (required by this issue's template)

Captured via `git stash` (reverting to `main`'s code in-place) → run → `git stash pop` → run again, same realistic inputs both times.

**Before:** `evidence == {"get_mariadb_global_status": {...raw dict...}, "tool_outputs": [...]}` — no `catalog_entries` key.
**After:** same two keys unchanged, plus `catalog_entries: [{"source": "get_mariadb_global_status", "label": "MariaDB Global Status", "summary": "18 metrics", "url": null, "snippet": null}]`. Same before→after shape held for all 5 tools.

1. **What the reader gains:** the report can now cite each tool's real finding by number — connection/thread/InnoDB counters, the InnoDB engine snapshot, the live query list, replication channel state, the slow-query digest — none of which were citeable before (only an opaque blob in `tool_outputs`).
2. **Context cost:** 127–150 characters of compact JSON per entry, measured directly. The summary is always a count or a character-length, never the payload itself.
3. **Empty/error result:** fed each mapper both `{}` and each tool's real `tool_unavailable()`-shaped error payload — `catalog_entries` was absent (not an empty list, not a blank entry) in all 10 cases.
4. **Double-recording:** `grep -rn 'source="get_mariadb'` across the whole repo matches only these 5 new call sites.
5. **Existing reports unaffected:** re-ran the pinned `TestGrafanaMappingCharacterization`/`TestJiraMapping` suites (11/11, byte-identical) plus the pre-existing mariadb tool contract tests and `tests/tools/test_telemetry.py` (32/32) — nothing else changed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours. Two judgment calls worth your own look: the innodb_status mapper summarizes by character count rather than the list-count template (it's unstructured text, not a list — modeled on the aws_operation_tool precedent of never echoing payload content); and summaries are unconditionally pluralized ("1 failures" style) matching the majority of existing mappers rather than the more elaborate AWS-style singularization.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (15 new tests, plus the full before/after behaviour comparison above)
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: implemented, tested, and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff. Will mark ready for review once confirmed.
