### PR TITLE
Feat: map Airflow tool output to citeable evidence

### DIFF
--- a/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from integrations.airflow.config import (
@@ -43,9 +44,23 @@ def _airflow_dag_id(sources: dict[str, Any]) -> str:
     ).strip()
 
 
+def _map_get_recent_airflow_failures(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    failures = output.get("failures", [])
+    if failures:
+        record_evidence_entry(
+            evidence,
+            source="get_recent_airflow_failures",
+            label="Airflow Recent Failures",
+            summary=f"{len(failures)} failures",
+        )
+
+
 @tool(
     name="get_recent_airflow_failures",
     source="airflow",
+    evidence_mapper=_map_get_recent_airflow_failures,
     description="Fetch recent failed or retrying Airflow task evidence for a DAG.",
     use_cases=[
         "Investigating Airflow DAG failures",
@@ -89,9 +104,23 @@ def get_recent_airflow_failures(
     }
 
 
+def _map_get_airflow_dag_runs(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    dag_runs = output.get("dag_runs", [])
+    if dag_runs:
+        record_evidence_entry(
+            evidence,
+            source="get_airflow_dag_runs",
+            label="Airflow DAG Runs",
+            summary=f"{len(dag_runs)} dag runs",
+        )
+
+
 @tool(
     name="get_airflow_dag_runs",
     source="airflow",
+    evidence_mapper=_map_get_airflow_dag_runs,
     description="Fetch recent Airflow DAG runs for a DAG.",
     use_cases=[
         "Checking recent Airflow DAG run state",
@@ -138,9 +167,23 @@ def get_airflow_dag_runs(
     }
 
 
+def _map_get_airflow_task_instances(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    task_instances = output.get("task_instances", [])
+    if task_instances:
+        record_evidence_entry(
+            evidence,
+            source="get_airflow_task_instances",
+            label="Airflow Task Instances",
+            summary=f"{len(task_instances)} task instances",
+        )
+
+
 @tool(
     name="get_airflow_task_instances",
     source="airflow",
+    evidence_mapper=_map_get_airflow_task_instances,
     description="Fetch Airflow task instances for a specific DAG run.",
     use_cases=[
         "Inspecting failed Airflow task instances",

--- a/tests/integrations/airflow/test_evidence_mappers.py
+++ b/tests/integrations/airflow/test_evidence_mappers.py
@@ -1,0 +1,159 @@
+"""Evidence mapper tests for the Airflow investigation tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.tracer.tools.tracer_airflow_dag_tool import (
+    _map_get_airflow_dag_runs,
+    _map_get_airflow_task_instances,
+    _map_get_recent_airflow_failures,
+)
+from tools.registry import get_registered_tool
+
+
+def test_dag_runs_mapper_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "airflow",
+        "dag_id": "etl_daily",
+        "dag_runs": [
+            {"dag_run_id": "run_1", "state": "success"},
+            {"dag_run_id": "run_2", "state": "failed"},
+        ],
+    }
+
+    _map_get_airflow_dag_runs(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_airflow_dag_runs",
+            "label": "Airflow DAG Runs",
+            "summary": "2 dag runs",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_dag_runs_mapper_records_nothing_without_runs() -> None:
+    evidence: dict[str, Any] = {}
+
+    _map_get_airflow_dag_runs(
+        evidence, {"source": "airflow", "dag_id": "etl_daily", "dag_runs": []}, {}
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+def test_dag_runs_mapper_records_nothing_on_error_payload() -> None:
+    evidence: dict[str, Any] = {}
+
+    _map_get_airflow_dag_runs(evidence, {"error": "dag_id is required"}, {})
+
+    assert "catalog_entries" not in evidence
+
+
+def test_task_instances_mapper_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "airflow",
+        "dag_id": "etl_daily",
+        "dag_run_id": "run_1",
+        "task_instances": [
+            {"task_id": "extract", "state": "success"},
+            {"task_id": "load", "state": "failed"},
+        ],
+    }
+
+    _map_get_airflow_task_instances(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_airflow_task_instances",
+            "label": "Airflow Task Instances",
+            "summary": "2 task instances",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_task_instances_mapper_records_nothing_without_instances() -> None:
+    evidence: dict[str, Any] = {}
+
+    _map_get_airflow_task_instances(
+        evidence,
+        {"source": "airflow", "dag_id": "etl_daily", "dag_run_id": "run_1", "task_instances": []},
+        {},
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+def test_task_instances_mapper_records_nothing_on_error_payload() -> None:
+    evidence: dict[str, Any] = {}
+
+    _map_get_airflow_task_instances(evidence, {"error": "dag_run_id is required"}, {})
+
+    assert "catalog_entries" not in evidence
+
+
+def test_recent_failures_mapper_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "airflow",
+        "dag_id": "etl_daily",
+        "failures": [
+            {"dag_run_id": "run_1", "task_id": "load", "task_state": "failed"},
+        ],
+    }
+
+    _map_get_recent_airflow_failures(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_recent_airflow_failures",
+            "label": "Airflow Recent Failures",
+            "summary": "1 failures",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_recent_failures_mapper_records_nothing_without_failures() -> None:
+    evidence: dict[str, Any] = {}
+
+    _map_get_recent_airflow_failures(
+        evidence, {"source": "airflow", "dag_id": "etl_daily", "failures": []}, {}
+    )
+
+    assert "catalog_entries" not in evidence
+
+
+def test_recent_failures_mapper_records_nothing_on_error_payload() -> None:
+    evidence: dict[str, Any] = {}
+
+    _map_get_recent_airflow_failures(evidence, {"error": "dag_id is required"}, {})
+
+    assert "catalog_entries" not in evidence
+
+
+def test_registered_tools_carry_their_mappers() -> None:
+    dag_runs_tool = get_registered_tool("get_airflow_dag_runs")
+    task_instances_tool = get_registered_tool("get_airflow_task_instances")
+    recent_failures_tool = get_registered_tool("get_recent_airflow_failures")
+
+    assert dag_runs_tool is not None
+    assert task_instances_tool is not None
+    assert recent_failures_tool is not None
+    assert dag_runs_tool.evidence_mapper is _map_get_airflow_dag_runs
+    assert task_instances_tool.evidence_mapper is _map_get_airflow_task_instances
+    assert recent_failures_tool.evidence_mapper is _map_get_recent_airflow_failures

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -35,9 +35,7 @@ fetch_failed_run
 find_yc_api
 fix_sentry_issue
 generate_work_status_report
-get_airflow_dag_runs
 get_airflow_metrics
-get_airflow_task_instances
 get_azure_sql_current_queries
 get_azure_sql_resource_stats
 get_azure_sql_server_status
@@ -127,7 +125,6 @@ get_rabbitmq_connection_stats
 get_rabbitmq_consumer_health
 get_rabbitmq_node_health
 get_rabbitmq_queue_backlog
-get_recent_airflow_failures
 get_redis_client_list
 get_redis_latency_doctor
 get_redis_list_depth


### PR DESCRIPTION
Fixes #5558

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires `evidence_mapper` functions onto the 3 Airflow tools named in the issue — `get_airflow_dag_runs`, `get_airflow_task_instances`, `get_recent_airflow_failures` — so their real output becomes a citeable entry in the investigation report. All three are genuine read tools (no side effects); none skipped.

**Where the tools actually live, and a decoy avoided:** the raw, undecorated Airflow REST client functions sit in `integrations/airflow/config.py`, but the actual `@tool(name="get_airflow_dag_runs", ...)` registrations — the only place in the repo with those literal names — live in `integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py`, which imports and wraps the raw functions. A sibling file, `tracer_airflow_metrics_tool/__init__.py`, registers a *different* tool (`get_airflow_metrics`, `source="tracer_web"`) backed by a different client — same topic, not one of the 3 named tools, correctly left untouched.

Each mapper reads the tool's real return field (`dag_runs`, `task_instances`, `failures`), following the shipped Grafana precedent. Removed the 3 handled tool names from `evidence_mapper_baseline.txt` (left `get_airflow_metrics` in place — unrelated tool). Added `tests/integrations/airflow/test_evidence_mappers.py` (10 tests).

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```
Registered-mapper check: {'get_airflow_dag_runs': True, 'get_airflow_task_instances': True, 'get_recent_airflow_failures': True}
merge_tool_evidence('get_airflow_dag_runs', {'dag_runs': [1, 2]}, {}) ->
  catalog_entries = [{'source': 'get_airflow_dag_runs', 'label': 'Airflow DAG Runs', 'summary': '2 dag runs', 'url': None, 'snippet': None}]

pytest tests/ -k airflow -> 32 passed (10 new + 22 pre-existing, including the unrelated tracer-metrics-tool
  tests, confirming no collateral impact)
make lint / format-check -> pass
mypy (targeted over integrations/) -> Success: no issues found in 775 source files
```

**Check 5 (evidence reaches a live report) — not run:** no Airflow credentials configured in this environment (confirmed: no `AIRFLOW_AUTH_TOKEN`/`AIRFLOW_USERNAME`/`AIRFLOW_PASSWORD`), which the issue calls a normal outcome. Additionally, this Mac's disk filled to ~100% partway through the session (unrelated to this repo, confirmed independently across three PRs in this batch) — chose not to attempt live `opensre investigate` calls while in that state.

## Behaviour comparison (required by this issue's template)

Branch was at `main`'s tip before this change (no prior commits), so before/after was captured via `git stash`/`git stash pop` around the same fixed comparison script.

**Diff** (realistic-sample case; empty-dict and error-shaped cases were identical `catalog_entries: null` in both states):
```diff
   "realistic_run": {
-    "catalog_entries": null,
+    "catalog_entries": [
+      {"label": "Airflow DAG Runs", "source": "get_airflow_dag_runs", "summary": "2 dag runs", ...},
+      {"label": "Airflow Task Instances", "source": "get_airflow_task_instances", "summary": "2 task instances", ...},
+      {"label": "Airflow Recent Failures", "source": "get_recent_airflow_failures", "summary": "1 failures", ...}
+    ]
   }
```

1. **What the reader gains:** DAG-run state/history, task-instance-level execution detail, and recent task failure evidence are now citeable — before, all three lived only in the opaque `tool_outputs` blob with no report-facing reference id.
2. **Context cost:** ~110–130 characters per entry (measured exactly: 109/127/123 chars respectively); dominated by fixed label/source text, barely grows with item count.
3. **Empty/error result:** confirmed by direct execution — `{}` and `{"error": "dag_id is required"}` produce `catalog_entries` absent (not present, not empty-list) for all three, both before and after.
4. **Double-recording:** grepped for all three `source=` strings across `integrations/` and `tools/` — only these new mappers use them; the unrelated `get_airflow_metrics` tool still has no mapper.
5. **Existing reports unaffected:** re-ran `TestGrafanaMappingCharacterization`/`TestJiraMapping` (11/11 unchanged), the pre-existing raw-client tests (8/8), and all 9 sibling tracer-tool test files including the metrics one (90/90) — nothing regressed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours. Worth a specific look: confirm you're comfortable that the mappers landed on tracer_airflow_dag_tool (the real registration site) rather than integrations/airflow/ itself, given issue #5092 (separate, not part of this PR) suggests the airflow integration's client/verifier situation is still being sorted out.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (10 new tests, plus the full before/after behaviour comparison above)
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: implemented, tested, and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff. Will mark ready for review once confirmed.
