### PR TITLE
Feat: wire evidence mappers for Bitbucket file-contents, commits, and code-search tools

### DIFF
--- a/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
@@ -30,10 +31,24 @@ def _list_bitbucket_commits_available(sources: dict[str, dict]) -> bool:
     return bool(bitbucket_available_or_backend(sources) and bb.get("repo_slug", bb.get("repo")))
 
 
+def _map_list_bitbucket_commits(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    commits = output.get("commits", [])
+    if commits:
+        record_evidence_entry(
+            evidence,
+            source="list_bitbucket_commits",
+            label="Bitbucket Commits",
+            summary=f"{len(commits)} commits",
+        )
+
+
 @tool(
     name="list_bitbucket_commits",
     description="List recent commits for a Bitbucket repository, optionally filtered by file path.",
     source="bitbucket",
+    evidence_mapper=_map_list_bitbucket_commits,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     use_cases=[
         "Checking whether a recent change could explain a failure",

--- a/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
@@ -34,10 +35,27 @@ def _get_bitbucket_file_contents_available(sources: dict[str, dict]) -> bool:
     )
 
 
+def _map_get_bitbucket_file_contents(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    content = output.get("content", "")
+    if content:
+        summary = f"{len(content)} chars from {output.get('path', '')}"
+        if output.get("truncated"):
+            summary += " (truncated)"
+        record_evidence_entry(
+            evidence,
+            source="get_bitbucket_file_contents",
+            label="Bitbucket File Contents",
+            summary=summary,
+        )
+
+
 @tool(
     name="get_bitbucket_file_contents",
     description="Retrieve the contents of a file from a Bitbucket repository at a specific revision.",
     source="bitbucket",
+    evidence_mapper=_map_get_bitbucket_file_contents,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     use_cases=[
         "Reading configuration files that may explain a failure",

--- a/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
@@ -65,10 +66,24 @@ def _search_bitbucket_code_available(sources: dict[str, dict]) -> bool:
     return bitbucket_available_or_backend(sources)
 
 
+def _map_search_bitbucket_code(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    results = output.get("results", [])
+    if results:
+        record_evidence_entry(
+            evidence,
+            source="search_bitbucket_code",
+            label="Bitbucket Code Search",
+            summary=f"{len(results)} matches",
+        )
+
+
 @tool(
     name="search_bitbucket_code",
     description="Search code across a Bitbucket workspace or specific repository.",
     source="bitbucket",
+    evidence_mapper=_map_search_bitbucket_code,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
     use_cases=[
         "Finding where a specific function or configuration is defined",

--- a/tests/integrations/bitbucket/test_evidence_mappers.py
+++ b/tests/integrations/bitbucket/test_evidence_mappers.py
@@ -1,0 +1,173 @@
+"""Evidence mapper tests for the Bitbucket tools."""
+
+from integrations.bitbucket.tools.bitbucket_commits_tool import _map_list_bitbucket_commits
+from integrations.bitbucket.tools.bitbucket_file_contents_tool import (
+    _map_get_bitbucket_file_contents,
+)
+from integrations.bitbucket.tools.bitbucket_search_code_tool import _map_search_bitbucket_code
+from tools.registry import get_registered_tool
+
+
+def test_file_contents_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    content = "print('hello')"
+    output = {
+        "source": "bitbucket",
+        "available": True,
+        "repo": "acme/backend-service",
+        "path": "src/main.py",
+        "ref": "main",
+        "content": content,
+        "truncated": False,
+    }
+
+    _map_get_bitbucket_file_contents(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "get_bitbucket_file_contents",
+            "label": "Bitbucket File Contents",
+            "summary": f"{len(content)} chars from src/main.py",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_file_contents_mapper_notes_truncation() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "bitbucket",
+        "available": True,
+        "repo": "acme/backend-service",
+        "path": "src/main.py",
+        "ref": "HEAD",
+        "content": "x" * 10000,
+        "truncated": True,
+    }
+
+    _map_get_bitbucket_file_contents(evidence, output, {})
+
+    entries = evidence["catalog_entries"]
+    assert isinstance(entries, list)
+    assert entries[0]["summary"] == "10000 chars from src/main.py (truncated)"
+
+
+def test_file_contents_mapper_records_nothing_on_error_payload() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "bitbucket",
+        "available": False,
+        "error": "Bitbucket integration is not configured.",
+        "file": {},
+    }
+
+    _map_get_bitbucket_file_contents(evidence, output, {})
+
+    assert "catalog_entries" not in evidence
+
+
+def test_commits_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "bitbucket",
+        "available": True,
+        "repo": "acme/backend-service",
+        "total_returned": 1,
+        "commits": [
+            {
+                "hash": "abc123def456",
+                "message": "Fix flaky test",
+                "author": "Jane Doe",
+                "date": "2026-04-28T10:00:00Z",
+            }
+        ],
+    }
+
+    _map_list_bitbucket_commits(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "list_bitbucket_commits",
+            "label": "Bitbucket Commits",
+            "summary": "1 commits",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_commits_mapper_records_nothing_on_error_payload() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "bitbucket",
+        "available": False,
+        "error": "Bitbucket integration is not configured.",
+        "commits": [],
+    }
+
+    _map_list_bitbucket_commits(evidence, output, {})
+
+    assert "catalog_entries" not in evidence
+
+
+def test_search_code_mapper_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "bitbucket",
+        "available": True,
+        "query": "error OR exception",
+        "total_returned": 1,
+        "results": [
+            {
+                "path": "src/main.py",
+                "repo": "acme/backend-service",
+                "content_matches": 2,
+            }
+        ],
+    }
+
+    _map_search_bitbucket_code(evidence, output, {})
+
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list)
+    assert entries == [
+        {
+            "source": "search_bitbucket_code",
+            "label": "Bitbucket Code Search",
+            "summary": "1 matches",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_search_code_mapper_records_nothing_on_error_payload() -> None:
+    evidence: dict[str, object] = {}
+    output = {
+        "source": "bitbucket",
+        "available": False,
+        "error": "Bitbucket integration is not configured.",
+        "results": [],
+    }
+
+    _map_search_bitbucket_code(evidence, output, {})
+
+    assert "catalog_entries" not in evidence
+
+
+def test_registered_tools_carry_their_mappers() -> None:
+    file_contents_tool = get_registered_tool("get_bitbucket_file_contents")
+    commits_tool = get_registered_tool("list_bitbucket_commits")
+    search_code_tool = get_registered_tool("search_bitbucket_code")
+
+    assert file_contents_tool is not None
+    assert commits_tool is not None
+    assert search_code_tool is not None
+    assert file_contents_tool.evidence_mapper is _map_get_bitbucket_file_contents
+    assert commits_tool.evidence_mapper is _map_list_bitbucket_commits
+    assert search_code_tool.evidence_mapper is _map_search_bitbucket_code

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -44,7 +44,6 @@ get_azure_sql_server_status
 get_azure_sql_slow_queries
 get_azure_sql_wait_stats
 get_batch_statistics
-get_bitbucket_file_contents
 get_clickhouse_query_activity
 get_clickhouse_system_health
 get_cloudwatch_batch_metrics
@@ -165,7 +164,6 @@ kubernetes_list_nodes
 kubernetes_list_pods
 kubernetes_list_services
 kubernetes_list_statefulsets
-list_bitbucket_commits
 list_dagster_assets
 list_dagster_runs
 list_dagster_schedule_ticks
@@ -234,7 +232,6 @@ redeploy_railway_service
 replay_slack_thread_locally
 rocketchat_send_message
 scan_redis_keys
-search_bitbucket_code
 search_github_code
 search_github_issues
 search_openclaw_conversations


### PR DESCRIPTION
Fixes #5559

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires `evidence_mapper` functions onto the 3 Bitbucket tools named in the issue — `get_bitbucket_file_contents`, `list_bitbucket_commits`, `search_bitbucket_code` — so their real output becomes a citeable entry in the investigation report. All three are pure read/GET calls against the Bitbucket Cloud REST API (verified from `integrations/bitbucket/client.py`); none skipped. Mappers check `content`, `commits`, and `results` respectively; the file-contents mapper also notes truncation (`"N chars from <path> (truncated)"`) when the client's own 10,000-char server-side truncation kicked in — the one place this goes slightly beyond the issue's literal "copy Grafana" template, modeled instead on `supabase_storage_tool`'s precedent for surfacing truncation. Removed the 3 handled tool names from `evidence_mapper_baseline.txt`. Added `tests/integrations/bitbucket/test_evidence_mappers.py` (8 tests, mirroring the sibling `tests/integrations/supabase/test_evidence_mappers.py` structure).

### Demo/Screenshot for feature changes and bug fixes -
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```
Registered-mapper check: {'get_bitbucket_file_contents': True, 'list_bitbucket_commits': True, 'search_bitbucket_code': True}
merge_tool_evidence('get_bitbucket_file_contents', {realistic 30-char file body}, {}) ->
  catalog_entries = [{'source': 'get_bitbucket_file_contents', 'label': 'Bitbucket File Contents',
    'summary': '30 chars from src/main.py', 'url': None, 'snippet': None}]

pytest tests/ -k bitbucket -> 81 passed (8 new + 61 pre-existing bitbucket tool tests, unchanged, confirming
  only tool metadata changed, not runtime behavior; plus 12 incidental)
make lint / format-check -> pass
mypy (targeted over integrations/) -> Success: no issues found in 775 source files
```

One transient flake during development worth noting for the record: `test_no_new_unmapped_tool` failed once on a first run, reporting the 3 tools as unmapped, then passed cleanly on 3 immediate re-runs plus every bisected sub-combination — looked like an artifact of rapid-fire `uv run` package reinstalls into the shared dev venv rather than a real defect. Flagging in case it recurs for a reviewer.

**Check 5 (evidence reaches a live report) — not run:** `uv run opensre integrations verify bitbucket` failed immediately with a disk-full error (this Mac's disk filled to ~100% partway through the session, unrelated to this repo, confirmed independently across three PRs in this batch), before it could report whether credentials are configured. Per the issue's own instructions this check is optional; a reviewer with a working environment and Bitbucket account should complete it.

## Behaviour comparison (required by this issue's template)

Branch was at `main`'s tip before this change, so before/after was captured via `git stash -u`/`git stash pop` around the same fixed comparison script.

**Diff:** only change is a new `catalog_entries` list (one entry per tool) in the happy-path case; error-payload and empty-dict cases are byte-identical before and after (no `catalog_entries` key in either state).

1. **What the reader gains:** a retrieved file's content (as "N chars from `<path>`"), a repo's commit history (as "N commits"), and code-search hits (as "N matches") are now citeable by report id — before, all three were opaque blobs under `evidence[tool_name]`/`tool_outputs` with no citation path.
2. **Context cost:** measured via `json.dumps`: 147 / 120 / 123 characters per entry for the three tools respectively. No mapper embeds actual file content, commit messages, or match text — only counts and a path — so a 10,000-character file still produces a ~150-character entry.
3. **Empty/error result:** confirmed directly — both states produce no `catalog_entries` key at all (not an empty list) for all three mappers.
4. **Double-recording:** grepped the whole codebase for the three new `source=` strings — each appears exactly once.
5. **Existing reports unaffected:** re-ran the full pinned `TestGrafanaMappingCharacterization` (7) and `TestJiraMapping` (2) suites, unchanged, plus all 61 pre-existing bitbucket tool tests, unchanged — confirming only `evidence_mapper=` metadata was added, no runtime behavior changed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

*(Left unchecked on purpose — @ckryptickunal will check these off personally after reading the diff, rather than have an assistant check them automatically. That's also why this PR opens as a draft.)*

**Explain your implementation approach:**
<!--
@ckryptickunal: please fill this in yourself once you've read the diff — this section exists to confirm your own understanding, so it's left blank rather than written in a voice that isn't yours. The truncation-note addition on the file-contents mapper (noted above) is the one place this PR goes slightly beyond the issue's minimal template — worth your own call on whether you'd rather keep it strict.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (8 new tests, plus the full before/after behaviour comparison above)
- [x] My code follows the project's style guidelines and conventions (`make lint` / `format-check` / `typecheck` all pass locally)

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---
Opened as a **draft**: implemented, tested, and passing this repo's required local checks, but the personal-attestation boxes above are for @ckryptickunal to confirm honestly after reading the diff. Will mark ready for review once confirmed.
