### PR TITLE
refactor(gateway): guard chat() door with AST allowlist border test (#5483)

### DIFF
--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -360,6 +360,19 @@ per-session lock). Different sessions stay concurrent under the capacity gate.
 There is no `dispatch_message_to_headless_agent` — that free-function dump was
 replaced by `HeadlessAgent.dispatch` / `AgentSession.chat`.
 
+### Two doors into a turn (Concurrency & Serialization)
+
+There are two ways into an agent turn:
+1. **The Host Loop (`TurnRunner` → `HeadlessAgent.handle`)**:
+   - Used by concurrent multi-actor hosts (**Gateway** transports and **Interactive Shell**).
+   - Takes the `SessionAgentPool` per-session lock (serializing turns for the same session to prevent `AgentBusyError` and state corruption).
+   - Takes the process turn capacity gate (`TurnConcurrencyGate` / `OPENSRE_MAX_CONCURRENT_TURNS`).
+   - Drives the full `SessionGoal` outer loop (`run_goal`).
+2. **Scripted / Headless API (`AgentSession.chat` / `chat_until_goal`)**:
+   - The un-gated single-turn API for programmatic scripts (`main.py`, notebooks), tests, and single-shot CLI (`opensre ask`).
+   - Deliberately kept as an unguarded entry point for single-tenant, scripted use.
+   - **Forbidden for concurrent hosts:** Gateway and Shell modules must never call `chat()` or `chat_until_goal()` directly (enforced by `gateway/tests/test_harness_behaviour_border.py`).
+
 **Scaling** is separate from the host API: local concurrency
 (`TurnConcurrencyGate` / transport pools / `OPENSRE_SIZE_PROFILE`) and cloud
 Fargate scale-out (spin more tasks; same API per task) sit *around*

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -371,7 +371,7 @@ There are two ways into an agent turn:
 2. **Scripted / Headless API (`AgentSession.chat` / `chat_until_goal`)**:
    - The un-gated single-turn API for programmatic scripts (`main.py`, notebooks), tests, and single-shot CLI (`opensre ask`).
    - Deliberately kept as an unguarded entry point for single-tenant, scripted use.
-   - **Forbidden for concurrent hosts:** Gateway and Shell modules must never call `chat()` or `chat_until_goal()` directly (enforced by `gateway/tests/test_harness_behaviour_border.py`).
+   - **Forbidden for concurrent hosts:** Gateway and Shell modules must never call `chat()` or `chat_until_goal()` directly (enforced by `gateway/tests/test_harness_behaviour_border.py` and `tests/interactive_shell/test_harness_api_border.py`).
 
 **Scaling** is separate from the host API: local concurrency
 (`TurnConcurrencyGate` / transport pools / `OPENSRE_SIZE_PROFILE`) and cloud

--- a/gateway/tests/test_harness_behaviour_border.py
+++ b/gateway/tests/test_harness_behaviour_border.py
@@ -147,17 +147,15 @@ def test_transports_name_harness_types_without_driving_the_agent() -> None:
 
 
 def _chat_methods_in_tree(tree: ast.AST) -> set[str]:
-    """Return 'chat' / 'chat_until_goal' method or function calls present in AST ``tree``."""
+    """Return 'chat' / 'chat_until_goal' attribute method calls present in AST ``tree``."""
     methods: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            if isinstance(node.func, ast.Attribute) and node.func.attr in {
-                "chat",
-                "chat_until_goal",
-            }:
-                methods.add(node.func.attr)
-            elif isinstance(node.func, ast.Name) and node.func.id in {"chat", "chat_until_goal"}:
-                methods.add(node.func.id)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"chat", "chat_until_goal"}
+        ):
+            methods.add(node.func.attr)
     return methods
 
 

--- a/gateway/tests/test_harness_behaviour_border.py
+++ b/gateway/tests/test_harness_behaviour_border.py
@@ -11,6 +11,9 @@ reach it at all:
   goal progress — belongs to the host layer. A transport that calls it has
   become a second turn runner, which is what
   ``infrastructure/turn_host/turn_runner.py`` exists to prevent.
+* **Direct chat() entrypoint** — ``AgentSession.chat()`` and ``chat_until_goal()``
+  bypass the session pool lock and the process capacity gate. Gateway modules
+  must never call them; turns must go through ``TurnRunner`` -> ``HeadlessAgent.handle``.
 
 The allowlist is compared exactly, so it can only shrink: a new caller fails
 immediately, and a module that stops calling must be removed from it.
@@ -62,6 +65,12 @@ _OUTSIDE_HOST_LAYER: frozenset[str] = frozenset(
         "gateway/web/worker.py",
     }
 )
+
+#: Gateway modules allowed to call unguarded chat() / chat_until_goal() directly.
+#: Empty: gateway turns must go through TurnRunner -> HeadlessAgent.handle to ensure
+#: same-session serialization (pool lock) and process turn capacity limits.
+#: Compared exactly, so it can only shrink.
+_ALLOWED_CHAT_CALLERS: frozenset[str] = frozenset()
 
 
 def _harness_names(tree: ast.AST) -> set[str]:
@@ -135,3 +144,63 @@ def test_transports_name_harness_types_without_driving_the_agent() -> None:
     assert importers, "expected transports to type their session parameters"
     for name, names in importers.items():
         assert names <= _HARNESS_CONTRACTS, f"{name} imports harness behaviour: {sorted(names)}"
+
+
+def _chat_methods_in_tree(tree: ast.AST) -> set[str]:
+    """Return 'chat' / 'chat_until_goal' method or function calls present in AST ``tree``."""
+    methods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute) and node.func.attr in {
+                "chat",
+                "chat_until_goal",
+            }:
+                methods.add(node.func.attr)
+            elif isinstance(node.func, ast.Name) and node.func.id in {"chat", "chat_until_goal"}:
+                methods.add(node.func.id)
+    return methods
+
+
+def _chat_callers() -> dict[str, set[str]]:
+    """Gateway modules calling .chat() or .chat_until_goal()."""
+    callers: dict[str, set[str]] = {}
+    for path in _gateway_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        methods = _chat_methods_in_tree(tree)
+        if methods:
+            callers[str(path.relative_to(REPO_ROOT))] = methods
+    return callers
+
+
+def test_gateway_modules_never_call_unguarded_chat() -> None:
+    """Gateway turns must go through TurnRunner -> HeadlessAgent.handle, never chat().
+
+    AgentSession.chat() and chat_until_goal() bypass the session agent pool lock
+    and process turn capacity gate. No gateway module is permitted to call them.
+    """
+    callers = _chat_callers()
+    actual = set(callers.keys())
+
+    added = sorted(actual - _ALLOWED_CHAT_CALLERS)
+    assert added == [], (
+        f"gateway modules calling unguarded chat() / chat_until_goal(): "
+        f"{ {name: sorted(callers[name]) for name in added} }. "
+        "Route turns through infrastructure/turn_host/turn_runner.py (TurnRunner.run / "
+        "HeadlessAgent.handle) to preserve same-session serialization and capacity limits."
+    )
+
+    stale = sorted(_ALLOWED_CHAT_CALLERS - actual)
+    assert stale == [], (
+        f"{stale} no longer call chat(); remove them from the allowlist so it keeps shrinking."
+    )
+
+
+def test_chat_border_fails_when_a_module_calls_chat() -> None:
+    """Demonstrate the border scanner catches direct .chat() or .chat_until_goal() invocations."""
+    tree = ast.parse("def bad_turn_handler(session, prompt):\n    return session.chat(prompt)\n")
+    assert _chat_methods_in_tree(tree) == {"chat"}
+
+    goal_tree = ast.parse(
+        "def bad_goal_handler(session, prompt):\n    return session.chat_until_goal(prompt)\n"
+    )
+    assert _chat_methods_in_tree(goal_tree) == {"chat_until_goal"}

--- a/tests/interactive_shell/test_harness_api_border.py
+++ b/tests/interactive_shell/test_harness_api_border.py
@@ -26,3 +26,53 @@ def test_surfaces_import_the_harness_only_through_its_api() -> None:
     assert_internal_imports_match_allowlist(
         imported, _ALLOWED_INTERNAL_IMPORTS, package="surfaces/"
     )
+
+
+#: Interactive shell modules allowed to call unguarded chat() / chat_until_goal() directly.
+#: Empty: the interactive shell must drive turns via TurnRunner -> SessionAgentPool -> HeadlessAgent.handle.
+#: Compared exactly, so it can only shrink.
+_ALLOWED_SHELL_CHAT_CALLERS: frozenset[str] = frozenset()
+
+
+def _shell_chat_callers() -> dict[str, set[str]]:
+    """Interactive shell modules calling .chat() or .chat_until_goal()."""
+    import ast
+
+    shell_root = REPO_ROOT / "surfaces" / "interactive_shell"
+    callers: dict[str, set[str]] = {}
+    for path in sorted(shell_root.rglob("*.py")):
+        if {"__pycache__", "tests"} & set(path.parts):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        methods = {
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"chat", "chat_until_goal"}
+        }
+        if methods:
+            callers[str(path.relative_to(REPO_ROOT))] = methods
+    return callers
+
+
+def test_interactive_shell_never_calls_unguarded_chat() -> None:
+    """Interactive shell turns must go through TurnRunner -> HeadlessAgent.handle, never chat().
+
+    AgentSession.chat() and chat_until_goal() bypass the session agent pool lock
+    and process turn capacity gate. Interactive shell modules must not call them.
+    """
+    callers = _shell_chat_callers()
+    actual = set(callers.keys())
+
+    added = sorted(actual - _ALLOWED_SHELL_CHAT_CALLERS)
+    assert added == [], (
+        f"interactive shell modules calling unguarded chat() / chat_until_goal(): {callers}. "
+        "Route turns through infrastructure/turn_host/turn_runner.py (TurnRunner.run / "
+        "HeadlessAgent.handle) to preserve turn serialization and capacity limits."
+    )
+
+    stale = sorted(_ALLOWED_SHELL_CHAT_CALLERS - actual)
+    assert stale == [], (
+        f"{stale} no longer call chat(); remove them from the allowlist so it keeps shrinking."
+    )


### PR DESCRIPTION
Fixes #5483

#### Describe the changes you have made in this PR -
- **Enforced Two-Door Turn Architecture**:
  - Documented in `core/agent_harness/AGENTS.md` that `AgentSession.chat()` / `chat_until_goal()` is intentionally an unguarded single-turn API for scripted/headless/SDK embedders, whereas concurrent hosts (Gateway transports and Interactive Shell) must drive turns exclusively via `TurnRunner` → `SessionAgentPool` → `HeadlessAgent.handle()`.
  - This preserves the per-session pool lock (preventing race conditions and `AgentBusyError` on overlapping turns) and respects `OPENSRE_MAX_CONCURRENT_TURNS` (process turn capacity gate).
- **Added AST Border Enforcement (Gateway & Interactive Shell)**:
  - In `gateway/tests/test_harness_behaviour_border.py`, added `_ALLOWED_CHAT_CALLERS = frozenset()` and `test_gateway_modules_never_call_unguarded_chat()` with a shrink-only allowlist check scanning all gateway AST sources for `.chat()` and `.chat_until_goal()` attribute calls.
  - In `tests/interactive_shell/test_harness_api_border.py`, added `_ALLOWED_SHELL_CHAT_CALLERS = frozenset()` and `test_interactive_shell_never_calls_unguarded_chat()` with a shrink-only allowlist check scanning all interactive shell AST sources.
  - Added `test_chat_border_fails_when_a_module_calls_chat()` to demonstrate that direct `.chat()` and `.chat_until_goal()` calls in host modules fail immediately.

### Demo/Screenshot for feature changes and bug fixes - 
```text
$ uv run python -m pytest gateway/tests/test_harness_behaviour_border.py tests/interactive_shell/test_harness_api_border.py -v
============================= test session starts ==============================
collecting ... collected 6 items

gateway/tests/test_harness_behaviour_border.py::test_only_the_host_layer_drives_the_agent PASSED [ 16%]
gateway/tests/test_harness_behaviour_border.py::test_transports_name_harness_types_without_driving_the_agent PASSED [ 33%]
gateway/tests/test_harness_behaviour_border.py::test_gateway_modules_never_call_unguarded_chat PASSED [ 50%]
gateway/tests/test_harness_behaviour_border.py::test_chat_border_fails_when_a_module_calls_chat PASSED [ 66%]
tests/interactive_shell/test_harness_api_border.py::test_surfaces_import_the_harness_only_through_its_api PASSED [ 83%]
tests/interactive_shell/test_harness_api_border.py::test_interactive_shell_never_calls_unguarded_chat PASSED [100%]

============================== 6 passed in 3.75s ===============================
```

Verification grep:
```text
$ grep -rn "\.chat(\|chat_until_goal(" --include='*.py' gateway surfaces tools core | grep -v __pycache__ | grep -v tests
surfaces/cli/ask/service.py:182:            return agent_session.chat_until_goal(prompt).last_result
core/agent_harness/harness.py:6:    result = session.chat("…")            # turn 1
core/agent_harness/harness.py:7:    follow = session.chat("…")            # turn 2 — same attached agent
core/agent_harness/harness.py:161:                result = session.chat(prompt)
core/agent_harness/harness.py:226:        ).chat(message)
core/agent_harness/harness.py:270:            session.chat(text)
core/agent_harness/harness.py:280:    def chat_until_goal(
```
*(0 gateway callers, 0 shell callers)*

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
We analyzed all callers of `.chat()` and `.chat_until_goal()` across the repository and confirmed that while scripted SDK embedders and single-shot CLI legitimately use `AgentSession.chat()`, concurrent hosts (Gateway transports and Interactive Shell) must never reach for it because doing so bypasses the `SessionAgentPool` per-session lock and `TurnConcurrencyGate`. We recorded this architectural decision in `core/agent_harness/AGENTS.md` and added AST-based shrink-only allowlist border tests in both `gateway/tests/test_harness_behaviour_border.py` and `tests/interactive_shell/test_harness_api_border.py` (with empty allowlists `_ALLOWED_CHAT_CALLERS` and `_ALLOWED_SHELL_CHAT_CALLERS`) alongside a failure-demonstration test to ensure the rule is strictly enforced by CI across all concurrent hosts.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
