### PR TITLE
test(harness): honour the execute_actions turn-seam contract in test_turn_loop.py (#5197)

### DIFF
--- a/tests/core/agent/test_turn_loop.py
+++ b/tests/core/agent/test_turn_loop.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Callable
+from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness import OutputSink
 from core.agent_harness.accounting.turn_accounting import DefaultTurnAccounting
+from core.agent_harness.ports import ConfirmFn
+from core.agent_harness.runtime import TurnPlan
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.turns.orchestrator import run_turn
+from core.tool import ToolExecutionHooks
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
@@ -33,7 +39,19 @@ def _console() -> Console:
     return Console(file=io.StringIO(), force_terminal=False, color_system=None, width=80)
 
 
-def _unhandled_turn(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+def _unhandled_turn(
+    message: str,
+    session: Session,
+    console: Console,
+    *,
+    confirm_fn: ConfirmFn | None = None,
+    is_tty: bool | None = None,
+    request_exit: Callable[[], None] | None = None,
+    turn_plan: TurnPlan | None = None,
+    output: OutputSink | None = None,
+    tool_hooks: ToolExecutionHooks | None = None,
+) -> ToolCallingTurnResult:
+    """A RunActionToolTurn seam whose action turn handles nothing."""
     return ToolCallingTurnResult(
         planned_count=0,
         executed_count=0,
@@ -65,7 +83,19 @@ def test_recorder_flushes_once_for_silent_handled_turn() -> None:
     recorder = _Recorder()
     session = Session()
 
-    def _handled(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _handled(
+        message: str,
+        session: Session,
+        console: Console,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        request_exit: Callable[[], None] | None = None,
+        turn_plan: TurnPlan | None = None,
+        output: OutputSink | None = None,
+        tool_hooks: ToolExecutionHooks | None = None,
+    ) -> ToolCallingTurnResult:
+        """A RunActionToolTurn seam whose action turn handles the request."""
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,
@@ -98,7 +128,14 @@ def test_default_turn_accounting_persists_action_only_context() -> None:
     session = Session(store=storage)
     storage.open_session(session)
 
-    def _handled(*_args: object, **_kwargs: object) -> ToolCallingTurnResult:
+    def _handled(
+        text: str,
+        *,
+        confirm_fn: ConfirmFn | None = None,
+        is_tty: bool | None = None,
+        turn_plan: Any = None,
+    ) -> ToolCallingTurnResult:
+        """An ExecuteActions seam whose action turn handles the request."""
         return ToolCallingTurnResult(
             planned_count=1,
             executed_count=1,


### PR DESCRIPTION
Fixes #5197

#### Describe the changes you have made in this PR -

**Context:** This issue's original targets — the `gather`/`answer` stage stubs faked as `lambda *_a, **_k` — were removed from this file by #5761, which collapsed chat into the shared ReAct agent. Those seams are no longer injected here, so that half of the issue is already satisfied on `main`.

The one turn seam **still** faked with a swallow-all `(*_args, **_kwargs)` signature is `execute_actions`, which every test in this file injects. This PR completes the issue's goal ("honour turn-seam contracts in `test_turn_loop.py`") for that remaining seam:

- `_unhandled_turn` and the `_handled` stub in `test_recorder_flushes_once_for_silent_handled_turn` now match the shell `RunActionToolTurn` Protocol (`surfaces/interactive_shell/runtime/turn_seams.py`).
- The `_handled` stub in `test_default_turn_accounting_persists_action_only_context` now matches the core `ExecuteActions` Protocol (`core/agent_harness/ports.py`) — the `run_turn` call uses the core seam, which has a different signature.

Bodies and assertions are unchanged; only the parameter lists were tightened. Add a required argument to either Protocol and these stubs now fail instead of silently passing.

**Why this is stronger than the gather/answer case:** `execute_actions` is invoked on **every** turn (the assertions depend on its return value), so contract drift is caught at **runtime** (a signature mismatch raises `TypeError` in `pytest`) as well as by mypy — there is no short-circuit/"not exercised" gap.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/core/agent/test_turn_loop.py -q
3 passed

$ .venv/bin/python -m ruff check tests/core/agent/test_turn_loop.py
All checks passed!

$ .venv/bin/python -m mypy tests/core/agent/test_turn_loop.py
Success: no issues found in 1 source file
```

Note: CI's `make typecheck` excludes `tests/`, but because `execute_actions` runs every turn, the pytest run itself enforces these signatures — so drift is caught in CI regardless.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The file injects test doubles for the agent's turn stages. After #5761 removed the gather/answer seams, the only stage still faked with a contract-blind `(*_args, **_kwargs)` signature was `execute_actions`. There are two distinct contracts: `run_harness_turn` takes the shell `RunActionToolTurn` (called `(message, session, console, *, confirm_fn, is_tty, request_exit, turn_plan, output, tool_hooks)`), while `run_turn` takes the core `ExecuteActions` (called `(text, *, confirm_fn, is_tty, turn_plan)`). I gave each stub the exact signature of the Protocol at its call site — verified from the adapter/orchestrator call sites — so mypy checks conformance and, since the stage always runs, pytest enforces it at runtime too. I did not name the Protocols in the stubs; conformance is checked where each stub is passed to its typed `execute_actions` parameter.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
