### PR TITLE
refactor(github): re-export the mcp and mcp_oauth API lazily

### DIFF
--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -24,6 +24,18 @@ _LAZY_EXPORTS: dict[str, str] = {
     "PullRequest": "integrations.github.pull_requests",
     "open_pull_request": "integrations.github.pull_requests",
     "resolve_repo_scope": "integrations.github.pull_requests",
+    "DEFAULT_GITHUB_MCP_MODE": "integrations.github.mcp",
+    "DEFAULT_GITHUB_MCP_URL": "integrations.github.mcp",
+    "GitHubMCPValidationResult": "integrations.github.mcp",
+    "GitHubMcpDisplayDetailLevel": "integrations.github.mcp",
+    "build_github_mcp_config": "integrations.github.mcp",
+    "format_github_mcp_validation_cli_report": "integrations.github.mcp",
+    "github_integration_is_configured": "integrations.github.mcp",
+    "print_github_mcp_validation_report": "integrations.github.mcp",
+    "validate_github_mcp_config": "integrations.github.mcp",
+    "GitHubDeviceCode": "integrations.github.mcp_oauth",
+    "GitHubDeviceFlowError": "integrations.github.mcp_oauth",
+    "authorize_github_via_device_flow": "integrations.github.mcp_oauth",
 }
 
 
@@ -43,6 +55,22 @@ if TYPE_CHECKING:
     from integrations.github.helpers import github_creds
     from integrations.github.identity import saved_github_username
     from integrations.github.login import GitHubLoginResult, authenticate_and_configure_github
+    from integrations.github.mcp import (
+        DEFAULT_GITHUB_MCP_MODE,
+        DEFAULT_GITHUB_MCP_URL,
+        GitHubMcpDisplayDetailLevel,
+        GitHubMCPValidationResult,
+        build_github_mcp_config,
+        format_github_mcp_validation_cli_report,
+        github_integration_is_configured,
+        print_github_mcp_validation_report,
+        validate_github_mcp_config,
+    )
+    from integrations.github.mcp_oauth import (
+        GitHubDeviceCode,
+        GitHubDeviceFlowError,
+        authorize_github_via_device_flow,
+    )
     from integrations.github.pull_requests import (
         ERR_GITHUB_TOKEN,
         GitHubPullRequestError,
@@ -53,16 +81,28 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "DEFAULT_GITHUB_MCP_MODE",
+    "DEFAULT_GITHUB_MCP_URL",
     "ERR_GITHUB_TOKEN",
     "GitHubApiError",
+    "GitHubDeviceCode",
+    "GitHubDeviceFlowError",
     "GitHubLoginResult",
+    "GitHubMCPValidationResult",
+    "GitHubMcpDisplayDetailLevel",
     "GitHubPullRequestError",
     "GitHubRestClient",
     "PullRequest",
     "authenticate_and_configure_github",
+    "authorize_github_via_device_flow",
+    "build_github_mcp_config",
+    "format_github_mcp_validation_cli_report",
     "github_creds",
+    "github_integration_is_configured",
     "open_pull_request",
+    "print_github_mcp_validation_report",
     "resolve_github_token",
     "resolve_repo_scope",
     "saved_github_username",
+    "validate_github_mcp_config",
 ]

--- a/surfaces/cli/wizard/configurators/github.py
+++ b/surfaces/cli/wizard/configurators/github.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import dataclasses
 
 from infrastructure.terminal.theme import DEVICE_CODE, SECONDARY
-from integrations.github.mcp import DEFAULT_GITHUB_MCP_MODE, DEFAULT_GITHUB_MCP_URL
+from integrations.github import DEFAULT_GITHUB_MCP_MODE, DEFAULT_GITHUB_MCP_URL
 from integrations.github.setup import GITHUB_SETUP
 from integrations.setup_flow import apply_setup
 from surfaces.cli.wizard.components import (
@@ -32,7 +32,7 @@ def _github_wizard_browser_authorize() -> str | None:
     """Run GitHub device-flow browser authorization inside the wizard."""
     from rich.markup import escape
 
-    from integrations.github.mcp_oauth import (
+    from integrations.github import (
         GitHubDeviceCode,
         GitHubDeviceFlowError,
         authorize_github_via_device_flow,

--- a/surfaces/cli/wizard/integration_validators/mcp_validators.py
+++ b/surfaces/cli/wizard/integration_validators/mcp_validators.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from integrations.github.mcp import (
+from integrations.github import (
     build_github_mcp_config,
     format_github_mcp_validation_cli_report,
     validate_github_mcp_config,

--- a/surfaces/cli/wizard/integration_validators/shared.py
+++ b/surfaces/cli/wizard/integration_validators/shared.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from integrations.github.mcp import GitHubMCPValidationResult
+    from integrations.github import GitHubMCPValidationResult
 
 
 @dataclass(frozen=True)

--- a/surfaces/cli/wizard/summaries.py
+++ b/surfaces/cli/wizard/summaries.py
@@ -148,7 +148,7 @@ def render_integration_result(
     github_display_level: str | None = None,
 ) -> None:
     if result.github_mcp is not None:
-        from integrations.github.mcp import (
+        from integrations.github import (
             GitHubMcpDisplayDetailLevel,
             print_github_mcp_validation_report,
         )

--- a/surfaces/interactive_shell/runtime/startup/first_launch_github.py
+++ b/surfaces/interactive_shell/runtime/startup/first_launch_github.py
@@ -96,7 +96,7 @@ def _github_login_explicitly_bypassed() -> bool:
 
 
 def _github_already_configured() -> bool:
-    from integrations.github.mcp import github_integration_is_configured
+    from integrations.github import github_integration_is_configured
 
     return github_integration_is_configured()
 
@@ -155,7 +155,7 @@ def _print_intro(console: Console, *, allow_skip: bool) -> None:
 
 
 def _show_device_code(console: Console, code: object, *, allow_skip: bool) -> None:
-    from integrations.github.mcp_oauth import GitHubDeviceCode
+    from integrations.github import GitHubDeviceCode
 
     if not isinstance(code, GitHubDeviceCode):
         return
@@ -283,8 +283,7 @@ def _ask_retry(_console: Console) -> str:
 
 def _attempt_login(console: Console, *, allow_skip: bool, variant: str) -> AttemptOutcome:
     """Run one login attempt."""
-    from integrations.github import authenticate_and_configure_github
-    from integrations.github.mcp_oauth import GitHubDeviceFlowError
+    from integrations.github import GitHubDeviceFlowError, authenticate_and_configure_github
 
     try:
         result = authenticate_and_configure_github(

--- a/tests/shared/test_integrations_api_border.py
+++ b/tests/shared/test_integrations_api_border.py
@@ -72,8 +72,6 @@ _ALLOWED: dict[str, frozenset[str]] = {
             "integrations.betterstack.setup",
             "integrations.buzz.alarms",
             "integrations.dagster.setup",
-            "integrations.github.mcp",
-            "integrations.github.mcp_oauth",
             "integrations.github.setup",
             "integrations.jenkins.setup",
             "integrations.openclaw.setup",


### PR DESCRIPTION
Extend github's lazy __getattr__ surface with the MCP config/validation names and the device-flow OAuth types so callers import them from the package root instead of reaching into integrations.github.mcp / .mcp_oauth. Migrate the five surfaces callers and drop the two allowlist entries; github.setup (verifier cycle) is left for a leaf-extraction follow-up.