### PR TITLE
fix: remediate GitHub code quality finding #3288

### DIFF
--- a/integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py
+++ b/integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py
@@ -31,6 +31,11 @@ from integrations.sqs import (
 
 logger = logging.getLogger(__name__)
 
+_BACKLOG_ALERT_USE_CASE = (
+    "Investigating a queue-age or backlog alert — returns depth, in-flight "
+    "count, and DLQ configuration"
+)
+
 
 def _queue_name_from_url(url: str) -> str:
     return url.rstrip("/").rsplit("/", 1)[-1]
@@ -88,8 +93,7 @@ def _parse_attributes(raw_attrs: dict[str, str]) -> dict[str, Any]:
         "Diagnosing stuck consumers: in-flight count equals the consumer/pod count",
         "Identifying a poison-pill message cycling due to a short VisibilityTimeout",
         "Checking whether a queue has a dead-letter queue configured at all",
-        "Investigating a queue-age or backlog alert — returns depth, in-flight "
-        "count, and DLQ configuration",
+        _BACKLOG_ALERT_USE_CASE,
         "Confirming whether a queue is draining after a consumer deploy or scale-up",
     ],
     requires=[],


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code quality finding #3288](https://github.com/Tracer-Cloud/opensre/security/quality/findings/3288).

**Alert summary**
Implicit string concatenation in a list

**Fix summary**
Fixed the finding with the repo's prescribed pattern for this exact CodeQL rule.

**Change** — `integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py`:
- Extracted the two adjacent string literals at lines 91-92 (the "Investigating a queue-age or backlog alert…" entry in `use_cases`) into a module constant `_BACKLOG_ALERT_USE_CASE`, and referenced that constant in the list.

**Why this way**: inside a list, two adjacent literals are indistinguishable from a missing comma — that's what `py/implicit-string-concatenation-in-list` flags. In a parenthesised assignment no comma could have been intended, so the concatenation is unambiguous there. This follows the AGENTS.md footgun guidance and the precedent `_RUNTIME_FACTS_ANTI_EXAMPLE` in `tools/system/python_execution_tool/__init__.py`. Behavior is unchanged — the resulting string is identical.

**Verification**: `ruff check` and `ruff format --check` pass, the module imports cleanly, and `tests/tools/test_sqs_queue_attributes.py` passes (30 tests). No commit made, per instructions.

**Files changed**
- `integrations/sqs/tools/sqs_queue_attributes_tool/__init__.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.