### PR TITLE
test(session): add cross-process soak matrix for the session file lock

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # Seconds to wait for the cross-process session lock before giving up. Generous:
 # same-session turns are already serialized in-process, so real contention here
 # is only two tasks racing one session — rare, and pathological beyond this.
-_SESSION_LOCK_TIMEOUT_SECONDS = 10
+_SESSION_LOCK_TIMEOUT_SECONDS: float = 10
 
 
 def _session_file_lock_enabled() -> bool:

--- a/tests/core/agent_harness/session/_lock_soak_worker.py
+++ b/tests/core/agent_harness/session/_lock_soak_worker.py
@@ -1,0 +1,90 @@
+"""Standalone writer process for the session-lock soak matrix.
+
+Run as a script, never imported by a test: the point is a genuinely separate
+interpreter, so ``SIGKILL`` proves what a thread cannot and no monkeypatched
+parent state leaks in. Configuration arrives as one JSON argument because the
+matrix varies enough parameters that positional argv would be unreadable.
+
+The worker never calls ``open_session``: that truncates an existing file
+(#5474), which would destroy the very interleaving these tests measure. The
+parent seeds the session file first.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.agent_harness.session.persistence import jsonl_store  # noqa: E402
+from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore  # noqa: E402
+
+
+def _session(session_id: str) -> Any:
+    """Minimal stand-in for the persistence source the store reads."""
+    return SimpleNamespace(
+        session_id=session_id,
+        started_at=0.0,
+        agent=SimpleNamespace(messages=[]),
+        accumulated_context={},
+    )
+
+
+def _wait_until(start_at: float) -> None:
+    """Block until ``start_at`` so sibling workers contend instead of queueing."""
+    delay = start_at - time.time()
+    if delay > 0:
+        time.sleep(delay)
+
+
+def main(config: dict[str, Any]) -> int:
+    worker_id = str(config["worker_id"])
+    session_ids: list[str] = list(config["session_ids"])
+    turns = int(config["turns"])
+    text_chars = int(config.get("text_chars", 32))
+    result_path = Path(config["result_path"])
+
+    timeout_seconds = config.get("lock_timeout_seconds")
+    if timeout_seconds is not None:
+        jsonl_store._SESSION_LOCK_TIMEOUT_SECONDS = float(timeout_seconds)
+
+    store = JsonlSessionStore()
+    sessions = {session_id: _session(session_id) for session_id in session_ids}
+    body = "x" * text_chars
+
+    _wait_until(float(config.get("start_at", 0.0)))
+
+    written: list[str] = []
+    first_write = time.time()
+    for index in range(turns):
+        session_id = session_ids[index % len(session_ids)]
+        marker = f"{worker_id}-{index}"
+        store.append_turn(sessions[session_id], "chat", f"{marker}:{body}")
+        written.append(f"{session_id}/{marker}")
+    last_write = time.time()
+
+    result_path.write_text(
+        json.dumps(
+            {
+                "worker_id": worker_id,
+                "pid": os.getpid(),
+                "first_write_ts": first_write,
+                "last_write_ts": last_write,
+                "written": written,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(json.loads(sys.argv[1])))

--- a/tests/core/agent_harness/session/_lock_soak_worker.py
+++ b/tests/core/agent_harness/session/_lock_soak_worker.py
@@ -30,6 +30,10 @@ from core.agent_harness.session.persistence.paths import session_path  # noqa: E
 
 _BARRIER_POLL_SECONDS = 0.01
 _BARRIER_TIMEOUT_SECONDS = 120.0
+# A stop marker the parent never writes must not mean an immortal writer: the
+# fixture kills survivors, but a parent that was itself killed cannot, and this
+# loop appends to disk on every pass.
+_MAX_RUN_SECONDS = 120.0
 
 
 def _session(session_id: str) -> Any:
@@ -72,7 +76,9 @@ def _hold_lock_forever(session_id: str, held_path: Path, seconds: float) -> None
     path = session_path(session_id)
     with store._locked(path):  # noqa: SLF001
         held_path.write_text(str(os.getpid()), encoding="utf-8")
-        time.sleep(seconds)
+        # Bounded: this process is meant to be killed, but a parent that dies
+        # first must not leave it holding the lock indefinitely.
+        time.sleep(min(seconds, _MAX_RUN_SECONDS))
 
 
 def main(config: dict[str, Any]) -> int:
@@ -111,12 +117,15 @@ def main(config: dict[str, Any]) -> int:
 
     written: list[str] = []
     first_write = time.time()
+    give_up_at = time.monotonic() + _MAX_RUN_SECONDS
     index = 0
     while True:
         if stop_path is None and index >= int(turns or 0):
             break
         if stop_path is not None and index > 0 and stop_path.exists():
             break
+        if time.monotonic() > give_up_at:
+            raise TimeoutError(f"no stop signal after {_MAX_RUN_SECONDS}s")
         session_id = session_ids[index % len(session_ids)]
         marker = f"{worker_id}-{index}"
         store.append_turn(sessions[session_id], "chat", f"{marker}:{body}")

--- a/tests/core/agent_harness/session/_lock_soak_worker.py
+++ b/tests/core/agent_harness/session/_lock_soak_worker.py
@@ -26,6 +26,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from core.agent_harness.session.persistence import jsonl_store  # noqa: E402
 from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore  # noqa: E402
+from core.agent_harness.session.persistence.paths import session_path  # noqa: E402
 
 _BARRIER_POLL_SECONDS = 0.01
 _BARRIER_TIMEOUT_SECONDS = 120.0
@@ -57,6 +58,23 @@ def _await_go(ready_path: Path, go_path: Path) -> None:
         time.sleep(_BARRIER_POLL_SECONDS)
 
 
+def _hold_lock_forever(session_id: str, held_path: Path, seconds: float) -> None:
+    """Take the store's own write lock, announce it, and keep holding it.
+
+    Through ``_locked`` rather than a ``FileLock`` built from a guessed filename:
+    the caller needs to hold *whatever* lock the store uses, so that renaming or
+    re-keying the lock cannot leave this quietly holding an unrelated file.
+
+    The marker is written from inside the locked region, so a parent that sees
+    it knows the lock is held right now — not that it might be soon.
+    """
+    store = JsonlSessionStore()
+    path = session_path(session_id)
+    with store._locked(path):  # noqa: SLF001
+        held_path.write_text(str(os.getpid()), encoding="utf-8")
+        time.sleep(seconds)
+
+
 def main(config: dict[str, Any]) -> int:
     worker_id = str(config["worker_id"])
     session_ids: list[str] = list(config["session_ids"])
@@ -75,6 +93,11 @@ def main(config: dict[str, Any]) -> int:
     store = JsonlSessionStore()
     sessions = {session_id: _session(session_id) for session_id in session_ids}
     body = "x" * text_chars
+
+    hold_seconds = config.get("hold_lock_seconds")
+    if hold_seconds is not None:
+        _hold_lock_forever(session_ids[0], Path(config["held_path"]), float(hold_seconds))
+        return 0
 
     go_path = config.get("go_path")
     if go_path is not None:

--- a/tests/core/agent_harness/session/_lock_soak_worker.py
+++ b/tests/core/agent_harness/session/_lock_soak_worker.py
@@ -27,6 +27,9 @@ if str(_REPO_ROOT) not in sys.path:
 from core.agent_harness.session.persistence import jsonl_store  # noqa: E402
 from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore  # noqa: E402
 
+_BARRIER_POLL_SECONDS = 0.01
+_BARRIER_TIMEOUT_SECONDS = 120.0
+
 
 def _session(session_id: str) -> Any:
     """Minimal stand-in for the persistence source the store reads."""
@@ -38,19 +41,32 @@ def _session(session_id: str) -> Any:
     )
 
 
-def _wait_until(start_at: float) -> None:
-    """Block until ``start_at`` so sibling workers contend instead of queueing."""
-    delay = start_at - time.time()
-    if delay > 0:
-        time.sleep(delay)
+def _await_go(ready_path: Path, go_path: Path) -> None:
+    """Announce readiness, then block until the parent releases every worker.
+
+    A wall-clock start time cannot do this job: interpreter startup is hundreds
+    of milliseconds and unbounded on a loaded runner, so a worker can miss a
+    fixed deadline and begin after a sibling has already finished. Signalling
+    after the imports are paid makes the release order independent of load.
+    """
+    ready_path.write_text(str(os.getpid()), encoding="utf-8")
+    deadline = time.monotonic() + _BARRIER_TIMEOUT_SECONDS
+    while not go_path.exists():
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"barrier {go_path} never opened")
+        time.sleep(_BARRIER_POLL_SECONDS)
 
 
 def main(config: dict[str, Any]) -> int:
     worker_id = str(config["worker_id"])
     session_ids: list[str] = list(config["session_ids"])
-    turns = int(config["turns"])
     text_chars = int(config.get("text_chars", 32))
     result_path = Path(config["result_path"])
+
+    # Exactly one of the two is set: ``turns`` for a bounded run, ``duration``
+    # when the run must still be going when something else happens to it.
+    turns = config.get("turns")
+    duration_seconds = config.get("duration_seconds")
 
     timeout_seconds = config.get("lock_timeout_seconds")
     if timeout_seconds is not None:
@@ -60,15 +76,24 @@ def main(config: dict[str, Any]) -> int:
     sessions = {session_id: _session(session_id) for session_id in session_ids}
     body = "x" * text_chars
 
-    _wait_until(float(config.get("start_at", 0.0)))
+    go_path = config.get("go_path")
+    if go_path is not None:
+        _await_go(Path(f"{result_path}.ready"), Path(go_path))
 
     written: list[str] = []
     first_write = time.time()
-    for index in range(turns):
+    deadline = time.monotonic() + float(duration_seconds) if duration_seconds else None
+    index = 0
+    while True:
+        if deadline is None and index >= int(turns or 0):
+            break
+        if deadline is not None and time.monotonic() >= deadline:
+            break
         session_id = session_ids[index % len(session_ids)]
         marker = f"{worker_id}-{index}"
         store.append_turn(sessions[session_id], "chat", f"{marker}:{body}")
         written.append(f"{session_id}/{marker}")
+        index += 1
     last_write = time.time()
 
     result_path.write_text(

--- a/tests/core/agent_harness/session/_lock_soak_worker.py
+++ b/tests/core/agent_harness/session/_lock_soak_worker.py
@@ -81,10 +81,9 @@ def main(config: dict[str, Any]) -> int:
     text_chars = int(config.get("text_chars", 32))
     result_path = Path(config["result_path"])
 
-    # Exactly one of the two is set: ``turns`` for a bounded run, ``duration``
-    # when the run must still be going when something else happens to it.
+    # Exactly one of the two is set: ``turns`` for a bounded run, ``stop_path``
+    # when the parent decides when everyone stops.
     turns = config.get("turns")
-    duration_seconds = config.get("duration_seconds")
 
     timeout_seconds = config.get("lock_timeout_seconds")
     if timeout_seconds is not None:
@@ -103,20 +102,31 @@ def main(config: dict[str, Any]) -> int:
     if go_path is not None:
         _await_go(Path(f"{result_path}.ready"), Path(go_path))
 
+    # ``stop_path`` mode writes until the parent says stop, rather than for a
+    # duration this process times itself. A worker the scheduler starves would
+    # otherwise measure its own window entirely after its siblings had finished,
+    # and the overlap assertion would fail on a correct lock.
+    stop_path = Path(config["stop_path"]) if config.get("stop_path") else None
+    writing_path = Path(f"{result_path}.writing")
+
     written: list[str] = []
     first_write = time.time()
-    deadline = time.monotonic() + float(duration_seconds) if duration_seconds else None
     index = 0
     while True:
-        if deadline is None and index >= int(turns or 0):
+        if stop_path is None and index >= int(turns or 0):
             break
-        if deadline is not None and time.monotonic() >= deadline:
+        if stop_path is not None and index > 0 and stop_path.exists():
             break
         session_id = session_ids[index % len(session_ids)]
         marker = f"{worker_id}-{index}"
         store.append_turn(sessions[session_id], "chat", f"{marker}:{body}")
         written.append(f"{session_id}/{marker}")
         index += 1
+        if index == 1:
+            # Announced only after a turn is on disk: the parent holds every
+            # worker open until all of them have written, so each one's interval
+            # provably contains the moment the last of them started.
+            writing_path.write_text(str(os.getpid()), encoding="utf-8")
     last_write = time.time()
 
     result_path.write_text(

--- a/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
@@ -41,12 +41,9 @@ _PROCESS_TIMEOUT_SECONDS = 60.0
 # How long concurrent writers run once released. Long enough that every worker
 # is provably writing while the others are, short enough not to pad the suite.
 _OVERLAP_SECONDS = 1.5
-# The victim of the kill case must still be writing when the signal lands, so it
-# runs on a clock it cannot outrun rather than a turn count it might finish.
+# The victim holds the lock for far longer than the parent needs to kill it,
+# so the kill can never land after it has let go.
 _VICTIM_SECONDS = 30.0
-_KILL_AFTER_SECONDS = 0.75
-# Big enough that a SIGKILL can land inside a single write() and tear the line.
-_TORN_WRITE_CHARS = 512 * 1024
 # The OS frees a dead holder's flock immediately; this is slack, not a wait.
 _LOCK_RECLAIM_SECONDS = 5.0
 # Short on purpose: a writer that should not be contending must fail fast
@@ -154,6 +151,17 @@ def _release(processes: list[subprocess.Popen[bytes]], result_paths: list[Path],
         )
         time.sleep(0.01)
     go.touch()
+
+
+def _await_marker(marker: Path, process: subprocess.Popen[bytes], failure: str) -> None:
+    """Block until ``marker`` appears, failing fast if the process dies first."""
+    deadline = time.monotonic() + _PROCESS_TIMEOUT_SECONDS
+    while not marker.exists():
+        if process.poll() is not None:
+            pytest.fail(f"{failure} (exited {process.returncode})")
+        if time.monotonic() > deadline:
+            pytest.fail(f"{failure} (timed out after {_PROCESS_TIMEOUT_SECONDS}s)")
+        time.sleep(0.01)
 
 
 def _await(processes: list[subprocess.Popen[bytes]]) -> None:
@@ -356,40 +364,41 @@ def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
     )
 
 
-def test_soak_sigkill_mid_write_strands_no_lock(soak_home: Path) -> None:
-    """Case 3: a hard kill releases the lock rather than stranding it.
+def test_soak_sigkill_while_holding_the_lock_strands_nothing(soak_home: Path) -> None:
+    """Case 3: a hard kill of the lock *holder* leaves the lock takeable.
 
     SIGKILL, not SIGTERM — a clean shutdown releases the lock through Python and
-    proves nothing about what the OS does for a process that never runs its
-    handlers. The claim is asserted directly against the lock, because where the
-    kill lands inside the write is a race and the file's shape is not.
+    proves nothing about a process that never runs its handlers.
+
+    The victim signals from inside the locked region and the parent waits for
+    that signal, because a fixed sleep only proves the process is alive: on a
+    loaded runner it may still be importing, and killing a victim that never
+    took the lock would let this pass while reclaiming nothing.
     """
     session_id = "soak-kill"
     path = _seed(session_id)
+    held_marker = soak_home / "victim.held"
 
     victim = _spawn(
         soak_home,
         {
             "worker_id": "victim",
             "session_ids": [session_id],
-            "duration_seconds": _VICTIM_SECONDS,
-            "text_chars": _TORN_WRITE_CHARS,
+            "hold_lock_seconds": _VICTIM_SECONDS,
+            "held_path": str(held_marker),
             "result_path": str(soak_home / "victim.json"),
         },
     )
-    time.sleep(_KILL_AFTER_SECONDS)
-    assert victim.poll() is None, "victim finished before it could be killed mid-write"
+    _await_marker(held_marker, victim, "victim never acquired the session lock")
+
+    assert victim.poll() is None, "victim exited before it could be killed holding the lock"
     os.kill(victim.pid, signal.SIGKILL)
     victim.wait(timeout=_PROCESS_TIMEOUT_SECONDS)
     assert victim.returncode == -signal.SIGKILL
 
-    # The lock the dead process held must be free: fcntl.flock is released by
-    # the OS on exit, so this fails only if the store has bolted something
-    # durable on top of it.
-    inherited = FileLock(f"{path}.lock", timeout=_LOCK_RECLAIM_SECONDS)
-    inherited.acquire()
-    inherited.release()
-
+    # The product-level claim: a writer that arrives after the holder died gets
+    # the lock and its turns land. A stranded lock turns these into timeouts,
+    # and the short timeout makes that a fast failure rather than a stall.
     size_before_survivor = path.stat().st_size
     survivor_result = soak_home / "survivor.json"
     _await(
@@ -401,6 +410,7 @@ def test_soak_sigkill_mid_write_strands_no_lock(soak_home: Path) -> None:
                     "session_ids": [session_id],
                     "turns": 5,
                     "result_path": str(survivor_result),
+                    "lock_timeout_seconds": _CONTENDED_TIMEOUT_SECONDS,
                 },
             )
         ]
@@ -408,6 +418,11 @@ def test_soak_sigkill_mid_write_strands_no_lock(soak_home: Path) -> None:
 
     _metrics(soak_home).report("sigkill")
     assert path.stat().st_size > size_before_survivor, "the survivor wrote nothing after the kill"
+    survivor = _results([survivor_result])[0]
+    expected = {marker.split("/", 1)[1] for marker in survivor.written}
+    assert expected <= _written_markers(_assert_readable(path)), (
+        "the survivor's turns are missing: the dead holder's lock was not reclaimed"
+    )
 
 
 @pytest.mark.xfail(

--- a/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
@@ -28,7 +28,7 @@ from typing import Any
 import pytest
 from filelock import FileLock
 
-from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
+from config.constants import OPENSRE_HOME_ENV, OPENSRE_OPERATIONS_LOG_PATH_ENV
 from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
 from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
 from core.agent_harness.session.persistence.paths import session_path, sessions_dir
@@ -37,11 +37,14 @@ from infrastructure.observability.operations_log import read_operations
 _WORKER = Path(__file__).with_name("_lock_soak_worker.py")
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
-# Long enough that every worker is running before any of them writes, short
-# enough not to pad the suite. The different-sessions case depends on it:
-# without a shared start the workers queue up and "overlap" proves nothing.
-_START_BARRIER_SECONDS = 1.0
 _PROCESS_TIMEOUT_SECONDS = 60.0
+# How long concurrent writers run once released. Long enough that every worker
+# is provably writing while the others are, short enough not to pad the suite.
+_OVERLAP_SECONDS = 1.5
+# The victim of the kill case must still be writing when the signal lands, so it
+# runs on a clock it cannot outrun rather than a turn count it might finish.
+_VICTIM_SECONDS = 30.0
+_KILL_AFTER_SECONDS = 0.75
 # Big enough that a SIGKILL can land inside a single write() and tear the line.
 _TORN_WRITE_CHARS = 512 * 1024
 # The OS frees a dead holder's flock immediately; this is slack, not a wait.
@@ -83,7 +86,7 @@ class WorkerResult:
 @pytest.fixture
 def soak_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point session storage and the operations log at a temp home."""
-    monkeypatch.setenv("OPENSRE_HOME", str(tmp_path))
+    monkeypatch.setenv(OPENSRE_HOME_ENV, str(tmp_path))
     monkeypatch.setenv(OPENSRE_SESSION_FILE_LOCK_ENV, "1")
     monkeypatch.setenv(OPENSRE_OPERATIONS_LOG_PATH_ENV, str(tmp_path / "operations.jsonl"))
     from config.constants import paths as paths_constants
@@ -114,7 +117,7 @@ def _seed(session_id: str) -> Path:
 def _worker_env(home: Path) -> dict[str, str]:
     return {
         **os.environ,
-        "OPENSRE_HOME": str(home),
+        OPENSRE_HOME_ENV: str(home),
         OPENSRE_SESSION_FILE_LOCK_ENV: "1",
         OPENSRE_OPERATIONS_LOG_PATH_ENV: str(home / "operations.jsonl"),
         "PYTHONPATH": str(_REPO_ROOT),
@@ -129,6 +132,28 @@ def _spawn(home: Path, config: dict[str, Any]) -> subprocess.Popen[bytes]:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+
+def _release(processes: list[subprocess.Popen[bytes]], result_paths: list[Path], go: Path) -> None:
+    """Block until every worker has imported and is waiting, then release them.
+
+    Interpreter startup is ~0.4s idle and unbounded under load, so a wall-clock
+    start time lets a slow worker begin after a fast one has already finished —
+    the overlap the concurrency case asserts would then be a property of the
+    runner, not the lock.
+    """
+    deadline = time.monotonic() + _PROCESS_TIMEOUT_SECONDS
+    ready = [Path(f"{path}.ready") for path in result_paths]
+    while not all(path.exists() for path in ready):
+        if time.monotonic() > deadline:
+            pytest.fail(
+                f"workers never signalled ready: {[p.name for p in ready if not p.exists()]}"
+            )
+        assert all(process.poll() is None for process in processes), (
+            "a worker exited before the barrier"
+        )
+        time.sleep(0.01)
+    go.touch()
 
 
 def _await(processes: list[subprocess.Popen[bytes]]) -> None:
@@ -213,7 +238,7 @@ def test_soak_same_session_writers_serialize_without_loss(soak_home: Path) -> No
     """Case 1: concurrent writers to one session lose no turn and tear no line."""
     session_id = "soak-same"
     path = _seed(session_id)
-    start_at = time.time() + _START_BARRIER_SECONDS
+    go = soak_home / "go-same"
 
     result_paths = [soak_home / f"result-{i}.json" for i in range(4)]
     processes = [
@@ -224,11 +249,12 @@ def test_soak_same_session_writers_serialize_without_loss(soak_home: Path) -> No
                 "session_ids": [session_id],
                 "turns": 25,
                 "result_path": str(result_paths[i]),
-                "start_at": start_at,
+                "go_path": str(go),
             },
         )
         for i in range(4)
     ]
+    _release(processes, result_paths, go)
     _await(processes)
 
     records = _assert_readable(path)
@@ -249,22 +275,26 @@ def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
     """
     session_ids = [f"soak-diff-{i}" for i in range(4)]
     paths = [_seed(session_id) for session_id in session_ids]
-    start_at = time.time() + _START_BARRIER_SECONDS
+    go = soak_home / "go-diff"
 
     result_paths = [soak_home / f"result-{i}.json" for i in range(len(session_ids))]
+    # A fixed duration rather than a turn count: released together and stopped
+    # by the same clock, the writers provably overlap instead of overlapping
+    # only when the runner happens to schedule them that way.
     processes = [
         _spawn(
             soak_home,
             {
                 "worker_id": f"w{i}",
                 "session_ids": [session_id],
-                "turns": 40,
+                "duration_seconds": _OVERLAP_SECONDS,
                 "result_path": str(result_paths[i]),
-                "start_at": start_at,
+                "go_path": str(go),
             },
         )
         for i, session_id in enumerate(session_ids)
     ]
+    _release(processes, result_paths, go)
     _await(processes)
 
     for path in paths:
@@ -309,7 +339,6 @@ def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
                         "session_ids": [session_ids[1]],
                         "turns": 3,
                         "result_path": str(blocked_result),
-                        "start_at": 0.0,
                         "lock_timeout_seconds": _CONTENDED_TIMEOUT_SECONDS,
                     },
                 )
@@ -343,13 +372,12 @@ def test_soak_sigkill_mid_write_strands_no_lock(soak_home: Path) -> None:
         {
             "worker_id": "victim",
             "session_ids": [session_id],
-            "turns": 400,
+            "duration_seconds": _VICTIM_SECONDS,
             "text_chars": _TORN_WRITE_CHARS,
             "result_path": str(soak_home / "victim.json"),
-            "start_at": 0.0,
         },
     )
-    time.sleep(0.75)
+    time.sleep(_KILL_AFTER_SECONDS)
     assert victim.poll() is None, "victim finished before it could be killed mid-write"
     os.kill(victim.pid, signal.SIGKILL)
     victim.wait(timeout=_PROCESS_TIMEOUT_SECONDS)
@@ -373,7 +401,6 @@ def test_soak_sigkill_mid_write_strands_no_lock(soak_home: Path) -> None:
                     "session_ids": [session_id],
                     "turns": 5,
                     "result_path": str(survivor_result),
-                    "start_at": 0.0,
                 },
             )
         ]
@@ -442,7 +469,6 @@ def test_soak_lock_timeout_fails_cleanly_without_partial_append(soak_home: Path)
                         "session_ids": [session_id],
                         "turns": 3,
                         "result_path": str(soak_home / "blocked.json"),
-                        "start_at": 0.0,
                         "lock_timeout_seconds": 0.3,
                     },
                 )

--- a/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
@@ -1,0 +1,458 @@
+"""Cross-process soak matrix for the session file lock (#5497).
+
+The same-process tests in ``test_jsonl_store_lock.py`` cannot distinguish a
+working lock from one that merely appears to work: a lock's happy path looks
+identical either way. These four cases run real writer processes, because the
+crash case needs a process the OS can kill and the concurrency cases need
+writers that are not sharing an interpreter lock.
+
+Run with ``-s`` to see the per-run lock-wait, timeout, and decode-failure
+numbers; they are printed for every case and are the signal worth watching
+while the lock is young.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from filelock import FileLock
+
+from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
+from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
+from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
+from core.agent_harness.session.persistence.paths import session_path, sessions_dir
+from infrastructure.observability.operations_log import read_operations
+
+_WORKER = Path(__file__).with_name("_lock_soak_worker.py")
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Long enough that every worker is running before any of them writes, short
+# enough not to pad the suite. The different-sessions case depends on it:
+# without a shared start the workers queue up and "overlap" proves nothing.
+_START_BARRIER_SECONDS = 1.0
+_PROCESS_TIMEOUT_SECONDS = 60.0
+# Big enough that a SIGKILL can land inside a single write() and tear the line.
+_TORN_WRITE_CHARS = 512 * 1024
+# The OS frees a dead holder's flock immediately; this is slack, not a wait.
+_LOCK_RECLAIM_SECONDS = 5.0
+# Short on purpose: a writer that should not be contending must fail fast
+# rather than stall the suite for the store's generous default.
+_CONTENDED_TIMEOUT_SECONDS = 0.5
+
+
+@dataclass(frozen=True, slots=True)
+class LockMetrics:
+    """What one soak run cost, as the issue asks it be reported."""
+
+    wait_max_ms: int
+    wait_p50_ms: int
+    wait_samples: int
+    timeouts: int
+    decode_failures: int
+
+    def report(self, case: str) -> None:
+        print(
+            f"\n[soak:{case}] lock-wait max={self.wait_max_ms}ms p50={self.wait_p50_ms}ms "
+            f"samples={self.wait_samples} timeouts={self.timeouts} "
+            f"decode_failures={self.decode_failures}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerResult:
+    """One writer process's own account of what it wrote and when."""
+
+    worker_id: str
+    pid: int
+    first_write_ts: float
+    last_write_ts: float
+    written: tuple[str, ...]
+
+
+@pytest.fixture
+def soak_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point session storage and the operations log at a temp home."""
+    monkeypatch.setenv("OPENSRE_HOME", str(tmp_path))
+    monkeypatch.setenv(OPENSRE_SESSION_FILE_LOCK_ENV, "1")
+    monkeypatch.setenv(OPENSRE_OPERATIONS_LOG_PATH_ENV, str(tmp_path / "operations.jsonl"))
+    from config.constants import paths as paths_constants
+
+    monkeypatch.setattr(paths_constants, "OPENSRE_HOME_DIR", tmp_path, raising=False)
+    return tmp_path
+
+
+def _session(session_id: str) -> Any:
+    return SimpleNamespace(
+        session_id=session_id,
+        started_at=0.0,
+        agent=SimpleNamespace(messages=[]),
+        accumulated_context={},
+    )
+
+
+def _seed(session_id: str) -> Path:
+    """Create the session file the workers append to.
+
+    The parent seeds it because ``open_session`` opens with ``"w"`` and would
+    truncate a session a sibling worker is already writing (#5474).
+    """
+    JsonlSessionStore().open_session(_session(session_id))
+    return session_path(session_id)
+
+
+def _worker_env(home: Path) -> dict[str, str]:
+    return {
+        **os.environ,
+        "OPENSRE_HOME": str(home),
+        OPENSRE_SESSION_FILE_LOCK_ENV: "1",
+        OPENSRE_OPERATIONS_LOG_PATH_ENV: str(home / "operations.jsonl"),
+        "PYTHONPATH": str(_REPO_ROOT),
+    }
+
+
+def _spawn(home: Path, config: dict[str, Any]) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [sys.executable, str(_WORKER), json.dumps(config)],
+        cwd=str(_REPO_ROOT),
+        env=_worker_env(home),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _await(processes: list[subprocess.Popen[bytes]]) -> None:
+    """Wait for every worker, failing loudly on a non-zero exit."""
+    deadline = time.monotonic() + _PROCESS_TIMEOUT_SECONDS
+    for process in processes:
+        remaining = max(0.1, deadline - time.monotonic())
+        try:
+            _stdout, stderr = process.communicate(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            pytest.fail(f"worker {process.pid} did not finish within {_PROCESS_TIMEOUT_SECONDS}s")
+        assert process.returncode == 0, f"worker {process.pid} failed: {stderr.decode()}"
+
+
+def _results(paths: list[Path]) -> list[WorkerResult]:
+    return [
+        WorkerResult(
+            worker_id=str(raw["worker_id"]),
+            pid=int(raw["pid"]),
+            first_write_ts=float(raw["first_write_ts"]),
+            last_write_ts=float(raw["last_write_ts"]),
+            written=tuple(raw["written"]),
+        )
+        for raw in (json.loads(path.read_text(encoding="utf-8")) for path in paths)
+    ]
+
+
+def _metrics(home: Path) -> LockMetrics:
+    records = read_operations(path=home / "operations.jsonl", limit=100_000)
+    waits = [int(r["data"]["wait_ms"]) for r in records if r["event"] == "session_file_lock_wait"]
+    return LockMetrics(
+        wait_max_ms=max(waits, default=0),
+        wait_p50_ms=int(statistics.median(waits)) if waits else 0,
+        wait_samples=len(waits),
+        timeouts=sum(1 for r in records if r["event"] == "session_file_lock_timeout"),
+        decode_failures=sum(1 for r in records if r["event"] == "session_jsonl_decode_failed"),
+    )
+
+
+def _assert_readable(path: Path) -> list[dict[str, Any]]:
+    """Assert the file is intact, tolerating one truncated final line.
+
+    A crash mid-append can leave a partial last record. Anything unparseable
+    *before* the last line is interleaving damage, which is what the lock exists
+    to prevent.
+    """
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    records: list[dict[str, Any]] = []
+    for index, line in enumerate(lines):
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            is_final = index == len(lines) - 1
+            assert is_final, f"torn line {index + 1} of {len(lines)} is not the final line"
+
+    headers = [r for r in records if r.get("type") == "session"]
+    assert len(headers) == 1, f"expected exactly one session header, found {len(headers)}"
+    assert records[0].get("type") == "session", "session header is not the first record"
+    return records
+
+
+def _parses(line: str) -> bool:
+    """Whether ``line`` is a decodable JSON record."""
+    try:
+        json.loads(line)
+    except json.JSONDecodeError:
+        return False
+    return True
+
+
+def _written_markers(records: list[dict[str, Any]]) -> set[str]:
+    """Marker prefixes (``w0-3``) of every turn stub in the file."""
+    return {
+        str(record.get("text", "")).split(":", 1)[0]
+        for record in records
+        if record.get("custom_type") == "turn_stub"
+    }
+
+
+def test_soak_same_session_writers_serialize_without_loss(soak_home: Path) -> None:
+    """Case 1: concurrent writers to one session lose no turn and tear no line."""
+    session_id = "soak-same"
+    path = _seed(session_id)
+    start_at = time.time() + _START_BARRIER_SECONDS
+
+    result_paths = [soak_home / f"result-{i}.json" for i in range(4)]
+    processes = [
+        _spawn(
+            soak_home,
+            {
+                "worker_id": f"w{i}",
+                "session_ids": [session_id],
+                "turns": 25,
+                "result_path": str(result_paths[i]),
+                "start_at": start_at,
+            },
+        )
+        for i in range(4)
+    ]
+    _await(processes)
+
+    records = _assert_readable(path)
+    metrics = _metrics(soak_home)
+    metrics.report("same-session")
+
+    expected = {marker.split("/", 1)[1] for r in _results(result_paths) for marker in r.written}
+    missing = expected - _written_markers(records)
+    assert not missing, f"{len(missing)} turns reported written but absent from the file: {missing}"
+
+
+def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
+    """Case 2: a per-path lock must not serialize unrelated sessions.
+
+    The overlap is asserted, not assumed: a global lock would still produce a
+    green run here, just a serial one, so the test would silently degrade into
+    proving nothing.
+    """
+    session_ids = [f"soak-diff-{i}" for i in range(4)]
+    paths = [_seed(session_id) for session_id in session_ids]
+    start_at = time.time() + _START_BARRIER_SECONDS
+
+    result_paths = [soak_home / f"result-{i}.json" for i in range(len(session_ids))]
+    processes = [
+        _spawn(
+            soak_home,
+            {
+                "worker_id": f"w{i}",
+                "session_ids": [session_id],
+                "turns": 40,
+                "result_path": str(result_paths[i]),
+                "start_at": start_at,
+            },
+        )
+        for i, session_id in enumerate(session_ids)
+    ]
+    _await(processes)
+
+    for path in paths:
+        _assert_readable(path)
+    metrics = _metrics(soak_home)
+    metrics.report("different-sessions")
+
+    results = _results(result_paths)
+    latest_start = max(r.first_write_ts for r in results)
+    earliest_end = min(r.last_write_ts for r in results)
+    assert earliest_end > latest_start, (
+        "writers to different sessions did not run at the same time, so this run "
+        "measured nothing: "
+        + ", ".join(
+            f"{r.worker_id}[{r.first_write_ts:.3f}..{r.last_write_ts:.3f}]" for r in results
+        )
+    )
+
+    # Overlapping wall-clock ranges are necessary but not sufficient. A single
+    # global lock still lets writers interleave turn by turn, so the check above
+    # passes under one — verified by rebuilding the store with one shared lock
+    # and watching this case stay green on timing alone. What a global lock
+    # cannot fake is the shape on disk: one lock file per session path, and no
+    # lock file shared between them.
+    lock_files = {path.name for path in sessions_dir().glob("*.lock")}
+    assert lock_files == {f"{path.name}.lock" for path in paths}, (
+        "expected one lock file per session and nothing else; the lock is not "
+        f"keyed by path, so unrelated sessions serialize against each other: {sorted(lock_files)}"
+    )
+
+    # And behaviourally, holding one session's own lock must not stall another.
+    blocked_result = soak_home / "unrelated.json"
+    held = FileLock(f"{paths[0]}.lock", timeout=_LOCK_RECLAIM_SECONDS)
+    held.acquire()
+    try:
+        _await(
+            [
+                _spawn(
+                    soak_home,
+                    {
+                        "worker_id": "unrelated",
+                        "session_ids": [session_ids[1]],
+                        "turns": 3,
+                        "result_path": str(blocked_result),
+                        "start_at": 0.0,
+                        "lock_timeout_seconds": _CONTENDED_TIMEOUT_SECONDS,
+                    },
+                )
+            ]
+        )
+    finally:
+        held.release()
+
+    unrelated = _results([blocked_result])[0]
+    expected = {marker.split("/", 1)[1] for marker in unrelated.written}
+    present = _written_markers(_assert_readable(paths[1]))
+    assert expected <= present, (
+        f"holding {session_ids[0]}'s lock blocked writes to {session_ids[1]}: the "
+        "lock is not per-path, so unrelated sessions serialize against each other"
+    )
+
+
+def test_soak_sigkill_mid_write_strands_no_lock(soak_home: Path) -> None:
+    """Case 3: a hard kill releases the lock rather than stranding it.
+
+    SIGKILL, not SIGTERM — a clean shutdown releases the lock through Python and
+    proves nothing about what the OS does for a process that never runs its
+    handlers. The claim is asserted directly against the lock, because where the
+    kill lands inside the write is a race and the file's shape is not.
+    """
+    session_id = "soak-kill"
+    path = _seed(session_id)
+
+    victim = _spawn(
+        soak_home,
+        {
+            "worker_id": "victim",
+            "session_ids": [session_id],
+            "turns": 400,
+            "text_chars": _TORN_WRITE_CHARS,
+            "result_path": str(soak_home / "victim.json"),
+            "start_at": 0.0,
+        },
+    )
+    time.sleep(0.75)
+    assert victim.poll() is None, "victim finished before it could be killed mid-write"
+    os.kill(victim.pid, signal.SIGKILL)
+    victim.wait(timeout=_PROCESS_TIMEOUT_SECONDS)
+    assert victim.returncode == -signal.SIGKILL
+
+    # The lock the dead process held must be free: fcntl.flock is released by
+    # the OS on exit, so this fails only if the store has bolted something
+    # durable on top of it.
+    inherited = FileLock(f"{path}.lock", timeout=_LOCK_RECLAIM_SECONDS)
+    inherited.acquire()
+    inherited.release()
+
+    size_before_survivor = path.stat().st_size
+    survivor_result = soak_home / "survivor.json"
+    _await(
+        [
+            _spawn(
+                soak_home,
+                {
+                    "worker_id": "survivor",
+                    "session_ids": [session_id],
+                    "turns": 5,
+                    "result_path": str(survivor_result),
+                    "start_at": 0.0,
+                },
+            )
+        ]
+    )
+
+    _metrics(soak_home).report("sigkill")
+    assert path.stat().st_size > size_before_survivor, "the survivor wrote nothing after the kill"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "#5750: a crash leaves a record with no trailing newline, and the next "
+        "append is concatenated onto it. That fuses both records into one "
+        "unparseable line, so the post-crash turn is invisible to every reader. "
+        "Strict, so this flips to a failure the moment #5750 is fixed."
+    ),
+)
+def test_soak_write_after_a_torn_tail_is_not_swallowed(soak_home: Path) -> None:
+    """Case 3, deterministic half: the record after a torn tail must survive.
+
+    A SIGKILL lands mid-write only sometimes, so the crash *artifact* is seeded
+    directly here — a final line with no newline is exactly what the killed
+    process leaves behind. Losing the next turn is worse than the torn line
+    itself: the torn line is one dead record a reader skips, while this silently
+    swallows a good one written afterwards.
+    """
+    session_id = "soak-torn"
+    path = _seed(session_id)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"id": "partial", "type": "custom_message", "text": "tor')
+
+    JsonlSessionStore().append_turn(_session(session_id), "chat", "after-the-crash")
+
+    _metrics(soak_home).report("torn-tail")
+    readable = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if _parses(line)
+    ]
+    texts = [str(r.get("text", "")) for r in readable if r.get("custom_type") == "turn_stub"]
+    assert any("after-the-crash" in text for text in texts), (
+        "the turn written after the torn tail is unreadable: it was appended onto "
+        "the partial line instead of a new one"
+    )
+
+
+def test_soak_lock_timeout_fails_cleanly_without_partial_append(soak_home: Path) -> None:
+    """Case 4: a write that cannot take the lock appends nothing at all.
+
+    The write being *dropped* rather than retried or surfaced is #5475; this
+    case pins the half that is not in dispute — whatever the caller is told, the
+    file must not gain a partial record.
+    """
+    session_id = "soak-timeout"
+    path = _seed(session_id)
+    before = path.read_bytes()
+
+    held = FileLock(f"{path}.lock", timeout=1.0)
+    held.acquire()
+    try:
+        _await(
+            [
+                _spawn(
+                    soak_home,
+                    {
+                        "worker_id": "blocked",
+                        "session_ids": [session_id],
+                        "turns": 3,
+                        "result_path": str(soak_home / "blocked.json"),
+                        "start_at": 0.0,
+                        "lock_timeout_seconds": 0.3,
+                    },
+                )
+            ]
+        )
+    finally:
+        held.release()
+
+    metrics = _metrics(soak_home)
+    metrics.report("timeout")
+
+    assert path.read_bytes() == before, "a timed-out write left bytes in the session file"
+    assert metrics.timeouts >= 1, "expected the blocked writer to record a lock timeout"

--- a/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
@@ -13,6 +13,7 @@ while the lock is young.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import signal
@@ -20,6 +21,7 @@ import statistics
 import subprocess
 import sys
 import time
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -38,6 +40,7 @@ _WORKER = Path(__file__).with_name("_lock_soak_worker.py")
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 _PROCESS_TIMEOUT_SECONDS = 60.0
+_REAP_TIMEOUT_SECONDS = 10.0
 # How long released writers contend once all of them are writing. Bounds the
 # soak; it never bounds correctness, because the parent ends the run.
 _SOAK_SECONDS = 1.0
@@ -121,14 +124,38 @@ def _worker_env(home: Path) -> dict[str, str]:
     }
 
 
-def _spawn(home: Path, config: dict[str, Any]) -> subprocess.Popen[bytes]:
-    return subprocess.Popen(
-        [sys.executable, str(_WORKER), json.dumps(config)],
-        cwd=str(_REPO_ROOT),
-        env=_worker_env(home),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+@pytest.fixture
+def spawn(soak_home: Path) -> Iterator[Callable[[dict[str, Any]], subprocess.Popen[bytes]]]:
+    """Spawn workers, and kill any that outlive the test.
+
+    Teardown rather than the test body, because a worker in stop-file mode
+    waits for a marker the parent may never write: any failure between spawn
+    and the stop signal — a failed handshake, an assertion, a KeyboardInterrupt
+    — would otherwise leave it appending turns forever on the CI runner.
+    """
+    started: list[subprocess.Popen[bytes]] = []
+
+    def _spawn(config: dict[str, Any]) -> subprocess.Popen[bytes]:
+        process = subprocess.Popen(
+            [sys.executable, str(_WORKER), json.dumps(config)],
+            cwd=str(_REPO_ROOT),
+            env=_worker_env(soak_home),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        started.append(process)
+        return process
+
+    try:
+        yield _spawn
+    finally:
+        for process in started:
+            if process.poll() is None:
+                process.kill()
+            # Always drain: the pipes are still open on a killed worker, and an
+            # unread PIPE is a file descriptor this process keeps.
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.communicate(timeout=_REAP_TIMEOUT_SECONDS)
 
 
 def _await_all(processes: list[subprocess.Popen[bytes]], markers: list[Path], what: str) -> None:
@@ -259,7 +286,9 @@ def _written_markers(records: list[dict[str, Any]]) -> set[str]:
     }
 
 
-def test_soak_same_session_writers_serialize_without_loss(soak_home: Path) -> None:
+def test_soak_same_session_writers_serialize_without_loss(
+    soak_home: Path, spawn: Callable[[dict[str, Any]], subprocess.Popen[bytes]]
+) -> None:
     """Case 1: concurrent writers to one session lose no turn and tear no line."""
     session_id = "soak-same"
     path = _seed(session_id)
@@ -267,8 +296,7 @@ def test_soak_same_session_writers_serialize_without_loss(soak_home: Path) -> No
 
     result_paths = [soak_home / f"result-{i}.json" for i in range(4)]
     processes = [
-        _spawn(
-            soak_home,
+        spawn(
             {
                 "worker_id": f"w{i}",
                 "session_ids": [session_id],
@@ -291,7 +319,9 @@ def test_soak_same_session_writers_serialize_without_loss(soak_home: Path) -> No
     assert not missing, f"{len(missing)} turns reported written but absent from the file: {missing}"
 
 
-def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
+def test_soak_different_sessions_write_concurrently(
+    soak_home: Path, spawn: Callable[[dict[str, Any]], subprocess.Popen[bytes]]
+) -> None:
     """Case 2: a per-path lock must not serialize unrelated sessions.
 
     The overlap is asserted, not assumed: a global lock would still produce a
@@ -308,8 +338,7 @@ def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
     # held open until all of them have written: the overlap the case asserts is
     # then guaranteed by construction rather than by the scheduler.
     processes = [
-        _spawn(
-            soak_home,
+        spawn(
             {
                 "worker_id": f"w{i}",
                 "session_ids": [session_id],
@@ -358,8 +387,7 @@ def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
     try:
         _await(
             [
-                _spawn(
-                    soak_home,
+                spawn(
                     {
                         "worker_id": "unrelated",
                         "session_ids": [session_ids[1]],
@@ -382,7 +410,9 @@ def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
     )
 
 
-def test_soak_sigkill_while_holding_the_lock_strands_nothing(soak_home: Path) -> None:
+def test_soak_sigkill_while_holding_the_lock_strands_nothing(
+    soak_home: Path, spawn: Callable[[dict[str, Any]], subprocess.Popen[bytes]]
+) -> None:
     """Case 3: a hard kill of the lock *holder* leaves the lock takeable.
 
     SIGKILL, not SIGTERM — a clean shutdown releases the lock through Python and
@@ -397,8 +427,7 @@ def test_soak_sigkill_while_holding_the_lock_strands_nothing(soak_home: Path) ->
     path = _seed(session_id)
     held_marker = soak_home / "victim.held"
 
-    victim = _spawn(
-        soak_home,
+    victim = spawn(
         {
             "worker_id": "victim",
             "session_ids": [session_id],
@@ -421,8 +450,7 @@ def test_soak_sigkill_while_holding_the_lock_strands_nothing(soak_home: Path) ->
     survivor_result = soak_home / "survivor.json"
     _await(
         [
-            _spawn(
-                soak_home,
+            spawn(
                 {
                     "worker_id": "survivor",
                     "session_ids": [session_id],
@@ -479,7 +507,9 @@ def test_soak_write_after_a_torn_tail_is_not_swallowed(soak_home: Path) -> None:
     )
 
 
-def test_soak_lock_timeout_fails_cleanly_without_partial_append(soak_home: Path) -> None:
+def test_soak_lock_timeout_fails_cleanly_without_partial_append(
+    soak_home: Path, spawn: Callable[[dict[str, Any]], subprocess.Popen[bytes]]
+) -> None:
     """Case 4: a write that cannot take the lock appends nothing at all.
 
     The write being *dropped* rather than retried or surfaced is #5475; this
@@ -495,8 +525,7 @@ def test_soak_lock_timeout_fails_cleanly_without_partial_append(soak_home: Path)
     try:
         _await(
             [
-                _spawn(
-                    soak_home,
+                spawn(
                     {
                         "worker_id": "blocked",
                         "session_ids": [session_id],

--- a/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
@@ -38,9 +38,9 @@ _WORKER = Path(__file__).with_name("_lock_soak_worker.py")
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 _PROCESS_TIMEOUT_SECONDS = 60.0
-# How long concurrent writers run once released. Long enough that every worker
-# is provably writing while the others are, short enough not to pad the suite.
-_OVERLAP_SECONDS = 1.5
+# How long released writers contend once all of them are writing. Bounds the
+# soak; it never bounds correctness, because the parent ends the run.
+_SOAK_SECONDS = 1.0
 # The victim holds the lock for far longer than the parent needs to kill it,
 # so the kill can never land after it has let go.
 _VICTIM_SECONDS = 30.0
@@ -131,26 +131,43 @@ def _spawn(home: Path, config: dict[str, Any]) -> subprocess.Popen[bytes]:
     )
 
 
-def _release(processes: list[subprocess.Popen[bytes]], result_paths: list[Path], go: Path) -> None:
-    """Block until every worker has imported and is waiting, then release them.
-
-    Interpreter startup is ~0.4s idle and unbounded under load, so a wall-clock
-    start time lets a slow worker begin after a fast one has already finished —
-    the overlap the concurrency case asserts would then be a property of the
-    runner, not the lock.
-    """
+def _await_all(processes: list[subprocess.Popen[bytes]], markers: list[Path], what: str) -> None:
+    """Block until every marker exists, failing fast if a worker dies first."""
     deadline = time.monotonic() + _PROCESS_TIMEOUT_SECONDS
-    ready = [Path(f"{path}.ready") for path in result_paths]
-    while not all(path.exists() for path in ready):
+    while not all(marker.exists() for marker in markers):
         if time.monotonic() > deadline:
-            pytest.fail(
-                f"workers never signalled ready: {[p.name for p in ready if not p.exists()]}"
-            )
+            missing = [marker.name for marker in markers if not marker.exists()]
+            pytest.fail(f"workers did not {what}: {missing}")
         assert all(process.poll() is None for process in processes), (
-            "a worker exited before the barrier"
+            f"a worker exited before it could {what}"
         )
         time.sleep(0.01)
+
+
+def _release(
+    processes: list[subprocess.Popen[bytes]],
+    result_paths: list[Path],
+    go: Path,
+    stop: Path | None = None,
+) -> None:
+    """Run every worker concurrently, then stop them all at the same instant.
+
+    Neither end of the window is left to the scheduler. Startup is ~0.4s idle
+    and unbounded under load, so workers are released together rather than at a
+    wall-clock time; and each one is held open until *every* worker has a turn
+    on disk, so a starved worker cannot measure its window after its siblings
+    have already exited. Overlap is then structural, not a property of the
+    runner.
+    """
+    _await_all(processes, [Path(f"{path}.ready") for path in result_paths], "signal ready")
     go.touch()
+    if stop is None:
+        return
+    _await_all(processes, [Path(f"{path}.writing") for path in result_paths], "write a first turn")
+    # Every worker is now provably writing. Let them contend for a while before
+    # calling stop, so the run is a soak and not just a handshake.
+    time.sleep(_SOAK_SECONDS)
+    stop.touch()
 
 
 def _await_marker(marker: Path, process: subprocess.Popen[bytes], failure: str) -> None:
@@ -284,25 +301,26 @@ def test_soak_different_sessions_write_concurrently(soak_home: Path) -> None:
     session_ids = [f"soak-diff-{i}" for i in range(4)]
     paths = [_seed(session_id) for session_id in session_ids]
     go = soak_home / "go-diff"
+    stop = soak_home / "stop-diff"
 
     result_paths = [soak_home / f"result-{i}.json" for i in range(len(session_ids))]
-    # A fixed duration rather than a turn count: released together and stopped
-    # by the same clock, the writers provably overlap instead of overlapping
-    # only when the runner happens to schedule them that way.
+    # Released together and stopped together by the parent, with every worker
+    # held open until all of them have written: the overlap the case asserts is
+    # then guaranteed by construction rather than by the scheduler.
     processes = [
         _spawn(
             soak_home,
             {
                 "worker_id": f"w{i}",
                 "session_ids": [session_id],
-                "duration_seconds": _OVERLAP_SECONDS,
+                "stop_path": str(stop),
                 "result_path": str(result_paths[i]),
                 "go_path": str(go),
             },
         )
         for i, session_id in enumerate(session_ids)
     ]
-    _release(processes, result_paths, go)
+    _release(processes, result_paths, go, stop)
     _await(processes)
 
     for path in paths:


### PR DESCRIPTION
Fixes #5497 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

The existing lock tests all run in one process, which can't tell a working lock from one
that only looks like it works. Added a soak matrix that spawns real writer processes for the
four cases in the issue — same-session writers, different-session writers, SIGKILL mid-write,
and lock timeout — each with a named assertion, plus lock-wait max/p50, timeout and decode-
failure counts printed per run. The crash case is split in two: the SIGKILL process asserts
the lock is reclaimable (deterministic), while the file-integrity half seeds the crash
artifact directly, since a kill only lands mid-write some of the time. This found a new bug
(#5750): a torn final line swallows the next turn written to that session, so that case is
xfail(strict=True) with the assertion left intact.


### Demo/Screenshot for feature changes and bug fixes - 

<img width="1488" height="922" alt="image" src="https://github.com/user-attachments/assets/334e2081-ebf7-47fa-8ec2-0e659f05537d" />


<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

A lock's happy path looks the same whether or not it works, so the goal was assertions that
fail for the right reason. I used real subprocesses, not threads, because SIGKILL has to prove
the OS releases the lock. Workers are configured purely through env vars, and never call
open_session since it truncates the file a sibling is writing (#5474).

Two assertions didn't survive contact. The overlap check passed even after I rebuilt the store
with a single global lock, because a global lock still interleaves turn by turn — so the
discriminator is now structural: one lock file per session path, which a global lock can't
fake. And the crash case failed once then passed, since SIGKILL only sometimes lands mid-write,
so I split it: the kill asserts the lock is reclaimable, and a separate deterministic test
seeds the partial line a crash leaves. That second test found #5750, which I left at full
strength as xfail(strict=True) rather than weakening it.


<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
