### PR TITLE
feat(interactive-shell): task-plan checklists, ask-user hand-off menus, and live tool-call feedback

### DIFF
--- a/infrastructure/safety/terminal_output.py
+++ b/infrastructure/safety/terminal_output.py
@@ -1,21 +1,34 @@
 """Strip terminal control characters from model-supplied text.
 
-Plan steps, menu titles, and option labels come from the model and are later
-written into raw ANSI output. An embedded escape (ESC, OSC, CR) could spoof the
-terminal or corrupt menu-row accounting, so this removes control characters at
-the parse boundary, before the text is stored or rendered.
+Plan steps, menu titles, option labels, and assistant prose come from the
+model and are later written into raw ANSI or Rich output. An embedded escape
+(ESC, OSC, CR) could spoof the terminal or corrupt menu-row accounting, so
+this removes control characters at the render/parse boundary.
 """
 
 from __future__ import annotations
 
+# LF / Tab keep multi-line markdown and report structure intact. ESC, CR, BEL,
+# and the rest of C0/C1 still go — those are the spoof/row-corruption vectors.
+_KEEP_WHITESPACE = frozenset("\n\t")
 
-def strip_terminal_controls(text: str) -> str:
+
+def strip_terminal_controls(text: str, *, keep_whitespace: bool = False) -> str:
     """Return ``text`` without C0/C1 control characters or DEL.
 
-    Removes ``0x00``–``0x1F`` (including ESC, CR, LF, and Tab), ``0x7F``, and
-    ``0x80``–``0x9F``. All printable content, Unicode included, is preserved.
+    Removes ``0x00``–``0x1F``, ``0x7F``, and ``0x80``–``0x9F``. When
+    ``keep_whitespace`` is true, LF and Tab are kept so multi-line markdown
+    bodies retain structure; ESC, CR, BEL, and other controls are still
+    removed. All printable content, Unicode included, is preserved.
     """
-    return "".join(ch for ch in text if not (ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F))
+
+    def _drop(ch: str) -> bool:
+        code = ord(ch)
+        if keep_whitespace and ch in _KEEP_WHITESPACE:
+            return False
+        return code < 0x20 or 0x7F <= code <= 0x9F
+
+    return "".join(ch for ch in text if not _drop(ch))
 
 
 __all__ = ["strip_terminal_controls"]

--- a/infrastructure/safety/terminal_output.py
+++ b/infrastructure/safety/terminal_output.py
@@ -1,0 +1,21 @@
+"""Strip terminal control characters from model-supplied text.
+
+Plan steps, menu titles, and option labels come from the model and are later
+written into raw ANSI output. An embedded escape (ESC, OSC, CR) could spoof the
+terminal or corrupt menu-row accounting, so this removes control characters at
+the parse boundary, before the text is stored or rendered.
+"""
+
+from __future__ import annotations
+
+
+def strip_terminal_controls(text: str) -> str:
+    """Return ``text`` without C0/C1 control characters or DEL.
+
+    Removes ``0x00``–``0x1F`` (including ESC, CR, LF, and Tab), ``0x7F``, and
+    ``0x80``–``0x9F``. All printable content, Unicode included, is preserved.
+    """
+    return "".join(ch for ch in text if not (ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F))
+
+
+__all__ = ["strip_terminal_controls"]

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -146,6 +146,7 @@ class ActionRenderObserver:
         if not content:
             return
         self.console.print()
+        # ``render_markdown_block`` sanitizes model text at ``_build_markdown_block``.
         render_markdown_block(self.console, content)
 
     def _render_skill_start(self, data: dict[str, Any]) -> None:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -20,6 +20,7 @@ from rich.console import Console
 from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
+from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, DIM, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.streaming import render_markdown_block
@@ -44,21 +45,28 @@ _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
 
 
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
-    """Return a ``(label, content)`` pair describing a planned tool call."""
+    """Return a ``(label, content)`` pair describing a planned tool call.
+
+    Both strings are stripped of terminal controls: callers append them to a
+    raw Rich line, and the tool name and args are model-supplied.
+    """
     if tool_name == "slash_invoke":
         command = str(args.get("command", "")).strip()
         raw_args = args.get("args")
         parsed_args = [str(item).strip() for item in raw_args] if isinstance(raw_args, list) else []
-        return "command", " ".join([command, *parsed_args]).strip()
-    if tool_name == "synthetic_run":
+        label, content = "command", " ".join([command, *parsed_args]).strip()
+    elif tool_name == "synthetic_run":
         suite = str(args.get("suite", "")).strip()
         scenario = str(args.get("scenario", "")).strip()
-        return "synthetic test", f"{suite}:{scenario}" if scenario else suite
-    simple = _SIMPLE_TOOL_LABELS.get(tool_name)
-    if simple is not None:
-        label, arg_key = simple
-        return label, str(args.get(arg_key, "")).strip()
-    return tool_name, json.dumps(args, default=str, sort_keys=True)
+        label, content = "synthetic test", f"{suite}:{scenario}" if scenario else suite
+    else:
+        simple = _SIMPLE_TOOL_LABELS.get(tool_name)
+        if simple is not None:
+            key_label, arg_key = simple
+            label, content = key_label, str(args.get(arg_key, "")).strip()
+        else:
+            label, content = tool_name, json.dumps(args, default=str, sort_keys=True)
+    return strip_terminal_controls(label), strip_terminal_controls(content)
 
 
 class ActionRenderObserver:
@@ -144,7 +152,7 @@ class ActionRenderObserver:
         """Print ``Skill <name>`` when the agent starts loading a skill."""
         args = data.get("input")
         raw_name = str(args.get("name", "")).strip() if isinstance(args, dict) else ""
-        slug = raw_name.replace("_", "-").lower() or "skill"
+        slug = strip_terminal_controls(raw_name.replace("_", "-").lower()) or "skill"
         self._pending_skill_calls[str(data.get("id") or "")] = slug
         # ``Text`` renders the (model-supplied) skill name literally — never
         # through Rich markup.

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -33,6 +33,10 @@ def _escape_markdown_dunder_filenames(text: str) -> str:
 def _build_markdown_block(text: str) -> Markdown:
     """Build a Markdown renderable with the shared escaping and code theme.
 
+    Strips terminal controls (ESC/CR/BEL/C1) while keeping LF/Tab so multi-line
+    model prose cannot spoof the TTY. All whole and streamed markdown paths
+    build through this helper.
+
     Reads the ``Markdown`` class off the already-loaded package module via
     ``sys.modules`` rather than importing it here (directly, or by importing
     the package back) — tests substitute the class by patching
@@ -43,7 +47,8 @@ def _build_markdown_block(text: str) -> Markdown:
     """
     assert __package__  # always set for a package submodule
     package = sys.modules[__package__]
-    spaced = normalize_three_tier_spacing(text)
+    safe = strip_terminal_controls(text, keep_whitespace=True)
+    spaced = normalize_three_tier_spacing(safe)
     return package.Markdown(  # type: ignore[no-any-return]
         _escape_markdown_dunder_filenames(spaced.rstrip()),
         code_theme=ui_theme.MARKDOWN_CODE_THEME,
@@ -55,14 +60,10 @@ def render_markdown_block(console: Console, text: str) -> None:
 
     The single rendering path for model prose that arrives whole (not
     chunk-streamed) — e.g. the action agent's intermediate phase headers —
-    so every markdown surface shares one escaping/theme policy.
+    so every markdown surface shares one escaping/theme policy. Terminal
+    controls are stripped inside ``_build_markdown_block``.
     """
-    # Model prose can carry ESC/CR/BEL; strip before Rich Markdown. Keep LF/Tab
-    # so phase headers and lists still parse as multi-line markdown.
-    visible = strip_terminal_controls(
-        strip_session_goal_progress_tags(text),
-        keep_whitespace=True,
-    )
+    visible = strip_session_goal_progress_tags(text)
     if not visible.strip():
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -11,6 +11,7 @@ from rich.console import Console
 import infrastructure.terminal.theme as ui_theme
 from core.agent_harness.spi.prompt_chrome import normalize_three_tier_spacing
 from core.agent_harness.spi.session_goal import strip_session_goal_progress_tags
+from infrastructure.safety.terminal_output import strip_terminal_controls
 
 if TYPE_CHECKING:
     from rich.markdown import Markdown
@@ -56,7 +57,12 @@ def render_markdown_block(console: Console, text: str) -> None:
     chunk-streamed) — e.g. the action agent's intermediate phase headers —
     so every markdown surface shares one escaping/theme policy.
     """
-    visible = strip_session_goal_progress_tags(text)
+    # Model prose can carry ESC/CR/BEL; strip before Rich Markdown. Keep LF/Tab
+    # so phase headers and lists still parse as multi-line markdown.
+    visible = strip_terminal_controls(
+        strip_session_goal_progress_tags(text),
+        keep_whitespace=True,
+    )
     if not visible.strip():
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):

--- a/tests/infrastructure/safety/test_terminal_output.py
+++ b/tests/infrastructure/safety/test_terminal_output.py
@@ -22,6 +22,14 @@ def test_strips_newlines_tabs_and_del_that_would_corrupt_row_accounting() -> Non
     assert strip_terminal_controls("line1\nline2\tcol\x7f") == "line1line2col"
 
 
+def test_keep_whitespace_preserves_lf_and_tab_but_still_strips_esc() -> None:
+    hostile = "### Phase\nline\tkeep\x1b[2J\x07"
+    cleaned = strip_terminal_controls(hostile, keep_whitespace=True)
+    assert cleaned == "### Phase\nline\tkeep[2J"
+    assert "\x1b" not in cleaned
+    assert "\x07" not in cleaned
+
+
 def test_preserves_printable_unicode() -> None:
     # Non-control Unicode (glyphs, accents, CJK) must pass through untouched.
     assert strip_terminal_controls("café ✓ 日本語 ●○") == "café ✓ 日本語 ●○"

--- a/tests/infrastructure/safety/test_terminal_output.py
+++ b/tests/infrastructure/safety/test_terminal_output.py
@@ -1,0 +1,27 @@
+"""Model-supplied text cannot inject terminal escapes into raw output."""
+
+from __future__ import annotations
+
+from infrastructure.safety.terminal_output import strip_terminal_controls
+
+
+def test_strips_ansi_escape_and_control_bytes() -> None:
+    # Arrange: a plan step carrying a screen-clear escape and a bell.
+    hostile = "rm the cache\x1b[2J\x1b[1;1H\x07"
+
+    # Act
+    cleaned = strip_terminal_controls(hostile)
+
+    # Assert: the ESC, CSI bytes, and BEL are gone; the words survive.
+    assert cleaned == "rm the cache[2J[1;1H"
+    assert "\x1b" not in cleaned
+    assert "\x07" not in cleaned
+
+
+def test_strips_newlines_tabs_and_del_that_would_corrupt_row_accounting() -> None:
+    assert strip_terminal_controls("line1\nline2\tcol\x7f") == "line1line2col"
+
+
+def test_preserves_printable_unicode() -> None:
+    # Non-control Unicode (glyphs, accents, CJK) must pass through untouched.
+    assert strip_terminal_controls("café ✓ 日本語 ●○") == "café ✓ 日本語 ●○"

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -14,7 +14,10 @@ from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from infrastructure.terminal.theme import BOLD_SKILL, HIGHLIGHT
 from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from surfaces.interactive_shell.session import Session
-from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
+from surfaces.interactive_shell.ui.action_rendering import (
+    ActionRenderObserver,
+    tool_call_display,
+)
 from surfaces.interactive_shell.ui.input_prompt.rendering import (
     _prompt_turn_number,
     render_submitted_prompt,
@@ -137,6 +140,34 @@ def test_skill_view_renders_bold_green_skill_label() -> None:
     assert len(heading.spans) == 2
     assert str(heading.spans[0].style) == BOLD_SKILL
     assert str(heading.spans[1].style) == str(HIGHLIGHT)
+
+
+def test_skill_view_strips_terminal_controls_from_model_name() -> None:
+    # Arrange: a model-supplied skill name carrying an ANSI escape + BEL
+    console = Mock(spec=Console)
+    observer = ActionRenderObserver(session=Session(), console=console, message="run code review")
+
+    # Act
+    observer(
+        "tool_start",
+        {"id": "t1", "name": "skill_view", "input": {"name": "code\x1b[2Kreview\x07"}},
+    )
+
+    # Assert: the rendered skill heading carries no C0/C1/DEL controls
+    heading = console.print.call_args_list[1].args[0]
+    assert isinstance(heading, Text)
+    assert "\x1b" not in heading.plain
+    assert "\x07" not in heading.plain
+
+
+def test_tool_call_display_strips_terminal_controls_from_model_args() -> None:
+    # Arrange + Act: a model-supplied tool arg with an ANSI escape + BEL
+    label, content = tool_call_display("shell_run", {"command": "ls\x1b[2Krm\x07"})
+
+    # Assert: no control characters survive into the raw Rich line
+    assert "\x1b" not in content
+    assert "\x07" not in content
+    assert content == "ls[2Krm"
 
 
 def test_skill_view_failure_renders_failure_child() -> None:

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -170,6 +170,27 @@ def test_tool_call_display_strips_terminal_controls_from_model_args() -> None:
     assert content == "ls[2Krm"
 
 
+def test_intermediate_message_strips_terminal_controls_before_markdown() -> None:
+    session = Session()
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False)
+    observer = ActionRenderObserver(session=session, console=console, message="x")
+
+    observer(
+        "message_update",
+        {
+            "has_tool_calls": True,
+            "content": "### [1/2] Scope\x1b[2J\nLooking at p99\x07",
+        },
+    )
+
+    output = buffer.getvalue()
+    assert "\x1b" not in output
+    assert "\x07" not in output
+    assert "Scope" in output
+    assert "Looking at p99" in output
+
+
 def test_skill_view_failure_renders_failure_child() -> None:
     observer, buffer = _skill_observer()
 

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -171,11 +171,15 @@ def test_tool_call_display_strips_terminal_controls_from_model_args() -> None:
 
 
 def test_intermediate_message_strips_terminal_controls_before_markdown() -> None:
+    # Arrange: a real terminal, where Rich would otherwise pass the model's
+    # control bytes straight through (a non-terminal console strips them anyway,
+    # so this must force a terminal to exercise the sanitizer).
     session = Session()
     buffer = io.StringIO()
-    console = Console(file=buffer, force_terminal=False, highlight=False)
+    console = Console(file=buffer, force_terminal=True, highlight=False, width=80)
     observer = ActionRenderObserver(session=session, console=console, message="x")
 
+    # Act: model narration carrying a clear-screen escape and a BEL
     observer(
         "message_update",
         {
@@ -184,8 +188,11 @@ def test_intermediate_message_strips_terminal_controls_before_markdown() -> None
         },
     )
 
+    # Assert: the dangerous payloads are gone (Rich's own styling escapes are
+    # ``ESC[…m``, never ``ESC[2J``, so this stays a clean security assertion),
+    # while the newline-separated prose survives.
     output = buffer.getvalue()
-    assert "\x1b" not in output
+    assert "\x1b[2J" not in output
     assert "\x07" not in output
     assert "Scope" in output
     assert "Looking at p99" in output

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -1048,6 +1048,22 @@ class TestRenderMarkdownBlock:
 
         assert "__init__.py" in _strip_ansi(buf.getvalue())
 
+    def test_strips_terminal_controls_from_model_prose(self) -> None:
+        """Intermediate/closing model commentary must not inject ESC/BEL."""
+        console, buf = _non_tty_console()
+
+        render_markdown_block(
+            console,
+            "### Phase\x1b[2J\nChecking the token\x07…",
+        )
+
+        output = buf.getvalue()
+        assert "\x1b" not in output
+        assert "\x07" not in output
+        plain = _strip_ansi(output)
+        assert "Phase" in plain
+        assert "Checking the token" in plain
+
 
 class TestDeferWantMeToCloser:
     """Gather path holds drifted Want-me-to until the canonical rewrite paints."""

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -65,6 +65,19 @@ class TestNonTtyFallback:
         # No spinner / Live cursor-movement artifacts in non-TTY captures.
         assert "thinking" not in output
 
+    def test_strips_terminal_controls_from_streamed_model_prose(self) -> None:
+        console, buf = _non_tty_console()
+        result = stream_to_console(
+            console,
+            label="assistant",
+            chunks=_yield_chunks(["Hello\x1b[2J", ", world\x07"]),
+        )
+
+        assert "\x1b" not in buf.getvalue()
+        assert "\x07" not in buf.getvalue()
+        assert "Hello" in result
+        assert "world" in result
+
     def test_suppression_drains_silently_in_non_tty(self) -> None:
         """Suppressed payloads (machine-readable payloads) must not appear in piped output."""
         console, buf = _non_tty_console()


### PR DESCRIPTION
Issue: #5754

Adds three related interactive-shell capabilities and the autonomy control they share, so the planner can lay out a verifiable plan, pause for the facts only the user has, and show what it is doing while it runs.

Planning (update_plan)

New update_plan action tool and a TaskPlan model (pending / in_progress / completed, at least two steps, last step must be a verification check).
~70-line planning section in the action system prompt (when to plan, verifiability, structure, good/bad examples).
Plan is session state: persisted and rehydrated so the checklist survives transcript compaction.
Human hand-off menus (ask_user_choice)

Batch ask-user menu: several blocking questions in one call, rendered as a distinct hand-off block; the user's answer is highlighted differently from the question.
Runs through the /choose picker with exclusive raw stdin; answers auto-submit back to the agent as one Q&A block.

Loading + tool-call feedback

Spinner phases Executing… / Invoking tools… driven by real agent events, with the active tool shown by a human label instead of a raw payload.
Autonomy (/auto)

off / low / med / high tool-approval levels surfaced in the status line (Auto (Med) · allow reversible commands).
Fixes made while integrating
Guard execution_confirm against a missing session.terminal — it was crashing every slash command on a headless session.
Suppress the raw ask_user_choice / /choose JSON payload in the live tool preview (the menu is the UI).
no-any-return fix in the terminal key reader; /auto help-parity; task_plan added to the session characterization golden.

