### PR TITLE
fix: remediate GitHub code scanning finding #2217

### DIFF
--- a/tests/bootstrap/test_subprocess_presenter.py
+++ b/tests/bootstrap/test_subprocess_presenter.py
@@ -19,7 +19,7 @@ from collections.abc import Iterator
 import pytest
 
 import infrastructure.harness_providers as harness_providers
-from infrastructure.harness_providers import subprocess_presenter
+import infrastructure.harness_providers.subprocess_presenter as subprocess_presenter
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Automated security or quality fix proposed by OpenSRE for [code scanning finding #2217](https://github.com/Tracer-Cloud/opensre/security/code-scanning/2217).

**Alert summary**
Module is imported with 'import' and 'import from'

**Fix summary**
Done.

**Change** — `tests/bootstrap/test_subprocess_presenter.py:21-22`: the file imported `infrastructure.harness_providers` with both `import … as` and `from … import subprocess_presenter`, which is exactly the mixed-style pair `py/import-and-import-from` flags. Following the AGENTS.md guidance to keep the file's established `import X as alias` style, I replaced the `from` import with `import infrastructure.harness_providers.subprocess_presenter as subprocess_presenter`. The two statements now name distinct modules, so the rule no longer applies — no suppression needed, and every usage in the file (`subprocess_presenter._installed`, `.reset()`, and the `harness_providers.*` calls) is unchanged.

**No new test** — this is a purely stylistic import fix with no behavioral surface; the existing three tests in the module pin the behavior.

**Verification** — `uv run pytest tests/bootstrap/test_subprocess_presenter.py` (3 passed), `ruff check` and `ruff format --check` clean.

**Files changed**
- `tests/bootstrap/test_subprocess_presenter.py`

> Generated by the OpenSRE `fix_github_security_alert` tool. Review before merging.