### PR TITLE
fix(gateway): cap request bodies on every mutating route

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -150,6 +150,7 @@ from config.constants.honeycomb import (
     HONEYCOMB_BASE_URL_ENV,
     HONEYCOMB_DATASET_ENV,
 )
+from config.constants.http import MAX_REQUEST_BODY_BYTES
 from config.constants.incident_io import INCIDENT_IO_API_KEY_ENV, INCIDENT_IO_BASE_URL_ENV
 from config.constants.investigation import (
     ALERT_TEMPLATE_CHOICES,
@@ -569,6 +570,7 @@ __all__ = [
     "INTEGRATIONS_SETUP_PREFIX",
     "INVESTIGATION_TOOL_CACHE_MAX_CHARS",
     "INVESTIGATION_TOOL_CACHE_MAX_ENTRIES",
+    "MAX_REQUEST_BODY_BYTES",
     "MAX_INVESTIGATION_LOOPS",
     "MONGODB_ATLAS_BASE_URL_ENV",
     "MONGODB_ATLAS_PRIVATE_KEY_ENV",

--- a/config/constants/http.py
+++ b/config/constants/http.py
@@ -1,0 +1,8 @@
+"""HTTP transport constants shared by every app OpenSRE serves."""
+
+#: Cap on request body size accepted from any caller (authed or not) on every
+#: mutating route. Realistic alert payloads top out around 50 KB, so 1 MiB is
+#: ~20x headroom.
+MAX_REQUEST_BODY_BYTES = 1 * 1024 * 1024
+
+__all__ = ["MAX_REQUEST_BODY_BYTES"]

--- a/gateway/tests/slack/test_routes.py
+++ b/gateway/tests/slack/test_routes.py
@@ -15,6 +15,7 @@ from urllib.parse import urlencode
 
 from fastapi.testclient import TestClient
 
+from config.constants.http import MAX_REQUEST_BODY_BYTES
 from gateway.core.middleware.approvals import ApprovalBroker
 from gateway.core.storage.events.repository import InMemoryHandledSlackEventRepository
 from gateway.transports.slack.settings import SlackGatewaySettings, SlackInboundTransport
@@ -339,4 +340,21 @@ def test_a_closed_listener_acts_on_nothing_on_either_route() -> None:
     # Assert — both refused, and no turn was queued.
     assert event.status_code == HTTPStatus.SERVICE_UNAVAILABLE
     assert click.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert submitted == []
+
+
+def test_oversized_event_body_is_rejected_before_signature_check() -> None:
+    """The listener binds 0.0.0.0 and cannot authenticate without reading the body.
+
+    Slack signs the raw bytes, so both routes must call ``request.body()``
+    before they know who is calling. Without a cap above routing, any
+    unauthenticated caller on the internet could make this host buffer a
+    payload of their choosing.
+    """
+    submitted: list[Any] = []
+    client = _client(submitted)
+
+    resp = client.post(EVENTS_PATH, content=b"x" * (MAX_REQUEST_BODY_BYTES + 1))
+
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert submitted == []

--- a/gateway/tests/web/test_api_investigations.py
+++ b/gateway/tests/web/test_api_investigations.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi.testclient import TestClient
 
+from config.constants.http import MAX_REQUEST_BODY_BYTES
 from gateway.web import webapp
 from infrastructure.safety.auth.jwt_auth import JWTClaims
 
@@ -288,3 +289,19 @@ def test_cancel_investigation_writes_security_audit(
     actions = [line for line in lines if '"investigation.cancel"' in line]
     assert actions
     assert investigation_id in actions[-1]
+
+
+def test_oversized_create_body_is_rejected_before_auth() -> None:
+    """The cap sits above routing, so it holds on the Clerk route with no token.
+
+    Authenticating first would mean buffering the payload to find out who sent
+    it, which is the memory cost the cap exists to avoid.
+    """
+    client = TestClient(webapp.app)
+
+    resp = client.post(
+        "/api/investigations",
+        json={"raw_alert": {"text": "x" * (MAX_REQUEST_BODY_BYTES + 1)}},
+    )
+
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE

--- a/gateway/tests/web/test_webapp_alerts.py
+++ b/gateway/tests/web/test_webapp_alerts.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 import pytest
 from fastapi.testclient import TestClient
 
+from config.constants.http import MAX_REQUEST_BODY_BYTES
 from core.domain.alerts.inbox import AlertInbox, set_current_inbox
 from gateway.web import webapp
 
@@ -84,7 +85,7 @@ def test_rejected_alert_does_not_leak_exception_detail(client: TestClient) -> No
 
 
 def test_oversized_body_returns_413(client: TestClient, inbox: AlertInbox) -> None:
-    resp = client.post("/alerts", json={"text": "x" * (webapp.MAX_ALERT_BODY_BYTES + 1)})
+    resp = client.post("/alerts", json={"text": "x" * (MAX_REQUEST_BODY_BYTES + 1)})
     assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert resp.json() == {"error": "payload too large"}
     assert inbox.pop_nowait() is None

--- a/gateway/tests/web/test_webapp_investigate.py
+++ b/gateway/tests/web/test_webapp_investigate.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
+from config.constants.http import MAX_REQUEST_BODY_BYTES
 from gateway.web import webapp
 
 _LOOPBACK = ("127.0.0.1", 40000)
@@ -185,3 +186,19 @@ def test_investigate_at_capacity_returns_503(
     finally:
         gate.release()
         reset_process_turn_gate_for_tests()
+
+
+def test_oversized_investigate_body_is_rejected(client: TestClient) -> None:
+    """Regression: /investigate took a Pydantic body, so nothing capped it.
+
+    The cap only ever guarded /alerts, and FastAPI buffers the whole payload
+    while solving the request model, so an oversized POST here was read into
+    memory in full and then run.
+    """
+    resp = client.post(
+        "/investigate",
+        json={"raw_alert": {"text": "x" * (MAX_REQUEST_BODY_BYTES + 1)}},
+    )
+
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": "payload too large"}

--- a/gateway/transports/slack/transport/events_api/server.py
+++ b/gateway/transports/slack/transport/events_api/server.py
@@ -38,6 +38,7 @@ from gateway.transports.slack.transport.events_api.receiver import (
     admit_slack_http_request,
     admit_slack_interactivity_request,
 )
+from infrastructure.request_body_limit import RequestBodyLimitMiddleware
 
 #: Starts a turn for one inbound message without blocking the request.
 SubmitTurn = Callable[[SlackInboundMessage], None]
@@ -110,6 +111,9 @@ def build_slack_http_app(
     without blocking — the route must answer Slack first.
     """
     app = FastAPI()
+    # Slack's signature covers the raw body, so both routes must read it before
+    # they can authenticate the caller. Bound the read itself.
+    app.add_middleware(RequestBodyLimitMiddleware)
 
     async def _admit(request: Request) -> Response:
         if not gate.accepting:

--- a/gateway/web/webapp.py
+++ b/gateway/web/webapp.py
@@ -26,13 +26,11 @@ from gateway.core.process.readiness import is_gateway_ready
 from gateway.core.storage import open_database
 from gateway.core.storage.investigations.repository import investigation_repository
 from gateway.web.investigations import router as investigations_router
-from infrastructure.alert_intake import (
-    MAX_ALERT_BODY_BYTES,
-    require_local_or_token,
-)
+from infrastructure.alert_intake import require_local_or_token
 from infrastructure.alert_intake import router as alert_router
 from infrastructure.observability.errors.sentry import capture_exception
 from infrastructure.process.turn_capacity import turn_slot
+from infrastructure.request_body_limit import RequestBodyLimitMiddleware
 from tools.investigation.capability import resolve_investigation_context, run_investigation_payload
 
 # Standalone uvicorn and in-process gateway both need adapters for /investigate.
@@ -40,8 +38,7 @@ configure_process(WEB_PROFILE)  # env → sentry → adapters
 
 logger = logging.getLogger(__name__)
 
-# Re-exported so callers and tests keep one name for the shared alert-body cap.
-__all__ = ["MAX_ALERT_BODY_BYTES", "app"]
+__all__ = ["app"]
 
 
 class HealthResponse(BaseModel):
@@ -52,6 +49,8 @@ class HealthResponse(BaseModel):
 
 
 app = FastAPI()
+# Above routing: every mutating route is bounded before FastAPI buffers a body.
+app.add_middleware(RequestBodyLimitMiddleware)
 app.state.investigations = investigation_repository(open_database())
 app.include_router(investigations_router)
 # Health liveness (/healthz) and alert intake (/alerts) live in the shared

--- a/infrastructure/alert_intake.py
+++ b/infrastructure/alert_intake.py
@@ -26,12 +26,9 @@ from core.domain.alerts.inbox import (
     get_current_inbox,
     set_current_inbox,
 )
+from infrastructure.request_body_limit import RequestBodyLimitMiddleware
 
 logger = logging.getLogger(__name__)
-
-# Cap on POST body size accepted from any caller (authed or not). Realistic
-# alert payloads top out around 50 KB, so 1 MiB is ~20× headroom.
-MAX_ALERT_BODY_BYTES = 1 * 1024 * 1024
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
@@ -85,16 +82,8 @@ async def receive_alert(request: Request) -> JSONResponse:
         return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
     if declared_length < 0:
         return JSONResponse({"error": "invalid Content-Length"}, status_code=HTTPStatus.BAD_REQUEST)
-    if declared_length > MAX_ALERT_BODY_BYTES:
-        return JSONResponse(
-            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-        )
-
+    # Size is bounded by RequestBodyLimitMiddleware before this handler runs.
     body = await request.body()
-    if len(body) > MAX_ALERT_BODY_BYTES:
-        return JSONResponse(
-            {"error": "payload too large"}, status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-        )
 
     try:
         data = json.loads(body)
@@ -133,12 +122,12 @@ def build_alert_intake_app() -> FastAPI:
     profile — it needs only the shared inbox the host installs.
     """
     app = FastAPI()
+    app.add_middleware(RequestBodyLimitMiddleware)
     app.include_router(router)
     return app
 
 
 __all__ = [
-    "MAX_ALERT_BODY_BYTES",
     "build_alert_intake_app",
     "require_local_or_token",
     "router",

--- a/infrastructure/request_body_limit.py
+++ b/infrastructure/request_body_limit.py
@@ -6,8 +6,9 @@ payload is already fully in memory. This sits above routing, rejects an
 oversized ``Content-Length`` outright, and counts bytes as the body streams in
 so a request that understates or omits its length is bounded too.
 
-Hosts that serve any mutating route must install it — see
-``build_alert_intake_app`` and ``gateway.web.webapp``.
+Every host that serves a mutating route must install it. All three do:
+``build_alert_intake_app``, ``gateway.web.webapp``, and the Slack events
+listener in ``build_slack_http_app``.
 """
 
 from __future__ import annotations

--- a/infrastructure/request_body_limit.py
+++ b/infrastructure/request_body_limit.py
@@ -1,0 +1,101 @@
+"""Cap request bodies on every mutating route, before anything buffers them.
+
+Pure ASGI rather than a FastAPI dependency: FastAPI parses the body while it
+solves a request's parameters, so by the time any dependency or handler runs the
+payload is already fully in memory. This sits above routing, rejects an
+oversized ``Content-Length`` outright, and counts bytes as the body streams in
+so a request that understates or omits its length is bounded too.
+
+Hosts that serve any mutating route must install it — see
+``build_alert_intake_app`` and ``gateway.web.webapp``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, MutableMapping
+from http import HTTPStatus
+from typing import Any
+
+from config.constants.http import MAX_REQUEST_BODY_BYTES
+
+# Local ASGI aliases: starlette ships these but is only a transitive dependency.
+Scope = MutableMapping[str, Any]
+Message = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+
+_BODY_METHODS = frozenset({"POST", "PUT", "PATCH"})
+_TOO_LARGE_BODY = b'{"error":"payload too large"}'
+
+
+class _BodyTooLarge(Exception):
+    """Raised out of the wrapped receive once the streamed body passes the cap."""
+
+
+class RequestBodyLimitMiddleware:
+    """Reject bodies over ``max_bytes`` with 413, without buffering them first."""
+
+    def __init__(self, app: ASGIApp, *, max_bytes: int = MAX_REQUEST_BODY_BYTES) -> None:
+        self._app = app
+        self._max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http" or scope.get("method", "") not in _BODY_METHODS:
+            await self._app(scope, receive, send)
+            return
+
+        declared = _declared_length(scope)
+        if declared is not None and declared > self._max_bytes:
+            await _send_too_large(send)
+            return
+
+        try:
+            await self._app(scope, self._counted(receive), send)
+        except _BodyTooLarge:
+            # Raised before the app could start a response, so 413 is still ours
+            # to send.
+            await _send_too_large(send)
+
+    def _counted(self, receive: Receive) -> Receive:
+        """Wrap ``receive`` so the running body total cannot pass the cap."""
+        seen = 0
+
+        async def limited() -> Message:
+            nonlocal seen
+            message = await receive()
+            if message.get("type") == "http.request":
+                seen += len(message.get("body", b""))
+                if seen > self._max_bytes:
+                    raise _BodyTooLarge
+            return message
+
+        return limited
+
+
+def _declared_length(scope: Scope) -> int | None:
+    """The request's Content-Length, or None when absent or unparseable."""
+    for name, value in scope.get("headers", ()):
+        if name == b"content-length":
+            try:
+                return int(value)
+            except ValueError:
+                return None
+    return None
+
+
+async def _send_too_large(send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(_TOO_LARGE_BODY)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": _TOO_LARGE_BODY})
+
+
+__all__ = ["RequestBodyLimitMiddleware"]

--- a/tests/infrastructure/test_alert_intake.py
+++ b/tests/infrastructure/test_alert_intake.py
@@ -8,8 +8,9 @@ from http import HTTPStatus
 import pytest
 from fastapi.testclient import TestClient
 
+from config.constants.http import MAX_REQUEST_BODY_BYTES
 from core.domain.alerts.inbox import AlertInbox, set_current_inbox
-from infrastructure.alert_intake import MAX_ALERT_BODY_BYTES, build_alert_intake_app
+from infrastructure.alert_intake import build_alert_intake_app
 
 _LOOPBACK = ("127.0.0.1", 40000)
 _REMOTE = ("203.0.113.9", 40000)
@@ -46,7 +47,7 @@ def test_post_alert_queues_into_the_shared_inbox(client: TestClient, inbox: Aler
 
 
 def test_oversized_body_returns_413(client: TestClient) -> None:
-    resp = client.post("/alerts", json={"text": "x" * (MAX_ALERT_BODY_BYTES + 1)})
+    resp = client.post("/alerts", json={"text": "x" * (MAX_REQUEST_BODY_BYTES + 1)})
     assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
 
 

--- a/tests/infrastructure/test_request_body_limit.py
+++ b/tests/infrastructure/test_request_body_limit.py
@@ -1,0 +1,54 @@
+"""The request-body cap must hold even when Content-Length does not declare it."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from http import HTTPStatus
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from config.constants.http import MAX_REQUEST_BODY_BYTES
+from infrastructure.request_body_limit import RequestBodyLimitMiddleware
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.add_middleware(RequestBodyLimitMiddleware)
+
+    @app.post("/echo")
+    async def echo(request: Request) -> dict[str, int]:
+        return {"read": len(await request.body())}
+
+    return TestClient(app)
+
+
+def _chunks(total: int) -> Iterator[bytes]:
+    """Stream ``total`` bytes, which makes httpx send no Content-Length."""
+    sent = 0
+    while sent < total:
+        chunk = b"x" * min(64 * 1024, total - sent)
+        sent += len(chunk)
+        yield chunk
+
+
+def test_streamed_body_without_content_length_is_capped(client: TestClient) -> None:
+    """The gap the route-level check missed: no Content-Length, so nothing rejected early.
+
+    The handler used to buffer the whole payload before any size check ran, so
+    peak memory was unbounded no matter what the post-read check then said.
+    """
+    resp = client.post("/echo", content=_chunks(MAX_REQUEST_BODY_BYTES + 1))
+
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": "payload too large"}
+
+
+def test_body_at_the_limit_still_passes(client: TestClient) -> None:
+    """The cap is inclusive; a payload exactly at the limit is a legitimate request."""
+    resp = client.post("/echo", content=b"x" * MAX_REQUEST_BODY_BYTES)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == {"read": MAX_REQUEST_BODY_BYTES}


### PR DESCRIPTION
Fixes #4770

#### Describe the changes you have made in this PR -

The 1 MiB cap lived inside the `/alerts` handler, which is too late to bound anything. FastAPI parses a Pydantic body while it solves the request, so `/investigate` and `/api/investigations` had already buffered the whole payload before a handler could look at it, and neither carried a cap at all. On `/alerts`, a request that omitted `Content-Length` skipped the early reject and got read in full before the post-read check ran.

The cap now lives in ASGI middleware above routing. It rejects an oversized `Content-Length` outright and counts bytes as the body streams in, so a request that understates or omits its length stays bounded. A FastAPI dependency cannot do this, because body parsing and dependency solving are the same step.

`MAX_ALERT_BODY_BYTES` moves to `config/constants/http.py` as `MAX_REQUEST_BODY_BYTES`. It is shared by `infrastructure/` and `gateway/` now, and it was never alert-specific. That let me drop the re-export in `webapp.py` and both size checks in the `/alerts` handler, so `alert_intake.py` comes out 14 lines lighter.

One deliberate behaviour change: the cap fires before authentication, so an unauthenticated caller gets 413 instead of 401. That is the point of moving it. Authenticating first means buffering the payload to decide whether to reject it, which is the cost the cap exists to avoid. nginx's `client_max_body_size` behaves the same way. There is a test pinning it rather than leaving it implicit.

### Demo/Screenshot for feature changes and bug fixes -

Real HTTP against the real gateway app, 2 MiB bodies against a 1 MiB cap:

| scenario | before | after |
| --- | --- | --- |
| `POST /api/investigations` 2 MiB, no token | **401**, peak 8.19 MiB | **413**, peak 5.54 MiB |
| `POST /alerts` 2 MiB chunked, no `Content-Length` | 413, peak **4.12 MiB** | 413, peak **1.66 MiB** |
| `POST /alerts` small, legitimate | 202, peak 0.10 MiB | 202, peak 0.10 MiB |

The 401 is the bug in miniature: the server buffered 2 MiB to work out that the caller was not authenticated.

The `/alerts` row is why this hid for so long. Same 413 both times, so no status code ever showed a problem, but peak memory drops by 2.5 MiB because the payload is no longer read in full.

Peaks are `tracemalloc`, and the `/api/investigations` figures include client-side allocation since client and server share a process. The chunked row is the clean server-side measurement.

Checks: ruff, format, mypy (1917 files, plus mypy run directly on the new test file since CI's typecheck skips `tests/`), tools-runtime 5946 passed, integrations-and-misc 5803 passed, shell and CLI suites 2219 passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The question that decided the design was where a body limit can run and still be honest. A dependency was the obvious first idea and it does not work: FastAPI resolves dependencies and parses the body in the same solve step, so a dependency that returns 413 has already paid the memory cost it was meant to prevent. Middleware above routing is the only layer that sees the request before anything reads it.

That left how to bound a body with no `Content-Length`. Checking the header alone is what the old code did, and it is exactly the hole in the issue. So the middleware wraps `receive` and keeps a running total across `http.request` messages, raising once the total passes the cap. The raise propagates out through the router to the middleware, which sends the 413 itself. It can do that safely because the app raised before starting a response.

The ASGI type aliases at the top of the module are deliberate. Starlette ships these types, but it is only a transitive dependency here, so importing them directly would mean relying on something the project does not declare. Five lines of aliases keep the module honest about what it depends on.

On tests, the streaming case is the one that earns its place, so I checked it fails for the right reason: dropping only the receive wrapper and keeping the `Content-Length` check lets the chunked body through with 200. The `/investigate` test returns 200 without the fix, and that revert run takes about 40 seconds because the endpoint accepts the oversized payload and actually runs an investigation on it. I skipped a separate `/api/investigations` size test as a duplicate of `/investigate` and wrote it against the pre-auth ordering instead, which is the one thing that route tests that the other does not.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
