### PR TITLE
feat(alertmanager): map alerts and silences into report evidence

### DIFF
--- a/integrations/alertmanager/tools/__init__.py
+++ b/integrations/alertmanager/tools/__init__.py
@@ -24,6 +24,10 @@ def _map_alertmanager_alerts(
 ) -> None:
     """Record the alert landscape as one citeable entry, or nothing.
 
+    The firing count is always stated, including zero: "3 alerts, 0 firing" is a
+    finding, while omitting it leaves a reader unable to tell nothing-firing from
+    a count the tool never returned.
+
     A failed call returns the unavailable envelope with ``alerts: []``, so the
     emptiness check covers the error shape too — an entry reading "0 alerts"
     would cost context on every later turn and support no claim.
@@ -31,15 +35,12 @@ def _map_alertmanager_alerts(
     alerts = output.get("alerts", [])
     if not alerts:
         return
-    summary = f"{len(alerts)} alerts"
     firing = output.get("firing_alerts", [])
-    if firing:
-        summary += f", {len(firing)} firing"
     record_evidence_entry(
         evidence,
         source="alertmanager_alerts",
         label="Alertmanager Alerts",
-        summary=summary,
+        summary=f"{len(alerts)} alerts, {len(firing)} firing",
     )
 
 
@@ -213,21 +214,19 @@ def _map_alertmanager_silences(
 ) -> None:
     """Record the silence landscape as one citeable entry, or nothing.
 
-    Same contract as the alerts mapper: the unavailable envelope carries
-    ``silences: []``, so a failed call records nothing.
+    Same contract as the alerts mapper: the active count is always stated, and
+    the unavailable envelope carries ``silences: []`` so a failed call records
+    nothing.
     """
     silences = output.get("silences", [])
     if not silences:
         return
-    summary = f"{len(silences)} silences"
     active = output.get("active_silences", [])
-    if active:
-        summary += f", {len(active)} active"
     record_evidence_entry(
         evidence,
         source="alertmanager_silences",
         label="Alertmanager Silences",
-        summary=summary,
+        summary=f"{len(silences)} silences, {len(active)} active",
     )
 
 

--- a/integrations/alertmanager/tools/__init__.py
+++ b/integrations/alertmanager/tools/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.alertmanager.client import make_alertmanager_client
@@ -18,10 +19,35 @@ from integrations.alertmanager.client import make_alertmanager_client
 _FIRING_STATES = {"active", "unprocessed"}
 
 
+def _map_alertmanager_alerts(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record the alert landscape as one citeable entry, or nothing.
+
+    A failed call returns the unavailable envelope with ``alerts: []``, so the
+    emptiness check covers the error shape too — an entry reading "0 alerts"
+    would cost context on every later turn and support no claim.
+    """
+    alerts = output.get("alerts", [])
+    if not alerts:
+        return
+    summary = f"{len(alerts)} alerts"
+    firing = output.get("firing_alerts", [])
+    if firing:
+        summary += f", {len(firing)} firing"
+    record_evidence_entry(
+        evidence,
+        source="alertmanager_alerts",
+        label="Alertmanager Alerts",
+        summary=summary,
+    )
+
+
 class AlertmanagerAlertsTool(BaseTool):
     """Query Alertmanager for active, silenced, and inhibited alerts to correlate incident signals."""
 
     name = "alertmanager_alerts"
+    evidence_mapper = _map_alertmanager_alerts
     source = "alertmanager"
     description = (
         "Query Alertmanager to list firing, silenced, and inhibited alerts. "
@@ -182,10 +208,34 @@ Useful for understanding whether an alert was intentionally suppressed
 from core.tool import BaseTool
 
 
+def _map_alertmanager_silences(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record the silence landscape as one citeable entry, or nothing.
+
+    Same contract as the alerts mapper: the unavailable envelope carries
+    ``silences: []``, so a failed call records nothing.
+    """
+    silences = output.get("silences", [])
+    if not silences:
+        return
+    summary = f"{len(silences)} silences"
+    active = output.get("active_silences", [])
+    if active:
+        summary += f", {len(active)} active"
+    record_evidence_entry(
+        evidence,
+        source="alertmanager_silences",
+        label="Alertmanager Silences",
+        summary=summary,
+    )
+
+
 class AlertmanagerSilencesTool(BaseTool):
     """Query Alertmanager silences to detect suppressed alerts."""
 
     name = "alertmanager_silences"
+    evidence_mapper = _map_alertmanager_silences
     source = "alertmanager"
     description = (
         "Query Alertmanager silences to see which alerts are currently suppressed and why. "

--- a/tests/integrations/alertmanager/test_evidence_mappers.py
+++ b/tests/integrations/alertmanager/test_evidence_mappers.py
@@ -106,3 +106,40 @@ def test_silences_mapper_records_nothing_without_silences(output: dict[str, Any]
     _map_alertmanager_silences(evidence, output, {})
 
     assert evidence == {}
+
+
+def test_alerts_mapper_states_zero_firing_rather_than_omitting_it() -> None:
+    """ "3 alerts, 0 firing" is a finding; a bare count hides whether any fired."""
+    # Arrange
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "alertmanager",
+        "available": True,
+        "alerts": [{"status": "suppressed"}, {"status": "suppressed"}],
+        "firing_alerts": [],
+        "total": 2,
+    }
+
+    # Act
+    _map_alertmanager_alerts(evidence, output, {})
+
+    # Assert
+    assert evidence["catalog_entries"][0]["summary"] == "2 alerts, 0 firing"
+
+
+def test_silences_mapper_states_zero_active_rather_than_omitting_it() -> None:
+    # Arrange
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "alertmanager_silences",
+        "available": True,
+        "silences": [{"status": {"state": "expired"}}],
+        "active_silences": [],
+        "total": 1,
+    }
+
+    # Act
+    _map_alertmanager_silences(evidence, output, {})
+
+    # Assert
+    assert evidence["catalog_entries"][0]["summary"] == "1 silences, 0 active"

--- a/tests/integrations/alertmanager/test_evidence_mappers.py
+++ b/tests/integrations/alertmanager/test_evidence_mappers.py
@@ -1,0 +1,108 @@
+"""Evidence mapper tests for the Alertmanager tools."""
+
+from typing import Any
+
+import pytest
+
+from core.tool_framework.utils import tool_unavailable
+from integrations.alertmanager.tools import (
+    _map_alertmanager_alerts,
+    _map_alertmanager_silences,
+)
+
+
+def test_alerts_mapper_records_an_entry_counting_firing_alerts() -> None:
+    # Arrange
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "alertmanager",
+        "available": True,
+        "alerts": [
+            {"status": "active", "labels": {"alertname": "HighCPU"}},
+            {"status": "suppressed", "labels": {"alertname": "DiskFilling"}},
+        ],
+        "firing_alerts": [{"status": "active", "labels": {"alertname": "HighCPU"}}],
+        "total": 2,
+    }
+
+    # Act
+    _map_alertmanager_alerts(evidence, output, {})
+
+    # Assert
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "alertmanager_alerts",
+            "label": "Alertmanager Alerts",
+            "summary": "2 alerts, 1 firing",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_silences_mapper_records_an_entry_counting_active_silences() -> None:
+    # Arrange
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "alertmanager_silences",
+        "available": True,
+        "silences": [{"status": {"state": "active"}}, {"status": {"state": "expired"}}],
+        "active_silences": [{"status": {"state": "active"}}],
+        "total": 2,
+    }
+
+    # Act
+    _map_alertmanager_silences(evidence, output, {})
+
+    # Assert
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "alertmanager_silences",
+            "label": "Alertmanager Silences",
+            "summary": "2 silences, 1 active",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        pytest.param({}, id="empty-payload"),
+        pytest.param(
+            tool_unavailable("alertmanager", "connection refused", alerts=[], total=0),
+            id="unavailable-envelope",
+        ),
+        pytest.param({"source": "alertmanager", "available": True, "alerts": []}, id="no-alerts"),
+    ],
+)
+def test_alerts_mapper_records_nothing_without_alerts(output: dict[str, Any]) -> None:
+    """A "0 alerts" entry supports no claim and costs context on every later turn."""
+    evidence: dict[str, Any] = {}
+
+    _map_alertmanager_alerts(evidence, output, {})
+
+    assert evidence == {}
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        pytest.param({}, id="empty-payload"),
+        pytest.param(
+            tool_unavailable("alertmanager", "connection refused", silences=[], total=0),
+            id="unavailable-envelope",
+        ),
+        pytest.param(
+            {"source": "alertmanager_silences", "available": True, "silences": []},
+            id="no-silences",
+        ),
+    ],
+)
+def test_silences_mapper_records_nothing_without_silences(output: dict[str, Any]) -> None:
+    evidence: dict[str, Any] = {}
+
+    _map_alertmanager_silences(evidence, output, {})
+
+    assert evidence == {}

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -13,8 +13,6 @@ GetErrorLogs
 GetRecentLogs
 GetResources
 GetServiceDependencies
-alertmanager_alerts
-alertmanager_silences
 argocd_application_diff
 argocd_application_status
 buzz_send_message


### PR DESCRIPTION
Fixes #5562
Epic: #5519 (part of #1079)

#### Describe the changes you have made in this PR -

`alertmanager_alerts` and `alertmanager_silences` both return diagnostic data that never reached the report, so an investigation could rest on the alert landscape with nothing a reader could cite.

Each tool now carries a mapper recording one catalog entry:

- `_map_alertmanager_alerts` — alert count, plus how many are firing
- `_map_alertmanager_silences` — silence count, plus how many are active

Both are attached as class attributes, following `ElasticsearchLogsTool` in `integrations/elasticsearch/tools/__init__.py`. (The issue points at the Grafana example, but those are `@tool` functions taking `evidence_mapper=` as a keyword — the alertmanager tools are `BaseTool` subclasses, so the class-attribute form applies.)

Both tools are removed from `evidence_mapper_baseline.txt`. Neither is an action tool; both are read-only queries, so neither is skipped.

### Demo/Screenshot for feature changes and bug fixes -

**Check 2 — the tools carry their mapper**

```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['alertmanager_alerts','alertmanager_silences']})"
{'alertmanager_alerts': True, 'alertmanager_silences': True}
```

**Check 3 — output really becomes report evidence**

```
$ uv run python -c "from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence; \
ev={}; merge_tool_evidence(ev, 'alertmanager_alerts', {'alerts':[1,2],'firing_alerts':[1]}, {}); \
print(ev.get('catalog_entries'))"
[{'source': 'alertmanager_alerts', 'label': 'Alertmanager Alerts', 'summary': '2 alerts, 1 firing', 'url': None, 'snippet': None}]

$ ... 'alertmanager_silences', {'silences':[1,2,3],'active_silences':[1]} ...
[{'source': 'alertmanager_silences', 'label': 'Alertmanager Silences', 'summary': '3 silences, 1 active', 'url': None, 'snippet': None}]
```

**Check 4 — nothing else broke**

```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py
11 passed

$ uv run pytest tests/ -k alertmanager
59 passed, 14570 deselected

$ make lint && make format-check && make typecheck
All checks passed!
3630 files already formatted
Success: no issues found in 1893 source files
```

Unit tests (check 1): 8 passing in `tests/integrations/alertmanager/test_evidence_mappers.py`. CI does not typecheck `tests/`, so `uv run mypy` on the new file directly — clean. Full `make test-cov`: **15082 passed**.

---

## Behaviour comparison

Captured `merge_tool_evidence` on `main` and on this branch with a realistic three-alert / two-silence payload.

```diff
$ diff /tmp/before.json /tmp/after.json
59a60,68
>     "catalog_entries": [
>       {
>         "label": "Alertmanager Alerts",
>         "snippet": null,
>         "source": "alertmanager_alerts",
>         "summary": "3 alerts, 2 firing",
>         "url": null
>       }
>     ],
167a177,185
>     "catalog_entries": [
>       {
>         "label": "Alertmanager Silences",
>         "snippet": null,
>         "source": "alertmanager_silences",
>         "summary": "2 silences, 1 active",
>         "url": null
>       }
>     ],
```

One added key per tool. Nothing else in the payload changed.

**What the reader gains.** The report can now cite how many alerts were firing at the time, and whether a silence was masking one. Previously a conclusion like "the alert was already silenced" had no entry behind it — the data was fetched and dropped.

**How much context it costs.** 128 characters per entry serialized. For scale, the raw alerts payload already sits in evidence at 1,700 characters, twice over (under the tool key and in `tool_outputs`). The mapper deliberately records counts only and re-dumps nothing.

**Empty or error result.** Both record nothing. The unavailable envelope carries `alerts: []` / `silences: []`, so the emptiness check covers a failed call as well as an empty one. Covered by parametrized tests over `{}`, a real `tool_unavailable(...)` envelope, and an available-but-empty result.

**Anything recorded twice?** No other mapper covers these tools — they were both on `evidence_mapper_baseline.txt` as known gaps until this PR. The raw payload is stored twice by the shared merge path, but that predates this change and the entries add no third copy.

**Did an existing report change shape?** No. The diff above is the whole delta: `catalog_entries` appears where there was none, and every pre-existing key is byte-identical. `test_evidence_mapper_coverage.py` (which characterizes the shipped Grafana mappings) still passes.

---

## One more check: the evidence has to reach a report

**Not run — no alertmanager credentials.** Checks 1–4 stand and the behaviour comparison above exercises the real `merge_tool_evidence` path, but I cannot run `uv run opensre investigate` against a live instance. Leaving that box unticked as the issue instructs; a reviewer with an account can confirm it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!-- to be completed by the author -->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
