### PR TITLE
refactor(twilio): give verifier a typed validation result

### DIFF
--- a/integrations/twilio/verifier.py
+++ b/integrations/twilio/verifier.py
@@ -8,21 +8,66 @@ standalone ``whatsapp`` integration.
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, TypedDict
 
 import requests
 
-from integrations.verification import register_verifier, result
+from integrations.verification import register_validation_verifier
 
 
-@register_verifier("twilio")
-def verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
-    account_sid = str(config.get("account_sid", "")).strip()
-    auth_token = str(config.get("auth_token", "")).strip()
+class TwilioFailureKind(StrEnum):
+    """Why validation failed — distinct from registry ``missing`` (build-time)."""
+
+    API_ERROR = "api_error"
+    SMS_NOT_READY = "sms_not_ready"
+
+
+@dataclass(frozen=True)
+class TwilioValidationResult:
+    """Outcome of validating Twilio credentials and SMS channel readiness."""
+
+    ok: bool
+    detail: str
+    failure_kind: TwilioFailureKind | None = None
+
+
+class TwilioVerifyConfig(TypedDict):
+    account_sid: str
+    auth_token: str
+    sms: dict[str, Any]
+
+
+def build_twilio_config(raw: dict[str, Any] | None) -> TwilioVerifyConfig:
+    """Require account fields before probing; SMS shape comes from classify/setup upstream."""
+    payload = raw or {}
+    account_sid = str(payload.get("account_sid", "")).strip()
+    auth_token = str(payload.get("auth_token", "")).strip()
     if not account_sid:
-        return result("twilio", source, "missing", "Missing account_sid.")
+        raise ValueError("Missing account_sid.")
     if not auth_token:
-        return result("twilio", source, "missing", "Missing auth_token.")
+        raise ValueError("Missing auth_token.")
+    sms_raw = payload.get("sms")
+    sms = dict(sms_raw) if isinstance(sms_raw, dict) else {}
+    return {
+        "account_sid": account_sid,
+        "auth_token": auth_token,
+        "sms": sms,
+    }
+
+
+def _sms_channel_ready(sms_cfg: dict[str, Any]) -> bool:
+    return bool(sms_cfg.get("enabled")) and bool(
+        str(sms_cfg.get("from_number") or "").strip()
+        or str(sms_cfg.get("messaging_service_sid") or "").strip()
+    )
+
+
+def validate_twilio_config(config: TwilioVerifyConfig) -> TwilioValidationResult:
+    """Probe the Twilio account API, then confirm the SMS channel is ready."""
+    account_sid = config["account_sid"]
+    auth_token = config["auth_token"]
 
     try:
         response = requests.get(
@@ -33,30 +78,41 @@ def verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
-        return result("twilio", source, "failed", f"Twilio API check failed: {exc}")
+        return TwilioValidationResult(
+            ok=False,
+            detail=f"Twilio API check failed: {exc}",
+            failure_kind=TwilioFailureKind.API_ERROR,
+        )
 
     friendly_name = str(payload.get("friendly_name", "")).strip() or account_sid
 
-    sms_cfg = config.get("sms") or {}
-    sms_ready = bool(sms_cfg.get("enabled")) and bool(
-        str(sms_cfg.get("from_number") or "").strip()
-        or str(sms_cfg.get("messaging_service_sid") or "").strip()
-    )
-
-    if not sms_ready:
-        return result(
-            "twilio",
-            source,
-            "failed",
-            (
+    if not _sms_channel_ready(config.get("sms") or {}):
+        return TwilioValidationResult(
+            ok=False,
+            detail=(
                 f"Connected to Twilio account {friendly_name} but the SMS channel "
                 "is not ready. Enable SMS and set a from_number or messaging_service_sid."
             ),
+            failure_kind=TwilioFailureKind.SMS_NOT_READY,
         )
 
-    return result(
-        "twilio",
-        source,
-        "passed",
-        f"Connected to Twilio account {friendly_name}; SMS channel ready.",
+    return TwilioValidationResult(
+        ok=True,
+        detail=f"Connected to Twilio account {friendly_name}; SMS channel ready.",
     )
+
+
+verify_twilio = register_validation_verifier(
+    "twilio",
+    build_config=build_twilio_config,
+    validate_config=validate_twilio_config,
+)
+
+__all__ = [
+    "TwilioFailureKind",
+    "TwilioValidationResult",
+    "TwilioVerifyConfig",
+    "build_twilio_config",
+    "validate_twilio_config",
+    "verify_twilio",
+]

--- a/tests/integrations/test_twilio.py
+++ b/tests/integrations/test_twilio.py
@@ -7,7 +7,14 @@ from typing import Any
 import pytest
 
 from integrations.config_models import TwilioIntegrationConfig, TwilioSMSChannelConfig
-from integrations.twilio.verifier import verify_twilio as _verify_twilio
+from integrations.twilio.verifier import (
+    TwilioFailureKind,
+    build_twilio_config,
+    validate_twilio_config,
+)
+from integrations.twilio.verifier import (
+    verify_twilio as _verify_twilio,
+)
 
 
 class _FakeResponse:
@@ -78,6 +85,53 @@ def test_config_rejects_blank_auth_token() -> None:
             auth_token="  ",
             sms=TwilioSMSChannelConfig(enabled=True, from_number="+1"),
         )
+
+
+# ---- build_twilio_config / validate_twilio_config -----------------------------
+
+
+def test_build_twilio_config_raises_for_missing_account_sid() -> None:
+    with pytest.raises(ValueError, match="Missing account_sid"):
+        build_twilio_config({"auth_token": "tok"})
+
+
+def test_build_twilio_config_raises_for_missing_auth_token() -> None:
+    with pytest.raises(ValueError, match="Missing auth_token"):
+        build_twilio_config({"account_sid": "AC1"})
+
+
+def test_validate_twilio_config_api_error_kind(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: Any, **_kw: Any) -> Any:
+        raise Exception("Connection timeout")
+
+    monkeypatch.setattr("integrations.twilio.verifier.requests.get", _raise)
+
+    outcome = validate_twilio_config(
+        build_twilio_config({"account_sid": "AC1", "auth_token": "tok"})
+    )
+
+    assert outcome.ok is False
+    assert outcome.failure_kind is TwilioFailureKind.API_ERROR
+
+
+def test_validate_twilio_config_sms_not_ready_kind(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "integrations.twilio.verifier.requests.get",
+        lambda *_a, **_kw: _FakeResponse({"friendly_name": "Demo"}),
+    )
+
+    outcome = validate_twilio_config(
+        build_twilio_config(
+            {
+                "account_sid": "AC1",
+                "auth_token": "tok",
+                "sms": {"enabled": False, "from_number": ""},
+            }
+        )
+    )
+
+    assert outcome.ok is False
+    assert outcome.failure_kind is TwilioFailureKind.SMS_NOT_READY
 
 
 # ---- _verify_twilio -----------------------------------------------------------


### PR DESCRIPTION
Fixes #5439

#### Describe the changes you have made in this PR -

Twilio verifier now returns `TwilioValidationResult` internally. `opensre integrations verify twilio` still prints the same `missing` / `failed` / `passed` outcomes.

- `TwilioValidationResult` and `TwilioFailureKind` — tests can tell API errors from SMS-not-ready without parsing `detail`.
- HTTP/SMS checks in `validate_twilio_config`; missing sid/token still map to `missing` via `build_twilio_config`.
- Tests for the new helpers and existing verify paths.

### Demo/Screenshot for feature changes and bug fixes -

Hand-tested missing and invalid credentials:

#### 1) Missing credentials → `missing`

```bash
TWILIO_ACCOUNT_SID= TWILIO_AUTH_TOKEN= TWILIO_SMS_FROM= TWILIO_SMS_MESSAGING_SERVICE_SID= \
  uv run opensre --json integrations verify twilio; echo "exit=$?"
```

```json
[
  {
    "service": "twilio",
    "source": "-",
    "status": "missing",
    "detail": "Not configured in local store or environment variables."
  }
]
```

```
exit=1
```

#### 2) Invalid credentials → `failed` (401)

```bash
TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000 \
TWILIO_AUTH_TOKEN=invalid_token_for_manual_test \
TWILIO_SMS_FROM=+14155551234 \
  uv run opensre --json integrations verify twilio; echo "exit=$?"
```

```json
[
  {
    "service": "twilio",
    "source": "local env",
    "status": "failed",
    "detail": "Twilio API check failed: 401 Client Error: Unauthorized for url: https://api.twilio.com/2010-04-01/Accounts/AC00000000000000000000000000000000.json"
  }
]
```

```
exit=1
```

#### Automated tests

```bash
make lint && make format-check && make typecheck

uv run python -m pytest \
  tests/integrations/test_twilio.py \
  tests/tools/test_twilio_notify_tool.py -v
```

Result: **31 passed** in ~1.65s.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Followed the PostHog example from the issue: validate returns a typed result; the registered verifier still returns a dict. Build checks required fields; validate hits the Twilio API and checks SMS readiness. Missing sid/token raise in build so status stays `missing` (PostHog treats empty fields as `failed` instead). Used `register_validation_verifier` for the final dict conversion, same as PostHog/ServiceNow.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
