### PR TITLE
fix(google_docs): add dedicated integrations setup command

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -121,6 +121,10 @@ from config.constants.github import (
     GITHUB_TOKEN_ENV,
 )
 from config.constants.gitlab import GITLAB_AUTH_TOKEN_ENV, GITLAB_BASE_URL_ENV
+from config.constants.google_docs import (
+    GOOGLE_CREDENTIALS_FILE_ENV,
+    GOOGLE_DRIVE_FOLDER_ID_ENV,
+)
 from config.constants.grafana import (
     GRAFANA_CA_BUNDLE_ENV,
     GRAFANA_INSTANCE_URL_ENV,
@@ -525,6 +529,8 @@ __all__ = [
     "OPENSRE_COMMIT_COAUTHOR_TRAILER",
     "GITLAB_AUTH_TOKEN_ENV",
     "GITLAB_BASE_URL_ENV",
+    "GOOGLE_CREDENTIALS_FILE_ENV",
+    "GOOGLE_DRIVE_FOLDER_ID_ENV",
     "GRAFANA_CA_BUNDLE_ENV",
     "GRAFANA_INSTANCE_URL_ENV",
     "GRAFANA_LOKI_DATASOURCE_UID_ENV",

--- a/config/constants/google_docs.py
+++ b/config/constants/google_docs.py
@@ -1,0 +1,11 @@
+"""Google Docs environment variable names."""
+
+from __future__ import annotations
+
+GOOGLE_CREDENTIALS_FILE_ENV = "GOOGLE_CREDENTIALS_FILE"
+GOOGLE_DRIVE_FOLDER_ID_ENV = "GOOGLE_DRIVE_FOLDER_ID"
+
+__all__ = [
+    "GOOGLE_CREDENTIALS_FILE_ENV",
+    "GOOGLE_DRIVE_FOLDER_ID_ENV",
+]

--- a/docs/google-docs.mdx
+++ b/docs/google-docs.mdx
@@ -7,24 +7,60 @@ description: "Connect Google Docs so OpenSRE can write investigation reports to 
 
 OpenSRE can write investigation findings directly to Google Drive as formatted Google Docs — creating a persistent, shareable record of each incident investigation linked to your team's existing Drive folder.
 
-## Prerequisites
+## Environment recipe
 
-- Google Cloud project with the Google Drive API enabled
-- Service account with access to a shared Drive folder
+Google Docs is a hosted Google API. There is no local Docker stack. You need a Google Cloud project, a service account JSON key, and a Drive folder that account can edit.
+
+### Bring up
+
+1. In [Google Cloud Console](https://console.cloud.google.com/), create or pick a project.
+2. Enable the **Google Drive API** and the **Google Docs API**.
+3. Create a service account (for example `opensre-docs`). Skip role assignment.
+4. Add a JSON key and download it to a path **outside** this repository.
+5. In Google Drive, create a folder for OpenSRE reports (or pick an existing one).
+6. Share that folder with the service account email (`opensre-docs@<project>.iam.gserviceaccount.com`) as **Editor**.
+7. Copy the folder ID from the Drive URL: `https://drive.google.com/drive/folders/<folder-id>`.
+
+### Credentials
+
+| Variable | Required | What it is |
+| --- | --- | --- |
+| `GOOGLE_CREDENTIALS_FILE` | yes | Absolute path to the service account JSON key |
+| `GOOGLE_DRIVE_FOLDER_ID` | yes | Drive folder ID where reports are created |
+
+Auth uses a **service account** only (Docs + Drive API scopes) — not end-user OAuth.
+
+### Tear down
+
+```bash
+opensre integrations remove google_docs
+```
+
+Then:
+
+1. Unshare the Drive folder from the service account (or delete the folder if it was created only for OpenSRE).
+2. In Google Cloud Console, delete the service account key (and the service account if nothing else uses it).
+3. Delete the JSON file from disk.
 
 ## Setup
 
-There is no dedicated `opensre integrations setup google_docs` command today. Configure Google Docs through the onboarding wizard, environment variables, or the persistent store.
+### Option 1: Interactive CLI
 
-### Option 1: Onboarding wizard
+```bash
+opensre integrations setup google_docs
+```
+
+Provide the credentials file path and folder ID when prompted. Setup verifies Drive access before saving.
+
+### Option 2: Onboarding wizard
 
 ```bash
 opensre onboard
 ```
 
-Select **Google Docs** when prompted and provide your credentials file path and folder ID.
+Select **Google Docs** when prompted.
 
-### Option 2: Environment variables
+### Option 3: Environment variables
 
 Add to your `.env`:
 
@@ -33,12 +69,7 @@ GOOGLE_CREDENTIALS_FILE=/path/to/service-account.json
 GOOGLE_DRIVE_FOLDER_ID=your-google-drive-folder-id
 ```
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `GOOGLE_CREDENTIALS_FILE` | — | **Required.** Path to the service account JSON file |
-| `GOOGLE_DRIVE_FOLDER_ID` | — | **Required.** Google Drive folder ID for investigation reports |
-
-### Option 3: Persistent store
+### Option 4: Persistent store
 
 ```json
 {
@@ -56,32 +87,6 @@ GOOGLE_DRIVE_FOLDER_ID=your-google-drive-folder-id
   ]
 }
 ```
-
-## Credentials
-
-### Creating a service account
-
-1. In Google Cloud Console, go to **IAM & Admin** → **Service Accounts**
-2. Click **Create Service Account**
-3. Give it a name (for example `opensre-docs`) and click **Create**
-4. Skip role assignment and click **Done**
-5. Click on the service account → **Keys** → **Add Key** → **Create new key** (JSON)
-6. Download the JSON file
-
-Auth uses a **service account** only (Google Docs + Drive API scopes) — not end-user OAuth.
-
-### Granting Drive folder access
-
-1. In Google Drive, open the folder where reports should be saved
-2. Click **Share**
-3. Add the service account email (for example `opensre-docs@your-project.iam.gserviceaccount.com`)
-4. Set the permission to **Editor**
-
-### Finding the folder ID
-
-The folder ID appears in the Drive URL:
-
-`https://drive.google.com/drive/folders/<folder-id>`
 
 ## Investigation tools
 
@@ -111,7 +116,7 @@ Verification probes Drive access to the configured folder.
 | --- | --- |
 | **Credentials file not found** | Check the path in `GOOGLE_CREDENTIALS_FILE` — use an absolute path |
 | **403 Forbidden** | The service account hasn't been added to the Drive folder with Editor access |
-| **Drive API not enabled** | Enable the **Google Drive API** in your Google Cloud project |
+| **Drive API not enabled** | Enable the **Google Drive API** and **Google Docs API** in your Google Cloud project |
 | **Folder not found** | Confirm the folder ID and that the service account has access |
 
 ## Security

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -84,6 +84,10 @@ from config.constants.github import (
     GITHUB_MCP_URL_ENV,
 )
 from config.constants.gitlab import GITLAB_AUTH_TOKEN_ENV, GITLAB_BASE_URL_ENV
+from config.constants.google_docs import (
+    GOOGLE_CREDENTIALS_FILE_ENV,
+    GOOGLE_DRIVE_FOLDER_ID_ENV,
+)
 from config.constants.grafana import (
     GRAFANA_CA_BUNDLE_ENV,
     GRAFANA_INSTANCE_URL_ENV,
@@ -277,6 +281,7 @@ from integrations.config_models import (
     CoralogixIntegrationConfig,
     DatadogIntegrationConfig,
     DiscordBotConfig,
+    GoogleDocsIntegrationConfig,
     GrafanaIntegrationConfig,
     HelmIntegrationConfig,
     IncidentIoIntegrationConfig,
@@ -1307,6 +1312,29 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 _active_env_record(
                     "jira",
                     jira_config.model_dump(exclude={"integration_id"}),
+                )
+            )
+
+    google_docs_credentials_file = os.getenv(GOOGLE_CREDENTIALS_FILE_ENV, "").strip()
+    google_docs_folder_id = os.getenv(GOOGLE_DRIVE_FOLDER_ID_ENV, "").strip()
+    if google_docs_credentials_file and google_docs_folder_id:
+        try:
+            google_docs_config = GoogleDocsIntegrationConfig.model_validate(
+                {
+                    "credentials_file": google_docs_credentials_file,
+                    "folder_id": google_docs_folder_id,
+                }
+            )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="google_docs")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "google_docs",
+                    {
+                        "credentials_file": google_docs_config.credentials_file,
+                        "folder_id": str(google_docs_config.folder_id).strip(),
+                    },
                 )
             )
 
@@ -2382,8 +2410,8 @@ def resolve_effective_integrations(
             },
         )
     else:
-        credentials_file = os.getenv("GOOGLE_CREDENTIALS_FILE", "").strip()
-        folder_id = os.getenv("GOOGLE_DRIVE_FOLDER_ID", "").strip()
+        credentials_file = os.getenv(GOOGLE_CREDENTIALS_FILE_ENV, "").strip()
+        folder_id = os.getenv(GOOGLE_DRIVE_FOLDER_ID_ENV, "").strip()
         if credentials_file and folder_id:
             effective["google_docs"] = _effective_entry(
                 "local env",

--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from config.constants.google_docs import (
+    GOOGLE_CREDENTIALS_FILE_ENV,
+    GOOGLE_DRIVE_FOLDER_ID_ENV,
+)
 from config.constants.helm import OSRE_HELM_INTEGRATION_ENV
 from config.constants.new_relic import (
     NEW_RELIC_ACCOUNT_ID_ENV,
@@ -118,6 +122,10 @@ def load_env_integration_services() -> list[str]:
     )
     add("sentry", _all_env("SENTRY_ORG_SLUG", "SENTRY_AUTH_TOKEN"))
     add("gitlab", _env_is_set("GITLAB_ACCESS_TOKEN"))
+    add(
+        "google_docs",
+        _all_env(GOOGLE_CREDENTIALS_FILE_ENV, GOOGLE_DRIVE_FOLDER_ID_ENV),
+    )
     add("mongodb", _env_is_set("MONGODB_CONNECTION_STRING"))
     add(
         "argocd",

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -772,6 +772,12 @@ def _setup_kubernetes() -> None:
     _run_spec_setup(KUBERNETES_SETUP)
 
 
+def _setup_google_docs() -> None:
+    from integrations.google_docs import GOOGLE_DOCS_SETUP
+
+    _run_spec_setup(GOOGLE_DOCS_SETUP)
+
+
 def _setup_yandex_cloud() -> None:
     from integrations.yandex_cloud.setup import setup_spec_for_this_host
 
@@ -826,6 +832,7 @@ _HANDLERS: dict[str, Any] = {
     "kubernetes": _setup_kubernetes,
     "servicenow": _setup_servicenow,
     "new_relic": _setup_new_relic,
+    "google_docs": _setup_google_docs,
     "yandex_cloud": _setup_yandex_cloud,
 }
 

--- a/integrations/google_docs/__init__.py
+++ b/integrations/google_docs/__init__.py
@@ -2,6 +2,31 @@
 
 from __future__ import annotations
 
+from config.constants.google_docs import (
+    GOOGLE_CREDENTIALS_FILE_ENV,
+    GOOGLE_DRIVE_FOLDER_ID_ENV,
+)
 from integrations.google_docs.client import GoogleDocsClient
+from integrations.google_docs.verifier import verify_google_docs
+from integrations.setup_flow import IntegrationSetupSpec, SetupField
 
-__all__ = ["GoogleDocsClient"]
+GOOGLE_DOCS_SETUP = IntegrationSetupSpec(
+    service="google_docs",
+    fields=(
+        SetupField(
+            name="credentials_file",
+            label="Service account credentials JSON path",
+            prompt="Path to Google service account credentials JSON file",
+            env_var=GOOGLE_CREDENTIALS_FILE_ENV,
+        ),
+        SetupField(
+            name="folder_id",
+            label="Drive folder ID",
+            prompt="Google Drive folder ID for incident reports",
+            env_var=GOOGLE_DRIVE_FOLDER_ID_ENV,
+        ),
+    ),
+    verify=verify_google_docs,
+)
+
+__all__ = ["GOOGLE_DOCS_SETUP", "GoogleDocsClient"]

--- a/integrations/google_docs/client.py
+++ b/integrations/google_docs/client.py
@@ -8,6 +8,10 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Any, cast
 
+from config.constants.google_docs import (
+    GOOGLE_CREDENTIALS_FILE_ENV,
+    GOOGLE_DRIVE_FOLDER_ID_ENV,
+)
 from integrations.config_models import GoogleDocsIntegrationConfig
 from integrations.probes import ProbeResult
 
@@ -462,8 +466,8 @@ def build_google_docs_client_from_env() -> GoogleDocsClient | None:
     """Build a GoogleDocsClient from environment variables if available."""
     import os
 
-    credentials_file = os.getenv("GOOGLE_CREDENTIALS_FILE", "").strip()
-    folder_id = os.getenv("GOOGLE_DRIVE_FOLDER_ID", "").strip()
+    credentials_file = os.getenv(GOOGLE_CREDENTIALS_FILE_ENV, "").strip()
+    folder_id = os.getenv(GOOGLE_DRIVE_FOLDER_ID_ENV, "").strip()
 
     if not credentials_file or not folder_id:
         return None

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -387,7 +387,12 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
         setup_order=25,
         verify_order=9,
     ),
-    IntegrationSpec(service="google_docs", has_verifier=True, verify_order=19),
+    IntegrationSpec(
+        service="google_docs",
+        has_verifier=True,
+        setup_order=55,
+        verify_order=19,
+    ),
     IntegrationSpec(service="kafka", has_verifier=True, verify_order=37),
     IntegrationSpec(service="clickhouse", has_verifier=True, verify_order=23),
     IntegrationSpec(service="alicloud", direct_effective=True),

--- a/surfaces/cli/wizard/configurators/productivity.py
+++ b/surfaces/cli/wizard/configurators/productivity.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 from config.env_file import sync_env_values
 from infrastructure.terminal.theme import SECONDARY
+from integrations.google_docs import GOOGLE_DOCS_SETUP
 from integrations.servicenow import SERVICENOW_SETUP
 from integrations.store import upsert_integration
 from surfaces.cli.wizard.components import (
     console,
     integration_defaults,
     prompt_value,
-    string_value,
 )
 from surfaces.cli.wizard.configurators.spec_configurator import configure_from_spec
 from surfaces.cli.wizard.integration_health import (
-    validate_google_docs_integration,
     validate_jira_integration,
     validate_notion_integration,
 )
@@ -96,37 +95,12 @@ def _configure_servicenow() -> tuple[str, str]:
 
 
 def _configure_google_docs() -> tuple[str, str]:
-    _, credentials = integration_defaults("google_docs")
-    while True:
-        credentials_file = prompt_value(
-            "Path to Google service account credentials JSON file",
-            default=string_value(credentials.get("credentials_file")),
-        )
-        folder_id = prompt_value(
-            "Google Drive folder ID for incident reports",
-            default=string_value(credentials.get("folder_id")),
-        )
-        with console.status("Validating Google Docs integration...", spinner="dots"):
-            result = validate_google_docs_integration(
-                credentials_file=credentials_file,
-                folder_id=folder_id,
-            )
-        render_integration_result("Google Docs", result)
-        if result.ok:
-            upsert_integration(
-                "google_docs",
-                {
-                    "credentials": {
-                        "credentials_file": credentials_file,
-                        "folder_id": folder_id,
-                    }
-                },
-            )
-            env_path = sync_env_values(
-                {
-                    "GOOGLE_CREDENTIALS_FILE": credentials_file,
-                    "GOOGLE_DRIVE_FOLDER_ID": folder_id,
-                }
-            )
-            return "Google Docs", str(env_path)
-        console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+    return configure_from_spec(
+        GOOGLE_DOCS_SETUP,
+        title="Google Docs",
+        intro=(
+            "\n[bold]Google Docs Integration[/bold]\n"
+            "Use a service account JSON key and share a Drive folder with that "
+            "account as Editor.\n"
+        ),
+    )

--- a/tests/integrations/test_cli_spec_setup.py
+++ b/tests/integrations/test_cli_spec_setup.py
@@ -34,6 +34,7 @@ import integrations.coralogix.setup as coralogix_setup
 import integrations.dagster.setup as dagster_setup
 import integrations.datadog.setup as datadog_setup
 import integrations.gitlab.setup as gitlab_setup
+import integrations.google_docs as google_docs_setup
 import integrations.grafana.setup as grafana_setup
 import integrations.groundcover.setup as groundcover_setup
 import integrations.helm.setup as helm_setup
@@ -91,6 +92,10 @@ _ANSWERS: dict[str, dict[str, str]] = {
     "gitlab": {
         "base_url": "https://gitlab.example.com/api/v4",
         "auth_token": "glpat-gitlab-token",
+    },
+    "google_docs": {
+        "credentials_file": "/opt/opensre/google-docs-sa.json",
+        "folder_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
     },
     "sentry": {
         "base_url": "https://sentry.example.com",
@@ -277,6 +282,7 @@ _CASES = [
     pytest.param(coralogix_setup, "CORALOGIX_SETUP", cli._setup_coralogix, id="coralogix"),
     pytest.param(groundcover_setup, "GROUNDCOVER_SETUP", cli._setup_groundcover, id="groundcover"),
     pytest.param(gitlab_setup, "GITLAB_SETUP", cli._setup_gitlab, id="gitlab"),
+    pytest.param(google_docs_setup, "GOOGLE_DOCS_SETUP", cli._setup_google_docs, id="google_docs"),
     pytest.param(sentry_setup, "SENTRY_SETUP", cli._setup_sentry, id="sentry"),
     pytest.param(posthog_setup, "POSTHOG_SETUP", cli._setup_posthog, id="posthog"),
     pytest.param(vercel_setup, "VERCEL_SETUP", cli._setup_vercel, id="vercel"),

--- a/tests/integrations/test_configured_integration_services.py
+++ b/tests/integrations/test_configured_integration_services.py
@@ -105,6 +105,18 @@ def test_slack_absent_without_slack_env(monkeypatch: Any) -> None:
     assert "slack" not in catalog.load_env_integration_services()
 
 
+def test_google_docs_env_marks_google_docs_configured(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GOOGLE_CREDENTIALS_FILE", "/path/to/sa.json")
+    monkeypatch.setenv("GOOGLE_DRIVE_FOLDER_ID", "folder-1")
+    assert "google_docs" in catalog.load_env_integration_services()
+
+
+def test_google_docs_absent_without_both_env_vars(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GOOGLE_CREDENTIALS_FILE", "/path/to/sa.json")
+    monkeypatch.delenv("GOOGLE_DRIVE_FOLDER_ID", raising=False)
+    assert "google_docs" not in catalog.load_env_integration_services()
+
+
 class TestConfiguredIntegrationHealth:
     """Offline health for the welcome banner: present vs. minimally usable.
 

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -86,6 +86,14 @@ def test_railway_is_registered_as_a_configurable_verified_integration() -> None:
     assert "railway" not in SKIP_CLASSIFIED_SERVICES
 
 
+def test_google_docs_has_a_dedicated_setup_command() -> None:
+    google_docs = next(spec for spec in INTEGRATION_SPECS if spec.service == "google_docs")
+
+    assert google_docs.has_verifier is True
+    assert google_docs.setup_order is not None
+    assert "google_docs" in SUPPORTED_SETUP_SERVICES
+
+
 def test_prefect_is_registered_as_a_directly_effective_integration() -> None:
     # prefect's classify() resolves store credentials into a config object
     # just like dagster/temporal, but its spec was missing direct_effective=True

--- a/tests/integrations/test_setup_spec_env_round_trip.py
+++ b/tests/integrations/test_setup_spec_env_round_trip.py
@@ -38,6 +38,7 @@ from integrations.dagster.setup import DAGSTER_SETUP
 from integrations.datadog.setup import DATADOG_SETUP
 from integrations.github.setup import GITHUB_SETUP
 from integrations.gitlab.setup import GITLAB_SETUP
+from integrations.google_docs import GOOGLE_DOCS_SETUP
 from integrations.grafana.setup import GRAFANA_SETUP
 from integrations.groundcover.setup import GROUNDCOVER_SETUP
 from integrations.helm.setup import HELM_SETUP
@@ -100,6 +101,10 @@ _SUBMITTED: dict[str, dict[str, str]] = {
     "gitlab": {
         "base_url": "https://gitlab.example.com/api/v4",
         "auth_token": "glpat-gitlab-token",
+    },
+    "google_docs": {
+        "credentials_file": "/opt/opensre/google-docs-sa.json",
+        "folder_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
     },
     "sentry": {
         "base_url": "https://sentry.example.com",
@@ -322,6 +327,7 @@ _SPECS = [
     DAGSTER_SETUP,
     DATADOG_SETUP,
     GITLAB_SETUP,
+    GOOGLE_DOCS_SETUP,
     GROUNDCOVER_SETUP,
     HELM_SETUP,
     HONEYCOMB_SETUP,


### PR DESCRIPTION
Fixes #5763

#### Describe the changes you have made in this PR -

`opensre integrations setup google_docs` was not a supported command. Verify, onboard, and #5123 all assume it exists, but the registry had a verifier and no `setup_order` / CLI handler.

This adds the spec-driven setup flow (service-account JSON path + Drive folder ID, verify, persist) and wires env/catalog so those values round-trip like other integrations. The onboard wizard now uses the same spec. Docs list the setup command as option 1.
<img width="629" height="284" alt="Screenshot 2026-08-26 at 1 15 04 PM" src="https://github.com/user-attachments/assets/c19e5adb-c02b-4ffd-a327-5f50d6f821c0" />
<img width="629" height="152" alt="Screenshot 2026-08-26 at 1 15 45 PM" src="https://github.com/user-attachments/assets/f299800a-b7e0-4cc9-8837-1c5404ff6020" />

