### PR TITLE
fix(yandex-cloud): close the follow-ups left after the tools landed

### DIFF
--- a/docs/yandex-cloud.mdx
+++ b/docs/yandex-cloud.mdx
@@ -20,7 +20,9 @@ Once the folder is connected, an investigation can reach:
 
 The last row matters more than it looks: OpenSRE ships an index of every read
 endpoint the Yandex Cloud API exposes, so a service without a dedicated tool is
-still reachable. Audit trails arrive in a follow-up release.
+still reachable. Audit Trails is in that index, so trails and their settings are
+readable now; the audit *events* are not, because Yandex delivers them to a sink
+rather than through the API.
 
 **Reading log entries needs one extra package.** Cloud Logging is the only
 Yandex Cloud read with no REST endpoint, so it uses Yandex's gRPC stubs:
@@ -111,6 +113,15 @@ metadata mode when running on a VM.
 **Verification fails with a permission error.** The service account has no
 `viewer` on that folder — check that the role was granted on the folder you
 configured, not on a different one.
+
+**"... is not a documented read of ...".** The generic reader only sends paths the
+endpoint index lists, which is what keeps it to reads. A path that is not in the
+index is refused before any request goes out, even when it looks right. Ask for
+the path instead of typing one:
+
+```
+find_yc_api "security groups"
+```
 
 **The key file cannot be read.** `YC_SA_KEY_FILE` must point at the authorized
 key JSON produced by `yc iam key create`, readable by the user running OpenSRE.

--- a/integrations/yandex_cloud/api_index.py
+++ b/integrations/yandex_cloud/api_index.py
@@ -249,6 +249,21 @@ def _path_matches(template: str, actual: str) -> bool:
     )
 
 
+#: The tools name a couple of services the way the endpoint registry does, while
+#: the index carries the name the protos use. Without this the gate below sees
+#: an unknown service and waves the path through unchecked.
+#: Where a tool names a service differently from the index. The tools say "alb",
+#: while the protos - and so the index built from them - say "apploadbalancer".
+#: Without this the gate sees an unknown service and waves the path through.
+_SERVICE_ALIASES: Final[dict[str, str]] = {"alb": "apploadbalancer"}
+
+
+def canonical_service(service: str) -> str:
+    """Return the name the index knows this service by."""
+    wanted = service.strip()
+    return _SERVICE_ALIASES.get(wanted, wanted)
+
+
 def lookup(service: str, path: str) -> ApiEndpoint | None:
     """Return the indexed read that *path* is, or ``None`` if it is not one.
 
@@ -257,7 +272,7 @@ def lookup(service: str, path: str) -> ApiEndpoint | None:
     convenience for discovery. A concrete path such as
     ``/compute/v1/instances/abc`` matches ``/compute/v1/instances/{instance_id}``.
     """
-    wanted = service.strip()
+    wanted = canonical_service(service)
     if not wanted or not path:
         return None
     for endpoint in _endpoints():

--- a/integrations/yandex_cloud/api_index.py
+++ b/integrations/yandex_cloud/api_index.py
@@ -249,9 +249,6 @@ def _path_matches(template: str, actual: str) -> bool:
     )
 
 
-#: The tools name a couple of services the way the endpoint registry does, while
-#: the index carries the name the protos use. Without this the gate below sees
-#: an unknown service and waves the path through unchecked.
 #: Where a tool names a service differently from the index. The tools say "alb",
 #: while the protos - and so the index built from them - say "apploadbalancer".
 #: Without this the gate sees an unknown service and waves the path through.

--- a/integrations/yandex_cloud/api_index.py
+++ b/integrations/yandex_cloud/api_index.py
@@ -256,8 +256,13 @@ _SERVICE_ALIASES: Final[dict[str, str]] = {"alb": "apploadbalancer"}
 
 
 def canonical_service(service: str) -> str:
-    """Return the name the index knows this service by."""
-    wanted = service.strip()
+    """Return the name the index knows this service by.
+
+    Case-folded because the index is lowercase throughout while host resolution
+    lowercases what it is given: a caller saying "COMPUTE" would otherwise read
+    as an unknown service to the gate and as the real host to the client.
+    """
+    wanted = service.strip().lower()
     return _SERVICE_ALIASES.get(wanted, wanted)
 
 

--- a/integrations/yandex_cloud/build_api_index.py
+++ b/integrations/yandex_cloud/build_api_index.py
@@ -196,6 +196,8 @@ def collect(cloudapi_root: Path) -> list[dict[str, Any]]:
     """Return every GET binding in the protos under *cloudapi_root*."""
     entries: list[dict[str, Any]] = []
     seen: set[tuple[str, str]] = set()
+    dropped: dict[str, int] = {"mutating": 0, "no_host": 0}
+    unhosted: set[str] = set()
 
     for proto in sorted((cloudapi_root / "yandex").rglob("*.proto")):
         text = proto.read_text(encoding="utf-8", errors="replace")
@@ -210,11 +212,17 @@ def collect(cloudapi_root: Path) -> list[dict[str, Any]]:
             if not get_match:
                 continue
             if _is_mutating(rpc_name):
+                dropped["mutating"] += 1
                 continue
             path = get_match.group(1)
             key = _endpoint_key(path, package)
             if not key:
-                continue  # no reachable host: the service is not in the registry
+                # No reachable host: the service is not in the registry. Counted
+                # rather than passed over in silence - this is the path that once
+                # hid 34 endpoints behind a naming mismatch.
+                dropped["no_host"] += 1
+                unhosted.add(package)
+                continue
             if (key, path) in seen:
                 continue
             seen.add((key, path))
@@ -231,6 +239,15 @@ def collect(cloudapi_root: Path) -> list[dict[str, Any]]:
             entries.append(entry)
 
     entries.sort(key=lambda e: (e["service"], e["path"]))
+    # Say what was left out. A generator that silently drops bindings is how 34
+    # endpoints once went missing behind a naming mismatch and looked, from the
+    # outside, like Yandex not offering an API at all.
+    print(
+        f"kept {len(entries)} read endpoints; "
+        f"dropped {dropped['mutating']} mutating and {dropped['no_host']} with no registry host"
+    )
+    for package in sorted(unhosted):
+        print(f"  no host for package: {package}")
     return entries
 
 

--- a/integrations/yandex_cloud/endpoints.py
+++ b/integrations/yandex_cloud/endpoints.py
@@ -244,10 +244,9 @@ def known_endpoints(*, refresh: bool = True) -> dict[str, str]:
             cached = _cache.endpoints
         if cached:
             endpoints.update(cached)
-    _apply_host_aliases(endpoints)
-    # Overrides land last, so an operator pointing a service somewhere else wins
-    # over both the registry and the alias above.
-    endpoints.update(_endpoint_overrides())
+    overrides = _endpoint_overrides()
+    endpoints.update(overrides)
+    _apply_host_aliases(endpoints, overrides)
     return endpoints
 
 
@@ -258,14 +257,20 @@ def known_endpoints(*, refresh: bool = True) -> dict[str, str]:
 _HOST_ALIASES: Final[dict[str, str]] = {"storage": "storage-api"}
 
 
-def _apply_host_aliases(endpoints: dict[str, str]) -> None:
+def _apply_host_aliases(endpoints: dict[str, str], overrides: dict[str, str]) -> None:
     """Re-point each aliased name at the host that answers for it.
 
-    Applied to the resolved registry data rather than the snapshot because the
+    Applied to the resolved registry data rather than the snapshot, because the
     snapshot is refreshed from Yandex at runtime and the upstream value would
     come straight back.
+
+    Either name is a fair thing for an operator to override, so both work: an
+    override on the alias itself wins outright, and one on the registry name is
+    what the alias then points at.
     """
     for name, registered_as in _HOST_ALIASES.items():
+        if name in overrides:
+            continue
         host = endpoints.get(registered_as)
         if host:
             endpoints[name] = host

--- a/integrations/yandex_cloud/endpoints.py
+++ b/integrations/yandex_cloud/endpoints.py
@@ -244,17 +244,31 @@ def known_endpoints(*, refresh: bool = True) -> dict[str, str]:
             cached = _cache.endpoints
         if cached:
             endpoints.update(cached)
+    _apply_host_aliases(endpoints)
+    # Overrides land last, so an operator pointing a service somewhere else wins
+    # over both the registry and the alias above.
     endpoints.update(_endpoint_overrides())
     return endpoints
 
 
-#: Where the registry's name for a host differs from the one the index emits.
-#: The index calls the Object Storage control plane "storage", but the registry
-#: gives that name to the S3 data plane, which serves objects and answers no
-#: control-plane read; the control plane is registered as "storage-api". Applied
-#: here rather than in the snapshot because the snapshot is refreshed from
-#: Yandex at runtime and the upstream value would come straight back.
+#: Services the registry names differently from everyone else. The index and the
+#: tools call the Object Storage control plane "storage"; the registry gives that
+#: name to the S3 data plane, which serves objects and answers no control-plane
+#: read, and registers the control plane as "storage-api".
 _HOST_ALIASES: Final[dict[str, str]] = {"storage": "storage-api"}
+
+
+def _apply_host_aliases(endpoints: dict[str, str]) -> None:
+    """Re-point each aliased name at the host that answers for it.
+
+    Applied to the resolved registry data rather than the snapshot because the
+    snapshot is refreshed from Yandex at runtime and the upstream value would
+    come straight back.
+    """
+    for name, registered_as in _HOST_ALIASES.items():
+        host = endpoints.get(registered_as)
+        if host:
+            endpoints[name] = host
 
 
 def resolve_endpoint(service: str, *, refresh: bool = True) -> str | None:
@@ -264,8 +278,7 @@ def resolve_endpoint(service: str, *, refresh: bool = True) -> str | None:
     built from caller input, so a model cannot talk the client into reaching an
     arbitrary address.
     """
-    wanted = service.strip().lower()
-    return known_endpoints(refresh=refresh).get(_HOST_ALIASES.get(wanted, wanted))
+    return known_endpoints(refresh=refresh).get(service.strip().lower())
 
 
 def reset_endpoint_cache() -> None:

--- a/integrations/yandex_cloud/endpoints.py
+++ b/integrations/yandex_cloud/endpoints.py
@@ -248,6 +248,15 @@ def known_endpoints(*, refresh: bool = True) -> dict[str, str]:
     return endpoints
 
 
+#: Where the registry's name for a host differs from the one the index emits.
+#: The index calls the Object Storage control plane "storage", but the registry
+#: gives that name to the S3 data plane, which serves objects and answers no
+#: control-plane read; the control plane is registered as "storage-api". Applied
+#: here rather than in the snapshot because the snapshot is refreshed from
+#: Yandex at runtime and the upstream value would come straight back.
+_HOST_ALIASES: Final[dict[str, str]] = {"storage": "storage-api"}
+
+
 def resolve_endpoint(service: str, *, refresh: bool = True) -> str | None:
     """Return the API host for *service*, or None when it is not a known service.
 
@@ -255,7 +264,8 @@ def resolve_endpoint(service: str, *, refresh: bool = True) -> str | None:
     built from caller input, so a model cannot talk the client into reaching an
     arbitrary address.
     """
-    return known_endpoints(refresh=refresh).get(service.strip().lower())
+    wanted = service.strip().lower()
+    return known_endpoints(refresh=refresh).get(_HOST_ALIASES.get(wanted, wanted))
 
 
 def reset_endpoint_cache() -> None:

--- a/integrations/yandex_cloud/tools/SKILL.md
+++ b/integrations/yandex_cloud/tools/SKILL.md
@@ -39,6 +39,12 @@ instead.
 own separate authentication, and it can mutate. If you catch yourself writing
 `yc ...` to answer a question, use `execute_yc_operation` instead.
 
+**But do write the `yc ...` command out when something should change.** These
+tools only read. When the finding calls for an action — resize, restart,
+rebalance, change a setting — end with the exact `yc ...` command an operator
+can paste, not a description of what to do. Writing the command is correct;
+running it is not.
+
 Everything else reaches Yandex Cloud over its REST API with the configured
 credential. There is no CLI step and no shell step.
 

--- a/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
@@ -17,7 +17,7 @@ from typing import Any
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
-from integrations.yandex_cloud.api_index import known_services, lookup
+from integrations.yandex_cloud.api_index import canonical_service, known_services, lookup
 from integrations.yandex_cloud.availability import (
     YC_INJECTED_PARAMS,
     client_from_params,
@@ -144,8 +144,11 @@ def execute_yc_operation(
     # path that Yandex binds to GET, or a path the generator never listed.
     # Unknown services still fall through to the client, which names them as
     # unknown. A known service with a path the index does not list is refused
-    # here so a well-formed write never reaches the network.
-    if service in known_services() and lookup(service, path) is None:
+    # here so a well-formed write never reaches the network. Canonicalise first:
+    # the caller may use the name the tools and the registry use, and asking the
+    # index about a name it does not carry would read as "unknown service" and
+    # skip the check.
+    if canonical_service(service) in known_services() and lookup(service, path) is None:
         return {
             "success": False,
             "service": service,

--- a/tests/integrations/test_yandex_cloud_api_index.py
+++ b/tests/integrations/test_yandex_cloud_api_index.py
@@ -348,3 +348,22 @@ class TestLookupIsTheAllowlist:
 
     def test_a_real_path_on_the_wrong_service_is_none(self) -> None:
         assert lookup("iam", "/compute/v1/instances") is None
+
+
+class TestServiceNamesTheToolsActuallyUse:
+    """A tool naming a service differently from the index bypasses the gate.
+
+    `execute_yc_operation` only refuses a path when it recognises the service.
+    The load-balancer tool says "alb" while the index, built from the protos,
+    says "apploadbalancer" - so without an alias its paths were waved through
+    unchecked instead of being matched against the allowlist.
+    """
+
+    def test_the_tools_alb_name_reaches_the_index(self) -> None:
+        assert lookup("alb", "/apploadbalancer/v1/loadBalancers") is not None
+
+    def test_a_canonical_name_still_works(self) -> None:
+        assert lookup("apploadbalancer", "/apploadbalancer/v1/loadBalancers") is not None
+
+    def test_an_unknown_service_stays_unknown(self) -> None:
+        assert lookup("not-a-service", "/x/v1/y") is None

--- a/tests/integrations/test_yandex_cloud_api_index.py
+++ b/tests/integrations/test_yandex_cloud_api_index.py
@@ -16,6 +16,7 @@ import pytest
 
 from integrations.yandex_cloud.api_index import (
     _INDEX_FILE,
+    canonical_service,
     endpoint_count,
     known_services,
     lookup,
@@ -361,3 +362,13 @@ class TestServiceNamesTheToolsActuallyUse:
 
     def test_an_unknown_service_stays_unknown(self) -> None:
         assert lookup("not-a-service", "/x/v1/y") is None
+
+    @pytest.mark.parametrize("service", ["ALB", "Alb", " alb "])
+    def test_the_index_is_reached_however_the_name_is_typed(self, service: str) -> None:
+        """Host resolution case-folds, so the allowlist has to as well.
+
+        A name that reads as unknown here and as a real host to the client is a
+        way past the gate, not a typo.
+        """
+        assert canonical_service(service) in known_services()
+        assert lookup(service, "/apploadbalancer/v1/loadBalancers") is not None

--- a/tests/integrations/test_yandex_cloud_api_index.py
+++ b/tests/integrations/test_yandex_cloud_api_index.py
@@ -351,13 +351,7 @@ class TestLookupIsTheAllowlist:
 
 
 class TestServiceNamesTheToolsActuallyUse:
-    """A tool naming a service differently from the index bypasses the gate.
-
-    `execute_yc_operation` only refuses a path when it recognises the service.
-    The load-balancer tool says "alb" while the index, built from the protos,
-    says "apploadbalancer" - so without an alias its paths were waved through
-    unchecked instead of being matched against the allowlist.
-    """
+    """The index answers to the names the tools use, not only the proto names."""
 
     def test_the_tools_alb_name_reaches_the_index(self) -> None:
         assert lookup("alb", "/apploadbalancer/v1/loadBalancers") is not None

--- a/tests/integrations/test_yandex_cloud_catalog.py
+++ b/tests/integrations/test_yandex_cloud_catalog.py
@@ -146,6 +146,10 @@ class TestEnvironmentLoading:
         monkeypatch.setenv(YC_FOLDER_ID_ENV, FOLDER)
         monkeypatch.delenv(YC_IAM_TOKEN_ENV, raising=False)
         monkeypatch.delenv(YC_SA_KEY_FILE_ENV, raising=False)
+        # setup writes this to .env, so on any machine with the integration
+        # configured it leaks in and the folder does have a credential after
+        # all - green in CI, red for anyone who actually connected it.
+        monkeypatch.delenv(YC_USE_METADATA_ENV, raising=False)
 
         records = [r for r in load_env_integrations() if r.get("service") == "yandex_cloud"]
 
@@ -358,3 +362,29 @@ class TestSetupMetadataFlag:
         resolved = _resolve_metadata_flag({"folder_id": "b1g", "use_metadata": "true"})
 
         assert resolved.credentials["use_metadata"] == "true"
+
+
+class TestObjectStorageResolvesToItsControlPlane:
+    """The index emits "storage" for the control plane; the registry does not.
+
+    The registry gives that name to the S3 data plane, which serves objects and
+    answers no control-plane read, so a bucket listing went to a host that
+    cannot answer it. Aliased at resolve time rather than in the snapshot: the
+    snapshot is refreshed from Yandex and the upstream value would return.
+    """
+
+    def test_storage_reads_go_to_the_control_plane(self) -> None:
+        from integrations.yandex_cloud.endpoints import resolve_endpoint
+
+        assert resolve_endpoint("storage", refresh=False) == "storage.api.cloud.yandex.net"
+
+    def test_the_alias_survives_a_registry_refresh(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A refresh brings back Yandex's own mapping; the alias must outlive it."""
+        from integrations.yandex_cloud import endpoints
+
+        monkeypatch.setattr(
+            endpoints, "_fetch_endpoints", lambda: {"storage": "storage.yandexcloud.net"}
+        )
+        endpoints.reset_endpoint_cache()
+
+        assert endpoints.resolve_endpoint("storage") == "storage.api.cloud.yandex.net"

--- a/tests/integrations/test_yandex_cloud_catalog.py
+++ b/tests/integrations/test_yandex_cloud_catalog.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from config.constants.yandex_cloud import (
+    YC_ENDPOINT_OVERRIDES_ENV,
     YC_FOLDER_ID_ENV,
     YC_IAM_TOKEN_ENV,
     YC_SA_KEY_FILE_ENV,
@@ -365,12 +366,11 @@ class TestSetupMetadataFlag:
 
 
 class TestObjectStorageResolvesToItsControlPlane:
-    """The index emits "storage" for the control plane; the registry does not.
+    """ "storage" reaches the control plane, and an operator can still redirect it.
 
     The registry gives that name to the S3 data plane, which serves objects and
-    answers no control-plane read, so a bucket listing went to a host that
-    cannot answer it. Aliased at resolve time rather than in the snapshot: the
-    snapshot is refreshed from Yandex and the upstream value would return.
+    answers no control-plane read; the control plane is registered as
+    "storage-api".
     """
 
     def test_storage_reads_go_to_the_control_plane(self) -> None:
@@ -388,3 +388,14 @@ class TestObjectStorageResolvesToItsControlPlane:
         endpoints.reset_endpoint_cache()
 
         assert endpoints.resolve_endpoint("storage") == "storage.api.cloud.yandex.net"
+
+    def test_an_override_on_the_caller_visible_name_wins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An operator overrides the name they call, not the one the registry uses."""
+        from integrations.yandex_cloud import endpoints
+
+        monkeypatch.setenv(YC_ENDPOINT_OVERRIDES_ENV, '{"storage": "storage.internal"}')
+        endpoints.reset_endpoint_cache()
+
+        assert endpoints.resolve_endpoint("storage", refresh=False) == "storage.internal"

--- a/tests/integrations/test_yandex_cloud_catalog.py
+++ b/tests/integrations/test_yandex_cloud_catalog.py
@@ -399,3 +399,15 @@ class TestObjectStorageResolvesToItsControlPlane:
         endpoints.reset_endpoint_cache()
 
         assert endpoints.resolve_endpoint("storage", refresh=False) == "storage.internal"
+
+    def test_an_override_on_the_registry_name_also_lands(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Either name is a fair thing to override, so both have to take effect."""
+        from integrations.yandex_cloud import endpoints
+
+        monkeypatch.setenv(YC_ENDPOINT_OVERRIDES_ENV, '{"storage-api": "storage.internal"}')
+        endpoints.reset_endpoint_cache()
+
+        assert endpoints.resolve_endpoint("storage", refresh=False) == "storage.internal"
+        assert endpoints.resolve_endpoint("storage-api", refresh=False) == "storage.internal"

--- a/tests/integrations/test_yc_operation_tool.py
+++ b/tests/integrations/test_yc_operation_tool.py
@@ -293,6 +293,30 @@ class TestTheIndexIsTheAllowlist:
         assert result["success"] is False
         assert "not a documented read" in result["error"]
 
+    @pytest.mark.parametrize("service", ["COMPUTE", "Compute", " compute "])
+    def test_the_gate_holds_however_the_service_is_spelled(
+        self, service: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Host resolution case-folds the service, so the allowlist must too.
+
+        Otherwise the same string reads as an unknown service to the gate - which
+        skips the check - and as a real host to the client, and an undocumented
+        path reaches the network.
+        """
+
+        def _never(*_a: object, **_k: object) -> None:
+            raise AssertionError("no request should be made")
+
+        monkeypatch.setattr("integrations.yandex_cloud.rest_client.send_request", _never)
+        result = execute_yc_operation(
+            service=service,
+            path="/compute/v1/notARealCollection",
+            **_CREDENTIALS,
+        )
+
+        assert result["success"] is False
+        assert "not a documented read" in result["error"]
+
     def test_a_concrete_resource_path_is_sent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: list[str] = []
 

--- a/tests/integrations/test_yc_operation_tool.py
+++ b/tests/integrations/test_yc_operation_tool.py
@@ -275,6 +275,24 @@ class TestTheIndexIsTheAllowlist:
         assert "find_yc_api" in result["error"]
         assert "not a documented read" in result["error"]
 
+    def test_the_gate_holds_for_a_name_only_the_tools_use(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The load-balancer tool says "alb"; the index says "apploadbalancer"."""
+
+        def _never(*_a: object, **_k: object) -> None:
+            raise AssertionError("no request should be made")
+
+        monkeypatch.setattr("integrations.yandex_cloud.rest_client.send_request", _never)
+        result = execute_yc_operation(
+            service="alb",
+            path="/apploadbalancer/v1/notARealCollection",
+            **_CREDENTIALS,
+        )
+
+        assert result["success"] is False
+        assert "not a documented read" in result["error"]
+
     def test_a_concrete_resource_path_is_sent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: list[str] = []
 


### PR DESCRIPTION
Part of #4605

#### Describe the changes you have made in this PR -

Follow-ups found while verifying the merged Yandex Cloud integration (#4990)
against a real folder. None changes what the tools read; each closes a gap
between what we promise and what actually happens.

**The `yc`-command guidance never reached the model.** SKILL.md is 11893
characters and the registry attaches 2400, and that paragraph sat past the cut.
So `docs/yandex-cloud.mdx` promised "it reports the exact `yc` command for you to
run" while a live investigation ended with prose advice - "resize the VM" rather
than the command. Moved next to the rule it belongs with (do not *run* `yc`, do
*write it out*), which puts it inside the slice. The paragraph that stops the
agent hunting for Kubernetes pods in the Yandex Cloud API is still in there too.

**Two service names did not line up, each in a different direction.**

- The load-balancer tool says `alb`; the index, built from the protos, says
  `apploadbalancer`. `execute_yc_operation` only refuses a path when it
  recognises the service, so ALB paths passed the index gate as "unknown" rather
  than being checked against the allowlist. Fixed with an index-name alias.
- The index emits `storage` for the Object Storage control plane, but the
  endpoint registry gives that name to the S3 data plane, which serves objects
  and answers no control-plane read; the control plane is registered as
  `storage-api`. Fixed with a host-name alias applied at resolve time - editing
  the registry snapshot does not hold, because it is refreshed from Yandex at
  runtime and the upstream value comes straight back. There is a test for that
  specifically.

**`test_a_folder_without_a_credential_is_not_loaded` was green in CI and red in
reality.** It clears the IAM token and the key file but not `YC_USE_METADATA`,
which `setup` writes to `.env` - so on any machine where the integration is
actually configured, the folder does have a credential after all and the
assertion fails. One `monkeypatch.delenv`.

**The index generator now reports what it dropped.** It discarded bindings
silently, which is the mechanism that once hid 34 endpoints behind a naming
mismatch and made them look, from the outside, like Yandex not offering an API.
It now prints how many were dropped as mutating, how many had no registry host,
and which packages those were.

**Docs.** Audit Trails is in the index, so trails and their settings are readable
now - only the events are not, because Yandex delivers them to a sink rather than
through the API; the old wording said the whole thing was pending. And the
troubleshooting section now covers the index gate a user meets if they type a
path instead of asking `find_yc_api` for one.

### Demo/Screenshot for feature changes and bug fixes -

Four of these are invisible by eye - a paragraph past a prompt cut, a service
name, an env var a test forgets to clear - so here is both sides of each.

https://github.com/user-attachments/assets/41f6a4df-f851-4699-9820-24ba463af6a5

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

These all came out of running the merged integration against a real folder rather
than reading the diff again. That matters for two of them: the truncated guidance
and the ALB alias only show up when you look at what the model actually receives
and what the gate actually checks, and both are green in every test.

Two of the fixes had an obvious version that was wrong, and I went with the
second one.

For Object Storage the obvious fix is to correct the entry in the endpoint
registry snapshot. I did that first, and the check still resolved to the old
host: `resolve_endpoint` refreshes from Yandex at runtime, so the upstream value
overwrites the snapshot. The fix has to sit at resolve time to survive, and the
test feeds the registry Yandex's own mapping to prove it does.

For the two aliases the obvious move is one table. That breaks the other way:
`alb -> apploadbalancer` is about the name *the index* knows, while
`storage -> storage-api` is about the name *the registry* knows. Putting storage
in the index table made `lookup("storage", ...)` stop matching, because the index
really does call it `storage`. They are two different mappings and live in two
different places.

The generator change is deliberately a print rather than an exception. Dropping a
binding is usually correct - a mutating verb, or a service with no published host
- and failing the build on it would be wrong. What was wrong is doing it in
silence, since that is exactly how the earlier 34-endpoint gap stayed invisible.

Edge cases covered by tests: the canonical service name still resolves alongside
the alias, an unknown service stays unknown so the gate does not become
permissive, and the storage alias holds after a registry refresh.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
