### PR TITLE
feat(mysql): add evidence mappers for all 5 mysql investigation tools

### DIFF
--- a/integrations/mysql/tools/mysql_current_processes_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_current_processes_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,27 @@ from integrations.mysql import (
     mysql_is_available,
     resolve_mysql_config,
 )
+
+
+def _map_get_mysql_current_processes(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the count of long-running processes above the threshold."""
+    if not output.get("available"):
+        return
+    processes = output.get("processes") or []
+    if not processes:
+        return
+    longest = max((p.get("time_seconds", 0) for p in processes), default=0)
+    record_evidence_entry(
+        evidence,
+        source="get_mysql_current_processes",
+        label="MySQL Current Processes",
+        summary=(
+            f"{output.get('total_processes', len(processes))} process(es) over "
+            f"{output.get('threshold_seconds', 0)}s, longest running {longest}s"
+        ),
+    )
 
 
 @tool(
@@ -29,6 +51,7 @@ from integrations.mysql import (
     is_available=mysql_is_available,
     injected_params=("host",),
     extract_params=mysql_extract_params,
+    evidence_mapper=_map_get_mysql_current_processes,
 )
 def get_mysql_current_processes(
     host: str,

--- a/integrations/mysql/tools/mysql_replication_status_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_replication_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,53 @@ from integrations.mysql import (
     mysql_is_available,
     resolve_mysql_config,
 )
+
+
+def _replica_thread_status(replica: dict[str, Any], key_new: str, key_old: str) -> str | None:
+    """Read a thread-status field, accepting either the 8.0.22+ or legacy column name."""
+    return replica.get(key_new, replica.get(key_old))
+
+
+def _map_get_mysql_replication_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite replica thread health and lag, or that this server isn't a replica."""
+    if not output.get("available"):
+        return
+    replicas = output.get("replicas") or []
+    if not replicas:
+        note = output.get("note")
+        if note:
+            record_evidence_entry(
+                evidence,
+                source="get_mysql_replication_status",
+                label="MySQL Replication Status",
+                summary=note,
+            )
+        return
+    stalled = [
+        r
+        for r in replicas
+        if _replica_thread_status(r, "Replica_IO_Running", "Slave_IO_Running") != "Yes"
+        or _replica_thread_status(r, "Replica_SQL_Running", "Slave_SQL_Running") != "Yes"
+    ]
+    lag_values = [
+        lag
+        for r in replicas
+        if (lag := _replica_thread_status(r, "Seconds_Behind_Source", "Seconds_Behind_Master"))
+        is not None
+    ]
+    parts = [f"{len(replicas)} replica(s)"]
+    if stalled:
+        parts.append(f"{len(stalled)} with a stopped IO/SQL thread")
+    if lag_values:
+        parts.append(f"max lag {max(lag_values)}s")
+    record_evidence_entry(
+        evidence,
+        source="get_mysql_replication_status",
+        label="MySQL Replication Status",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -26,6 +74,7 @@ from integrations.mysql import (
     is_available=mysql_is_available,
     injected_params=("host",),
     extract_params=mysql_extract_params,
+    evidence_mapper=_map_get_mysql_replication_status,
 )
 def get_mysql_replication_status(
     host: str,

--- a/integrations/mysql/tools/mysql_server_status_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_server_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,29 @@ from integrations.mysql import (
     mysql_is_available,
     resolve_mysql_config,
 )
+
+
+def _map_get_mysql_server_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite version, connection load, and InnoDB deadlock count."""
+    if not output.get("available"):
+        return
+    connections = output.get("connections") or {}
+    innodb = output.get("innodb") or {}
+    parts = [
+        f"MySQL {output.get('version', 'unknown')}",
+        f"{connections.get('current', 0)}/{connections.get('max', 0)} connections",
+    ]
+    deadlocks = innodb.get("deadlocks", 0)
+    if deadlocks:
+        parts.append(f"{deadlocks} InnoDB deadlock(s)")
+    record_evidence_entry(
+        evidence,
+        source="get_mysql_server_status",
+        label="MySQL Server Status",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -26,6 +50,7 @@ from integrations.mysql import (
     is_available=mysql_is_available,
     injected_params=("host",),
     extract_params=mysql_extract_params,
+    evidence_mapper=_map_get_mysql_server_status,
 )
 def get_mysql_server_status(
     host: str,

--- a/integrations/mysql/tools/mysql_slow_queries_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_slow_queries_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,36 @@ from integrations.mysql import (
     mysql_is_available,
     resolve_mysql_config,
 )
+
+
+def _map_get_mysql_slow_queries(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the slow-query count and worst offender, or why none could be collected."""
+    if not output.get("available"):
+        return
+    if not output.get("performance_schema_available", True):
+        record_evidence_entry(
+            evidence,
+            source="get_mysql_slow_queries",
+            label="MySQL Slow Queries",
+            summary=output.get("note", "performance_schema is disabled."),
+        )
+        return
+    queries = output.get("queries") or []
+    if not queries:
+        return
+    # Rows are pre-sorted by AVG_TIMER_WAIT DESC, so queries[0] is the slowest.
+    slowest = queries[0]
+    record_evidence_entry(
+        evidence,
+        source="get_mysql_slow_queries",
+        label="MySQL Slow Queries",
+        summary=(
+            f"{output.get('total_queries', len(queries))} quer{'y' if len(queries) == 1 else 'ies'} "
+            f"above {output.get('threshold_ms', 0)}ms, slowest avg {slowest.get('avg_time_ms', 0)}ms"
+        ),
+    )
 
 
 @tool(
@@ -26,6 +57,7 @@ from integrations.mysql import (
     is_available=mysql_is_available,
     injected_params=("host",),
     extract_params=mysql_extract_params,
+    evidence_mapper=_map_get_mysql_slow_queries,
 )
 def get_mysql_slow_queries(
     host: str,

--- a/integrations/mysql/tools/mysql_table_stats_tool/__init__.py
+++ b/integrations/mysql/tools/mysql_table_stats_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,29 @@ from integrations.mysql import (
     mysql_is_available,
     resolve_mysql_config,
 )
+
+
+def _map_get_mysql_table_stats(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the table count and the single largest table by total size."""
+    if not output.get("available"):
+        return
+    tables = output.get("tables") or []
+    if not tables:
+        return
+    # Rows are pre-sorted by (DATA_LENGTH + INDEX_LENGTH) DESC, so tables[0] is the largest.
+    largest = tables[0]
+    largest_mb = (largest.get("size") or {}).get("total_mb", 0)
+    record_evidence_entry(
+        evidence,
+        source="get_mysql_table_stats",
+        label="MySQL Table Stats",
+        summary=(
+            f"{output.get('total_tables', len(tables))} table(s) in '{output.get('database', '')}', "
+            f"largest '{largest.get('table_name', '')}' at {largest_mb}MB"
+        ),
+    )
 
 
 @tool(
@@ -26,6 +50,7 @@ from integrations.mysql import (
     is_available=mysql_is_available,
     injected_params=("host",),
     extract_params=mysql_extract_params,
+    evidence_mapper=_map_get_mysql_table_stats,
 )
 def get_mysql_table_stats(
     host: str,

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -103,11 +103,6 @@ get_mongodb_current_ops
 get_mongodb_profiler_data
 get_mongodb_replica_status
 get_mongodb_server_status
-get_mysql_current_processes
-get_mysql_replication_status
-get_mysql_server_status
-get_mysql_slow_queries
-get_mysql_table_stats
 get_openclaw_conversation
 get_pods_on_node
 get_postgresql_current_queries

--- a/tests/tools/test_mysql_current_processes_tool.py
+++ b/tests/tools/test_mysql_current_processes_tool.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
-from integrations.mysql.tools.mysql_current_processes_tool import get_mysql_current_processes
+from integrations.mysql.tools.mysql_current_processes_tool import (
+    _map_get_mysql_current_processes,
+    get_mysql_current_processes,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -89,3 +92,45 @@ def test_no_default_db_warning_when_database_provided() -> None:
     ):
         result = get_mysql_current_processes(host="localhost", database="mydb")
     assert "default_db_warning" not in result
+
+
+class TestMapGetMysqlCurrentProcesses:
+    def test_records_entry_with_longest_running(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_current_processes(
+            evidence,
+            {
+                "available": True,
+                "threshold_seconds": 2,
+                "total_processes": 2,
+                "processes": [
+                    {"id": 42, "time_seconds": 15},
+                    {"id": 43, "time_seconds": 30},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mysql_current_processes"
+        assert entries[0]["summary"] == "2 process(es) over 2s, longest running 30s"
+
+    def test_records_nothing_when_no_processes(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_current_processes(
+            evidence, {"available": True, "threshold_seconds": 1, "processes": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_current_processes(
+            evidence, {"available": False, "error": "access denied"}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mysql_replication_status_tool.py
+++ b/tests/tools/test_mysql_replication_status_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mysql.tools.mysql_replication_status_tool import get_mysql_replication_status
+from integrations.mysql.tools.mysql_replication_status_tool import (
+    _map_get_mysql_replication_status,
+    get_mysql_replication_status,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -65,3 +69,75 @@ def test_run_error_propagated() -> None:
         result = get_mysql_replication_status(host="invalid", database="testdb")
     assert "error" in result
     assert result["available"] is False
+
+
+class TestMapGetMysqlReplicationStatus:
+    def test_records_entry_with_stalled_thread_and_lag(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_replication_status(
+            evidence,
+            {
+                "available": True,
+                "replica_count": 1,
+                "replicas": [
+                    {
+                        "Replica_IO_Running": "No",
+                        "Replica_SQL_Running": "Yes",
+                        "Seconds_Behind_Source": 120,
+                    }
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mysql_replication_status"
+        assert entries[0]["summary"] == "1 replica(s), 1 with a stopped IO/SQL thread, max lag 120s"
+
+    def test_records_entry_healthy_replica_without_clauses(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_replication_status(
+            evidence,
+            {
+                "available": True,
+                "replica_count": 1,
+                "replicas": [
+                    {
+                        "Replica_IO_Running": "Yes",
+                        "Replica_SQL_Running": "Yes",
+                        "Seconds_Behind_Source": 0,
+                    }
+                ],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "1 replica(s), max lag 0s"
+
+    def test_records_note_when_not_a_replica(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_replication_status(
+            evidence,
+            {
+                "available": True,
+                "note": "This server is not configured as a replica.",
+                "replicas": [],
+            },
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"]
+            == "This server is not configured as a replica."
+        )
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_replication_status(evidence, {"available": False, "error": "timeout"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mysql_server_status_tool.py
+++ b/tests/tools/test_mysql_server_status_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mysql.tools.mysql_server_status_tool import get_mysql_server_status
+from integrations.mysql.tools.mysql_server_status_tool import (
+    _map_get_mysql_server_status,
+    get_mysql_server_status,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -60,3 +64,47 @@ def test_run_error_propagated() -> None:
         result = get_mysql_server_status(host="invalid", database="testdb")
     assert "error" in result
     assert result["available"] is False
+
+
+class TestMapGetMysqlServerStatus:
+    def test_records_entry_with_deadlocks(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_server_status(
+            evidence,
+            {
+                "available": True,
+                "version": "8.0.32",
+                "connections": {"current": 25, "max": 151},
+                "innodb": {"deadlocks": 3},
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mysql_server_status"
+        assert entries[0]["summary"] == "MySQL 8.0.32, 25/151 connections, 3 InnoDB deadlock(s)"
+
+    def test_records_entry_without_deadlock_clause_when_zero(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_server_status(
+            evidence,
+            {
+                "available": True,
+                "version": "8.0.32",
+                "connections": {"current": 5, "max": 151},
+                "innodb": {"deadlocks": 0},
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "MySQL 8.0.32, 5/151 connections"
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_server_status(evidence, {"available": False, "error": "timeout"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mysql_slow_queries_tool.py
+++ b/tests/tools/test_mysql_slow_queries_tool.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
-from integrations.mysql.tools.mysql_slow_queries_tool import get_mysql_slow_queries
+from integrations.mysql.tools.mysql_slow_queries_tool import (
+    _map_get_mysql_slow_queries,
+    get_mysql_slow_queries,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -89,3 +92,65 @@ def test_run_error_propagated() -> None:
         result = get_mysql_slow_queries(host="localhost", database="invalid_db")
     assert "error" in result
     assert result["available"] is False
+
+
+class TestMapGetMysqlSlowQueries:
+    def test_records_entry_with_slowest_query(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_slow_queries(
+            evidence,
+            {
+                "available": True,
+                "performance_schema_available": True,
+                "threshold_ms": 500.0,
+                "total_queries": 2,
+                "queries": [
+                    {"digest_text": "SELECT * FROM orders", "avg_time_ms": 850.1},
+                    {"digest_text": "UPDATE inventory", "avg_time_ms": 620.5},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mysql_slow_queries"
+        assert entries[0]["summary"] == "2 queries above 500.0ms, slowest avg 850.1ms"
+
+    def test_records_note_when_performance_schema_disabled(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_slow_queries(
+            evidence,
+            {
+                "available": True,
+                "performance_schema_available": False,
+                "note": "performance_schema is disabled. Enable it in my.cnf to collect slow query data.",
+                "queries": [],
+            },
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"]
+            == "performance_schema is disabled. Enable it in my.cnf to collect slow query data."
+        )
+
+    def test_records_nothing_when_no_slow_queries_found(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_slow_queries(
+            evidence,
+            {"available": True, "performance_schema_available": True, "queries": []},
+            {},
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_slow_queries(evidence, {"available": False, "error": "timeout"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mysql_table_stats_tool.py
+++ b/tests/tools/test_mysql_table_stats_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mysql.tools.mysql_table_stats_tool import get_mysql_table_stats
+from integrations.mysql.tools.mysql_table_stats_tool import (
+    _map_get_mysql_table_stats,
+    get_mysql_table_stats,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -76,3 +80,45 @@ def test_run_error_propagated() -> None:
         result = get_mysql_table_stats(host="localhost", database="invalid_db")
     assert "error" in result
     assert result["available"] is False
+
+
+class TestMapGetMysqlTableStats:
+    def test_records_entry_with_largest_table(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_table_stats(
+            evidence,
+            {
+                "available": True,
+                "database": "application_db",
+                "total_tables": 2,
+                "tables": [
+                    {"table_name": "orders", "size": {"total_mb": 640.0}},
+                    {"table_name": "users", "size": {"total_mb": 10.5}},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mysql_table_stats"
+        assert (
+            entries[0]["summary"] == "2 table(s) in 'application_db', largest 'orders' at 640.0MB"
+        )
+
+    def test_records_nothing_when_no_tables(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_table_stats(
+            evidence, {"available": True, "database": "empty_db", "tables": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mysql_table_stats(evidence, {"available": False, "error": "unknown database"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5549

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all 5 MySQL investigation tools to `record_evidence_entry` so their
output stops being silently dropped and becomes a citeable line in the
investigation report.

- `_map_get_mysql_server_status`
  (`integrations/mysql/tools/mysql_server_status_tool/__init__.py`): cites
  version, current/max connection load, and InnoDB deadlock count when any
  are present.
- `_map_get_mysql_current_processes`
  (`integrations/mysql/tools/mysql_current_processes_tool/__init__.py`):
  cites the count of long-running processes above the threshold and the
  longest running time.
- `_map_get_mysql_slow_queries`
  (`integrations/mysql/tools/mysql_slow_queries_tool/__init__.py`): cites
  the slow-query count and the slowest offender's average time (rows are
  pre-sorted by `AVG_TIMER_WAIT DESC`), or the diagnostic note when
  `performance_schema` is disabled (that's actionable information, distinct
  from "nothing to report").
- `_map_get_mysql_replication_status`
  (`integrations/mysql/tools/mysql_replication_status_tool/__init__.py`):
  cites replica count, flags any replica with a stopped IO/SQL thread, and
  reports max lag — or the "not configured as a replica" note when the
  server isn't a replica.
- `_map_get_mysql_table_stats`
  (`integrations/mysql/tools/mysql_table_stats_tool/__init__.py`): cites the
  table count and the single largest table by total size (rows are
  pre-sorted by `DATA_LENGTH + INDEX_LENGTH DESC`).

All 5 are read-only diagnostic queries — none is an action/notification
tool, so all are in scope per the issue.

Every mapper records nothing when `available` is falsy, or when its list
field is empty with no accompanying `note` — a genuinely empty result has
nothing worth citing, while a `note` explaining *why* a list is empty (no
replica configured, `performance_schema` disabled) is real diagnostic
signal and is cited instead.

Removed all 5 tool names from `evidence_mapper_baseline.txt` now that they
carry a mapper.

**A note on existing tool tests:** `tests/tools/test_mysql_replication_status_tool.py`,
`test_mysql_slow_queries_tool.py`, `test_mysql_current_processes_tool.py`,
and `test_mysql_table_stats_tool.py` had pre-existing `test_run_*` fixtures
using field names that don't match the real client functions in
`integrations/mysql/__init__.py` (e.g. `is_replica`/`replica_io_running`
instead of the actual `replica_count`/`replicas: [{"Replica_IO_Running": ...}]`
shape; `digest`/`calls` instead of `digest_text`/`count`; flat `total_mb`
instead of nested `size: {"total_mb": ...}`). Per this project's convention
of grounding mappers in the actual client code, I wrote all mapper tests
against the real shapes read directly from `integrations/mysql/__init__.py`
(`get_server_status`, `get_current_processes`, `get_replication_status`,
`get_slow_queries`, `get_table_stats`) rather than reusing the stale
fixtures. I left the existing (pre-existing, out-of-scope) `test_run_*`
tests untouched since fixing them isn't part of this issue — flagging here
in case it's worth a follow-up.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in [
  'get_mysql_server_status', 'get_mysql_current_processes',
  'get_mysql_slow_queries', 'get_mysql_replication_status',
  'get_mysql_table_stats']})"
{'get_mysql_server_status': True, 'get_mysql_current_processes': True,
 'get_mysql_slow_queries': True, 'get_mysql_replication_status': True,
 'get_mysql_table_stats': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each function's
return shape in `integrations/mysql/__init__.py`:**
```
get_mysql_server_status:        'MySQL 8.0.32, 25/151 connections, 3 InnoDB deadlock(s)'
get_mysql_current_processes:    '2 process(es) over 2s, longest running 30s'
get_mysql_slow_queries:         '2 queries above 500.0ms, slowest avg 850.1ms'
get_mysql_replication_status:   '1 replica(s), 1 with a stopped IO/SQL thread, max lag 120s'
get_mysql_table_stats:          "2 table(s) in 'application_db', largest 'orders' at 640.0MB"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/ -k mysql -q
118 passed, 2 skipped (pre-existing, unrelated to this change)

$ make lint && make format-check && make typecheck
All checks passed! / 3631 files already formatted / Success: no issues found in 1893 source files
```

**No live MySQL instance available in this environment**, so leaving that
box unticked per the issue's own guidance. The checks above stand as
evidence the mappers are attached and produce real report entries from
realistic sample payloads matching the actual client functions' return
shapes; a reviewer with a MySQL instance (or the `tests/e2e/mysql/` mocked
suite) can finish the live check.

## Behaviour comparison (required)

**1–2. Before/after**, run with realistic samples matching each function's
actual return shape (via `merge_tool_evidence`):

Before: `evidence` has no `catalog_entries` key for any of the 5 tools.

After, each adds exactly one new `catalog_entries` list item, e.g. for
`get_mysql_replication_status`:
```diff
+  "catalog_entries": [
+    {
+      "source": "get_mysql_replication_status",
+      "label": "MySQL Replication Status",
+      "summary": "1 replica(s), 1 with a stopped IO/SQL thread, max lag 120s",
+      "url": null,
+      "snippet": null
+    }
+  ]
```
(and analogously for the other 4 — one new entry each, nothing else in
`evidence` changes.)

**3. Explain every difference:** each diff adds exactly one new
`catalog_entries` list item per tool — nothing else in `evidence` changes.

**4. Answers:**

- **What the reader gains.** Server load and deadlock counts, a long-running
  process count with the worst offender's duration, the slowest query's
  average time (or why no slow-query data could be collected), replica
  thread health and lag (or that the server isn't a replica), and the
  single largest table by size — all previously invisible in the report
  even though the agent already paid to fetch them.
- **How much context it costs.** 156–182 characters (JSON-serialized) per
  entry — single-line summaries, no inlined per-process/per-query/per-table
  lists.
- **What happens on an empty or error result.** Verified directly in the
  new tests: `available: False` for all 5; an empty `processes`/`queries`/
  `tables` list with `performance_schema_available` true (slow queries) or
  no note attached; all produce zero `catalog_entries`.
- **Whether anything is now recorded twice.** No. These are the only 5
  MySQL tools in the codebase (confirmed via the baseline gaps file, which
  listed exactly these 5 for `mysql` and nothing else), and no other mapper
  reads any of their output.
- **Whether an existing report changed shape.** `tests/ -k mysql` (118
  tests, 2 pre-existing skips unrelated to this change) and the full
  evidence-mapper coverage suite (11 tests) pass unchanged.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Two of the five tools (`slow_queries`, `replication_status`) return a
"note" field explaining *why* their list is empty (performance_schema
disabled; server isn't a replica), rather than an error or a plain empty
result. I treated that note as citeable evidence in its own right — it
answers a real question the agent or reader would otherwise have to dig
for in the tool-call transcript — while a genuinely empty list with no
note (no slow queries found, no long-running processes) still records
nothing, matching the project's "no noise" convention. For replication
status, I read the actual column names the client selects
(`Replica_IO_Running`/`Slave_IO_Running`, etc. — MySQL renamed these in
8.0.22+ and the client tries the new statement first with a fallback), so
`_replica_thread_status` accepts either name rather than assuming one
MySQL version. For slow queries and table stats, I relied on the client's
existing `ORDER BY ... DESC` sort rather than re-scanning for the
worst/largest, since the query already guarantees `queries[0]` /
`tables[0]` is correct.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
