### PR TITLE
feat(mariadb): add evidence mappers for all 5 mariadb investigation tools

### DIFF
--- a/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,6 +14,26 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_innodb_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite that InnoDB status was captured, flagging a recorded deadlock section."""
+    if not output.get("available"):
+        return
+    status_text = output.get("innodb_status") or ""
+    if not status_text:
+        return
+    summary = "InnoDB engine status captured"
+    if "LATEST DETECTED DEADLOCK" in status_text:
+        summary += " — includes a recorded deadlock"
+    record_evidence_entry(
+        evidence,
+        source="get_mariadb_innodb_status",
+        label="MariaDB InnoDB Status",
+        summary=summary,
+    )
+
+
 @tool(
     name="get_mariadb_innodb_status",
     description="Retrieve InnoDB engine internals including deadlocks, buffer pool state, and I/O activity from SHOW ENGINE INNODB STATUS.",
@@ -21,6 +42,7 @@ from integrations.mariadb import (
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
+    evidence_mapper=_map_get_mariadb_innodb_status,
 )
 def get_mariadb_innodb_status(
     host: str,

--- a/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,27 @@ from integrations.mariadb import (
     mariadb_extract_params,
     mariadb_is_available,
 )
+
+
+def _map_get_mariadb_process_list(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the active process count and the longest-running query."""
+    if not output.get("available"):
+        return
+    processes = output.get("processes") or []
+    if not processes:
+        return
+    longest = max((p.get("time_secs", 0) for p in processes), default=0)
+    record_evidence_entry(
+        evidence,
+        source="get_mariadb_process_list",
+        label="MariaDB Process List",
+        summary=(
+            f"{output.get('total_processes', len(processes))} active process(es), "
+            f"longest running {longest}s"
+        ),
+    )
 
 
 @tool(
@@ -24,6 +46,7 @@ from integrations.mariadb import (
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
+    evidence_mapper=_map_get_mariadb_process_list,
 )
 def get_mariadb_process_list(
     host: str,

--- a/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_process_list_tool/__init__.py
@@ -17,7 +17,14 @@ from integrations.mariadb import (
 def _map_get_mariadb_process_list(
     evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
 ) -> None:
-    """Cite the active process count and the longest-running query."""
+    """Cite the returned process count and the longest-running query.
+
+    ``get_process_list`` applies its ``LIMIT`` in SQL itself, so
+    ``total_processes`` is always exactly ``len(processes)`` -- there is no
+    separate unbounded count. Say "shown" rather than implying this is every
+    active process on the server, since a busy server can have more active
+    processes than the query's result cap.
+    """
     if not output.get("available"):
         return
     processes = output.get("processes") or []
@@ -29,7 +36,7 @@ def _map_get_mariadb_process_list(
         source="get_mariadb_process_list",
         label="MariaDB Process List",
         summary=(
-            f"{output.get('total_processes', len(processes))} active process(es), "
+            f"{output.get('total_processes', len(processes))} active process(es) shown, "
             f"longest running {longest}s"
         ),
     )

--- a/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_replication_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,6 +14,44 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_replication_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite replication channel health and lag, or that this server isn't a replica."""
+    if not output.get("available"):
+        return
+    channels = output.get("channels") or []
+    if not channels:
+        note = output.get("note")
+        if note:
+            record_evidence_entry(
+                evidence,
+                source="get_mariadb_replication_status",
+                label="MariaDB Replication Status",
+                summary=note,
+            )
+        return
+    stalled = [
+        c
+        for c in channels
+        if c.get("Slave_IO_Running") != "Yes" or c.get("Slave_SQL_Running") != "Yes"
+    ]
+    lag_values = [
+        c["Seconds_Behind_Master"] for c in channels if c.get("Seconds_Behind_Master") is not None
+    ]
+    parts = [f"{len(channels)} channel(s)"]
+    if stalled:
+        parts.append(f"{len(stalled)} with a stopped IO/SQL thread")
+    if lag_values:
+        parts.append(f"max lag {max(lag_values)}s")
+    record_evidence_entry(
+        evidence,
+        source="get_mariadb_replication_status",
+        label="MariaDB Replication Status",
+        summary=", ".join(parts),
+    )
+
+
 @tool(
     name="get_mariadb_replication_status",
     description="Retrieve MariaDB replication status including I/O and SQL thread state, lag, and errors from SHOW ALL SLAVES STATUS.",
@@ -21,6 +60,7 @@ from integrations.mariadb import (
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
+    evidence_mapper=_map_get_mariadb_replication_status,
 )
 def get_mariadb_replication_status(
     host: str,

--- a/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,6 +14,36 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_slow_queries(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the slowest query, or why none could be collected."""
+    if not output.get("available"):
+        return
+    queries = output.get("queries") or []
+    if not queries:
+        note = output.get("note")
+        if note:
+            record_evidence_entry(
+                evidence,
+                source="get_mariadb_slow_queries",
+                label="MariaDB Slow Queries",
+                summary=note,
+            )
+        return
+    # Rows are pre-sorted by AVG_TIMER_WAIT DESC, so queries[0] is the slowest.
+    slowest = queries[0]
+    record_evidence_entry(
+        evidence,
+        source="get_mariadb_slow_queries",
+        label="MariaDB Slow Queries",
+        summary=(
+            f"{output.get('total_queries', len(queries))} quer{'y' if len(queries) == 1 else 'ies'} "
+            f"surveyed, slowest avg {slowest.get('avg_time_ms', 0)}ms"
+        ),
+    )
+
+
 @tool(
     name="get_mariadb_slow_queries",
     description="Retrieve top MariaDB queries by average execution time from performance_schema.events_statements_summary_by_digest.",
@@ -21,6 +52,7 @@ from integrations.mariadb import (
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
+    evidence_mapper=_map_get_mariadb_slow_queries,
 )
 def get_mariadb_slow_queries(
     host: str,

--- a/integrations/mariadb/tools/mariadb_status_tool/__init__.py
+++ b/integrations/mariadb/tools/mariadb_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -13,6 +14,33 @@ from integrations.mariadb import (
 )
 
 
+def _map_get_mariadb_global_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite uptime, connected threads, and InnoDB deadlock count."""
+    if not output.get("available"):
+        return
+    metrics = output.get("metrics") or {}
+    if not metrics:
+        return
+    parts = []
+    if (uptime := metrics.get("Uptime")) is not None:
+        parts.append(f"uptime {uptime}s")
+    if (connected := metrics.get("Threads_connected")) is not None:
+        parts.append(f"{connected} thread(s) connected")
+    deadlocks = int(metrics.get("Innodb_deadlocks") or 0)
+    if deadlocks:
+        parts.append(f"{deadlocks} InnoDB deadlock(s)")
+    if not parts:
+        return
+    record_evidence_entry(
+        evidence,
+        source="get_mariadb_global_status",
+        label="MariaDB Global Status",
+        summary=", ".join(parts),
+    )
+
+
 @tool(
     name="get_mariadb_global_status",
     description="Retrieve key MariaDB server metrics including connections, threads, slow queries, InnoDB buffer pool stats, and uptime from SHOW GLOBAL STATUS.",
@@ -21,6 +49,7 @@ from integrations.mariadb import (
     is_available=mariadb_is_available,
     injected_params=("host", "password", "username"),
     extract_params=mariadb_extract_params,
+    evidence_mapper=_map_get_mariadb_global_status,
 )
 def get_mariadb_global_status(
     host: str,

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -88,11 +88,6 @@ get_kafka_topic_health
 get_lambda_configuration
 get_lambda_errors
 get_lambda_invocation_logs
-get_mariadb_global_status
-get_mariadb_innodb_status
-get_mariadb_process_list
-get_mariadb_replication_status
-get_mariadb_slow_queries
 get_mongodb_atlas_alerts
 get_mongodb_atlas_cluster_events
 get_mongodb_atlas_cluster_metrics

--- a/tests/tools/test_mariadb_innodb_status_tool.py
+++ b/tests/tools/test_mariadb_innodb_status_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mariadb.tools.mariadb_innodb_status_tool import get_mariadb_innodb_status
+from integrations.mariadb.tools.mariadb_innodb_status_tool import (
+    _map_get_mariadb_innodb_status,
+    get_mariadb_innodb_status,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -41,3 +45,51 @@ def test_run_error_propagated() -> None:
     ):
         result = get_mariadb_innodb_status(host="invalid", database="test", username="user")
     assert "error" in result
+
+
+class TestMapGetMariadbInnodbStatus:
+    def test_records_entry_flagging_deadlock_section(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_innodb_status(
+            evidence,
+            {
+                "available": True,
+                "innodb_status": "...\nLATEST DETECTED DEADLOCK\n...",
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mariadb_innodb_status"
+        assert (
+            entries[0]["summary"] == "InnoDB engine status captured — includes a recorded deadlock"
+        )
+
+    def test_records_entry_without_deadlock_clause(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_innodb_status(
+            evidence,
+            {"available": True, "innodb_status": "BUFFER POOL AND MEMORY\n..."},
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "InnoDB engine status captured"
+
+    def test_records_nothing_when_status_text_empty(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_innodb_status(evidence, {"available": True, "innodb_status": ""}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_innodb_status(
+            evidence, {"available": False, "error": "connection timeout"}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mariadb_process_list_tool.py
+++ b/tests/tools/test_mariadb_process_list_tool.py
@@ -87,7 +87,7 @@ class TestMapGetMariadbProcessList:
         entries = evidence["catalog_entries"]
         assert len(entries) == 1
         assert entries[0]["source"] == "get_mariadb_process_list"
-        assert entries[0]["summary"] == "2 active process(es), longest running 40s"
+        assert entries[0]["summary"] == "2 active process(es) shown, longest running 40s"
 
     def test_records_nothing_when_no_processes(self) -> None:
         evidence: dict[str, Any] = {}

--- a/tests/tools/test_mariadb_process_list_tool.py
+++ b/tests/tools/test_mariadb_process_list_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mariadb.tools.mariadb_process_list_tool import get_mariadb_process_list
+from integrations.mariadb.tools.mariadb_process_list_tool import (
+    _map_get_mariadb_process_list,
+    get_mariadb_process_list,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -61,3 +65,42 @@ def test_no_default_db_warning_when_database_provided() -> None:
     ):
         result = get_mariadb_process_list(host="localhost", username="user", database="mydb")
     assert "default_db_warning" not in result
+
+
+class TestMapGetMariadbProcessList:
+    def test_records_entry_with_longest_running(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_process_list(
+            evidence,
+            {
+                "available": True,
+                "total_processes": 2,
+                "processes": [
+                    {"id": 1, "time_secs": 15},
+                    {"id": 2, "time_secs": 40},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mariadb_process_list"
+        assert entries[0]["summary"] == "2 active process(es), longest running 40s"
+
+    def test_records_nothing_when_no_processes(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_process_list(evidence, {"available": True, "processes": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_process_list(
+            evidence, {"available": False, "error": "connection timeout"}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mariadb_replication_tool.py
+++ b/tests/tools/test_mariadb_replication_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mariadb.tools.mariadb_replication_tool import get_mariadb_replication_status
+from integrations.mariadb.tools.mariadb_replication_tool import (
+    _map_get_mariadb_replication_status,
+    get_mariadb_replication_status,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -43,3 +47,75 @@ def test_run_error_propagated() -> None:
     ):
         result = get_mariadb_replication_status(host="invalid", database="test", username="user")
     assert "error" in result
+
+
+class TestMapGetMariadbReplicationStatus:
+    def test_records_entry_with_stalled_thread_and_lag(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_replication_status(
+            evidence,
+            {
+                "available": True,
+                "channels": [
+                    {
+                        "Slave_IO_Running": "No",
+                        "Slave_SQL_Running": "Yes",
+                        "Seconds_Behind_Master": 90,
+                    }
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mariadb_replication_status"
+        assert entries[0]["summary"] == "1 channel(s), 1 with a stopped IO/SQL thread, max lag 90s"
+
+    def test_records_entry_healthy_channel_without_clauses(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_replication_status(
+            evidence,
+            {
+                "available": True,
+                "channels": [
+                    {
+                        "Slave_IO_Running": "Yes",
+                        "Slave_SQL_Running": "Yes",
+                        "Seconds_Behind_Master": 0,
+                    }
+                ],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "1 channel(s), max lag 0s"
+
+    def test_records_note_when_not_a_replica(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_replication_status(
+            evidence,
+            {
+                "available": True,
+                "note": "This server is not configured as a replica.",
+                "channels": [],
+            },
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"]
+            == "This server is not configured as a replica."
+        )
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_replication_status(
+            evidence, {"available": False, "error": "connection timeout"}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mariadb_slow_queries_tool.py
+++ b/tests/tools/test_mariadb_slow_queries_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mariadb.tools.mariadb_slow_queries_tool import get_mariadb_slow_queries
+from integrations.mariadb.tools.mariadb_slow_queries_tool import (
+    _map_get_mariadb_slow_queries,
+    get_mariadb_slow_queries,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -42,3 +46,60 @@ def test_run_error_propagated() -> None:
     ):
         result = get_mariadb_slow_queries(host="invalid", database="test", username="user")
     assert "error" in result
+
+
+class TestMapGetMariadbSlowQueries:
+    def test_records_entry_with_slowest_query(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_slow_queries(
+            evidence,
+            {
+                "available": True,
+                "total_queries": 2,
+                "queries": [
+                    {"digest_text": "SELECT * FROM orders", "avg_time_ms": 90.5},
+                    {"digest_text": "UPDATE inventory", "avg_time_ms": 40.2},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mariadb_slow_queries"
+        assert entries[0]["summary"] == "2 queries surveyed, slowest avg 90.5ms"
+
+    def test_records_note_when_performance_schema_disabled(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_slow_queries(
+            evidence,
+            {
+                "available": True,
+                "note": "performance_schema is disabled. Enable it in my.cnf to collect slow query data.",
+                "queries": [],
+            },
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"]
+            == "performance_schema is disabled. Enable it in my.cnf to collect slow query data."
+        )
+
+    def test_records_nothing_when_no_slow_queries_found(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_slow_queries(evidence, {"available": True, "queries": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_slow_queries(
+            evidence, {"available": False, "error": "connection timeout"}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_mariadb_status_tool.py
+++ b/tests/tools/test_mariadb_status_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.mariadb.tools.mariadb_status_tool import get_mariadb_global_status
+from integrations.mariadb.tools.mariadb_status_tool import (
+    _map_get_mariadb_global_status,
+    get_mariadb_global_status,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -40,3 +44,62 @@ def test_run_error_propagated() -> None:
     ):
         result = get_mariadb_global_status(host="invalid", database="test", username="user")
     assert "error" in result
+
+
+class TestMapGetMariadbGlobalStatus:
+    def test_records_entry_with_deadlocks(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_global_status(
+            evidence,
+            {
+                "available": True,
+                "metrics": {
+                    "Threads_connected": "10",
+                    "Uptime": "86400",
+                    "Innodb_deadlocks": "2",
+                },
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_mariadb_global_status"
+        assert (
+            entries[0]["summary"] == "uptime 86400s, 10 thread(s) connected, 2 InnoDB deadlock(s)"
+        )
+
+    def test_records_entry_without_deadlock_clause_when_zero(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_global_status(
+            evidence,
+            {
+                "available": True,
+                "metrics": {
+                    "Threads_connected": "5",
+                    "Uptime": "3600",
+                    "Innodb_deadlocks": "0",
+                },
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "uptime 3600s, 5 thread(s) connected"
+
+    def test_records_nothing_when_no_metrics(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_global_status(evidence, {"available": True, "metrics": {}}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_mariadb_global_status(
+            evidence, {"available": False, "error": "connection timeout"}, {}
+        )
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5546

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all 5 MariaDB investigation tools to `record_evidence_entry` so their
output stops being silently dropped and becomes a citeable line in the
investigation report.

- `_map_get_mariadb_global_status`
  (`integrations/mariadb/tools/mariadb_status_tool/__init__.py`): cites
  uptime, connected threads, and InnoDB deadlock count when present. Unlike
  MySQL's version, MariaDB's `get_global_status` returns a flat `metrics`
  dict of raw `SHOW GLOBAL STATUS` string values (no nested
  `connections`/`innodb` structure), so the mapper reads keys directly.
- `_map_get_mariadb_process_list`
  (`integrations/mariadb/tools/mariadb_process_list_tool/__init__.py`):
  cites the active process count and the longest-running query's duration.
- `_map_get_mariadb_innodb_status`
  (`integrations/mariadb/tools/mariadb_innodb_status_tool/__init__.py`):
  this tool's output is a raw truncated `SHOW ENGINE INNODB STATUS` text
  blob, not structured data, so the mapper cites that the status was
  captured and scans the text for a `LATEST DETECTED DEADLOCK` section to
  flag a real deadlock finding.
- `_map_get_mariadb_slow_queries`
  (`integrations/mariadb/tools/mariadb_slow_queries_tool/__init__.py`):
  cites the surveyed query count and the slowest offender's average time
  (rows are pre-sorted by `AVG_TIMER_WAIT DESC`), or the diagnostic note
  when `performance_schema` is disabled — actionable information, distinct
  from "nothing to report."
- `_map_get_mariadb_replication_status`
  (`integrations/mariadb/tools/mariadb_replication_tool/__init__.py`): cites
  channel count, flags any channel with a stopped IO/SQL thread, and
  reports max lag — or the "not configured as a replica" note when the
  server isn't a replica.

All 5 are read-only diagnostic queries — none is an action/notification
tool, so all are in scope per the issue.

Every mapper records nothing when `available` is falsy, or when its data
field is empty with no accompanying `note`/explanatory text — a genuinely
empty result has nothing worth citing, while a `note` explaining *why* a
list is empty (no replica configured, `performance_schema` disabled) is
real diagnostic signal and is cited instead.

Removed all 5 tool names from `evidence_mapper_baseline.txt` now that they
carry a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in [
  'get_mariadb_global_status', 'get_mariadb_process_list',
  'get_mariadb_innodb_status', 'get_mariadb_slow_queries',
  'get_mariadb_replication_status']})"
{'get_mariadb_global_status': True, 'get_mariadb_process_list': True,
 'get_mariadb_innodb_status': True, 'get_mariadb_slow_queries': True,
 'get_mariadb_replication_status': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each function's
return shape in `integrations/mariadb/__init__.py`:**
```
get_mariadb_global_status:       'uptime 86400s, 10 thread(s) connected, 2 InnoDB deadlock(s)'
get_mariadb_process_list:        '2 active process(es), longest running 40s'
get_mariadb_innodb_status:       'InnoDB engine status captured — includes a recorded deadlock'
get_mariadb_slow_queries:        '2 queries surveyed, slowest avg 90.5ms'
get_mariadb_replication_status:  '1 channel(s), 1 with a stopped IO/SQL thread, max lag 90s'
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/ -k mariadb -q
183 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3631 files already formatted / Success: no issues found in 1893 source files
```

**No live MariaDB instance available in this environment**, so leaving that
box unticked per the issue's own guidance. The checks above stand as
evidence the mappers are attached and produce real report entries from
realistic sample payloads matching the actual client functions' return
shapes; a reviewer with a MariaDB instance can finish the live check.

## Behaviour comparison (required)

**1–2. Before/after**, run with realistic samples matching each function's
actual return shape (via `merge_tool_evidence`):

Before: `evidence` has no `catalog_entries` key for any of the 5 tools.

After, each adds exactly one new `catalog_entries` list item, e.g. for
`get_mariadb_innodb_status`:
```diff
+  "catalog_entries": [
+    {
+      "source": "get_mariadb_innodb_status",
+      "label": "MariaDB InnoDB Status",
+      "summary": "InnoDB engine status captured — includes a recorded deadlock",
+      "url": null,
+      "snippet": null
+    }
+  ]
```
(and analogously for the other 4 — one new entry each, nothing else in
`evidence` changes.)

**3. Explain every difference:** each diff adds exactly one new
`catalog_entries` list item per tool — nothing else in `evidence` changes.

**4. Answers:**

- **What the reader gains.** Uptime/connection load and deadlock counts, a
  long-running process count with the worst offender's duration, a flagged
  InnoDB deadlock section extracted from an otherwise-opaque status blob,
  the slowest query's average time (or why no slow-query data could be
  collected), and replication channel health and lag (or that the server
  isn't a replica) — all previously invisible in the report even though the
  agent already paid to fetch them.
- **How much context it costs.** 154–185 characters (JSON-serialized) per
  entry — single-line summaries, no inlined per-process/per-query/per-channel
  lists, and no attempt to cite the multi-KB raw InnoDB status text itself.
- **What happens on an empty or error result.** Verified directly in the new
  tests: `available: False` for all 5; empty `processes`/`queries`/
  `channels` lists with no note attached, and an empty `innodb_status`
  string, all produce zero `catalog_entries`.
- **Whether anything is now recorded twice.** No. These are the only 5
  MariaDB tools in the codebase (confirmed via the baseline gaps file,
  which listed exactly these 5 for `mariadb` and nothing else), and no
  other mapper reads any of their output.
- **Whether an existing report changed shape.** `tests/ -k mariadb` (183
  tests) and the full evidence-mapper coverage suite (11 tests) pass
  unchanged.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The InnoDB status tool was the one requiring a different approach from the
other four: `get_innodb_status` returns a single truncated free-text blob
from `SHOW ENGINE INNODB STATUS`, not structured rows, so there's no count
or numeric field to cite. Rather than skip it or dump the (multi-KB) text
into the report, I scan for the literal `LATEST DETECTED DEADLOCK` section
header InnoDB always emits when a deadlock occurred — a cheap, reliable
signal of a real finding without re-parsing the whole engine-status format.
For the two "explanatory empty" cases (`slow_queries`'s
`performance_schema` disabled, `replication_status`'s "not a replica"), I
treated the `note` field as citeable evidence in its own right, since it
answers a real question the agent would otherwise have to dig for in the
tool-call transcript — distinct from a genuinely empty list with no note,
which still records nothing per the project's "no noise" convention. I
confirmed MariaDB's `get_replication_status` only ever returns the legacy
`Slave_IO_Running`/`Slave_SQL_Running`/`Seconds_Behind_Master` column names
(no `Replica_*` variant, unlike MySQL 8.0.22+) by reading the client's own
`_KEYS` tuple, so the mapper doesn't need the dual-name fallback the MySQL
mapper does.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
