### PR TITLE
feat(opensearch): add evidence mapper for query_opensearch_analytics

### DIFF
--- a/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
+++ b/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
@@ -21,6 +22,26 @@ def _bounded_limit(limit: int, max_results: int) -> int:
 def _opensearch_available(sources: dict[str, dict[str, Any]]) -> bool:
     source = sources.get("opensearch", {})
     return bool(source.get("connection_verified") and source.get("url"))
+
+
+def _map_query_opensearch_analytics(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the number of log entries retrieved for the query."""
+    if not output.get("available"):
+        return
+    logs = output.get("logs") or []
+    if not logs:
+        return
+    record_evidence_entry(
+        evidence,
+        source="query_opensearch_analytics",
+        label="OpenSearch Analytics",
+        summary=(
+            f"{output.get('total_returned', len(logs))} log(s) for query "
+            f"'{output.get('query', '*')}' on '{output.get('index_pattern', '*')}'"
+        ),
+    )
 
 
 def _opensearch_extract_params(sources: dict[str, dict[str, Any]]) -> dict[str, Any]:
@@ -64,6 +85,7 @@ def _opensearch_extract_params(sources: dict[str, dict[str, Any]]) -> dict[str, 
     is_available=_opensearch_available,
     injected_params=("url",),
     extract_params=_opensearch_extract_params,
+    evidence_mapper=_map_query_opensearch_analytics,
 )
 def query_opensearch_analytics(
     url: str,

--- a/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
+++ b/integrations/opensearch/tools/opensearch_analytics_tool/__init__.py
@@ -8,10 +8,12 @@ from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from infrastructure.text.truncation import truncate
 from integrations.elasticsearch.client import ElasticsearchClient, ElasticsearchConfig
 
 _DEFAULT_MAX_RESULTS = 100
 _MAX_HARD_LIMIT = 200
+_SUMMARY_FIELD_TRUNCATE_LEN = 80
 
 
 def _bounded_limit(limit: int, max_results: int) -> int:
@@ -27,19 +29,26 @@ def _opensearch_available(sources: dict[str, dict[str, Any]]) -> bool:
 def _map_query_opensearch_analytics(
     evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
 ) -> None:
-    """Cite the number of log entries retrieved for the query."""
+    """Cite the number of log entries retrieved for the query.
+
+    ``query`` and ``index_pattern`` are caller-supplied and unbounded in
+    length -- truncate both before embedding them in the summary so a long
+    or malformed value can't produce an oversized report line.
+    """
     if not output.get("available"):
         return
     logs = output.get("logs") or []
     if not logs:
         return
+    query = truncate(str(output.get("query", "*")), _SUMMARY_FIELD_TRUNCATE_LEN)
+    index_pattern = truncate(str(output.get("index_pattern", "*")), _SUMMARY_FIELD_TRUNCATE_LEN)
     record_evidence_entry(
         evidence,
         source="query_opensearch_analytics",
         label="OpenSearch Analytics",
         summary=(
             f"{output.get('total_returned', len(logs))} log(s) for query "
-            f"'{output.get('query', '*')}' on '{output.get('index_pattern', '*')}'"
+            f"'{query}' on '{index_pattern}'"
         ),
     )
 

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -217,7 +217,6 @@ query_honeycomb_traces
 query_new_relic_alerts
 query_new_relic_metrics
 query_openobserve_logs
-query_opensearch_analytics
 query_signoz_logs
 query_signoz_metrics
 query_signoz_traces

--- a/tests/tools/test_opensearch_analytics_tool.py
+++ b/tests/tools/test_opensearch_analytics_tool.py
@@ -385,6 +385,28 @@ class TestMapQueryOpensearchAnalytics:
         assert entries[0]["source"] == "query_opensearch_analytics"
         assert entries[0]["summary"] == "2 log(s) for query 'service:checkout' on 'logs-*'"
 
+    def test_truncates_long_query_and_index_pattern_in_summary(self) -> None:
+        evidence: dict[str, Any] = {}
+        long_query = "service:checkout AND " + "x" * 200
+        long_index_pattern = "logs-" + "y" * 200
+
+        _map_query_opensearch_analytics(
+            evidence,
+            {
+                "available": True,
+                "total_returned": 1,
+                "query": long_query,
+                "index_pattern": long_index_pattern,
+                "logs": [{"message": "error 1"}],
+            },
+            {},
+        )
+
+        summary = evidence["catalog_entries"][0]["summary"]
+        assert len(summary) < len(long_query) + len(long_index_pattern)
+        assert long_query not in summary
+        assert long_index_pattern not in summary
+
     def test_records_nothing_when_no_logs(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_opensearch_analytics_tool.py
+++ b/tests/tools/test_opensearch_analytics_tool.py
@@ -13,7 +13,10 @@ from typing import Any
 import pytest
 
 from integrations.elasticsearch.client import ElasticsearchConfig
-from integrations.opensearch.tools.opensearch_analytics_tool import query_opensearch_analytics
+from integrations.opensearch.tools.opensearch_analytics_tool import (
+    _map_query_opensearch_analytics,
+    query_opensearch_analytics,
+)
 from tests.tools.conftest import BaseToolContract
 
 # ---------------------------------------------------------------------------
@@ -354,3 +357,48 @@ def test_propagates_unknown_client_error(monkeypatch: pytest.MonkeyPatch) -> Non
     assert result["available"] is False
     # Tool falls back to a generic message rather than raising
     assert "Unknown OpenSearch error" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Evidence mapper
+# ---------------------------------------------------------------------------
+
+
+class TestMapQueryOpensearchAnalytics:
+    def test_records_entry_with_log_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_opensearch_analytics(
+            evidence,
+            {
+                "available": True,
+                "total_returned": 2,
+                "query": "service:checkout",
+                "index_pattern": "logs-*",
+                "logs": [{"message": "error 1"}, {"message": "error 2"}],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "query_opensearch_analytics"
+        assert entries[0]["summary"] == "2 log(s) for query 'service:checkout' on 'logs-*'"
+
+    def test_records_nothing_when_no_logs(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_opensearch_analytics(
+            evidence, {"available": True, "total_returned": 0, "logs": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_opensearch_analytics(
+            evidence, {"available": False, "error": "auth failed", "logs": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5588

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires `query_opensearch_analytics` — the only OpenSearch investigation
tool — to `record_evidence_entry` so its output stops being silently
dropped and becomes a citeable line in the investigation report.

- `_map_query_opensearch_analytics`
  (`integrations/opensearch/tools/opensearch_analytics_tool/__init__.py`):
  cites the number of log entries retrieved, the query string, and the
  index pattern searched. Mirrors the existing precedent at
  `integrations/elasticsearch/tools/__init__.py`'s `_map_elasticsearch_logs`
  (the same underlying `ElasticsearchClient` backs both tools), adapted to
  this tool's actual output shape — `total_returned`/`query`/
  `index_pattern`/`logs`, no `error_logs` field, unlike the Elasticsearch
  tool.

This is a read-only diagnostic query — not an action/notification tool —
so it's in scope per the issue.

The mapper records nothing when `available` is falsy or `logs` is empty —
zero log entries matching a query is a real, useful "no matches" finding
in principle, but the project's "no noise" convention treats an empty
result list the same way the existing Elasticsearch precedent does (no
entry when `logs` is empty), so I matched that behavior rather than
diverging from established practice for this integration.

Removed `query_opensearch_analytics` from `evidence_mapper_baseline.txt`
now that it carries a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tool carries its mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({'query_opensearch_analytics': bool(g('query_opensearch_analytics').evidence_mapper)})"
{'query_opensearch_analytics': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using a realistic sample matching the tool's return
shape:**
```
query_opensearch_analytics: "2 log(s) for query 'service:checkout' on 'logs-*'"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/ -k opensearch -q
51 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3631 files already formatted / Success: no issues found in 1893 source files
```

**No live OpenSearch instance available in this environment**, so leaving
that box unticked per the issue's own guidance. The checks above stand as
evidence the mapper is attached and produces a real report entry from a
realistic sample payload matching the actual tool's return shape; a
reviewer with an OpenSearch instance can finish the live check.

## Behaviour comparison (required)

**1–2. Before/after**, run with a realistic sample matching the tool's
actual return shape (via `merge_tool_evidence`):

Before: `evidence` has no `catalog_entries` key.

After:
```diff
+  "catalog_entries": [
+    {
+      "source": "query_opensearch_analytics",
+      "label": "OpenSearch Analytics",
+      "summary": "2 log(s) for query 'service:checkout' on 'logs-*'",
+      "url": null,
+      "snippet": null
+    }
+  ]
```

**3. Explain every difference:** the diff adds exactly one new
`catalog_entries` list item — nothing else in `evidence` changes.

**4. Answers:**

- **What the reader gains.** How many log entries matched the query and
  index pattern searched — previously invisible in the report even though
  the agent already paid to run the query.
- **How much context it costs.** 167 characters (JSON-serialized) — a
  single-line summary, no inlined log entries.
- **What happens on an empty or error result.** Verified directly in the
  new tests: `available: False`, and an empty `logs` list, both produce
  zero `catalog_entries`.
- **Whether anything is now recorded twice.** No. This is the only
  OpenSearch tool in the codebase (confirmed via the baseline gaps file,
  which listed only this one tool for `opensearch`), and no other mapper
  reads its output. It shares an underlying client with
  `query_elasticsearch_logs`, but that tool has its own separate mapper
  keyed on a different `source` string, so there's no double-recording risk.
- **Whether an existing report changed shape.** `tests/ -k opensearch` (51
  tests) and the full evidence-mapper coverage suite (11 tests) pass
  unchanged.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Before writing this mapper I checked whether OpenSearch's sibling
integration, Elasticsearch, already had one — it does
(`_map_elasticsearch_logs` in `integrations/elasticsearch/tools/__init__.py`),
since both tools sit on top of the same `ElasticsearchClient`. Rather than
copy it wholesale, I read `query_opensearch_analytics`'s actual return
dict and found it's a narrower shape than Elasticsearch's tool output —
no `error_logs` field, and it carries `total_returned`/`query`/
`index_pattern` fields the Elasticsearch mapper doesn't reference. I wrote
a mapper specific to this shape rather than importing or generalizing the
Elasticsearch one, since the two tools' outputs aren't guaranteed to stay
in sync and the project's convention is one mapper per tool, living with
that tool.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
