### PR TITLE
feat(gitlab): add evidence mappers for all 4 gitlab investigation tools

### DIFF
--- a/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_commits_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
@@ -13,6 +14,17 @@ from integrations.gitlab import (
     get_gitlab_commits,
     gitlab_config_from_env,
 )
+
+
+#: Every GitLab list tool (commits/pipelines/MRs) sends ``per_page`` straight
+#: to the GitLab API as its own page-size param and returns the raw page with
+#: no separate total-count field -- a returned page cannot be distinguished
+#: from every matching record except by comparing it against the page size
+#: that was requested.
+def _gitlab_count_label(count: int, requested_per_page: int) -> str:
+    """Format a list count, appending "+" when the page may be truncated."""
+    effective_per_page = max(requested_per_page, 1)
+    return f"{count}+" if count >= effective_per_page else str(count)
 
 
 def _clean_optional(value: str | None) -> str:
@@ -74,6 +86,24 @@ def _list_gitlab_commits_available(sources: dict[str, dict]) -> bool:
     return bool(_gitlab_available(sources) and gl.get("project_id"))
 
 
+def _map_list_gitlab_commits(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the number of commits retrieved."""
+    if not output.get("available"):
+        return
+    commits = output.get("commits") or []
+    if not commits:
+        return
+    label = _gitlab_count_label(len(commits), tool_input.get("per_page", 10))
+    record_evidence_entry(
+        evidence,
+        source="list_gitlab_commits",
+        label="GitLab Commits",
+        summary=f"{label} commit(s)",
+    )
+
+
 @tool(
     name="list_gitlab_commits",
     source="gitlab",
@@ -96,6 +126,7 @@ def _list_gitlab_commits_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_list_gitlab_commits_available,
     extract_params=_list_gitlab_commits_extract_params,
+    evidence_mapper=_map_list_gitlab_commits,
 )
 def list_gitlab_commits(
     project_id: str,

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload, tool_unavailable
@@ -16,6 +17,25 @@ from integrations.gitlab.tools.gitlab_commits_tool import (
     _gl_creds,
     _resolve_config,
 )
+
+
+def _map_get_gitlab_file_contents(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the file path, ref, and line count read."""
+    if not output.get("available"):
+        return
+    file = output.get("file") or {}
+    if not file:
+        return
+    content = file.get("content") or ""
+    line_count = content.count("\n") + 1 if content else 0
+    record_evidence_entry(
+        evidence,
+        source="get_gitlab_file",
+        label="GitLab File",
+        summary=(f"'{file.get('file_path', '')}' @ {file.get('ref', '')}, {line_count} line(s)"),
+    )
 
 
 def _get_gitlab_file_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -55,6 +75,7 @@ def _get_gitlab_file_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_get_gitlab_file_available,
     extract_params=_get_gitlab_file_extract_params,
+    evidence_mapper=_map_get_gitlab_file_contents,
 )
 def get_gitlab_file_contents(
     project_id: str,

--- a/integrations/gitlab/tools/gitlab_file_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_file_tool/__init__.py
@@ -29,7 +29,7 @@ def _map_get_gitlab_file_contents(
     if not file:
         return
     content = file.get("content") or ""
-    line_count = content.count("\n") + 1 if content else 0
+    line_count = content.count("\n") + (not content.endswith("\n")) if content else 0
     record_evidence_entry(
         evidence,
         source="get_gitlab_file",

--- a/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_mrs_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
@@ -12,9 +13,29 @@ from integrations.gitlab import (
 )
 from integrations.gitlab.tools.gitlab_commits_tool import (
     _gitlab_available,
+    _gitlab_count_label,
     _gl_creds,
     _resolve_config,
 )
+
+
+def _map_list_gitlab_mrs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the number of merge requests retrieved and the target branch."""
+    if not output.get("available"):
+        return
+    mrs = output.get("mrs") or []
+    if not mrs:
+        return
+    label = _gitlab_count_label(len(mrs), tool_input.get("per_page", 10))
+    target_branch = tool_input.get("target_branch", "main")
+    record_evidence_entry(
+        evidence,
+        source="list_gitlab_mrs",
+        label="GitLab Merge Requests",
+        summary=f"{label} merge request(s) targeting '{target_branch}'",
+    )
 
 
 def _list_gitlab_mrs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -56,6 +77,7 @@ def _list_gitlab_mrs_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_list_gitlab_mrs_available,
     extract_params=_list_gitlab_mrs_extract_params,
+    evidence_mapper=_map_list_gitlab_mrs,
 )
 def list_gitlab_mrs(
     project_id: str,

--- a/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
+++ b/integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
@@ -12,9 +13,29 @@ from integrations.gitlab import (
 )
 from integrations.gitlab.tools.gitlab_commits_tool import (
     _gitlab_available,
+    _gitlab_count_label,
     _gl_creds,
     _resolve_config,
 )
+
+
+def _map_list_gitlab_pipelines(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the number of pipelines retrieved and the status filter used."""
+    if not output.get("available"):
+        return
+    pipelines = output.get("pipelines") or []
+    if not pipelines:
+        return
+    label = _gitlab_count_label(len(pipelines), tool_input.get("per_page", 10))
+    status = tool_input.get("status", "failed")
+    record_evidence_entry(
+        evidence,
+        source="list_gitlab_pipelines",
+        label="GitLab Pipelines",
+        summary=f"{label} pipeline(s) with status '{status}'",
+    )
 
 
 def _list_gitlab_pipelines_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -58,6 +79,7 @@ def _list_gitlab_pipelines_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_list_gitlab_pipelines_available,
     extract_params=_list_gitlab_pipelines_extract_params,
+    evidence_mapper=_map_list_gitlab_pipelines,
 )
 def list_gitlab_pipelines(
     project_id: str,

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -59,7 +59,6 @@ get_error_logs
 get_failed_jobs
 get_failed_tools
 get_github_star_history
-get_gitlab_file
 get_groundcover_query_reference
 get_hermes_adapter_catalog
 get_hermes_approval_events
@@ -174,9 +173,6 @@ list_github_actions_workflow_runs
 list_github_commits
 list_github_security_alerts
 list_github_work_items
-list_gitlab_commits
-list_gitlab_mrs
-list_gitlab_pipelines
 list_jenkins_builds
 list_jenkins_jobs
 list_jenkins_running_builds

--- a/tests/tools/test_gitlab_commits_tool.py
+++ b/tests/tools/test_gitlab_commits_tool.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integrations.gitlab.tools.gitlab_commits_tool import _resolve_config, list_gitlab_commits
+from integrations.gitlab.tools.gitlab_commits_tool import (
+    _map_list_gitlab_commits,
+    _resolve_config,
+    list_gitlab_commits,
+)
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -199,3 +204,44 @@ def test_run_error_path_returns_empty_commits_when_integration_returns_empty() -
         result = list_gitlab_commits(project_id="42")
     assert result["available"] is True
     assert result["commits"] == []
+
+
+class TestMapListGitlabCommits:
+    def test_records_plain_count_when_under_page_size(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_commits(
+            evidence,
+            {"available": True, "commits": [{"id": "abc"}, {"id": "def"}]},
+            {"per_page": 10},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "list_gitlab_commits"
+        assert entries[0]["summary"] == "2 commit(s)"
+
+    def test_qualifies_count_when_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_commits(
+            evidence,
+            {"available": True, "commits": [{"id": str(i)} for i in range(10)]},
+            {"per_page": 10},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "10+ commit(s)"
+
+    def test_records_nothing_when_no_commits(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_commits(evidence, {"available": True, "commits": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_commits(evidence, {"available": False, "error": "not configured"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_gitlab_file_tool.py
+++ b/tests/tools/test_gitlab_file_tool.py
@@ -8,7 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integrations.gitlab.tools.gitlab_file_tool import get_gitlab_file_contents
+from integrations.gitlab.tools.gitlab_file_tool import (
+    _map_get_gitlab_file_contents,
+    get_gitlab_file_contents,
+)
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -240,3 +243,51 @@ def test_run_handles_empty_content() -> None:
         result = get_gitlab_file_contents(project_id="42", file_path="empty.txt")
     assert result["available"] is True
     assert result["file"]["content"] == ""
+
+
+class TestMapGetGitlabFileContents:
+    def test_records_entry_with_line_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_gitlab_file_contents(
+            evidence,
+            {
+                "available": True,
+                "file": {
+                    "file_path": "config/settings.yaml",
+                    "ref": "main",
+                    "content": "line1\nline2\nline3",
+                },
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_gitlab_file"
+        assert entries[0]["summary"] == "'config/settings.yaml' @ main, 3 line(s)"
+
+    def test_records_entry_with_zero_lines_for_empty_file(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_gitlab_file_contents(
+            evidence,
+            {"available": True, "file": {"file_path": "empty.txt", "ref": "main", "content": ""}},
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "'empty.txt' @ main, 0 line(s)"
+
+    def test_records_nothing_when_file_empty_dict(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_gitlab_file_contents(evidence, {"available": True, "file": {}}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_gitlab_file_contents(evidence, {"available": False, "error": "not configured"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_gitlab_file_tool.py
+++ b/tests/tools/test_gitlab_file_tool.py
@@ -267,6 +267,27 @@ class TestMapGetGitlabFileContents:
         assert entries[0]["source"] == "get_gitlab_file"
         assert entries[0]["summary"] == "'config/settings.yaml' @ main, 3 line(s)"
 
+    def test_records_correct_line_count_with_trailing_newline(self) -> None:
+        """Regression: a trailing newline must not be counted as an extra line."""
+        evidence: dict[str, Any] = {}
+
+        _map_get_gitlab_file_contents(
+            evidence,
+            {
+                "available": True,
+                "file": {
+                    "file_path": "config/settings.yaml",
+                    "ref": "main",
+                    "content": "line1\nline2\nline3\n",
+                },
+            },
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"] == "'config/settings.yaml' @ main, 3 line(s)"
+        )
+
     def test_records_entry_with_zero_lines_for_empty_file(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_gitlab_mrs_tool.py
+++ b/tests/tools/test_gitlab_mrs_tool.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-from integrations.gitlab.tools.gitlab_mrs_tool import list_gitlab_mrs
+from integrations.gitlab.tools.gitlab_mrs_tool import _map_list_gitlab_mrs, list_gitlab_mrs
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -142,3 +143,44 @@ def test_run_error_path_returns_empty_mrs_when_integration_returns_empty() -> No
         result = list_gitlab_mrs(project_id="42")
     assert result["available"] is True
     assert result["mrs"] == []
+
+
+class TestMapListGitlabMrs:
+    def test_records_plain_count_with_target_branch(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_mrs(
+            evidence,
+            {"available": True, "mrs": [{"id": 1}, {"id": 2}]},
+            {"per_page": 10, "target_branch": "main"},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "list_gitlab_mrs"
+        assert entries[0]["summary"] == "2 merge request(s) targeting 'main'"
+
+    def test_qualifies_count_when_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_mrs(
+            evidence,
+            {"available": True, "mrs": [{"id": i} for i in range(10)]},
+            {"per_page": 10, "target_branch": "main"},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "10+ merge request(s) targeting 'main'"
+
+    def test_records_nothing_when_no_mrs(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_mrs(evidence, {"available": True, "mrs": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_mrs(evidence, {"available": False, "error": "not configured"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_gitlab_pipelines_tool.py
+++ b/tests/tools/test_gitlab_pipelines_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-from integrations.gitlab.tools.gitlab_pipelines_tool import list_gitlab_pipelines
+from integrations.gitlab.tools.gitlab_pipelines_tool import (
+    _map_list_gitlab_pipelines,
+    list_gitlab_pipelines,
+)
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -149,3 +153,44 @@ def test_run_error_path_returns_empty_pipelines_when_integration_returns_empty()
         result = list_gitlab_pipelines(project_id="42")
     assert result["available"] is True
     assert result["pipelines"] == []
+
+
+class TestMapListGitlabPipelines:
+    def test_records_plain_count_with_status_filter(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_pipelines(
+            evidence,
+            {"available": True, "pipelines": [{"id": 1}, {"id": 2}]},
+            {"per_page": 10, "status": "failed"},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "list_gitlab_pipelines"
+        assert entries[0]["summary"] == "2 pipeline(s) with status 'failed'"
+
+    def test_qualifies_count_when_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_pipelines(
+            evidence,
+            {"available": True, "pipelines": [{"id": i} for i in range(10)]},
+            {"per_page": 10, "status": "failed"},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "10+ pipeline(s) with status 'failed'"
+
+    def test_records_nothing_when_no_pipelines(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_pipelines(evidence, {"available": True, "pipelines": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_gitlab_pipelines(evidence, {"available": False, "error": "not configured"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5552

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all 4 GitLab investigation tools to `record_evidence_entry` so their
output stops being silently dropped and becomes a citeable line in the
investigation report.

- `_map_get_gitlab_file_contents`
  (`integrations/gitlab/tools/gitlab_file_tool/__init__.py`): cites the
  file path, ref, and line count read.
- `_map_list_gitlab_commits`
  (`integrations/gitlab/tools/gitlab_commits_tool/__init__.py`): cites the
  number of commits retrieved.
- `_map_list_gitlab_pipelines`
  (`integrations/gitlab/tools/gitlab_pipelines_tool/__init__.py`): cites
  the pipeline count and the status filter that was applied.
- `_map_list_gitlab_mrs`
  (`integrations/gitlab/tools/gitlab_mrs_tool/__init__.py`): cites the
  merge request count and the target branch.

All 4 are read-only diagnostic queries — none is an action/notification
tool, so all are in scope per the issue.

**On count honesty:** `get_gitlab_commits`, `get_gitlab_pipelines`, and
`get_gitlab_mrs` in `integrations/gitlab/client.py` all send `per_page`
straight to the GitLab API as its own page-size param and return the raw
page with no separate total-count field — a returned page can't be told
apart from every matching record except by comparing it against the page
size that was requested. I hit the identical problem earlier in this same
session on the companion Sentry and PagerDuty evidence-mapper issues, and
both already established a shared `"N+"` convention for it (Sentry's
`validate_sentry_config` has the original precedent; PagerDuty's
`_pagerduty_count_label` mirrors it). I added the equivalent
`_gitlab_count_label(count, requested_per_page)` helper in
`gitlab_commits_tool/__init__.py` (re-exported to the pipelines and MRs
tools alongside the existing shared `_gitlab_available`/`_gl_creds`/
`_resolve_config` helpers) and used it in all 3 list mappers, so the
report never states a capped page as if it were the true count.
`get_gitlab_file` has no such ambiguity — it's a single file, not a list.

Every mapper records nothing when `available` is falsy, or when its
list/dict field is empty.

Removed all 4 tool names from `evidence_mapper_baseline.txt` now that they
carry a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in [
  'get_gitlab_file', 'list_gitlab_commits',
  'list_gitlab_pipelines', 'list_gitlab_mrs']})"
{'get_gitlab_file': True, 'list_gitlab_commits': True,
 'list_gitlab_pipelines': True, 'list_gitlab_mrs': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each tool's return
shape:**
```
get_gitlab_file:        "'config/settings.yaml' @ main, 3 line(s)"
list_gitlab_commits:    '2 commit(s)'                                (under page size)
list_gitlab_pipelines:  "2 pipeline(s) with status 'failed'"
list_gitlab_mrs:        "2 merge request(s) targeting 'main'"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/ -k gitlab -q
167 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3631 files already formatted / Success: no issues found in 1893 source files
```

**No live GitLab project available in this environment**, so leaving that
box unticked per the issue's own guidance. The checks above stand as
evidence the mappers are attached and produce real report entries from
realistic sample payloads matching the actual client functions' return
shapes; a reviewer with a GitLab project can finish the live check.

## Behaviour comparison (required)

**1–2. Before/after**, run with realistic samples matching each tool's
actual return shape (via `merge_tool_evidence`):

Before: `evidence` has no `catalog_entries` key for any of the 4 tools.

After, each adds exactly one new `catalog_entries` list item, e.g. for
`list_gitlab_pipelines`:
```diff
+  "catalog_entries": [
+    {
+      "source": "list_gitlab_pipelines",
+      "label": "GitLab Pipelines",
+      "summary": "2 pipeline(s) with status 'failed'",
+      "url": null,
+      "snippet": null
+    }
+  ]
```
(and analogously for the other 3 — one new entry each, nothing else in
`evidence` changes.)

**3. Explain every difference:** each diff adds exactly one new
`catalog_entries` list item per tool — nothing else in `evidence` changes.

**4. Answers:**

- **What the reader gains.** A specific file's path/ref/line count, a
  commit count for the queried window, a failed-pipeline count for the
  ref, and a merge-request count for the target branch — all previously
  invisible in the report even though the agent already paid to fetch
  them, and honestly qualified with "+" whenever a list result may be a
  capped page rather than every match.
- **How much context it costs.** 116–143 characters (JSON-serialized) per
  entry — single-line summaries, no inlined commit/pipeline/MR lists, and
  no file content dumped into the report.
- **What happens on an empty or error result.** Verified directly in the
  new tests: `available: False` for all 4; an empty `file` dict,
  `commits`/`pipelines`/`mrs` list all produce zero `catalog_entries`.
- **Whether anything is now recorded twice.** No. These are the only 4
  GitLab tools targeted by this issue (confirmed via the baseline gaps
  file, which listed exactly these 4 for `gitlab`), and no other mapper
  reads any of their output.
- **Whether an existing report changed shape.** `tests/ -k gitlab` (167
  tests) and the full evidence-mapper coverage suite (11 tests) pass
  unchanged.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Before writing the three list mappers I checked `get_gitlab_commits`,
`get_gitlab_pipelines`, and `get_gitlab_mrs` in
`integrations/gitlab/client.py` for the same capped-page-as-total issue
Greptile flagged on my Sentry PR earlier in this session — all three send
`per_page` directly as a GitLab API query param and return the raw JSON
list with zero pagination metadata (no `total`, no `X-Total` header
capture), confirming the same risk applies. Rather than invent a third
different phrasing after already establishing the `"N+"` convention twice
today (Sentry, PagerDuty), I placed one `_gitlab_count_label` helper in
`gitlab_commits_tool/__init__.py` — the module the other three tool files
already import their shared `_gitlab_available`/`_gl_creds`/
`_resolve_config` helpers from — and reused it identically in all three
list mappers. `get_gitlab_file`'s mapper doesn't need this: it always
returns exactly one file, so I cite its line count directly (via
`content.count("\n") + 1`) without any pagination ambiguity, and I
deliberately did not attempt to embed or summarize the file's actual
content in the report, since that could be arbitrarily large or contain
sensitive data — the citation is metadata only (path, ref, size), not the
text itself.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
