### PR TITLE
feat(interactive-shell): /auto tool-approval autonomy levels

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -297,6 +297,15 @@ from config.constants.redis import (
     REDIS_SSL_ENV,
     REDIS_USERNAME_ENV,
 )
+from config.constants.repl_autonomy import (
+    AUTO_LEVEL_ASK_TOOL_TYPES,
+    AUTO_LEVEL_CAPTIONS,
+    AUTO_LEVEL_TITLES,
+    DEFAULT_AUTO_LEVEL,
+    AutoLevel,
+    format_auto_status_plain,
+    parse_auto_level,
+)
 from config.constants.repl_theme import DEFAULT_THEME_NAME, THEME_NAMES, Theme
 from config.constants.reporting import SLACK_LINK_RE
 from config.constants.runtime_metadata import (
@@ -488,6 +497,13 @@ __all__ = [
     "DEFAULT_REMOTE_SYNC_PREFIX",
     "DEFAULT_REMOTE_SYNC_PROVIDER",
     "DEFAULT_THEME_NAME",
+    "AUTO_LEVEL_ASK_TOOL_TYPES",
+    "AUTO_LEVEL_CAPTIONS",
+    "AUTO_LEVEL_TITLES",
+    "AutoLevel",
+    "DEFAULT_AUTO_LEVEL",
+    "format_auto_status_plain",
+    "parse_auto_level",
     "REMOTE_SYNC_BUCKET_ENV",
     "REMOTE_SYNC_ENDPOINT_URL_ENV",
     "REMOTE_SYNC_ENV",

--- a/config/constants/repl_autonomy.py
+++ b/config/constants/repl_autonomy.py
@@ -60,8 +60,10 @@ AUTO_LEVEL_ASK_TOOL_TYPES: Final[dict[AutoLevel, frozenset[str] | None]] = {
     # Med "allow reversible commands": read-only work runs, but mutation-capable
     # tool types still need confirmation.
     AutoLevel.MED: _MUTATING_AGENT_TOOL_TYPES,
-    # Low also asks before starting a full investigation.
-    AutoLevel.LOW: _MUTATING_AGENT_TOOL_TYPES | frozenset({"investigation"}),
+    # Low also asks before starting a full investigation — including the
+    # sample-alert path, which uses tool_type ``sample_alert`` (not
+    # ``investigation``) but still launches an investigation with side effects.
+    AutoLevel.LOW: _MUTATING_AGENT_TOOL_TYPES | frozenset({"investigation", "sample_alert"}),
     AutoLevel.OFF: None,  # ask every tool type
 }
 

--- a/config/constants/repl_autonomy.py
+++ b/config/constants/repl_autonomy.py
@@ -1,0 +1,94 @@
+"""Auto (Off|Low|Med|High) autonomy levels for the REPL.
+
+Default is High: alpha still allows every action without a prompt. Lower
+levels opt into the existing ``ask`` confirmation hook — they are not a
+shell-command allowlist.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+
+class AutoLevel(StrEnum):
+    """Autonomy shown on the status line above the input."""
+
+    OFF = "off"
+    LOW = "low"
+    MED = "med"
+    HIGH = "high"
+
+
+DEFAULT_AUTO_LEVEL: Final[AutoLevel] = AutoLevel.HIGH
+
+AUTO_LEVEL_CAPTIONS: Final[dict[AutoLevel, str]] = {
+    AutoLevel.OFF: "all actions require approval",
+    AutoLevel.LOW: "edits and read-only commands",
+    AutoLevel.MED: "allow reversible commands",
+    AutoLevel.HIGH: "all actions allowed",
+}
+
+# Display title inside ``Auto (Med)`` — Factory uses Med, not medium.
+AUTO_LEVEL_TITLES: Final[dict[AutoLevel, str]] = {
+    AutoLevel.OFF: "Off",
+    AutoLevel.LOW: "Low",
+    AutoLevel.MED: "Med",
+    AutoLevel.HIGH: "High",
+}
+
+# tool_type values that still need confirmation at this level (High: none).
+# Mutation-capable agent tools ask at Med+ — including synthetic_test (spawns a
+# mutation-classified subprocess), slash/CLI, and Sentry issue-fix (edits the
+# working tree and can commit/push/open a PR) — otherwise those run without
+# the confirmation promised by ``/auto med``.
+_MUTATING_AGENT_TOOL_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "shell",
+        "code_agent",
+        "slash",
+        "cli_command",
+        "opensre_cli",
+        "switch_llm_provider",
+        "synthetic_test",
+        "sentry_issue_fix",
+    }
+)
+
+AUTO_LEVEL_ASK_TOOL_TYPES: Final[dict[AutoLevel, frozenset[str] | None]] = {
+    AutoLevel.HIGH: frozenset(),
+    # Med "allow reversible commands": read-only work runs, but mutation-capable
+    # tool types still need confirmation.
+    AutoLevel.MED: _MUTATING_AGENT_TOOL_TYPES,
+    # Low also asks before starting a full investigation.
+    AutoLevel.LOW: _MUTATING_AGENT_TOOL_TYPES | frozenset({"investigation"}),
+    AutoLevel.OFF: None,  # ask every tool type
+}
+
+
+def parse_auto_level(raw: str) -> AutoLevel | None:
+    """Parse a user-facing auto level, or ``None`` when unknown."""
+    token = raw.strip().lower()
+    aliases = {"medium": AutoLevel.MED, "off": AutoLevel.OFF}
+    if token in aliases:
+        return aliases[token]
+    try:
+        return AutoLevel(token)
+    except ValueError:
+        return None
+
+
+def format_auto_status_plain(level: AutoLevel) -> str:
+    """``Auto (Med) · allow reversible commands`` without ANSI."""
+    return f"Auto ({AUTO_LEVEL_TITLES[level]}) · {AUTO_LEVEL_CAPTIONS[level]}"
+
+
+__all__ = [
+    "AUTO_LEVEL_ASK_TOOL_TYPES",
+    "AUTO_LEVEL_CAPTIONS",
+    "AUTO_LEVEL_TITLES",
+    "AutoLevel",
+    "DEFAULT_AUTO_LEVEL",
+    "format_auto_status_plain",
+    "parse_auto_level",
+]

--- a/docs/interactive-shell-action-policy.md
+++ b/docs/interactive-shell-action-policy.md
@@ -180,13 +180,37 @@ What changed:
 - The **only** remaining non-execution outcome is genuinely empty input (a bare
   `!` or whitespace), which is rejected as input validation, not as a guardrail.
 
-The `ask`/confirmation machinery (`trust_mode` plus the confirmation UX) is
-retained as an unused hook, split across two layers: the pure decision lives in
-`tools/interactive_shell/shared/execution_policy.py` (`resolve_confirmation`), and the terminal
-interaction (`execution_allowed` — console output, the `Proceed? [Y/n]` prompt,
-analytics) lives in `surfaces/interactive_shell/ui/execution_confirm.py`. If command
-guardrails are reintroduced after alpha, gate them here at the execution stage —
-never with an action-selection denial in the planner.
+The `ask`/confirmation machinery is retained and used by **`/auto`** (Off/Low/Med)
+plus `trust_mode`. It is split across two layers: the pure decision lives in
+`tools/interactive_shell/shared/execution_policy.py` (`resolve_confirmation`,
+`apply_auto_level`), and the terminal interaction (`execution_allowed` — console
+output, the approval prompt, analytics) lives in
+`surfaces/interactive_shell/ui/execution_confirm.py`.
+
+### `/auto` autonomy (tool-type confirmations)
+
+Addendum — Aug 2026.
+
+**Decision:** the REPL exposes `/auto off|low|med|high` as session-scoped
+tool-approval autonomy. Default is **high** (alpha: no confirmation). Lower
+levels promote a default-`allow` policy result to `ask` based on `tool_type`
+(`config/constants/repl_autonomy.py`), not a shell-command allowlist.
+
+| Level | Asks before |
+| --- | --- |
+| `high` | Nothing |
+| `med` | Mutating agent tools (`shell`, `code_agent`, `slash`, `cli_command`, `opensre_cli`, `switch_llm_provider`, `synthetic_test`, `sentry_issue_fix`, …) |
+| `low` | Med set, plus `investigation` / `sample_alert` |
+| `off` | Every tool type |
+
+**Interaction with `/trust`:** `trust_mode` still short-circuits `ask` to allow
+(skip the prompt). Non-TTY `ask` remains fail-closed.
+
+**Still true:** there is no shell argv allowlist/deny floor under alpha. `/auto`
+only gates whether the existing confirmation UX runs before a tool launch.
+
+If a shell-command allowlist is reintroduced after alpha, gate it here at the
+execution stage — never with an action-selection denial in the planner.
 
 ### Deterministic literal-`/slash` dispatch (no LLM)
 

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -13,7 +13,10 @@ opensre
 When you type `/` and browse with the arrow keys, the hint line above the prompt shows the highlighted command's description.
 
 <Info>
-  Commands marked **elevated** may ask for confirmation unless trust mode is on (`/trust on`). Outside a TTY, elevated actions are blocked.
+  Confirmation prompts come from **`/auto`** (tool-approval autonomy) and from
+  elevated slash commands. Default `/auto` is **high** (alpha: no tool prompts).
+  `/trust on` skips approval prompts for the rest of the session. Outside a TTY,
+  actions that would ask are blocked.
 </Info>
 
 ## How the REPL works
@@ -59,6 +62,7 @@ When you first launch the shell with no scheduled loops, a picker offers three s
 | `/cost` | Token usage and LLM call count for the current session |
 | `/context` | Infra metadata accumulated during the session |
 | `/effort` | Set or show reasoning effort (`low` … `max`) |
+| `/auto` | Tool-approval autonomy (`off` / `low` / `med` / `high`; default `high`) |
 | `/trust` | Enable or disable trust mode (skip confirmation prompts) |
 | `/verbose` | Toggle verbose logging |
 | `/clear` | Clear the screen and re-render the banner |
@@ -302,6 +306,31 @@ Set reasoning depth for **OpenAI and Codex** providers in this REPL session only
 Bare `/effort` prints the current level, the config default for your provider/model, and supported choices. `/status` includes the same field.
 
 Other providers (Anthropic, Ollama, etc.) ignore `/effort`; the shell prints a hint suggesting `/model set openai` or `/model set codex`. Set `OPENSRE_REASONING_EFFORT` in the environment for non-interactive defaults. See [LLM providers](/llm-providers).
+
+</Accordion>
+
+<Accordion title="/auto">
+
+Set how often the REPL asks before running agent tools. Shown on the status line as `Auto (Med) · …`.
+
+```text
+/auto
+/auto med
+/auto high
+```
+
+| Level | Prompts before |
+| --- | --- |
+| `high` (default) | Nothing — alpha default; every tool runs immediately |
+| `med` | Mutating agent tools: shell, code agent, slash/CLI, synthetic tests, LLM provider switch, Sentry issue fix, … |
+| `low` | Everything `med` asks about, plus starting an investigation (including sample-alert) |
+| `off` | Every tool type |
+
+`/auto` is **not** a shell-command allowlist: under alpha, shell strings still run when approved (or when High skips the prompt). Lower levels only promote the existing `ask` confirmation hook by `tool_type`.
+
+**With `/trust`:** `/trust on` skips approval prompts even when `/auto` would ask. Turn trust off to restore `/auto` prompts.
+
+Session preference only — not restored by `/resume`. Bare `/auto` prints the current level, the default, and each caption.
 
 </Accordion>
 
@@ -1318,19 +1347,28 @@ goodbye.
 
 </AccordionGroup>
 
-## Trust mode and confirmations
+## Trust mode, `/auto`, and confirmations
+
+Two controls decide whether the REPL prompts before an action:
+
+| Control | Role |
+| --- | --- |
+| `/auto` | Which **agent tool types** need approval (default **high** = none) |
+| `/trust` | Session override that **skips** approval prompts when `/auto` (or an elevated slash command) would ask |
 
 | Tier | Examples | Confirmation |
 | --- | --- | --- |
-| Exempt | `/help`, `/exit`, `/trust` | Never prompts |
+| Exempt | `/help`, `/exit`, `/trust`, `/auto` | Never prompts |
 | Safe | `/status`, `/health`, `/investigate`, `/integrations list` | Read-only or standard risk |
-| Elevated | `/save`, `/watch`, `/cancel`, `/integrations remove`, `/fleet kill`, `/uninstall` | Prompt `[y/N]` unless trust on |
+| Elevated | `/save`, `/watch`, `/cancel`, `/integrations remove`, `/fleet kill`, `/uninstall` | Prompt unless trust on |
 
-Non-TTY: elevated commands **fail closed** (error message, no side effect).
+Non-TTY: actions that would ask **fail closed** (error message, no side effect).
 
 ```text
+/auto med   # ask before mutating agent tools
+/auto high  # alpha default — no tool prompts
 /trust on   # skip prompts for this session
-/trust off  # restore prompts
+/trust off  # restore /auto (and elevated) prompts
 ```
 
 ---

--- a/surfaces/interactive_shell/AGENTS.md
+++ b/surfaces/interactive_shell/AGENTS.md
@@ -67,24 +67,22 @@ owning area rather than adding more logic to the caller.
   trigger confirmations or side effects.
 - Send command execution through the central dispatch and execution-policy
   helpers. Do not bypass `execution_policy.py` for new commands.
-- **Alpha allow-all execution policy (current behavior):** the REPL runs with
-  **no command guardrails**. `execution_policy.py` resolves every action to
-  `allow` with **no confirmation prompt** — all slash/`opensre` commands,
-  investigations, synthetic tests, code-agent launches, LLM runtime switches, and
-  **all** shell commands run immediately, in any context (TTY or not, trust mode
-  or not). There is **no shell-command safety policy**: the
+- **Alpha allow-all execution policy (current behavior):** the REPL defaults to
+  **`/auto high`** — no tool confirmation. `execution_policy.py` resolves every
+  action to `allow`; `apply_auto_level` promotes to `ask` only when `/auto` is
+  below High. There is **no shell-command safety policy**: the
   read-only/mutating/restricted classification and the `deny` floor were removed
   (`shell_policy.py` deleted; parsing/policy/execution live under
   `tools/shell/`). Mutating commands (`rm`/`mv`/`docker`), `restricted` commands
   (`sudo`, `systemctl`, `kill`, `dd`, …), shell operators (`| && ; > <`), and
-  command substitution all run; the `!` prefix is honored but optional. The only
-  shell input still rejected is genuinely empty input (a bare `!` or whitespace).
-  Do **not** re-add a shell allowlist or deny floor while in alpha — see
-  `docs/interactive-shell-action-policy.md`. The former `ExecutionTier`
-  classification was removed because it gated nothing under default-allow; if an
-  opt-in stricter policy is reintroduced after alpha, gate it in
-  `execution_policy.py` (the `ask` verdict, confirmation UX, and `trust_mode` are
-  retained as the hook), not via a planner-stage denial.
+  command substitution all run once approved (or immediately at High). The `!`
+  prefix is honored but optional. The only shell input still rejected is
+  genuinely empty input (a bare `!` or whitespace). Document levels and
+  `/trust` interaction in `docs/interactive-shell-commands.mdx` (`/auto`) and
+  `docs/interactive-shell-action-policy.md`. Do **not** re-add a shell allowlist
+  or deny floor while in alpha — gate stricter policy in `execution_policy.py`
+  (the `ask` verdict, confirmation UX, `trust_mode`, and `/auto` are the hooks),
+  not via a planner-stage denial.
 - Non-TTY behavior under default-allow: actions no longer fail closed on
   non-interactive stdin (there is nothing to confirm). The fail-closed path only
   applies if a verdict is explicitly `ask`, which the default policy does not

--- a/surfaces/interactive_shell/command_registry/settings_cmds.py
+++ b/surfaces/interactive_shell/command_registry/settings_cmds.py
@@ -9,6 +9,12 @@ from rich.markup import escape
 
 import surfaces.interactive_shell.command_registry.repl_data as repl_data
 from config.constants.llm import LLM_PROVIDER_ENV
+from config.constants.repl_autonomy import (
+    AUTO_LEVEL_CAPTIONS,
+    AutoLevel,
+    format_auto_status_plain,
+    parse_auto_level,
+)
 from config.llm_reasoning_effort import (
     REASONING_EFFORT_OPTIONS,
     ReasoningEffort,
@@ -37,10 +43,34 @@ _TRUST_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("off", "disable trust mode"),
 )
 
+_AUTO_FIRST_ARGS: tuple[tuple[str, str], ...] = tuple(
+    (level.value, AUTO_LEVEL_CAPTIONS[level]) for level in AutoLevel
+)
+
 _VERBOSE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("on", "enable verbose logging"),
     ("off", "disable verbose logging"),
 )
+
+
+def _cmd_auto(session: Session, console: Console, args: list[str]) -> bool:
+    if not args:
+        console.print(f"[{HIGHLIGHT}]{format_auto_status_plain(session.terminal.auto_level)}[/]")
+        choices = ", ".join(level.value for level in AutoLevel)
+        console.print(f"[{DIM}]usage:[/] /auto <{choices}>")
+        return True
+    level = parse_auto_level(args[0])
+    if level is None:
+        choices = ", ".join(level.value for level in AutoLevel)
+        console.print(
+            f"[{ERROR}]unknown auto level:[/] {escape(args[0])} [{DIM}](choices: {choices})[/]"
+        )
+        session.mark_latest(ok=False, kind="slash")
+        return True
+    session.terminal.auto_level = level
+    console.print(f"[{HIGHLIGHT}]{format_auto_status_plain(level)}[/]")
+    return True
+
 
 _EFFORT_HELP: dict[ReasoningEffort, str] = {
     ReasoningEffort.LOW: "favor speed and lower reasoning cost",
@@ -157,6 +187,13 @@ def _cmd_verbose(_session: Session, console: Console, args: list[str]) -> bool:
 
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
+        "/auto",
+        "Set tool-approval autonomy: off, low, med, or high.",
+        _cmd_auto,
+        usage=("/auto", "/auto med", "/auto high"),
+        first_arg_completions=_AUTO_FIRST_ARGS,
+    ),
+    SlashCommand(
         "/trust",
         "Manage trust mode.",
         _cmd_trust,
@@ -181,4 +218,10 @@ COMMANDS: list[SlashCommand] = [
     ),
 ]
 
-__all__ = ["COMMANDS", "_TRUST_FIRST_ARGS", "_VERBOSE_FIRST_ARGS", "_EFFORT_FIRST_ARGS"]
+__all__ = [
+    "COMMANDS",
+    "_AUTO_FIRST_ARGS",
+    "_TRUST_FIRST_ARGS",
+    "_VERBOSE_FIRST_ARGS",
+    "_EFFORT_FIRST_ARGS",
+]

--- a/surfaces/interactive_shell/command_registry/settings_cmds.py
+++ b/surfaces/interactive_shell/command_registry/settings_cmds.py
@@ -1,4 +1,4 @@
-"""Slash commands: session settings (/trust, /effort, /verbose, /compact)."""
+"""Slash commands: session settings (/auto, /trust, /effort, /verbose)."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import surfaces.interactive_shell.command_registry.repl_data as repl_data
 from config.constants.llm import LLM_PROVIDER_ENV
 from config.constants.repl_autonomy import (
     AUTO_LEVEL_CAPTIONS,
+    DEFAULT_AUTO_LEVEL,
     AutoLevel,
     format_auto_status_plain,
     parse_auto_level,
@@ -56,19 +57,29 @@ _VERBOSE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
 def _cmd_auto(session: Session, console: Console, args: list[str]) -> bool:
     if not args:
         console.print(f"[{HIGHLIGHT}]{format_auto_status_plain(session.terminal.auto_level)}[/]")
+        console.print(
+            f"[{DIM}]default:[/] {DEFAULT_AUTO_LEVEL.value} "
+            f"({AUTO_LEVEL_CAPTIONS[DEFAULT_AUTO_LEVEL]})"
+        )
+        for level in AutoLevel:
+            console.print(f"[{DIM}]  {level.value}[/] — {AUTO_LEVEL_CAPTIONS[level]}")
+        console.print(
+            f"[{DIM}]/trust on skips approval prompts even when /auto would ask. "
+            "Session-only; not restored by /resume.[/]"
+        )
         choices = ", ".join(level.value for level in AutoLevel)
         console.print(f"[{DIM}]usage:[/] /auto <{choices}>")
         return True
-    level = parse_auto_level(args[0])
-    if level is None:
+    parsed = parse_auto_level(args[0])
+    if parsed is None:
         choices = ", ".join(level.value for level in AutoLevel)
         console.print(
             f"[{ERROR}]unknown auto level:[/] {escape(args[0])} [{DIM}](choices: {choices})[/]"
         )
         session.mark_latest(ok=False, kind="slash")
         return True
-    session.terminal.auto_level = level
-    console.print(f"[{HIGHLIGHT}]{format_auto_status_plain(level)}[/]")
+    session.terminal.auto_level = parsed
+    console.print(f"[{HIGHLIGHT}]{format_auto_status_plain(parsed)}[/]")
     return True
 
 
@@ -191,6 +202,14 @@ COMMANDS: list[SlashCommand] = [
         "Set tool-approval autonomy: off, low, med, or high.",
         _cmd_auto,
         usage=("/auto", "/auto med", "/auto high"),
+        notes=(
+            "Default is high (alpha): actions run without approval.",
+            "off asks before every tool; low also asks before investigations; "
+            "med asks before mutating agent tools (shell, code, slash/CLI, …); "
+            "high asks nothing.",
+            "/trust on skips approval prompts even when /auto would ask.",
+            "Session preference — not restored by /resume.",
+        ),
         first_arg_completions=_AUTO_FIRST_ARGS,
     ),
     SlashCommand(

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -16,6 +16,7 @@ from surfaces.shared.terminal.components.token_format import (
     _CHARS_PER_TOKEN,
     format_token_count_short,
 )
+from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_line_width
 
 # How often prompt-toolkit refreshes prompt callbacks and confirmation polling.
 PROMPT_REFRESH_INTERVAL_S = 0.25
@@ -302,9 +303,20 @@ class SpinnerState:
         else:
             suffix = f" ({elapsed:.0f}s)"
         label = self.phase or f"{self._verb}…"
+        cancel = "  esc to cancel"
+        # One prompt-region row only: a long investigation phase (or a narrow
+        # terminal) must not soft-wrap — that desyncs row height vs the one-row
+        # confirmation prefix and leaves stale spinner/status lines.
+        width = prompt_line_width()
+        lead = f"{glyph} "
+        reserved = len(lead) + len(suffix) + len(cancel)
+        if reserved >= width:
+            visible = clip_prompt_text(f"{lead}{label}{suffix}{cancel}", width)
+            return f"{ui_theme.PROMPT_ACCENT_ANSI}{visible}{ui_theme.ANSI_RESET}"
+        clipped_label = clip_prompt_text(label, width - reserved)
         return (
-            f"{ui_theme.PROMPT_ACCENT_ANSI}{glyph} {label}{ui_theme.ANSI_RESET}"
-            f"{ui_theme.ANSI_DIM}{suffix}  esc to cancel{ui_theme.ANSI_RESET}"
+            f"{ui_theme.PROMPT_ACCENT_ANSI}{lead}{clipped_label}{ui_theme.ANSI_RESET}"
+            f"{ui_theme.ANSI_DIM}{suffix}{cancel}{ui_theme.ANSI_RESET}"
         )
 
 

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from config.constants.repl_autonomy import DEFAULT_AUTO_LEVEL, AutoLevel
 from surfaces.interactive_shell.session.background_investigations import (
     BackgroundInvestigationRecord,
     BackgroundNotificationPreferences,
@@ -44,6 +45,9 @@ class TerminalSession:
 
     trust_mode: bool = False
     """When True, confirmation prompts for elevated REPL actions are skipped."""
+
+    auto_level: AutoLevel = DEFAULT_AUTO_LEVEL
+    """Auto (Off|Low|Med|High) shown above the input box."""
 
     prompt_history_backend: History | None = None
     """The live ``prompt_toolkit.History`` object backing the input prompt.

--- a/surfaces/interactive_shell/ui/auto_status.py
+++ b/surfaces/interactive_shell/ui/auto_status.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from config.constants.repl_autonomy import DEFAULT_AUTO_LEVEL, format_auto_status_plain
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal import theme as ui_theme
-from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
 from surfaces.shared.terminal.tables.provider import detect_provider_model
+
+if TYPE_CHECKING:
+    from surfaces.interactive_shell.session import Session
 
 
 def auto_status_ansi(session: Session) -> str:

--- a/surfaces/interactive_shell/ui/auto_status.py
+++ b/surfaces/interactive_shell/ui/auto_status.py
@@ -1,0 +1,39 @@
+"""Auto (Med) status line above the prompt input."""
+
+from __future__ import annotations
+
+from config.constants.repl_autonomy import DEFAULT_AUTO_LEVEL, format_auto_status_plain
+from infrastructure.safety.terminal_output import strip_terminal_controls
+from infrastructure.terminal import theme as ui_theme
+from surfaces.interactive_shell.runtime import Session
+from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
+from surfaces.shared.terminal.tables.provider import detect_provider_model
+
+
+def auto_status_ansi(session: Session) -> str:
+    """One row: ``Auto (Med) · allow reversible commands`` plus the model name."""
+    level = getattr(session.terminal, "auto_level", DEFAULT_AUTO_LEVEL)
+    left = format_auto_status_plain(level)
+    _provider, model = detect_provider_model()
+    width = prompt_line_width()
+    # Model ids come from config/env. CPR stripping on the composed prompt
+    # region does not remove OSC/CSI/BEL, so sanitize before interpolating.
+    right = strip_terminal_controls(model or "").strip()
+    gap = 2
+    if right and len(left) + gap + len(right) > width:
+        right = ""
+    title_end = left.find(" · ")
+    title = left if title_end < 0 else left[:title_end]
+    rest = "" if title_end < 0 else left[title_end:]
+    if not right:
+        clipped = clip_prompt_text(left, width)
+        return f"{ui_theme.PROMPT_ACCENT_ANSI}{clipped}{ui_theme.ANSI_RESET}"
+    pad = max(width - len(left) - len(right), gap)
+    return (
+        f"{ui_theme.PROMPT_ACCENT_ANSI}{title}{ui_theme.ANSI_RESET}"
+        f"{ui_theme.DIM_ANSI}{rest}{ui_theme.ANSI_RESET}"
+        f"{' ' * pad}{ui_theme.BRAND_ANSI}{right}{ui_theme.ANSI_RESET}"
+    )
+
+
+__all__ = ["auto_status_ansi"]

--- a/surfaces/interactive_shell/ui/execution_confirm.py
+++ b/surfaces/interactive_shell/ui/execution_confirm.py
@@ -1,8 +1,9 @@
 """Interaction layer for the REPL execution policy.
 
 This module owns the *user-facing* half of the execution gate: it renders the
-policy decision (``Action blocked``, the non-TTY warning, the ``Proceed? [Y/n]``
-prompt), reads the user's confirmation, and emits analytics. The pure decision
+policy decision (``Action blocked``, the non-TTY warning, the
+``Command to approve`` card, the ``Yes, allow? [Y/n]`` prompt), reads the
+user's confirmation, and emits analytics. The pure decision
 itself is computed by
 :func:`tools.interactive_shell.shared.resolve_confirmation`,
 which has no console, ``input``, or analytics dependency.
@@ -20,15 +21,18 @@ from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.markup import escape
+from rich.text import Text
 
+from config.constants.repl_autonomy import DEFAULT_AUTO_LEVEL
 from core.agent_harness.spi.session_state import trust_mode_enabled
 from infrastructure.analytics.cli import capture_repl_execution_policy_decision
 from infrastructure.analytics.provider import Properties
-from infrastructure.terminal.theme import DIM, WARNING
+from infrastructure.terminal.theme import DIM, HIGHLIGHT, SECONDARY, TEXT, WARNING
 from tools.interactive_shell.shared import (
     ConfirmationOutcome,
     ExecutionPolicyResult,
     ExecutionVerdict,
+    apply_auto_level,
     resolve_confirmation,
 )
 
@@ -41,6 +45,34 @@ def _default_confirm_fn(prompt: str) -> str:
 
 
 DEFAULT_CONFIRM_FN: Callable[[str], str] = _default_confirm_fn
+_APPROVE_PROMPT = "Yes, allow? [Y/n] "
+
+
+def _render_command_to_approve(
+    console: Console,
+    *,
+    summary: str,
+    reason: str,
+    action_already_listed: bool,
+) -> None:
+    """Approval card: header, command child, why-this-needs-approval."""
+    header = Text()
+    header.append("Command to approve", style=str(HIGHLIGHT))
+    header.append(" · ", style=str(DIM))
+    header.append("needs confirmation", style=str(HIGHLIGHT))
+    console.print()
+    console.print(header)
+    if summary and not action_already_listed:
+        child = Text()
+        child.append("↳ ", style=str(DIM))
+        child.append(summary, style=str(TEXT))
+        console.print(child)
+    why = Text()
+    why.append("Why this needs approval: ", style=str(DIM))
+    why.append(reason, style=str(SECONDARY))
+    console.print(why)
+    console.print(Text("Yes, allow  ·  No, cancel", style=str(DIM)))
+    console.print()
 
 
 def _emit_decision(
@@ -83,6 +115,8 @@ def execution_allowed(
     trust_mode = trust_mode_enabled(session)
     tty = sys.stdin.isatty() if is_tty is None else is_tty
     confirm = confirm_fn or DEFAULT_CONFIRM_FN
+    auto_level = getattr(getattr(session, "terminal", None), "auto_level", DEFAULT_AUTO_LEVEL)
+    result = apply_auto_level(result, auto_level)
 
     plan = resolve_confirmation(result, trust_mode=trust_mode, is_tty=tty)
 
@@ -127,15 +161,13 @@ def execution_allowed(
     # NEEDS_CONFIRMATION
     reason = (result.reason or "this action").strip()
     summary = action_summary.strip()
-    if action_already_listed:
-        console.print(f"[{WARNING}]Confirm:[/] [{DIM}]{escape(reason)}[/]")
-    elif summary:
-        console.print(
-            f"[{WARNING}]Confirm[/] [bold]{escape(summary)}[/bold] [{DIM}]— {escape(reason)}[/]"
-        )
-    else:
-        console.print(f"[{WARNING}]Confirm:[/] [{DIM}]{escape(reason)}[/]")
-    answer = confirm("Proceed? [Y/n] ").strip().lower()
+    _render_command_to_approve(
+        console,
+        summary=summary,
+        reason=reason,
+        action_already_listed=action_already_listed,
+    )
+    answer = confirm(_APPROVE_PROMPT).strip().lower()
     if answer not in {"", "y", "yes"}:
         _emit_decision(
             tool_type=result.tool_type,

--- a/surfaces/interactive_shell/ui/input_prompt/completion.py
+++ b/surfaces/interactive_shell/ui/input_prompt/completion.py
@@ -14,10 +14,10 @@ from surfaces.interactive_shell.command_registry.help import QUICK_ACCESS_COMMAN
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.ui.input_prompt.layout import (
     _DEFAULT_TERMINAL_COLUMNS,
-    _clip_text,
-    _prompt_line_width,
     _short_meta,
     _terminal_columns,
+    clip_prompt_text,
+    prompt_line_width,
 )
 from surfaces.shared.terminal.components.choice_menu import repl_tty_interactive
 
@@ -77,9 +77,9 @@ def completion_preview_hint_ansi() -> str:
         cols = _DEFAULT_TERMINAL_COLUMNS
     # Leave the last column empty so this context line cannot soft-wrap on
     # shrink-resize and orphan stale prompt frames (same budget as the rule).
-    line = _clip_text(
+    line = clip_prompt_text(
         f"{label}{_COMPLETION_PREVIEW_SEP}{description}",
-        _prompt_line_width(cols),
+        prompt_line_width(cols),
     )
     return f"{ui_theme.ANSI_DIM}{line}{ui_theme.ANSI_RESET}"
 

--- a/surfaces/interactive_shell/ui/input_prompt/completion.py
+++ b/surfaces/interactive_shell/ui/input_prompt/completion.py
@@ -13,13 +13,15 @@ from surfaces.interactive_shell.command_registry import SLASH_COMMANDS
 from surfaces.interactive_shell.command_registry.help import QUICK_ACCESS_COMMANDS
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.ui.input_prompt.layout import (
-    _DEFAULT_TERMINAL_COLUMNS,
     _short_meta,
-    _terminal_columns,
     clip_prompt_text,
     prompt_line_width,
 )
 from surfaces.shared.terminal.components.choice_menu import repl_tty_interactive
+from surfaces.shared.terminal.prompt_layout import (
+    DEFAULT_TERMINAL_COLUMNS,
+    terminal_columns,
+)
 
 _COMPLETION_PREVIEW_SEP = " — "
 
@@ -74,7 +76,7 @@ def completion_preview_hint_ansi() -> str:
     try:
         cols = app.output.get_size().columns
     except Exception:
-        cols = _DEFAULT_TERMINAL_COLUMNS
+        cols = DEFAULT_TERMINAL_COLUMNS
     # Leave the last column empty so this context line cannot soft-wrap on
     # shrink-resize and orphan stale prompt frames (same budget as the rule).
     line = clip_prompt_text(
@@ -116,7 +118,7 @@ class ShellCompleter(Completer):
         trailing_space = text != text.rstrip(" ")
         if len(parts) == 1 and not trailing_space:
             needle = parts[0].lower()
-            cols = _terminal_columns()
+            cols = terminal_columns()
             if needle == "/":
                 # Bare `/`: show most important commands first, then the rest.
                 for name in QUICK_ACCESS_COMMANDS:

--- a/surfaces/interactive_shell/ui/input_prompt/layout.py
+++ b/surfaces/interactive_shell/ui/input_prompt/layout.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from surfaces.shared.terminal.prompt_layout import (
-    DEFAULT_TERMINAL_COLUMNS,
     clip_prompt_text,
     prompt_line_width,
     terminal_columns,
@@ -11,12 +10,6 @@ from surfaces.shared.terminal.prompt_layout import (
 
 _COMPLETION_META_PADDING = 6
 _COMPLETION_META_MIN_WIDTH = 24
-
-# In-package aliases (prompt rendering / completion stay on the private names).
-_DEFAULT_TERMINAL_COLUMNS = DEFAULT_TERMINAL_COLUMNS
-_terminal_columns = terminal_columns
-_prompt_line_width = prompt_line_width
-_clip_text = clip_prompt_text
 
 
 def _completion_meta_width(command_name: str, cols: int) -> int:

--- a/surfaces/interactive_shell/ui/input_prompt/layout.py
+++ b/surfaces/interactive_shell/ui/input_prompt/layout.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from prompt_toolkit.application.current import get_app_or_none
 
+from infrastructure.safety.terminal_output import strip_terminal_controls
+
 _DEFAULT_TERMINAL_COLUMNS = 80
 _COMPLETION_META_PADDING = 6
 _COMPLETION_META_MIN_WIDTH = 24
@@ -19,7 +21,7 @@ def _terminal_columns() -> int:
         return _DEFAULT_TERMINAL_COLUMNS
 
 
-def _prompt_line_width(cols: int | None = None) -> int:
+def prompt_line_width(cols: int | None = None) -> int:
     """Visible width for a live prompt-region line.
 
     Leave the last terminal column empty. A glyph in that column puts the
@@ -31,12 +33,19 @@ def _prompt_line_width(cols: int | None = None) -> int:
     return max(width - 1, 1)
 
 
-def _clip_text(text: str, max_len: int) -> str:
+def clip_prompt_text(text: str, max_len: int) -> str:
+    """Truncate to ``max_len`` visible characters after stripping controls.
+
+    Overlay and menu rows interpolate this into raw ANSI. Control characters
+    (ESC, OSC, CR) would spoof the terminal and break row accounting, so they
+    are removed before width is measured.
+    """
+    visible = strip_terminal_controls(text)
     if max_len <= 0:
         return ""
-    if len(text) <= max_len:
-        return text
-    return text[: max_len - 1] + "…"
+    if len(visible) <= max_len:
+        return visible
+    return visible[: max_len - 1] + "…"
 
 
 def _completion_meta_width(command_name: str, cols: int) -> int:
@@ -55,4 +64,4 @@ def _short_meta(
             max_len = _completion_meta_width(command_name, cols or _terminal_columns())
         else:
             max_len = 54
-    return _clip_text(text, max_len)
+    return clip_prompt_text(text, max_len)

--- a/surfaces/interactive_shell/ui/input_prompt/layout.py
+++ b/surfaces/interactive_shell/ui/input_prompt/layout.py
@@ -2,50 +2,21 @@
 
 from __future__ import annotations
 
-from prompt_toolkit.application.current import get_app_or_none
+from surfaces.shared.terminal.prompt_layout import (
+    DEFAULT_TERMINAL_COLUMNS,
+    clip_prompt_text,
+    prompt_line_width,
+    terminal_columns,
+)
 
-from infrastructure.safety.terminal_output import strip_terminal_controls
-
-_DEFAULT_TERMINAL_COLUMNS = 80
 _COMPLETION_META_PADDING = 6
 _COMPLETION_META_MIN_WIDTH = 24
 
-
-def _terminal_columns() -> int:
-    app = get_app_or_none()
-    if app is None:
-        return _DEFAULT_TERMINAL_COLUMNS
-    try:
-        return app.output.get_size().columns
-    except Exception:
-        return _DEFAULT_TERMINAL_COLUMNS
-
-
-def prompt_line_width(cols: int | None = None) -> int:
-    """Visible width for a live prompt-region line.
-
-    Leave the last terminal column empty. A glyph in that column puts the
-    cursor in the pending-wrap state; on shrink-resize the emulator soft-wraps
-    the line, prompt-toolkit's row accounting drifts, and stale hint/rule
-    frames are left in scrollback.
-    """
-    width = _terminal_columns() if cols is None else cols
-    return max(width - 1, 1)
-
-
-def clip_prompt_text(text: str, max_len: int) -> str:
-    """Truncate to ``max_len`` visible characters after stripping controls.
-
-    Overlay and menu rows interpolate this into raw ANSI. Control characters
-    (ESC, OSC, CR) would spoof the terminal and break row accounting, so they
-    are removed before width is measured.
-    """
-    visible = strip_terminal_controls(text)
-    if max_len <= 0:
-        return ""
-    if len(visible) <= max_len:
-        return visible
-    return visible[: max_len - 1] + "…"
+# In-package aliases (prompt rendering / completion stay on the private names).
+_DEFAULT_TERMINAL_COLUMNS = DEFAULT_TERMINAL_COLUMNS
+_terminal_columns = terminal_columns
+_prompt_line_width = prompt_line_width
+_clip_text = clip_prompt_text
 
 
 def _completion_meta_width(command_name: str, cols: int) -> int:
@@ -61,7 +32,13 @@ def _short_meta(
 ) -> str:
     if max_len is None:
         if command_name:
-            max_len = _completion_meta_width(command_name, cols or _terminal_columns())
+            max_len = _completion_meta_width(command_name, cols or terminal_columns())
         else:
             max_len = 54
     return clip_prompt_text(text, max_len)
+
+
+__all__ = [
+    "clip_prompt_text",
+    "prompt_line_width",
+]

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -11,9 +11,9 @@ from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.input_prompt.completion import completion_preview_hint_ansi
 from surfaces.interactive_shell.ui.input_prompt.layout import (
-    _clip_text,
-    _prompt_line_width,
     _short_meta,
+    clip_prompt_text,
+    prompt_line_width,
 )
 from surfaces.shared.terminal.banner.banner_state import integration_display_name
 
@@ -32,9 +32,7 @@ def _prompt_rule_ansi() -> str:
     # One column short of the terminal width so shrink-resize cannot soft-wrap
     # this line and orphan stale prompt frames in scrollback.
     return (
-        f"{ui_theme.PROMPT_FRAME_ANSI}"
-        f"{_prompt_rule_line(_prompt_line_width())}"
-        f"{ui_theme.ANSI_RESET}"
+        f"{ui_theme.PROMPT_FRAME_ANSI}{_prompt_rule_line(prompt_line_width())}{ui_theme.ANSI_RESET}"
     )
 
 
@@ -130,7 +128,7 @@ def resolve_idle_hint_ansi(session: Session) -> str:
         parts.append("esc to clear")
     # Clip to the safe prompt-region width so a long integration list cannot
     # reach the last column and soft-wrap on shrink-resize.
-    hint = _clip_text(" · ".join(parts), _prompt_line_width())
+    hint = clip_prompt_text(" · ".join(parts), prompt_line_width())
     return f"{ui_theme.DIM_ANSI}{hint}{ui_theme.ANSI_RESET}"
 
 

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -57,15 +57,18 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     with the rest of the region on submit (``erase_when_done=True``).
     """
     base = prompt_rendering._prompt_message(session).value
-    if state.is_awaiting_confirmation():
-        return ANSI(f"\n{state.confirm_prompt_text}\n{base}")
-    prefix = strip_cpr_sequences(
-        prompt_rendering.resolve_prompt_prefix_ansi(
-            inline_spinner=spinner.inline_spinner_ansi(),
-            idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
-        )
-    )
     auto_line = strip_cpr_sequences(auto_status_ansi(session))
+    # The confirmation prompt takes the prefix row so every state renders the
+    # same rows (blank, prefix, auto status, input) — no height delta on redraw.
+    if state.is_awaiting_confirmation():
+        prefix = state.confirm_prompt_text
+    else:
+        prefix = strip_cpr_sequences(
+            prompt_rendering.resolve_prompt_prefix_ansi(
+                inline_spinner=spinner.inline_spinner_ansi(),
+                idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
+            )
+        )
     return ANSI(f"\n{prefix}\n{auto_line}\n{base}")
 
 

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from prompt_toolkit.formatted_text import ANSI
 from rich.console import Console
 
+from surfaces.interactive_shell.ui.auto_status import auto_status_ansi
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
 from surfaces.shared.terminal.banner import render_ready_box
 from surfaces.shared.terminal.components.cpr_stdin import strip_cpr_sequences
@@ -47,7 +48,8 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     """Compose the live prompt region: context line plus rule and input prefix.
 
     The top line is the pending confirmation prompt when one is active,
-    otherwise the spinner, completion preview, or idle hint.
+    otherwise the spinner, completion preview, or idle hint, followed by the
+    autonomy status line showing the active ``/auto`` level.
 
     The region always starts with one blank row so the hint/spinner line never
     sits flush against whatever output scrolled above it. The row is constant
@@ -63,7 +65,8 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
             idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
         )
     )
-    return ANSI(f"\n{prefix}\n{base}")
+    auto_line = strip_cpr_sequences(auto_status_ansi(session))
+    return ANSI(f"\n{prefix}\n{auto_line}\n{base}")
 
 
 __all__ = ["render_prompt_region", "render_terminal_ui"]

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -23,6 +23,7 @@ from surfaces.interactive_shell.ui.auto_status import auto_status_ansi
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
 from surfaces.shared.terminal.banner import render_ready_box
 from surfaces.shared.terminal.components.cpr_stdin import strip_cpr_sequences
+from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_line_width
 
 if TYPE_CHECKING:
     from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
@@ -61,7 +62,9 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     # The confirmation prompt takes the prefix row so every state renders the
     # same rows (blank, prefix, auto status, input) — no height delta on redraw.
     if state.is_awaiting_confirmation():
-        prefix = state.confirm_prompt_text
+        # Same one-row budget as the spinner/idle hint: a long confirm string
+        # must not soft-wrap when the spinner path is clipped to width.
+        prefix = clip_prompt_text(state.confirm_prompt_text, prompt_line_width())
     else:
         prefix = strip_cpr_sequences(
             prompt_rendering.resolve_prompt_prefix_ansi(

--- a/surfaces/shared/terminal/prompt_layout.py
+++ b/surfaces/shared/terminal/prompt_layout.py
@@ -1,0 +1,45 @@
+"""Prompt-region line width and clipping (leaf — no shell runtime imports).
+
+Live prompt rows (spinner, idle hint, auto status, overlays) must stay one
+terminal line. A glyph in the last column puts the cursor in pending-wrap;
+on shrink-resize the emulator soft-wraps and prompt-toolkit row accounting
+drifts, leaving stale frames in scrollback.
+"""
+
+from __future__ import annotations
+
+from prompt_toolkit.application.current import get_app_or_none
+
+from infrastructure.safety.terminal_output import strip_terminal_controls
+
+DEFAULT_TERMINAL_COLUMNS = 80
+
+
+def terminal_columns() -> int:
+    """Current terminal width, or 80 when no prompt_toolkit app is active."""
+    app = get_app_or_none()
+    if app is None:
+        return DEFAULT_TERMINAL_COLUMNS
+    try:
+        return app.output.get_size().columns
+    except Exception:
+        return DEFAULT_TERMINAL_COLUMNS
+
+
+def prompt_line_width(cols: int | None = None) -> int:
+    """Visible width for a live prompt-region line (last column left empty)."""
+    width = terminal_columns() if cols is None else cols
+    return max(width - 1, 1)
+
+
+def clip_prompt_text(text: str, max_len: int) -> str:
+    """Truncate to ``max_len`` visible characters after stripping controls."""
+    visible = strip_terminal_controls(text)
+    if max_len <= 0:
+        return ""
+    if len(visible) <= max_len:
+        return visible
+    return visible[: max_len - 1] + "…"
+
+
+__all__ = ["DEFAULT_TERMINAL_COLUMNS", "clip_prompt_text", "prompt_line_width", "terminal_columns"]

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 import time
 
+import pytest
+
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 
 _GLYPHS = SpinnerState._SPINNER_FRAMES
@@ -63,3 +65,17 @@ def test_spinner_empty_when_not_streaming() -> None:
     spinner.start()
     spinner.stop()
     assert spinner.inline_spinner_ansi() == ""
+
+
+def test_spinner_clips_long_phase_to_one_prompt_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Long investigation labels must not soft-wrap the prompt prefix row."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.core.state.prompt_line_width",
+        lambda: 40,
+    )
+    spinner = SpinnerState()
+    spinner.set_phase("Gathering Datadog APM spans for checkout-service p99 regression analysis")
+    rendered = re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", spinner.inline_spinner_ansi())
+    assert "\n" not in rendered
+    assert len(rendered) <= 40
+    assert rendered.endswith("…") or "esc to cancel" in rendered

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -204,6 +204,16 @@ class TestDispatchSlash:
         assert "Auto (Med)" in buf.getvalue()
         assert "allow reversible commands" in buf.getvalue()
 
+    def test_auto_bare_shows_default_and_levels(self) -> None:
+        session = Session()
+        console, buf = _capture()
+        dispatch_slash("/auto", session, console)
+        out = buf.getvalue()
+        assert "Auto (High)" in out
+        assert "default:" in out
+        assert "off" in out and "all actions require approval" in out
+        assert "/trust on skips approval" in out
+
     def test_effort_sets_session_preference(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class _FakeLLM:
             provider = "openai"

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -196,6 +196,14 @@ class TestDispatchSlash:
         dispatch_slash("/trust off", session, console)
         assert session.terminal.trust_mode is False
 
+    def test_auto_sets_med(self) -> None:
+        session = Session()
+        console, buf = _capture()
+        dispatch_slash("/auto med", session, console)
+        assert session.terminal.auto_level == "med"
+        assert "Auto (Med)" in buf.getvalue()
+        assert "allow reversible commands" in buf.getvalue()
+
     def test_effort_sets_session_preference(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class _FakeLLM:
             provider = "openai"

--- a/tests/interactive_shell/tools/shared/test_execution_policy.py
+++ b/tests/interactive_shell/tools/shared/test_execution_policy.py
@@ -15,12 +15,14 @@ lives in ``tools.interactive_shell.shell.policy`` and is covered by
 
 from __future__ import annotations
 
+from config.constants.repl_autonomy import AutoLevel
 from tools.interactive_shell.shared import (
     ConfirmationOutcome,
     ExecutionPolicyResult,
     ToolExecutionMode,
     ToolExecutionPlan,
     allow_tool,
+    apply_auto_level,
     plan_foreground_tool,
     resolve_confirmation,
 )
@@ -114,3 +116,40 @@ def test_resolve_ask_tty_needs_confirmation() -> None:
     # The analytics outcome for a prompt is decided by the interaction layer.
     assert plan.analytics_outcome is None
     assert plan.analytics_reason is None
+
+
+def test_auto_high_leaves_default_allow() -> None:
+    result = apply_auto_level(allow_tool("shell"), AutoLevel.HIGH)
+    assert result.verdict == "allow"
+
+
+def test_auto_med_asks_mutating_tools_and_allows_read_only() -> None:
+    # Med "allow reversible commands": mutation-capable tools still require
+    # approval (including agent-selected slash/CLI and synthetic_test); read-only
+    # investigation runs without a prompt.
+    for mutating in (
+        "shell",
+        "code_agent",
+        "slash",
+        "cli_command",
+        "opensre_cli",
+        "switch_llm_provider",
+        "synthetic_test",
+        "sentry_issue_fix",
+    ):
+        result = apply_auto_level(allow_tool(mutating), AutoLevel.MED)
+        assert result.verdict == "ask", mutating
+        assert "Auto (Med)" in (result.reason or "")
+    read_only = apply_auto_level(allow_tool("investigation"), AutoLevel.MED)
+    assert read_only.verdict == "allow"
+
+
+def test_auto_low_asks_slash_and_investigation() -> None:
+    for tool_type in ("slash", "investigation", "synthetic_test"):
+        result = apply_auto_level(allow_tool(tool_type), AutoLevel.LOW)
+        assert result.verdict == "ask", tool_type
+
+
+def test_auto_off_asks_every_tool_type() -> None:
+    result = apply_auto_level(allow_tool("slash"), AutoLevel.OFF)
+    assert result.verdict == "ask"

--- a/tests/interactive_shell/tools/shared/test_execution_policy.py
+++ b/tests/interactive_shell/tools/shared/test_execution_policy.py
@@ -144,10 +144,15 @@ def test_auto_med_asks_mutating_tools_and_allows_read_only() -> None:
     assert read_only.verdict == "allow"
 
 
-def test_auto_low_asks_slash_and_investigation() -> None:
-    for tool_type in ("slash", "investigation", "synthetic_test"):
+def test_auto_low_asks_slash_investigation_and_sample_alert() -> None:
+    for tool_type in ("slash", "investigation", "sample_alert", "synthetic_test"):
         result = apply_auto_level(allow_tool(tool_type), AutoLevel.LOW)
         assert result.verdict == "ask", tool_type
+
+
+def test_auto_med_allows_sample_alert() -> None:
+    # Sample alerts are investigation-shaped; Med still allows them (Low gates).
+    assert apply_auto_level(allow_tool("sample_alert"), AutoLevel.MED).verdict == "allow"
 
 
 def test_auto_off_asks_every_tool_type() -> None:

--- a/tests/interactive_shell/ui/test_auto_status.py
+++ b/tests/interactive_shell/ui/test_auto_status.py
@@ -61,3 +61,25 @@ def test_render_prompt_region_shows_the_auto_status_line() -> None:
     plain = re.sub(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07", "", rendered)
 
     assert "Auto (Med)" in plain
+
+
+def test_prompt_region_height_is_constant_across_confirmation() -> None:
+    """Entering/leaving confirmation must not change the region's row count."""
+    from surfaces.interactive_shell.runtime.core.state import (
+        ReplState,
+        SpinnerState,
+        TurnPhase,
+    )
+    from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
+
+    session = Session()
+    spinner = SpinnerState()
+
+    normal_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
+
+    confirming = ReplState()
+    confirming.phase = TurnPhase.AWAITING_CONFIRMATION
+    confirming.confirm_prompt_text = "Proceed? [Y/n]"
+    confirm_rows = render_prompt_region(session, confirming, spinner).value.count("\n")
+
+    assert normal_rows == confirm_rows

--- a/tests/interactive_shell/ui/test_auto_status.py
+++ b/tests/interactive_shell/ui/test_auto_status.py
@@ -1,0 +1,47 @@
+"""Auto-status ANSI line: model labels must not inject terminal controls."""
+
+from __future__ import annotations
+
+from config.constants.repl_autonomy import AutoLevel
+from surfaces.interactive_shell.session import Session
+from surfaces.interactive_shell.ui.auto_status import auto_status_ansi
+
+
+def test_model_label_strips_terminal_controls(monkeypatch) -> None:
+    """A configured model id with ESC/OSC/BEL must not reach the ANSI status line."""
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.auto_status.detect_provider_model",
+        lambda: ("openai", "gpt-4\x1b]0;pwn\x07o\x1b[2J\x1b[1;1H"),
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.auto_status.prompt_line_width",
+        lambda: 120,
+    )
+    session = Session()
+    session.terminal.auto_level = AutoLevel.MED
+
+    rendered = auto_status_ansi(session)
+
+    assert "\x1b]" not in rendered
+    assert "\x07" not in rendered
+    assert "\x1b[2J" not in rendered
+    assert "\x1b[1;1H" not in rendered
+    assert "gpt-4" in rendered
+    assert "Auto (Med)" in rendered
+
+
+def test_all_control_model_falls_back_to_left_only(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.auto_status.detect_provider_model",
+        lambda: ("openai", "\x1b\x07\x9b"),
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.auto_status.prompt_line_width",
+        lambda: 80,
+    )
+
+    rendered = auto_status_ansi(Session())
+
+    assert "\x1b[2J" not in rendered
+    assert "\x07" not in rendered
+    assert "Auto (" in rendered

--- a/tests/interactive_shell/ui/test_auto_status.py
+++ b/tests/interactive_shell/ui/test_auto_status.py
@@ -45,3 +45,19 @@ def test_all_control_model_falls_back_to_left_only(monkeypatch) -> None:
     assert "\x1b[2J" not in rendered
     assert "\x07" not in rendered
     assert "Auto (" in rendered
+
+
+def test_render_prompt_region_shows_the_auto_status_line() -> None:
+    """The live prompt composition must reach ``auto_status_ansi`` so the level shows."""
+    import re
+
+    from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+    from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
+
+    session = Session()
+    session.terminal.auto_level = AutoLevel.MED
+
+    rendered = render_prompt_region(session, ReplState(), SpinnerState()).value
+    plain = re.sub(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07", "", rendered)
+
+    assert "Auto (Med)" in plain

--- a/tests/interactive_shell/ui/test_execution_confirm.py
+++ b/tests/interactive_shell/ui/test_execution_confirm.py
@@ -11,6 +11,7 @@ import io
 
 from rich.console import Console
 
+from config.constants.repl_autonomy import AutoLevel
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
 from tools.interactive_shell.shared import (
@@ -139,7 +140,9 @@ def test_explicit_ask_tty_accepts_empty_confirmation() -> None:
         confirm_fn=_confirm,
         is_tty=True,
     )
-    assert captured == ["Proceed? [Y/n] "]
+    assert captured == ["Yes, allow? [Y/n] "]
+    assert "Command to approve" in buf.getvalue()
+    assert "Why this needs approval:" in buf.getvalue()
 
 
 def test_explicit_ask_tty_rejects_explicit_no() -> None:
@@ -155,3 +158,91 @@ def test_explicit_ask_tty_rejects_explicit_no() -> None:
         is_tty=True,
     )
     assert "cancelled" in buf.getvalue()
+
+
+def test_auto_med_prompts_before_mutating_shell() -> None:
+    session = Session()
+    session.terminal.auto_level = AutoLevel.MED
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    prompted = {"asked": False}
+
+    def _confirm(_: str) -> str:
+        prompted["asked"] = True
+        return "n"
+
+    # Med must not silently run a mutation-capable shell command.
+    assert not execution_allowed(
+        allow_tool("shell"),
+        session=session,
+        console=console,
+        action_summary="!pytest",
+        confirm_fn=_confirm,
+        is_tty=True,
+    )
+    assert prompted["asked"] is True
+    assert "Command to approve" in buf.getvalue()
+
+
+def test_auto_med_prompts_before_agent_slash_mutation() -> None:
+    """Med must ask before agent-selected mutating slash (e.g. integrations remove)."""
+    session = Session()
+    session.terminal.auto_level = AutoLevel.MED
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    prompted = {"asked": False}
+
+    def _confirm(_: str) -> str:
+        prompted["asked"] = True
+        return "n"
+
+    assert not execution_allowed(
+        allow_tool("slash"),
+        session=session,
+        console=console,
+        action_summary="/integrations remove posthog",
+        confirm_fn=_confirm,
+        is_tty=True,
+    )
+    assert prompted["asked"] is True
+
+
+def test_auto_med_prompts_before_sentry_issue_fix() -> None:
+    """Med must ask before a Sentry issue-fix that can edit, commit, and open a PR."""
+    session = Session()
+    session.terminal.auto_level = AutoLevel.MED
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    prompted = {"asked": False}
+
+    def _confirm(_: str) -> str:
+        prompted["asked"] = True
+        return "n"
+
+    assert not execution_allowed(
+        allow_tool("sentry_issue_fix"),
+        session=session,
+        console=console,
+        action_summary="fix Sentry issue https://acme.sentry.io/issues/1/ and open a pull request",
+        confirm_fn=_confirm,
+        is_tty=True,
+    )
+    assert prompted["asked"] is True
+    assert "Command to approve" in buf.getvalue()
+
+
+def test_auto_off_shows_command_to_approve() -> None:
+    session = Session()
+    session.terminal.auto_level = AutoLevel.OFF
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    assert execution_allowed(
+        allow_tool("slash"),
+        session=session,
+        console=console,
+        action_summary="/status",
+        confirm_fn=lambda _: "y",
+        is_tty=True,
+    )
+    assert "Command to approve" in buf.getvalue()
+    assert "Why this needs approval:" in buf.getvalue()

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -16,7 +16,7 @@ from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.input_prompt import completion as prompt_completion
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
 from surfaces.interactive_shell.ui.input_prompt.completion import completion_preview_hint_ansi
-from surfaces.interactive_shell.ui.input_prompt.layout import _prompt_line_width
+from surfaces.interactive_shell.ui.input_prompt.layout import prompt_line_width
 from surfaces.interactive_shell.ui.input_prompt.refresh import wire_prompt_refresh
 from surfaces.interactive_shell.ui.input_prompt.rendering import (
     DEFAULT_PLACEHOLDER_TEXT,
@@ -188,7 +188,7 @@ class TestResolveIdleHint:
             "vercel",
             "aws",
         )
-        monkeypatch.setattr(prompt_rendering, "_prompt_line_width", lambda: 40)
+        monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 40)
         rendered = _strip_ansi(resolve_idle_hint_ansi(session))
         assert len(rendered) <= 40
         assert rendered.endswith("…")
@@ -197,13 +197,13 @@ class TestResolveIdleHint:
 class TestPromptRuleWidth:
     def test_rule_leaves_last_column_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A full-width rule soft-wraps on shrink and orphans stale prompt frames."""
-        monkeypatch.setattr(prompt_rendering, "_prompt_line_width", lambda: 79)
+        monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 79)
         rule = _strip_ansi(_prompt_rule_ansi())
         assert len(rule) == 79
         assert set(rule) == {"─"}
 
     def test_prompt_message_rule_uses_safe_width(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(prompt_rendering, "_prompt_line_width", lambda: 79)
+        monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 79)
         rendered = _strip_ansi(_prompt_message(Session()).value)
         rule_line, _prompt_line = rendered.split("\n", 1)
         assert len(rule_line) == 79
@@ -403,7 +403,7 @@ class TestCompletionPreviewHint:
         rendered = _strip_ansi(completion_preview_hint_ansi())
         assert rendered.endswith("…")
         # One column short of the terminal width (pending-wrap guard).
-        assert len(rendered) <= _prompt_line_width(40)
+        assert len(rendered) <= prompt_line_width(40)
         assert rendered.startswith("/plugin-cmd — ")
 
 

--- a/tests/tools/test_sentry_fix_action.py
+++ b/tests/tools/test_sentry_fix_action.py
@@ -8,6 +8,7 @@ intent selection is a live concern exercised via ReplDriver, not here.
 from __future__ import annotations
 
 import io
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,15 +20,43 @@ from core.agent_harness.tools.tool_context import (
     ActionToolScope,
 )
 from core.tool.contracts import AgentToolContext
+from tools.interactive_shell.shared import ExecutionPolicyResult
+from tools.interactive_shell.subprocess_presenter import HeadlessSubprocessPresenter
 
 _TOOL_RUN = "tools.interactive_shell.actions.sentry_fix.fix_sentry_issue.run"
 _URL = "https://acme.sentry.io/issues/12345/"
 
 
-def _ctx() -> tuple[ActionToolScope, io.StringIO]:
+class _GatePresenter(HeadlessSubprocessPresenter):
+    """Headless presenter that records the execution-policy gate."""
+
+    def __init__(self, session: Any, console: Any, *, allowed: bool = True) -> None:
+        super().__init__(session, console)
+        self.allowed = allowed
+        self.gate_calls: list[tuple[ExecutionPolicyResult, str]] = []
+
+    def execution_allowed(
+        self,
+        policy: ExecutionPolicyResult,
+        *,
+        action_summary: str,
+    ) -> bool:
+        self.gate_calls.append((policy, action_summary))
+        return self.allowed
+
+
+def _ctx(*, allowed: bool = True) -> tuple[ActionToolScope, io.StringIO]:
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False, highlight=False, width=200)
-    return ActionToolScope(session=MagicMock(), console=console), buf
+    session = MagicMock()
+    return (
+        ActionToolScope(
+            session=session,
+            console=console,
+            subprocess_presenter=_GatePresenter(session, console, allowed=allowed),
+        ),
+        buf,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -147,6 +176,21 @@ def test_renders_pr_failed_recovery_says_already_pushed(mock_run: MagicMock) -> 
     assert "pushed to branch" in out
     assert "open the PR manually" in out
     assert "push and open" not in out
+
+
+@patch(_TOOL_RUN)
+def test_refused_approval_does_not_run_the_fix(mock_run: MagicMock) -> None:
+    ctx, _ = _ctx(allowed=False)
+    handled = sentry_fix.execute_sentry_fix_tool({"sentry_url": _URL, "open_pr": True}, ctx)
+
+    assert handled is True
+    mock_run.assert_not_called()
+    presenter = ctx.subprocess_presenter
+    assert isinstance(presenter, _GatePresenter)
+    assert len(presenter.gate_calls) == 1
+    policy, summary = presenter.gate_calls[0]
+    assert policy.tool_type == "sentry_issue_fix"
+    assert "open a pull request" in summary
 
 
 # --------------------------------------------------------------------------- #

--- a/tools/interactive_shell/actions/sentry_fix.py
+++ b/tools/interactive_shell/actions/sentry_fix.py
@@ -19,6 +19,8 @@ from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from tools.cross_vendor.fix_sentry_issue import fix_sentry_issue
 from tools.cross_vendor.fix_sentry_issue.runner import is_issue_fix_enabled
+from tools.interactive_shell.shared import allow_tool
+from tools.interactive_shell.subprocess import require_subprocess_presenter
 
 
 def _render_result(console: Any, out: dict[str, Any]) -> None:
@@ -74,6 +76,15 @@ def execute_sentry_fix_tool(args: dict[str, Any], ctx: ActionToolScope) -> bool:
     if not sentry_url:
         return False
     open_pr = bool(args.get("open_pr", False))
+    presenter = require_subprocess_presenter(ctx)
+    summary = f"fix Sentry issue {sentry_url}"
+    if open_pr:
+        summary += " and open a pull request"
+    if not presenter.execution_allowed(
+        allow_tool("sentry_issue_fix"),
+        action_summary=summary,
+    ):
+        return True
 
     ctx.console.print(
         f"[bold]Fixing Sentry issue[/] {sentry_url}"

--- a/tools/interactive_shell/shared/__init__.py
+++ b/tools/interactive_shell/shared/__init__.py
@@ -16,6 +16,7 @@ from tools.interactive_shell.shared.execution_policy import (
     ToolExecutionMode,
     ToolExecutionPlan,
     allow_tool,
+    apply_auto_level,
     plan_foreground_tool,
     resolve_confirmation,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "ToolExecutionMode",
     "ToolExecutionPlan",
     "allow_tool",
+    "apply_auto_level",
     "plan_foreground_tool",
     "resolve_confirmation",
 ]

--- a/tools/interactive_shell/shared/execution_policy.py
+++ b/tools/interactive_shell/shared/execution_policy.py
@@ -17,15 +17,16 @@ read-only / mutating / restricted classification and its deny floor were removed
 evaluation still rejects is genuinely empty input (a bare ``!`` or whitespace),
 which is input validation rather than a guardrail.
 
-The ``ask`` verdict is retained so that ``trust_mode`` and any future opt-in
-stricter policy still have a hook, but the policy functions here never emit
-``ask``. If guardrails are reintroduced after alpha, gate them here at the
-execution stage (not the planner).
+The ``ask`` verdict is retained so that ``trust_mode``, ``/auto`` (Off/Low/Med),
+and any future opt-in stricter policy still have a hook. ``allow_tool`` still
+returns ``allow``; :func:`apply_auto_level` may promote that to ``ask``. High
+(the default) never does. If a shell-command allowlist is reintroduced after
+alpha, gate it here at the execution stage (not the planner).
 
 This module is intentionally **pure**: it has no terminal I/O, no analytics, and
 no console dependency. The decision is computed by :func:`resolve_confirmation`,
-and the interaction layer (printing the reason/hint, the ``Proceed? [Y/n]``
-prompt, and analytics emission) lives in
+and the interaction layer (printing the reason/hint, the
+``Command to approve`` prompt, and analytics emission) lives in
 ``interactive_shell.ui.execution_confirm.execution_allowed``.
 
 Shell-specific evaluation (empty-input rejection, ``plan_shell_execution``)
@@ -35,9 +36,15 @@ lives next to the rest of the shell machinery in
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Literal
+
+from config.constants.repl_autonomy import (
+    AUTO_LEVEL_ASK_TOOL_TYPES,
+    AUTO_LEVEL_TITLES,
+    AutoLevel,
+)
 
 ExecutionVerdict = Literal["allow", "ask", "deny"]
 
@@ -145,6 +152,27 @@ def resolve_confirmation(
     )
 
 
+def apply_auto_level(
+    result: ExecutionPolicyResult,
+    auto_level: AutoLevel,
+) -> ExecutionPolicyResult:
+    """Promote a default-allow verdict to ``ask`` when ``/auto`` is below High.
+
+    High (alpha default) is a no-op. Lower levels use tool_type, not a shell
+    command allowlist.
+    """
+    if result.verdict != "allow":
+        return result
+    ask_types = AUTO_LEVEL_ASK_TOOL_TYPES[auto_level]
+    if ask_types is not None and result.tool_type not in ask_types:
+        return result
+    return replace(
+        result,
+        verdict="ask",
+        reason=f"Auto ({AUTO_LEVEL_TITLES[auto_level]}) requires approval for this action",
+    )
+
+
 def allow_tool(tool_type: str) -> ExecutionPolicyResult:
     """Default-allow verdict for a tool launch.
 
@@ -177,6 +205,7 @@ __all__ = [
     "ToolExecutionMode",
     "ToolExecutionPlan",
     "allow_tool",
+    "apply_auto_level",
     "plan_foreground_tool",
     "resolve_confirmation",
 ]

--- a/tools/interactive_shell/shared/slash_catalog.py
+++ b/tools/interactive_shell/shared/slash_catalog.py
@@ -71,8 +71,8 @@ MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         anti_examples=("User asks to configure an observability integration (use /integrations)",),
     ),
     "/auto": _mcp(
-        "Set Auto autonomy: off (approve all), low (edits and read-only), "
-        "med (reversible commands), high (allow all, alpha default).",
+        "Set Auto autonomy: off (ask before every tool), low (also ask before investigations), "
+        "med (ask before mutating agent tools), high (ask nothing, alpha default).",
         "User asks to change Auto Off/Low/Med/High or how much the agent may run without approval",
         anti_examples=("User asks to enable trust mode (use /trust)",),
     ),

--- a/tools/interactive_shell/shared/slash_catalog.py
+++ b/tools/interactive_shell/shared/slash_catalog.py
@@ -70,6 +70,12 @@ MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "User asks to log in, authenticate, connect an LLM provider, or check provider auth",
         anti_examples=("User asks to configure an observability integration (use /integrations)",),
     ),
+    "/auto": _mcp(
+        "Set Auto autonomy: off (approve all), low (edits and read-only), "
+        "med (reversible commands), high (allow all, alpha default).",
+        "User asks to change Auto Off/Low/Med/High or how much the agent may run without approval",
+        anti_examples=("User asks to enable trust mode (use /trust)",),
+    ),
     "/background": _mcp(
         "Manage session-local background investigation mode and completed RCA summaries. "
         "Subcommands: on, off, status, list, show <task_id>, use <task_id>, notify list, notify set.",


### PR DESCRIPTION
Adds the /auto autonomy control: Off / Low / Med / High tool-approval levels that decide which tool types require confirmation before running, shown in the status line.

- Off asks for every tool; Low asks mutating tools plus investigations; Med asks the mutating set (shell, code_agent, slash, …); High (default)  runs everything without prompting.
- The execution gate promotes a default-allow verdict to "ask" per level;  the confirmation renders a "Command to approve" card with the reason.
- /auto <level> sets it, /auto shows the current level; the level lives on  the terminal session and is read defensively (no crash on a headless  session with no terminal).
- Prompt width/clip helpers are made public so the status line can reuse  them; clip strips terminal controls before measuring (builds on the  merged terminal-control sanitizer).