### PR TITLE
fix(reporting): escape untrusted evidence text before Slack rendering

### DIFF
--- a/tests/delivery/test_evidence_slack_escaping.py
+++ b/tests/delivery/test_evidence_slack_escaping.py
@@ -13,6 +13,9 @@ not just the three characters Slack's spec calls out.
 
 from __future__ import annotations
 
+from typing import Any
+
+from tools.investigation.reporting.context import ReportContext
 from tools.investigation.reporting.formatters.base import (
     escape_slack_mrkdwn,
     format_slack_link,
@@ -59,10 +62,17 @@ class TestFormatSlackLinkEscaping:
 
         assert result == "<https://example.com/incidents/1?a=1&amp;b=2|［fake］(url)>"
 
+    def test_neutralizes_pipe_in_url(self) -> None:
+        """Regression: a literal "|" in the URL collides with Slack's own
+        <url|label> delimiter and would corrupt the link structure."""
+        result = format_slack_link("Incident", "https://example.com/x|y")
+
+        assert result == "<https://example.com/x%7Cy|Incident>"
+
 
 class TestFormatCitedEvidenceSectionEscaping:
-    def _ctx_with_entry(self, **entry_overrides: object) -> dict:
-        entry = {
+    def _ctx_with_entry(self, **entry_overrides: object) -> ReportContext:
+        entry: dict[str, Any] = {
             "display_id": "E1",
             "label": "Sentry Issue Details",
             "url": None,
@@ -71,7 +81,7 @@ class TestFormatCitedEvidenceSectionEscaping:
             "provenance": None,
         }
         entry.update(entry_overrides)
-        return {"evidence_catalog": {"evidence/mapped/get_sentry_issue_details": entry}}
+        return ReportContext(evidence_catalog={"evidence/mapped/get_sentry_issue_details": entry})
 
     def test_escapes_malicious_title_in_summary(self) -> None:
         ctx = self._ctx_with_entry(

--- a/tests/delivery/test_evidence_slack_escaping.py
+++ b/tests/delivery/test_evidence_slack_escaping.py
@@ -1,0 +1,112 @@
+"""Tests for Slack mrkdwn escaping of untrusted evidence text.
+
+Regression coverage for a real, exploitable gap: evidence-mapper-contributed
+``summary``/``label``/``snippet``/``provenance`` text (issue titles, incident
+names, service names, etc. -- all externally/caller controlled) was embedded
+into Slack report text with no escaping. Slack's own ``&``/``<``/``>`` mrkdwn
+syntax lets such text render as a live link or ``<!channel>``/``<!here>``
+mention, and this project's own ``markdown_to_slack_mrkdwn`` additionally
+converts any ``[text](url)`` pattern found later in the assembled report into
+a real Slack link -- so untrusted text needs its brackets neutralized too,
+not just the three characters Slack's spec calls out.
+"""
+
+from __future__ import annotations
+
+from tools.investigation.reporting.formatters.base import (
+    escape_slack_mrkdwn,
+    format_slack_link,
+)
+from tools.investigation.reporting.formatters.evidence import (
+    format_cited_evidence_section,
+)
+
+
+class TestEscapeSlackMrkdwn:
+    def test_escapes_ampersand_and_angle_brackets(self) -> None:
+        assert escape_slack_mrkdwn("Tom & Jerry <script>") == "Tom &amp; Jerry &lt;script&gt;"
+
+    def test_neutralizes_channel_mention_syntax(self) -> None:
+        assert escape_slack_mrkdwn("<!channel> urgent") == "&lt;!channel&gt; urgent"
+
+    def test_neutralizes_raw_slack_link_syntax(self) -> None:
+        assert (
+            escape_slack_mrkdwn("<https://evil.example/steal|click me>")
+            == "&lt;https://evil.example/steal|click me&gt;"
+        )
+
+    def test_neutralizes_markdown_link_brackets(self) -> None:
+        """Regression: markdown_to_slack_mrkdwn runs on the full report text
+        after this escaping and would otherwise convert a literal
+        [text](url) pattern in untrusted text into a live Slack link."""
+        result = escape_slack_mrkdwn("[Click here](https://evil.example/steal)")
+        assert "[" not in result
+        assert "]" not in result
+        assert "https://evil.example/steal" in result
+
+    def test_plain_text_is_unchanged(self) -> None:
+        assert escape_slack_mrkdwn("TypeError: cannot read property") == (
+            "TypeError: cannot read property"
+        )
+
+
+class TestFormatSlackLinkEscaping:
+    def test_escapes_label_without_url(self) -> None:
+        assert format_slack_link("<!channel> alert", None) == "&lt;!channel&gt; alert"
+
+    def test_escapes_label_and_url_when_present(self) -> None:
+        result = format_slack_link("[fake](url)", "https://example.com/incidents/1?a=1&b=2")
+
+        assert result == "<https://example.com/incidents/1?a=1&amp;b=2|［fake］(url)>"
+
+
+class TestFormatCitedEvidenceSectionEscaping:
+    def _ctx_with_entry(self, **entry_overrides: object) -> dict:
+        entry = {
+            "display_id": "E1",
+            "label": "Sentry Issue Details",
+            "url": None,
+            "summary": "'TypeError'",
+            "snippet": None,
+            "provenance": None,
+        }
+        entry.update(entry_overrides)
+        return {"evidence_catalog": {"evidence/mapped/get_sentry_issue_details": entry}}
+
+    def test_escapes_malicious_title_in_summary(self) -> None:
+        ctx = self._ctx_with_entry(
+            summary="'[Click here](https://evil.example/steal)', level error"
+        )
+
+        section = format_cited_evidence_section(ctx)
+
+        assert "[Click here]" not in section
+        assert "［Click here］" in section
+        assert "https://evil.example/steal" in section
+
+    def test_escapes_channel_mention_in_summary(self) -> None:
+        ctx = self._ctx_with_entry(summary="<!channel> everyone look, error found")
+
+        section = format_cited_evidence_section(ctx)
+
+        assert "<!channel>" not in section
+        assert "&lt;!channel&gt;" in section
+
+    def test_escapes_provenance_and_snippet(self) -> None:
+        ctx = self._ctx_with_entry(
+            provenance="<!here> ping",
+            snippet="[link](https://evil.example)",
+        )
+
+        section = format_cited_evidence_section(ctx)
+
+        assert "<!here>" not in section
+        assert "[link](" not in section
+
+    def test_plain_summary_still_renders_normally(self) -> None:
+        ctx = self._ctx_with_entry(summary="'TypeError: cannot read property', 3 event(s)")
+
+        section = format_cited_evidence_section(ctx)
+
+        assert "TypeError: cannot read property" in section
+        assert "3 event(s)" in section

--- a/tools/investigation/reporting/formatters/base.py
+++ b/tools/investigation/reporting/formatters/base.py
@@ -57,8 +57,13 @@ def format_slack_link(label: str, url: str | None) -> str:
     if not url:
         return escape_slack_mrkdwn(label)
 
+    # A literal "|" in either half collides with Slack's own <url|label>
+    # delimiter -- percent-encode it in the URL (semantically correct, stays
+    # a valid link) and swap it for a lookalike in the label (consistent with
+    # how escape_slack_mrkdwn neutralizes other structural characters).
+    safe_url = escape_slack_mrkdwn(url).replace("|", "%7C")
     safe_label = escape_slack_mrkdwn(label.replace("|", "¦").strip()) or url
-    return f"<{escape_slack_mrkdwn(url)}|{safe_label}>"
+    return f"<{safe_url}|{safe_label}>"
 
 
 def slack_links_to_plain_text(text: str) -> str:

--- a/tools/investigation/reporting/formatters/base.py
+++ b/tools/investigation/reporting/formatters/base.py
@@ -7,7 +7,29 @@ import re
 
 from config.constants import SLACK_LINK_RE
 
-__all__ = ["format_html_link", "format_slack_link", "shorten_text", "slack_links_to_plain_text"]
+__all__ = [
+    "escape_slack_mrkdwn",
+    "format_html_link",
+    "format_slack_link",
+    "shorten_text",
+    "slack_links_to_plain_text",
+]
+
+
+def escape_slack_mrkdwn(text: str) -> str:
+    """Neutralize Slack mrkdwn markup in untrusted external text.
+
+    Slack's own spec requires literal ``&``, ``<``, ``>`` to be escaped as
+    HTML entities, or text can inject a fake link/mention (``<url|label>``,
+    ``<!channel>``). This project's ``markdown_to_slack_mrkdwn`` additionally
+    rewrites any ``[text](url)`` pattern found anywhere in the final report
+    text into a live Slack link *after* this function runs, so bracket
+    characters are also neutralized (fullwidth lookalikes keep the text
+    readable) -- HTML-entity escaping alone would not stop that later pass
+    from matching literal ``[``/``]`` in untrusted text.
+    """
+    escaped = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return escaped.replace("[", "［").replace("]", "］")
 
 
 def shorten_text(text: str, max_chars: int = 120, suffix: str = "...") -> str:
@@ -33,10 +55,10 @@ def shorten_text(text: str, max_chars: int = 120, suffix: str = "...") -> str:
 def format_slack_link(label: str, url: str | None) -> str:
     """Return a Slack-formatted hyperlink, falling back to plain text."""
     if not url:
-        return label
+        return escape_slack_mrkdwn(label)
 
-    safe_label = label.replace("|", "¦").strip() or url
-    return f"<{url}|{safe_label}>"
+    safe_label = escape_slack_mrkdwn(label.replace("|", "¦").strip()) or url
+    return f"<{escape_slack_mrkdwn(url)}|{safe_label}>"
 
 
 def slack_links_to_plain_text(text: str) -> str:

--- a/tools/investigation/reporting/formatters/evidence.py
+++ b/tools/investigation/reporting/formatters/evidence.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from tools.investigation.reporting.context import ReportContext
 from tools.investigation.reporting.formatters.base import (
+    escape_slack_mrkdwn,
     format_html_link,
     format_slack_link,
     shorten_text,
@@ -270,14 +271,18 @@ def format_cited_evidence_section(ctx: ReportContext) -> str:
             summary = entry.get("summary")
             snippet = entry.get("snippet")
             provenance = entry.get("provenance")
+            # label/url are escaped inside format_slack_link; summary, provenance,
+            # and snippet are free text from tool output (including third-party
+            # data like issue titles or incident names) and need the same
+            # treatment here so they can't inject a live link or mention.
             link = format_slack_link(label, url or None)
             line = f"- {display_id} — {link}"
             if summary:
-                line += f" — {summary}"
+                line += f" — {escape_slack_mrkdwn(str(summary))}"
             if provenance:
-                line += f" — provenance: {provenance}"
+                line += f" — provenance: {escape_slack_mrkdwn(str(provenance))}"
             if snippet:
-                line += f" — {shorten_text(snippet, max_chars=100)}"
+                line += f" — {escape_slack_mrkdwn(shorten_text(str(snippet), max_chars=100))}"
             lines.append(line)
 
     tool_calls_line = _format_tool_calls_line(ctx)


### PR DESCRIPTION
Fixes #

<!-- Not tied to a tracked issue -- found during Greptile review of the
Sentry (#5774) and PagerDuty (#5775) evidence-mapper PRs; see below. -->

#### Describe the changes you have made in this PR -

Greptile flagged that my Sentry and PagerDuty evidence mappers place raw,
externally-controlled text (issue titles, incident titles, service names,
search queries) into report summaries with only newline-stripping and
truncation — no Slack-markup escaping. I traced the full delivery path to
confirm this is real and reachable, and found it's actually a **systemic
gap in the shared Slack report renderer**, not something specific to those
two PRs — every already-merged evidence mapper across this epic (rds,
mariadb, mysql, rabbitmq, mongodb, kafka, clickhouse, argocd, new_relic,
opensearch) has the identical exposure for whatever external text it cites.

**The confirmed chain:**
1. A tool's evidence mapper puts external text into `summary`/`label`/
   `snippet`/`provenance` via `record_evidence_entry`.
2. `format_cited_evidence_section` (`tools/investigation/reporting/formatters/evidence.py`)
   embeds that text into the report's "Cited Evidence" section verbatim.
3. Nothing escapes it: `_sanitize_for_slack` in `formatters/report.py`
   (despite its name) only rewrites `#`/`**` markdown into Slack's `*bold*`
   syntax — it does not neutralize anything dangerous, and the Block Kit
   rendering path doesn't even call it.
4. The assembled report text is later passed through
   `markdown_to_slack_mrkdwn` (`integrations/slack/formatting.py`) before
   Slack delivery, which actively **converts any `[text](url)` pattern
   into a live Slack link** — so a Sentry issue titled
   `[Click here](http://evil.example)` becomes a real clickable link in
   the delivered report. Raw Slack syntax like `<!channel>` or
   `<url|label>` embedded in external text survives untouched too.

**Why this is the right fix location:** the sibling Telegram/HTML renderer
in the same file, `format_cited_evidence_section_html`, already does
`html.escape()` on these exact same fields — proving the codebase's own
established pattern is to escape untrusted text at this shared render
boundary, not per-mapper. Patching only the Sentry/PagerDuty mapper files
(as suggested) would be inconsistent with that pattern and would leave
every other already-merged mapper's cited text equally exposed.

**The fix:**
- `escape_slack_mrkdwn()` (new, in `tools/investigation/reporting/formatters/base.py`):
  escapes Slack's required `&`/`<`/`>` (preventing raw `<!channel>` /
  `<url|label>` injection), and additionally neutralizes `[`/`]` with
  fullwidth lookalikes — needed specifically because this project's own
  `markdown_to_slack_mrkdwn` runs a second, regex-based pass over the
  *entire* assembled report afterward and would otherwise still convert
  `[text](url)` in already-"escaped" (HTML-entity-style) text into a link,
  since `&`/`<`/`>` escaping alone doesn't touch brackets.
- `format_slack_link()` (`base.py`): now escapes `label` and `url` through
  the same helper. This is used by every caller of `format_slack_link`
  across the reporting module, not just the evidence section, for free
  defense-in-depth.
- `format_cited_evidence_section()` (`evidence.py`): escapes `summary`,
  `provenance`, and `snippet` before embedding them (mirroring exactly
  what the HTML sibling function already does for those same fields).

This fixes both Slack rendering paths (`format_slack_message`'s plain-text
path and `build_slack_blocks`'s Block Kit path) at their one shared source,
since both call `format_cited_evidence_section`.

### Demo/Screenshot for feature changes and bug fixes -

**Before (vulnerable):**
```
$ uv run python -c "
from tools.investigation.reporting.formatters.evidence import format_cited_evidence_section
ctx = {'evidence_catalog': {'evidence/mapped/x': {
    'display_id': 'E1', 'label': 'Sentry Issue Details', 'url': None,
    'summary': \"'[Click here](https://evil.example/steal)', level error\",
}}}
print(format_cited_evidence_section(ctx))
"
*Cited Evidence:*
- E1 — Sentry Issue Details — '[Click here](https://evil.example/steal)', level error
```
That `[Click here](https://evil.example/steal)` becomes a live Slack link
once `markdown_to_slack_mrkdwn` runs over the assembled report.

**After (fixed):**
```
*Cited Evidence:*
- E1 — Sentry Issue Details — '［Click here］(https://evil.example/steal)', level error
```
The bracket pair is neutralized (fullwidth lookalikes, still readable),
so `markdown_to_slack_mrkdwn`'s link-conversion regex can never match it.

**Tests and quality gates:**
```
$ uv run pytest tests/delivery/test_evidence_slack_escaping.py -q
11 passed

$ uv run pytest tests/delivery/ tests/synthetic/grafana/test_report_delivery_e2e.py \
    tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
117 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3637 files already formatted / Success: no issues found in 1894 source files
```

No existing tests asserted exact evidence-section string content, so this
change carries no risk of silently changing other reports' rendered output
in a way tests would have masked — confirmed by running the full
`tests/delivery/` and report-delivery e2e suites, all passing unchanged.

## Behaviour comparison (required)

**1–2. Before/after:** shown above — the only observable change is that
`&`, `<`, `>`, `[`, `]` characters *within externally-controlled evidence
text* (summary/label/snippet/provenance/url) are now escaped/neutralized
before being embedded in Slack-rendered reports. Agent-authored report
text elsewhere (claims, remediation steps, headings) is untouched — those
already go through `_sanitize_for_slack`'s legitimate markdown-to-mrkdwn
conversion and are not affected by this change.

**3. Explain every difference:** for any evidence entry whose `summary`/
`label`/`snippet`/`provenance`/`url` fields contain `&`, `<`, `>`, `[`, or
`]`, those characters are now escaped in the rendered report. Entries with
none of those characters (the common case — most summaries are just counts
and short labels) render byte-identical to before.

**4. Answers:**
- **What the reader gains.** Protection against a real, remotely-triggerable
  injection: any tool that cites externally-controlled text (an issue
  title, incident name, file path, commit message, etc.) can no longer
  have that text rendered as a live Slack link or a `<!channel>`/`<!here>`
  mention in a delivered investigation report.
- **How much context it costs.** None — escaping is a few extra bytes per
  affected character, not a structural change.
- **What happens on an empty or error result.** Unaffected; this only
  touches string content already present, not control flow.
- **Whether anything is now recorded twice.** No — this doesn't touch
  `record_evidence_entry` or any mapper; it only escapes at render time.
- **Whether an existing report changed shape.** No test asserts exact
  cited-evidence string content, and the full `tests/delivery/` +
  report-delivery e2e suites (117 tests) pass unchanged — confirming no
  existing report's structure or non-special-character content changed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The key design decision was *where* to fix this. Greptile's suggestion was
to patch the two vendor-specific mapper files that happened to trigger the
finding. I traced the actual delivery pipeline instead of taking that at
face value: `format_cited_evidence_section` → (no escaping) →
`markdown_to_slack_mrkdwn` → Slack. That trace showed the vulnerability is
in the shared renderer, not the mappers — every vendor's evidence mapper
that cites free text hits the exact same unescaped path, and roughly ten
of them are already merged into main. Patching two files would have given
a false sense of security while leaving the other ten (and every future
evidence mapper) equally exposed. I found the correct precedent already
in the same file: `format_cited_evidence_section_html` uses `html.escape()`
on identical fields for the Telegram path, so I mirrored that pattern for
Slack rather than inventing a new one — with one addition specific to this
project's pipeline: `markdown_to_slack_mrkdwn` runs a second regex pass
over the *whole* assembled report and will convert `[text](url)` into a
live link wherever it appears, so HTML-entity-style escaping of `&`/`<`/`>`
alone (which is all Slack's own spec requires) isn't sufficient here —
brackets need neutralizing too, which I did with fullwidth lookalikes so
the text stays readable rather than becoming a `\[`-style escape sequence
Slack doesn't understand anyway.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
