### PR TITLE
revert(ci): stop Release workflow on pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "tests/**"
-      - "*.md"
-      - "*.mdx"
-      - ".claude/**"
   push:
     branches: [main]
     paths-ignore:
@@ -42,7 +34,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: release-${{ github.event_name == 'pull_request' && github.event.pull_request.number || (github.event_name == 'push' && 'main') || (github.event_name == 'workflow_dispatch' && inputs.channel == 'main' && 'main') || 'stable' }}
+  group: release-${{ github.event_name == 'push' && 'main' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'main' && 'main') || 'stable' }}
   cancel-in-progress: true
 
 jobs:
@@ -70,18 +62,6 @@ jobs:
           set -euo pipefail
 
           channel="release"
-
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            short_sha="${GITHUB_SHA:0:7}"
-            year="$(date -u +%Y)"
-            month="$(date -u +%-m)"
-            day="$(date -u +%-d)"
-
-            echo "channel=pr" >> "$GITHUB_OUTPUT"
-            echo "tag_name=pr-build" >> "$GITHUB_OUTPUT"
-            echo "version_name=0.1.${year}.${month}.${day}+pr.${short_sha}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
           if [ "$EVENT_NAME" = "push" ]; then
             channel="main"
@@ -489,10 +469,8 @@ jobs:
           set -euo pipefail
           if [ "$RELEASE_CHANNEL" = "release" ]; then
             ASSET_BASENAME="opensre_${TAG_NAME#v}_${{ matrix.target }}"
-          elif [ "$RELEASE_CHANNEL" = "main" ]; then
-            ASSET_BASENAME="opensre_main_${{ matrix.target }}"
           else
-            ASSET_BASENAME="opensre_pr_${{ matrix.target }}"
+            ASSET_BASENAME="opensre_main_${{ matrix.target }}"
           fi
           tar -C dist -czf "${ASSET_BASENAME}.tar.gz" "${{ matrix.binary_name }}"
           shasum -a 256 "${ASSET_BASENAME}.tar.gz" > "${ASSET_BASENAME}.tar.gz.sha256"
@@ -503,10 +481,8 @@ jobs:
         run: |
           if ($env:RELEASE_CHANNEL -eq "release") {
             $assetBaseName = "opensre_$($env:TAG_NAME.TrimStart('v'))_${{ matrix.target }}"
-          } elseif ($env:RELEASE_CHANNEL -eq "main") {
-            $assetBaseName = "opensre_main_${{ matrix.target }}"
           } else {
-            $assetBaseName = "opensre_pr_${{ matrix.target }}"
+            $assetBaseName = "opensre_main_${{ matrix.target }}"
           }
           Compress-Archive -Path "dist\${{ matrix.binary_name }}" -DestinationPath "${assetBaseName}.zip"
           $hash = (Get-FileHash -Algorithm SHA256 "${assetBaseName}.zip").Hash.ToLowerInvariant()
@@ -515,7 +491,7 @@ jobs:
       - name: Upload binary archive
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.RELEASE_CHANNEL == 'pr' && 'pr-' || env.RELEASE_CHANNEL == 'main' && 'main-' || '' }}release-${{ matrix.target }}
+          name: ${{ env.RELEASE_CHANNEL == 'main' && 'main-' || '' }}release-${{ matrix.target }}
           path: |
             opensre_*_${{ matrix.target }}.${{ matrix.archive_ext }}
             opensre_*_${{ matrix.target }}.${{ matrix.archive_ext }}.sha256

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from infrastructure.deployment.packaging.release_manifest import (
     infrastructure_data_entries,
     required_skill_files,
@@ -87,8 +89,11 @@ def test_release_build_uses_checked_in_spec() -> None:
 
 def test_release_workflow_does_not_run_on_pull_requests() -> None:
     workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    triggers = yaml.load(workflow, Loader=yaml.BaseLoader)["on"]
 
-    assert "  pull_request:" not in workflow
+    assert isinstance(triggers, dict)
+    assert "pull_request" not in triggers
+    assert triggers["push"]["branches"] == ["main"]
     assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' not in workflow
     assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' not in workflow
     assert "opensre_pr_" not in workflow

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -85,15 +85,13 @@ def test_release_build_uses_checked_in_spec() -> None:
     assert "skill_data_entries(ROOT)" in spec
 
 
-def test_pull_requests_build_release_binaries_without_publishing() -> None:
+def test_release_workflow_does_not_run_on_pull_requests() -> None:
     workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "  pull_request:\n    branches: [main]" in workflow
-    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in workflow
-    assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' in workflow
-    assert workflow.count('ASSET_BASENAME="opensre_pr_${{ matrix.target }}"') == 1
-    assert workflow.count('$assetBaseName = "opensre_pr_${{ matrix.target }}"') == 1
-    assert "if: needs.prepare.outputs.channel == 'release'" in workflow
+    assert "  pull_request:" not in workflow
+    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' not in workflow
+    assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' not in workflow
+    assert "opensre_pr_" not in workflow
 
 
 def test_infrastructure_data_excludes_the_cloudflare_worker() -> None:


### PR DESCRIPTION
Reverts the pull-request CI behavior introduced by #5733.

#### Describe the changes you have made in this PR -

This is a focused partial revert of our former PR, #5733 (`fix(packaging): bundle prompts and validate PR binaries`). That PR made the Release workflow run its five-platform binary matrix for every runtime pull request. Normal PR CI should not invoke Release.

- Remove the `pull_request` trigger from `.github/workflows/release.yml`.
- Remove the now-dead `pr` release channel, PR concurrency branch, and PR artifact naming.
- Restore artifact selection to the existing `main` and stable `release` channels.
- Replace the PR-binary contract with a regression test that forbids re-adding a Release pull-request trigger.

This does **not** revert #5733's prompt-packaging fix or its least-privilege permission hardening. Release continues to run for pushes to `main`, the scheduled stable release, and explicit manual dispatches.

### Demo/Screenshot for feature changes and bug fixes -

Before this revert, opening a runtime PR started `Release` and five binary builds. For example, PR #5780 started Release run `32983515907` solely because it changed `integrations/sentry/**`.

After this revert, the workflow trigger starts with:

```yaml
on:
  push:
    branches: [main]
```

and contains no `pull_request` event or `pr` release channel.

#### Validation

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/packaging/test_release_manifest.py` — 10 passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I traced the unexpected Release run to the `pull_request` workflow trigger added in #5733. Because the intended policy is that normal PR CI must not run Release, the direct fix is to remove that event rather than add path heuristics or labels that would leave the workflow partially active on pull requests.

I also removed every branch that existed only for the PR release channel so the workflow retains exactly two artifact modes: rolling `main` and stable `release`. The prompt data bundled by #5733 and the safer job-scoped write permissions remain intact because neither caused the CI behavior being reverted.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the former PR being reverted
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
