### PR TITLE
revert(ci): restore main-only releases and clarify API docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "tests/**"
-      - "*.md"
-      - "*.mdx"
-      - ".claude/**"
   push:
     branches: [main]
     paths-ignore:
@@ -42,7 +34,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: release-${{ github.event_name == 'pull_request' && github.event.pull_request.number || (github.event_name == 'push' && 'main') || (github.event_name == 'workflow_dispatch' && inputs.channel == 'main' && 'main') || 'stable' }}
+  group: release-${{ github.event_name == 'push' && 'main' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'main' && 'main') || 'stable' }}
   cancel-in-progress: true
 
 jobs:
@@ -70,18 +62,6 @@ jobs:
           set -euo pipefail
 
           channel="release"
-
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            short_sha="${GITHUB_SHA:0:7}"
-            year="$(date -u +%Y)"
-            month="$(date -u +%-m)"
-            day="$(date -u +%-d)"
-
-            echo "channel=pr" >> "$GITHUB_OUTPUT"
-            echo "tag_name=pr-build" >> "$GITHUB_OUTPUT"
-            echo "version_name=0.1.${year}.${month}.${day}+pr.${short_sha}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
           if [ "$EVENT_NAME" = "push" ]; then
             channel="main"
@@ -489,10 +469,8 @@ jobs:
           set -euo pipefail
           if [ "$RELEASE_CHANNEL" = "release" ]; then
             ASSET_BASENAME="opensre_${TAG_NAME#v}_${{ matrix.target }}"
-          elif [ "$RELEASE_CHANNEL" = "main" ]; then
-            ASSET_BASENAME="opensre_main_${{ matrix.target }}"
           else
-            ASSET_BASENAME="opensre_pr_${{ matrix.target }}"
+            ASSET_BASENAME="opensre_main_${{ matrix.target }}"
           fi
           tar -C dist -czf "${ASSET_BASENAME}.tar.gz" "${{ matrix.binary_name }}"
           shasum -a 256 "${ASSET_BASENAME}.tar.gz" > "${ASSET_BASENAME}.tar.gz.sha256"
@@ -503,10 +481,8 @@ jobs:
         run: |
           if ($env:RELEASE_CHANNEL -eq "release") {
             $assetBaseName = "opensre_$($env:TAG_NAME.TrimStart('v'))_${{ matrix.target }}"
-          } elseif ($env:RELEASE_CHANNEL -eq "main") {
-            $assetBaseName = "opensre_main_${{ matrix.target }}"
           } else {
-            $assetBaseName = "opensre_pr_${{ matrix.target }}"
+            $assetBaseName = "opensre_main_${{ matrix.target }}"
           }
           Compress-Archive -Path "dist\${{ matrix.binary_name }}" -DestinationPath "${assetBaseName}.zip"
           $hash = (Get-FileHash -Algorithm SHA256 "${assetBaseName}.zip").Hash.ToLowerInvariant()
@@ -515,7 +491,7 @@ jobs:
       - name: Upload binary archive
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.RELEASE_CHANNEL == 'pr' && 'pr-' || env.RELEASE_CHANNEL == 'main' && 'main-' || '' }}release-${{ matrix.target }}
+          name: ${{ env.RELEASE_CHANNEL == 'main' && 'main-' || '' }}release-${{ matrix.target }}
           path: |
             opensre_*_${{ matrix.target }}.${{ matrix.archive_ext }}
             opensre_*_${{ matrix.target }}.${{ matrix.archive_ext }}.sha256

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ The tool registry auto-discovers modules under `tools/`, so the normal path is t
 
 Steps:
 
-1. Pick the simplest shape that fits the tool. Use a `BaseTool` subclass (from `core.tool`) for richer behavior; use `@tool(...)` from `core.tool_framework` for a lightweight function tool. Import through those tier doors, not their internal submodules — the border test in `tests/shared/test_tool_api_border.py` enforces it.
+1. Pick the simplest shape that fits the tool. Use a `BaseTool` subclass (from `core.tool`) for richer behavior; use `@tool(...)` from `core.tool_framework` for a lightweight function tool. Import through those public APIs, not their internal submodules — the border test in `tests/shared/test_tool_api_border.py` enforces it.
 2. Declare clear metadata: `name`, `description`, `source`, `input_schema`, and any `use_cases`, `requires`, `outputs`, or `retrieval_controls` you need.
 3. Before opening or approving the PR, follow [docs/adding-tools-and-integrations.md](docs/adding-tools-and-integrations.md).
 

--- a/core/tool_framework/__init__.py
+++ b/core/tool_framework/__init__.py
@@ -1,7 +1,7 @@
 """Tool authoring helpers: the ``@tool`` decorator, planning tags, skill guidance.
 
-The tier's door for consumers above it. Schema and payload utilities live behind
-the sibling ``core.tool_framework.utils`` door; the tool contract itself (what a
+The tier's public API for consumers above it. Schema and payload utilities live behind
+the sibling ``core.tool_framework.utils`` public API; the tool contract itself (what a
 tool is, how it runs, where it is registered) is ``core.tool``.
 """
 

--- a/core/tool_framework/utils/__init__.py
+++ b/core/tool_framework/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Tool utilities — the one door consumers import these helpers through.
+"""Tool utilities — the one package entry consumers import these helpers through.
 
 Schema builders, MCP payload readers, code-host and availability envelopes, and
 database-warning wrappers. Importing the submodules directly still works inside

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from infrastructure.deployment.packaging.release_manifest import (
     infrastructure_data_entries,
     required_skill_files,
@@ -87,8 +89,11 @@ def test_release_build_uses_checked_in_spec() -> None:
 
 def test_release_workflow_does_not_run_on_pull_requests() -> None:
     workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    triggers = yaml.load(workflow, Loader=yaml.BaseLoader)["on"]
 
-    assert "  pull_request:" not in workflow
+    assert isinstance(triggers, dict)
+    assert "pull_request" not in triggers
+    assert triggers["push"]["branches"] == ["main"]
     assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' not in workflow
     assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' not in workflow
     assert "opensre_pr_" not in workflow

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -85,15 +85,13 @@ def test_release_build_uses_checked_in_spec() -> None:
     assert "skill_data_entries(ROOT)" in spec
 
 
-def test_pull_requests_build_release_binaries_without_publishing() -> None:
+def test_release_workflow_does_not_run_on_pull_requests() -> None:
     workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "  pull_request:\n    branches: [main]" in workflow
-    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' in workflow
-    assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' in workflow
-    assert workflow.count('ASSET_BASENAME="opensre_pr_${{ matrix.target }}"') == 1
-    assert workflow.count('$assetBaseName = "opensre_pr_${{ matrix.target }}"') == 1
-    assert "if: needs.prepare.outputs.channel == 'release'" in workflow
+    assert "  pull_request:" not in workflow
+    assert 'if [ "$EVENT_NAME" = "pull_request" ]; then' not in workflow
+    assert 'echo "channel=pr" >> "$GITHUB_OUTPUT"' not in workflow
+    assert "opensre_pr_" not in workflow
 
 
 def test_infrastructure_data_excludes_the_cloudflare_worker() -> None:


### PR DESCRIPTION
Fixes #5626

#### Describe the changes you have made in this PR -

This PR combines two small, independently committed changes:

1. **Revert the pull-request Release behavior introduced by our former PR #5733.**
   - Remove the pull_request trigger from .github/workflows/release.yml.
   - Remove the PR-only release channel, concurrency branch, metadata, and artifact naming.
   - Keep Release running for pushes to main, scheduled stable releases, and manual dispatches.
   - Keep #5733's prompt-packaging fix and least-privilege permission hardening.
   - Add a semantic regression test that prevents the Release pull-request trigger from returning.

2. **Clarify the tool-framework public import API for #5626.**
   - Replace all four uses of the "door" metaphor with public API or package entry.
   - Preserve the existing import-boundary instructions and package structure.

This is a replacement experiment containing the CI changes currently proposed in #5781. Per request, #5781 remains open until explicitly directed otherwise.

### Demo/Screenshot for feature changes and bug fixes -

The focused verification completed successfully:

    $ grep -rn "door" --include='*.py' --include='*.md' core/ AGENTS.md docs/
    # no matches

    $ uv run python -m pytest tests/packaging/test_release_manifest.py tests/shared/test_tool_api_border.py -q
    17 passed

The Release workflow now has no pull-request event; normal PRs use the regular CI workflow instead of starting the five-platform release build.

#### Validation

- make lint
- make format-check
- make typecheck
- uv run python -m pytest tests/packaging/test_release_manifest.py tests/shared/test_tool_api_border.py -q — 17 passed
- grep -rn "door" --include='*.py' --include='*.md' core/ AGENTS.md docs/ — no matches

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The CI behavior came from the pull_request trigger added in #5733. Removing that event is simpler and safer than adding labels or path filters because Release should not run for any normal pull request. PR-only workflow branches were removed with the trigger, while main, stable, and manual release paths remain unchanged.

For #5626, only the four identified prose occurrences changed. Each metaphor was replaced with terminology that describes the package boundary directly, without changing imports, exports, or the border test.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
