### PR TITLE
feat(betterstack): add evidence mapper for query_betterstack_logs

### DIFF
--- a/integrations/betterstack/tools/betterstack_logs_tool/__init__.py
+++ b/integrations/betterstack/tools/betterstack_logs_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from integrations.betterstack import (
@@ -12,6 +13,34 @@ from integrations.betterstack import (
     betterstack_is_available,
     query_logs,
 )
+
+
+def _map_query_betterstack_logs(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the row count and source queried.
+
+    ``query_logs`` always clamps its effective ``limit`` to
+    ``config.max_rows``, so a returned count equal to that limit may be a
+    truncated page rather than every matching row -- use the "N+" convention.
+    """
+    if not output.get("available"):
+        return
+    row_count = output.get("row_count", 0)
+    if not row_count:
+        return
+    limit = output.get("limit", 0)
+    count_label = f"{row_count}+" if limit and row_count >= limit else str(row_count)
+    summary = f"{count_label} log row(s)"
+    source = output.get("betterstack_source")
+    if source:
+        summary += f" from '{source}'"
+    record_evidence_entry(
+        evidence,
+        source="query_betterstack_logs",
+        label="Better Stack Logs",
+        summary=summary,
+    )
 
 
 @tool(
@@ -34,6 +63,7 @@ from integrations.betterstack import (
     is_available=betterstack_is_available,
     injected_params=("password", "query_endpoint", "username"),
     extract_params=betterstack_extract_params,
+    evidence_mapper=_map_query_betterstack_logs,
 )
 def query_betterstack_logs(
     query_endpoint: str,

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -180,7 +180,6 @@ pi_coding_task
 prefect_flow_runs
 prefect_worker_health
 query_azure_monitor_logs
-query_betterstack_logs
 query_coralogix_logs
 query_datadog_all
 query_datadog_events

--- a/tests/tools/test_betterstack_logs_tool.py
+++ b/tests/tools/test_betterstack_logs_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from integrations.betterstack.tools.betterstack_logs_tool import query_betterstack_logs
+from integrations.betterstack.tools.betterstack_logs_tool import (
+    _map_query_betterstack_logs,
+    query_betterstack_logs,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -90,3 +94,54 @@ def test_missing_source_and_no_hints_surfaces_downstream() -> None:
     assert args[1] == ""
     assert result["available"] is False
     assert "invalid" in result["error"].lower()
+
+
+class TestMapQueryBetterstackLogs:
+    def test_records_entry_with_source(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_betterstack_logs(
+            evidence,
+            {
+                "available": True,
+                "betterstack_source": "t1_myapp",
+                "row_count": 5,
+                "limit": 1000,
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "query_betterstack_logs"
+        assert entries[0]["summary"] == "5 log row(s) from 't1_myapp'"
+
+    def test_qualifies_count_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_betterstack_logs(
+            evidence,
+            {
+                "available": True,
+                "betterstack_source": "t1_myapp",
+                "row_count": 1000,
+                "limit": 1000,
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "1000+ log row(s) from 't1_myapp'"
+
+    def test_records_nothing_when_no_rows(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_betterstack_logs(evidence, {"available": True, "row_count": 0, "rows": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_betterstack_logs(evidence, {"available": False, "error": "not configured"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5580

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires the single Better Stack investigation tool, `query_betterstack_logs`, to
`record_evidence_entry` so its output stops being silently dropped and becomes
a citeable line in the investigation report.

- `_map_query_betterstack_logs`: cites the row count and the Better Stack
  source queried.

This is the only tool in `integrations/betterstack/tools/` — it's a read-only
diagnostic query, so it's in scope per the issue.

**On count honesty — the "N+" convention:** `query_logs` in
`integrations/betterstack/__init__.py` always clamps its effective query
`limit` to `config.max_rows` (`min(max(1, limit or config.max_rows),
config.max_rows)`) and returns that same clamped value back as `limit` in the
output. A returned `row_count` equal to that `limit` can therefore be a
truncated page rather than every matching row, so the mapper shows `"N+"`
when `row_count >= limit`, matching the convention already established
elsewhere in this codebase for the identical ambiguity (e.g.
`validate_sentry_config` in `integrations/sentry/__init__.py`).

The mapper records nothing when `available` is falsy or `row_count` is 0.

Removed `query_betterstack_logs` from `evidence_mapper_baseline.txt` now that
it carries a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tool carries its mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print(bool(g('query_betterstack_logs').evidence_mapper))"
True
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using a realistic sample matching the tool's return
shape:**
```
query_betterstack_logs:  "5 log row(s) from 't1_myapp'"
query_betterstack_logs (saturated page):  "1000+ log row(s) from 't1_myapp'"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_betterstack_logs_tool.py -q
14 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3638 files already formatted / Success: no issues found in 1895 source files
```

**No live Better Stack account available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the mapper
and its tests were added, using the tool's own realistic mock payload shapes.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read `query_logs` and its error-shape helper `_error_evidence` in
`integrations/betterstack/__init__.py` first to find the tool's actual return
shape (`row_count`, `limit`, `betterstack_source`) rather than assume the
issue's generic template. `limit` is the one field worth double-checking
because `query_logs` always clamps it to `config.max_rows` regardless of
whether the caller requested less — so a returned `row_count` at that ceiling
can't be trusted as "every row" any more than PagerDuty's or Sentry's capped
list counts could in the companion PRs from this same session. I reused the
same `"N+"` phrasing rather than invent a new one.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
