### PR TITLE
feat(cloudtrail): add evidence mapper for lookup_cloudtrail_events

### DIFF
--- a/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
+++ b/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
@@ -18,8 +18,10 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from infrastructure.text.truncation import truncate
 from integrations.aws.aws_sdk_client import execute_aws_sdk_call
 from integrations.cloudtrail import (
     DEFAULT_CLOUDTRAIL_REGION,
@@ -34,6 +36,50 @@ DEFAULT_DURATION_MINUTES = 60
 MAX_DURATION_MINUTES = 90 * 24 * 60
 DEFAULT_MAX_RESULTS = 50
 MAX_RESULTS_LIMIT = 50
+
+#: Bound the filter value echoed into a report summary -- it is a caller-
+#: supplied lookup argument (resource name, username, or event source), not
+#: bounded by the input schema, and can be arbitrarily long.
+_FILTER_VALUE_SUMMARY_TRUNCATE_LEN = 80
+
+
+def _map_lookup_cloudtrail_events(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the event count, filter applied, and how many were writes or errors.
+
+    ``truncated`` reflects whether CloudTrail returned a ``NextToken`` (more
+    events exist beyond this page) -- an explicit signal from the API itself,
+    not an inferred page-size heuristic.
+    """
+    if not output.get("available"):
+        return
+    events = output.get("events") or []
+    if not events:
+        return
+    total = output.get("total_events", len(events))
+    count_label = f"{total}+" if output.get("truncated") else str(total)
+    write_count = sum(1 for e in events if e.get("read_only") is False)
+    error_count = sum(1 for e in events if e.get("error_code"))
+    parts = [f"{count_label} event(s)"]
+    if write_count:
+        parts.append(f"{write_count} write")
+    if error_count:
+        parts.append(f"{error_count} with error")
+    event_filter = output.get("filter")
+    if event_filter:
+        filter_key = event_filter.get("AttributeKey")
+        filter_value = truncate(
+            str(event_filter.get("AttributeValue", "")).replace("\n", " "),
+            _FILTER_VALUE_SUMMARY_TRUNCATE_LEN,
+        )
+        parts.append(f"filtered by {filter_key}={filter_value!r}")
+    record_evidence_entry(
+        evidence,
+        source="lookup_cloudtrail_events",
+        label="CloudTrail Events",
+        summary=", ".join(parts),
+    )
 
 
 def _build_lookup_attribute(
@@ -181,6 +227,7 @@ def _shape_event(raw: dict[str, Any]) -> dict[str, Any]:
     injected_params=("aws_backend",),
     is_available=cloudtrail_is_available,
     extract_params=cloudtrail_extract_params,
+    evidence_mapper=_map_lookup_cloudtrail_events,
 )
 def lookup_cloudtrail_events(
     resource_name: str = "",

--- a/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
+++ b/integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py
@@ -58,21 +58,25 @@ def _map_lookup_cloudtrail_events(
     if not events:
         return
     total = output.get("total_events", len(events))
-    count_label = f"{total}+" if output.get("truncated") else str(total)
+    truncated = bool(output.get("truncated"))
+    count_label = f"{total}+" if truncated else str(total)
     write_count = sum(1 for e in events if e.get("read_only") is False)
     error_count = sum(1 for e in events if e.get("error_code"))
     parts = [f"{count_label} event(s)"]
     if write_count:
-        parts.append(f"{write_count} write")
+        # write_count/error_count are tallied over this page only (bounded by
+        # max_results) -- on a truncated page they are a floor, not a total.
+        write_label = f"{write_count}+" if truncated else str(write_count)
+        parts.append(f"{write_label} write")
     if error_count:
-        parts.append(f"{error_count} with error")
+        error_label = f"{error_count}+" if truncated else str(error_count)
+        parts.append(f"{error_label} with error")
     event_filter = output.get("filter")
     if event_filter:
         filter_key = event_filter.get("AttributeKey")
-        filter_value = truncate(
-            str(event_filter.get("AttributeValue", "")).replace("\n", " "),
-            _FILTER_VALUE_SUMMARY_TRUNCATE_LEN,
-        )
+        raw_value = str(event_filter.get("AttributeValue", ""))
+        collapsed_value = raw_value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+        filter_value = truncate(collapsed_value, _FILTER_VALUE_SUMMARY_TRUNCATE_LEN)
         parts.append(f"filtered by {filter_key}={filter_value!r}")
     record_evidence_entry(
         evidence,

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -167,7 +167,6 @@ list_x_tools
 list_yc_instances
 list_yc_log_groups
 list_yc_metrics
-lookup_cloudtrail_events
 memory_recall
 memory_remember
 opsgenie_alert_detail

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -546,6 +546,48 @@ class TestMapLookupCloudtrailEvents:
 
         assert evidence["catalog_entries"][0]["summary"] == "50+ event(s)"
 
+    def test_qualifies_write_and_error_counts_when_truncated(self) -> None:
+        """Regression: write_count/error_count are tallied over the returned
+        page only -- on a truncated page they must be marked as a floor, not
+        presented as exact totals."""
+        evidence: dict[str, Any] = {}
+
+        _map_lookup_cloudtrail_events(
+            evidence,
+            {
+                "available": True,
+                "total_events": 50,
+                "truncated": True,
+                "events": [
+                    {"read_only": False, "error_code": None},
+                    {"read_only": False, "error_code": "AccessDenied"},
+                ],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "50+ event(s), 2+ write, 1+ with error"
+
+    def test_strips_carriage_returns_from_filter_value(self) -> None:
+        """Regression: a filter value with bare \\r or \\r\\n line endings
+        must not leave a literal carriage return in the report summary."""
+        evidence: dict[str, Any] = {}
+
+        _map_lookup_cloudtrail_events(
+            evidence,
+            {
+                "available": True,
+                "total_events": 1,
+                "truncated": False,
+                "filter": {"AttributeKey": "Username", "AttributeValue": "alice\r\nbob\r"},
+                "events": [{"read_only": True, "error_code": None}],
+            },
+            {},
+        )
+
+        summary = evidence["catalog_entries"][0]["summary"]
+        assert "\r" not in summary
+
     def test_includes_filter_when_applied(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_cloudtrail_events.py
+++ b/tests/tools/test_cloudtrail_events.py
@@ -18,7 +18,10 @@ from integrations.cloudtrail import (
     cloudtrail_extract_params,
     cloudtrail_is_available,
 )
-from integrations.cloudtrail.tools.cloudtrail_events_tool import lookup_cloudtrail_events
+from integrations.cloudtrail.tools.cloudtrail_events_tool import (
+    _map_lookup_cloudtrail_events,
+    lookup_cloudtrail_events,
+)
 from tests.tools.conftest import BaseToolContract
 
 _RT = lookup_cloudtrail_events.__opensre_registered_tool__
@@ -497,3 +500,84 @@ def test_weird_page_survives_and_shapes_gracefully(mock_call) -> None:
 
     assert result["truncated"] is True
     assert result["next_token"] == "AAAAweirdPageToken"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Evidence mapper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMapLookupCloudtrailEvents:
+    def test_records_entry_with_write_and_error_counts(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_lookup_cloudtrail_events(
+            evidence,
+            {
+                "available": True,
+                "total_events": 2,
+                "truncated": False,
+                "events": [
+                    {"read_only": False, "error_code": None},
+                    {"read_only": False, "error_code": "AccessDenied"},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "lookup_cloudtrail_events"
+        assert entries[0]["summary"] == "2 event(s), 2 write, 1 with error"
+
+    def test_qualifies_count_when_truncated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_lookup_cloudtrail_events(
+            evidence,
+            {
+                "available": True,
+                "total_events": 50,
+                "truncated": True,
+                "events": [{"read_only": True, "error_code": None}],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "50+ event(s)"
+
+    def test_includes_filter_when_applied(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_lookup_cloudtrail_events(
+            evidence,
+            {
+                "available": True,
+                "total_events": 1,
+                "truncated": False,
+                "filter": {"AttributeKey": "ResourceName", "AttributeValue": "sg-1"},
+                "events": [{"read_only": True, "error_code": None}],
+            },
+            {},
+        )
+
+        summary = evidence["catalog_entries"][0]["summary"]
+        assert "filtered by ResourceName='sg-1'" in summary
+
+    def test_records_nothing_when_no_events(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_lookup_cloudtrail_events(
+            evidence, {"available": True, "total_events": 0, "events": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_lookup_cloudtrail_events(
+            evidence, {"available": False, "error": "ThrottlingException"}, {}
+        )
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5581

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires the single CloudTrail investigation tool, `lookup_cloudtrail_events`, to
`record_evidence_entry` so its output stops being silently dropped and becomes
a citeable line in the investigation report.

- `_map_lookup_cloudtrail_events`: cites the event count, how many were write
  (non-`ReadOnly`) events, how many carried an error code, and the forensic
  filter applied (resource name, username, or event source), when one was set.

This is the only tool in `integrations/cloudtrail/tools/` — it's a read-only
diagnostic query, so it's in scope per the issue.

**On count honesty:** unlike most of the companion evidence-mapper PRs in this
session, this tool doesn't need the `"N+"` page-cap heuristic — CloudTrail's
`LookupEvents` API returns an explicit `NextToken` when more matching events
exist beyond the current page, and the tool already surfaces that as
`truncated: bool(returned_token)`. The mapper uses that real signal directly
(`f"{total}+"` when `truncated` is true) rather than guessing from a
requested-vs-returned comparison.

The filter value (`AttributeValue`) is a caller-supplied lookup argument
(resource name/username/event source), not bounded by the input schema, so I
collapsed newlines and capped it to 80 chars before embedding it in the
summary — the same defensive truncation already applied to free-form text in
the Sentry and PagerDuty evidence mappers from this same session.

The mapper records nothing when `available` is falsy or `events` is empty.

Removed `lookup_cloudtrail_events` from `evidence_mapper_baseline.txt` now
that it carries a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tool carries its mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print(bool(g('lookup_cloudtrail_events').evidence_mapper))"
True
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching the tool's return
shape:**
```
lookup_cloudtrail_events:  "2 event(s), 2 write, 1 with error"
lookup_cloudtrail_events (truncated, filtered):  "50+ event(s), filtered by ResourceName='sg-1'"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_cloudtrail_events.py -q
60 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3638 files already formatted / Success: no issues found in 1895 source files
```

**No live AWS account available in this environment**, so leaving the existing
`is_available`/`extract_params`/synthetic-backend wiring untouched — only the
mapper and its tests were added, using the tool's own realistic mock payload
shapes (including the live-payload fixtures already checked into the repo).

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read `lookup_cloudtrail_events`'s full `run()` and `_shape_event()` in
`integrations/cloudtrail/tools/cloudtrail_events_tool/__init__.py` before
writing anything, because the issue's generic template wouldn't have told me
that this tool already computes `truncated`/`next_token` from CloudTrail's own
`NextToken` — an explicit truncation signal, not a heuristic. I used it
directly instead of reapplying the page-cap "N+" pattern I'd just written for
Sentry/PagerDuty/Better Stack in this same session, since CloudTrail doesn't
need the heuristic here. I did keep the same defensive-truncation instinct for
the one piece of free text that does flow into the summary: the caller-
supplied `AttributeValue` filter, which has no length bound in the schema.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
