### PR TITLE
feat(coralogix): add evidence mapper for query_coralogix_logs

### DIFF
--- a/integrations/coralogix/tools/__init__.py
+++ b/integrations/coralogix/tools/__init__.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
+from infrastructure.text.truncation import truncate
 from integrations.config_models import CoralogixIntegrationConfig
 from integrations.coralogix.client import (
     CoralogixClient,
@@ -23,6 +25,54 @@ _ERROR_KEYWORDS = (
     "panic",
     "timeout",
 )
+
+#: Scope fields (app/subsystem/trace) echoed into a report summary are
+#: caller-supplied and not bounded by the input schema.
+_SCOPE_SUMMARY_TRUNCATE_LEN = 60
+
+
+def _map_query_coralogix_logs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the log count, keyword-matched error count, and query scope.
+
+    ``client.query_logs`` sends the caller's own ``limit`` straight into the
+    DataPrime query with no server-side clamp, so a returned ``total`` at
+    that ceiling may understate the true match count -- use the "N+"
+    convention against the caller's requested limit.
+    """
+    if not output.get("available"):
+        return
+    logs = output.get("logs") or []
+    if not logs:
+        return
+    total = output.get("total", len(logs))
+    requested_limit = tool_input.get("limit", 50)
+    count_label = f"{total}+" if total >= max(requested_limit, 1) else str(total)
+    parts = [f"{count_label} log(s)"]
+    error_count = len(output.get("error_logs") or [])
+    if error_count:
+        parts.append(f"{error_count} matching an error keyword")
+
+    def _safe(value: str) -> str:
+        return truncate(value.replace("\n", " "), _SCOPE_SUMMARY_TRUNCATE_LEN)
+
+    scope = []
+    if output.get("application_name"):
+        scope.append(f"app '{_safe(str(output['application_name']))}'")
+    if output.get("subsystem_name"):
+        scope.append(f"subsystem '{_safe(str(output['subsystem_name']))}'")
+    if output.get("trace_id"):
+        scope.append(f"trace '{_safe(str(output['trace_id']))}'")
+    if scope:
+        parts.append(", ".join(scope))
+
+    record_evidence_entry(
+        evidence,
+        source="query_coralogix_logs",
+        label="Coralogix Logs",
+        summary=", ".join(parts),
+    )
 
 
 def _coralogix_available(sources: dict) -> bool:
@@ -41,6 +91,7 @@ class CoralogixLogsTool(BaseTool):
 
     name = "query_coralogix_logs"
     source = "coralogix"
+    evidence_mapper = _map_query_coralogix_logs
     description = "Query Coralogix DataPrime logs for error signatures and incident context."
     use_cases = [
         "Searching Coralogix logs for a failing service or subsystem",

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -162,7 +162,6 @@ pi_coding_task
 prefect_flow_runs
 prefect_worker_health
 query_azure_monitor_logs
-query_coralogix_logs
 query_datadog_all
 query_datadog_events
 query_datadog_logs

--- a/tests/tools/test_coralogix_logs_tool.py
+++ b/tests/tools/test_coralogix_logs_tool.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-from integrations.coralogix.tools import CoralogixLogsTool
+from integrations.coralogix.tools import CoralogixLogsTool, _map_query_coralogix_logs
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -78,3 +79,63 @@ def test_run_api_error() -> None:
     ):
         result = tool.run(query="source logs", coralogix_api_key="cx_key")
     assert result["available"] is False
+
+
+class TestMapQueryCoralogixLogs:
+    def test_records_entry_with_error_count_and_scope(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_coralogix_logs(
+            evidence,
+            {
+                "available": True,
+                "logs": [{"message": "error: failed"}, {"message": "info: ok"}],
+                "error_logs": [{"message": "error: failed"}],
+                "total": 2,
+                "application_name": "checkout",
+                "subsystem_name": "",
+                "trace_id": "",
+            },
+            {"limit": 50},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "query_coralogix_logs"
+        assert entries[0]["summary"] == "2 log(s), 1 matching an error keyword, app 'checkout'"
+
+    def test_records_entry_without_optional_clauses(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_coralogix_logs(
+            evidence,
+            {"available": True, "logs": [{"message": "info: ok"}], "total": 1},
+            {"limit": 50},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "1 log(s)"
+
+    def test_qualifies_count_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_coralogix_logs(
+            evidence,
+            {"available": True, "logs": [{"message": "info"}], "total": 50},
+            {"limit": 50},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "50+ log(s)"
+
+    def test_records_nothing_when_no_logs(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_coralogix_logs(evidence, {"available": True, "logs": [], "total": 0}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_coralogix_logs(evidence, {"available": False, "error": "Rate limited"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5582

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires the single Coralogix investigation tool, `query_coralogix_logs`, to
`record_evidence_entry` so its output stops being silently dropped and becomes
a citeable line in the investigation report.

- `_map_query_coralogix_logs`: cites the log count, keyword-matched error-log
  count, and the app/subsystem/trace scope of the query.

This is the only tool in `integrations/coralogix/tools/` — it's a read-only
diagnostic query, so it's in scope per the issue.

**On count honesty:** `client.query_logs` sends the caller's own `limit`
straight into the DataPrime query with no server-side clamp (unlike
PagerDuty/OpsGenie/Better Stack, which clamp to a fixed page size) — so the
mapper's "N+" check compares the returned `total` against the caller's
requested `limit` directly, the same approach I used for Honeycomb earlier in
this session once I found the same "no fixed ceiling" shape there.

**On phrasing:** `error_logs` is a keyword-substring match (`_ERROR_KEYWORDS`),
not an authoritative severity classification from Coralogix, so I phrased the
citation "N matching an error keyword" rather than "N errors" — the tool
itself doesn't claim these are confirmed errors, and the mapper shouldn't
overstate that either.

The mapper records nothing when `available` is falsy or no logs were returned.

Removed `query_coralogix_logs` from `evidence_mapper_baseline.txt` now that
it carries a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tool carries its mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print(bool(g('query_coralogix_logs').evidence_mapper))"
True
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching the tool's return
shape:**
```
query_coralogix_logs:  "2 log(s), 1 matching an error keyword, app 'checkout'"
query_coralogix_logs (saturated page):  "50+ log(s)"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_coralogix_logs_tool.py -q
16 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live Coralogix account available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the mapper
and its tests were added, using the tool's own realistic mock payload shape.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read `client.query_logs`'s `_ensure_limit_clause` before writing the "N+"
check, since I'd just hit two different truncation shapes earlier in this
session (a fixed server-side page cap for PagerDuty/OpsGenie, an unclamped
caller-supplied limit for Honeycomb) and didn't want to assume which one
applied here without checking. Coralogix turned out to match Honeycomb's
shape. I also deliberately avoided calling the keyword-matched subset
"errors" outright in the summary text, since `_ERROR_KEYWORDS` is a simple
substring match on the log message and can both over- and under-match real
errors — the citation should reflect what was actually measured.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
