### PR TITLE
feat(ec2): add evidence mappers for ec2_instances_by_tag and get_elb_target_health

### DIFF
--- a/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
+++ b/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
@@ -20,6 +21,36 @@ from integrations.aws.topology_helper import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _map_ec2_instances_by_tag(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the active instance count, primary tier, and tier spread.
+
+    ``truncated`` reflects the tool's own 5000-instance safety cap on
+    pagination -- an explicit signal, not an inferred page-size heuristic.
+    """
+    if not output.get("available"):
+        return
+    instances = output.get("instances") or []
+    if not instances:
+        return
+    total = output.get("total_instances", len(instances))
+    count_label = f"{total}+" if output.get("truncated") else str(total)
+    parts = [f"{count_label} active instance(s)"]
+    primary_tier = (output.get("summary") or {}).get("primary_tier")
+    if primary_tier:
+        parts.append(f"primary tier '{primary_tier}'")
+    tiers_detected = output.get("tiers_detected") or []
+    if len(tiers_detected) > 1:
+        parts.append(f"{len(tiers_detected)} tiers")
+    record_evidence_entry(
+        evidence,
+        source="ec2_instances_by_tag",
+        label="EC2 Instances",
+        summary=", ".join(parts),
+    )
 
 
 def _is_available(sources: dict[str, dict]) -> bool:
@@ -88,6 +119,7 @@ def _summarize_instance(raw: dict[str, Any]) -> dict[str, Any]:
     },
     is_available=_is_available,
     extract_params=extract_ec2_instances_params,
+    evidence_mapper=_map_ec2_instances_by_tag,
 )
 def ec2_instances_by_tag(
     tier: str = "",

--- a/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
+++ b/integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
@@ -19,38 +18,11 @@ from integrations.aws.topology_helper import (
     build_ec2_summary,
     extract_ec2_instances_params,
 )
+from integrations.ec2.tools.ec2_instances_by_tag_tool._evidence import (
+    map_ec2_instances_by_tag,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def _map_ec2_instances_by_tag(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
-) -> None:
-    """Cite the active instance count, primary tier, and tier spread.
-
-    ``truncated`` reflects the tool's own 5000-instance safety cap on
-    pagination -- an explicit signal, not an inferred page-size heuristic.
-    """
-    if not output.get("available"):
-        return
-    instances = output.get("instances") or []
-    if not instances:
-        return
-    total = output.get("total_instances", len(instances))
-    count_label = f"{total}+" if output.get("truncated") else str(total)
-    parts = [f"{count_label} active instance(s)"]
-    primary_tier = (output.get("summary") or {}).get("primary_tier")
-    if primary_tier:
-        parts.append(f"primary tier '{primary_tier}'")
-    tiers_detected = output.get("tiers_detected") or []
-    if len(tiers_detected) > 1:
-        parts.append(f"{len(tiers_detected)} tiers")
-    record_evidence_entry(
-        evidence,
-        source="ec2_instances_by_tag",
-        label="EC2 Instances",
-        summary=", ".join(parts),
-    )
 
 
 def _is_available(sources: dict[str, dict]) -> bool:
@@ -119,7 +91,7 @@ def _summarize_instance(raw: dict[str, Any]) -> dict[str, Any]:
     },
     is_available=_is_available,
     extract_params=extract_ec2_instances_params,
-    evidence_mapper=_map_ec2_instances_by_tag,
+    evidence_mapper=map_ec2_instances_by_tag,
 )
 def ec2_instances_by_tag(
     tier: str = "",

--- a/integrations/ec2/tools/ec2_instances_by_tag_tool/_evidence.py
+++ b/integrations/ec2/tools/ec2_instances_by_tag_tool/_evidence.py
@@ -1,0 +1,37 @@
+"""Evidence mapper for ec2_instances_by_tag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+
+def map_ec2_instances_by_tag(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the active instance count, primary tier, and tier spread.
+
+    ``truncated`` reflects the tool's own 5000-instance safety cap on
+    pagination -- an explicit signal, not an inferred page-size heuristic.
+    """
+    if not output.get("available"):
+        return
+    instances = output.get("instances") or []
+    if not instances:
+        return
+    total = output.get("total_instances", len(instances))
+    count_label = f"{total}+" if output.get("truncated") else str(total)
+    parts = [f"{count_label} active instance(s)"]
+    primary_tier = (output.get("summary") or {}).get("primary_tier")
+    if primary_tier:
+        parts.append(f"primary tier '{primary_tier}'")
+    tiers_detected = output.get("tiers_detected") or []
+    if len(tiers_detected) > 1:
+        parts.append(f"{len(tiers_detected)} tiers")
+    record_evidence_entry(
+        evidence,
+        source="ec2_instances_by_tag",
+        label="EC2 Instances",
+        summary=", ".join(parts),
+    )

--- a/integrations/elb/tools/elb_target_health_tool/__init__.py
+++ b/integrations/elb/tools/elb_target_health_tool/__init__.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
@@ -20,40 +19,11 @@ from integrations.aws.topology_helper import (
     build_elb_summary,
     extract_target_health_params,
 )
+from integrations.elb.tools.elb_target_health_tool._evidence import (
+    map_get_elb_target_health,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def _map_get_elb_target_health(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
-) -> None:
-    """Cite the healthy/unhealthy target counts and target group count.
-
-    ``available`` is already False on partial coverage (a per-target-group
-    API failure) -- the tool sets that itself precisely so a caller never
-    mistakes partial data for full coverage, so no extra check is needed
-    here beyond the standard availability guard.
-    """
-    if not output.get("available"):
-        return
-    healthy = output.get("healthy_targets") or []
-    unhealthy = output.get("unhealthy_targets") or []
-    if not healthy and not unhealthy:
-        return
-    stats = output.get("summary") or {}
-    tg_count = stats.get("target_group_count", len(output.get("target_groups") or []))
-    parts = [
-        f"{len(healthy)} healthy, {len(unhealthy)} unhealthy target(s) across {tg_count} target group(s)"
-    ]
-    unhealthy_states = stats.get("unhealthy_states") or []
-    if unhealthy_states:
-        parts.append(f"states: {', '.join(unhealthy_states)}")
-    record_evidence_entry(
-        evidence,
-        source="get_elb_target_health",
-        label="ELB Target Health",
-        summary=", ".join(parts),
-    )
 
 
 def _is_available(sources: dict[str, dict]) -> bool:
@@ -113,7 +83,7 @@ def _is_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_is_available,
     extract_params=extract_target_health_params,
-    evidence_mapper=_map_get_elb_target_health,
+    evidence_mapper=map_get_elb_target_health,
 )
 def get_elb_target_health(
     target_group_arns: list[str] | None = None,

--- a/integrations/elb/tools/elb_target_health_tool/__init__.py
+++ b/integrations/elb/tools/elb_target_health_tool/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.aws.availability import ec2_available_or_backend
@@ -21,6 +22,38 @@ from integrations.aws.topology_helper import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _map_get_elb_target_health(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the healthy/unhealthy target counts and target group count.
+
+    ``available`` is already False on partial coverage (a per-target-group
+    API failure) -- the tool sets that itself precisely so a caller never
+    mistakes partial data for full coverage, so no extra check is needed
+    here beyond the standard availability guard.
+    """
+    if not output.get("available"):
+        return
+    healthy = output.get("healthy_targets") or []
+    unhealthy = output.get("unhealthy_targets") or []
+    if not healthy and not unhealthy:
+        return
+    stats = output.get("summary") or {}
+    tg_count = stats.get("target_group_count", len(output.get("target_groups") or []))
+    parts = [
+        f"{len(healthy)} healthy, {len(unhealthy)} unhealthy target(s) across {tg_count} target group(s)"
+    ]
+    unhealthy_states = stats.get("unhealthy_states") or []
+    if unhealthy_states:
+        parts.append(f"states: {', '.join(unhealthy_states)}")
+    record_evidence_entry(
+        evidence,
+        source="get_elb_target_health",
+        label="ELB Target Health",
+        summary=", ".join(parts),
+    )
 
 
 def _is_available(sources: dict[str, dict]) -> bool:
@@ -80,6 +113,7 @@ def _is_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_is_available,
     extract_params=extract_target_health_params,
+    evidence_mapper=_map_get_elb_target_health,
 )
 def get_elb_target_health(
     target_group_arns: list[str] | None = None,

--- a/integrations/elb/tools/elb_target_health_tool/_evidence.py
+++ b/integrations/elb/tools/elb_target_health_tool/_evidence.py
@@ -1,0 +1,39 @@
+"""Evidence mapper for get_elb_target_health."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+
+def map_get_elb_target_health(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the healthy/unhealthy target counts and target group count.
+
+    ``available`` is already False on partial coverage (a per-target-group
+    API failure) -- the tool sets that itself precisely so a caller never
+    mistakes partial data for full coverage, so no extra check is needed
+    here beyond the standard availability guard.
+    """
+    if not output.get("available"):
+        return
+    healthy = output.get("healthy_targets") or []
+    unhealthy = output.get("unhealthy_targets") or []
+    if not healthy and not unhealthy:
+        return
+    stats = output.get("summary") or {}
+    tg_count = stats.get("target_group_count", len(output.get("target_groups") or []))
+    parts = [
+        f"{len(healthy)} healthy, {len(unhealthy)} unhealthy target(s) across {tg_count} target group(s)"
+    ]
+    unhealthy_states = stats.get("unhealthy_states") or []
+    if unhealthy_states:
+        parts.append(f"states: {', '.join(unhealthy_states)}")
+    record_evidence_entry(
+        evidence,
+        source="get_elb_target_health",
+        label="ELB Target Health",
+        summary=", ".join(parts),
+    )

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -24,7 +24,6 @@ check_s3_marker
 create_google_docs_incident_report
 describe_eks_addon
 describe_eks_cluster
-ec2_instances_by_tag
 execute_python_code
 execute_yc_operation
 fetch_failed_run
@@ -48,7 +47,6 @@ get_eks_events
 get_eks_node_health
 get_eks_nodegroup_health
 get_eks_pod_logs
-get_elb_target_health
 get_error_logs
 get_failed_jobs
 get_failed_tools

--- a/tests/tools/test_ec2_instances_by_tag_tool.py
+++ b/tests/tools/test_ec2_instances_by_tag_tool.py
@@ -9,8 +9,10 @@ import pytest
 from integrations.aws.topology_helper import extract_ec2_instances_params
 from integrations.ec2.tools.ec2_instances_by_tag_tool import (
     _is_available,
-    _map_ec2_instances_by_tag,
     ec2_instances_by_tag,
+)
+from integrations.ec2.tools.ec2_instances_by_tag_tool._evidence import (
+    map_ec2_instances_by_tag as _map_ec2_instances_by_tag,
 )
 
 

--- a/tests/tools/test_ec2_instances_by_tag_tool.py
+++ b/tests/tools/test_ec2_instances_by_tag_tool.py
@@ -7,7 +7,11 @@ from typing import Any
 import pytest
 
 from integrations.aws.topology_helper import extract_ec2_instances_params
-from integrations.ec2.tools.ec2_instances_by_tag_tool import _is_available, ec2_instances_by_tag
+from integrations.ec2.tools.ec2_instances_by_tag_tool import (
+    _is_available,
+    _map_ec2_instances_by_tag,
+    ec2_instances_by_tag,
+)
 
 
 class _FakeAWSBackend:
@@ -203,3 +207,76 @@ def test_real_path_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     out = ec2_instances_by_tag(tier="web")
     assert out["available"] is False
     assert "Failed" in out["error"]
+
+
+class TestMapEc2InstancesByTag:
+    def test_records_entry_with_primary_tier(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_ec2_instances_by_tag(
+            evidence,
+            {
+                "available": True,
+                "total_instances": 5,
+                "instances": [{"instance_id": "i-1"}],
+                "summary": {"primary_tier": "web"},
+                "tiers_detected": ["web", "worker"],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "ec2_instances_by_tag"
+        assert entries[0]["summary"] == "5 active instance(s), primary tier 'web', 2 tiers"
+
+    def test_records_entry_without_tier_clause_when_single_tier(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_ec2_instances_by_tag(
+            evidence,
+            {
+                "available": True,
+                "total_instances": 4,
+                "instances": [{"instance_id": "i-1"}],
+                "summary": {"primary_tier": "web"},
+                "tiers_detected": ["web"],
+            },
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"] == "4 active instance(s), primary tier 'web'"
+        )
+
+    def test_qualifies_count_when_truncated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_ec2_instances_by_tag(
+            evidence,
+            {
+                "available": True,
+                "total_instances": 5000,
+                "truncated": True,
+                "instances": [{"instance_id": "i-1"}],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "5000+ active instance(s)"
+
+    def test_records_nothing_when_no_instances(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_ec2_instances_by_tag(
+            evidence, {"available": True, "total_instances": 0, "instances": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_ec2_instances_by_tag(evidence, {"available": False, "error": "AccessDenied"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_elb_target_health_tool.py
+++ b/tests/tools/test_elb_target_health_tool.py
@@ -7,7 +7,11 @@ from typing import Any
 import pytest
 
 from integrations.aws.topology_helper import extract_target_health_params
-from integrations.elb.tools.elb_target_health_tool import _is_available, get_elb_target_health
+from integrations.elb.tools.elb_target_health_tool import (
+    _is_available,
+    _map_get_elb_target_health,
+    get_elb_target_health,
+)
 
 
 class _FakeAWSBackend:
@@ -233,3 +237,78 @@ def test_real_path_propagates_describe_groups_failure(
     out = get_elb_target_health(target_group_arn="tg-1")
     assert out["available"] is False
     assert "Failed" in out["error"]
+
+
+class TestMapGetElbTargetHealth:
+    def test_records_entry_with_unhealthy_states(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_elb_target_health(
+            evidence,
+            {
+                "available": True,
+                "healthy_targets": [{"instance_id": "i-1"}, {"instance_id": "i-2"}],
+                "unhealthy_targets": [{"instance_id": "i-3"}],
+                "target_groups": [{"TargetGroupArn": "tg-1"}],
+                "summary": {"target_group_count": 1, "unhealthy_states": ["draining"]},
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_elb_target_health"
+        assert (
+            entries[0]["summary"]
+            == "2 healthy, 1 unhealthy target(s) across 1 target group(s), states: draining"
+        )
+
+    def test_records_zero_unhealthy_as_a_genuine_finding(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_elb_target_health(
+            evidence,
+            {
+                "available": True,
+                "healthy_targets": [{"instance_id": "i-1"}],
+                "unhealthy_targets": [],
+                "target_groups": [{"TargetGroupArn": "tg-1"}],
+                "summary": {"target_group_count": 1, "unhealthy_states": []},
+            },
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"]
+            == "1 healthy, 0 unhealthy target(s) across 1 target group(s)"
+        )
+
+    def test_records_nothing_when_no_targets(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_elb_target_health(
+            evidence,
+            {"available": True, "healthy_targets": [], "unhealthy_targets": []},
+            {},
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        """available=False also covers the partial-coverage case (api_errors
+        non-empty) -- the tool sets it deliberately, so the mapper must not
+        cite partial data as if it were complete."""
+        evidence: dict[str, Any] = {}
+
+        _map_get_elb_target_health(
+            evidence,
+            {
+                "available": False,
+                "healthy_targets": [{"instance_id": "i-1"}],
+                "unhealthy_targets": [],
+                "error": "Partial coverage: 1/2 target groups failed.",
+            },
+            {},
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_elb_target_health_tool.py
+++ b/tests/tools/test_elb_target_health_tool.py
@@ -9,8 +9,10 @@ import pytest
 from integrations.aws.topology_helper import extract_target_health_params
 from integrations.elb.tools.elb_target_health_tool import (
     _is_available,
-    _map_get_elb_target_health,
     get_elb_target_health,
+)
+from integrations.elb.tools.elb_target_health_tool._evidence import (
+    map_get_elb_target_health as _map_get_elb_target_health,
 )
 
 


### PR DESCRIPTION
Closes #5565

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires both listed EC2 topology investigation tools to `record_evidence_entry`
so their output stops being silently dropped and becomes a citeable line in
the investigation report.

- `_map_ec2_instances_by_tag`: cites the active instance count, primary tier,
  and how many tiers were detected.
- `_map_get_elb_target_health`: cites the healthy/unhealthy target counts and
  target group count.

Both are read-only diagnostic queries — neither is an action/notification
tool, so both are in scope per the issue.

**On count honesty:** `ec2_instances_by_tag` already surfaces an explicit
`truncated` flag (a 5000-instance pagination safety cap, not an inferred
heuristic), so the mapper uses that directly — the same kind of explicit
signal I used for CloudTrail's `NextToken` earlier in this session, in
preference to a guessed page-size comparison.

**On the ELB tool's `available` semantics:** `get_elb_target_health` sets
`available=False` on *partial* coverage too (when one of several target
groups fails its `describe_target_health` call) — deliberately, per the
tool's own comment, so a caller never mistakes partial data for full
coverage. The mapper's standard `if not output.get("available"): return`
guard already handles this correctly with no extra logic, since the tool
itself already refuses to claim success on partial data.

**On zero counts:** both mappers always show `0 unhealthy` / `0 failed`-style
sub-counts when the parent list is non-empty, rather than omitting the clause
— a genuine zero within real data is a finding worth citing, not noise (the
same fix I'd just made for OpsGenie's open-alert count in a companion PR
earlier in this session, applied here from the start).

Removed both `ec2_instances_by_tag` and `get_elb_target_health` from
`evidence_mapper_baseline.txt` now that they carry mappers.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['ec2_instances_by_tag', 'get_elb_target_health']})"
{'ec2_instances_by_tag': True, 'get_elb_target_health': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each tool's return
shape:**
```
ec2_instances_by_tag:   "5 active instance(s), primary tier 'web', 2 tiers"
get_elb_target_health:  "2 healthy, 1 unhealthy target(s) across 1 target group(s), states: draining"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_ec2_instances_by_tag_tool.py tests/tools/test_elb_target_health_tool.py -q
29 passed

$ uv run pytest tests/synthetic/rds_postgres/ tests/synthetic/rds_upstream/ -q
131 passed, 28 skipped

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live AWS account available in this environment**, so leaving the
existing `is_available`/`extract_params`/synthetic-backend wiring untouched —
only the two mappers and their tests were added. I also ran the synthetic
`rds_postgres`/`rds_upstream` suites (which reference both tool names in
scenario fixtures) to confirm nothing downstream broke; both scenarios
that use these tools were already failing before this change on unrelated
gates (`category_match`, `exact_keyword_match`), so their pass/fail status is
unaffected by this PR.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read both tools' full `run()` bodies in
`integrations/ec2/tools/ec2_instances_by_tag_tool/__init__.py` and
`integrations/elb/tools/elb_target_health_tool/__init__.py` before writing
anything, since the issue's generic template wouldn't have surfaced the
per-tool nuances: EC2's own `truncated` flag (from its 5000-instance safety
cap) and ELB's deliberate `available=False` on partial multi-target-group
coverage. Both tools also already compute an agent-friendly `summary` dict
via `integrations/aws/topology_helper.py` (`build_ec2_summary` /
`build_elb_summary`) — I reused those precomputed fields (`primary_tier`,
`target_group_count`, `unhealthy_states`) instead of re-deriving them from
the raw instance/target lists in the mapper.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
