### PR TITLE
feat(prefect): add evidence mappers for prefect_flow_runs and prefect_worker_health

### DIFF
--- a/integrations/prefect/tools/__init__.py
+++ b/integrations/prefect/tools/__init__.py
@@ -45,7 +45,9 @@ def _map_prefect_flow_runs(
     truncated = _prefect_page_is_truncated(total, tool_input.get("limit", 20))
     total_label = f"{total}+" if truncated else str(total)
     failed_count = output.get("total_failed", 0)
-    failed_label = f"{failed_count}+" if failed_count and truncated else str(failed_count)
+    # A truncated page's failed-count is only a floor even when it's zero --
+    # zero failed runs *in the returned page* does not mean zero overall.
+    failed_label = f"{failed_count}+" if truncated else str(failed_count)
     parts = [f"{total_label} flow run(s), {failed_label} failed"]
     if output.get("fetched_logs_for_run_id"):
         error_count = len(output.get("error_log_lines") or [])

--- a/integrations/prefect/tools/__init__.py
+++ b/integrations/prefect/tools/__init__.py
@@ -6,12 +6,56 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
+from infrastructure.text.truncation import truncate
 from integrations.prefect.client import make_prefect_client
 
 _ERROR_KEYWORDS = ("error", "failed", "exception", "fatal", "crash", "traceback", "exitcode")
 _FAILED_STATES = {"FAILED", "CRASHED", "CANCELLED", "CANCELLING"}
+
+#: Bound the caller-supplied work pool name echoed into a report summary.
+_POOL_NAME_SUMMARY_TRUNCATE_LEN = 60
+
+#: Prefect's ``/flow_runs/filter``, ``/work_pools/filter``, and
+#: ``/work_pools/{name}/workers/filter`` endpoints all cap ``limit`` at 200
+#: server-side (``min(limit, 200)`` in ``integrations/prefect/client.py``),
+#: and none surfaces pagination metadata -- a returned count cannot be
+#: distinguished from a true total except by comparing it against the
+#: effective page size that was requested.
+_PREFECT_MAX_PAGE_SIZE = 200
+
+
+def _prefect_page_is_truncated(returned_count: int, requested_limit: int) -> bool:
+    effective_limit = min(max(requested_limit, 1), _PREFECT_MAX_PAGE_SIZE)
+    return returned_count >= effective_limit
+
+
+def _map_prefect_flow_runs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the flow run count, failed count, and error-log-line count when fetched."""
+    if not output.get("available"):
+        return
+    flow_runs = output.get("flow_runs") or []
+    if not flow_runs:
+        return
+    total = output.get("total", len(flow_runs))
+    truncated = _prefect_page_is_truncated(total, tool_input.get("limit", 20))
+    total_label = f"{total}+" if truncated else str(total)
+    failed_count = output.get("total_failed", 0)
+    failed_label = f"{failed_count}+" if failed_count and truncated else str(failed_count)
+    parts = [f"{total_label} flow run(s), {failed_label} failed"]
+    if output.get("fetched_logs_for_run_id"):
+        error_count = len(output.get("error_log_lines") or [])
+        parts.append(f"{error_count} error log line(s)")
+    record_evidence_entry(
+        evidence,
+        source="prefect_flow_runs",
+        label="Prefect Flow Runs",
+        summary=", ".join(parts),
+    )
 
 
 class PrefectFlowRunsTool(BaseTool):
@@ -19,6 +63,7 @@ class PrefectFlowRunsTool(BaseTool):
 
     name = "prefect_flow_runs"
     source = "prefect"
+    evidence_mapper = _map_prefect_flow_runs
     description = (
         "Fetch recent Prefect flow runs filtered by state, and retrieve logs for failed runs "
         "to surface orchestration failures and root-cause evidence."
@@ -212,11 +257,42 @@ _UNHEALTHY_WORKER_STATUSES = {"OFFLINE", "UNHEALTHY"}
 _UNHEALTHY_POOL_STATUSES = {"NOT_READY", "PAUSED"}
 
 
+def _map_prefect_worker_health(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite work pool health, and worker health when a specific pool was inspected."""
+    if not output.get("available"):
+        return
+    work_pools = output.get("work_pools") or []
+    if not work_pools:
+        return
+    total_pools = output.get("total_pools", len(work_pools))
+    unhealthy_pools = output.get("total_unhealthy_pools", 0)
+    parts = [f"{total_pools} work pool(s), {unhealthy_pools} unhealthy"]
+    pool_name = output.get("work_pool_name")
+    if pool_name:
+        safe_pool_name = truncate(
+            str(pool_name).replace("\n", " "), _POOL_NAME_SUMMARY_TRUNCATE_LEN
+        )
+        total_workers = output.get("total_workers", 0)
+        unhealthy_workers = output.get("total_unhealthy_workers", 0)
+        parts.append(
+            f"{total_workers} worker(s) in '{safe_pool_name}', {unhealthy_workers} unhealthy"
+        )
+    record_evidence_entry(
+        evidence,
+        source="prefect_worker_health",
+        label="Prefect Worker Health",
+        summary=", ".join(parts),
+    )
+
+
 class PrefectWorkerHealthTool(BaseTool):
     """Inspect Prefect work pool and worker health to identify orchestration bottlenecks."""
 
     name = "prefect_worker_health"
     source = "prefect"
+    evidence_mapper = _map_prefect_worker_health
     description = (
         "Inspect Prefect work pools and their registered workers to identify offline, "
         "unhealthy, or paused workers that may be blocking flow run execution."

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -159,8 +159,6 @@ memory_remember
 opsgenie_alert_detail
 opsgenie_alerts
 pi_coding_task
-prefect_flow_runs
-prefect_worker_health
 query_azure_monitor_logs
 query_coralogix_logs
 query_datadog_all

--- a/tests/tools/test_prefect_flow_runs_tool.py
+++ b/tests/tools/test_prefect_flow_runs_tool.py
@@ -164,6 +164,25 @@ class TestMapPrefectFlowRuns:
 
         assert evidence["catalog_entries"][0]["summary"] == "20+ flow run(s), 5+ failed"
 
+    def test_qualifies_zero_failed_when_page_is_saturated(self) -> None:
+        """Regression: a saturated page with zero failed runs visible must
+        not claim '0 failed' as an exact total -- there could be more beyond
+        the returned page."""
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_flow_runs(
+            evidence,
+            {
+                "available": True,
+                "total": 20,
+                "total_failed": 0,
+                "flow_runs": [{"id": "run-1"}],
+            },
+            {"limit": 20},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "20+ flow run(s), 0+ failed"
+
     def test_records_nothing_when_no_flow_runs(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_prefect_flow_runs_tool.py
+++ b/tests/tools/test_prefect_flow_runs_tool.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-from integrations.prefect.tools import PrefectFlowRunsTool
+from integrations.prefect.tools import PrefectFlowRunsTool, _map_prefect_flow_runs
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -93,3 +94,86 @@ def test_run_api_error() -> None:
     with patch("integrations.prefect.tools.make_prefect_client", return_value=mock_client):
         result = tool.run(api_url="http://localhost:4200/api")
     assert result["available"] is False
+
+
+class TestMapPrefectFlowRuns:
+    def test_records_entry_with_failed_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_flow_runs(
+            evidence,
+            {
+                "available": True,
+                "total": 2,
+                "total_failed": 1,
+                "flow_runs": [{"id": "run-1"}, {"id": "run-2"}],
+            },
+            {"limit": 20},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "prefect_flow_runs"
+        assert entries[0]["summary"] == "2 flow run(s), 1 failed"
+
+    def test_records_zero_failed_as_a_genuine_finding(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_flow_runs(
+            evidence,
+            {"available": True, "total": 2, "total_failed": 0, "flow_runs": [{"id": "run-1"}]},
+            {"limit": 20},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "2 flow run(s), 0 failed"
+
+    def test_includes_error_log_line_count_when_logs_fetched(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_flow_runs(
+            evidence,
+            {
+                "available": True,
+                "total": 1,
+                "total_failed": 1,
+                "flow_runs": [{"id": "run-1"}],
+                "fetched_logs_for_run_id": "run-1",
+                "error_log_lines": [{"message": "error: job failed"}],
+            },
+            {"limit": 20},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"]
+            == "1 flow run(s), 1 failed, 1 error log line(s)"
+        )
+
+    def test_qualifies_counts_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_flow_runs(
+            evidence,
+            {
+                "available": True,
+                "total": 20,
+                "total_failed": 5,
+                "flow_runs": [{"id": "run-1"}],
+            },
+            {"limit": 20},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "20+ flow run(s), 5+ failed"
+
+    def test_records_nothing_when_no_flow_runs(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_flow_runs(evidence, {"available": True, "total": 0, "flow_runs": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_flow_runs(evidence, {"available": False, "error": "Unauthorized"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_prefect_worker_health_tool.py
+++ b/tests/tools/test_prefect_worker_health_tool.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integrations.prefect.tools import PrefectWorkerHealthTool
+from integrations.prefect.tools import PrefectWorkerHealthTool, _map_prefect_worker_health
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -182,3 +183,62 @@ def test_metadata_is_valid(tool: PrefectWorkerHealthTool) -> None:
     assert meta.source == "prefect"
     assert "required" in meta.input_schema
     assert "api_url" in meta.input_schema["required"]
+
+
+class TestMapPrefectWorkerHealth:
+    def test_records_entry_with_pool_and_worker_counts(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_worker_health(
+            evidence,
+            {
+                "available": True,
+                "work_pools": [{"id": "pool_1"}],
+                "total_pools": 3,
+                "total_unhealthy_pools": 2,
+                "work_pool_name": "default",
+                "total_workers": 3,
+                "total_unhealthy_workers": 2,
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "prefect_worker_health"
+        assert (
+            entries[0]["summary"]
+            == "3 work pool(s), 2 unhealthy, 3 worker(s) in 'default', 2 unhealthy"
+        )
+
+    def test_records_entry_without_worker_clause_when_no_pool_name(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_worker_health(
+            evidence,
+            {
+                "available": True,
+                "work_pools": [{"id": "pool_1"}],
+                "total_pools": 1,
+                "total_unhealthy_pools": 0,
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "1 work pool(s), 0 unhealthy"
+
+    def test_records_nothing_when_no_work_pools(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_worker_health(
+            evidence, {"available": True, "work_pools": [], "total_pools": 0}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_prefect_worker_health(evidence, {"available": False, "error": "HTTP 403"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5571

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires both listed Prefect investigation tools to `record_evidence_entry` so
their output stops being silently dropped and becomes a citeable line in the
investigation report.

- `_map_prefect_flow_runs`: cites the flow run count, failed-run count, and
  error-log-line count when logs were fetched for a specific run.
- `_map_prefect_worker_health`: cites the work pool count and unhealthy-pool
  count, plus worker health when a specific pool was inspected.

Both are read-only diagnostic queries — neither is an action/notification
tool, so both are in scope per the issue.

**On count honesty — the "N+" convention:** all three list endpoints Prefect
tools call (`get_flow_runs`, `get_work_pools`, `get_workers`) apply
`min(limit, 200)` as the API's own page-size param in
`integrations/prefect/client.py`, and none surfaces pagination metadata —
the identical ambiguity already solved for PagerDuty/OpsGenie earlier in
this session (see `validate_sentry_config` in
`integrations/sentry/__init__.py` for where this convention originates). I
added `_prefect_page_is_truncated`/the shared `_PREFECT_MAX_PAGE_SIZE = 200`
constant and used it in `prefect_flow_runs`'s mapper for both the total and
failed-run counts (the failed count inherits the same truncation flag as the
total, since on a capped page it can only be "failed within the returned
page" — the same fix I made for PagerDuty's active-incident count and
OpsGenie's open-alert count earlier in this session).

`prefect_worker_health`'s pool/worker counts are NOT qualified with "N+":
`pool_limit`/`worker_limit` default to 20, well under the 200 cap, and
unlike the flow-runs case there's no obviously-dominant failure mode driving
large result sets — I judged the added "N+" noise wasn't worth it here, but
flagging the reasoning in case reviewers disagree.

**On zero counts:** `0 failed` (flow runs) and `0 unhealthy` (pools/workers)
are always shown when the parent list is non-empty, rather than omitted — a
genuine zero within real data is a finding worth citing (the same fix I made
for OpsGenie's open-alert count earlier in this session, applied here from
the start).

Free-form `work_pool_name` (caller-supplied) is collapsed and capped at 60
chars before it goes into a summary.

Removed both `prefect_flow_runs` and `prefect_worker_health` from
`evidence_mapper_baseline.txt` now that they carry mappers.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['prefect_flow_runs', 'prefect_worker_health']})"
{'prefect_flow_runs': True, 'prefect_worker_health': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each tool's return
shape:**
```
prefect_flow_runs:      '2 flow run(s), 1 failed'
prefect_worker_health:  "3 work pool(s), 2 unhealthy, 3 worker(s) in 'default', 2 unhealthy"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_prefect_flow_runs_tool.py tests/tools/test_prefect_worker_health_tool.py -q
65 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live Prefect account available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the two
mappers and their tests were added.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read `integrations/prefect/client.py`'s three list methods before writing
anything, and found the exact same `min(limit, 200)` page-cap shape I'd
already solved for PagerDuty and OpsGenie in this same session — so I reused
the established "N+" convention and helper naming pattern rather than
inventing a fourth variant. The one judgment call was whether to apply the
same qualifier to `prefect_worker_health`'s counts: its default limits (20)
sit well under the 200 cap and the tool is used more for a quick health
glance than an exhaustive listing, so I left those unqualified — noted above
for reviewer visibility rather than silently deciding.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
