### PR TITLE
feat(airflow): add evidence mappers for airflow DAG/task investigation tools

### DIFF
--- a/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
-from infrastructure.text.truncation import truncate
 from integrations.airflow.config import (
     AirflowConfig,
     build_airflow_config,
@@ -22,105 +20,11 @@ from integrations.airflow.config import (
 from integrations.airflow.config import (
     get_recent_airflow_failures as fetch_recent_airflow_failures,
 )
-
-#: These tools have no ``available``/success flag -- ``{"error": ...}`` is the
-#: only failure signal, and a request failure (auth, network, 5xx) inside the
-#: config-layer fetch functions is swallowed into an empty list rather than
-#: surfaced. A mapper therefore cannot distinguish "genuinely zero results"
-#: from "the fetch silently failed", so it stays silent on empty lists rather
-#: than assert a false zero -- the same conservative choice made throughout
-#: this codebase's other evidence mappers.
-_ID_SUMMARY_TRUNCATE_LEN = 60
-_FAILED_DAG_RUN_STATES = frozenset({"failed"})
-_FAILED_TASK_STATES = frozenset({"failed", "upstream_failed", "up_for_retry"})
-
-
-def _safe_id(value: str) -> str:
-    return truncate(str(value).replace("\n", " "), _ID_SUMMARY_TRUNCATE_LEN)
-
-
-def _map_get_recent_airflow_failures(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
-) -> None:
-    """Cite the count of failed/retrying task instances found for the DAG."""
-    if output.get("error"):
-        return
-    failures = output.get("failures") or []
-    if not failures:
-        return
-    summary = f"{len(failures)} failed/retrying task instance(s)"
-    dag_id = output.get("dag_id")
-    if dag_id:
-        summary += f" for DAG '{_safe_id(dag_id)}'"
-    record_evidence_entry(
-        evidence,
-        source="get_recent_airflow_failures",
-        label="Airflow Recent Failures",
-        summary=summary,
-    )
-
-
-def _map_get_airflow_dag_runs(
-    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
-) -> None:
-    """Cite the DAG run count and how many are in a failed state.
-
-    ``state`` filters the API query itself (only runs in that state come
-    back), so when it's set the "N failed" count would either be trivially
-    all of them (state="failed") or a misleading, unqualified zero for any
-    other state -- the caller filtered failures out of view, not confirmed
-    their absence. Cite the filter instead of a derived failure count in
-    that case.
-    """
-    if output.get("error"):
-        return
-    dag_runs = output.get("dag_runs") or []
-    if not dag_runs:
-        return
-    total = len(dag_runs)
-    requested_limit = tool_input.get("limit", 10)
-    count_label = f"{total}+" if total >= max(requested_limit, 1) else str(total)
-    state_filter = tool_input.get("state")
-    if state_filter:
-        summary = f"{count_label} DAG run(s) with state '{_safe_id(str(state_filter))}'"
-    else:
-        failed = sum(
-            1 for run in dag_runs if str(run.get("state", "")).lower() in _FAILED_DAG_RUN_STATES
-        )
-        summary = f"{count_label} DAG run(s), {failed} failed"
-    dag_id = output.get("dag_id")
-    if dag_id:
-        summary += f" for '{_safe_id(dag_id)}'"
-    record_evidence_entry(
-        evidence,
-        source="get_airflow_dag_runs",
-        label="Airflow DAG Runs",
-        summary=summary,
-    )
-
-
-def _map_get_airflow_task_instances(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
-) -> None:
-    """Cite the task instance count and how many failed or are up for retry."""
-    if output.get("error"):
-        return
-    task_instances = output.get("task_instances") or []
-    if not task_instances:
-        return
-    failed = sum(
-        1 for t in task_instances if str(t.get("state", "")).lower() in _FAILED_TASK_STATES
-    )
-    summary = f"{len(task_instances)} task instance(s), {failed} failed/retrying"
-    dag_run_id = output.get("dag_run_id")
-    if dag_run_id:
-        summary += f" for run '{_safe_id(dag_run_id)}'"
-    record_evidence_entry(
-        evidence,
-        source="get_airflow_task_instances",
-        label="Airflow Task Instances",
-        summary=summary,
-    )
+from integrations.tracer.tools.tracer_airflow_dag_tool._evidence import (
+    map_get_airflow_dag_runs,
+    map_get_airflow_task_instances,
+    map_get_recent_airflow_failures,
+)
 
 
 def _airflow_available(sources: dict[str, Any]) -> bool:
@@ -168,7 +72,7 @@ def _airflow_dag_id(sources: dict[str, Any]) -> str:
         "config": _airflow_config(sources),
         "dag_id": _airflow_dag_id(sources),
     },
-    evidence_mapper=_map_get_recent_airflow_failures,
+    evidence_mapper=map_get_recent_airflow_failures,
 )
 def get_recent_airflow_failures(
     config: AirflowConfig,
@@ -216,7 +120,7 @@ def get_recent_airflow_failures(
         "config": _airflow_config(sources),
         "dag_id": _airflow_dag_id(sources),
     },
-    evidence_mapper=_map_get_airflow_dag_runs,
+    evidence_mapper=map_get_airflow_dag_runs,
 )
 def get_airflow_dag_runs(
     config: AirflowConfig,
@@ -265,7 +169,7 @@ def get_airflow_dag_runs(
         "config": _airflow_config(sources),
         "dag_id": _airflow_dag_id(sources),
     },
-    evidence_mapper=_map_get_airflow_task_instances,
+    evidence_mapper=map_get_airflow_task_instances,
 )
 def get_airflow_task_instances(
     config: AirflowConfig,

--- a/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
+from infrastructure.text.truncation import truncate
 from integrations.airflow.config import (
     AirflowConfig,
     build_airflow_config,
@@ -20,6 +22,93 @@ from integrations.airflow.config import (
 from integrations.airflow.config import (
     get_recent_airflow_failures as fetch_recent_airflow_failures,
 )
+
+#: These tools have no ``available``/success flag -- ``{"error": ...}`` is the
+#: only failure signal, and a request failure (auth, network, 5xx) inside the
+#: config-layer fetch functions is swallowed into an empty list rather than
+#: surfaced. A mapper therefore cannot distinguish "genuinely zero results"
+#: from "the fetch silently failed", so it stays silent on empty lists rather
+#: than assert a false zero -- the same conservative choice made throughout
+#: this codebase's other evidence mappers.
+_ID_SUMMARY_TRUNCATE_LEN = 60
+_FAILED_DAG_RUN_STATES = frozenset({"failed"})
+_FAILED_TASK_STATES = frozenset({"failed", "upstream_failed", "up_for_retry"})
+
+
+def _safe_id(value: str) -> str:
+    return truncate(str(value).replace("\n", " "), _ID_SUMMARY_TRUNCATE_LEN)
+
+
+def _map_get_recent_airflow_failures(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the count of failed/retrying task instances found for the DAG."""
+    if output.get("error"):
+        return
+    failures = output.get("failures") or []
+    if not failures:
+        return
+    summary = f"{len(failures)} failed/retrying task instance(s)"
+    dag_id = output.get("dag_id")
+    if dag_id:
+        summary += f" for DAG '{_safe_id(dag_id)}'"
+    record_evidence_entry(
+        evidence,
+        source="get_recent_airflow_failures",
+        label="Airflow Recent Failures",
+        summary=summary,
+    )
+
+
+def _map_get_airflow_dag_runs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the DAG run count and how many are in a failed state."""
+    if output.get("error"):
+        return
+    dag_runs = output.get("dag_runs") or []
+    if not dag_runs:
+        return
+    total = len(dag_runs)
+    requested_limit = tool_input.get("limit", 10)
+    count_label = f"{total}+" if total >= max(requested_limit, 1) else str(total)
+    failed = sum(
+        1 for run in dag_runs if str(run.get("state", "")).lower() in _FAILED_DAG_RUN_STATES
+    )
+    summary = f"{count_label} DAG run(s), {failed} failed"
+    dag_id = output.get("dag_id")
+    if dag_id:
+        summary += f" for '{_safe_id(dag_id)}'"
+    record_evidence_entry(
+        evidence,
+        source="get_airflow_dag_runs",
+        label="Airflow DAG Runs",
+        summary=summary,
+    )
+
+
+def _map_get_airflow_task_instances(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the task instance count and how many failed or are up for retry."""
+    if output.get("error"):
+        return
+    task_instances = output.get("task_instances") or []
+    if not task_instances:
+        return
+    failed = sum(
+        1 for t in task_instances if str(t.get("state", "")).lower() in _FAILED_TASK_STATES
+    )
+    summary = f"{len(task_instances)} task instance(s), {failed} failed/retrying"
+    dag_run_id = output.get("dag_run_id")
+    if dag_run_id:
+        summary += f" for run '{_safe_id(dag_run_id)}'"
+    record_evidence_entry(
+        evidence,
+        source="get_airflow_task_instances",
+        label="Airflow Task Instances",
+        summary=summary,
+    )
 
 
 def _airflow_available(sources: dict[str, Any]) -> bool:
@@ -67,6 +156,7 @@ def _airflow_dag_id(sources: dict[str, Any]) -> str:
         "config": _airflow_config(sources),
         "dag_id": _airflow_dag_id(sources),
     },
+    evidence_mapper=_map_get_recent_airflow_failures,
 )
 def get_recent_airflow_failures(
     config: AirflowConfig,
@@ -114,6 +204,7 @@ def get_recent_airflow_failures(
         "config": _airflow_config(sources),
         "dag_id": _airflow_dag_id(sources),
     },
+    evidence_mapper=_map_get_airflow_dag_runs,
 )
 def get_airflow_dag_runs(
     config: AirflowConfig,
@@ -162,6 +253,7 @@ def get_airflow_dag_runs(
         "config": _airflow_config(sources),
         "dag_id": _airflow_dag_id(sources),
     },
+    evidence_mapper=_map_get_airflow_task_instances,
 )
 def get_airflow_task_instances(
     config: AirflowConfig,

--- a/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py
@@ -63,7 +63,15 @@ def _map_get_recent_airflow_failures(
 def _map_get_airflow_dag_runs(
     evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
 ) -> None:
-    """Cite the DAG run count and how many are in a failed state."""
+    """Cite the DAG run count and how many are in a failed state.
+
+    ``state`` filters the API query itself (only runs in that state come
+    back), so when it's set the "N failed" count would either be trivially
+    all of them (state="failed") or a misleading, unqualified zero for any
+    other state -- the caller filtered failures out of view, not confirmed
+    their absence. Cite the filter instead of a derived failure count in
+    that case.
+    """
     if output.get("error"):
         return
     dag_runs = output.get("dag_runs") or []
@@ -72,10 +80,14 @@ def _map_get_airflow_dag_runs(
     total = len(dag_runs)
     requested_limit = tool_input.get("limit", 10)
     count_label = f"{total}+" if total >= max(requested_limit, 1) else str(total)
-    failed = sum(
-        1 for run in dag_runs if str(run.get("state", "")).lower() in _FAILED_DAG_RUN_STATES
-    )
-    summary = f"{count_label} DAG run(s), {failed} failed"
+    state_filter = tool_input.get("state")
+    if state_filter:
+        summary = f"{count_label} DAG run(s) with state '{_safe_id(str(state_filter))}'"
+    else:
+        failed = sum(
+            1 for run in dag_runs if str(run.get("state", "")).lower() in _FAILED_DAG_RUN_STATES
+        )
+        summary = f"{count_label} DAG run(s), {failed} failed"
     dag_id = output.get("dag_id")
     if dag_id:
         summary += f" for '{_safe_id(dag_id)}'"

--- a/integrations/tracer/tools/tracer_airflow_dag_tool/_evidence.py
+++ b/integrations/tracer/tools/tracer_airflow_dag_tool/_evidence.py
@@ -1,0 +1,107 @@
+"""Evidence mappers for the Tracer Airflow DAG/task investigation tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: These tools have no ``available``/success flag -- ``{"error": ...}`` is the
+#: only failure signal, and a request failure (auth, network, 5xx) inside the
+#: config-layer fetch functions is swallowed into an empty list rather than
+#: surfaced. A mapper therefore cannot distinguish "genuinely zero results"
+#: from "the fetch silently failed", so it stays silent on empty lists rather
+#: than assert a false zero -- the same conservative choice made throughout
+#: this codebase's other evidence mappers.
+_ID_SUMMARY_TRUNCATE_LEN = 60
+_FAILED_DAG_RUN_STATES = frozenset({"failed"})
+_FAILED_TASK_STATES = frozenset({"failed", "upstream_failed", "up_for_retry"})
+
+
+def _safe_id(value: str) -> str:
+    return truncate(str(value).replace("\n", " "), _ID_SUMMARY_TRUNCATE_LEN)
+
+
+def map_get_recent_airflow_failures(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the count of failed/retrying task instances found for the DAG."""
+    if output.get("error"):
+        return
+    failures = output.get("failures") or []
+    if not failures:
+        return
+    summary = f"{len(failures)} failed/retrying task instance(s)"
+    dag_id = output.get("dag_id")
+    if dag_id:
+        summary += f" for DAG '{_safe_id(dag_id)}'"
+    record_evidence_entry(
+        evidence,
+        source="get_recent_airflow_failures",
+        label="Airflow Recent Failures",
+        summary=summary,
+    )
+
+
+def map_get_airflow_dag_runs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the DAG run count and how many are in a failed state.
+
+    ``state`` filters the API query itself (only runs in that state come
+    back), so when it's set the "N failed" count would either be trivially
+    all of them (state="failed") or a misleading, unqualified zero for any
+    other state -- the caller filtered failures out of view, not confirmed
+    their absence. Cite the filter instead of a derived failure count in
+    that case.
+    """
+    if output.get("error"):
+        return
+    dag_runs = output.get("dag_runs") or []
+    if not dag_runs:
+        return
+    total = len(dag_runs)
+    requested_limit = tool_input.get("limit", 10)
+    count_label = f"{total}+" if total >= max(requested_limit, 1) else str(total)
+    state_filter = tool_input.get("state")
+    if state_filter:
+        summary = f"{count_label} DAG run(s) with state '{_safe_id(str(state_filter))}'"
+    else:
+        failed = sum(
+            1 for run in dag_runs if str(run.get("state", "")).lower() in _FAILED_DAG_RUN_STATES
+        )
+        summary = f"{count_label} DAG run(s), {failed} failed"
+    dag_id = output.get("dag_id")
+    if dag_id:
+        summary += f" for '{_safe_id(dag_id)}'"
+    record_evidence_entry(
+        evidence,
+        source="get_airflow_dag_runs",
+        label="Airflow DAG Runs",
+        summary=summary,
+    )
+
+
+def map_get_airflow_task_instances(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the task instance count and how many failed or are up for retry."""
+    if output.get("error"):
+        return
+    task_instances = output.get("task_instances") or []
+    if not task_instances:
+        return
+    failed = sum(
+        1 for t in task_instances if str(t.get("state", "")).lower() in _FAILED_TASK_STATES
+    )
+    summary = f"{len(task_instances)} task instance(s), {failed} failed/retrying"
+    dag_run_id = output.get("dag_run_id")
+    if dag_run_id:
+        summary += f" for run '{_safe_id(dag_run_id)}'"
+    record_evidence_entry(
+        evidence,
+        source="get_airflow_task_instances",
+        label="Airflow Task Instances",
+        summary=summary,
+    )

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -30,9 +30,7 @@ execute_yc_operation
 fetch_failed_run
 find_yc_api
 fix_sentry_issue
-get_airflow_dag_runs
 get_airflow_metrics
-get_airflow_task_instances
 get_azure_sql_current_queries
 get_azure_sql_resource_stats
 get_azure_sql_server_status
@@ -92,7 +90,6 @@ get_postgresql_replication_status
 get_postgresql_server_status
 get_postgresql_slow_queries
 get_postgresql_table_stats
-get_recent_airflow_failures
 get_redis_client_list
 get_redis_latency_doctor
 get_redis_list_depth

--- a/tests/tools/test_tracer_airflow_dag_tool.py
+++ b/tests/tools/test_tracer_airflow_dag_tool.py
@@ -11,12 +11,18 @@ from __future__ import annotations
 from typing import Any
 
 from integrations.tracer.tools.tracer_airflow_dag_tool import (
-    _map_get_airflow_dag_runs,
-    _map_get_airflow_task_instances,
-    _map_get_recent_airflow_failures,
     get_airflow_dag_runs,
     get_airflow_task_instances,
     get_recent_airflow_failures,
+)
+from integrations.tracer.tools.tracer_airflow_dag_tool._evidence import (
+    map_get_airflow_dag_runs as _map_get_airflow_dag_runs,
+)
+from integrations.tracer.tools.tracer_airflow_dag_tool._evidence import (
+    map_get_airflow_task_instances as _map_get_airflow_task_instances,
+)
+from integrations.tracer.tools.tracer_airflow_dag_tool._evidence import (
+    map_get_recent_airflow_failures as _map_get_recent_airflow_failures,
 )
 
 

--- a/tests/tools/test_tracer_airflow_dag_tool.py
+++ b/tests/tools/test_tracer_airflow_dag_tool.py
@@ -101,6 +101,28 @@ class TestMapGetAirflowDagRuns:
 
         assert evidence["catalog_entries"][0]["summary"] == "1 DAG run(s), 0 failed for 'etl_daily'"
 
+    def test_cites_state_filter_instead_of_a_misleading_failed_count(self) -> None:
+        """Regression: `state` filters the API query itself, so a
+        state='success' query returning zero 'failed' runs does not mean
+        there were no failures -- they were filtered out before the mapper
+        ever saw them. Cite the filter, not a derived (and misleading)
+        zero-failed count."""
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_dag_runs(
+            evidence,
+            {
+                "source": "airflow",
+                "dag_id": "etl_daily",
+                "dag_runs": [{"state": "success"}, {"state": "success"}],
+            },
+            {"limit": 10, "state": "success"},
+        )
+
+        summary = evidence["catalog_entries"][0]["summary"]
+        assert summary == "2 DAG run(s) with state 'success' for 'etl_daily'"
+        assert "failed" not in summary
+
     def test_qualifies_count_when_page_is_saturated(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_tracer_airflow_dag_tool.py
+++ b/tests/tools/test_tracer_airflow_dag_tool.py
@@ -1,0 +1,164 @@
+"""Tests for the evidence mappers on integrations.tracer.tools.tracer_airflow_dag_tool.
+
+These tools have no ``@tool`` ``BaseToolContract``-friendly single entrypoint to
+mock uniformly (each wraps a different ``integrations.airflow.config`` fetch
+function directly), so coverage here focuses on the mappers themselves --
+the ``run()`` bodies are exercised end-to-end by ``tests/e2e/airflow/``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.tracer.tools.tracer_airflow_dag_tool import (
+    _map_get_airflow_dag_runs,
+    _map_get_airflow_task_instances,
+    _map_get_recent_airflow_failures,
+    get_airflow_dag_runs,
+    get_airflow_task_instances,
+    get_recent_airflow_failures,
+)
+
+
+def test_get_recent_airflow_failures_carries_mapper() -> None:
+    rt = get_recent_airflow_failures.__opensre_registered_tool__
+    assert rt.evidence_mapper is _map_get_recent_airflow_failures
+
+
+def test_get_airflow_dag_runs_carries_mapper() -> None:
+    rt = get_airflow_dag_runs.__opensre_registered_tool__
+    assert rt.evidence_mapper is _map_get_airflow_dag_runs
+
+
+def test_get_airflow_task_instances_carries_mapper() -> None:
+    rt = get_airflow_task_instances.__opensre_registered_tool__
+    assert rt.evidence_mapper is _map_get_airflow_task_instances
+
+
+class TestMapGetRecentAirflowFailures:
+    def test_records_entry_with_dag_id(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_recent_airflow_failures(
+            evidence,
+            {
+                "source": "airflow",
+                "dag_id": "etl_daily",
+                "failures": [{"state": "failed"}, {"state": "up_for_retry"}],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_recent_airflow_failures"
+        assert entries[0]["summary"] == "2 failed/retrying task instance(s) for DAG 'etl_daily'"
+
+    def test_records_nothing_when_no_failures(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_recent_airflow_failures(
+            evidence, {"source": "airflow", "dag_id": "etl_daily", "failures": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_error_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_recent_airflow_failures(evidence, {"error": "dag_id is required"}, {})
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapGetAirflowDagRuns:
+    def test_records_entry_with_failed_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_dag_runs(
+            evidence,
+            {
+                "source": "airflow",
+                "dag_id": "etl_daily",
+                "dag_runs": [{"state": "success"}, {"state": "failed"}],
+            },
+            {"limit": 10},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_airflow_dag_runs"
+        assert entries[0]["summary"] == "2 DAG run(s), 1 failed for 'etl_daily'"
+
+    def test_records_zero_failed_as_a_genuine_finding(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_dag_runs(
+            evidence,
+            {"source": "airflow", "dag_id": "etl_daily", "dag_runs": [{"state": "success"}]},
+            {"limit": 10},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "1 DAG run(s), 0 failed for 'etl_daily'"
+
+    def test_qualifies_count_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_dag_runs(
+            evidence,
+            {"source": "airflow", "dag_runs": [{"state": "success"}] * 10},
+            {"limit": 10},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"].startswith("10+ DAG run(s)")
+
+    def test_records_nothing_when_no_dag_runs(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_dag_runs(evidence, {"source": "airflow", "dag_runs": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_error_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_dag_runs(evidence, {"error": "dag_id is required"}, {})
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapGetAirflowTaskInstances:
+    def test_records_entry_with_failed_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_task_instances(
+            evidence,
+            {
+                "source": "airflow",
+                "dag_id": "etl_daily",
+                "dag_run_id": "run-123",
+                "task_instances": [{"state": "success"}, {"state": "failed"}],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_airflow_task_instances"
+        assert entries[0]["summary"] == "2 task instance(s), 1 failed/retrying for run 'run-123'"
+
+    def test_records_nothing_when_no_task_instances(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_task_instances(
+            evidence, {"source": "airflow", "dag_run_id": "run-123", "task_instances": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_error_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_airflow_task_instances(evidence, {"error": "dag_run_id is required"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5558

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all three listed Airflow investigation tools to `record_evidence_entry`
so their output stops being silently dropped and becomes a citeable line in
the investigation report.

- `_map_get_recent_airflow_failures`: cites the count of failed/retrying task
  instances found for the DAG.
- `_map_get_airflow_dag_runs`: cites the DAG run count and how many are in a
  failed state.
- `_map_get_airflow_task_instances`: cites the task instance count and how
  many failed or are up for retry.

All three are read-only diagnostic queries — none is an action/notification
tool, so all are in scope per the issue. They live in
`integrations/tracer/tools/tracer_airflow_dag_tool/__init__.py`, not under
`integrations/airflow/` (the actual HTTP calls are in
`integrations/airflow/config.py`; the `@tool`-decorated wrappers are under
`integrations/tracer/tools/`) — worth flagging since the issue's generic
template names only point at the tool names, not the file.

**On error handling — these tools have no `available` flag:** unlike every
other tool I've wired to evidence in this session, none of the three sets an
`available`/success flag on their output — `{"error": "..."}` is the *only*
failure signal, and a request failure inside the `integrations/airflow/config.py`
fetch functions (auth, network, 5xx) is swallowed into an empty list rather
than surfaced (see `get_airflow_dag_runs`/`get_airflow_task_instances` in
that file: `if not isinstance(payload, dict): return []`). That means a
mapper cannot distinguish "genuinely zero results" from "the fetch silently
failed" from the tool's output alone. I did not try to fix that ambiguity
here (it's a client-layer design question outside this issue's scope) —
each mapper checks for `output.get("error")` and otherwise stays silent on
an empty list, the same conservative choice used for every other "empty
list → no citation" case in this session, so at worst a silent failure
produces no evidence rather than a false claim.

**On count honesty:** `get_airflow_dag_runs`'s `dag_runs` list is capped by
`min(limit, config.max_results)`, but the mapper only has the caller's own
`limit` (10 by default) from `tool_input`, not the resolved `config.max_results` —
so it compares the returned count against the caller's own requested `limit`,
the same approach I used for Honeycomb/Coralogix earlier in this session when
a hidden server-side ceiling wasn't visible to the mapper. `get_recent_airflow_failures`'s
`failures` count is an aggregate over multiple DAG runs (multiple task
instances can fail per run), not a value directly capped by any single
`limit`, so I did not apply the "N+" heuristic there.

Removed all three tool names from `evidence_mapper_baseline.txt` now that
they carry mappers.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in [
  'get_recent_airflow_failures', 'get_airflow_dag_runs', 'get_airflow_task_instances']})"
{'get_recent_airflow_failures': True, 'get_airflow_dag_runs': True, 'get_airflow_task_instances': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each tool's return
shape:**
```
get_recent_airflow_failures:  "2 failed/retrying task instance(s) for DAG 'etl_daily'"
get_airflow_dag_runs:         "2 DAG run(s), 1 failed for 'etl_daily'"
get_airflow_task_instances:   "2 task instance(s), 1 failed/retrying for run 'run-123'"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_tracer_airflow_dag_tool.py -q
14 passed

$ uv run pytest tests/e2e/airflow/ -q
5 skipped   # requires live Airflow credentials, unaffected by this change

$ make lint && make format-check && make typecheck
All checks passed! / 3645 files already formatted / Success: no issues found in 1899 source files
```

No existing unit test file covered this module directly (only a
credentials-gated `tests/e2e/airflow/test_orchestrator.py`, which I confirmed
still collects and skips cleanly), so I added
`tests/tools/test_tracer_airflow_dag_tool.py` focused on the new mappers.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read all three tool wrappers and their backing
`integrations/airflow/config.py` fetch functions before writing anything,
because this integration's error-handling shape is different from every
other tool I've mapped this session — no `available` flag, and HTTP
failures silently degrade to an empty list rather than an explicit error.
That meant I couldn't reuse the `if not output.get("available"): return`
guard pattern verbatim; I used `output.get("error")` instead, and made the
same silent-on-empty choice as everywhere else rather than trying to
retrofit a "was this actually fetched" signal into the client layer, which
would have been a materially larger change than this issue asks for.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
