### PR TITLE
feat(openobserve): add evidence mapper for query_openobserve_logs

### DIFF
--- a/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
+++ b/integrations/openobserve/tools/openobserve_logs_tool/__init__.py
@@ -8,18 +8,59 @@ from typing import Any
 
 import httpx
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from infrastructure.text.truncation import truncate
 
 _DEFAULT_MAX_RESULTS = 100
 _MAX_HARD_LIMIT = 200
+
+#: Bound the SQL query text echoed into a report summary -- it can be a long
+#: or multi-line query built by the caller, not just the default form.
+_QUERY_SUMMARY_TRUNCATE_LEN = 80
 
 
 def _bounded_limit(limit: int, max_results: int) -> int:
     safe_max = max(1, min(max_results, _MAX_HARD_LIMIT))
     return max(1, min(limit, safe_max))
+
+
+def _map_query_openobserve_logs(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the row count, stream, and a bounded snippet of the query executed.
+
+    ``records`` is truncated to ``effective_limit`` after the query runs, so
+    a returned count at that ceiling may understate how many rows actually
+    matched -- use the "N+" convention.
+    """
+    if not output.get("available"):
+        return
+    total = output.get("total_returned", 0)
+    if not total:
+        return
+    effective_limit = output.get("effective_limit", total)
+    count_label = f"{total}+" if total >= effective_limit else str(total)
+    parts = [f"{count_label} record(s)"]
+    stream = output.get("stream")
+    if stream:
+        safe_stream = truncate(str(stream).replace("\n", " "), 60)
+        parts.append(f"stream '{safe_stream}'")
+    query = truncate(
+        str(output.get("query", "")).replace("\r\n", " ").replace("\r", " ").replace("\n", " "),
+        _QUERY_SUMMARY_TRUNCATE_LEN,
+    )
+    if query:
+        parts.append(f"query '{query}'")
+    record_evidence_entry(
+        evidence,
+        source="query_openobserve_logs",
+        label="OpenObserve Logs",
+        summary=", ".join(parts),
+    )
 
 
 def _openobserve_available(sources: dict[str, dict[str, Any]]) -> bool:
@@ -107,6 +148,7 @@ def _extract_records(body: dict[str, Any]) -> list[dict[str, Any]]:
     is_available=_openobserve_available,
     injected_params=("base_url",),
     extract_params=_openobserve_extract_params,
+    evidence_mapper=_map_query_openobserve_logs,
 )
 def query_openobserve_logs(
     base_url: str,
@@ -195,5 +237,6 @@ def query_openobserve_logs(
         "integration_id": integration_id,
         "query": normalized_query,
         "total_returned": len(records),
+        "effective_limit": effective_limit,
         "records": records,
     }

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -171,7 +171,6 @@ query_datadog_monitors
 query_grafana_annotations
 query_groundcover_logs
 query_groundcover_traces
-query_openobserve_logs
 query_splunk_logs
 query_yc_metrics
 read_yc_logs

--- a/tests/tools/test_openobserve_logs_tool.py
+++ b/tests/tools/test_openobserve_logs_tool.py
@@ -14,7 +14,10 @@ from typing import Any
 
 import pytest
 
-from integrations.openobserve.tools.openobserve_logs_tool import query_openobserve_logs
+from integrations.openobserve.tools.openobserve_logs_tool import (
+    _map_query_openobserve_logs,
+    query_openobserve_logs,
+)
 from tests.tools.conftest import BaseToolContract, MockHttpxResponse
 
 # ---------------------------------------------------------------------------
@@ -567,3 +570,76 @@ def test_no_stream_and_no_query_is_unavailable(monkeypatch: pytest.MonkeyPatch) 
     assert result["available"] is False
     assert "OPENOBSERVE_STREAM" in result["error"]
     assert result["records"] == []
+
+
+# ---------------------------------------------------------------------------
+# Evidence mapper
+# ---------------------------------------------------------------------------
+
+
+class TestMapQueryOpenobserveLogs:
+    def test_records_entry_with_stream_and_query(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_openobserve_logs(
+            evidence,
+            {
+                "available": True,
+                "total_returned": 2,
+                "effective_limit": 50,
+                "stream": "app_logs",
+                "query": "SELECT * FROM \"app_logs\" WHERE level = 'error'",
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "query_openobserve_logs"
+        assert (
+            entries[0]["summary"]
+            == "2 record(s), stream 'app_logs', query 'SELECT * FROM \"app_logs\" WHERE level = 'error''"
+        )
+
+    def test_qualifies_count_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_openobserve_logs(
+            evidence,
+            {"available": True, "total_returned": 50, "effective_limit": 50},
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"].startswith("50+ record(s)")
+
+    def test_strips_carriage_returns_from_query(self) -> None:
+        """Regression: a query with bare \\r or \\r\\n line endings must not
+        leave a literal carriage return in the report summary."""
+        evidence: dict[str, Any] = {}
+
+        _map_query_openobserve_logs(
+            evidence,
+            {
+                "available": True,
+                "total_returned": 1,
+                "effective_limit": 50,
+                "query": "SELECT *\r\nFROM logs\r",
+            },
+            {},
+        )
+
+        assert "\r" not in evidence["catalog_entries"][0]["summary"]
+
+    def test_records_nothing_when_no_records(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_openobserve_logs(evidence, {"available": True, "total_returned": 0}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_query_openobserve_logs(evidence, {"available": False, "error": "HTTP 502"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5587

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires the single OpenObserve investigation tool, `query_openobserve_logs`, to
`record_evidence_entry` so its output stops being silently dropped and becomes
a citeable line in the investigation report.

- `_map_query_openobserve_logs`: cites the record count, stream, and a
  bounded snippet of the SQL query executed.

This is the only tool in `integrations/openobserve/tools/` — it's a
read-only diagnostic query, so it's in scope per the issue.

**On count honesty — the "N+" convention:** `query_openobserve_logs` has the
identical shape to Azure Monitor's mapper I wrote earlier in this session:
`records` is truncated to a locally-computed `effective_limit` that the tool
never echoed back. I applied the same fix (add `effective_limit` to the
output) rather than re-deriving `_bounded_limit`'s clamp logic inside the
mapper.

The SQL query text and stream name are caller-built/-supplied and unbounded,
so both are collapsed and capped (80 / 60 chars) before going into the
summary.

The mapper records nothing when `available` is falsy or no records were
returned.

Removed `query_openobserve_logs` from `evidence_mapper_baseline.txt` now
that it carries a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tool carries its mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print(bool(g('query_openobserve_logs').evidence_mapper))"
True
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching the tool's return
shape:**
```
query_openobserve_logs:  "2 record(s), stream 'app_logs', query 'SELECT * FROM \"app_logs\" WHERE level = 'error''"
query_openobserve_logs (saturated page):  "50+ record(s)"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_openobserve_logs_tool.py -q
66 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live OpenObserve account available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the mapper,
the `effective_limit` field, and their tests were added.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Having just worked through the identical `effective_limit`-not-echoed gap
for Azure Monitor Logs and SigNoz earlier in this session, I checked
OpenObserve's `run()` for the same pattern before writing the mapper rather
than assuming it was different, and confirmed it clamps and truncates
`records` the same way. Reusing the exact fix (add the field to the tool's
own output rather than duplicating the clamp formula in the mapper) keeps
all three integrations consistent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
