### PR TITLE
feat(railway): add evidence mapper for inspect_railway_deployment

### DIFF
--- a/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
+++ b/integrations/railway/tools/railway_deployment_tool/inspect_tool.py
@@ -2,16 +2,51 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from core.domain.types.evidence import EvidenceSource
+from core.domain.types.evidence import EvidenceSource, record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import tool
+from infrastructure.text.truncation import truncate
 from integrations.config_models import RailwayIntegrationConfig
 from integrations.railway.client import (
     RailwayClient,
     RailwayOperationError,
     railway_config_from_sources,
 )
+
+#: git commit messages are free-form and unbounded; cap the length used in a
+#: report summary so one long or multi-line message can't produce a
+#: malformed or oversized report line.
+_COMMIT_MESSAGE_TRUNCATE_LEN = 100
+_COMMIT_HASH_DISPLAY_LEN = 12
+
+
+def _map_inspect_railway_deployment(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the deployment's status and source commit."""
+    if output.get("status") != "ok":
+        return
+    deployment = output.get("deployment") or {}
+    if not deployment:
+        return
+    parts = [f"status {deployment.get('status') or 'unknown'}"]
+    commit_hash = deployment.get("commit_hash")
+    if commit_hash:
+        parts.append(f"commit {str(commit_hash)[:_COMMIT_HASH_DISPLAY_LEN]}")
+    commit_message = deployment.get("commit_message")
+    if commit_message:
+        safe_message = truncate(
+            str(commit_message).replace("\r\n", " ").replace("\r", " ").replace("\n", " "),
+            _COMMIT_MESSAGE_TRUNCATE_LEN,
+        )
+        parts.append(f"'{safe_message}'")
+    record_evidence_entry(
+        evidence,
+        source="inspect_railway_deployment",
+        label="Railway Deployment",
+        summary=", ".join(parts),
+    )
 
 
 class InspectRailwayDeploymentTool(BaseTool):
@@ -74,4 +109,5 @@ inspect_railway_deployment = InspectRailwayDeploymentTool()
 tool(
     inspect_railway_deployment,
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION),
+    evidence_mapper=_map_inspect_railway_deployment,
 )

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -112,7 +112,6 @@ helm_list_releases
 helm_release_history
 helm_release_status
 inspect_lambda_function
-inspect_railway_deployment
 inspect_s3_object
 jira_add_comment
 jira_create_issue

--- a/tests/tools/test_railway_deployment_tool.py
+++ b/tests/tools/test_railway_deployment_tool.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 from integrations.railway.tools.railway_deployment_tool.inspect_tool import (
+    _map_inspect_railway_deployment,
     inspect_railway_deployment,
 )
 from integrations.railway.tools.railway_deployment_tool.redeploy_tool import (
@@ -20,3 +23,73 @@ def test_generic_redeploy_still_requires_confirmation() -> None:
 
     assert result["status"] == "failed"
     assert result["error_type"] == "confirmation_required"
+
+
+def test_inspect_railway_deployment_carries_mapper() -> None:
+    rt = inspect_railway_deployment.__opensre_registered_tool__
+    assert rt.evidence_mapper is _map_inspect_railway_deployment
+
+
+class TestMapInspectRailwayDeployment:
+    def test_records_entry_with_commit(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_inspect_railway_deployment(
+            evidence,
+            {
+                "status": "ok",
+                "deployment": {
+                    "status": "SUCCESS",
+                    "commit_hash": "abcdef1234567890",
+                    "commit_message": "Fix connection pool leak",
+                },
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "inspect_railway_deployment"
+        assert (
+            entries[0]["summary"]
+            == "status SUCCESS, commit abcdef123456, 'Fix connection pool leak'"
+        )
+
+    def test_records_entry_without_optional_clauses(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_inspect_railway_deployment(
+            evidence, {"status": "ok", "deployment": {"status": "SUCCESS"}}, {}
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "status SUCCESS"
+
+    def test_strips_carriage_returns_from_commit_message(self) -> None:
+        """Regression: a commit message with bare \\r or \\r\\n line endings
+        must not leave a literal carriage return in the report summary."""
+        evidence: dict[str, Any] = {}
+
+        _map_inspect_railway_deployment(
+            evidence,
+            {
+                "status": "ok",
+                "deployment": {"status": "SUCCESS", "commit_message": "Fix bug\r\nline two\r"},
+            },
+            {},
+        )
+
+        assert "\r" not in evidence["catalog_entries"][0]["summary"]
+
+    def test_records_nothing_when_deployment_empty(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_inspect_railway_deployment(evidence, {"status": "ok", "deployment": {}}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_failed_status(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_inspect_railway_deployment(evidence, {"status": "failed", "error": "not found"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5589

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires the single listed Railway investigation tool, `inspect_railway_deployment`,
to `record_evidence_entry` so its output stops being silently dropped and
becomes a citeable line in the investigation report.

- `_map_inspect_railway_deployment`: cites the deployment's status, source
  commit (short hash), and commit message.

This tool is registered differently from every other tool I've wired this
session: it's a `BaseTool` instance registered via a standalone `tool(instance,
surfaces=...)` call rather than a class-attribute `evidence_mapper` or a
`@tool(...)`-decorated function — worth flagging since `evidence_mapper` had
to be passed as a kwarg to that `tool()` call, and the mapper only shows up on
`inspect_railway_deployment.__opensre_registered_tool__.evidence_mapper`, not
on the `BaseTool` instance's own attribute (which stays `None` — that's the
`RegisteredTool` wrapper's field, not the instance's).

**On the tool's own status convention:** this tool uses `status: "ok"/"failed"`
rather than `available: True/False` like every other tool in this batch, so
the mapper guards on `output.get("status") != "ok"` instead.

Commit messages are free-form git text and unbounded, so they're collapsed
and capped at 100 chars before going into the summary; the commit hash is
displayed at its conventional 12-char short form.

Removed `inspect_railway_deployment` from `evidence_mapper_baseline.txt` now
that it carries a mapper.

### Demo/Screenshot for feature changes and bug fixes -

**Tool carries its mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print(bool(g('inspect_railway_deployment').evidence_mapper))"
True
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using a realistic sample matching the tool's return
shape:**
```
inspect_railway_deployment:  "status SUCCESS, commit abcdef123456, 'Fix connection pool leak'"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_railway_deployment_tool.py -q
8 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live Railway account available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the mapper
and its tests were added.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

My first pass at the mapper-coverage test failed because I asserted
`inspect_railway_deployment.evidence_mapper is _map_inspect_railway_deployment`
directly on the `BaseTool` instance — that reads `None` because this tool's
registration path stores the mapper on the `RegisteredTool` wrapper attached
via `tool(instance, evidence_mapper=...)`, not as an instance/class attribute
the way `evidence_mapper = _map_...` works for the other BaseTool-subclass
mappers I wrote earlier in this session (OpsGenie, Prefect, Temporal). I
traced `merge_tool_evidence` → `get_registered_tool` in
`tools/investigation/stages/gather_evidence/tools.py` to confirm the actual
lookup path, then fixed the test to check
`inspect_railway_deployment.__opensre_registered_tool__.evidence_mapper`
instead — the same attribute the function-tool tests in this repo already
use, just reached through a `BaseTool` instance rather than a decorated
function.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
