### PR TITLE
feat(temporal): add evidence mappers for all 4 temporal investigation tools

### DIFF
--- a/integrations/temporal/tools/__init__.py
+++ b/integrations/temporal/tools/__init__.py
@@ -6,9 +6,42 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.temporal.client import TemporalClient, TemporalConfig
+
+#: CountWorkflowExecutions GROUP BY results use short Temporal Payload
+#: status names ("Running", "Failed", "TimedOut"), decoded by
+#: TemporalClient._flatten_status_groups -- a different vocabulary from the
+#: raw HTTP API's WORKFLOW_EXECUTION_STATUS_* enum strings used elsewhere in
+#: this file (list_workflow_executions), so this constant is scoped to the
+#: namespace-info mapper only.
+_UNHEALTHY_GROUP_STATUSES = frozenset({"Failed", "TimedOut", "Terminated"})
+
+
+def _map_temporal_namespace_info(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the namespace state, workflow count, and unhealthy workflow count."""
+    if not output.get("available") or output.get("error"):
+        return
+    groups = output.get("groups") or []
+    unhealthy = sum(
+        int(g.get("count", 0) or 0) for g in groups if g.get("status") in _UNHEALTHY_GROUP_STATUSES
+    )
+    parts = [
+        f"namespace '{output.get('name', 'unknown')}' ({output.get('state', 'unknown')})",
+        f"{output.get('workflow_count', 0)} workflow(s)",
+    ]
+    if groups:
+        parts.append(f"{unhealthy} failed/timed-out/terminated")
+    record_evidence_entry(
+        evidence,
+        source="temporal_namespace_info",
+        label="Temporal Namespace Info",
+        summary=", ".join(parts),
+    )
 
 
 class TemporalNamespaceInfoTool(BaseTool):
@@ -22,6 +55,7 @@ class TemporalNamespaceInfoTool(BaseTool):
 
     name = "temporal_namespace_info"
     source = "temporal"
+    evidence_mapper = _map_temporal_namespace_info
     description = (
         "Fetch Temporal namespace health overview: namespace state and workflow "
         "execution counts grouped by status (Running, Failed, TimedOut, etc.). "
@@ -113,6 +147,35 @@ temporal_namespace_info = TemporalNamespaceInfoTool()
 from core.tool import BaseTool
 
 
+def _map_temporal_task_queue(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the active poller count and backlog stats.
+
+    An empty poller list is itself the tool's primary failure signal (workers
+    are down, per this tool's own docstring) -- unlike most list-based
+    mappers, a genuine zero is always cited rather than treated as "nothing
+    to report". ``total`` is only absent from the output when the required
+    ``task_queue_name`` param was missing (an input-validation error, not a
+    real zero), so its presence is the guard.
+    """
+    if not output.get("available") or output.get("error"):
+        return
+    total = output.get("total")
+    if total is None:
+        return
+    parts = [f"{total} active poller(s)"]
+    backlog = (output.get("stats") or {}).get("approximateBacklogCount")
+    if backlog:
+        parts.append(f"backlog {backlog}")
+    record_evidence_entry(
+        evidence,
+        source="temporal_task_queue",
+        label="Temporal Task Queue",
+        summary=", ".join(parts),
+    )
+
+
 class TemporalTaskQueueTool(BaseTool):
     """Describe a task queue's pollers and backlog stats.
 
@@ -129,6 +192,7 @@ class TemporalTaskQueueTool(BaseTool):
 
     name = "temporal_task_queue"
     source = "temporal"
+    evidence_mapper = _map_temporal_task_queue
     description = (
         "Describe a Temporal task queue: active worker pollers and backlog stats "
         "(approximate count, age, add/dispatch rates). Use after identifying failed "
@@ -238,6 +302,36 @@ temporal_task_queue = TemporalTaskQueueTool()
 
 from core.tool import BaseTool
 
+_FAILURE_EVENT_TYPE_MARKERS = ("FAILED", "TIMED_OUT", "TERMINATED")
+
+
+def _map_temporal_workflow_history(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the event count and how many are failure/timeout/termination events."""
+    if not output.get("available") or output.get("error"):
+        return
+    events = output.get("events") or []
+    if not events:
+        return
+    total = output.get("total", len(events))
+    failure_events = sum(
+        1
+        for e in events
+        if any(marker in str(e.get("eventType", "")) for marker in _FAILURE_EVENT_TYPE_MARKERS)
+    )
+    parts = [f"{total} event(s), {failure_events} failure/timeout/termination event(s)"]
+    if output.get("archived"):
+        parts.append("from archival storage")
+    if output.get("next_page_token"):
+        parts.append("more available")
+    record_evidence_entry(
+        evidence,
+        source="temporal_workflow_history",
+        label="Temporal Workflow History",
+        summary=", ".join(parts),
+    )
+
 
 class TemporalWorkflowHistoryTool(BaseTool):
     """Fetch the event history for a specific workflow execution.
@@ -251,6 +345,7 @@ class TemporalWorkflowHistoryTool(BaseTool):
 
     name = "temporal_workflow_history"
     source = "temporal"
+    evidence_mapper = _map_temporal_workflow_history
     description = (
         "Fetch the event history for a specific Temporal workflow execution. "
         "Shows the ordered sequence of events (started, activity scheduled, "
@@ -376,6 +471,37 @@ temporal_workflow_history = TemporalWorkflowHistoryTool()
 
 from core.tool import BaseTool
 
+#: Raw HTTP API executions use the WORKFLOW_EXECUTION_STATUS_* proto enum
+#: naming, a different vocabulary from CountWorkflowExecutions' short status
+#: names used by the namespace-info mapper above.
+_FAILURE_STATUS_MARKERS = ("FAILED", "TIMED_OUT", "TERMINATED")
+
+
+def _map_temporal_workflows(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the execution count and how many are in a failed/timed-out/terminated state."""
+    if not output.get("available"):
+        return
+    executions = output.get("executions") or []
+    if not executions:
+        return
+    total = output.get("total", len(executions))
+    failed = sum(
+        1
+        for e in executions
+        if any(marker in str(e.get("status", "")) for marker in _FAILURE_STATUS_MARKERS)
+    )
+    parts = [f"{total} execution(s), {failed} failed/timed-out/terminated"]
+    if output.get("next_page_token"):
+        parts.append("more available")
+    record_evidence_entry(
+        evidence,
+        source="temporal_workflows",
+        label="Temporal Workflows",
+        summary=", ".join(parts),
+    )
+
 
 class TemporalWorkflowsTool(BaseTool):
     """List recent workflow executions with status and failure reason.
@@ -388,6 +514,7 @@ class TemporalWorkflowsTool(BaseTool):
 
     name = "temporal_workflows"
     source = "temporal"
+    evidence_mapper = _map_temporal_workflows
     description = (
         "List recent Temporal workflow executions showing workflowId, type, status, "
         "taskQueue, and timing. Use after namespace info reveals failures, to identify "

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -195,10 +195,6 @@ slack_send_message
 summarize_community_followups
 summarize_github_pr_status
 telegram_send_message
-temporal_namespace_info
-temporal_task_queue
-temporal_workflow_history
-temporal_workflows
 twilio_notify
 vercel_deployment_logs
 vercel_deployment_status

--- a/tests/tools/test_temporal_namespace_info_tool.py
+++ b/tests/tools/test_temporal_namespace_info_tool.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
-from integrations.temporal.tools import TemporalNamespaceInfoTool
+from integrations.temporal.tools import TemporalNamespaceInfoTool, _map_temporal_namespace_info
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -92,3 +93,60 @@ def test_run_returns_error_on_failure(monkeypatch) -> None:
     result = tool.run(base_url="http://localhost:7233", namespace="bad-ns")
     assert result["available"] is False
     assert "404" in result["error"]
+
+
+class TestMapTemporalNamespaceInfo:
+    def test_records_entry_with_unhealthy_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_namespace_info(
+            evidence,
+            {
+                "available": True,
+                "name": "default",
+                "state": "NAMESPACE_STATE_REGISTERED",
+                "workflow_count": "58",
+                "groups": [
+                    {"status": "Running", "count": "45"},
+                    {"status": "Failed", "count": "8"},
+                    {"status": "TimedOut", "count": "5"},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "temporal_namespace_info"
+        assert entries[0]["summary"] == (
+            "namespace 'default' (NAMESPACE_STATE_REGISTERED), 58 workflow(s), "
+            "13 failed/timed-out/terminated"
+        )
+
+    def test_records_entry_without_unhealthy_clause_when_no_groups(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_namespace_info(
+            evidence,
+            {
+                "available": True,
+                "name": "default",
+                "state": "NAMESPACE_STATE_REGISTERED",
+                "workflow_count": "0",
+                "groups": [],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == (
+            "namespace 'default' (NAMESPACE_STATE_REGISTERED), 0 workflow(s)"
+        )
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_namespace_info(
+            evidence, {"available": False, "error": "HTTP 404: Namespace not found."}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_temporal_task_queue_tool.py
+++ b/tests/tools/test_temporal_task_queue_tool.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
-from integrations.temporal.tools import TemporalTaskQueueTool
+from integrations.temporal.tools import TemporalTaskQueueTool, _map_temporal_task_queue
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -119,3 +120,63 @@ def test_run_returns_error_on_failure(monkeypatch) -> None:
     assert "404" in result["error"]
     assert result["pollers"] == []
     assert result["stats"] == {}
+
+
+class TestMapTemporalTaskQueue:
+    def test_records_entry_with_backlog(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_task_queue(
+            evidence,
+            {
+                "available": True,
+                "total": 2,
+                "pollers": [{"identity": "worker-1"}, {"identity": "worker-2"}],
+                "stats": {"approximateBacklogCount": "42"},
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "temporal_task_queue"
+        assert entries[0]["summary"] == "2 active poller(s), backlog 42"
+
+    def test_records_zero_pollers_as_the_primary_outage_signal(self) -> None:
+        """Regression: an empty poller list means workers are down -- this is
+        the tool's main signal, so it must be cited, not treated as noise."""
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_task_queue(
+            evidence, {"available": True, "total": 0, "pollers": [], "stats": {}}, {}
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "0 active poller(s)"
+
+    def test_records_nothing_when_task_queue_name_missing(self) -> None:
+        """The 'task_queue_name is required' error path returns
+        available=True with no 'total' key -- must not be mistaken for a
+        genuine zero-poller result."""
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_task_queue(
+            evidence,
+            {
+                "available": True,
+                "error": "task_queue_name is required.",
+                "pollers": [],
+                "stats": {},
+            },
+            {},
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_task_queue(
+            evidence, {"available": False, "error": "HTTP 404: Task queue not found."}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_temporal_workflow_history_tool.py
+++ b/tests/tools/test_temporal_workflow_history_tool.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
-from integrations.temporal.tools import TemporalWorkflowHistoryTool
+from integrations.temporal.tools import (
+    TemporalWorkflowHistoryTool,
+    _map_temporal_workflow_history,
+)
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -131,3 +135,75 @@ def test_run_returns_error_on_failure(monkeypatch) -> None:
     assert result["available"] is False
     assert "404" in result["error"]
     assert result["events"] == []
+
+
+class TestMapTemporalWorkflowHistory:
+    def test_records_entry_with_failure_event_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflow_history(
+            evidence,
+            {
+                "available": True,
+                "total": 3,
+                "events": [
+                    {"eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED"},
+                    {"eventType": "EVENT_TYPE_ACTIVITY_TASK_FAILED"},
+                    {"eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_FAILED"},
+                ],
+                "archived": False,
+                "next_page_token": "",
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "temporal_workflow_history"
+        assert entries[0]["summary"] == "3 event(s), 2 failure/timeout/termination event(s)"
+
+    def test_includes_archived_and_pagination_clauses(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflow_history(
+            evidence,
+            {
+                "available": True,
+                "total": 1,
+                "events": [{"eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED"}],
+                "archived": True,
+                "next_page_token": "tok-2",
+            },
+            {},
+        )
+
+        summary = evidence["catalog_entries"][0]["summary"]
+        assert "from archival storage" in summary
+        assert "more available" in summary
+
+    def test_records_nothing_when_no_events(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflow_history(evidence, {"available": True, "events": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_when_workflow_id_missing(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflow_history(
+            evidence,
+            {"available": True, "error": "workflow_id is required.", "events": []},
+            {},
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflow_history(
+            evidence, {"available": False, "error": "HTTP 404: Workflow not found."}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_temporal_workflows_tool.py
+++ b/tests/tools/test_temporal_workflows_tool.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
-from integrations.temporal.tools import TemporalWorkflowsTool
+from integrations.temporal.tools import TemporalWorkflowsTool, _map_temporal_workflows
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -114,3 +115,57 @@ def test_run_passes_pagination_token(monkeypatch) -> None:
 
     tool.run(base_url="http://localhost:7233", namespace="default", next_page_token="abc123")
     mock_client.list_workflow_executions.assert_called_once_with(next_page_token="abc123")
+
+
+class TestMapTemporalWorkflows:
+    def test_records_entry_with_failed_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflows(
+            evidence,
+            {
+                "available": True,
+                "total": 2,
+                "executions": [
+                    {"status": "WORKFLOW_EXECUTION_STATUS_COMPLETED"},
+                    {"status": "WORKFLOW_EXECUTION_STATUS_FAILED"},
+                ],
+                "next_page_token": "",
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "temporal_workflows"
+        assert entries[0]["summary"] == "2 execution(s), 1 failed/timed-out/terminated"
+
+    def test_includes_pagination_clause(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflows(
+            evidence,
+            {
+                "available": True,
+                "total": 1,
+                "executions": [{"status": "WORKFLOW_EXECUTION_STATUS_RUNNING"}],
+                "next_page_token": "tok-2",
+            },
+            {},
+        )
+
+        assert "more available" in evidence["catalog_entries"][0]["summary"]
+
+    def test_records_nothing_when_no_executions(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflows(evidence, {"available": True, "executions": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_temporal_workflows(evidence, {"available": False, "error": "HTTP 401"}, {})
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5557

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all four listed Temporal investigation tools to `record_evidence_entry`
so their output stops being silently dropped and becomes a citeable line in
the investigation report.

- `_map_temporal_namespace_info`: cites the namespace name/state, total
  workflow count, and how many are failed/timed-out/terminated.
- `_map_temporal_task_queue`: cites the active poller count and backlog.
- `_map_temporal_workflow_history`: cites the event count and how many are
  failure/timeout/termination events.
- `_map_temporal_workflows`: cites the execution count and how many are
  failed/timed-out/terminated.

All four are read-only diagnostic queries — none is an action/notification
tool, so all are in scope per the issue.

**Two different status vocabularies in the same integration:**
`temporal_namespace_info`'s `groups` field comes from
`CountWorkflowExecutions`, whose short status names ("Running", "Failed",
"TimedOut") are decoded from base64 Temporal Payloads by
`TemporalClient._flatten_status_groups`. `temporal_workflows`'s raw
`executions` list and `temporal_workflow_history`'s `events` list come
straight from the HTTP API and use the `WORKFLOW_EXECUTION_STATUS_*` /
`EVENT_TYPE_*` proto enum naming instead. I kept two separate constant sets
(`_UNHEALTHY_GROUP_STATUSES` vs `_FAILURE_STATUS_MARKERS` /
`_FAILURE_EVENT_TYPE_MARKERS`) rather than one shared set, since merging them
would either miss matches or silently rely on substring collisions between
the two vocabularies.

**On `temporal_task_queue`'s zero-poller case — a deliberate exception to the
"skip empty lists" convention used elsewhere in this session:** the tool's
own docstring states "Empty pollers mean workers are down" — an empty poller
list *is* the tool's primary failure signal, not an absence of data. I
special-cased this mapper to always cite the poller count (including zero),
distinguishing it from the "task_queue_name is required" input-validation
error (which returns `available: True` with no `total` key at all) by
checking for the presence of `total` rather than truthiness.

**Two tools return `available: True` alongside an `error` key on missing
required params** (`temporal_task_queue` without `task_queue_name`,
`temporal_workflow_history` without `workflow_id`) instead of using
`tool_unavailable(...)`. Both mappers guard on `output.get("error")` in
addition to `available`, since `available` alone doesn't catch this case.

Removed all four temporal tool names from `evidence_mapper_baseline.txt` now
that they carry mappers.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in [
  'temporal_namespace_info', 'temporal_task_queue',
  'temporal_workflow_history', 'temporal_workflows']})"
{'temporal_namespace_info': True, 'temporal_task_queue': True,
 'temporal_workflow_history': True, 'temporal_workflows': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each tool's return
shape:**
```
temporal_namespace_info:     "namespace 'default' (NAMESPACE_STATE_REGISTERED), 58 workflow(s), 13 failed/timed-out/terminated"
temporal_task_queue:         '2 active poller(s), backlog 42'
temporal_task_queue (down):  '0 active poller(s)'
temporal_workflow_history:   '3 event(s), 2 failure/timeout/termination event(s)'
temporal_workflows:          '2 execution(s), 1 failed/timed-out/terminated'
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_temporal_namespace_info_tool.py tests/tools/test_temporal_task_queue_tool.py \
  tests/tools/test_temporal_workflow_history_tool.py tests/tools/test_temporal_workflows_tool.py -q
91 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live Temporal cluster available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the four
mappers and their tests were added, using each tool's own existing test
fixtures as the realistic-payload basis.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read all four `run()` bodies and their backing `TemporalClient` methods in
`integrations/temporal/client.py` before writing anything, and it's a good
thing I did — the two different status-string vocabularies and the
"available=True + error key" input-validation pattern on two of the four
tools would not have been visible from the issue's generic template. The one
judgment call I flagged inline in the code comment is treating
`temporal_task_queue`'s zero-poller result as a citation-worthy finding
rather than noise, since the tool's own documentation frames an empty poller
list as the outage signal it exists to detect — silently dropping it would
hide the one result this tool is most likely to be called to check for.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
