### PR TITLE
feat(bitbucket): add evidence mappers for all 3 bitbucket investigation tools

### DIFF
--- a/integrations/bitbucket/client.py
+++ b/integrations/bitbucket/client.py
@@ -99,6 +99,7 @@ def list_commits(
                 "available": True,
                 "repo": f"{config.workspace}/{repo_slug}",
                 "total_returned": len(commits),
+                "effective_limit": effective_limit,
                 "commits": commits,
             }
         finally:
@@ -181,6 +182,7 @@ def search_code(
                 "available": True,
                 "query": query,
                 "total_returned": len(results),
+                "effective_limit": effective_limit,
                 "results": results,
             }
         finally:

--- a/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
@@ -13,6 +14,35 @@ from integrations.bitbucket.tools.bitbucket_search_code_tool import (
     _bb_creds,
     _resolve_config,
 )
+
+
+def _map_list_bitbucket_commits(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the commit count and repo, qualifying page-capped totals.
+
+    ``effective_limit`` is the real ceiling ``list_commits`` applied --
+    ``min(limit, config.max_results)`` -- so a returned count at that ceiling
+    may understate the true number of matching commits.
+    """
+    if not output.get("available"):
+        return
+    commits = output.get("commits") or []
+    if not commits:
+        return
+    total = output.get("total_returned", len(commits))
+    effective_limit = output.get("effective_limit", total)
+    count_label = f"{total}+" if total >= effective_limit else str(total)
+    summary = f"{count_label} commit(s)"
+    repo = output.get("repo")
+    if repo:
+        summary += f" for '{repo}'"
+    record_evidence_entry(
+        evidence,
+        source="list_bitbucket_commits",
+        label="Bitbucket Commits",
+        summary=summary,
+    )
 
 
 def _list_bitbucket_commits_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -57,6 +87,7 @@ def _list_bitbucket_commits_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_list_bitbucket_commits_available,
     extract_params=_list_bitbucket_commits_extract_params,
+    evidence_mapper=_map_list_bitbucket_commits,
 )
 def list_bitbucket_commits(
     repo_slug: str,

--- a/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_commits_tool/__init__.py
@@ -4,45 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.bitbucket.client import list_commits
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend
+from integrations.bitbucket.tools.bitbucket_commits_tool._evidence import (
+    map_list_bitbucket_commits,
+)
 from integrations.bitbucket.tools.bitbucket_search_code_tool import (
     _bb_creds,
     _resolve_config,
 )
-
-
-def _map_list_bitbucket_commits(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
-) -> None:
-    """Cite the commit count and repo, qualifying page-capped totals.
-
-    ``effective_limit`` is the real ceiling ``list_commits`` applied --
-    ``min(limit, config.max_results)`` -- so a returned count at that ceiling
-    may understate the true number of matching commits.
-    """
-    if not output.get("available"):
-        return
-    commits = output.get("commits") or []
-    if not commits:
-        return
-    total = output.get("total_returned", len(commits))
-    effective_limit = output.get("effective_limit", total)
-    count_label = f"{total}+" if total >= effective_limit else str(total)
-    summary = f"{count_label} commit(s)"
-    repo = output.get("repo")
-    if repo:
-        summary += f" for '{repo}'"
-    record_evidence_entry(
-        evidence,
-        source="list_bitbucket_commits",
-        label="Bitbucket Commits",
-        summary=summary,
-    )
 
 
 def _list_bitbucket_commits_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -87,7 +60,7 @@ def _list_bitbucket_commits_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_list_bitbucket_commits_available,
     extract_params=_list_bitbucket_commits_extract_params,
-    evidence_mapper=_map_list_bitbucket_commits,
+    evidence_mapper=map_list_bitbucket_commits,
 )
 def list_bitbucket_commits(
     repo_slug: str,

--- a/integrations/bitbucket/tools/bitbucket_commits_tool/_evidence.py
+++ b/integrations/bitbucket/tools/bitbucket_commits_tool/_evidence.py
@@ -1,0 +1,36 @@
+"""Evidence mapper for list_bitbucket_commits."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+
+def map_list_bitbucket_commits(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the commit count and repo, qualifying page-capped totals.
+
+    ``effective_limit`` is the real ceiling ``list_commits`` applied --
+    ``min(limit, config.max_results)`` -- so a returned count at that ceiling
+    may understate the true number of matching commits.
+    """
+    if not output.get("available"):
+        return
+    commits = output.get("commits") or []
+    if not commits:
+        return
+    total = output.get("total_returned", len(commits))
+    effective_limit = output.get("effective_limit", total)
+    count_label = f"{total}+" if total >= effective_limit else str(total)
+    summary = f"{count_label} commit(s)"
+    repo = output.get("repo")
+    if repo:
+        summary += f" for '{repo}'"
+    record_evidence_entry(
+        evidence,
+        source="list_bitbucket_commits",
+        label="Bitbucket Commits",
+        summary=summary,
+    )

--- a/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
@@ -21,6 +21,11 @@ from integrations.bitbucket.tools.bitbucket_search_code_tool import (
 _ID_SUMMARY_TRUNCATE_LEN = 80
 
 
+def _safe_id(value: str) -> str:
+    collapsed = value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    return truncate(collapsed, _ID_SUMMARY_TRUNCATE_LEN)
+
+
 def _map_get_bitbucket_file_contents(
     evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
 ) -> None:
@@ -39,12 +44,10 @@ def _map_get_bitbucket_file_contents(
     parts = [f"{count_label} char(s)"]
     path = output.get("path")
     if path:
-        safe_path = truncate(str(path).replace("\n", " "), _ID_SUMMARY_TRUNCATE_LEN)
-        parts.append(f"from '{safe_path}'")
+        parts.append(f"from '{_safe_id(str(path))}'")
     ref = output.get("ref")
     if ref:
-        safe_ref = truncate(str(ref).replace("\n", " "), _ID_SUMMARY_TRUNCATE_LEN)
-        parts.append(f"at '{safe_ref}'")
+        parts.append(f"at '{_safe_id(str(ref))}'")
     record_evidence_entry(
         evidence,
         source="get_bitbucket_file_contents",

--- a/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
@@ -4,15 +4,53 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from infrastructure.text.truncation import truncate
 from integrations.bitbucket.client import get_file_contents
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend
 from integrations.bitbucket.tools.bitbucket_search_code_tool import (
     _bb_creds,
     _resolve_config,
 )
+
+#: Bound the path/ref echoed into a report summary -- caller-supplied and not
+#: bounded by the input schema.
+_ID_SUMMARY_TRUNCATE_LEN = 80
+
+
+def _map_get_bitbucket_file_contents(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the fetched file's path, revision, and content length.
+
+    ``truncated`` reflects the client's own 10000-char cap on file content --
+    an explicit signal, not an inferred heuristic.
+    """
+    if not output.get("available"):
+        return
+    content = output.get("content")
+    if content is None:
+        return
+    length = len(content)
+    count_label = f"{length}+" if output.get("truncated") else str(length)
+    parts = [f"{count_label} char(s)"]
+    path = output.get("path")
+    if path:
+        safe_path = truncate(str(path).replace("\n", " "), _ID_SUMMARY_TRUNCATE_LEN)
+        parts.append(f"from '{safe_path}'")
+    ref = output.get("ref")
+    if ref:
+        safe_ref = truncate(str(ref).replace("\n", " "), _ID_SUMMARY_TRUNCATE_LEN)
+        parts.append(f"at '{safe_ref}'")
+    record_evidence_entry(
+        evidence,
+        source="get_bitbucket_file_contents",
+        label="Bitbucket File Contents",
+        summary=", ".join(parts),
+    )
 
 
 def _get_bitbucket_file_contents_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -61,6 +99,7 @@ def _get_bitbucket_file_contents_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_get_bitbucket_file_contents_available,
     extract_params=_get_bitbucket_file_contents_extract_params,
+    evidence_mapper=_map_get_bitbucket_file_contents,
 )
 def get_bitbucket_file_contents(
     repo_slug: str,

--- a/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_file_contents_tool/__init__.py
@@ -4,56 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
-from infrastructure.text.truncation import truncate
 from integrations.bitbucket.client import get_file_contents
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend
+from integrations.bitbucket.tools.bitbucket_file_contents_tool._evidence import (
+    map_get_bitbucket_file_contents,
+)
 from integrations.bitbucket.tools.bitbucket_search_code_tool import (
     _bb_creds,
     _resolve_config,
 )
-
-#: Bound the path/ref echoed into a report summary -- caller-supplied and not
-#: bounded by the input schema.
-_ID_SUMMARY_TRUNCATE_LEN = 80
-
-
-def _safe_id(value: str) -> str:
-    collapsed = value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
-    return truncate(collapsed, _ID_SUMMARY_TRUNCATE_LEN)
-
-
-def _map_get_bitbucket_file_contents(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
-) -> None:
-    """Cite the fetched file's path, revision, and content length.
-
-    ``truncated`` reflects the client's own 10000-char cap on file content --
-    an explicit signal, not an inferred heuristic.
-    """
-    if not output.get("available"):
-        return
-    content = output.get("content")
-    if content is None:
-        return
-    length = len(content)
-    count_label = f"{length}+" if output.get("truncated") else str(length)
-    parts = [f"{count_label} char(s)"]
-    path = output.get("path")
-    if path:
-        parts.append(f"from '{_safe_id(str(path))}'")
-    ref = output.get("ref")
-    if ref:
-        parts.append(f"at '{_safe_id(str(ref))}'")
-    record_evidence_entry(
-        evidence,
-        source="get_bitbucket_file_contents",
-        label="Bitbucket File Contents",
-        summary=", ".join(parts),
-    )
 
 
 def _get_bitbucket_file_contents_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -102,7 +64,7 @@ def _get_bitbucket_file_contents_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_get_bitbucket_file_contents_available,
     extract_params=_get_bitbucket_file_contents_extract_params,
-    evidence_mapper=_map_get_bitbucket_file_contents,
+    evidence_mapper=map_get_bitbucket_file_contents,
 )
 def get_bitbucket_file_contents(
     repo_slug: str,

--- a/integrations/bitbucket/tools/bitbucket_file_contents_tool/_evidence.py
+++ b/integrations/bitbucket/tools/bitbucket_file_contents_tool/_evidence.py
@@ -1,0 +1,47 @@
+"""Evidence mapper for get_bitbucket_file_contents."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: Bound the path/ref echoed into a report summary -- caller-supplied and not
+#: bounded by the input schema.
+_ID_SUMMARY_TRUNCATE_LEN = 80
+
+
+def _safe_id(value: str) -> str:
+    collapsed = value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    return truncate(collapsed, _ID_SUMMARY_TRUNCATE_LEN)
+
+
+def map_get_bitbucket_file_contents(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the fetched file's path, revision, and content length.
+
+    ``truncated`` reflects the client's own 10000-char cap on file content --
+    an explicit signal, not an inferred heuristic.
+    """
+    if not output.get("available"):
+        return
+    content = output.get("content")
+    if content is None:
+        return
+    length = len(content)
+    count_label = f"{length}+" if output.get("truncated") else str(length)
+    parts = [f"{count_label} char(s)"]
+    path = output.get("path")
+    if path:
+        parts.append(f"from '{_safe_id(str(path))}'")
+    ref = output.get("ref")
+    if ref:
+        parts.append(f"at '{_safe_id(str(ref))}'")
+    record_evidence_entry(
+        evidence,
+        source="get_bitbucket_file_contents",
+        label="Bitbucket File Contents",
+        summary=", ".join(parts),
+    )

--- a/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
+from infrastructure.text.truncation import truncate
 from integrations.bitbucket.client import search_code
 from integrations.bitbucket.config import (
     BitbucketConfig,
@@ -14,6 +16,35 @@ from integrations.bitbucket.config import (
     build_bitbucket_config,
 )
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend
+
+#: Bound the search query text echoed into a report summary -- unbounded and
+#: caller-supplied.
+_QUERY_SUMMARY_TRUNCATE_LEN = 80
+
+
+def _map_search_bitbucket_code(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the match count and search query, qualifying page-capped totals."""
+    if not output.get("available"):
+        return
+    results = output.get("results") or []
+    if not results:
+        return
+    total = output.get("total_returned", len(results))
+    effective_limit = output.get("effective_limit", total)
+    count_label = f"{total}+" if total >= effective_limit else str(total)
+    summary = f"{count_label} match(es)"
+    query = output.get("query")
+    if query:
+        safe_query = truncate(str(query).replace("\n", " "), _QUERY_SUMMARY_TRUNCATE_LEN)
+        summary += f" for '{safe_query}'"
+    record_evidence_entry(
+        evidence,
+        source="search_bitbucket_code",
+        label="Bitbucket Code Search",
+        summary=summary,
+    )
 
 
 def _resolve_config(
@@ -92,6 +123,7 @@ def _search_bitbucket_code_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_search_bitbucket_code_available,
     extract_params=_search_bitbucket_code_extract_params,
+    evidence_mapper=_map_search_bitbucket_code,
 )
 def search_bitbucket_code(
     query: str,

--- a/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
@@ -37,7 +37,8 @@ def _map_search_bitbucket_code(
     summary = f"{count_label} match(es)"
     query = output.get("query")
     if query:
-        safe_query = truncate(str(query).replace("\n", " "), _QUERY_SUMMARY_TRUNCATE_LEN)
+        collapsed = str(query).replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+        safe_query = truncate(collapsed, _QUERY_SUMMARY_TRUNCATE_LEN)
         summary += f" for '{safe_query}'"
     record_evidence_entry(
         evidence,

--- a/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
+++ b/integrations/bitbucket/tools/bitbucket_search_code_tool/__init__.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import code_host_unavailable_payload
-from infrastructure.text.truncation import truncate
 from integrations.bitbucket.client import search_code
 from integrations.bitbucket.config import (
     BitbucketConfig,
@@ -16,36 +14,9 @@ from integrations.bitbucket.config import (
     build_bitbucket_config,
 )
 from integrations.bitbucket.tools.availability import bitbucket_available_or_backend
-
-#: Bound the search query text echoed into a report summary -- unbounded and
-#: caller-supplied.
-_QUERY_SUMMARY_TRUNCATE_LEN = 80
-
-
-def _map_search_bitbucket_code(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
-) -> None:
-    """Cite the match count and search query, qualifying page-capped totals."""
-    if not output.get("available"):
-        return
-    results = output.get("results") or []
-    if not results:
-        return
-    total = output.get("total_returned", len(results))
-    effective_limit = output.get("effective_limit", total)
-    count_label = f"{total}+" if total >= effective_limit else str(total)
-    summary = f"{count_label} match(es)"
-    query = output.get("query")
-    if query:
-        collapsed = str(query).replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
-        safe_query = truncate(collapsed, _QUERY_SUMMARY_TRUNCATE_LEN)
-        summary += f" for '{safe_query}'"
-    record_evidence_entry(
-        evidence,
-        source="search_bitbucket_code",
-        label="Bitbucket Code Search",
-        summary=summary,
-    )
+from integrations.bitbucket.tools.bitbucket_search_code_tool._evidence import (
+    map_search_bitbucket_code,
+)
 
 
 def _resolve_config(
@@ -124,7 +95,7 @@ def _search_bitbucket_code_available(sources: dict[str, dict]) -> bool:
     },
     is_available=_search_bitbucket_code_available,
     extract_params=_search_bitbucket_code_extract_params,
-    evidence_mapper=_map_search_bitbucket_code,
+    evidence_mapper=map_search_bitbucket_code,
 )
 def search_bitbucket_code(
     query: str,

--- a/integrations/bitbucket/tools/bitbucket_search_code_tool/_evidence.py
+++ b/integrations/bitbucket/tools/bitbucket_search_code_tool/_evidence.py
@@ -1,0 +1,38 @@
+"""Evidence mapper for search_bitbucket_code."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: Bound the search query text echoed into a report summary -- unbounded and
+#: caller-supplied.
+_QUERY_SUMMARY_TRUNCATE_LEN = 80
+
+
+def map_search_bitbucket_code(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the match count and search query, qualifying page-capped totals."""
+    if not output.get("available"):
+        return
+    results = output.get("results") or []
+    if not results:
+        return
+    total = output.get("total_returned", len(results))
+    effective_limit = output.get("effective_limit", total)
+    count_label = f"{total}+" if total >= effective_limit else str(total)
+    summary = f"{count_label} match(es)"
+    query = output.get("query")
+    if query:
+        collapsed = str(query).replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+        safe_query = truncate(collapsed, _QUERY_SUMMARY_TRUNCATE_LEN)
+        summary += f" for '{safe_query}'"
+    record_evidence_entry(
+        evidence,
+        source="search_bitbucket_code",
+        label="Bitbucket Code Search",
+        summary=summary,
+    )

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -39,7 +39,6 @@ get_azure_sql_server_status
 get_azure_sql_slow_queries
 get_azure_sql_wait_stats
 get_batch_statistics
-get_bitbucket_file_contents
 get_cloudwatch_batch_metrics
 get_cloudwatch_logs
 get_dagster_run_logs
@@ -128,7 +127,6 @@ kubernetes_list_nodes
 kubernetes_list_pods
 kubernetes_list_services
 kubernetes_list_statefulsets
-list_bitbucket_commits
 list_dagster_assets
 list_dagster_runs
 list_dagster_schedule_ticks
@@ -179,7 +177,6 @@ redeploy_railway_service
 replay_slack_thread_locally
 rocketchat_send_message
 scan_redis_keys
-search_bitbucket_code
 search_github_code
 search_github_issues
 search_openclaw_conversations

--- a/tests/tools/test_bitbucket_commits_tool.py
+++ b/tests/tools/test_bitbucket_commits_tool.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from integrations.bitbucket.tools.bitbucket_commits_tool import (
-    _map_list_bitbucket_commits,
     list_bitbucket_commits,
+)
+from integrations.bitbucket.tools.bitbucket_commits_tool._evidence import (
+    map_list_bitbucket_commits as _map_list_bitbucket_commits,
 )
 from tests.tools.conftest import BaseToolContract
 

--- a/tests/tools/test_bitbucket_commits_tool.py
+++ b/tests/tools/test_bitbucket_commits_tool.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 
 import pytest
 
-from integrations.bitbucket.tools.bitbucket_commits_tool import list_bitbucket_commits
+from integrations.bitbucket.tools.bitbucket_commits_tool import (
+    _map_list_bitbucket_commits,
+    list_bitbucket_commits,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -135,3 +138,58 @@ def test_run_returns_unavailable_without_credentials() -> None:
     assert result["available"] is False
     assert result["commits"] == []
     assert result["error"] == "Bitbucket integration is not configured."
+
+
+class TestMapListBitbucketCommits:
+    def test_records_entry_with_repo(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_bitbucket_commits(
+            evidence,
+            {
+                "available": True,
+                "repo": "acme/backend-service",
+                "total_returned": 1,
+                "effective_limit": 20,
+                "commits": [{"hash": "abc123"}],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "list_bitbucket_commits"
+        assert entries[0]["summary"] == "1 commit(s) for 'acme/backend-service'"
+
+    def test_qualifies_count_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_bitbucket_commits(
+            evidence,
+            {
+                "available": True,
+                "repo": "acme/backend-service",
+                "total_returned": 20,
+                "effective_limit": 20,
+                "commits": [{"hash": "abc123"}],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"].startswith("20+ commit(s)")
+
+    def test_records_nothing_when_no_commits(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_bitbucket_commits(
+            evidence, {"available": True, "total_returned": 0, "commits": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_list_bitbucket_commits(evidence, {"available": False, "error": "not configured"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_bitbucket_file_contents_tool.py
+++ b/tests/tools/test_bitbucket_file_contents_tool.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 
 import pytest
 
-from integrations.bitbucket.tools.bitbucket_file_contents_tool import get_bitbucket_file_contents
+from integrations.bitbucket.tools.bitbucket_file_contents_tool import (
+    _map_get_bitbucket_file_contents,
+    get_bitbucket_file_contents,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -153,3 +156,57 @@ def test_run_returns_unavailable_without_credentials() -> None:
     assert result["available"] is False
     assert result["file"] == {}
     assert result["error"] == "Bitbucket integration is not configured."
+
+
+class TestMapGetBitbucketFileContents:
+    def test_records_entry_with_path_and_ref(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_bitbucket_file_contents(
+            evidence,
+            {
+                "available": True,
+                "path": "src/main.py",
+                "ref": "main",
+                "content": "print('hello')",
+                "truncated": False,
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_bitbucket_file_contents"
+        assert entries[0]["summary"] == "14 char(s), from 'src/main.py', at 'main'"
+
+    def test_qualifies_length_when_truncated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_bitbucket_file_contents(
+            evidence,
+            {
+                "available": True,
+                "path": "src/main.py",
+                "content": "x" * 10000,
+                "truncated": True,
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"].startswith("10000+ char(s)")
+
+    def test_records_nothing_when_content_missing(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_bitbucket_file_contents(evidence, {"available": True}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_bitbucket_file_contents(
+            evidence, {"available": False, "error": "not configured"}, {}
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_bitbucket_file_contents_tool.py
+++ b/tests/tools/test_bitbucket_file_contents_tool.py
@@ -195,6 +195,25 @@ class TestMapGetBitbucketFileContents:
 
         assert evidence["catalog_entries"][0]["summary"].startswith("10000+ char(s)")
 
+    def test_strips_carriage_returns_from_path_and_ref(self) -> None:
+        """Regression: a path/ref with bare \\r or \\r\\n line endings must not
+        leave a literal carriage return in the report summary."""
+        evidence: dict[str, Any] = {}
+
+        _map_get_bitbucket_file_contents(
+            evidence,
+            {
+                "available": True,
+                "path": "src\r\nmain.py",
+                "ref": "feature\rbranch",
+                "content": "x",
+                "truncated": False,
+            },
+            {},
+        )
+
+        assert "\r" not in evidence["catalog_entries"][0]["summary"]
+
     def test_records_nothing_when_content_missing(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_bitbucket_file_contents_tool.py
+++ b/tests/tools/test_bitbucket_file_contents_tool.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from integrations.bitbucket.tools.bitbucket_file_contents_tool import (
-    _map_get_bitbucket_file_contents,
     get_bitbucket_file_contents,
+)
+from integrations.bitbucket.tools.bitbucket_file_contents_tool._evidence import (
+    map_get_bitbucket_file_contents as _map_get_bitbucket_file_contents,
 )
 from tests.tools.conftest import BaseToolContract
 

--- a/tests/tools/test_bitbucket_search_code_tool.py
+++ b/tests/tools/test_bitbucket_search_code_tool.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 
 import pytest
 
-from integrations.bitbucket.tools.bitbucket_search_code_tool import search_bitbucket_code
+from integrations.bitbucket.tools.bitbucket_search_code_tool import (
+    _map_search_bitbucket_code,
+    search_bitbucket_code,
+)
 from tests.tools.conftest import BaseToolContract
 
 
@@ -131,3 +134,74 @@ def test_run_happy_path() -> None:
         "repo_slug": "backend-service",
         "limit": 5,
     }
+
+
+class TestMapSearchBitbucketCode:
+    def test_records_entry_with_query(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_search_bitbucket_code(
+            evidence,
+            {
+                "available": True,
+                "query": "error OR exception",
+                "total_returned": 1,
+                "effective_limit": 20,
+                "results": [{"path": "src/main.py"}],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "search_bitbucket_code"
+        assert entries[0]["summary"] == "1 match(es) for 'error OR exception'"
+
+    def test_qualifies_count_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_search_bitbucket_code(
+            evidence,
+            {
+                "available": True,
+                "query": "error",
+                "total_returned": 20,
+                "effective_limit": 20,
+                "results": [{"path": "src/main.py"}],
+            },
+            {},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"].startswith("20+ match(es)")
+
+    def test_strips_newlines_from_query(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_search_bitbucket_code(
+            evidence,
+            {
+                "available": True,
+                "query": "error\nOR\nexception",
+                "total_returned": 1,
+                "results": [{"path": "src/main.py"}],
+            },
+            {},
+        )
+
+        assert "\n" not in evidence["catalog_entries"][0]["summary"]
+
+    def test_records_nothing_when_no_results(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_search_bitbucket_code(
+            evidence, {"available": True, "total_returned": 0, "results": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_search_bitbucket_code(evidence, {"available": False, "error": "not configured"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_bitbucket_search_code_tool.py
+++ b/tests/tools/test_bitbucket_search_code_tool.py
@@ -190,6 +190,24 @@ class TestMapSearchBitbucketCode:
 
         assert "\n" not in evidence["catalog_entries"][0]["summary"]
 
+    def test_strips_carriage_returns_from_query(self) -> None:
+        """Regression: a query with bare \\r or \\r\\n line endings must not
+        leave a literal carriage return in the report summary."""
+        evidence: dict[str, Any] = {}
+
+        _map_search_bitbucket_code(
+            evidence,
+            {
+                "available": True,
+                "query": "error\r\nOR\rexception",
+                "total_returned": 1,
+                "results": [{"path": "src/main.py"}],
+            },
+            {},
+        )
+
+        assert "\r" not in evidence["catalog_entries"][0]["summary"]
+
     def test_records_nothing_when_no_results(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_bitbucket_search_code_tool.py
+++ b/tests/tools/test_bitbucket_search_code_tool.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from integrations.bitbucket.tools.bitbucket_search_code_tool import (
-    _map_search_bitbucket_code,
     search_bitbucket_code,
+)
+from integrations.bitbucket.tools.bitbucket_search_code_tool._evidence import (
+    map_search_bitbucket_code as _map_search_bitbucket_code,
 )
 from tests.tools.conftest import BaseToolContract
 


### PR DESCRIPTION
Closes #5559

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all three listed Bitbucket investigation tools to `record_evidence_entry`
so their output stops being silently dropped and becomes a citeable line in
the investigation report.

- `_map_get_bitbucket_file_contents`: cites the fetched file's path,
  revision, and content length.
- `_map_list_bitbucket_commits`: cites the commit count and repo, qualifying
  page-capped totals.
- `_map_search_bitbucket_code`: cites the match count and search query,
  qualifying page-capped totals.

All three are read-only diagnostic queries — none is an action/notification
tool, so all are in scope per the issue.

**On count honesty — the "N+" convention:** `list_commits` and `search_code`
in `integrations/bitbucket/client.py` both apply
`min(limit or config.max_results, config.max_results)` as the effective page
size, but neither echoed that ceiling back — the mapper only had the
caller's own requested `limit` via `tool_input`, and `config.max_results`
(which can be lower) isn't visible there. I added `effective_limit` to both
functions' output dicts (the same fix I made for Azure Monitor Logs,
OpenObserve, and SigNoz's client earlier in this session) rather than
guessing from `tool_input` alone, since a hidden `max_results` clamp could
otherwise cause a false negative on saturation detection.

`get_bitbucket_file_contents` already had a real `truncated` flag (the
client's own 10000-char content cap) — used directly, no heuristic needed.

Free-form search queries and file paths/refs are collapsed and capped before
going into a summary; `list_commits` and `search_code` already truncate
commit messages/hashes themselves, so no extra sanitization was needed there.

Removed all three bitbucket tool names from `evidence_mapper_baseline.txt`
now that they carry mappers.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in [
  'get_bitbucket_file_contents', 'list_bitbucket_commits', 'search_bitbucket_code']})"
{'get_bitbucket_file_contents': True, 'list_bitbucket_commits': True, 'search_bitbucket_code': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each tool's return
shape:**
```
get_bitbucket_file_contents:  "14 char(s), from 'src/main.py', at 'main'"
list_bitbucket_commits:       "1 commit(s) for 'acme/backend-service'"
search_bitbucket_code:        "1 match(es) for 'error OR exception'"
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_bitbucket_file_contents_tool.py tests/tools/test_bitbucket_commits_tool.py \
  tests/tools/test_bitbucket_search_code_tool.py tests/integrations/test_bitbucket.py -q
98 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live Bitbucket account available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the three
mappers, the `effective_limit` additions to `client.py`, and their tests
were added.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read all three tool wrappers plus their backing `integrations/bitbucket/client.py`
functions (`get_file_contents`, `list_commits`, `search_code`) before writing
anything. `get_file_contents` already exposed a real `truncated` flag so no
extra work was needed there, but `list_commits`/`search_code` had the same
"caller's limit isn't the real ceiling" gap I'd already hit and fixed for
Azure Monitor Logs, OpenObserve, and SigNoz earlier in this session — I
applied the identical fix (echo `effective_limit` from the client) rather
than inventing a fourth approach for the same underlying problem.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
