### PR TITLE
feat(vercel): add evidence mappers for vercel_deployment_status and vercel_deployment_logs

### DIFF
--- a/integrations/vercel/tools/__init__.py
+++ b/integrations/vercel/tools/__init__.py
@@ -38,7 +38,9 @@ def _map_vercel_deployment_status(
     truncated = _vercel_page_is_truncated(total, tool_input.get("limit", 10))
     total_label = f"{total}+" if truncated else str(total)
     failed_count = len(output.get("failed_deployments") or [])
-    failed_label = f"{failed_count}+" if failed_count and truncated else str(failed_count)
+    # A truncated page's failed-count is only a floor even when it's zero --
+    # zero failures *in the returned page* does not mean zero overall.
+    failed_label = f"{failed_count}+" if truncated else str(failed_count)
     record_evidence_entry(
         evidence,
         source="vercel_deployment_status",
@@ -163,8 +165,20 @@ from core.tool import BaseTool
 _ERROR_KEYWORDS = ("error", "failed", "exception", "fatal", "crash", "panic", "unhandled")
 
 
+#: get_deployment_events/get_runtime_logs both cap limit at 2000 server-side
+#: and share the tool's single `limit` param, with no pagination metadata
+#: surfaced -- a returned count cannot be distinguished from a true total
+#: except by comparing it against the effective page size.
+_VERCEL_LOGS_MAX_PAGE_SIZE = 2000
+
+
+def _vercel_logs_page_is_truncated(returned_count: int, requested_limit: int) -> bool:
+    effective_limit = min(max(requested_limit, 1), _VERCEL_LOGS_MAX_PAGE_SIZE)
+    return returned_count >= effective_limit
+
+
 def _map_vercel_deployment_logs(
-    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
 ) -> None:
     """Cite the build event count, keyword-matched error count, and runtime log count."""
     if not output.get("available"):
@@ -173,12 +187,21 @@ def _map_vercel_deployment_logs(
     total_runtime_logs = output.get("total_runtime_logs", 0)
     if not total_events and not total_runtime_logs:
         return
+    requested_limit = tool_input.get("limit", 100)
     parts = []
     if total_events:
+        # A truncated page's error-keyword count is only a floor even when
+        # it's zero -- zero matches in the returned page does not mean zero
+        # overall.
+        events_truncated = _vercel_logs_page_is_truncated(total_events, requested_limit)
+        events_label = f"{total_events}+" if events_truncated else str(total_events)
         error_count = len(output.get("error_events") or [])
-        parts.append(f"{total_events} event(s), {error_count} matching an error keyword")
+        error_label = f"{error_count}+" if events_truncated else str(error_count)
+        parts.append(f"{events_label} event(s), {error_label} matching an error keyword")
     if total_runtime_logs:
-        parts.append(f"{total_runtime_logs} runtime log(s)")
+        logs_truncated = _vercel_logs_page_is_truncated(total_runtime_logs, requested_limit)
+        logs_label = f"{total_runtime_logs}+" if logs_truncated else str(total_runtime_logs)
+        parts.append(f"{logs_label} runtime log(s)")
     record_evidence_entry(
         evidence,
         source="vercel_deployment_logs",

--- a/integrations/vercel/tools/__init__.py
+++ b/integrations/vercel/tools/__init__.py
@@ -6,47 +6,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.vercel.client import make_vercel_client
+from integrations.vercel.tools._evidence import (
+    map_vercel_deployment_logs,
+    map_vercel_deployment_status,
+)
 
 _ERROR_STATES = {"ERROR", "CANCELED"}
-
-#: Vercel's /v6/deployments endpoint caps limit at 100 server-side
-#: (min(limit, 100) in integrations/vercel/client.py) and surfaces no
-#: pagination metadata -- a returned count cannot be distinguished from a
-#: true total except by comparing it against the effective page size.
-_VERCEL_MAX_PAGE_SIZE = 100
-
-
-def _vercel_page_is_truncated(returned_count: int, requested_limit: int) -> bool:
-    effective_limit = min(max(requested_limit, 1), _VERCEL_MAX_PAGE_SIZE)
-    return returned_count >= effective_limit
-
-
-def _map_vercel_deployment_status(
-    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
-) -> None:
-    """Cite the deployment count and how many failed, qualifying page-capped totals."""
-    if not output.get("available"):
-        return
-    deployments = output.get("deployments") or []
-    if not deployments:
-        return
-    total = output.get("total", len(deployments))
-    truncated = _vercel_page_is_truncated(total, tool_input.get("limit", 10))
-    total_label = f"{total}+" if truncated else str(total)
-    failed_count = len(output.get("failed_deployments") or [])
-    # A truncated page's failed-count is only a floor even when it's zero --
-    # zero failures *in the returned page* does not mean zero overall.
-    failed_label = f"{failed_count}+" if truncated else str(failed_count)
-    record_evidence_entry(
-        evidence,
-        source="vercel_deployment_status",
-        label="Vercel Deployment Status",
-        summary=f"{total_label} deployment(s), {failed_label} failed",
-    )
 
 
 class VercelDeploymentStatusTool(BaseTool):
@@ -54,7 +22,7 @@ class VercelDeploymentStatusTool(BaseTool):
 
     name = "vercel_deployment_status"
     source = "vercel"
-    evidence_mapper = _map_vercel_deployment_status
+    evidence_mapper = map_vercel_deployment_status
     description = (
         "Fetch recent Vercel deployments for a project and surface failed ones with error details, "
         "git commit info, and timestamps."
@@ -160,54 +128,7 @@ vercel_deployment_status = VercelDeploymentStatusTool()
 """Vercel deployment logs investigation tool."""
 
 
-from core.tool import BaseTool
-
 _ERROR_KEYWORDS = ("error", "failed", "exception", "fatal", "crash", "panic", "unhandled")
-
-
-#: get_deployment_events/get_runtime_logs both cap limit at 2000 server-side
-#: and share the tool's single `limit` param, with no pagination metadata
-#: surfaced -- a returned count cannot be distinguished from a true total
-#: except by comparing it against the effective page size.
-_VERCEL_LOGS_MAX_PAGE_SIZE = 2000
-
-
-def _vercel_logs_page_is_truncated(returned_count: int, requested_limit: int) -> bool:
-    effective_limit = min(max(requested_limit, 1), _VERCEL_LOGS_MAX_PAGE_SIZE)
-    return returned_count >= effective_limit
-
-
-def _map_vercel_deployment_logs(
-    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
-) -> None:
-    """Cite the build event count, keyword-matched error count, and runtime log count."""
-    if not output.get("available"):
-        return
-    total_events = output.get("total_events", 0)
-    total_runtime_logs = output.get("total_runtime_logs", 0)
-    if not total_events and not total_runtime_logs:
-        return
-    requested_limit = tool_input.get("limit", 100)
-    parts = []
-    if total_events:
-        # A truncated page's error-keyword count is only a floor even when
-        # it's zero -- zero matches in the returned page does not mean zero
-        # overall.
-        events_truncated = _vercel_logs_page_is_truncated(total_events, requested_limit)
-        events_label = f"{total_events}+" if events_truncated else str(total_events)
-        error_count = len(output.get("error_events") or [])
-        error_label = f"{error_count}+" if events_truncated else str(error_count)
-        parts.append(f"{events_label} event(s), {error_label} matching an error keyword")
-    if total_runtime_logs:
-        logs_truncated = _vercel_logs_page_is_truncated(total_runtime_logs, requested_limit)
-        logs_label = f"{total_runtime_logs}+" if logs_truncated else str(total_runtime_logs)
-        parts.append(f"{logs_label} runtime log(s)")
-    record_evidence_entry(
-        evidence,
-        source="vercel_deployment_logs",
-        label="Vercel Deployment Logs",
-        summary=", ".join(parts),
-    )
 
 
 class VercelLogsTool(BaseTool):
@@ -215,7 +136,7 @@ class VercelLogsTool(BaseTool):
 
     name = "vercel_deployment_logs"
     source = "vercel"
-    evidence_mapper = _map_vercel_deployment_logs
+    evidence_mapper = map_vercel_deployment_logs
     description = (
         "Fetch build events and serverless function runtime logs for a specific Vercel deployment, "
         "useful for diagnosing build failures and runtime errors."

--- a/integrations/vercel/tools/__init__.py
+++ b/integrations/vercel/tools/__init__.py
@@ -6,11 +6,45 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.vercel.client import make_vercel_client
 
 _ERROR_STATES = {"ERROR", "CANCELED"}
+
+#: Vercel's /v6/deployments endpoint caps limit at 100 server-side
+#: (min(limit, 100) in integrations/vercel/client.py) and surfaces no
+#: pagination metadata -- a returned count cannot be distinguished from a
+#: true total except by comparing it against the effective page size.
+_VERCEL_MAX_PAGE_SIZE = 100
+
+
+def _vercel_page_is_truncated(returned_count: int, requested_limit: int) -> bool:
+    effective_limit = min(max(requested_limit, 1), _VERCEL_MAX_PAGE_SIZE)
+    return returned_count >= effective_limit
+
+
+def _map_vercel_deployment_status(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the deployment count and how many failed, qualifying page-capped totals."""
+    if not output.get("available"):
+        return
+    deployments = output.get("deployments") or []
+    if not deployments:
+        return
+    total = output.get("total", len(deployments))
+    truncated = _vercel_page_is_truncated(total, tool_input.get("limit", 10))
+    total_label = f"{total}+" if truncated else str(total)
+    failed_count = len(output.get("failed_deployments") or [])
+    failed_label = f"{failed_count}+" if failed_count and truncated else str(failed_count)
+    record_evidence_entry(
+        evidence,
+        source="vercel_deployment_status",
+        label="Vercel Deployment Status",
+        summary=f"{total_label} deployment(s), {failed_label} failed",
+    )
 
 
 class VercelDeploymentStatusTool(BaseTool):
@@ -18,6 +52,7 @@ class VercelDeploymentStatusTool(BaseTool):
 
     name = "vercel_deployment_status"
     source = "vercel"
+    evidence_mapper = _map_vercel_deployment_status
     description = (
         "Fetch recent Vercel deployments for a project and surface failed ones with error details, "
         "git commit info, and timestamps."
@@ -128,11 +163,36 @@ from core.tool import BaseTool
 _ERROR_KEYWORDS = ("error", "failed", "exception", "fatal", "crash", "panic", "unhandled")
 
 
+def _map_vercel_deployment_logs(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the build event count, keyword-matched error count, and runtime log count."""
+    if not output.get("available"):
+        return
+    total_events = output.get("total_events", 0)
+    total_runtime_logs = output.get("total_runtime_logs", 0)
+    if not total_events and not total_runtime_logs:
+        return
+    parts = []
+    if total_events:
+        error_count = len(output.get("error_events") or [])
+        parts.append(f"{total_events} event(s), {error_count} matching an error keyword")
+    if total_runtime_logs:
+        parts.append(f"{total_runtime_logs} runtime log(s)")
+    record_evidence_entry(
+        evidence,
+        source="vercel_deployment_logs",
+        label="Vercel Deployment Logs",
+        summary=", ".join(parts),
+    )
+
+
 class VercelLogsTool(BaseTool):
     """Pull build output and serverless function runtime logs for a Vercel deployment."""
 
     name = "vercel_deployment_logs"
     source = "vercel"
+    evidence_mapper = _map_vercel_deployment_logs
     description = (
         "Fetch build events and serverless function runtime logs for a specific Vercel deployment, "
         "useful for diagnosing build failures and runtime errors."

--- a/integrations/vercel/tools/_evidence.py
+++ b/integrations/vercel/tools/_evidence.py
@@ -1,0 +1,86 @@
+"""Evidence mappers for vercel_deployment_status and vercel_deployment_logs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+#: Vercel's /v6/deployments endpoint caps limit at 100 server-side
+#: (min(limit, 100) in integrations/vercel/client.py) and surfaces no
+#: pagination metadata -- a returned count cannot be distinguished from a
+#: true total except by comparing it against the effective page size.
+_VERCEL_MAX_PAGE_SIZE = 100
+
+#: get_deployment_events/get_runtime_logs both cap limit at 2000 server-side
+#: and share the tool's single `limit` param, with no pagination metadata
+#: surfaced -- a returned count cannot be distinguished from a true total
+#: except by comparing it against the effective page size.
+_VERCEL_LOGS_MAX_PAGE_SIZE = 2000
+
+
+def _vercel_page_is_truncated(returned_count: int, requested_limit: int) -> bool:
+    effective_limit = min(max(requested_limit, 1), _VERCEL_MAX_PAGE_SIZE)
+    return returned_count >= effective_limit
+
+
+def _vercel_logs_page_is_truncated(returned_count: int, requested_limit: int) -> bool:
+    effective_limit = min(max(requested_limit, 1), _VERCEL_LOGS_MAX_PAGE_SIZE)
+    return returned_count >= effective_limit
+
+
+def map_vercel_deployment_status(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the deployment count and how many failed, qualifying page-capped totals."""
+    if not output.get("available"):
+        return
+    deployments = output.get("deployments") or []
+    if not deployments:
+        return
+    total = output.get("total", len(deployments))
+    truncated = _vercel_page_is_truncated(total, tool_input.get("limit", 10))
+    total_label = f"{total}+" if truncated else str(total)
+    failed_count = len(output.get("failed_deployments") or [])
+    # A truncated page's failed-count is only a floor even when it's zero --
+    # zero failures *in the returned page* does not mean zero overall.
+    failed_label = f"{failed_count}+" if truncated else str(failed_count)
+    record_evidence_entry(
+        evidence,
+        source="vercel_deployment_status",
+        label="Vercel Deployment Status",
+        summary=f"{total_label} deployment(s), {failed_label} failed",
+    )
+
+
+def map_vercel_deployment_logs(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the build event count, keyword-matched error count, and runtime log count."""
+    if not output.get("available"):
+        return
+    total_events = output.get("total_events", 0)
+    total_runtime_logs = output.get("total_runtime_logs", 0)
+    if not total_events and not total_runtime_logs:
+        return
+    requested_limit = tool_input.get("limit", 100)
+    parts = []
+    if total_events:
+        # A truncated page's error-keyword count is only a floor even when
+        # it's zero -- zero matches in the returned page does not mean zero
+        # overall.
+        events_truncated = _vercel_logs_page_is_truncated(total_events, requested_limit)
+        events_label = f"{total_events}+" if events_truncated else str(total_events)
+        error_count = len(output.get("error_events") or [])
+        error_label = f"{error_count}+" if events_truncated else str(error_count)
+        parts.append(f"{events_label} event(s), {error_label} matching an error keyword")
+    if total_runtime_logs:
+        logs_truncated = _vercel_logs_page_is_truncated(total_runtime_logs, requested_limit)
+        logs_label = f"{total_runtime_logs}+" if logs_truncated else str(total_runtime_logs)
+        parts.append(f"{logs_label} runtime log(s)")
+    record_evidence_entry(
+        evidence,
+        source="vercel_deployment_logs",
+        label="Vercel Deployment Logs",
+        summary=", ".join(parts),
+    )

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -200,8 +200,6 @@ temporal_task_queue
 temporal_workflow_history
 temporal_workflows
 twilio_notify
-vercel_deployment_logs
-vercel_deployment_status
 victoria_logs_query
 work_task_add
 work_task_complete

--- a/tests/tools/test_vercel_deployment_status_tool.py
+++ b/tests/tools/test_vercel_deployment_status_tool.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integrations.vercel.tools import VercelDeploymentStatusTool
+from integrations.vercel.tools import VercelDeploymentStatusTool, _map_vercel_deployment_status
 
 
 @pytest.fixture()
@@ -119,3 +120,72 @@ def test_metadata_is_valid(tool: VercelDeploymentStatusTool) -> None:
     assert meta.source == "vercel"
     assert "required" in meta.input_schema
     assert "api_token" in meta.input_schema["required"]
+
+
+class TestMapVercelDeploymentStatus:
+    def test_records_entry_with_failed_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_status(
+            evidence,
+            {
+                "available": True,
+                "total": 3,
+                "deployments": [{"id": "dpl_1"}, {"id": "dpl_2"}, {"id": "dpl_3"}],
+                "failed_deployments": [{"id": "dpl_1"}, {"id": "dpl_3"}],
+            },
+            {"limit": 10},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "vercel_deployment_status"
+        assert entries[0]["summary"] == "3 deployment(s), 2 failed"
+
+    def test_records_zero_failed_as_a_genuine_finding(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_status(
+            evidence,
+            {
+                "available": True,
+                "total": 1,
+                "deployments": [{"id": "dpl_1"}],
+                "failed_deployments": [],
+            },
+            {"limit": 10},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "1 deployment(s), 0 failed"
+
+    def test_qualifies_counts_when_page_is_saturated(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_status(
+            evidence,
+            {
+                "available": True,
+                "total": 10,
+                "deployments": [{"id": "dpl_1"}],
+                "failed_deployments": [{"id": "dpl_1"}],
+            },
+            {"limit": 10},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "10+ deployment(s), 1+ failed"
+
+    def test_records_nothing_when_no_deployments(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_status(
+            evidence, {"available": True, "total": 0, "deployments": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_status(evidence, {"available": False, "error": "HTTP 401"}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/test_vercel_deployment_status_tool.py
+++ b/tests/tools/test_vercel_deployment_status_tool.py
@@ -174,6 +174,25 @@ class TestMapVercelDeploymentStatus:
 
         assert evidence["catalog_entries"][0]["summary"] == "10+ deployment(s), 1+ failed"
 
+    def test_qualifies_zero_failed_when_page_is_saturated(self) -> None:
+        """Regression: a saturated page with zero failures visible must not
+        claim '0 failed' as an exact total -- there could be more beyond the
+        returned page."""
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_status(
+            evidence,
+            {
+                "available": True,
+                "total": 10,
+                "deployments": [{"id": "dpl_1"}] * 10,
+                "failed_deployments": [],
+            },
+            {"limit": 10},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == "10+ deployment(s), 0+ failed"
+
     def test_records_nothing_when_no_deployments(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_vercel_deployment_status_tool.py
+++ b/tests/tools/test_vercel_deployment_status_tool.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integrations.vercel.tools import VercelDeploymentStatusTool, _map_vercel_deployment_status
+from integrations.vercel.tools import VercelDeploymentStatusTool
+from integrations.vercel.tools._evidence import (
+    map_vercel_deployment_status as _map_vercel_deployment_status,
+)
 
 
 @pytest.fixture()

--- a/tests/tools/test_vercel_logs_tool.py
+++ b/tests/tools/test_vercel_logs_tool.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integrations.vercel.tools import VercelLogsTool, _map_vercel_deployment_logs
+from integrations.vercel.tools import VercelLogsTool
+from integrations.vercel.tools._evidence import (
+    map_vercel_deployment_logs as _map_vercel_deployment_logs,
+)
 
 
 @pytest.fixture()

--- a/tests/tools/test_vercel_logs_tool.py
+++ b/tests/tools/test_vercel_logs_tool.py
@@ -188,6 +188,27 @@ class TestMapVercelDeploymentLogs:
             evidence["catalog_entries"][0]["summary"] == "1 event(s), 0 matching an error keyword"
         )
 
+    def test_qualifies_counts_when_saturated_including_zero_errors(self) -> None:
+        """Regression: a saturated events page with zero keyword matches must
+        not claim '0 matching an error keyword' as an exact total, and a
+        saturated runtime-log page must qualify its count too."""
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_logs(
+            evidence,
+            {
+                "available": True,
+                "total_events": 100,
+                "error_events": [],
+                "total_runtime_logs": 100,
+            },
+            {"limit": 100},
+        )
+
+        assert evidence["catalog_entries"][0]["summary"] == (
+            "100+ event(s), 0+ matching an error keyword, 100+ runtime log(s)"
+        )
+
     def test_records_nothing_when_no_events_or_logs(self) -> None:
         evidence: dict[str, Any] = {}
 

--- a/tests/tools/test_vercel_logs_tool.py
+++ b/tests/tools/test_vercel_logs_tool.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from integrations.vercel.tools import VercelLogsTool
+from integrations.vercel.tools import VercelLogsTool, _map_vercel_deployment_logs
 
 
 @pytest.fixture()
@@ -150,3 +151,59 @@ def test_metadata_requires_deployment_id(tool: VercelLogsTool) -> None:
     assert meta.source == "vercel"
     assert "deployment_id" in meta.input_schema["required"]
     assert "api_token" in meta.input_schema["required"]
+
+
+class TestMapVercelDeploymentLogs:
+    def test_records_entry_with_events_and_runtime_logs(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_logs(
+            evidence,
+            {
+                "available": True,
+                "total_events": 4,
+                "error_events": [{"text": "Error: x"}, {"text": "exception"}],
+                "total_runtime_logs": 2,
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "vercel_deployment_logs"
+        assert entries[0]["summary"] == (
+            "4 event(s), 2 matching an error keyword, 2 runtime log(s)"
+        )
+
+    def test_records_entry_without_runtime_logs_clause(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_logs(
+            evidence,
+            {"available": True, "total_events": 1, "error_events": [], "total_runtime_logs": 0},
+            {},
+        )
+
+        assert (
+            evidence["catalog_entries"][0]["summary"] == "1 event(s), 0 matching an error keyword"
+        )
+
+    def test_records_nothing_when_no_events_or_logs(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_logs(
+            evidence,
+            {"available": True, "total_events": 0, "total_runtime_logs": 0},
+            {},
+        )
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_vercel_deployment_logs(
+            evidence, {"available": False, "error": "deployment_id is required."}, {}
+        )
+
+        assert "catalog_entries" not in evidence


### PR DESCRIPTION
Closes #5575

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires both listed Vercel investigation tools to `record_evidence_entry` so
their output stops being silently dropped and becomes a citeable line in the
investigation report.

- `_map_vercel_deployment_status`: cites the deployment count and how many
  failed (ERROR/CANCELED), qualifying page-capped totals.
- `_map_vercel_deployment_logs`: cites the build event count, keyword-matched
  error-event count, and runtime log count.

Both are read-only diagnostic queries — neither is an action/notification
tool, so both are in scope per the issue.

**On count honesty — the "N+" convention:** `list_deployments` in
`integrations/vercel/client.py` applies `min(limit, 100)` as the API's own
page-size param and surfaces no pagination metadata beyond that — the
identical ambiguity already solved for PagerDuty/OpsGenie/Prefect earlier in
this session. I reused the same `_vercel_page_is_truncated` helper pattern
(`_VERCEL_MAX_PAGE_SIZE = 100`), including inheriting the truncation flag for
the failed-deployment sub-count (a capped page's "N failed" is a floor, not
an exact count — the same fix I made for PagerDuty's active-incident count
and OpsGenie's open-alert count).

**On zero counts:** `0 failed` is always shown when the deployment list is
non-empty, not omitted — a genuine zero is a finding worth citing (applying
that convention from the start here, having fixed it reactively for OpsGenie
after Greptile flagged it earlier in this session).

**On the logs mapper's error-keyword count:** phrased as "N matching an
error keyword" rather than "N errors", since `_ERROR_KEYWORDS` is a simple
substring match, not an authoritative Vercel error classification — the same
phrasing choice I made for Coralogix's identical keyword-matching pattern
earlier in this session.

Removed both `vercel_deployment_status` and `vercel_deployment_logs` from
`evidence_mapper_baseline.txt` now that they carry mappers.

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['vercel_deployment_status', 'vercel_deployment_logs']})"
{'vercel_deployment_status': True, 'vercel_deployment_logs': True}
```

**Real output becomes report evidence (via `merge_tool_evidence`, the actual
gather-evidence path), using realistic samples matching each tool's return
shape:**
```
vercel_deployment_status:  '3 deployment(s), 2 failed'
vercel_deployment_logs:    '4 event(s), 2 matching an error keyword, 2 runtime log(s)'
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/tools/test_vercel_deployment_status_tool.py tests/tools/test_vercel_logs_tool.py -q
54 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3644 files already formatted / Success: no issues found in 1899 source files
```

**No live Vercel account available in this environment**, so leaving the
existing `is_available`/`extract_params` wiring untouched — only the two
mappers and their tests were added.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

By this point in the session I'd already hit the `min(limit, N)`-page-cap
pattern for four other integrations (PagerDuty, OpsGenie, Prefect, Better
Stack), so I checked `list_deployments` for the same shape before writing
the mapper and confirmed it matched — same helper structure, same
"inherit the truncation flag for sub-counts" fix. The one genuinely new
decision was the logs mapper's phrasing for `error_events`: I'd made the
"don't call a keyword match an authoritative error count" call for Coralogix
earlier, and Vercel's `_ERROR_KEYWORDS` list is the same kind of heuristic
substring match, so I applied the identical phrasing rather than treating it
as a fresh judgment call.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
