### PR TITLE
fix(tools): satisfy description contract for session_goal_set

### DIFF
--- a/tests/tools/test_description_contract.py
+++ b/tests/tools/test_description_contract.py
@@ -62,7 +62,6 @@ _MIN_REGISTRY_SIZE = 290
 _DESCRIPTION_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
     {
         "alert_sample",
-        "assistant_handoff",
         "cli_exec",
         "code_implement",
         "fix_sentry_issue_start",

--- a/tools/interactive_shell/actions/session_goal.py
+++ b/tools/interactive_shell/actions/session_goal.py
@@ -74,6 +74,21 @@ session_goal_tool = RegisteredTool(
         "the user asked to continue without pausing. Do not use for local shell "
         "work or a single-turn answer."
     ),
+    use_cases=[
+        (
+            "User asks to walk a multi-step checklist or keep going across turns "
+            "until a finish condition is met (e.g. a 5-step sequential process)"
+        ),
+        (
+            "Action handoff needs a durable SessionGoal so the host continues "
+            "outer turns until the checklist is done"
+        ),
+    ],
+    anti_examples=[
+        "One-shot Q&A or a single lookup that finishes this turn",
+        "Local shell / code-edit work that should use shell_run or update_plan",
+        "User only wants a written plan with no execution (use update_plan)",
+    ],
     input_schema=object_schema(
         properties={
             "condition": string_property(


### PR DESCRIPTION
## Summary
- `session_goal_set` was failing `tests/tools/test_description_contract.py` (empty `use_cases` with siblings in `interactive_shell`).
- Added `use_cases` / `anti_examples` and removed the stale `assistant_handoff` allowlist entry.

## Test plan
- [x] `uv run python -m pytest tests/tools/test_description_contract.py -q`