### PR TITLE
feat(interactive-shell): loading spinner phases and live tool-call preview

### DIFF
--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -16,7 +16,6 @@ from surfaces.shared.terminal.components.token_format import (
     _CHARS_PER_TOKEN,
     format_token_count_short,
 )
-from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_line_width
 
 # How often prompt-toolkit refreshes prompt callbacks and confirmation polling.
 PROMPT_REFRESH_INTERVAL_S = 0.25
@@ -153,6 +152,9 @@ class SpinnerState:
     # render pass (layout measurement + paint), so a per-call counter can land
     # on the same frame every visible render and freeze the animation.
     _FRAME_INTERVAL_SECONDS = 0.1
+    EXECUTING_PHASE = "Thinking…"
+    INVOKING_TOOLS_PHASE = "Invoking tools…"
+    _STOP_HINT = "(Press ESC to stop)"
     # Netrunner verb pools, escalating with time spent in the net: the longer
     # the run, the hotter the trace. Each entry maps the minimum elapsed
     # seconds to the pool active from that point on (tiers never de-escalate
@@ -212,7 +214,7 @@ class SpinnerState:
         self.bytes_in = 0
         self._verb_tier = 0
         self._verb = self._pick_verb()
-        self.phase = ""
+        self.phase = self.EXECUTING_PHASE
 
     def advance_verb(self) -> None:
         """Pick a fresh thinking verb (the rotation cadence is the caller's).
@@ -287,7 +289,10 @@ class SpinnerState:
         app = get_app_or_none()
         if app is not None and app.current_buffer.text:
             hint += "  ·  esc to clear"
-        return f"{ui_theme.DIM_ANSI}{hint}{ui_theme.ANSI_RESET}"
+        return (
+            f"{ui_theme.PROMPT_ACCENT_ANSI}Ready{ui_theme.ANSI_RESET}"
+            f"{ui_theme.DIM_ANSI} · {hint}{ui_theme.ANSI_RESET}"
+        )
 
     def inline_spinner_ansi(self) -> str:
         if not self.streaming:
@@ -299,24 +304,13 @@ class SpinnerState:
         glyph = self._SPINNER_FRAMES[frame_idx % len(self._SPINNER_FRAMES)]
         if token_count > 0:
             tokens_str = format_token_count_short(token_count)
-            suffix = f" ({elapsed:.0f}s · ↓ {tokens_str} tokens)"
+            elapsed_badge = f"[ {elapsed:.0f}s · ↓ {tokens_str} tokens]"
         else:
-            suffix = f" ({elapsed:.0f}s)"
+            elapsed_badge = f"[ {elapsed:.0f}s]"
         label = self.phase or f"{self._verb}…"
-        cancel = "  esc to cancel"
-        # One prompt-region row only: a long investigation phase (or a narrow
-        # terminal) must not soft-wrap — that desyncs row height vs the one-row
-        # confirmation prefix and leaves stale spinner/status lines.
-        width = prompt_line_width()
-        lead = f"{glyph} "
-        reserved = len(lead) + len(suffix) + len(cancel)
-        if reserved >= width:
-            visible = clip_prompt_text(f"{lead}{label}{suffix}{cancel}", width)
-            return f"{ui_theme.PROMPT_ACCENT_ANSI}{visible}{ui_theme.ANSI_RESET}"
-        clipped_label = clip_prompt_text(label, width - reserved)
         return (
-            f"{ui_theme.PROMPT_ACCENT_ANSI}{lead}{clipped_label}{ui_theme.ANSI_RESET}"
-            f"{ui_theme.ANSI_DIM}{suffix}{cancel}{ui_theme.ANSI_RESET}"
+            f"{ui_theme.PROMPT_ACCENT_ANSI}{glyph} {label}{ui_theme.ANSI_RESET}"
+            f"{ui_theme.ANSI_DIM} {self._STOP_HINT}  {elapsed_badge}{ui_theme.ANSI_RESET}"
         )
 
 

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -16,6 +16,7 @@ from surfaces.shared.terminal.components.token_format import (
     _CHARS_PER_TOKEN,
     format_token_count_short,
 )
+from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_line_width
 
 # How often prompt-toolkit refreshes prompt callbacks and confirmation polling.
 PROMPT_REFRESH_INTERVAL_S = 0.25
@@ -308,9 +309,20 @@ class SpinnerState:
         else:
             elapsed_badge = f"[ {elapsed:.0f}s]"
         label = self.phase or f"{self._verb}…"
+        # One prompt-region row only: a long phase (or a narrow terminal) must
+        # not soft-wrap, which desyncs row height vs the one-row confirmation
+        # prefix and leaves stale spinner/status lines.
+        lead = f"{glyph} "
+        tail = f" {self._STOP_HINT}  {elapsed_badge}"
+        width = prompt_line_width()
+        reserved = len(lead) + len(tail)
+        if reserved >= width:
+            visible = clip_prompt_text(f"{lead}{label}{tail}", width)
+            return f"{ui_theme.PROMPT_ACCENT_ANSI}{visible}{ui_theme.ANSI_RESET}"
+        clipped_label = clip_prompt_text(label, width - reserved)
         return (
-            f"{ui_theme.PROMPT_ACCENT_ANSI}{glyph} {label}{ui_theme.ANSI_RESET}"
-            f"{ui_theme.ANSI_DIM} {self._STOP_HINT}  {elapsed_badge}{ui_theme.ANSI_RESET}"
+            f"{ui_theme.PROMPT_ACCENT_ANSI}{lead}{clipped_label}{ui_theme.ANSI_RESET}"
+            f"{ui_theme.ANSI_DIM}{tail}{ui_theme.ANSI_RESET}"
         )
 
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -21,8 +21,9 @@ from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from infrastructure.safety.terminal_output import strip_terminal_controls
-from infrastructure.terminal.theme import BOLD_SKILL, DIM, HIGHLIGHT
+from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session
+from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.ui.streaming import render_markdown_block
 from surfaces.shared.terminal.output.console_state import get_investigation_spinner
 
@@ -40,8 +41,13 @@ _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
     "task_cancel": ("cancel task", "target"),
     "cli_exec": ("opensre", "payload"),
     "code_implement": ("implementation", "task"),
-    "shell_run": ("shell", "command"),
+    "shell_run": ("Execute", "command"),
 }
+
+#: Tools that render their own dedicated UI (the investigation lap/spinner
+#: progress). The generic live tool-call preview is suppressed for these so it
+#: does not duplicate that UI as a wall of text.
+_SELF_RENDERING_TOOLS: frozenset[str] = frozenset({"investigation_start"})
 
 
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
@@ -87,6 +93,7 @@ class ActionRenderObserver:
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         if kind == "llm_start":
+            self._set_spinner_phase(SpinnerState.EXECUTING_PHASE)
             self._advance_spinner_verb(data)
             return
         if kind == "message_update":
@@ -104,17 +111,28 @@ class ActionRenderObserver:
         if kind == "tool_end":
             if str(data.get("name", "")).strip() == "skill_view":
                 self._render_skill_end(data)
+            self._set_spinner_phase(SpinnerState.EXECUTING_PHASE)
             return
         if kind != "tool_start":
             return
         name = str(data.get("name", "")).strip()
         if not name:
             return
+        self._set_spinner_phase(SpinnerState.INVOKING_TOOLS_PHASE)
         if name == "skill_view":
             self._render_skill_start(data)
+        elif name in _SELF_RENDERING_TOOLS:
+            pass  # owns its UI; a generic preview would duplicate it
+        else:
+            self._render_tool_invocation(name, data)
         if self.planned_count == 0 and name not in SELF_RECORDING_ACTION_TOOL_NAMES:
             self.session.record("cli_agent", self.message)
         self.planned_count += 1
+
+    def _set_spinner_phase(self, label: str) -> None:
+        spinner = get_investigation_spinner()
+        if spinner is not None:
+            spinner.set_phase(label)
 
     def _advance_spinner_verb(self, data: dict[str, Any]) -> None:
         """Rotate the prompt spinner's thinking verb every two agent steps.
@@ -160,6 +178,17 @@ class ActionRenderObserver:
         line = Text()
         line.append("Skill ", style=BOLD_SKILL)
         line.append(slug, style=HIGHLIGHT)
+        self.console.print()
+        self.console.print(line)
+
+    def _render_tool_invocation(self, name: str, data: dict[str, Any]) -> None:
+        """Show the running tool: orange verb, then payload."""
+        args = data.get("input")
+        label, content = tool_call_display(name, args if isinstance(args, dict) else {})
+        line = Text()
+        line.append(label, style=str(HIGHLIGHT))
+        if content:
+            line.append(f" {content}", style=str(BRAND))
         self.console.print()
         self.console.print(line)
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -130,8 +130,11 @@ class ActionRenderObserver:
         self.planned_count += 1
 
     def _set_spinner_phase(self, label: str) -> None:
+        # Only relabel an already-running spinner; never activate one. Literal
+        # slash turns suppress the spinner (turn_start skips ``start()``) and
+        # never call ``stop()``, so activating it here would leave it on screen.
         spinner = get_investigation_spinner()
-        if spinner is not None:
+        if spinner is not None and getattr(spinner, "streaming", False):
             spinner.set_phase(label)
 
     def _advance_spinner_verb(self, data: dict[str, Any]) -> None:

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import re
 import time
 
-import pytest
-
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 
 _GLYPHS = SpinnerState._SPINNER_FRAMES
@@ -55,8 +53,20 @@ def test_spinner_renders_elapsed_seconds_and_cancel_hint() -> None:
 
     rendered = spinner.inline_spinner_ansi()
 
-    assert "(8s)" in rendered
-    assert "esc to cancel" in rendered
+    assert "[ 8s]" in rendered
+    assert "(Press ESC to stop)" in rendered
+    assert SpinnerState.EXECUTING_PHASE in rendered
+
+
+def test_spinner_invoking_tools_phase_matches_factory_copy() -> None:
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
+
+    rendered = spinner.inline_spinner_ansi()
+
+    assert SpinnerState.INVOKING_TOOLS_PHASE in rendered
+    assert "(Press ESC to stop)" in rendered
 
 
 def test_spinner_empty_when_not_streaming() -> None:
@@ -65,17 +75,3 @@ def test_spinner_empty_when_not_streaming() -> None:
     spinner.start()
     spinner.stop()
     assert spinner.inline_spinner_ansi() == ""
-
-
-def test_spinner_clips_long_phase_to_one_prompt_row(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Long investigation labels must not soft-wrap the prompt prefix row."""
-    monkeypatch.setattr(
-        "surfaces.interactive_shell.runtime.core.state.prompt_line_width",
-        lambda: 40,
-    )
-    spinner = SpinnerState()
-    spinner.set_phase("Gathering Datadog APM spans for checkout-service p99 regression analysis")
-    rendered = re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", spinner.inline_spinner_ansi())
-    assert "\n" not in rendered
-    assert len(rendered) <= 40
-    assert rendered.endswith("…") or "esc to cancel" in rendered

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -75,3 +75,15 @@ def test_spinner_empty_when_not_streaming() -> None:
     spinner.start()
     spinner.stop()
     assert spinner.inline_spinner_ansi() == ""
+
+
+def test_inline_spinner_clips_a_long_phase_to_one_prompt_row() -> None:
+    """A long phase label must not soft-wrap past the one reserved prompt row."""
+    from surfaces.shared.terminal.prompt_layout import prompt_line_width
+
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_phase("X" * 400)
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
+
+    assert len(rendered) <= prompt_line_width()

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -700,9 +700,7 @@ class TestSpinnerState:
         spinner.start()
         spinner.bytes_in = 1234 * _CHARS_PER_TOKEN  # = 1234 tokens
         rendered = _strip_ansi(spinner.inline_spinner_ansi())
-        # The verb is randomly picked from the tier pools per turn —
-        # any of them followed by ``…`` is acceptable.
-        assert any(f"{verb}…" in rendered for verb in self._all_verbs(spinner))
+        assert loop_state.SpinnerState.EXECUTING_PHASE in rendered
         # 1234 tokens → "1.2k" via format_token_count_short.
         assert "1.2k tokens" in rendered
         # Spinner glyph from the brail palette.
@@ -734,17 +732,16 @@ class TestSpinnerState:
 
     def test_streaming_inline_spinner_verb_stays_constant_across_calls(self) -> None:
         """A turn's verb is fixed at ``start()`` so the indicator
-        doesn't flicker between words mid-stream."""
+        doesn't flicker between words mid-stream. The visible label is the
+        executing phase; the verb is kept for investigation-stage fallback.
+        """
         spinner = loop_state.SpinnerState()
         spinner.start()
-        verbs_seen: set[str] = set()
+        first = spinner._verb
         for _ in range(20):
             rendered = _strip_ansi(spinner.inline_spinner_ansi())
-            for verb in self._all_verbs(spinner):
-                if f"{verb}…" in rendered:
-                    verbs_seen.add(verb)
-                    break
-        assert len(verbs_seen) == 1, f"verb changed mid-turn — saw {verbs_seen}"
+            assert spinner._verb == first
+            assert loop_state.SpinnerState.EXECUTING_PHASE in rendered
 
     def test_advance_verb_changes_verb_between_agent_steps(self) -> None:
         """``advance_verb`` re-rolls the verb and never repeats the current one."""
@@ -871,6 +868,7 @@ class TestSpinnerState:
         """
         spinner = loop_state.SpinnerState()
         rendered = _strip_ansi(spinner.idle_hint_ansi())
+        assert rendered.startswith("Ready")
         assert "/ for commands" in rendered
         assert "tab tool details" in rendered
         assert "history" in rendered
@@ -900,15 +898,15 @@ class TestSpinnerState:
         assert "esc to clear" in rendered
         assert "/ for commands" in rendered
 
-    def test_inline_spinner_contains_esc_to_cancel_when_streaming(self) -> None:
+    def test_inline_spinner_contains_stop_hint_when_streaming(self) -> None:
         """During streaming the inline spinner (shown in the prompt's first
-        reserved line) carries the ``esc to cancel`` hint so the user can
+        reserved line) carries ``(Press ESC to stop)`` so the user can
         interrupt the dispatch.
         """
         spinner = loop_state.SpinnerState()
         spinner.start()
         rendered = _strip_ansi(spinner.inline_spinner_ansi())
-        assert "esc to cancel" in rendered
+        assert "(Press ESC to stop)" in rendered
         # Idle hint text should NOT appear in the spinner row.
         assert "/ for commands" not in rendered
 

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -41,9 +41,11 @@ def test_slash_invoke_tool_start_does_not_record_cli_agent() -> None:
         {"name": "slash_invoke", "input": {"command": "/model", "args": ["show"]}},
     )
 
+    # slash_invoke is self-recording, so no cli_agent history row is written,
+    # but the live tool-call preview still shows what is running.
     assert session.history == []
     assert observer.planned_count == 1
-    assert buffer.getvalue() == ""
+    assert "/model show" in buffer.getvalue()
 
 
 def test_shell_run_tool_start_does_not_record_cli_agent() -> None:
@@ -281,12 +283,14 @@ def test_non_skill_tool_end_prints_nothing() -> None:
     observer, buffer = _skill_observer()
 
     observer("tool_start", {"id": "t1", "name": "shell_run", "input": {"command": "true"}})
+    after_start = buffer.getvalue()
     observer(
         "tool_end",
         {"id": "t1", "name": "shell_run", "input": {"command": "true"}, "output": {"ok": True}},
     )
 
-    assert buffer.getvalue() == ""
+    # tool_end adds a child line only for skill_view; a non-skill tool_end is silent.
+    assert buffer.getvalue() == after_start
 
 
 def test_literal_slash_command_records_single_history_entry(

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -360,3 +360,23 @@ def test_chat_turn_records_single_cli_agent_history_entry() -> None:
     # The turn's history recording must not advance the prompt number; only the
     # submission itself does.
     assert _prompt_turn_number(session) == 2
+
+
+def test_set_spinner_phase_does_not_activate_a_suppressed_spinner() -> None:
+    """A suppressed (never-started) spinner must not be activated by the observer.
+
+    Literal slash turns skip spinner start()/stop(); activating it on
+    llm_start / tool_start would leave the spinner on screen after the command.
+    """
+    from surfaces.interactive_shell.runtime.core.state import SpinnerState
+    from surfaces.shared.terminal.output.console_state import set_investigation_spinner
+
+    observer, _buffer = _observer_with_buffer()
+    spinner = SpinnerState()  # not started -> streaming False (suppressed)
+    set_investigation_spinner(spinner)
+    try:
+        observer("llm_start", {"iteration": 0})
+        observer("tool_start", {"name": "slash_invoke", "input": {"command": "/model"}})
+        assert spinner.streaming is False
+    finally:
+        set_investigation_spinner(None)

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -423,7 +423,7 @@ class TestResolvePromptPrefix:
             idle_hint=spinner.idle_hint_ansi(),
         )
         assert "preview line" not in prefix
-        assert "esc to cancel" in _strip_ansi(prefix)
+        assert "Press ESC to stop" in _strip_ansi(prefix)
 
     def test_prefers_completion_preview_over_idle_hint(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/tools/test_description_contract.py
+++ b/tests/tools/test_description_contract.py
@@ -62,7 +62,6 @@ _MIN_REGISTRY_SIZE = 290
 _DESCRIPTION_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
     {
         "alert_sample",
-        "assistant_handoff",
         "cli_exec",
         "code_implement",
         "fix_sentry_issue_start",

--- a/tools/interactive_shell/actions/session_goal.py
+++ b/tools/interactive_shell/actions/session_goal.py
@@ -74,6 +74,21 @@ session_goal_tool = RegisteredTool(
         "the user asked to continue without pausing. Do not use for local shell "
         "work or a single-turn answer."
     ),
+    use_cases=[
+        (
+            "User asks to walk a multi-step checklist or keep going across turns "
+            "until a finish condition is met (e.g. a 5-step sequential process)"
+        ),
+        (
+            "Action handoff needs a durable SessionGoal so the host continues "
+            "outer turns until the checklist is done"
+        ),
+    ],
+    anti_examples=[
+        "One-shot Q&A or a single lookup that finishes this turn",
+        "Local shell / code-edit work that should use shell_run or update_plan",
+        "User only wants a written plan with no execution (use update_plan)",
+    ],
     input_schema=object_schema(
         properties={
             "condition": string_property(


### PR DESCRIPTION
Drives the prompt spinner from real agent events and shows what each tool
call is doing while it runs.

Loading spinner
- SpinnerState gains two phases — Thinking… and Invoking tools… — set by the
  action observer on llm_start / tool_start / tool_end, so the indicator
  reflects what the turn is actually doing.
- Spinner line redesign: a Ready idle hint, a one-row elapsed/token badge, and
  a "(Press ESC to stop)" hint (replacing the old "esc to cancel" tail).

Live tool-call preview
- Non-skill tool calls render a one-line preview (verb + payload) via
  tool_call_display; investigation_start keeps its own progress UI, so the
  generic preview doesn't duplicate it.

