### PR TITLE
feat(interactive-shell): ask-user hand-off menus

### DIFF
--- a/core/agent_harness/session/pending_choice.py
+++ b/core/agent_harness/session/pending_choice.py
@@ -1,16 +1,36 @@
-"""Structured multiple-choice question awaiting the user's menu selection.
+"""Structured questions awaiting the user's menu selection.
 
 The ``ask_user_choice`` action tool writes a :class:`PendingUserChoice` onto the
 session and queues the ``/choose`` slash command; the shell's ``/choose`` handler
 pops the object and renders it as an inline arrow-key menu with exclusive stdin.
-The selected option label is then auto-submitted as the next user message, so the
-agent receives the decision as structured conversation input — no prose scraping
+
+A single decision uses ``title`` + ``options``. Several blockers go in
+``questions`` as one payload (batched Ask User) — not one question per turn.
+Selected labels are auto-submitted as the next user message, so the agent
+receives the decision as structured conversation input — no prose scraping
 and no "Reply with 1, 2, or 3" free-text parsing.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+
+_ANSWER_HEADER = re.compile(r"^(\d+)\.\s+(.+)$")
+
+
+@dataclass(frozen=True, slots=True)
+class AskUserQuestion:
+    """One question in a batched Ask User payload."""
+
+    label: str
+    """Short breadcrumb name (e.g. ``Codebase``, ``Metrics``)."""
+
+    title: str
+    """Full question shown for this step."""
+
+    options: tuple[str, ...]
+    """Option labels in display order."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,10 +38,62 @@ class PendingUserChoice:
     """A blocking decision the user makes via the shell selection menu."""
 
     title: str
-    """Short question rendered as the menu title."""
+    """Wizard header, or the question when ``questions`` is empty."""
 
     options: tuple[str, ...]
-    """Option labels in display order; the selected label becomes the next user message."""
+    """Option labels for the single-question path."""
+
+    questions: tuple[AskUserQuestion, ...] = ()
+    """Batched Ask User questions; empty means a single ``title`` + ``options`` menu."""
+
+    def items(self) -> tuple[AskUserQuestion, ...]:
+        """Questions to render: ``questions`` when set, otherwise one from title/options."""
+        if self.questions:
+            return self.questions
+        return (AskUserQuestion(label="", title=self.title, options=self.options),)
+
+    def is_batch(self) -> bool:
+        """True when the menu is a multi-question Ask User wizard."""
+        return len(self.items()) >= 2
 
 
-__all__ = ["PendingUserChoice"]
+def format_ask_user_answers(
+    questions: tuple[AskUserQuestion, ...],
+    answers: tuple[str, ...],
+) -> str:
+    """Serialize Q→A pairs as the next user message after Ask User."""
+    if len(questions) != len(answers):
+        raise ValueError("questions and answers must be the same length")
+    blocks: list[str] = []
+    for index, (question, answer) in enumerate(zip(questions, answers, strict=True), start=1):
+        blocks.append(f"{index}. {question.title}\n{answer}")
+    return "\n\n".join(blocks)
+
+
+def parse_ask_user_answers(text: str) -> list[tuple[str, str]]:
+    """Parse :func:`format_ask_user_answers` output into ``(question, answer)`` pairs."""
+    stripped = text.strip()
+    if not stripped:
+        return []
+    pairs: list[tuple[str, str]] = []
+    for block in stripped.split("\n\n"):
+        lines = [line.rstrip() for line in block.splitlines() if line.strip()]
+        if len(lines) < 2:
+            return []
+        match = _ANSWER_HEADER.match(lines[0])
+        if match is None:
+            return []
+        question = match.group(2).strip()
+        answer = "\n".join(lines[1:]).strip()
+        if not question or not answer:
+            return []
+        pairs.append((question, answer))
+    return pairs
+
+
+__all__ = [
+    "AskUserQuestion",
+    "PendingUserChoice",
+    "format_ask_user_answers",
+    "parse_ask_user_answers",
+]

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -165,6 +165,10 @@ class SessionCore:
     """Structured multiple-choice question queued for the ``/choose`` selection
     menu — set by the ``ask_user_choice`` action tool, consumed once by the
     ``/choose`` handler."""
+
+    ask_user_rounds: int = 0
+    """Ask-User clarification rounds asked this workload; caps repeated batches.
+    Reset on a genuine user turn."""
     pending_recovery_note: str | None = None
     """WAL recovery note for the next action turn — set on ``/resume`` when the
     resumed session log holds tool intents that never committed (the process
@@ -408,6 +412,7 @@ class SessionCore:
         self.session_goal = None
         self.offered_upgrade_ctas.clear()
         self.pending_user_choice = None
+        self.ask_user_rounds = 0
         self.pending_recovery_note = None
         self.gather_unreachable_tools.clear()
         self.gather_unreachable_sources.clear()

--- a/core/agent_harness/spi/handoff.py
+++ b/core/agent_harness/spi/handoff.py
@@ -1,0 +1,21 @@
+"""Human hand-off types a host renders: the ask-user question and answer block.
+
+A surface renders :class:`AskUserQuestion` items as an interactive menu and
+round-trips the user's selections through :func:`format_ask_user_answers` /
+:func:`parse_ask_user_answers`. The hand-off marker itself lives in
+:mod:`core.agent_harness.spi.prompt_chrome`.
+"""
+
+from __future__ import annotations
+
+from core.agent_harness.session.pending_choice import (
+    AskUserQuestion,
+    format_ask_user_answers,
+    parse_ask_user_answers,
+)
+
+__all__ = [
+    "AskUserQuestion",
+    "format_ask_user_answers",
+    "parse_ask_user_answers",
+]

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -12,11 +12,12 @@ as the next user message so the agent receives the decision verbatim.
 from __future__ import annotations
 
 from rich.console import Console
-from rich.markup import escape
 
+from core.agent_harness.spi.handoff import format_ask_user_answers
 from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
+from surfaces.interactive_shell.ui.ask_user import CUSTOM_OPTION, repl_ask_user
 from surfaces.shared.terminal.components.choice_menu import (
     print_valid_choice_list,
     repl_choose_one,
@@ -33,26 +34,43 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         return True
 
     if not repl_tty_interactive():
-        # Non-TTY fallback: show the options; the user replies in plain text.
-        print_valid_choice_list(
-            console,
-            title=escape(pending.title),
-            choices=list(pending.options),
-        )
+        for question in pending.items():
+            print_valid_choice_list(
+                console,
+                title=question.title,
+                choices=list(question.options),
+            )
         console.print(f"[{ui_theme.DIM}]Reply with the option you want.[/]")
         return True
 
-    picked = repl_choose_one(
-        title=pending.title,
-        choices=[(option, option) for option in pending.options],
+    items = pending.items()
+    if pending.is_batch():
+        picked = repl_ask_user(items)
+        if picked is None:
+            console.print(f"[{ui_theme.DIM}]Selection cancelled — type a reply instead.[/]")
+            session.terminal.awaiting_handoff_answer = False
+            return True
+        if CUSTOM_OPTION in picked:
+            console.print(f"[{ui_theme.DIM}]Type your answers in the prompt.[/]")
+            session.terminal.awaiting_handoff_answer = True
+            return True
+        session.terminal.set_auto_command(format_ask_user_answers(items, picked))
+        session.terminal.awaiting_handoff_answer = True
+        return True
+
+    picked_one = repl_choose_one(
+        title=items[0].title,
+        choices=[(option, option) for option in items[0].options],
     )
-    if picked is None:
+    if picked_one is None:
         console.print(f"[{ui_theme.DIM}]Selection cancelled — type a reply instead.[/]")
+        session.terminal.awaiting_handoff_answer = False
         return True
 
     # Auto-submit the chosen label as the next user message; the prompt echo is
     # the confirmation, so nothing is printed here.
-    session.terminal.set_auto_command(picked)
+    session.terminal.set_auto_command(picked_one)
+    session.terminal.awaiting_handoff_answer = True
     return True
 
 

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -51,8 +51,15 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
             session.terminal.awaiting_handoff_answer = False
             return True
         if CUSTOM_OPTION in picked:
-            console.print(f"[{ui_theme.DIM}]Type your answers in the prompt.[/]")
+            # Keep the answers already chosen; only the "type your own" slots
+            # need the user. Prefill the Q→A block with the picked answers filled
+            # and the custom slots blank, and do NOT auto-submit — the user
+            # completes the blanks and presses Enter.
+            partial = tuple("" if answer == CUSTOM_OPTION else answer for answer in picked)
+            console.print(f"[{ui_theme.DIM}]Fill in your own answer, then press Enter.[/]")
+            session.terminal.pending_prompt_default = format_ask_user_answers(items, partial)
             session.terminal.awaiting_handoff_answer = True
+            session.terminal.notify_prompt_changed()
             return True
         session.terminal.set_auto_command(format_ask_user_answers(items, picked))
         session.terminal.awaiting_handoff_answer = True

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -281,12 +281,17 @@ class InteractiveShellController:
                 self.state.deliver_confirmation(text)
                 return True
             case SubmitTurn(text=text, wait_until_idle=wait, warning=warning):
-                # Read before render_submitted_prompt — that clears the flag.
+                # Read before render_submitted_prompt — that clears the autosubmit
+                # and handoff-answer flags.
+                autosubmitted = bool(self.session.terminal.last_input_autosubmitted)
+                ask_user_answers = bool(self.session.terminal.awaiting_handoff_answer)
+                if not autosubmitted and not ask_user_answers:
+                    # A genuine typed turn starts a new workload: reset the ask-user
+                    # round counter so the two-round cap is per-request, not per-session.
+                    self.session.ask_user_rounds = 0
                 wait_for_turn = _should_wait_until_turn_finishes(
                     exclusive_stdin=wait,
-                    goal_condition_autosubmitted=bool(
-                        self.session.terminal.last_input_autosubmitted
-                    ),
+                    goal_condition_autosubmitted=autosubmitted and not ask_user_answers,
                 )
                 if warning:
                     self.echo_console.print(warning)

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -99,6 +99,12 @@ class TerminalSession:
     so the work turn can show a distinct ``↗ /goal`` marker above ``[N] ❯``.
     """
 
+    awaiting_handoff_answer: bool = False
+    """True when the next submitted line answers a human hand-off question.
+
+    Set by ``ask_user_choice`` (and the ``/choose`` pick). Cleared when the
+    submitted prompt is painted so the answer uses the brand colour."""
+
     exclusive_stdin_active: bool = False
     """True while a turn is running with exclusive stdin reserved (no live prompt).
 

--- a/surfaces/interactive_shell/ui/ask_user.py
+++ b/surfaces/interactive_shell/ui/ask_user.py
@@ -1,0 +1,268 @@
+"""Batched Ask User wizard for the interactive shell.
+
+One payload with several questions: header **Ask User**, breadcrumb
+``● Shape → ○ Onset → ○ Signals`` (filled = answered, open = remaining),
+Tab / Shift+Tab between questions, ↑↓ through options, Enter or Submit to
+select. Esc cancels (the agent does not continue). ``Or type your own...``
+skips auto-submit so the user can type.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from core.agent_harness.spi.handoff import AskUserQuestion
+from infrastructure.safety.terminal_output import strip_terminal_controls
+from infrastructure.terminal import theme as ui_theme
+from surfaces.shared.terminal.components.choice_menu import (
+    erase_menu_lines,
+    menu_columns,
+    repl_tty_interactive,
+    write_menu_line,
+)
+from surfaces.shared.terminal.components.key_reader import (
+    flush_pending_input,
+    read_key_unix,
+    read_key_windows,
+    restore_stdin_terminal,
+)
+
+CUSTOM_OPTION = "Or type your own..."
+_HEADER = "Ask User"
+_SUBMIT = "Submit"
+_HINT = "Tab/⇧Tab or ←/→ Questions    ↑/↓ Navigate    Enter/1-9 Select    Esc cancel"
+_BREADCRUMB_SEP = " → "
+_MENU_LEADING_LINES = 1
+_FILLED = "●"
+_OPEN = "○"
+
+
+def format_ask_user_breadcrumb(
+    questions: tuple[AskUserQuestion, ...] | list[AskUserQuestion],
+    *,
+    answered: tuple[bool, ...] | list[bool],
+) -> str:
+    """Breadcrumb: ● replied, ○ not yet (current is distinguished by colour, not glyph)."""
+    return _BREADCRUMB_SEP.join(
+        f"{glyph} {label}" for glyph, label in _breadcrumb_items(questions, answered)
+    )
+
+
+def _breadcrumb_items(
+    questions: tuple[AskUserQuestion, ...] | list[AskUserQuestion],
+    answered: tuple[bool, ...] | list[bool],
+) -> list[tuple[str, str]]:
+    """``(glyph, label)`` pairs shared by plain and ANSI breadcrumbs."""
+    items: list[tuple[str, str]] = []
+    for index, question in enumerate(questions):
+        replied = bool(answered[index]) if index < len(answered) else False
+        glyph = _FILLED if replied else _OPEN
+        label = strip_terminal_controls(question.label).strip() or f"Q{index + 1}"
+        items.append((glyph, label))
+    return items
+
+
+def _option_labels(question: AskUserQuestion) -> list[str]:
+    return [strip_terminal_controls(option) for option in question.options] + [CUSTOM_OPTION]
+
+
+def _menu_height(question: AskUserQuestion) -> int:
+    # leading, header, breadcrumb, rule, question, choices, Submit, blank, hint
+    return _MENU_LEADING_LINES + 1 + 1 + 1 + 1 + len(_option_labels(question)) + 1 + 1 + 1
+
+
+def _row_count(question: AskUserQuestion) -> int:
+    return len(_option_labels(question)) + 1
+
+
+def _breadcrumb_ansi(
+    questions: tuple[AskUserQuestion, ...],
+    *,
+    current: int,
+    answered: tuple[bool, ...],
+) -> str:
+    """Glyph marks reply state (● replied, ○ not); colour marks position.
+
+    Current step in the accent colour, replied steps in brand (same green as
+    answers in the transcript), remaining steps dimmed.
+    """
+    parts: list[str] = []
+    for index, (glyph, label) in enumerate(_breadcrumb_items(questions, answered)):
+        if index:
+            parts.append(f"{ui_theme.DIM_COUNTER_ANSI}{_BREADCRUMB_SEP}{ui_theme.ANSI_RESET}")
+        if index == current:
+            style = ui_theme.PROMPT_ACCENT_ANSI
+        elif answered[index] if index < len(answered) else False:
+            style = ui_theme.BRAND_ANSI
+        else:
+            style = ui_theme.DIM_COUNTER_ANSI
+        parts.append(f"{style}{glyph} {label}{ui_theme.ANSI_RESET}")
+    return "".join(parts)
+
+
+def _padded_row(marker: str, label: str, width: int) -> str:
+    content = f" {marker} {label}"
+    padding = width - len(content)
+    return content + (" " * padding if padding > 0 else "")
+
+
+def _draw_ask_user(
+    *,
+    questions: tuple[AskUserQuestion, ...],
+    current: int,
+    answers: list[str | None],
+    option_index: int,
+    erase_lines: int,
+) -> None:
+    question = questions[current]
+    labels = _option_labels(question)
+    answered = tuple(item is not None for item in answers)
+    breadcrumb = _breadcrumb_ansi(questions, current=current, answered=answered)
+    width = menu_columns()
+    if erase_lines:
+        erase_menu_lines(erase_lines)
+    for _ in range(_MENU_LEADING_LINES):
+        write_menu_line()
+    write_menu_line(f"{ui_theme.PROMPT_ACCENT_ANSI}{_HEADER}{ui_theme.ANSI_RESET}")
+    write_menu_line(breadcrumb)
+    write_menu_line(f"{ui_theme.DIM_COUNTER_ANSI}{'─' * width}{ui_theme.ANSI_RESET}")
+    write_menu_line(
+        f"{ui_theme.TEXT_ANSI}{strip_terminal_controls(question.title)}{ui_theme.ANSI_RESET}"
+    )
+    submit_row = len(labels)
+    for position, label in enumerate(labels):
+        is_selected = position == option_index
+        numbered_label = f"{position + 1}. {label}"
+        marker = ">" if is_selected else " "
+        row = _padded_row(marker, numbered_label, width)
+        if is_selected:
+            write_menu_line(f"{ui_theme.MENU_SELECTION_ROW_ANSI}{row}{ui_theme.ANSI_RESET}")
+        else:
+            write_menu_line(f"{ui_theme.DIM_COUNTER_ANSI}{row}{ui_theme.ANSI_RESET}")
+    submit_selected = option_index == submit_row
+    submit_line = _padded_row(">" if submit_selected else " ", _SUBMIT, width)
+    if submit_selected:
+        write_menu_line(f"{ui_theme.MENU_SELECTION_ROW_ANSI}{submit_line}{ui_theme.ANSI_RESET}")
+    else:
+        write_menu_line(f"{ui_theme.PROMPT_ACCENT_ANSI}{submit_line}{ui_theme.ANSI_RESET}")
+    write_menu_line()
+    write_menu_line(f"{ui_theme.DIM_COUNTER_ANSI}{_HINT}{ui_theme.ANSI_RESET}")
+    sys.stdout.flush()
+
+
+def _erase_ask_user(question: AskUserQuestion) -> None:
+    erase_menu_lines(_menu_height(question))
+    sys.stdout.flush()
+
+
+def _read_wizard_action() -> str:
+    # Space must not confirm — leftover whitespace from the previous prompt
+    # would otherwise pick option 1 on every question before the user sees it.
+    if os.name == "nt":
+        return read_key_windows(space_confirms=False)
+    return read_key_unix(space_confirms=False)
+
+
+def _next_unanswered(answers: list[str | None], start: int) -> int:
+    n = len(answers)
+    for offset in range(n):
+        index = (start + offset) % n
+        if answers[index] is None:
+            return index
+    return start
+
+
+def repl_ask_user(
+    questions: tuple[AskUserQuestion, ...] | list[AskUserQuestion],
+) -> tuple[str, ...] | None:
+    """Show the Ask User wizard; return selected labels or None on Esc.
+
+    Only call when :func:`repl_tty_interactive` is True. A ``CUSTOM_OPTION``
+    value means the user chose to type that answer themselves.
+    """
+    from surfaces.shared.terminal.components.cpr_stdin import drain_stale_cpr_bytes
+
+    items = tuple(questions)
+    if len(items) < 2 or not repl_tty_interactive():
+        return None
+    drain_stale_cpr_bytes()
+    flush_pending_input()
+    answers: list[str | None] = [None] * len(items)
+    q_idx = 0
+    opt_idx = 0
+    option_focus = 0
+    first = True
+    current_height = 0
+    while True:
+        question = items[q_idx]
+        labels = _option_labels(question)
+        rows = _row_count(question)
+        opt_idx %= rows
+        _draw_ask_user(
+            questions=items,
+            current=q_idx,
+            answers=answers,
+            option_index=opt_idx,
+            erase_lines=0 if first else current_height,
+        )
+        if first:
+            # Drop the newline that submitted this turn / autosubmitted
+            # ``/choose``. Flush after the first draw so the menu is on
+            # screen before we wait — leftover Enter must not auto-pick.
+            flush_pending_input()
+            first = False
+        current_height = _menu_height(question)
+        action = _read_wizard_action()
+        if action in ("tab", "right"):
+            q_idx = min(q_idx + 1, len(items) - 1)
+            opt_idx = 0
+            option_focus = 0
+            continue
+        if action in ("shift_tab", "left"):
+            q_idx = max(q_idx - 1, 0)
+            opt_idx = 0
+            option_focus = 0
+            continue
+        if action == "up":
+            opt_idx = (opt_idx - 1) % rows
+            if opt_idx < len(labels):
+                option_focus = opt_idx
+            continue
+        if action == "down":
+            opt_idx = (opt_idx + 1) % rows
+            if opt_idx < len(labels):
+                option_focus = opt_idx
+            continue
+        selected: int | None = None
+        submit_row = len(labels)
+        if action == "enter":
+            selected = option_focus if opt_idx == submit_row else opt_idx
+            if selected < len(labels):
+                option_focus = selected
+        elif len(action) == 1 and action.isdigit():
+            picked = int(action) - 1
+            if 0 <= picked < len(labels):
+                selected = picked
+        if selected is not None:
+            answers[q_idx] = labels[selected]
+            if all(item is not None for item in answers):
+                _erase_ask_user(question)
+                restore_stdin_terminal()
+                return tuple(str(item) for item in answers)
+            q_idx = _next_unanswered(answers, q_idx + 1)
+            opt_idx = 0
+            option_focus = 0
+            continue
+        if action in ("cancel", "eof"):
+            _erase_ask_user(question)
+            restore_stdin_terminal()
+            return None
+        # ignore / unmapped
+
+
+__all__ = [
+    "CUSTOM_OPTION",
+    "format_ask_user_breadcrumb",
+    "repl_ask_user",
+]

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -1,0 +1,120 @@
+"""Detect and style human hand-off questions vs the user's answers.
+
+Questions the agent asks the user (a closing ``?``, or a Want-me-to offer)
+render in the highlight colour. The user's reply to that question uses the
+brand colour so the two are visually distinct in the transcript — the same
+split used for hand-off vs continuation.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.text import Text
+
+from core.agent_harness.spi.handoff import parse_ask_user_answers
+from core.agent_harness.spi.prompt_chrome import WANT_ME_TO_MARKER
+from infrastructure.safety.terminal_output import strip_terminal_controls
+from infrastructure.terminal import theme as ui_theme
+
+_QUESTION_MAX_CHARS = 400
+
+
+def _display_safe(text: str) -> str:
+    """Strip terminal controls while keeping newlines for multi-line questions."""
+    return "\n".join(strip_terminal_controls(line) for line in text.splitlines())
+
+
+def is_handoff_question(text: str) -> bool:
+    """True when ``text`` is a short question waiting on the user.
+
+    Structural only: a Want-me-to closer, or a short block whose last line
+    ends with ``?``. Does not scan user prose for intent keywords.
+    """
+    stripped = text.strip()
+    if not stripped or stripped.startswith("```"):
+        return False
+    if WANT_ME_TO_MARKER in stripped.lower():
+        return True
+    if len(stripped) > _QUESTION_MAX_CHARS:
+        return False
+    last = ""
+    for line in reversed(stripped.splitlines()):
+        candidate = line.strip().strip("*").strip()
+        if candidate:
+            last = candidate
+            break
+    return last.endswith("?")
+
+
+def last_assistant_asked_handoff(messages: list[tuple[str, str]]) -> bool:
+    """True when the most recent assistant turn is a hand-off question."""
+    for role, content in reversed(messages):
+        if role == "assistant":
+            return is_handoff_question(content)
+        if role == "user":
+            return False
+    return False
+
+
+def render_handoff_question(console: Console, text: str) -> None:
+    """Print a hand-off question in highlight, prefixed with ``?``."""
+    body = _display_safe(text.strip())
+    line = Text()
+    line.append("  ?  ", style=f"bold {ui_theme.HIGHLIGHT}")
+    line.append(body, style=str(ui_theme.HIGHLIGHT))
+    console.print()
+    console.print(line)
+    console.print()
+
+
+def render_handoff_answer_marker() -> Text:
+    """Dim marker painted above a submitted answer to a hand-off question."""
+    return Text("↗ answer", style=str(ui_theme.DIM))
+
+
+def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:
+    """Print Ask User Q→A: orange header, numbered questions, brand answers.
+
+    Each pair is a two-line block with a blank row after the header and
+    between items so the list is scannable.
+    """
+    console.print()
+    console.print(Text("Ask User", style=f"bold {ui_theme.HIGHLIGHT}"))
+    console.print()
+    for index, (question, answer) in enumerate(pairs):
+        if index:
+            console.print()
+        qline = Text()
+        qline.append(f"  {index + 1}.  ", style=str(ui_theme.DIM))
+        qline.append(_display_safe(question), style=str(ui_theme.TEXT))
+        console.print(qline)
+        aline = Text()
+        aline.append("      ", style=str(ui_theme.DIM))
+        aline.append(_display_safe(answer), style=str(ui_theme.BRAND))
+        console.print(aline)
+    console.print()
+
+
+def try_render_ask_user_submission(console: Console, text: str) -> bool:
+    """Render a batched Ask User answer block. True when the text matched."""
+    pairs = parse_ask_user_answers(text)
+    if len(pairs) < 2:
+        return False
+    render_ask_user_qa(console, pairs)
+    return True
+
+
+def handoff_answer_style() -> str:
+    """Brand colour for the user's answer text."""
+    return str(ui_theme.BRAND)
+
+
+__all__ = [
+    "handoff_answer_style",
+    "is_handoff_question",
+    "last_assistant_asked_handoff",
+    "render_ask_user_qa",
+    "render_handoff_answer_marker",
+    "render_handoff_question",
+    "try_render_ask_user_submission",
+]

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -84,8 +84,11 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
     that attached the goal.
     """
     stripped = text.strip()
-    # Internal exclusive-stdin turn — never echo ``/choose``.
+    # Internal exclusive-stdin turn — never echo ``/choose``. Clear the autosubmit
+    # flag the queued ``/choose`` carried so a genuine turn after a cancelled menu
+    # reads as a new workload (which resets the ask-user round counter).
     if stripped == "/choose" or stripped.startswith("/choose "):
+        session.terminal.last_input_autosubmitted = False
         return
     is_handoff_answer = bool(session.terminal.awaiting_handoff_answer)
     if not is_handoff_answer:

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -7,8 +7,15 @@ from prompt_toolkit.formatted_text import ANSI
 from rich.console import Console
 from rich.text import Text
 
+from core.agent_harness.spi.handoff import parse_ask_user_answers
 from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.runtime import Session
+from surfaces.interactive_shell.ui.handoff_questions import (
+    handoff_answer_style,
+    last_assistant_asked_handoff,
+    render_ask_user_qa,
+    render_handoff_answer_marker,
+)
 from surfaces.interactive_shell.ui.input_prompt.completion import completion_preview_hint_ansi
 from surfaces.interactive_shell.ui.input_prompt.layout import (
     _short_meta,
@@ -76,9 +83,29 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
     ``↗ /goal`` marker so the work turn is visually distinct from the slash
     that attached the goal.
     """
+    stripped = text.strip()
+    # Internal exclusive-stdin turn — never echo ``/choose``.
+    if stripped == "/choose" or stripped.startswith("/choose "):
+        return
+    is_handoff_answer = bool(session.terminal.awaiting_handoff_answer)
+    if not is_handoff_answer:
+        is_handoff_answer = last_assistant_asked_handoff(
+            list(getattr(session, "cli_agent_messages", []) or [])
+        )
+    session.terminal.awaiting_handoff_answer = False
+    ask_user_pairs = parse_ask_user_answers(stripped) if is_handoff_answer else []
+    if len(ask_user_pairs) >= 2:
+        # Keep the Ask User block in the transcript (Q white, A brand). Claim the
+        # turn number so the next prompt still advances; do not paint a fake
+        # ``[N] ❯`` — leave this as the Ask User card.
+        session.terminal.claim_turn_number()
+        render_ask_user_qa(console, ask_user_pairs)
+        return
     autosubmitted = bool(session.terminal.last_input_autosubmitted)
     session.terminal.last_input_autosubmitted = False
-    if autosubmitted:
+    if is_handoff_answer:
+        console.print(render_handoff_answer_marker())
+    elif autosubmitted:
         # Keep this shorter than the condition — the ``[N] ❯`` line carries the
         # full text; this only answers "is this still /goal set or real work?".
         console.print(
@@ -93,13 +120,14 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
     rendered = Text()
     # Rich's Style.parse() reads the bare str value of a _LazyRichStyle (""),
     # so resolve to a concrete string at the call site to keep palette colors.
+    body_style = handoff_answer_style() if is_handoff_answer else str(ui_theme.TEXT)
     rendered.append(counter, style=str(ui_theme.DIM))
     rendered.append("❯ ", style=f"bold {ui_theme.HIGHLIGHT}")
-    rendered.append(lines[0], style=str(ui_theme.TEXT))
+    rendered.append(lines[0], style=body_style)
     for line in lines[1:]:
         rendered.append("\n")
         rendered.append(continuation_prefix, style=str(ui_theme.DIM))
-        rendered.append(line, style=str(ui_theme.TEXT))
+        rendered.append(line, style=body_style)
     console.print(rendered)
 
 

--- a/surfaces/shared/terminal/components/choice_menu.py
+++ b/surfaces/shared/terminal/components/choice_menu.py
@@ -19,9 +19,10 @@ from rich.console import Console
 from rich.markup import escape
 
 import infrastructure.terminal.theme as ui_theme
+from infrastructure.safety.terminal_output import strip_terminal_controls
 from surfaces.shared.terminal.components.key_reader import read_key_unix, read_key_windows
 
-_HINT = "↑↓/j/k/Tab  Enter/Space  Esc/q"
+_HINT = "↑↓ navigate    Enter select    Esc cancel"
 CRUMB_SEP = "  ›  "
 # Blank line after the submitted slash line before the menu header (all pickers).
 _MENU_LEADING_LINES = 1
@@ -102,6 +103,19 @@ def _pad(sym: str, label: str, width: int) -> str:
     return content + (" " * pad if pad > 0 else "")
 
 
+def _sanitize_menu(
+    title: str,
+    crumb: str,
+    labels: list[str],
+) -> tuple[str, str, list[str]]:
+    """Strip model-supplied controls before raw ANSI write or row counting."""
+    return (
+        strip_terminal_controls(title),
+        strip_terminal_controls(crumb),
+        [strip_terminal_controls(label) for label in labels],
+    )
+
+
 def _menu_height(crumb: str, labels: list[str]) -> int:
     # leading, title, [crumb], rule, blank, choices, blank, hint
     return _MENU_LEADING_LINES + 1 + (1 if crumb else 0) + 1 + 1 + len(labels) + 1 + 1
@@ -147,6 +161,7 @@ def _draw_menu(
 ) -> None:
     out = sys.stdout
     w = _cols()
+    title, crumb, labels = _sanitize_menu(title, crumb, labels)
     if erase_lines:
         _erase_menu_block(erase_lines)
     for _ in range(_MENU_LEADING_LINES):
@@ -162,8 +177,9 @@ def _draw_menu(
     # choices
     for i, label in enumerate(labels):
         here = i == index
+        numbered = f"{i + 1}. {label}"
         sym = ">" if here else " "
-        padded = _pad(sym, label, w)
+        padded = _pad(sym, numbered, w)
         if here:
             write_menu_line(f"{ui_theme.MENU_SELECTION_ROW_ANSI}{padded}{ui_theme.ANSI_RESET}")
         else:
@@ -175,6 +191,7 @@ def _draw_menu(
 
 def _erase_menu(crumb: str, labels: list[str]) -> None:
     """Move cursor up to the start of this menu block and wipe it."""
+    _, crumb, labels = _sanitize_menu("", crumb, labels)
     height = _menu_height(crumb, labels)
     _erase_menu_block(height)
     sys.stdout.flush()
@@ -193,6 +210,7 @@ def _pick(
     """Draw an inline menu, let user navigate, erase on exit. Returns index or None."""
     if not labels:
         return None
+    title, crumb, labels = _sanitize_menu(title, crumb, labels)
     idx = initial_index % len(labels)
     height = _menu_height(crumb, labels)
     first = True
@@ -264,9 +282,11 @@ def print_valid_choice_list(
     """Print one choice per line for scan-friendly fallback/error messaging."""
     if not choices:
         return
+    title = escape(strip_terminal_controls(title))
     console.print(f"[{ui_theme.SECONDARY}]{title}[/]")
-    for choice in choices:
-        console.print(f"[{ui_theme.SECONDARY}]  - {escape(choice)}[/]")
+    for index, choice in enumerate(choices, start=1):
+        safe = escape(strip_terminal_controls(choice))
+        console.print(f"[{ui_theme.SECONDARY}]  {index}. {safe}[/]")
 
 
 __all__ = [

--- a/surfaces/shared/terminal/components/key_reader.py
+++ b/surfaces/shared/terminal/components/key_reader.py
@@ -6,7 +6,8 @@ terminal I/O lives in one place.
 
 Return values from :func:`read_key_unix` / :func:`read_key_windows`:
   ``"up"``, ``"down"``, ``"enter"``, ``"cancel"``, ``"tab"``,
-  ``"right"``, ``"left"``, ``"eof"``, ``"ignore"``.
+  ``"shift_tab"``, ``"right"``, ``"left"``, ``"1"``–``"9"``, ``"eof"``,
+  ``"ignore"``.
 """
 
 from __future__ import annotations
@@ -22,6 +23,22 @@ def flush_stdin_unix() -> None:
         import termios
 
         termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)  # type: ignore[attr-defined]
+
+
+def flush_pending_input() -> None:
+    """Drop leftover keypresses (Enter from the previous prompt, CPR, etc.).
+
+    Ask User must not treat the newline that submitted the last prompt — or
+    the ``/choose`` autosubmit — as answering every question with option 1.
+    """
+    flush_stdin_unix()
+    if os.name != "nt":
+        return
+    with contextlib.suppress(Exception):
+        import msvcrt  # type: ignore[import,attr-defined]
+
+        while msvcrt.kbhit():  # type: ignore[attr-defined]
+            msvcrt.getwch()  # type: ignore[attr-defined]
 
 
 def restore_stdin_terminal() -> None:
@@ -50,12 +67,16 @@ def restore_stdin_terminal() -> None:
         termios.tcflush(fd, termios.TCIFLUSH)  # type: ignore[attr-defined]
 
 
-def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
+def read_key_unix(
+    *,
+    also_cancel: tuple[bytes, ...] = (),
+    space_confirms: bool = True,
+) -> str:
     """Read one logical keypress in raw mode; return a normalised key name.
 
     Possible return values: ``"up"``, ``"down"``, ``"enter"``,
-    ``"cancel"``, ``"tab"``, ``"right"``, ``"left"``, ``"eof"``,
-    ``"ignore"``.
+    ``"cancel"``, ``"tab"``, ``"shift_tab"``, ``"right"``, ``"left"``,
+    ``"1"``–``"9"``, ``"eof"``, ``"ignore"``.
 
     ``also_cancel`` treats additional single-byte keys as ``"cancel"`` (e.g.
     ``(b"s", b"S")`` for an explicit skip shortcut).
@@ -74,10 +95,12 @@ def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
         b = ch[0]
         if b in (3, 4) or ch in also_cancel:  # Ctrl-C / Ctrl-D / caller shortcuts
             return "cancel"
-        if b in (10, 13, 32):  # LF / CR / Space
+        if b in (10, 13) or (space_confirms and b == 32):  # LF / CR / optional Space
             return "enter"
         if b == 9:  # Tab
             return "tab"
+        if 0x31 <= b <= 0x39:  # 1-9
+            return chr(b)
         if ch in (b"j", b"J"):
             return "down"
         if ch in (b"k", b"K"):
@@ -97,6 +120,8 @@ def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
                         return "right"
                     if arr == b"D":
                         return "left"
+                    if arr == b"Z":
+                        return "shift_tab"
                     # Not an arrow key — drain the rest of the CSI sequence so
                     # bytes like "0;1R" from a CPR (ESC[row;colR) don't leak into
                     # the next read or the prompt buffer as literal characters.
@@ -111,12 +136,16 @@ def read_key_unix(*, also_cancel: tuple[bytes, ...] = ()) -> str:
         termios.tcsetattr(fd, termios.TCSADRAIN, old)  # type: ignore[attr-defined]
 
 
-def read_key_windows(*, also_cancel: tuple[bytes, ...] = ()) -> str:
+def read_key_windows(
+    *,
+    also_cancel: tuple[bytes, ...] = (),
+    space_confirms: bool = True,
+) -> str:
     """Read one logical keypress on Windows; return a normalised key name.
 
     Possible return values: ``"up"``, ``"down"``, ``"enter"``,
-    ``"cancel"``, ``"tab"``, ``"right"``, ``"left"``, ``"eof"``,
-    ``"ignore"``.
+    ``"cancel"``, ``"tab"``, ``"shift_tab"``, ``"right"``, ``"left"``,
+    ``"1"``–``"9"``, ``"eof"``, ``"ignore"``.
 
     ``also_cancel`` treats additional single-byte keys as ``"cancel"``.
     """
@@ -125,10 +154,12 @@ def read_key_windows(*, also_cancel: tuple[bytes, ...] = ()) -> str:
     ch = msvcrt.getch()  # type: ignore[attr-defined]
     if ch in (b"\x03", b"\x1b") or ch in also_cancel:
         return "cancel"
-    if ch in (b"\r", b"\n", b" "):
+    if ch in (b"\r", b"\n") or (space_confirms and ch == b" "):
         return "enter"
     if ch == b"\t":
         return "tab"
+    if len(ch) == 1 and b"1" <= ch <= b"9":
+        return str(ch.decode("ascii"))
     if ch in (b"j", b"J"):
         return "down"
     if ch in (b"k", b"K"):
@@ -145,8 +176,16 @@ def read_key_windows(*, also_cancel: tuple[bytes, ...] = ()) -> str:
             return "right"
         if ch2 == b"K":
             return "left"
+        if ch2 == b"\x0f":
+            return "shift_tab"
         return "ignore"
     return "ignore"
 
 
-__all__ = ["flush_stdin_unix", "read_key_unix", "read_key_windows", "restore_stdin_terminal"]
+__all__ = [
+    "flush_pending_input",
+    "flush_stdin_unix",
+    "read_key_unix",
+    "read_key_windows",
+    "restore_stdin_terminal",
+]

--- a/tests/core/agent/orchestration/test_ask_choice_tool.py
+++ b/tests/core/agent/orchestration/test_ask_choice_tool.py
@@ -131,3 +131,72 @@ def test_too_many_options_is_rejected() -> None:
     options = [f"Option {index}" for index in range(9)]
     result = execute_ask_user_choice_tool({"title": _TITLE, "options": options}, _ctx())
     assert result["ok"] is False
+
+
+_QUESTIONS = [
+    {
+        "label": "Codebase",
+        "title": "Where does the /api/orders service live?",
+        "options": ["Hypothetical/demo scenario, no real code", "I'll point you at a repo"],
+    },
+    {
+        "label": "Metrics",
+        "title": "How should I get the p99 latency data?",
+        "options": ["I'll paste the raw numbers/graph description", "Query Datadog"],
+    },
+    {
+        "label": "Window",
+        "title": "What's the time window of the p99 regression?",
+        "options": ["Last 7 days", "Last 24 hours"],
+    },
+]
+
+
+def test_batched_questions_queue_one_ask_user_menu() -> None:
+    session = Session()
+    ctx = _ctx(session=session)
+
+    result = execute_ask_user_choice_tool(
+        {"title": "Ask User", "questions": _QUESTIONS},
+        ctx,
+    )
+
+    assert result["ok"] is True
+    assert result["menu"] == "queued"
+    assert "update_plan" in result["instruction"]
+    pending = session.pending_user_choice
+    assert pending is not None
+    assert pending.is_batch() is True
+    assert len(pending.questions) == 3
+    assert pending.questions[0].label == "Codebase"
+    assert session.terminal.pending_prompt_default == "/choose"
+    assert session.terminal.awaiting_handoff_answer is True
+
+
+def test_questions_only_payload_is_valid_and_queues() -> None:
+    """The model omits title when sending a batched questions payload."""
+    session = Session()
+    error = ask_user_choice_tool.validate_public_input({"questions": _QUESTIONS})
+    assert error is None
+    result = execute_ask_user_choice_tool({"questions": _QUESTIONS}, _ctx(session=session))
+    assert result["ok"] is True
+    assert result["menu"] == "queued"
+    assert session.pending_user_choice is not None
+    assert session.pending_user_choice.title == "Ask User"
+
+
+def test_one_item_questions_array_is_rejected() -> None:
+    result = execute_ask_user_choice_tool(
+        {"title": "Ask User", "questions": _QUESTIONS[:1]},
+        _ctx(),
+    )
+    assert result["ok"] is False
+    assert "title and options" in result["error"]
+
+
+def test_malformed_question_is_rejected() -> None:
+    result = execute_ask_user_choice_tool(
+        {"title": "Ask User", "questions": [{"label": "Codebase", "title": "Where?"}]},
+        _ctx(),
+    )
+    assert result["ok"] is False

--- a/tests/core/agent_harness/session/test_session_characterization.py
+++ b/tests/core/agent_harness/session/test_session_characterization.py
@@ -29,6 +29,7 @@ _CORE_FIELDS = (
     "pending_schedule_offer",
     "pending_investigation_offer",
     "pending_user_choice",
+    "ask_user_rounds",
     "pending_recovery_note",
     # Outer multi-turn goal, plus the evidence-tier upgrade CTA it can offer.
     "session_goal",

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -150,6 +150,13 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
             "sessions_dir",
         }
     ),
+    "handoff": frozenset(
+        {
+            "AskUserQuestion",
+            "format_ask_user_answers",
+            "parse_ask_user_answers",
+        }
+    ),
 }
 
 RUNTIME = frozenset(

--- a/tests/fleet_monitoring/test_pricing.py
+++ b/tests/fleet_monitoring/test_pricing.py
@@ -81,11 +81,11 @@ class TestUsdPerTokenBlended:
 
 
 class TestGpt56Family:
-    """GPT-5.6 Sol / Terra / Luna (#3931) — the confirmed litellm gap.
+    """GPT-5.6 Sol / Terra / Luna — local overrides for published OpenAI rates.
 
-    litellm's bundled table doesn't have this family yet (GA'd 2026-07-09).
-    Rates from https://developers.openai.com/api/docs/pricing, per 1M
-    tokens: sol 5/30, terra 2.50/15, luna 1/6. Cached input is 90% off.
+    litellm ships rows for this family, but terra/luna diverge from
+    https://developers.openai.com/api/docs/pricing (per 1M tokens:
+    sol 5/30, terra 2.50/15, luna 1/6). Cached input is 90% off.
     """
 
     @pytest.mark.parametrize(

--- a/tests/interactive_shell/session/test_session_facets.py
+++ b/tests/interactive_shell/session/test_session_facets.py
@@ -22,7 +22,7 @@ from surfaces.interactive_shell.session.session import Session
 # pending_recovery_note (WAL recovery note for the first turn after /resume),
 # plus the session-goal trio (session_goal, pending_integration_setup_offer,
 # offered_upgrade_ctas).
-_CORE_FIELD_COUNT = 28
+_CORE_FIELD_COUNT = 29
 _FACET_FIELDS = ("alerts", "terminal")
 
 

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -152,9 +152,10 @@ def test_batch_answers_are_auto_submitted_as_qa_block(
     )
 
 
-def test_batch_custom_option_leaves_the_prompt_open(
+def test_batch_custom_option_preserves_the_picked_answers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A custom slot must not discard the fixed answers already picked."""
     session = Session()
     session.pending_user_choice = _BATCH_CHOICE
     console, buf = _console()
@@ -167,9 +168,13 @@ def test_batch_custom_option_leaves_the_prompt_open(
     )
 
     assert _handler(session, console) is True
+    # Not auto-submitted: the user completes the custom slot then presses Enter.
     assert session.terminal.pending_prompt_autosubmit is False
     assert session.terminal.awaiting_handoff_answer is True
-    assert "type your answers" in buf.getvalue().lower()
+    # The already-chosen answer is prefilled, not dropped.
+    prefill = session.terminal.pending_prompt_default or ""
+    assert "Hypothetical/demo scenario, no real code" in prefill
+    assert "fill in your own answer" in buf.getvalue().lower()
 
 
 def test_non_tty_batch_prints_every_question(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -8,8 +8,13 @@ import pytest
 from rich.console import Console
 
 import surfaces.interactive_shell.command_registry.choice_prompt as choice_prompt
-from core.agent_harness.session.pending_choice import PendingUserChoice
+from core.agent_harness.session.pending_choice import (
+    AskUserQuestion,
+    PendingUserChoice,
+    format_ask_user_answers,
+)
 from surfaces.interactive_shell.session import Session
+from surfaces.interactive_shell.ui.ask_user import CUSTOM_OPTION
 
 _CHOICE = PendingUserChoice(
     title="How should I handle the uncommitted changes?",
@@ -98,3 +103,85 @@ def test_choose_is_registered_with_exclusive_stdin(monkeypatch: pytest.MonkeyPat
     # interactive so the registration (not the test environment) is asserted.
     monkeypatch.setattr(input_policy, "repl_tty_interactive", lambda: True)
     assert input_policy.turn_needs_exclusive_stdin("/choose", Session()) is True
+
+
+_BATCH_QUESTIONS = (
+    AskUserQuestion(
+        label="Codebase",
+        title="Where does the /api/orders service live?",
+        options=("Hypothetical/demo scenario, no real code", "I'll point you at a repo"),
+    ),
+    AskUserQuestion(
+        label="Window",
+        title="What's the time window of the p99 regression?",
+        options=("Last 7 days", "Last 24 hours"),
+    ),
+)
+_BATCH_CHOICE = PendingUserChoice(
+    title="Ask User",
+    options=_BATCH_QUESTIONS[0].options,
+    questions=_BATCH_QUESTIONS,
+)
+
+
+def test_batch_answers_are_auto_submitted_as_qa_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = Session()
+    session.pending_user_choice = _BATCH_CHOICE
+    console, _buf = _console()
+    answers = (
+        "Hypothetical/demo scenario, no real code",
+        "Last 7 days",
+    )
+
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(choice_prompt, "repl_ask_user", lambda _questions: answers)
+    monkeypatch.setattr(
+        choice_prompt,
+        "repl_choose_one",
+        lambda **_kw: (_ for _ in ()).throw(AssertionError("single menu must not run")),
+    )
+
+    assert _handler(session, console) is True
+    assert session.pending_user_choice is None
+    assert session.terminal.pending_prompt_autosubmit is True
+    assert session.terminal.awaiting_handoff_answer is True
+    assert session.terminal.pending_prompt_default == format_ask_user_answers(
+        _BATCH_QUESTIONS, answers
+    )
+
+
+def test_batch_custom_option_leaves_the_prompt_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = Session()
+    session.pending_user_choice = _BATCH_CHOICE
+    console, buf = _console()
+
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(
+        choice_prompt,
+        "repl_ask_user",
+        lambda _questions: ("Hypothetical/demo scenario, no real code", CUSTOM_OPTION),
+    )
+
+    assert _handler(session, console) is True
+    assert session.terminal.pending_prompt_autosubmit is False
+    assert session.terminal.awaiting_handoff_answer is True
+    assert "type your answers" in buf.getvalue().lower()
+
+
+def test_non_tty_batch_prints_every_question(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = Session()
+    session.pending_user_choice = _BATCH_CHOICE
+    console, buf = _console()
+
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: False)
+
+    assert _handler(session, console) is True
+    output = buf.getvalue()
+    for question in _BATCH_QUESTIONS:
+        assert question.title in output
+        for option in question.options:
+            assert option in output

--- a/tests/interactive_shell/ui/test_ask_user.py
+++ b/tests/interactive_shell/ui/test_ask_user.py
@@ -1,0 +1,194 @@
+"""Ask User wizard: breadcrumb and key loop."""
+
+from __future__ import annotations
+
+from core.agent_harness.session.pending_choice import (
+    AskUserQuestion,
+    format_ask_user_answers,
+    parse_ask_user_answers,
+)
+from surfaces.interactive_shell.ui.ask_user import format_ask_user_breadcrumb, repl_ask_user
+
+_QUESTIONS = (
+    AskUserQuestion(
+        label="Codebase",
+        title="Where does the /api/orders service live?",
+        options=("Hypothetical/demo scenario, no real code", "I'll point you at a repo"),
+    ),
+    AskUserQuestion(
+        label="Metrics",
+        title="How should I get the p99 latency data?",
+        options=("I'll paste the raw numbers/graph description", "Query Datadog"),
+    ),
+    AskUserQuestion(
+        label="Window",
+        title="What's the time window of the p99 regression?",
+        options=("Last 7 days", "Last 24 hours"),
+    ),
+)
+
+
+def test_breadcrumb_hollow_until_a_question_is_replied() -> None:
+    # The current question is not filled just for being current — only replies fill it.
+    crumb = format_ask_user_breadcrumb(
+        _QUESTIONS,
+        answered=(False, False, False),
+    )
+    assert crumb == "○ Codebase → ○ Metrics → ○ Window"
+
+
+def test_breadcrumb_fills_only_replied_questions() -> None:
+    # Codebase is replied (●); Metrics unanswered stays ○.
+    crumb = format_ask_user_breadcrumb(
+        _QUESTIONS,
+        answered=(True, False, False),
+    )
+    assert crumb == "● Codebase → ○ Metrics → ○ Window"
+
+
+def test_answer_block_round_trips() -> None:
+    answers = (
+        "Hypothetical/demo scenario, no real code",
+        "I'll paste the raw numbers/graph description",
+        "Last 7 days",
+    )
+    text = format_ask_user_answers(_QUESTIONS, answers)
+    parsed = parse_ask_user_answers(text)
+    assert parsed == list(zip((q.title for q in _QUESTIONS), answers, strict=True))
+
+
+def test_wizard_enter_on_each_question_submits(monkeypatch) -> None:
+    actions = iter(["enter", "enter", "enter"])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user.repl_tty_interactive",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._read_wizard_action",
+        lambda: next(actions),
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._draw_ask_user",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._erase_ask_user",
+        lambda _question: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.cpr_stdin.drain_stale_cpr_bytes",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user.flush_pending_input",
+        lambda: None,
+    )
+
+    picked = repl_ask_user(_QUESTIONS)
+    assert picked == (
+        "Hypothetical/demo scenario, no real code",
+        "I'll paste the raw numbers/graph description",
+        "Last 7 days",
+    )
+
+
+def test_wizard_esc_cancels(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user.repl_tty_interactive",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._read_wizard_action",
+        lambda: "cancel",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._draw_ask_user",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._erase_ask_user",
+        lambda _question: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.cpr_stdin.drain_stale_cpr_bytes",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user.flush_pending_input",
+        lambda: None,
+    )
+
+    assert repl_ask_user(_QUESTIONS) is None
+
+
+def test_wizard_flushes_leftover_keys_before_reading(monkeypatch) -> None:
+    flushed = {"count": 0}
+
+    def _flush() -> None:
+        flushed["count"] += 1
+
+    actions = iter(["enter", "enter", "enter"])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user.repl_tty_interactive",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._read_wizard_action",
+        lambda: next(actions),
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._draw_ask_user",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._erase_ask_user",
+        lambda _question: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.cpr_stdin.drain_stale_cpr_bytes",
+        lambda: None,
+    )
+    monkeypatch.setattr("surfaces.interactive_shell.ui.ask_user.flush_pending_input", _flush)
+
+    assert repl_ask_user(_QUESTIONS) is not None
+    # Once before the loop, once after the first draw — leftover Enter from
+    # the previous prompt must not auto-select option 1 on every question.
+    assert flushed["count"] >= 2
+
+
+def test_wizard_submit_row_confirms_highlighted_option(monkeypatch) -> None:
+    """Arrow to Submit then Enter uses the option that was highlighted."""
+    # First question has 2 options + custom = 3 rows + Submit. Up from the
+    # first option wraps onto Submit without changing the highlighted option.
+    actions = iter(["up", "enter", "enter", "enter"])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user.repl_tty_interactive",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._read_wizard_action",
+        lambda: next(actions),
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._draw_ask_user",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._erase_ask_user",
+        lambda _question: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.cpr_stdin.drain_stale_cpr_bytes",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user.flush_pending_input",
+        lambda: None,
+    )
+
+    picked = repl_ask_user(_QUESTIONS)
+    assert picked == (
+        "Hypothetical/demo scenario, no real code",
+        "I'll paste the raw numbers/graph description",
+        "Last 7 days",
+    )

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -101,6 +101,9 @@ def test_choose_slash_is_not_echoed() -> None:
     assert session.terminal.awaiting_handoff_answer is True
     assert buffer.getvalue() == ""
     assert session.terminal.submitted_turn_count == 0
+    # The queued /choose must not leave a stale autosubmit flag, or the next
+    # genuine turn is misread as autosubmitted and skips the round-counter reset.
+    assert session.terminal.last_input_autosubmitted is False
 
 
 def test_try_render_rejects_a_single_choice_label() -> None:

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -1,0 +1,121 @@
+"""Human hand-off questions vs answers are styled differently."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from surfaces.interactive_shell.session import Session
+from surfaces.interactive_shell.ui.handoff_questions import (
+    is_handoff_question,
+    last_assistant_asked_handoff,
+    render_ask_user_qa,
+    render_handoff_question,
+    try_render_ask_user_submission,
+)
+from surfaces.interactive_shell.ui.input_prompt.rendering import render_submitted_prompt
+from surfaces.interactive_shell.ui.streaming.renderer import render_markdown_block
+
+
+def test_short_closing_question_is_a_handoff() -> None:
+    assert is_handoff_question("Which environment should I investigate first?")
+    assert is_handoff_question("**Want me to:** run a full investigation?")
+    assert not is_handoff_question("checkout is returning 502s")
+    assert not is_handoff_question("### [1/8] Prerequisite checks")
+
+
+def test_render_markdown_block_highlights_a_question() -> None:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    render_markdown_block(console, "Which environment should I investigate first?")
+    output = buffer.getvalue()
+    assert "?" in output
+    assert "Which environment should I investigate first?" in output
+
+
+def test_submitted_answer_to_a_handoff_is_marked() -> None:
+    session = Session()
+    session.cli_agent_messages = [
+        ("user", "checkout is 502ing"),
+        ("assistant", "Which environment should I investigate first?"),
+    ]
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    assert last_assistant_asked_handoff(list(session.cli_agent_messages))
+    render_submitted_prompt(console, session, "staging")
+    output = buffer.getvalue()
+    assert "↗ answer" in output
+    assert "staging" in output
+
+
+def test_ask_user_answers_render_as_numbered_qa() -> None:
+    session = Session()
+    session.terminal.awaiting_handoff_answer = True
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    text = (
+        "1. Where does the /api/orders service live?\n"
+        "Hypothetical/demo scenario, no real code\n"
+        "\n"
+        "2. What's the time window of the p99 regression?\n"
+        "Last 7 days"
+    )
+    render_submitted_prompt(console, session, text)
+    output = buffer.getvalue()
+    assert "Ask User" in output
+    assert "↗ You answered" not in output
+    assert "Where does the /api/orders service live?" in output
+    assert "Hypothetical/demo scenario, no real code" in output
+    assert "Last 7 days" in output
+    assert session.terminal.submitted_turn_count == 1
+
+
+def test_ask_user_qa_leaves_blank_rows_between_pairs() -> None:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    render_ask_user_qa(
+        console,
+        [
+            ("How large is the p99 regression on /api/orders?", "Percentage increase only"),
+            ("When did the regression begin?", "Sudden without known change"),
+        ],
+    )
+    lines = [line.rstrip() for line in buffer.getvalue().splitlines()]
+    header = next(index for index, line in enumerate(lines) if line.strip() == "Ask User")
+    assert lines[header + 1] == ""
+    first_answer = next(
+        index for index, line in enumerate(lines) if "Percentage increase only" in line
+    )
+    assert lines[first_answer + 1] == ""
+    assert "When did the regression begin?" in lines[first_answer + 2]
+
+
+def test_choose_slash_is_not_echoed() -> None:
+    session = Session()
+    session.terminal.awaiting_handoff_answer = True
+    session.terminal.last_input_autosubmitted = True
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    render_submitted_prompt(console, session, "/choose")
+    assert session.terminal.awaiting_handoff_answer is True
+    assert buffer.getvalue() == ""
+    assert session.terminal.submitted_turn_count == 0
+
+
+def test_try_render_rejects_a_single_choice_label() -> None:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    assert try_render_ask_user_submission(console, "Commit the changes") is False
+    assert buffer.getvalue() == ""
+
+
+def test_render_handoff_question_strips_terminal_controls() -> None:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    render_handoff_question(console, "Which env?\x1b]0;pwn\x07\x1b[2K staging")
+    output = buffer.getvalue()
+    assert "\x1b" not in output
+    assert "\x07" not in output
+    assert "Which env?" in output
+    assert "staging" in output

--- a/tests/shared/harness_api.py
+++ b/tests/shared/harness_api.py
@@ -27,6 +27,7 @@ SPI_ROLES: frozenset[str] = frozenset(
         "integrations",
         "grounding",
         "defaults",
+        "handoff",
     }
 )
 

--- a/tests/shared/terminal/test_choice_menu.py
+++ b/tests/shared/terminal/test_choice_menu.py
@@ -37,7 +37,46 @@ def test_draw_menu_uses_carriage_return_newlines(monkeypatch) -> None:
     assert all(rendered[index - 1] == "\r" for index, char in enumerate(rendered) if char == "\n")
     assert "\rintegrations" in plain
     assert "\r/integrations" in plain
-    assert "\r > /integrations list" in plain
+    assert "\r > 1. /integrations list" in plain
+
+
+def test_draw_menu_strips_control_characters_from_title_and_labels(monkeypatch) -> None:
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+
+    choice_menu._draw_menu(
+        title="\x1b]0;pwn\x07integrations",
+        crumb="\x1b]/integrations",
+        labels=["\x07/integrations list", "/integrations verify"],
+        index=0,
+        erase_lines=0,
+    )
+
+    rendered = out.getvalue()
+    assert "\x1b]" not in rendered
+    assert "\x07" not in rendered
+    plain = _ANSI_RE.sub("", rendered)
+    assert "integrations" in plain
+    assert "/integrations list" in plain
+
+
+def test_print_valid_choice_list_strips_controls_and_escapes_markup() -> None:
+    from rich.console import Console
+
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    choice_menu.print_valid_choice_list(
+        console,
+        title="\x1b]0;pwn\x07Pick [one]",
+        choices=["\x07alpha [bold]"],
+    )
+    output = buffer.getvalue()
+    assert "\x1b]" not in output
+    assert "\x07" not in output
+    assert "Pick [one]" in output
+    assert "alpha [bold]" in output
+    assert "[bold]" in output
 
 
 def test_erase_menu_block_resets_to_column_zero(monkeypatch) -> None:
@@ -111,7 +150,7 @@ def test_repl_choose_one_starts_at_initial_value(monkeypatch) -> None:
 
     assert result == "blue"
     plain = _ANSI_RE.sub("", out.getvalue())
-    assert "> blue (current)" in plain
+    assert "> 2. blue (current)" in plain
 
 
 def test_read_action_ignores_left_arrow(monkeypatch) -> None:

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -7,12 +7,17 @@ leak into the input line (same constraint as the deferred pickers in
 :class:`~core.agent_harness.session.pending_choice.PendingUserChoice` and queues
 the literal ``/choose`` command, which the loop dispatches with exclusive stdin.
 The selected option label is auto-submitted as the next user message.
+
+Pass ``questions`` (label, title, options) when several facts block the work —
+one payload, then STOP. After answers arrive, call ``update_plan`` and execute.
+A single decision still uses ``title`` + ``options``.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from core.agent_harness.spi.handoff import AskUserQuestion
 from core.agent_harness.spi.session_state import (
     PendingUserChoice,
     session_terminal,
@@ -22,10 +27,15 @@ from core.agent_harness.tools import ActionToolScope, execute_with_action_contex
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_array_property, string_property
+from infrastructure.safety.terminal_output import strip_terminal_controls
 
 _MIN_OPTIONS = 2
 _MAX_OPTIONS = 8
+_MIN_QUESTIONS = 2
+_MAX_QUESTIONS = 6
+_MAX_ASK_ROUNDS = 2
 _CHOOSE_COMMAND = "/choose"
+_DEFAULT_HEADER = "Ask User"
 
 _FALLBACK_INSTRUCTION = (
     "No interactive selection menu is available on this surface. Present the "
@@ -38,6 +48,38 @@ _QUEUED_INSTRUCTION = (
     "do NOT ask the user to type a number. The user's selection arrives as the "
     "next user message (the chosen option label, verbatim)."
 )
+_QUEUED_BATCH_INSTRUCTION = (
+    "The Ask User menu opens after this turn ends. Before it, say in one or two "
+    "sentences WHY you are asking rather than assuming, and preview the rounds "
+    '(e.g. "two short rounds: the shape and available signals first, then scope '
+    'and constraints"). Do NOT repeat the questions themselves as text and do '
+    "NOT call update_plan yet. The user's answers arrive as the next user "
+    "message. After they arrive, call update_plan then execute."
+)
+
+_QUESTION_ITEM_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["label", "title", "options"],
+    "properties": {
+        "label": string_property(
+            description=(
+                "Short breadcrumb name, one or two words, e.g. 'Codebase', 'Metrics', 'Window'."
+            ),
+            min_length=1,
+        ),
+        "title": string_property(
+            description="Full question shown for this step.",
+            min_length=1,
+        ),
+        "options": string_array_property(
+            description=(
+                "Two to eight short option labels, recommended option first. "
+                "The selected label is echoed back verbatim."
+            ),
+        ),
+    },
+}
 
 
 def _menu_available(ctx: ActionToolScope) -> bool:
@@ -53,49 +95,131 @@ def _menu_available(ctx: ActionToolScope) -> bool:
     return ports is not None and bool(ports.tty_interactive())
 
 
-def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
-    title = str(args.get("title", "")).strip()
-    raw_options = args.get("options")
+def _parse_options(raw: object) -> list[str]:
     options: list[str] = []
     seen: set[str] = set()
-    if isinstance(raw_options, list):
-        for item in raw_options:
-            text = str(item).strip()
-            if text and text not in seen:
-                seen.add(text)
-                options.append(text)
+    if not isinstance(raw, list):
+        return options
+    for item in raw:
+        text = strip_terminal_controls(str(item)).strip()
+        if text and text not in seen:
+            seen.add(text)
+            options.append(text)
+    return options
 
-    if not title:
-        return {"ok": False, "error": "title is required"}
+
+def _options_error(options: list[str]) -> str | None:
     if len(options) < _MIN_OPTIONS:
-        return {
-            "ok": False,
-            "error": f"at least {_MIN_OPTIONS} distinct non-empty options are required",
-        }
+        return f"at least {_MIN_OPTIONS} distinct non-empty options are required"
     if len(options) > _MAX_OPTIONS:
-        return {"ok": False, "error": f"at most {_MAX_OPTIONS} options are supported"}
+        return f"at most {_MAX_OPTIONS} options are supported"
+    return None
+
+
+def _parse_questions(raw: object) -> tuple[list[AskUserQuestion] | None, str | None]:
+    """Return ``(questions, error)``. Absent/empty ``raw`` yields ``([], None)``."""
+    if raw is None:
+        return [], None
+    if not isinstance(raw, list):
+        return None, "questions must be an array of {label, title, options}"
+    if not raw:
+        return [], None
+    parsed: list[AskUserQuestion] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            return None, f"questions[{index}] must be an object"
+        label = strip_terminal_controls(str(item.get("label", ""))).strip()
+        title = strip_terminal_controls(str(item.get("title", ""))).strip()
+        options = _parse_options(item.get("options"))
+        if not label:
+            return None, f"questions[{index}].label is required"
+        if not title:
+            return None, f"questions[{index}].title is required"
+        option_error = _options_error(options)
+        if option_error is not None:
+            return None, f"questions[{index}]: {option_error}"
+        parsed.append(AskUserQuestion(label=label, title=title, options=tuple(options)))
+    if len(parsed) > _MAX_QUESTIONS:
+        return None, f"at most {_MAX_QUESTIONS} questions are supported"
+    return parsed, None
+
+
+def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
+    questions, questions_error = _parse_questions(args.get("questions"))
+    if questions_error is not None:
+        return {"ok": False, "error": questions_error}
+
+    title = strip_terminal_controls(str(args.get("title", ""))).strip()
+    options = _parse_options(args.get("options"))
+
+    if questions:
+        if getattr(ctx.session, "ask_user_rounds", 0) >= _MAX_ASK_ROUNDS:
+            return {
+                "ok": False,
+                "error": (
+                    "Two clarification rounds already asked this workload — do "
+                    "not ask a third. Write the diagnosis (facts, what the "
+                    "signature tells us, a ranked hypothesis table with a "
+                    "discriminator) and call update_plan now with your best "
+                    "hypothesis."
+                ),
+            }
+        if len(questions) < _MIN_QUESTIONS:
+            return {
+                "ok": False,
+                "error": (
+                    f"questions must contain at least {_MIN_QUESTIONS} items; "
+                    "use title and options for a single decision"
+                ),
+            }
+        header = title or _DEFAULT_HEADER
+        pending = PendingUserChoice(
+            title=header,
+            options=questions[0].options,
+            questions=tuple(questions),
+        )
+        queued = _QUEUED_BATCH_INSTRUCTION
+        summary = f"Ask User menu queued: {len(questions)} questions"
+    else:
+        if not title:
+            return {"ok": False, "error": "title is required"}
+        option_error = _options_error(options)
+        if option_error is not None:
+            return {"ok": False, "error": option_error}
+        pending = PendingUserChoice(title=title, options=tuple(options))
+        queued = _QUEUED_INSTRUCTION
+        summary = f"selection menu queued: {title}"
 
     if not _menu_available(ctx):
         return {"ok": True, "menu": "unavailable", "instruction": _FALLBACK_INSTRUCTION}
 
-    ctx.session.pending_user_choice = PendingUserChoice(title=title, options=tuple(options))
+    ctx.session.pending_user_choice = pending
+    if questions:
+        ctx.session.ask_user_rounds = getattr(ctx.session, "ask_user_rounds", 0) + 1
     set_auto_command(ctx.session, _CHOOSE_COMMAND)
+    terminal = session_terminal(ctx.session)
+    if terminal is not None:
+        terminal.awaiting_handoff_answer = True
     return {
         "ok": True,
         "menu": "queued",
-        "summary": f"selection menu queued: {title}",
-        "instruction": _QUEUED_INSTRUCTION,
+        "summary": summary,
+        "instruction": queued,
     }
 
 
 def run_ask_user_choice(
     *,
-    title: str,
+    title: str = "",
     options: list[str] | None = None,
+    questions: list[dict[str, Any]] | None = None,
     context: Any,
 ) -> dict[str, Any]:
+    payload: dict[str, Any] = {"title": title, "options": options or []}
+    if questions is not None:
+        payload["questions"] = questions
     return execute_with_action_context(
-        {"title": title, "options": options or []},
+        payload,
         context,
         execute_ask_user_choice_tool,
     )
@@ -104,18 +228,24 @@ def run_ask_user_choice(
 ask_user_choice_tool = RegisteredTool(
     name="ask_user_choice",
     description=(
-        "Ask the user to pick ONE option from a small fixed set via the "
-        "interactive shell's arrow-key selection menu. Use this INSTEAD of "
-        "writing a numbered list ('Reply with 1, 2, or 3') whenever a required "
-        "decision blocks further progress. The menu opens after the turn ends "
-        "and the chosen option label arrives verbatim as the next user "
-        "message, so end the turn right after calling this. If the result "
-        "says the menu is unavailable, fall back to a numbered list."
+        "Ask the user to pick from a small fixed set via the interactive "
+        "shell's selection menu. When several missing facts block a multi-step "
+        "job, pass ALL of them in questions (label, title, options) in ONE "
+        "call, then end the turn — do not drip questions and do not call "
+        "update_plan until the answers arrive. A single decision uses title "
+        "and options. The menu opens after the turn ends; answers arrive "
+        "verbatim as the next user message. If the result says the menu is "
+        "unavailable, fall back to a numbered list."
     ),
     use_cases=[
         (
             "A workflow is blocked on one required decision between a small "
             "fixed set of actions (e.g. stash vs commit vs worktree)"
+        ),
+        (
+            "Investigation or triage is blocked on several facts the user "
+            "must supply (where a service lives, how to get metrics, the "
+            "time window) — one questions payload, then plan"
         ),
         "A skill instructs presenting a structured choice / dropdown to the user",
     ],
@@ -123,27 +253,35 @@ ask_user_choice_tool = RegisteredTool(
         "Open-ended questions with no fixed option set (ask in plain text)",
         "Yes/no confirmations already covered by the execution confirmation flow",
         "Presenting information that requires no decision",
+        "One ask_user_choice call per question when several facts block the same job",
+        "Calling update_plan before the Ask User answers arrive",
     ],
     input_schema=object_schema(
         properties={
             "title": string_property(
                 description=(
-                    "Short question shown as the menu title, e.g. 'How should "
-                    "I handle the uncommitted changes?'"
+                    "Menu header, or the question when questions is omitted. "
+                    "Use 'Ask User' for a batched questions payload."
                 ),
                 min_length=1,
             ),
             "options": string_array_property(
                 description=(
-                    "Two to eight short option labels, recommended option "
-                    "first, e.g. ['Stash the changes (recommended)', 'Commit "
-                    "the changes', 'Use a separate git worktree']. The "
-                    "selected label is echoed back verbatim as the user's "
-                    "reply, so each label must be self-explanatory."
+                    "Two to eight short option labels for a single decision, "
+                    "recommended option first. Omit when questions is set."
                 ),
             ),
+            "questions": {
+                "type": "array",
+                "description": (
+                    "Two to six blockers to ask in one Ask User wizard. Each "
+                    "item is {label, title, options}. Prefer this over several "
+                    "turns when missing facts block a plan."
+                ),
+                "items": _QUESTION_ITEM_SCHEMA,
+            },
         },
-        required=("title", "options"),
+        required=(),
     ),
     source="interactive_shell",
     surfaces=(ToolSurface.ACTION,),

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -18,11 +18,11 @@ have yet). This module is imported unconditionally by the always-on
 dashboard sampler, so pricing lookups must stay a pure, deterministic
 offline dict read regardless of what else the process has imported,
 and must degrade to "no rates" rather than crash the sampler if the
-data file is ever missing. A tiny local override table covers the
-rare model litellm's snapshot hasn't picked up yet (a brand-new
-release, or a routing alias OpenAI/Anthropic don't publish as their
-own price-table row). Unknown models return ``None`` so the dashboard
-renders ``-`` rather than inventing a rate.
+data file is ever missing. A small local override table covers models
+litellm's snapshot lacks or has drifted from the vendor's published
+rates; those overrides win for both exact ids and family-suffix
+variants. Unknown models return ``None`` so the dashboard renders
+``-`` rather than inventing a rate.
 """
 
 from __future__ import annotations
@@ -135,15 +135,13 @@ def _price(
     )
 
 
-# Models confirmed absent from litellm's bundled price table. This is an
-# escape hatch for the rare model litellm's table hasn't (yet, or ever again)
-# picked up, not a general config surface: entries here are only consulted
-# after a direct litellm lookup misses.
+# Intentional overrides when litellm's snapshot is missing a model or has
+# drifted from the vendor's published rates. These win over a litellm hit
+# for the same bare id so exact ids and family-suffix variants stay aligned.
 _LOCAL_MODEL_PRICES: dict[str, ModelPrice] = {
-    # GPT-5.6 (GA 2026-07-09) — too new for litellm's bundled
-    # snapshot. Per 1M tokens, from
-    # https://developers.openai.com/api/docs/pricing: sol 5/30, terra
-    # 2.50/15, luna 1/6. Cached input is 90% off.
+    # GPT-5.6 — OpenAI published rates (litellm's terra/luna rows diverge).
+    # Per 1M tokens, from https://developers.openai.com/api/docs/pricing:
+    # sol 5/30, terra 2.50/15, luna 1/6. Cached input is 90% off.
     "gpt-5.6-sol": _price(5.00, 30.00, cache_read_usd_per_million=0.50),
     "gpt-5.6-terra": _price(2.50, 15.00, cache_read_usd_per_million=0.25),
     "gpt-5.6-luna": _price(1.00, 6.00, cache_read_usd_per_million=0.10),
@@ -363,28 +361,37 @@ def _override_related_rate(
     return effective_input_rate * (base_related_rate / base_input_rate)
 
 
+def _canonical_tier_price(canonical_id: str) -> ModelPrice | None:
+    """Price for a bare tier id — local override first, then litellm.
+
+    Exact ids and family-suffix fallbacks both go through here so
+    ``gpt-5.6-terra`` and ``gpt-5.6-terra-preview`` cannot pick different
+    snapshots when litellm and ``_LOCAL_MODEL_PRICES`` disagree.
+    """
+    local = _LOCAL_MODEL_PRICES.get(canonical_id)
+    if local is not None:
+        return local
+    return _litellm_price(canonical_id)
+
+
 def _lookup_price(model: str) -> ModelPrice | None:
     candidates = _model_candidates(model)
     for candidate in candidates:
+        local = _LOCAL_MODEL_PRICES.get(candidate)
+        if local is not None:
+            return local
         price = _litellm_price(candidate)
         if price is not None:
             alias = _local_family_alias_canonical(candidate)
             if alias is not None:
-                local = _LOCAL_MODEL_PRICES.get(alias)
-                if local is not None:
-                    return local
+                aliased = _canonical_tier_price(alias)
+                if aliased is not None:
+                    return aliased
             return price
-        local = _LOCAL_MODEL_PRICES.get(candidate)
-        if local is not None:
-            return local
     for candidate in candidates:
         fallback = _local_family_fallback_canonical(candidate)
         if fallback is not None:
-            # Resolve the mapped tier from the same source as its exact id, so a
-            # suffix variant (``gpt-5.6-terra-preview``) never diverges from the
-            # base tier once litellm's snapshot prices that tier. The local table
-            # stays the last resort for a tier litellm still lacks.
-            return _litellm_price(fallback) or _LOCAL_MODEL_PRICES.get(fallback)
+            return _canonical_tier_price(fallback)
     for candidate in candidates:
         for provider_prefix in _COMPAT_PROVIDER_PREFIXES:
             price = _litellm_price(f"{provider_prefix}{candidate}")

--- a/tools/system/fleet_monitoring/pricing.py
+++ b/tools/system/fleet_monitoring/pricing.py
@@ -380,7 +380,11 @@ def _lookup_price(model: str) -> ModelPrice | None:
     for candidate in candidates:
         fallback = _local_family_fallback_canonical(candidate)
         if fallback is not None:
-            return _LOCAL_MODEL_PRICES.get(fallback)
+            # Resolve the mapped tier from the same source as its exact id, so a
+            # suffix variant (``gpt-5.6-terra-preview``) never diverges from the
+            # base tier once litellm's snapshot prices that tier. The local table
+            # stays the last resort for a tier litellm still lacks.
+            return _litellm_price(fallback) or _LOCAL_MODEL_PRICES.get(fallback)
     for candidate in candidates:
         for provider_prefix in _COMPAT_PROVIDER_PREFIXES:
             price = _litellm_price(f"{provider_prefix}{candidate}")


### PR DESCRIPTION
Add batched ask_user_choice hand-off menus: the planner asks several
blocking questions in one call, the /choose picker collects answers over
exclusive stdin, and they auto-submit back as one Q&A block.

- ask_user_choice queues a PendingUserChoice (single decision or a batch of questions) and arms the /choose picker; a two-round cap (ask_user_rounds) refuses a third clarification batch per workload.
- The submitted answer renders as a distinct Ask User card (question white, answer brand-coloured); the internal /choose command is never echoed.
- New spi.handoff role (AskUserQuestion, parse/format answers) pinned in the  harness API border.