### PR TITLE
feat(interactive-shell): update_plan task-plan checklists

### DIFF
--- a/core/agent_harness/prompts/action/assemble.py
+++ b/core/agent_harness/prompts/action/assemble.py
@@ -20,6 +20,11 @@ from core.agent_harness.prompts.memory.conversation import (
 )
 from core.agent_harness.prompts.runtime_facts import render_static_runtime_facts
 from core.agent_harness.prompts.skills.loader import load_skills_demo_block, load_skills_index
+from core.agent_harness.task_plan.prompt import (
+    ask_user_answered_block,
+    current_task_plan_block,
+    load_planning_instructions,
+)
 from infrastructure.harness_providers import action_prompt_vendor_fragments
 
 if TYPE_CHECKING:
@@ -123,6 +128,15 @@ def build_action_system_prompt_envelope(turn_snapshot: TurnSnapshot) -> PromptEn
             provenance="core.agent_harness.prompts.skills",
         )
     )
+    blocks.append(
+        PromptBlock(
+            id=PromptBlockId.ACTION_PLANNING_INSTRUCTIONS,
+            kind=PromptBlockKind.RULE,
+            tier=PromptTier.STABLE,
+            content="".join((load_planning_instructions(), "\n\n")),
+            provenance="core.agent_harness.task_plan.planning_instructions.md",
+        )
+    )
     if turn_snapshot.setup_state:
         blocks.append(
             PromptBlock(
@@ -152,6 +166,19 @@ def build_action_system_prompt_envelope(turn_snapshot: TurnSnapshot) -> PromptEn
             tier=PromptTier.VOLATILE,
             content=memory_block,
             provenance="core.domain.memory",
+        )
+    )
+    blocks.extend(
+        _optional_block(
+            id=PromptBlockId.ASK_USER_ANSWERED,
+            kind=PromptBlockKind.RULE,
+            tier=PromptTier.EPHEMERAL,
+            content=ask_user_answered_block(
+                turn_snapshot.text,
+                plan_only=turn_snapshot.plan_only_until_authorized,
+            ),
+            provenance="core.agent_harness.task_plan.prompt",
+            suffix="\n\n",
         )
     )
     blocks.append(
@@ -186,6 +213,20 @@ def build_action_system_prompt_envelope(turn_snapshot: TurnSnapshot) -> PromptEn
                 provenance="core.agent_harness.session.persistence.wal_recovery",
             )
         )
+    plan_block = current_task_plan_block(
+        turn_snapshot.task_plan,
+        plan_only=turn_snapshot.plan_only_until_authorized,
+    )
+    blocks.extend(
+        _optional_block(
+            id=PromptBlockId.CURRENT_TASK_PLAN,
+            kind=PromptBlockKind.CONTEXT,
+            tier=PromptTier.EPHEMERAL,
+            content=plan_block,
+            provenance="core.agent_harness.task_plan.prompt",
+            suffix="\n",
+        )
+    )
     return PromptEnvelope.from_blocks(
         blocks,
         separator="",

--- a/core/agent_harness/prompts/kernel/envelope.py
+++ b/core/agent_harness/prompts/kernel/envelope.py
@@ -22,6 +22,9 @@ class PromptBlockId(StrEnum):
     ACTION_RUNTIME_FACTS = "action-agent-runtime-facts"
     ACTION_SKILLS = "action-agent-skills"
     ACTION_SETUP_STATE = "action-agent-setup-state"
+    ACTION_PLANNING_INSTRUCTIONS = "action-agent-planning-instructions"
+    ASK_USER_ANSWERED = "ask-user-answered"
+    CURRENT_TASK_PLAN = "current-task-plan"
 
     # Shared across envelopes.
     CONNECTED_INTEGRATIONS = "connected-integrations"

--- a/core/agent_harness/session/lifecycle.py
+++ b/core/agent_harness/session/lifecycle.py
@@ -35,7 +35,11 @@ import logging
 from datetime import datetime
 from typing import Any, TypeVar
 
-from core.agent_harness.session.persistence.contracts import SessionRepo, SessionStore
+from core.agent_harness.session.persistence.contracts import (
+    RestoreContextKey,
+    SessionRepo,
+    SessionStore,
+)
 
 # Import from submodules (not the package __init__) so the session package can
 # re-export SessionManager without a circular import.
@@ -255,7 +259,7 @@ class SessionManager:
         """
         if not data:
             return session
-        messages = data.get("cli_agent_messages")
+        messages = data.get(RestoreContextKey.CLI_AGENT_MESSAGES)
         if isinstance(messages, list):
             restored: list[tuple[str, str]] = []
             for item in messages:
@@ -266,22 +270,22 @@ class SessionManager:
                 if role in {"user", "assistant"} and isinstance(content, str) and content:
                     restored.append((role, content))
             session.cli_agent_messages = restored
-        context = data.get("accumulated_context")
+        context = data.get(RestoreContextKey.ACCUMULATED_CONTEXT)
         if isinstance(context, dict):
             session.accumulated_context = dict(context)
-        goal_state = data.get("session_goal_state")
+        goal_state = data.get(RestoreContextKey.SESSION_GOAL_STATE)
         if isinstance(goal_state, dict):
             from core.agent_harness.session_goal.persist import (
                 apply_session_goal_state,
             )
 
             apply_session_goal_state(session, goal_state)
-        plan_state = data.get("task_plan_state")
+        plan_state = data.get(RestoreContextKey.TASK_PLAN_STATE)
         if plan_state is not None:
             from core.agent_harness.task_plan.persist import apply_task_plan_state
 
             apply_task_plan_state(session, plan_state)
-        history = data.get("history")
+        history = data.get(RestoreContextKey.HISTORY)
         if isinstance(history, list):
             session.history = [dict(item) for item in history if isinstance(item, dict)]
         return session

--- a/core/agent_harness/session/lifecycle.py
+++ b/core/agent_harness/session/lifecycle.py
@@ -276,6 +276,11 @@ class SessionManager:
             )
 
             apply_session_goal_state(session, goal_state)
+        plan_state = data.get("task_plan_state")
+        if plan_state is not None:
+            from core.agent_harness.task_plan.persist import apply_task_plan_state
+
+            apply_task_plan_state(session, plan_state)
         history = data.get("history")
         if isinstance(history, list):
             session.history = [dict(item) for item in history if isinstance(item, dict)]

--- a/core/agent_harness/session/persistence/contracts.py
+++ b/core/agent_harness/session/persistence/contracts.py
@@ -13,9 +13,25 @@ roles are kept deliberately separate, mirroring a storage-vs-repository split:
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any, Protocol, runtime_checkable
 
 from core.state import MutableAgentState
+
+
+class RestoreContextKey(StrEnum):
+    """Keys of the restore-context payload written by the repo and read on load.
+
+    Shared here so the write side (``SessionRepo``) and the read side
+    (``restore_context``) cannot drift: a rename lands in one spelling.
+    """
+
+    CLI_AGENT_MESSAGES = "cli_agent_messages"
+    ACCUMULATED_CONTEXT = "accumulated_context"
+    SESSION_GOAL_STATE = "session_goal_state"
+    TASK_PLAN_STATE = "task_plan_state"
+    HISTORY = "history"
+
 
 # Turn kinds that represent user-initiated chat messages. Session.record()
 # is called with the turn kind, not a normalized "chat" label, so this set must

--- a/core/agent_harness/session/persistence/jsonl_repo.py
+++ b/core/agent_harness/session/persistence/jsonl_repo.py
@@ -79,6 +79,7 @@ class JsonlSessionRepo:
             messages = _messages_for_branch(branch)
             context = _accumulated_context_for_branch(branch)
             goal_state = _session_goal_state_for_branch(branch)
+            plan_state = _task_plan_state_for_branch(branch)
             history = _history_for_branch(branch)
             turn_details = _turn_details_for_branch(branch)
             return {
@@ -90,6 +91,7 @@ class JsonlSessionRepo:
                 "cli_agent_messages": messages,
                 "accumulated_context": context,
                 "session_goal_state": goal_state,
+                "task_plan_state": plan_state,
                 "history": history,
                 "turn_details": turn_details,
                 "has_snapshot": False,
@@ -373,6 +375,22 @@ def _session_goal_state_for_branch(branch: list[dict[str, Any]]) -> dict[str, An
         if rec.get("type") != "custom_message":
             continue
         if rec.get("custom_type") != SESSION_GOAL_STATE_CUSTOM_TYPE:
+            continue
+        content = rec.get("content")
+        if isinstance(content, dict):
+            latest = content
+    return latest
+
+
+def _task_plan_state_for_branch(branch: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the last ``task_plan_state`` custom message on the branch."""
+    from core.agent_harness.task_plan.persist import TASK_PLAN_STATE_CUSTOM_TYPE
+
+    latest: dict[str, Any] | None = None
+    for rec in branch:
+        if rec.get("type") != "custom_message":
+            continue
+        if rec.get("custom_type") != TASK_PLAN_STATE_CUSTOM_TYPE:
             continue
         content = rec.get("content")
         if isinstance(content, dict):

--- a/core/agent_harness/session/persistence/jsonl_repo.py
+++ b/core/agent_harness/session/persistence/jsonl_repo.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import core.agent_harness.session.persistence.paths as storage_paths
-from core.agent_harness.session.persistence.contracts import CHAT_KINDS
+from core.agent_harness.session.persistence.contracts import CHAT_KINDS, RestoreContextKey
 from core.agent_harness.session.persistence.wal_recovery import dangling_tool_intents
 from core.state.transcript_window import SESSION_SUMMARY_PREFIX
 
@@ -88,11 +88,11 @@ class JsonlSessionRepo:
                 "leaf_id": _resolve_entry_id(entries, None),
                 "name": storage_paths.derive_name(_records_to_lines([header, *entries])),
                 "started_at": header.get("created_at"),
-                "cli_agent_messages": messages,
-                "accumulated_context": context,
-                "session_goal_state": goal_state,
-                "task_plan_state": plan_state,
-                "history": history,
+                RestoreContextKey.CLI_AGENT_MESSAGES: messages,
+                RestoreContextKey.ACCUMULATED_CONTEXT: context,
+                RestoreContextKey.SESSION_GOAL_STATE: goal_state,
+                RestoreContextKey.TASK_PLAN_STATE: plan_state,
+                RestoreContextKey.HISTORY: history,
                 "turn_details": turn_details,
                 "has_snapshot": False,
                 # WAL sidecars are off-branch, so scan the full entry list:

--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -468,6 +468,21 @@ class JsonlSessionStore:
                     content=goal_state,
                     display=False,
                 )
+        if hasattr(session, "task_plan"):
+            from core.agent_harness.task_plan.persist import (
+                TASK_PLAN_STATE_CUSTOM_TYPE,
+                should_persist_task_plan_state,
+                task_plan_state_snapshot,
+            )
+
+            plan_state = task_plan_state_snapshot(session)
+            if should_persist_task_plan_state(plan_state, prior_records=records):
+                self.append_custom_message(
+                    session.session_id,
+                    custom_type=TASK_PLAN_STATE_CUSTOM_TYPE,
+                    content=plan_state or {},
+                    display=False,
+                )
         if trailing_leaf:
             return
         if session.agent.messages and not any(rec.get("type") == "message" for rec in records):

--- a/core/agent_harness/session/persistence/memory.py
+++ b/core/agent_harness/session/persistence/memory.py
@@ -257,6 +257,25 @@ class InMemorySessionStore:
                     },
                 )
                 records = self._files.get(session.session_id, records)
+        if hasattr(session, "task_plan"):
+            from core.agent_harness.task_plan.persist import (
+                TASK_PLAN_STATE_CUSTOM_TYPE,
+                should_persist_task_plan_state,
+                task_plan_state_snapshot,
+            )
+
+            plan_state = task_plan_state_snapshot(session)
+            if should_persist_task_plan_state(plan_state, prior_records=records):
+                self._append(
+                    session.session_id,
+                    "custom_message",
+                    {
+                        "custom_type": TASK_PLAN_STATE_CUSTOM_TYPE,
+                        "content": plan_state or {},
+                        "display": False,
+                    },
+                )
+                records = self._files.get(session.session_id, records)
         if trailing_leaf:
             return
         if session.agent.messages and not any(rec.get("type") == "message" for rec in records):

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -34,6 +34,7 @@ from core.agent_harness.session.pending_offer import (
 from core.agent_harness.session.persistence.contracts import SessionStore
 from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
 from core.agent_harness.session_goal.goal import SessionGoal
+from core.agent_harness.task_plan.plan import TaskPlan
 from core.state import MutableAgentState
 from infrastructure.scheduling.task_registry import TaskRegistry
 
@@ -169,6 +170,16 @@ class SessionCore:
     ask_user_rounds: int = 0
     """Ask-User clarification rounds asked this workload; caps repeated batches.
     Reset on a genuine user turn."""
+
+    task_plan: TaskPlan | None = None
+    """Live execution checklist for the current workload, rendered above the
+    prompt and persisted so it survives transcript compaction."""
+
+    plan_only_until_authorized: bool = False
+    """Set when the user asked for a plan without running it; the execution gate
+    keeps mutating steps behind confirmation until a step is confirmed. Set-only
+    here — cleared only at the gate on a confirmed mutating step."""
+
     pending_recovery_note: str | None = None
     """WAL recovery note for the next action turn — set on ``/resume`` when the
     resumed session log holds tool intents that never committed (the process
@@ -413,6 +424,8 @@ class SessionCore:
         self.offered_upgrade_ctas.clear()
         self.pending_user_choice = None
         self.ask_user_rounds = 0
+        self.task_plan = None
+        self.plan_only_until_authorized = False
         self.pending_recovery_note = None
         self.gather_unreachable_tools.clear()
         self.gather_unreachable_sources.clear()

--- a/core/agent_harness/spi/task_plan.py
+++ b/core/agent_harness/spi/task_plan.py
@@ -1,0 +1,43 @@
+"""Task-plan types a host renders: the live checklist model and its parser.
+
+A surface reads a :class:`TaskPlan` off the session to draw the ``Plan · n/m``
+checklist and parses an ``update_plan`` payload through :func:`parse_task_plan`.
+"""
+
+from __future__ import annotations
+
+from core.agent_harness.task_plan.display import (
+    is_plan_diagnosis_prose,
+    promote_first_pending_step,
+)
+from core.agent_harness.task_plan.plan import (
+    PlanStep,
+    PlanStepStatus,
+    TaskPlan,
+    parse_task_plan,
+    task_plan_to_payload,
+)
+from core.agent_harness.task_plan.progress import (
+    PLAN_STATUS_GLYPH,
+    format_plan_header,
+    format_task_plan_plain,
+)
+from core.agent_harness.task_plan.update_plan_policy import (
+    apply_update_plan_host_policy,
+    apply_update_plan_session,
+)
+
+__all__ = [
+    "PLAN_STATUS_GLYPH",
+    "PlanStep",
+    "PlanStepStatus",
+    "TaskPlan",
+    "apply_update_plan_host_policy",
+    "apply_update_plan_session",
+    "format_plan_header",
+    "format_task_plan_plain",
+    "is_plan_diagnosis_prose",
+    "parse_task_plan",
+    "promote_first_pending_step",
+    "task_plan_to_payload",
+]

--- a/core/agent_harness/task_plan/__init__.py
+++ b/core/agent_harness/task_plan/__init__.py
@@ -1,0 +1,37 @@
+"""Live agent task plan (``update_plan``) — not ``/goal`` and not ``/work``.
+
+Leaves:
+
+* :mod:`plan` — ``TaskPlan``, parse/validate
+* :mod:`persist` — flush / restore
+* :mod:`progress` — plain-text ``Plan · n/m`` checklist
+* :mod:`prompt` — planning instructions + CURRENT PLAN block
+"""
+
+from __future__ import annotations
+
+from core.agent_harness.task_plan.plan import (
+    PlanStep,
+    PlanStepStatus,
+    TaskPlan,
+    parse_task_plan,
+    task_plan_from_payload,
+    task_plan_to_payload,
+)
+from core.agent_harness.task_plan.progress import (
+    PLAN_STATUS_GLYPH,
+    format_plan_header,
+    format_task_plan_plain,
+)
+
+__all__ = [
+    "PLAN_STATUS_GLYPH",
+    "PlanStep",
+    "PlanStepStatus",
+    "TaskPlan",
+    "format_plan_header",
+    "format_task_plan_plain",
+    "parse_task_plan",
+    "task_plan_from_payload",
+    "task_plan_to_payload",
+]

--- a/core/agent_harness/task_plan/display.py
+++ b/core/agent_harness/task_plan/display.py
@@ -1,0 +1,50 @@
+"""Terminal display helpers for live task plans."""
+
+from __future__ import annotations
+
+from core.agent_harness.task_plan.plan import PlanStep, PlanStepStatus, TaskPlan
+
+
+def is_plan_diagnosis_prose(text: str) -> bool:
+    """True when prose repeats the Ask User facts/hypothesis block.
+
+    The checklist and Ask User Q&A already show this; re-printing it as
+    assistant markdown collapses into an unreadable wall of pipe characters.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    lowered = stripped.lower()
+    has_facts = "facts:" in lowered or "established facts" in lowered
+    has_hypothesis = "hypothesis" in lowered
+    return (
+        (has_facts and has_hypothesis)
+        or (
+            has_hypothesis
+            and (
+                "|" in stripped
+                or ("primary" in lowered and "secondary" in lowered)
+                or "ranked" in lowered
+            )
+        )
+        or (has_facts and "leading hypothesis" in lowered)
+    )
+
+
+def promote_first_pending_step(plan: TaskPlan) -> TaskPlan:
+    """Mark the first step in_progress when every step is still pending."""
+    if not plan.all_pending or not plan.steps:
+        return plan
+    steps: list[PlanStep] = []
+    for index, item in enumerate(plan.steps):
+        if index == 0:
+            steps.append(PlanStep(step=item.step, status=PlanStepStatus.IN_PROGRESS))
+        else:
+            steps.append(item)
+    return TaskPlan(steps=tuple(steps), explanation=plan.explanation)
+
+
+__all__ = [
+    "is_plan_diagnosis_prose",
+    "promote_first_pending_step",
+]

--- a/core/agent_harness/task_plan/persist.py
+++ b/core/agent_harness/task_plan/persist.py
@@ -15,11 +15,19 @@ TASK_PLAN_STATE_CUSTOM_TYPE = "task_plan_state"
 
 
 def task_plan_state_snapshot(session: Any) -> dict[str, Any] | None:
-    """Flush payload for the session's live task plan, or ``None`` when empty."""
+    """Flush payload for the session's live task plan, or ``None`` when empty.
+
+    Includes ``plan_only_until_authorized`` so resume keeps the confirmation
+    latch that gates mutating tools until the user explicitly authorizes.
+    """
     plan = getattr(session, "task_plan", None)
     if not isinstance(plan, TaskPlan) or not plan.steps:
         return None
-    return task_plan_to_payload(plan)
+    payload = task_plan_to_payload(plan)
+    payload["plan_only_until_authorized"] = bool(
+        getattr(session, "plan_only_until_authorized", False)
+    )
+    return payload
 
 
 def _last_task_plan_content(
@@ -53,13 +61,21 @@ def should_persist_task_plan_state(
 
 
 def apply_task_plan_state(session: Any, payload: Any) -> None:
-    """Rehydrate ``session.task_plan`` from a flush snapshot or tombstone."""
+    """Rehydrate ``session.task_plan`` (and the plan-only latch) from a snapshot."""
     if not hasattr(session, "task_plan"):
         return
-    if payload is None or payload == {}:
+    if not isinstance(payload, dict) or not payload:
         session.task_plan = None
+        if hasattr(session, "plan_only_until_authorized"):
+            session.plan_only_until_authorized = False
         return
-    session.task_plan = task_plan_from_payload(payload)
+    restored = task_plan_from_payload(payload)
+    session.task_plan = restored
+    if hasattr(session, "plan_only_until_authorized"):
+        # Do not arm the confirmation boundary without a restored checklist.
+        session.plan_only_until_authorized = bool(
+            restored is not None and payload.get("plan_only_until_authorized")
+        )
 
 
 __all__ = [

--- a/core/agent_harness/task_plan/persist.py
+++ b/core/agent_harness/task_plan/persist.py
@@ -1,0 +1,70 @@
+"""Flush / restore the live :class:`TaskPlan` so resume keeps the checklist."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from core.agent_harness.task_plan.plan import (
+    TaskPlan,
+    task_plan_from_payload,
+    task_plan_to_payload,
+)
+
+TASK_PLAN_STATE_CUSTOM_TYPE = "task_plan_state"
+
+
+def task_plan_state_snapshot(session: Any) -> dict[str, Any] | None:
+    """Flush payload for the session's live task plan, or ``None`` when empty."""
+    plan = getattr(session, "task_plan", None)
+    if not isinstance(plan, TaskPlan) or not plan.steps:
+        return None
+    return task_plan_to_payload(plan)
+
+
+def _last_task_plan_content(
+    prior_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    for record in reversed(prior_records):
+        if record.get("type") != "custom_message":
+            continue
+        if record.get("custom_type") != TASK_PLAN_STATE_CUSTOM_TYPE:
+            continue
+        content = record.get("content")
+        return content if isinstance(content, dict) else None
+    return None
+
+
+def should_persist_task_plan_state(
+    snapshot: dict[str, Any] | None,
+    *,
+    prior_records: Sequence[Mapping[str, Any]],
+) -> bool:
+    """Whether flush should append ``snapshot`` as a ``task_plan_state`` record.
+
+    Skip identical tips. A ``None`` snapshot is a tombstone only when the
+    transcript already stored a plan — otherwise skip so sessions that never
+    planned stay quiet.
+    """
+    last = _last_task_plan_content(prior_records)
+    if snapshot is None:
+        return last is not None
+    return last != snapshot
+
+
+def apply_task_plan_state(session: Any, payload: Any) -> None:
+    """Rehydrate ``session.task_plan`` from a flush snapshot or tombstone."""
+    if not hasattr(session, "task_plan"):
+        return
+    if payload is None or payload == {}:
+        session.task_plan = None
+        return
+    session.task_plan = task_plan_from_payload(payload)
+
+
+__all__ = [
+    "TASK_PLAN_STATE_CUSTOM_TYPE",
+    "apply_task_plan_state",
+    "should_persist_task_plan_state",
+    "task_plan_state_snapshot",
+]

--- a/core/agent_harness/task_plan/plan.py
+++ b/core/agent_harness/task_plan/plan.py
@@ -1,0 +1,152 @@
+"""Live agent task plan — create, revise, and mark steps complete.
+
+Distinct from :class:`~core.agent_harness.session_goal.goal.SessionGoal`
+(``/goal`` keep-going) and from durable human work items (``work_task_*``).
+This is the in-session execution checklist the agent keeps current so progress
+survives transcript compaction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from infrastructure.safety.terminal_output import strip_terminal_controls
+
+
+class PlanStepStatus(StrEnum):
+    """Allowed ``update_plan`` step statuses."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+_ALLOWED_STATUSES: frozenset[str] = frozenset(PlanStepStatus)
+
+
+@dataclass(frozen=True, slots=True)
+class PlanStep:
+    """One plan step with a 1-sentence outcome and a status."""
+
+    step: str
+    status: PlanStepStatus
+
+
+@dataclass(frozen=True, slots=True)
+class TaskPlan:
+    """The agent's current execution plan for this workload."""
+
+    steps: tuple[PlanStep, ...]
+    explanation: str = ""
+
+    @property
+    def total(self) -> int:
+        return len(self.steps)
+
+    @property
+    def completed_count(self) -> int:
+        return sum(1 for item in self.steps if item.status is PlanStepStatus.COMPLETED)
+
+    @property
+    def current_index(self) -> int:
+        """1-based index of the focused step (in-progress, else first pending).
+
+        Drives the ``Plan · 2/5`` counter: current step versus all steps.
+        """
+        if not self.steps:
+            return 0
+        return self.steps.index(self.focused_step) + 1
+
+    @property
+    def focused_step(self) -> PlanStep:
+        """The step the live overlay should show: in-progress, else first pending.
+
+        When every step is completed, returns the last step (verification).
+        """
+        for item in self.steps:
+            if item.status is PlanStepStatus.IN_PROGRESS:
+                return item
+        for item in self.steps:
+            if item.status is PlanStepStatus.PENDING:
+                return item
+        return self.steps[-1]
+
+    @property
+    def all_completed(self) -> bool:
+        return bool(self.steps) and self.completed_count == self.total
+
+    @property
+    def all_pending(self) -> bool:
+        """True when every step is still pending (plan ready, nothing started)."""
+        return bool(self.steps) and all(
+            item.status is PlanStepStatus.PENDING for item in self.steps
+        )
+
+
+def parse_task_plan(args: dict[str, Any]) -> tuple[TaskPlan | None, str | None]:
+    """Validate ``update_plan`` arguments. Returns ``(plan, error)``."""
+    explanation_raw = args.get("explanation")
+    explanation = (
+        strip_terminal_controls(explanation_raw).strip() if isinstance(explanation_raw, str) else ""
+    )
+    raw_plan = args.get("plan")
+    if not isinstance(raw_plan, list) or len(raw_plan) < 2:
+        return None, "plan must list at least two steps (last step verifies)"
+    steps: list[PlanStep] = []
+    in_progress = 0
+    for item in raw_plan:
+        if not isinstance(item, dict):
+            return None, "each plan item must be an object with step and status"
+        step_text = strip_terminal_controls(str(item.get("step", ""))).strip()
+        status_raw = str(item.get("status", "")).strip()
+        if not step_text:
+            return None, "each plan item needs a non-empty step"
+        if status_raw not in _ALLOWED_STATUSES:
+            return None, "status must be pending, in_progress, or completed"
+        status = PlanStepStatus(status_raw)
+        if status is PlanStepStatus.IN_PROGRESS:
+            in_progress += 1
+        steps.append(PlanStep(step=step_text, status=status))
+    if in_progress > 1:
+        return None, "at most one step can be in_progress at a time"
+    last = steps[-1]
+    if last.status is PlanStepStatus.COMPLETED and in_progress:
+        return None, "cannot complete the verification step while another step is in_progress"
+    return TaskPlan(steps=tuple(steps), explanation=explanation), None
+
+
+def task_plan_to_payload(plan: TaskPlan) -> dict[str, Any]:
+    """JSON-ready dict for persistence and tool results."""
+    payload: dict[str, Any] = {
+        "plan": [{"step": item.step, "status": str(item.status)} for item in plan.steps],
+        "current": plan.current_index,
+        "total": plan.total,
+        "completed": plan.completed_count,
+    }
+    if plan.explanation:
+        payload["explanation"] = plan.explanation
+    return payload
+
+
+def task_plan_from_payload(payload: Any) -> TaskPlan | None:
+    """Rebuild a :class:`TaskPlan` from :func:`task_plan_to_payload` output."""
+    if not isinstance(payload, dict):
+        return None
+    plan, error = parse_task_plan(
+        {"plan": payload.get("plan"), "explanation": payload.get("explanation", "")}
+    )
+    if error is not None:
+        return None
+    return plan
+
+
+__all__ = [
+    "PlanStep",
+    "PlanStepStatus",
+    "TaskPlan",
+    "parse_task_plan",
+    "task_plan_from_payload",
+    "task_plan_to_payload",
+]

--- a/core/agent_harness/task_plan/planning_instructions.md
+++ b/core/agent_harness/task_plan/planning_instructions.md
@@ -42,10 +42,13 @@ Discriminator (the one observation that confirms or rules each out vs the others
 Skip Ask User when you already have enough to plan.
 
 WHEN TO PLAN
-Call update_plan BEFORE executing any workload that has two or more
-meaningful steps: investigate-then-act-then-verify, compound operations,
-multi-step local workflows, or skill sequences. Skip it for one obvious
-lookup, a greeting, or a single slash command.
+Call update_plan BEFORE executing a workload with several meaningful,
+data-dependent steps where later steps build on earlier results:
+investigate-then-act-then-verify, multi-step local workflows, or skill
+sequences. Skip it for a single action, a greeting, one obvious lookup, a
+single slash command, or two quick sequential actions that do not depend on
+each other (e.g. a slash command plus one alert/investigation/lookup) — just
+run those directly.
 
 VERIFIABILITY (required — never skip)
 A plan is not a wish list. Each step is an observable outcome someone

--- a/core/agent_harness/task_plan/planning_instructions.md
+++ b/core/agent_harness/task_plan/planning_instructions.md
@@ -1,0 +1,103 @@
+══════════════════════════════════════════════════════════
+PLANNING — update_plan
+══════════════════════════════════════════════════════════
+You have access to update_plan. It keeps a concise live plan in context
+and renders it to the user as a checklist (Plan · n/m, ✓ done, ● current,
+○ pending). Older chat messages — including an earlier plan — are dropped
+or summarised. The CURRENT PLAN block plus this tool are the durable
+record. Always keep the plan current; never reconstruct it from memory.
+
+This is the agent's execution plan for THIS workload. It is not
+work_task_* (durable human todos / /work) and not /goal (session-goal
+keep-going). Do not use those tools to track live step progress.
+
+ASK THEN PLAN
+If missing facts block the work, call ask_user_choice with every question
+in that round (`questions`: label, title, options) and STOP. Before the menu,
+say in one or two sentences WHY you are asking rather than assuming, and
+preview the rounds ("two short rounds: shape and signals first, then scope").
+Prefer 2–4 short labels (Shape, Onset, Blast-radius, Signals). Options are
+concrete diagnostic alternatives the answer discriminates between ("p99 only"
+vs "whole distribution", "sudden step" vs "gradual") — never data-availability
+answers like "unknown" or "no data". If the request is hypothetical, a demo, or
+an example, say so and treat the answers as the SCENARIO's shape, not real
+telemetry to fetch. Do not drip one
+question per turn. Ask a SECOND scoped round ONLY IF the first answers open new
+discriminating questions — round 1 fixes the shape, round 2 narrows within it
+(which operation, what changed near onset, traffic mix, persistent vs peak).
+TWO rounds is the hard maximum: if you have already asked two rounds (see the
+Ask User Q&A above), you MUST write the diagnosis and plan now — never ask a
+third round. If facts still feel thin, commit with your best hypothesis anyway.
+Do NOT call update_plan until facts are in. After answers: continue (another
+round, or a written plan). Answering is the go-ahead to continue the
+original request. Do not invent a pause. If the user said not to run
+yet, pass plan_only_after=true on ask_user_choice, then after answers call
+update_plan with plan_only=true and every step pending, and STOP. Otherwise
+set the first step in_progress and execute. Do not restate the checklist in prose —
+it already sits above the prompt. After the answers, write the diagnosis in
+structured sections, never one dense paragraph: Facts (short bullets), "What the
+signature tells us" (for each fact, what it RULES OUT — not just what it is), and
+a Hypothesis-ranking table with columns # | Hypothesis | Why it fits |
+Discriminator (the one observation that confirms or rules each out vs the others).
+Skip Ask User when you already have enough to plan.
+
+WHEN TO PLAN
+Call update_plan BEFORE executing any workload that has two or more
+meaningful steps: investigate-then-act-then-verify, compound operations,
+multi-step local workflows, or skill sequences. Skip it for one obvious
+lookup, a greeting, or a single slash command.
+
+VERIFIABILITY (required — never skip)
+A plan is not a wish list. Each step is an observable outcome someone
+could check. The LAST step is always a verification step: an explicit
+check that proves the work succeeded (command output, a metric, a health
+probe, a test, a user-visible result). Never end a plan on "do the
+thing"; end on "confirm the thing worked." Do not start executing the
+workload until this verifiable plan exists — unless Ask User is pending.
+
+STRUCTURE
+- 2–7 steps. Each step is one short sentence (about 5–10 words).
+- Status is pending, in_progress, or completed.
+- While work is underway, exactly one step is in_progress.
+- Do not jump pending → completed: set in_progress first.
+- As soon as a step is done, mark it completed and move in_progress to
+  the next. You may complete several in one call if they finished
+  together; leave exactly one in_progress, or mark every step completed.
+- If understanding changes (split, merge, reorder), call update_plan
+  with the revised steps and an explanation of why.
+- Plan-only requests ("don't run anything yet"): after Ask User answers
+  are in, update_plan with plan_only=true and every step pending and STOP.
+  Do not execute. Do not set plan_only just because Ask User was answered.
+- Before you conclude a workload that did run, every step — including
+  verification — is completed. Do not leave pending or in_progress items.
+
+HOW TO CALL
+update_plan(plan=[{step, status}, …], explanation?, plan_only?)
+The checklist steps stay short (5–10 words). Put the readable diagnosis in
+``explanation`` — the UI renders it as markdown under the checklist:
+Facts (bullets), "What the signature tells us", hypothesis-ranking table,
+and for plan-only workloads optional phased narrative (Phase 1 — …) plus
+"Biggest risk". Do not repeat that prose in the assistant closing reply.
+explanation is optional on revisions; include it when the plan or diagnosis
+changes.
+plan_only is optional; true only for an explicit "don't run yet" request.
+
+GOOD PLAN — checkout 502s (last step verifies):
+1. pending         Capture 502 samples from checkout
+2. in_progress     Trace 502s to the last deploy
+3. pending         Roll back or patch the failing change
+4. pending         Confirm checkout returns 2xx
+
+GOOD PLAN — plan-only (user said do not execute yet):
+1. pending         Inspect the failing GitHub Actions job
+2. pending         Patch the workflow from the error
+3. pending         Confirm the workflow run is green
+
+BAD PLANS (never do these)
+- A single step ("fix it").
+- Last step is "make the change" with no check.
+- Two or more steps in_progress at once.
+- Executing a multi-step workload without calling update_plan first.
+- Calling update_plan before Ask User when missing facts still block.
+- Leaving every step pending after answers when the user asked to execute.
+- Treating /work or /goal as a substitute for this live checklist.

--- a/core/agent_harness/task_plan/progress.py
+++ b/core/agent_harness/task_plan/progress.py
@@ -1,0 +1,36 @@
+"""Plain-text task-plan formatting (prompts, logs, non-TTY).
+
+Rich rendering lives in
+``surfaces.interactive_shell.ui.task_plan``.
+"""
+
+from __future__ import annotations
+
+from core.agent_harness.task_plan.plan import PlanStepStatus, TaskPlan
+
+PLAN_STATUS_GLYPH: dict[PlanStepStatus, str] = {
+    PlanStepStatus.COMPLETED: "✓",
+    PlanStepStatus.IN_PROGRESS: "●",
+    PlanStepStatus.PENDING: "○",
+}
+
+
+def format_plan_header(plan: TaskPlan) -> str:
+    """Counter line shared by plain text and the live overlay."""
+    if plan.all_pending:
+        return f"Plan ready · 0/{plan.total} executed"
+    return f"Plan · {plan.current_index}/{plan.total}"
+
+
+def format_task_plan_plain(plan: TaskPlan) -> str:
+    """Checklist with ``Plan · n/m`` header and ✓ / ● / ○ step marks."""
+    lines = [format_plan_header(plan)]
+    last_index = plan.total - 1
+    for index, item in enumerate(plan.steps):
+        mark = PLAN_STATUS_GLYPH[item.status]
+        suffix = "  (verify)" if index == last_index else ""
+        lines.append(f"  {mark} {item.step}{suffix}")
+    return "\n".join(lines)
+
+
+__all__ = ["PLAN_STATUS_GLYPH", "format_plan_header", "format_task_plan_plain"]

--- a/core/agent_harness/task_plan/prompt.py
+++ b/core/agent_harness/task_plan/prompt.py
@@ -1,0 +1,124 @@
+"""Prompt fragments for the live task plan.
+
+The STABLE planning instructions live in ``planning_instructions.md``. This
+module renders the per-turn CURRENT PLAN block from the snapshotted plan so
+transcript compaction cannot drop it.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from core.agent_harness.session.pending_choice import parse_ask_user_answers
+from core.agent_harness.task_plan.plan import PlanStepStatus, TaskPlan
+from core.agent_harness.task_plan.progress import format_task_plan_plain
+
+ASK_USER_ANSWERED_GUIDANCE = (
+    "ASK USER JUST ANSWERED (this turn). Continue — do not sit idle. "
+    "If this is the FIRST round and the answers open new discriminating "
+    "questions, call ask_user_choice for ONE more scoped round. If two rounds "
+    "are already answered (see the Q&A above), do NOT ask again — write the "
+    "analysis now with your best hypothesis. Two rounds is the hard maximum.\n"
+    "Write the analysis in structured sections, then update_plan:\n"
+    "- Facts: the answers as short bullets.\n"
+    "- What the signature tells us: for each fact state what it RULES OUT, not "
+    "just what it is; name the narrowing in one line.\n"
+    "- Hypothesis ranking: a table with columns # | Hypothesis | Why it fits | "
+    "Discriminator — the single observation that confirms or rules each one out "
+    "versus the others. Rank by how well current evidence fits.\n"
+    "Put that analysis in update_plan(..., explanation=...) — the UI renders it "
+    "under the checklist. Use headers and a table, never one dense paragraph. "
+    "Do not repeat it in the assistant closing reply. "
+    "Answering is the go-ahead to continue the original request. "
+    "Do not invent a plan-only pause. Set ask_user_choice(plan_only_after=true) "
+    "only when the original request asked not to run yet; then after answers "
+    "call update_plan(plan_only=true) and leave every step pending and STOP. "
+    "Otherwise set the first step in_progress and execute it now."
+)
+
+ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE = (
+    "ASK USER JUST ANSWERED (this turn). This request is plan-only — answering "
+    "does not authorize execution. If this is the FIRST round and the answers "
+    "open new discriminating questions, call ask_user_choice for ONE more "
+    "scoped round. If two rounds are already answered, do NOT ask again. "
+    "Write the analysis in structured sections, then update_plan with every "
+    "step pending and STOP:\n"
+    "- Facts: the answers as short bullets.\n"
+    "- What the signature tells us: for each fact state what it RULES OUT.\n"
+    "- Hypothesis ranking: # | Hypothesis | Why it fits | Discriminator.\n"
+    "Put that analysis in update_plan(..., explanation=...). Do not pass "
+    "plan_only=false; the host keeps the plan-only latch until the user "
+    "confirms a mutating step at the execution gate."
+)
+
+
+_INSTRUCTIONS_FILENAME = "planning_instructions.md"
+
+
+@lru_cache(maxsize=1)
+def load_planning_instructions() -> str:
+    """Return the bundled planning-instruction markdown."""
+    path = Path(__file__).with_name(_INSTRUCTIONS_FILENAME)
+    return path.read_text(encoding="utf-8")
+
+
+def ask_user_answered_block(text: str, *, plan_only: bool = False) -> str:
+    """Ephemeral start-now rule when this turn is structured Ask User answers."""
+    if not parse_ask_user_answers(text):
+        return ""
+    if plan_only:
+        return ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE
+    return ASK_USER_ANSWERED_GUIDANCE
+
+
+def current_task_plan_block(
+    plan: TaskPlan | None,
+    *,
+    plan_only: bool = False,
+) -> str:
+    """Render the CURRENT PLAN block, or ``""`` when no plan is attached."""
+    if plan is None or not plan.steps:
+        return ""
+    if plan.all_completed:
+        status = "complete"
+    elif plan.all_pending:
+        status = "ready, nothing executed"
+    else:
+        status = "in progress"
+    lines = [
+        f"CURRENT PLAN ({status}; Plan · {plan.current_index}/{plan.total}). "
+        "This is the durable record — older messages may have dropped an "
+        "earlier version. Keep it current with update_plan; do not recreate "
+        "it from memory.",
+        format_task_plan_plain(plan),
+    ]
+    if plan.explanation:
+        lines.append(f"explanation: {plan.explanation}")
+    if plan.all_pending and not plan_only:
+        lines.append(
+            "Execution is authorized: set the first step to in_progress and "
+            "run its tools — do not wait for the user to say go."
+        )
+    in_progress = next(
+        (item.step for item in plan.steps if item.status is PlanStepStatus.IN_PROGRESS),
+        None,
+    )
+    if in_progress is not None:
+        lines.append(f"now: {in_progress}")
+        lines.append(
+            "Do not conclude this turn while a step is in_progress. "
+            "Keep working that step, or ask_user_choice if facts are missing. "
+            "Do not start another investigation."
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ASK_USER_ANSWERED_GUIDANCE",
+    "ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE",
+    "ask_user_answered_block",
+    "current_task_plan_block",
+    "load_planning_instructions",
+]

--- a/core/agent_harness/task_plan/update_plan_policy.py
+++ b/core/agent_harness/task_plan/update_plan_policy.py
@@ -1,0 +1,62 @@
+"""Host policy for ``update_plan`` — normalize model mistakes after Ask User."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.session.pending_choice import parse_ask_user_answers
+from core.agent_harness.task_plan.display import promote_first_pending_step
+from core.agent_harness.task_plan.plan import TaskPlan
+
+
+def apply_update_plan_host_policy(
+    plan: TaskPlan,
+    *,
+    plan_only_requested: bool,
+    turn_user_message: str,
+    session: Any,
+) -> tuple[TaskPlan, bool]:
+    """Return ``(plan, effective_plan_only)`` after Ask User rules.
+
+    A user-originated plan-only restriction (the armed ``plan_only_until_authorized``
+    latch, set either by ``ask_user_choice(plan_only_after=true)`` or a prior
+    ``update_plan(plan_only=true)``) cannot be dropped by a model
+    ``plan_only=false``. Ask User answers otherwise continue the original
+    request — models often mis-set ``plan_only`` there.
+    """
+    ask_user_turn = bool(parse_ask_user_answers(turn_user_message))
+    user_plan_only = bool(getattr(session, "plan_only_until_authorized", False))
+
+    if ask_user_turn:
+        if user_plan_only:
+            effective_plan_only = True
+        else:
+            effective_plan_only = False
+            if plan.all_pending:
+                plan = promote_first_pending_step(plan)
+        return plan, effective_plan_only
+
+    return plan, plan_only_requested
+
+
+def apply_update_plan_session(
+    session: Any,
+    plan: TaskPlan,
+    *,
+    plan_only: bool,
+) -> None:
+    """Persist plan and the plan-only latch from normalized policy output.
+
+    The latch is set-only here: marking a step in_progress must NOT clear it, or
+    the model could authorize its own execution. Only the user confirming a
+    mutating step at the execution gate lifts the latch.
+    """
+    session.task_plan = plan
+    if plan_only:
+        session.plan_only_until_authorized = True
+
+
+__all__ = [
+    "apply_update_plan_host_policy",
+    "apply_update_plan_session",
+]

--- a/core/agent_harness/tools/tool_context.py
+++ b/core/agent_harness/tools/tool_context.py
@@ -31,6 +31,8 @@ class ActionToolScope:
     #: Length of ``session.history`` when this turn began, so a tool can tell
     #: what THIS turn produced from what the session already contained.
     history_start: int = 0
+    #: User message that started this action turn (Ask User answers, slash, …).
+    turn_user_message: str = ""
     # Surface-injected subprocess presenter (``tools.interactive_shell.subprocess``).
     subprocess_presenter: Any = None
     investigation_ports: Any = None

--- a/core/agent_harness/tools/tool_provider.py
+++ b/core/agent_harness/tools/tool_provider.py
@@ -83,6 +83,7 @@ class DefaultToolProvider:
         confirm_fn: ConfirmFn | None,
         is_tty: bool | None,
         resolved_integrations: dict[str, Any] | None = None,
+        turn_user_message: str = "",
     ) -> list[Any]:
         subprocess_presenter = None
         presenter_factory = self._subprocess_presenter_factory
@@ -121,6 +122,7 @@ class DefaultToolProvider:
             # Built once per turn, before any tool runs — so the current
             # history length is this turn's starting boundary.
             history_start=len(getattr(self._session, "history", None) or []),
+            turn_user_message=turn_user_message,
             subprocess_presenter=subprocess_presenter,
             investigation_ports=investigation_ports,
             llm_provider_ports=llm_provider_ports,

--- a/core/agent_harness/turns/turn_snapshot.py
+++ b/core/agent_harness/turns/turn_snapshot.py
@@ -17,6 +17,7 @@ from infrastructure.setup_state import cached_setup_state
 
 if TYPE_CHECKING:
     from config.llm_reasoning_effort import ReasoningEffortChoice
+    from core.agent_harness.task_plan.plan import TaskPlan
     from core.messages import RuntimeMessage
 
 RuntimeTool = Any
@@ -187,6 +188,12 @@ class TurnSnapshot:
     the action agent. Consumed from ``session.pending_recovery_note`` (popped:
     the note rides exactly one turn)."""
 
+    task_plan: TaskPlan | None = None
+    """Live ``update_plan`` checklist at turn start (survives transcript drop)."""
+
+    plan_only_until_authorized: bool = False
+    """When true, the user asked for a plan without running it yet."""
+
     @classmethod
     def from_session(
         cls,
@@ -237,6 +244,8 @@ class TurnSnapshot:
             model=getattr(runtime_input, "model", None),
             last_observation=last_observation,
             recovery_note=recovery_note,
+            task_plan=_read_task_plan(session),
+            plan_only_until_authorized=bool(getattr(session, "plan_only_until_authorized", False)),
         )
 
     def render_system_prompt(self) -> str:
@@ -271,6 +280,14 @@ def _pop_recovery_note(session: TurnSnapshotSource) -> str | None:
         return None
     setattr(session, "pending_recovery_note", None)  # noqa: B010 - protocol lacks the optional field
     return note
+
+
+def _read_task_plan(session: TurnSnapshotSource) -> TaskPlan | None:
+    """Copy the live task plan if the source carries one."""
+    from core.agent_harness.task_plan.plan import TaskPlan
+
+    plan = getattr(session, "task_plan", None)
+    return plan if isinstance(plan, TaskPlan) else None
 
 
 def _read_last_observation(session: TurnSnapshotSource, runtime_input: Any | None) -> str | None:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -20,11 +20,21 @@ from rich.console import Console
 from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
+from core.agent_harness.spi.task_plan import (
+    apply_update_plan_host_policy,
+    apply_update_plan_session,
+    is_plan_diagnosis_prose,
+    parse_task_plan,
+)
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.ui.streaming import render_markdown_block
+from surfaces.interactive_shell.ui.task_plan import (
+    render_plan_updated,
+    render_task_plan,
+)
 from surfaces.shared.terminal.output.console_state import get_investigation_spinner
 
 # Tools whose preview is just ``(label, single-arg)``. The display content is the
@@ -90,6 +100,7 @@ class ActionRenderObserver:
         self.message = message
         self.planned_count = 0
         self._pending_skill_calls: dict[str, str] = {}
+        self._last_plan_signature: tuple[tuple[str, Any], ...] | None = None
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         if kind == "llm_start":
@@ -121,6 +132,8 @@ class ActionRenderObserver:
         self._set_spinner_phase(SpinnerState.INVOKING_TOOLS_PHASE)
         if name == "skill_view":
             self._render_skill_start(data)
+        elif name == "update_plan":
+            self._render_plan_update(data)
         elif name in _SELF_RENDERING_TOOLS:
             pass  # owns its UI; a generic preview would duplicate it
         else:
@@ -166,6 +179,8 @@ class ActionRenderObserver:
         content = str(data.get("content", "")).strip()
         if not content:
             return
+        if is_plan_diagnosis_prose(content):
+            return
         self.console.print()
         # ``render_markdown_block`` sanitizes model text at ``_build_markdown_block``.
         render_markdown_block(self.console, content)
@@ -194,6 +209,33 @@ class ActionRenderObserver:
             line.append(f" {content}", style=str(BRAND))
         self.console.print()
         self.console.print(line)
+
+    def _render_plan_update(self, data: dict[str, Any]) -> None:
+        args = data.get("input")
+        if not isinstance(args, dict):
+            self._render_tool_invocation("update_plan", data)
+            return
+        plan, error = parse_task_plan(args)
+        if error is not None or plan is None:
+            self._render_tool_invocation("update_plan", data)
+            return
+        plan, plan_only = apply_update_plan_host_policy(
+            plan,
+            plan_only_requested=bool(args.get("plan_only")),
+            turn_user_message=self.message,
+            session=self.session,
+        )
+        apply_update_plan_session(self.session, plan, plan_only=plan_only)
+        # Dedupe: redundant update_plan calls in one workload must not reprint
+        # the unchanged checklist.
+        signature = tuple((item.step, item.status) for item in plan.steps)
+        if signature == self._last_plan_signature:
+            return
+        self._last_plan_signature = signature
+        if plan.all_pending:
+            render_task_plan(self.console, plan)
+            return
+        render_plan_updated(self.console, plan)
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:
         """Print the ``↳`` child line under the skill's ``tool_start`` parent."""

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -31,6 +31,7 @@ from surfaces.interactive_shell.ui.task_plan import (
     render_task_plan,
 )
 from surfaces.shared.terminal.output.console_state import get_investigation_spinner
+from tools.interactive_shell.action_names import ActionToolName
 
 # Tools whose preview is just ``(label, single-arg)``. The display content is the
 # stripped string value of that single argument. Anything that needs to combine
@@ -40,19 +41,19 @@ from surfaces.shared.terminal.output.console_state import get_investigation_spin
 _VERB_ROTATION_STEP_INTERVAL = 2
 
 _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
-    "llm_set_provider": ("LLM provider", "target"),
-    "alert_sample": ("sample alert", "template"),
-    "investigation_start": ("investigation", "alert_text"),
-    "task_cancel": ("cancel task", "target"),
-    "cli_exec": ("opensre", "payload"),
-    "code_implement": ("implementation", "task"),
-    "shell_run": ("Execute", "command"),
+    ActionToolName.LLM_SET_PROVIDER: ("LLM provider", "target"),
+    ActionToolName.ALERT_SAMPLE: ("sample alert", "template"),
+    ActionToolName.INVESTIGATION_START: ("investigation", "alert_text"),
+    ActionToolName.TASK_CANCEL: ("cancel task", "target"),
+    ActionToolName.CLI_EXEC: ("opensre", "payload"),
+    ActionToolName.CODE_IMPLEMENT: ("implementation", "task"),
+    ActionToolName.SHELL_RUN: ("Execute", "command"),
 }
 
 #: Tools that render their own dedicated UI (the investigation lap/spinner
 #: progress). The generic live tool-call preview is suppressed for these so it
 #: does not duplicate that UI as a wall of text.
-_SELF_RENDERING_TOOLS: frozenset[str] = frozenset({"investigation_start"})
+_SELF_RENDERING_TOOLS: frozenset[str] = frozenset({ActionToolName.INVESTIGATION_START})
 
 
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
@@ -61,12 +62,12 @@ def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
     Both strings are stripped of terminal controls: callers append them to a
     raw Rich line, and the tool name and args are model-supplied.
     """
-    if tool_name == "slash_invoke":
+    if tool_name == ActionToolName.SLASH_INVOKE:
         command = str(args.get("command", "")).strip()
         raw_args = args.get("args")
         parsed_args = [str(item).strip() for item in raw_args] if isinstance(raw_args, list) else []
         label, content = "command", " ".join([command, *parsed_args]).strip()
-    elif tool_name == "synthetic_run":
+    elif tool_name == ActionToolName.SYNTHETIC_RUN:
         suite = str(args.get("suite", "")).strip()
         scenario = str(args.get("scenario", "")).strip()
         label, content = "synthetic test", f"{suite}:{scenario}" if scenario else suite
@@ -117,9 +118,9 @@ class ActionRenderObserver:
             return
         if kind == "tool_end":
             name = str(data.get("name", "")).strip()
-            if name == "skill_view":
+            if name == ActionToolName.SKILL_VIEW:
                 self._render_skill_end(data)
-            elif name == "update_plan":
+            elif name == ActionToolName.UPDATE_PLAN:
                 # Commit lives in the tool; paint only after a successful result
                 # so a rejected call cannot leave session/overlay on a failed plan.
                 self._render_plan_update(data)
@@ -131,9 +132,9 @@ class ActionRenderObserver:
         if not name:
             return
         self._set_spinner_phase(SpinnerState.INVOKING_TOOLS_PHASE)
-        if name == "skill_view":
+        if name == ActionToolName.SKILL_VIEW:
             self._render_skill_start(data)
-        elif name == "update_plan":
+        elif name == ActionToolName.UPDATE_PLAN:
             pass  # render on tool_end after the tool commits session state
         elif name in _SELF_RENDERING_TOOLS:
             pass  # owns its UI; a generic preview would duplicate it

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -20,12 +20,7 @@ from rich.console import Console
 from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
-from core.agent_harness.spi.task_plan import (
-    apply_update_plan_host_policy,
-    apply_update_plan_session,
-    is_plan_diagnosis_prose,
-    parse_task_plan,
-)
+from core.agent_harness.spi.task_plan import TaskPlan, is_plan_diagnosis_prose
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session
@@ -100,7 +95,8 @@ class ActionRenderObserver:
         self.message = message
         self.planned_count = 0
         self._pending_skill_calls: dict[str, str] = {}
-        self._last_plan_signature: tuple[tuple[str, Any], ...] | None = None
+        # (explanation, ((step, status), ...)) — explanation changes must refresh.
+        self._last_plan_signature: tuple[str, tuple[tuple[str, str], ...]] | None = None
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         if kind == "llm_start":
@@ -120,8 +116,13 @@ class ActionRenderObserver:
                 )
             return
         if kind == "tool_end":
-            if str(data.get("name", "")).strip() == "skill_view":
+            name = str(data.get("name", "")).strip()
+            if name == "skill_view":
                 self._render_skill_end(data)
+            elif name == "update_plan":
+                # Commit lives in the tool; paint only after a successful result
+                # so a rejected call cannot leave session/overlay on a failed plan.
+                self._render_plan_update(data)
             self._set_spinner_phase(SpinnerState.EXECUTING_PHASE)
             return
         if kind != "tool_start":
@@ -133,7 +134,7 @@ class ActionRenderObserver:
         if name == "skill_view":
             self._render_skill_start(data)
         elif name == "update_plan":
-            self._render_plan_update(data)
+            pass  # render on tool_end after the tool commits session state
         elif name in _SELF_RENDERING_TOOLS:
             pass  # owns its UI; a generic preview would duplicate it
         else:
@@ -211,24 +212,22 @@ class ActionRenderObserver:
         self.console.print(line)
 
     def _render_plan_update(self, data: dict[str, Any]) -> None:
-        args = data.get("input")
-        if not isinstance(args, dict):
-            self._render_tool_invocation("update_plan", data)
+        """Paint the checklist after a successful ``update_plan`` tool result.
+
+        Session state is written by the tool itself — this observer must not
+        commit on ``tool_start``, or a later validation/hook failure would leave
+        the overlay and flush transcript advertising a plan that never landed.
+        """
+        output = data.get("output")
+        if not isinstance(output, dict) or not output.get("ok"):
             return
-        plan, error = parse_task_plan(args)
-        if error is not None or plan is None:
-            self._render_tool_invocation("update_plan", data)
+        plan = getattr(self.session, "task_plan", None)
+        if not isinstance(plan, TaskPlan) or not plan.steps:
             return
-        plan, plan_only = apply_update_plan_host_policy(
-            plan,
-            plan_only_requested=bool(args.get("plan_only")),
-            turn_user_message=self.message,
-            session=self.session,
+        signature = (
+            plan.explanation,
+            tuple((item.step, str(item.status)) for item in plan.steps),
         )
-        apply_update_plan_session(self.session, plan, plan_only=plan_only)
-        # Dedupe: redundant update_plan calls in one workload must not reprint
-        # the unchanged checklist.
-        signature = tuple((item.step, item.status) for item in plan.steps)
         if signature == self._last_plan_signature:
             return
         self._last_plan_signature = signature
@@ -236,6 +235,9 @@ class ActionRenderObserver:
             render_task_plan(self.console, plan)
             return
         render_plan_updated(self.console, plan)
+        explanation = strip_terminal_controls(plan.explanation)
+        if explanation:
+            render_markdown_block(self.console, explanation)
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:
         """Print the ``↳`` child line under the skill's ``tool_start`` parent."""

--- a/surfaces/interactive_shell/ui/execution_confirm.py
+++ b/surfaces/interactive_shell/ui/execution_confirm.py
@@ -33,6 +33,8 @@ from tools.interactive_shell.shared import (
     ExecutionPolicyResult,
     ExecutionVerdict,
     apply_auto_level,
+    apply_plan_only_gate,
+    is_mutating_tool_type,
     resolve_confirmation,
 )
 
@@ -117,6 +119,8 @@ def execution_allowed(
     confirm = confirm_fn or DEFAULT_CONFIRM_FN
     auto_level = getattr(getattr(session, "terminal", None), "auto_level", DEFAULT_AUTO_LEVEL)
     result = apply_auto_level(result, auto_level)
+    plan_only_active = bool(getattr(session, "plan_only_until_authorized", False))
+    result = apply_plan_only_gate(result, plan_only_active=plan_only_active)
 
     plan = resolve_confirmation(result, trust_mode=trust_mode, is_tty=tty)
 
@@ -188,6 +192,10 @@ def execution_allowed(
         reason="user_confirmed",
         user_prompted=True,
     )
+    if plan_only_active and is_mutating_tool_type(result.tool_type):
+        # Confirming a mutating step at the gate is the explicit authorization
+        # that lifts a plan-only request; the rest of the plan runs normally.
+        session.plan_only_until_authorized = False
     return True
 
 

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -143,7 +143,12 @@ def resolve_prompt_prefix_ansi(*, inline_spinner: str, idle_hint: str) -> str:
 
 
 def resolve_idle_hint_ansi(session: Session) -> str:
-    """Dim hint line above the prompt rule: shortcuts plus connected integrations."""
+    """Status line when no turn is running: ``Ready`` plus shortcuts.
+
+    The live prompt always shows either ``Thinking…`` (spinner) or ``Ready``.
+    Without ``Ready``, an in-progress plan overlay looks like the agent is
+    still working after the turn has already returned the prompt.
+    """
     parts = ["/ for commands", "tab tool details", "↑↓ history"]
     if session.configured_integrations_known and session.configured_integrations:
         max_shown = 4
@@ -159,8 +164,13 @@ def resolve_idle_hint_ansi(session: Session) -> str:
         parts.append("esc to clear")
     # Clip to the safe prompt-region width so a long integration list cannot
     # reach the last column and soft-wrap on shrink-resize.
-    hint = clip_prompt_text(" · ".join(parts), prompt_line_width())
-    return f"{ui_theme.DIM_ANSI}{hint}{ui_theme.ANSI_RESET}"
+    width = prompt_line_width()
+    status = "Ready"
+    rest = clip_prompt_text(" · ".join(parts), max(width - len(status) - 3, 1))
+    return (
+        f"{ui_theme.PROMPT_ACCENT_ANSI}{status}{ui_theme.ANSI_RESET}"
+        f"{ui_theme.DIM_ANSI} · {rest}{ui_theme.ANSI_RESET}"
+    )
 
 
 def resolve_prompt_placeholder(session: Session) -> ANSI:
@@ -175,4 +185,12 @@ def resolve_prompt_placeholder(session: Session) -> ANSI:
         parts.append(f"resumed: {_short_meta(session.resumed_from_name, max_len=32)}")
     if parts:
         return ANSI(f"{ui_theme.ANSI_DIM}{' · '.join(parts)}{ui_theme.ANSI_RESET}")
+    if (
+        session.task_plan is not None
+        and session.task_plan.all_pending
+        and session.plan_only_until_authorized
+    ):
+        return ANSI(
+            f"{ui_theme.ANSI_DIM}say go to start the plan, or type a message{ui_theme.ANSI_RESET}"
+        )
     return _DEFAULT_PLACEHOLDER_ANSI

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -1,0 +1,116 @@
+"""Live task-plan checklist for the interactive shell.
+
+The transcript prints a dim toast when the agent revises the plan, and the
+full checklist once when every step is still pending. The live prompt overlay
+is only the header plus the current step — a six-step list in the prompt
+region is reprinted into scrollback on every ``patch_stdout`` tool line.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.text import Text
+
+from core.agent_harness.spi.task_plan import (
+    PLAN_STATUS_GLYPH,
+    PlanStep,
+    PlanStepStatus,
+    TaskPlan,
+    format_plan_header,
+    parse_task_plan,
+)
+from infrastructure.safety.terminal_output import strip_terminal_controls
+from infrastructure.terminal import theme as ui_theme
+from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
+from surfaces.interactive_shell.ui.streaming import render_markdown_block
+
+
+def task_plan_from_tool_args(args: dict[str, object]) -> TaskPlan | None:
+    """Parse a plan from an ``update_plan`` tool-call payload."""
+    if not isinstance(args, dict):
+        return None
+    plan, _error = parse_task_plan(args)
+    return plan
+
+
+def render_plan_updated(console: Console, plan: TaskPlan | None = None) -> None:
+    """Print the transcript toast: ready (nothing ran) or updated (work underway)."""
+    console.print()
+    if plan is not None and plan.all_pending:
+        console.print(Text("Plan ready — nothing executed", style=str(ui_theme.DIM)))
+        return
+    console.print(Text("Plan updated", style=str(ui_theme.DIM)))
+
+
+def _overlay_line(text: str, style: str, width: int) -> str:
+    """One ANSI overlay row: strip controls via ``clip_prompt_text``, then style.
+
+    ``clip_prompt_text`` is the single sanitize+truncate boundary for raw ANSI
+    overlays (including ``PlanStep`` instances built outside ``parse_task_plan``).
+    """
+    return f"{style}{clip_prompt_text(text, width)}{ui_theme.ANSI_RESET}"
+
+
+def _step_overlay_line(item: PlanStep, width: int) -> str:
+    step = item.step
+    glyph = PLAN_STATUS_GLYPH[item.status]
+    if item.status is PlanStepStatus.IN_PROGRESS:
+        return _overlay_line(
+            f"{glyph} {step}",
+            f"{ui_theme.ANSI_BOLD}{ui_theme.TEXT_ANSI}",
+            width,
+        )
+    if item.status is PlanStepStatus.COMPLETED:
+        clipped = clip_prompt_text(step, max(width - 2, 1))
+        return (
+            f"{ui_theme.HIGHLIGHT_ANSI}{glyph} {ui_theme.ANSI_RESET}"
+            f"{ui_theme.DIM_ANSI}{clipped}{ui_theme.ANSI_RESET}"
+        )
+    return _overlay_line(f"{glyph} {step}", ui_theme.DIM_ANSI, width)
+
+
+def task_plan_overlay_ansi(plan: TaskPlan) -> str:
+    """Two-line ANSI overlay: ``Plan · n/m`` plus the current step."""
+    width = prompt_line_width()
+    return "\n".join(
+        (
+            _overlay_line(format_plan_header(plan), ui_theme.SECONDARY_ANSI, width),
+            _step_overlay_line(plan.focused_step, width),
+        )
+    )
+
+
+def render_task_plan(console: Console, plan: TaskPlan) -> None:
+    """Print the toast plus the full checklist (ready dump and tests)."""
+    render_plan_updated(console, plan)
+    header = Text()
+    header.append(format_plan_header(plan), style=str(ui_theme.SECONDARY))
+    console.print(header)
+    for item in plan.steps:
+        # Sanitize at this sink: ``PlanStep`` may be built outside parse
+        # (tests, restored payloads that skipped ``parse_task_plan``).
+        glyph = PLAN_STATUS_GLYPH[item.status]
+        step = strip_terminal_controls(item.step)
+        line = Text()
+        if item.status is PlanStepStatus.IN_PROGRESS:
+            line.append(f"{glyph} ", style=f"bold {ui_theme.TEXT}")
+            line.append(step, style=f"bold {ui_theme.TEXT}")
+        elif item.status is PlanStepStatus.COMPLETED:
+            line.append(f"{glyph} ", style=str(ui_theme.HIGHLIGHT))
+            line.append(step, style=str(ui_theme.DIM))
+        else:
+            line.append(f"{glyph} ", style=str(ui_theme.DIM))
+            line.append(step, style=str(ui_theme.DIM))
+        console.print(line)
+    explanation = strip_terminal_controls(plan.explanation)
+    if explanation:
+        render_markdown_block(console, explanation)
+    console.print()
+
+
+__all__ = [
+    "render_plan_updated",
+    "render_task_plan",
+    "task_plan_from_tool_args",
+    "task_plan_overlay_ansi",
+]

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -21,6 +21,7 @@ from rich.console import Console
 
 from surfaces.interactive_shell.ui.auto_status import auto_status_ansi
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
+from surfaces.interactive_shell.ui.task_plan import task_plan_overlay_ansi
 from surfaces.shared.terminal.banner import render_ready_box
 from surfaces.shared.terminal.components.cpr_stdin import strip_cpr_sequences
 from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_line_width
@@ -72,6 +73,13 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
+    # A live plan sits as an overlay above the prefix. Its presence tracks
+    # ``session.task_plan`` (stable across redraws), not the prompt state, so it
+    # adds a constant row whether or not a confirmation is pending.
+    plan = session.task_plan
+    if plan is not None and plan.steps:
+        overlay = strip_cpr_sequences(task_plan_overlay_ansi(plan))
+        return ANSI(f"\n{overlay}\n{prefix}\n{auto_line}\n{base}")
     return ANSI(f"\n{prefix}\n{auto_line}\n{base}")
 
 

--- a/tests/core/agent/orchestration/test_update_plan_ask_user.py
+++ b/tests/core/agent/orchestration/test_update_plan_ask_user.py
@@ -1,0 +1,103 @@
+"""Tests for update_plan host policy after Ask User answers."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness.session.pending_choice import (
+    AskUserQuestion,
+    format_ask_user_answers,
+)
+from core.agent_harness.task_plan.plan import PlanStepStatus
+from core.agent_harness.tools.tool_context import ActionToolScope
+from surfaces.interactive_shell.session import Session
+from tools.interactive_shell.actions.update_plan import execute_update_plan_tool
+
+
+def _ctx(
+    session: Session | None = None,
+    *,
+    turn_user_message: str = "",
+) -> ActionToolScope:
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    return ActionToolScope(
+        session=session if session is not None else Session(),
+        console=console,
+        turn_user_message=turn_user_message,
+    )
+
+
+def _ask_user_turn_text() -> str:
+    return format_ask_user_answers(
+        (
+            AskUserQuestion(label="Onset", title="When did it start?", options=("Gradual",)),
+            AskUserQuestion(label="Signal", title="Strongest signal?", options=("CPU",)),
+        ),
+        ("Gradual", "CPU"),
+    )
+
+
+_PLAN: list[dict[str, Any]] = [
+    {"step": "Pinpoint onset on p99", "status": "pending"},
+    {"step": "Confirm checkout returns 2xx", "status": "pending"},
+]
+
+
+def test_update_plan_strips_plan_only_after_ask_user_answers() -> None:
+    session = Session()
+    result = execute_update_plan_tool(
+        {"plan": _PLAN, "plan_only": True},
+        _ctx(session=session, turn_user_message=_ask_user_turn_text()),
+    )
+
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is False
+    assert session.task_plan is not None
+    assert session.task_plan.steps[0].status is PlanStepStatus.IN_PROGRESS
+    assert "Execution is authorized" in result["instruction"]
+
+
+def test_update_plan_honors_plan_only_on_normal_turn() -> None:
+    session = Session()
+    result = execute_update_plan_tool(
+        {"plan": _PLAN, "plan_only": True},
+        _ctx(session=session, turn_user_message="plan only — do not run yet"),
+    )
+
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is True
+    assert session.task_plan is not None
+    assert session.task_plan.all_pending is True
+    assert "Plan-only" in result["instruction"]
+
+
+def test_update_plan_honors_plan_only_after_ask_user_when_workload_flag_set() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    result = execute_update_plan_tool(
+        {"plan": _PLAN, "plan_only": True},
+        _ctx(session=session, turn_user_message=_ask_user_turn_text()),
+    )
+
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is True
+    assert session.task_plan is not None
+    assert session.task_plan.all_pending is True
+
+
+def test_update_plan_model_false_cannot_clear_plan_only_after_ask_user() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    result = execute_update_plan_tool(
+        {"plan": _PLAN, "plan_only": False},
+        _ctx(session=session, turn_user_message=_ask_user_turn_text()),
+    )
+
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is True
+    assert session.task_plan is not None
+    assert session.task_plan.all_pending is True
+    assert "Plan-only" in result["instruction"]

--- a/tests/core/agent/orchestration/test_update_plan_tool.py
+++ b/tests/core/agent/orchestration/test_update_plan_tool.py
@@ -1,0 +1,64 @@
+"""Tests for the agent update_plan tool."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness.tools.tool_context import ActionToolScope
+from surfaces.interactive_shell.session import Session
+from tools.interactive_shell.actions.update_plan import (
+    execute_update_plan_tool,
+    update_plan_tool,
+)
+
+
+def _ctx(session: Session | None = None) -> ActionToolScope:
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    return ActionToolScope(
+        session=session if session is not None else Session(),
+        console=console,
+    )
+
+
+_PLAN: list[dict[str, Any]] = [
+    {"step": "Capture 502 samples from checkout", "status": "completed"},
+    {"step": "Trace 502s to the last deploy", "status": "in_progress"},
+    {"step": "Confirm checkout returns 2xx", "status": "pending"},
+]
+
+
+def test_update_plan_tool_is_action_surface_read_only() -> None:
+    assert update_plan_tool.name == "update_plan"
+    assert "action" in update_plan_tool.surfaces
+    assert update_plan_tool.side_effect_level == "read_only"
+    assert update_plan_tool.parallel_safe is False
+
+
+def test_update_plan_stores_the_checklist_on_the_session() -> None:
+    session = Session()
+    result = execute_update_plan_tool({"plan": _PLAN}, _ctx(session=session))
+
+    assert result["ok"] is True
+    assert result["current"] == 2
+    assert result["total"] == 3
+    assert session.task_plan is not None
+    assert session.task_plan.current_index == 2
+    assert "Plan · 2/3" in result["summary"]
+    assert "(verify)" in result["summary"]
+
+
+def test_update_plan_rejects_two_in_progress_steps() -> None:
+    result = execute_update_plan_tool(
+        {
+            "plan": [
+                {"step": "First", "status": "in_progress"},
+                {"step": "Second", "status": "in_progress"},
+            ]
+        },
+        _ctx(),
+    )
+    assert result["ok"] is False
+    assert "at most one" in result["error"]

--- a/tests/core/agent/orchestration/test_update_plan_tool.py
+++ b/tests/core/agent/orchestration/test_update_plan_tool.py
@@ -51,14 +51,18 @@ def test_update_plan_stores_the_checklist_on_the_session() -> None:
 
 
 def test_update_plan_rejects_two_in_progress_steps() -> None:
+    session = Session()
     result = execute_update_plan_tool(
         {
             "plan": [
                 {"step": "First", "status": "in_progress"},
                 {"step": "Second", "status": "in_progress"},
-            ]
+            ],
+            "plan_only": True,
         },
-        _ctx(),
+        _ctx(session=session),
     )
     assert result["ok"] is False
     assert "at most one" in result["error"]
+    assert session.task_plan is None
+    assert session.plan_only_until_authorized is False

--- a/tests/core/agent/test_prompt_envelope.py
+++ b/tests/core/agent/test_prompt_envelope.py
@@ -74,6 +74,7 @@ def test_action_system_prompt_envelope_matches_legacy_rendering(
         PromptBlockId.ACTION_VENDOR_FRAGMENTS,
         PromptBlockId.ACTION_RUNTIME_FACTS,
         PromptBlockId.ACTION_SKILLS,
+        PromptBlockId.ACTION_PLANNING_INSTRUCTIONS,
         PromptBlockId.CONNECTED_INTEGRATIONS,
         PromptBlockId.RECENT_CONVERSATION,
     ]
@@ -86,6 +87,10 @@ def test_action_system_prompt_envelope_matches_legacy_rendering(
         envelope.require_block(PromptBlockId.ACTION_RUNTIME_FACTS).kind == PromptBlockKind.CONTEXT
     )
     assert envelope.require_block(PromptBlockId.ACTION_SKILLS).kind == PromptBlockKind.RULE
+    assert (
+        envelope.require_block(PromptBlockId.ACTION_PLANNING_INSTRUCTIONS).kind
+        == PromptBlockKind.RULE
+    )
     assert (
         envelope.require_block(PromptBlockId.CONNECTED_INTEGRATIONS).kind == PromptBlockKind.CONTEXT
     )
@@ -186,6 +191,7 @@ def test_every_block_declares_which_tier_it_belongs_to(
         PromptBlockId.ACTION_VENDOR_FRAGMENTS: PromptTier.STABLE,
         PromptBlockId.ACTION_RUNTIME_FACTS: PromptTier.STABLE,
         PromptBlockId.ACTION_SKILLS: PromptTier.STABLE,
+        PromptBlockId.ACTION_PLANNING_INSTRUCTIONS: PromptTier.STABLE,
         PromptBlockId.CONNECTED_INTEGRATIONS: PromptTier.CONTEXT,
         PromptBlockId.RECENT_CONVERSATION: PromptTier.EPHEMERAL,
     }

--- a/tests/core/agent/test_turn_scenarios.py
+++ b/tests/core/agent/test_turn_scenarios.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict, cast
 
@@ -46,7 +47,7 @@ from tests.core.agent.scenario_loader import (
     select_cases,
     select_representative,
 )
-from tools.interactive_shell.action_names import TOOL_KIND_TO_NAME, ToolKind
+from tools.interactive_shell.action_names import TOOL_KIND_TO_NAME, ActionToolName, ToolKind
 from tools.interactive_shell.actions.investigation import normalize_investigation_alert_text
 
 
@@ -74,6 +75,15 @@ _ALL_CASES = load_all_scenarios()
 _DEFAULT_GATE_CASES = select_representative(_ALL_CASES)
 _LIVE_CASES = iter_scenarios_for_shard(_DEFAULT_GATE_CASES)
 _NAME_TO_TOOL_KIND = {tool: kind for kind, tool in TOOL_KIND_TO_NAME.items()}
+# Playbook / session-meta tools the live planner may emit before a scenario
+# kind. They are not ToolKind members, so fixtures never list them.
+_PLANNING_PRELUDE_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        ActionToolName.ASK_USER_CHOICE,
+        ActionToolName.SKILL_VIEW,
+        ActionToolName.UPDATE_PLAN,
+    }
+)
 # Mirror the production action loop budget so live planning can exercise the same
 # multi-step, data-dependent compound chains the real gateway/REPL turns allow,
 # instead of drifting from a stale hardcoded cap.
@@ -186,6 +196,11 @@ def _build_actual_action(action: ToolCall) -> ExpectedAction:
             str(template_value).strip() if isinstance(template_value, str) else content
         )
     return expected
+
+
+def _scenario_tool_calls(actions: Sequence[ToolCall]) -> list[ToolCall]:
+    """Drop playbook/session-meta calls before matching fixture planned_actions."""
+    return [action for action in actions if action.name not in _PLANNING_PRELUDE_TOOL_NAMES]
 
 
 def _planning_probe_tool(tool: AgentTool) -> AgentTool:
@@ -448,7 +463,7 @@ def _assert_live_action_planning_once(case: ScenarioCase) -> None:
         resolved_integrations={},
         max_iterations=_LIVE_PLANNING_MAX_ITERATIONS,
     ).run([{"role": "user", "content": build_action_user_message(prompt)}])
-    actions = [tool_call for tool_call, _output in result.executed]
+    actions = _scenario_tool_calls([tool_call for tool_call, _output in result.executed])
     actual_actions = [_build_actual_action(action) for action in actions]
     actual_actions_for_match = _planning_actions_for_match(actual_actions, expected_actions)
 
@@ -567,6 +582,35 @@ def test_live_turn_execution_oracle(
         f"oracle case {live_oracle_case.scenario.id!r} failed {runs - passed_count}/{runs} runs; "
         f"artifact: {artifact_file}; failed_details={json.dumps(failed_details, ensure_ascii=True)}"
     )
+
+
+def test_planning_match_strips_skill_view_prelude() -> None:
+    """skill_view loads a playbook; fixtures pin the following scenario kind."""
+    skill = ToolCall(id="t1", name=ActionToolName.SKILL_VIEW, input={"name": "github-cli"})
+    cli = ToolCall(
+        id="t2",
+        name=ActionToolName.CLI_EXEC,
+        input={"payload": "integrations verify --dry-run"},
+    )
+    expected = cast(
+        "list[ExpectedAction]",
+        [
+            {
+                "kind": "cli_command",
+                "content": "integrations verify --dry-run",
+                "source": "llm",
+                "target_surface": "terminal",
+                "payload": "integrations verify --dry-run",
+            }
+        ],
+    )
+    actual = [_build_actual_action(action) for action in _scenario_tool_calls([skill, cli])]
+    _assert_planned_actions_match(actual, expected)
+
+
+def test_unknown_action_tool_still_fails_planning_match() -> None:
+    with pytest.raises(AssertionError, match="Unexpected action tool call"):
+        _build_actual_action(ToolCall(id="t1", name="not_a_registered_action", input={}))
 
 
 def test_planning_match_strips_redundant_integrations_list_for_investigation() -> None:

--- a/tests/core/agent_harness/session/test_session_characterization.py
+++ b/tests/core/agent_harness/session/test_session_characterization.py
@@ -30,6 +30,8 @@ _CORE_FIELDS = (
     "pending_investigation_offer",
     "pending_user_choice",
     "ask_user_rounds",
+    "task_plan",
+    "plan_only_until_authorized",
     "pending_recovery_note",
     # Outer multi-turn goal, plus the evidence-tier upgrade CTA it can offer.
     "session_goal",

--- a/tests/core/agent_harness/task_plan/test_display.py
+++ b/tests/core/agent_harness/task_plan/test_display.py
@@ -1,0 +1,46 @@
+"""Tests for task-plan terminal display helpers."""
+
+from __future__ import annotations
+
+from core.agent_harness.task_plan.display import is_plan_diagnosis_prose, promote_first_pending_step
+from core.agent_harness.task_plan.plan import PlanStepStatus, parse_task_plan
+
+
+def test_is_plan_diagnosis_prose_detects_established_facts_block() -> None:
+    text = (
+        "**Established facts**\n"
+        "- Onset: gradual\n\n"
+        "**Hypotheses**\n"
+        "| Priority | Hypothesis | Why |\n"
+        "| --- | --- | --- |"
+    )
+    assert is_plan_diagnosis_prose(text) is True
+
+
+def test_is_plan_diagnosis_prose_detects_facts_hypothesis_table() -> None:
+    text = (
+        "Facts: gradual degradation on /api/orders.\n\n"
+        "Hypothesis (ranked):\n"
+        "| rank | hypothesis | why | next check |\n"
+        "| --- | --- | --- | --- |"
+    )
+    assert is_plan_diagnosis_prose(text) is True
+
+
+def test_is_plan_diagnosis_prose_ignores_short_explanation() -> None:
+    assert is_plan_diagnosis_prose("Revised after deploy window narrowed.") is False
+
+
+def test_promote_first_pending_step() -> None:
+    plan, _error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "First", "status": "pending"},
+                {"step": "Verify", "status": "pending"},
+            ]
+        }
+    )
+    assert plan is not None
+    promoted = promote_first_pending_step(plan)
+    assert promoted.steps[0].status is PlanStepStatus.IN_PROGRESS
+    assert promoted.steps[1].status is PlanStepStatus.PENDING

--- a/tests/core/agent_harness/task_plan/test_persist.py
+++ b/tests/core/agent_harness/task_plan/test_persist.py
@@ -6,9 +6,10 @@ from core.agent_harness.session import InMemorySessionStore, SessionCore, Sessio
 from core.agent_harness.task_plan.persist import (
     TASK_PLAN_STATE_CUSTOM_TYPE,
     apply_task_plan_state,
+    should_persist_task_plan_state,
     task_plan_state_snapshot,
 )
-from core.agent_harness.task_plan.plan import parse_task_plan
+from core.agent_harness.task_plan.plan import parse_task_plan, task_plan_to_payload
 
 
 def _plan():
@@ -31,12 +32,14 @@ def test_flush_persists_task_plan_and_restore_context_applies_it() -> None:
     storage.open_session(session)
     storage.append_turn(session, "chat", "start")
     session.task_plan = _plan()
+    session.plan_only_until_authorized = True
 
     storage.flush(session)
     records = storage.read(session.session_id)
     content = next(
         rec["content"] for rec in records if rec.get("custom_type") == TASK_PLAN_STATE_CUSTOM_TYPE
     )
+    assert content["plan_only_until_authorized"] is True
 
     restored = SessionCore(store=InMemorySessionStore())
     SessionManager(store=InMemorySessionStore()).restore_context(
@@ -51,6 +54,7 @@ def test_flush_persists_task_plan_and_restore_context_applies_it() -> None:
     assert restored.task_plan is not None
     assert restored.task_plan.current_index == 2
     assert restored.task_plan.steps[-1].step.startswith("Confirm")
+    assert restored.plan_only_until_authorized is True
 
 
 def test_clearing_the_plan_writes_a_tombstone() -> None:
@@ -59,6 +63,7 @@ def test_clearing_the_plan_writes_a_tombstone() -> None:
     storage.open_session(session)
     storage.append_turn(session, "chat", "start")
     session.task_plan = _plan()
+    session.plan_only_until_authorized = True
     storage.flush(session)
 
     session.task_plan = None
@@ -73,4 +78,55 @@ def test_clearing_the_plan_writes_a_tombstone() -> None:
     restored = SessionCore(store=InMemorySessionStore())
     apply_task_plan_state(restored, snapshots[-1])
     assert restored.task_plan is None
+    assert restored.plan_only_until_authorized is False
     assert task_plan_state_snapshot(restored) is None
+
+
+def test_apply_task_plan_state_restores_plan_only_latch() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    session.task_plan = _plan()
+    session.plan_only_until_authorized = True
+    payload = task_plan_state_snapshot(session)
+    assert payload is not None
+    assert payload["plan_only_until_authorized"] is True
+
+    restored = SessionCore(store=InMemorySessionStore())
+    apply_task_plan_state(restored, payload)
+    assert restored.plan_only_until_authorized is True
+    assert restored.task_plan is not None
+    assert restored.task_plan.current_index == 2
+
+
+def test_legacy_snapshot_without_latch_key_does_not_arm_authorization() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    session.plan_only_until_authorized = True
+    apply_task_plan_state(session, task_plan_to_payload(_plan()))
+    assert session.task_plan is not None
+    assert session.plan_only_until_authorized is False
+
+
+def test_corrupt_snapshot_does_not_arm_authorization() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    session.plan_only_until_authorized = True
+    apply_task_plan_state(session, {"plan_only_until_authorized": True})
+    assert session.task_plan is None
+    assert session.plan_only_until_authorized is False
+
+
+def test_latch_change_without_plan_change_is_persisted() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    session.task_plan = _plan()
+    unarmed = task_plan_state_snapshot(session)
+    session.plan_only_until_authorized = True
+    armed = task_plan_state_snapshot(session)
+    assert unarmed is not None and armed is not None
+    assert should_persist_task_plan_state(
+        armed,
+        prior_records=[
+            {
+                "type": "custom_message",
+                "custom_type": TASK_PLAN_STATE_CUSTOM_TYPE,
+                "content": unarmed,
+            }
+        ],
+    )

--- a/tests/core/agent_harness/task_plan/test_persist.py
+++ b/tests/core/agent_harness/task_plan/test_persist.py
@@ -1,0 +1,76 @@
+"""TaskPlan survives flush → restore so compacted transcripts keep the checklist."""
+
+from __future__ import annotations
+
+from core.agent_harness.session import InMemorySessionStore, SessionCore, SessionManager
+from core.agent_harness.task_plan.persist import (
+    TASK_PLAN_STATE_CUSTOM_TYPE,
+    apply_task_plan_state,
+    task_plan_state_snapshot,
+)
+from core.agent_harness.task_plan.plan import parse_task_plan
+
+
+def _plan():
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Run /health and read the result", "status": "completed"},
+                {"step": "List connected integrations", "status": "in_progress"},
+                {"step": "Confirm both outputs answered the ask", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    return plan
+
+
+def test_flush_persists_task_plan_and_restore_context_applies_it() -> None:
+    storage = InMemorySessionStore()
+    session = SessionCore(store=storage)
+    storage.open_session(session)
+    storage.append_turn(session, "chat", "start")
+    session.task_plan = _plan()
+
+    storage.flush(session)
+    records = storage.read(session.session_id)
+    content = next(
+        rec["content"] for rec in records if rec.get("custom_type") == TASK_PLAN_STATE_CUSTOM_TYPE
+    )
+
+    restored = SessionCore(store=InMemorySessionStore())
+    SessionManager(store=InMemorySessionStore()).restore_context(
+        restored,
+        {
+            "cli_agent_messages": [],
+            "accumulated_context": {},
+            "task_plan_state": content,
+            "history": [],
+        },
+    )
+    assert restored.task_plan is not None
+    assert restored.task_plan.current_index == 2
+    assert restored.task_plan.steps[-1].step.startswith("Confirm")
+
+
+def test_clearing_the_plan_writes_a_tombstone() -> None:
+    storage = InMemorySessionStore()
+    session = SessionCore(store=storage)
+    storage.open_session(session)
+    storage.append_turn(session, "chat", "start")
+    session.task_plan = _plan()
+    storage.flush(session)
+
+    session.task_plan = None
+    storage.flush(session)
+
+    snapshots = [
+        record["content"]
+        for record in storage.read(session.session_id)
+        if record.get("custom_type") == TASK_PLAN_STATE_CUSTOM_TYPE
+    ]
+    assert len(snapshots) >= 2
+    restored = SessionCore(store=InMemorySessionStore())
+    apply_task_plan_state(restored, snapshots[-1])
+    assert restored.task_plan is None
+    assert task_plan_state_snapshot(restored) is None

--- a/tests/core/agent_harness/task_plan/test_plan.py
+++ b/tests/core/agent_harness/task_plan/test_plan.py
@@ -1,0 +1,77 @@
+"""TaskPlan parse/validate and progress counter."""
+
+from __future__ import annotations
+
+from core.agent_harness.task_plan.plan import (
+    PlanStepStatus,
+    parse_task_plan,
+    task_plan_from_payload,
+    task_plan_to_payload,
+)
+from core.agent_harness.task_plan.progress import format_task_plan_plain
+
+
+def _items(*statuses: str) -> list[dict[str, str]]:
+    labels = [
+        "Capture 502 samples from checkout",
+        "Trace 502s to the last deploy",
+        "Confirm checkout returns 2xx",
+    ]
+    return [{"step": labels[index], "status": status} for index, status in enumerate(statuses)]
+
+
+def test_parse_rejects_a_single_step() -> None:
+    plan, error = parse_task_plan({"plan": [{"step": "fix it", "status": "in_progress"}]})
+    assert plan is None
+    assert error is not None
+    assert "at least two" in error
+
+
+def test_parse_rejects_two_in_progress_steps() -> None:
+    plan, error = parse_task_plan({"plan": _items("in_progress", "in_progress", "pending")})
+    assert plan is None
+    assert error is not None
+    assert "at most one" in error
+
+
+def test_parse_accepts_a_verifiable_plan() -> None:
+    plan, error = parse_task_plan({"plan": _items("completed", "in_progress", "pending")})
+    assert error is None
+    assert plan is not None
+    assert plan.current_index == 2
+    assert plan.total == 3
+    assert plan.steps[-1].status is PlanStepStatus.PENDING
+    text = format_task_plan_plain(plan)
+    assert text.startswith("Plan · 2/3")
+    assert "✓" in text and "●" in text and "○" in text
+    assert "(verify)" in text
+
+
+def test_payload_round_trips() -> None:
+    plan, error = parse_task_plan(
+        {"plan": _items("pending", "pending", "pending"), "explanation": "draft"}
+    )
+    assert error is None and plan is not None
+    assert plan.all_pending is True
+    restored = task_plan_from_payload(task_plan_to_payload(plan))
+    assert restored == plan
+    assert format_task_plan_plain(plan).startswith("Plan ready · 0/3 executed")
+
+
+def test_parse_strips_terminal_controls_from_steps_and_explanation() -> None:
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "\x1b]0;pwn\x07Capture samples", "status": "in_progress"},
+                {"step": "Verify\x07 recovery", "status": "pending"},
+            ],
+            "explanation": "why\x1b[0m now",
+        }
+    )
+    assert error is None and plan is not None
+    assert "\x1b" not in plan.steps[0].step
+    assert "\x07" not in plan.steps[0].step
+    assert "Capture samples" in plan.steps[0].step
+    assert "\x07" not in plan.steps[1].step
+    assert "\x1b" not in plan.explanation
+    assert "why" in plan.explanation

--- a/tests/core/agent_harness/task_plan/test_prompt.py
+++ b/tests/core/agent_harness/task_plan/test_prompt.py
@@ -1,0 +1,144 @@
+"""Planning instructions and CURRENT PLAN prompt injection."""
+
+from __future__ import annotations
+
+from core.agent_harness.prompts import (
+    PromptBlockId,
+    PromptTier,
+    build_action_system_prompt,
+    build_action_system_prompt_envelope,
+)
+from core.agent_harness.task_plan.plan import parse_task_plan
+from core.agent_harness.task_plan.prompt import load_planning_instructions
+from core.agent_harness.turns.turn_snapshot import TurnSnapshot
+
+
+def _ctx(*, plan=None) -> TurnSnapshot:
+    return TurnSnapshot(
+        text="investigate checkout 502s",
+        conversation_messages=(),
+        configured_integrations=(),
+        configured_integrations_known=True,
+        last_state=None,
+        last_synthetic_observation_path=None,
+        reasoning_effort=None,
+        task_plan=plan,
+    )
+
+
+def test_planning_instructions_are_about_seventy_lines_with_examples() -> None:
+    text = load_planning_instructions()
+    lines = text.splitlines()
+    assert 60 <= len(lines) <= 120
+    assert "update_plan" in text
+    assert "ASK THEN PLAN" in text
+    assert "ask_user_choice" in text
+    assert "go-ahead to continue" in text
+    assert "do not invent a pause" in text.lower()
+    assert "VERIFIABILITY" in text
+    assert "Confirm checkout returns 2xx" in text
+    assert "work_task_*" in text
+    assert "/goal" in text
+
+
+def test_composed_prompt_includes_planning_instructions() -> None:
+    prompt = build_action_system_prompt(_ctx())
+    assert "PLANNING — update_plan" in prompt
+    assert "The LAST step is always a verification step" in prompt
+
+
+def test_current_plan_is_ephemeral_so_compaction_cannot_drop_it() -> None:
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Run /health and read the result", "status": "completed"},
+                {"step": "List connected integrations", "status": "in_progress"},
+                {"step": "Confirm both outputs answered the ask", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    envelope = build_action_system_prompt_envelope(_ctx(plan=plan))
+    block = envelope.require_block(PromptBlockId.CURRENT_TASK_PLAN)
+    assert block.tier == PromptTier.EPHEMERAL
+    assert "Plan · 2/3" in block.content
+    assert "CURRENT PLAN" in block.content
+    assert "Do not conclude this turn while a step is in_progress" in block.content
+    cached = envelope.render_cached()
+    assert "Plan · 2/3" not in cached
+    assert "Plan · 2/3" in envelope.render()
+
+
+def test_ask_user_answers_inject_start_now_block() -> None:
+    from core.agent_harness.session.pending_choice import (
+        AskUserQuestion,
+        format_ask_user_answers,
+    )
+    from core.agent_harness.task_plan.prompt import ASK_USER_ANSWERED_GUIDANCE
+
+    answers = format_ask_user_answers(
+        (
+            AskUserQuestion(label="Env", title="Where is it?", options=("Prod", "Dev")),
+            AskUserQuestion(label="Window", title="What window?", options=("24h", "7d")),
+        ),
+        ("Dev", "24h"),
+    )
+    snapshot = TurnSnapshot(
+        text=answers,
+        conversation_messages=(),
+        configured_integrations=(),
+        configured_integrations_known=True,
+        last_state=None,
+        last_synthetic_observation_path=None,
+        reasoning_effort=None,
+    )
+    envelope = build_action_system_prompt_envelope(snapshot)
+    block = envelope.require_block(PromptBlockId.ASK_USER_ANSWERED)
+    assert block.tier == PromptTier.EPHEMERAL
+    assert ASK_USER_ANSWERED_GUIDANCE in block.content
+    assert ASK_USER_ANSWERED_GUIDANCE not in envelope.render_cached()
+    assert ASK_USER_ANSWERED_GUIDANCE in envelope.render()
+    assert envelope.block(PromptBlockId.ASK_USER_ANSWERED) is not None
+    idle = build_action_system_prompt_envelope(_ctx())
+    assert idle.block(PromptBlockId.ASK_USER_ANSWERED) is None
+
+
+def test_ask_user_answered_guidance_defaults_to_execute_not_pause() -> None:
+    from core.agent_harness.task_plan.prompt import ASK_USER_ANSWERED_GUIDANCE
+
+    text = ASK_USER_ANSWERED_GUIDANCE.lower()
+    assert "go-ahead to continue" in text
+    assert "do not invent a plan-only pause" in text
+    assert "plan_only_after=true" in text
+    assert "in_progress and execute it now" in text
+
+
+def test_ask_user_answered_plan_only_guidance_does_not_authorize_execute() -> None:
+    from core.agent_harness.session.pending_choice import (
+        AskUserQuestion,
+        format_ask_user_answers,
+    )
+    from core.agent_harness.task_plan.prompt import ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE
+
+    answers = format_ask_user_answers(
+        (
+            AskUserQuestion(label="Env", title="Where is it?", options=("Prod", "Dev")),
+            AskUserQuestion(label="Window", title="What window?", options=("24h", "7d")),
+        ),
+        ("Dev", "24h"),
+    )
+    snapshot = TurnSnapshot(
+        text=answers,
+        conversation_messages=(),
+        configured_integrations=(),
+        configured_integrations_known=True,
+        last_state=None,
+        last_synthetic_observation_path=None,
+        reasoning_effort=None,
+        plan_only_until_authorized=True,
+    )
+    envelope = build_action_system_prompt_envelope(snapshot)
+    block = envelope.require_block(PromptBlockId.ASK_USER_ANSWERED)
+    assert ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE in block.content
+    assert "do not pass plan_only=false" in block.content.lower()
+    assert "in_progress and execute it now" not in block.content.lower()

--- a/tests/core/agent_harness/task_plan/test_update_plan_policy.py
+++ b/tests/core/agent_harness/task_plan/test_update_plan_policy.py
@@ -1,0 +1,110 @@
+"""Tests for update_plan host policy."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness.session.pending_choice import (
+    AskUserQuestion,
+    format_ask_user_answers,
+)
+from core.agent_harness.task_plan.plan import PlanStepStatus, parse_task_plan
+from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_host_policy
+from core.agent_harness.tools.tool_context import ActionToolScope
+from surfaces.interactive_shell.session import Session
+from tools.interactive_shell.actions.update_plan import execute_update_plan_tool
+
+
+def _ask_user_turn_text() -> str:
+    return format_ask_user_answers(
+        (
+            AskUserQuestion(label="Onset", title="When did it start?", options=("Gradual",)),
+            AskUserQuestion(label="Signal", title="Strongest signal?", options=("CPU",)),
+        ),
+        ("Gradual", "CPU"),
+    )
+
+
+_PLAN: list[dict[str, Any]] = [
+    {"step": "Pinpoint onset on p99", "status": "pending"},
+    {"step": "Confirm checkout returns 2xx", "status": "pending"},
+]
+
+
+def test_ask_user_turn_strips_plan_only_by_default() -> None:
+    session = Session()
+    plan, _error = parse_task_plan({"plan": _PLAN})
+    assert plan is not None
+    normalized, plan_only = apply_update_plan_host_policy(
+        plan,
+        plan_only_requested=True,
+        turn_user_message=_ask_user_turn_text(),
+        session=session,
+    )
+    assert plan_only is False
+    assert normalized.steps[0].status is PlanStepStatus.IN_PROGRESS
+
+
+def test_ask_user_turn_honors_armed_plan_only_latch() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    plan, _error = parse_task_plan({"plan": _PLAN})
+    assert plan is not None
+    normalized, plan_only = apply_update_plan_host_policy(
+        plan,
+        plan_only_requested=True,
+        turn_user_message=_ask_user_turn_text(),
+        session=session,
+    )
+    assert plan_only is True
+    assert normalized.all_pending is True
+    # Set-only: the policy does not consume the latch — only the gate lifts it.
+    assert session.plan_only_until_authorized is True
+
+
+def test_ask_user_turn_model_cannot_drop_user_plan_only() -> None:
+    """A plan-only Ask User hand-off stays gated even if the model sends false."""
+    session = Session()
+    session.plan_only_until_authorized = True
+    plan, _error = parse_task_plan({"plan": _PLAN})
+    assert plan is not None
+    normalized, plan_only = apply_update_plan_host_policy(
+        plan,
+        plan_only_requested=False,
+        turn_user_message=_ask_user_turn_text(),
+        session=session,
+    )
+    assert plan_only is True
+    assert normalized.all_pending is True
+
+
+def test_ask_user_turn_existing_latch_survives_model_false() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    plan, _error = parse_task_plan({"plan": _PLAN})
+    assert plan is not None
+    normalized, plan_only = apply_update_plan_host_policy(
+        plan,
+        plan_only_requested=False,
+        turn_user_message=_ask_user_turn_text(),
+        session=session,
+    )
+    assert plan_only is True
+    assert normalized.all_pending is True
+
+
+def test_update_plan_tool_end_to_end_after_ask_user() -> None:
+    session = Session()
+    ctx = ActionToolScope(
+        session=session,
+        console=Console(file=io.StringIO(), force_terminal=False, highlight=False),
+        turn_user_message=_ask_user_turn_text(),
+    )
+    result = execute_update_plan_tool({"plan": _PLAN, "plan_only": True}, ctx)
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is False
+    assert session.task_plan is not None
+    assert session.task_plan.steps[0].status is PlanStepStatus.IN_PROGRESS

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -157,6 +157,22 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
             "parse_ask_user_answers",
         }
     ),
+    "task_plan": frozenset(
+        {
+            "PLAN_STATUS_GLYPH",
+            "PlanStep",
+            "PlanStepStatus",
+            "TaskPlan",
+            "apply_update_plan_host_policy",
+            "apply_update_plan_session",
+            "format_plan_header",
+            "format_task_plan_plain",
+            "is_plan_diagnosis_prose",
+            "parse_task_plan",
+            "promote_first_pending_step",
+            "task_plan_to_payload",
+        }
+    ),
 }
 
 RUNTIME = frozenset(

--- a/tests/interactive_shell/session/test_session_facets.py
+++ b/tests/interactive_shell/session/test_session_facets.py
@@ -22,7 +22,7 @@ from surfaces.interactive_shell.session.session import Session
 # pending_recovery_note (WAL recovery note for the first turn after /resume),
 # plus the session-goal trio (session_goal, pending_integration_setup_offer,
 # offered_upgrade_ctas).
-_CORE_FIELD_COUNT = 29
+_CORE_FIELD_COUNT = 31
 _FACET_FIELDS = ("alerts", "terminal")
 
 

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -380,3 +380,103 @@ def test_set_spinner_phase_does_not_activate_a_suppressed_spinner() -> None:
         assert spinner.streaming is False
     finally:
         set_investigation_spinner(None)
+
+
+_UPDATE_PLAN = [
+    {"step": "Measure wait vs work", "status": "pending"},
+    {"step": "Verify p99 recovery", "status": "pending"},
+]
+
+
+def test_update_plan_tool_start_does_not_commit_session_state() -> None:
+    """Rejected update_plan must not leave a plan that never succeeded."""
+    from core.agent_harness.task_plan.plan import parse_task_plan
+
+    observer, buffer = _observer_with_buffer("plan the fix")
+    plan, error = parse_task_plan({"plan": _UPDATE_PLAN, "explanation": "### Facts\n- p99 up"})
+    assert error is None and plan is not None
+
+    observer(
+        "tool_start",
+        {
+            "id": "p1",
+            "name": "update_plan",
+            "input": {
+                "plan": _UPDATE_PLAN,
+                "explanation": "### Facts\n- p99 up",
+                "plan_only": True,
+            },
+        },
+    )
+    assert observer.session.task_plan is None
+    assert observer.session.plan_only_until_authorized is False
+    assert "Plan" not in buffer.getvalue()
+
+    # Simulate a failed tool (schema/hook rejection) — still no session write.
+    observer(
+        "tool_end", {"id": "p1", "name": "update_plan", "output": {"ok": False, "error": "nope"}}
+    )
+    assert observer.session.task_plan is None
+    assert observer.session.plan_only_until_authorized is False
+    assert "Plan" not in buffer.getvalue()
+
+
+def test_update_plan_tool_end_renders_after_successful_commit() -> None:
+    from core.agent_harness.task_plan.plan import parse_task_plan
+    from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session
+
+    observer, buffer = _observer_with_buffer("plan the fix")
+    plan, error = parse_task_plan({"plan": _UPDATE_PLAN, "explanation": "### Facts\n- p99 up"})
+    assert error is None and plan is not None
+    apply_update_plan_session(observer.session, plan, plan_only=True)
+
+    observer(
+        "tool_end",
+        {"id": "p1", "name": "update_plan", "output": {"ok": True, "total": 2}},
+    )
+    output = buffer.getvalue()
+    assert "Plan ready" in output or "Plan ·" in output
+    assert "Measure wait vs work" in output
+    assert "p99 up" in output
+
+
+def test_update_plan_dedupe_refreshes_when_only_explanation_changes() -> None:
+    from core.agent_harness.task_plan.plan import parse_task_plan
+    from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session
+
+    observer, buffer = _observer_with_buffer("plan the fix")
+    first, error = parse_task_plan({"plan": _UPDATE_PLAN, "explanation": "first diagnosis"})
+    assert error is None and first is not None
+    apply_update_plan_session(observer.session, first, plan_only=True)
+    observer("tool_end", {"id": "p1", "name": "update_plan", "output": {"ok": True}})
+    assert "first diagnosis" in buffer.getvalue()
+
+    second, error = parse_task_plan({"plan": _UPDATE_PLAN, "explanation": "revised diagnosis"})
+    assert error is None and second is not None
+    apply_update_plan_session(observer.session, second, plan_only=True)
+    observer("tool_end", {"id": "p2", "name": "update_plan", "output": {"ok": True}})
+    assert "revised diagnosis" in buffer.getvalue()
+
+
+_IN_PROGRESS_PLAN = [
+    {"step": "Measure wait vs work", "status": "in_progress"},
+    {"step": "Verify p99 recovery", "status": "pending"},
+]
+
+
+def test_in_progress_explanation_only_update_renders_markdown() -> None:
+    from core.agent_harness.task_plan.plan import parse_task_plan
+    from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session
+
+    observer, buffer = _observer_with_buffer("keep going")
+    first, error = parse_task_plan({"plan": _IN_PROGRESS_PLAN, "explanation": "first diagnosis"})
+    assert error is None and first is not None
+    apply_update_plan_session(observer.session, first, plan_only=False)
+    observer("tool_end", {"id": "p1", "name": "update_plan", "output": {"ok": True}})
+    assert "first diagnosis" in buffer.getvalue()
+
+    second, error = parse_task_plan({"plan": _IN_PROGRESS_PLAN, "explanation": "revised diagnosis"})
+    assert error is None and second is not None
+    apply_update_plan_session(observer.session, second, plan_only=False)
+    observer("tool_end", {"id": "p2", "name": "update_plan", "output": {"ok": True}})
+    assert "revised diagnosis" in buffer.getvalue()

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -159,11 +159,11 @@ class TestResolveIdleHint:
         session.configured_integrations_known = True
         session.configured_integrations = ("datadog", "github", "grafana")
         rendered = _strip_ansi(resolve_idle_hint_ansi(session))
+        assert rendered.startswith("Ready")
         assert "/ for commands" in rendered
         assert "tab tool details" in rendered
         assert "Datadog" in rendered
         assert "GitHub" in rendered
-        assert "Grafana" in rendered
 
     def test_omits_integrations_when_none_configured(self) -> None:
         session = Session()

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -1,0 +1,180 @@
+"""Task-plan checklist rendering."""
+
+from __future__ import annotations
+
+import io
+import re
+
+from rich.console import Console
+
+from core.agent_harness.task_plan.plan import parse_task_plan
+from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+from surfaces.interactive_shell.session import Session
+from surfaces.interactive_shell.ui.task_plan import (
+    render_plan_updated,
+    render_task_plan,
+    task_plan_overlay_ansi,
+)
+from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _sample_plan():
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Capture 502 samples from checkout", "status": "completed"},
+                {"step": "Trace 502s to the last deploy", "status": "in_progress"},
+                {"step": "Confirm checkout returns 2xx", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    return plan
+
+
+def test_render_task_plan_shows_counter_and_status_glyphs() -> None:
+    plan = _sample_plan()
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    render_task_plan(console, plan)
+    output = buffer.getvalue()
+    assert "Plan updated" in output
+    assert "Plan · 2/3" in output
+    assert "✓" in output
+    assert "●" in output
+    assert "○" in output
+    assert "(verify)" not in output
+    assert "Confirm checkout returns 2xx" in output
+
+
+def test_all_pending_plan_says_ready_not_updated() -> None:
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Confirm scope", "status": "pending"},
+                {"step": "Verify recovery", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    render_plan_updated(console, plan)
+    output = buffer.getvalue()
+    assert "Plan ready — nothing executed" in output
+    assert "Plan updated" not in output
+    overlay = _strip_ansi(task_plan_overlay_ansi(plan))
+    assert overlay.startswith("Plan ready · 0/2 executed")
+    assert "○ Confirm scope" in overlay
+    assert "Verify recovery" not in overlay
+
+
+def test_task_plan_overlay_shows_only_the_current_step() -> None:
+    overlay = _strip_ansi(task_plan_overlay_ansi(_sample_plan()))
+    assert overlay.startswith("Plan · 2/3")
+    assert "● Trace 502s to the last deploy" in overlay
+    assert "Capture 502 samples from checkout" not in overlay
+    assert "Confirm checkout returns 2xx" not in overlay
+
+
+def test_overlay_strips_control_characters_from_a_raw_step() -> None:
+    from core.agent_harness.task_plan.plan import PlanStep, PlanStepStatus, TaskPlan
+
+    plan = TaskPlan(
+        steps=(
+            PlanStep(step="\x1b]0;pwn\x07Capture samples", status=PlanStepStatus.IN_PROGRESS),
+            PlanStep(step="Verify recovery", status=PlanStepStatus.PENDING),
+        )
+    )
+    overlay = task_plan_overlay_ansi(plan)
+    assert "\x1b]" not in overlay
+    assert "\x07" not in overlay
+    assert "Capture samples" in overlay
+
+
+def test_clip_text_strips_controls_before_measuring_width() -> None:
+    from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text
+
+    assert clip_prompt_text("\x1b" * 50 + "ok", 5) == "ok"
+    clipped = clip_prompt_text("\x1b]0;pwn\x07hello", 80)
+    assert "\x1b" not in clipped
+    assert "\x07" not in clipped
+    assert "hello" in clipped
+
+
+def test_render_task_plan_strips_control_characters_from_raw_steps() -> None:
+    from core.agent_harness.task_plan.plan import PlanStep, PlanStepStatus, TaskPlan
+
+    plan = TaskPlan(
+        steps=(
+            PlanStep(step="\x1b]0;pwn\x07Capture samples", status=PlanStepStatus.IN_PROGRESS),
+            PlanStep(step="Verify recovery", status=PlanStepStatus.PENDING),
+        ),
+        explanation="why\x07 now",
+    )
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+    render_task_plan(console, plan)
+    output = buffer.getvalue()
+    assert "\x1b]" not in output
+    assert "\x07" not in output
+    assert "Capture samples" in output
+    assert "why now" in output
+
+
+def test_render_task_plan_renders_explanation_as_markdown() -> None:
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Measure wait vs work", "status": "pending"},
+                {"step": "Verify p99 recovery", "status": "pending"},
+            ],
+            "explanation": (
+                "### Facts\n"
+                "- p99 up, p50 flat\n\n"
+                "### Hypothesis ranking\n"
+                "| # | Hypothesis | Why it fits | Discriminator |\n"
+                "| --- | --- | --- | --- |\n"
+                "| 1 | Queue knee | peak-only | wait time up |"
+            ),
+        }
+    )
+    assert error is None and plan is not None
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=100)
+    render_task_plan(console, plan)
+    output = buffer.getvalue()
+    assert "Hypothesis" in output
+    assert "Queue knee" in output
+    assert "wait time up" in output
+
+
+def test_prompt_region_keeps_the_checklist_above_invoking_tools() -> None:
+    session = Session()
+    session.task_plan = _sample_plan()
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
+    rendered = _strip_ansi(render_prompt_region(session, ReplState(), spinner).value)
+    assert "Plan updated" not in rendered
+    assert "Plan · 2/3" in rendered
+    assert "● Trace 502s to the last deploy" in rendered
+    assert SpinnerState.INVOKING_TOOLS_PHASE in rendered
+    assert rendered.index("Plan · 2/3") < rendered.index(SpinnerState.INVOKING_TOOLS_PHASE)
+    assert "Auto (High)" in rendered
+    assert rendered.index(SpinnerState.INVOKING_TOOLS_PHASE) < rendered.index("Auto (High)")
+
+
+def test_idle_prompt_region_shows_ready_not_thinking() -> None:
+    session = Session()
+    session.task_plan = _sample_plan()
+    rendered = _strip_ansi(render_prompt_region(session, ReplState(), SpinnerState()).value)
+    assert "Ready" in rendered
+    assert "Thinking" not in rendered
+    assert SpinnerState.EXECUTING_PHASE not in rendered
+    assert "Plan · 2/3" in rendered
+    assert rendered.index("Ready") < rendered.index("Auto (High)")

--- a/tests/shared/harness_api.py
+++ b/tests/shared/harness_api.py
@@ -28,6 +28,7 @@ SPI_ROLES: frozenset[str] = frozenset(
         "grounding",
         "defaults",
         "handoff",
+        "task_plan",
     }
 )
 

--- a/tests/tools/interactive_shell/test_action_names.py
+++ b/tests/tools/interactive_shell/test_action_names.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tools.interactive_shell.action_names import TOOL_KIND_TO_NAME, ToolKind
+from tools.interactive_shell.action_names import TOOL_KIND_TO_NAME, ActionToolName, ToolKind
 
 
 def test_tool_kind_members_are_stable() -> None:
@@ -52,3 +52,27 @@ def test_tool_kind_to_name_lookup_by_plain_string_key() -> None:
     since StrEnum members hash and compare equal to their value."""
     assert TOOL_KIND_TO_NAME["slash"] == "slash_invoke"
     assert TOOL_KIND_TO_NAME.get("session_goal") == "session_goal_set"
+
+
+def test_action_tool_name_members_are_stable() -> None:
+    assert [name.value for name in ActionToolName] == [
+        "alert_sample",
+        "ask_user_choice",
+        "cli_exec",
+        "code_implement",
+        "fix_sentry_issue_start",
+        "investigation_start",
+        "llm_set_provider",
+        "propose_scheduled_delivery",
+        "session_goal_set",
+        "shell_run",
+        "skill_view",
+        "slash_invoke",
+        "synthetic_run",
+        "task_cancel",
+        "update_plan",
+    ]
+
+
+def test_tool_kind_to_name_maps_onto_action_tool_name() -> None:
+    assert set(TOOL_KIND_TO_NAME.values()) <= set(ActionToolName)

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -1269,6 +1269,9 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         "summarize_github_pr_status",
         "synthetic_run",
         "task_cancel",
+        # update_plan returns structured invalid-plan dicts; unexpected
+        # exceptions escape to the global wrapper.
+        "update_plan",
         "work_task_add",
         "work_task_complete",
         "work_task_list",

--- a/tools/interactive_shell/__init__.py
+++ b/tools/interactive_shell/__init__.py
@@ -27,6 +27,7 @@ TOOL_MODULES = (
     "actions.slash",
     "actions.synthetic",
     "actions.task_cancel",
+    "actions.update_plan",
 )
 
 __all__ = ["TOOL_MODULES"]

--- a/tools/interactive_shell/action_names.py
+++ b/tools/interactive_shell/action_names.py
@@ -1,4 +1,4 @@
-"""Stable action-tool names used by scenario fixtures and tests."""
+"""Stable action-tool names used by scenario fixtures, tests, and observers."""
 
 from __future__ import annotations
 
@@ -26,18 +26,42 @@ class ToolKind(StrEnum):
     SESSION_GOAL = "session_goal"
 
 
-TOOL_KIND_TO_NAME: dict[ToolKind, str] = {
-    ToolKind.SLASH: "slash_invoke",
-    ToolKind.SHELL: "shell_run",
-    ToolKind.INVESTIGATION: "investigation_start",
-    ToolKind.ALERT: "alert_sample",
-    ToolKind.SAMPLE_ALERT: "alert_sample",
-    ToolKind.SYNTHETIC_TEST: "synthetic_run",
-    ToolKind.TASK_CANCEL: "task_cancel",
-    ToolKind.CLI_COMMAND: "cli_exec",
-    ToolKind.IMPLEMENTATION: "code_implement",
-    ToolKind.LLM_PROVIDER: "llm_set_provider",
-    ToolKind.SESSION_GOAL: "session_goal_set",
+class ActionToolName(StrEnum):
+    """Registered ``RegisteredTool.name`` values for interactive-shell actions.
+
+    Observer dispatch and :data:`TOOL_KIND_TO_NAME` share this closed set so a
+    renamed tool cannot silently miss a render branch.
+    """
+
+    ALERT_SAMPLE = "alert_sample"
+    ASK_USER_CHOICE = "ask_user_choice"
+    CLI_EXEC = "cli_exec"
+    CODE_IMPLEMENT = "code_implement"
+    FIX_SENTRY_ISSUE_START = "fix_sentry_issue_start"
+    INVESTIGATION_START = "investigation_start"
+    LLM_SET_PROVIDER = "llm_set_provider"
+    PROPOSE_SCHEDULED_DELIVERY = "propose_scheduled_delivery"
+    SESSION_GOAL_SET = "session_goal_set"
+    SHELL_RUN = "shell_run"
+    SKILL_VIEW = "skill_view"
+    SLASH_INVOKE = "slash_invoke"
+    SYNTHETIC_RUN = "synthetic_run"
+    TASK_CANCEL = "task_cancel"
+    UPDATE_PLAN = "update_plan"
+
+
+TOOL_KIND_TO_NAME: dict[ToolKind, ActionToolName] = {
+    ToolKind.SLASH: ActionToolName.SLASH_INVOKE,
+    ToolKind.SHELL: ActionToolName.SHELL_RUN,
+    ToolKind.INVESTIGATION: ActionToolName.INVESTIGATION_START,
+    ToolKind.ALERT: ActionToolName.ALERT_SAMPLE,
+    ToolKind.SAMPLE_ALERT: ActionToolName.ALERT_SAMPLE,
+    ToolKind.SYNTHETIC_TEST: ActionToolName.SYNTHETIC_RUN,
+    ToolKind.TASK_CANCEL: ActionToolName.TASK_CANCEL,
+    ToolKind.CLI_COMMAND: ActionToolName.CLI_EXEC,
+    ToolKind.IMPLEMENTATION: ActionToolName.CODE_IMPLEMENT,
+    ToolKind.LLM_PROVIDER: ActionToolName.LLM_SET_PROVIDER,
+    ToolKind.SESSION_GOAL: ActionToolName.SESSION_GOAL_SET,
 }
 
-__all__ = ["TOOL_KIND_TO_NAME", "ToolKind"]
+__all__ = ["ActionToolName", "TOOL_KIND_TO_NAME", "ToolKind"]

--- a/tools/interactive_shell/actions/skill_view.py
+++ b/tools/interactive_shell/actions/skill_view.py
@@ -9,6 +9,7 @@ from core.agent_harness.tools import ActionToolScope, execute_with_action_contex
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
+from tools.interactive_shell.action_names import ActionToolName
 
 
 def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
@@ -46,7 +47,7 @@ def run_skill_view(*, name: str, context: Any) -> dict[str, Any]:
 
 
 skill_view_tool = RegisteredTool(
-    name="skill_view",
+    name=ActionToolName.SKILL_VIEW,
     description=(
         "Load the full body of one action-agent skill by name from the "
         "SKILLS INDEX. Call this in the same turn when the user request matches "

--- a/tools/interactive_shell/actions/update_plan.py
+++ b/tools/interactive_shell/actions/update_plan.py
@@ -16,6 +16,7 @@ from core.agent_harness.tools import ActionToolScope, execute_with_action_contex
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
+from tools.interactive_shell.action_names import ActionToolName
 
 _PLAN_ITEM_SCHEMA = {
     "type": "object",
@@ -78,7 +79,7 @@ def run_update_plan(
 
 
 update_plan_tool = RegisteredTool(
-    name="update_plan",
+    name=ActionToolName.UPDATE_PLAN,
     description=(
         "Create or revise the live execution plan for this workload, and mark "
         "steps pending, in_progress, or completed. Call this BEFORE executing "

--- a/tools/interactive_shell/actions/update_plan.py
+++ b/tools/interactive_shell/actions/update_plan.py
@@ -1,0 +1,145 @@
+"""Create, revise, and mark steps on the agent's live task plan."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.spi.handoff import parse_ask_user_answers
+from core.agent_harness.spi.task_plan import (
+    apply_update_plan_host_policy,
+    apply_update_plan_session,
+    format_task_plan_plain,
+    parse_task_plan,
+    task_plan_to_payload,
+)
+from core.agent_harness.tools import ActionToolScope, execute_with_action_context
+from core.domain.types.tools import ToolSurface
+from core.tool import RegisteredTool, SideEffectLevel
+from core.tool_framework.utils import object_schema, string_property
+
+_PLAN_ITEM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "step": string_property(
+            description="One short observable outcome (about 5–10 words).",
+            min_length=1,
+        ),
+        "status": string_property(
+            description="One of: pending, in_progress, completed.",
+            enum=("pending", "in_progress", "completed"),
+        ),
+    },
+    "required": ["step", "status"],
+    "additionalProperties": False,
+}
+
+
+def execute_update_plan_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
+    plan, error = parse_task_plan(args)
+    if error is not None or plan is None:
+        return {"ok": False, "error": error or "invalid plan"}
+    turn_text = getattr(ctx, "turn_user_message", "") or ""
+    plan, plan_only_requested = apply_update_plan_host_policy(
+        plan,
+        plan_only_requested=bool(args.get("plan_only")),
+        turn_user_message=turn_text,
+        session=ctx.session,
+    )
+    apply_update_plan_session(ctx.session, plan, plan_only=plan_only_requested)
+    payload = task_plan_to_payload(plan)
+    payload["ok"] = True
+    payload["summary"] = format_task_plan_plain(plan)
+    payload["instruction"] = (
+        "Plan stored. Keep it current with update_plan; the CURRENT PLAN "
+        "block is the durable record when older messages drop."
+    )
+    if plan_only_requested:
+        payload["instruction"] += " Plan-only: leave every step pending until the user says go."
+    elif parse_ask_user_answers(turn_text) and not plan.all_pending:
+        payload["instruction"] += (
+            " Execution is authorized: the first step is in_progress — run it now."
+        )
+    return payload
+
+
+def run_update_plan(
+    *,
+    plan: list[dict[str, Any]] | None = None,
+    explanation: str | None = None,
+    plan_only: bool = False,
+    context: Any,
+) -> dict[str, Any]:
+    args: dict[str, Any] = {"plan": plan or []}
+    if explanation is not None:
+        args["explanation"] = explanation
+    if plan_only:
+        args["plan_only"] = True
+    return execute_with_action_context(args, context, execute_update_plan_tool)
+
+
+update_plan_tool = RegisteredTool(
+    name="update_plan",
+    description=(
+        "Create or revise the live execution plan for this workload, and mark "
+        "steps pending, in_progress, or completed. Call this BEFORE executing "
+        "any multi-step workload. The last step must be a verification check. "
+        "At most one step may be in_progress. Not for durable human todos "
+        "(use work_task_*) and not for /goal keep-going."
+    ),
+    use_cases=[
+        "A multi-step investigation, fix, and verify workload is about to start",
+        "A step just finished and the next step is starting",
+        "The plan changed and the checklist must be revised",
+        "The user asked for a plan only, with no execution yet",
+    ],
+    anti_examples=[
+        "A single obvious lookup or one slash command",
+        "Durable human todos / reminders (use work_task_add)",
+        "Session-goal keep-going checklists (use session_goal_set)",
+    ],
+    input_schema=object_schema(
+        properties={
+            "explanation": string_property(
+                description=(
+                    "Markdown diagnosis rendered under the checklist: Facts, "
+                    "What the signature tells us, hypothesis-ranking table; "
+                    "for plan-only requests add phased narrative and biggest "
+                    "risk. Do not repeat in assistant closing prose."
+                ),
+            ),
+            "plan": {
+                "type": "array",
+                "description": (
+                    "Ordered steps. Last item is always the verification check. "
+                    "At most one status may be in_progress."
+                ),
+                "items": _PLAN_ITEM_SCHEMA,
+                "minItems": 2,
+            },
+            "plan_only": {
+                "type": "boolean",
+                "description": (
+                    "Set true only when the user's original request asked for "
+                    "a plan without running it yet. Do not set this because "
+                    "Ask User was answered. Then leave every step pending "
+                    "and stop."
+                ),
+            },
+        },
+        required=("plan",),
+    ),
+    source="interactive_shell",
+    surfaces=(ToolSurface.ACTION,),
+    parallel_safe=False,
+    accepts_runtime_context=True,
+    run=run_update_plan,
+    tags=("safe", "fast", "no-credentials"),
+    side_effect_level=SideEffectLevel.READ_ONLY,
+)
+
+
+__all__ = [
+    "execute_update_plan_tool",
+    "run_update_plan",
+    "update_plan_tool",
+]

--- a/tools/interactive_shell/shared/__init__.py
+++ b/tools/interactive_shell/shared/__init__.py
@@ -17,6 +17,8 @@ from tools.interactive_shell.shared.execution_policy import (
     ToolExecutionPlan,
     allow_tool,
     apply_auto_level,
+    apply_plan_only_gate,
+    is_mutating_tool_type,
     plan_foreground_tool,
     resolve_confirmation,
 )
@@ -30,6 +32,8 @@ __all__ = [
     "ToolExecutionPlan",
     "allow_tool",
     "apply_auto_level",
+    "apply_plan_only_gate",
+    "is_mutating_tool_type",
     "plan_foreground_tool",
     "resolve_confirmation",
 ]

--- a/tools/interactive_shell/shared/execution_policy.py
+++ b/tools/interactive_shell/shared/execution_policy.py
@@ -173,6 +173,33 @@ def apply_auto_level(
     )
 
 
+def is_mutating_tool_type(tool_type: str) -> bool:
+    """True for tool types that can change state (the Med approval set)."""
+    return tool_type in (AUTO_LEVEL_ASK_TOOL_TYPES[AutoLevel.MED] or frozenset())
+
+
+def apply_plan_only_gate(
+    result: ExecutionPolicyResult,
+    *,
+    plan_only_active: bool,
+) -> ExecutionPolicyResult:
+    """Promote a mutating default-allow verdict to ``ask`` while a plan-only request stands.
+
+    The user asked for a plan without running it, so execution stays gated —
+    regardless of the ``/auto`` level — until the user confirms a mutating step
+    at the gate. Read-only tool types run normally.
+    """
+    if not plan_only_active or result.verdict != "allow":
+        return result
+    if not is_mutating_tool_type(result.tool_type):
+        return result
+    return replace(
+        result,
+        verdict="ask",
+        reason="Plan-only request stands — confirm before running this step",
+    )
+
+
 def allow_tool(tool_type: str) -> ExecutionPolicyResult:
     """Default-allow verdict for a tool launch.
 
@@ -206,6 +233,8 @@ __all__ = [
     "ToolExecutionPlan",
     "allow_tool",
     "apply_auto_level",
+    "apply_plan_only_gate",
+    "is_mutating_tool_type",
     "plan_foreground_tool",
     "resolve_confirmation",
 ]

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -59,6 +59,13 @@ def _fallback_descriptors() -> tuple[ToolDescriptor, ...]:
             "tools.interactive_shell.actions.ask_choice",
         ),
         ToolDescriptor(
+            "update_plan",
+            (ToolSurface.ACTION,),
+            "interactive_shell",
+            None,
+            "tools.interactive_shell.actions.update_plan",
+        ),
+        ToolDescriptor(
             "cli_exec",
             (ToolSurface.ACTION,),
             "interactive_shell",


### PR DESCRIPTION
Add the update_plan action tool and TaskPlan model: a live execution
checklist (pending / in_progress / completed, >=2 steps, last step verifies)
rendered above the prompt and persisted so it survives transcript compaction.

- core/agent_harness/task_plan/: model, parse/policy, prompt blocks, and
  persistence; spi.task_plan public-API role pinned in the harness border.
- Session gains task_plan + plan_only_until_authorized; the execution gate
  keeps mutating steps behind confirmation while a plan-only request stands,
  clearing only on a confirmed mutating step.
- Planning instructions composed into the action prompt; checklist renders
  once per change (dedupe); idle prompt shows Ready vs Thinking.