### PR TITLE
docs: keep __init__.py files as package facades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ The Cursor project hook [`.cursor/hooks/check-ci-failures.sh`](.cursor/hooks/che
 
 - Use strict typing, follow DRY principle
 - One clear purpose per file (separation of concerns)
+- Keep every Python `__init__.py` as a lightweight package facade: declare the
+  public interface with imports and `__all__` only. Put implementation,
+  orchestration, and side effects in focused modules, then re-export only the
+  intended public API; never let `__init__.py` become a god file.
 - Keep docstrings concise and contract-focused. Use one sentence for straightforward
   APIs; add only non-obvious invariants, failure behavior, or layering constraints
   callers must understand. Keep bug history and implementation narration in tests,


### PR DESCRIPTION
Fixes #

<!-- No linked issue; this is a maintainer-requested guidance update. -->

#### Describe the changes you have made in this PR -

Added a repository-wide `AGENTS.md` rule requiring Python `__init__.py` files to remain lightweight package facades. Public symbols may be exposed through imports and `__all__`; implementation, orchestration, and side effects belong in focused modules.

### Demo/Screenshot for feature changes and bug fixes -

Documentation-only change. Verified the branch diff contains one commit and only four added lines in `AGENTS.md`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated change
- [x] I can explain the purpose and logic of each change
- [x] I have considered edge cases relevant to this documentation-only change
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The rule is placed in the root `AGENTS.md` Code Style section because it applies to every Python package. A package-local instruction would cover only one subtree. The wording defines both the allowed facade responsibilities and where implementation should move.

---

## Checklist before requesting a review
- [x] I have added a proper PR title
- [x] I have performed a self-review of my change
- [x] **I can explain the purpose of every line I added**
- [x] I understand why my change works and have checked its scope
- [x] I have considered relevant edge cases
- [x] Tests are not required for this documentation-only change
- [x] My change follows the project's style guidelines and conventions

---

Note: Maintainers may edit this branch.