### PR TITLE
fix(agent): preserve interactive choices and repository scope

### DIFF
--- a/core/agent/agent.py
+++ b/core/agent/agent.py
@@ -46,6 +46,7 @@ class Agent[RuntimeToolT: RuntimeTool](EventEmitterMixin, ToolFilterMixin, Steer
         tools: Sequence[RuntimeToolT] | None = None,
         resolved_integrations: dict[str, Any] | None = None,
         max_iterations: int | None = None,
+        max_stagnant_iterations: int | None = None,
         on_event: TupleEventCallback | None = None,
         on_runtime_event: RuntimeEventCallback | None = None,
         tool_hooks: ToolExecutionHooks | None = None,
@@ -60,6 +61,9 @@ class Agent[RuntimeToolT: RuntimeTool](EventEmitterMixin, ToolFilterMixin, Steer
         self._tools: list[RuntimeToolT] | None = list(tools) if tools is not None else None
         self._resolved = resolved_integrations
         self._max_iterations = max_iterations
+        if max_stagnant_iterations is not None and max_stagnant_iterations < 1:
+            raise ValueError("Agent: max_stagnant_iterations must be positive when set.")
+        self._max_stagnant_iterations = max_stagnant_iterations
         # Set per run from the run input; falls back to the constructed value.
         self._effective_max_iterations = max_iterations
         self._on_tuple_event = on_event
@@ -130,6 +134,7 @@ class Agent[RuntimeToolT: RuntimeTool](EventEmitterMixin, ToolFilterMixin, Steer
                 resolved=self._resolved,
                 tool_resources=self._tool_resources,
                 max_iterations=self._max_iterations,
+                max_stagnant_iterations=self._max_stagnant_iterations,
             )
         raise ValueError("Agent.run requires initial_messages or runtime_request.")
 

--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -82,7 +82,7 @@ def _update_fingerprint(digest: Any, value: Any) -> None:
     """Feed a stable, bounded-memory representation of a tool value into ``digest``."""
     if isinstance(value, dict):
         digest.update(b"{")
-        for key in sorted(value, key=lambda item: repr(item)):
+        for key in sorted(value, key=repr):
             _update_fingerprint(digest, key)
             _update_fingerprint(digest, value[key])
         digest.update(b"}")

--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -2,7 +2,7 @@
 
 ``ReactLoop`` runs the loop. Each pass asks the LLM what to do (reason); if it
 requests tools, they run and their results are fed back in (act + observe); this
-repeats until the LLM answers with no tool calls or an iteration cap is hit. The
+repeats until the LLM answers with no tool calls or a safety limit is hit. The
 loop knows nothing about ``Agent`` — it takes an ``AgentRunInput``
 (``core.agent.run_io``, the resolved inputs) and a ``LoopHost``
 (``core.agent.loop_host``, the callbacks it needs), so anything implementing that
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from hashlib import sha256
 from typing import Any
 
 from core.agent.cancel import tool_resources_cancel_requested
@@ -38,7 +39,7 @@ from core.events import (
     TurnStartEvent,
 )
 from core.llm.types import ToolCall
-from core.messages import MessageMapper, UserRuntimeMessage
+from core.messages import AssistantRuntimeMessage, MessageMapper, UserRuntimeMessage
 from core.provider import ProviderRequest
 from core.tool.contracts import RuntimeTool
 from core.tool.execution import (
@@ -58,6 +59,67 @@ from infrastructure.observability.trace.spans import (
 )
 
 logger = logging.getLogger(__name__)
+
+_SAFETY_HANDOFF_PROMPT = """\
+The tool loop has stopped for safety ({reason}). Tools are disabled for this response.
+Give the user a concise final handoff based only on the work and tool results above:
+summarize useful partial results, state what prevented completion, and give the next
+practical step. Do not claim the task completed and do not request or describe another
+tool call.
+"""
+_ITERATION_CAP_FALLBACK = (
+    "I reached the emergency tool-iteration ceiling. Partial results are preserved, "
+    "but I could not complete the request. Continue with a narrower next step."
+)
+_STAGNATION_FALLBACK = (
+    "I stopped after repeated tool calls produced no new result. Partial results are "
+    "preserved, but I could not complete the request. Change the inputs or tool strategy "
+    "before continuing."
+)
+
+
+def _update_fingerprint(digest: Any, value: Any) -> None:
+    """Feed a stable, bounded-memory representation of a tool value into ``digest``."""
+    if isinstance(value, dict):
+        digest.update(b"{")
+        for key in sorted(value, key=lambda item: repr(item)):
+            _update_fingerprint(digest, key)
+            _update_fingerprint(digest, value[key])
+        digest.update(b"}")
+        return
+    if isinstance(value, (list, tuple)):
+        digest.update(b"[")
+        for item in value:
+            _update_fingerprint(digest, item)
+        digest.update(b"]")
+        return
+    if isinstance(value, (set, frozenset)):
+        digest.update(b"<")
+        for item in sorted(value, key=repr):
+            _update_fingerprint(digest, item)
+        digest.update(b">")
+        return
+    digest.update(type(value).__qualname__.encode("utf-8", errors="replace"))
+    digest.update(b":")
+    digest.update(repr(value).encode("utf-8", errors="replace"))
+    digest.update(b";")
+
+
+def _observation_fingerprint(
+    tool_calls: list[ToolCall],
+    results: list[ToolExecutionResult],
+) -> bytes:
+    """Identify one tool batch by public inputs and the observations it produced."""
+    digest = sha256()
+    for tool_call, result in zip(tool_calls, results, strict=True):
+        _update_fingerprint(digest, tool_call.name)
+        _update_fingerprint(digest, public_tool_input(tool_call.input))
+        _update_fingerprint(digest, result.is_error)
+        # Repeating a failed call with identical input is not progress even when
+        # the provider decorates each error with a fresh request id or timestamp.
+        if not result.is_error:
+            _update_fingerprint(digest, result.provider_content())
+    return digest.digest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,6 +153,7 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         self._resolved = run_input.resolved
         self._tool_resources = run_input.tool_resources
         self._max_iterations = run_input.max_iterations
+        self._max_stagnant_iterations = run_input.max_stagnant_iterations
         self._messages = run_input.messages
         self._msg_formatter = MessageMapper(self._llm)
         self._runtime_tools = list(host._filter_tools(run_input.tools))
@@ -107,6 +170,9 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         self._cancelled = False
         self._iterations_used = 0
         self._stop_reason = "iteration_cap"
+        self._seen_observations: set[bytes] = set()
+        self._stagnant_iterations = 0
+        self._safety_handoff_attempted = False
         self._operation_run_id = uuid.uuid4().hex[:12]
 
     def run(self) -> AgentRunResult:
@@ -141,6 +207,11 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                         iteration_result = self._run_iteration(iteration)
                         if iteration_result.should_stop:
                             break
+                if self._hit_cap and not self._cancelled and not self._terminated_by_tool:
+                    if self._cancel_requested():
+                        self._mark_cancelled()
+                    else:
+                        self._run_safety_handoff()
                 run_result = self._finalize()
                 self._mark_loop_span(loop_attrs)
                 self._record_loop_finished()
@@ -252,8 +323,15 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             return self._handle_conclusion(response, assistant_message, iteration)
         return self._observe(response, assistant_message, iteration)
 
-    def _think(self, iteration: int) -> Any:
+    def _think(
+        self,
+        iteration: int,
+        *,
+        tool_schemas: list[dict[str, Any]] | None = None,
+        request_kind: str = "work",
+    ) -> Any:
         """Build the request, apply the provider hooks, and call the LLM."""
+        request_tools = self._tool_schemas if tool_schemas is None else tool_schemas
         transformed_messages = self._host._transform_messages(self._messages)
         llm_messages = self._host._convert_to_llm(self._llm, transformed_messages)
         enforce_context_budget(
@@ -264,10 +342,14 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         provider_request = ProviderRequest(
             messages=llm_messages,
             system=self._system,
-            tools=self._tool_schemas,
-            metadata={"iteration": iteration},
+            tools=request_tools,
+            metadata={"iteration": iteration, "request_kind": request_kind},
         )
         provider_request = self._host._before_request(provider_request)
+        if tool_schemas is not None:
+            # A provider hook may normally add tools. The safety handoff is the
+            # one exception: it must be incapable of starting more work.
+            provider_request = replace(provider_request, tools=list(tool_schemas))
         self._final_system_prompt = provider_request.system or self._system
         self._host._emit_runtime(
             ProviderRequestStartEvent(
@@ -425,12 +507,101 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                 tool_error_count=tool_error_count,
                 terminated_tool_count=terminated_tool_count,
             )
+        fingerprint = _observation_fingerprint(response.tool_calls, results)
+        if fingerprint in self._seen_observations:
+            self._stagnant_iterations += 1
+        else:
+            self._seen_observations.add(fingerprint)
+            self._stagnant_iterations = 0
+        if (
+            self._max_stagnant_iterations is not None
+            and self._stagnant_iterations >= self._max_stagnant_iterations
+        ):
+            self._stop_reason = "stagnation_limit"
+            return _IterationResult(
+                should_stop=True,
+                outcome=self._stop_reason,
+                requested_tool_count=requested_tool_count,
+                tool_error_count=tool_error_count,
+                terminated_tool_count=0,
+            )
         return _IterationResult(
             should_stop=False,
             outcome="tool_observed",
             requested_tool_count=requested_tool_count,
             tool_error_count=tool_error_count,
             terminated_tool_count=0,
+        )
+
+    def _run_safety_handoff(self) -> None:
+        """Make one tool-disabled call that turns a hard stop into a visible handoff."""
+        self._safety_handoff_attempted = True
+        iteration = self._iterations_used
+        reason = self._stop_reason.replace("_", " ")
+        self._messages.append(
+            UserRuntimeMessage(content=_SAFETY_HANDOFF_PROMPT.format(reason=reason))
+        )
+        self._host._emit_runtime(
+            TurnStartEvent(
+                iteration=iteration,
+                data={"safety_handoff": True, "stop_reason": self._stop_reason},
+            )
+        )
+        try:
+            response = self._think(
+                iteration,
+                tool_schemas=[],
+                request_kind="safety_handoff",
+            )
+            content = str(response.content or "").strip()
+            if content:
+                # Do not retain tool calls a non-conforming provider may emit
+                # despite the empty schema: the handoff never executes them.
+                assistant_message = AssistantRuntimeMessage(
+                    content=content,
+                    metadata={"safety_handoff": True, "stop_reason": self._stop_reason},
+                )
+            else:
+                assistant_message = self._fallback_handoff_message()
+        except Exception:  # noqa: BLE001 - the deterministic handoff must survive provider failure
+            logger.debug(
+                "Safety handoff request failed; using deterministic fallback", exc_info=True
+            )
+            assistant_message = self._fallback_handoff_message()
+
+        self._messages.append(assistant_message)
+        self._final_text = str(assistant_message.content or "").strip()
+        self._host._emit_runtime(MessageStartEvent(message=assistant_message, iteration=iteration))
+        self._host._emit_runtime(
+            MessageUpdateEvent(
+                message=assistant_message,
+                delta=self._final_text,
+                iteration=iteration,
+                data={"has_tool_calls": False, "safety_handoff": True},
+            )
+        )
+        self._host._emit_runtime(
+            TurnEndEvent(
+                iteration=iteration,
+                message=assistant_message,
+                data={
+                    "accepted": True,
+                    "safety_handoff": True,
+                    "stop_reason": self._stop_reason,
+                },
+            )
+        )
+
+    def _fallback_handoff_message(self) -> AssistantRuntimeMessage:
+        """Build the deterministic handoff used when final sampling cannot answer."""
+        content = (
+            _STAGNATION_FALLBACK
+            if self._stop_reason == "stagnation_limit"
+            else _ITERATION_CAP_FALLBACK
+        )
+        return AssistantRuntimeMessage(
+            content=content,
+            metadata={"safety_handoff": True, "stop_reason": self._stop_reason},
         )
 
     def _emit_tool_update(
@@ -475,6 +646,7 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                     "final_text": self._final_text,
                     "stop_reason": self._stop_reason,
                     "hit_iteration_cap": self._hit_cap,
+                    "safety_handoff_attempted": self._safety_handoff_attempted,
                     "terminated_by_tool": self._terminated_by_tool,
                     "cancelled": self._cancelled,
                     "llm_iterations_used": self._iterations_used,

--- a/core/agent/run_io.py
+++ b/core/agent/run_io.py
@@ -49,6 +49,7 @@ class AgentRunInput[RuntimeToolT: RuntimeTool]:
     tool_resources: dict[str, Any]
     max_iterations: int
     messages: list[RuntimeMessage]
+    max_stagnant_iterations: int | None = None
 
     @classmethod
     def from_runtime_request(cls, request: Any, *, llm: Any) -> AgentRunInput[RuntimeToolT]:
@@ -70,6 +71,7 @@ class AgentRunInput[RuntimeToolT: RuntimeTool]:
             tool_resources=dict(getattr(request, "tool_resources", {}) or {}),
             max_iterations=request.max_iterations,
             messages=messages,
+            max_stagnant_iterations=getattr(request, "max_stagnant_iterations", None),
         )
 
     @classmethod
@@ -83,6 +85,7 @@ class AgentRunInput[RuntimeToolT: RuntimeTool]:
         resolved: dict[str, Any] | None,
         tool_resources: dict[str, Any],
         max_iterations: int,
+        max_stagnant_iterations: int | None = None,
     ) -> AgentRunInput[RuntimeToolT]:
         """Build from raw messages and a caller's construction-time config."""
         return cls(
@@ -93,6 +96,7 @@ class AgentRunInput[RuntimeToolT: RuntimeTool]:
             tool_resources=dict(tool_resources),
             max_iterations=max_iterations,
             messages=MessageMapper.to_runtime_messages(messages),
+            max_stagnant_iterations=max_stagnant_iterations,
         )
 
 

--- a/core/agent_harness/AGENTS.md
+++ b/core/agent_harness/AGENTS.md
@@ -126,9 +126,11 @@ subpackage. Default port implementations live with the concern they serve, not i
        Want-me-to, stream flush). Stream rewrite locals
        (`text_changed_after_streaming`) stay inside finalize and must **never**
        gate route selection.
-    Resolves integrations **once** at the top of the turn onto the frozen
-    `turn_snapshot`, so `turn_snapshot.resolved_integrations` is the single
-    source of truth for what the turn knows. Downstream components (e.g.
+    Resolves base integrations **once** at the top of the turn, enriches that
+    per-turn copy with repository scopes from the frozen message/history, and
+    stores it on `turn_snapshot`, so `turn_snapshot.resolved_integrations` is
+    the single source of truth for what the turn knows without mutating the
+    session's base integration cache. Downstream components (e.g.
     `action_driver._resolved_integrations_for_turn`) read it from there rather
     than re-resolving. Do NOT reintroduce per-component integration resolution.
   - `turn_route.py` / `answer_finalize.py` / `handoff_policy.py` — the seams

--- a/core/agent_harness/agent_builder.py
+++ b/core/agent_harness/agent_builder.py
@@ -33,6 +33,7 @@ class AgentConfig(Generic[RuntimeToolT]):  # noqa: UP046
     tools: tuple[RuntimeToolT, ...]
     resolved_integrations: ResolvedIntegrations
     max_iterations: int
+    max_stagnant_iterations: int | None = None
     tool_resources: dict[str, Any] = field(default_factory=dict)
     tool_hooks: ToolExecutionHooks | None = None
     provider_hooks: ProviderHooks | None = None
@@ -54,6 +55,7 @@ def build_agent(  # noqa: UP047
         tools=config.tools,
         resolved_integrations=config.resolved_integrations,
         max_iterations=config.max_iterations,
+        max_stagnant_iterations=config.max_stagnant_iterations,
         tool_resources=config.tool_resources,
         tool_hooks=config.tool_hooks,
         provider_hooks=config.provider_hooks,

--- a/core/agent_harness/task_plan/prompt.py
+++ b/core/agent_harness/task_plan/prompt.py
@@ -30,6 +30,9 @@ ASK_USER_ANSWERED_GUIDANCE = (
     "Put that analysis in update_plan(..., explanation=...) — the UI renders it "
     "under the checklist. Use headers and a table, never one dense paragraph. "
     "Do not repeat it in the assistant closing reply. "
+    "Treat RECENT CONVERSATION as authoritative: preserve the original target "
+    "repository and every requested output or metric. The Q&A answers refine "
+    "that request; they never replace it. "
     "Answering is the go-ahead to continue the original request. "
     "Do not invent a plan-only pause. Set ask_user_choice(plan_only_after=true) "
     "only when the original request asked not to run yet; then after answers "
@@ -47,8 +50,11 @@ ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE = (
     "- Facts: the answers as short bullets.\n"
     "- What the signature tells us: for each fact state what it RULES OUT.\n"
     "- Hypothesis ranking: # | Hypothesis | Why it fits | Discriminator.\n"
-    "Put that analysis in update_plan(..., explanation=...). Do not pass "
-    "plan_only=false; the host keeps the plan-only latch until the user "
+    "Put that analysis in update_plan(..., explanation=...). "
+    "Treat RECENT CONVERSATION as authoritative: preserve the original target "
+    "repository and every requested output or metric. The Q&A answers refine "
+    "that request; they never replace it. "
+    "Do not pass plan_only=false; the host keeps the plan-only latch until the user "
     "confirms a mutating step at the execution gate."
 )
 

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -204,14 +204,11 @@ def with_duplicate_action_call_guard(
     )
 
 
-# Some hosted tool-calling models emit one tool call per assistant turn even when
-# parallel tool calls are enabled. Keep the tool-calling loop bounded, but leave
-# enough headroom for a *data-dependent* compound request that must run
-# sequentially: each step waits for the previous tool's result before the next
-# call can be emitted (e.g. "look up the weather and then send it to Slack" =
-# Architecture audit needs headroom for clone + ≤3 agent-scan probes +
-# 4 heuristic shells + cleanup + save observations (then a no-tool report).
-_MAX_TOOL_CALLING_ITERATIONS = 13
+# This is an emergency ceiling, not the normal workflow budget. Productive
+# action turns may need many sequential calls; repeated observations are stopped
+# independently by the stagnation guard below.
+_MAX_TOOL_CALLING_ITERATIONS = 64
+_MAX_STAGNANT_TOOL_ITERATIONS = 3
 _EXECUTED_HISTORY_TYPES = {
     "slash",
     "shell",
@@ -716,6 +713,7 @@ def _build_action_agent(
         tools=tuple(agent_tools),
         resolved_integrations=resolved_integrations,
         max_iterations=_MAX_TOOL_CALLING_ITERATIONS,
+        max_stagnant_iterations=_MAX_STAGNANT_TOOL_ITERATIONS,
         tool_resources=tool_resources,
         tool_hooks=tool_hooks,
         on_runtime_event=on_runtime_event,
@@ -1094,7 +1092,7 @@ def _run_action_turn(
         False,
         False if cancelled else counts.handled,
         response_text="" if cancelled else response_text,
-        response_streamed=bool(use_final_text and not result.hit_iteration_cap and not cancelled),
+        response_streamed=bool(use_final_text and not cancelled),
         investigation_dispatched=(False if cancelled else counts.investigation_dispatched),
         hit_iteration_cap=bool(result.hit_iteration_cap and not cancelled),
         cancelled=cancelled,

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -226,7 +226,7 @@ INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
 # Tools whose user-facing event is owned by the host UI, so the end-of-turn
 # generic formatter must stay silent: repeating their summary would double-print,
 # and their payload (e.g. the full skill body) is for the model only.
-_HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset({"skill_view"})
+_HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset({"ask_user_choice", "skill_view"})
 
 
 @dataclass(frozen=True)
@@ -834,7 +834,7 @@ def _compose_response(
     """
     final_text = str(getattr(result, "final_text", "") or "").strip()
     waiting_for_choice = getattr(session, "pending_user_choice", None) is not None
-    generic_text = "" if waiting_for_choice else _response_text_from_generic_results(result)
+    generic_text = _response_text_from_generic_results(result)
     hint = _pop_turn_outcome_hint(session)
     prefer_tool_response_text = _has_preferred_tool_response_text(result)
     terminal = getattr(session, "terminal", None)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -223,11 +223,10 @@ _EXECUTED_HISTORY_TYPES = {
 INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
     {"investigation_start", "alert_sample"}
 )
-# Tools whose user-facing event is rendered live by the surface's tool-event
-# observer (``tool_start``/``tool_end``), so the end-of-turn generic formatter
-# must stay silent for them: repeating their summary would double-print, and
-# their payload (e.g. the full skill body) is for the model only.
-_OBSERVER_RENDERED_TOOL_NAMES: frozenset[str] = frozenset({"skill_view"})
+# Tools whose user-facing event is owned by the host UI, so the end-of-turn
+# generic formatter must stay silent: repeating their summary would double-print,
+# and their payload (e.g. the full skill body) is for the model only.
+_HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset({"skill_view"})
 
 
 @dataclass(frozen=True)
@@ -338,7 +337,7 @@ def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
 
 def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
     """Build a user-visible summary for one non-self-recording tool result."""
-    if tool_call.name in _OBSERVER_RENDERED_TOOL_NAMES:
+    if tool_call.name in _HOST_RENDERED_TOOL_NAMES:
         return ""
     preferred_response = _preferred_tool_response_text(tool_result)
     if preferred_response:
@@ -834,9 +833,17 @@ def _compose_response(
     Consumes the session's pending outcome hint.
     """
     final_text = str(getattr(result, "final_text", "") or "").strip()
-    generic_text = _response_text_from_generic_results(result)
+    waiting_for_choice = getattr(session, "pending_user_choice", None) is not None
+    generic_text = "" if waiting_for_choice else _response_text_from_generic_results(result)
     hint = _pop_turn_outcome_hint(session)
     prefer_tool_response_text = _has_preferred_tool_response_text(result)
+    terminal = getattr(session, "terminal", None)
+    pending_choice_response = getattr(terminal, "pending_choice_response", None)
+    selected_choice = (
+        pending_choice_response.strip() if isinstance(pending_choice_response, str) else ""
+    )
+    if selected_choice and terminal is not None:
+        terminal.pending_choice_response = None
     # Self-recording tools (slash/shell/…) already rendered the real output.
     # Drop model closings so they cannot contradict what the user just saw
     # (classic failure: inventing "health check passed" after a failed /health).
@@ -845,11 +852,16 @@ def _compose_response(
     # question, which seeks direction instead of restating output; and any
     # quiet ``shell_run``, which withheld live stdout so the closing *is*
     # the turn's display.
-    suppress_final = prefer_tool_response_text or (
-        _self_recording_tools_only(result)
-        and not _multi_step_grounded_chain(result)
-        and not _asks_the_user(final_text)
-        and not _has_quiet_shell_run(result)
+    suppress_final = (
+        waiting_for_choice
+        or _is_choice_acknowledgement(final_text, selected_choice)
+        or prefer_tool_response_text
+        or (
+            _self_recording_tools_only(result)
+            and not _multi_step_grounded_chain(result)
+            and not _asks_the_user(final_text)
+            and not _has_quiet_shell_run(result)
+        )
     )
     final_text_chunk = "" if suppress_final else final_text
     display_final = final_text_chunk
@@ -871,6 +883,22 @@ def _compose_response(
     use_final_text = bool(final_text_chunk)
     response_text = final_text if use_final_text else "\n".join(response_chunks)
     return response_text, display_chunks, use_final_text
+
+
+def _is_choice_acknowledgement(text: str, selected_choice: str) -> bool:
+    """True only for a bare restatement of the selected picker label."""
+    if not text or not selected_choice:
+        return False
+    choice = " ".join(selected_choice.casefold().split())
+    response = " ".join(text.casefold().strip().rstrip(".!?").split())
+    return response in {
+        choice,
+        f"{choice} selected",
+        f"{choice} was selected",
+        f"selected {choice}",
+        f"selected: {choice}",
+        f"you selected {choice}",
+    }
 
 
 def _show_response(

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shlex
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -224,13 +225,24 @@ INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
 # generic formatter must stay silent: repeating their summary would double-print,
 # and their payload (e.g. the full skill body) is for the model only.
 _HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset({"ask_user_choice", "skill_view"})
-_CHOICE_INVITATION_PREFIXES: tuple[str, ...] = (
-    "choose ",
-    "please choose ",
-    "select ",
-    "please select ",
-    "pick ",
-    "please pick ",
+_CHOICE_INVITATION_WORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "choose",
+        "following",
+        "from",
+        "of",
+        "one",
+        "option",
+        "options",
+        "pick",
+        "please",
+        "preferred",
+        "select",
+        "the",
+        "your",
+    }
 )
 
 
@@ -892,20 +904,23 @@ def _compose_response(
 
 
 def _is_redundant_choice_invitation(result: Any, final_text: str) -> bool:
-    """True when a short single-choice closing duplicates the queued picker."""
-    normalized = " ".join(final_text.casefold().strip().rstrip(".!?").split())
-    if not normalized:
+    """True when a single-choice closing adds no words beyond picker context."""
+    final_words = set(re.findall(r"[a-z0-9]+", final_text.casefold()))
+    if not final_words:
         return True
-    for tool_call, _tool_result in getattr(result, "tool_results", []):
+    for tool_call, tool_result in getattr(result, "tool_results", []):
         if tool_call.name != "ask_user_choice":
             continue
         args = public_tool_input(tool_call.input)
         if args.get("questions"):
             return False
-        title = " ".join(str(args.get("title", "")).casefold().strip().rstrip(".!?").split())
-        if title and normalized == title:
-            return True
-        return len(normalized.split()) <= 16 and normalized.startswith(_CHOICE_INVITATION_PREFIXES)
+        picker_words = set(re.findall(r"[a-z0-9]+", str(args.get("title", "")).casefold()))
+        details = getattr(tool_result, "details", None)
+        if isinstance(details, dict):
+            picker_words.update(
+                re.findall(r"[a-z0-9]+", str(details.get("summary", "")).casefold())
+            )
+        return final_words <= picker_words | _CHOICE_INVITATION_WORDS
     return False
 
 

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -38,6 +38,7 @@ from core.agent_harness.prompts import (
     build_action_user_message,
 )
 from core.agent_harness.session.integration_resolution import resolve_and_cache_integrations
+from core.agent_harness.session.pending_choice import parse_ask_user_answers
 from core.agent_harness.session.terminal_access import execute_cli_onboard_on_missing_key
 from core.agent_harness.session_goal.goal import strip_session_goal_progress_tags
 from core.agent_harness.turns.conversation_recording import record_conversation_turn
@@ -715,7 +716,11 @@ def _build_action_agent(
         # The reviewer reads executed tool names from the shared list the
         # event tap below fills, so it can stand down on handoff/dispatch
         # turns whose outcome is not reviewable at conclusion time.
-        goal = build_goal_reviewer(llm, message, executed_tool_names)
+        goal = build_goal_reviewer(
+            llm,
+            _goal_review_user_request(message, turn_snapshot),
+            executed_tool_names,
+        )
 
     # WAL first, observer second: the tool intent must be on disk before
     # any surface side effect reacts to the same event.
@@ -745,6 +750,19 @@ def _build_action_agent(
         llm=llm,
         max_iterations=_MAX_TOOL_CALLING_ITERATIONS,
     )
+
+
+def _goal_review_user_request(message: str, turn_snapshot: TurnSnapshot | None) -> str:
+    """Recover the original user request when this turn contains Ask User answers."""
+    if turn_snapshot is None or not parse_ask_user_answers(message):
+        return message
+    for role, content in reversed(turn_snapshot.conversation_messages):
+        if role.casefold() != "user" or not content.strip():
+            continue
+        if parse_ask_user_answers(content):
+            continue
+        return content
+    return message
 
 
 @dataclass(frozen=True)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -226,25 +226,6 @@ INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
 # generic formatter must stay silent: repeating their summary would double-print,
 # and their payload (e.g. the full skill body) is for the model only.
 _HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset({"ask_user_choice", "skill_view"})
-_CHOICE_INVITATION_WORDS: frozenset[str] = frozenset(
-    {
-        "a",
-        "an",
-        "choose",
-        "following",
-        "from",
-        "of",
-        "one",
-        "option",
-        "options",
-        "pick",
-        "please",
-        "preferred",
-        "select",
-        "the",
-        "your",
-    }
-)
 
 
 @dataclass(frozen=True)
@@ -917,14 +898,14 @@ def _compose_response(
         if chunk
     ]
     use_final_text = bool(final_text_chunk)
-    response_text = final_text if use_final_text else "\n".join(response_chunks)
+    response_text = "\n".join(display_chunks) if use_final_text else "\n".join(response_chunks)
     return response_text, display_chunks, use_final_text
 
 
 def _is_redundant_choice_invitation(result: Any, final_text: str) -> bool:
-    """True when a single-choice closing adds no words beyond picker context."""
-    final_words = set(re.findall(r"[a-z0-9]+", final_text.casefold()))
-    if not final_words:
+    """True when a single-choice closing repeats the title or tool summary."""
+    final_tokens = _choice_invitation_tokens(final_text)
+    if not final_tokens:
         return True
     for tool_call, tool_result in getattr(result, "tool_results", []):
         if tool_call.name != "ask_user_choice":
@@ -932,14 +913,21 @@ def _is_redundant_choice_invitation(result: Any, final_text: str) -> bool:
         args = public_tool_input(tool_call.input)
         if args.get("questions"):
             return False
-        picker_words = set(re.findall(r"[a-z0-9]+", str(args.get("title", "")).casefold()))
+        picker_copy = {_choice_invitation_tokens(str(args.get("title", "")))}
         details = getattr(tool_result, "details", None)
         if isinstance(details, dict):
-            picker_words.update(
-                re.findall(r"[a-z0-9]+", str(details.get("summary", "")).casefold())
-            )
-        return final_words <= picker_words | _CHOICE_INVITATION_WORDS
+            picker_copy.add(_choice_invitation_tokens(str(details.get("summary", ""))))
+        picker_copy.discard(())
+        return final_tokens in picker_copy
     return False
+
+
+def _choice_invitation_tokens(text: str) -> tuple[str, ...]:
+    """Normalize picker copy while allowing an optional polite prefix."""
+    tokens = tuple(re.findall(r"[a-z0-9]+", text.casefold()))
+    if tokens[:1] == ("please",):
+        return tokens[1:]
+    return tokens
 
 
 def _is_choice_acknowledgement(text: str, selected_choice: str) -> bool:

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -224,6 +224,14 @@ INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
 # generic formatter must stay silent: repeating their summary would double-print,
 # and their payload (e.g. the full skill body) is for the model only.
 _HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset({"ask_user_choice", "skill_view"})
+_CHOICE_INVITATION_PREFIXES: tuple[str, ...] = (
+    "choose ",
+    "please choose ",
+    "select ",
+    "please select ",
+    "pick ",
+    "please pick ",
+)
 
 
 @dataclass(frozen=True)
@@ -334,7 +342,7 @@ def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
 
 def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
     """Build a user-visible summary for one non-self-recording tool result."""
-    if tool_call.name in _HOST_RENDERED_TOOL_NAMES:
+    if tool_call.name in _HOST_RENDERED_TOOL_NAMES and not getattr(tool_result, "is_error", False):
         return ""
     preferred_response = _preferred_tool_response_text(tool_result)
     if preferred_response:
@@ -851,7 +859,7 @@ def _compose_response(
     # quiet ``shell_run``, which withheld live stdout so the closing *is*
     # the turn's display.
     suppress_final = (
-        waiting_for_choice
+        (waiting_for_choice and _is_redundant_choice_invitation(result, final_text))
         or _is_choice_acknowledgement(final_text, selected_choice)
         or prefer_tool_response_text
         or (
@@ -881,6 +889,24 @@ def _compose_response(
     use_final_text = bool(final_text_chunk)
     response_text = final_text if use_final_text else "\n".join(response_chunks)
     return response_text, display_chunks, use_final_text
+
+
+def _is_redundant_choice_invitation(result: Any, final_text: str) -> bool:
+    """True when a short single-choice closing duplicates the queued picker."""
+    normalized = " ".join(final_text.casefold().strip().rstrip(".!?").split())
+    if not normalized:
+        return True
+    for tool_call, _tool_result in getattr(result, "tool_results", []):
+        if tool_call.name != "ask_user_choice":
+            continue
+        args = public_tool_input(tool_call.input)
+        if args.get("questions"):
+            return False
+        title = " ".join(str(args.get("title", "")).casefold().strip().rstrip(".!?").split())
+        if title and normalized == title:
+            return True
+        return len(normalized.split()) <= 16 and normalized.startswith(_CHOICE_INVITATION_PREFIXES)
+    return False
 
 
 def _is_choice_acknowledgement(text: str, selected_choice: str) -> bool:

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -898,7 +898,7 @@ def _compose_response(
         if chunk
     ]
     use_final_text = bool(final_text_chunk)
-    response_text = "\n".join(display_chunks) if use_final_text else "\n".join(response_chunks)
+    response_text = "\n".join(response_chunks)
     return response_text, display_chunks, use_final_text
 
 
@@ -1119,8 +1119,9 @@ def _run_action_turn(
         _show_response(
             args.output,
             handled=counts.handled,
-            # use_final_text means the composed text *is* the closing message.
-            final_text=response_text if use_final_text else "",
+            # Stream only terminal-visible chunks. ``response_text`` may also
+            # contain self-recording history for persistence/headless surfaces.
+            final_text="\n".join(display_chunks) if use_final_text else "",
             display_chunks=display_chunks,
         )
 

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -121,7 +121,7 @@ def run_turn(
         return _cancelled_turn_result(accounting, action_result)
 
     response_text = action_result.response_text.strip()
-    if action_result.hit_iteration_cap:
+    if action_result.hit_iteration_cap and not action_result.response_streamed:
         response_text = "\n\n".join(filter(None, (response_text, _ITERATION_CAP_MESSAGE)))
     if response_text:
         record_conversation_turn(session, text, response_text)

--- a/core/agent_harness/turns/turn_plan.py
+++ b/core/agent_harness/turns/turn_plan.py
@@ -24,6 +24,7 @@ from core.agent_harness.session.integration_resolution import (
     resolve_and_cache_integrations,
 )
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
+from infrastructure.harness_providers import enrich_resolved_with_repo_scopes
 
 
 @dataclass(frozen=True)
@@ -60,6 +61,25 @@ def build_turn_plan(snapshot: TurnSnapshot, session: SessionState) -> TurnPlan:
     """
     if not has_resolved_integrations(snapshot.resolved_integrations):
         snapshot = replace(snapshot, resolved_integrations=resolve_and_cache_integrations(session))
+
+    def _set_cached_scope(vendor: str, scope: tuple[str, ...] | None) -> None:
+        scopes = dict(session.vcs_repo_scopes)
+        if scope is None:
+            scopes.pop(vendor, None)
+        else:
+            scopes[vendor] = scope
+        session.vcs_repo_scopes = scopes
+
+    enriched = enrich_resolved_with_repo_scopes(
+        resolved=snapshot.resolved_integrations,
+        message=snapshot.text,
+        conversation_messages=snapshot.conversation_messages,
+        env=None,
+        cwd=snapshot.working_directory,
+        cached_scopes=session.vcs_repo_scopes,
+        set_cached_scope=_set_cached_scope,
+    )
+    snapshot = replace(snapshot, resolved_integrations=enriched)
     return TurnPlan(snapshot=snapshot)
 
 

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -18,6 +18,7 @@ from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.ask_user import CUSTOM_OPTION, repl_ask_user
+from surfaces.interactive_shell.ui.handoff_questions import render_choice_selection
 from surfaces.shared.terminal.components.choice_menu import (
     print_valid_choice_list,
     repl_choose_one,
@@ -74,8 +75,9 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         session.terminal.awaiting_handoff_answer = False
         return True
 
-    # Auto-submit the chosen label as the next user message; the prompt echo is
-    # the confirmation, so nothing is printed here.
+    # The picker is transient, so leave one compact result in scrollback. The
+    # synthetic answer turn itself stays hidden by submitted-prompt rendering.
+    render_choice_selection(console, items[0].title, picked_one)
     session.terminal.set_auto_command(picked_one)
     session.terminal.awaiting_handoff_answer = True
     return True

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -289,6 +289,7 @@ class InteractiveShellController:
                     # A genuine typed turn starts a new workload: reset the ask-user
                     # round counter so the two-round cap is per-request, not per-session.
                     self.session.ask_user_rounds = 0
+                    self.session.terminal.pending_choice_response = None
                 wait_for_turn = _should_wait_until_turn_finishes(
                     exclusive_stdin=wait,
                     goal_condition_autosubmitted=autosubmitted and not ask_user_answers,

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -153,6 +153,14 @@ async def run_agent_turn(runtime: AgentTurnResources, text: str) -> None:
         set_investigation_spinner(None)
         runtime.session.terminal.exclusive_stdin_active = False
         runtime.session.terminal.dispatch_active = False
+        # ``set_auto_command`` deliberately avoids submitting while a turn is
+        # active. If the input prompt was already open, wake it again now that
+        # the turn is idle so deferred commands such as ``/choose`` can run.
+        if (
+            runtime.session.terminal.pending_prompt_default
+            and runtime.session.terminal.pending_prompt_autosubmit
+        ):
+            runtime.session.terminal.notify_prompt_changed()
         emit_thread_boundary(
             runtime.session.session_id,
             name="turn_boundary",

--- a/surfaces/interactive_shell/session/session.py
+++ b/surfaces/interactive_shell/session/session.py
@@ -104,6 +104,7 @@ class Session(SessionCore):
         self.terminal.pending_prompt_default = None
         self.terminal.pending_prompt_autosubmit = False
         self.terminal.last_input_autosubmitted = False
+        self.terminal.pending_choice_response = None
         self.terminal.dispatch_active = False
         self.terminal.exclusive_stdin_active = False
         self.terminal.background_mode_enabled = False

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -105,6 +105,12 @@ class TerminalSession:
     Set by ``ask_user_choice`` (and the ``/choose`` pick). Cleared when the
     submitted prompt is painted so the answer uses the brand colour."""
 
+    pending_choice_response: str | None = None
+    """Selected label while its synthetic answer turn awaits a response.
+
+    The response composer consumes the label to hide a pure acknowledgement
+    while preserving meaningful follow-up the selected option unlocks."""
+
     exclusive_stdin_active: bool = False
     """True while a turn is running with exclusive stdin reserved (no live prompt).
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -53,7 +53,20 @@ _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
 #: Tools that render their own dedicated UI (the investigation lap/spinner
 #: progress). The generic live tool-call preview is suppressed for these so it
 #: does not duplicate that UI as a wall of text.
-_SELF_RENDERING_TOOLS: frozenset[str] = frozenset({ActionToolName.INVESTIGATION_START})
+_SELF_RENDERING_TOOLS: frozenset[str] = frozenset(
+    {
+        ActionToolName.ASK_USER_CHOICE,
+        ActionToolName.INVESTIGATION_START,
+    }
+)
+
+
+def _is_internal_choice_command(name: str, data: dict[str, Any]) -> bool:
+    """True for the private slash turn that opens the choice picker."""
+    if name != ActionToolName.SLASH_INVOKE:
+        return False
+    args = data.get("input")
+    return isinstance(args, dict) and str(args.get("command", "")).strip() == "/choose"
 
 
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
@@ -136,6 +149,8 @@ class ActionRenderObserver:
             self._render_skill_start(data)
         elif name == ActionToolName.UPDATE_PLAN:
             pass  # render on tool_end after the tool commits session state
+        elif _is_internal_choice_command(name, data):
+            pass  # private picker plumbing; the menu owns the visible interaction
         elif name in _SELF_RENDERING_TOOLS:
             pass  # owns its UI; a generic preview would duplicate it
         else:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -12,7 +12,9 @@ binding core ports while terminal formatting stays in ``ui/``.
 
 from __future__ import annotations
 
+import ast
 import contextlib
+import re
 import shlex
 from typing import Any
 
@@ -52,6 +54,7 @@ _SENSITIVE_KEY_PARTS = (
     "secret",
     "token",
 )
+_PYTHON_URL_RE = re.compile(r"https?://[^\s'\"`]+")
 
 _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
     ActionToolName.LLM_SET_PROVIDER: ("LLM provider", "target"),
@@ -136,14 +139,91 @@ def _python_execution_display(args: dict[str, Any]) -> tuple[str, str]:
     details = ["run analysis"]
     if args.get("allow_network") is True:
         details.append("network enabled")
+    code = str(args.get("code", "") or "")
+    targets = _python_network_targets(code)
+    if targets:
+        details.append(f"target: {', '.join(targets)}")
+    outputs = _python_output_fields(code)
+    if outputs:
+        details.append(f"outputs: {', '.join(outputs)}")
     inputs = args.get("inputs")
     if isinstance(inputs, dict):
-        names = sorted(
-            str(key) for key in inputs if key != "opensre_runtime" and not _is_sensitive_key(key)
+        safe_inputs = redact_sensitive(
+            {
+                str(key): value
+                for key, value in inputs.items()
+                if key != "opensre_runtime" and not _is_sensitive_key(key)
+            }
         )
-        if names:
-            details.append(f"inputs: {', '.join(names)}")
-    return "Python", _bounded_preview(" · ".join(details))
+        rendered_inputs = [
+            f"{key}={_bounded_preview(str(value), limit=40)}"
+            for key, value in sorted(safe_inputs.items())
+        ]
+        if rendered_inputs:
+            details.append(f"inputs: {', '.join(rendered_inputs)}")
+    else:
+        referenced_inputs = _python_referenced_inputs(code)
+        if referenced_inputs:
+            details.append(f"inputs: {', '.join(referenced_inputs)}")
+    return "Python", _bounded_preview(" · ".join(details), limit=240)
+
+
+def _python_network_targets(code: str) -> list[str]:
+    targets: list[str] = []
+    for match in _PYTHON_URL_RE.finditer(code):
+        target = match.group(0).split("://", 1)[1].split("?", 1)[0].rstrip("/),]")
+        if not target or any(existing.startswith(target) for existing in targets):
+            continue
+        targets = [existing for existing in targets if not target.startswith(existing)]
+        targets.append(_bounded_preview(target, limit=64))
+    return targets[:2]
+
+
+def _python_tree(code: str) -> ast.AST | None:
+    try:
+        return ast.parse(code)
+    except (SyntaxError, ValueError):
+        return None
+
+
+def _python_referenced_inputs(code: str) -> list[str]:
+    tree = _python_tree(code)
+    if tree is None:
+        return []
+    names = {
+        str(node.slice.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "inputs"
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, str)
+        and not _is_sensitive_key(node.slice.value)
+    }
+    return sorted(names)
+
+
+def _python_output_fields(code: str) -> list[str]:
+    tree = _python_tree(code)
+    if tree is None:
+        return []
+    fields: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id != "print" or not node.args:
+            continue
+        value = node.args[0]
+        while isinstance(value, ast.Call) and value.args:
+            value = value.args[0]
+        if not isinstance(value, ast.Dict):
+            continue
+        for key in value.keys:
+            if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+                continue
+            if key.value not in fields and not _is_sensitive_key(key.value):
+                fields.append(key.value)
+    return fields[:4]
 
 
 def _generic_tool_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -13,7 +13,7 @@ binding core ports while terminal formatting stays in ``ui/``.
 from __future__ import annotations
 
 import contextlib
-import json
+import shlex
 from typing import Any
 
 from rich.console import Console
@@ -21,6 +21,7 @@ from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.spi.task_plan import TaskPlan, is_plan_diagnosis_prose
+from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session
@@ -39,6 +40,18 @@ from tools.interactive_shell.action_names import ActionToolName
 # in :func:`tool_call_display`.
 # The spinner's thinking verb re-rolls once per this many agent-loop steps.
 _VERB_ROTATION_STEP_INTERVAL = 2
+_TOOL_PREVIEW_MAX_CHARS = 180
+_TOOL_VALUE_MAX_CHARS = 64
+_GH_VERBOSE_VALUE_FLAGS = frozenset({"--jq", "--template", "-t"})
+_GENERIC_EXECUTION_KEYS = frozenset({"runtime_metadata", "timeout"})
+_SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "authorization",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
 
 _SIMPLE_TOOL_LABELS: dict[str, tuple[str, str]] = {
     ActionToolName.LLM_SET_PROVIDER: ("LLM provider", "target"),
@@ -69,13 +82,108 @@ def _is_internal_choice_command(name: str, data: dict[str, Any]) -> bool:
     return isinstance(args, dict) and str(args.get("command", "")).strip() == "/choose"
 
 
+def _bounded_preview(value: str, *, limit: int = _TOOL_PREVIEW_MAX_CHARS) -> str:
+    """Keep live progress on one useful terminal line."""
+    collapsed = " ".join(value.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 1].rstrip() + "…"
+
+
+def _is_sensitive_key(key: object) -> bool:
+    normalized = str(key).casefold().replace("-", "_")
+    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
+def _compact_gh_args(raw_args: object) -> list[str]:
+    """Retain the command shape while hiding verbose expression bodies."""
+    if not isinstance(raw_args, list):
+        return []
+    tokens = [strip_terminal_controls(str(item).strip()) for item in raw_args]
+    compact: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        compact.append(token)
+        if token in _GH_VERBOSE_VALUE_FLAGS and index + 1 < len(tokens):
+            compact.append("…")
+            index += 2
+            continue
+        if token in {"-H", "--header"} and index + 1 < len(tokens):
+            header = tokens[index + 1]
+            compact.append("…" if _is_sensitive_key(header) else _bounded_preview(header, limit=40))
+            index += 2
+            continue
+        if index + 1 < len(tokens) and token in {"-f", "-F", "--field", "--raw-field"}:
+            compact.append(_bounded_preview(tokens[index + 1], limit=_TOOL_VALUE_MAX_CHARS))
+            index += 2
+            continue
+        index += 1
+    return compact
+
+
+def _github_cli_display(args: dict[str, Any]) -> tuple[str, str]:
+    command = ["gh"]
+    repo = strip_terminal_controls(str(args.get("repo", "")).strip())
+    if repo:
+        command.extend(["-R", repo])
+    command.extend(_compact_gh_args(args.get("args")))
+    preview = shlex.join(command).replace("'…'", "…")
+    return "GitHub CLI", _bounded_preview(preview)
+
+
+def _python_execution_display(args: dict[str, Any]) -> tuple[str, str]:
+    details = ["run analysis"]
+    if args.get("allow_network") is True:
+        details.append("network enabled")
+    inputs = args.get("inputs")
+    if isinstance(inputs, dict):
+        names = sorted(
+            str(key) for key in inputs if key != "opensre_runtime" and not _is_sensitive_key(key)
+        )
+        if names:
+            details.append(f"inputs: {', '.join(names)}")
+    return "Python", _bounded_preview(" · ".join(details))
+
+
+def _generic_tool_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
+    safe_args = {
+        str(key): value
+        for key, value in args.items()
+        if key not in _GENERIC_EXECUTION_KEYS and not _is_sensitive_key(key)
+    }
+    redacted = redact_sensitive(safe_args)
+    content = " · ".join(
+        f"{key}: {_generic_value_preview(value)}" for key, value in sorted(redacted.items())
+    )
+    return tool_name.replace("_", " "), _bounded_preview(content)
+
+
+def _generic_value_preview(value: Any) -> str:
+    if isinstance(value, dict):
+        keys = [str(key) for key in value if not _is_sensitive_key(key)]
+        return f"fields {', '.join(keys[:4])}" + (f" +{len(keys) - 4}" if len(keys) > 4 else "")
+    if isinstance(value, (list, tuple)):
+        items = [_bounded_preview(str(item), limit=24) for item in value[:4]]
+        return ", ".join(items) + (f" +{len(value) - 4}" if len(value) > 4 else "")
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return _bounded_preview(str(value), limit=_TOOL_VALUE_MAX_CHARS)
+
+
 def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
     """Return a ``(label, content)`` pair describing a planned tool call.
 
     Both strings are stripped of terminal controls: callers append them to a
     raw Rich line, and the tool name and args are model-supplied.
     """
-    if tool_name == ActionToolName.SLASH_INVOKE:
+    if tool_name == "github_cli":
+        label, content = _github_cli_display(args)
+    elif tool_name == "execute_python_code":
+        label, content = _python_execution_display(args)
+    elif tool_name == ActionToolName.SLASH_INVOKE:
         command = str(args.get("command", "")).strip()
         raw_args = args.get("args")
         parsed_args = [str(item).strip() for item in raw_args] if isinstance(raw_args, list) else []
@@ -90,7 +198,7 @@ def tool_call_display(tool_name: str, args: dict[str, Any]) -> tuple[str, str]:
             key_label, arg_key = simple
             label, content = key_label, str(args.get(arg_key, "")).strip()
         else:
-            label, content = tool_name, json.dumps(args, default=str, sort_keys=True)
+            label, content = _generic_tool_display(tool_name, args)
     return strip_terminal_controls(label), strip_terminal_controls(content)
 
 

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -72,6 +72,19 @@ def render_handoff_answer_marker() -> Text:
     return Text("↗ answer", style=str(ui_theme.DIM))
 
 
+def render_choice_selection(console: Console, title: str, answer: str) -> None:
+    """Persist a compact selected-choice result after the transient picker closes."""
+    heading = Text()
+    heading.append("✓ ", style=f"bold {ui_theme.HIGHLIGHT}")
+    heading.append(_display_safe(title.strip()), style=str(ui_theme.TEXT))
+    selected = Text("  ", style=str(ui_theme.DIM))
+    selected.append(_display_safe(answer.strip()), style=str(ui_theme.BRAND))
+    console.print()
+    console.print(heading)
+    console.print(selected)
+    console.print()
+
+
 def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:
     """Print Ask User Q→A: orange header, numbered questions, brand answers.
 
@@ -114,6 +127,7 @@ __all__ = [
     "is_handoff_question",
     "last_assistant_asked_handoff",
     "render_ask_user_qa",
+    "render_choice_selection",
     "render_handoff_answer_marker",
     "render_handoff_question",
     "try_render_ask_user_submission",

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -106,6 +106,12 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
         return
     autosubmitted = bool(session.terminal.last_input_autosubmitted)
     session.terminal.last_input_autosubmitted = False
+    if is_handoff_answer and autosubmitted:
+        # A fixed picker choice already has a compact persistent result. Do not
+        # manufacture a second user turn in scrollback; only mark the synthetic
+        # answer so a no-op model acknowledgement can be omitted as well.
+        session.terminal.pending_choice_response = stripped
+        return
     if is_handoff_answer:
         console.print(render_handoff_answer_marker())
     elif autosubmitted:

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -81,6 +81,7 @@ def test_gateway_turn_runner_does_not_finalize_answered_turn(
             False,
             False,
             response_streamed=True,
+            hit_iteration_cap=True,
         ),
         assistant_response_text="streamed answer",
     )
@@ -157,6 +158,39 @@ def test_run_turn_surfaces_iteration_cap_as_incomplete() -> None:
 
     assert result.final_intent == "agent_incomplete"
     assert "iteration limit reached" in result.primary_response_text
+
+
+def test_run_turn_does_not_duplicate_a_streamed_safety_handoff() -> None:
+    handoff = "Partial results are preserved; the repeated query is still blocked."
+
+    def execute_actions(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
+        return ToolCallingTurnResult(
+            1,
+            1,
+            0,
+            False,
+            True,
+            response_text=handoff,
+            response_streamed=True,
+            hit_iteration_cap=True,
+        )
+
+    class _Accounting:
+        def record_action_result(self, _result: ToolCallingTurnResult) -> None:
+            return None
+
+        def finalize(self, result: TurnResult) -> TurnResult:
+            return result
+
+    result = run_turn(
+        "finish the task",
+        Session(store=InMemorySessionStore()),
+        execute_actions=execute_actions,
+        accounting=_Accounting(),
+    )
+
+    assert result.final_intent == "agent_incomplete"
+    assert result.primary_response_text == handoff
 
 
 def test_run_turn_builds_turn_plan_for_action_path(

--- a/tests/core/agent/orchestration/test_cross_surface_components.py
+++ b/tests/core/agent/orchestration/test_cross_surface_components.py
@@ -219,14 +219,21 @@ def test_run_turn_builds_turn_plan_for_action_path(
 
     session = Session(store=InMemorySessionStore())
     run_turn(
-        "hi",
+        "check facebook/react",
         session,
         execute_actions=execute_actions,
         accounting=_Accounting(),
     )
 
     assert captured, "execute_actions was never called"
-    assert captured[0].resolved_integrations == resolved
+    assert captured[0].resolved_integrations == {
+        "github": {
+            "configured": True,
+            "owner": "facebook",
+            "repo": "react",
+        }
+    }
+    assert resolved == {"github": {"configured": True}}
 
 
 def test_action_tools_uses_passed_resolved_integrations(

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -275,6 +275,54 @@ def test_queued_choice_preserves_substantive_closing_text() -> None:
     assert use_final_text is True
 
 
+def test_queued_choice_preserves_recommendation_using_picker_words() -> None:
+    choice = ToolCall(
+        id="1",
+        name="ask_user_choice",
+        input={
+            "title": "Choose a deployment environment: staging or production",
+            "options": ["Staging", "Production"],
+        },
+    )
+    closing = "Choose staging."
+    result = _Result(
+        tool_results=[(choice, _ToolResult({"ok": True, "menu": "queued"}))],
+        final_text=closing,
+    )
+    session = _Session()
+    session.pending_user_choice = object()
+
+    response_text, display_chunks, use_final_text = _compose_response(result, session, _counts(1))
+
+    assert response_text == closing
+    assert display_chunks == [closing]
+    assert use_final_text is True
+
+
+def test_choice_failure_remains_visible_with_model_closing() -> None:
+    choice = ToolCall(id="1", name="ask_user_choice", input={"title": "", "options": []})
+    result = _Result(
+        tool_results=[
+            (
+                choice,
+                _ToolResult(
+                    {"ok": False, "error": "title is required"},
+                    is_error=True,
+                ),
+            )
+        ],
+        final_text="I could not open the picker.",
+    )
+
+    response_text, display_chunks, use_final_text = _compose_response(
+        result, _Session(), _counts(1)
+    )
+
+    assert response_text == "I could not open the picker.\ntitle is required"
+    assert display_chunks == ["I could not open the picker.", "title is required"]
+    assert use_final_text is True
+
+
 def test_choice_failure_remains_visible_beside_preferred_sibling_response() -> None:
     github = ToolCall(id="1", name="github_cli", input={"command": "run list"})
     choice = ToolCall(id="2", name="ask_user_choice", input={"title": "", "options": []})

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -220,6 +220,39 @@ def test_queued_choice_owns_the_turn_display() -> None:
     assert use_final_text is False
 
 
+def test_queued_choice_preserves_sibling_tool_results() -> None:
+    github = ToolCall(id="1", name="github_cli", input={"command": "run list"})
+    choice = ToolCall(
+        id="2",
+        name="ask_user_choice",
+        input={"title": "Deploy how?", "options": ["Canary", "Rolling"]},
+    )
+    result = _Result(
+        tool_results=[
+            (github, _ToolResult(_payload("3 failed, 59 succeeded"))),
+            (
+                choice,
+                _ToolResult(
+                    {
+                        "ok": True,
+                        "menu": "queued",
+                        "summary": "Choose your preferred deployment strategy.",
+                    }
+                ),
+            ),
+        ],
+        final_text="Choose your preferred deployment strategy.",
+    )
+    session = _Session()
+    session.pending_user_choice = object()
+
+    response_text, display_chunks, use_final_text = _compose_response(result, session, _counts(2))
+
+    assert response_text == "3 failed, 59 succeeded"
+    assert display_chunks == ["3 failed, 59 succeeded"]
+    assert use_final_text is False
+
+
 def test_selected_choice_hides_only_a_pure_acknowledgement() -> None:
     result = _Result(tool_results=[], final_text="Blue-green selected.")
     session = _Session()

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -52,9 +52,13 @@ def _payload(response_text: str) -> dict[str, Any]:
     return {"ok": True, "response_text": response_text}
 
 
-def _counts(steps: int) -> _TurnCounts:
+def _counts(
+    steps: int,
+    *,
+    executed_entries: list[dict[str, Any]] | None = None,
+) -> _TurnCounts:
     return _TurnCounts(
-        executed_entries=[],
+        executed_entries=executed_entries or [],
         executed_count=steps,
         executed_success_count=steps,
         generic_success_count=0,
@@ -319,6 +323,43 @@ def test_choice_failure_remains_visible_with_model_closing() -> None:
     )
 
     assert response_text == "I could not open the picker.\ntitle is required"
+    assert display_chunks == ["I could not open the picker.", "title is required"]
+    assert use_final_text is True
+
+
+def test_choice_failure_closing_preserves_self_recording_sibling_history() -> None:
+    slash = ToolCall(id="1", name="slash_invoke", input={"command": "/health"})
+    choice = ToolCall(id="2", name="ask_user_choice", input={"title": "", "options": []})
+    result = _Result(
+        tool_results=[
+            (slash, _ToolResult({"ok": True})),
+            (
+                choice,
+                _ToolResult(
+                    {"ok": False, "error": "title is required"},
+                    is_error=True,
+                ),
+            ),
+        ],
+        final_text="I could not open the picker.",
+    )
+    counts = _counts(
+        2,
+        executed_entries=[
+            {
+                "type": "slash",
+                "text": "/health",
+                "ok": True,
+                "response_text": "Health check: degraded",
+            }
+        ],
+    )
+
+    response_text, display_chunks, use_final_text = _compose_response(result, _Session(), counts)
+
+    assert response_text == (
+        "Health check: degraded\nI could not open the picker.\ntitle is required"
+    )
     assert display_chunks == ["I could not open the picker.", "title is required"]
     assert use_final_text is True
 

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -35,6 +35,12 @@ class _Result:
 class _Session:
     def __init__(self) -> None:
         self.history: list[dict[str, Any]] = []
+        self.pending_user_choice: object | None = None
+
+        class _Terminal:
+            pending_choice_response: str | None = None
+
+        self.terminal = _Terminal()
 
 
 def _shell_call(call_id: str, command: str, *, quiet: bool) -> ToolCall:
@@ -181,3 +187,62 @@ def test_a_generic_tool_result_is_not_replaced_by_quiet_stdout() -> None:
     shown = "\n".join(display_chunks)
     assert "3 failed, 59 succeeded" in shown
     assert "rate limit 4998" not in shown
+
+
+def test_queued_choice_owns_the_turn_display() -> None:
+    call = ToolCall(
+        id="1",
+        name="ask_user_choice",
+        input={"title": "Deploy how?", "options": ["Canary", "Rolling"]},
+    )
+    result = _Result(
+        tool_results=[
+            (
+                call,
+                _ToolResult(
+                    {
+                        "ok": True,
+                        "menu": "queued",
+                        "summary": "Choose your preferred deployment strategy.",
+                    }
+                ),
+            )
+        ],
+        final_text="Choose your preferred deployment strategy.",
+    )
+    session = _Session()
+    session.pending_user_choice = object()
+
+    response_text, display_chunks, use_final_text = _compose_response(result, session, _counts(1))
+
+    assert response_text == ""
+    assert display_chunks == []
+    assert use_final_text is False
+
+
+def test_selected_choice_hides_only_a_pure_acknowledgement() -> None:
+    result = _Result(tool_results=[], final_text="Blue-green selected.")
+    session = _Session()
+    session.terminal.pending_choice_response = "Blue-green"
+
+    response_text, display_chunks, use_final_text = _compose_response(result, session, _counts(0))
+
+    assert response_text == ""
+    assert display_chunks == []
+    assert use_final_text is False
+    assert session.terminal.pending_choice_response is None
+
+
+def test_selected_choice_keeps_meaningful_follow_up_response() -> None:
+    result = _Result(
+        tool_results=[],
+        final_text="Blue-green avoids routing a full release to every instance at once.",
+    )
+    session = _Session()
+    session.terminal.pending_choice_response = "Blue-green"
+
+    _response_text, display_chunks, _use_final_text = _compose_response(result, session, _counts(0))
+
+    shown = "\n".join(display_chunks)
+    assert "Blue-green avoids routing" in shown
+    assert session.terminal.pending_choice_response is None

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -14,9 +14,10 @@ from core.llm.types import ToolCall
 
 
 class _ToolResult:
-    def __init__(self, payload: dict[str, Any]) -> None:
+    def __init__(self, payload: dict[str, Any], *, is_error: bool = False) -> None:
         self.content = json.dumps(payload)
-        self.is_error = False
+        self.details = payload
+        self.is_error = is_error
 
 
 class _Result:
@@ -250,6 +251,54 @@ def test_queued_choice_preserves_sibling_tool_results() -> None:
 
     assert response_text == "3 failed, 59 succeeded"
     assert display_chunks == ["3 failed, 59 succeeded"]
+    assert use_final_text is False
+
+
+def test_queued_choice_preserves_substantive_closing_text() -> None:
+    choice = ToolCall(
+        id="1",
+        name="ask_user_choice",
+        input={"title": "Deploy how?", "options": ["Canary", "Rolling"]},
+    )
+    closing = "I found three failed checks; review those while choosing the rollout strategy."
+    result = _Result(
+        tool_results=[(choice, _ToolResult({"ok": True, "menu": "queued"}))],
+        final_text=closing,
+    )
+    session = _Session()
+    session.pending_user_choice = object()
+
+    response_text, display_chunks, use_final_text = _compose_response(result, session, _counts(1))
+
+    assert response_text == closing
+    assert display_chunks == [closing]
+    assert use_final_text is True
+
+
+def test_choice_failure_remains_visible_beside_preferred_sibling_response() -> None:
+    github = ToolCall(id="1", name="github_cli", input={"command": "run list"})
+    choice = ToolCall(id="2", name="ask_user_choice", input={"title": "", "options": []})
+    result = _Result(
+        tool_results=[
+            (github, _ToolResult(_payload("3 failed, 59 succeeded"))),
+            (
+                choice,
+                _ToolResult(
+                    {"ok": False, "error": "title is required"},
+                    is_error=True,
+                ),
+            ),
+        ],
+        final_text="I could not open the picker.",
+    )
+
+    response_text, display_chunks, use_final_text = _compose_response(
+        result, _Session(), _counts(2)
+    )
+
+    assert "3 failed, 59 succeeded" in response_text
+    assert "title is required" in response_text
+    assert display_chunks == ["3 failed, 59 succeeded\ntitle is required"]
     assert use_final_text is False
 
 

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -260,7 +260,7 @@ def test_queued_choice_preserves_substantive_closing_text() -> None:
         name="ask_user_choice",
         input={"title": "Deploy how?", "options": ["Canary", "Rolling"]},
     )
-    closing = "I found three failed checks; review those while choosing the rollout strategy."
+    closing = "Choose Canary only if the error rate remains stable."
     result = _Result(
         tool_results=[(choice, _ToolResult({"ok": True, "menu": "queued"}))],
         final_text=closing,

--- a/tests/core/agent_harness/task_plan/test_prompt.py
+++ b/tests/core/agent_harness/task_plan/test_prompt.py
@@ -113,6 +113,35 @@ def test_ask_user_answered_guidance_defaults_to_execute_not_pause() -> None:
     assert "in_progress and execute it now" in text
 
 
+def test_ask_user_answers_preserve_original_repo_and_all_requested_metrics() -> None:
+    from core.agent_harness.session.pending_choice import (
+        AskUserQuestion,
+        format_ask_user_answers,
+    )
+
+    original = "For facebook/react, return merged PR count, median time-to-merge, and star gain."
+    answers = format_ask_user_answers(
+        (AskUserQuestion(label="Window", title="Which date window?", options=("7d", "30d")),),
+        ("7d",),
+    )
+    snapshot = TurnSnapshot(
+        text=answers,
+        conversation_messages=(("user", original),),
+        configured_integrations=(),
+        configured_integrations_known=True,
+        last_state=None,
+        last_synthetic_observation_path=None,
+        reasoning_effort=None,
+    )
+
+    rendered = build_action_system_prompt_envelope(snapshot).render()
+
+    assert original in rendered
+    assert "preserve the original target repository" in rendered
+    assert "every requested output or metric" in rendered
+    assert "Q&A answers refine that request; they never replace it" in rendered
+
+
 def test_ask_user_answered_plan_only_guidance_does_not_authorize_execute() -> None:
     from core.agent_harness.session.pending_choice import (
         AskUserQuestion,

--- a/tests/core/agent_harness/test_action_turn_outcome.py
+++ b/tests/core/agent_harness/test_action_turn_outcome.py
@@ -97,7 +97,7 @@ def test_a_terse_closing_line_is_the_answer_when_nothing_else_ran() -> None:
 
 def test_iteration_cap_is_preserved_on_turn_result() -> None:
     harness = ActionExecutionHarness(
-        llm=FakeActionLLM([tool_response("skill_view", {"name": "missing"}) for _ in range(13)])
+        llm=FakeActionLLM([tool_response("skill_view", {"name": "missing"}) for _ in range(5)])
     )
 
     result = run_action_tool_turn(
@@ -108,3 +108,7 @@ def test_iteration_cap_is_preserved_on_turn_result() -> None:
     )
 
     assert result.hit_iteration_cap is True
+    assert result.response_streamed is True
+    assert "repeated tool calls produced no new result" in result.response_text
+    assert _console_text(harness).count("repeated tool calls produced no new result") == 1
+    assert harness.llm.invocations == 5

--- a/tests/core/agent_harness/test_goal_review_structured.py
+++ b/tests/core/agent_harness/test_goal_review_structured.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from core.agent.goals import GoalObservation
+from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
+from core.agent_harness.turns.action_driver import _goal_review_user_request
 from core.agent_harness.turns.goal_review import build_goal_reviewer
+from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.llm.types import AgentLLMResponse
 
 
@@ -62,3 +65,45 @@ def test_goal_reviewer_fails_open_on_free_text() -> None:
     goal = build_goal_reviewer(llm, "delete the cron", executed_tool_names=["shell_run"])
     assert goal.verify is not None
     assert goal.verify(_obs()) is True
+
+
+def test_structured_answer_goal_review_recovers_latest_non_qa_user_request() -> None:
+    original = "For facebook/react, return merged PR count, median time-to-merge, and star gain."
+    prior_answers = format_ask_user_answers(
+        (AskUserQuestion(label="Window", title="Which window?", options=("7d", "30d")),),
+        ("7d",),
+    )
+    current_answers = format_ask_user_answers(
+        (AskUserQuestion(label="Zone", title="Which timezone?", options=("UTC", "Local")),),
+        ("UTC",),
+    )
+    snapshot = TurnSnapshot(
+        text=current_answers,
+        conversation_messages=(
+            ("user", original),
+            ("assistant", "Which window?"),
+            ("user", prior_answers),
+            ("assistant", "Which timezone?"),
+        ),
+        configured_integrations=(),
+        configured_integrations_known=True,
+        last_state=None,
+        last_synthetic_observation_path=None,
+        reasoning_effort=None,
+    )
+
+    assert _goal_review_user_request(current_answers, snapshot) == original
+
+
+def test_ordinary_turn_goal_review_uses_current_message() -> None:
+    snapshot = TurnSnapshot(
+        text="Run the same analysis for vercel/next.js",
+        conversation_messages=(("user", "Analyze facebook/react"),),
+        configured_integrations=(),
+        configured_integrations_known=True,
+        last_state=None,
+        last_synthetic_observation_path=None,
+        reasoning_effort=None,
+    )
+
+    assert _goal_review_user_request(snapshot.text, snapshot) == snapshot.text

--- a/tests/core/agent_harness/test_turn_plan.py
+++ b/tests/core/agent_harness/test_turn_plan.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 
 import pytest
 
+from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
 from core.agent_harness.turns.turn_plan import TurnPlan, build_turn_plan
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from surfaces.interactive_shell.session import Session
@@ -19,18 +20,32 @@ def _snapshot(text: str = "q", *, resolved: dict | None = None) -> TurnSnapshot:
 
 
 def test_build_turn_plan_composes_the_snapshot() -> None:
-    snapshot = _snapshot("why did it fail?", resolved={"github": {"configured": True}})
+    snapshot = _snapshot(
+        "why did example/repository fail?",
+        resolved={
+            "github": {
+                "configured": True,
+                "owner": "example",
+                "repo": "repository",
+            }
+        },
+    )
 
     plan = build_turn_plan(snapshot, Session())
 
     assert isinstance(plan, TurnPlan)
-    assert plan.snapshot is snapshot
-    assert plan.text == "why did it fail?"
+    assert plan.text == "why did example/repository fail?"
 
 
 def test_turn_plan_exposes_resolved_integrations_from_snapshot() -> None:
-    resolved = {"github": {"configured": True}}
-    snapshot = _snapshot(resolved=resolved)
+    resolved = {
+        "github": {
+            "configured": True,
+            "owner": "example",
+            "repo": "repository",
+        }
+    }
+    snapshot = _snapshot("check example/repository", resolved=resolved)
 
     plan = build_turn_plan(snapshot, Session())
 
@@ -49,7 +64,7 @@ def test_build_turn_plan_resolves_integrations_when_snapshot_has_none(
         lambda _session: resolved,
     )
 
-    plan = build_turn_plan(_snapshot(), Session())
+    plan = build_turn_plan(_snapshot("check example/repository"), Session())
 
     assert plan.resolved_integrations == resolved
 
@@ -65,8 +80,92 @@ def test_build_turn_plan_resolves_when_snapshot_is_metadata_only(
     )
 
     plan = build_turn_plan(
-        _snapshot(resolved={"_gateway_chat_id": "C0123ABCD"}),
+        _snapshot("check example/repository", resolved={"_gateway_chat_id": "C0123ABCD"}),
         Session(),
     )
 
     assert plan.resolved_integrations == resolved
+
+
+def test_ask_user_answer_resolves_explicit_repo_from_history_without_mutating_base() -> None:
+    session = Session()
+    base = {
+        "github": {
+            "connection_verified": True,
+            "owner": "Tracer-Cloud",
+            "repo": "opensre",
+        }
+    }
+    session.resolved_integrations_cache = base
+    session.cli_agent_messages = [
+        (
+            "user",
+            "For facebook/react, return merged PR count, median time-to-merge, and star gain.",
+        ),
+        ("assistant", "Which date window should I use?"),
+    ]
+    answers = format_ask_user_answers(
+        (AskUserQuestion(label="Window", title="Which date window?", options=("7d", "30d")),),
+        ("7d",),
+    )
+
+    plan = build_turn_plan(
+        TurnSnapshot.from_session(answers, session, surface="interactive_shell"),
+        session,
+    )
+
+    assert plan.resolved_integrations["github"]["owner"] == "facebook"
+    assert plan.resolved_integrations["github"]["repo"] == "react"
+    assert session.vcs_repo_scopes["github"] == ("facebook", "react")
+    assert session.resolved_integrations_cache == base
+    assert session.resolved_integrations_cache["github"]["owner"] == "Tracer-Cloud"
+
+
+def test_repo_scope_is_sticky_and_current_message_can_override_it() -> None:
+    session = Session()
+    session.resolved_integrations_cache = {"github": {"connection_verified": True}}
+    session.vcs_repo_scopes = {"github": ("facebook", "react")}
+
+    follow_up = build_turn_plan(
+        TurnSnapshot.from_session(
+            "Now compare that with the prior week",
+            session,
+            surface="interactive_shell",
+        ),
+        session,
+    )
+    override = build_turn_plan(
+        TurnSnapshot.from_session(
+            "Run the same analysis for vercel/next.js",
+            session,
+            surface="interactive_shell",
+        ),
+        session,
+    )
+
+    assert follow_up.resolved_integrations["github"]["owner"] == "facebook"
+    assert follow_up.resolved_integrations["github"]["repo"] == "react"
+    assert override.resolved_integrations["github"]["owner"] == "vercel"
+    assert override.resolved_integrations["github"]["repo"] == "next.js"
+    assert session.vcs_repo_scopes["github"] == ("vercel", "next.js")
+
+
+def test_repo_scope_uses_workspace_only_without_explicit_or_sticky_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSRE_WORKSPACE_REPO", "Tracer-Cloud/opensre")
+    session = Session()
+    session.resolved_integrations_cache = {"github": {"connection_verified": True}}
+
+    plan = build_turn_plan(
+        TurnSnapshot.from_session(
+            "How many stars did this repo gain?",
+            session,
+            surface="interactive_shell",
+        ),
+        session,
+    )
+
+    assert plan.resolved_integrations["github"]["owner"] == "Tracer-Cloud"
+    assert plan.resolved_integrations["github"]["repo"] == "opensre"
+    assert session.vcs_repo_scopes["github"][:2] == ("Tracer-Cloud", "opensre")

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -40,6 +40,7 @@ class FakeLLM:
         self.invocations = 0
         self.schema_tool_names: list[list[str]] = []
         self.seen_messages: list[list[dict[str, Any]]] = []
+        self.seen_tools: list[list[dict[str, Any]] | None] = []
         self.model_id: str | None = None
 
     def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
@@ -55,6 +56,7 @@ class FakeLLM:
     ) -> AgentLLMResponse:
         self.invocations += 1
         self.seen_messages.append(messages)
+        self.seen_tools.append(tools)
         return next(self._responses)
 
     def build_assistant_message(
@@ -104,10 +106,14 @@ def _text_response(content: str) -> AgentLLMResponse:
     return AgentLLMResponse(content=content, tool_calls=[], raw_content=None)
 
 
-def _tool_call_response(call_id: str, name: str) -> AgentLLMResponse:
+def _tool_call_response(
+    call_id: str,
+    name: str,
+    tool_input: dict[str, Any] | None = None,
+) -> AgentLLMResponse:
     return AgentLLMResponse(
         content="",
-        tool_calls=[ToolCall(id=call_id, name=name, input={})],
+        tool_calls=[ToolCall(id=call_id, name=name, input=dict(tool_input or {}))],
         raw_content=None,
     )
 
@@ -116,6 +122,7 @@ def _agent(
     llm: FakeLLM,
     tools: list[Any],
     max_iterations: int = 5,
+    max_stagnant_iterations: int | None = None,
     on_event: Any = None,
     on_runtime_event: Any = None,
 ) -> Agent:
@@ -125,6 +132,7 @@ def _agent(
         tools=tools,
         resolved_integrations={},
         max_iterations=max_iterations,
+        max_stagnant_iterations=max_stagnant_iterations,
         on_event=on_event,
         on_runtime_event=on_runtime_event,
     )
@@ -585,15 +593,17 @@ def test_tool_filtering_runs_after_subclass_initialization() -> None:
     assert [(tc.name, tool_output) for tc, tool_output in result.executed] == [("keep", output)]
 
 
-def test_always_tool_call_hits_iteration_cap() -> None:
-    def always_tool_calls() -> Iterator[AgentLLMResponse]:
-        counter = 0
-        while True:
-            counter += 1
-            yield _tool_call_response(f"c{counter}", "query_logs")
-
+def test_iteration_cap_gets_one_tool_disabled_final_handoff() -> None:
     max_iterations = 3
-    llm = FakeLLM(always_tool_calls())
+    llm = FakeLLM(
+        iter(
+            [
+                _tool_call_response(f"c{step}", "query_logs", {"step": step})
+                for step in range(max_iterations)
+            ]
+            + [_text_response("I completed two checks; the remaining work is blocked.")]
+        )
+    )
 
     result = _agent(llm, _tools(FakeTool("query_logs")), max_iterations=max_iterations).run(
         [{"role": "user", "content": "hello"}]
@@ -602,8 +612,74 @@ def test_always_tool_call_hits_iteration_cap() -> None:
     assert result.hit_iteration_cap is True
     assert result.llm_iterations_used == max_iterations
     assert len(result.executed) == max_iterations
-    assert result.final_text == ""
-    assert llm.invocations == max_iterations
+    assert result.final_text == "I completed two checks; the remaining work is blocked."
+    assert llm.invocations == max_iterations + 1
+    assert llm.seen_tools[-1] == []
+
+
+def test_productive_tool_run_can_continue_past_thirteen_iterations() -> None:
+    tool_iterations = 14
+    llm = FakeLLM(
+        iter(
+            [
+                _tool_call_response(f"c{step}", "query_logs", {"step": step})
+                for step in range(tool_iterations)
+            ]
+            + [_text_response("all steps completed")]
+        )
+    )
+
+    result = _agent(
+        llm,
+        _tools(FakeTool("query_logs")),
+        max_iterations=20,
+        max_stagnant_iterations=3,
+    ).run([{"role": "user", "content": "run every step"}])
+
+    assert result.hit_iteration_cap is False
+    assert result.llm_iterations_used == tool_iterations + 1
+    assert len(result.executed) == tool_iterations
+    assert result.final_text == "all steps completed"
+
+
+def test_repeated_observations_stop_early_with_one_tool_disabled_handoff() -> None:
+    llm = FakeLLM(
+        iter(
+            [_tool_call_response(f"c{step}", "query_logs") for step in range(4)]
+            + [_text_response("The same query failed repeatedly; use a narrower time range.")]
+        )
+    )
+
+    result = _agent(
+        llm,
+        _tools(FakeTool("query_logs", {"error": "unavailable"})),
+        max_iterations=20,
+        max_stagnant_iterations=3,
+    ).run([{"role": "user", "content": "keep trying"}])
+
+    assert result.hit_iteration_cap is True
+    assert result.llm_iterations_used == 4
+    assert len(result.executed) == 4
+    assert result.final_text == "The same query failed repeatedly; use a narrower time range."
+    assert llm.invocations == 5
+    assert llm.seen_tools[-1] == []
+
+
+def test_failed_safety_handoff_uses_deterministic_final_text() -> None:
+    def responses() -> Iterator[AgentLLMResponse]:
+        yield _tool_call_response("c1", "query_logs")
+        raise RuntimeError("final sampling unavailable")
+
+    llm = FakeLLM(responses())
+
+    result = _agent(llm, _tools(FakeTool("query_logs")), max_iterations=1).run(
+        [{"role": "user", "content": "finish this"}]
+    )
+
+    assert result.hit_iteration_cap is True
+    assert "emergency tool-iteration ceiling" in result.final_text
+    assert llm.invocations == 2
+    assert llm.seen_tools[-1] == []
 
 
 def test_react_loop_records_partial_iterations_when_llm_raises() -> None:

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -40,7 +40,7 @@ def test_selection_is_auto_submitted_as_next_user_message(
 ) -> None:
     session = Session()
     session.pending_user_choice = _CHOICE
-    console, _buf = _console()
+    console, buf = _console()
 
     def _pick_second(**kwargs: object) -> str:
         assert kwargs["title"] == _CHOICE.title
@@ -53,6 +53,10 @@ def test_selection_is_auto_submitted_as_next_user_message(
     assert session.pending_user_choice is None
     assert session.terminal.pending_prompt_default == "Commit the changes"
     assert session.terminal.pending_prompt_autosubmit is True
+    output = buf.getvalue()
+    assert "✓" in output
+    assert _CHOICE.title in output
+    assert "Commit the changes" in output
 
 
 def test_cancelled_menu_leaves_prompt_free(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -11,10 +11,15 @@ from rich.console import Console
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 from core.llm.types import AgentLLMResponse, ToolCall
 from surfaces.interactive_shell.runtime import input_policy as loop_input_policy
+from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
 from surfaces.interactive_shell.runtime.core.turn_accounting import (
     ToolCallingTurnResult,
 )
-from surfaces.interactive_shell.runtime.turn_host import run_agent_turn_queue
+from surfaces.interactive_shell.runtime.turn_host import (
+    AgentTurnResources,
+    run_agent_turn,
+    run_agent_turn_queue,
+)
 from surfaces.interactive_shell.session import Session
 from tests.core.agent.orchestration.action_execution_test_harness import (
     FakeActionLLM,
@@ -234,6 +239,40 @@ def test_queued_literal_quit_requests_runtime_exit() -> None:
         await asyncio.wait_for(worker, timeout=1)
 
         assert state.exit_requested is True
+
+    asyncio.run(_scenario())
+
+
+def test_turn_end_retries_auto_command_deferred_during_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ask-user ``/choose`` queued mid-turn must wake the open prompt."""
+
+    async def _scenario() -> None:
+        from surfaces.interactive_shell.runtime import shell_turn_execution
+
+        session = Session()
+        refresh_dispatch_states: list[bool] = []
+        session.terminal.prompt_refresh_fn = lambda: refresh_dispatch_states.append(
+            session.terminal.dispatch_active
+        )
+
+        def _queue_choose(*_args: object, **_kwargs: object) -> None:
+            session.terminal.set_auto_command("/choose")
+
+        monkeypatch.setattr(shell_turn_execution, "execute_shell_turn", _queue_choose)
+        runtime = AgentTurnResources(
+            session=session,
+            state=ReplState(),
+            spinner=SpinnerState(),
+            invalidate_prompt=lambda: None,
+            console=Console(file=io.StringIO(), force_terminal=False, highlight=False),
+        )
+
+        await run_agent_turn(runtime, "ask me to choose")
+
+        assert session.terminal.pending_prompt_default == "/choose"
+        assert refresh_dispatch_states == [True, False]
 
     asyncio.run(_scenario())
 

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -236,7 +236,7 @@ def test_github_cli_tool_call_display_uses_sdk_arguments_without_runtime_details
     assert "120" not in content
 
 
-def test_python_tool_call_display_summarizes_execution_without_source_or_values() -> None:
+def test_python_tool_call_display_summarizes_execution_with_safe_input_values() -> None:
     label, content = tool_call_display(
         "execute_python_code",
         {
@@ -252,11 +252,37 @@ def test_python_tool_call_display_summarizes_execution_without_source_or_values(
     )
 
     assert label == "Python"
-    assert content == "run analysis · network enabled · inputs: owner, repo, week_start_local"
+    assert content == (
+        "run analysis · network enabled · inputs: owner=react, repo=react, "
+        "week_start_local=2026-08-24T00:00:00+01:00"
+    )
     assert "print" not in content
-    assert "react" not in content
     assert "timeout" not in content
     assert "60" not in content
+
+
+def test_python_tool_call_display_derives_high_level_details_from_source() -> None:
+    label, content = tool_call_display(
+        "execute_python_code",
+        {
+            "allow_network": True,
+            "code": """
+owner = inputs["owner"]
+url = f"https://api.github.com/repos/{owner}/react/stargazers?per_page=100"
+print({"stars_gained": 3, "pages_scanned": 2})
+""",
+            "timeout": 60,
+        },
+    )
+
+    assert label == "Python"
+    assert "target: api.github.com/repos/{owner}/react/stargazers" in content
+    assert "inputs: owner" in content
+    assert "outputs: stars_gained, pages_scanned" in content
+    assert "network enabled" in content
+    assert "per_page" not in content
+    assert "print" not in content
+    assert "timeout" not in content
 
 
 def test_generic_tool_call_display_is_bounded_and_omits_execution_controls() -> None:

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -202,6 +202,85 @@ def test_tool_call_display_strips_terminal_controls_from_model_args() -> None:
     assert content == "ls[2Krm"
 
 
+def test_github_cli_tool_call_display_uses_sdk_arguments_without_runtime_details() -> None:
+    label, content = tool_call_display(
+        "github_cli",
+        {
+            "args": [
+                "search",
+                "prs",
+                "-H",
+                "Authorization: Bearer should-not-render",
+                "--repo",
+                "react/react",
+                "--merged",
+                "--merged-at",
+                "2026-08-01..2026-08-26",
+                "--jq",
+                ".[] | [.createdAt, .closedAt] | @tsv",
+            ],
+            "repo": "facebook/react",
+            "timeout": 120,
+        },
+    )
+
+    assert label == "GitHub CLI"
+    assert content.startswith("gh -R facebook/react search prs")
+    assert "-H …" in content
+    assert "should-not-render" not in content
+    assert "--repo react/react" in content
+    assert "--merged-at 2026-08-01..2026-08-26" in content
+    assert "--jq …" in content
+    assert ".createdAt" not in content
+    assert "timeout" not in content
+    assert "120" not in content
+
+
+def test_python_tool_call_display_summarizes_execution_without_source_or_values() -> None:
+    label, content = tool_call_display(
+        "execute_python_code",
+        {
+            "allow_network": True,
+            "code": "print(inputs['github_token'])",
+            "inputs": {
+                "owner": "react",
+                "repo": "react",
+                "week_start_local": "2026-08-24T00:00:00+01:00",
+            },
+            "timeout": 60,
+        },
+    )
+
+    assert label == "Python"
+    assert content == "run analysis · network enabled · inputs: owner, repo, week_start_local"
+    assert "print" not in content
+    assert "react" not in content
+    assert "timeout" not in content
+    assert "60" not in content
+
+
+def test_generic_tool_call_display_is_bounded_and_omits_execution_controls() -> None:
+    label, content = tool_call_display(
+        "custom_registry_tool",
+        {
+            "query": "x" * 400,
+            "limit": 25,
+            "timeout": 120,
+            "api_token": "secret-token",
+        },
+    )
+
+    assert label == "custom registry tool"
+    assert len(content) <= 180
+    assert content.endswith("…")
+    assert not content.startswith("{")
+    assert "limit: 25" in content
+    assert "query:" in content
+    assert "timeout" not in content
+    assert "api_token" not in content
+    assert "secret-token" not in content
+
+
 def test_intermediate_message_strips_terminal_controls_before_markdown() -> None:
     # Arrange: a real terminal, where Rich would otherwise pass the model's
     # control bytes straight through (a non-terminal console strips them anyway,

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -48,6 +48,36 @@ def test_slash_invoke_tool_start_does_not_record_cli_agent() -> None:
     assert "/model show" in buffer.getvalue()
 
 
+def test_internal_choose_slash_has_no_tool_preview() -> None:
+    session = Session()
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False)
+    observer = ActionRenderObserver(session=session, console=console, message="/choose")
+
+    observer(
+        "tool_start",
+        {"name": "slash_invoke", "input": {"command": "/choose", "args": []}},
+    )
+
+    assert observer.planned_count == 1
+    assert buffer.getvalue() == ""
+
+
+def test_ask_user_choice_has_no_generic_tool_preview() -> None:
+    observer, buffer = _observer_with_buffer("ask me to choose")
+
+    observer(
+        "tool_start",
+        {
+            "name": "ask_user_choice",
+            "input": {"title": "Deploy how?", "options": ["Canary", "Rolling"]},
+        },
+    )
+
+    assert observer.planned_count == 1
+    assert buffer.getvalue() == ""
+
+
 def test_shell_run_tool_start_does_not_record_cli_agent() -> None:
     session = Session()
     console = Console(file=io.StringIO(), force_terminal=False, highlight=False)

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -11,6 +11,7 @@ from surfaces.interactive_shell.ui.handoff_questions import (
     is_handoff_question,
     last_assistant_asked_handoff,
     render_ask_user_qa,
+    render_choice_selection,
     render_handoff_question,
     try_render_ask_user_submission,
 )
@@ -104,6 +105,33 @@ def test_choose_slash_is_not_echoed() -> None:
     # The queued /choose must not leave a stale autosubmit flag, or the next
     # genuine turn is misread as autosubmitted and skips the round-counter reset.
     assert session.terminal.last_input_autosubmitted is False
+
+
+def test_auto_submitted_single_choice_is_not_echoed_as_a_user_turn() -> None:
+    session = Session()
+    session.terminal.awaiting_handoff_answer = True
+    session.terminal.last_input_autosubmitted = True
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+
+    render_submitted_prompt(console, session, "Blue-green")
+
+    assert buffer.getvalue() == ""
+    assert session.terminal.submitted_turn_count == 0
+    assert session.terminal.pending_choice_response == "Blue-green"
+
+
+def test_choice_selection_strips_terminal_controls() -> None:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+
+    render_choice_selection(console, "Deploy?\x1b]0;pwn\x07", "Canary\x1b[2K")
+
+    output = buffer.getvalue()
+    assert "\x1b" not in output
+    assert "\x07" not in output
+    assert "✓ Deploy?" in output
+    assert "Canary" in output
 
 
 def test_try_render_rejects_a_single_choice_label() -> None:

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -43,10 +43,11 @@ _FALLBACK_INSTRUCTION = (
     "the number or the option text."
 )
 _QUEUED_INSTRUCTION = (
-    "The selection menu opens after this turn ends. End the turn now with at "
-    "most one short sentence of context; do NOT repeat the options as text and "
-    "do NOT ask the user to type a number. The user's selection arrives as the "
-    "next user message (the chosen option label, verbatim)."
+    "The selection menu opens after this turn ends. End the turn now without a "
+    "user-facing sentence; do NOT repeat the options as text or ask the user to "
+    "type a number. The user's selection arrives as the next user message (the "
+    "chosen option label, verbatim). After selection, continue the original work "
+    "and do not merely repeat or acknowledge the chosen label."
 )
 _QUEUED_BATCH_INSTRUCTION = (
     "The Ask User menu opens after this turn ends. Before it, say in one or two "


### PR DESCRIPTION
Fixes: N/A

#### Describe the changes you have made in this PR -
- Wake deferred `/choose` autosubmission after the active action turn releases the prompt, let the picker own terminal presentation, and preserve meaningful sibling and follow-up output.
- Replace the normal 13-iteration stop with bounded stagnation detection, a larger emergency ceiling, and exactly one tool-disabled final handoff when a safety limit is reached.
- Enrich the frozen per-turn integration view with explicit GitHub repository scope while preserving current-message, recent-conversation, sticky-session, and workspace-fallback precedence.
- Recover the original non-Q&A user request for goal review after structured Ask User answers, and tell task-plan continuation prompts to preserve the original repository and every requested metric.
- Keep the base integration cache immutable and persist only the per-session VCS scope bag.

### Demo/Screenshot for feature changes and bug fixes -
Expected repository behavior:
- `For facebook/react, compare merged PRs and stars` scopes GitHub tools to `facebook/react` even in the OpenSRE checkout.
- Date-window Ask User answers retain the original repository and all requested outputs.
- Follow-ups stay scoped to `facebook/react`; an explicit `vercel/next.js` request overrides it.
- Workspace repository fallback applies only when the current request, relevant history, and sticky scope contain no repository.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project coding standards and conventions

**Explain your implementation approach:**
The turn host retries a queued choice submission only after active dispatch releases the prompt. The picker remains the single exclusive-input renderer, while response composition hides duplicate plumbing without dropping substantive results.

The shared ReAct loop now treats its iteration cap as an emergency ceiling. Repeated identical observations stop unproductive loops earlier, while productive tool sequences can continue beyond the former fixed limit. Any safety stop receives one bounded, tool-disabled finalization call so the user gets a partial-result handoff instead of a silent stop.

Turn planning resolves the base integration view once, passes the frozen turn text and conversation snapshot through the registered repository-scope providers, and stores the enriched copy on `TurnSnapshot`. Only the session VCS scope bag is updated; the base integration cache is not mutated. Structured Ask User answer turns recover the latest non-Q&A user request for goal review, and prompt guidance preserves the original target and requested outputs.

Local validation:
- `make lint`
- `make format-check`
- `make typecheck` (1,913 source files)
- `uv run python -m pytest -q tests/core/` (1,911 passed, 2 xfailed)
- Focused GitHub scope, stargazer injection, provider registry, and API-border suites (78 passed)

---

## Checklist before requesting a review
- [x] I have added a descriptive PR title; no issue is linked for these regressions
- [x] I have performed a self-review of the code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why the changes work and have tested them thoroughly
- [x] I have considered precedence, cache immutability, structured-answer, and safety-limit edge cases
- [x] Core behavior has deterministic regression coverage
- [x] The code follows the project style and package-boundary rules

Made with [Cursor](https://cursor.com)