### PR TITLE
docs: align the integration checklist with the __init__.py facade rule

### DIFF
--- a/docs/adding-tools-and-integrations.md
+++ b/docs/adding-tools-and-integrations.md
@@ -99,7 +99,10 @@ disable-model-invocation: false   # optional — set true to suppress attachment
 
 ### Files usually involved
 
-- `integrations/<name>/__init__.py` — config builders, validators, selectors, normalization helpers
+- `integrations/<name>/__init__.py` — package facade: a docstring, plus re-exports of the
+  public API when callers need them (see the `__init__.py` rule in [AGENTS.md](../AGENTS.md))
+- `integrations/<name>/config.py` — config model, `classify()`, validators, selectors,
+  normalization helpers
 - `integrations/<name>/client.py` — a dedicated API client, when the integration makes direct remote calls
 - `integrations/<name>/verifier.py` — local verification logic
 - `integrations/<name>/tools/<tool_name>_tool/` — the vendor's agent-callable tools (see §1)
@@ -116,10 +119,11 @@ disable-model-invocation: false   # optional — set true to suppress attachment
 - Datadog: `integrations/datadog/` (with `integrations/datadog/tools/`), `integrations/catalog.py`, tests under `tests/integrations/datadog/` and `tests/tools/test_datadog_*.py`.
 - Grafana: `integrations/grafana/` (with `integrations/grafana/tools/`), `integrations/catalog.py`, `surfaces/cli/wizard/local_grafana_stack/`, tests under `tests/integrations/grafana/` and `tests/tools/test_grafana_*.py`.
 - Hermes: `integrations/hermes/` (with `integrations/hermes/tools/hermes_logs_tool/` and `.../hermes_session_evidence_tool/`), `surfaces/cli/commands/hermes.py`, `tests/hermes/`, `tests/synthetic/hermes/`.
+- Bitbucket: `integrations/bitbucket/` shows the facade layout — a one-line `__init__.py` beside `config.py`, `client.py`, `verifier.py`, and `tools/`.
 
 ### Core completeness
 
-- [ ] Config, normalization, and validators are in place under `integrations/<name>/__init__.py`
+- [ ] Config, normalization, validators, and `classify()` are in place under `integrations/<name>/config.py`, leaving `__init__.py` a facade
 - [ ] Catalog resolution / env loading is wired correctly
 - [ ] Verification path is wired in `integrations/verify.py` and adapters/registry as needed
 - [ ] Integration-local client added under `integrations/<name>/client.py` (only if it makes direct remote calls)


### PR DESCRIPTION
Fixes #

<!-- No linked issue; this is a follow-up to the guidance merged in #5809. -->

#### Describe the changes you have made in this PR -

#5809 added the rule that every `__init__.py` stays a lightweight package facade. The integration checklist in `docs/adding-tools-and-integrations.md` still told contributors to do the opposite:

- `integrations/<name>/__init__.py` — config builders, validators, selectors, normalization helpers
- [ ] Config, normalization, and validators are in place under `integrations/<name>/__init__.py`

A contributor following the guide would break AGENTS.md on their first integration. This aligns both places on `config.py` and adds Bitbucket to the examples, since `integrations/bitbucket/` is already in the compliant shape — a one-line `__init__.py` beside `config.py`, `client.py`, `verifier.py`, and `tools/`. The Datadog and Honeycomb examples already listed still define `classify()` in `__init__.py`, so neither reads as a model for the new rule.

Section 1 of the same file already had the correct wording for tool packages ("leaving `__init__.py` as a small registry entrypoint"), so only the integration section needed the change.

### Demo/Screenshot for feature changes and bug fixes -

Documentation-only change, one file, +6/−2.

I swept the rest of `docs/` and the root `.md` files for other text that pushes implementation into `__init__.py`. Nothing else contradicts the rule. `docs/python-api.mdx:317` says tools may be defined in a package `__init__.py`, but that describes what `register_external_tool_package` discovers in an external user's own package, not where repo code belongs, so I left it alone.

Per CI.md section 0 this is a docs-only diff, so the code-quality and test commands are skipped; `git status --short` is clean apart from the one file. The file is not listed in `docs/docs.json`, so no navigation entry is needed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The fix targets the guide rather than the 225 `__init__.py` files that currently define classes or functions, because the guide is what new contributors read before writing an integration. Leaving it stale means the violation count keeps growing no matter how the existing files are cleaned up.

I considered rewording only the checklist item, but the "files usually involved" list is the part a contributor copies when scaffolding a new vendor package, so both needed to move. I also considered dropping the `classify()` mention, but naming it is what makes the split concrete — it is the one symbol most vendor `__init__.py` files still hold.

Bitbucket is cited by name because a rule without a worked example gets interpreted loosely. Cleaning up the existing vendor packages is separate work and out of scope here.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] Tests are not required for this documentation-only change
- [x] My code follows the project's style guidelines and conventions

---

Note: Maintainers may edit this branch.
