### PR TITLE
feat(grafana): add evidence mapper for query_grafana_annotations

### DIFF
--- a/integrations/grafana/tools/__init__.py
+++ b/integrations/grafana/tools/__init__.py
@@ -189,10 +189,25 @@ def _iso_to_epoch_ms(value: str) -> int:
     return int(dt.timestamp() * 1000)
 
 
+def _map_grafana_annotations(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    annotations = output.get("annotations", [])
+    evidence["grafana_annotations"] = annotations
+    if annotations:
+        record_evidence_entry(
+            evidence,
+            source="query_grafana_annotations",
+            label="Grafana Annotations",
+            summary=f"{len(annotations)} annotations",
+        )
+
+
 @tool(
     name="query_grafana_annotations",
     display_name="Grafana annotations",
     source="grafana",
+    evidence_mapper=_map_grafana_annotations,
     description=(
         "Query Grafana deployment/config-change annotations to correlate changes with "
         "an incident — the source-agnostic 'what changed and when' marker."

--- a/tests/integrations/grafana/test_evidence_mappers.py
+++ b/tests/integrations/grafana/test_evidence_mappers.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+import pytest
+
+from core.tool_framework.utils import tool_unavailable
+from integrations.grafana.tools import _map_grafana_annotations
+
+
+def test_annotations_mapper_records_an_entry_counting_annotations() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "grafana_annotations",
+        "available": True,
+        "annotations": [
+            {"text": "deploy v2.4.1", "time": "2026-05-26T16:30:00Z", "tags": ["deploy"]},
+            {"text": "config update", "time": "2026-05-26T16:35:00Z", "tags": ["config"]},
+        ],
+        "total": 2,
+    }
+
+    _map_grafana_annotations(evidence, output, {})
+
+    assert evidence["grafana_annotations"] == output["annotations"]
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "query_grafana_annotations",
+            "label": "Grafana Annotations",
+            "summary": "2 annotations",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        pytest.param({}, id="empty-payload"),
+        pytest.param(
+            tool_unavailable("grafana_annotations", "not configured", annotations=[]),
+            id="unavailable-envelope",
+        ),
+        pytest.param(
+            {"source": "grafana_annotations", "available": True, "annotations": []},
+            id="no-annotations",
+        ),
+    ],
+)
+def test_annotations_mapper_records_nothing_without_annotations(output: dict[str, Any]) -> None:
+    evidence: dict[str, Any] = {}
+    _map_grafana_annotations(evidence, output, {})
+    assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -162,7 +162,6 @@ query_datadog_events
 query_datadog_logs
 query_datadog_metrics
 query_datadog_monitors
-query_grafana_annotations
 query_groundcover_logs
 query_groundcover_traces
 query_splunk_logs


### PR DESCRIPTION
Closes #5584

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires `query_grafana_annotations` to `record_evidence_entry` so its output becomes a citeable line in the investigation report.

- `_map_grafana_annotations`: extracts `annotations` list from tool output, stashes it on `evidence["grafana_annotations"]`, and records a citeable catalog entry (`query_grafana_annotations`) with summary `f"{len(annotations)} annotations"`.
- Added `evidence_mapper=_map_grafana_annotations` to the `@tool` decorator.
- Removed `query_grafana_annotations` from `evidence_mapper_baseline.txt`.
- Added unit test suite in `tests/integrations/grafana/test_evidence_mappers.py` covering normal citation and empty/unavailable guards.

### Behavior Comparison

1. **What the reader gains**: The report can now cite recent deployment/config-change annotations (e.g. `2 annotations`) that preceded an alert.
2. **How much context it costs**: ~80 characters for the summary catalog entry. The payload is not inlined into prompt context.
3. **Empty/error result**: When empty (`{"annotations": []}`) or on error/unavailable envelope, no catalog entry is recorded to avoid noise.
4. **Duplicate recording**: None; `query_grafana_annotations` is the sole source for Grafana annotations.
5. **Existing report shape**: Unaffected; existing Grafana mappers (logs, metrics, traces) remain unchanged.

### Demo / Verification

**Tool carries mapper in registry:**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; print(bool(g('query_grafana_annotations').evidence_mapper))"
True
```

**Real output becomes report evidence:**
```
$ uv run python -c "from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence; ev={}; merge_tool_evidence(ev, 'query_grafana_annotations', {'annotations': [{'text': 'deploy v2.4'}]}, {}); print(ev.get('catalog_entries'))"
[{'source': 'query_grafana_annotations', 'label': 'Grafana Annotations', 'summary': '1 annotations', 'url': None, 'snippet': None}]
```

**Tests:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py tests/integrations/grafana/test_evidence_mappers.py
15 passed in 1.95s
```

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions
