### PR TITLE
feat(argocd): add evidence mappers for argocd investigation tools

### DIFF
--- a/integrations/argocd/tools/__init__.py
+++ b/integrations/argocd/tools/__init__.py
@@ -6,9 +6,29 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.argocd.client import make_argocd_client
+
+
+def _map_argocd_application_diff(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    diffs = output.get("diffs", [])
+    drift = output.get("drift_detected", False)
+    app_name = output.get("application_name", "unknown")
+    if diffs or drift:
+        record_evidence_entry(
+            evidence,
+            source="argocd_application_diff",
+            label="Argo CD Application Diff",
+            summary=(
+                f"{app_name}: {len(diffs)} drifted resources"
+                if diffs
+                else f"{app_name}: drift detected (no resource-level diffs)"
+            ),
+        )
 
 
 class ArgoCDApplicationDiffTool(BaseTool):
@@ -16,6 +36,7 @@ class ArgoCDApplicationDiffTool(BaseTool):
 
     name = "argocd_application_diff"
     source = "argocd"
+    evidence_mapper = _map_argocd_application_diff
     description = (
         "Fetch Argo CD server-side diff output and report whether live cluster state "
         "has drifted from the desired GitOps state."
@@ -143,11 +164,37 @@ argocd_application_diff = ArgoCDApplicationDiffTool()
 from core.tool import BaseTool
 
 
+def _map_argocd_application_status(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    app = output.get("application")
+    if isinstance(app, dict) and app.get("name"):
+        sync = app.get("sync_status", "unknown")
+        health = app.get("health_status", "unknown")
+        record_evidence_entry(
+            evidence,
+            source="argocd_application_status",
+            label="Argo CD Application Status",
+            summary=f"{app['name']}: sync={sync}, health={health}",
+        )
+        return
+
+    apps = output.get("applications", [])
+    if apps:
+        record_evidence_entry(
+            evidence,
+            source="argocd_application_status",
+            label="Argo CD Application Status",
+            summary=f"{len(apps)} applications",
+        )
+
+
 class ArgoCDApplicationStatusTool(BaseTool):
     """Fetch Argo CD application sync and health status."""
 
     name = "argocd_application_status"
     source = "argocd"
+    evidence_mapper = _map_argocd_application_status
     description = (
         "Fetch Argo CD application sync status, health status, current revision, "
         "and recent deployment history."

--- a/tests/integrations/argocd/test_evidence_mappers.py
+++ b/tests/integrations/argocd/test_evidence_mappers.py
@@ -1,0 +1,165 @@
+from typing import Any
+
+import pytest
+
+from core.tool_framework.utils import tool_unavailable
+from integrations.argocd.tools import (
+    _map_argocd_application_diff,
+    _map_argocd_application_status,
+)
+
+
+def test_diff_mapper_records_an_entry_when_diffs_present() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "argocd",
+        "available": True,
+        "success": True,
+        "application_name": "payment-service",
+        "drift_detected": True,
+        "diffs": [
+            {"kind": "Deployment", "name": "payment-svc"},
+            {"kind": "ConfigMap", "name": "payment-config"},
+        ],
+        "diff_count": 2,
+    }
+
+    _map_argocd_application_diff(evidence, output, {})
+
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "argocd_application_diff",
+            "label": "Argo CD Application Diff",
+            "summary": "payment-service: 2 drifted resources",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_diff_mapper_records_drift_detected_when_diffs_list_is_empty() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "argocd",
+        "available": True,
+        "success": True,
+        "application_name": "frontend",
+        "drift_detected": True,
+        "diffs": [],
+        "diff_count": 0,
+    }
+
+    _map_argocd_application_diff(evidence, output, {})
+
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "argocd_application_diff",
+            "label": "Argo CD Application Diff",
+            "summary": "frontend: drift detected (no resource-level diffs)",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        pytest.param({}, id="empty-payload"),
+        pytest.param(
+            tool_unavailable(
+                "argocd",
+                "connection refused",
+                diffs=[],
+                diff_count=0,
+                drift_detected=False,
+            ),
+            id="unavailable-envelope",
+        ),
+        pytest.param(
+            {"source": "argocd", "available": True, "diffs": [], "drift_detected": False},
+            id="no-drift",
+        ),
+    ],
+)
+def test_diff_mapper_records_nothing_when_no_drift(output: dict[str, Any]) -> None:
+    evidence: dict[str, Any] = {}
+    _map_argocd_application_diff(evidence, output, {})
+    assert "catalog_entries" not in evidence
+
+
+def test_status_mapper_records_single_app_sync_and_health() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "argocd",
+        "available": True,
+        "success": True,
+        "application": {
+            "name": "payment-service",
+            "sync_status": "OutOfSync",
+            "health_status": "Degraded",
+        },
+    }
+
+    _map_argocd_application_status(evidence, output, {})
+
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "argocd_application_status",
+            "label": "Argo CD Application Status",
+            "summary": "payment-service: sync=OutOfSync, health=Degraded",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+def test_status_mapper_records_application_list() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "argocd",
+        "available": True,
+        "success": True,
+        "applications": [
+            {"name": "payment-service"},
+            {"name": "auth-service"},
+            {"name": "order-service"},
+        ],
+        "total": 3,
+    }
+
+    _map_argocd_application_status(evidence, output, {})
+
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "argocd_application_status",
+            "label": "Argo CD Application Status",
+            "summary": "3 applications",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        pytest.param({}, id="empty-payload"),
+        pytest.param(
+            tool_unavailable("argocd", "connection refused", application={}, applications=[]),
+            id="unavailable-envelope",
+        ),
+        pytest.param(
+            {"source": "argocd", "available": True, "application": {}},
+            id="empty-application",
+        ),
+        pytest.param(
+            {"source": "argocd", "available": True, "applications": []},
+            id="empty-applications-list",
+        ),
+    ],
+)
+def test_status_mapper_records_nothing_when_empty_or_unavailable(output: dict[str, Any]) -> None:
+    evidence: dict[str, Any] = {}
+    _map_argocd_application_status(evidence, output, {})
+    assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -13,8 +13,6 @@ GetErrorLogs
 GetRecentLogs
 GetResources
 GetServiceDependencies
-argocd_application_diff
-argocd_application_status
 buzz_send_message
 call_openclaw_tool
 call_posthog_tool


### PR DESCRIPTION
Closes #5563

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires both Argo CD investigation tools to `record_evidence_entry` so their output becomes citeable evidence in the investigation report:

- `_map_argocd_application_diff`: tracks granular drifted resources (`{app_name}: {N} drifted resources`) or notes server-side drift when individual diffs are omitted. Attached to `ArgoCDApplicationDiffTool`.
- `_map_argocd_application_status`: handles both single-application status (`{name}: sync={sync}, health={health}`) and multi-application listing results (`{N} applications`). Attached to `ArgoCDApplicationStatusTool`.
- Removed `argocd_application_diff` and `argocd_application_status` from `evidence_mapper_baseline.txt`.
- Added unit test suite in `tests/integrations/argocd/test_evidence_mappers.py` covering diff and status mapping, multi-app listing, and empty/unavailable guards.

### Behavior Comparison

1. **What the reader gains**: The report can now cite GitOps drift (e.g. `payment-service: 2 drifted resources`) and deployment sync/health status (e.g. `sync=OutOfSync, health=Degraded`).
2. **How much context it costs**: ~60–80 characters for the summary catalog entry.
3. **Empty/error result**: When empty or on error/unavailable envelope, no catalog entry is recorded.
4. **Duplicate recording**: None; these are the sole Argo CD diff and status investigation tools.
5. **Existing report shape**: Unaffected.

### Demo / Verification

**Tools carry mapper in registry:**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; print({n: bool(g(n).evidence_mapper) for n in ['argocd_application_diff', 'argocd_application_status']})"
{'argocd_application_diff': True, 'argocd_application_status': True}
```

**Real output becomes report evidence:**
```
$ uv run python -c "from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence; ev={}; merge_tool_evidence(ev, 'argocd_application_diff', {'application_name': 'app1', 'drift_detected': True, 'diffs': [{'kind': 'Deployment'}]}, {}); print(ev.get('catalog_entries'))"
[{'source': 'argocd_application_diff', 'label': 'Argo CD Application Diff', 'summary': 'app1: 1 drifted resources', 'url': None, 'snippet': None}]
```

**Tests:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py tests/integrations/argocd/test_evidence_mappers.py
22 passed in 2.16s
```

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions
