### PR TITLE
feat(victoria_logs): add evidence mapper for victoria_logs_query

### DIFF
--- a/integrations/victoria_logs/tools/__init__.py
+++ b/integrations/victoria_logs/tools/__init__.py
@@ -18,10 +18,24 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool
 from core.tool_framework.utils import tool_unavailable
 from integrations.victoria_logs.client import make_victoria_logs_client
+
+
+def _map_victoria_logs_query(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    rows = output.get("rows", [])
+    if rows:
+        record_evidence_entry(
+            evidence,
+            source="victoria_logs_query",
+            label="VictoriaLogs",
+            summary=f"{len(rows)} log entries",
+        )
 
 
 class VictoriaLogsTool(BaseTool):
@@ -29,6 +43,7 @@ class VictoriaLogsTool(BaseTool):
 
     name = "victoria_logs_query"
     source = "victoria_logs"
+    evidence_mapper = _map_victoria_logs_query
     description = (
         "Query structured logs from VictoriaLogs using LogsQL to investigate "
         "application errors, request anomalies, or other log-correlated signals."

--- a/tests/integrations/victoria_logs/test_evidence_mappers.py
+++ b/tests/integrations/victoria_logs/test_evidence_mappers.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import pytest
+
+from core.tool_framework.utils import tool_unavailable
+from integrations.victoria_logs.tools import _map_victoria_logs_query
+
+
+def test_victoria_logs_mapper_records_an_entry_counting_rows() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "source": "victoria_logs",
+        "available": True,
+        "rows": [
+            {"_time": "2026-05-26T16:43:18Z", "_msg": "connection timeout in payment service"},
+            {"_time": "2026-05-26T16:43:19Z", "_msg": "failed to acquire lock"},
+        ],
+        "total": 2,
+    }
+
+    _map_victoria_logs_query(evidence, output, {})
+
+    assert evidence["catalog_entries"] == [
+        {
+            "source": "victoria_logs_query",
+            "label": "VictoriaLogs",
+            "summary": "2 log entries",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        pytest.param({}, id="empty-payload"),
+        pytest.param(
+            tool_unavailable("victoria_logs", "connection refused", rows=[], total=0),
+            id="unavailable-envelope",
+        ),
+        pytest.param(
+            {"source": "victoria_logs", "available": True, "rows": []},
+            id="no-rows",
+        ),
+    ],
+)
+def test_victoria_logs_mapper_records_nothing_without_rows(output: dict[str, Any]) -> None:
+    evidence: dict[str, Any] = {}
+    _map_victoria_logs_query(evidence, output, {})
+    assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -191,7 +191,6 @@ telegram_send_message
 twilio_notify
 vercel_deployment_logs
 vercel_deployment_status
-victoria_logs_query
 work_task_add
 work_task_complete
 work_task_list


### PR DESCRIPTION
Closes #5594

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires `victoria_logs_query` to `record_evidence_entry` so its output becomes a citeable line in the investigation report.

- `_map_victoria_logs_query`: extracts query `rows` list from tool output, and records a citeable catalog entry (`victoria_logs_query`) with summary `f"{len(rows)} log entries"`.
- Attached `evidence_mapper = _map_victoria_logs_query` class attribute on `VictoriaLogsTool`.
- Removed `victoria_logs_query` from `evidence_mapper_baseline.txt`.
- Added unit test suite in `tests/integrations/victoria_logs/test_evidence_mappers.py` covering normal row counts and empty/unavailable guards.

### Behavior Comparison

1. **What the reader gains**: The report can now cite VictoriaLogs structured log queries (e.g. `2 log entries`) during incident investigations.
2. **How much context it costs**: ~60 characters for the summary catalog entry. Log rows are not inlined into the context.
3. **Empty/error result**: When empty (`{"rows": []}`) or on error/unavailable envelope, no catalog entry is recorded.
4. **Duplicate recording**: None; `victoria_logs_query` is the sole VictoriaLogs query tool.
5. **Existing report shape**: Unaffected.

### Demo / Verification

**Tool carries mapper in registry:**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; print(bool(g('victoria_logs_query').evidence_mapper))"
True
```

**Real output becomes report evidence:**
```
$ uv run python -c "from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence; ev={}; merge_tool_evidence(ev, 'victoria_logs_query', {'rows': [{'_msg': 'error'}]}, {}); print(ev.get('catalog_entries'))"
[{'source': 'victoria_logs_query', 'label': 'VictoriaLogs', 'summary': '1 log entries', 'url': None, 'snippet': None}]
```

**Tests:**
```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py tests/integrations/victoria_logs/test_evidence_mappers.py
15 passed in 2.19s
```

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions
