### PR TITLE
feat(hermes): integrate Hermes log path handling 

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -149,6 +149,7 @@ from config.constants.helm import (
     HELM_PATH_ENV,
     OSRE_HELM_INTEGRATION_ENV,
 )
+from config.constants.hermes import HERMES_LOG_PATH_ENV
 from config.constants.honeycomb import (
     HONEYCOMB_API_KEY_ENV,
     HONEYCOMB_BASE_URL_ENV,
@@ -566,6 +567,7 @@ __all__ = [
     "HELM_NAMESPACE_ENV",
     "HELM_PATH_ENV",
     "OSRE_HELM_INTEGRATION_ENV",
+    "HERMES_LOG_PATH_ENV",
     "HONEYCOMB_API_KEY_ENV",
     "HONEYCOMB_BASE_URL_ENV",
     "HONEYCOMB_DATASET_ENV",

--- a/config/constants/hermes.py
+++ b/config/constants/hermes.py
@@ -1,0 +1,7 @@
+"""Hermes log-path environment variable names."""
+
+from __future__ import annotations
+
+HERMES_LOG_PATH_ENV = "HERMES_LOG_PATH"
+
+__all__ = ["HERMES_LOG_PATH_ENV"]

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -717,7 +717,7 @@ Mirror conversation history and memory to a user-owned object store. Details: [R
 | `OPENOBSERVE_MAX_RESULTS` | `100` | Max OpenObserve results |
 | `VICTORIA_LOGS_URL` |  | VictoriaLogs instance URL |
 | `VICTORIA_LOGS_TENANT_ID` |  | VictoriaLogs tenant ID |
-| `HERMES_LOG_PATH` | `~/.hermes/logs/errors.log` | Default path and path sandbox for the `get_hermes_logs` tool |
+| `HERMES_LOG_PATH` | `~/.hermes/logs/errors.log` | Default path and path sandbox for `get_hermes_logs`. When set (or when the default file exists), Hermes investigations offer that tool without a credential verifier. |
 | `OPENSRE_HERMES_INVESTIGATE` |  | Set to `1` to enable Hermes watch auto-investigation when the CLI flag is omitted |
 | `CLICKHOUSE_HOST` |  | ClickHouse host |
 | `CLICKHOUSE_PORT` | `8123` | ClickHouse port |

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -10,6 +10,7 @@ entrypoint.
 from __future__ import annotations
 
 from integrations.hermes.agent import DEFAULT_LOG_PATH, HermesAgent, IncidentSink
+from integrations.hermes.availability import attach_hermes_log_source
 from integrations.hermes.classifier import (
     DEFAULT_TRACEBACK_FOLLOWUP_S,
     DEFAULT_WARNING_BURST_THRESHOLD,
@@ -54,6 +55,7 @@ __all__ = [
     "RouteDestination",
     "TelegramSink",
     "TelegramSinkConfig",
+    "attach_hermes_log_source",
     "build_alert_from_incident",
     "classify_all",
     "make_telegram_sink",

--- a/integrations/hermes/availability.py
+++ b/integrations/hermes/availability.py
@@ -1,16 +1,46 @@
-"""Backend-aware availability check for Hermes tools.
-
-The synthetic harnesses under ``tests/synthetic/`` inject a fixture
-``_backend`` object via the integration source dict so tools can run
-against mocks. This helper accepts either real connection-verified
-credentials or a fixture backend, so vendor tools share one consistent
-availability check.
-"""
+"""When Hermes tools may run: catalog connection, fixture backend, or local log."""
 
 from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from config.constants.hermes import HERMES_LOG_PATH_ENV
+
+_DEFAULT_LOG_RELATIVE: tuple[str, ...] = (".hermes", "logs", "errors.log")
 
 
 def hermes_available_or_backend(sources: dict[str, dict]) -> bool:
     """Available when Hermes integration is connected or a fixture backend is injected."""
     hermes = sources.get("hermes", {})
     return bool(hermes.get("connection_verified") or hermes.get("_backend"))
+
+
+def default_hermes_log_path() -> Path:
+    """Resolve ``$HERMES_LOG_PATH`` or ``~/.hermes/logs/errors.log``."""
+    override = os.environ.get(HERMES_LOG_PATH_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home().joinpath(*_DEFAULT_LOG_RELATIVE)
+
+
+def attach_hermes_log_source(
+    resolved: dict[str, Any],
+    *,
+    alert_source: str,
+) -> dict[str, Any]:
+    """Add Hermes when this is a Hermes alert with a configured local log.
+
+    Leaves an existing ``hermes`` entry unchanged. Does not attach on other
+    alert sources even if the default log file exists.
+    """
+    attached = dict(resolved)
+    if "hermes" in attached or alert_source.strip().lower() != "hermes":
+        return attached
+    override = os.environ.get(HERMES_LOG_PATH_ENV, "").strip()
+    path = default_hermes_log_path()
+    if not override and not path.is_file():
+        return attached
+    attached["hermes"] = {"log_path": str(path), "connection_verified": True}
+    return attached

--- a/integrations/hermes/tools/hermes_logs_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_logs_tool/__init__.py
@@ -44,17 +44,15 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+from config.constants.hermes import HERMES_LOG_PATH_ENV
 from core.tool_framework import tool
-from integrations.hermes.availability import hermes_available_or_backend
+from integrations.hermes.availability import (
+    default_hermes_log_path,
+    hermes_available_or_backend,
+)
 from integrations.hermes.classifier import IncidentClassifier
 from integrations.hermes.incident import HermesIncident, LogLevel, LogRecord
 from integrations.hermes.poller import HermesLogCursor, HermesLogPoll, poll_hermes_logs
-
-# Default location of Hermes' own error log. The agent tool resolves
-# this lazily so a non-default ``$HERMES_HOME`` is respected without
-# import-time side effects.
-_ENV_LOG_PATH: str = "HERMES_LOG_PATH"
-_DEFAULT_LOG_RELATIVE: tuple[str, ...] = (".hermes", "logs", "errors.log")
 
 # Cap how many records the tool will serialise into a single
 # response. The poller has its own byte budget; this is the
@@ -62,14 +60,6 @@ _DEFAULT_LOG_RELATIVE: tuple[str, ...] = (".hermes", "logs", "errors.log")
 _MAX_RECORDS_PER_CALL: int = 200
 _MAX_INCIDENTS_PER_CALL: int = 50
 _VALID_OPS = ("scan", "tail")
-
-
-def _default_log_path() -> Path:
-    """Resolve the Hermes log file path with environment override."""
-    override = os.environ.get(_ENV_LOG_PATH, "").strip()
-    if override:
-        return Path(override).expanduser()
-    return Path.home().joinpath(*_DEFAULT_LOG_RELATIVE)
 
 
 def _allowed_log_dirs() -> tuple[Path, ...]:
@@ -81,7 +71,7 @@ def _allowed_log_dirs() -> tuple[Path, ...]:
     operators with non-standard log locations don't need extra config.
     """
     dirs: list[Path] = [Path.home() / ".hermes"]
-    override = os.environ.get(_ENV_LOG_PATH, "").strip()
+    override = os.environ.get(HERMES_LOG_PATH_ENV, "").strip()
     if override:
         dirs.append(Path(override).expanduser().resolve(strict=False).parent)
     return tuple(dirs)
@@ -323,7 +313,7 @@ def get_hermes_logs(
     except ValueError as exc:
         return {"error": str(exc), "records": [], "incidents": []}
 
-    resolved_path = Path(log_path).expanduser() if log_path else _default_log_path()
+    resolved_path = Path(log_path).expanduser() if log_path else default_hermes_log_path()
 
     try:
         _validate_log_path(resolved_path)

--- a/tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py
+++ b/tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
+from config.constants.hermes import HERMES_LOG_PATH_ENV
 from core.agent_harness.session.integration_resolution import IntegrationResolutionResult
 from tools.investigation.stages.resolve_integrations import node
 
@@ -82,3 +84,87 @@ def test_resolve_integrations_keeps_idempotency_guard_before_progress(monkeypatc
     assert updates == {"resolved_integrations": {"github": {}}}
     assert tracker.started == []
     assert tracker.completed == []
+
+
+def test_resolve_integrations_attaches_hermes_log_source_for_hermes_alerts(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(HERMES_LOG_PATH_ENV, str(tmp_path / "errors.log"))
+    monkeypatch.setattr(
+        node,
+        "resolve_integrations_with_metadata",
+        lambda _state: IntegrationResolutionResult(
+            resolved_integrations={"datadog": {"site": "datadoghq.com"}},
+            progress_message="Resolved local integrations from store: ['datadog']",
+        ),
+    )
+
+    updates = node.resolve_integrations(  # type: ignore[arg-type]
+        {"alert_source": "hermes"}
+    )
+
+    assert updates["resolved_integrations"]["datadog"] == {"site": "datadoghq.com"}
+    assert updates["resolved_integrations"]["hermes"]["connection_verified"] is True
+    assert updates["resolved_integrations"]["hermes"]["log_path"] == str(tmp_path / "errors.log")
+
+
+def test_resolve_integrations_does_not_attach_hermes_on_other_alerts(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(HERMES_LOG_PATH_ENV, str(tmp_path / "errors.log"))
+    monkeypatch.setattr(
+        node,
+        "resolve_integrations_with_metadata",
+        lambda _state: IntegrationResolutionResult(
+            resolved_integrations={"datadog": {"site": "datadoghq.com"}},
+            progress_message="Resolved local integrations from store: ['datadog']",
+        ),
+    )
+
+    updates = node.resolve_integrations(  # type: ignore[arg-type]
+        {"alert_source": "datadog"}
+    )
+
+    assert updates == {"resolved_integrations": {"datadog": {"site": "datadoghq.com"}}}
+
+
+def test_resolve_integrations_skips_hermes_when_log_is_missing(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(HERMES_LOG_PATH_ENV, raising=False)
+    monkeypatch.setattr(
+        "integrations.hermes.availability.default_hermes_log_path",
+        lambda: tmp_path / "missing.log",
+    )
+    monkeypatch.setattr(
+        node,
+        "resolve_integrations_with_metadata",
+        lambda _state: IntegrationResolutionResult(
+            resolved_integrations={},
+            progress_message="Resolved integrations",
+        ),
+    )
+
+    updates = node.resolve_integrations({"alert_source": "hermes"})  # type: ignore[arg-type]
+
+    assert "hermes" not in updates["resolved_integrations"]
+
+
+def test_resolve_integrations_preserves_injected_hermes_backend(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(HERMES_LOG_PATH_ENV, str(tmp_path / "errors.log"))
+    backend = object()
+    monkeypatch.setattr(
+        node,
+        "resolve_integrations_with_metadata",
+        lambda _state: IntegrationResolutionResult(
+            resolved_integrations={"hermes": {"_backend": backend}},
+            progress_message="Resolved integrations",
+        ),
+    )
+
+    updates = node.resolve_integrations({"alert_source": "hermes"})  # type: ignore[arg-type]
+
+    assert updates["resolved_integrations"]["hermes"]["_backend"] is backend
+    assert "log_path" not in updates["resolved_integrations"]["hermes"]

--- a/tests/tools/test_hermes_session_evidence_tool.py
+++ b/tests/tools/test_hermes_session_evidence_tool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.tool.contracts import REGISTERED_TOOL_ATTR, RegisteredTool
 from integrations.hermes.tools.hermes_session_evidence_tool import (
     get_hermes_cron_state,
     get_hermes_kv_cache_state,
@@ -72,3 +73,11 @@ def test_tools_require_backend_when_not_configured() -> None:
     result = get_hermes_session_log(session_id="")
     assert result["available"] is False
     assert "requires a Hermes backend" in str(result["error"])
+
+
+def test_session_tools_stay_unavailable_without_fixture_backend() -> None:
+    """Live Hermes log presence must not unlock the 18 fixture-only tools."""
+    registered = getattr(get_hermes_session_log, REGISTERED_TOOL_ATTR)
+    assert isinstance(registered, RegisteredTool)
+    sources = {"hermes": {"connection_verified": True, "log_path": "/tmp/errors.log"}}
+    assert registered.is_available(sources) is False

--- a/tools/investigation/stages/resolve_integrations/node.py
+++ b/tools/investigation/stages/resolve_integrations/node.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.alerts.alert_source import resolve_alert_source
 from core.state import InvestigationState
 from infrastructure.harness_providers import resolve_integrations_with_metadata
 from infrastructure.observability import get_progress_tracker as get_tracker
+from integrations.hermes import attach_hermes_log_source
 
 
 def resolve_integrations(state: InvestigationState) -> dict[str, Any]:
@@ -33,13 +35,17 @@ def _resolve(state: InvestigationState, *, emit_progress: bool) -> dict[str, Any
         tracker.start("resolve_integrations", "Fetching org integrations")
 
     result = resolve_integrations_with_metadata(state)
+    resolved = attach_hermes_log_source(
+        dict(result.resolved_integrations),
+        alert_source=resolve_alert_source(dict(state)),
+    )
     _complete_tracker(
         tracker,
         "resolve_integrations",
         fields_updated=["resolved_integrations"],
         message=result.progress_message,
     )
-    return result.resolved_integrations
+    return resolved
 
 
 def _complete_tracker(tracker: Any | None, node_name: str, **kwargs: Any) -> None:


### PR DESCRIPTION
/fix #5818 

This pull request refactors how the Hermes log tool is enabled and discovered by the system. Now, Hermes log access is automatically offered for "hermes" alerts when a configured log file exists, without requiring a credential verifier. The changes introduce a new utility for attaching Hermes log sources, update environment variable handling, and add comprehensive tests for the new logic.

**Hermes log source attachment and availability logic:**

* Added `attach_hermes_log_source` in `integrations/hermes/availability.py`, which attaches a Hermes log source to resolved integrations only for "hermes" alerts and only if the log file is configured or exists. This ensures Hermes log tools are available without credential verification when appropriate. [[1]](diffhunk://#diff-ade55106099306469b53c53f84df3af3c4831a204c88d0fb45377ba696bf72b2L1-R46) [[2]](diffhunk://#diff-9a1dbb17c5c0c2bbd55273abc2f9420ae3b570a4e73e696464a8d759c22799f2R13) [[3]](diffhunk://#diff-9a1dbb17c5c0c2bbd55273abc2f9420ae3b570a4e73e696464a8d759c22799f2R58) [[4]](diffhunk://#diff-fb8a6cb5bc04f75e1781bbcc59eaabc15ca6c49a539dd0de9a376e0b6c45267aR7-R11) [[5]](diffhunk://#diff-fb8a6cb5bc04f75e1781bbcc59eaabc15ca6c49a539dd0de9a376e0b6c45267aR38-R48)
* Updated `tools/investigation/stages/resolve_integrations/node.py` to use `attach_hermes_log_source` during integration resolution, ensuring the new logic is applied consistently.

**Environment variable and configuration improvements:**

* Centralized the `HERMES_LOG_PATH_ENV` environment variable in `config.constants.hermes` and updated all references to use this constant, improving maintainability and reducing duplication. [[1]](diffhunk://#diff-750cacca527c2a3807b0c9342c54cf6b74d4ddcc2b889578b9bf417a54889b51R152) [[2]](diffhunk://#diff-750cacca527c2a3807b0c9342c54cf6b74d4ddcc2b889578b9bf417a54889b51R570) [[3]](diffhunk://#diff-40ff756cb9d9c70e5120b57f9d2deddee685f2e1d5449824ec65972e9064368aR1-R7) [[4]](diffhunk://#diff-209fd9d957c9ab19e5d9ad0ec232e3b560a25652ed1d71f1f960dd0b4577c902R47-L58) [[5]](diffhunk://#diff-209fd9d957c9ab19e5d9ad0ec232e3b560a25652ed1d71f1f960dd0b4577c902L84-R74)
* Refactored log path resolution to use `default_hermes_log_path()` everywhere, removing redundant code and ensuring consistent behavior. [[1]](diffhunk://#diff-209fd9d957c9ab19e5d9ad0ec232e3b560a25652ed1d71f1f960dd0b4577c902L67-L74) [[2]](diffhunk://#diff-209fd9d957c9ab19e5d9ad0ec232e3b560a25652ed1d71f1f960dd0b4577c902L326-R316)

**Documentation:**

* Clarified the behavior of `HERMES_LOG_PATH` in the environment variable documentation, noting that the tool is available without a credential verifier when the log is present.

**Testing:**

* Added comprehensive tests in `tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py` to verify Hermes log source attachment logic for different alert types, log presence, and preservation of backends. [[1]](diffhunk://#diff-e7981abd26eb89613b44a3c440858ac49e7abf49cd974625807e34f8cc4ab513R5-R8) [[2]](diffhunk://#diff-e7981abd26eb89613b44a3c440858ac49e7abf49cd974625807e34f8cc4ab513R87-R170)
* Added a test in `tests/tools/test_hermes_session_evidence_tool.py` to ensure Hermes session tools remain unavailable unless a fixture backend is present, even if the log is available. [[1]](diffhunk://#diff-3f594598060a9611a252f0d13300e06476c2b6240aafc561c12ddea80088f512R5) [[2]](diffhunk://#diff-3f594598060a9611a252f0d13300e06476c2b6240aafc561c12ddea80088f512R76-R83)