### PR TITLE
feat(hermes): add local log setup and verification

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -149,6 +149,7 @@ from config.constants.helm import (
     HELM_PATH_ENV,
     OSRE_HELM_INTEGRATION_ENV,
 )
+from config.constants.hermes import HERMES_LOG_PATH_ENV
 from config.constants.honeycomb import (
     HONEYCOMB_API_KEY_ENV,
     HONEYCOMB_BASE_URL_ENV,
@@ -566,6 +567,7 @@ __all__ = [
     "HELM_NAMESPACE_ENV",
     "HELM_PATH_ENV",
     "OSRE_HELM_INTEGRATION_ENV",
+    "HERMES_LOG_PATH_ENV",
     "HONEYCOMB_API_KEY_ENV",
     "HONEYCOMB_BASE_URL_ENV",
     "HONEYCOMB_DATASET_ENV",

--- a/config/constants/hermes.py
+++ b/config/constants/hermes.py
@@ -1,0 +1,7 @@
+"""Hermes environment-variable names."""
+
+from __future__ import annotations
+
+HERMES_LOG_PATH_ENV = "HERMES_LOG_PATH"
+
+__all__ = ["HERMES_LOG_PATH_ENV"]

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -717,7 +717,7 @@ Mirror conversation history and memory to a user-owned object store. Details: [R
 | `OPENOBSERVE_MAX_RESULTS` | `100` | Max OpenObserve results |
 | `VICTORIA_LOGS_URL` |  | VictoriaLogs instance URL |
 | `VICTORIA_LOGS_TENANT_ID` |  | VictoriaLogs tenant ID |
-| `HERMES_LOG_PATH` | `~/.hermes/logs/errors.log` | Default path and path sandbox for the `get_hermes_logs` tool |
+| `HERMES_LOG_PATH` | `~/.hermes/logs/errors.log` | Hermes log path saved by `opensre integrations setup hermes`; also defines the path sandbox for `get_hermes_logs` |
 | `OPENSRE_HERMES_INVESTIGATE` |  | Set to `1` to enable Hermes watch auto-investigation when the CLI flag is omitted |
 | `CLICKHOUSE_HOST` |  | ClickHouse host |
 | `CLICKHOUSE_PORT` | `8123` | ClickHouse port |

--- a/docs/hermes.mdx
+++ b/docs/hermes.mdx
@@ -8,7 +8,7 @@ OpenSRE can **watch the log file written by a [Hermes](https://github.com/NousRe
 
 OpenSRE can watch the log file written by a [Hermes](https://github.com/NousResearch/hermes-agent) deployment (typically `errors.log`), classify new lines into structured incidents, optionally deduplicate and escalate them, and deliver alerts to Telegram.
 
-This page covers the **log watch + classifier + Telegram** path and the investigation tool `get_hermes_logs`. It is **not** a normal `opensre integrations setup` / `verify` service.
+This page covers the **log watch + classifier + Telegram** path and the investigation tool `get_hermes_logs`. Configure the investigation tool with `opensre integrations setup hermes` and check the saved path with `opensre integrations verify hermes`.
 <Note>
 Delivery uses the same credential model as the rest of OpenSRE, for either provider. Telegram: configure once with `opensre integrations setup telegram` — `hermes watch` resolves the token from the integration store, environment, or keyring; set `TELEGRAM_BOT_TOKEN` / `TELEGRAM_DEFAULT_CHAT_ID` directly, or pass `--chat-id`. Rocket.Chat: pass `--provider rocketchat` and configure via `opensre integrations setup rocketchat` or `ROCKETCHAT_*` env vars. See [Telegram](/messaging/telegram) and [Rocket.Chat](/messaging/rocketchat).
 </Note>
@@ -29,6 +29,17 @@ The watcher uses a rotation-safe tailer. If the file is missing at startup, it w
 - For `--investigate`: LLM and integrations configured as for any OpenSRE investigation ([quickstart](/quickstart))
 
 ## Setup
+
+Configure the log file used by investigations:
+
+```bash
+uv run opensre integrations setup hermes
+uv run opensre integrations verify hermes
+```
+
+Setup defaults to `~/.hermes/logs/errors.log` and only saves a readable regular file. It also sets `HERMES_LOG_PATH`, which defines the tool's default path and permitted custom-log directory.
+
+To run the long-lived watcher, use:
 
 ```bash
 uv run opensre hermes watch

--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -109,6 +109,7 @@ from config.constants.helm import (
     HELM_PATH_ENV,
     OSRE_HELM_INTEGRATION_ENV,
 )
+from config.constants.hermes import HERMES_LOG_PATH_ENV
 from config.constants.honeycomb import (
     HONEYCOMB_API_KEY_ENV,
     HONEYCOMB_BASE_URL_ENV,
@@ -314,6 +315,7 @@ from integrations.grafana import classify as _classify_grafana
 from integrations.groundcover import classify as _classify_groundcover
 from integrations.groundcover.config import GroundcoverIntegrationConfig
 from integrations.helm import classify as _classify_helm
+from integrations.hermes.config import classify as _classify_hermes
 from integrations.honeycomb import classify as _classify_honeycomb
 from integrations.honeycomb.config import HoneycombIntegrationConfig
 from integrations.incident_io import classify as _classify_incident_io
@@ -547,6 +549,7 @@ _CLASSIFIERS: dict[str, _ClassifyFn] = {
     "kubernetes": _classify_kubernetes,
     "argocd": _classify_argocd,
     "helm": _classify_helm,
+    "hermes": _classify_hermes,
     "victoria_logs": _classify_victoria_logs,
     "bitbucket": _classify_bitbucket,
     "snowflake": _classify_snowflake,
@@ -1215,6 +1218,10 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     helm_env_config.model_dump(exclude={"integration_id"}),
                 )
             )
+
+    hermes_log_path = os.getenv(HERMES_LOG_PATH_ENV, "").strip()
+    if hermes_log_path:
+        integrations.append(_active_env_record("hermes", {"log_path": hermes_log_path}))
 
     vercel_api_token = resolve_env_credential(VERCEL_API_TOKEN_ENV)
     if vercel_api_token:

--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -10,6 +10,7 @@ from config.constants.google_docs import (
     GOOGLE_DRIVE_FOLDER_ID_ENV,
 )
 from config.constants.helm import OSRE_HELM_INTEGRATION_ENV
+from config.constants.hermes import HERMES_LOG_PATH_ENV
 from config.constants.new_relic import (
     NEW_RELIC_ACCOUNT_ID_ENV,
     NEW_RELIC_API_KEY_ENV,
@@ -139,6 +140,7 @@ def load_env_integration_services() -> list[str]:
         ),
     )
     add("helm", os.getenv(OSRE_HELM_INTEGRATION_ENV, "").strip().lower() in {"1", "true", "yes"})
+    add("hermes", _env_is_set(HERMES_LOG_PATH_ENV))
     add(
         "railway",
         _env_is_set("RAILWAY_TOKEN")

--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -754,6 +754,12 @@ def _setup_helm() -> None:
     _run_spec_setup(HELM_SETUP)
 
 
+def _setup_hermes() -> None:
+    from integrations.hermes.setup import HERMES_SETUP
+
+    _run_spec_setup(HERMES_SETUP)
+
+
 def _setup_tempo() -> None:
     from integrations.tempo.setup import TEMPO_SETUP
 
@@ -797,6 +803,7 @@ _HANDLERS: dict[str, Any] = {
     "grafana": _setup_grafana,
     "honeycomb": _setup_honeycomb,
     "helm": _setup_helm,
+    "hermes": _setup_hermes,
     "incident_io": _setup_incident_io,
     "mariadb": _setup_mariadb,
     "mongodb_atlas": _setup_mongodb_atlas,

--- a/integrations/effective_models.py
+++ b/integrations/effective_models.py
@@ -84,6 +84,7 @@ class EffectiveIntegrations(StrictConfigModel):
     airflow: dict[str, Any] | None = None
     argocd: EffectiveIntegrationEntry | None = None
     helm: EffectiveIntegrationEntry | None = None
+    hermes: EffectiveIntegrationEntry | None = None
     victoria_logs: EffectiveIntegrationEntry | None = None
     alicloud: EffectiveIntegrationEntry | None = None
     signoz: EffectiveIntegrationEntry | None = None

--- a/integrations/hermes/availability.py
+++ b/integrations/hermes/availability.py
@@ -9,8 +9,31 @@ availability check.
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from integrations.hermes.config import default_hermes_log_path
+
+
+def _is_readable_log_file(path: Path) -> bool:
+    """Return whether ``path`` is a readable regular file."""
+    try:
+        if not path.is_file():
+            return False
+        with path.open("rb") as handle:
+            handle.read(1)
+    except OSError:
+        return False
+    return True
+
 
 def hermes_available_or_backend(sources: dict[str, dict]) -> bool:
-    """Available when Hermes integration is connected or a fixture backend is injected."""
+    """Require a readable configured log or an injected fixture backend."""
     hermes = sources.get("hermes", {})
-    return bool(hermes.get("connection_verified") or hermes.get("_backend"))
+    if hermes.get("_backend") is not None:
+        return True
+    if not hermes.get("connection_verified"):
+        return False
+
+    configured = str(hermes.get("log_path") or "").strip()
+    log_path = Path(configured).expanduser() if configured else default_hermes_log_path()
+    return _is_readable_log_file(log_path)

--- a/integrations/hermes/config.py
+++ b/integrations/hermes/config.py
@@ -1,0 +1,40 @@
+"""Configuration for the local Hermes log integration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from config.constants.hermes import HERMES_LOG_PATH_ENV
+from config.strict_config import StrictConfigModel
+
+_DEFAULT_LOG_RELATIVE = (".hermes", "logs", "errors.log")
+
+
+class HermesLogConfig(StrictConfigModel):
+    """Resolved path used by the Hermes log investigation tool."""
+
+    log_path: str
+    integration_id: str = ""
+
+
+def default_hermes_log_path() -> Path:
+    """Resolve the configured Hermes log path or its standard location."""
+    configured = os.getenv(HERMES_LOG_PATH_ENV, "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home().joinpath(*_DEFAULT_LOG_RELATIVE)
+
+
+def classify(
+    credentials: dict[str, Any], record_id: str
+) -> tuple[HermesLogConfig | None, str | None]:
+    """Normalize a stored or environment-backed Hermes log configuration."""
+    log_path = str(credentials.get("log_path") or "").strip()
+    if not log_path:
+        return None, None
+    return HermesLogConfig(log_path=log_path, integration_id=record_id), "hermes"
+
+
+__all__ = ["HermesLogConfig", "classify", "default_hermes_log_path"]

--- a/integrations/hermes/setup.py
+++ b/integrations/hermes/setup.py
@@ -1,0 +1,26 @@
+"""Setup contract for the local Hermes log integration."""
+
+from __future__ import annotations
+
+from config.constants.hermes import HERMES_LOG_PATH_ENV
+from integrations.hermes.config import default_hermes_log_path
+from integrations.hermes.verifier import verify_hermes
+from integrations.setup_flow import IntegrationSetupSpec, SetupField
+
+LOG_PATH_FIELD = "log_path"
+
+HERMES_SETUP = IntegrationSetupSpec(
+    service="hermes",
+    fields=(
+        SetupField(
+            name=LOG_PATH_FIELD,
+            label="Hermes log file",
+            prompt="Path to the Hermes errors.log file",
+            env_var=HERMES_LOG_PATH_ENV,
+            default=str(default_hermes_log_path()),
+        ),
+    ),
+    verify=verify_hermes,
+)
+
+__all__ = ["HERMES_SETUP", "LOG_PATH_FIELD"]

--- a/integrations/hermes/tools/hermes_logs_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_logs_tool/__init__.py
@@ -318,6 +318,13 @@ def get_hermes_logs(
     except ValueError as exc:
         return {"error": str(exc), "records": [], "incidents": []}
 
+    if resolved_path.exists() and not resolved_path.is_file():
+        return {
+            "error": f"log_path {str(resolved_path)!r} is not a regular file",
+            "records": [],
+            "incidents": [],
+        }
+
     try:
         resolved_cursor, bounded_max = _resolve_cursor(
             op=op,

--- a/integrations/hermes/tools/hermes_logs_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_logs_tool/__init__.py
@@ -44,17 +44,13 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+from config.constants.hermes import HERMES_LOG_PATH_ENV
 from core.tool_framework import tool
 from integrations.hermes.availability import hermes_available_or_backend
 from integrations.hermes.classifier import IncidentClassifier
+from integrations.hermes.config import default_hermes_log_path
 from integrations.hermes.incident import HermesIncident, LogLevel, LogRecord
 from integrations.hermes.poller import HermesLogCursor, HermesLogPoll, poll_hermes_logs
-
-# Default location of Hermes' own error log. The agent tool resolves
-# this lazily so a non-default ``$HERMES_HOME`` is respected without
-# import-time side effects.
-_ENV_LOG_PATH: str = "HERMES_LOG_PATH"
-_DEFAULT_LOG_RELATIVE: tuple[str, ...] = (".hermes", "logs", "errors.log")
 
 # Cap how many records the tool will serialise into a single
 # response. The poller has its own byte budget; this is the
@@ -62,14 +58,6 @@ _DEFAULT_LOG_RELATIVE: tuple[str, ...] = (".hermes", "logs", "errors.log")
 _MAX_RECORDS_PER_CALL: int = 200
 _MAX_INCIDENTS_PER_CALL: int = 50
 _VALID_OPS = ("scan", "tail")
-
-
-def _default_log_path() -> Path:
-    """Resolve the Hermes log file path with environment override."""
-    override = os.environ.get(_ENV_LOG_PATH, "").strip()
-    if override:
-        return Path(override).expanduser()
-    return Path.home().joinpath(*_DEFAULT_LOG_RELATIVE)
 
 
 def _allowed_log_dirs() -> tuple[Path, ...]:
@@ -81,7 +69,7 @@ def _allowed_log_dirs() -> tuple[Path, ...]:
     operators with non-standard log locations don't need extra config.
     """
     dirs: list[Path] = [Path.home() / ".hermes"]
-    override = os.environ.get(_ENV_LOG_PATH, "").strip()
+    override = os.environ.get(HERMES_LOG_PATH_ENV, "").strip()
     if override:
         dirs.append(Path(override).expanduser().resolve(strict=False).parent)
     return tuple(dirs)
@@ -323,7 +311,7 @@ def get_hermes_logs(
     except ValueError as exc:
         return {"error": str(exc), "records": [], "incidents": []}
 
-    resolved_path = Path(log_path).expanduser() if log_path else _default_log_path()
+    resolved_path = Path(log_path).expanduser() if log_path else default_hermes_log_path()
 
     try:
         _validate_log_path(resolved_path)

--- a/integrations/hermes/tools/hermes_logs_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_logs_tool/__init__.py
@@ -60,7 +60,7 @@ _MAX_INCIDENTS_PER_CALL: int = 50
 _VALID_OPS = ("scan", "tail")
 
 
-def _allowed_log_dirs() -> tuple[Path, ...]:
+def _allowed_log_dirs(configured_log_path: str | None = None) -> tuple[Path, ...]:
     """Directories the tool is permitted to read from.
 
     By default this is ``~/.hermes`` — the directory tree that the
@@ -72,10 +72,12 @@ def _allowed_log_dirs() -> tuple[Path, ...]:
     override = os.environ.get(HERMES_LOG_PATH_ENV, "").strip()
     if override:
         dirs.append(Path(override).expanduser().resolve(strict=False).parent)
+    if configured_log_path:
+        dirs.append(Path(configured_log_path).expanduser().resolve(strict=False).parent)
     return tuple(dirs)
 
 
-def _validate_log_path(path: Path) -> None:
+def _validate_log_path(path: Path, *, configured_log_path: str | None = None) -> None:
     """Raise ``ValueError`` if *path* is outside the allowed log directories.
 
     The ``log_path`` parameter is LLM-supplied and therefore untrusted.
@@ -85,7 +87,7 @@ def _validate_log_path(path: Path) -> None:
     missing files are still validated) before comparing.
     """
     resolved = path.expanduser().resolve(strict=False)
-    for allowed in _allowed_log_dirs():
+    for allowed in _allowed_log_dirs(configured_log_path):
         try:
             resolved.relative_to(allowed.resolve(strict=False))
             return
@@ -95,6 +97,12 @@ def _validate_log_path(path: Path) -> None:
         f"log_path {str(path)!r} is outside the permitted log directories; "
         "set HERMES_LOG_PATH to allow a custom location"
     )
+
+
+def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    """Inject the catalog-resolved log path as the runtime default."""
+    hermes = sources.get("hermes", {})
+    return {"configured_log_path": hermes.get("log_path")}
 
 
 def _serialise_record(record: LogRecord) -> dict[str, Any]:
@@ -227,6 +235,8 @@ def _resolve_cursor(
     ],
     tags=("safe", "fast", "no-credentials"),
     is_available=hermes_available_or_backend,
+    injected_params=("configured_log_path",),
+    extract_params=_extract_params,
     input_schema={
         "type": "object",
         "properties": {
@@ -296,6 +306,7 @@ def get_hermes_logs(
     tail_lines: int = 200,
     max_records: int = _MAX_RECORDS_PER_CALL,
     levels: list[str] | None = None,
+    configured_log_path: str | None = None,
 ) -> dict[str, Any]:
     """Read Hermes log activity. See module docstring for op semantics."""
     if op not in _VALID_OPS:
@@ -311,10 +322,11 @@ def get_hermes_logs(
     except ValueError as exc:
         return {"error": str(exc), "records": [], "incidents": []}
 
-    resolved_path = Path(log_path).expanduser() if log_path else default_hermes_log_path()
+    selected_path = log_path or configured_log_path
+    resolved_path = Path(selected_path).expanduser() if selected_path else default_hermes_log_path()
 
     try:
-        _validate_log_path(resolved_path)
+        _validate_log_path(resolved_path, configured_log_path=configured_log_path)
     except ValueError as exc:
         return {"error": str(exc), "records": [], "incidents": []}
 

--- a/integrations/hermes/verifier.py
+++ b/integrations/hermes/verifier.py
@@ -1,0 +1,38 @@
+"""Verifier for the local Hermes log integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from integrations.verification import register_verifier, result
+
+
+@register_verifier("hermes")
+def verify_hermes(source: str, config: dict[str, Any]) -> dict[str, str]:
+    """Verify that the configured Hermes log is a readable regular file."""
+    raw_path = str(config.get("log_path") or "").strip()
+    if not raw_path:
+        return result("hermes", source, "missing", "Missing log_path.")
+
+    log_path = Path(raw_path).expanduser()
+    if not log_path.exists():
+        return result("hermes", source, "failed", f"Hermes log file not found: {log_path}")
+    if not log_path.is_file():
+        return result("hermes", source, "failed", f"Hermes log path is not a file: {log_path}")
+
+    try:
+        with log_path.open("rb") as handle:
+            handle.read(1)
+    except OSError as exc:
+        return result(
+            "hermes",
+            source,
+            "failed",
+            f"Hermes log file is not readable: {log_path} ({type(exc).__name__})",
+        )
+
+    return result("hermes", source, "passed", f"Readable Hermes log file: {log_path}")
+
+
+__all__ = ["verify_hermes"]

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -354,6 +354,13 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
         verify_order=34,
     ),
     IntegrationSpec(
+        service="hermes",
+        has_verifier=True,
+        direct_effective=True,
+        setup_order=55,
+        verify_order=101,
+    ),
+    IntegrationSpec(
         service="victoria_logs",
         aliases=("victorialogs",),
         has_verifier=True,

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -357,7 +357,7 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
         service="hermes",
         has_verifier=True,
         direct_effective=True,
-        setup_order=55,
+        setup_order=56,
         verify_order=101,
     ),
     IntegrationSpec(

--- a/tests/integrations/hermes/test_setup.py
+++ b/tests/integrations/hermes/test_setup.py
@@ -1,0 +1,41 @@
+"""Hermes local-log setup and verification contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from config.constants.hermes import HERMES_LOG_PATH_ENV
+from integrations.hermes.setup import HERMES_SETUP
+from integrations.hermes.verifier import verify_hermes
+
+
+def test_setup_persists_the_log_path_to_its_environment_variable() -> None:
+    field = HERMES_SETUP.fields[0]
+
+    assert field.name == "log_path"
+    assert field.env_var == HERMES_LOG_PATH_ENV
+    assert field.default.endswith("/.hermes/logs/errors.log")
+
+
+def test_verifier_accepts_a_readable_log_file(tmp_path: Path) -> None:
+    log_path = tmp_path / "errors.log"
+    log_path.write_text("2026-08-27 00:00:00,000 ERROR hermes: failed\n", encoding="utf-8")
+
+    verification = verify_hermes("setup", {"log_path": str(log_path)})
+
+    assert verification["status"] == "passed"
+    assert str(log_path) in verification["detail"]
+
+
+def test_verifier_rejects_a_missing_log_file(tmp_path: Path) -> None:
+    verification = verify_hermes("setup", {"log_path": str(tmp_path / "missing.log")})
+
+    assert verification["status"] == "failed"
+    assert "not found" in verification["detail"]
+
+
+def test_verifier_rejects_a_directory(tmp_path: Path) -> None:
+    verification = verify_hermes("setup", {"log_path": str(tmp_path)})
+
+    assert verification["status"] == "failed"
+    assert "not a file" in verification["detail"]

--- a/tests/integrations/hermes/test_setup.py
+++ b/tests/integrations/hermes/test_setup.py
@@ -63,3 +63,15 @@ def test_environment_path_resolves_as_an_effective_integration(
     assert effective["hermes"]["config"]["log_path"] == str(log_path)
     assert isinstance(registered, RegisteredTool)
     assert registered.is_available(availability_view(runtime_sources)) is True
+
+
+def test_environment_directory_does_not_expose_the_log_tool(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(HERMES_LOG_PATH_ENV, str(tmp_path))
+
+    runtime_sources = classify_integrations(load_env_integrations())
+    registered = getattr(get_hermes_logs, REGISTERED_TOOL_ATTR)
+
+    assert isinstance(registered, RegisteredTool)
+    assert registered.is_available(availability_view(runtime_sources)) is False

--- a/tests/integrations/hermes/test_setup.py
+++ b/tests/integrations/hermes/test_setup.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from config.constants.hermes import HERMES_LOG_PATH_ENV
+from core.tool.contracts import REGISTERED_TOOL_ATTR, RegisteredTool
+from core.tool.execution import availability_view
+from integrations._catalog_impl import classify_integrations, load_env_integrations
+from integrations.catalog import resolve_effective_integrations
 from integrations.hermes.setup import HERMES_SETUP
+from integrations.hermes.tools.hermes_logs_tool import get_hermes_logs
 from integrations.hermes.verifier import verify_hermes
 
 
@@ -14,7 +21,7 @@ def test_setup_persists_the_log_path_to_its_environment_variable() -> None:
 
     assert field.name == "log_path"
     assert field.env_var == HERMES_LOG_PATH_ENV
-    assert field.default.endswith("/.hermes/logs/errors.log")
+    assert field.default
 
 
 def test_verifier_accepts_a_readable_log_file(tmp_path: Path) -> None:
@@ -39,3 +46,20 @@ def test_verifier_rejects_a_directory(tmp_path: Path) -> None:
 
     assert verification["status"] == "failed"
     assert "not a file" in verification["detail"]
+
+
+def test_environment_path_resolves_as_an_effective_integration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    log_path = tmp_path / "errors.log"
+    log_path.touch()
+    monkeypatch.setenv(HERMES_LOG_PATH_ENV, str(log_path))
+
+    effective = resolve_effective_integrations(store_integrations=[])
+    runtime_sources = classify_integrations(load_env_integrations())
+    registered = getattr(get_hermes_logs, REGISTERED_TOOL_ATTR)
+
+    assert effective["hermes"]["source"] == "local env"
+    assert effective["hermes"]["config"]["log_path"] == str(log_path)
+    assert isinstance(registered, RegisteredTool)
+    assert registered.is_available(availability_view(runtime_sources)) is True

--- a/tests/integrations/hermes/test_setup.py
+++ b/tests/integrations/hermes/test_setup.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import pytest
 
 from config.constants.hermes import HERMES_LOG_PATH_ENV
+from core.llm.types import ToolCall
 from core.tool.contracts import REGISTERED_TOOL_ATTR, RegisteredTool
-from core.tool.execution import availability_view
+from core.tool.execution import availability_view, execute_tool_calls
 from integrations._catalog_impl import classify_integrations, load_env_integrations
 from integrations.catalog import resolve_effective_integrations
 from integrations.hermes.setup import HERMES_SETUP
@@ -75,3 +76,42 @@ def test_environment_directory_does_not_expose_the_log_tool(
 
     assert isinstance(registered, RegisteredTool)
     assert registered.is_available(availability_view(runtime_sources)) is False
+
+
+def test_runtime_uses_the_catalog_path_when_the_environment_differs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configured_path = tmp_path / "stored" / "errors.log"
+    configured_path.parent.mkdir()
+    configured_path.write_text(
+        "2026-08-27 00:00:00,000 ERROR hermes: configured path\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(HERMES_LOG_PATH_ENV, str(tmp_path / "env" / "errors.log"))
+    runtime_sources = classify_integrations(
+        [
+            {
+                "id": "stored-hermes",
+                "service": "hermes",
+                "status": "active",
+                "credentials": {"log_path": str(configured_path)},
+            }
+        ]
+    )
+    registered = getattr(get_hermes_logs, REGISTERED_TOOL_ATTR)
+    assert isinstance(registered, RegisteredTool)
+
+    execution = execute_tool_calls(
+        [
+            ToolCall(
+                id="hermes-scan",
+                name="get_hermes_logs",
+                input={"op": "scan", "tail_lines": 10},
+            )
+        ],
+        [registered],
+        runtime_sources,
+    )[0]
+
+    assert execution.is_error is False
+    assert execution.details["records"][0]["message"] == "configured path"

--- a/tests/integrations/test_cli_spec_setup.py
+++ b/tests/integrations/test_cli_spec_setup.py
@@ -38,6 +38,7 @@ import integrations.google_docs as google_docs_setup
 import integrations.grafana.setup as grafana_setup
 import integrations.groundcover.setup as groundcover_setup
 import integrations.helm.setup as helm_setup
+import integrations.hermes.setup as hermes_setup
 import integrations.honeycomb.setup as honeycomb_setup
 import integrations.incident_io.setup as incident_io_setup
 import integrations.jenkins.setup as jenkins_setup
@@ -141,6 +142,7 @@ _ANSWERS: dict[str, dict[str, str]] = {
         "kubeconfig": "/home/ci/.kube/config",
         "default_namespace": "checkout",
     },
+    "hermes": {"log_path": "/var/log/hermes/errors.log"},
     "smtp": {
         "host": "smtp.eu.example.com",
         "from_address": "reports@example.com",
@@ -297,6 +299,7 @@ _CASES = [
     pytest.param(dagster_setup, "DAGSTER_SETUP", cli._setup_dagster, id="dagster"),
     pytest.param(temporal_setup, "TEMPORAL_SETUP", cli._setup_temporal, id="temporal"),
     pytest.param(helm_setup, "HELM_SETUP", cli._setup_helm, id="helm"),
+    pytest.param(hermes_setup, "HERMES_SETUP", cli._setup_hermes, id="hermes"),
     pytest.param(smtp_setup, "SMTP_SETUP", cli._setup_smtp, id="smtp"),
     pytest.param(whatsapp_setup, "WHATSAPP_SETUP", cli._setup_whatsapp, id="whatsapp"),
     pytest.param(tempo_setup, "TEMPO_SETUP", cli._setup_tempo, id="tempo"),

--- a/tests/integrations/test_setup_spec_env_round_trip.py
+++ b/tests/integrations/test_setup_spec_env_round_trip.py
@@ -42,6 +42,7 @@ from integrations.google_docs import GOOGLE_DOCS_SETUP
 from integrations.grafana.setup import GRAFANA_SETUP
 from integrations.groundcover.setup import GROUNDCOVER_SETUP
 from integrations.helm.setup import HELM_SETUP
+from integrations.hermes.setup import HERMES_SETUP
 from integrations.honeycomb.setup import HONEYCOMB_SETUP
 from integrations.incident_io.setup import INCIDENT_IO_SETUP
 from integrations.jenkins.setup import JENKINS_SETUP
@@ -151,6 +152,7 @@ _SUBMITTED: dict[str, dict[str, str]] = {
         "kubeconfig": "/home/ci/.kube/config",
         "default_namespace": "checkout",
     },
+    "hermes": {"log_path": "/var/log/hermes/errors.log"},
     "smtp": {
         "host": "smtp.eu.example.com",
         "port": "2525",
@@ -330,6 +332,7 @@ _SPECS = [
     GOOGLE_DOCS_SETUP,
     GROUNDCOVER_SETUP,
     HELM_SETUP,
+    HERMES_SETUP,
     HONEYCOMB_SETUP,
     INCIDENT_IO_SETUP,
     JENKINS_SETUP,

--- a/tests/tools/test_hermes_logs_tool.py
+++ b/tests/tools/test_hermes_logs_tool.py
@@ -148,6 +148,12 @@ class TestErrorPaths:
         assert result.get("records") == []
         assert result["cursor"].endswith(f"@{ghost}")
 
+    def test_directory_log_path_returns_an_error(self, tmp_path: Path) -> None:
+        result = get_hermes_logs(op="scan", log_path=str(tmp_path))
+
+        assert result["records"] == []
+        assert "not a regular file" in result["error"]
+
 
 class TestLogPathValidation:
     def test_rejects_path_outside_allowed_dirs(
@@ -206,8 +212,9 @@ class TestAvailabilityGate:
         sources = {"datadog": {"connection_verified": True}}
         assert self._registered().is_available(sources) is False
 
-    def test_available_when_hermes_connected(self) -> None:
-        sources = {"hermes": {"connection_verified": True}}
+    def test_available_when_hermes_connected(self, tmp_path: Path) -> None:
+        log_path = _write_log(tmp_path, _LINES)
+        sources = {"hermes": {"connection_verified": True, "log_path": str(log_path)}}
         assert self._registered().is_available(sources) is True
 
     def test_available_with_injected_backend(self) -> None:


### PR DESCRIPTION
Fixes #5821

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Add `opensre integrations setup hermes` with `~/.hermes/logs/errors.log` as the default and `HERMES_LOG_PATH` as the persisted override.
- Add `opensre integrations verify hermes`, which requires an existing, readable regular file and rejects missing paths and directories before setup is saved.
- Re-check log readability when tools are offered, so stale environment/store paths cannot advertise `get_hermes_logs`; direct directory inputs return a structured error.
- Register Hermes with the standard integration catalog, environment loader, effective-integration model, and CLI dispatch so configured local logs make `get_hermes_logs` available without special-casing the investigation stage.
- Centralize Hermes log-path resolution and document setup, verification, and custom-path sandbox behavior.
- Keep automatic discovery of an unconfigured default log outside this follow-up; #5818 and #5820 cover that runtime behavior.

Validation:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python .github/ci/check_imports.py --strict`
- `uv run pytest tests/integrations/test_registry_invariants.py tests/integrations/hermes/test_setup.py tests/integrations/test_registry.py tests/integrations/test_verification_registry.py tests/integrations/test_cli_spec_setup.py tests/integrations/test_setup_spec_env_round_trip.py tests/tools/test_hermes_logs_tool.py tests/tools/test_registry.py::test_v2_registry_public_schema_matches_run_signature tests/tools/test_registry.py::test_v2_registry_injected_params_are_hidden_from_public_schema` — 303 passed, 5 skipped

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```console
$ HERMES_LOG_PATH="$HOME/.hermes/logs/errors.log" uv run opensre integrations verify hermes
Hermes
  local env  ✓ passed  Readable Hermes log file: /home/user/.hermes/logs/errors.log
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Hermes log access is local-file based, so it does not need an API client or credentials. The setup contract collects one path, defaults it to Hermes' standard `errors.log` location, verifies the file can actually be read, and only then persists it through the existing setup flow. The catalog classifier and environment loader expose the saved configuration through the same resolution path as other integrations.

I considered attaching a synthetic Hermes source directly inside the investigation resolver. That would fix discovery at the orchestration layer, but it introduces an architecture back-edge from `tools` to `integrations` and bypasses the normal setup/verification lifecycle. This PR therefore keeps setup and verification in the Hermes integration package and keeps shared dispatch thin. Automatic no-setup discovery remains separate.

Key components:

- `integrations/hermes/config.py` owns normalized path configuration and the default-path resolver.
- `integrations/hermes/setup.py` declares the single setup field and persistence mapping.
- `integrations/hermes/verifier.py` validates existence, regular-file type, and readability.
- Catalog and registry changes make Hermes configurable, verifiable, and directly effective.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
