### PR TITLE
docs(deployment): clarify multi-task gateway deployment and session store requirements

### DIFF
--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -103,21 +103,23 @@ Complete route reference: [HTTP API](/api).
 
 ## Horizontal scale-out
 
-Run more than one gateway task to serve more concurrent conversations.
+Run **one** gateway task and leave `OPENSRE_SESSION_FILE_LOCK` off. More than
+one gateway task sharing `OPENSRE_HOME` is not supported yet. Follow
+[#5474](https://github.com/Tracer-Cloud/opensre/issues/5474) and add a second
+task only after that lands.
 
-### Required: a shared, locked session store
-
-All tasks must use the same session store — a shared mount such as an S3 Files or
-EFS volume. Turn on the cross-process lock so two tasks never corrupt one
-session's file:
+To serve more concurrent conversations today, raise in-process concurrency on
+that single task (next section). After #5474, put every task on the same
+session store — a shared mount such as S3 Files or EFS — and set:
 
 ```bash
 OPENSRE_SESSION_FILE_LOCK=1
 ```
 
-Without it, two tasks handling turns for the same conversation at the same moment
-can interleave writes and lose turns. A single-task deployment does not need it
-and should leave it off.
+Do not turn the lock on to make a multi-task fleet safe until then. Even after
+the fix, `fcntl.flock` is weak on some shared mounts (NFS, and EFS depending on
+configuration) — stay on a single task there, or use a mount that honors POSIX
+locks.
 
 ### Concurrency per task
 
@@ -161,9 +163,9 @@ that file, so a separate filesystem would leave it running a stale task set.
 
 ### Optional: conversation affinity
 
-The lock keeps N tasks correct. Affinity — routing a conversation to the same
-task each time — is a performance option: it keeps that conversation's warm agent
-in one task's memory instead of cold-rebuilding when a turn lands elsewhere.
+Skip affinity until you run more than one gateway task (after #5474). Then it is
+a performance option: it keeps a conversation's warm agent in one task's memory
+instead of cold-rebuilding when a turn lands elsewhere.
 
 Affinity is a routing concern, not an app setting:
 
@@ -171,6 +173,5 @@ Affinity is a routing concern, not an app setting:
   the conversation (Slack channel and thread) so a thread sticks to one task.
 - With the pull transports (Slack Socket Mode, Telegram, Discord), each task
   connects independently and the provider spreads events across tasks, so there
-  is no built-in affinity. The lock keeps this correct; affinity would need an
-  external dispatcher and is worth adding only when warm-agent reuse measurably
-  helps.
+  is no built-in affinity. Affinity would need an external dispatcher and is
+  worth adding only when warm-agent reuse measurably helps.

--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -108,13 +108,18 @@ one gateway task sharing `OPENSRE_HOME` is not supported yet. Follow
 [#5474](https://github.com/Tracer-Cloud/opensre/issues/5474) and add a second
 task only after that lands.
 
-To serve more concurrent conversations today, raise in-process concurrency on
-that single task (next section). After #5474, put every task on the same
-session store — a shared mount such as S3 Files or EFS — and set:
+To serve more concurrent conversations today, raise concurrency on that single
+task (next section). After #5474, put every task on the same session store — a
+shared mount such as S3 Files or EFS — and set:
 
 ```bash
 OPENSRE_SESSION_FILE_LOCK=1
 ```
+
+Slack Events API tasks must also share `DATABASE_URL`. Without it, a Slack retry
+that lands on another replica runs the same turn twice. Socket Mode, Telegram,
+and Discord do not use that store. Do not set `SLACK_GATEWAY_ALLOW_LOCAL_DEDUP=1`
+on more than one replica.
 
 Do not turn the lock on to make a multi-task fleet safe until then. Even after
 the fix, `fcntl.flock` is weak on some shared mounts (NFS, and EFS depending on
@@ -123,14 +128,27 @@ locks.
 
 ### Concurrency per task
 
-Each task runs a bounded number of turns at once (default 1). Turns are I/O-bound
-— mostly waiting on the model — so a small task can run several; the limit is the
-task's memory, since each concurrent turn holds its context resident. Raise it
-without changing the task size:
+Each task has two caps, and the lower one wins. `OPENSRE_MAX_CONCURRENT_TURNS`
+limits every turn in the process (default 1 on SMALL). Slack, Telegram, and
+Discord each have their own pool (`SLACK_GATEWAY_MAX_CONCURRENT`,
+`TELEGRAM_GATEWAY_MAX_CONCURRENT`, `DISCORD_GATEWAY_MAX_CONCURRENT`), which also
+defaults to 1 on SMALL. Raising only the process cap leaves chat at one
+concurrent turn.
+
+Turns are I/O-bound — mostly waiting on the model — so a small task can run
+several; the ceiling is the task's memory, since each concurrent turn holds its
+context resident. Raise both without changing the task size, using the transport
+vars for the chats you run:
 
 ```bash
 OPENSRE_MAX_CONCURRENT_TURNS=2
+SLACK_GATEWAY_MAX_CONCURRENT=2
+TELEGRAM_GATEWAY_MAX_CONCURRENT=2
+DISCORD_GATEWAY_MAX_CONCURRENT=2
 ```
+
+Or set `OPENSRE_SIZE_PROFILE=MEDIUM` (2) or `LARGE` (4) to raise both defaults
+together.
 
 Read the `gateway_turn_memory` debug lines (`delta_mb`, `peak_mb`) from a real run
 to size this against the task's memory limit before raising it.
@@ -169,8 +187,10 @@ instead of cold-rebuilding when a turn lands elsewhere.
 
 Affinity is a routing concern, not an app setting:
 
-- Behind an HTTP load balancer (Slack Events API), enable consistent hashing on
-  the conversation (Slack channel and thread) so a thread sticks to one task.
+- Behind an HTTP load balancer (Slack Events API), set the shared
+  `DATABASE_URL` above, then enable consistent hashing on the conversation
+  (Slack channel and thread) so a thread sticks to one task. Hashing does not
+  replace event dedup.
 - With the pull transports (Slack Socket Mode, Telegram, Discord), each task
   connects independently and the provider spreads events across tasks, so there
   is no built-in affinity. Affinity would need an external dispatcher and is


### PR DESCRIPTION
Fixes #5482

#### Describe the changes you have made in this PR -

`docs/deployment.mdx` promised that turning on `OPENSRE_SESSION_FILE_LOCK` makes N gateway tasks safe ("two tasks never corrupt one", "the lock keeps N tasks correct"). That is false while `open_session` still truncates the session file under the lock (#5474).

This PR only corrects the shipped guidance:

- Run **one** gateway task with the lock off. More than one task sharing `OPENSRE_HOME` is not supported yet.
- Scale today with in-process concurrency (`OPENSRE_MAX_CONCURRENT_TURNS`), not extra tasks.
- Link #5474 so the page says when multi-task becomes true instead of going quiet.
- Document that `fcntl.flock` is weak on NFS and some EFS mounts — do not treat the lock as cluster-safe everywhere.

No runtime code change. Re-tighten this wording in the same PR that lands #5474, or immediately after.

### Demo/Screenshot for feature changes and bug fixes -

Issue verification — no remaining unqualified multi-task correctness claims:

    $ grep -n -i "lock keeps\|never corrupt\|N tasks" docs/deployment.mdx
    # (no matches)

Page still listed in the Mintlify nav:

    $ grep -n "deployment" docs/docs.json
    101:              "deployment",

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The real bug is in `open_session` (`path.open("w")` inside the lock), but this issue is docs-only: stop promising multi-task correctness until that fix ships.

I considered two other options and rejected them:

1. **Fix `open_session` here** — that is #5474 (already assigned). Mixing it in would hide the docs lie behind a code change.
2. **Delete the Horizontal scale-out section** — operators still need the supported path (one task, raise `OPENSRE_MAX_CONCURRENT_TURNS`) and the scheduler split.

So the page now states what to do today, points at #5474 for when N tasks become true, and adds the NFS/EFS `flock` caveat. Scheduler copy is unchanged — double-firing crons is a separate fact from the session-file truncate.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions