### PR TITLE
fix(investigation): wire repo scope enrichment into resolve_integrations stage

### DIFF
--- a/tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py
+++ b/tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py
@@ -31,6 +31,7 @@ def test_resolve_integrations_wraps_platform_result_with_progress(monkeypatch: A
             progress_message="Resolved local integrations from store: ['datadog']",
         ),
     )
+    monkeypatch.setattr(node, "enrich_resolved_with_repo_scopes", lambda **kw: kw["resolved"])
 
     updates = node.resolve_integrations({"org_id": "org-1"})  # type: ignore[arg-type]
 
@@ -58,6 +59,7 @@ def test_resolve_integrations_quiet_skips_progress(monkeypatch: Any) -> None:
             progress_message="Resolved integrations",
         ),
     )
+    monkeypatch.setattr(node, "enrich_resolved_with_repo_scopes", lambda **kw: kw["resolved"])
 
     resolved = node.resolve_integrations_quiet({})  # type: ignore[arg-type]
 

--- a/tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_repo_scope.py
+++ b/tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_repo_scope.py
@@ -1,0 +1,82 @@
+"""Tests for VCS repo scope enrichment in the investigation resolve-integrations stage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.session.integration_resolution import IntegrationResolutionResult
+from tools.investigation.stages.resolve_integrations import node
+
+
+def _stub_metadata(
+    resolved: dict[str, Any],
+    *,
+    progress_message: str = "Resolved",
+) -> Any:
+    """Return a monkeypatch-friendly factory for ``resolve_integrations_with_metadata``."""
+    return lambda _state: IntegrationResolutionResult(
+        resolved_integrations=resolved,
+        progress_message=progress_message,
+    )
+
+
+def test_resolve_calls_repo_scope_enrichment(monkeypatch: Any) -> None:
+    """``_resolve`` must pass the base result through ``enrich_resolved_with_repo_scopes``."""
+    base = {"datadog": {"site": "datadoghq.com"}}
+    enriched = {"datadog": {"site": "datadoghq.com"}, "github": {"owner": "Acme", "repo": "app"}}
+    enrichment_calls: list[dict[str, Any]] = []
+
+    def _fake_enrich(**kwargs: Any) -> dict[str, Any]:
+        enrichment_calls.append(kwargs)
+        return enriched
+
+    monkeypatch.setattr(node, "get_tracker", lambda: None)
+    monkeypatch.setattr(node, "resolve_integrations_with_metadata", _stub_metadata(base))
+    monkeypatch.setattr(node, "enrich_resolved_with_repo_scopes", _fake_enrich)
+
+    state: dict[str, Any] = {"raw_alert": "Pod crash in https://github.com/Acme/app"}
+    updates = node.resolve_integrations(state)  # type: ignore[arg-type]
+
+    assert updates["resolved_integrations"] == enriched
+    assert len(enrichment_calls) == 1
+    call = enrichment_calls[0]
+    assert call["resolved"] == base
+    assert call["message"] == "Pod crash in https://github.com/Acme/app"
+    assert call["conversation_messages"] is None
+    assert call["cached_scopes"] == {}
+
+
+def test_enrichment_receives_stringified_dict_alert(monkeypatch: Any) -> None:
+    """When ``raw_alert`` is a dict, it must be stringified for URL parsing."""
+    base = {"sentry": {}}
+
+    def _fake_enrich(**kwargs: Any) -> dict[str, Any]:
+        assert isinstance(kwargs["message"], str)
+        return kwargs["resolved"]
+
+    monkeypatch.setattr(node, "get_tracker", lambda: None)
+    monkeypatch.setattr(node, "resolve_integrations_with_metadata", _stub_metadata(base))
+    monkeypatch.setattr(node, "enrich_resolved_with_repo_scopes", _fake_enrich)
+
+    state: dict[str, Any] = {"raw_alert": {"title": "OOMKilled", "url": "https://github.com/X/Y"}}
+    result = node.resolve_integrations(state)  # type: ignore[arg-type]
+
+    assert result["resolved_integrations"] == base
+
+
+def test_enrichment_skipped_for_idempotent_resolve(monkeypatch: Any) -> None:
+    """When resolved_integrations already exist in state, enrichment must not run."""
+    enrichment_called = False
+
+    def _unexpected_enrich(**_kwargs: Any) -> dict[str, Any]:
+        nonlocal enrichment_called
+        enrichment_called = True
+        raise AssertionError("enrichment should not be called for cached state")
+
+    monkeypatch.setattr(node, "enrich_resolved_with_repo_scopes", _unexpected_enrich)
+
+    state: dict[str, Any] = {"resolved_integrations": {"github": {"owner": "X", "repo": "Y"}}}
+    updates = node.resolve_integrations(state)  # type: ignore[arg-type]
+
+    assert updates == {"resolved_integrations": {"github": {"owner": "X", "repo": "Y"}}}
+    assert not enrichment_called

--- a/tools/investigation/stages/resolve_integrations/node.py
+++ b/tools/investigation/stages/resolve_integrations/node.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from core.state import InvestigationState
-from infrastructure.harness_providers import resolve_integrations_with_metadata
+from infrastructure.harness_providers import (
+    enrich_resolved_with_repo_scopes,
+    resolve_integrations_with_metadata,
+)
 from infrastructure.observability import get_progress_tracker as get_tracker
 
 
@@ -39,7 +43,24 @@ def _resolve(state: InvestigationState, *, emit_progress: bool) -> dict[str, Any
         fields_updated=["resolved_integrations"],
         message=result.progress_message,
     )
-    return result.resolved_integrations
+    return _enrich_with_repo_scopes(result.resolved_integrations, state)
+
+
+def _enrich_with_repo_scopes(
+    resolved: dict[str, Any],
+    state: InvestigationState,
+) -> dict[str, Any]:
+    """Inject VCS repo scopes (owner/repo) inferred from the alert and environment."""
+    raw_alert = state.get("raw_alert", "")
+    message = raw_alert if isinstance(raw_alert, str) else str(raw_alert)
+    return enrich_resolved_with_repo_scopes(
+        resolved=resolved,
+        message=message,
+        conversation_messages=None,
+        env=os.environ,
+        cwd=None,
+        cached_scopes={},
+    )
 
 
 def _complete_tracker(tracker: Any | None, node_name: str, **kwargs: Any) -> None:


### PR DESCRIPTION
Fixes #5782

#### Describe the changes you have made in this PR -

`enrich_resolved_with_repo_scopes()` was registered at boot via `integrations/harness_adapters.py` (GitHub + GitLab providers) but **never called in any production code path** — only in 2 unit tests. This meant GitHub `owner`/`repo` were never injected into `resolved_integrations` during investigations, potentially making GitHub tools unavailable.

**Key Changes:**
1. **`tools/investigation/stages/resolve_integrations/node.py`**:
   - After `resolve_integrations_with_metadata()` returns the base integration dict, call `enrich_resolved_with_repo_scopes()` to inject VCS repo scopes.
   - Uses `raw_alert` from `InvestigationState` as the `message` for GitHub URL parsing.
   - Uses `os.environ` for env-var-based scope resolution (e.g. `GITHUB_OWNER`/`GITHUB_REPO`).
   - Extracted into `_enrich_with_repo_scopes()` helper function.

2. **`tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_repo_scope.py` [NEW]**:
   - `test_resolve_calls_repo_scope_enrichment`: Verifies enrichment is called with correct parameters.
   - `test_enrichment_receives_stringified_dict_alert`: Verifies dict alerts are stringified cleanly.
   - `test_enrichment_skipped_for_idempotent_resolve`: Verifies idempotency guard skips enrichment if already resolved.

3. **`tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py` [MODIFIED]**:
   - Added passthrough monkeypatch for `enrich_resolved_with_repo_scopes` to isolate pre-existing tests.

### Demo/Screenshot for feature changes and bug fixes - 
```text
$ uv run pytest tests/tools/investigation/stages/resolve_integrations/ -xvs
============================= test session starts =============================
collected 6 items

tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py::test_resolve_integrations_wraps_platform_result_with_progress PASSED
tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py::test_resolve_integrations_quiet_skips_progress PASSED
tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_node.py::test_resolve_integrations_keeps_idempotency_guard_before_progress PASSED
tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_repo_scope.py::test_resolve_calls_repo_scope_enrichment PASSED
tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_repo_scope.py::test_enrichment_receives_stringified_dict_alert PASSED
tests/tools/investigation/stages/resolve_integrations/test_resolve_integrations_repo_scope.py::test_enrichment_skipped_for_idempotent_resolve PASSED

============================= 6 passed in 11.17s ==============================