### PR TITLE
test(planning): wide test coverage for the plan feature + fix flattened diagnosis explanation

### DIFF
--- a/core/agent_harness/task_plan/plan.py
+++ b/core/agent_harness/task_plan/plan.py
@@ -88,8 +88,12 @@ class TaskPlan:
 def parse_task_plan(args: dict[str, Any]) -> tuple[TaskPlan | None, str | None]:
     """Validate ``update_plan`` arguments. Returns ``(plan, error)``."""
     explanation_raw = args.get("explanation")
+    # The explanation is multi-line markdown (Facts, hypothesis table); keep its
+    # newlines so the rendered diagnosis is not flattened onto one line.
     explanation = (
-        strip_terminal_controls(explanation_raw).strip() if isinstance(explanation_raw, str) else ""
+        strip_terminal_controls(explanation_raw, keep_whitespace=True).strip()
+        if isinstance(explanation_raw, str)
+        else ""
     )
     raw_plan = args.get("plan")
     if not isinstance(raw_plan, list) or len(raw_plan) < 2:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -439,7 +439,9 @@ class ActionRenderObserver:
             render_task_plan(self.console, plan)
             return
         render_plan_updated(self.console, plan)
-        explanation = strip_terminal_controls(plan.explanation)
+        # Keep the explanation's newlines: it is multi-line markdown (Facts,
+        # hypothesis table) that render_markdown_block lays out line by line.
+        explanation = strip_terminal_controls(plan.explanation, keep_whitespace=True)
         if explanation:
             render_markdown_block(self.console, explanation)
 

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -102,7 +102,9 @@ def render_task_plan(console: Console, plan: TaskPlan) -> None:
             line.append(f"{glyph} ", style=str(ui_theme.DIM))
             line.append(step, style=str(ui_theme.DIM))
         console.print(line)
-    explanation = strip_terminal_controls(plan.explanation)
+    # Keep the explanation's newlines: it is multi-line markdown (Facts,
+    # hypothesis table) that render_markdown_block lays out line by line.
+    explanation = strip_terminal_controls(plan.explanation, keep_whitespace=True)
     if explanation:
         render_markdown_block(console, explanation)
     console.print()

--- a/tests/core/agent/orchestration/test_update_plan_tool.py
+++ b/tests/core/agent/orchestration/test_update_plan_tool.py
@@ -7,6 +7,11 @@ from typing import Any
 
 from rich.console import Console
 
+from core.agent_harness.task_plan.plan import (
+    PlanStepStatus,
+    parse_task_plan,
+    task_plan_from_payload,
+)
 from core.agent_harness.tools.tool_context import ActionToolScope
 from surfaces.interactive_shell.session import Session
 from tools.interactive_shell.actions.update_plan import (
@@ -66,3 +71,95 @@ def test_update_plan_rejects_two_in_progress_steps() -> None:
     assert "at most one" in result["error"]
     assert session.task_plan is None
     assert session.plan_only_until_authorized is False
+
+
+def test_update_plan_stores_explanation_and_revises_in_place() -> None:
+    # Arrange: an initial two-step plan with a first diagnosis.
+    session = Session()
+    initial: list[dict[str, Any]] = [
+        {"step": "Reproduce the 502 on checkout", "status": "in_progress"},
+        {"step": "Confirm checkout returns 2xx", "status": "pending"},
+    ]
+    first = execute_update_plan_tool(
+        {"plan": initial, "explanation": "first diagnosis"},
+        _ctx(session=session),
+    )
+    assert first["ok"] is True
+    assert session.task_plan is not None
+    assert session.task_plan.total == 2
+    assert session.task_plan.explanation == "first diagnosis"
+
+    # Act: a second call revises to three advanced steps and a new diagnosis.
+    revised = [
+        {"step": "Capture 502 samples from checkout", "status": "completed"},
+        {"step": "Trace 502s to the last deploy", "status": "completed"},
+        {"step": "Confirm checkout returns 2xx", "status": "in_progress"},
+    ]
+    second = execute_update_plan_tool(
+        {"plan": revised, "explanation": "moved to verify"},
+        _ctx(session=session),
+    )
+
+    # Assert: the session holds only the revision — replaced, not merged.
+    assert second["ok"] is True
+    assert session.task_plan is not None
+    assert session.task_plan.total == 3
+    assert session.task_plan.current_index == 3
+    assert session.task_plan.steps[0].status is PlanStepStatus.COMPLETED
+    assert session.task_plan.explanation == "moved to verify"
+
+
+def test_update_plan_tool_name_is_the_action_enum() -> None:
+    from tools.interactive_shell.action_names import ActionToolName
+
+    assert update_plan_tool.name == ActionToolName.UPDATE_PLAN
+
+
+# --- create → mark-complete flow --------------------------------------------
+
+
+def test_update_plan_marks_a_fully_completed_plan_as_terminal() -> None:
+    # Arrange / Act: every step completed (the verification step last).
+    session = Session()
+    done: list[dict[str, Any]] = [
+        {"step": "Capture 502 samples from checkout", "status": "completed"},
+        {"step": "Trace 502s to the last deploy", "status": "completed"},
+        {"step": "Confirm checkout returns 2xx", "status": "completed"},
+    ]
+    result = execute_update_plan_tool({"plan": done}, _ctx(session=session))
+
+    # Assert: the focused index sits on the final step and no step reopens.
+    assert result["ok"] is True
+    assert session.task_plan is not None
+    assert session.task_plan.all_completed is True
+    assert session.task_plan.current_index == session.task_plan.total == 3
+    assert "Plan · 3/3" in result["summary"]
+    # A terminal plan is neither plan-only nor a freshly authorized execution.
+    assert "Plan-only" not in result["instruction"]
+    assert "Execution is authorized" not in result["instruction"]
+
+
+def test_update_plan_normal_create_carries_only_the_base_instruction() -> None:
+    # A plain create (no plan_only, no Ask User answers on the turn) must not
+    # emit the plan-only or execution-authorized suffixes.
+    session = Session()
+    result = execute_update_plan_tool({"plan": _PLAN}, _ctx(session=session))
+
+    assert result["ok"] is True
+    assert "Plan stored." in result["instruction"]
+    assert "Plan-only" not in result["instruction"]
+    assert "Execution is authorized" not in result["instruction"]
+
+
+def test_update_plan_result_payload_is_a_reparseable_durable_record() -> None:
+    # The tool result doubles as the durable CURRENT PLAN record: it must parse
+    # back into an equivalent plan when older messages drop from context.
+    session = Session()
+    result = execute_update_plan_tool({"plan": _PLAN}, _ctx(session=session))
+
+    restored = task_plan_from_payload(result)
+    reparsed, error = parse_task_plan(result)
+    assert error is None
+    assert restored is not None and reparsed is not None
+    assert [step.step for step in restored.steps] == [item["step"] for item in _PLAN]
+    assert restored.current_index == reparsed.current_index == 2

--- a/tests/core/agent_harness/task_plan/test_display.py
+++ b/tests/core/agent_harness/task_plan/test_display.py
@@ -31,16 +31,41 @@ def test_is_plan_diagnosis_prose_ignores_short_explanation() -> None:
     assert is_plan_diagnosis_prose("Revised after deploy window narrowed.") is False
 
 
-def test_promote_first_pending_step() -> None:
-    plan, _error = parse_task_plan(
+def test_is_plan_diagnosis_prose_ignores_empty() -> None:
+    assert is_plan_diagnosis_prose("") is False
+    assert is_plan_diagnosis_prose("   ") is False
+
+
+def test_is_plan_diagnosis_prose_detects_facts_and_leading_hypothesis() -> None:
+    text = "Facts: p99 only.\nLeading hypothesis: a queue knee after deploy."
+    assert is_plan_diagnosis_prose(text) is True
+
+
+def test_promote_first_pending_step_is_noop_when_work_already_started() -> None:
+    plan, error = parse_task_plan(
         {
             "plan": [
-                {"step": "First", "status": "pending"},
+                {"step": "First", "status": "in_progress"},
                 {"step": "Verify", "status": "pending"},
             ]
         }
     )
-    assert plan is not None
+    assert error is None and plan is not None
+    assert promote_first_pending_step(plan) is plan
+
+
+def test_promote_first_pending_step_preserves_explanation() -> None:
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "First", "status": "pending"},
+                {"step": "Verify", "status": "pending"},
+            ],
+            "explanation": "### Facts\n- gradual",
+        }
+    )
+    assert error is None and plan is not None
     promoted = promote_first_pending_step(plan)
+    assert promoted.explanation == plan.explanation
+    assert "gradual" in promoted.explanation
     assert promoted.steps[0].status is PlanStepStatus.IN_PROGRESS
-    assert promoted.steps[1].status is PlanStepStatus.PENDING

--- a/tests/core/agent_harness/task_plan/test_persist.py
+++ b/tests/core/agent_harness/task_plan/test_persist.py
@@ -97,6 +97,49 @@ def test_apply_task_plan_state_restores_plan_only_latch() -> None:
     assert restored.task_plan.current_index == 2
 
 
+def test_apply_task_plan_state_restores_disarmed_latch() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    session.task_plan = _plan()
+    payload = task_plan_state_snapshot(session)
+    assert payload is not None
+    assert payload["plan_only_until_authorized"] is False
+
+    restored = SessionCore(store=InMemorySessionStore())
+    restored.plan_only_until_authorized = True
+    apply_task_plan_state(restored, payload)
+    assert restored.plan_only_until_authorized is False
+
+
+def test_should_not_persist_identical_snapshot() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    session.task_plan = _plan()
+    snapshot = task_plan_state_snapshot(session)
+    assert snapshot is not None
+    assert not should_persist_task_plan_state(
+        snapshot,
+        prior_records=[
+            {
+                "type": "custom_message",
+                "custom_type": TASK_PLAN_STATE_CUSTOM_TYPE,
+                "content": snapshot,
+            }
+        ],
+    )
+
+
+def test_should_not_tombstone_a_session_that_never_planned() -> None:
+    assert not should_persist_task_plan_state(None, prior_records=[])
+
+
+def test_apply_non_dict_payload_is_a_tombstone() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    session.task_plan = _plan()
+    session.plan_only_until_authorized = True
+    apply_task_plan_state(session, ["not", "a", "dict"])
+    assert session.task_plan is None
+    assert session.plan_only_until_authorized is False
+
+
 def test_legacy_snapshot_without_latch_key_does_not_arm_authorization() -> None:
     session = SessionCore(store=InMemorySessionStore())
     session.plan_only_until_authorized = True

--- a/tests/core/agent_harness/task_plan/test_plan.py
+++ b/tests/core/agent_harness/task_plan/test_plan.py
@@ -75,3 +75,113 @@ def test_parse_strips_terminal_controls_from_steps_and_explanation() -> None:
     assert "\x07" not in plan.steps[1].step
     assert "\x1b" not in plan.explanation
     assert "why" in plan.explanation
+
+
+# --- parse_task_plan: every remaining rejection branch ------------------------
+
+
+def test_parse_rejects_a_non_list_plan() -> None:
+    # Arrange / Act: the plan field is not a list of steps.
+    for bad in (None, "just do it", {"step": "x", "status": "pending"}):
+        plan, error = parse_task_plan({"plan": bad})
+        # Assert: rejected with the two-step message (the list guard).
+        assert plan is None
+        assert error is not None and "at least two" in error
+
+
+def test_parse_rejects_a_non_object_item() -> None:
+    plan, error = parse_task_plan({"plan": ["do a thing", {"step": "verify", "status": "pending"}]})
+    assert plan is None
+    assert "object with step and status" in (error or "")
+
+
+def test_parse_rejects_an_empty_step() -> None:
+    plan, error = parse_task_plan(
+        {"plan": [{"step": "   ", "status": "pending"}, {"step": "verify", "status": "pending"}]}
+    )
+    assert plan is None
+    assert "non-empty step" in (error or "")
+
+
+def test_parse_rejects_an_unknown_status() -> None:
+    plan, error = parse_task_plan(
+        {"plan": [{"step": "do it", "status": "done"}, {"step": "verify", "status": "pending"}]}
+    )
+    assert plan is None
+    assert "pending, in_progress, or completed" in (error or "")
+
+
+def test_parse_rejects_completing_the_verification_step_while_another_runs() -> None:
+    # The final step is completed while an earlier step is still in_progress —
+    # a distinct rule from "more than one in_progress".
+    plan, error = parse_task_plan({"plan": _items("in_progress", "completed")})
+    assert plan is None
+    assert "cannot complete the verification step" in (error or "")
+
+
+def test_parse_ignores_a_non_string_explanation() -> None:
+    plan, error = parse_task_plan({"plan": _items("pending", "pending"), "explanation": 123})
+    assert error is None and plan is not None
+    assert plan.explanation == ""
+
+
+# --- TaskPlan progress properties: every focus/count state -------------------
+
+
+def test_focused_step_prefers_the_in_progress_step() -> None:
+    plan, _ = parse_task_plan({"plan": _items("completed", "in_progress", "pending")})
+    assert plan is not None
+    assert plan.focused_step.status is PlanStepStatus.IN_PROGRESS
+    assert plan.current_index == 2
+
+
+def test_focused_step_falls_back_to_the_first_pending_step() -> None:
+    plan, _ = parse_task_plan({"plan": _items("completed", "pending", "pending")})
+    assert plan is not None
+    assert plan.focused_step.status is PlanStepStatus.PENDING
+    assert plan.current_index == 2
+
+
+def test_focused_step_is_the_last_verification_step_when_all_completed() -> None:
+    plan, _ = parse_task_plan({"plan": _items("completed", "completed", "completed")})
+    assert plan is not None
+    assert plan.all_completed
+    assert plan.focused_step is plan.steps[-1]
+    assert plan.current_index == plan.total == 3
+
+
+def test_all_pending_and_all_completed_counts_are_exclusive() -> None:
+    pending, _ = parse_task_plan({"plan": _items("pending", "pending")})
+    assert pending is not None
+    assert pending.all_pending and not pending.all_completed
+    assert pending.completed_count == 0
+
+    done, _ = parse_task_plan({"plan": _items("completed", "completed")})
+    assert done is not None
+    assert done.all_completed and not done.all_pending
+    assert done.completed_count == done.total == 2
+
+
+def test_parse_accepts_a_seven_step_plan() -> None:
+    items = [{"step": f"Step {index} outcome", "status": "pending"} for index in range(7)]
+    items[-1]["step"] = "Confirm the check passed"
+    plan, error = parse_task_plan({"plan": items})
+    assert error is None and plan is not None
+    assert plan.total == 7
+    assert plan.all_pending is True
+
+
+def test_payload_round_trip_drops_unknown_keys() -> None:
+    plan, error = parse_task_plan({"plan": _items("pending", "pending")})
+    assert error is None and plan is not None
+    payload = task_plan_to_payload(plan)
+    payload["plan_only_until_authorized"] = True
+    payload["extra"] = "ignored"
+    restored = task_plan_from_payload(payload)
+    assert restored == plan
+
+
+def test_from_payload_rejects_garbage() -> None:
+    assert task_plan_from_payload(None) is None
+    assert task_plan_from_payload([]) is None
+    assert task_plan_from_payload({"plan": [{"step": "only one", "status": "pending"}]}) is None

--- a/tests/core/agent_harness/task_plan/test_planning_journeys.py
+++ b/tests/core/agent_harness/task_plan/test_planning_journeys.py
@@ -1,0 +1,318 @@
+"""Cross-seam journeys for the live task plan (update_plan + plan-only latch).
+
+These pin the planning feature as a user-facing capability: the checklist is
+the durable record, a failed or cancelled update does not commit, resume keeps
+the confirmation boundary, and the prompt/gate honor that latch.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness.session import InMemorySessionStore, SessionCore, SessionManager
+from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
+from core.agent_harness.task_plan.persist import (
+    TASK_PLAN_STATE_CUSTOM_TYPE,
+    apply_task_plan_state,
+    should_persist_task_plan_state,
+    task_plan_state_snapshot,
+)
+from core.agent_harness.task_plan.plan import PlanStepStatus, parse_task_plan
+from core.agent_harness.task_plan.prompt import current_task_plan_block
+from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session
+from core.agent_harness.tools.tool_context import (
+    ACTION_TOOL_CONTEXT_RESOURCE_KEY,
+    ActionToolScope,
+)
+from core.tool.contracts import AgentToolContext
+from surfaces.interactive_shell.session import Session
+from surfaces.interactive_shell.ui.action_rendering import ActionRenderObserver
+from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
+from tools.interactive_shell.action_names import ActionToolName
+from tools.interactive_shell.actions.update_plan import (
+    execute_update_plan_tool,
+    run_update_plan,
+    update_plan_tool,
+)
+from tools.interactive_shell.shared import allow_tool
+
+
+def _console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+
+def _scope(
+    session: Session,
+    *,
+    turn_user_message: str = "",
+    console: Any = None,
+) -> ActionToolScope:
+    return ActionToolScope(
+        session=session,
+        console=console if console is not None else _console(),
+        turn_user_message=turn_user_message,
+    )
+
+
+def _agent_context(scope: ActionToolScope) -> AgentToolContext:
+    return AgentToolContext(
+        resolved_integrations={},
+        resources={ACTION_TOOL_CONTEXT_RESOURCE_KEY: scope},
+    )
+
+
+def _pending_plan(*, explanation: str = "") -> list[dict[str, str]]:
+    return [
+        {"step": "Capture checkout 502 samples", "status": "pending"},
+        {"step": "Confirm checkout returns 2xx", "status": "pending"},
+    ]
+
+
+def _ask_user_turn_text() -> str:
+    return format_ask_user_answers(
+        (
+            AskUserQuestion(label="Onset", title="When did it start?", options=("Gradual",)),
+            AskUserQuestion(label="Signal", title="Strongest signal?", options=("CPU",)),
+        ),
+        ("Gradual", "CPU"),
+    )
+
+
+class _CancelConsole:
+    cancel_requested = True
+
+    def print(self, *_args: object, **_kwargs: object) -> None:
+        return
+
+
+def test_plan_only_survives_flush_restore_and_still_gates_mutating_tools() -> None:
+    storage = InMemorySessionStore()
+    live = Session(store=storage)
+    storage.open_session(live)
+    storage.append_turn(live, "chat", "start")
+    result = execute_update_plan_tool(
+        {"plan": _pending_plan(), "plan_only": True, "explanation": "do not run yet"},
+        _scope(live),
+    )
+    assert result["ok"] is True
+    assert live.plan_only_until_authorized is True
+    assert live.task_plan is not None
+    assert live.task_plan.all_pending is True
+
+    storage.flush(live)
+    records = storage.read(live.session_id)
+    content = next(
+        rec["content"] for rec in records if rec.get("custom_type") == TASK_PLAN_STATE_CUSTOM_TYPE
+    )
+
+    restored = Session()
+    SessionManager(store=InMemorySessionStore()).restore_context(
+        restored,
+        {
+            "cli_agent_messages": [],
+            "accumulated_context": {},
+            "task_plan_state": content,
+            "history": [],
+        },
+    )
+    assert restored.task_plan is not None
+    assert restored.task_plan.all_pending is True
+    assert restored.plan_only_until_authorized is True
+    assert "Execution is authorized" not in current_task_plan_block(
+        restored.task_plan, plan_only=True
+    )
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    assert not execution_allowed(
+        allow_tool("shell"),
+        session=restored,
+        console=console,
+        action_summary="!deploy",
+        confirm_fn=lambda _: "n",
+        is_tty=True,
+    )
+    assert restored.plan_only_until_authorized is True
+    assert "Command to approve" in buf.getvalue()
+
+
+def test_failed_update_plan_does_not_replace_or_persist_an_existing_plan() -> None:
+    session = Session()
+    first = execute_update_plan_tool({"plan": _pending_plan(), "plan_only": True}, _scope(session))
+    assert first["ok"] is True
+    before = task_plan_state_snapshot(session)
+    assert before is not None
+    assert before["plan_only_until_authorized"] is True
+
+    failed = execute_update_plan_tool(
+        {
+            "plan": [
+                {"step": "First", "status": "in_progress"},
+                {"step": "Second", "status": "in_progress"},
+            ],
+            "plan_only": False,
+        },
+        _scope(session),
+    )
+    assert failed["ok"] is False
+    assert session.task_plan is not None
+    assert session.task_plan.all_pending is True
+    assert session.plan_only_until_authorized is True
+    after = task_plan_state_snapshot(session)
+    assert after == before
+
+
+def test_cancelled_update_plan_wrapper_does_not_commit_session_state() -> None:
+    session = Session()
+    scope = _scope(session, console=_CancelConsole())
+    result = run_update_plan(
+        plan=_pending_plan(),
+        plan_only=True,
+        context=_agent_context(scope),
+    )
+    assert result["ok"] is False
+    assert result["cancelled"] is True
+    assert session.task_plan is None
+    assert session.plan_only_until_authorized is False
+    assert task_plan_state_snapshot(session) is None
+
+
+def test_ask_user_answers_without_latch_authorize_execution_and_prompt() -> None:
+    session = Session()
+    result = execute_update_plan_tool(
+        {"plan": _pending_plan(), "plan_only": True, "explanation": "### Facts\n- gradual"},
+        _scope(session, turn_user_message=_ask_user_turn_text()),
+    )
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is False
+    assert session.task_plan is not None
+    assert session.task_plan.steps[0].status is PlanStepStatus.IN_PROGRESS
+    assert "Execution is authorized" in result["instruction"]
+    block = current_task_plan_block(session.task_plan, plan_only=False)
+    assert "in progress" in block
+    assert "Do not conclude this turn while a step is in_progress" in block
+
+
+def test_ask_user_answers_with_latch_stay_plan_only_through_prompt_and_persist() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    result = execute_update_plan_tool(
+        {"plan": _pending_plan(), "plan_only": False},
+        _scope(session, turn_user_message=_ask_user_turn_text()),
+    )
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is True
+    assert session.task_plan is not None
+    assert session.task_plan.all_pending is True
+    assert "Plan-only" in result["instruction"]
+    block = current_task_plan_block(session.task_plan, plan_only=True)
+    assert "Execution is authorized" not in block
+    snapshot = task_plan_state_snapshot(session)
+    assert snapshot is not None and snapshot["plan_only_until_authorized"] is True
+
+
+def test_observer_does_not_commit_before_tool_success_so_flush_stays_empty() -> None:
+    session = Session()
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=100)
+    observer = ActionRenderObserver(session=session, console=console, message="plan the fix")
+    observer(
+        "tool_start",
+        {
+            "id": "p1",
+            "name": ActionToolName.UPDATE_PLAN,
+            "input": {"plan": _pending_plan(), "plan_only": True},
+        },
+    )
+    assert session.task_plan is None
+    assert task_plan_state_snapshot(session) is None
+    observer(
+        "tool_end",
+        {"id": "p1", "name": ActionToolName.UPDATE_PLAN, "output": {"ok": False, "error": "nope"}},
+    )
+    assert session.task_plan is None
+    assert not should_persist_task_plan_state(None, prior_records=[])
+
+
+def test_successful_tool_then_observer_paints_without_double_commit() -> None:
+    session = Session()
+    result = execute_update_plan_tool(
+        {"plan": _pending_plan(), "plan_only": True, "explanation": "### Facts\n- p99 up"},
+        _scope(session),
+    )
+    assert result["ok"] is True
+    first_snapshot = task_plan_state_snapshot(session)
+
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=100)
+    observer = ActionRenderObserver(session=session, console=console, message="plan the fix")
+    observer("tool_end", {"id": "p1", "name": ActionToolName.UPDATE_PLAN, "output": {"ok": True}})
+    assert "Plan ready" in buffer.getvalue()
+    assert "p99 up" in buffer.getvalue()
+    assert task_plan_state_snapshot(session) == first_snapshot
+
+
+def test_identical_plan_snapshot_is_not_flushed_twice() -> None:
+    storage = InMemorySessionStore()
+    session = SessionCore(store=storage)
+    storage.open_session(session)
+    storage.append_turn(session, "chat", "start")
+    plan, error = parse_task_plan({"plan": _pending_plan()})
+    assert error is None and plan is not None
+    apply_update_plan_session(session, plan, plan_only=True)
+    storage.flush(session)
+    first = [
+        rec
+        for rec in storage.read(session.session_id)
+        if rec.get("custom_type") == TASK_PLAN_STATE_CUSTOM_TYPE
+    ]
+    storage.flush(session)
+    second = [
+        rec
+        for rec in storage.read(session.session_id)
+        if rec.get("custom_type") == TASK_PLAN_STATE_CUSTOM_TYPE
+    ]
+    assert len(second) == len(first)
+
+
+def test_session_clear_drops_the_checklist_and_the_latch() -> None:
+    session = SessionCore(store=InMemorySessionStore())
+    plan, error = parse_task_plan({"plan": _pending_plan()})
+    assert error is None and plan is not None
+    apply_update_plan_session(session, plan, plan_only=True)
+    session.clear()
+    assert session.task_plan is None
+    assert session.plan_only_until_authorized is False
+    assert task_plan_state_snapshot(session) is None
+
+
+def test_revision_keeps_the_latch_and_updates_the_durable_record() -> None:
+    session = Session()
+    execute_update_plan_tool({"plan": _pending_plan(), "plan_only": True}, _scope(session))
+    revised: list[dict[str, Any]] = [
+        {"step": "Inspect the failing Actions job", "status": "pending"},
+        {"step": "Patch the workflow from the error", "status": "pending"},
+        {"step": "Confirm the workflow run is green", "status": "pending"},
+    ]
+    result = execute_update_plan_tool(
+        {"plan": revised, "plan_only": False, "explanation": "split the verify step"},
+        _scope(session),
+    )
+    assert result["ok"] is True
+    assert session.plan_only_until_authorized is True
+    assert session.task_plan is not None
+    assert session.task_plan.total == 3
+    assert session.task_plan.explanation == "split the verify step"
+    snapshot = task_plan_state_snapshot(session)
+    restored = Session()
+    apply_task_plan_state(restored, snapshot)
+    assert restored.plan_only_until_authorized is True
+    assert restored.task_plan is not None
+    assert restored.task_plan.total == 3
+
+
+def test_update_plan_tool_is_the_registered_action_name() -> None:
+    assert update_plan_tool.name == ActionToolName.UPDATE_PLAN

--- a/tests/core/agent_harness/task_plan/test_prompt.py
+++ b/tests/core/agent_harness/task_plan/test_prompt.py
@@ -171,3 +171,64 @@ def test_ask_user_answered_plan_only_guidance_does_not_authorize_execute() -> No
     assert ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE in block.content
     assert "do not pass plan_only=false" in block.content.lower()
     assert "in_progress and execute it now" not in block.content.lower()
+
+
+def test_current_task_plan_block_is_empty_without_steps() -> None:
+    from core.agent_harness.task_plan.prompt import current_task_plan_block
+
+    assert current_task_plan_block(None) == ""
+    empty, error = parse_task_plan({"plan": [{"step": "x", "status": "pending"}]})
+    assert error is not None
+    assert current_task_plan_block(empty) == ""
+
+
+def test_current_task_plan_block_plan_only_does_not_authorize_execution() -> None:
+    from core.agent_harness.task_plan.prompt import current_task_plan_block
+
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Inspect the failing job", "status": "pending"},
+                {"step": "Confirm the workflow is green", "status": "pending"},
+            ],
+            "explanation": "do not run yet",
+        }
+    )
+    assert error is None and plan is not None
+    block = current_task_plan_block(plan, plan_only=True)
+    assert "CURRENT PLAN (ready, nothing executed" in block
+    assert "explanation: do not run yet" in block
+    assert "Execution is authorized" not in block
+
+
+def test_current_task_plan_block_all_pending_without_latch_authorizes() -> None:
+    from core.agent_harness.task_plan.prompt import current_task_plan_block
+
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Inspect the failing job", "status": "pending"},
+                {"step": "Confirm the workflow is green", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    block = current_task_plan_block(plan, plan_only=False)
+    assert "Execution is authorized" in block
+
+
+def test_current_task_plan_block_completed_status() -> None:
+    from core.agent_harness.task_plan.prompt import current_task_plan_block
+
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Inspect the failing job", "status": "completed"},
+                {"step": "Confirm the workflow is green", "status": "completed"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    block = current_task_plan_block(plan)
+    assert "CURRENT PLAN (complete" in block
+    assert "in_progress" not in block

--- a/tests/core/agent_harness/task_plan/test_update_plan_policy.py
+++ b/tests/core/agent_harness/task_plan/test_update_plan_policy.py
@@ -108,3 +108,29 @@ def test_update_plan_tool_end_to_end_after_ask_user() -> None:
     assert session.plan_only_until_authorized is False
     assert session.task_plan is not None
     assert session.task_plan.steps[0].status is PlanStepStatus.IN_PROGRESS
+
+
+def test_normal_turn_honors_requested_plan_only() -> None:
+    session = Session()
+    plan, _error = parse_task_plan({"plan": _PLAN})
+    assert plan is not None
+    normalized, plan_only = apply_update_plan_host_policy(
+        plan,
+        plan_only_requested=True,
+        turn_user_message="plan this, do not run yet",
+        session=session,
+    )
+    assert plan_only is True
+    assert normalized.all_pending is True
+
+
+def test_apply_update_plan_session_is_set_only_for_the_latch() -> None:
+    from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session
+
+    session = Session()
+    session.plan_only_until_authorized = True
+    plan, _error = parse_task_plan({"plan": _PLAN})
+    assert plan is not None
+    apply_update_plan_session(session, plan, plan_only=False)
+    assert session.task_plan is plan
+    assert session.plan_only_until_authorized is True

--- a/tests/interactive_shell/tools/shared/test_execution_policy.py
+++ b/tests/interactive_shell/tools/shared/test_execution_policy.py
@@ -23,6 +23,7 @@ from tools.interactive_shell.shared import (
     ToolExecutionPlan,
     allow_tool,
     apply_auto_level,
+    apply_plan_only_gate,
     plan_foreground_tool,
     resolve_confirmation,
 )
@@ -158,3 +159,25 @@ def test_auto_med_allows_sample_alert() -> None:
 def test_auto_off_asks_every_tool_type() -> None:
     result = apply_auto_level(allow_tool("slash"), AutoLevel.OFF)
     assert result.verdict == "ask"
+
+
+# --- plan-only execution gate (pure decision) --------------------------------
+
+
+def test_plan_only_gate_asks_before_every_mutating_tool_even_at_high() -> None:
+    # A standing plan-only request gates mutating tools regardless of /auto.
+    for mutating in ("shell", "code_agent", "slash", "synthetic_test", "sentry_issue_fix"):
+        result = apply_plan_only_gate(allow_tool(mutating), plan_only_active=True)
+        assert result.verdict == "ask", mutating
+    # Read-only tool types still run — plan-only gates mutation, not evidence.
+    read_only = apply_plan_only_gate(allow_tool("investigation"), plan_only_active=True)
+    assert read_only.verdict == "allow"
+
+
+def test_plan_only_gate_is_a_noop_when_not_active() -> None:
+    assert apply_plan_only_gate(allow_tool("shell"), plan_only_active=False).verdict == "allow"
+
+
+def test_plan_only_gate_leaves_a_non_allow_verdict_untouched() -> None:
+    denied = ExecutionPolicyResult(verdict="deny", tool_type="shell", reason="empty")
+    assert apply_plan_only_gate(denied, plan_only_active=True).verdict == "deny"

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -615,3 +615,17 @@ def test_in_progress_explanation_only_update_renders_markdown() -> None:
     apply_update_plan_session(observer.session, second, plan_only=False)
     observer("tool_end", {"id": "p2", "name": "update_plan", "output": {"ok": True}})
     assert "revised diagnosis" in buffer.getvalue()
+
+
+def test_unchanged_plan_signature_does_not_reprint() -> None:
+    from core.agent_harness.task_plan.plan import parse_task_plan
+    from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session
+
+    observer, buffer = _observer_with_buffer("plan the fix")
+    plan, error = parse_task_plan({"plan": _UPDATE_PLAN, "explanation": "same diagnosis"})
+    assert error is None and plan is not None
+    apply_update_plan_session(observer.session, plan, plan_only=True)
+    observer("tool_end", {"id": "p1", "name": "update_plan", "output": {"ok": True}})
+    first = buffer.getvalue()
+    observer("tool_end", {"id": "p2", "name": "update_plan", "output": {"ok": True}})
+    assert buffer.getvalue() == first

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -617,6 +617,28 @@ def test_in_progress_explanation_only_update_renders_markdown() -> None:
     assert "revised diagnosis" in buffer.getvalue()
 
 
+def test_multiline_explanation_keeps_its_line_breaks_when_rendered() -> None:
+    # Arrange: a multi-line markdown explanation (a Facts heading + a bullet).
+    from core.agent_harness.task_plan.plan import parse_task_plan
+    from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session
+
+    observer, buffer = _observer_with_buffer("keep going")
+    plan, error = parse_task_plan(
+        {"plan": _IN_PROGRESS_PLAN, "explanation": "### Facts\n- gradual onset"}
+    )
+    assert error is None and plan is not None
+
+    # Act: render the plan update through the observer.
+    apply_update_plan_session(observer.session, plan, plan_only=False)
+    observer("tool_end", {"id": "p1", "name": "update_plan", "output": {"ok": True}})
+
+    # Assert: both lines survive and are not flattened onto one line.
+    output = buffer.getvalue()
+    assert "Facts" in output
+    assert "gradual onset" in output
+    assert "Facts- gradual onset" not in output
+
+
 def test_unchanged_plan_signature_does_not_reprint() -> None:
     from core.agent_harness.task_plan.plan import parse_task_plan
     from core.agent_harness.task_plan.update_plan_policy import apply_update_plan_session

--- a/tests/interactive_shell/ui/test_execution_confirm.py
+++ b/tests/interactive_shell/ui/test_execution_confirm.py
@@ -246,3 +246,61 @@ def test_auto_off_shows_command_to_approve() -> None:
     )
     assert "Command to approve" in buf.getvalue()
     assert "Why this needs approval:" in buf.getvalue()
+
+
+# --- plan-only execution gate (integration + latch clearing) -----------------
+
+
+def test_plan_only_guard_prompts_then_clears_on_a_confirmed_mutating_step() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    # A mutating step under a standing plan-only request must prompt...
+    assert execution_allowed(
+        allow_tool("shell"),
+        session=session,
+        console=console,
+        action_summary="!deploy",
+        confirm_fn=lambda _: "y",
+        is_tty=True,
+    )
+    assert "Command to approve" in buf.getvalue()
+    # ...and confirming it is the explicit authorization that lifts the guard.
+    assert session.plan_only_until_authorized is False
+
+
+def test_plan_only_guard_survives_a_declined_confirmation() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    assert not execution_allowed(
+        allow_tool("shell"),
+        session=session,
+        console=console,
+        action_summary="!deploy",
+        confirm_fn=lambda _: "n",
+        is_tty=True,
+    )
+    # Declining does not authorize; the guard still stands for the next step.
+    assert session.plan_only_until_authorized is True
+
+
+def test_plan_only_guard_is_not_cleared_by_a_read_only_step() -> None:
+    session = Session()
+    session.plan_only_until_authorized = True
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    # A read-only tool runs without a prompt and must NOT lift the plan-only latch.
+    assert execution_allowed(
+        allow_tool("investigation"),
+        session=session,
+        console=console,
+        action_summary="investigate the 502s",
+        is_tty=True,
+    )
+    assert session.plan_only_until_authorized is True


### PR DESCRIPTION
## What

Broadens test coverage across the whole planning feature (plan model, the update_plan tool, the plan-only execution gate, persistence, and rendering) and fixes one product bug the new tests surfaced.

## Product fix

`parse_task_plan` was running `strip_terminal_controls` on the plan `explanation` without `keep_whitespace=True`, so it stripped newlines from the multi-line markdown diagnosis — `### Facts\n- gradual` became `### Facts- gradual`, collapsing the Facts / hypothesis table onto one line. Steps stay single-line, so their sanitization is unchanged; only the explanation now preserves whitespace. Same class of bug already fixed for the markdown streaming block.