### PR TITLE
fix(packaging): bundle task planning instructions

### DIFF
--- a/core/agent_harness/spi/task_plan.py
+++ b/core/agent_harness/spi/task_plan.py
@@ -22,6 +22,7 @@ from core.agent_harness.task_plan.progress import (
     format_plan_header,
     format_task_plan_plain,
 )
+from core.agent_harness.task_plan.prompt import load_planning_instructions
 from core.agent_harness.task_plan.update_plan_policy import (
     apply_update_plan_host_policy,
     apply_update_plan_session,
@@ -37,6 +38,7 @@ __all__ = [
     "format_plan_header",
     "format_task_plan_plain",
     "is_plan_diagnosis_prose",
+    "load_planning_instructions",
     "parse_task_plan",
     "promote_first_pending_step",
     "task_plan_to_payload",

--- a/infrastructure/deployment/packaging/release_manifest.py
+++ b/infrastructure/deployment/packaging/release_manifest.py
@@ -11,10 +11,12 @@ _RUNTIME_PACKAGE_NAMES = (
 )
 _ACTION_SKILLS_DIR = Path("core/agent_harness/prompts/skills")
 _SKILL_DATA_ROOTS = (Path("integrations"), Path("tools"))
-#: Data files a tool reads at runtime that are not skill documents. Without an
-#: entry here a file is absent from both the wheel and the frozen binary, and
-#: the tool that reads it degrades silently rather than failing to import.
-_RUNTIME_DATA_FILES = (Path("integrations/yandex_cloud/api_index.json"),)
+#: Data files read at runtime that are not skill documents. Without an entry
+#: here a file can be absent from both the wheel and the frozen binary.
+_RUNTIME_DATA_FILES = (
+    Path("core/agent_harness/task_plan/planning_instructions.md"),
+    Path("integrations/yandex_cloud/api_index.json"),
+)
 _RUNTIME_DISCOVERY_EXCLUSIONS = frozenset({"registry.py"})
 #: Non-Python trees under ``infrastructure/`` that never run from the frozen
 #: binary (e.g. a Cloudflare Worker deployed separately via ``wrangler``).

--- a/opensre.spec
+++ b/opensre.spec
@@ -24,10 +24,6 @@ datas += collect_data_files(
     "core.agent_harness.prompts",
     includes=["opensre_system_prompt.md"],
 )
-datas += collect_data_files(
-    "core.agent_harness.task_plan",
-    includes=["planning_instructions.md"],
-)
 datas += collect_data_files("surfaces.cli")
 datas += collect_data_files("surfaces.shared")
 datas += collect_data_files("config")

--- a/opensre.spec
+++ b/opensre.spec
@@ -24,6 +24,10 @@ datas += collect_data_files(
     "core.agent_harness.prompts",
     includes=["opensre_system_prompt.md"],
 )
+datas += collect_data_files(
+    "core.agent_harness.task_plan",
+    includes=["planning_instructions.md"],
+)
 datas += collect_data_files("surfaces.cli")
 datas += collect_data_files("surfaces.shared")
 datas += collect_data_files("config")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ include = [
 [tool.setuptools.package-data]
 "surfaces.shared" = ["sample_alerts/*.json"]
 "core.agent_harness.prompts" = ["opensre_system_prompt.md", "skills/**/*.md"]
+"core.agent_harness.task_plan" = ["planning_instructions.md"]
 "integrations" = ["**/SKILL.md", "yandex_cloud/api_index.json"]
 "tools" = ["**/SKILL.md"]
 

--- a/surfaces/cli/commands/package_smoke.py
+++ b/surfaces/cli/commands/package_smoke.py
@@ -29,12 +29,14 @@ _REQUIRED_ACTION_SKILL_NAMES = frozenset(
 _REQUIRED_INTEGRATION_VERIFIER_NAMES = frozenset({"datadog", "grafana", "x_mcp"})
 _GUIDED_TOOL_NAMES = frozenset({"execute_python_code", "generate_work_status_report"})
 _ACTION_SKILL_BODY_MARKERS = {"architecture-audit": "REPORT TEMPLATE from"}
+_PLANNING_INSTRUCTIONS_MARKER = "PLANNING — update_plan"
 
 
 @click.command(name="_package-smoke", hidden=True)
 def package_smoke_command() -> None:
     """Fail unless essential dynamically bundled code and data are available."""
     from core.agent_harness.spi.grounding import list_action_skills, load_skill_body
+    from core.agent_harness.task_plan.prompt import load_planning_instructions
     from integrations._verifiers_loader import register_all_verifiers
     from integrations.verification import list_verifiers
     from tools.registry import get_registered_tool_map
@@ -44,6 +46,7 @@ def package_smoke_command() -> None:
     tool_names = set(tool_map)
     action_skill_names = {skill.name for skill in list_action_skills()}
     integration_verifier_names = set(list_verifiers())
+    planning_instructions = load_planning_instructions()
 
     missing_tools = sorted(_REQUIRED_TOOL_NAMES - tool_names)
     missing_action_skills = sorted(_REQUIRED_ACTION_SKILL_NAMES - action_skill_names)
@@ -65,6 +68,9 @@ def package_smoke_command() -> None:
         "missing_action_skills": missing_action_skills,
         "missing_action_skill_data": missing_action_skill_data,
         "missing_integration_verifiers": missing_integration_verifiers,
+        "missing_planning_instructions": (
+            [] if _PLANNING_INSTRUCTIONS_MARKER in planning_instructions else ["marker"]
+        ),
         "missing_tool_guidance": missing_guidance,
     }
     if any(failures.values()):
@@ -75,6 +81,7 @@ def package_smoke_command() -> None:
             {
                 "action_skills": len(action_skill_names),
                 "integration_verifiers": len(integration_verifier_names),
+                "planning_instructions": "ok",
                 "registered_tools": len(tool_names),
                 "status": "ok",
             },

--- a/surfaces/cli/commands/package_smoke.py
+++ b/surfaces/cli/commands/package_smoke.py
@@ -36,7 +36,7 @@ _PLANNING_INSTRUCTIONS_MARKER = "PLANNING — update_plan"
 def package_smoke_command() -> None:
     """Fail unless essential dynamically bundled code and data are available."""
     from core.agent_harness.spi.grounding import list_action_skills, load_skill_body
-    from core.agent_harness.task_plan.prompt import load_planning_instructions
+    from core.agent_harness.spi.task_plan import load_planning_instructions
     from integrations._verifiers_loader import register_all_verifiers
     from integrations.verification import list_verifiers
     from tools.registry import get_registered_tool_map

--- a/tests/cli/test_package_smoke.py
+++ b/tests/cli/test_package_smoke.py
@@ -18,6 +18,7 @@ def test_package_smoke_finds_essential_tools_and_skills() -> None:
     assert payload["registered_tools"] >= 250
     assert payload["action_skills"] >= 5
     assert payload["integration_verifiers"] >= 60
+    assert payload["planning_instructions"] == "ok"
 
 
 def test_package_smoke_command_is_hidden_from_help() -> None:

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -168,6 +168,7 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
             "format_plan_header",
             "format_task_plan_plain",
             "is_plan_diagnosis_prose",
+            "load_planning_instructions",
             "parse_task_plan",
             "promote_first_pending_step",
             "task_plan_to_payload",

--- a/tests/packaging/test_frozen_entrypoint.py
+++ b/tests/packaging/test_frozen_entrypoint.py
@@ -73,9 +73,6 @@ def test_release_artifacts_ship_the_planning_instructions() -> None:
     """The task-plan prompt loader reads its adjacent Markdown at runtime."""
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     package_data = pyproject["tool"]["setuptools"]["package-data"]
-    spec = (REPO_ROOT / "opensre.spec").read_text(encoding="utf-8")
 
     assert package_data["core.agent_harness.task_plan"] == ["planning_instructions.md"]
-    assert '"core.agent_harness.task_plan"' in spec
-    assert 'includes=["planning_instructions.md"]' in spec
     assert (REPO_ROOT / "core/agent_harness/task_plan/planning_instructions.md").is_file()

--- a/tests/packaging/test_frozen_entrypoint.py
+++ b/tests/packaging/test_frozen_entrypoint.py
@@ -67,3 +67,15 @@ def test_frozen_bundle_ships_the_shared_system_prompt() -> None:
     assert '"core.agent_harness.prompts"' in spec
     assert 'includes=["opensre_system_prompt.md"]' in spec
     assert (REPO_ROOT / "core/agent_harness/prompts/opensre_system_prompt.md").is_file()
+
+
+def test_release_artifacts_ship_the_planning_instructions() -> None:
+    """The task-plan prompt loader reads its adjacent Markdown at runtime."""
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    package_data = pyproject["tool"]["setuptools"]["package-data"]
+    spec = (REPO_ROOT / "opensre.spec").read_text(encoding="utf-8")
+
+    assert package_data["core.agent_harness.task_plan"] == ["planning_instructions.md"]
+    assert '"core.agent_harness.task_plan"' in spec
+    assert 'includes=["planning_instructions.md"]' in spec
+    assert (REPO_ROOT / "core/agent_harness/task_plan/planning_instructions.md").is_file()

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -60,9 +60,10 @@ def test_required_skill_data_covers_action_and_tool_guidance() -> None:
     )
 
 
-def test_required_data_covers_tool_data_files_that_are_not_documents() -> None:
-    """A tool reading a data file degrades silently when it is left out of the build.
+def test_required_data_covers_runtime_files_that_are_not_skill_documents() -> None:
+    """Runtime file loading breaks or degrades when data is left out of the build.
 
+    The task-plan loader requires adjacent Markdown or fails the turn outright.
     ``find_yc_api`` reads its endpoint index from a JSON file rather than a
     document, so the ``SKILL.md`` globs above do not reach it. Left out, the
     tool reports no endpoints at all instead of failing to import, which reads
@@ -72,6 +73,7 @@ def test_required_data_covers_tool_data_files_that_are_not_documents() -> None:
         path.relative_to(_REPO_ROOT).as_posix() for path in required_skill_files(_REPO_ROOT)
     }
 
+    assert "core/agent_harness/task_plan/planning_instructions.md" in relative_paths
     assert "integrations/yandex_cloud/api_index.json" in relative_paths
 
 


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

- Bundle `planning_instructions.md` in PyInstaller releases.
- Include the same runtime resource in Python wheels.
- Add regression coverage for both packaging declarations.

This is a hotfix for the planning failure introduced by #5807, where the frozen application loaded an adjacent Markdown file that was absent from the release artifact.

### Demo/Screenshot for feature changes and bug fixes -

- `uv run pytest -q tests/packaging` — 34 passed.
- Built the wheel and verified `core/agent_harness/task_plan/planning_instructions.md` is present.
- Built `opensre.spec` and verified `_internal/core/agent_harness/task_plan/planning_instructions.md` is present in the frozen bundle.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The task-plan prompt loader resolves `planning_instructions.md` beside its Python module at runtime. The fix declares that file as package data for wheels and explicitly collects it in the PyInstaller spec, matching the existing shared-system-prompt packaging pattern. A packaging regression test locks both declarations so source-only tests cannot miss this artifact failure again.

---

## Checklist before requesting a review
- [x] I have added proper PR title
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Made with [Cursor](https://cursor.com)