### PR TITLE
feat(hermes): add evidence mappers for Hermes tools

### DIFF
--- a/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
@@ -7,6 +7,14 @@ from typing import Any, cast
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
+from integrations.hermes.tools.hermes_session_evidence_tool._evidence import (
+    map_get_hermes_adapter_catalog,
+    map_get_hermes_approval_events,
+    map_get_hermes_audit_trail,
+    map_get_hermes_config,
+    map_get_hermes_credential_state,
+    map_get_hermes_cron_state,
+)
 
 
 def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -87,6 +95,7 @@ def get_hermes_provider_traffic(
 @tool(
     name="get_hermes_adapter_catalog",
     source="hermes",
+    evidence_mapper=map_get_hermes_adapter_catalog,
     description="Get Hermes adapter catalog and registered surface families.",
     use_cases=[
         "Identify messaging adapters, LLM providers, execution backends, and unknown adapter attribution"
@@ -114,6 +123,7 @@ def get_hermes_adapter_catalog(
 @tool(
     name="get_hermes_config",
     source="hermes",
+    evidence_mapper=map_get_hermes_config,
     description="Get resolved Hermes provider, model, region, and transport configuration.",
     use_cases=[
         "Diagnose provider selection, Bedrock IMDS overrides, transport limits, and adapter config mismatches"
@@ -216,6 +226,7 @@ def get_hermes_runtime_state(
 @tool(
     name="get_hermes_cron_state",
     source="hermes",
+    evidence_mapper=map_get_hermes_cron_state,
     description="Get Hermes cron execution and delivery timing state.",
     use_cases=["Differentiate agent completion from downstream delivery hangs"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -366,6 +377,7 @@ def get_hermes_filesystem_state(
 @tool(
     name="get_hermes_audit_trail",
     source="hermes",
+    evidence_mapper=map_get_hermes_audit_trail,
     description="Get Hermes audit policy and observed audit-chain/signature state.",
     use_cases=["Diagnose missing cryptographic audit trails and broken hash chains"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -391,6 +403,7 @@ def get_hermes_audit_trail(
 @tool(
     name="get_hermes_approval_events",
     source="hermes",
+    evidence_mapper=map_get_hermes_approval_events,
     description="Get Hermes approval prompts and destructive-command approval outcomes.",
     use_cases=["Diagnose destructive commands that ran without explicit approval"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -441,6 +454,7 @@ def get_hermes_rbac_state(
 @tool(
     name="get_hermes_credential_state",
     source="hermes",
+    evidence_mapper=map_get_hermes_credential_state,
     description="Get Hermes credential isolation mode and outbound credential usage.",
     use_cases=["Diagnose in-process credential exposure and missing credential proxy isolation"],
     surfaces=(ToolSurface.INVESTIGATION,),

--- a/integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py
+++ b/integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py
@@ -1,0 +1,94 @@
+"""Evidence mappers for Hermes session-evidence investigation tools."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from core.domain.types.evidence import EvidenceMapper, record_evidence_entry
+
+_Summarize = Callable[[dict[str, Any]], str | None]
+
+
+def _mapper(source: str, label: str, summarize: _Summarize) -> EvidenceMapper:
+    def map_output(
+        evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+    ) -> None:
+        if not output.get("available"):
+            return
+        summary = summarize(output)
+        if summary:
+            record_evidence_entry(evidence, source=source, label=label, summary=summary)
+
+    map_output.__name__ = f"map_{source}"
+    return map_output
+
+
+def _count(output: dict[str, Any], key: str) -> int:
+    rows = output.get(key) or []
+    return len(rows) if isinstance(rows, list) else 0
+
+
+def _catalog(output: dict[str, Any]) -> str | None:
+    counts = (
+        _count(output, "messaging_adapters"),
+        _count(output, "llm_providers"),
+        _count(output, "execution_backends"),
+    )
+    if not any(counts):
+        return None
+    return (
+        f"{counts[0]} messaging adapter(s), "
+        f"{counts[1]} LLM provider(s), "
+        f"{counts[2]} execution backend(s)"
+    )
+
+
+def _config(output: dict[str, Any]) -> str | None:
+    parts = [str(output.get(key) or "") for key in ("provider", "model", "region")]
+    n_providers = _count(output, "providers")
+    if n_providers:
+        parts.append(f"{n_providers} provider(s)")
+    return ", ".join(part for part in parts if part) or None
+
+
+def _cron(output: dict[str, Any]) -> str | None:
+    last_run = output.get("last_run")
+    status = last_run.get("delivery_status") if isinstance(last_run, dict) else None
+    parts = []
+    if schedule := str(output.get("schedule_cron") or ""):
+        parts.append(f"schedule {schedule}")
+    if status:
+        parts.append(f"last delivery {status}")
+    return ", ".join(parts) or None
+
+
+def _events(output: dict[str, Any]) -> str | None:
+    n_events = _count(output, "events")
+    return f"{n_events} event(s)" if n_events else None
+
+
+def _credentials(output: dict[str, Any]) -> str | None:
+    parts = []
+    if mode := str(output.get("mode") or ""):
+        parts.append(f"{mode} mode")
+    in_memory = output.get("in_memory_credential_count")
+    if isinstance(in_memory, int):
+        parts.append(f"{in_memory} in-memory credential(s)")
+    if n_outbound := _count(output, "outbound_calls"):
+        parts.append(f"{n_outbound} outbound call(s)")
+    return ", ".join(parts) or None
+
+
+map_get_hermes_adapter_catalog = _mapper(
+    "get_hermes_adapter_catalog", "Hermes Adapter Catalog", _catalog
+)
+map_get_hermes_config = _mapper("get_hermes_config", "Hermes Config", _config)
+map_get_hermes_cron_state = _mapper("get_hermes_cron_state", "Hermes Cron State", _cron)
+map_get_hermes_audit_trail = _mapper("get_hermes_audit_trail", "Hermes Audit Trail", _events)
+map_get_hermes_approval_events = _mapper(
+    "get_hermes_approval_events", "Hermes Approval Events", _events
+)
+map_get_hermes_credential_state = _mapper(
+    "get_hermes_credential_state", "Hermes Credential State", _credentials
+)

--- a/tests/integrations/hermes/test_evidence_mappers.py
+++ b/tests/integrations/hermes/test_evidence_mappers.py
@@ -1,0 +1,123 @@
+"""Evidence mapper tests for Hermes session-evidence tools."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from integrations.hermes.tools.hermes_session_evidence_tool._evidence import (
+    map_get_hermes_adapter_catalog,
+    map_get_hermes_approval_events,
+    map_get_hermes_audit_trail,
+    map_get_hermes_config,
+    map_get_hermes_credential_state,
+    map_get_hermes_cron_state,
+)
+
+_Mapper = Callable[[dict[str, Any], dict[str, Any], dict[str, Any]], None]
+_UNAVAILABLE = {"available": False, "error": "requires a Hermes backend"}
+_CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
+    (
+        map_get_hermes_adapter_catalog,
+        "get_hermes_adapter_catalog",
+        {
+            "available": True,
+            "messaging_adapters": ["slack", "discord"],
+            "llm_providers": ["openai"],
+            "execution_backends": ["local", "docker"],
+        },
+        "2 messaging adapter(s), 1 LLM provider(s), 2 execution backend(s)",
+        {
+            "available": True,
+            "messaging_adapters": [],
+            "llm_providers": [],
+            "execution_backends": [],
+        },
+    ),
+    (
+        map_get_hermes_approval_events,
+        "get_hermes_approval_events",
+        {
+            "available": True,
+            "events": [{"command": "kubectl delete ns prod", "approval_kind": "never_prompted"}],
+        },
+        "1 event(s)",
+        {"available": True, "events": []},
+    ),
+    (
+        map_get_hermes_audit_trail,
+        "get_hermes_audit_trail",
+        {
+            "available": True,
+            "events": [
+                {"action": "update_prod_routing_policy", "signature_present": False},
+                {"action": "rotate_prod_credentials", "signature_present": False},
+            ],
+        },
+        "2 event(s)",
+        {"available": True, "events": []},
+    ),
+    (
+        map_get_hermes_config,
+        "get_hermes_config",
+        {
+            "available": True,
+            "provider": "codex",
+            "model": "gpt-5.4-mini",
+            "region": "us-east-1",
+            "providers": [{"name": "codex"}],
+        },
+        "codex, gpt-5.4-mini, us-east-1, 1 provider(s)",
+        {"available": True, "provider": "", "model": "", "region": "", "providers": []},
+    ),
+    (
+        map_get_hermes_credential_state,
+        "get_hermes_credential_state",
+        {
+            "available": True,
+            "mode": "in_process",
+            "in_memory_credential_count": 2,
+            "outbound_calls": [{"url": "https://api.example/v1/deploy"}],
+        },
+        "in_process mode, 2 in-memory credential(s), 1 outbound call(s)",
+        {"available": True, "mode": "", "outbound_calls": []},
+    ),
+    (
+        map_get_hermes_cron_state,
+        "get_hermes_cron_state",
+        {
+            "available": True,
+            "schedule_cron": "0 */2 * * *",
+            "last_run": {"delivery_status": "never_started"},
+        },
+        "schedule 0 */2 * * *, last delivery never_started",
+        {"available": True, "schedule_cron": "", "last_run": {}},
+    ),
+]
+
+
+@pytest.mark.parametrize(("mapper", "source", "output", "summary", "empty"), _CASES)
+def test_mapper_records_summary(
+    mapper: _Mapper, source: str, output: dict[str, Any], summary: str, empty: dict[str, Any]
+) -> None:
+    evidence: dict[str, Any] = {}
+    mapper(evidence, output, {})
+    assert evidence["catalog_entries"][0]["source"] == source
+    assert evidence["catalog_entries"][0]["summary"] == summary
+
+    skipped: dict[str, Any] = {}
+    mapper(skipped, empty, {})
+    mapper(skipped, _UNAVAILABLE, {})
+    assert "catalog_entries" not in skipped
+
+
+def test_credential_state_records_zero_in_memory_count() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_hermes_credential_state(
+        evidence,
+        {"available": True, "mode": "proxy", "in_memory_credential_count": 0, "outbound_calls": []},
+        {},
+    )
+    assert evidence["catalog_entries"][0]["summary"] == "proxy mode, 0 in-memory credential(s)"

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -51,12 +51,6 @@ get_failed_jobs
 get_failed_tools
 get_github_star_history
 get_groundcover_query_reference
-get_hermes_adapter_catalog
-get_hermes_approval_events
-get_hermes_audit_trail
-get_hermes_config
-get_hermes_credential_state
-get_hermes_cron_state
 get_hermes_filesystem_state
 get_hermes_kv_cache_state
 get_hermes_logs


### PR DESCRIPTION
Closes #5520

#### Describe the changes you have made in this PR -

Wires the six listed Hermes investigation tools to `record_evidence_entry` so
their output stops being silently dropped and becomes a citeable line in the
investigation report.

- `map_get_hermes_adapter_catalog`: cites messaging-adapter, LLM-provider, and execution-backend counts.
- `map_get_hermes_approval_events`: cites the approval / destructive-command event count.
- `map_get_hermes_audit_trail`: cites the observed audit-trail event count.
- `map_get_hermes_config`: cites resolved provider, model, region, and configured provider count.
- `map_get_hermes_credential_state`: cites isolation mode, in-memory credential count, and outbound call count.
- `map_get_hermes_cron_state`: cites the cron schedule and last delivery status.

All six are read-only diagnostic queries — none send, notify, create, or redeploy — so all are in scope per the issue.

Mappers live in `integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py`. The tool package only imports them and attaches `evidence_mapper=...`. A shared `_mapper` helper owns the `available` guard and catalog write; each tool only supplies its summary. Audit trail and approval events share `_events`. A present `in_memory_credential_count` of `0` is cited, not omitted. Empty or unavailable output still records nothing.

Removed these six names from `evidence_mapper_baseline.txt` now that they carry mappers.

### Before / after

**Before:** the tools ran and returned useful dicts, but had no `evidence_mapper`. Gather-evidence stored an opaque blob. The report had nothing citeable. They were listed as known gaps.

**After:** the same output is lifted into `catalog_entries` with a `source`, label, and summary the report can number and cite.

```
# before — tool registered, no mapper, gap list still names it
@tool(name="get_hermes_adapter_catalog", source="hermes", ...)
# evidence_mapper_baseline.txt includes:
#   get_hermes_adapter_catalog
# merge_tool_evidence(...) → catalog_entries missing / None

# after — mapper attached, gap line gone
@tool(
    name="get_hermes_adapter_catalog",
    source="hermes",
    evidence_mapper=map_get_hermes_adapter_catalog,
    ...
)
# merge_tool_evidence(..., {"available": True, "messaging_adapters": [1, 2]}, {})
# → [{'source': 'get_hermes_adapter_catalog', 'label': 'Hermes Adapter Catalog',
#     'summary': '2 messaging adapter(s), 0 LLM provider(s), 0 execution backend(s)', ...}]
```

Fixture envelopes through `merge_tool_evidence`:

```
get_hermes_adapter_catalog:  '3 messaging adapter(s), 4 LLM provider(s), 3 execution backend(s)'
get_hermes_approval_events:  '1 event(s)'
get_hermes_audit_trail:      '1 event(s)'
get_hermes_config:           'codex, gpt-5.4-mini, us-east-1, 1 provider(s)'
get_hermes_credential_state: 'in_process mode, 2 in-memory credential(s), 1 outbound call(s)'
get_hermes_cron_state:       'schedule 0 */2 * * *, last delivery never_started'
```

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**

```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['get_hermes_adapter_catalog', 'get_hermes_approval_events', 'get_hermes_audit_trail', 'get_hermes_config', 'get_hermes_credential_state', 'get_hermes_cron_state']})"
{'get_hermes_adapter_catalog': True, 'get_hermes_approval_events': True, 'get_hermes_audit_trail': True, 'get_hermes_config': True, 'get_hermes_credential_state': True, 'get_hermes_cron_state': True}
```

**Tests and quality gates:**

```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/integrations/hermes/test_evidence_mappers.py tests/tools/test_hermes_session_evidence_tool.py -q
9 passed

$ make lint && make format-check && make typecheck
All checks passed! / 3598 files already formatted / Success: no issues found in 1924 source files
```

**Live investigate:** Hermes is configured (`opensre integrations verify hermes` passes). A live `opensre investigate` run completed and polled Hermes logs, but grep did not find these six tool names in `/tmp/rca.json`. They are `_fixture_backend_only`, so a log-file Hermes install exposes `get_hermes_logs`, not these session-evidence tools. The mappers are attached; this environment never invoked them. Left `is_available` / `extract_params` untouched.

- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Issue #5520 is a mapper backfill: these six read tools already return diagnostic data, but gather-evidence dropped it. Each mapper turns that dict into one `record_evidence_entry`. Implementation lives next to the tools in `_evidence.py` so the package `__init__.py` stays the public tool surface. The six tools share the same available-then-summarize-then-record path, so `_mapper` owns that once and each tool only writes its summary. Audit and approval both cite `events`, so they share `_events`. Empty and `available: False` outputs record nothing. `is_available=_fixture_backend_only` is unchanged.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.