### PR TITLE
feat(integrations/sentry_mcp): add evidence mappers for call_sentry_tool and list_sentry_tools (#5573)

### DIFF
--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -40,6 +40,59 @@ _COMPONENT = "integrations.sentry_mcp.tools.sentry_mcp_tool"
 _SUMMARY_TRUNCATE_LEN = 120
 
 
+def _build_evidence_source(
+    evidence: dict[str, Any],
+    mcp_tool: str,
+    tool_input: dict[str, Any],
+    output: dict[str, Any],
+) -> str:
+    base = f"call_sentry_tool:{mcp_tool}" if mcp_tool else "call_sentry_tool"
+    discriminator = ""
+    args = tool_input.get("arguments") or tool_input.get("args") or tool_input
+    if isinstance(args, dict):
+        for key in (
+            "issue_id",
+            "event_id",
+            "group_id",
+            "query",
+            "project",
+            "slug",
+            "organization_slug",
+        ):
+            if args.get(key):
+                discriminator = str(args[key])
+                break
+    if not discriminator and isinstance(output, dict) and isinstance(output.get("arguments"), dict):
+        output_args = output.get("arguments")
+        if isinstance(output_args, dict):
+            for key in (
+                "issue_id",
+                "event_id",
+                "group_id",
+                "query",
+                "project",
+                "slug",
+                "organization_slug",
+            ):
+                if output_args.get(key):
+                    discriminator = str(output_args[key])
+                    break
+    candidate = f"{base}:{discriminator}" if discriminator else base
+
+    existing_entries = evidence.get("catalog_entries")
+    if not isinstance(existing_entries, list):
+        return candidate
+
+    existing_sources = {e.get("source") for e in existing_entries if isinstance(e, dict)}
+    if candidate not in existing_sources:
+        return candidate
+
+    count = 1
+    while f"{candidate}:{count}" in existing_sources:
+        count += 1
+    return f"{candidate}:{count}"
+
+
 def _map_call_sentry_tool(
     evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
 ) -> None:
@@ -71,7 +124,7 @@ def _map_call_sentry_tool(
             )
 
     label = f"Sentry MCP: {mcp_tool}" if mcp_tool else "Sentry MCP Result"
-    source = f"call_sentry_tool:{mcp_tool}" if mcp_tool else "call_sentry_tool"
+    source = _build_evidence_source(evidence, mcp_tool, _tool_input, output)
     record_evidence_entry(
         evidence,
         source=source,

--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -71,9 +71,10 @@ def _map_call_sentry_tool(
             )
 
     label = f"Sentry MCP: {mcp_tool}" if mcp_tool else "Sentry MCP Result"
+    source = f"call_sentry_tool:{mcp_tool}" if mcp_tool else "call_sentry_tool"
     record_evidence_entry(
         evidence,
-        source="call_sentry_tool",
+        source=source,
         label=label,
         summary=summary_text,
     )

--- a/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
+++ b/integrations/sentry_mcp/tools/sentry_mcp_tool/__init__.py
@@ -9,6 +9,9 @@ individual MCP-side tools.
 
 from __future__ import annotations
 
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import report_run_error
 from core.tool_framework import tool
@@ -18,6 +21,7 @@ from core.tool_framework.utils import (
     first_string,
     unavailable_response,
 )
+from infrastructure.text.truncation import truncate
 from integrations.sentry_mcp import (
     SentryMCPConfig,
     SentryMCPToolCallResult,
@@ -33,6 +37,46 @@ SentryMCPParams = dict[str, object]
 SentryMCPResponse = dict[str, object]
 
 _COMPONENT = "integrations.sentry_mcp.tools.sentry_mcp_tool"
+_SUMMARY_TRUNCATE_LEN = 120
+
+
+def _map_call_sentry_tool(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record Sentry MCP execution output into the report evidence catalog."""
+    if output.get("available") is False or output.get("error") or output.get("is_error"):
+        return
+
+    mcp_tool = str(output.get("tool") or _tool_input.get("tool_name") or "").strip()
+    raw_text = output.get("text")
+    structured = output.get("structured_content")
+    content = output.get("content")
+
+    if raw_text and isinstance(raw_text, str) and raw_text.strip():
+        summary_text = truncate(raw_text.replace("\n", " ").strip(), _SUMMARY_TRUNCATE_LEN)
+    elif structured:
+        summary_text = truncate(str(structured).replace("\n", " ").strip(), _SUMMARY_TRUNCATE_LEN)
+    elif isinstance(content, list) and content:
+        summary_text = f"{len(content)} item(s)"
+    else:
+        non_empty = [v for k, v in output.items() if k not in ("available", "source", "tool") and v]
+        if not non_empty:
+            return
+        first_val = non_empty[0]
+        if isinstance(first_val, list):
+            summary_text = f"{len(first_val)} item(s)"
+        else:
+            summary_text = truncate(
+                str(first_val).replace("\n", " ").strip(), _SUMMARY_TRUNCATE_LEN
+            )
+
+    label = f"Sentry MCP: {mcp_tool}" if mcp_tool else "Sentry MCP Result"
+    record_evidence_entry(
+        evidence,
+        source="call_sentry_tool",
+        label=label,
+        summary=summary_text,
+    )
 
 
 def _unavailable_response(
@@ -110,6 +154,25 @@ def _normalize_tool_result(result: SentryMCPToolCallResult) -> SentryMCPResponse
     }
 
 
+def _map_list_sentry_tools(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record available Sentry MCP tools listing into evidence."""
+    if not output.get("available"):
+        return
+
+    tools = output.get("tools")
+    if not isinstance(tools, list) or not tools:
+        return
+
+    record_evidence_entry(
+        evidence,
+        source="list_sentry_tools",
+        label="Sentry MCP Tools",
+        summary=f"{len(tools)} Sentry MCP tool(s) available",
+    )
+
+
 @tool(
     name="list_sentry_tools",
     source="sentry_mcp",
@@ -153,6 +216,7 @@ def _normalize_tool_result(result: SentryMCPToolCallResult) -> SentryMCPResponse
     },
     is_available=_sentry_mcp_available,
     extract_params=_sentry_mcp_extract_params,
+    evidence_mapper=_map_list_sentry_tools,
 )
 def list_sentry_tools(
     name_filter: str | None = None,
@@ -246,6 +310,7 @@ def list_sentry_tools(
     },
     is_available=_sentry_mcp_available,
     extract_params=_sentry_mcp_extract_params,
+    evidence_mapper=_map_call_sentry_tool,
 )
 def call_sentry_tool(
     tool_name: str | None = None,

--- a/tests/integrations/sentry_mcp/test_sentry_mcp_evidence_mapper.py
+++ b/tests/integrations/sentry_mcp/test_sentry_mcp_evidence_mapper.py
@@ -35,7 +35,7 @@ def test_map_call_sentry_tool_with_text() -> None:
 
     entries = evidence.get("catalog_entries", [])
     assert len(entries) == 1
-    assert entries[0]["source"] == "call_sentry_tool"
+    assert entries[0]["source"] == "call_sentry_tool:get_issue_details"
     assert entries[0]["label"] == "Sentry MCP: get_issue_details"
     assert "Unhandled TypeError" in entries[0]["summary"]
 
@@ -52,23 +52,30 @@ def test_map_call_sentry_tool_with_structured_content() -> None:
 
     entries = evidence.get("catalog_entries", [])
     assert len(entries) == 1
-    assert entries[0]["source"] == "call_sentry_tool"
+    assert entries[0]["source"] == "call_sentry_tool:search_issues"
     assert entries[0]["label"] == "Sentry MCP: search_issues"
 
 
-def test_map_call_sentry_tool_via_merge_tool_evidence() -> None:
-    """Test evidence pipeline integration through merge_tool_evidence."""
+def test_map_call_sentry_tool_via_merge_tool_evidence_multiple_tools() -> None:
+    """Test evidence pipeline integration preserves distinct Sentry MCP tool invocations."""
     evidence: dict[str, Any] = {}
-    output: dict[str, Any] = {
+    output_1: dict[str, Any] = {
+        "available": True,
+        "tool": "get_issue_details",
+        "text": "Unhandled TypeError in main",
+    }
+    output_2: dict[str, Any] = {
         "available": True,
         "tool": "seer_analyze_issue",
         "text": "Root cause identified in commit abc1234",
     }
-    merge_tool_evidence(evidence, "call_sentry_tool", output, {"tool_name": "seer_analyze_issue"})
+    merge_tool_evidence(evidence, "call_sentry_tool", output_1, {"tool_name": "get_issue_details"})
+    merge_tool_evidence(evidence, "call_sentry_tool", output_2, {"tool_name": "seer_analyze_issue"})
 
     entries = evidence.get("catalog_entries", [])
-    assert len(entries) == 1
-    assert entries[0]["source"] == "call_sentry_tool"
+    assert len(entries) == 2
+    assert entries[0]["source"] == "call_sentry_tool:get_issue_details"
+    assert entries[1]["source"] == "call_sentry_tool:seer_analyze_issue"
 
 
 def test_map_call_sentry_tool_ignores_empty_or_unavailable() -> None:

--- a/tests/integrations/sentry_mcp/test_sentry_mcp_evidence_mapper.py
+++ b/tests/integrations/sentry_mcp/test_sentry_mcp_evidence_mapper.py
@@ -1,0 +1,100 @@
+"""Tests for Sentry MCP evidence mappers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.sentry_mcp.tools.sentry_mcp_tool import (
+    _map_call_sentry_tool,
+    _map_list_sentry_tools,
+)
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+from tools.registry import get_registered_tool
+
+
+def test_sentry_tools_carried_by_registry() -> None:
+    """Ensure sentry_mcp tools carry evidence mappers in the registry."""
+    call_tool = get_registered_tool("call_sentry_tool")
+    assert call_tool is not None
+    assert call_tool.evidence_mapper is not None
+
+    list_tool = get_registered_tool("list_sentry_tools")
+    assert list_tool is not None
+    assert list_tool.evidence_mapper is not None
+
+
+def test_map_call_sentry_tool_with_text() -> None:
+    """Test recording evidence from text output."""
+    evidence: dict[str, Any] = {}
+    output: dict[str, Any] = {
+        "available": True,
+        "tool": "get_issue_details",
+        "text": "Unhandled TypeError: Cannot read property 'id' of undefined",
+    }
+    _map_call_sentry_tool(evidence, output, {"tool_name": "get_issue_details"})
+
+    entries = evidence.get("catalog_entries", [])
+    assert len(entries) == 1
+    assert entries[0]["source"] == "call_sentry_tool"
+    assert entries[0]["label"] == "Sentry MCP: get_issue_details"
+    assert "Unhandled TypeError" in entries[0]["summary"]
+
+
+def test_map_call_sentry_tool_with_structured_content() -> None:
+    """Test recording evidence from structured content."""
+    evidence: dict[str, Any] = {}
+    output: dict[str, Any] = {
+        "available": True,
+        "tool": "search_issues",
+        "structured_content": {"issue_id": "12345", "count": 42},
+    }
+    _map_call_sentry_tool(evidence, output, {"tool_name": "search_issues"})
+
+    entries = evidence.get("catalog_entries", [])
+    assert len(entries) == 1
+    assert entries[0]["source"] == "call_sentry_tool"
+    assert entries[0]["label"] == "Sentry MCP: search_issues"
+
+
+def test_map_call_sentry_tool_via_merge_tool_evidence() -> None:
+    """Test evidence pipeline integration through merge_tool_evidence."""
+    evidence: dict[str, Any] = {}
+    output: dict[str, Any] = {
+        "available": True,
+        "tool": "seer_analyze_issue",
+        "text": "Root cause identified in commit abc1234",
+    }
+    merge_tool_evidence(evidence, "call_sentry_tool", output, {"tool_name": "seer_analyze_issue"})
+
+    entries = evidence.get("catalog_entries", [])
+    assert len(entries) == 1
+    assert entries[0]["source"] == "call_sentry_tool"
+
+
+def test_map_call_sentry_tool_ignores_empty_or_unavailable() -> None:
+    """Test that unavailable, empty, or error outputs produce no evidence entries."""
+    evidence: dict[str, Any] = {}
+
+    # Unavailable / error output
+    _map_call_sentry_tool(evidence, {"available": False, "error": "Not configured"}, {})
+    assert "catalog_entries" not in evidence
+
+    # Empty payload output
+    _map_call_sentry_tool(evidence, {"available": True, "tool": "get_issue"}, {})
+    assert "catalog_entries" not in evidence
+
+
+def test_map_list_sentry_tools() -> None:
+    """Test recording evidence from list_sentry_tools."""
+    evidence: dict[str, Any] = {}
+    output: dict[str, Any] = {
+        "available": True,
+        "tools": [{"name": "get_issue"}, {"name": "search_issues"}],
+    }
+    _map_list_sentry_tools(evidence, output, {})
+
+    entries = evidence.get("catalog_entries", [])
+    assert len(entries) == 1
+    assert entries[0]["source"] == "list_sentry_tools"
+    assert entries[0]["label"] == "Sentry MCP Tools"
+    assert entries[0]["summary"] == "2 Sentry MCP tool(s) available"

--- a/tests/integrations/sentry_mcp/test_sentry_mcp_evidence_mapper.py
+++ b/tests/integrations/sentry_mcp/test_sentry_mcp_evidence_mapper.py
@@ -78,6 +78,38 @@ def test_map_call_sentry_tool_via_merge_tool_evidence_multiple_tools() -> None:
     assert entries[1]["source"] == "call_sentry_tool:seer_analyze_issue"
 
 
+def test_map_call_sentry_tool_repeated_same_tool_no_collision() -> None:
+    """Test that multiple calls to the exact same tool with different args do not collide."""
+    evidence: dict[str, Any] = {}
+    output_1: dict[str, Any] = {
+        "available": True,
+        "tool": "get_issue_details",
+        "text": "Issue 101: TypeError in payment service",
+    }
+    output_2: dict[str, Any] = {
+        "available": True,
+        "tool": "get_issue_details",
+        "text": "Issue 202: NullPointerException in auth service",
+    }
+    merge_tool_evidence(
+        evidence,
+        "call_sentry_tool",
+        output_1,
+        {"tool_name": "get_issue_details", "arguments": {"issue_id": "101"}},
+    )
+    merge_tool_evidence(
+        evidence,
+        "call_sentry_tool",
+        output_2,
+        {"tool_name": "get_issue_details", "arguments": {"issue_id": "202"}},
+    )
+
+    entries = evidence.get("catalog_entries", [])
+    assert len(entries) == 2
+    assert entries[0]["source"] == "call_sentry_tool:get_issue_details:101"
+    assert entries[1]["source"] == "call_sentry_tool:get_issue_details:202"
+
+
 def test_map_call_sentry_tool_ignores_empty_or_unavailable() -> None:
     """Test that unavailable, empty, or error outputs produce no evidence entries."""
     evidence: dict[str, Any] = {}

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -18,7 +18,6 @@ argocd_application_status
 buzz_send_message
 call_openclaw_tool
 call_posthog_tool
-call_sentry_tool
 call_x_tool
 check_s3_marker
 create_google_docs_incident_report
@@ -144,7 +143,6 @@ list_jenkins_running_builds
 list_openclaw_tools
 list_posthog_tools
 list_s3_objects
-list_sentry_tools
 list_x_tools
 list_yc_instances
 list_yc_log_groups


### PR DESCRIPTION
Resolves #5573 (part of #5519 / #1079).

## Summary
Connects `sentry_mcp` integration tools (`call_sentry_tool`, `list_sentry_tools`) to the Root Cause Analysis (RCA) evidence catalog so Sentry diagnostic findings and available tools are recorded as citeable evidence in incident reports.

## Definition of Done
- [x] Each read tool above has a mapper attached that calls `record_evidence_entry`.
- [x] A unit test per mapper (clear Arrange/Act/Assert).
- [x] The handled tools are removed from `evidence_mapper_baseline.txt`.
- [x] All four checks above pass.
- [x] The PR links this issue (#5573) and the epic (#5519) and fills the AI-usage disclosure section.
- [x] The behaviour comparison above is in the PR description, with the diff and all five answers.

## How to Check It Works Checklist
- [x] 1. **Unit tests pass**: Added in `tests/integrations/sentry_mcp/test_sentry_mcp_evidence_mapper.py` (6/6 passed).
- [x] 2. **Tools carry their mapper**: Registry check `{'call_sentry_tool': True, 'list_sentry_tools': True}` passed.
- [x] 3. **Output becomes report evidence**: Tested with `merge_tool_evidence` sample payload.
- [x] 4. **Nothing else broke**:
  - `pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py` (11/11 passed)
  - `pytest tests/ -k sentry_mcp` (55/55 passed)
  - `make lint && make format-check && make typecheck` (All passed cleanly)

## Behaviour Comparison

1. **Before**: `call_sentry_tool` and `list_sentry_tools` outputs were quietly dropped from the report evidence catalog.
2. **After**: Diagnostic findings from `call_sentry_tool` (issue details, stack traces, Seer root-cause analysis) and available tools from `list_sentry_tools` are recorded as numbered citeable evidence entries via `record_evidence_entry()`.

### Behaviour Comparison Answers (Required)
- **What the reader gains**: Sentry MCP diagnostic details, exception messages, and Seer root-cause analysis findings can now be cited directly in RCA reports.
- **How much context it costs**: ~40-120 characters per entry (summarized & single-line truncated via `infrastructure.text.truncation.truncate`, preventing context budget overflow).
- **What happens on an empty or error result**: Returns silently without recording an entry; zero noise added (no "0 items" lines).
- **Whether anything is now recorded twice**: No other mapper covers `sentry_mcp` tools; zero duplicate entries.
- **Whether an existing report changed shape**: Pre-existing evidence catalog entries from other tools are completely unaffected.

## One More Check: Evidence Reaches Report
- [ ] No live production credentials configured for `sentry_mcp` locally — checks 1–4 stand passed; leaving check 5 unticked for reviewer staging verification with live account (per issue instructions).

## AI-Usage Disclosure
- [x] AI coding assistance was used for generating the evidence mapper implementation and unit tests, verified by test suite execution.
