### PR TITLE
refactor(investigation): agent-first pipeline; deprecate lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,16 +260,20 @@ Steps:
 
 ### Changing the investigation pipeline
 
-Investigations are coordinated in `tools/investigation/lifecycle.py` and exposed via
+Investigations are coordinated in `tools/investigation/agent_pipeline.py`
+(`run_agent_investigation`) and exposed via
 `tools/investigation/capability.py`. Semantic stages live under
 `tools/investigation/stages/`; reporting lives under
 `tools/investigation/reporting/`. See
 [docs/investigation-pipeline-architecture.md](docs/investigation-pipeline-architecture.md)
 for the end-to-end stage/loop diagrams before making structural changes.
 
+`tools/investigation/lifecycle.py` is a **deprecated** compatibility facade
+over `agent_pipeline` — do not add new callers; keep the module until removal.
+
 Files to touch:
 
-- `tools/investigation/lifecycle.py` for high-level stage ordering.
+- `tools/investigation/agent_pipeline.py` for high-level stage ordering.
 - `core/state/` for shared agent state and investigation pipeline slice contracts
   that cross stage boundaries.
 - `core/domain/` for pure investigation rules (alert source mapping, tool planning,

--- a/core/state/models.py
+++ b/core/state/models.py
@@ -121,6 +121,10 @@ class AgentStateModel(StrictConfigModel):
     hypothesis_results: list[dict[str, Any]] = Field(default_factory=list)
     action_to_run: str = ""
     investigation_started_at: float = 0.0
+    pipeline_steps: list[str] = Field(
+        default_factory=list,
+        description="Host stage span names completed by the agent investigation pipeline",
+    )
     incident_window: dict[str, Any] | None = None
     incident_window_history: list[dict[str, Any]] | None = None
     masking_map: dict[str, str] = Field(default_factory=dict)

--- a/core/state/runtime_slices.py
+++ b/core/state/runtime_slices.py
@@ -84,6 +84,7 @@ class InvestigationRuntimeSlice(TypedDict, total=False):
     hypothesis_results: list[dict[str, Any]]
     action_to_run: str
     investigation_started_at: float
+    pipeline_steps: list[str]
 
 
 class DiagnosisSlice(TypedDict, total=False):

--- a/docs/investigation-pipeline-architecture.md
+++ b/docs/investigation-pipeline-architecture.md
@@ -11,7 +11,8 @@ pipeline and loop control flow around that.
 
 | Concern                        | Location                                                                                       |
 | ------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Stage ordering                  | `tools/investigation/lifecycle.py` (`run_connected_investigation`)                             |
+| Stage ordering (SoT)            | `tools/investigation/agent_pipeline.py` (`run_agent_investigation`)                            |
+| Deprecated lifecycle facade     | `tools/investigation/lifecycle.py` (`run_connected_investigation` → agent pipeline)            |
 | Public runner entrypoint        | `tools/investigation/capability.py`                                                            |
 | Integration discovery           | `tools/investigation/stages/resolve_integrations/node.py`                                      |
 | Alert classification/extraction | `tools/investigation/stages/intake/node.py`                                                    |

--- a/tests/tools/investigation/test_agent_pipeline.py
+++ b/tests/tools/investigation/test_agent_pipeline.py
@@ -1,0 +1,130 @@
+"""Agent-first investigation pipeline — stages still run; lifecycle is a facade."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tools.investigation.agent_pipeline import (
+    INVESTIGATION_STAGE_ORDER,
+    completed_pipeline_steps,
+    run_agent_investigation,
+)
+from tools.investigation.stages.gather_evidence import ConnectedInvestigationAgent
+from tools.investigation.state_factory import make_initial_state
+
+
+class _QuietAgent(ConnectedInvestigationAgent):
+    def run(  # type: ignore[override]
+        self,
+        state: dict[str, Any],  # noqa: ARG002
+        on_event: Any | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        return {"gather_evidence_ran": True}
+
+
+@contextmanager
+def _stubbed_stages(*, is_noise: bool = False) -> Iterator[None]:
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "tools.investigation.stages.resolve_integrations.resolve_integrations",
+                return_value={"resolved_integrations": {}},
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tools.investigation.stages.intake.extract_alert",
+                return_value={
+                    "is_noise": is_noise,
+                    "alert_name": "a",
+                    "severity": "warning",
+                },
+            )
+        )
+        if not is_noise:
+            stack.enter_context(
+                patch("tools.investigation.stages.plan_evidence.plan_actions", return_value={})
+            )
+            stack.enter_context(
+                patch(
+                    "tools.investigation.stages.diagnose.diagnose",
+                    return_value={"root_cause": "rc", "validity_score": 0.5},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "tools.investigation.reporting.upstream_correlation.node."
+                    "node_correlate_upstream",
+                    return_value={},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "tools.investigation.reporting.deliver",
+                    return_value={
+                        "slack_message": "report",
+                        "problem_md": "md",
+                        "report": "report",
+                    },
+                )
+            )
+        yield
+
+
+def test_run_agent_investigation_records_full_stage_order() -> None:
+    state = make_initial_state(raw_alert="alert text")
+    with _stubbed_stages():
+        out = run_agent_investigation(state, agent_class=_QuietAgent)
+
+    assert list(completed_pipeline_steps(out)) == list(INVESTIGATION_STAGE_ORDER)
+    assert out.get("gather_evidence_ran") is True
+    assert out.get("root_cause") == "rc"
+    assert out.get("slack_message") == "report"
+
+
+def test_run_agent_investigation_stops_after_intake_on_noise() -> None:
+    state = make_initial_state(raw_alert="noise")
+    with _stubbed_stages(is_noise=True):
+        out = run_agent_investigation(state, agent_class=_QuietAgent)
+
+    assert list(completed_pipeline_steps(out)) == [
+        "resolve_integrations",
+        "intake",
+    ]
+    assert out.get("is_noise") is True
+
+
+def test_run_investigation_uses_agent_pipeline_and_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.investigation.capability import run_investigation
+
+    monkeypatch.setattr(
+        "tools.investigation.capability.init_sentry",
+        lambda **_kw: None,
+    )
+    with _stubbed_stages():
+        out = run_investigation(raw_alert={"alert": "x"}, agent_class=_QuietAgent)
+
+    assert out["root_cause"] == "rc"
+    assert out["slack_message"] == "report"
+    assert list(completed_pipeline_steps(out)) == list(INVESTIGATION_STAGE_ORDER)
+
+
+def test_lifecycle_facade_warns_and_delegates() -> None:
+    from tools.investigation.lifecycle import run_connected_investigation
+
+    state = make_initial_state(raw_alert="alert text")
+    with (
+        pytest.warns(DeprecationWarning, match="deprecated"),
+        _stubbed_stages(is_noise=True),
+    ):
+        out = run_connected_investigation(state, agent_class=_QuietAgent)
+
+    assert out.get("is_noise") is True
+    assert list(completed_pipeline_steps(out)) == ["resolve_integrations", "intake"]

--- a/tests/tools/investigation/test_layering.py
+++ b/tests/tools/investigation/test_layering.py
@@ -6,7 +6,8 @@ transport-layer modules. Integration-specific wiring lives behind the
 similar factories for future correlation sources).
 
 Without this guard the dependency drift is easy:
-``tools.investigation.lifecycle`` previously imported ``DatadogClient``
+``tools.investigation.agent_pipeline`` (and the deprecated
+``tools.investigation.lifecycle`` facade) previously imported ``DatadogClient``
 directly, coupling the orchestrator to one vendor and making "add a
 second correlation source" an edit-this-file change instead of a
 new-file change. See issue #34 and the refactor that introduced
@@ -21,6 +22,7 @@ from pathlib import Path
 import pytest
 
 _ORCHESTRATION_PIPELINE_FILES: tuple[Path, ...] = (
+    Path("tools/investigation/agent_pipeline.py"),
     Path("tools/investigation/lifecycle.py"),
     Path("tools/investigation/capability.py"),
     Path("tools/investigation/state_factory.py"),

--- a/tests/tools/investigation/test_lifecycle_spans.py
+++ b/tests/tools/investigation/test_lifecycle_spans.py
@@ -57,6 +57,7 @@ def test_run_connected_investigation_emits_stage_spans(
 
     state = make_initial_state(raw_alert="alert text")
     with (
+        pytest.warns(DeprecationWarning, match="deprecated"),
         bind_session_trace(session_id),
         patch(
             "tools.investigation.stages.resolve_integrations.resolve_integrations",
@@ -114,6 +115,7 @@ def test_run_connected_investigation_skips_later_stages_on_noise(
 
     state = make_initial_state(raw_alert="noise")
     with (
+        pytest.warns(DeprecationWarning, match="deprecated"),
         bind_session_trace(session_id),
         patch(
             "tools.investigation.stages.resolve_integrations.resolve_integrations",
@@ -144,6 +146,7 @@ def test_run_connected_investigation_noop_sink_emits_nothing() -> None:
     assert isinstance(get_session_trace_store(), NoopSessionTraceStore)
     state = make_initial_state(raw_alert="alert text")
     with (
+        pytest.warns(DeprecationWarning, match="deprecated"),
         patch(
             "tools.investigation.stages.resolve_integrations.resolve_integrations",
             return_value={"resolved_integrations": {}},

--- a/tests/tools/investigation/test_runners_agent_class.py
+++ b/tests/tools/investigation/test_runners_agent_class.py
@@ -5,6 +5,7 @@ public surfaces:
 
   - :func:`tools.investigation.capability.run_investigation`
   - :func:`tools.investigation.lifecycle.run_connected_investigation`
+    (deprecated facade over :func:`tools.investigation.agent_pipeline.run_agent_investigation`)
 
 The parameter MUST thread cleanly from the outer ``run_investigation``
 all the way to where the agent is constructed, so callers (e.g. test
@@ -81,7 +82,7 @@ def test_run_connected_investigation_uses_agent_class_when_provided() -> None:
     from tools.investigation.state_factory import make_initial_state
 
     state = make_initial_state(raw_alert="alert text")
-    with _stubbed_stages():
+    with _stubbed_stages(), pytest.warns(DeprecationWarning, match="deprecated"):
         run_connected_investigation(state, agent_class=_SentinelAgent)
 
     assert len(_SentinelAgent.instances_constructed) == 1
@@ -101,6 +102,7 @@ def test_run_connected_investigation_picks_default_policy_from_routing(cli_backe
     # agent ran.
     with (
         _stubbed_stages(),
+        pytest.warns(DeprecationWarning, match="deprecated"),
         patch(
             "core.agent_harness.runtime.agent_llm_is_cli_backed",
             return_value=cli_backed,
@@ -156,8 +158,8 @@ async def test_astream_investigation_picks_default_policy_from_routing(cli_backe
 def test_run_investigation_forwards_agent_class_to_pipeline() -> None:
     """End-to-end: passing ``agent_class`` to the outermost
     :func:`run_investigation` MUST reach the agent constructor — proves
-    the parameter threads through ``runners.run_investigation`` →
-    ``pipeline.run_connected_investigation`` → ``ConnectedInvestigationAgent``.
+    the parameter threads through ``capability.run_investigation`` →
+    ``agent_pipeline.run_agent_investigation`` → investigation agent.
     """
     _reset_sentinel()
     from tools.investigation.capability import run_investigation
@@ -211,6 +213,7 @@ def test_run_connected_investigation_runs_plan_actions_before_agent() -> None:
             return_value={},
         ),
         patch("tools.investigation.reporting.deliver", return_value={}),
+        pytest.warns(DeprecationWarning, match="deprecated"),
     ):
         run_connected_investigation(state, agent_class=_OrderAgent)
 

--- a/tests/tools/investigation/test_runners_sentry.py
+++ b/tests/tools/investigation/test_runners_sentry.py
@@ -19,11 +19,11 @@ def test_run_investigation_initializes_sentry_and_captures_unhandled_errors(
     def capture_stub(exc: BaseException, **_kwargs: object) -> None:
         captured_errors.append(exc)
 
-    import tools.investigation.lifecycle as pipeline_module
-
     monkeypatch.setattr(runners, "init_sentry", lambda **_kw: sentry_init_calls.append(None))
     monkeypatch.setattr(boundary, "capture_exception", capture_stub)
-    monkeypatch.setattr(pipeline_module, "run_connected_investigation", failing_run)
+    import tools.investigation.agent_pipeline as pipeline_module
+
+    monkeypatch.setattr(pipeline_module, "run_agent_investigation", failing_run)
 
     with pytest.raises(RuntimeError, match="investigation failed"):
         runners.run_investigation("cpu high on api")

--- a/tests/tools/investigation/test_streaming_loop_metrics.py
+++ b/tests/tools/investigation/test_streaming_loop_metrics.py
@@ -65,7 +65,14 @@ async def test_astream_delivers_stream_error_when_deferred_import_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A failing deferred stage import must still reach the consumer as a wrapped error."""
-    monkeypatch.delattr("core.state.updates.apply_state_updates")
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise ImportError("simulated deferred stage import failure")
+
+    monkeypatch.setattr(
+        "tools.investigation.stages.resolve_integrations.resolve_integrations",
+        _boom,
+    )
 
     with pytest.raises(InvestigationPipelineStreamError) as exc_info:
         async for _event in astream_investigation("alert text"):

--- a/tools/investigation/agent_pipeline.py
+++ b/tools/investigation/agent_pipeline.py
@@ -1,0 +1,305 @@
+"""Agent-first investigation runner: host stages + native ``Agent`` gather loop.
+
+This is the source of truth for investigation stage order. Host-side stages
+(resolve, intake, plan, diagnose, deliver) stay pure ``(state) -> updates``
+functions; evidence gathering runs through
+``ConnectedInvestigationAgent`` / ``build_agent`` / ``core.agent.Agent``.
+
+``tools.investigation.lifecycle.run_connected_investigation`` is a deprecated
+facade over this module — keep it until callers migrate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from core.state import AgentState
+from core.state.updates import apply_state_updates
+from infrastructure.analytics.investigation_loop import bind_investigation_loop_metrics_from_state
+
+if TYPE_CHECKING:
+    from tools.investigation.stages.gather_evidence import ConnectedInvestigationAgent
+
+# Canonical host stage order (span names). Gather is the native ReAct agent.
+INVESTIGATION_STAGE_ORDER: tuple[str, ...] = (
+    "resolve_integrations",
+    "intake",
+    "plan_evidence",
+    "gather_evidence",
+    "diagnose",
+    "deliver",
+)
+
+# Stream UI historically used different node names than span names.
+_STREAM_NAME_BY_STAGE: Mapping[str, str] = {
+    "resolve_integrations": "resolve_integrations",
+    "intake": "extract_alert",
+    "plan_evidence": "plan_actions",
+    "gather_evidence": "investigation_agent",
+    "diagnose": "diagnose",
+    "correlate_upstream": "correlate_upstream",
+    "deliver": "publish_findings",
+}
+
+
+class DeliverStyle(StrEnum):
+    """How the final report stage runs."""
+
+    FULL = "full"
+    """``deliver()`` — optional eval + report + terminal/editor (sync CLI/API)."""
+
+    STREAM = "stream"
+    """Headless report for streaming UIs: correlate as its own step, then
+    ``generate_report(render_terminal=False, open_editor=False)``.
+    """
+
+
+@dataclass(frozen=True)
+class PipelineHooks:
+    """Optional observers for streaming / telemetry around host stages.
+
+    ``on_agent_event`` is forwarded to ``ConnectedInvestigationAgent.run`` so
+    tool/LLM iterations surface as stream events. Stage start/end use the
+    stream node names (e.g. ``extract_alert``), not internal span names.
+    """
+
+    on_stage_start: Callable[[str], None] | None = None
+    on_stage_end: Callable[[str, Mapping[str, Any]], None] | None = None
+    on_agent_event: Callable[..., Any] | None = None
+
+
+@dataclass
+class _StepRecorder:
+    """Records completed host stages onto ``state['pipeline_steps']``."""
+
+    steps: list[str] = field(default_factory=list)
+
+    def mark(self, stage: str) -> None:
+        self.steps.append(stage)
+
+    def bind(self, state: AgentState) -> None:
+        state["pipeline_steps"] = list(self.steps)
+
+
+def _run_stage(
+    span_name: str,
+    stage: Callable[[AgentState], Any],
+    state: AgentState,
+    *,
+    hooks: PipelineHooks | None,
+    recorder: _StepRecorder,
+    stream_name: str | None = None,
+    end_output: Callable[[AgentState], Mapping[str, Any]] | None = None,
+) -> None:
+    """Merge one stage's updates under a stage span; optionally notify hooks."""
+    from infrastructure.observability.trace.spans import stage_span
+
+    stream = stream_name or _STREAM_NAME_BY_STAGE.get(span_name, span_name)
+    if hooks and hooks.on_stage_start is not None:
+        hooks.on_stage_start(stream)
+
+    with stage_span(span_name):
+        apply_state_updates(state, stage(state))
+
+    recorder.mark(span_name)
+    if hooks and hooks.on_stage_end is not None:
+        output = end_output(state) if end_output is not None else {}
+        hooks.on_stage_end(stream, output)
+
+
+def run_agent_investigation(
+    state: AgentState,
+    *,
+    agent_class: type[ConnectedInvestigationAgent] | None = None,
+    hooks: PipelineHooks | None = None,
+    deliver_style: DeliverStyle = DeliverStyle.FULL,
+) -> AgentState:
+    """Run resolve → intake → plan → native-agent gather → diagnose → deliver.
+
+    Same stage functions as the legacy lifecycle graph; gather is the shared
+    ``core.agent.Agent`` ReAct loop via ``ConnectedInvestigationAgent``.
+
+    On success, ``state['pipeline_steps']`` lists completed host stage span
+    names (noise short-circuit stops after ``intake``).
+    """
+    from infrastructure.observability.errors.sentry import capture_exception
+    from tools.investigation.stages.diagnose import diagnose
+    from tools.investigation.stages.gather_evidence import get_investigation_agent_class
+    from tools.investigation.stages.intake import extract_alert
+    from tools.investigation.stages.plan_evidence import plan_actions
+    from tools.investigation.stages.resolve_integrations import resolve_integrations
+
+    agent_class = agent_class or get_investigation_agent_class()
+    recorder = _StepRecorder()
+    hooks = hooks or PipelineHooks()
+
+    try:
+        _run_stage(
+            "resolve_integrations",
+            resolve_integrations,
+            state,
+            hooks=hooks,
+            recorder=recorder,
+            end_output=lambda s: {
+                "resolved_integrations": _resolved_for_stream(s.get("resolved_integrations")),
+            },
+        )
+        _run_stage(
+            "intake",
+            extract_alert,
+            state,
+            hooks=hooks,
+            recorder=recorder,
+            end_output=lambda s: {k: s.get(k) for k in ("alert_name", "severity")},
+        )
+        if state.get("is_noise"):
+            recorder.bind(state)
+            return state
+
+        _run_stage(
+            "plan_evidence",
+            plan_actions,
+            state,
+            hooks=hooks,
+            recorder=recorder,
+            end_output=lambda s: {
+                "planned_actions": s.get("planned_actions", []),
+                "plan_rationale": s.get("plan_rationale", ""),
+                "plan_audit": s.get("plan_audit", {}),
+            },
+        )
+
+        _run_gather_stage(state, agent_class=agent_class, hooks=hooks, recorder=recorder)
+
+        _run_stage(
+            "diagnose",
+            diagnose,
+            state,
+            hooks=hooks,
+            recorder=recorder,
+            end_output=lambda s: {
+                "root_cause": s.get("root_cause", ""),
+                "root_cause_category": s.get("root_cause_category", ""),
+                "validity_score": s.get("validity_score"),
+                "validated_claims": s.get("validated_claims", []),
+                "remediation_steps": s.get("remediation_steps", []),
+            },
+        )
+
+        _run_deliver_stages(state, hooks=hooks, recorder=recorder, deliver_style=deliver_style)
+    except Exception as exc:
+        bind_investigation_loop_metrics_from_state(state)
+        recorder.bind(state)
+        capture_exception(exc)
+        raise
+
+    recorder.bind(state)
+    return state
+
+
+def _run_gather_stage(
+    state: AgentState,
+    *,
+    agent_class: type[ConnectedInvestigationAgent],
+    hooks: PipelineHooks,
+    recorder: _StepRecorder,
+) -> None:
+    """Run the native investigation agent under the gather_evidence span."""
+    from infrastructure.observability.trace.spans import stage_span
+
+    # Stream UIs get start/end from the agent's own on_event callbacks
+    # (agent_start / agent_end); do not emit a second host chain for gather.
+    with stage_span("gather_evidence"):
+        if hooks.on_agent_event is not None:
+            apply_state_updates(
+                state,
+                agent_class().run(state, on_event=hooks.on_agent_event),
+            )
+        else:
+            apply_state_updates(state, agent_class().run(state))
+    recorder.mark("gather_evidence")
+
+
+def _run_deliver_stages(
+    state: AgentState,
+    *,
+    hooks: PipelineHooks,
+    recorder: _StepRecorder,
+    deliver_style: DeliverStyle,
+) -> None:
+    if deliver_style is DeliverStyle.STREAM:
+        from tools.investigation.reporting.node import generate_report
+        from tools.investigation.reporting.upstream_correlation import (
+            enrich_upstream_correlation,
+        )
+
+        _run_stage(
+            "correlate_upstream",
+            enrich_upstream_correlation,
+            state,
+            hooks=hooks,
+            recorder=recorder,
+            stream_name="correlate_upstream",
+            end_output=lambda s: {"correlation": s.get("correlation", {})},
+        )
+
+        def _publish(s: AgentState) -> dict[str, Any]:
+            return generate_report(s, render_terminal=False, open_editor=False)
+
+        _run_stage(
+            "deliver",
+            _publish,
+            state,
+            hooks=hooks,
+            recorder=recorder,
+            stream_name="publish_findings",
+            end_output=lambda s: {
+                "root_cause": s.get("root_cause", ""),
+                "root_cause_category": s.get("root_cause_category", ""),
+                "validity_score": s.get("validity_score"),
+                "report": s.get("report", ""),
+                "slack_message": s.get("slack_message", ""),
+                "problem_md": s.get("problem_md", ""),
+                "validated_claims": s.get("validated_claims", []),
+                "remediation_steps": s.get("remediation_steps", []),
+            },
+        )
+        return
+
+    from tools.investigation.reporting import deliver
+
+    _run_stage(
+        "deliver",
+        deliver,
+        state,
+        hooks=hooks,
+        recorder=recorder,
+        end_output=lambda s: {
+            "root_cause": s.get("root_cause", ""),
+            "slack_message": s.get("slack_message", ""),
+            "problem_md": s.get("problem_md", ""),
+        },
+    )
+
+
+def _resolved_for_stream(resolved: Any) -> Any:
+    """Serialize resolved integrations for stream payloads when available."""
+    if not isinstance(resolved, dict):
+        return {}
+    try:
+        from tools.investigation.streaming import resolved_integrations_stream_payload
+
+        return resolved_integrations_stream_payload(resolved)
+    except Exception:
+        return resolved
+
+
+def completed_pipeline_steps(state: Mapping[str, Any]) -> Sequence[str]:
+    """Return recorded host stages from a finished investigation state."""
+    raw = state.get("pipeline_steps")
+    if isinstance(raw, list):
+        return [str(item) for item in raw]
+    return ()

--- a/tools/investigation/capability.py
+++ b/tools/investigation/capability.py
@@ -18,10 +18,7 @@ from infrastructure.observability.errors.boundary import report_and_reraise
 from infrastructure.observability.errors.sentry import init_sentry
 from infrastructure.observability.trace.spans import stage_span
 from tools.investigation.state_factory import make_initial_state
-from tools.investigation.streaming import (
-    InvestigationPipelineStreamError,
-    resolved_integrations_stream_payload,
-)
+from tools.investigation.streaming import InvestigationPipelineStreamError
 
 if TYPE_CHECKING:
     # Type-only — avoids paying the agent module's heavy import cost at
@@ -103,7 +100,7 @@ def run_investigation(
             agent-level extensions can pass a subclass instead.
     """
     init_sentry(entrypoint="pipeline")
-    from tools.investigation.lifecycle import run_connected_investigation as _run
+    from tools.investigation.agent_pipeline import run_agent_investigation as _run
 
     initial = make_initial_state(
         raw_alert=raw_alert,
@@ -306,162 +303,32 @@ async def astream_investigation(
     def _run_pipeline() -> None:
         state = initial
         try:
-            from core.state.updates import apply_state_updates
-            from tools.investigation.reporting.node import generate_report
-            from tools.investigation.stages.diagnose import diagnose
-            from tools.investigation.stages.gather_evidence import get_investigation_agent_class
-            from tools.investigation.stages.intake import extract_alert
-            from tools.investigation.stages.plan_evidence import plan_actions
-            from tools.investigation.stages.resolve_integrations import resolve_integrations
-
-            # --- resolve_integrations ---
-            _put(_make_node_event("on_chain_start", "resolve_integrations", {}))
-            resolved_updates = _traced_node("resolve_integrations", resolve_integrations, state)
-            apply_state_updates(state, resolved_updates)
-            resolved = resolved_updates.get("resolved_integrations") or {}
-            _put(
-                _make_node_event(
-                    "on_chain_end",
-                    "resolve_integrations",
-                    {
-                        "output": {
-                            "resolved_integrations": resolved_integrations_stream_payload(resolved)
-                        }
-                    },
-                )
+            from tools.investigation.agent_pipeline import (
+                DeliverStyle,
+                PipelineHooks,
+                run_agent_investigation,
             )
 
-            # --- extract_alert ---
-            _put(_make_node_event("on_chain_start", "extract_alert", {}))
-            apply_state_updates(state, _traced_node("extract_alert", extract_alert, state))
-            _put(
-                _make_node_event(
-                    "on_chain_end",
-                    "extract_alert",
-                    {"output": {k: state.get(k) for k in ("alert_name", "severity")}},
+            def _on_stage_start(stream_name: str) -> None:
+                _put(_make_node_event("on_chain_start", stream_name, {}))
+
+            def _on_stage_end(stream_name: str, output: Mapping[str, Any]) -> None:
+                _put(
+                    _make_node_event(
+                        "on_chain_end",
+                        stream_name,
+                        {"output": dict(output)},
+                    )
                 )
-            )
 
-            if state.get("is_noise"):
-                with contextlib.suppress(RuntimeError):  # loop closed (consumer cancelled)
-                    loop.call_soon_threadsafe(event_queue.put_nowait, None)
-                return
-
-            # --- plan_actions ---
-            _put(_make_node_event("on_chain_start", "plan_actions", {}))
-            apply_state_updates(
+            run_agent_investigation(
                 state,
-                _traced_node("plan_actions", plan_actions, state),
-            )
-            _put(
-                _make_node_event(
-                    "on_chain_end",
-                    "plan_actions",
-                    {
-                        "output": {
-                            "planned_actions": state.get("planned_actions", []),
-                            "plan_rationale": state.get("plan_rationale", ""),
-                            "plan_audit": state.get("plan_audit", {}),
-                        }
-                    },
-                )
-            )
-
-            # --- investigation agent (with real tool events) ---
-            agent_class = get_investigation_agent_class()
-            apply_state_updates(
-                state,
-                _traced_node(
-                    "investigation_agent",
-                    agent_class().run,
-                    state,
-                    on_event=_on_agent_event,
+                hooks=PipelineHooks(
+                    on_stage_start=_on_stage_start,
+                    on_stage_end=_on_stage_end,
+                    on_agent_event=_on_agent_event,
                 ),
-            )
-
-            # --- diagnose ---
-            _put(_make_node_event("on_chain_start", "diagnose", {}))
-            apply_state_updates(state, _traced_node("diagnose", diagnose, state))
-            _put(
-                _make_node_event(
-                    "on_chain_end",
-                    "diagnose",
-                    {
-                        "output": {
-                            "root_cause": state.get("root_cause", ""),
-                            "root_cause_category": state.get("root_cause_category", ""),
-                            "validity_score": state.get("validity_score"),
-                            "validated_claims": state.get("validated_claims", []),
-                            "remediation_steps": state.get("remediation_steps", []),
-                        }
-                    },
-                )
-            )
-
-            # --- upstream correlation ---
-            from tools.investigation.reporting.upstream_correlation import (
-                enrich_upstream_correlation,
-            )
-
-            _put(
-                _make_node_event(
-                    "on_chain_start",
-                    "correlate_upstream",
-                    {},
-                )
-            )
-
-            apply_state_updates(
-                state,
-                _traced_node(
-                    "correlate_upstream",
-                    enrich_upstream_correlation,
-                    state,
-                ),
-            )
-
-            _put(
-                _make_node_event(
-                    "on_chain_end",
-                    "correlate_upstream",
-                    {
-                        "output": {
-                            "correlation": state.get("correlation", {}),
-                        }
-                    },
-                )
-            )
-
-            # --- deliver / publish (skip terminal/editor render; StreamRenderer owns output) ---
-            _put(_make_node_event("on_chain_start", "publish_findings", {}))
-            apply_state_updates(
-                state,
-                _traced_node(
-                    "publish_findings",
-                    generate_report,
-                    state,
-                    render_terminal=False,
-                    open_editor=False,
-                ),
-            )
-
-            _put(
-                _make_node_event(
-                    "on_chain_end",
-                    "publish_findings",
-                    {
-                        "output": {
-                            "root_cause": state.get("root_cause", ""),
-                            "root_cause_category": state.get("root_cause_category", ""),
-                            "validity_score": state.get("validity_score"),
-                            "report": state.get("report", ""),
-                            "slack_message": state.get("slack_message", ""),
-                            "problem_md": state.get("problem_md", ""),
-                            "validated_claims": state.get("validated_claims", []),
-                            "remediation_steps": state.get("remediation_steps", []),
-                        }
-                    },
-                )
+                deliver_style=DeliverStyle.STREAM,
             )
 
         except Exception as exc:

--- a/tools/investigation/lifecycle.py
+++ b/tools/investigation/lifecycle.py
@@ -1,27 +1,26 @@
-"""Raw-alert-first connected investigation pipeline."""
+"""Deprecated facade for the connected investigation pipeline.
+
+Prefer :func:`tools.investigation.agent_pipeline.run_agent_investigation`.
+This module remains for import compatibility; it delegates to the agent-first
+runner and emits :class:`DeprecationWarning`.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+import warnings
+from typing import TYPE_CHECKING
 
 from core.state import AgentState
-from core.state.updates import apply_state_updates
-from infrastructure.analytics.investigation_loop import bind_investigation_loop_metrics_from_state
 
 if TYPE_CHECKING:
-    # Type-only import — avoids paying the agent module's heavy import cost
-    # at pipeline load while still letting static type-checkers validate
-    # ``agent_class`` injections.
     from tools.investigation.stages.gather_evidence import ConnectedInvestigationAgent
 
-
-def _run_stage(name: str, stage: Callable[[AgentState], Any], state: AgentState) -> None:
-    """Merge one pipeline stage's updates into ``state`` under a stage trace span."""
-    from infrastructure.observability.trace.spans import stage_span
-
-    with stage_span(name):
-        apply_state_updates(state, stage(state))
+_DEPRECATION_MESSAGE = (
+    "tools.investigation.lifecycle.run_connected_investigation is deprecated; "
+    "use tools.investigation.agent_pipeline.run_agent_investigation instead. "
+    "The lifecycle module remains as a compatibility facade and will be removed "
+    "in a later release."
+)
 
 
 def run_connected_investigation(
@@ -29,40 +28,13 @@ def run_connected_investigation(
     *,
     agent_class: type[ConnectedInvestigationAgent] | None = None,
 ) -> AgentState:
-    """Resolve connected integrations → parse alert → investigate → diagnose → deliver.
+    """Deprecated: resolve → intake → plan → gather → diagnose → deliver.
 
-    All steps mutate a shared state dict. Each step returns a dict of updates
-    which are merged in. Pure function: inputs in, state out.
-
-    ``agent_class``: optional override for the investigation agent class.
-    When omitted, the pipeline selects CLI-backed vs hosted policy from
-    configured LLM routing without constructing a client. Callers that need a
-    custom termination policy, structured-stage progression, or other
-    agent-level extensions can pass a subclass instead.
+    Delegates to :func:`tools.investigation.agent_pipeline.run_agent_investigation`,
+    which keeps the same stage functions and runs gather via the native
+    ``core.agent.Agent`` ReAct loop.
     """
-    from infrastructure.observability.errors.sentry import capture_exception
-    from tools.investigation.reporting import deliver
-    from tools.investigation.stages.diagnose import diagnose
-    from tools.investigation.stages.gather_evidence import get_investigation_agent_class
-    from tools.investigation.stages.intake import extract_alert
-    from tools.investigation.stages.plan_evidence import plan_actions
-    from tools.investigation.stages.resolve_integrations import resolve_integrations
+    warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
+    from tools.investigation.agent_pipeline import run_agent_investigation
 
-    agent_class = agent_class or get_investigation_agent_class()
-
-    try:
-        _run_stage("resolve_integrations", resolve_integrations, state)
-        _run_stage("intake", extract_alert, state)
-        if state.get("is_noise"):
-            return state
-
-        _run_stage("plan_evidence", plan_actions, state)
-        _run_stage("gather_evidence", agent_class().run, state)
-        _run_stage("diagnose", diagnose, state)
-        _run_stage("deliver", deliver, state)
-    except Exception as exc:
-        bind_investigation_loop_metrics_from_state(state)
-        capture_exception(exc)
-        raise
-
-    return state
+    return run_agent_investigation(state, agent_class=agent_class)


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

- Add `tools/investigation/agent_pipeline.py` as the source of truth for investigation stage order (`resolve → intake → plan → gather → diagnose → deliver`), still calling the existing stage functions and the native `ConnectedInvestigationAgent` / `core.agent.Agent` ReAct gather loop.
- Wire `run_investigation` and `astream_investigation` through that shared runner so sync and stream no longer diverge.
- Deprecate `lifecycle.run_connected_investigation` (kept as a compatibility facade with `DeprecationWarning`) — code not removed.
- Record completed host stages on `state["pipeline_steps"]` so callers/tests can assert steps ran.
- Update docs/`AGENTS.md` to point at the new SoT.

### Demo/Screenshot for feature changes and bug fixes -

Smoke (stubbed stages) via `run_investigation`:

```
ok ['resolve_integrations', 'intake', 'plan_evidence', 'gather_evidence', 'diagnose', 'deliver']
payload keys ['is_noise', 'problem_md', 'report', 'root_cause', 'validity_score']
```

Focused tests: `118 passed` under `tests/tools/investigation/` + `tests/cli/test_investigate.py`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Investigation still needs host stages (creds resolve, noise gate, deterministic plan, structured diagnose, deliver) around a native agent gather loop. Rather than stuffing everything into ReAct or deleting the old graph-shaped lifecycle, I extracted one `run_agent_investigation` runner that owns stage order, uses the same stage modules, and drives gather through `ConnectedInvestigationAgent`. Capability (sync + stream) calls that runner; lifecycle becomes a deprecated thin wrapper so existing imports keep working until a later removal PR.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] CI local baseline: `make lint`, `make format-check`, `make typecheck`
- [x] Focused tests for touched modules (listed above)

## Test plan
- [x] `uv run pytest tests/tools/investigation/ tests/cli/test_investigate.py`
- [x] `make lint && make format-check && make typecheck`
- [x] Smoke: stubbed `run_investigation` returns RCA payload and full `pipeline_steps`
- [ ] CI Gate green on PR