### PR TITLE
feat(posthog_mcp): add evidence mappers for list_posthog_tools and call_posthog_tool

### DIFF
--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/__init__.py
@@ -33,6 +33,10 @@ from integrations.posthog_mcp import (
     posthog_mcp_config_from_env,
     posthog_mcp_runtime_unavailable_reason,
 )
+from integrations.posthog_mcp.tools.posthog_mcp_tool._evidence import (
+    map_call_posthog_tool,
+    map_list_posthog_tools,
+)
 
 PostHogMCPParams = dict[str, object]
 PostHogMCPResponse = dict[str, object]
@@ -350,6 +354,7 @@ def _normalize_tool_result(result: PostHogMCPToolCallResult) -> PostHogMCPRespon
     ),
     is_available=_posthog_mcp_available,
     extract_params=_posthog_mcp_extract_params,
+    evidence_mapper=map_list_posthog_tools,
 )
 def list_posthog_tools(
     name_filter: str | None = None,
@@ -466,6 +471,7 @@ def list_posthog_tools(
     ),
     is_available=_posthog_mcp_available,
     extract_params=_posthog_mcp_extract_params,
+    evidence_mapper=map_call_posthog_tool,
 )
 def call_posthog_tool(
     tool_name: str | None = None,

--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/_evidence.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/_evidence.py
@@ -11,6 +11,14 @@ from infrastructure.text.truncation import truncate
 #: both are caller/upstream-supplied and unbounded.
 _SUMMARY_TRUNCATE_LEN = 120
 
+#: Bound the dispatched MCP tool name -- caller-controlled and unbounded --
+#: before it flows into the summary, label, and evidence source key.
+_TOOL_NAME_TRUNCATE_LEN = 60
+
+
+def _safe_tool_name(tool_name: str) -> str:
+    return truncate(tool_name.replace("\n", " "), _TOOL_NAME_TRUNCATE_LEN)
+
 
 def _next_unique_source(evidence: dict[str, Any], base: str) -> str:
     """Disambiguate repeat calls to a generic dispatcher tool.
@@ -73,7 +81,8 @@ def map_call_posthog_tool(
     """
     if not output.get("available"):
         return
-    tool_name = str(output.get("tool") or tool_input.get("tool_name") or "").strip()
+    raw_tool_name = str(output.get("tool") or tool_input.get("tool_name") or "").strip()
+    tool_name = _safe_tool_name(raw_tool_name) if raw_tool_name else ""
     results = output.get("results")
     text = output.get("text")
     structured = output.get("structured_content")

--- a/integrations/posthog_mcp/tools/posthog_mcp_tool/_evidence.py
+++ b/integrations/posthog_mcp/tools/posthog_mcp_tool/_evidence.py
@@ -1,0 +1,103 @@
+"""Evidence mappers for the PostHog MCP-backed tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: Bound a name_filter or a generic tool result echoed into a report summary --
+#: both are caller/upstream-supplied and unbounded.
+_SUMMARY_TRUNCATE_LEN = 120
+
+
+def _next_unique_source(evidence: dict[str, Any], base: str) -> str:
+    """Disambiguate repeat calls to a generic dispatcher tool.
+
+    ``record_evidence_entry`` lets the first entry for a given ``source`` win,
+    but ``call_posthog_tool`` is a single dispatcher that can be invoked many
+    times per investigation with different underlying PostHog tools/arguments
+    -- reusing one source key would silently drop every call after the first.
+    """
+    entries = evidence.get("catalog_entries")
+    if not isinstance(entries, list):
+        return base
+    existing = {e.get("source") for e in entries if isinstance(e, dict)}
+    if base not in existing:
+        return base
+    suffix = 2
+    while f"{base}#{suffix}" in existing:
+        suffix += 1
+    return f"{base}#{suffix}"
+
+
+def map_list_posthog_tools(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the matched tool count from the bounded MCP catalog listing.
+
+    ``build_mcp_tool_listing`` caps ``returned_tools`` at 80 regardless of how
+    many actually matched -- a real truncation signal, not an inferred one --
+    so ``matched_tools`` is qualified with "+" whenever the listing shown is
+    smaller than what actually matched.
+    """
+    if not output.get("available"):
+        return
+    returned = output.get("returned_tools", 0)
+    if not returned:
+        return
+    matched = output.get("matched_tools", returned)
+    count_label = f"{matched}+" if returned < matched else str(matched)
+    summary = f"{count_label} tool(s) listed"
+    name_filter = output.get("name_filter")
+    if name_filter:
+        summary += f" matching '{truncate(str(name_filter), _SUMMARY_TRUNCATE_LEN)}'"
+    record_evidence_entry(
+        evidence,
+        source="list_posthog_tools",
+        label="PostHog MCP Tools",
+        summary=summary,
+    )
+
+
+def map_call_posthog_tool(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the result of a dispatched PostHog MCP tool call.
+
+    The underlying MCP tool varies per call (HogQL rows, feature-flag lists,
+    docs text, ...), so the summary shape follows whichever result field is
+    populated: row count for ``execute-sql``/``query-run``, otherwise the
+    response text/structured content, bounded.
+    """
+    if not output.get("available"):
+        return
+    tool_name = str(output.get("tool") or tool_input.get("tool_name") or "").strip()
+    results = output.get("results")
+    text = output.get("text")
+    structured = output.get("structured_content")
+    content = output.get("content")
+
+    if isinstance(results, list):
+        if not results:
+            return
+        summary = f"{len(results)} row(s)"
+    elif text:
+        summary = truncate(str(text).replace("\n", " ").strip(), _SUMMARY_TRUNCATE_LEN)
+    elif structured is not None:
+        summary = truncate(str(structured).replace("\n", " ").strip(), _SUMMARY_TRUNCATE_LEN)
+    elif isinstance(content, list) and content:
+        summary = f"{len(content)} item(s)"
+    else:
+        return
+
+    if tool_name:
+        summary += f" (tool: {tool_name})"
+    base_source = f"call_posthog_tool:{tool_name}" if tool_name else "call_posthog_tool"
+    record_evidence_entry(
+        evidence,
+        source=_next_unique_source(evidence, base_source),
+        label=f"PostHog MCP: {tool_name}" if tool_name else "PostHog MCP",
+        summary=summary,
+    )

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -17,7 +17,6 @@ argocd_application_diff
 argocd_application_status
 buzz_send_message
 call_openclaw_tool
-call_posthog_tool
 call_sentry_tool
 call_x_tool
 check_s3_marker
@@ -139,7 +138,6 @@ list_jenkins_builds
 list_jenkins_jobs
 list_jenkins_running_builds
 list_openclaw_tools
-list_posthog_tools
 list_s3_objects
 list_sentry_tools
 list_x_tools

--- a/tests/tools/test_posthog_mcp_tool.py
+++ b/tests/tools/test_posthog_mcp_tool.py
@@ -581,6 +581,22 @@ def test_map_call_posthog_tool_disambiguates_repeat_calls() -> None:
     assert sources == ["call_posthog_tool:execute-sql", "call_posthog_tool:execute-sql#2"]
 
 
+def test_map_call_posthog_tool_bounds_oversized_tool_name() -> None:
+    """Regression: tool_name is caller-controlled and unbounded -- an
+    oversized name must not inflate the summary, label, or source key."""
+    evidence: dict[str, object] = {}
+    huge_name = "x" * 500
+    map_call_posthog_tool(
+        evidence,
+        {"available": True, "tool": huge_name, "results": [[1]]},
+        {"tool_name": huge_name},
+    )
+    entry = evidence["catalog_entries"][0]
+    assert len(entry["source"]) < 100
+    assert len(entry["label"]) < 100
+    assert len(entry["summary"]) < 200
+
+
 def test_map_call_posthog_tool_skips_when_no_result_content() -> None:
     evidence: dict[str, object] = {}
     map_call_posthog_tool(

--- a/tests/tools/test_posthog_mcp_tool.py
+++ b/tests/tools/test_posthog_mcp_tool.py
@@ -12,6 +12,10 @@ from integrations.posthog_mcp.tools.posthog_mcp_tool import (
     call_posthog_tool,
     list_posthog_tools,
 )
+from integrations.posthog_mcp.tools.posthog_mcp_tool._evidence import (
+    map_call_posthog_tool,
+    map_list_posthog_tools,
+)
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -505,3 +509,87 @@ def test_query_values_are_first_in_normalized_result() -> None:
     assert normalized["results"] == [[4271, 3900]]
     assert "arguments" not in normalized
     assert "content" not in normalized
+
+
+# ---------------------------------------------------------------------------
+# Evidence mappers
+# ---------------------------------------------------------------------------
+
+
+def test_map_list_posthog_tools_records_entry() -> None:
+    evidence: dict[str, object] = {}
+    map_list_posthog_tools(
+        evidence,
+        {"available": True, "returned_tools": 2, "matched_tools": 2, "total_tools": 244},
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "list_posthog_tools"
+    assert entries[0]["summary"] == "2 tool(s) listed"
+
+
+def test_map_list_posthog_tools_qualifies_when_listing_is_capped() -> None:
+    evidence: dict[str, object] = {}
+    map_list_posthog_tools(
+        evidence,
+        {"available": True, "returned_tools": 80, "matched_tools": 244, "total_tools": 244},
+        {},
+    )
+    assert evidence["catalog_entries"][0]["summary"].startswith("244+ tool(s)")
+
+
+def test_map_list_posthog_tools_skips_empty_listing() -> None:
+    evidence: dict[str, object] = {}
+    map_list_posthog_tools(evidence, {"available": True, "returned_tools": 0}, {})
+    assert "catalog_entries" not in evidence
+
+
+def test_map_call_posthog_tool_records_row_count() -> None:
+    evidence: dict[str, object] = {}
+    map_call_posthog_tool(
+        evidence,
+        {"available": True, "tool": "execute-sql", "results": [[1], [2], [3]]},
+        {"tool_name": "execute-sql"},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "call_posthog_tool:execute-sql"
+    assert "3 row(s)" in entries[0]["summary"]
+
+
+def test_map_call_posthog_tool_records_text_when_no_rows() -> None:
+    evidence: dict[str, object] = {}
+    map_call_posthog_tool(
+        evidence,
+        {"available": True, "tool": "feature-flag-get-all", "text": "flag-a, flag-b"},
+        {"tool_name": "feature-flag-get-all"},
+    )
+    assert "flag-a, flag-b" in evidence["catalog_entries"][0]["summary"]
+
+
+def test_map_call_posthog_tool_disambiguates_repeat_calls() -> None:
+    """Regression: call_posthog_tool is a generic dispatcher invoked many times
+    per investigation with different arguments -- record_evidence_entry lets
+    the first entry for a source win, so reusing one source key would
+    silently drop every call after the first."""
+    evidence: dict[str, object] = {}
+    output = {"available": True, "tool": "execute-sql", "results": [[1]]}
+    map_call_posthog_tool(evidence, output, {"tool_name": "execute-sql"})
+    map_call_posthog_tool(evidence, output, {"tool_name": "execute-sql"})
+    sources = [e["source"] for e in evidence["catalog_entries"]]
+    assert sources == ["call_posthog_tool:execute-sql", "call_posthog_tool:execute-sql#2"]
+
+
+def test_map_call_posthog_tool_skips_when_no_result_content() -> None:
+    evidence: dict[str, object] = {}
+    map_call_posthog_tool(
+        evidence, {"available": True, "tool": "feature-flag-create"}, {"tool_name": "x"}
+    )
+    assert "catalog_entries" not in evidence
+
+
+def test_map_call_posthog_tool_skips_unavailable() -> None:
+    evidence: dict[str, object] = {}
+    map_call_posthog_tool(evidence, {"available": False, "error": "denied"}, {})
+    assert "catalog_entries" not in evidence


### PR DESCRIPTION
## Summary
Wires `list_posthog_tools` and `call_posthog_tool` into `record_evidence_entry` so their output becomes citeable investigation-report evidence, per #5570 (part of #5519 / #1079).

- `list_posthog_tools` cites the matched tool count, qualified "+" using `build_mcp_tool_listing`'s own explicit truncation signal (`returned_tools < matched_tools`) rather than an inferred heuristic.
- `call_posthog_tool` is a generic dispatcher that can be invoked many times per investigation with different underlying PostHog MCP tools/arguments (HogQL queries, feature-flag lookups, etc). Since `record_evidence_entry` lets the first entry for a given `source` win, reusing one source key would silently drop every call after the first — so each call gets a disambiguated source (`call_posthog_tool:<tool_name>`, then `#2`, `#3`, ... on repeat calls to the same underlying tool). `tool_name` itself is caller/upstream-controlled, so it's bounded to 60 chars before it flows into the summary, label, or source key (Greptile P2 finding, fixed).
- Mappers live in a new `_evidence.py` sibling module rather than inline in `__init__.py` (Yauhen review feedback, fixed).

## Test plan
- [x] `uv run pytest tests/tools/test_posthog_mcp_tool.py tests/tools/investigation/stages/gather_evidence/` — all pass
- [x] `make lint` / `make format-check` / `make typecheck` — clean
- [x] Removed both tools from `evidence_mapper_baseline.txt`
- [x] `uv run python -c "from tools.registry import get_registered_tool as g; print({n: bool(g(n).evidence_mapper) for n in ['call_posthog_tool', 'list_posthog_tools']})"` → `{'call_posthog_tool': True, 'list_posthog_tools': True}`

## Behaviour comparison (required)

**Before** (main, no mapper) — `merge_tool_evidence` on realistic sample output for both tools:
```
BEFORE catalog_entries: null
```

**After** (this branch) — same sample output:
```json
[
  {
    "source": "list_posthog_tools",
    "label": "PostHog MCP Tools",
    "summary": "12 tool(s) listed matching 'events query sql'",
    "url": null,
    "snippet": null
  },
  {
    "source": "call_posthog_tool:execute-sql",
    "label": "PostHog MCP: execute-sql",
    "summary": "2 row(s) (tool: execute-sql)",
    "url": null,
    "snippet": null
  }
]
```

**1. What the reader gains.** The report can now cite that a specific PostHog MCP tool ran and what it returned (e.g. "2 row(s) (tool: execute-sql)" for a HogQL query, or "12 tool(s) listed matching 'events query sql'" for a discovery call) — previously this was invisible: the tool ran, cost tokens, but left no trace in the report.

**2. How much context it costs.** One entry is a single short line, ~40–90 characters depending on tool name and result shape (bounded: summary text is truncated to 120 chars, tool name to 60 chars). `call_posthog_tool`'s summary never inlines full row data or raw response text beyond that bound — it cites a count or a bounded snippet, not a dump.

**3. What happens on an empty or error result.** Verified directly:
```
empty listing entries: None
error call entries: None
bare {} entries: None
```
No entry is recorded for `{"available": True, "returned_tools": 0}`, `{"available": False, "error": ...}`, or a bare `{}` — confirmed no "0 items" noise.

**4. Whether anything is now recorded twice.** No other mapper in the codebase covers posthog_mcp output (`grep -rln "evidence_mapper" integrations/posthog_mcp/` only matches this file) — no overlap.

**5. Whether an existing report changed shape.** This only adds new entries under the new `call_posthog_tool*`/`list_posthog_tools` source keys; it doesn't touch how any other tool's output is merged, so pre-existing evidence entries from other tools are unaffected in an investigation that already worked before this change.

## Live-report check (#5)
I don't have PostHog MCP credentials configured, so I can't run `opensre investigate` against a real alert to confirm the entry lands in an actual generated report — per the issue's own note ("No credentials? That is a normal outcome... leave it unticked"), I'm leaving that box unticked. Checks 1–4 above (plus the behaviour comparison) all pass and demonstrate the mapper is wired and produces the expected entry via the real `merge_tool_evidence` path a live investigation would call.

Closes #5570

🧙 Built with [WOZCODE](https://wozcode.com)
