### PR TITLE
fix(turn-host): avoid resource import crash on Windows

### DIFF
--- a/infrastructure/turn_host/turn_memory.py
+++ b/infrastructure/turn_host/turn_memory.py
@@ -10,8 +10,12 @@ helpers let the turn host log that cost from a real run instead of guessing it.
 from __future__ import annotations
 
 import logging
-import resource
 import sys
+
+try:
+    import resource as _resource
+except ImportError:  # Windows / non-POSIX
+    _resource = None  # type: ignore[assignment]
 
 _BYTES_PER_MB = 1_048_576
 
@@ -20,21 +24,25 @@ def resident_memory_bytes() -> int | None:
     """This process's current resident memory in bytes, or ``None`` if unknown.
 
     Reads ``/proc/self/statm`` for an accurate live reading on Linux (the Fargate
-    runtime); returns ``None`` where that file is absent so callers skip the
-    measurement rather than report a wrong number.
+    runtime); returns ``None`` where the required platform APIs are absent so
+    callers skip the measurement rather than report a wrong number.
     """
+    if _resource is None:
+        return None
     try:
         with open("/proc/self/statm", encoding="ascii") as statm:
             resident_pages = int(statm.read().split()[1])
     except (OSError, ValueError, IndexError):
         return None
-    return resident_pages * resource.getpagesize()
+    return resident_pages * _resource.getpagesize()
 
 
 def peak_resident_memory_bytes() -> int | None:
     """This process's peak resident memory in bytes, or ``None`` if unknown."""
+    if _resource is None:
+        return None
     try:
-        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        peak = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
     except (OSError, ValueError):
         return None
     # Linux reports kibibytes; macOS and the BSDs report bytes.

--- a/tests/infrastructure/turn_host/test_turn_memory.py
+++ b/tests/infrastructure/turn_host/test_turn_memory.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 from infrastructure.turn_host.turn_memory import (
     peak_resident_memory_bytes,
     resident_memory_bytes,
@@ -18,3 +21,20 @@ def test_resident_memory_bytes_is_a_positive_measurement_or_none() -> None:
 def test_peak_resident_memory_bytes_is_a_positive_measurement_or_none() -> None:
     peak = peak_resident_memory_bytes()
     assert peak is None or peak > 0
+
+
+def test_import_and_sampling_succeed_without_resource_module() -> None:
+    script = """
+import sys
+
+sys.modules["resource"] = None
+
+from infrastructure.turn_host.turn_memory import (
+    peak_resident_memory_bytes,
+    resident_memory_bytes,
+)
+
+assert resident_memory_bytes() is None
+assert peak_resident_memory_bytes() is None
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
Fixes #5845

#### Describe the changes you have made in this PR -

- Guard the POSIX-only `resource` import so the turn host remains importable on Windows.
- Return `None` from resident/peak memory sampling when the platform API is unavailable, preserving the existing no-op telemetry contract.
- Add an isolated regression test that imports and exercises the module with `resource` unavailable.

### Demo/Screenshot for feature changes and bug fixes -

```text
tests/infrastructure/turn_host/test_turn_memory.py ... 3 passed
make lint .......................................... passed
make format-check ................................. passed
make typecheck ..................................... Success: no issues found in 1941 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The memory helper is Linux/Fargate telemetry whose callers already accept `None` when sampling is unsupported. Rather than adding a separate Windows measurement implementation, this change follows the existing cross-platform pattern in `infrastructure/observability/trace/process_stats.py`: it catches `ImportError` around `resource` and makes both sampling functions return `None` when that module is unavailable.

This keeps Linux behavior unchanged and prevents the Windows interactive shell from crashing at module import. A subprocess regression test removes `resource` before the first import, accurately exercising the packaged-Windows failure without mutating the test runner's module state.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.