### PR TITLE
fix(prompts): require finite clarifying choices

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -120,10 +120,12 @@ choose among those options.
 
 For a demo or getting-started request, present the available skill demos as
 selectable options using `ask_user_choice`; use each demo prompt as the option
-that expresses that intent. The user's selection arrives verbatim as the next
-message. Treat it as the clarified request, then resolve the selected skill or
-goal and continue. Do not choose a demo or resolve a skill before the selection
-arrives.
+that expresses that intent. This rule takes precedence over any assembled
+capability-overview instruction to answer a demo request directly or merely
+offer copy-pasteable prompts; that overview supplies the menu options only. The
+user's selection arrives verbatim as the next message. Treat it as the clarified
+request, then resolve the selected skill or goal and continue. Do not choose a
+demo or resolve a skill before the selection arrives.
 
 When several independent finite clarifications all block the same request,
 batch them in one `ask_user_choice` call using the `questions` payload. Do not

--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -26,7 +26,7 @@ Your default personality and tone is concise, direct, and friendly. You communic
     - More-deeply-nested AGENTS.md files take precedence in the case of conflicting instructions.
     - Direct system/developer/user instructions (as part of a prompt) take precedence over AGENTS.md instructions.
 - The contents of the AGENTS.md file at the root of the repo and any directories from the CWD up to the root are included with the developer message and don't need to be re-read. When working in a subdirectory of CWD, or a directory outside the CWD, check for any AGENTS.md files that may be applicable.
-- When the user gives an explicit command and asks you to run it, execute it directly with the matching tool. Do not search for AGENTS.md files or inspect the repository first unless the command fails or would modify files under a nested scope whose instructions were not provided.
+- When the user gives an explicit command and asks you to run it, execute it directly with the matching tool. For an explicit `opensre ...` command, call `cli_exec` with the leading `opensre` prefix removed; do not route it through `shell_run`. Do not search for AGENTS.md files or inspect the repository first unless the command fails or would modify files under a nested scope whose instructions were not provided.
 
 ## Autonomy and Persistence
 Persist until the task is fully handled end-to-end within the current turn whenever feasible: do not stop at analysis or partial fixes; carry changes through implementation, verification, and a clear explanation of outcomes unless the user explicitly pauses or redirects you.

--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -110,17 +110,33 @@ If you need to write a plan, only write high quality plans, not low quality ones
 
 ## Structured choices
 
-Whenever the user must choose between a small, fixed set of actions **before
-work can continue**, call the `ask_user_choice` tool so the interactive shell
-renders an arrow-key selection menu. Do not ask for free-form text, write a
-numbered "reply with 1, 2, or 3" list, or end the turn with prose asking the
-user to choose among those actions.
+Clarification is blocking whenever an underspecified request has a small,
+fixed set of materially different intents, goals, or execution paths. Do not
+guess which one the user meant. When TURN INTERACTION reports the menu is
+available, you MUST call `ask_user_choice` so the interactive shell renders an
+arrow-key selection menu. Do not ask for free-form text, write a numbered
+"reply with 1, 2, or 3" list, or end the turn with prose asking the user to
+choose among those options.
+
+For a demo or getting-started request, present the available skill demos as
+selectable options using `ask_user_choice`; use each demo prompt as the option
+that expresses that intent. The user's selection arrives verbatim as the next
+message. Treat it as the clarified request, then resolve the selected skill or
+goal and continue. Do not choose a demo or resolve a skill before the selection
+arrives.
+
+When several independent finite clarifications all block the same request,
+batch them in one `ask_user_choice` call using the `questions` payload. Do not
+drip them across turns. Proceed directly without clarification when the user's
+intent is explicit, when a safe default would not materially change the result,
+or when the possible answers are open-ended rather than a small fixed set.
 
 After calling `ask_user_choice`, end the turn with at most one short sentence of
 context. The user's selection arrives verbatim as the next message; resume from
 that selection. If the tool reports that the menu is unavailable **and the
 choice is required to continue**, fall back to a short numbered list and ask
-the user to reply with their choice.
+the user to reply with their choice. Use this numbered fallback only for
+required clarification when TURN INTERACTION reports the menu is unavailable.
 
 Do **not** call `ask_user_choice` just to park an optional follow-up (run tests,
 commit, build the next component) when TURN INTERACTION says the menu is

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -71,6 +71,7 @@ def test_agent_prompt_combines_demo_catalog_with_selectable_choice_contract() ->
     assert "For a demo or getting-started request" in collapsed
     assert "available skill demos as selectable options" in collapsed
     assert "ONLY the skill demos below" in collapsed
+    assert "that overview supplies the menu options only" in collapsed
     for skill in list_action_skills():
         if skill.demo:
             assert skill.demo in prompt

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -50,6 +50,32 @@ def test_agent_prompt_includes_skill_demos() -> None:
     assert "Set up a weekday morning briefing with weather and news" in prompt
 
 
+def test_agent_prompt_combines_demo_catalog_with_selectable_choice_contract() -> None:
+    clear_skills_caches()
+    prompt = build_action_system_prompt(
+        TurnSnapshot(
+            text="Give me a demo",
+            conversation_messages=(),
+            configured_integrations=(),
+            configured_integrations_known=True,
+            last_state=None,
+            last_synthetic_observation_path=None,
+            reasoning_effort=None,
+            prompt_surface="interactive_shell",
+            interactive_choice_available=True,
+        )
+    )
+    collapsed = " ".join(prompt.split())
+
+    assert "ask_user_choice menu: available" in prompt
+    assert "For a demo or getting-started request" in collapsed
+    assert "available skill demos as selectable options" in collapsed
+    assert "ONLY the skill demos below" in collapsed
+    for skill in list_action_skills():
+        if skill.demo:
+            assert skill.demo in prompt
+
+
 def test_skills_index_routes_capability_questions_to_direct_answer() -> None:
     clear_skills_caches()
     index = load_skills_index()

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -38,6 +38,8 @@ def test_demo_requests_require_selection_before_skill_resolution() -> None:
     collapsed = " ".join(_SYSTEM_PROMPT_BASE.split())
     assert "For a demo or getting-started request" in collapsed
     assert "available skill demos as selectable options" in collapsed
+    assert "takes precedence over any assembled capability-overview instruction" in collapsed
+    assert "that overview supplies the menu options only" in collapsed
     assert "selection arrives verbatim as the next message" in collapsed
     assert "then resolve the selected skill or goal" in collapsed
     assert "Do not choose a demo or resolve a skill before the selection arrives" in collapsed

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -18,6 +18,8 @@ def test_system_prompt_base_comes_from_markdown_file() -> None:
 
 def test_system_prompt_runs_explicit_commands_without_repository_probe() -> None:
     assert "execute it directly with the matching tool" in _SYSTEM_PROMPT_BASE
+    assert "call `cli_exec` with the leading `opensre` prefix removed" in _SYSTEM_PROMPT_BASE
+    assert "do not route it through `shell_run`" in _SYSTEM_PROMPT_BASE
     assert "Do not search for AGENTS.md files or inspect the repository first" in (
         _SYSTEM_PROMPT_BASE
     )

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -23,11 +23,39 @@ def test_system_prompt_runs_explicit_commands_without_repository_probe() -> None
     )
 
 
-def test_ask_user_choice_is_for_blocking_decisions_not_automated_follow_ups() -> None:
+def test_finite_material_ambiguity_requires_selectable_clarification() -> None:
+    text = _SYSTEM_PROMPT_BASE
+    collapsed = " ".join(text.split())
+    assert "Clarification is blocking whenever an underspecified request" in collapsed
+    assert "materially different intents, goals, or execution paths" in collapsed
+    assert "When TURN INTERACTION reports the menu is available" in collapsed
+    assert "you MUST call `ask_user_choice`" in collapsed
+    assert "numbered fallback only for required clarification" in collapsed
+    assert "TURN INTERACTION reports the menu is unavailable" in collapsed
+
+
+def test_demo_requests_require_selection_before_skill_resolution() -> None:
+    collapsed = " ".join(_SYSTEM_PROMPT_BASE.split())
+    assert "For a demo or getting-started request" in collapsed
+    assert "available skill demos as selectable options" in collapsed
+    assert "selection arrives verbatim as the next message" in collapsed
+    assert "then resolve the selected skill or goal" in collapsed
+    assert "Do not choose a demo or resolve a skill before the selection arrives" in collapsed
+
+
+def test_finite_clarifications_are_batched_without_over_questioning() -> None:
+    collapsed = " ".join(_SYSTEM_PROMPT_BASE.split())
+    assert "batch them in one `ask_user_choice` call using the `questions` payload" in collapsed
+    assert "Do not drip them across turns" in collapsed
+    assert "when the user's intent is explicit" in collapsed
+    assert "a safe default would not materially change the result" in collapsed
+    assert "answers are open-ended rather than a small fixed set" in collapsed
+
+
+def test_optional_choice_protections_follow_turn_interaction_facts() -> None:
     """Optional next-step menus follow TURN INTERACTION facts, not surface guessing."""
     text = _SYSTEM_PROMPT_BASE
     collapsed = " ".join(text.split())
-    assert "before work can continue" in collapsed
     assert "Do **not** call `ask_user_choice` just to park an optional follow-up" in collapsed
     assert "when TURN INTERACTION says the menu is unavailable" in collapsed
     assert "session_goal` is attached" in collapsed


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

- Make clarification blocking when an underspecified request has a small fixed set of materially different intents, goals, or execution paths.
- Require the interactive choice picker when available, while retaining the numbered fallback only for required choices on unavailable-menu surfaces.
- Route demo and getting-started requests through the discovered demo choices, batch independent finite clarifications, and avoid questions for explicit, immaterial-default, or open-ended cases.
- Route explicit `opensre ...` requests through the dedicated `cli_exec` tool rather than generic shell execution.
- Add prompt regressions covering the universal policy and its composition with skill demo metadata.

### Demo/Screenshot for feature changes and bug fixes -

Manual interactive-shell verification:

```text
Give me a demo
→ "Choose a Demo" arrow-key picker with the four discovered skill demos
→ selecting "Audit this repo's architecture and give me a sequenced refactor plan"
→ selected text returned as the next turn
→ Skill architecture-audit activated

Audit this repo's architecture and give me a sequenced refactor plan
→ Skill architecture-audit activated directly, with no clarification picker
```

Local verification:

```text
make lint
make format-check
make typecheck
uv run pytest tests/core/agent/prompts/test_system_prompt_markdown.py tests/core/agent/prompts/test_skills_demo.py tests/core/agent/prompts/test_turn_interaction.py tests/core/agent/orchestration/test_ask_choice_tool.py
24 passed
uv run python -m pytest -v tests/core/agent/test_turn_scenarios.py -k '203-cli-verify-dry-run' -m 'not synthetic'
2 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The main system prompt owns the universal interaction contract, so the change is confined there rather than altering skill discovery or demo metadata. The policy distinguishes blocking finite ambiguity from explicit intent, immaterial defaults, and open-ended questions. It also connects the existing skill demo catalog to the existing `ask_user_choice` handoff contract. Regression tests pin the stable prompt language and verify the assembled prompt contains both the catalog and the selectable-choice rule.

I considered changing `skills/loader.py` to make the demo block menu-specific, but kept it unchanged because discovery and metadata are already correct and the universal interaction policy belongs in the main prompt.

---

## Checklist before requesting a review
- [x] I have added a proper PR title; no issue number was supplied
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
