### PR TITLE
test(github): add repo-scope synthetic scenario

### DIFF
--- a/tests/synthetic/github_repo_scope/001-alert-repository-url/scenario.json
+++ b/tests/synthetic/github_repo_scope/001-alert-repository-url/scenario.json
@@ -1,0 +1,19 @@
+{
+  "scenario_id": "001-alert-repository-url",
+  "description": "A GitHub repository URL in the investigation request enriches the turn before action-tool planning.",
+  "user_message": "Investigate the latest change in https://github.com/Tracer-Cloud/opensre that could explain the incident.",
+  "base_resolved_integrations": {
+    "github": {
+      "connection_verified": true,
+      "mode": "stdio",
+      "command": "synthetic-github-mcp",
+      "args": []
+    }
+  },
+  "expected": {
+    "owner": "Tracer-Cloud",
+    "repo": "opensre",
+    "tool_name": "list_github_commits",
+    "commit_sha": "synthetic-repo-scope-5782"
+  }
+}

--- a/tests/synthetic/github_repo_scope/test_scenario.py
+++ b/tests/synthetic/github_repo_scope/test_scenario.py
@@ -1,0 +1,146 @@
+"""Synthetic regression scenario for GitHub repository-scope enrichment.
+
+The scenario drives the production headless turn and real action-tool registry.
+Only the LLM decision and GitHub MCP transport are scripted, so a regression in
+turn-plan enrichment makes ``list_github_commits`` disappear before planning.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from core.agent_harness.runtime import DefaultToolProvider, InMemoryHeadlessBuild, TurnBinding
+from core.agent_harness.turns.headless_adapters import BufferOutputSink, InMemorySessionState
+from core.llm.types import AgentLLMResponse, ToolCall
+
+_SCENARIO_PATH = Path(__file__).parent / "001-alert-repository-url" / "scenario.json"
+
+
+class _ScriptedActionLlm:
+    """Choose the expected GitHub tool, then conclude from its fixture result."""
+
+    model_id = "synthetic-github-repo-scope"
+
+    def __init__(self, responses: Iterator[AgentLLMResponse]) -> None:
+        self._responses = responses
+        self.tool_schema_names: list[str] = []
+
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+        self.tool_schema_names = [str(tool.name) for tool in tools]
+        return [{"name": tool.name} for tool in tools]
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        _ = (messages, system, tools)
+        return next(self._responses)
+
+    @staticmethod
+    def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": call.id, "name": call.name, "input": call.input} for call in tool_calls
+            ],
+        }
+
+    @staticmethod
+    def build_tool_result_message(
+        tool_calls: list[ToolCall],
+        results: list[Any],
+    ) -> dict[str, Any]:
+        return {
+            "role": "tool",
+            "results": [
+                {"id": call.id, "name": call.name, "output": result}
+                for call, result in zip(tool_calls, results)
+            ],
+        }
+
+
+def test_alert_repository_url_enables_github_tool_in_production_turn(
+    monkeypatch: Any,
+) -> None:
+    """A message repo URL exposes and executes the GitHub tool through the real turn."""
+    scenario = json.loads(_SCENARIO_PATH.read_text(encoding="utf-8"))
+    expected = scenario["expected"]
+    base_integrations = scenario["base_resolved_integrations"]
+    transport_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _fixture_github_mcp_call(
+        _config: Any,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        transport_calls.append((tool_name, arguments))
+        commits = [{"sha": expected["commit_sha"], "message": "Synthetic scope regression"}]
+        return {
+            "is_error": False,
+            "tool": tool_name,
+            "arguments": arguments,
+            "structured_content": commits,
+            "text": json.dumps(commits),
+            "content": [],
+        }
+
+    monkeypatch.setattr(
+        "integrations.github.tools.commits.call_github_mcp_tool",
+        _fixture_github_mcp_call,
+    )
+
+    tool_call = ToolCall(
+        id="github-commits-5782",
+        name=expected["tool_name"],
+        input={"owner": expected["owner"], "repo": expected["repo"]},
+    )
+    llm = _ScriptedActionLlm(
+        iter(
+            [
+                AgentLLMResponse(content="", tool_calls=[tool_call]),
+                AgentLLMResponse(
+                    content=f"The latest relevant commit is {expected['commit_sha']}.",
+                ),
+                AgentLLMResponse(content='{"verdict":"GOAL_REACHED"}'),
+            ]
+        )
+    )
+
+    session = InMemorySessionState(
+        configured_integrations=["github"],
+        configured_integrations_known=True,
+        resolved_integrations_cache=base_integrations,
+    )
+    output = BufferOutputSink()
+    tools = DefaultToolProvider(
+        session,
+        Console(file=StringIO(), force_terminal=False, highlight=False),
+    )
+    agent = InMemoryHeadlessBuild(session=session, output=output).agent(
+        tools=tools,
+        llm_factory=lambda: llm,
+    )
+
+    result = agent.handle(scenario["user_message"], TurnBinding())
+
+    assert expected["tool_name"] in llm.tool_schema_names
+    assert transport_calls == [
+        (
+            "list_commits",
+            {"owner": expected["owner"], "repo": expected["repo"], "perPage": 10},
+        )
+    ]
+    assert expected["commit_sha"] in result.assistant_response_text
+    assert session.vcs_repo_scopes["github"] == (expected["owner"], expected["repo"])
+    assert "owner" not in session.resolved_integrations_cache["github"]
+    assert "repo" not in session.resolved_integrations_cache["github"]


### PR DESCRIPTION
Fixes #5782

#### Describe the changes you have made in this PR -

The production repository-scope fix landed in #5811. This PR adds the missing runnable regression scenario for #5782:

- adds a fixture whose connected GitHub integration deliberately has no owner/repo while the investigation request names `https://github.com/Tracer-Cloud/opensre`
- drives the fixture through `HeadlessAgent.handle`, production turn-plan enrichment, the real action-tool registry, and the real `list_github_commits` executor
- scripts only the LLM choice and GitHub MCP network boundary
- proves the GitHub tool is available during planning, receives the inferred repository, returns fixture evidence, caches the scope, and does not mutate the base integration cache
- lives under `tests/synthetic/`, so the existing deterministic synthetic CI command collects it automatically without workflow changes

### Demo/Screenshot for feature changes and bug fixes -

```text
$ uv run python -m pytest tests/synthetic/github_repo_scope tests/core/agent_harness/test_turn_plan.py -q
collected 8 items
tests/synthetic/github_repo_scope/test_scenario.py .       [12%]
tests/core/agent_harness/test_turn_plan.py .......          [100%]
8 passed in 2.44s
```

The scenario asserted that the real GitHub executor called the mocked MCP boundary as:

```text
list_commits(owner=Tracer-Cloud, repo=opensre, perPage=10)
```

Validation:

- `make lint` — passed
- `make format-check` — 3715 files already formatted
- `make typecheck` — success, 1942 source files
- focused synthetic + turn-plan tests — 8 passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

A helper-level test would repeat the limitation called out in the issue discussion, so the scenario enters at the production headless turn API. The base GitHub integration is intentionally valid but unscoped. The request supplies the repository URL, and the real turn planner must enrich its per-turn copy before `DefaultToolProvider` resolves action tools. If that ordering regresses, `list_github_commits` is absent from the LLM schemas and the scenario fails before any fixture result can mask the problem.

The LLM is scripted because model choice is not the behavior under test. The MCP transport is mocked because CI must stay deterministic and credential-free. Tool discovery, availability checks, argument flow, execution, turn recording, and final response shaping all remain production code.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and understand how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
