### PR TITLE
ci: investigate Windows cold-start behavior

### DIFF
--- a/.github/scripts/measure-windows-startup.ps1
+++ b/.github/scripts/measure-windows-startup.ps1
@@ -89,8 +89,15 @@ function Get-OpenSreMainArtifact {
 
     $archivePath = Join-Path $Destination $archiveName
     $checksumPath = "$archivePath.sha256"
-    Invoke-WebRequest -Uri $archiveAsset.browser_download_url -Headers $headers -OutFile $archivePath
-    Invoke-WebRequest -Uri $checksumAsset.browser_download_url -Headers $headers -OutFile $checksumPath
+    $assetHeaders = @{
+        "Accept" = "application/octet-stream"
+        "User-Agent" = "opensre-windows-startup-investigation"
+    }
+    if ($headers.ContainsKey("Authorization")) {
+        $assetHeaders["Authorization"] = $headers["Authorization"]
+    }
+    Invoke-WebRequest -Uri $archiveAsset.url -Headers $assetHeaders -OutFile $archivePath
+    Invoke-WebRequest -Uri $checksumAsset.url -Headers $assetHeaders -OutFile $checksumPath
 
     $checksumLine = Get-Content -LiteralPath $checksumPath | Where-Object { $_ -match '^[A-Fa-f0-9]{64}\s+' } | Select-Object -First 1
     if (-not $checksumLine) {
@@ -112,6 +119,9 @@ function Get-OpenSreMainArtifact {
     return [ordered]@{
         binary_path = [string]$binaries[0].FullName
         artifact_name = $archiveName
+        artifact_id = [Int64]$archiveAsset.id
+        checksum_id = [Int64]$checksumAsset.id
+        release_id = [Int64]$release.id
         release_published_at = [string]$release.published_at
     }
 }
@@ -121,6 +131,9 @@ New-Item -ItemType Directory -Path $benchmarkRoot | Out-Null
 
 $installDurationMs = $null
 $artifactName = ""
+$artifactId = $null
+$checksumId = $null
+$releaseId = $null
 $releasePublishedAt = ""
 $installMethod = ""
 $binaryPath = ""
@@ -154,6 +167,9 @@ try {
         $artifact = Get-OpenSreMainArtifact -RepositoryName $Repository -Destination $benchmarkRoot
         $binaryPath = [string]$artifact.binary_path
         $artifactName = [string]$artifact.artifact_name
+        $artifactId = [Int64]$artifact.artifact_id
+        $checksumId = [Int64]$artifact.checksum_id
+        $releaseId = [Int64]$artifact.release_id
         $releasePublishedAt = [string]$artifact.release_published_at
         $installMethod = "download and extract main-build artifact without executing it"
     }
@@ -178,6 +194,9 @@ try {
         second_help_ms = $secondHelpMs
         binary_size_bytes = $binarySizeBytes
         artifact_name = $artifactName
+        artifact_id = $artifactId
+        checksum_id = $checksumId
+        release_id = $releaseId
         release_published_at = $releasePublishedAt
         packaging_mode = "PyInstaller onefile"
         windows = $facts

--- a/.github/scripts/measure-windows-startup.ps1
+++ b/.github/scripts/measure-windows-startup.ps1
@@ -1,0 +1,219 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("readme-install", "raw-artifact")]
+    [string]$Mode,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath,
+
+    [string]$Repository = "Tracer-Cloud/opensre",
+    [string]$InstallerUri = "https://install.opensre.com"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-OpenSreWindowsFacts {
+    $operatingSystem = Get-CimInstance -ClassName Win32_OperatingSystem
+    $defenderEnabled = $null
+    $realTimeProtectionEnabled = $null
+
+    try {
+        $defender = Get-MpComputerStatus -ErrorAction Stop
+        $defenderEnabled = [bool]$defender.AntivirusEnabled
+        $realTimeProtectionEnabled = [bool]$defender.RealTimeProtectionEnabled
+    }
+    catch {
+        # Defender status is best-effort because third-party antivirus and some
+        # restricted Windows hosts do not expose Get-MpComputerStatus.
+    }
+
+    return [ordered]@{
+        caption = [string]$operatingSystem.Caption
+        version = [string]$operatingSystem.Version
+        architecture = [string][System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        defender_enabled = $defenderEnabled
+        defender_realtime_enabled = $realTimeProtectionEnabled
+    }
+}
+
+function Measure-OpenSreHelp {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BinaryPath
+    )
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    & $BinaryPath --help 1> $null 2> $null
+    $exitCode = $LASTEXITCODE
+    $stopwatch.Stop()
+
+    if ($exitCode -ne 0) {
+        throw "'$BinaryPath --help' exited with status $exitCode."
+    }
+
+    return [Math]::Round($stopwatch.Elapsed.TotalMilliseconds, 2)
+}
+
+function Get-OpenSreMainArtifact {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Destination
+    )
+
+    $headers = @{
+        "Accept" = "application/vnd.github+json"
+        "User-Agent" = "opensre-windows-startup-investigation"
+    }
+    $release = Invoke-RestMethod `
+        -Uri "https://api.github.com/repos/$RepositoryName/releases/tags/main-build" `
+        -Headers $headers
+    $architecture = [string][System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    if ($architecture -ne "X64") {
+        throw "The raw-artifact benchmark currently requires an x64 Windows runner; found '$architecture'."
+    }
+
+    $archiveName = "opensre_main_windows-x64.zip"
+    $archiveAsset = @($release.assets) | Where-Object { $_.name -eq $archiveName } | Select-Object -First 1
+    $checksumAsset = @($release.assets) | Where-Object { $_.name -eq "$archiveName.sha256" } | Select-Object -First 1
+    if ($null -eq $archiveAsset -or $null -eq $checksumAsset) {
+        throw "The main-build release is missing '$archiveName' or its checksum."
+    }
+
+    $archivePath = Join-Path $Destination $archiveName
+    $checksumPath = "$archivePath.sha256"
+    Invoke-WebRequest -Uri $archiveAsset.browser_download_url -Headers $headers -OutFile $archivePath
+    Invoke-WebRequest -Uri $checksumAsset.browser_download_url -Headers $headers -OutFile $checksumPath
+
+    $checksumLine = Get-Content -LiteralPath $checksumPath | Where-Object { $_ -match '^[A-Fa-f0-9]{64}\s+' } | Select-Object -First 1
+    if (-not $checksumLine) {
+        throw "Checksum file '$checksumPath' does not contain a SHA256 value."
+    }
+    $expectedHash = ($checksumLine -split '\s+')[0].ToLowerInvariant()
+    $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHash -ne $expectedHash) {
+        throw "Checksum mismatch for '$archiveName'."
+    }
+
+    $extractionRoot = Join-Path $Destination "extracted"
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $extractionRoot -Force
+    $binaries = @(Get-ChildItem -LiteralPath $extractionRoot -Filter "opensre.exe" -File -Recurse)
+    if ($binaries.Count -ne 1) {
+        throw "Expected one opensre.exe in '$archiveName'; found $($binaries.Count)."
+    }
+
+    return [ordered]@{
+        binary_path = [string]$binaries[0].FullName
+        artifact_name = $archiveName
+        release_published_at = [string]$release.published_at
+    }
+}
+
+$benchmarkRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("opensre-startup-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $benchmarkRoot | Out-Null
+
+$installDurationMs = $null
+$artifactName = ""
+$releasePublishedAt = ""
+$installMethod = ""
+$binaryPath = ""
+$overriddenEnvironment = @(
+    "OPENSRE_INSTALL_DIR",
+    "OPENSRE_INSTALL_CHANNEL",
+    "OPENSRE_SKIP_GH_INSTALL",
+    "OPENSRE_AUTO_LAUNCH"
+)
+$originalEnvironment = @{}
+foreach ($name in $overriddenEnvironment) {
+    $originalEnvironment[$name] = [System.Environment]::GetEnvironmentVariable($name, "Process")
+}
+
+try {
+    if ($Mode -eq "readme-install") {
+        $installDir = Join-Path $benchmarkRoot "bin"
+        $env:OPENSRE_INSTALL_DIR = $installDir
+        $env:OPENSRE_INSTALL_CHANNEL = "main"
+        $env:OPENSRE_SKIP_GH_INSTALL = "1"
+        $env:OPENSRE_AUTO_LAUNCH = "0"
+
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        Invoke-Expression (Invoke-RestMethod -Uri $InstallerUri)
+        $stopwatch.Stop()
+        $installDurationMs = [Math]::Round($stopwatch.Elapsed.TotalMilliseconds, 2)
+        $binaryPath = Join-Path $installDir "opensre.exe"
+        $installMethod = "irm $InstallerUri | iex"
+    }
+    else {
+        $artifact = Get-OpenSreMainArtifact -RepositoryName $Repository -Destination $benchmarkRoot
+        $binaryPath = [string]$artifact.binary_path
+        $artifactName = [string]$artifact.artifact_name
+        $releasePublishedAt = [string]$artifact.release_published_at
+        $installMethod = "download and extract main-build artifact without executing it"
+    }
+
+    if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
+        throw "OpenSRE binary was not found at '$binaryPath'."
+    }
+
+    $firstHelpMs = Measure-OpenSreHelp -BinaryPath $binaryPath
+    $secondHelpMs = Measure-OpenSreHelp -BinaryPath $binaryPath
+    $binarySizeBytes = (Get-Item -LiteralPath $binaryPath).Length
+    $facts = Get-OpenSreWindowsFacts
+
+    $result = [ordered]@{
+        schema_version = 1
+        measured_at_utc = [DateTime]::UtcNow.ToString("o")
+        mode = $Mode
+        install_method = $installMethod
+        install_channel = "main"
+        install_duration_ms = $installDurationMs
+        first_help_ms = $firstHelpMs
+        second_help_ms = $secondHelpMs
+        binary_size_bytes = $binarySizeBytes
+        artifact_name = $artifactName
+        release_published_at = $releasePublishedAt
+        packaging_mode = "PyInstaller onefile"
+        windows = $facts
+        notes = @(
+            "The README installer runs opensre.exe --version while verifying the archive, before the first user invocation.",
+            "The raw-artifact mode avoids that verification launch and therefore measures the executable's first process start.",
+            "Bare interactive-shell startup is not measured because GitHub-hosted runners are non-interactive."
+        )
+    }
+
+    $outputDirectory = Split-Path -Parent $OutputPath
+    if ($outputDirectory) {
+        New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+    }
+    $result | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+
+    $summary = @"
+### OpenSRE Windows startup: $Mode
+
+| Measurement | Result |
+| --- | ---: |
+| Windows | $($facts.caption) $($facts.version) ($($facts.architecture)) |
+| Defender real-time protection | $($facts.defender_realtime_enabled) |
+| Install / extraction | $installDurationMs ms |
+| First opensre --help | $firstHelpMs ms |
+| Second opensre --help | $secondHelpMs ms |
+| Binary size | $binarySizeBytes bytes |
+| Packaging | PyInstaller onefile |
+
+The README installer executes opensre.exe --version during verification. Only the raw-artifact job measures the binary's true first process start.
+"@
+    Write-Host $summary
+    if ($env:GITHUB_STEP_SUMMARY) {
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $summary
+    }
+}
+finally {
+    foreach ($name in $overriddenEnvironment) {
+        [System.Environment]::SetEnvironmentVariable($name, $originalEnvironment[$name], "Process")
+    }
+    Remove-Item -LiteralPath $benchmarkRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/.github/scripts/measure-windows-startup.ps1
+++ b/.github/scripts/measure-windows-startup.ps1
@@ -69,6 +69,9 @@ function Get-OpenSreMainArtifact {
         "Accept" = "application/vnd.github+json"
         "User-Agent" = "opensre-windows-startup-investigation"
     }
+    if ($env:GITHUB_TOKEN) {
+        $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+    }
     $release = Invoke-RestMethod `
         -Uri "https://api.github.com/repos/$RepositoryName/releases/tags/main-build" `
         -Headers $headers

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,6 +8,7 @@ Internal notes for repository automation under `.github/workflows/`. Not publish
 | -------- | ------- |
 | [`ci.yml`](ci.yml) | PR/push quality gates and sharded pytest |
 | [`ci-labels-windows.yml`](ci-labels-windows.yml) | Optional Windows CI (`ci:windows` label) |
+| [`windows-startup-investigation.yml`](windows-startup-investigation.yml) | Manual and change-scoped Windows binary startup measurements |
 | [`codeql.yml`](codeql.yml) | Full post-merge CodeQL and manual PR-profile benchmarks |
 | [`greptile-pr-reminder.yml`](greptile-pr-reminder.yml) | Greptile review nudge on PR open |
 | [`celebrate-merged-pr.yml`](celebrate-merged-pr.yml) | Post-merge celebration comment |

--- a/.github/workflows/windows-startup-investigation.yml
+++ b/.github/workflows/windows-startup-investigation.yml
@@ -1,0 +1,46 @@
+name: Windows Startup Investigation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/scripts/measure-windows-startup.ps1"
+      - ".github/workflows/windows-startup-investigation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: windows-startup-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  measure:
+    name: ${{ matrix.mode }}
+    runs-on: windows-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [readme-install, raw-artifact]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Measure startup
+        shell: pwsh
+        run: >-
+          ./.github/scripts/measure-windows-startup.ps1
+          -Mode "${{ matrix.mode }}"
+          -OutputPath "startup-${{ matrix.mode }}.json"
+
+      - name: Upload measurements
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-startup-${{ matrix.mode }}
+          path: startup-${{ matrix.mode }}.json
+          if-no-files-found: error

--- a/.github/workflows/windows-startup-investigation.yml
+++ b/.github/workflows/windows-startup-investigation.yml
@@ -29,19 +29,21 @@ jobs:
         mode: [readme-install, raw-artifact]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
 
       - name: Measure startup
         shell: pwsh
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ matrix.mode == 'raw-artifact' && github.token || '' }}
         run: >-
           ./.github/scripts/measure-windows-startup.ps1
           -Mode "${{ matrix.mode }}"
           -OutputPath "startup-${{ matrix.mode }}.json"
 
       - name: Upload measurements
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-startup-${{ matrix.mode }}
           path: startup-${{ matrix.mode }}.json

--- a/.github/workflows/windows-startup-investigation.yml
+++ b/.github/workflows/windows-startup-investigation.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Measure startup
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           ./.github/scripts/measure-windows-startup.ps1
           -Mode "${{ matrix.mode }}"


### PR DESCRIPTION
Fixes #5848

#### Describe the changes you have made in this PR -

- Add a reproducible Windows startup investigation workflow that runs when its own benchmark files change and can be dispatched manually later.
- Measure the README PowerShell install path on a fresh `windows-latest` runner, including install time and the first two user `opensre --help` invocations.
- Measure the same main-build artifact on a separate clean runner after checksum-verified extraction, without executing the binary first.
- Upload structured JSON results and render a job summary with Windows version, architecture, Defender state, binary size, and timings.

The two-runner design avoids a measurement trap in the current installer: archive verification executes `opensre.exe --version`, so the first user command after installation is not the executable's true first process start.

### Results

Two complete workflow runs used four fresh GitHub-hosted Windows Server 2025 Datacenter x64 runners. All reported Defender real-time protection disabled. The main-build `opensre.exe` was 117,774,474 bytes.

| Run | Path | Install / extraction | First `opensre --help` | Second `opensre --help` |
| --- | --- | ---: | ---: | ---: |
| 1 | README `irm … \| iex` | 19.77 s | 14.20 s | 11.76 s |
| 1 | Raw artifact, no prior execution | n/a | 16.24 s | 12.88 s |
| 2 | README `irm … \| iex` | 17.54 s | 14.65 s | 22.82 s |
| 2 | Raw artifact, no prior execution | n/a | 17.25 s | 12.56 s |

Windows is the same order of magnitude as Unix's reported 7–14 s, but the true first process start was worse at 16.24–17.25 s. The raw-artifact second launch was stable at 12.56–12.88 s. Installer verification pre-warmed the first user start by roughly two seconds; the 22.82 s README outlier also shows that a nominally warm invocation is not reliably fast on a hosted runner.

### Root-cause hypothesis

Defender is not required to reproduce the slowdown: it was disabled on all four runners. The strongest platform-specific suspect is therefore the Windows PyInstaller `onefile` layout—Unix release targets use `onedir`—combined with the shared eager import/startup cost. Because a onefile executable extracts its bundled runtime on every process launch, the small cold/warm delta and persistently slow second run fit repeated extraction/import work better than a one-time installer or antivirus penalty.

A follow-up fix should benchmark Windows `onedir` against `onefile` and profile imports before changing packaging. These are hosted-runner samples, so consumer Defender impact should still be measured separately.

### Demo/Screenshot for feature changes and bug fixes -

The PR's **Windows Startup Investigation** check publishes both timing tables and downloadable JSON artifacts.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The workflow uses two isolated Windows runners so the README-path result is not confused with the executable's actual first launch. The raw-artifact path independently downloads the published main-build zip and checksum, validates SHA-256, extracts it, and only then starts the executable. The script records machine facts and timings as versioned JSON so future measurements remain comparable. Temporary files are created under a unique temp directory and removed in `finally`; process environment overrides are restored.

Alternatives considered:
- A single post-install benchmark was rejected because the installer pre-launches the binary for version verification.
- Adding the benchmark to every Windows-labeled PR was rejected because it would consume runner time unrelated to startup changes.
- Changing packaging or startup code was intentionally left out because #5848 is investigation-only.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

### Validation

- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`
- [x] Workflow YAML parsed locally
- [x] Windows Startup Investigation jobs green
- [x] Repository PR checks green
