### PR TITLE
fix(integrations): report resolved setup store path

### DIFF
--- a/integrations/cli.py
+++ b/integrations/cli.py
@@ -35,10 +35,10 @@ if TYPE_CHECKING:
 
 from integrations.registry import SUPPORTED_SETUP_SERVICES, resolve_management_service
 from integrations.store import (
-    STORE_PATH,
     get_integration,
     list_integrations,
     remove_integration,
+    resolve_store_path,
 )
 from integrations.verify import (
     SUPPORTED_VERIFY_SERVICES,
@@ -909,7 +909,7 @@ def cmd_setup(service: str | None) -> str:
         _die(f"Usage: setup <service>. Supported: {', '.join(available)}")
     print(f"\n  Setting up {_B}{service}{_R}\n")
     _HANDLERS[service]()
-    print(f"\n  {GLYPH_SUCCESS} Saved → {STORE_PATH}\n")
+    print(f"\n  {GLYPH_SUCCESS} Saved → {resolve_store_path()}\n")
     return service
 
 

--- a/integrations/harness_adapters.py
+++ b/integrations/harness_adapters.py
@@ -14,11 +14,11 @@ def register_harness_adapters() -> None:
         merge_local_integrations,
     )
     from integrations.cli import setup_services
-    from integrations.store import STORE_PATH, load_integrations
+    from integrations.store import load_integrations, resolve_store_path
 
     IntegrationResolutionAdapters(
         load_integrations=load_integrations,
-        integration_store_path=lambda: str(STORE_PATH),
+        integration_store_path=lambda: str(resolve_store_path()),
         load_env_integrations=load_env_integrations,
         classify_integrations=classify_integrations,
         merge_local_integrations=merge_local_integrations,

--- a/integrations/store.py
+++ b/integrations/store.py
@@ -55,7 +55,8 @@ logger = logging.getLogger(__name__)
 STORE_PATH: Path | None = None
 
 
-def _store_path() -> Path:
+def resolve_store_path() -> Path:
+    """Return the effective integration store path for the current scope."""
     return Path(STORE_PATH) if STORE_PATH is not None else integrations_store_path()
 
 
@@ -73,7 +74,7 @@ class IntegrationStoreLockTimeout(TimeoutError):
 
 def _lock_timeout_error() -> IntegrationStoreLockTimeout:
     return IntegrationStoreLockTimeout(
-        f"Integration store locked: {_lock_path()} (store: {_store_path()})"
+        f"Integration store locked: {_lock_path()} (store: {resolve_store_path()})"
     )
 
 
@@ -116,7 +117,7 @@ def _migrate_if_needed(data: dict[str, Any]) -> tuple[dict[str, Any], bool]:
 
 def _lock_path() -> Path:
     """Return the file lock path derived from the current STORE_PATH."""
-    return _store_path().with_suffix(".lock")
+    return resolve_store_path().with_suffix(".lock")
 
 
 def _ensure_private_store_directory(path: Path) -> None:
@@ -129,7 +130,7 @@ def _ensure_private_store_directory(path: Path) -> None:
 
 def _acquire_lock() -> FileLock:
     """Create and return a FileLock for the current STORE_PATH."""
-    _ensure_private_store_directory(_store_path().parent)
+    _ensure_private_store_directory(resolve_store_path().parent)
     return FileLock(str(_lock_path()), timeout=_LOCK_TIMEOUT_SECONDS)
 
 
@@ -164,7 +165,7 @@ def _save_unlocked(data: dict[str, Any]) -> None:
 
     Callers must already hold the store lock.
     """
-    _atomic_write(_store_path(), data)
+    _atomic_write(resolve_store_path(), data)
 
 
 def _load_raw_unlocked() -> tuple[dict[str, Any], bool]:
@@ -173,13 +174,15 @@ def _load_raw_unlocked() -> tuple[dict[str, Any], bool]:
     Returns ``(data, did_migrate)``.  This helper does **not** write back
     migrations and does **not** acquire any lock.
     """
-    if not _store_path().exists():
+    if not resolve_store_path().exists():
         return {"version": _VERSION, "integrations": []}, False
     try:
-        text = _store_path().read_text(encoding="utf-8")
+        text = resolve_store_path().read_text(encoding="utf-8")
         data = json.loads(text)
     except (json.JSONDecodeError, OSError):
-        logger.warning("Failed to read integrations store at %s", _store_path(), exc_info=True)
+        logger.warning(
+            "Failed to read integrations store at %s", resolve_store_path(), exc_info=True
+        )
         return {"version": _VERSION, "integrations": []}, False
     if not isinstance(data, dict) or "integrations" not in data:
         return {"version": _VERSION, "integrations": []}, False

--- a/surfaces/cli/wizard/summaries.py
+++ b/surfaces/cli/wizard/summaries.py
@@ -143,7 +143,7 @@ def render_saved_summary(
         credentials ~/.opensre/credentials.json  [SECONDARY key] [TEXT value]
         store       ~/.opensre/store.json        [SECONDARY key] [BRAND path]
     """
-    from integrations.store import STORE_PATH
+    from integrations.store import resolve_store_path
 
     console.print()
     console.print(Rule(style=DIM))
@@ -169,7 +169,7 @@ def render_saved_summary(
     _kv("config", saved_path, BRAND)
     _kv("env", env_path, BRAND)
     _kv("credentials", credential_line)
-    _kv("store", str(STORE_PATH), BRAND)
+    _kv("store", str(resolve_store_path()), BRAND)
     console.print()
 
 

--- a/surfaces/shared/doctor_checks.py
+++ b/surfaces/shared/doctor_checks.py
@@ -51,11 +51,11 @@ def _check_llm_provider() -> tuple[bool, str]:
 
 
 def _check_integrations() -> tuple[bool, str]:
-    from integrations.store import STORE_PATH, list_integrations
+    from integrations.store import list_integrations, resolve_store_path
 
-    path = Path(str(STORE_PATH))
+    path = resolve_store_path()
     if not path.exists():
-        return False, f"{STORE_PATH} not found — run 'opensre integrations setup'"
+        return False, f"{path} not found — run 'opensre integrations setup'"
     items = list_integrations()
     if not items:
         return False, "no integrations configured"

--- a/tests/cli/test_integrations_setup_github.py
+++ b/tests/cli/test_integrations_setup_github.py
@@ -9,6 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 import integrations.setup_flow as setup_flow
+from config.constants import INTEGRATIONS_STORE_PATH_ENV
 from integrations.cli import _github_browser_auth_token, _setup_github, cmd_setup
 from integrations.github.mcp import GitHubMCPValidationResult
 from surfaces.cli.app import cli
@@ -271,9 +272,13 @@ def test_cmd_setup_github_skips_saved_line_on_validation_failure(
 def test_cmd_setup_github_prints_saved_after_success(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
 ) -> None:
     """Full cmd_setup('github') prints validation, Saved line, and does not duplicate handlers."""
 
+    store_path = tmp_path / "integrations.json"
+    monkeypatch.setenv(INTEGRATIONS_STORE_PATH_ENV, str(store_path))
+    monkeypatch.setattr("integrations.store.STORE_PATH", None)
     answers = iter(["https://api.githubcopilot.com/mcp/", "repos"])
 
     def fake_p(_label: str, default: str = "", secret: bool = False) -> str:
@@ -304,7 +309,7 @@ def test_cmd_setup_github_prints_saved_after_success(
     out = capsys.readouterr().out
     assert "Configuration validation: succeeded" in out
     assert "@u" in out
-    assert "Saved" in out
+    assert f"Saved → {store_path}" in out
 
 
 def test_integrations_setup_github_cli_invokes_cmd_setup() -> None:


### PR DESCRIPTION
Fixes #5853

#### Describe the changes you have made in this PR -

- Expose `resolve_store_path()` as the integration store's lazy, tenant-aware path resolver.
- Use the resolver in integration setup output, onboarding summaries, doctor checks, and harness adapter wiring instead of rendering the normally unset `STORE_PATH` test hook.
- Add regression coverage proving an `OPENSRE_INTEGRATIONS_STORE_PATH` override is reported after successful setup.

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python .github/ci/run_test_scope.py --base upstream/main` — 4,478 passed, 15 skipped
- Docker-backed Tempo setup and persistence check

### Demo/Screenshot for feature changes and bug fixes -

Before:

```text
✓ Saved → None
```

After a successful setup against the disposable Tempo Docker service:

```text
Validating tempo credentials...
Connected to Grafana Tempo HTTP API (/api/search/tags).
✓ Saved → /tmp/opensre-store-path-fix.rBLe0i/integrations.json
```

The displayed file was then read back and contained the persisted `tempo` integration.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The setup command imported `STORE_PATH`, which is intentionally `None` at runtime because it exists as a test override. Actual persistence already used a private lazy resolver that accounts for environment overrides and the current tenant scope. I considered removing the path from the success message, but that would discard useful confirmation. Instead, this PR makes the resolver public and updates every production consumer that was reading the test hook directly. The function stays lazy, so it does not introduce an import-time path or break tenant-aware storage.

The regression test runs the successful GitHub setup path with a temporary `OPENSRE_INTEGRATIONS_STORE_PATH` and asserts that the exact resolved destination appears in the success line. Existing store, wizard, doctor, and harness tests cover the other updated consumers.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Maintainers can edit this upstream branch directly.
