### PR TITLE
fix(tests): remove mapped tools from evidence gaps

### DIFF
--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -86,8 +86,6 @@ get_redis_replication
 get_redis_server_info
 get_redis_slowlog
 get_s3_object
-get_sentry_issue_details
-get_sqs_queue_attributes
 get_sre_guidance
 get_tracer_run
 get_tracer_tasks


### PR DESCRIPTION
Fixes #5855

#### Describe the changes you have made in this PR -

- Remove `get_sentry_issue_details` and `get_sqs_queue_attributes` from the known-gap baseline now that both tools declare evidence mappers.
- Restore the evidence-mapper coverage ratchet that currently fails two CI shards on `main`.

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q` — 11 passed

### Demo/Screenshot for feature changes and bug fixes -

Before on current `main`:

```text
AssertionError: Tool(s) both mapped and listed as a gap:
['get_sentry_issue_details', 'get_sqs_queue_attributes'].
```

After removing the stale baseline entries:

```text
tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py ........... [100%]
11 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The baseline is an explicit list of investigation tools that intentionally lack evidence mappers. Its coverage test rejects any tool that is simultaneously mapped and still listed as a gap. The Sentry issue-details and SQS queue-attributes tools now both declare mappers, so retaining their names violates the baseline contract and deterministically fails CI.

The smallest correct repair is to remove only those two stale lines. Changing or weakening the coverage assertion would hide future baseline drift, and changing the mapper implementations would undo valid citeable evidence behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Maintainers can edit this upstream branch directly.
