### PR TITLE
feat(shell): arrow-navigable confirmation and collapsible plan overlay

### DIFF
--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -17,7 +17,6 @@ from surfaces.interactive_shell.controller import InteractiveShellController
 from surfaces.interactive_shell.runtime.context import create_repl_runtime
 from surfaces.interactive_shell.runtime.startup.initial_input import run_initial_input
 from surfaces.interactive_shell.runtime.startup.loop_suggestions import offer_loop_suggestions
-from surfaces.interactive_shell.ui.input_prompt import build_prompt_session
 from surfaces.interactive_shell.ui.terminal_ui import render_terminal_ui
 
 # Fallback when a caller does not supply one. Forces a terminal because the
@@ -51,8 +50,9 @@ async def run_repl_async(
     # probe thread while a status spinner animates lands whole above it instead
     # of racing the spinner's redraw on the tty and staircasing what follows.
     install_shell_log_handler(lambda: out)
-    pt_session = build_prompt_session()
-    runtime_context = create_repl_runtime(pt_session=pt_session)
+    # Let PromptBuilder build the prompt session so it can wire the
+    # composer-hide (needs the session + REPL state, which do not exist yet).
+    runtime_context = create_repl_runtime()
     session = runtime_context.session
     session.terminal.cli_command_group = cli_command_group
 

--- a/surfaces/interactive_shell/runtime/core/confirmation.py
+++ b/surfaces/interactive_shell/runtime/core/confirmation.py
@@ -22,18 +22,20 @@ def request_confirmation_via_prompt(
     state: ReplState,
     prompt_text: str,
     *,
+    options: tuple[tuple[str, str], ...] | None = None,
     redraw: Callable[[], None] | None = None,
     prepare_ui: Callable[[], None] | None = None,
 ) -> str:
-    """Park until the prompt loop delivers a y/n answer.
+    """Park until the prompt loop delivers an answer for one of ``options``.
 
+    ``options`` are the rows the arrow-nav choice shows (default Yes/No).
     ``prepare_ui`` runs once after confirmation begins (clear typeahead under
     the hidden composer). ``redraw`` (typically prompt invalidate) runs after
     begin and again after clear so the typing box hides and restores
     immediately rather than waiting for the next refresh tick.
     """
     response_event = threading.Event()
-    state.begin_confirmation(response_event, prompt_text)
+    state.begin_confirmation(response_event, prompt_text, options)
     if prepare_ui is not None:
         prepare_ui()
     if redraw is not None:

--- a/surfaces/interactive_shell/runtime/core/confirmation.py
+++ b/surfaces/interactive_shell/runtime/core/confirmation.py
@@ -23,15 +23,19 @@ def request_confirmation_via_prompt(
     prompt_text: str,
     *,
     redraw: Callable[[], None] | None = None,
+    prepare_ui: Callable[[], None] | None = None,
 ) -> str:
     """Park until the prompt loop delivers a y/n answer.
 
-    ``redraw`` (typically prompt invalidate) runs after confirmation begins and
-    again after it clears so the free-text typing box hides and restores
+    ``prepare_ui`` runs once after confirmation begins (clear typeahead under
+    the hidden composer). ``redraw`` (typically prompt invalidate) runs after
+    begin and again after clear so the typing box hides and restores
     immediately rather than waiting for the next refresh tick.
     """
     response_event = threading.Event()
     state.begin_confirmation(response_event, prompt_text)
+    if prepare_ui is not None:
+        prepare_ui()
     if redraw is not None:
         redraw()
     try:

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -18,6 +18,10 @@ from surfaces.interactive_shell.runtime.core.state import (
 )
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui import input_prompt
+from surfaces.interactive_shell.ui.hooks import (
+    install_confirmation_key_bindings,
+    install_plan_expand_key_bindings,
+)
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
 from surfaces.interactive_shell.ui.input_prompt.key_bindings import (
     build_cancel_key_bindings,
@@ -56,7 +60,10 @@ class PromptBuilder:
 
     def setup(self) -> None:
         if self.pt_session is None:
-            self.pt_session = input_prompt.build_prompt_session(self.session)
+            self.pt_session = input_prompt.build_prompt_session(
+                self.session,
+                hide_composer=lambda: typing_box_hidden(self.session, self.state),
+            )
             self.session.terminal.prompt_history_backend = self.pt_session.history
 
         cancel_kb = build_cancel_key_bindings(self.state)
@@ -69,6 +76,18 @@ class PromptBuilder:
         self.session.terminal.main_loop = self.loop
         self.state.bind_loop(self.loop)
         self._invalidate_prompt = wire_prompt_refresh(self.session, self.pt_app, self.loop)
+        # Arrow-navigable Yes/No for the execution-confirmation gate: ↑/↓ move the
+        # selection, Enter (or a/b/y/n) delivers it. Installed after the redraw
+        # hook so a selection change repaints immediately.
+        confirm_kb = install_confirmation_key_bindings(self.state, self._invalidate_prompt)
+        install_session_key_bindings(self.pt_session, confirm_kb)
+        # Ctrl+P expands/collapses the pinned plan while one is on screen.
+        plan_kb = install_plan_expand_key_bindings(
+            self.state,
+            lambda: self.session.task_plan is not None and bool(self.session.task_plan.steps),
+            self._invalidate_prompt,
+        )
+        install_session_key_bindings(self.pt_session, plan_kb)
 
     @property
     def invalidate_prompt(self) -> Callable[[], None]:

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application import Application
 from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import ANSI
 from rich.console import Console
 
@@ -58,11 +59,19 @@ class PromptBuilder:
         self._submitted: asyncio.Queue[str] = asyncio.Queue()
         self._prompt_task: asyncio.Task[str] | None = None
 
+    def _composer_hidden(self) -> bool:
+        """True while structured input (confirmation, menus) owns the keyboard.
+
+        The prompt reads this to collapse the free-text composer box so it does
+        not sit under the pending choice.
+        """
+        return typing_box_hidden(self.session, self.state)
+
     def setup(self) -> None:
         if self.pt_session is None:
             self.pt_session = input_prompt.build_prompt_session(
                 self.session,
-                hide_composer=lambda: typing_box_hidden(self.session, self.state),
+                hide_composer=self._composer_hidden,
             )
             self.session.terminal.prompt_history_backend = self.pt_session.history
 
@@ -71,6 +80,10 @@ class PromptBuilder:
 
         self.pt_app = self.pt_session.app
         self.pt_session.default_buffer.accept_handler = self._accept_prompt_buffer
+        # While the Yes/No gate owns the keyboard the composer is hidden but its
+        # buffer still receives unbound keys unless it is read-only. Lock it so
+        # typeahead cannot accumulate under the overlay and submit after close.
+        self.pt_session.default_buffer.read_only = Condition(self.state.is_awaiting_confirmation)
         self.loop = asyncio.get_running_loop()
         self.session.terminal.prompt_app = self.pt_app
         self.session.terminal.main_loop = self.loop
@@ -116,6 +129,10 @@ class PromptBuilder:
 
     def _accept_prompt_buffer(self, buffer: Buffer) -> bool:
         """Queue accepted text while keeping the prompt application alive."""
+        # Enter during confirmation is handled by the Yes/No bindings; never
+        # treat residual buffer text as a submitted message while the gate is up.
+        if self.state.is_awaiting_confirmation():
+            return True
         self._submitted.put_nowait(buffer.text)
         return False
 

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -55,11 +55,17 @@ class ReplState:
     confirm_event: threading.Event | None = None
     confirm_response: list[str] = field(default_factory=list)
     confirm_prompt_text: str = ""
+    confirm_selected: int = 0
+    plan_expanded: bool = False
     phase: TurnPhase = TurnPhase.IDLE
     ctrl_c_exit_hint_until: float = 0.0
 
     def is_dispatch_running(self) -> bool:
         return self.current_task is not None and not self.current_task.done()
+
+    def toggle_plan_expanded(self) -> None:
+        """Flip the collapsed/expanded state of the pinned plan overlay."""
+        self.plan_expanded = not self.plan_expanded
 
     def is_awaiting_confirmation(self) -> bool:
         return self.phase is TurnPhase.AWAITING_CONFIRMATION
@@ -98,6 +104,8 @@ class ReplState:
         # as awaiting confirmation the instant the event is visible.
         self.confirm_response = []
         self.confirm_prompt_text = prompt_text
+        # Default the arrow selection to Yes (the allow row) each time.
+        self.confirm_selected = 0
         self.phase = TurnPhase.AWAITING_CONFIRMATION
         self.confirm_event = event
 

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -104,8 +104,8 @@ class ReplState:
         # as awaiting confirmation the instant the event is visible.
         self.confirm_response = []
         self.confirm_prompt_text = prompt_text
-        # Default the arrow selection to Yes (the allow row) each time.
-        self.confirm_selected = 0
+        # Default the arrow on No so a stray Enter cancels instead of approving.
+        self.confirm_selected = 1
         self.phase = TurnPhase.AWAITING_CONFIRMATION
         self.confirm_event = event
 

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -57,6 +57,8 @@ class ReplState:
     confirm_prompt_text: str = ""
     confirm_selected: int = 0
     plan_expanded: bool = False
+    # Checklist identity for ``plan_expanded`` — step texts, ignoring status.
+    plan_step_texts: tuple[str, ...] | None = None
     phase: TurnPhase = TurnPhase.IDLE
     ctrl_c_exit_hint_until: float = 0.0
 

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -21,6 +21,14 @@ from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_line
 # How often prompt-toolkit refreshes prompt callbacks and confirmation polling.
 PROMPT_REFRESH_INTERVAL_S = 0.25
 
+# Default confirmation rows: (answer, label). The execution gate reads "", "y",
+# "yes" as allow and "always" as allow-and-raise-auto; anything else cancels.
+# The cancel row is always last so the default selection lands on it.
+DEFAULT_CONFIRM_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("y", "Yes, allow"),
+    ("n", "No, cancel"),
+)
+
 
 class TurnPhase(enum.Enum):
     """Explicit lifecycle phase of the current interactive-shell turn.
@@ -56,6 +64,7 @@ class ReplState:
     confirm_response: list[str] = field(default_factory=list)
     confirm_prompt_text: str = ""
     confirm_selected: int = 0
+    confirm_options: tuple[tuple[str, str], ...] = DEFAULT_CONFIRM_OPTIONS
     plan_expanded: bool = False
     # Checklist identity for ``plan_expanded`` — step texts, ignoring status.
     plan_step_texts: tuple[str, ...] | None = None
@@ -99,15 +108,22 @@ class ReplState:
         """Return whether the transient Ctrl-C exit hint is still active."""
         return time.monotonic() <= self.ctrl_c_exit_hint_until
 
-    def begin_confirmation(self, event: threading.Event, prompt_text: str = "") -> None:
+    def begin_confirmation(
+        self,
+        event: threading.Event,
+        prompt_text: str = "",
+        options: tuple[tuple[str, str], ...] | None = None,
+    ) -> None:
         # Reset the response list BEFORE publishing ``confirm_event`` so a
         # concurrent ``deliver_confirmation`` cannot have its answer clobbered.
         # ``phase`` is set before the publish so a parked worker is observable
         # as awaiting confirmation the instant the event is visible.
         self.confirm_response = []
         self.confirm_prompt_text = prompt_text
-        # Default the arrow on No so a stray Enter cancels instead of approving.
-        self.confirm_selected = 1
+        self.confirm_options = options or DEFAULT_CONFIRM_OPTIONS
+        # Default the arrow on the last row (cancel) so a stray Enter aborts
+        # instead of approving.
+        self.confirm_selected = len(self.confirm_options) - 1
         self.phase = TurnPhase.AWAITING_CONFIRMATION
         self.confirm_event = event
 
@@ -115,6 +131,7 @@ class ReplState:
         self.confirm_event = None
         self.confirm_response = []
         self.confirm_prompt_text = ""
+        self.confirm_options = DEFAULT_CONFIRM_OPTIONS
         # Only a normal confirmation completion returns to dispatching/idle; a
         # cancel in progress must keep its CANCELLING phase.
         if self.phase is TurnPhase.AWAITING_CONFIRMATION:

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -86,13 +86,40 @@ def _confirm_via_prompt(runtime: AgentTurnResources, prompt: str) -> str:
     ``begin_confirmation`` flips ``state.is_awaiting_confirmation()``, which
     ``typing_box_hidden`` / ``render_prompt_region`` already honor. ``redraw``
     invalidates the live prompt immediately so the box hides and restores
-    without waiting for the next refresh tick.
+    without waiting for the next refresh tick. ``prepare_ui`` clears any
+    typeahead that landed in the (hidden) composer before the gate opened.
     """
     return request_confirmation_via_prompt(
         runtime.state,
         prompt,
         redraw=runtime.invalidate_prompt,
+        prepare_ui=lambda: _reset_prompt_buffer(runtime.session),
     )
+
+
+def _reset_prompt_buffer(session: Session) -> None:
+    """Empty the live prompt buffer so hidden typeahead cannot submit later.
+
+    Confirmation parks on a worker thread; prompt-toolkit buffer mutations must
+    run on the UI loop (same rule as ``invalidate_prompt`` / refresh prefill).
+    """
+    terminal = getattr(session, "terminal", None)
+    if terminal is None:
+        return
+    app = getattr(terminal, "prompt_app", None)
+    if app is None:
+        return
+
+    def _reset() -> None:
+        buffer = getattr(app, "current_buffer", None)
+        if buffer is not None:
+            buffer.reset()
+
+    loop = getattr(terminal, "main_loop", None)
+    if loop is not None:
+        loop.call_soon_threadsafe(_reset)
+        return
+    _reset()
 
 
 def _streaming_console(

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -89,9 +89,15 @@ def _confirm_via_prompt(runtime: AgentTurnResources, prompt: str) -> str:
     without waiting for the next refresh tick. ``prepare_ui`` clears any
     typeahead that landed in the (hidden) composer before the gate opened.
     """
+    # The execution gate stashes the rows it wants (e.g. an "always allow" row)
+    # on the terminal just before calling this; consume them for the choice.
+    terminal = runtime.session.terminal
+    options = terminal.pending_confirm_options
+    terminal.pending_confirm_options = None
     return request_confirmation_via_prompt(
         runtime.state,
         prompt,
+        options=options,
         redraw=runtime.invalidate_prompt,
         prepare_ui=lambda: _reset_prompt_buffer(runtime.session),
     )

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -111,6 +111,13 @@ class TerminalSession:
     The response composer consumes the label to hide a pure acknowledgement
     while preserving meaningful follow-up the selected option unlocks."""
 
+    pending_confirm_options: tuple[tuple[str, str], ...] | None = None
+    """Rows the next execution confirmation should offer, or None for Yes/No.
+
+    Set by the execution gate just before it calls the confirm function; the
+    REPL confirm path reads and clears it so the arrow-nav shows the same rows
+    (e.g. an "always allow" row for an auto-level gate)."""
+
     exclusive_stdin_active: bool = False
     """True while a turn is running with exclusive stdin reserved (no live prompt).
 

--- a/surfaces/interactive_shell/ui/ask_user.py
+++ b/surfaces/interactive_shell/ui/ask_user.py
@@ -27,7 +27,6 @@ from surfaces.shared.terminal.components.choice_menu import (
     leave_inline_menu,
     menu_columns,
     repl_tty_interactive,
-    show_terminal_cursor,
     write_menu_line,
 )
 from surfaces.shared.terminal.components.key_reader import (
@@ -186,14 +185,13 @@ def _erase_ask_user(question: AskUserQuestion) -> None:
 
 
 def _leave_ask_user(question: AskUserQuestion) -> None:
-    """Erase the menu and restore TTY so the next Rich line starts at column 0.
+    """Erase the menu so the next Rich line is not painted over leftover rows.
 
-    Menu rows are padded to the full terminal width; without a column reset,
-    later prints (``Selection cancelled``, ``/exit`` resume hint) stagger
-    diagonally across the screen.
+    Menu rows are padded to the full terminal width. TTY recook and column
+    reset belong in :func:`repl_ask_user`'s ``finally`` so exceptions still
+    restore cooked stdin.
     """
     _erase_ask_user(question)
-    leave_inline_menu()
 
 
 def _next_unanswered(answers: list[str | None], start: int) -> int:
@@ -246,7 +244,7 @@ def repl_ask_user(
     try:
         return _run_ask_user(items)
     finally:
-        show_terminal_cursor()
+        leave_inline_menu()
 
 
 def _run_ask_user(

--- a/surfaces/interactive_shell/ui/execution_confirm.py
+++ b/surfaces/interactive_shell/ui/execution_confirm.py
@@ -47,7 +47,7 @@ def _default_confirm_fn(prompt: str) -> str:
 
 
 DEFAULT_CONFIRM_FN: Callable[[str], str] = _default_confirm_fn
-_APPROVE_PROMPT = "Yes, allow? [Y/n] "
+_APPROVE_PROMPT = "Approve this action?"
 
 
 def _render_command_to_approve(
@@ -73,7 +73,6 @@ def _render_command_to_approve(
     why.append("Why this needs approval: ", style=str(DIM))
     why.append(reason, style=str(SECONDARY))
     console.print(why)
-    console.print(Text("Yes, allow  ·  No, cancel", style=str(DIM)))
     console.print()
 
 

--- a/surfaces/interactive_shell/ui/execution_confirm.py
+++ b/surfaces/interactive_shell/ui/execution_confirm.py
@@ -23,7 +23,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.text import Text
 
-from config.constants.repl_autonomy import DEFAULT_AUTO_LEVEL
+from config.constants.repl_autonomy import AUTO_LEVEL_TITLES, DEFAULT_AUTO_LEVEL, AutoLevel
 from core.agent_harness.spi.session_state import trust_mode_enabled
 from infrastructure.analytics.cli import capture_repl_execution_policy_decision
 from infrastructure.analytics.provider import Properties
@@ -37,6 +37,7 @@ from tools.interactive_shell.shared import (
     is_mutating_tool_type,
     resolve_confirmation,
 )
+from tools.interactive_shell.shell.risk import CommandRisk, classify_command_risk
 
 if TYPE_CHECKING:
     from surfaces.interactive_shell.runtime import Session
@@ -50,18 +51,46 @@ DEFAULT_CONFIRM_FN: Callable[[str], str] = _default_confirm_fn
 _APPROVE_PROMPT = "Approve this action?"
 
 
+_ALWAYS_ALLOW_LABEL = {
+    AutoLevel.MED: "Yes, and always allow reversible commands",
+    AutoLevel.HIGH: "Yes, and always allow all commands",
+}
+
+
+def _confirm_options_and_target(
+    risk: CommandRisk, plan_only: bool
+) -> tuple[tuple[tuple[str, str], ...], AutoLevel | None]:
+    """The confirmation rows and the auto level an "always allow" row would set.
+
+    Plan-only confirmations offer only Yes/No — raising the auto level would not
+    lift the plan-only latch. Auto-level confirmations add an "always allow" row
+    targeting the level that runs this command's risk (reversible → Med, else
+    High).
+    """
+    if plan_only:
+        return (("y", "Yes, allow"), ("n", "No, cancel")), None
+    target = AutoLevel.MED if risk in (CommandRisk.LOW, CommandRisk.MEDIUM) else AutoLevel.HIGH
+    return (
+        (("y", "Yes, allow"), ("always", _ALWAYS_ALLOW_LABEL[target]), ("n", "No, cancel")),
+        target,
+    )
+
+
 def _render_command_to_approve(
     console: Console,
     *,
     summary: str,
-    reason: str,
+    risk: CommandRisk,
+    why: str,
     action_already_listed: bool,
 ) -> None:
-    """Approval card: header, command child, why-this-needs-approval."""
+    """Approval card: header with the risk level, the command, and its impact."""
     header = Text()
     header.append("Command to approve", style=str(HIGHLIGHT))
     header.append(" · ", style=str(DIM))
-    header.append("needs confirmation", style=str(HIGHLIGHT))
+    header.append(
+        f"{risk.value} risk", style=str(WARNING if risk is CommandRisk.HIGH else SECONDARY)
+    )
     console.print()
     console.print(header)
     if summary and not action_already_listed:
@@ -69,10 +98,10 @@ def _render_command_to_approve(
         child.append("↳ ", style=str(DIM))
         child.append(summary, style=str(TEXT))
         console.print(child)
-    why = Text()
-    why.append("Why this needs approval: ", style=str(DIM))
-    why.append(reason, style=str(SECONDARY))
-    console.print(why)
+    why_line = Text()
+    why_line.append("Why this needs approval: ", style=str(DIM))
+    why_line.append(why, style=str(SECONDARY))
+    console.print(why_line)
     console.print()
 
 
@@ -162,16 +191,25 @@ def execution_allowed(
         return False
 
     # NEEDS_CONFIRMATION
-    reason = (result.reason or "this action").strip()
     summary = action_summary.strip()
+    risk, impact = classify_command_risk(summary)
+    # The classifier's impact replaces only the generic auto-level reason; a
+    # specific policy reason (e.g. a fleet-scan explanation, plan-only) wins.
+    policy_reason = (result.reason or "").strip()
+    why = impact if (not policy_reason or policy_reason.startswith("Auto (")) else policy_reason
     _render_command_to_approve(
         console,
         summary=summary,
-        reason=reason,
+        risk=risk,
+        why=why,
         action_already_listed=action_already_listed,
     )
+    options, always_target = _confirm_options_and_target(risk, plan_only_active)
+    terminal = getattr(session, "terminal", None)
+    if terminal is not None:
+        terminal.pending_confirm_options = options
     answer = confirm(_APPROVE_PROMPT).strip().lower()
-    if answer not in {"", "y", "yes"}:
+    if answer not in {"", "y", "yes", "always"}:
         _emit_decision(
             tool_type=result.tool_type,
             policy_verdict=result.verdict,
@@ -183,12 +221,20 @@ def execution_allowed(
         console.print(f"[{DIM}]cancelled.[/]")
         return False
 
+    if answer == "always" and always_target is not None and terminal is not None:
+        # "Yes, and always allow …" both approves now and raises the auto level
+        # so commands of this risk stop asking for the rest of the session.
+        terminal.auto_level = always_target
+        console.print(
+            f"[{DIM}]Auto raised to {AUTO_LEVEL_TITLES[always_target]}; "
+            f"commands like this now run without asking.[/]"
+        )
     _emit_decision(
         tool_type=result.tool_type,
         policy_verdict=result.verdict,
         outcome="allowed",
         trust_mode=trust_mode,
-        reason="user_confirmed",
+        reason="user_confirmed_always" if answer == "always" else "user_confirmed",
         user_prompted=True,
     )
     if plan_only_active and is_mutating_tool_type(result.tool_type):

--- a/surfaces/interactive_shell/ui/execution_confirm.py
+++ b/surfaces/interactive_shell/ui/execution_confirm.py
@@ -2,7 +2,7 @@
 
 This module owns the *user-facing* half of the execution gate: it renders the
 policy decision (``Action blocked``, the non-TTY warning, the
-``Command to approve`` card, the ``Yes, allow? [Y/n]`` prompt), reads the
+``Command to approve`` card, the arrow Yes/No choice), reads the
 user's confirmation, and emits analytics. The pure decision
 itself is computed by
 :func:`tools.interactive_shell.shared.resolve_confirmation`,

--- a/surfaces/interactive_shell/ui/hooks/__init__.py
+++ b/surfaces/interactive_shell/ui/hooks/__init__.py
@@ -1,0 +1,22 @@
+"""Reusable interactive-prompt hooks (self-contained UI + key-binding units).
+
+Each hook owns one keyboard-driven prompt element — its rendering and its key
+bindings — so hosts wire a clearly-scoped piece rather than scattering the
+state, render, and key handling across the prompt loop.
+"""
+
+from surfaces.interactive_shell.ui.hooks.confirmation_choice import (
+    confirmation_choice_overlay_ansi,
+    confirmation_option_count,
+    install_confirmation_key_bindings,
+)
+from surfaces.interactive_shell.ui.hooks.plan_expand import (
+    install_plan_expand_key_bindings,
+)
+
+__all__ = [
+    "confirmation_choice_overlay_ansi",
+    "confirmation_option_count",
+    "install_confirmation_key_bindings",
+    "install_plan_expand_key_bindings",
+]

--- a/surfaces/interactive_shell/ui/hooks/__init__.py
+++ b/surfaces/interactive_shell/ui/hooks/__init__.py
@@ -7,7 +7,6 @@ state, render, and key handling across the prompt loop.
 
 from surfaces.interactive_shell.ui.hooks.confirmation_choice import (
     confirmation_choice_overlay_ansi,
-    confirmation_option_count,
     install_confirmation_key_bindings,
 )
 from surfaces.interactive_shell.ui.hooks.plan_expand import (
@@ -16,7 +15,6 @@ from surfaces.interactive_shell.ui.hooks.plan_expand import (
 
 __all__ = [
     "confirmation_choice_overlay_ansi",
-    "confirmation_option_count",
     "install_confirmation_key_bindings",
     "install_plan_expand_key_bindings",
 ]

--- a/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
+++ b/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
@@ -1,10 +1,12 @@
-"""Arrow-navigable Yes/No hook for the execution-confirmation gate.
+"""Arrow-navigable choice hook for the execution-confirmation gate.
 
-Renders the pending confirmation as a stacked ``[a] Yes`` / ``[b] No`` choice
-driven with ↑/↓ and Enter (or the ``a``/``b``/``y``/``n`` letters) instead of a
-typed ``Y/n`` answer. The free-text box is hidden while a confirmation is
-active (see ``typing_box_hidden``), so the choice cannot be confused with a
-message. Selecting delivers the answer straight to the parked turn worker.
+Renders the pending confirmation as a stacked, tagged choice (``[a] …`` /
+``[b] …`` / …) driven with ↑/↓ and Enter — or the row's letter, the ``y``/``n``
+answer keys, or a digit — instead of a typed answer. The free-text box is
+hidden while a confirmation is active (see ``typing_box_hidden``), so the choice
+cannot be confused with a message. The options are supplied per confirmation by
+``ReplState.confirm_options`` (default Yes/No; the auto-level gate adds an
+"always allow" row). Selecting delivers the answer to the parked turn worker.
 """
 
 from __future__ import annotations
@@ -17,15 +19,16 @@ from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
 from infrastructure.terminal import theme as ui_theme
 
-# (answer delivered to the gate, visible label). The gate treats "", "y", "yes"
-# as allow and everything else as cancel, so "y"/"n" map cleanly to Yes/No.
-_CONFIRM_OPTIONS: tuple[tuple[str, str], ...] = (("y", "Yes"), ("n", "No"))
+# Rows are supplied per confirmation via ``ReplState.confirm_options``. The gate
+# reads "", "y", "yes" as allow; "always" as allow-and-raise-auto; else cancel.
+_MAX_TAGGED = 9
 
 
 class ConfirmChoiceState(Protocol):
     """The subset of ``ReplState`` this hook drives."""
 
     confirm_selected: int
+    confirm_options: tuple[tuple[str, str], ...]
 
     def is_awaiting_confirmation(self) -> bool:
         """True while a confirmation is pending and owns the keyboard."""
@@ -34,16 +37,13 @@ class ConfirmChoiceState(Protocol):
         """Hand ``answer`` to the parked turn worker and wake it."""
 
 
-def confirmation_option_count() -> int:
-    """Number of selectable rows, so callers can clamp ``confirm_selected``."""
-    return len(_CONFIRM_OPTIONS)
-
-
-def confirmation_choice_overlay_ansi(selected: int) -> str:
-    """Stacked ``❯ [a] Yes`` / ``  [b] No`` rows, accenting the selected one."""
-    index = selected % len(_CONFIRM_OPTIONS)
+def confirmation_choice_overlay_ansi(selected: int, options: tuple[tuple[str, str], ...]) -> str:
+    """Stacked ``❯ [a] …`` rows for ``options``, accenting the selected one."""
+    if not options:
+        return ""
+    index = selected % len(options)
     rows: list[str] = []
-    for position, (_answer, label) in enumerate(_CONFIRM_OPTIONS):
+    for position, (_answer, label) in enumerate(options):
         tag = chr(ord("a") + position)
         chosen = position == index
         marker = "❯" if chosen else " "
@@ -53,15 +53,28 @@ def confirmation_choice_overlay_ansi(selected: int) -> str:
 
 
 def install_confirmation_key_bindings(state: ConfirmChoiceState, redraw: object) -> KeyBindings:
-    """Bindings active only while awaiting confirmation: ↑/↓ move, Enter/letters pick.
+    """Bindings active only while awaiting confirmation: ↑/↓ move, Enter/letters/digits pick.
 
     ``redraw`` invalidates the prompt so a selection change repaints at once.
+    The handlers read ``state.confirm_options`` at press time, so a confirmation
+    with two or three rows is driven by the same fixed bindings.
     """
     kb = KeyBindings()
     awaiting = Condition(state.is_awaiting_confirmation)
-    count = len(_CONFIRM_OPTIONS)
+
+    def _deliver_index(index: int) -> None:
+        options = state.confirm_options
+        if 0 <= index < len(options):
+            state.deliver_confirmation(options[index][0])
+
+    def _deliver_answer(answer: str) -> None:
+        for option_answer, _label in state.confirm_options:
+            if option_answer == answer:
+                state.deliver_confirmation(answer)
+                return
 
     def _move(delta: int) -> None:
+        count = len(state.confirm_options) or 1
         state.confirm_selected = (state.confirm_selected + delta) % count
         if callable(redraw):
             redraw()
@@ -76,16 +89,22 @@ def install_confirmation_key_bindings(state: ConfirmChoiceState, redraw: object)
 
     @kb.add("c-m", filter=awaiting, eager=True)
     def _on_enter(_event: KeyPressEvent) -> None:
-        answer, _label = _CONFIRM_OPTIONS[state.confirm_selected % count]
-        state.deliver_confirmation(answer)
+        _deliver_index(state.confirm_selected)
 
-    # Letter shortcuts: the a/b row tags and the y/n answer keys both pick a row.
-    for position, (answer, _label) in enumerate(_CONFIRM_OPTIONS):
-        for key in {chr(ord("a") + position), answer}:
+    # Row tags [a]..[i] and digits 1..9 pick that row directly.
+    for position in range(_MAX_TAGGED):
+        for key in (chr(ord("a") + position), str(position + 1)):
 
             @kb.add(key, filter=awaiting, eager=True)
-            def _on_letter(_event: KeyPressEvent, _answer: str = answer) -> None:
-                state.deliver_confirmation(_answer)
+            def _on_row_key(_event: KeyPressEvent, _index: int = position) -> None:
+                _deliver_index(_index)
+
+    # y / n stay as answer shortcuts for the common allow / cancel rows.
+    for answer in ("y", "n"):
+
+        @kb.add(answer, filter=awaiting, eager=True)
+        def _on_answer_key(_event: KeyPressEvent, _answer: str = answer) -> None:
+            _deliver_answer(_answer)
 
     return kb
 
@@ -93,6 +112,5 @@ def install_confirmation_key_bindings(state: ConfirmChoiceState, redraw: object)
 __all__ = [
     "ConfirmChoiceState",
     "confirmation_choice_overlay_ansi",
-    "confirmation_option_count",
     "install_confirmation_key_bindings",
 ]

--- a/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
+++ b/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
@@ -1,0 +1,98 @@
+"""Arrow-navigable Yes/No hook for the execution-confirmation gate.
+
+Renders the pending confirmation as a stacked ``[a] Yes`` / ``[b] No`` choice
+driven with ↑/↓ and Enter (or the ``a``/``b``/``y``/``n`` letters) instead of a
+typed ``Y/n`` answer. The free-text box is hidden while a confirmation is
+active (see ``typing_box_hidden``), so the choice cannot be confused with a
+message. Selecting delivers the answer straight to the parked turn worker.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+
+from infrastructure.terminal import theme as ui_theme
+
+# (answer delivered to the gate, visible label). The gate treats "", "y", "yes"
+# as allow and everything else as cancel, so "y"/"n" map cleanly to Yes/No.
+_CONFIRM_OPTIONS: tuple[tuple[str, str], ...] = (("y", "Yes"), ("n", "No"))
+
+
+class ConfirmChoiceState(Protocol):
+    """The subset of ``ReplState`` this hook drives."""
+
+    confirm_selected: int
+
+    def is_awaiting_confirmation(self) -> bool:
+        """True while a confirmation is pending and owns the keyboard."""
+
+    def deliver_confirmation(self, answer: str) -> None:
+        """Hand ``answer`` to the parked turn worker and wake it."""
+
+
+def confirmation_option_count() -> int:
+    """Number of selectable rows, so callers can clamp ``confirm_selected``."""
+    return len(_CONFIRM_OPTIONS)
+
+
+def confirmation_choice_overlay_ansi(selected: int) -> str:
+    """Stacked ``❯ [a] Yes`` / ``  [b] No`` rows, accenting the selected one."""
+    index = selected % len(_CONFIRM_OPTIONS)
+    rows: list[str] = []
+    for position, (_answer, label) in enumerate(_CONFIRM_OPTIONS):
+        tag = chr(ord("a") + position)
+        chosen = position == index
+        marker = "❯" if chosen else " "
+        style = ui_theme.PROMPT_ACCENT_ANSI if chosen else ui_theme.DIM_COUNTER_ANSI
+        rows.append(f"{style} {marker} [{tag}] {label}{ui_theme.ANSI_RESET}")
+    return "\n".join(rows)
+
+
+def install_confirmation_key_bindings(state: ConfirmChoiceState, redraw: object) -> KeyBindings:
+    """Bindings active only while awaiting confirmation: ↑/↓ move, Enter/letters pick.
+
+    ``redraw`` invalidates the prompt so a selection change repaints at once.
+    """
+    kb = KeyBindings()
+    awaiting = Condition(state.is_awaiting_confirmation)
+    count = len(_CONFIRM_OPTIONS)
+
+    def _move(delta: int) -> None:
+        state.confirm_selected = (state.confirm_selected + delta) % count
+        if callable(redraw):
+            redraw()
+
+    @kb.add("up", filter=awaiting, eager=True)
+    def _on_up(_event: KeyPressEvent) -> None:
+        _move(-1)
+
+    @kb.add("down", filter=awaiting, eager=True)
+    def _on_down(_event: KeyPressEvent) -> None:
+        _move(1)
+
+    @kb.add("c-m", filter=awaiting, eager=True)
+    def _on_enter(_event: KeyPressEvent) -> None:
+        answer, _label = _CONFIRM_OPTIONS[state.confirm_selected % count]
+        state.deliver_confirmation(answer)
+
+    # Letter shortcuts: the a/b row tags and the y/n answer keys both pick a row.
+    for position, (answer, _label) in enumerate(_CONFIRM_OPTIONS):
+        for key in {chr(ord("a") + position), answer}:
+
+            @kb.add(key, filter=awaiting, eager=True)
+            def _on_letter(_event: KeyPressEvent, _answer: str = answer) -> None:
+                state.deliver_confirmation(_answer)
+
+    return kb
+
+
+__all__ = [
+    "ConfirmChoiceState",
+    "confirmation_choice_overlay_ansi",
+    "confirmation_option_count",
+    "install_confirmation_key_bindings",
+]

--- a/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
+++ b/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
@@ -18,10 +18,15 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
 from infrastructure.terminal import theme as ui_theme
+from surfaces.shared.terminal.prompt_layout import prompt_line_width
 
 # Rows are supplied per confirmation via ``ReplState.confirm_options``. The gate
 # reads "", "y", "yes" as allow; "always" as allow-and-raise-auto; else cancel.
 _MAX_TAGGED = 9
+_BOX_MIN_INNER = 24
+# Leave room for the ``│ `` / ` │`` box chrome plus one spare column so the
+# border never reaches the last cell and soft-wraps.
+_BOX_CHROME = 5
 
 
 class ConfirmChoiceState(Protocol):
@@ -38,18 +43,30 @@ class ConfirmChoiceState(Protocol):
 
 
 def confirmation_choice_overlay_ansi(selected: int, options: tuple[tuple[str, str], ...]) -> str:
-    """Stacked ``❯ [a] …`` rows for ``options``, accenting the selected one."""
+    """Bordered ``❯ [a] …`` rows for ``options``, accenting the selected one.
+
+    The options sit inside a dim box (like the composer frame) so the pending
+    decision reads as its own panel; the selected row carries the accent arrow.
+    """
     if not options:
         return ""
     index = selected % len(options)
-    rows: list[str] = []
-    for position, (_answer, label) in enumerate(options):
-        tag = chr(ord("a") + position)
-        chosen = position == index
-        marker = "❯" if chosen else " "
-        style = ui_theme.PROMPT_ACCENT_ANSI if chosen else ui_theme.DIM_COUNTER_ANSI
-        rows.append(f"{style} {marker} [{tag}] {label}{ui_theme.ANSI_RESET}")
-    return "\n".join(rows)
+    contents = [
+        f"{'❯' if position == index else ' '} [{chr(ord('a') + position)}] {label}"
+        for position, (_answer, label) in enumerate(options)
+    ]
+    inner = min(
+        max(_BOX_MIN_INNER, *(len(row) for row in contents)), prompt_line_width() - _BOX_CHROME
+    )
+    border = ui_theme.PROMPT_FRAME_ANSI
+    reset = ui_theme.ANSI_RESET
+    lines = [f"{border}┌{'─' * (inner + 2)}┐{reset}"]
+    for position, content in enumerate(contents):
+        style = ui_theme.PROMPT_ACCENT_ANSI if position == index else ui_theme.DIM_COUNTER_ANSI
+        padded = content[:inner].ljust(inner)
+        lines.append(f"{border}│{reset} {style}{padded}{reset} {border}│{reset}")
+    lines.append(f"{border}└{'─' * (inner + 2)}┘{reset}")
+    return "\n".join(lines)
 
 
 def install_confirmation_key_bindings(state: ConfirmChoiceState, redraw: object) -> KeyBindings:

--- a/surfaces/interactive_shell/ui/hooks/plan_expand.py
+++ b/surfaces/interactive_shell/ui/hooks/plan_expand.py
@@ -1,0 +1,42 @@
+"""Ctrl+P hook to expand/collapse the pinned task-plan overlay.
+
+A long plan collapses to a window around the current step; this toggles the
+full checklist. The binding is gated on a plan being present, so when there is
+no plan Ctrl+P falls through to its default (history) behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+
+
+class PlanExpandState(Protocol):
+    """The subset of ``ReplState`` this hook drives."""
+
+    def toggle_plan_expanded(self) -> None:
+        """Flip the collapsed/expanded state of the plan overlay."""
+
+
+def install_plan_expand_key_bindings(
+    state: PlanExpandState,
+    has_plan: Callable[[], bool],
+    redraw: Callable[[], None],
+) -> KeyBindings:
+    """Bind Ctrl+P to toggle the plan overlay while a plan is on screen."""
+    kb = KeyBindings()
+    plan_shown = Condition(has_plan)
+
+    @kb.add("c-p", filter=plan_shown, eager=True)
+    def _toggle(_event: KeyPressEvent) -> None:
+        state.toggle_plan_expanded()
+        redraw()
+
+    return kb
+
+
+__all__ = ["PlanExpandState", "install_plan_expand_key_bindings"]

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -30,6 +30,10 @@ from surfaces.interactive_shell.ui.input_prompt.rendering import (
 )
 from surfaces.interactive_shell.ui.input_prompt.style import _build_prompt_style
 
+# Frame (height 3) plus the help/status footer (height 1): the blank stand-in
+# shown while the composer is hidden must match this so the region height holds.
+_COMPOSER_ROWS = 4
+
 
 def _install_prompt_frame(
     session: PromptSession[str],
@@ -63,14 +67,22 @@ def _install_prompt_frame(
         dont_extend_height=True,
         style="class:composer-footer",
     )
+    box_rows: list[AnyContainer] = [composer, footer]
     if hide_composer is not None:
         shown = Condition(lambda: not hide_composer())
-        composer = ConditionalContainer(composer, filter=shown)
-        footer = ConditionalContainer(footer, filter=shown)
+        # Swap the box for a blank pad of the SAME height while structured input
+        # owns the keyboard. Collapsing to zero height shrinks the region, and a
+        # shrinking prompt under patch_stdout leaves stale border fragments — a
+        # constant-height stand-in overwrites the box cleanly instead.
+        box_rows = [
+            ConditionalContainer(composer, filter=shown),
+            ConditionalContainer(footer, filter=shown),
+            ConditionalContainer(Window(height=_COMPOSER_ROWS, char=" "), filter=~shown),
+        ]
     # Keep the final terminal column empty. Painting a frame border there puts
     # the cursor in pending-wrap, which makes patch_stdout redraws jump and
     # leaves stale composer fragments after output or a terminal resize.
-    chrome = HSplit([before_input, composer, footer], width=prompt_line_width)
+    chrome = HSplit([before_input, *box_rows], width=prompt_line_width)
     framed_input = FloatContainer(
         chrome,
         floats=main_input.floats,

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from prompt_toolkit import PromptSession
+from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.layout.containers import (
+    AnyContainer,
     ConditionalContainer,
     FloatContainer,
     HSplit,
@@ -27,8 +31,17 @@ from surfaces.interactive_shell.ui.input_prompt.rendering import (
 from surfaces.interactive_shell.ui.input_prompt.style import _build_prompt_style
 
 
-def _install_prompt_frame(session: PromptSession[str]) -> PromptSession[str]:
-    """Wrap only the editable buffer, leaving live status rows above it."""
+def _install_prompt_frame(
+    session: PromptSession[str],
+    *,
+    hide_composer: Callable[[], bool] | None = None,
+) -> PromptSession[str]:
+    """Wrap only the editable buffer, leaving live status rows above it.
+
+    ``hide_composer`` (when given) collapses the composer box and its footer
+    while structured input owns the keyboard (confirmation choice, option
+    menus), so the free-text box does not sit under the pending decision.
+    """
     root = session.app.layout.container
     if not isinstance(root, HSplit) or not root.children:
         raise RuntimeError("prompt-toolkit returned an unsupported root layout")
@@ -43,13 +56,17 @@ def _install_prompt_frame(session: PromptSession[str]) -> PromptSession[str]:
 
     before_input = main_input.content.children[0]
     editable_body = HSplit(main_input.content.children[1:])
-    composer = Frame(editable_body, style="class:composer", height=3)
-    footer = Window(
+    composer: AnyContainer = Frame(editable_body, style="class:composer", height=3)
+    footer: AnyContainer = Window(
         FormattedTextControl(lambda: ANSI(composer_footer_ansi())),
         height=1,
         dont_extend_height=True,
         style="class:composer-footer",
     )
+    if hide_composer is not None:
+        shown = Condition(lambda: not hide_composer())
+        composer = ConditionalContainer(composer, filter=shown)
+        footer = ConditionalContainer(footer, filter=shown)
     # Keep the final terminal column empty. Painting a frame border there puts
     # the cursor in pending-wrap, which makes patch_stdout redraws jump and
     # leaves stale composer fragments after output or a terminal resize.
@@ -69,7 +86,11 @@ def _install_prompt_frame(session: PromptSession[str]) -> PromptSession[str]:
     return session
 
 
-def build_prompt_session(session: Session | None = None) -> PromptSession[str]:
+def build_prompt_session(
+    session: Session | None = None,
+    *,
+    hide_composer: Callable[[], bool] | None = None,
+) -> PromptSession[str]:
     placeholder = (
         (lambda: resolve_prompt_placeholder(session))
         if session is not None
@@ -87,7 +108,8 @@ def build_prompt_session(session: Session | None = None) -> PromptSession[str]:
             style=_build_prompt_style(),
             erase_when_done=True,
             placeholder=placeholder,
-        )
+        ),
+        hide_composer=hide_composer,
     )
 
 

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -21,6 +21,10 @@ from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
 
 _STEP_INDENT = "  "
+# Steps shown before the plan collapses; a longer plan folds to a window
+# around the current step until the user expands it.
+_COLLAPSED_MAX_STEPS = 3
+_EXPAND_HINT = "Ctrl+P for full plan"
 
 
 def task_plan_from_tool_args(args: dict[str, object]) -> TaskPlan | None:
@@ -63,16 +67,48 @@ def _indented_step_overlay_line(item: PlanStep, width: int) -> str:
     return _STEP_INDENT + _step_overlay_line(item, max(width - len(_STEP_INDENT), 1))
 
 
-def task_plan_overlay_ansi(plan: TaskPlan) -> str:
-    """ANSI plan overlay pinned above the prompt: the whole checklist, indented
-    under its header, with ✓ done / ● current / ○ pending.
+def _focus_index(plan: TaskPlan) -> int:
+    """Index the collapsed window centers on: the current step (else next up)."""
+    for index, item in enumerate(plan.steps):
+        if item.status is PlanStepStatus.IN_PROGRESS:
+            return index
+    for index, item in enumerate(plan.steps):
+        if item.status is PlanStepStatus.PENDING:
+            return index
+    return len(plan.steps) - 1
 
-    Every step is shown at all times — before and during execution — so the user
-    always sees progress across the full plan, at the bottom above the action bar.
+
+def _collapsed_window(plan: TaskPlan) -> tuple[int, int]:
+    """``[start, end)`` slice of steps to show when the plan is collapsed."""
+    total = len(plan.steps)
+    half = _COLLAPSED_MAX_STEPS // 2
+    start = max(0, min(_focus_index(plan) - half, total - _COLLAPSED_MAX_STEPS))
+    return start, start + _COLLAPSED_MAX_STEPS
+
+
+def task_plan_overlay_ansi(plan: TaskPlan, *, expanded: bool = False) -> str:
+    """ANSI plan overlay pinned above the prompt: a checklist indented under its
+    header, with ✓ done / ● current / ○ pending.
+
+    A short plan (or ``expanded``) shows every step. A longer one collapses to a
+    window around the current step with ``… N earlier`` / ``… N more`` markers
+    and a hint to expand, so the prompt region stays short while output streams.
     """
     width = prompt_line_width()
     header = _overlay_line(format_plan_header(plan), ui_theme.SECONDARY_ANSI, width)
-    rows = [header, *(_indented_step_overlay_line(item, width) for item in plan.steps)]
+    total = len(plan.steps)
+    if expanded or total <= _COLLAPSED_MAX_STEPS:
+        rows = [header, *(_indented_step_overlay_line(item, width) for item in plan.steps)]
+        return "\n".join(rows)
+
+    start, end = _collapsed_window(plan)
+    rows = [header]
+    if start > 0:
+        rows.append(_overlay_line(f"{_STEP_INDENT}… {start} earlier", ui_theme.DIM_ANSI, width))
+    rows.extend(_indented_step_overlay_line(item, width) for item in plan.steps[start:end])
+    hidden_after = total - end
+    tail = f"… {hidden_after} more · {_EXPAND_HINT}" if hidden_after else _EXPAND_HINT
+    rows.append(_overlay_line(f"{_STEP_INDENT}{tail}", ui_theme.DIM_ANSI, width))
     return "\n".join(rows)
 
 

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -19,7 +19,9 @@ from typing import TYPE_CHECKING
 from prompt_toolkit.formatted_text import ANSI
 from rich.console import Console
 
+from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.ui.auto_status import auto_status_ansi
+from surfaces.interactive_shell.ui.hooks import confirmation_choice_overlay_ansi
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
 from surfaces.interactive_shell.ui.prompt_visibility import (
     hidden_typing_box_pad,
@@ -74,13 +76,21 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     else:
         base = prompt_rendering._prompt_message(session).value
     auto_line = strip_cpr_sequences(auto_status_ansi(session))
-    # The confirmation prompt takes the prefix row so every state renders the
-    # same rows (blank, prefix, auto status, input) — no height delta on redraw.
+    plan = session.task_plan
+    plan_overlay = (
+        strip_cpr_sequences(task_plan_overlay_ansi(plan, expanded=state.plan_expanded))
+        if plan is not None and plan.steps
+        else ""
+    )
+    plan_prefix = f"{plan_overlay}\n\n" if plan_overlay else ""
+
+    # A pending confirmation renders a stacked, arrow-navigable Yes/No choice
+    # (box hidden) with blank rows above and below so it reads as its own block.
     if state.is_awaiting_confirmation():
-        # Same one-row budget as the spinner/idle spacer: a long confirm string
-        # must not soft-wrap when the spinner path is clipped to width.
-        prefix = clip_prompt_text(state.confirm_prompt_text, prompt_line_width())
-    elif state.is_ctrl_c_exit_hint_visible():
+        choice = _confirmation_block(state)
+        return ANSI(f"\n{plan_prefix}{choice}\n\n{auto_line}\n{base}")
+
+    if state.is_ctrl_c_exit_hint_visible():
         prefix = prompt_rendering.ctrl_c_exit_hint_ansi()
     else:
         prefix = strip_cpr_sequences(
@@ -89,16 +99,25 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
-    # A live plan sits as an overlay above the prefix. Its presence tracks
-    # ``session.task_plan`` (stable across redraws), not the prompt state, so it
-    # adds a constant row whether or not a confirmation is pending.
-    plan = session.task_plan
-    if plan is not None and plan.steps:
-        overlay = strip_cpr_sequences(task_plan_overlay_ansi(plan))
-        # A blank row separates the plan block from the status line so the
-        # checklist reads as its own element, not flush against the prompt.
-        return ANSI(f"\n{overlay}\n\n{prefix}\n{auto_line}\n{base}")
-    return ANSI(f"\n{prefix}\n{auto_line}\n{base}")
+    # A blank row separates the plan block from the status line so the checklist
+    # reads as its own element, not flush against the prompt.
+    return ANSI(f"\n{plan_prefix}{prefix}\n{auto_line}\n{base}")
+
+
+_CONFIRM_HINT = "↑↓ Navigate • Enter confirm • Esc cancel"
+
+
+def _confirmation_block(state: ReplState) -> str:
+    """Header, the stacked ``[a] Yes`` / ``[b] No`` choice, and a nav hint.
+
+    Blank rows separate the header, the options, and the hint so the pending
+    decision reads as a clear, self-contained block above the status line.
+    """
+    header = clip_prompt_text(state.confirm_prompt_text.strip(), prompt_line_width())
+    header_ansi = f"{ui_theme.SECONDARY_ANSI}{header}{ui_theme.ANSI_RESET}"
+    choice = strip_cpr_sequences(confirmation_choice_overlay_ansi(state.confirm_selected))
+    hint = f"{ui_theme.DIM_ANSI}{_CONFIRM_HINT}{ui_theme.ANSI_RESET}"
+    return f"{header_ansi}\n\n{choice}\n\n{hint}"
 
 
 __all__ = ["render_prompt_region", "render_terminal_ui"]

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -81,8 +81,14 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         # Drop expand so the next plan opens collapsed rather than inheriting
         # a sticky Ctrl+P from a previous checklist.
         state.plan_expanded = False
+        state.plan_step_texts = None
         plan_overlay = ""
     else:
+        # Status-only updates keep expand; a different checklist must not.
+        step_texts = tuple(item.step for item in plan.steps)
+        if state.plan_step_texts is not None and state.plan_step_texts != step_texts:
+            state.plan_expanded = False
+        state.plan_step_texts = step_texts
         plan_overlay = strip_cpr_sequences(
             task_plan_overlay_ansi(plan, expanded=state.plan_expanded)
         )

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -125,7 +125,9 @@ def _confirmation_block(state: ReplState) -> str:
     """
     header = clip_prompt_text(state.confirm_prompt_text.strip(), prompt_line_width())
     header_ansi = f"{ui_theme.SECONDARY_ANSI}{header}{ui_theme.ANSI_RESET}"
-    choice = strip_cpr_sequences(confirmation_choice_overlay_ansi(state.confirm_selected))
+    choice = strip_cpr_sequences(
+        confirmation_choice_overlay_ansi(state.confirm_selected, state.confirm_options)
+    )
     hint = f"{ui_theme.DIM_ANSI}{_CONFIRM_HINT}{ui_theme.ANSI_RESET}"
     return f"{header_ansi}\n\n{choice}\n\n{hint}"
 

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -77,11 +77,15 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         base = prompt_rendering._prompt_message(session).value
     auto_line = strip_cpr_sequences(auto_status_ansi(session))
     plan = session.task_plan
-    plan_overlay = (
-        strip_cpr_sequences(task_plan_overlay_ansi(plan, expanded=state.plan_expanded))
-        if plan is not None and plan.steps
-        else ""
-    )
+    if plan is None or not plan.steps:
+        # Drop expand so the next plan opens collapsed rather than inheriting
+        # a sticky Ctrl+P from a previous checklist.
+        state.plan_expanded = False
+        plan_overlay = ""
+    else:
+        plan_overlay = strip_cpr_sequences(
+            task_plan_overlay_ansi(plan, expanded=state.plan_expanded)
+        )
     plan_prefix = f"{plan_overlay}\n\n" if plan_overlay else ""
 
     # A pending confirmation renders a stacked, arrow-navigable Yes/No choice

--- a/surfaces/shared/terminal/components/choice_menu.py
+++ b/surfaces/shared/terminal/components/choice_menu.py
@@ -175,9 +175,10 @@ def show_terminal_cursor() -> None:
 def leave_inline_menu() -> None:
     """Restore cooked stdin and start the next Rich line at column zero.
 
-    Call after every inline menu exits (select or Esc). Without this, padded
-    menu rows leave the cursor mid-line and later prints (cancelled notice,
-    ``/exit`` resume hint) stagger diagonally.
+    Pair with :func:`hide_terminal_cursor` in a ``finally`` so select, Esc,
+    and exceptions all recook stdin. Without this, padded menu rows leave the
+    cursor mid-line and an inherited non-canonical or no-echo TTY breaks later
+    shell input.
     """
     from surfaces.shared.terminal.components.key_reader import restore_stdin_terminal
 
@@ -388,11 +389,9 @@ def _pick(
                 if not parts:
                     continue
                 _erase_menu(crumb, display, multi_select=True, header=header)
-                leave_inline_menu()
                 return "\n".join(parts)
             if action in ("cancel", "eof"):
                 _erase_menu(crumb, display, multi_select=True, header=header)
-                leave_inline_menu()
                 return None
             continue
         if (not on_custom) and len(action) == 1 and action.isdigit():
@@ -402,7 +401,6 @@ def _pick(
                     idx = picked
                     continue
                 _erase_menu(crumb, labels, header=header)
-                leave_inline_menu()
                 return picked
             continue
         if action == "enter":
@@ -411,14 +409,11 @@ def _pick(
                 if not text:
                     continue
                 _erase_menu(crumb, display, header=header)
-                leave_inline_menu()
                 return text
             _erase_menu(crumb, labels, header=header)
-            leave_inline_menu()
             return idx
         if action in ("cancel", "eof"):
             _erase_menu(crumb, display if on_custom else labels, header=header)
-            leave_inline_menu()
             return None
         if action == "ignore":
             continue
@@ -482,7 +477,7 @@ def repl_choose_one(
         value = choices[picked][0]
         return value if isinstance(value, str) else None
     finally:
-        show_terminal_cursor()
+        leave_inline_menu()
 
 
 def print_valid_choice_list(

--- a/tests/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -225,7 +225,6 @@ def test_run_repl_async_identifies_saved_github_username(monkeypatch: Any) -> No
         lambda **_kwargs: SimpleNamespace(session=Session(), inbox=None),
     )
 
-
     import asyncio
 
     asyncio.run(main_entrypoint.run_repl_async(initial_input="hello"))

--- a/tests/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -225,14 +225,6 @@ def test_run_repl_async_identifies_saved_github_username(monkeypatch: Any) -> No
         lambda **_kwargs: SimpleNamespace(session=Session(), inbox=None),
     )
 
-    class _PromptSession:
-        history = None
-
-    monkeypatch.setattr(
-        main_entrypoint,
-        "build_prompt_session",
-        lambda: _PromptSession(),
-    )
 
     import asyncio
 
@@ -269,14 +261,6 @@ def test_run_repl_async_failed_resume_flushes_starter_session(
 
     monkeypatch.setattr(session.store, "flush", _track_flush)
 
-    class _PromptSession:
-        history = None
-
-    monkeypatch.setattr(
-        main_entrypoint,
-        "build_prompt_session",
-        lambda: _PromptSession(),
-    )
     monkeypatch.setattr(
         main_entrypoint,
         "create_repl_runtime",
@@ -382,10 +366,6 @@ def test_run_repl_async_routes_the_console_into_resume(monkeypatch: Any, tmp_pat
         _resume,
     )
 
-    class _PromptSession:
-        history = None
-
-    monkeypatch.setattr(main_entrypoint, "build_prompt_session", lambda: _PromptSession())
     monkeypatch.setattr(
         main_entrypoint,
         "create_repl_runtime",
@@ -517,9 +497,6 @@ def test_initial_input_replay_uses_the_supplied_console(monkeypatch: Any) -> Non
 
     monkeypatch.setattr(replay, "render_terminal_ui", _fake_terminal_ui)
 
-    class _PromptSession:
-        history = None
-
     # Rendering happens before the first turn; stub the turn so this pins the
     # console wiring rather than the whole execution stack.
     monkeypatch.setattr(replay, "render_submitted_prompt", lambda *_a, **_kw: None)
@@ -528,7 +505,6 @@ def test_initial_input_replay_uses_the_supplied_console(monkeypatch: Any) -> Non
         lambda *_a, **_kw: None,
     )
 
-    monkeypatch.setattr(main_entrypoint, "build_prompt_session", lambda: _PromptSession())
     monkeypatch.setattr(
         main_entrypoint,
         "create_repl_runtime",

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -1591,6 +1591,43 @@ class TestRequestConfirmationViaPrompt:
         assert state.confirm_response == []
 
 
+def test_reset_prompt_buffer_schedules_on_the_ui_loop() -> None:
+    """Confirmation parks on a worker thread; buffer.reset must not run there."""
+    from surfaces.interactive_shell.runtime.turn_host import _reset_prompt_buffer
+
+    scheduled: list[object] = []
+
+    class _Loop:
+        def call_soon_threadsafe(self, fn: object, *args: object) -> None:
+            scheduled.append((fn, args))
+
+    class _Buffer:
+        def __init__(self) -> None:
+            self.resets = 0
+
+        def reset(self) -> None:
+            self.resets += 1
+
+    class _App:
+        def __init__(self) -> None:
+            self.current_buffer = _Buffer()
+
+    session = Session()
+    app = _App()
+    session.terminal.prompt_app = app
+    session.terminal.main_loop = _Loop()
+
+    _reset_prompt_buffer(session)
+
+    assert app.current_buffer.resets == 0
+    assert len(scheduled) == 1
+    fn, args = scheduled[0]
+    assert args == ()
+    assert callable(fn)
+    fn()
+    assert app.current_buffer.resets == 1
+
+
 class TestExecutionAllowedRespectsDispatchCancelled:
     """End-to-end contract: cancelling during ``Proceed? [Y/n]`` must
     actually STOP the in-flight action — not just stop the spinner.

--- a/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
+++ b/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
@@ -7,7 +7,9 @@ execution gate reads (allow vs cancel).
 from __future__ import annotations
 
 import re
+import threading
 
+from surfaces.interactive_shell.runtime.core.state import ReplState
 from surfaces.interactive_shell.ui.hooks import (
     confirmation_choice_overlay_ansi,
     confirmation_option_count,
@@ -82,3 +84,16 @@ def test_arrow_keys_move_and_wrap_the_selection_then_enter_delivers_it() -> None
     assert state.delivered == ["n"]
     # Every movement repainted the prompt.
     assert redraws == [True, True, True]
+
+
+def test_enter_on_default_selection_cancels() -> None:
+    # Production begin_confirmation defaults the arrow to No so a stray Enter
+    # cancels instead of approving.
+    state = ReplState()
+    state.begin_confirmation(threading.Event(), "Proceed?")
+    assert state.confirm_selected == 1
+
+    bindings = install_confirmation_key_bindings(state, lambda: None)
+    by_key = {str(b.keys[0]): b.handler for b in bindings.bindings}
+    by_key["Keys.ControlM"](None)
+    assert state.confirm_response == ["n"]

--- a/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
+++ b/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
@@ -1,0 +1,84 @@
+"""The confirmation hook renders a stacked Yes/No choice and delivers a pick.
+
+The arrow marker follows ``confirm_selected``; ``y``/``n`` are the answers the
+execution gate reads (allow vs cancel).
+"""
+
+from __future__ import annotations
+
+import re
+
+from surfaces.interactive_shell.ui.hooks import (
+    confirmation_choice_overlay_ansi,
+    confirmation_option_count,
+    install_confirmation_key_bindings,
+)
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI.sub("", text)
+
+
+class _FakeState:
+    def __init__(self) -> None:
+        self.confirm_selected = 0
+        self.awaiting = True
+        self.delivered: list[str] = []
+
+    def is_awaiting_confirmation(self) -> bool:
+        return self.awaiting
+
+    def deliver_confirmation(self, answer: str) -> None:
+        self.delivered.append(answer)
+
+
+def test_overlay_marks_the_selected_row_with_the_arrow() -> None:
+    # Arrange / Act
+    yes = _plain(confirmation_choice_overlay_ansi(0))
+    no = _plain(confirmation_choice_overlay_ansi(1))
+
+    # Assert: exactly one arrow, on the selected row.
+    assert "❯ [a] Yes" in yes and "❯ [b] No" not in yes
+    assert "❯ [b] No" in no and "❯ [a] Yes" not in no
+
+
+def test_option_count_is_two() -> None:
+    assert confirmation_option_count() == 2
+
+
+def test_letter_keys_deliver_the_matching_answer() -> None:
+    # Arrange
+    state = _FakeState()
+    redraws: list[bool] = []
+    bindings = install_confirmation_key_bindings(state, lambda: redraws.append(True))
+    by_key = {str(b.keys[0]): b.handler for b in bindings.bindings}
+
+    # Act: pressing "n" cancels, "y" allows, regardless of the current arrow.
+    by_key["n"](None)
+    by_key["y"](None)
+
+    # Assert
+    assert state.delivered == ["n", "y"]
+
+
+def test_arrow_keys_move_and_wrap_the_selection_then_enter_delivers_it() -> None:
+    # Arrange
+    state = _FakeState()
+    redraws: list[bool] = []
+    bindings = install_confirmation_key_bindings(state, lambda: redraws.append(True))
+    by_key = {str(b.keys[0]): b.handler for b in bindings.bindings}
+
+    # Act / Assert: Down moves Yes(0) -> No(1) and wraps No -> Yes.
+    by_key["Keys.Down"](None)
+    assert state.confirm_selected == 1
+    by_key["Keys.Down"](None)
+    assert state.confirm_selected == 0
+    # Up wraps Yes(0) -> No(1); Enter then delivers the No answer.
+    by_key["Keys.Up"](None)
+    assert state.confirm_selected == 1
+    by_key["Keys.ControlM"](None)
+    assert state.delivered == ["n"]
+    # Every movement repainted the prompt.
+    assert redraws == [True, True, True]

--- a/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
+++ b/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
@@ -1,7 +1,9 @@
-"""The confirmation hook renders a stacked Yes/No choice and delivers a pick.
+"""The confirmation hook renders the state's rows and delivers a pick.
 
-The arrow marker follows ``confirm_selected``; ``y``/``n`` are the answers the
-execution gate reads (allow vs cancel).
+Rows come from ``ReplState.confirm_options`` (Yes/No, or the three-row auto-level
+gate with an "always" row). ↑/↓, Enter, row tags, digits, and the ``y``/``n``
+answer keys all resolve to one of those rows; the default selection is the last
+(cancel) row so a stray Enter aborts.
 """
 
 from __future__ import annotations
@@ -12,11 +14,16 @@ import threading
 from surfaces.interactive_shell.runtime.core.state import ReplState
 from surfaces.interactive_shell.ui.hooks import (
     confirmation_choice_overlay_ansi,
-    confirmation_option_count,
     install_confirmation_key_bindings,
 )
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_YES_NO = (("y", "Yes, allow"), ("n", "No, cancel"))
+_THREE = (
+    ("y", "Yes, allow"),
+    ("always", "Yes, and always allow reversible commands"),
+    ("n", "No, cancel"),
+)
 
 
 def _plain(text: str) -> str:
@@ -24,74 +31,77 @@ def _plain(text: str) -> str:
 
 
 class _FakeState:
-    def __init__(self) -> None:
-        self.confirm_selected = 0
-        self.awaiting = True
+    def __init__(self, options: tuple[tuple[str, str], ...]) -> None:
+        self.confirm_options = options
+        self.confirm_selected = len(options) - 1
         self.delivered: list[str] = []
 
     def is_awaiting_confirmation(self) -> bool:
-        return self.awaiting
+        return True
 
     def deliver_confirmation(self, answer: str) -> None:
         self.delivered.append(answer)
 
 
 def test_overlay_marks_the_selected_row_with_the_arrow() -> None:
-    # Arrange / Act
-    yes = _plain(confirmation_choice_overlay_ansi(0))
-    no = _plain(confirmation_choice_overlay_ansi(1))
+    yes = _plain(confirmation_choice_overlay_ansi(0, _YES_NO))
+    no = _plain(confirmation_choice_overlay_ansi(1, _YES_NO))
 
-    # Assert: exactly one arrow, on the selected row.
-    assert "❯ [a] Yes" in yes and "❯ [b] No" not in yes
-    assert "❯ [b] No" in no and "❯ [a] Yes" not in no
+    assert "❯ [a] Yes, allow" in yes and "❯ [b] No, cancel" not in yes
+    assert "❯ [b] No, cancel" in no and "❯ [a] Yes, allow" not in no
 
 
-def test_option_count_is_two() -> None:
-    assert confirmation_option_count() == 2
+def test_overlay_renders_three_tagged_rows_for_the_auto_gate() -> None:
+    rendered = _plain(confirmation_choice_overlay_ansi(1, _THREE))
+    assert "[a] Yes, allow" in rendered
+    assert "❯ [b] Yes, and always allow reversible commands" in rendered
+    assert "[c] No, cancel" in rendered
 
 
 def test_letter_keys_deliver_the_matching_answer() -> None:
-    # Arrange
-    state = _FakeState()
-    redraws: list[bool] = []
-    bindings = install_confirmation_key_bindings(state, lambda: redraws.append(True))
+    state = _FakeState(_YES_NO)
+    bindings = install_confirmation_key_bindings(state, lambda: None)
     by_key = {str(b.keys[0]): b.handler for b in bindings.bindings}
 
-    # Act: pressing "n" cancels, "y" allows, regardless of the current arrow.
     by_key["n"](None)
     by_key["y"](None)
-
-    # Assert
     assert state.delivered == ["n", "y"]
 
 
-def test_arrow_keys_move_and_wrap_the_selection_then_enter_delivers_it() -> None:
-    # Arrange
-    state = _FakeState()
+def test_arrow_keys_move_and_wrap_then_enter_delivers_the_row() -> None:
+    state = _FakeState(_THREE)  # starts on the last row (No)
     redraws: list[bool] = []
     bindings = install_confirmation_key_bindings(state, lambda: redraws.append(True))
     by_key = {str(b.keys[0]): b.handler for b in bindings.bindings}
 
-    # Act / Assert: Down moves Yes(0) -> No(1) and wraps No -> Yes.
-    by_key["Keys.Down"](None)
-    assert state.confirm_selected == 1
-    by_key["Keys.Down"](None)
+    by_key["Keys.Down"](None)  # No(2) -> wrap Yes(0)
     assert state.confirm_selected == 0
-    # Up wraps Yes(0) -> No(1); Enter then delivers the No answer.
-    by_key["Keys.Up"](None)
+    by_key["Keys.Up"](None)  # Yes(0) -> wrap No(2)
+    assert state.confirm_selected == 2
+    by_key["Keys.Down"](None)  # No(2) -> Yes(0)
+    by_key["Keys.Down"](None)  # Yes(0) -> always(1)
     assert state.confirm_selected == 1
     by_key["Keys.ControlM"](None)
-    assert state.delivered == ["n"]
-    # Every movement repainted the prompt.
-    assert redraws == [True, True, True]
+    assert state.delivered == ["always"]
+    assert redraws == [True, True, True, True]
+
+
+def test_digit_and_tag_keys_pick_a_row_directly() -> None:
+    state = _FakeState(_THREE)
+    bindings = install_confirmation_key_bindings(state, lambda: None)
+    by_key = {str(b.keys[0]): b.handler for b in bindings.bindings}
+
+    by_key["2"](None)  # second row = always
+    by_key["c"](None)  # third row tag = No
+    assert state.delivered == ["always", "n"]
 
 
 def test_enter_on_default_selection_cancels() -> None:
-    # Production begin_confirmation defaults the arrow to No so a stray Enter
-    # cancels instead of approving.
+    # begin_confirmation defaults the arrow to the last row (cancel) so a stray
+    # Enter aborts instead of approving.
     state = ReplState()
     state.begin_confirmation(threading.Event(), "Proceed?")
-    assert state.confirm_selected == 1
+    assert state.confirm_selected == 1  # Yes/No default -> No is last
 
     bindings = install_confirmation_key_bindings(state, lambda: None)
     by_key = {str(b.keys[0]): b.handler for b in bindings.bindings}

--- a/tests/interactive_shell/ui/hooks/test_plan_expand.py
+++ b/tests/interactive_shell/ui/hooks/test_plan_expand.py
@@ -1,0 +1,37 @@
+"""Ctrl+P toggles the plan overlay only while a plan is on screen."""
+
+from __future__ import annotations
+
+from surfaces.interactive_shell.ui.hooks import install_plan_expand_key_bindings
+
+
+class _FakeState:
+    def __init__(self) -> None:
+        self.plan_expanded = False
+
+    def toggle_plan_expanded(self) -> None:
+        self.plan_expanded = not self.plan_expanded
+
+
+def test_ctrl_p_toggles_expansion_and_redraws() -> None:
+    # Arrange
+    state = _FakeState()
+    redraws: list[bool] = []
+    kb = install_plan_expand_key_bindings(state, lambda: True, lambda: redraws.append(True))
+    handler = kb.bindings[0].handler
+
+    # Act: two presses flip and flip back.
+    handler(None)
+    handler(None)
+
+    # Assert
+    assert state.plan_expanded is False
+    assert redraws == [True, True]
+
+
+def test_binding_is_gated_on_a_plan_being_present() -> None:
+    # The filter is False with no plan, so Ctrl+P keeps its default behavior.
+    state = _FakeState()
+    kb = install_plan_expand_key_bindings(state, lambda: False, lambda: None)
+
+    assert kb.bindings[0].filter() is False

--- a/tests/interactive_shell/ui/test_ask_user.py
+++ b/tests/interactive_shell/ui/test_ask_user.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from core.agent_harness.session.pending_choice import (
     AskUserQuestion,
     format_ask_user_answers,
@@ -164,6 +166,31 @@ def test_wizard_multi_select_toggles_and_submits(monkeypatch) -> None:
     )
     picked = repl_ask_user(questions)
     assert picked == ("Unit tests\nDockerfile", "Python")
+
+
+def test_wizard_restores_terminal_when_draw_raises(monkeypatch) -> None:
+    restored: list[bool] = []
+
+    def _restore() -> None:
+        restored.append(True)
+
+    def _boom(**_kwargs: object) -> None:
+        raise RuntimeError("draw failed")
+
+    _patch_wizard(monkeypatch, [])
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.ask_user._draw_ask_user",
+        _boom,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.key_reader.restore_stdin_terminal",
+        _restore,
+    )
+
+    with pytest.raises(RuntimeError, match="draw failed"):
+        repl_ask_user(_QUESTIONS)
+
+    assert restored == [True]
 
 
 def test_draw_ask_user_multi_uses_checkboxes(monkeypatch) -> None:

--- a/tests/interactive_shell/ui/test_auto_status.py
+++ b/tests/interactive_shell/ui/test_auto_status.py
@@ -63,8 +63,9 @@ def test_render_prompt_region_shows_the_auto_status_line() -> None:
     assert "Auto (Med)" in plain
 
 
-def test_prompt_region_height_is_constant_across_confirmation() -> None:
-    """Entering/leaving confirmation must not change the region's row count."""
+def test_confirmation_region_height_is_constant_while_confirming() -> None:
+    """The Yes/No block is a taller modal than the idle prompt, but its own
+    height must not change as the arrow selection moves between the options."""
     from surfaces.interactive_shell.runtime.core.state import (
         ReplState,
         SpinnerState,
@@ -75,11 +76,11 @@ def test_prompt_region_height_is_constant_across_confirmation() -> None:
     session = Session()
     spinner = SpinnerState()
 
-    normal_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
+    def _confirm_rows(selected: int) -> int:
+        state = ReplState()
+        state.phase = TurnPhase.AWAITING_CONFIRMATION
+        state.confirm_prompt_text = "Approve this action?"
+        state.confirm_selected = selected
+        return render_prompt_region(session, state, spinner).value.count("\n")
 
-    confirming = ReplState()
-    confirming.phase = TurnPhase.AWAITING_CONFIRMATION
-    confirming.confirm_prompt_text = "Proceed? [Y/n]"
-    confirm_rows = render_prompt_region(session, confirming, spinner).value.count("\n")
-
-    assert normal_rows == confirm_rows
+    assert _confirm_rows(0) == _confirm_rows(1)

--- a/tests/interactive_shell/ui/test_execution_confirm.py
+++ b/tests/interactive_shell/ui/test_execution_confirm.py
@@ -140,7 +140,7 @@ def test_explicit_ask_tty_accepts_empty_confirmation() -> None:
         confirm_fn=_confirm,
         is_tty=True,
     )
-    assert captured == ["Yes, allow? [Y/n] "]
+    assert captured == ["Approve this action?"]
     assert "Command to approve" in buf.getvalue()
     assert "Why this needs approval:" in buf.getvalue()
 

--- a/tests/interactive_shell/ui/test_execution_confirm.py
+++ b/tests/interactive_shell/ui/test_execution_confirm.py
@@ -304,3 +304,44 @@ def test_plan_only_guard_is_not_cleared_by_a_read_only_step() -> None:
         is_tty=True,
     )
     assert session.plan_only_until_authorized is True
+
+
+def test_always_allow_approves_and_raises_the_auto_level() -> None:
+    from config.constants.repl_autonomy import AutoLevel
+
+    session = Session()
+    session.terminal.auto_level = AutoLevel.LOW
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    # A reversible command approved with "always" runs now AND lifts Auto to Med
+    # so commands like it stop asking.
+    assert execution_allowed(
+        _ask_result(),
+        session=session,
+        console=console,
+        action_summary="echo hi > /tmp/s1.txt",
+        confirm_fn=lambda _: "always",
+        is_tty=True,
+    )
+    assert session.terminal.auto_level is AutoLevel.MED
+    assert "medium risk" in buf.getvalue()
+
+
+def test_plain_yes_does_not_change_the_auto_level() -> None:
+    from config.constants.repl_autonomy import AutoLevel
+
+    session = Session()
+    session.terminal.auto_level = AutoLevel.LOW
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    assert execution_allowed(
+        _ask_result(),
+        session=session,
+        console=console,
+        action_summary="echo hi > /tmp/s1.txt",
+        confirm_fn=lambda _: "y",
+        is_tty=True,
+    )
+    assert session.terminal.auto_level is AutoLevel.LOW

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -24,12 +24,12 @@ def test_typing_box_hidden_while_awaiting_confirmation() -> None:
     session = Session()
     confirming = ReplState()
     confirming.phase = TurnPhase.AWAITING_CONFIRMATION
-    confirming.confirm_prompt_text = "Yes, allow? [Y/n] "
+    confirming.confirm_prompt_text = "Approve this action?"
 
     assert typing_box_hidden(session, confirming) is True
     rendered = _plain(render_prompt_region(session, confirming, SpinnerState()).value)
     assert ">" not in rendered
-    assert "Yes, allow? [Y/n]" in rendered
+    assert "Approve this action?" in rendered
 
 
 def test_typing_box_hidden_while_ask_user_options_pending() -> None:
@@ -89,17 +89,42 @@ def test_idle_prompt_still_shows_typing_box() -> None:
     assert ">" in rendered
 
 
-def test_prompt_region_height_stable_when_typing_box_hides() -> None:
+def test_confirmation_region_height_is_stable_across_selection_changes() -> None:
+    # Confirmation is a taller modal block than the idle prompt, so entering it
+    # shifts height once. What must stay constant is height WHILE confirming —
+    # moving the arrow selection (Yes -> No) must not resize the region.
     session = Session()
     spinner = SpinnerState()
-    idle_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
 
-    confirming = ReplState()
-    confirming.phase = TurnPhase.AWAITING_CONFIRMATION
-    confirming.confirm_prompt_text = "Proceed? [Y/n]"
-    confirm_rows = render_prompt_region(session, confirming, spinner).value.count("\n")
+    yes_state = ReplState()
+    yes_state.phase = TurnPhase.AWAITING_CONFIRMATION
+    yes_state.confirm_prompt_text = "Approve this action?"
+    yes_state.confirm_selected = 0
+    yes_rows = render_prompt_region(session, yes_state, spinner).value.count("\n")
 
-    assert idle_rows == confirm_rows
+    no_state = ReplState()
+    no_state.phase = TurnPhase.AWAITING_CONFIRMATION
+    no_state.confirm_prompt_text = "Approve this action?"
+    no_state.confirm_selected = 1
+    no_rows = render_prompt_region(session, no_state, spinner).value.count("\n")
+
+    assert yes_rows == no_rows
+
+
+def test_confirmation_region_shows_stacked_yes_no_choice() -> None:
+    session = Session()
+    state = ReplState()
+    state.phase = TurnPhase.AWAITING_CONFIRMATION
+    state.confirm_prompt_text = "Approve this action?"
+    state.confirm_selected = 1
+
+    rendered = _plain(render_prompt_region(session, state, SpinnerState()).value)
+
+    assert "[a] Yes" in rendered
+    assert "[b] No" in rendered
+    # The selected row (No) carries the arrow; the typing box is hidden.
+    assert "❯ [b] No" in rendered
+    assert ">" not in rendered
 
 
 def test_clear_live_prompt_paint_erases_only_the_app_region() -> None:

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -163,3 +163,65 @@ def test_expanded_long_plan_shows_every_step() -> None:
     assert lines[5] == "  ○ Confirm green"
     assert "earlier" not in overlay
     assert "Ctrl+P" not in overlay
+
+
+def _other_long_plan():
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Map the services", "status": "completed"},
+                {"step": "Pull the traces", "status": "completed"},
+                {"step": "Find the timeout", "status": "in_progress"},
+                {"step": "Raise the limit", "status": "pending"},
+                {"step": "Verify p99", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    return plan
+
+
+def test_replacing_a_plan_resets_expanded_state() -> None:
+    # Ctrl+P on plan A must not stick when plan B is assigned without a
+    # None/empty gap — the replacement should open in its collapsed window.
+    session = Session()
+    session.task_plan = _long_plan()
+    state = ReplState()
+    state.plan_expanded = True
+    first = _strip_ansi(render_prompt_region(session, state, SpinnerState()).value)
+    assert state.plan_expanded is True
+    assert "Inspect the repo" in first
+
+    session.task_plan = _other_long_plan()
+    second = _strip_ansi(render_prompt_region(session, state, SpinnerState()).value)
+    assert state.plan_expanded is False
+    assert "Ctrl+P for full plan" in second
+    assert "Map the services" not in second
+    assert "Verify p99" not in second
+
+
+def test_updating_plan_status_keeps_expanded_state() -> None:
+    # Status-only updates are the same checklist; an open overlay stays open.
+    session = Session()
+    session.task_plan = _long_plan()
+    state = ReplState()
+    _ = render_prompt_region(session, state, SpinnerState())
+    state.plan_expanded = True
+
+    updated, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Inspect the repo", "status": "completed"},
+                {"step": "Read the config", "status": "completed"},
+                {"step": "Patch the bug", "status": "completed"},
+                {"step": "Run the tests", "status": "in_progress"},
+                {"step": "Confirm green", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and updated is not None
+    session.task_plan = updated
+    rendered = _strip_ansi(render_prompt_region(session, state, SpinnerState()).value)
+    assert state.plan_expanded is True
+    assert "Inspect the repo" in rendered
+    assert "Confirm green" in rendered

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -108,6 +108,19 @@ def test_idle_prompt_region_keeps_status_spacer_not_thinking() -> None:
     assert rendered.index("Plan · 2/3") < rendered.index("Auto (High)")
 
 
+def test_clearing_the_plan_resets_expanded_state() -> None:
+    session = Session()
+    session.task_plan = _sample_plan()
+    state = ReplState()
+    state.plan_expanded = True
+    _ = render_prompt_region(session, state, SpinnerState())
+    assert state.plan_expanded is True
+
+    session.task_plan = None
+    _ = render_prompt_region(session, state, SpinnerState())
+    assert state.plan_expanded is False
+
+
 def _long_plan():
     plan, error = parse_task_plan(
         {

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -106,3 +106,47 @@ def test_idle_prompt_region_keeps_status_spacer_not_thinking() -> None:
     assert SpinnerState.EXECUTING_PHASE not in rendered
     assert "Plan · 2/3" in rendered
     assert rendered.index("Plan · 2/3") < rendered.index("Auto (High)")
+
+
+def _long_plan():
+    plan, error = parse_task_plan(
+        {
+            "plan": [
+                {"step": "Inspect the repo", "status": "completed"},
+                {"step": "Read the config", "status": "completed"},
+                {"step": "Patch the bug", "status": "in_progress"},
+                {"step": "Run the tests", "status": "pending"},
+                {"step": "Confirm green", "status": "pending"},
+            ]
+        }
+    )
+    assert error is None and plan is not None
+    return plan
+
+
+def test_long_plan_collapses_to_a_window_around_the_current_step() -> None:
+    # A 5-step plan folds to the current step plus one neighbour each side,
+    # with count markers for the hidden ranges and a hint to expand.
+    overlay = _strip_ansi(task_plan_overlay_ansi(_long_plan()))
+    lines = overlay.splitlines()
+
+    assert lines[0].startswith("Plan · 3/5")
+    assert lines[1] == "  … 1 earlier"
+    assert lines[2] == "  ✓ Read the config"
+    assert lines[3] == "  ● Patch the bug"
+    assert lines[4] == "  ○ Run the tests"
+    assert lines[5] == "  … 1 more · Ctrl+P for full plan"
+    # The collapsed view hides the far ends.
+    assert "Inspect the repo" not in overlay
+    assert "Confirm green" not in overlay
+
+
+def test_expanded_long_plan_shows_every_step() -> None:
+    overlay = _strip_ansi(task_plan_overlay_ansi(_long_plan(), expanded=True))
+    lines = overlay.splitlines()
+
+    assert lines[0].startswith("Plan · 3/5")
+    assert lines[1] == "  ✓ Inspect the repo"
+    assert lines[5] == "  ○ Confirm green"
+    assert "earlier" not in overlay
+    assert "Ctrl+P" not in overlay

--- a/tests/shared/terminal/test_choice_menu.py
+++ b/tests/shared/terminal/test_choice_menu.py
@@ -7,6 +7,8 @@ import re
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 from surfaces.shared.terminal.components import choice_menu
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;:]*[A-Za-z]")
@@ -75,10 +77,6 @@ def test_pick_multi_select_returns_values_not_labels(monkeypatch) -> None:
     monkeypatch.setattr(
         "surfaces.shared.terminal.components.key_reader.read_menu_or_char",
         lambda **_kwargs: next(actions),
-    )
-    monkeypatch.setattr(
-        "surfaces.shared.terminal.components.key_reader.restore_stdin_terminal",
-        lambda: None,
     )
     monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
 
@@ -220,6 +218,65 @@ def test_repl_choose_one_starts_at_initial_value(monkeypatch) -> None:
     assert result == "blue"
     plain = _ANSI_RE.sub("", out.getvalue())
     assert "❯ 2. blue (current)" in plain
+
+
+def test_repl_choose_one_restores_terminal_when_menu_raises(monkeypatch) -> None:
+    """Exceptions during draw/read still recook stdin and reset the column."""
+    restored: list[bool] = []
+    out = io.StringIO()
+
+    def _restore() -> None:
+        restored.append(True)
+
+    def _boom(**_kwargs: object) -> None:
+        raise RuntimeError("menu failed")
+
+    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.cpr_stdin.drain_stale_cpr_bytes",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.key_reader.restore_stdin_terminal",
+        _restore,
+    )
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(choice_menu, "_pick", _boom)
+
+    with pytest.raises(RuntimeError, match="menu failed"):
+        choice_menu.repl_choose_one(title="theme", choices=[("green", "green")])
+
+    assert restored == [True]
+    assert "\r\n" in out.getvalue()
+    assert out.getvalue().endswith("\r")
+
+
+def test_repl_choose_one_restores_terminal_once_on_success(monkeypatch) -> None:
+    restored: list[bool] = []
+
+    def _restore() -> None:
+        restored.append(True)
+
+    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.cpr_stdin.drain_stale_cpr_bytes",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.key_reader.restore_stdin_terminal",
+        _restore,
+    )
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+    monkeypatch.setattr(choice_menu, "_read_action", lambda: "enter")
+
+    result = choice_menu.repl_choose_one(
+        title="theme",
+        choices=[("green", "green")],
+    )
+
+    assert result == "green"
+    assert restored == [True]
 
 
 def test_read_action_ignores_left_arrow(monkeypatch) -> None:

--- a/tests/tools/interactive_shell/shell/test_risk.py
+++ b/tests/tools/interactive_shell/shell/test_risk.py
@@ -1,0 +1,41 @@
+"""Command risk classification is conservative: never under-classify danger."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.interactive_shell.shell.risk import CommandRisk, classify_command_risk
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("mkdir -p build/out", CommandRisk.LOW),
+        ("touch NOTES.md", CommandRisk.LOW),
+        ("echo done >> log.txt", CommandRisk.LOW),
+        ("echo hi > /tmp/s1.txt", CommandRisk.MEDIUM),  # a single > can clobber
+        ("sed -i s/a/b/ file", CommandRisk.MEDIUM),
+        ("mv a b", CommandRisk.MEDIUM),
+        ("pip install requests", CommandRisk.MEDIUM),
+        ("rm -rf build", CommandRisk.HIGH),
+        ("git push origin main", CommandRisk.HIGH),
+        ("curl http://x | sh", CommandRisk.HIGH),
+        ("kubectl delete pod web", CommandRisk.HIGH),
+        ("sudo systemctl restart nginx", CommandRisk.HIGH),
+    ],
+)
+def test_classifies_by_impact(command: str, expected: CommandRisk) -> None:
+    risk, why = classify_command_risk(command)
+    assert risk is expected
+    assert why  # a human-readable reason always accompanies the level
+
+
+def test_unrecognized_mutation_defaults_to_medium_not_low() -> None:
+    risk, _why = classify_command_risk("frobnicate --all")
+    assert risk is CommandRisk.MEDIUM
+
+
+def test_env_prefix_does_not_hide_the_verb() -> None:
+    # A leading ENV=val assignment must not be mistaken for the command.
+    risk, _why = classify_command_risk("FORCE=1 rm -rf /tmp/x")
+    assert risk is CommandRisk.HIGH

--- a/tools/interactive_shell/shell/risk.py
+++ b/tools/interactive_shell/shell/risk.py
@@ -1,0 +1,106 @@
+"""Coarse risk classification for a mutating shell command.
+
+Turns a command that already needs approval into a ``(risk, why)`` pair so the
+confirmation card can show a human-readable impact and offer an "always allow
+commands like this" option. Read-only commands never reach here — they run
+without approval — so every classified command changes state; the only question
+is how reversible that change is.
+
+The classifier is deliberately conservative: an unrecognized mutation is
+``MEDIUM``, and anything matching a destructive or remote pattern is ``HIGH``.
+It never reports ``LOW`` for a command it does not positively recognize as a
+small, local, reversible write.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+
+_OPERATOR_SPLIT = re.compile(r"\|\||&&|[|;\n]|>>|>|<|&")
+
+
+class CommandRisk(StrEnum):
+    """How much a mutating command can hurt if approved."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+# First-token verbs that destroy data or cannot be undone.
+_DESTRUCTIVE_VERBS = frozenset(
+    {"rm", "rmdir", "shred", "dd", "mkfs", "fdisk", "truncate", "unlink", "srm"}
+)
+# Substrings that mark a remote, irreversible, or destructive action regardless
+# of the leading verb (checked against the whole command, lowercased).
+_HIGH_RISK_PATTERNS: tuple[str, ...] = (
+    "git push",
+    "git reset --hard",
+    "git clean",
+    "git rebase",
+    "kubectl delete",
+    "docker rm",
+    "docker rmi",
+    "drop table",
+    "drop database",
+    "> /dev/",
+    "chmod -r",
+    "chown -r",
+    "sudo ",
+)
+# Commands that reach the network / a remote system.
+_NETWORK_VERBS = frozenset(
+    {"curl", "wget", "ssh", "scp", "rsync", "kubectl", "helm", "aws", "gcloud", "terraform"}
+)
+# Verbs that change installed software.
+_PACKAGE_VERBS = frozenset({"pip", "pip3", "uv", "npm", "yarn", "pnpm", "brew", "apt", "cargo"})
+# Small, local, reversible writes.
+_CREATE_VERBS = frozenset({"mkdir", "touch"})
+_EDIT_VERBS = frozenset({"cp", "mv", "ln", "sed", "tee"})
+
+
+def _first_verb(segment: str) -> str:
+    """The executable name of a command segment, ignoring env-var prefixes."""
+    for token in segment.strip().split():
+        if "=" in token and not token.startswith("-"):
+            continue  # skip ENV=val prefixes
+        return token.rsplit("/", 1)[-1]
+    return ""
+
+
+def _segments(command: str) -> list[str]:
+    return [seg for seg in _OPERATOR_SPLIT.split(command) if seg.strip()]
+
+
+def classify_command_risk(command: str) -> tuple[CommandRisk, str]:
+    """Return the risk level and a one-line human impact for ``command``.
+
+    ``command`` is the full shell string the user is being asked to approve.
+    """
+    lowered = command.lower()
+    if any(pattern in lowered for pattern in _HIGH_RISK_PATTERNS):
+        return CommandRisk.HIGH, "Destructive or remote action that may be irreversible."
+
+    verbs = [_first_verb(seg) for seg in _segments(command)]
+    verbs = [verb for verb in verbs if verb]
+
+    if any(verb in _DESTRUCTIVE_VERBS for verb in verbs):
+        return CommandRisk.HIGH, "Deletes or overwrites data; likely irreversible."
+    if any(verb in _NETWORK_VERBS for verb in verbs):
+        return CommandRisk.HIGH, "Contacts a remote system or network resource."
+    if any(verb in _PACKAGE_VERBS for verb in verbs):
+        return CommandRisk.MEDIUM, "Changes installed packages or the environment."
+
+    # A single ``>`` can clobber an existing file, and in-place edits change
+    # existing data — reversible in principle, but not a no-op.
+    overwrites = re.search(r"(?<!>)>(?!>)", command) is not None
+    if overwrites or any(verb in _EDIT_VERBS for verb in verbs):
+        return CommandRisk.MEDIUM, "Creates, overwrites, or edits local files."
+    if ">>" in command or any(verb in _CREATE_VERBS for verb in verbs):
+        return CommandRisk.LOW, "Creates new files or appends to them; reversible."
+
+    return CommandRisk.MEDIUM, "Changes local state."
+
+
+__all__ = ["CommandRisk", "classify_command_risk"]


### PR DESCRIPTION
Two planning-controls polish items for the interactive shell.

**Arrow-navigable execution confirmation**
- The `Yes, allow? [Y/n]` gate is now a stacked, arrow-selectable choice:
  `[a] Yes` / `[b] No`. Up/Down move the selection (with wrap), Enter confirms;
  `a`/`b` and `y`/`n` are one-key shortcuts. No typed answer required.
- The free-text composer box is hidden while the choice is active — a
  `ConditionalContainer` collapses the composer frame and footer whenever
  structured input owns the keyboard, so the box cannot compete with the choice.
- The selected row is marked with the accent arrow; the block has blank-row
  spacing around its header, options, and nav hint for a clear hierarchy.
- New `surfaces/interactive_shell/ui/hooks/` package holds the self-contained
  render + key-binding units (`confirmation_choice.py`, `plan_expand.py`).

**Collapsible plan overlay**
- A plan longer than a few steps collapses to a window around the current step
  with `… N earlier` / `… N more · Ctrl+P for full plan` markers; short plans
  and the expanded view show every step. Done / current / pending keep their
  glyphs. Ctrl+P toggles the full list (gated on a plan being present, so it
  keeps its default behavior otherwise).