### PR TITLE
fix(shell): unhang subprocess confirmation and stop risk-grading non-shell commands

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -207,6 +207,8 @@ Your final message should read naturally, like an update from a concise teammate
 
 You can skip heavy formatting for single, simple actions or confirmations. In these cases, respond in plain sentences with any relevant next step or quick option. Reserve multi-section structured responses for results that need grouping or explanation.
 
+After running a command or action, always close the turn with a one-line confirmation of what happened: the concrete result (what was created, changed, or removed, and a nonzero exit if any) plus anything the user should know, such as a step you skipped or that was cancelled. Do not end a turn silently right after a tool call — the terminal shows the command ran, but not what it means.
+
 The user is working on the same computer as you, and has access to your work. As such there's no need to show the contents of files you have already written unless the user explicitly asks for them. Similarly, if you've created or modified files using `apply_patch`, there's no need to tell users to "save the file" or "copy the code into a file"—just reference the file path.
 
 If there's something that you think you could help with as a logical next step

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -484,27 +484,27 @@ def _self_recording_tools_only(result: Any) -> bool:
 
 # Self-recording tools whose result payload carries the real command output
 # back to the model (shell: stdout/stderr/exit_code; slash: the captured
-# console output read back from the history row). A closing summary after a
-# chain of these is grounded in observed output, unlike the bare success flags
-# most self-recording tools return.
-_GROUNDED_CHAIN_TOOL_NAMES: frozenset[str] = frozenset({"shell_run", "slash_invoke"})
+# console output read back from the history row). A closing summary after these
+# is grounded in observed output, unlike the bare success flags most
+# self-recording tools return.
+_GROUNDED_OUTPUT_TOOL_NAMES: frozenset[str] = frozenset({"shell_run", "slash_invoke"})
 
 
-def _multi_step_grounded_chain(result: Any) -> bool:
-    """True when the turn chained two or more output-carrying tool steps.
+def _grounded_output_tools_only(result: Any) -> bool:
+    """True when every tool this turn carried its real output back to the model.
 
     ``_self_recording_tools_only`` suppresses model closings because most
     self-recording tools hand the model a bare success flag, so closing prose
     would be invented. ``shell_run`` and ``slash_invoke`` are the exceptions —
-    their tool results carry the real output back to the model — so after a
-    multi-step chain the completion summary is grounded in output the model
-    actually observed, and dropping it left workflow turns ending on raw step
-    output with no wrap-up. Single commands keep the suppression: their one
-    output block is already on screen, and a paraphrase only adds
-    contradiction risk.
+    their tool results carry the real stdout/exit (or captured console output)
+    back to the model — so their closing summary is grounded in output the model
+    actually observed. That holds whether the turn ran one command or a chain:
+    keeping the closing lets the agent report what a command did (result, exit,
+    any skipped step) instead of ending on raw output, matching how a teammate
+    would confirm the outcome.
     """
     names = [tool_call.name for tool_call, _tool_result in getattr(result, "tool_results", [])]
-    return len(names) >= 2 and all(name in _GROUNDED_CHAIN_TOOL_NAMES for name in names)
+    return bool(names) and all(name in _GROUNDED_OUTPUT_TOOL_NAMES for name in names)
 
 
 def _asks_the_user(final_text: str) -> bool:
@@ -927,18 +927,18 @@ def _compose_response(
     # Self-recording tools (slash/shell/…) already rendered the real output.
     # Drop model closings so they cannot contradict what the user just saw
     # (classic failure: inventing "health check passed" after a failed /health).
-    # Exceptions: a multi-step shell/slash chain, whose closing summary is
-    # grounded in the output the model observed between steps; a closing
-    # question, which seeks direction instead of restating output; and any
-    # quiet ``shell_run``, which withheld live stdout so the closing *is*
-    # the turn's display.
+    # Exceptions: a shell/slash command, whose closing summary is grounded in the
+    # output the model observed (so the agent can confirm the outcome, one command
+    # or a chain); a closing question, which seeks direction instead of restating
+    # output; and any quiet ``shell_run``, which withheld live stdout so the
+    # closing *is* the turn's display.
     suppress_final = (
         (waiting_for_choice and _is_redundant_choice_invitation(result, final_text))
         or _is_choice_acknowledgement(final_text, selected_choice)
         or prefer_tool_response_text
         or (
             _self_recording_tools_only(result)
-            and not _multi_step_grounded_chain(result)
+            and not _grounded_output_tools_only(result)
             and not _asks_the_user(final_text)
             and not _has_quiet_shell_run(result)
         )

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -41,7 +41,11 @@ from surfaces.interactive_shell.runtime.core.confirmation import (
     DispatchCancelled,
     request_confirmation_via_prompt,
 )
-from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+from surfaces.interactive_shell.runtime.core.state import (
+    DEFAULT_CONFIRM_OPTIONS,
+    ReplState,
+    SpinnerState,
+)
 from surfaces.interactive_shell.runtime.input import PromptInputReader
 from surfaces.interactive_shell.runtime.input.actions import (
     InputAction,
@@ -94,6 +98,12 @@ def _confirm_via_prompt(runtime: AgentTurnResources, prompt: str) -> str:
     terminal = runtime.session.terminal
     options = terminal.pending_confirm_options
     terminal.pending_confirm_options = None
+    app = terminal.prompt_app
+    if app is None or not getattr(app, "is_running", False):
+        # The live prompt app is suspended (an exclusive-stdin / subprocess turn
+        # owns the terminal). Parking on it would hang while the cooked terminal
+        # echoes the arrow keys, so read a plain line instead.
+        return _confirm_via_readline(prompt, options)
     return request_confirmation_via_prompt(
         runtime.state,
         prompt,
@@ -101,6 +111,26 @@ def _confirm_via_prompt(runtime: AgentTurnResources, prompt: str) -> str:
         redraw=runtime.invalidate_prompt,
         prepare_ui=lambda: _reset_prompt_buffer(runtime.session),
     )
+
+
+def _confirm_via_readline(prompt: str, options: tuple[tuple[str, str], ...] | None) -> str:
+    """Cooked-stdin confirmation for when the arrow-nav prompt app is unavailable.
+
+    Prints the rows and reads one line; a row tag, digit, or answer key resolves
+    to that row's answer, which the execution gate interprets.
+    """
+    rows = options or DEFAULT_CONFIRM_OPTIONS
+    for index, (_answer, label) in enumerate(rows):
+        print(f"  [{chr(ord('a') + index)}] {label}")
+    tags = "/".join(chr(ord("a") + index) for index in range(len(rows)))
+    try:
+        raw = input(f"{prompt} [{tags}] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return "n"
+    for index, (answer, _label) in enumerate(rows):
+        if raw in {chr(ord("a") + index), str(index + 1), answer}:
+            return answer
+    return raw
 
 
 def _reset_prompt_buffer(session: Session) -> None:

--- a/surfaces/interactive_shell/runtime/turn_host.py
+++ b/surfaces/interactive_shell/runtime/turn_host.py
@@ -99,10 +99,11 @@ def _confirm_via_prompt(runtime: AgentTurnResources, prompt: str) -> str:
     options = terminal.pending_confirm_options
     terminal.pending_confirm_options = None
     app = terminal.prompt_app
-    if app is None or not getattr(app, "is_running", False):
-        # The live prompt app is suspended (an exclusive-stdin / subprocess turn
-        # owns the terminal). Parking on it would hang while the cooked terminal
-        # echoes the arrow keys, so read a plain line instead.
+    prompt_running = app is not None and getattr(app, "is_running", False)
+    if terminal.exclusive_stdin_active or not prompt_running:
+        # Exclusive-stdin / subprocess turns own the TTY (and ``is_running`` can
+        # still be true). Parking on the prompt app hangs while the cooked
+        # terminal echoes the arrow keys, so read a plain line instead.
         return _confirm_via_readline(prompt, options)
     return request_confirmation_via_prompt(
         runtime.state,
@@ -117,16 +118,20 @@ def _confirm_via_readline(prompt: str, options: tuple[tuple[str, str], ...] | No
     """Cooked-stdin confirmation for when the arrow-nav prompt app is unavailable.
 
     Prints the rows and reads one line; a row tag, digit, or answer key resolves
-    to that row's answer, which the execution gate interprets.
+    to that row's answer, which the execution gate interprets. An empty line
+    matches the arrow-nav default: the last row (cancel).
     """
     rows = options or DEFAULT_CONFIRM_OPTIONS
     for index, (_answer, label) in enumerate(rows):
         print(f"  [{chr(ord('a') + index)}] {label}")
     tags = "/".join(chr(ord("a") + index) for index in range(len(rows)))
+    cancel = rows[-1][0]
     try:
         raw = input(f"{prompt} [{tags}] ").strip().lower()
     except (EOFError, KeyboardInterrupt):
-        return "n"
+        return cancel
+    if not raw:
+        return cancel
     for index, (answer, _label) in enumerate(rows):
         if raw in {chr(ord("a") + index), str(index + 1), answer}:
             return answer

--- a/surfaces/interactive_shell/ui/execution_confirm.py
+++ b/surfaces/interactive_shell/ui/execution_confirm.py
@@ -49,6 +49,9 @@ def _default_confirm_fn(prompt: str) -> str:
 
 DEFAULT_CONFIRM_FN: Callable[[str], str] = _default_confirm_fn
 _APPROVE_PROMPT = "Approve this action?"
+# Only shell commands get a per-command risk grade; matches ``tool_type`` set by
+# ``tools.interactive_shell.shell.policy``.
+_SHELL_TOOL_TYPE = "shell"
 
 
 _ALWAYS_ALLOW_LABEL = {
@@ -80,17 +83,24 @@ def _render_command_to_approve(
     console: Console,
     *,
     summary: str,
-    risk: CommandRisk,
+    risk: CommandRisk | None,
     why: str,
     action_already_listed: bool,
 ) -> None:
-    """Approval card: header with the risk level, the command, and its impact."""
+    """Approval card: header with the risk level (shell only), command, and impact.
+
+    ``risk`` is ``None`` for non-shell actions (slash commands, tools), which get
+    a plain "needs confirmation" header instead of a risk grade.
+    """
     header = Text()
     header.append("Command to approve", style=str(HIGHLIGHT))
     header.append(" · ", style=str(DIM))
-    header.append(
-        f"{risk.value} risk", style=str(WARNING if risk is CommandRisk.HIGH else SECONDARY)
-    )
+    if risk is None:
+        header.append("needs confirmation", style=str(SECONDARY))
+    else:
+        header.append(
+            f"{risk.value} risk", style=str(WARNING if risk is CommandRisk.HIGH else SECONDARY)
+        )
     console.print()
     console.print(header)
     if summary and not action_already_listed:
@@ -192,11 +202,22 @@ def execution_allowed(
 
     # NEEDS_CONFIRMATION
     summary = action_summary.strip()
-    risk, impact = classify_command_risk(summary)
-    # The classifier's impact replaces only the generic auto-level reason; a
-    # specific policy reason (e.g. a fleet-scan explanation, plan-only) wins.
     policy_reason = (result.reason or "").strip()
-    why = impact if (not policy_reason or policy_reason.startswith("Auto (")) else policy_reason
+    if result.tool_type == _SHELL_TOOL_TYPE:
+        # Only shell commands carry a per-command risk grade and an "always allow
+        # reversible" row. The classifier's impact replaces the generic auto-level
+        # reason; a specific policy reason still wins.
+        risk: CommandRisk | None
+        risk, impact = classify_command_risk(summary)
+        why = impact if (not policy_reason or policy_reason.startswith("Auto (")) else policy_reason
+        options, always_target = _confirm_options_and_target(risk, plan_only_active)
+    else:
+        # Slash commands and other tools are not shell mutations: no risk grade,
+        # no "always allow" row — a plain Yes/No with the policy reason.
+        risk = None
+        why = policy_reason or "this action"
+        options = (("y", "Yes, allow"), ("n", "No, cancel"))
+        always_target = None
     _render_command_to_approve(
         console,
         summary=summary,
@@ -204,7 +225,6 @@ def execution_allowed(
         why=why,
         action_already_listed=action_already_listed,
     )
-    options, always_target = _confirm_options_and_target(risk, plan_only_active)
     terminal = getattr(session, "terminal", None)
     if terminal is not None:
         terminal.pending_confirm_options = options

--- a/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
+++ b/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
@@ -55,9 +55,8 @@ def confirmation_choice_overlay_ansi(selected: int, options: tuple[tuple[str, st
         f"{'❯' if position == index else ' '} [{chr(ord('a') + position)}] {label}"
         for position, (_answer, label) in enumerate(options)
     ]
-    inner = min(
-        max(_BOX_MIN_INNER, *(len(row) for row in contents)), prompt_line_width() - _BOX_CHROME
-    )
+    # Span the full prompt width (like the composer box below), not the content.
+    inner = max(_BOX_MIN_INNER, prompt_line_width() - _BOX_CHROME)
     border = ui_theme.PROMPT_FRAME_ANSI
     reset = ui_theme.ANSI_RESET
     lines = [f"{border}┌{'─' * (inner + 2)}┐{reset}"]

--- a/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
+++ b/surfaces/interactive_shell/ui/hooks/confirmation_choice.py
@@ -23,7 +23,6 @@ from surfaces.shared.terminal.prompt_layout import prompt_line_width
 # Rows are supplied per confirmation via ``ReplState.confirm_options``. The gate
 # reads "", "y", "yes" as allow; "always" as allow-and-raise-auto; else cancel.
 _MAX_TAGGED = 9
-_BOX_MIN_INNER = 24
 # Leave room for the ``│ `` / ` │`` box chrome plus one spare column so the
 # border never reaches the last cell and soft-wraps.
 _BOX_CHROME = 5
@@ -55,8 +54,8 @@ def confirmation_choice_overlay_ansi(selected: int, options: tuple[tuple[str, st
         f"{'❯' if position == index else ' '} [{chr(ord('a') + position)}] {label}"
         for position, (_answer, label) in enumerate(options)
     ]
-    # Span the full prompt width (like the composer box below), not the content.
-    inner = max(_BOX_MIN_INNER, prompt_line_width() - _BOX_CHROME)
+    # Span the available prompt width (like the composer box below), not the content.
+    inner = max(0, prompt_line_width() - _BOX_CHROME)
     border = ui_theme.PROMPT_FRAME_ANSI
     reset = ui_theme.ANSI_RESET
     lines = [f"{border}┌{'─' * (inner + 2)}┐{reset}"]

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -1,7 +1,9 @@
-"""Quiet ``shell_run`` keeps the model closing — it withheld live stdout.
+"""A ``shell_run`` turn keeps the model's grounded closing.
 
-Loud single ``shell_run`` still suppresses closings (output is already on
-screen). Quiet probes never enter display_chunks; the composed closing does.
+Quiet ``shell_run`` withheld live stdout, so its closing *is* the display. A
+loud ``shell_run`` also keeps its closing (grounded in the stdout/exit the model
+observed), but its already-painted stdout is not reprinted under it. Raw command
+output never enters display_chunks; the composed closing does.
 """
 
 from __future__ import annotations
@@ -88,8 +90,9 @@ def test_single_quiet_shell_run_keeps_the_model_closing() -> None:
     assert "Amsterdam: +18C" not in shown
 
 
-def test_quiet_string_false_still_suppresses_loud_closing() -> None:
-    # Arrange: models sometimes emit quiet as a string; "false" must not keep closings.
+def test_quiet_string_false_is_coerced_to_loud() -> None:
+    # Arrange: models sometimes emit quiet as a string; "false" must read as loud
+    # (already-on-screen stdout), not as a quiet probe.
     call = ToolCall(
         id="1",
         name="shell_run",
@@ -105,8 +108,10 @@ def test_quiet_string_false_still_suppresses_loud_closing() -> None:
         result, _Session(), _counts(1)
     )
 
-    # Assert: treated as loud — closing suppressed, no stdout reprint.
-    assert "\n".join(display_chunks) == ""
+    # Assert: the grounded closing shows; the loud stdout is not reprinted under it.
+    shown = "\n".join(display_chunks)
+    assert "done" in shown
+    assert "hi" not in shown
 
 
 def test_quiet_probes_stay_hidden_when_a_composed_closing_is_shown() -> None:
@@ -138,7 +143,7 @@ def test_quiet_probes_stay_hidden_when_a_composed_closing_is_shown() -> None:
     assert "Markets open higher" not in shown
 
 
-def test_loud_shell_run_does_not_reprint_stdout_in_display_chunks() -> None:
+def test_loud_shell_run_keeps_closing_without_reprinting_stdout() -> None:
     # Arrange: a non-quiet step, whose stdout the runner already painted.
     call = _shell_call("1", "echo hi", quiet=False)
     result = _Result(
@@ -151,8 +156,10 @@ def test_loud_shell_run_does_not_reprint_stdout_in_display_chunks() -> None:
         result, _Session(), _counts(1)
     )
 
-    # Assert: nothing to show, so the turn cannot print stdout twice.
-    assert "\n".join(display_chunks) == ""
+    # Assert: the grounded closing is shown; stdout is not reprinted under it.
+    shown = "\n".join(display_chunks)
+    assert "done" in shown
+    assert "hi" not in shown
 
 
 def test_silent_tool_turn_prints_a_blank_line() -> None:

--- a/tests/interactive_shell/runtime/test_confirm_fallback.py
+++ b/tests/interactive_shell/runtime/test_confirm_fallback.py
@@ -1,0 +1,49 @@
+"""When the prompt app is suspended (subprocess turns), confirmation reads a
+plain line instead of parking on the hidden arrow-nav — otherwise it hangs while
+the cooked terminal echoes the arrow keys.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+from surfaces.interactive_shell.runtime.turn_host import _confirm_via_readline
+
+_THREE = (
+    ("y", "Yes, allow"),
+    ("always", "Yes, and always allow reversible commands"),
+    ("n", "No, cancel"),
+)
+
+
+@pytest.mark.parametrize(
+    ("typed", "expected"),
+    [
+        ("a", "y"),  # row tag
+        ("2", "always"),  # digit
+        ("n", "n"),  # answer key
+        ("y", "y"),
+        ("weird", "weird"),  # passthrough for the gate to interpret
+    ],
+)
+def test_readline_maps_tags_digits_and_answers(monkeypatch, typed: str, expected: str) -> None:
+    monkeypatch.setattr(builtins, "input", lambda _prompt: typed)
+    assert _confirm_via_readline("Approve?", _THREE) == expected
+
+
+def test_readline_treats_interrupt_as_cancel(monkeypatch) -> None:
+    def _raise(_prompt: str) -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(builtins, "input", _raise)
+    assert _confirm_via_readline("Approve?", _THREE) == "n"
+
+
+def test_readline_defaults_to_yes_no_without_options(monkeypatch) -> None:
+    captured: list[str] = []
+    monkeypatch.setattr(builtins, "input", lambda prompt: captured.append(prompt) or "y")
+    assert _confirm_via_readline("Approve?", None) == "y"
+    # Two default rows -> a two-tag prompt.
+    assert captured == ["Approve? [a/b] "]

--- a/tests/interactive_shell/runtime/test_confirm_fallback.py
+++ b/tests/interactive_shell/runtime/test_confirm_fallback.py
@@ -9,13 +9,37 @@ import builtins
 
 import pytest
 
-from surfaces.interactive_shell.runtime.turn_host import _confirm_via_readline
+from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+from surfaces.interactive_shell.runtime.turn_host import (
+    AgentTurnResources,
+    _confirm_via_prompt,
+    _confirm_via_readline,
+)
+from surfaces.interactive_shell.session import Session
 
 _THREE = (
     ("y", "Yes, allow"),
     ("always", "Yes, and always allow reversible commands"),
     ("n", "No, cancel"),
 )
+
+
+class _FakeApp:
+    def __init__(self, *, running: bool) -> None:
+        self.is_running = running
+
+
+def _runtime(*, running: bool | None, exclusive: bool) -> AgentTurnResources:
+    session = Session()
+    session.terminal.prompt_app = None if running is None else _FakeApp(running=running)
+    session.terminal.exclusive_stdin_active = exclusive
+    session.terminal.pending_confirm_options = _THREE
+    return AgentTurnResources(
+        session=session,
+        state=ReplState(),
+        spinner=SpinnerState(),
+        invalidate_prompt=lambda: None,
+    )
 
 
 @pytest.mark.parametrize(
@@ -33,6 +57,13 @@ def test_readline_maps_tags_digits_and_answers(monkeypatch, typed: str, expected
     assert _confirm_via_readline("Approve?", _THREE) == expected
 
 
+def test_readline_empty_enter_cancels_like_the_arrow_nav_default(monkeypatch) -> None:
+    # Arrow-nav defaults the selection to the last row (cancel). A stray Enter
+    # on the cooked fallback must not approve.
+    monkeypatch.setattr(builtins, "input", lambda _prompt: "  ")
+    assert _confirm_via_readline("Approve?", _THREE) == "n"
+
+
 def test_readline_treats_interrupt_as_cancel(monkeypatch) -> None:
     def _raise(_prompt: str) -> str:
         raise KeyboardInterrupt
@@ -47,3 +78,40 @@ def test_readline_defaults_to_yes_no_without_options(monkeypatch) -> None:
     assert _confirm_via_readline("Approve?", None) == "y"
     # Two default rows -> a two-tag prompt.
     assert captured == ["Approve? [a/b] "]
+
+
+def _stub_confirm_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.turn_host._confirm_via_readline",
+        lambda *_args, **_kwargs: "readline",
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.turn_host.request_confirmation_via_prompt",
+        lambda *_args, **_kwargs: "arrow",
+    )
+
+
+def test_confirm_via_prompt_uses_readline_when_exclusive_stdin_owns_the_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The live prompt app can still report is_running during an exclusive-stdin
+    # turn; parking on it hangs. Exclusive stdin must force the cooked path.
+    _stub_confirm_paths(monkeypatch)
+    runtime = _runtime(running=True, exclusive=True)
+    assert _confirm_via_prompt(runtime, "Approve?") == "readline"
+    assert runtime.session.terminal.pending_confirm_options is None
+
+
+def test_confirm_via_prompt_uses_readline_when_the_prompt_app_is_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_confirm_paths(monkeypatch)
+    assert _confirm_via_prompt(_runtime(running=False, exclusive=False), "Approve?") == "readline"
+    assert _confirm_via_prompt(_runtime(running=None, exclusive=False), "Approve?") == "readline"
+
+
+def test_confirm_via_prompt_uses_arrow_nav_when_the_live_prompt_owns_the_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_confirm_paths(monkeypatch)
+    assert _confirm_via_prompt(_runtime(running=True, exclusive=False), "Approve?") == "arrow"

--- a/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
+++ b/tests/interactive_shell/ui/hooks/test_confirmation_choice.py
@@ -58,6 +58,20 @@ def test_overlay_renders_three_tagged_rows_for_the_auto_gate() -> None:
     assert "[c] No, cancel" in rendered
 
 
+def test_overlay_fits_inside_a_narrow_prompt(monkeypatch) -> None:
+    """A prompt narrower than a typical option label must not wrap the box."""
+    width = 20
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.confirmation_choice.prompt_line_width",
+        lambda: width,
+    )
+    rendered = _plain(confirmation_choice_overlay_ansi(0, _YES_NO))
+    for line in rendered.splitlines():
+        assert len(line) <= width
+    assert "❯ [a]" in rendered
+    assert "[b]" in rendered
+
+
 def test_letter_keys_deliver_the_matching_answer() -> None:
     state = _FakeState(_YES_NO)
     bindings = install_confirmation_key_bindings(state, lambda: None)

--- a/tests/interactive_shell/ui/test_execution_confirm.py
+++ b/tests/interactive_shell/ui/test_execution_confirm.py
@@ -368,6 +368,8 @@ def test_non_shell_action_gets_plain_confirmation_no_risk_grade() -> None:
     )
     out = buf.getvalue()
     assert "needs confirmation" in out
-    assert "risk" not in out
+    assert "low risk" not in out
+    assert "medium risk" not in out
+    assert "high risk" not in out
     assert "always allow" not in out
     assert session.terminal.auto_level is AutoLevel.LOW

--- a/tests/interactive_shell/ui/test_execution_confirm.py
+++ b/tests/interactive_shell/ui/test_execution_confirm.py
@@ -317,7 +317,7 @@ def test_always_allow_approves_and_raises_the_auto_level() -> None:
     # A reversible command approved with "always" runs now AND lifts Auto to Med
     # so commands like it stop asking.
     assert execution_allowed(
-        _ask_result(),
+        ExecutionPolicyResult(verdict="ask", tool_type="shell", reason=None),
         session=session,
         console=console,
         action_summary="echo hi > /tmp/s1.txt",
@@ -337,11 +337,37 @@ def test_plain_yes_does_not_change_the_auto_level() -> None:
     console = Console(file=buf, force_terminal=False)
 
     assert execution_allowed(
-        _ask_result(),
+        ExecutionPolicyResult(verdict="ask", tool_type="shell", reason=None),
         session=session,
         console=console,
         action_summary="echo hi > /tmp/s1.txt",
         confirm_fn=lambda _: "y",
         is_tty=True,
     )
+    assert session.terminal.auto_level is AutoLevel.LOW
+
+
+def test_non_shell_action_gets_plain_confirmation_no_risk_grade() -> None:
+    from config.constants.repl_autonomy import AutoLevel
+
+    session = Session()
+    session.terminal.auto_level = AutoLevel.LOW
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    captured: list[str] = []
+
+    # A slash command is not a shell mutation: no "risk" grade, no "always allow
+    # reversible" row, and "always" must not raise the auto level.
+    execution_allowed(
+        ExecutionPolicyResult(verdict="ask", tool_type="slash", reason="explains itself"),
+        session=session,
+        console=console,
+        action_summary="/auto low",
+        confirm_fn=lambda p: captured.append(p) or "always",
+        is_tty=True,
+    )
+    out = buf.getvalue()
+    assert "needs confirmation" in out
+    assert "risk" not in out
+    assert "always allow" not in out
     assert session.terminal.auto_level is AutoLevel.LOW

--- a/tests/tools/interactive_shell/shell/test_risk.py
+++ b/tests/tools/interactive_shell/shell/test_risk.py
@@ -30,6 +30,32 @@ def test_classifies_by_impact(command: str, expected: CommandRisk) -> None:
     assert why  # a human-readable reason always accompanies the level
 
 
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        # A single explicitly-named file is a bounded delete: medium, not high.
+        ("rm notes.md", CommandRisk.MEDIUM),
+        ("rm -rf /tmp/t1.txt", CommandRisk.MEDIUM),
+        ("rm data.json && echo done", CommandRisk.MEDIUM),
+        # Directories, globs, and root-ish paths are not bounded: high.
+        ("rm -rf build", CommandRisk.HIGH),  # no extension -> directory
+        ("rm -rf logs/", CommandRisk.HIGH),  # trailing slash -> directory
+        ("rm *.log", CommandRisk.HIGH),  # glob -> many files
+        ("rm -rf /", CommandRisk.HIGH),  # root
+        ("rm -rf /tmp", CommandRisk.HIGH),  # top-level dir
+        ("rm -rf ~", CommandRisk.HIGH),  # home
+        ("rm", CommandRisk.HIGH),  # no target named -> conservative
+        # Low-level wipes are always high regardless of target.
+        ("dd if=/dev/zero of=disk.img", CommandRisk.HIGH),
+        ("shred secret.txt", CommandRisk.HIGH),
+    ],
+)
+def test_delete_grades_by_target(command: str, expected: CommandRisk) -> None:
+    risk, why = classify_command_risk(command)
+    assert risk is expected
+    assert why
+
+
 def test_unrecognized_mutation_defaults_to_medium_not_low() -> None:
     risk, _why = classify_command_risk("frobnicate --all")
     assert risk is CommandRisk.MEDIUM

--- a/tests/tools/interactive_shell/shell/test_risk.py
+++ b/tests/tools/interactive_shell/shell/test_risk.py
@@ -39,3 +39,11 @@ def test_env_prefix_does_not_hide_the_verb() -> None:
     # A leading ENV=val assignment must not be mistaken for the command.
     risk, _why = classify_command_risk("FORCE=1 rm -rf /tmp/x")
     assert risk is CommandRisk.HIGH
+
+
+def test_leading_dollar_display_prefix_is_ignored() -> None:
+    # action_summary is rendered as "$ <command>"; the "$" must not be read as
+    # the verb (which mislabeled every command as a generic MEDIUM state change).
+    assert classify_command_risk("$ curl -s https://api.github.com/zen")[0] is CommandRisk.HIGH
+    assert classify_command_risk("$ rm -rf build")[0] is CommandRisk.HIGH
+    assert classify_command_risk("$ mkdir out")[0] is CommandRisk.LOW

--- a/tools/interactive_shell/actions/shell.py
+++ b/tools/interactive_shell/actions/shell.py
@@ -46,8 +46,11 @@ shell_run_tool = RegisteredTool(
         "Run a local shell command on this machine. Use for read-only inspection, "
         "controlled operational steps, and user-requested local workflows — including "
         "creating files or scripts and executing multi-step sequences, one shell_run call "
-        "per step when a step consumes the previous step's output. Avoid destructive, "
-        "credential-exfiltrating, or unrelated commands. Set quiet=true to hide the $ line "
+        "per step when a step consumes the previous step's output. When the user asks for "
+        "a specific command, propose it exactly as requested — the approval gate confirms "
+        "anything risky before it runs, so do not refuse a destructive command the user "
+        "explicitly asked for. Do not volunteer destructive, credential-exfiltrating, or "
+        "unrelated commands the user did not ask for. Set quiet=true to hide the $ line "
         "and stdout/stderr from the terminal while still returning output to the agent "
         "(required for architecture-audit probes)."
     ),
@@ -58,8 +61,10 @@ shell_run_tool = RegisteredTool(
                     "Exact shell command to execute — a diagnostic (for example: `ls`, "
                     "`pwd`, `git status`, `uv run python -m pytest ...`) or one step of a "
                     "local workflow the user asked for (writing a file or script, running "
-                    "it, updating state a later step reads). Do not use commands that wipe "
-                    "data or alter unrelated system state."
+                    "it, updating state a later step reads). Run a user-requested command "
+                    "as written; the approval gate grades and confirms its risk. Do not "
+                    "introduce commands that wipe data or alter unrelated system state on "
+                    "your own initiative."
                 ),
                 min_length=1,
             ),

--- a/tools/interactive_shell/shell/risk.py
+++ b/tools/interactive_shell/shell/risk.py
@@ -28,10 +28,6 @@ class CommandRisk(StrEnum):
     HIGH = "high"
 
 
-# First-token verbs that destroy data or cannot be undone.
-_DESTRUCTIVE_VERBS = frozenset(
-    {"rm", "rmdir", "shred", "dd", "mkfs", "fdisk", "truncate", "unlink", "srm"}
-)
 # Substrings that mark a remote, irreversible, or destructive action regardless
 # of the leading verb (checked against the whole command, lowercased).
 _HIGH_RISK_PATTERNS: tuple[str, ...] = (
@@ -69,8 +65,66 @@ def _first_verb(segment: str) -> str:
     return ""
 
 
+def _args_after_verb(segment: str) -> list[str]:
+    """Tokens after the command verb, skipping any leading ``ENV=val`` prefixes."""
+    tokens = segment.strip().split()
+    seen_verb = False
+    args: list[str] = []
+    for token in tokens:
+        if not seen_verb:
+            if "=" in token and not token.startswith("-"):
+                continue  # env prefix precedes the verb
+            seen_verb = True  # this token is the verb itself
+            continue
+        args.append(token)
+    return args
+
+
 def _segments(command: str) -> list[str]:
     return [seg for seg in _OPERATOR_SPLIT.split(command) if seg.strip()]
+
+
+_RM_VERBS = frozenset({"rm", "rmdir", "unlink"})
+_HARD_DESTRUCTIVE_VERBS = frozenset({"shred", "srm", "dd", "mkfs", "fdisk", "truncate"})
+_RM_RECURSIVE_FLAGS = frozenset({"-r", "-R", "-rf", "-fr", "-rF", "-Rf", "-fR", "--recursive"})
+
+
+def _looks_like_directory(target: str) -> bool:
+    """A path with no filename extension (or a trailing slash) reads as a dir."""
+    return target.endswith("/") or "." not in target.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _is_broad_path(target: str) -> bool:
+    """A root-ish or home-root target whose deletion is not bounded."""
+    normalized = target.rstrip("/")
+    if normalized in {"", "~", "."}:
+        return True
+    return normalized.startswith(("/", "~")) and normalized.count("/") <= 1
+
+
+def _delete_risk(command: str) -> tuple[CommandRisk, str] | None:
+    """Grade a delete command by its target, or ``None`` if it is not one.
+
+    Deleting a single explicitly-named file is bounded (medium); globs,
+    recursive directory removals, root-ish paths, and low-level wipes are not.
+    """
+    for segment in _segments(command):
+        verb = _first_verb(segment)
+        if verb in _HARD_DESTRUCTIVE_VERBS:
+            return CommandRisk.HIGH, "Destroys data at a low level; irreversible."
+        if verb not in _RM_VERBS:
+            continue
+        args = _args_after_verb(segment)
+        targets = [token for token in args if not token.startswith("-")]
+        recursive = any(token in _RM_RECURSIVE_FLAGS for token in args)
+        if any(char in target for target in targets for char in "*?["):
+            return CommandRisk.HIGH, "Deletes multiple files via a glob; irreversible."
+        if any(_is_broad_path(target) for target in targets):
+            return CommandRisk.HIGH, "Deletes a broad or system path; irreversible."
+        if not targets or (recursive and any(_looks_like_directory(t) for t in targets)):
+            return CommandRisk.HIGH, "Recursively deletes a directory; irreversible."
+        return CommandRisk.MEDIUM, "Deletes a single named file; recoverable only from a backup."
+    return None
 
 
 def classify_command_risk(command: str) -> tuple[CommandRisk, str]:
@@ -86,11 +140,13 @@ def classify_command_risk(command: str) -> tuple[CommandRisk, str]:
     if any(pattern in lowered for pattern in _HIGH_RISK_PATTERNS):
         return CommandRisk.HIGH, "Destructive or remote action that may be irreversible."
 
+    delete = _delete_risk(command)
+    if delete is not None:
+        return delete
+
     verbs = [_first_verb(seg) for seg in _segments(command)]
     verbs = [verb for verb in verbs if verb]
 
-    if any(verb in _DESTRUCTIVE_VERBS for verb in verbs):
-        return CommandRisk.HIGH, "Deletes or overwrites data; likely irreversible."
     if any(verb in _NETWORK_VERBS for verb in verbs):
         return CommandRisk.HIGH, "Contacts a remote system or network resource."
     if any(verb in _PACKAGE_VERBS for verb in verbs):

--- a/tools/interactive_shell/shell/risk.py
+++ b/tools/interactive_shell/shell/risk.py
@@ -76,8 +76,12 @@ def _segments(command: str) -> list[str]:
 def classify_command_risk(command: str) -> tuple[CommandRisk, str]:
     """Return the risk level and a one-line human impact for ``command``.
 
-    ``command`` is the full shell string the user is being asked to approve.
+    ``command`` is the full shell string the user is being asked to approve; a
+    leading ``$ `` display prompt is stripped so it is not read as the verb.
     """
+    command = command.strip()
+    if command.startswith("$"):
+        command = command[1:].lstrip()
     lowered = command.lower()
     if any(pattern in lowered for pattern in _HIGH_RISK_PATTERNS):
         return CommandRisk.HIGH, "Destructive or remote action that may be irreversible."


### PR DESCRIPTION
Two bug fixes for the arrow-navigable execution confirmation (#5861).

**Subprocess confirmation dead-end.** During a subprocess / exclusive-stdin turn
(the demo runner, code-implement) the live prompt application is suspended, so a
confirmation that parked on it for an arrow-nav answer hung — and the cooked
terminal echoed the arrow keys as `^[[A`, so it could not be closed. When the
prompt app is not running, `_confirm_via_prompt` now falls back to
`_confirm_via_readline`: it prints the option rows and reads a single line, where
a row tag (`a`/`b`/`c`), a digit, or a `y`/`n` answer resolves the choice, and
Ctrl-C / EOF cancels. Normal turns keep the bordered arrow-nav.

**Non-shell commands mislabeled.** The per-command risk grade and the
"always allow reversible commands" row only make sense for real shell commands,
but they were applied to every gated action — a slash command (`/auto low`) or a
tool showed "· medium risk · Changes local state" and offered to "always allow
reversible commands". Risk classification is now gated on `tool_type == "shell"`;
other actions render a plain "· needs confirmation" header with the policy reason
and a Yes/No choice, and "always allow" cannot raise the auto level for them.
