### PR TITLE
refactor(hermes): consolidate evidence mappers and enhance tool integration

### DIFF
--- a/integrations/hermes/tools/hermes_logs_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_logs_tool/__init__.py
@@ -51,6 +51,7 @@ from integrations.hermes.classifier import IncidentClassifier
 from integrations.hermes.config import default_hermes_log_path
 from integrations.hermes.incident import HermesIncident, LogLevel, LogRecord
 from integrations.hermes.poller import HermesLogCursor, HermesLogPoll, poll_hermes_logs
+from integrations.hermes.tools.hermes_session_evidence_tool._evidence import MAPPERS
 
 # Cap how many records the tool will serialise into a single
 # response. The poller has its own byte budget; this is the
@@ -217,6 +218,7 @@ def _resolve_cursor(
     name="get_hermes_logs",
     display_name="Hermes log poll",
     source="hermes",
+    evidence_mapper=MAPPERS["get_hermes_logs"],
     description=(
         "Read Hermes Agent's own ~/.hermes/logs/errors.log (or another "
         "Hermes log file) incrementally. Use op='scan' for a one-shot "

--- a/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
+++ b/integrations/hermes/tools/hermes_session_evidence_tool/__init__.py
@@ -7,14 +7,7 @@ from typing import Any, cast
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
-from integrations.hermes.tools.hermes_session_evidence_tool._evidence import (
-    map_get_hermes_adapter_catalog,
-    map_get_hermes_approval_events,
-    map_get_hermes_audit_trail,
-    map_get_hermes_config,
-    map_get_hermes_credential_state,
-    map_get_hermes_cron_state,
-)
+from integrations.hermes.tools.hermes_session_evidence_tool._evidence import MAPPERS
 
 
 def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -95,7 +88,7 @@ def get_hermes_provider_traffic(
 @tool(
     name="get_hermes_adapter_catalog",
     source="hermes",
-    evidence_mapper=map_get_hermes_adapter_catalog,
+    evidence_mapper=MAPPERS["get_hermes_adapter_catalog"],
     description="Get Hermes adapter catalog and registered surface families.",
     use_cases=[
         "Identify messaging adapters, LLM providers, execution backends, and unknown adapter attribution"
@@ -123,7 +116,7 @@ def get_hermes_adapter_catalog(
 @tool(
     name="get_hermes_config",
     source="hermes",
-    evidence_mapper=map_get_hermes_config,
+    evidence_mapper=MAPPERS["get_hermes_config"],
     description="Get resolved Hermes provider, model, region, and transport configuration.",
     use_cases=[
         "Diagnose provider selection, Bedrock IMDS overrides, transport limits, and adapter config mismatches"
@@ -151,6 +144,7 @@ def get_hermes_config(
 @tool(
     name="get_hermes_message_history",
     source="hermes",
+    evidence_mapper=MAPPERS["get_hermes_message_history"],
     description="Get full Hermes conversation message history for ordering/invariant checks.",
     use_cases=["Detect malformed tool_call/tool sequencing after compression"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -176,6 +170,7 @@ def get_hermes_message_history(
 @tool(
     name="get_hermes_kv_cache_state",
     source="hermes",
+    evidence_mapper=MAPPERS["get_hermes_kv_cache_state"],
     description="Get Hermes KV cache counters and miss-diff diagnostics.",
     use_cases=["Diagnose cache-thrash caused by formatting drift"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -226,7 +221,7 @@ def get_hermes_runtime_state(
 @tool(
     name="get_hermes_cron_state",
     source="hermes",
-    evidence_mapper=map_get_hermes_cron_state,
+    evidence_mapper=MAPPERS["get_hermes_cron_state"],
     description="Get Hermes cron execution and delivery timing state.",
     use_cases=["Differentiate agent completion from downstream delivery hangs"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -277,6 +272,7 @@ def get_hermes_session_topology(
 @tool(
     name="get_hermes_orchestration_state",
     source="hermes",
+    evidence_mapper=MAPPERS["get_hermes_orchestration_state"],
     description="Get Hermes orchestration role/topology execution state.",
     use_cases=["Diagnose collapsed orchestration, isolated ACP sessions, and role execution drift"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -327,6 +323,7 @@ def get_hermes_routing_decisions(
 @tool(
     name="get_hermes_memory_state",
     source="hermes",
+    evidence_mapper=MAPPERS["get_hermes_memory_state"],
     description="Get Hermes memory backend health and parse/fallback state.",
     use_cases=["Diagnose memory backend outages, corruption, and parse failures"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -352,6 +349,7 @@ def get_hermes_memory_state(
 @tool(
     name="get_hermes_filesystem_state",
     source="hermes",
+    evidence_mapper=MAPPERS["get_hermes_filesystem_state"],
     description="Get Hermes filesystem persistence and corruption state.",
     use_cases=["Diagnose corrupted memory snapshots and missing recovery backups"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -377,7 +375,7 @@ def get_hermes_filesystem_state(
 @tool(
     name="get_hermes_audit_trail",
     source="hermes",
-    evidence_mapper=map_get_hermes_audit_trail,
+    evidence_mapper=MAPPERS["get_hermes_audit_trail"],
     description="Get Hermes audit policy and observed audit-chain/signature state.",
     use_cases=["Diagnose missing cryptographic audit trails and broken hash chains"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -403,7 +401,7 @@ def get_hermes_audit_trail(
 @tool(
     name="get_hermes_approval_events",
     source="hermes",
-    evidence_mapper=map_get_hermes_approval_events,
+    evidence_mapper=MAPPERS["get_hermes_approval_events"],
     description="Get Hermes approval prompts and destructive-command approval outcomes.",
     use_cases=["Diagnose destructive commands that ran without explicit approval"],
     surfaces=(ToolSurface.INVESTIGATION,),
@@ -454,7 +452,7 @@ def get_hermes_rbac_state(
 @tool(
     name="get_hermes_credential_state",
     source="hermes",
-    evidence_mapper=map_get_hermes_credential_state,
+    evidence_mapper=MAPPERS["get_hermes_credential_state"],
     description="Get Hermes credential isolation mode and outbound credential usage.",
     use_cases=["Diagnose in-process credential exposure and missing credential proxy isolation"],
     surfaces=(ToolSurface.INVESTIGATION,),

--- a/integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py
+++ b/integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py
@@ -1,4 +1,4 @@
-"""Evidence mappers for Hermes session-evidence investigation tools."""
+"""Evidence mappers for Hermes investigation tools."""
 
 from __future__ import annotations
 
@@ -14,10 +14,7 @@ def _mapper(source: str, label: str, summarize: _Summarize) -> EvidenceMapper:
     def map_output(
         evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
     ) -> None:
-        if not output.get("available"):
-            return
-        summary = summarize(output)
-        if summary:
+        if output.get("available") is not False and (summary := summarize(output)):
             record_evidence_entry(evidence, source=source, label=label, summary=summary)
 
     map_output.__name__ = f"map_{source}"
@@ -29,66 +26,130 @@ def _count(output: dict[str, Any], key: str) -> int:
     return len(rows) if isinstance(rows, list) else 0
 
 
+def _join(*parts: str | None) -> str | None:
+    return ", ".join(part for part in parts if part) or None
+
+
+def _str(data: dict[str, Any], key: str, prefix: str = "") -> str | None:
+    value = str(data.get(key) or "")
+    return f"{prefix}{value}" if value else None
+
+
+def _int(data: dict[str, Any], key: str, noun: str) -> str | None:
+    value = data.get(key)
+    return f"{value} {noun}" if isinstance(value, int) else None
+
+
+def _n(data: dict[str, Any], key: str, noun: str) -> str | None:
+    n = _count(data, key)
+    return f"{n} {noun}" if n else None
+
+
+def _flag(data: dict[str, Any], key: str, yes: str, no: str) -> str | None:
+    value = data.get(key)
+    return None if value is None else (yes if value else no)
+
+
+def _counts(*fields: tuple[str, str]) -> _Summarize:
+    return lambda output: _join(*(_n(output, key, noun) for key, noun in fields))
+
+
 def _catalog(output: dict[str, Any]) -> str | None:
-    counts = (
-        _count(output, "messaging_adapters"),
-        _count(output, "llm_providers"),
-        _count(output, "execution_backends"),
+    a, b, c = (
+        _count(output, k) for k in ("messaging_adapters", "llm_providers", "execution_backends")
     )
-    if not any(counts):
+    if not (a or b or c):
         return None
-    return (
-        f"{counts[0]} messaging adapter(s), "
-        f"{counts[1]} LLM provider(s), "
-        f"{counts[2]} execution backend(s)"
-    )
+    return f"{a} messaging adapter(s), {b} LLM provider(s), {c} execution backend(s)"
 
 
 def _config(output: dict[str, Any]) -> str | None:
-    parts = [str(output.get(key) or "") for key in ("provider", "model", "region")]
-    n_providers = _count(output, "providers")
-    if n_providers:
-        parts.append(f"{n_providers} provider(s)")
-    return ", ".join(part for part in parts if part) or None
+    return _join(
+        *(_str(output, key) for key in ("provider", "model", "region")),
+        _n(output, "providers", "provider(s)"),
+    )
 
 
 def _cron(output: dict[str, Any]) -> str | None:
     last_run = output.get("last_run")
     status = last_run.get("delivery_status") if isinstance(last_run, dict) else None
-    parts = []
-    if schedule := str(output.get("schedule_cron") or ""):
-        parts.append(f"schedule {schedule}")
-    if status:
-        parts.append(f"last delivery {status}")
-    return ", ".join(parts) or None
-
-
-def _events(output: dict[str, Any]) -> str | None:
-    n_events = _count(output, "events")
-    return f"{n_events} event(s)" if n_events else None
+    return _join(
+        _str(output, "schedule_cron", "schedule "), f"last delivery {status}" if status else None
+    )
 
 
 def _credentials(output: dict[str, Any]) -> str | None:
-    parts = []
-    if mode := str(output.get("mode") or ""):
-        parts.append(f"{mode} mode")
-    in_memory = output.get("in_memory_credential_count")
-    if isinstance(in_memory, int):
-        parts.append(f"{in_memory} in-memory credential(s)")
-    if n_outbound := _count(output, "outbound_calls"):
-        parts.append(f"{n_outbound} outbound call(s)")
-    return ", ".join(parts) or None
+    mode = _str(output, "mode")
+    return _join(
+        f"{mode} mode" if mode else None,
+        _int(output, "in_memory_credential_count", "in-memory credential(s)"),
+        _n(output, "outbound_calls", "outbound call(s)"),
+    )
 
 
-map_get_hermes_adapter_catalog = _mapper(
-    "get_hermes_adapter_catalog", "Hermes Adapter Catalog", _catalog
-)
-map_get_hermes_config = _mapper("get_hermes_config", "Hermes Config", _config)
-map_get_hermes_cron_state = _mapper("get_hermes_cron_state", "Hermes Cron State", _cron)
-map_get_hermes_audit_trail = _mapper("get_hermes_audit_trail", "Hermes Audit Trail", _events)
-map_get_hermes_approval_events = _mapper(
-    "get_hermes_approval_events", "Hermes Approval Events", _events
-)
-map_get_hermes_credential_state = _mapper(
-    "get_hermes_credential_state", "Hermes Credential State", _credentials
-)
+def _filesystem(output: dict[str, Any]) -> str | None:
+    return _join(
+        _n(output, "files", "file(s)"),
+        _flag(output, "backups_present", "backups present", "backups absent"),
+        _flag(output, "vcs_present", "VCS present", "no VCS"),
+    )
+
+
+def _kv_cache(output: dict[str, Any]) -> str | None:
+    return _join(
+        _int(output, "cache_hits", "cache hit(s)"),
+        _int(output, "cache_misses", "cache miss(es)"),
+        _str(output, "last_invalidated_reason", "invalidated: "),
+        _n(output, "messages_with_cache_miss", "cache-miss message(s)"),
+    )
+
+
+def _memory(output: dict[str, Any]) -> str | None:
+    parse_error = output.get("last_parse_error")
+    fallback = output.get("fallback_active")
+    return _join(
+        _str(output, "backend"),
+        _str(output, "backend_status"),
+        "fallback active" if fallback else None,
+        _str(output, "fallback_reason") if fallback else None,
+        f"parse error: {parse_error}" if parse_error else None,
+    )
+
+
+def _orchestration(output: dict[str, Any]) -> str | None:
+    raw = output.get("observed")
+    observed: dict[str, Any] = raw if isinstance(raw, dict) else {}
+    return _join(
+        _n(output, "declared_roles", "declared role(s)"),
+        _str(output, "declared_topology", "topology "),
+        _str(observed, "actual_topology", "observed "),
+        _n(observed, "actual_runs", "observed run(s)"),
+    )
+
+
+_events = _counts(("events", "event(s)"))
+MAPPERS: dict[str, EvidenceMapper] = {
+    source: _mapper(source, label, summarize)
+    for source, label, summarize in (
+        ("get_hermes_adapter_catalog", "Hermes Adapter Catalog", _catalog),
+        ("get_hermes_config", "Hermes Config", _config),
+        ("get_hermes_cron_state", "Hermes Cron State", _cron),
+        ("get_hermes_audit_trail", "Hermes Audit Trail", _events),
+        ("get_hermes_approval_events", "Hermes Approval Events", _events),
+        ("get_hermes_credential_state", "Hermes Credential State", _credentials),
+        ("get_hermes_filesystem_state", "Hermes Filesystem State", _filesystem),
+        ("get_hermes_kv_cache_state", "Hermes KV Cache State", _kv_cache),
+        (
+            "get_hermes_logs",
+            "Hermes Logs",
+            _counts(("records", "record(s)"), ("incidents", "incident(s)")),
+        ),
+        ("get_hermes_memory_state", "Hermes Memory State", _memory),
+        (
+            "get_hermes_message_history",
+            "Hermes Message History",
+            _counts(("messages", "message(s)")),
+        ),
+        ("get_hermes_orchestration_state", "Hermes Orchestration State", _orchestration),
+    )
+}

--- a/integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py
+++ b/integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py
@@ -21,6 +21,10 @@ def _mapper(source: str, label: str, summarize: _Summarize) -> EvidenceMapper:
     return map_output
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 def _count(output: dict[str, Any], key: str) -> int:
     rows = output.get(key) or []
     return len(rows) if isinstance(rows, list) else 0
@@ -71,10 +75,9 @@ def _config(output: dict[str, Any]) -> str | None:
 
 
 def _cron(output: dict[str, Any]) -> str | None:
-    last_run = output.get("last_run")
-    status = last_run.get("delivery_status") if isinstance(last_run, dict) else None
     return _join(
-        _str(output, "schedule_cron", "schedule "), f"last delivery {status}" if status else None
+        _str(output, "schedule_cron", "schedule "),
+        _str(_as_dict(output.get("last_run")), "delivery_status", "last delivery "),
     )
 
 
@@ -105,20 +108,22 @@ def _kv_cache(output: dict[str, Any]) -> str | None:
 
 
 def _memory(output: dict[str, Any]) -> str | None:
-    parse_error = output.get("last_parse_error")
     fallback = output.get("fallback_active")
+    err = _as_dict(output.get("last_parse_error"))
+    error_class = _str(err, "error_class")
+    model = _str(err, "model_name")
+    parse = f"parse error {error_class}" + (f" ({model})" if model else "") if error_class else None
     return _join(
         _str(output, "backend"),
         _str(output, "backend_status"),
         "fallback active" if fallback else None,
         _str(output, "fallback_reason") if fallback else None,
-        f"parse error: {parse_error}" if parse_error else None,
+        parse,
     )
 
 
 def _orchestration(output: dict[str, Any]) -> str | None:
-    raw = output.get("observed")
-    observed: dict[str, Any] = raw if isinstance(raw, dict) else {}
+    observed = _as_dict(output.get("observed"))
     return _join(
         _n(output, "declared_roles", "declared role(s)"),
         _str(output, "declared_topology", "topology "),

--- a/tests/integrations/hermes/test_evidence_mappers.py
+++ b/tests/integrations/hermes/test_evidence_mappers.py
@@ -1,26 +1,16 @@
-"""Evidence mapper tests for Hermes session-evidence tools."""
+"""Evidence mapper tests for Hermes investigation tools."""
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 import pytest
 
-from integrations.hermes.tools.hermes_session_evidence_tool._evidence import (
-    map_get_hermes_adapter_catalog,
-    map_get_hermes_approval_events,
-    map_get_hermes_audit_trail,
-    map_get_hermes_config,
-    map_get_hermes_credential_state,
-    map_get_hermes_cron_state,
-)
+from integrations.hermes.tools.hermes_session_evidence_tool import _evidence as mappers
 
-_Mapper = Callable[[dict[str, Any], dict[str, Any], dict[str, Any]], None]
 _UNAVAILABLE = {"available": False, "error": "requires a Hermes backend"}
-_CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
+_CASES: list[tuple[str, dict[str, Any], str, dict[str, Any]]] = [
     (
-        map_get_hermes_adapter_catalog,
         "get_hermes_adapter_catalog",
         {
             "available": True,
@@ -37,7 +27,6 @@ _CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
         },
     ),
     (
-        map_get_hermes_approval_events,
         "get_hermes_approval_events",
         {
             "available": True,
@@ -47,7 +36,6 @@ _CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
         {"available": True, "events": []},
     ),
     (
-        map_get_hermes_audit_trail,
         "get_hermes_audit_trail",
         {
             "available": True,
@@ -60,7 +48,6 @@ _CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
         {"available": True, "events": []},
     ),
     (
-        map_get_hermes_config,
         "get_hermes_config",
         {
             "available": True,
@@ -73,7 +60,6 @@ _CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
         {"available": True, "provider": "", "model": "", "region": "", "providers": []},
     ),
     (
-        map_get_hermes_credential_state,
         "get_hermes_credential_state",
         {
             "available": True,
@@ -85,7 +71,6 @@ _CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
         {"available": True, "mode": "", "outbound_calls": []},
     ),
     (
-        map_get_hermes_cron_state,
         "get_hermes_cron_state",
         {
             "available": True,
@@ -95,13 +80,87 @@ _CASES: list[tuple[_Mapper, str, dict[str, Any], str, dict[str, Any]]] = [
         "schedule 0 */2 * * *, last delivery never_started",
         {"available": True, "schedule_cron": "", "last_run": {}},
     ),
+    (
+        "get_hermes_filesystem_state",
+        {
+            "available": True,
+            "files": [{"path": "/tmp/hermes/memory/state.json", "is_corrupted": True}],
+            "backups_present": False,
+            "vcs_present": False,
+        },
+        "1 file(s), backups absent, no VCS",
+        {"available": True, "files": []},
+    ),
+    (
+        "get_hermes_kv_cache_state",
+        {
+            "available": True,
+            "cache_hits": 14,
+            "cache_misses": 36,
+            "last_invalidated_reason": "role format drift",
+            "messages_with_cache_miss": [{"message_index": 40}, {"message_index": 41}],
+        },
+        (
+            "14 cache hit(s), 36 cache miss(es), invalidated: role format drift, "
+            "2 cache-miss message(s)"
+        ),
+        {"available": True, "last_invalidated_reason": "", "messages_with_cache_miss": []},
+    ),
+    (
+        "get_hermes_logs",
+        {
+            "records": [{"level": "ERROR", "message": "gateway crash"}],
+            "incidents": [{"rule": "error_severity", "title": "ERROR burst"}],
+        },
+        "1 record(s), 1 incident(s)",
+        {"records": [], "incidents": []},
+    ),
+    (
+        "get_hermes_memory_state",
+        {
+            "available": True,
+            "backend": "mempalace",
+            "backend_status": "unreachable",
+            "fallback_active": True,
+            "fallback_reason": "External memory backend connection failed",
+        },
+        "mempalace, unreachable, fallback active, External memory backend connection failed",
+        {"available": True, "backend": "", "backend_status": "", "fallback_active": False},
+    ),
+    (
+        "get_hermes_message_history",
+        {
+            "available": True,
+            "messages": [{"role": "system"}, {"role": "tool"}, {"role": "tool_call"}],
+        },
+        "3 message(s)",
+        {"available": True, "messages": []},
+    ),
+    (
+        "get_hermes_orchestration_state",
+        {
+            "available": True,
+            "declared_roles": [{"name": "planner"}, {"name": "worker"}, {"name": "reviewer"}],
+            "declared_topology": "planner_worker_reviewer",
+            "observed": {
+                "actual_topology": "single_agent_loop",
+                "actual_runs": [{"role": "default"}],
+            },
+        },
+        (
+            "3 declared role(s), topology planner_worker_reviewer, "
+            "observed single_agent_loop, 1 observed run(s)"
+        ),
+        {"available": True, "declared_roles": [], "declared_topology": "", "observed": {}},
+    ),
 ]
 
 
-@pytest.mark.parametrize(("mapper", "source", "output", "summary", "empty"), _CASES)
+@pytest.mark.parametrize(("source", "output", "summary", "empty"), _CASES)
 def test_mapper_records_summary(
-    mapper: _Mapper, source: str, output: dict[str, Any], summary: str, empty: dict[str, Any]
+    source: str, output: dict[str, Any], summary: str, empty: dict[str, Any]
 ) -> None:
+    mapper = mappers.MAPPERS[source]
     evidence: dict[str, Any] = {}
     mapper(evidence, output, {})
     assert evidence["catalog_entries"][0]["source"] == source
@@ -115,7 +174,7 @@ def test_mapper_records_summary(
 
 def test_credential_state_records_zero_in_memory_count() -> None:
     evidence: dict[str, Any] = {}
-    map_get_hermes_credential_state(
+    mappers.MAPPERS["get_hermes_credential_state"](
         evidence,
         {"available": True, "mode": "proxy", "in_memory_credential_count": 0, "outbound_calls": []},
         {},

--- a/tests/integrations/hermes/test_evidence_mappers.py
+++ b/tests/integrations/hermes/test_evidence_mappers.py
@@ -128,6 +128,21 @@ _CASES: list[tuple[str, dict[str, Any], str, dict[str, Any]]] = [
         {"available": True, "backend": "", "backend_status": "", "fallback_active": False},
     ),
     (
+        "get_hermes_memory_state",
+        {
+            "available": True,
+            "backend": "in_process",
+            "backend_status": "degraded",
+            "last_parse_error": {
+                "error_class": "JSONDecodeError",
+                "snippet": '{ "memory": [1,2,], }',
+                "model_name": "llama.cpp",
+            },
+        },
+        "in_process, degraded, parse error JSONDecodeError (llama.cpp)",
+        {"available": True, "backend": "", "backend_status": ""},
+    ),
+    (
         "get_hermes_message_history",
         {
             "available": True,

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -49,12 +49,6 @@ get_failed_jobs
 get_failed_tools
 get_github_star_history
 get_groundcover_query_reference
-get_hermes_filesystem_state
-get_hermes_kv_cache_state
-get_hermes_logs
-get_hermes_memory_state
-get_hermes_message_history
-get_hermes_orchestration_state
 get_hermes_provider_traffic
 get_hermes_rbac_state
 get_hermes_routing_decisions


### PR DESCRIPTION
Closes #5521

#### Describe the changes you have made in this PR -

Wires the six listed Hermes investigation tools to `record_evidence_entry` so
their output stops being silently dropped and becomes a citeable line in the
investigation report.

- `get_hermes_filesystem_state`: cites file count, backups present/absent, and VCS present/absent.
- `get_hermes_kv_cache_state`: cites cache hits/misses, last invalidation reason, and cache-miss message count.
- `get_hermes_logs`: cites parsed record count and classifier incident count.
- `get_hermes_memory_state`: cites backend, status, fallback, and parse error.
- `get_hermes_message_history`: cites the conversation message count.
- `get_hermes_orchestration_state`: cites declared role count, declared topology, observed topology, and observed run count.

All six are read-only diagnostic queries — none send, notify, create, or redeploy — so all are in scope per the issue.

Mappers live in `integrations/hermes/tools/hermes_session_evidence_tool/_evidence.py`. The tool packages only import `MAPPERS` and attach `evidence_mapper=MAPPERS["…"]`. A shared `_mapper` helper owns the available guard and catalog write; each tool only supplies its summary. Message history and logs use `_counts`. A present `cache_hits` / `cache_misses` of `0` is cited, not omitted. Empty output, or `available: False`, still records nothing. `get_hermes_logs` does not set `available`, so the guard skips only on an explicit `False`.

Removed these six names from `evidence_mapper_baseline.txt` now that they carry mappers.

### Before / after

**Before:** the tools ran and returned useful dicts, but had no `evidence_mapper`. Gather-evidence stored an opaque blob. The report had nothing citeable. They were listed as known gaps.

**After:** the same output is lifted into `catalog_entries` with a `source`, label, and summary the report can number and cite.

```
# before — tool registered, no mapper, gap list still names it
@tool(name="get_hermes_filesystem_state", source="hermes", ...)
# evidence_mapper_baseline.txt includes:
#   get_hermes_filesystem_state
# merge_tool_evidence(...) → catalog_entries missing / None

# after — mapper attached, gap line gone
@tool(
    name="get_hermes_filesystem_state",
    source="hermes",
    evidence_mapper=MAPPERS["get_hermes_filesystem_state"],
    ...
)
# merge_tool_evidence(..., {"available": True, "files": [1, 2], "backups_present": False, "vcs_present": False}, {})
# → [{'source': 'get_hermes_filesystem_state', 'label': 'Hermes Filesystem State',
#     'summary': '2 file(s), backups absent, no VCS', ...}]
```

Fixture envelopes through `merge_tool_evidence`:

```
get_hermes_filesystem_state:     '1 file(s), backups absent, no VCS'
get_hermes_kv_cache_state:       '14 cache hit(s), 36 cache miss(es), invalidated: role format drift, 2 cache-miss message(s)'
get_hermes_logs:                 '1 record(s), 1 incident(s)'
get_hermes_memory_state:         'mempalace, unreachable, fallback active, External memory backend connection failed'
get_hermes_message_history:      '3 message(s)'
get_hermes_orchestration_state:  '3 declared role(s), topology planner_worker_reviewer, observed single_agent_loop, 1 observed run(s)'
```

### Demo/Screenshot for feature changes and bug fixes -

**Tools carry their mapper (via the real registry):**

```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['get_hermes_filesystem_state', 'get_hermes_kv_cache_state', 'get_hermes_logs', 'get_hermes_memory_state', 'get_hermes_message_history', 'get_hermes_orchestration_state']})"
{'get_hermes_filesystem_state': True, 'get_hermes_kv_cache_state': True, 'get_hermes_logs': True, 'get_hermes_memory_state': True, 'get_hermes_message_history': True, 'get_hermes_orchestration_state': True}
```

**Tests and quality gates:**

```
$ uv run pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
11 passed

$ uv run pytest tests/integrations/hermes/test_evidence_mappers.py tests/tools/test_hermes_session_evidence_tool.py tests/tools/test_hermes_logs_tool.py -q
35 passed

$ make lint && make format-check && make typecheck
All checks passed! / files already formatted / Success: no issues found in 1942 source files
```


**Explain your implementation approach:**

Issue #5521 is a mapper backfill: these six read tools already return diagnostic data, but gather-evidence dropped it. Each mapper turns that dict into one `record_evidence_entry`. Implementation lives next to the tools in `_evidence.py` so the package `__init__.py` stays the public tool surface. The tools share the same available-then-summarize-then-record path, so `_mapper` owns that once and each tool only writes its summary. Count-only tools share `_counts`. Empty and `available: False` outputs record nothing. `is_available` is unchanged.

