### PR TITLE
Fix: Added evidence mappers for openclaw

### DIFF
--- a/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
@@ -6,6 +6,7 @@ Package layout (separation of concerns):
 - ``results.py``  — pure shaping of MCP results/failures into agent payloads.
 - ``params.py``   — availability + ``extract_params`` reads over the agent-state
   ``openclaw`` source.
+- ``evidence.py`` — report catalog mappers for the read tools.
 - ``__init__.py`` — this file: config resolution, MCP dispatch, and the
   ``@tool`` entrypoints. They stay here because the tool registry discovers a
   package's tools on its own module (``TOOL_MODULES`` would be needed to look
@@ -30,6 +31,12 @@ from integrations.openclaw import (
 )
 from integrations.openclaw import (
     list_openclaw_tools as list_openclaw_mcp_tools,
+)
+from integrations.openclaw.tools.openclaw_mcp_tool.evidence import (
+    map_call_openclaw_tool,
+    map_get_openclaw_conversation,
+    map_list_openclaw_tools,
+    map_search_openclaw_conversations,
 )
 from integrations.openclaw.tools.openclaw_mcp_tool.models import (
     OpenClawBridgeResponse,
@@ -156,6 +163,7 @@ def _normalize_named_bridge_call(
     },
     is_available=is_available,
     extract_params=extract_params,
+    evidence_mapper=map_list_openclaw_tools,
 )
 def list_openclaw_bridge_tools(
     name_filter: str | None = None,
@@ -244,6 +252,7 @@ def list_openclaw_bridge_tools(
     },
     is_available=is_available,
     extract_params=conversation_search_params,
+    evidence_mapper=map_search_openclaw_conversations,
 )
 def search_openclaw_conversations(
     search: str = "",
@@ -327,6 +336,7 @@ def search_openclaw_conversations(
     },
     is_available=is_available,
     extract_params=conversation_detail_params,
+    evidence_mapper=map_get_openclaw_conversation,
 )
 def get_openclaw_conversation(
     conversation_id: str | None = None,
@@ -455,6 +465,7 @@ def send_openclaw_message(
     },
     is_available=is_available,
     extract_params=extract_params,
+    evidence_mapper=map_call_openclaw_tool,
 )
 def call_openclaw_bridge_tool(
     tool_name: str | None = None,

--- a/integrations/openclaw/tools/openclaw_mcp_tool/evidence.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/evidence.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from core.domain.types.evidence import record_evidence_entry
 
-_MAX_TITLE_CHARS = 80
+_MAX_FIELD_CHARS = 80
 
 
 def _available(output: dict[str, Any]) -> bool:
@@ -27,11 +27,12 @@ def _nonempty_structured(value: object) -> bool:
     return isinstance(value, list) and bool(value)
 
 
-def _short_title(value: object) -> str:
+def _bounded_field(value: object) -> str:
+    """Collapse whitespace and cap OpenClaw metadata used in catalog summaries."""
     text = " ".join(str(value).split())
-    if len(text) <= _MAX_TITLE_CHARS:
+    if len(text) <= _MAX_FIELD_CHARS:
         return text
-    return text[: _MAX_TITLE_CHARS - 1].rstrip() + "…"
+    return text[: _MAX_FIELD_CHARS - 1].rstrip() + "…"
 
 
 def _conversation_label(structured: object, tool_input: dict[str, Any]) -> str:
@@ -42,12 +43,18 @@ def _conversation_label(structured: object, tool_input: dict[str, Any]) -> str:
             or structured.get("session_key")
         )
         title = structured.get("title") or structured.get("derivedTitle")
-        parts = [str(ident).strip()] if ident else []
+        parts: list[str] = []
+        if ident:
+            bounded_ident = _bounded_field(ident)
+            if bounded_ident:
+                parts.append(bounded_ident)
         if title:
-            parts.append(_short_title(title))
+            bounded_title = _bounded_field(title)
+            if bounded_title:
+                parts.append(bounded_title)
         if parts:
             return " — ".join(parts)
-    conversation_id = str(tool_input.get("conversation_id") or "").strip()
+    conversation_id = _bounded_field(tool_input.get("conversation_id") or "")
     if conversation_id:
         return conversation_id
     return "conversation loaded"
@@ -113,7 +120,7 @@ def map_search_openclaw_conversations(
     summary = f"{count} {word}"
     search = str(output.get("search") or tool_input.get("search") or "").strip()
     if search:
-        summary += f" matching '{_short_title(search)}'"
+        summary += f" matching '{_bounded_field(search)}'"
     record_evidence_entry(
         evidence,
         source="search_openclaw_conversations",
@@ -148,7 +155,7 @@ def map_call_openclaw_tool(
     hint = _call_size_hint(output)
     if hint is None:
         return
-    tool_name = str(output.get("tool") or tool_input.get("tool_name") or "").strip()
+    tool_name = _bounded_field(output.get("tool") or tool_input.get("tool_name") or "")
     summary = f"{tool_name} returned {hint}" if tool_name else hint
     record_evidence_entry(
         evidence,

--- a/integrations/openclaw/tools/openclaw_mcp_tool/evidence.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/evidence.py
@@ -1,0 +1,158 @@
+"""Evidence mappers for OpenClaw read tools.
+
+Summaries only — conversation bodies, MCP text, and tool schemas stay out of
+the catalog so they do not compete for later-turn context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+_MAX_TITLE_CHARS = 80
+
+
+def _available(output: dict[str, Any]) -> bool:
+    return output.get("available") is not False
+
+
+def _nonempty_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _nonempty_structured(value: object) -> bool:
+    if isinstance(value, dict):
+        return bool(value)
+    return isinstance(value, list) and bool(value)
+
+
+def _short_title(value: object) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= _MAX_TITLE_CHARS:
+        return text
+    return text[: _MAX_TITLE_CHARS - 1].rstrip() + "…"
+
+
+def _conversation_label(structured: object, tool_input: dict[str, Any]) -> str:
+    if isinstance(structured, dict):
+        ident = (
+            structured.get("id")
+            or structured.get("conversationId")
+            or structured.get("session_key")
+        )
+        title = structured.get("title") or structured.get("derivedTitle")
+        parts = [str(ident).strip()] if ident else []
+        if title:
+            parts.append(_short_title(title))
+        if parts:
+            return " — ".join(parts)
+    conversation_id = str(tool_input.get("conversation_id") or "").strip()
+    if conversation_id:
+        return conversation_id
+    return "conversation loaded"
+
+
+def _call_size_hint(output: dict[str, Any]) -> str | None:
+    structured = output.get("structured_content")
+    if isinstance(structured, list) and structured:
+        n = len(structured)
+        return f"{n} structured item" if n == 1 else f"{n} structured items"
+    if isinstance(structured, dict) and structured:
+        return "structured result"
+    content = output.get("content")
+    if isinstance(content, list) and content:
+        n = len(content)
+        return f"{n} content item" if n == 1 else f"{n} content items"
+    if _nonempty_text(output.get("text")):
+        return "text returned"
+    return None
+
+
+def map_list_openclaw_tools(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite a non-empty OpenClaw MCP tool listing."""
+    if not _available(output):
+        return
+    tools = output.get("tools")
+    if not isinstance(tools, list) or not tools:
+        return
+    returned = output.get("returned_tools", len(tools))
+    try:
+        returned_n = int(returned)
+    except (TypeError, ValueError):
+        returned_n = len(tools)
+    total = output.get("total_tools")
+    try:
+        total_n = int(total) if total is not None else None
+    except (TypeError, ValueError):
+        total_n = None
+    summary = f"{returned_n} tools listed"
+    if total_n is not None and total_n != returned_n:
+        summary = f"{returned_n} tools listed ({total_n} total)"
+    record_evidence_entry(
+        evidence,
+        source="list_openclaw_tools",
+        label="OpenClaw Tools",
+        summary=summary,
+    )
+
+
+def map_search_openclaw_conversations(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite matching OpenClaw conversations without inlining their transcripts."""
+    if not _available(output):
+        return
+    conversations = output.get("conversations")
+    if not isinstance(conversations, list) or not conversations:
+        return
+    count = len(conversations)
+    word = "conversation" if count == 1 else "conversations"
+    summary = f"{count} {word}"
+    search = str(output.get("search") or tool_input.get("search") or "").strip()
+    if search:
+        summary += f" matching '{_short_title(search)}'"
+    record_evidence_entry(
+        evidence,
+        source="search_openclaw_conversations",
+        label="OpenClaw Conversations",
+        summary=summary,
+    )
+
+
+def map_get_openclaw_conversation(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite that one OpenClaw conversation was retrieved."""
+    if not _available(output):
+        return
+    structured = output.get("structured_content")
+    if not _nonempty_structured(structured) and not _nonempty_text(output.get("text")):
+        return
+    record_evidence_entry(
+        evidence,
+        source="get_openclaw_conversation",
+        label="OpenClaw Conversation",
+        summary=_conversation_label(structured, tool_input),
+    )
+
+
+def map_call_openclaw_tool(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite a successful OpenClaw MCP tool result without dumping the payload."""
+    if not _available(output):
+        return
+    hint = _call_size_hint(output)
+    if hint is None:
+        return
+    tool_name = str(output.get("tool") or tool_input.get("tool_name") or "").strip()
+    summary = f"{tool_name} returned {hint}" if tool_name else hint
+    record_evidence_entry(
+        evidence,
+        source="call_openclaw_tool",
+        label="OpenClaw Tool Result",
+        summary=summary,
+    )

--- a/tests/integrations/openclaw/test_evidence_mappers.py
+++ b/tests/integrations/openclaw/test_evidence_mappers.py
@@ -1,0 +1,192 @@
+"""Evidence mapper coverage for the OpenClaw read tools."""
+
+from __future__ import annotations
+
+from integrations.openclaw.tools.openclaw_mcp_tool.evidence import (
+    map_call_openclaw_tool,
+    map_get_openclaw_conversation,
+    map_list_openclaw_tools,
+    map_search_openclaw_conversations,
+)
+
+
+class TestMapListOpenclawTools:
+    def test_records_entry_when_tools_present(self) -> None:
+        evidence: dict = {}
+
+        map_list_openclaw_tools(
+            evidence,
+            {
+                "available": True,
+                "tools": [{"name": "messages_read"}, {"name": "events_list"}],
+                "returned_tools": 2,
+                "total_tools": 12,
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "list_openclaw_tools"
+        assert entries[0]["label"] == "OpenClaw Tools"
+        assert entries[0]["summary"] == "2 tools listed (12 total)"
+        assert "messages_read" not in (entries[0]["summary"] or "")
+
+    def test_records_nothing_when_listing_is_empty(self) -> None:
+        evidence: dict = {}
+
+        map_list_openclaw_tools(evidence, {"available": True, "tools": []}, {})
+        map_list_openclaw_tools(evidence, {}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict = {}
+
+        map_list_openclaw_tools(
+            evidence,
+            {
+                "available": False,
+                "error": "OpenClaw MCP integration is not configured.",
+                "tools": [],
+            },
+            {},
+        )
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapSearchOpenclawConversations:
+    def test_records_entry_when_conversations_present(self) -> None:
+        evidence: dict = {}
+
+        map_search_openclaw_conversations(
+            evidence,
+            {
+                "available": True,
+                "search": "checkout-api",
+                "conversations": [{"session_key": "sess-1", "title": "Checkout debugging"}],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "search_openclaw_conversations"
+        assert entries[0]["summary"] == "1 conversation matching 'checkout-api'"
+
+    def test_records_nothing_when_no_conversations(self) -> None:
+        evidence: dict = {}
+
+        map_search_openclaw_conversations(evidence, {"available": True, "conversations": []}, {})
+        map_search_openclaw_conversations(evidence, {}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict = {}
+
+        map_search_openclaw_conversations(
+            evidence,
+            {
+                "available": False,
+                "error": "OpenClaw MCP integration is not configured.",
+                "conversations": [],
+            },
+            {},
+        )
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapGetOpenclawConversation:
+    def test_records_entry_with_id_and_title(self) -> None:
+        evidence: dict = {}
+
+        map_get_openclaw_conversation(
+            evidence,
+            {
+                "available": True,
+                "tool": "conversations_get",
+                "text": "ok",
+                "structured_content": {"id": "conv-1", "title": "Checkout debugging"},
+            },
+            {"conversation_id": "conv-1"},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_openclaw_conversation"
+        assert entries[0]["summary"] == "conv-1 — Checkout debugging"
+        assert "ok" not in (entries[0]["summary"] or "")
+
+    def test_records_nothing_when_payload_is_empty(self) -> None:
+        evidence: dict = {}
+
+        map_get_openclaw_conversation(
+            evidence, {"available": True, "structured_content": {}, "text": ""}, {}
+        )
+        map_get_openclaw_conversation(evidence, {}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict = {}
+
+        map_get_openclaw_conversation(
+            evidence, {"available": False, "error": "conversation_id is required."}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapCallOpenclawTool:
+    def test_records_entry_for_structured_result(self) -> None:
+        evidence: dict = {}
+
+        map_call_openclaw_tool(
+            evidence,
+            {
+                "available": True,
+                "tool": "messages_read",
+                "text": "a long transcript that must not be inlined into the catalog",
+                "structured_content": [{"id": "msg-1"}, {"id": "msg-2"}],
+                "content": [],
+            },
+            {"tool_name": "messages_read"},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "call_openclaw_tool"
+        assert entries[0]["summary"] == "messages_read returned 2 structured items"
+        assert "transcript" not in (entries[0]["summary"] or "")
+
+    def test_records_nothing_when_payload_is_empty(self) -> None:
+        evidence: dict = {}
+
+        map_call_openclaw_tool(
+            evidence,
+            {
+                "available": True,
+                "tool": "messages_read",
+                "text": "",
+                "structured_content": None,
+                "content": [],
+            },
+            {},
+        )
+        map_call_openclaw_tool(evidence, {}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_on_unavailable_result(self) -> None:
+        evidence: dict = {}
+
+        map_call_openclaw_tool(
+            evidence,
+            {"available": False, "error": "tool_name is required to call an OpenClaw MCP tool."},
+            {},
+        )
+
+        assert "catalog_entries" not in evidence

--- a/tests/integrations/openclaw/test_evidence_mappers.py
+++ b/tests/integrations/openclaw/test_evidence_mappers.py
@@ -120,6 +120,26 @@ class TestMapGetOpenclawConversation:
         assert entries[0]["summary"] == "conv-1 — Checkout debugging"
         assert "ok" not in (entries[0]["summary"] or "")
 
+    def test_bounds_long_conversation_identifier(self) -> None:
+        evidence: dict = {}
+        long_id = "c" * 120
+
+        map_get_openclaw_conversation(
+            evidence,
+            {
+                "available": True,
+                "structured_content": {"id": long_id, "title": "Checkout debugging"},
+            },
+            {},
+        )
+
+        summary = evidence["catalog_entries"][0]["summary"] or ""
+        ident, _, title = summary.partition(" — ")
+        assert ident.endswith("…")
+        assert len(ident) == 80
+        assert long_id not in summary
+        assert title == "Checkout debugging"
+
     def test_records_nothing_when_payload_is_empty(self) -> None:
         evidence: dict = {}
 
@@ -161,6 +181,29 @@ class TestMapCallOpenclawTool:
         assert entries[0]["source"] == "call_openclaw_tool"
         assert entries[0]["summary"] == "messages_read returned 2 structured items"
         assert "transcript" not in (entries[0]["summary"] or "")
+
+    def test_bounds_long_tool_name(self) -> None:
+        evidence: dict = {}
+        long_name = "openclaw_" + ("x" * 120)
+
+        map_call_openclaw_tool(
+            evidence,
+            {
+                "available": True,
+                "tool": long_name,
+                "text": "ok",
+                "structured_content": [{"id": "msg-1"}],
+                "content": [],
+            },
+            {},
+        )
+
+        summary = evidence["catalog_entries"][0]["summary"] or ""
+        name, _, rest = summary.partition(" returned ")
+        assert name.endswith("…")
+        assert len(name) == 80
+        assert long_name not in summary
+        assert rest == "1 structured item"
 
     def test_records_nothing_when_payload_is_empty(self) -> None:
         evidence: dict = {}

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -16,7 +16,6 @@ GetServiceDependencies
 argocd_application_diff
 argocd_application_status
 buzz_send_message
-call_openclaw_tool
 call_posthog_tool
 call_sentry_tool
 call_x_tool
@@ -65,7 +64,6 @@ get_mongodb_atlas_cluster_events
 get_mongodb_atlas_cluster_metrics
 get_mongodb_atlas_clusters
 get_mongodb_atlas_performance_advisor
-get_openclaw_conversation
 get_pods_on_node
 get_postgresql_current_queries
 get_postgresql_lock_status
@@ -118,7 +116,6 @@ list_github_work_items
 list_jenkins_builds
 list_jenkins_jobs
 list_jenkins_running_builds
-list_openclaw_tools
 list_posthog_tools
 list_s3_objects
 list_sentry_tools
@@ -146,7 +143,6 @@ rocketchat_send_message
 scan_redis_keys
 search_github_code
 search_github_issues
-search_openclaw_conversations
 send_openclaw_message
 slack_add_reaction
 slack_join_channel


### PR DESCRIPTION
Fixes #5553 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Mappers live in `integrations/openclaw/tools/openclaw_mcp_tool/evidence.py` and are wired on `@tool`. Empty `{}`, empty lists, and `available: False` record nothing.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->
Before (`merge_tool_evidence` on `main`): raw `call_openclaw_tool` payload and `tool_outputs` only—no `catalog_entries`.
After (this branch, same sample): the same raw keys, plus:
```
"catalog_entries": [
  {
    "source": "call_openclaw_tool",
    "label": "OpenClaw Tool Result",
    "summary": "messages_read returned 1 structured item",
    "url": null,
    "snippet": null
  }
]
```
Registry check: all four read tools report `evidence_mapper=True`; `send_openclaw_message` remains `False`.
All the test under `tests/integrations/openclaw/` are passed.

### Behaviour comparison-
Sample input:
`{'available': True, 'tool': 'messages_read', 'text': 'ok', 'structured_content': [{'id': 'msg-1'}], 'content': []}`

**Before:**
```
{
  "call_openclaw_tool": {
    "available": true,
    "tool": "messages_read",
    "text": "ok",
    "structured_content": [
      {
        "id": "msg-1"
      }
    ],
    "content": []
  },
  "tool_outputs": [
    {
      "tool_name": "call_openclaw_tool",
      "tool_args": {},
      "data": {
        "available": true,
        "tool": "messages_read",
        "text": "ok",
        "structured_content": [
          {
            "id": "msg-1"
          }
        ],
        "content": []
      }
    }
  ]
}
```
**After:**
```
{
  "call_openclaw_tool": {
    "available": true,
    "tool": "messages_read",
    "text": "ok",
    "structured_content": [
      {
        "id": "msg-1"
      }
    ],
    "content": []
  },
  "tool_outputs": [
    {
      "tool_name": "call_openclaw_tool",
      "tool_args": {},
      "data": {
        "available": true,
        "tool": "messages_read",
        "text": "ok",
        "structured_content": [
          {
            "id": "msg-1"
          }
        ],
        "content": []
      }
    }
  ],
  "catalog_entries": [
    {
      "source": "call_openclaw_tool",
      "label": "OpenClaw Tool Result",
      "summary": "messages_read returned 1 structured item",
      "url": null,
      "snippet": null
    }
  ]
}
```

- **What the reader gains.** The report can now cite that OpenClaw `messages_read` returned a structured result (and, for the other tools, that a tool listing, conversation search hits, or a named conversation was retrieved) instead of leaving that work as an uncited blob.

- **How much context it costs.** One compact catalog entry is ~150 characters (`{"source": "call_openclaw_tool", "label": "OpenClaw Tool Result", "summary": "messages_read returned 1 structured item", "url": null, "snippet": null}`). Transcripts, MCP text, and tool schemas are not inlined.

- **What happens on an empty or error result.** {}, empty tools/conversations/payload, and available: False record no catalog entry (covered by unit tests).

- **Whether anything is now recorded twice.** No prior mapper covered these tools. If the agent later calls both call_openclaw_tool and get_openclaw_conversation on the same thread, two entries can appear—they are different tools with different source keys, not a duplicate of one mapper.

- **Whether an existing report changed shape.** Only OpenClaw read tools gained mappers; Grafana/S3/other catalog keys are untouched. `test_evidence_mapper_coverage.py` still passes.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
The listed 4 tools in the issue description had the missing evidence mappers. Due to this citetable `catelog_entries` were missing. I added a smaller mapper in `evidence.py`
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
