### PR TITLE
docs(splunk): stop telling readers to grant a capability that does not exist

### DIFF
--- a/docs/splunk.mdx
+++ b/docs/splunk.mdx
@@ -107,11 +107,12 @@ purpose); omitting it fails with `The following required arguments are missing: 
 </Warning>
 
 The token needs the `search` capability. The `admin` role includes this by
-default. For a dedicated service account, ensure the role includes:
+default.
 
-- `search`
-- `read_splunkd_private_settings` (needed for the verify call against
-  `/services/server/info`)
+`opensre integrations verify splunk` also reads `/services/server/info`, so a
+least-privilege service account needs a role that can reach that endpoint as
+well as search. If `verify` reports `HTTP 403`, the role is missing access to
+that endpoint rather than to search.
 
 ### Quick local test with Docker
 
@@ -290,7 +291,7 @@ Detail: Connected to Splunk 9.x.x
 
 - Use a **read-only bearer token** — never use an admin token in production.
 - Store `SPLUNK_TOKEN` in `.env` or the credential store, not in source code or CI logs.
-- Prefer a dedicated `opensre` service account with only the `search` capability (plus `read_splunkd_private_settings` for verify).
+- Prefer a dedicated `opensre` service account scoped to `search`. `verify` additionally reads `/services/server/info`, so the role must be able to reach that endpoint too.
 - For enterprise self-signed certificates, set `SPLUNK_CA_BUNDLE` rather than disabling verification entirely.
 - Set `SPLUNK_VERIFY_SSL=false` only in local or dev environments when you cannot supply a CA bundle.
 - Rotate tokens on a schedule and revoke them when no longer needed.


### PR DESCRIPTION
Refs #5692

<!-- Deliberately "Refs", not "Fixes": this ships the verified half only.
     The open half needs a live Splunk — see "What this does not answer" below. -->

#### Describe the changes you have made in this PR -

#5692 contains two separate claims. One is verifiable from Splunk's published capability list; the other needs a live instance. This PR ships the first and leaves the second open.

**Removed, because it is verifiably wrong.** Two places told readers to grant `read_splunkd_private_settings` to a least-privilege service account. That capability does not appear in Splunk's documented capability list — the only one containing "splunkd" is `restart_splunkd`. Anyone following the least-privilege path builds a role around a name Splunk does not recognise, and either `verify` fails or it succeeds for an unrelated reason.

**Replaced with what the code actually does.** `integrations/splunk/client.py` → `validate_access` issues one call:

```python
info_url = f"{self.config.base_url}/services/server/info"
response = httpx.get(info_url, headers={"Authorization": f"Bearer {self.config.token}"}, ...)
```

and formats a failure as `HTTP {status}`. So both doc lines now name the endpoint and the `HTTP 403` signal a reader would actually see, instead of naming a capability.

```diff
-default. For a dedicated service account, ensure the role includes:
-
-- `search`
-- `read_splunkd_private_settings` (needed for the verify call against
-  `/services/server/info`)
+default.
+
+`opensre integrations verify splunk` also reads `/services/server/info`, so a
+least-privilege service account needs a role that can reach that endpoint as
+well as search. If `verify` reports `HTTP 403`, the role is missing access to
+that endpoint rather than to search.
```

```diff
-- Prefer a dedicated `opensre` service account with only the `search` capability (plus `read_splunkd_private_settings` for verify).
+- Prefer a dedicated `opensre` service account scoped to `search`. `verify` additionally reads `/services/server/info`, so the role must be able to reach that endpoint too.
```

### What this does **not** answer

The issue's other two questions are still open, and I have not answered them:

- which capability (if any) `/services/server/info` needs beyond `search`
- whether index-level access matters for the indexes OpenSRE searches

I could not stand up the Docker recipe on this machine, so I have no empirical result — and I would rather not swap one unverified claim for another, which is the failure mode the issue exists to correct. I also checked Splunk's published REST reference for a documented capability on `server/info` and could not find one: it is absent from both the System endpoints and Introspection endpoints pages for 10.2.

So please keep #5692 open after merging this, hence `Refs` rather than `Fixes`. Removing a false instruction is strictly better than leaving it, and does not depend on the unanswered half.

If you would rather this waited until someone can run the experiment, say so and I will close it — no objection.

### Demo/Screenshot for feature changes and bug fixes -

Docs-only change. The capability is gone from the page:

```
$ grep -c "read_splunkd_private_settings" docs/splunk.mdx
0
```

```
$ make lint
All checks passed!

$ make format-check
3738 files already formatted
```

`docs/splunk.mdx` is already listed in `docs/docs.json` navigation, so no nav entry is needed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

<!-- to be completed by the author -->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions
