### PR TITLE
test(ci): ignore tests/tools/selection in CI and add related test for live tool selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,6 +620,7 @@ jobs:
           ${PYTEST_COVERAGE_ARGS}
           --ignore=tests/e2e/kubernetes_local_alert_simulation
           --ignore=tests/synthetic
+          --ignore=tests/tools/selection
           ${{ matrix.extra_pytest_args }}
           ${{ matrix.split_args }}
           -m "${PYTEST_MARKER_EXPR}"

--- a/tests/github_ci/test_empty_collection_guard.py
+++ b/tests/github_ci/test_empty_collection_guard.py
@@ -36,6 +36,8 @@ _NOT_IN_PR_CI = (
     "tests/e2e/install",
     "tests/e2e/quickstart",
     "tests/e2e/kubernetes_local_alert_simulation",
+    # Opt-in live tool selection: real LLM tool-choice, not a required gate.
+    "tests/tools/selection",
 )
 
 
@@ -171,3 +173,10 @@ def test_every_test_directory_runs_in_a_shard() -> None:
         + "\n".join(f"  - {item}" for item in uncovered)
         + "\nAdd each to a shard's pytest_paths in .github/workflows/ci.yml."
     )
+
+
+def test_live_tool_selection_is_ignored_on_claimed_tools_shards() -> None:
+    """``tests/tools`` claims the live suite, so the shared ignore is load-bearing."""
+    claimed = [shard for shard in _shards() if _covers(shard.claims, "tests/tools/selection")]
+    assert claimed
+    assert all("tests/tools/selection" in shard.ignores for shard in claimed)

--- a/tests/tools/selection/test_tool_selection.py
+++ b/tests/tools/selection/test_tool_selection.py
@@ -14,6 +14,7 @@ from config.llm_settings import (
     resolve_llm_settings,
 )
 from core.llm.factory import LLMRole, get_llm
+from core.llm.shared.llm_retry import LLMCreditExhaustedError
 from core.llm.types import SchemaDescribedTool
 from tools.registry import get_registered_tool_map
 
@@ -161,7 +162,12 @@ def test_live_tool_selection_matches_target_tool(scenario: SelectionScenario) ->
         }
     ]
 
-    response = llm.invoke(messages=messages, tools=tool_schemas)
+    response = None
+    try:
+        response = llm.invoke(messages=messages, tools=tool_schemas)
+    except LLMCreditExhaustedError as exc:
+        pytest.skip(f"Skipping live tool selection; provider credit/quota is exhausted. {exc}")
+    assert response is not None
 
     assert response.has_tool_calls, (
         f"Model did not issue a tool call for scenario {scenario.scenario_id!r}. Content: {response.content!r}"


### PR DESCRIPTION
This pull request improves the handling and CI integration of the live tool selection tests, ensuring they are properly ignored in the main test suite and skipped when LLM provider quotas are exhausted. The changes also add a test to guarantee the ignore logic works as intended.

**Test suite management:**

* Updated `.github/workflows/ci.yml` to explicitly ignore the `tests/tools/selection` directory, preventing live tool selection tests from running in standard CI jobs.
* Added `tests/tools/selection` to the list of intentionally ignored test directories in `test_empty_collection_guard.py`, clarifying its opt-in status.
* Introduced `test_live_tool_selection_is_ignored_on_claimed_tools_shards` to assert that any shard claiming `tests/tools/selection` also ignores it, ensuring the ignore logic is enforced.

**Test robustness and reliability:**

* Modified `test_tool_selection.py` to skip tests gracefully when LLM provider credit/quota is exhausted, using `LLMCreditExhaustedError`, instead of failing the test. [[1]](diffhunk://#diff-cf6c733d02f27afc77e18440e1f8936ebe4cba860fd9a771e6f21ab6e25df791R17) [[2]](diffhunk://#diff-cf6c733d02f27afc77e18440e1f8936ebe4cba860fd9a771e6f21ab6e25df791R165-R170)