### PR TITLE
feat(datadog): add investigation evidence mappers

### DIFF
--- a/core/domain/types/evidence.py
+++ b/core/domain/types/evidence.py
@@ -34,14 +34,18 @@ def record_evidence_entry(
     """Record a citeable report entry from inside an evidence mapper.
 
     The report's evidence catalog turns each entry into a display id (``E1`` …)
-    the agent can cite. ``source`` is the claim-facing key; the first entry for a
-    given ``source`` wins, and a bespoke catalog reader for the same key takes
-    precedence. Lets a tool's output become citeable without editing the shared
+    the agent can cite. ``source`` is the claim-facing key; a bespoke catalog
+    reader for the same key takes precedence over this one. A later call with
+    the same ``source`` (e.g. the same tool invoked again with a different
+    query in one investigation) replaces the earlier entry rather than adding a
+    second one, so the catalog always cites the most recent call for that
+    source. Lets a tool's output become citeable without editing the shared
     catalog builder.
     """
     entries = evidence.setdefault(CATALOG_ENTRIES_KEY, [])
     if not isinstance(entries, list):
         return
+    entries[:] = [e for e in entries if not (isinstance(e, dict) and e.get("source") == source)]
     entries.append(
         {"source": source, "label": label, "summary": summary, "url": url, "snippet": snippet}
     )

--- a/integrations/datadog/tools/__init__.py
+++ b/integrations/datadog/tools/__init__.py
@@ -9,6 +9,7 @@ import concurrent.futures
 import re
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
@@ -166,10 +167,30 @@ def _context_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     }
 
 
+def _map_query_datadog_all(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    counts = {
+        "log line(s)": len(output.get("logs", [])),
+        "monitor(s)": len(output.get("monitors", [])),
+        "event(s)": len(output.get("events", [])),
+        "failed pod(s)": len(output.get("failed_pods", [])),
+    }
+    parts = [f"{count} {label}" for label, count in counts.items() if count]
+    if parts:
+        record_evidence_entry(
+            evidence,
+            source="query_datadog_all",
+            label="Datadog Context",
+            summary=", ".join(parts),
+        )
+
+
 @tool(
     name="query_datadog_all",
     display_name="Datadog",
     source="datadog",
+    evidence_mapper=_map_query_datadog_all,
     description="Fetch Datadog logs, monitors, and events in parallel for fast investigation.",
     use_cases=[
         "Full Datadog context in a single fast operation",
@@ -308,10 +329,24 @@ def _events_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     }
 
 
+def _map_query_datadog_events(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    events = output.get("events", [])
+    if events:
+        record_evidence_entry(
+            evidence,
+            source="query_datadog_events",
+            label="Datadog Events",
+            summary=f"{len(events)} event(s)",
+        )
+
+
 @tool(
     name="query_datadog_events",
     display_name="Datadog events",
     source="datadog",
+    evidence_mapper=_map_query_datadog_events,
     description="Query Datadog events for deployments, alerts, and system changes.",
     use_cases=[
         "Finding recent deployment events that may correlate with failures",
@@ -414,10 +449,24 @@ _DATADOG_LOGS_ANTI = (
 )
 
 
+def _map_query_datadog_logs(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    logs = output.get("logs", [])
+    if logs:
+        record_evidence_entry(
+            evidence,
+            source="query_datadog_logs",
+            label="Datadog Logs",
+            summary=f"{len(logs)} log line(s)",
+        )
+
+
 @tool(
     name="query_datadog_logs",
     display_name="Datadog logs",
     source="datadog",
+    evidence_mapper=_map_query_datadog_logs,
     tags=("logs", "observability"),
     description=(
         "Search Datadog Logs with a concrete query string (required), e.g. "
@@ -547,9 +596,25 @@ def _metrics_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     }
 
 
+def _map_query_datadog_metrics(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    # The tool is currently a stub that returns no series; this becomes live
+    # evidence only once the Datadog Metrics API v2 implementation lands.
+    series = output.get("metrics", [])
+    if series:
+        record_evidence_entry(
+            evidence,
+            source="query_datadog_metrics",
+            label="Datadog Metrics",
+            summary=f"{len(series)} series",
+        )
+
+
 @tool(
     name="query_datadog_metrics",
     source="datadog",
+    evidence_mapper=_map_query_datadog_metrics,
     description="Query Datadog metrics for infrastructure and application performance data.",
     use_cases=[
         "Investigating CPU or memory spikes correlated with an alert",
@@ -614,10 +679,24 @@ def _monitors_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     }
 
 
+def _map_query_datadog_monitors(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    monitors = output.get("monitors", [])
+    if monitors:
+        record_evidence_entry(
+            evidence,
+            source="query_datadog_monitors",
+            label="Datadog Monitors",
+            summary=f"{len(monitors)} monitor(s)",
+        )
+
+
 @tool(
     name="query_datadog_monitors",
     display_name="Datadog monitors",
     source="datadog",
+    evidence_mapper=_map_query_datadog_monitors,
     description="List Datadog monitors to understand alerting configuration and current states.",
     use_cases=[
         "Understanding which monitors triggered an alert",
@@ -697,9 +776,23 @@ def _node_pods_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     }
 
 
+def _map_get_pods_on_node(
+    evidence: dict[str, Any], output: dict[str, Any], _input: dict[str, Any]
+) -> None:
+    pods = output.get("pods", [])
+    if pods:
+        record_evidence_entry(
+            evidence,
+            source="get_pods_on_node",
+            label="Datadog Pods on Node",
+            summary=f"{len(pods)} pod(s)",
+        )
+
+
 @tool(
     name="get_pods_on_node",
     source="datadog",
+    evidence_mapper=_map_get_pods_on_node,
     description="Resolve a node IP address to all pods running on that node via Datadog.",
     use_cases=[
         "Mapping a node IP from an infrastructure alert to specific pods",

--- a/tests/core/domain/types/test_evidence.py
+++ b/tests/core/domain/types/test_evidence.py
@@ -1,0 +1,37 @@
+"""Repeated-call semantics for record_evidence_entry (Greptile P1, PR #5869)."""
+
+from __future__ import annotations
+
+from core.domain.types.evidence import record_evidence_entry
+
+
+class TestRecordEvidenceEntry:
+    def test_second_call_with_same_source_replaces_the_first(self) -> None:
+        evidence: dict = {}
+
+        record_evidence_entry(
+            evidence, source="query_datadog_logs", label="Datadog Logs", summary="2 log line(s)"
+        )
+        record_evidence_entry(
+            evidence, source="query_datadog_logs", label="Datadog Logs", summary="9 log line(s)"
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["summary"] == "9 log line(s)"
+
+    def test_calls_with_different_sources_both_stay(self) -> None:
+        evidence: dict = {}
+
+        record_evidence_entry(
+            evidence, source="query_datadog_logs", label="Datadog Logs", summary="2 log line(s)"
+        )
+        record_evidence_entry(
+            evidence,
+            source="query_datadog_monitors",
+            label="Datadog Monitors",
+            summary="1 monitor(s)",
+        )
+
+        entries = evidence["catalog_entries"]
+        assert {e["source"] for e in entries} == {"query_datadog_logs", "query_datadog_monitors"}

--- a/tests/integrations/datadog/test_evidence_mappers.py
+++ b/tests/integrations/datadog/test_evidence_mappers.py
@@ -1,0 +1,133 @@
+"""Evidence mapper coverage for the datadog tools (#5539)."""
+
+from __future__ import annotations
+
+from integrations.datadog.tools import (
+    _map_get_pods_on_node,
+    _map_query_datadog_all,
+    _map_query_datadog_events,
+    _map_query_datadog_logs,
+    _map_query_datadog_metrics,
+    _map_query_datadog_monitors,
+)
+
+
+class TestMapQueryDatadogAll:
+    def test_records_entry_counting_each_payload(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_all(
+            evidence,
+            {
+                "logs": [{"message": "a"}, {"message": "b"}],
+                "monitors": [{"id": 1}],
+                "events": [],
+                "failed_pods": [{"pod_name": "p"}],
+            },
+            {},
+        )
+
+        entry = evidence["catalog_entries"][0]
+        assert entry["source"] == "query_datadog_all"
+        assert entry["summary"] == "2 log line(s), 1 monitor(s), 1 failed pod(s)"
+
+    def test_records_nothing_when_every_payload_empty(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_all(
+            evidence, {"logs": [], "monitors": [], "events": [], "failed_pods": []}, {}
+        )
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapQueryDatadogEvents:
+    def test_records_entry_when_events_present(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_events(evidence, {"events": [{"title": "deploy"}]}, {})
+
+        entry = evidence["catalog_entries"][0]
+        assert entry["source"] == "query_datadog_events"
+        assert entry["summary"] == "1 event(s)"
+
+    def test_records_nothing_when_no_events(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_events(evidence, {"events": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapQueryDatadogLogs:
+    def test_records_entry_when_logs_present(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_logs(evidence, {"logs": [{"message": "ok"}, {"message": "boom"}]}, {})
+
+        entry = evidence["catalog_entries"][0]
+        assert entry["source"] == "query_datadog_logs"
+        assert entry["summary"] == "2 log line(s)"
+
+    def test_records_nothing_when_no_logs(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_logs(evidence, {"logs": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapQueryDatadogMonitors:
+    def test_records_entry_when_monitors_present(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_monitors(evidence, {"monitors": [{"id": 1}, {"id": 2}]}, {})
+
+        entry = evidence["catalog_entries"][0]
+        assert entry["source"] == "query_datadog_monitors"
+        assert entry["summary"] == "2 monitor(s)"
+
+    def test_records_nothing_when_no_monitors(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_monitors(evidence, {"monitors": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+
+class TestMapQueryDatadogMetrics:
+    def test_stub_output_records_nothing(self) -> None:
+        """The tool is not implemented and always returns no series, so the
+        mapper contributes no evidence until a real Metrics API call lands."""
+        evidence: dict = {}
+
+        _map_query_datadog_metrics(evidence, {"available": False, "metrics": []}, {})
+
+        assert "catalog_entries" not in evidence
+
+    def test_records_entry_once_series_are_returned(self) -> None:
+        evidence: dict = {}
+
+        _map_query_datadog_metrics(evidence, {"metrics": [{"points": []}, {"points": []}]}, {})
+
+        entry = evidence["catalog_entries"][0]
+        assert entry["source"] == "query_datadog_metrics"
+        assert entry["summary"] == "2 series"
+
+
+class TestMapGetPodsOnNode:
+    def test_records_entry_when_pods_present(self) -> None:
+        evidence: dict = {}
+
+        _map_get_pods_on_node(evidence, {"pods": ["pod-a", "pod-b"]}, {})
+
+        entry = evidence["catalog_entries"][0]
+        assert entry["source"] == "get_pods_on_node"
+        assert entry["summary"] == "2 pod(s)"
+
+    def test_records_nothing_when_no_pods(self) -> None:
+        evidence: dict = {}
+
+        _map_get_pods_on_node(evidence, {"pods": []}, {})
+
+        assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -66,7 +66,6 @@ get_mongodb_atlas_cluster_metrics
 get_mongodb_atlas_clusters
 get_mongodb_atlas_performance_advisor
 get_openclaw_conversation
-get_pods_on_node
 get_postgresql_current_queries
 get_postgresql_lock_status
 get_postgresql_replication_status
@@ -130,11 +129,6 @@ memory_recall
 memory_remember
 pi_coding_task
 query_azure_monitor_logs
-query_datadog_all
-query_datadog_events
-query_datadog_logs
-query_datadog_metrics
-query_datadog_monitors
 query_grafana_annotations
 query_groundcover_logs
 query_groundcover_traces


### PR DESCRIPTION
Fixes #5539

Part of epic #5519 (Discussion #1079).

#### Describe the changes you have made in this PR -

Wire the six read-only Datadog tools to the report evidence catalog via an
`evidence_mapper`, so the data they fetch becomes numbered, citeable evidence
instead of being silently dropped:

| Tool | Field mapped | Records |
| --- | --- | --- |
| `query_datadog_all` | `logs` / `monitors` / `events` / `failed_pods` | composite count of each non-empty payload |
| `query_datadog_events` | `events` | `N event(s)` |
| `query_datadog_logs` | `logs` | `N log line(s)` |
| `query_datadog_monitors` | `monitors` | `N monitor(s)` |
| `get_pods_on_node` | `pods` | `N pod(s)` |
| `query_datadog_metrics` | `metrics` | nothing yet — see below |

Each mapper follows the shipped Grafana pattern: read the list off the tool
output, and only when it is non-empty call `record_evidence_entry` with the
tool name as `source`.

`query_datadog_metrics` is still a stub (`is_available=False`, always returns
`metrics: []`). Its mapper is added for consistency and to clear the baseline,
but it records nothing until the Metrics API v2 implementation lands and
populates `metrics`. This is called out in a code comment.

All six tools are removed from
`tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt`,
and a unit test per mapper is added under `tests/integrations/datadog/`.

No refactor of the surrounding 759-line `integrations/datadog/tools/__init__.py`
(one file holding six tool packages) — out of scope here, but worth flagging as
a follow-up.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['query_datadog_all','query_datadog_events','query_datadog_logs','query_datadog_metrics','query_datadog_monitors','get_pods_on_node']})"
{'query_datadog_all': True, 'query_datadog_events': True, 'query_datadog_logs': True, 'query_datadog_metrics': True, 'query_datadog_monitors': True, 'get_pods_on_node': True}

$ uv run python -c "from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence; \
ev={}; merge_tool_evidence(ev, 'query_datadog_logs', {'available': True, 'logs': [1,2]}, {}); print(ev.get('catalog_entries'))"
[{'source': 'query_datadog_logs', 'label': 'Datadog Logs', 'summary': '2 log line(s)', 'url': None, 'snippet': None}]

$ uv run pytest tests/integrations/datadog/ tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q
55 passed

$ uv run pytest tests/ -k datadog -q
162 passed, 1 skipped

$ make lint && make format-check && make typecheck
All checks passed! / 3741 files already formatted / Success: no issues found in 1952 source files
```

End-to-end check (issue check 5): requires live Datadog credentials, which I do
not have, so it is left unverified here — checks 1–4 stand. A reviewer with an
account can finish it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: OpenSRE runs Datadog tools during an investigation, but their
output never reaches the report's evidence catalog, so findings that rely on
Datadog data look unsupported. The fix connects each read tool to the catalog.

The mechanism already exists — `record_evidence_entry` accumulates entries under
`evidence["catalog_entries"]`, and a tool opts in by declaring
`@tool(evidence_mapper=...)`; `merge_tool_evidence` calls it as
`mapper(evidence, output, tool_input)`. So each mapper only has to lift the
useful list out of the tool's output dict and, when it is non-empty, record one
entry keyed by the tool name.

I first added an `available` guard to every mapper, then removed it: on failure
these tools already return the relevant list empty (`unavailable()` sets
`key=[]`), so `if <list>:` is sufficient and matches the issue's template.
Five of the six mappers are that minimal shape. `query_datadog_all` is the
exception — it returns four distinct payloads in one call, so a single count
would lose information; it builds a composite summary of the non-empty ones.

`query_datadog_metrics` is a stub; I map it for consistency and to clear the
baseline, but guard on a non-empty `metrics` list so it stays inert until the
real Metrics API call exists.

Tests: one class per mapper under `tests/integrations/datadog/`, each with a
"records an entry" case and a "records nothing when empty" case, mirroring the
existing `tests/integrations/rds/test_evidence_mappers.py`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
