### PR TITLE
fix(ci): restore live tool selection gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
               --ignore=tests/core/agent
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
+              --ignore=tests/tools/selection
             split_args: >-
               --ci-splits=6 --ci-group=1
               --ci-durations-path=.github/ci/pytest-file-durations.json
@@ -165,6 +166,7 @@ jobs:
               --ignore=tests/core/agent
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
+              --ignore=tests/tools/selection
             split_args: >-
               --ci-splits=6 --ci-group=2
               --ci-durations-path=.github/ci/pytest-file-durations.json
@@ -182,6 +184,7 @@ jobs:
               --ignore=tests/core/agent
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
+              --ignore=tests/tools/selection
             split_args: >-
               --ci-splits=6 --ci-group=3
               --ci-durations-path=.github/ci/pytest-file-durations.json
@@ -199,6 +202,7 @@ jobs:
               --ignore=tests/core/agent
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
+              --ignore=tests/tools/selection
             split_args: >-
               --ci-splits=6 --ci-group=4
               --ci-durations-path=.github/ci/pytest-file-durations.json
@@ -216,6 +220,7 @@ jobs:
               --ignore=tests/core/agent
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
+              --ignore=tests/tools/selection
             split_args: >-
               --ci-splits=6 --ci-group=5
               --ci-durations-path=.github/ci/pytest-file-durations.json
@@ -233,6 +238,7 @@ jobs:
               --ignore=tests/core/agent
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
+              --ignore=tests/tools/selection
             split_args: >-
               --ci-splits=6 --ci-group=6
               --ci-durations-path=.github/ci/pytest-file-durations.json
@@ -381,8 +387,12 @@ jobs:
               tests/hermes
           - os: ubuntu-latest
             shard: cli-live-agent
+            # Keep all required live agent/tool-choice contracts on the
+            # credentialed provider already used by this gate.
             llm_provider: openai
-            pytest_paths: tests/core/agent/test_turn_scenarios.py
+            pytest_paths: >-
+              tests/core/agent/test_turn_scenarios.py
+              tests/tools/selection
           # This subprocess-heavy file dominated a whole duration-balanced
           # shard. Run complementary selections independently so its tests can
           # use four runner cores without changing or dropping coverage.
@@ -620,7 +630,6 @@ jobs:
           ${PYTEST_COVERAGE_ARGS}
           --ignore=tests/e2e/kubernetes_local_alert_simulation
           --ignore=tests/synthetic
-          --ignore=tests/tools/selection
           ${{ matrix.extra_pytest_args }}
           ${{ matrix.split_args }}
           -m "${PYTEST_MARKER_EXPR}"

--- a/tests/github_ci/test_empty_collection_guard.py
+++ b/tests/github_ci/test_empty_collection_guard.py
@@ -36,8 +36,6 @@ _NOT_IN_PR_CI = (
     "tests/e2e/install",
     "tests/e2e/quickstart",
     "tests/e2e/kubernetes_local_alert_simulation",
-    # Opt-in live tool selection: real LLM tool-choice, not a required gate.
-    "tests/tools/selection",
 )
 
 
@@ -175,8 +173,14 @@ def test_every_test_directory_runs_in_a_shard() -> None:
     )
 
 
-def test_live_tool_selection_is_ignored_on_claimed_tools_shards() -> None:
-    """``tests/tools`` claims the live suite, so the shared ignore is load-bearing."""
+def test_live_tool_selection_runs_only_on_openai_live_shard() -> None:
+    """Keep selection tests out of broad shards and in the required live gate."""
     claimed = [shard for shard in _shards() if _covers(shard.claims, "tests/tools/selection")]
-    assert claimed
-    assert all("tests/tools/selection" in shard.ignores for shard in claimed)
+    running = [shard for shard in claimed if not _covers(shard.ignores, "tests/tools/selection")]
+
+    assert [shard.name for shard in running] == ["cli-live-agent"]
+    assert all(
+        "tests/tools/selection" in shard.ignores
+        for shard in claimed
+        if shard.name.startswith("tools-runtime-")
+    )

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -62,7 +62,15 @@ def test_heavy_test_suites_are_duration_balanced_with_measured_headroom() -> Non
         assert all(f"--ci-splits={splits}" in entry["split_args"] for entry in groups)
 
     live_agent = next(entry for entry in entries if entry["shard"] == "cli-live-agent")
-    assert live_agent["pytest_paths"] == "tests/core/agent/test_turn_scenarios.py"
+    assert live_agent["llm_provider"] == "openai"
+    assert live_agent["pytest_paths"].split() == [
+        "tests/core/agent/test_turn_scenarios.py",
+        "tests/tools/selection",
+    ]
+    tool_groups = [entry for entry in entries if entry["shard"].startswith("tools-runtime-")]
+    assert all(
+        "--ignore=tests/tools/selection" in entry["extra_pytest_args"] for entry in tool_groups
+    )
     cli_groups = [entry for entry in entries if entry["shard"].startswith("cli-runtime-")]
     assert all(
         "--ignore=tests/core/agent/test_turn_scenarios.py" in entry["extra_pytest_args"]

--- a/tests/tools/selection/test_tool_selection.py
+++ b/tests/tools/selection/test_tool_selection.py
@@ -23,6 +23,12 @@ from tools.registry import get_registered_tool_map
 
 pytestmark = [pytest.mark.live_llm, pytest.mark.integration]
 
+_TOOL_SELECTION_SYSTEM_PROMPT = (
+    "You are selecting the first diagnostic tool for a live contract test. "
+    "You must call exactly one of the provided tools. Do not answer in prose "
+    "and do not merely name the tool."
+)
+
 
 @dataclass(frozen=True, slots=True)
 class SelectionScenario:
@@ -179,7 +185,11 @@ def test_live_tool_selection_matches_target_tool(scenario: SelectionScenario) ->
 
     response = None
     try:
-        response = llm.invoke(messages=messages, tools=tool_schemas)
+        response = llm.invoke(
+            messages=messages,
+            system=_TOOL_SELECTION_SYSTEM_PROMPT,
+            tools=tool_schemas,
+        )
     except LLMCreditExhaustedError as exc:
         skip_or_fail(f"Live tool selection provider credit/quota is exhausted. {exc}")
     assert response is not None

--- a/tests/tools/selection/test_tool_selection.py
+++ b/tests/tools/selection/test_tool_selection.py
@@ -8,6 +8,8 @@ import pytest
 from pydantic import ValidationError
 
 from config.llm_auth.credentials import status as credential_status
+from config.llm_auth.provider_catalog import provider_spec
+from config.llm_credentials import resolve_env_credential
 from config.llm_settings import (
     get_configured_llm_provider,
     get_llm_provider_api_key_env,
@@ -16,6 +18,7 @@ from config.llm_settings import (
 from core.llm.factory import LLMRole, get_llm
 from core.llm.shared.llm_retry import LLMCreditExhaustedError
 from core.llm.types import SchemaDescribedTool
+from tests.core.agent._ci_gates import skip_or_fail
 from tools.registry import get_registered_tool_map
 
 pytestmark = [pytest.mark.live_llm, pytest.mark.integration]
@@ -108,15 +111,27 @@ def _require_live_llm_credentials() -> None:
         hint = f" configured provider={provider!r}"
         if env_var is not None:
             hint += f", required key={env_var}"
-        pytest.skip(f"Skipping live tool selection; missing LLM configuration:{hint}. {msg}")
+        skip_or_fail(f"Live tool selection requires LLM configuration:{hint}. {msg}")
 
     if settings is None:
-        pytest.skip("Skipping live tool selection; LLM settings could not be resolved.")
+        skip_or_fail("Live tool selection requires resolvable LLM settings.")
 
     auth = credential_status(settings.provider)
     if not auth.configured or auth.stale:
-        pytest.skip(
-            f"Skipping live tool selection; unconfigured or stale credentials for provider {settings.provider!r}."
+        skip_or_fail(
+            "Live tool selection requires configured, current credentials for "
+            f"provider {settings.provider!r}."
+        )
+
+    spec = provider_spec(settings.provider)
+    if (
+        spec is not None
+        and spec.credential_kind == "api_key"
+        and spec.api_key_env
+        and not resolve_env_credential(spec.api_key_env)
+    ):
+        skip_or_fail(
+            f"Live tool selection requires a resolvable API key for provider {settings.provider!r}."
         )
 
 
@@ -166,7 +181,7 @@ def test_live_tool_selection_matches_target_tool(scenario: SelectionScenario) ->
     try:
         response = llm.invoke(messages=messages, tools=tool_schemas)
     except LLMCreditExhaustedError as exc:
-        pytest.skip(f"Skipping live tool selection; provider credit/quota is exhausted. {exc}")
+        skip_or_fail(f"Live tool selection provider credit/quota is exhausted. {exc}")
     assert response is not None
 
     assert response.has_tool_calls, (


### PR DESCRIPTION
Follow-up to #5868

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Restore `tests/tools/selection` as a required CI suite instead of globally ignoring it.
- Run the four live tool-selection scenarios in the existing `cli-live-agent` shard, which is already pinned to OpenAI and receives the repository's OpenAI credential.
- Keep the six broad `tools-runtime` shards from collecting the suite a second time.
- Preserve local opt-in behavior, but fail closed in GitHub Actions when credentials are unavailable or provider quota is exhausted.
- Explicitly instruct the live selection turn to issue one tool call rather than merely naming the chosen tool in prose; the strict assertions remain unchanged.
- Update workflow contract tests so a future edit cannot silently remove or duplicate the suite.

The post-merge failure after #5746 was not a selection assertion failure: all four scenarios used the default Anthropic provider and raised `LLMCreditExhaustedError`. #5868 made CI green by excluding the suite. Reusing the existing OpenAI live shard fixes the provider routing without adding another runner or weakening the assertions.

### Demo/Screenshot for feature changes and bug fixes - 

```text
$ make lint
All checks passed!

$ make format-check
3740 files already formatted

$ make typecheck
Success: no issues found in 1952 source files

$ uv run python -m pytest     tests/github_ci/test_empty_collection_guard.py     tests/github_ci/test_pr_pipeline_slo.py     tests/tools/test_tool_selection_contracts.py
20 passed in 2.71s

$ OPENSRE_DISABLE_KEYRING=1 LLM_PROVIDER=openai     uv run python -m pytest -q tests/tools/selection -m live_llm
4 skipped in 1.08s

$ GITHUB_ACTIONS=true OPENSRE_DISABLE_KEYRING=1 LLM_PROVIDER=openai     uv run python -m pytest -q tests/tools/selection -m live_llm --maxfail=1
Failed: Live tool selection requires a resolvable API key for provider 'openai'.
```

The credentialed live calls are intentionally left to this PR's trusted GitHub Actions run.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **Problem:** A required live tool-selection suite was globally ignored after the default Anthropic CI credential exhausted its quota.
- **Alternatives considered:** Pin every tools shard to OpenAI, add a new dedicated runner, or reuse the existing credentialed live shard. Pinning all tools shards would broaden provider-dependent behavior, while a new runner would add setup latency.
- **Chosen approach:** Reuse `cli-live-agent`, which already runs required live LLM contracts on OpenAI. Broad tools shards ignore only this subdirectory to prevent duplicate collection.
- **Failure behavior:** Local runs may skip when live prerequisites are absent. GitHub Actions uses the existing `skip_or_fail` helper, so missing credentials and quota exhaustion fail the gate rather than silently passing. The selection system prompt requires the tool-call response shape while leaving the model responsible for choosing the correct tool.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and understand how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

