### PR TITLE
fix(session): preserve writes after a torn JSONL tail

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_repo.py
+++ b/core/agent_harness/session/persistence/jsonl_repo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -106,7 +107,7 @@ class JsonlSessionRepo:
     def _collect_investigation_records(
         path: Path,
         *,
-        lines: list[str] | None = None,
+        lines: Sequence[str | bytes] | None = None,
     ) -> list[dict[str, Any]]:
         with contextlib.suppress(Exception):
             loaded = _load_v2_lines(lines) if lines is not None else _load_v2_file(path)
@@ -153,7 +154,7 @@ class JsonlSessionRepo:
         results: list[dict[str, Any]] = []
         for path in sorted(root.glob("*.jsonl"), key=_mtime, reverse=True):
             with contextlib.suppress(Exception):
-                lines = path.read_text(encoding="utf-8").splitlines()
+                lines = path.read_bytes().splitlines()
                 results.extend(self._collect_investigation_records(path, lines=lines))
             if len(results) >= n * 3:
                 break
@@ -170,7 +171,7 @@ class JsonlSessionRepo:
         count = 0
         for path in root.glob("*.jsonl"):
             with contextlib.suppress(Exception):
-                lines = path.read_text(encoding="utf-8").splitlines()
+                lines = path.read_bytes().splitlines()
                 for rec in JsonlSessionRepo._collect_investigation_records(path, lines=lines):
                     inv_id = str(rec.get("investigation_id") or "").lower()
                     if not inv_id.startswith(normalized):
@@ -235,15 +236,20 @@ def _split_session_ref(ref: str) -> tuple[str, str | None]:
 
 
 def _load_v2_file(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
-    return _load_v2_lines(path.read_text(encoding="utf-8").splitlines())
+    return _load_v2_lines(path.read_bytes().splitlines())
 
 
-def _load_v2_lines(lines: list[str]) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+def _load_v2_lines(
+    lines: Sequence[str | bytes],
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
     if not lines:
         return None
     try:
-        header = json.loads(lines[0])
-    except json.JSONDecodeError:
+        first_line = lines[0]
+        header = json.loads(
+            first_line.decode("utf-8") if isinstance(first_line, bytes) else first_line
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return None
     if (
         not isinstance(header, dict)
@@ -253,8 +259,9 @@ def _load_v2_lines(lines: list[str]) -> tuple[dict[str, Any], list[dict[str, Any
         return None
     entries: list[dict[str, Any]] = []
     for line in lines[1:]:
-        with contextlib.suppress(json.JSONDecodeError):
-            rec = json.loads(line)
+        with contextlib.suppress(json.JSONDecodeError, UnicodeDecodeError):
+            decoded = line.decode("utf-8") if isinstance(line, bytes) else line
+            rec = json.loads(decoded)
             if isinstance(rec, dict) and "id" in rec and "type" in rec:
                 entries.append(rec)
     return header, entries

--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -565,7 +565,16 @@ class JsonlSessionStore:
                     **({"sidecar": True} if sidecar else {}),
                     **{key: value for key, value in payload.items() if value is not None},
                 }
+                needs_separator = path.stat().st_size > 0
+                if needs_separator:
+                    # A killed writer can leave one torn record without its newline.
+                    # Keep that dead line isolated so it cannot absorb this good record.
+                    with path.open("rb") as existing:
+                        existing.seek(-1, os.SEEK_END)
+                        needs_separator = existing.read(1) != b"\n"
                 with path.open("a", encoding="utf-8") as fh:
+                    if needs_separator:
+                        fh.write("\n")
                     fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
                     if durable:
                         fh.flush()
@@ -605,7 +614,7 @@ class JsonlSessionStore:
         self._leaf_ids[key] = entry_id
 
     @staticmethod
-    def _loads_record(line: str, *, path: Path | None = None) -> dict[str, Any] | None:
+    def _loads_record(line: str | bytes, *, path: Path | None = None) -> dict[str, Any] | None:
         """Parse one JSONL line into a record dict, or ``None`` if unusable.
 
         A decode failure here is a torn tail or truncation on the read side —
@@ -613,8 +622,9 @@ class JsonlSessionStore:
         different failure modes on either end of the same file.
         """
         try:
-            rec = json.loads(line)
-        except json.JSONDecodeError:
+            decoded = line.decode("utf-8") if isinstance(line, bytes) else line
+            rec = json.loads(decoded)
+        except (json.JSONDecodeError, UnicodeDecodeError):
             record_operation(
                 "session_jsonl_decode_failed",
                 {"line_chars": len(line), "path": str(path) if path else ""},
@@ -625,7 +635,9 @@ class JsonlSessionStore:
     @staticmethod
     def _read_records(path: Path) -> list[dict[str, Any]]:
         records: list[dict[str, Any]] = []
-        for line in path.read_text(encoding="utf-8").splitlines():
+        # Parse bytes one line at a time so one torn UTF-8 code point cannot make
+        # later complete records unreadable or be replaced inside a corrupt record.
+        for line in path.read_bytes().splitlines():
             rec = JsonlSessionStore._loads_record(line, path=path)
             if rec is not None:
                 records.append(rec)
@@ -706,7 +718,7 @@ class JsonlSessionStore:
                 region_end = scanned_low if scanned_low is not None else len(buffer)
                 if region_start < region_end:
                     region = buffer[region_start:region_end]
-                    for line in reversed(region.decode("utf-8").splitlines()):
+                    for line in reversed(region.splitlines()):
                         if not line.strip():
                             continue
                         rec = self._loads_record(line, path=path)

--- a/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
+++ b/tests/core/agent_harness/session/test_jsonl_store_lock_soak.py
@@ -32,7 +32,7 @@ from filelock import FileLock
 
 from config.constants import OPENSRE_HOME_ENV, OPENSRE_OPERATIONS_LOG_PATH_ENV
 from config.constants.session_store import OPENSRE_SESSION_FILE_LOCK_ENV
-from core.agent_harness.session.persistence.jsonl_store import JsonlSessionStore
+from core.agent_harness.session import JsonlSessionRepo, JsonlSessionStore
 from core.agent_harness.session.persistence.paths import session_path, sessions_dir
 from infrastructure.observability.operations_log import read_operations
 
@@ -268,15 +268,6 @@ def _assert_readable(path: Path) -> list[dict[str, Any]]:
     return records
 
 
-def _parses(line: str) -> bool:
-    """Whether ``line`` is a decodable JSON record."""
-    try:
-        json.loads(line)
-    except json.JSONDecodeError:
-        return False
-    return True
-
-
 def _written_markers(records: list[dict[str, Any]]) -> set[str]:
     """Marker prefixes (``w0-3``) of every turn stub in the file."""
     return {
@@ -471,16 +462,15 @@ def test_soak_sigkill_while_holding_the_lock_strands_nothing(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "#5750: a crash leaves a record with no trailing newline, and the next "
-        "append is concatenated onto it. That fuses both records into one "
-        "unparseable line, so the post-crash turn is invisible to every reader. "
-        "Strict, so this flips to a failure the moment #5750 is fixed."
-    ),
+@pytest.mark.parametrize(
+    "torn_tail",
+    [
+        b'{"id": "partial", "type": "custom_message", "text": "tor',
+        b'{"id": "partial", "type": "custom_message", "text": "\xe2\x82',
+    ],
+    ids=("partial-json", "partial-utf8-code-point"),
 )
-def test_soak_write_after_a_torn_tail_is_not_swallowed(soak_home: Path) -> None:
+def test_soak_write_after_a_torn_tail_is_not_swallowed(soak_home: Path, torn_tail: bytes) -> None:
     """Case 3, deterministic half: the record after a torn tail must survive.
 
     A SIGKILL lands mid-write only sometimes, so the crash *artifact* is seeded
@@ -491,20 +481,21 @@ def test_soak_write_after_a_torn_tail_is_not_swallowed(soak_home: Path) -> None:
     """
     session_id = "soak-torn"
     path = _seed(session_id)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write('{"id": "partial", "type": "custom_message", "text": "tor')
+    with path.open("ab") as handle:
+        handle.write(torn_tail)
 
     JsonlSessionStore().append_turn(_session(session_id), "chat", "after-the-crash")
 
     _metrics(soak_home).report("torn-tail")
-    readable = [
-        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if _parses(line)
-    ]
+    readable = JsonlSessionStore._read_records(path)
     texts = [str(r.get("text", "")) for r in readable if r.get("custom_type") == "turn_stub"]
     assert any("after-the-crash" in text for text in texts), (
         "the turn written after the torn tail is unreadable: it was appended onto "
         "the partial line instead of a new one"
     )
+    restored = JsonlSessionRepo().load_session(session_id)
+    assert restored is not None
+    assert any("after-the-crash" in str(item.get("text", "")) for item in restored["history"])
 
 
 def test_soak_lock_timeout_fails_cleanly_without_partial_append(


### PR DESCRIPTION
Fixes #5750

#### Describe the changes you have made in this PR -

- Separate a torn final JSONL record from the next append so a valid post-crash turn remains readable.
- Parse store and repository session files as strict UTF-8 one line at a time, allowing a malformed line to be skipped without accepting replacement-corrupted data or blocking later records.
- Keep production session restore, recent-session summaries, and investigation history readable after a torn UTF-8 line.
- Promote the existing strict xfail into a passing regression and cover partial JSON, a crash in the middle of a UTF-8 code point, and production restoration.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix:

```text
FAILED test_soak_write_after_a_torn_tail_is_not_swallowed
AssertionError: the turn written after the torn tail is unreadable
UnicodeDecodeError: invalid continuation byte during JsonlSessionRepo.load_session
```

After the fix:

```text
test_soak_write_after_a_torn_tail_is_not_swallowed[partial-json] PASSED
test_soak_write_after_a_torn_tail_is_not_swallowed[partial-utf8-code-point] PASSED
tests/interactive_shell/sessions/test_store.py: 65 passed
tests/core/: 1971 passed, 16 skipped, 1 xfailed
```

Validation:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run pytest tests/interactive_shell/sessions/test_store.py -q`
- `uv run python -m pytest tests/core/ -q`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The store already holds its per-session file lock while resolving the parent and appending a record. Inside that lock, the change checks the final byte of a non-empty file. If it is not a newline, the writer emits one separator before the new JSON record. This preserves the append-only file, leaves the one crash-damaged record for the decode-failure path to skip, and prevents it from absorbing the next valid turn.

A crash can also stop in the middle of a multibyte UTF-8 code point. I considered decoding with replacement, but that could turn corrupted bytes into apparently valid record content. Instead, both the write-side store and the read-only repository split files into byte lines, decode each line strictly as UTF-8, and reject invalid UTF-8 or JSON only for that line. The same behavior now applies to production restoration, recent-session summaries, and investigation lookup/history.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Allow edits from maintainers is enabled.
