### PR TITLE
fix(shell): Run opensre integrations read-only subcommands in the foreground

### DIFF
--- a/integrations/grafana/verifier.py
+++ b/integrations/grafana/verifier.py
@@ -36,9 +36,13 @@ def _discover_datasources(config: GrafanaIntegrationConfig) -> list[Any] | str:
         detail = f"Datasource discovery failed: HTTP {status} from {url}"
         return f"{detail}: {body}" if body else detail
     except requests.RequestException as exc:
-        return f"Datasource discovery failed: could not reach {config.endpoint} ({exc})."
+        # Keep DETAIL short for the verify table — the full HTTPConnectionPool
+        # dump overflows even with fold, and the endpoint + exception type
+        # are enough to diagnose unreachable Grafana.
+        kind = type(exc).__name__
+        return f"Datasource discovery failed: could not reach {config.endpoint} ({kind})"
     except Exception as exc:
-        return f"Datasource discovery failed: {exc}"
+        return f"Datasource discovery failed: {type(exc).__name__}: {exc}"
 
 
 @register_verifier("grafana")

--- a/surfaces/shared/terminal/health/__init__.py
+++ b/surfaces/shared/terminal/health/__init__.py
@@ -114,10 +114,13 @@ def render_health_report(
     console.print()
 
     table = Table(title="Integration Checks", box=box.SIMPLE_HEAVY, show_lines=False)
-    table.add_column("Service", style=BOLD_BRAND)
-    table.add_column("Source", style=SECONDARY)
-    table.add_column("Status")
-    table.add_column("Detail")
+    table.add_column("Service", style=BOLD_BRAND, no_wrap=True)
+    table.add_column("Source", style=SECONDARY, no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    # Fold long connect-timeout DETAIL so the table stays within the terminal
+    # (and within COLUMNS-minus-prefix when relayed from a background task).
+    detail_width = max(24, min(console.width, 120) - 36)
+    table.add_column("Detail", overflow="fold", max_width=detail_width)
 
     for result in normalized_results:
         table.add_row(

--- a/tests/cli/test_health_view.py
+++ b/tests/cli/test_health_view.py
@@ -1,4 +1,5 @@
 import json
+import re
 from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -130,19 +131,41 @@ def test_render_health_json(capsys) -> None:
 
 
 @patch("infrastructure.safety.guardrails.rules.get_default_rules_path")
-def test_render_health_report_action_messages(mock_rules_path: MagicMock) -> None:
+def test_render_health_report_folds_long_detail(mock_rules_path: MagicMock) -> None:
     mock_rules_path.return_value = Path("/nonexistent/rules")
-
-    # Case 1: All healthy
-    console = Console(file=StringIO(), force_terminal=False, width=100)
+    long_detail = (
+        "Datasource discovery failed: could not reach http://172.29.15.185:3001 "
+        "(HTTPConnectionPool(host='172.29.15.185', port=3001): Max retries exceeded "
+        "with url: /api/datasources (Caused by ConnectTimeoutError(...)))"
+    )
+    console = Console(file=StringIO(), force_terminal=True, width=80)
     render_health_report(
         console=console,
         environment="test",
         integration_store_path="/tmp",
-        results=[{"service": "s1", "status": "passed"}],
+        results=[
+            {
+                "service": "grafana",
+                "source": "local store",
+                "status": "failed",
+                "detail": long_detail,
+            }
+        ],
     )
     output = console.file.getvalue()
-    assert "All configured integrations look healthy." in output
+    assert "grafana" in output
+    assert "FAILED" in output
+    # Detail column is folded so no visible row spans the full dump. Measure the
+    # visible width (strip ANSI colors, which vary with theme state) against the
+    # 80-column terminal, not the raw byte length.
+    strip_ansi = re.compile(r"\x1b\[[0-9;]*m")
+    lines = [
+        strip_ansi.sub("", line)
+        for line in output.splitlines()
+        if "172.29" in line or "ConnectTimeout" in line
+    ]
+    assert lines, output
+    assert all(len(line) <= 80 for line in lines), lines
 
     # Case 2: Some missing
     console = Console(file=StringIO(), force_terminal=False, width=100)

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from typing import Any
 
 import pytest
+import requests
 
 
 @pytest.fixture(autouse=True)
@@ -436,6 +437,29 @@ def test_verify_grafana_passes_with_supported_datasource(monkeypatch: pytest.Mon
     assert result["status"] == "passed"
     assert "loki" in result["detail"]
     assert "prometheus" in result["detail"]
+
+
+def test_verify_grafana_connect_timeout_detail_is_compact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_timeout(*_args: Any, **_kwargs: Any) -> None:
+        raise requests.exceptions.ConnectTimeout(
+            "HTTPConnectionPool(host='172.29.15.185', port=3001): Max retries "
+            "exceeded with url: /api/datasources (Caused by ConnectTimeoutError("
+            "'Connection to 172.29.15.185 timed out. (connect timeout=10)'))"
+        )
+
+    monkeypatch.setattr("integrations.grafana.verifier.requests.get", _raise_timeout)
+
+    result = _verify_grafana(
+        "local env",
+        {"endpoint": "http://172.29.15.185:3001", "api_key": "token"},
+    )
+
+    assert result["status"] == "failed"
+    assert "ConnectTimeout" in result["detail"]
+    assert "HTTPConnectionPool" not in result["detail"]
+    assert len(result["detail"]) < 120
 
 
 def test_verify_datadog_reports_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/interactive_shell/runtime/test_subprocess_runner.py
+++ b/tests/interactive_shell/runtime/test_subprocess_runner.py
@@ -1670,22 +1670,34 @@ def test_run_opensre_cli_command_skips_confirmation_for_investigate(
     assert "may change local config" not in buf.getvalue()
 
 
-def test_run_opensre_cli_command_allows_integrations_list_without_blocking(
+def test_run_opensre_cli_command_runs_integrations_list_in_foreground(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Only the ``setup`` subcommand under ``integrations`` is the wizard.
-    Other ``integrations`` subcommands like ``integrations list`` must
-    not get caught by the interactive-wizard block — guard against an
-    over-broad refusal.
+    """``integrations list`` is read-only: it runs foreground so the action turn
+    observes the result, and is not caught by the interactive-wizard block (only
+    ``integrations setup`` is the wizard). Backgrounding it left the plan parked
+    on a task id while the turn ended.
     """
     start_calls: list[list[str]] = []
 
     def _fake_start_background_cli_task(*, argv_list: list[str], **_kw: object) -> None:
         start_calls.append(argv_list)
 
+    def _fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="SERVICE  STATUS  ID\ngithub   active  github-c943a332\n",
+            stderr="",
+        )
+
     monkeypatch.setattr(
         "surfaces.interactive_shell.runtime.subprocess_runner.start_background_cli_task",
         _fake_start_background_cli_task,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.subprocess_runner.subprocess.run",
+        _fake_run,
     )
 
     session = Session()
@@ -1704,12 +1716,12 @@ def test_run_opensre_cli_command_allows_integrations_list_without_blocking(
     )
 
     out = buf.getvalue()
-    assert "needs a full terminal" not in out
-    # The dispatcher should have reached the background-task path
-    # (proving the wizard block didn't fire).
-    assert start_calls, "background task starter was not invoked"
-    assert "integrations" in start_calls[0]
-    assert "list" in start_calls[0]
+    assert "needs a full terminal" not in out  # wizard block did not fire
+    assert "$ opensre integrations list" in out
+    assert "github-c943a332" in out
+    # Read-only integrations runs foreground, not as a background task, so the
+    # turn observes pass/fail instead of ending on a task id.
+    assert start_calls == []
 
 
 def test_start_background_cli_task_echoes_command_markup_literally(

--- a/tests/tools/interactive_shell/test_opensre_cli_plan.py
+++ b/tests/tools/interactive_shell/test_opensre_cli_plan.py
@@ -1,0 +1,73 @@
+"""Opensre CLI execution-plan policy for read-only vs background commands."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.interactive_shell.cli import (
+    OpensreCommandClass,
+    OpensreExecutionMode,
+    build_opensre_execution_plan,
+    classify_opensre_command,
+)
+
+
+@pytest.mark.parametrize(
+    ("tokens", "classification", "mode"),
+    [
+        (["health"], OpensreCommandClass.READ_ONLY, OpensreExecutionMode.FOREGROUND),
+        (["version"], OpensreCommandClass.READ_ONLY, OpensreExecutionMode.FOREGROUND),
+        (
+            ["integrations", "verify", "grafana"],
+            OpensreCommandClass.READ_ONLY,
+            OpensreExecutionMode.FOREGROUND,
+        ),
+        (
+            ["integrations", "list"],
+            OpensreCommandClass.READ_ONLY,
+            OpensreExecutionMode.FOREGROUND,
+        ),
+        (
+            ["integrations", "show", "grafana"],
+            OpensreCommandClass.READ_ONLY,
+            OpensreExecutionMode.FOREGROUND,
+        ),
+        (
+            ["integrations", "status"],
+            OpensreCommandClass.READ_ONLY,
+            OpensreExecutionMode.FOREGROUND,
+        ),
+        # Bare ``integrations`` defaults to list (read-only foreground).
+        (["integrations"], OpensreCommandClass.READ_ONLY, OpensreExecutionMode.FOREGROUND),
+        (
+            ["integrations", "setup", "grafana"],
+            OpensreCommandClass.MUTATING,
+            OpensreExecutionMode.BACKGROUND,
+        ),
+        (
+            ["investigate", "alert.json"],
+            OpensreCommandClass.INVESTIGATION,
+            OpensreExecutionMode.BACKGROUND,
+        ),
+    ],
+)
+def test_build_opensre_execution_plan_modes(
+    tokens: list[str],
+    classification: OpensreCommandClass,
+    mode: OpensreExecutionMode,
+) -> None:
+    plan = build_opensre_execution_plan(tokens)
+    assert plan.classification is classification
+    assert plan.execution_mode is mode
+    assert classify_opensre_command(tokens) == classification.value
+    if classification is OpensreCommandClass.MUTATING:
+        assert plan.requires_confirmation is True
+    else:
+        assert plan.requires_confirmation is False
+
+
+def test_integrations_verify_is_not_backgrounded() -> None:
+    """Regression: background verify left Invoking tools + 1 task running idle."""
+    plan = build_opensre_execution_plan(["integrations", "verify", "grafana"])
+    assert plan.execution_mode is OpensreExecutionMode.FOREGROUND
+    assert plan.classification is OpensreCommandClass.READ_ONLY

--- a/tools/interactive_shell/cli.py
+++ b/tools/interactive_shell/cli.py
@@ -44,6 +44,18 @@ READ_ONLY_OPENSRE_SUBCOMMANDS: frozenset[str] = frozenset(
     }
 )
 
+# ``opensre integrations <sub>`` — probes and listings must not background, or
+# the action turn ends on "started — task …" while verify still runs and the
+# plan hangs on Invoking tools with "1 task running".
+_READ_ONLY_INTEGRATIONS_SUBCOMMANDS: frozenset[str] = frozenset(
+    {
+        "list",
+        "show",
+        "verify",
+        "status",
+    }
+)
+
 INVESTIGATION_OPENSRE_SUBCOMMANDS: frozenset[str] = frozenset({"investigate"})
 
 
@@ -139,9 +151,23 @@ def interactive_wizard_handoff_response_text(command_str: str) -> str:
     )
 
 
+def _integrations_subcommand(tokens: list[str]) -> str | None:
+    """Return the integrations subcommand, or ``None`` when not an integrations call."""
+    if not tokens or tokens[0].lower() != "integrations":
+        return None
+    return tokens[1].lower() if len(tokens) > 1 else "list"
+
+
+def _is_read_only_integrations(tokens: list[str]) -> bool:
+    sub = _integrations_subcommand(tokens)
+    return sub is not None and sub in _READ_ONLY_INTEGRATIONS_SUBCOMMANDS
+
+
 def classify_opensre_command(tokens: list[str]) -> str:
     first_token = tokens[0].lower()
     if first_token in READ_ONLY_OPENSRE_SUBCOMMANDS:
+        return OpensreCommandClass.READ_ONLY.value
+    if _is_read_only_integrations(tokens):
         return OpensreCommandClass.READ_ONLY.value
     if first_token in INVESTIGATION_OPENSRE_SUBCOMMANDS:
         return OpensreCommandClass.INVESTIGATION.value
@@ -169,6 +195,10 @@ def build_opensre_execution_plan(tokens: list[str]) -> OpensreExecutionPlan:
 
     execution_mode = OpensreExecutionMode.BACKGROUND
     if first_token in READ_ONLY_OPENSRE_SUBCOMMANDS:
+        execution_mode = OpensreExecutionMode.FOREGROUND
+    elif _is_read_only_integrations(tokens):
+        # Wait for verify/list/show so the tool observation includes pass/fail
+        # and the plan can leave Invoking tools instead of parking on a task id.
         execution_mode = OpensreExecutionMode.FOREGROUND
     elif first_token == "fleet":
         subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
@@ -210,7 +240,7 @@ def to_tool_execution_plan(plan: OpensreExecutionPlan) -> ToolExecutionPlan:
             verdict="ask",
             tool_type="cli_command",
             reason=plan.confirmation_reason,
-            hint="Use a read-only subcommand (health, version, list, status, show)",
+            hint="Use a read-only subcommand (health, version, integrations verify/list/show)",
             shell_classification=plan.classification.value,
         )
     return ToolExecutionPlan(


### PR DESCRIPTION
## What
`opensre integrations list/show/verify/status` now run in the foreground
instead of backgrounding, and Grafana verify failures render compactly.

## Why
Backgrounding a read-only `integrations` call ended the action turn on
"started — task …" while `verify` was still running. The pinned plan then hung
on "Invoking tools · 1 task running" with nothing to observe, so the turn went
idle mid-plan. A connect-timeout also dumped the full `HTTPConnectionPool`
string into the verify table, overflowing the terminal.

## Changes
- `tools/interactive_shell/cli.py`: classify `integrations`
  `list`/`show`/`verify`/`status` (and bare `integrations`, which defaults to
  `list`) as read-only and run them foreground; `integrations setup` stays
  mutating/background. Updated the confirmation hint accordingly.
- `integrations/grafana/verifier.py`: on connect failure, report the endpoint
  and exception type, not the full pool/retry dump.
- `surfaces/shared/terminal/health/__init__.py`: fold the Detail column to the
  terminal width so long errors wrap instead of overflowing.

