### PR TITLE
feat(shell): Status labels: Thinking/Executing/Invoking phases + a live shimmer for the running action

### DIFF
--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -253,6 +253,24 @@ def _fg(rgb: tuple[int, int, int]) -> str:
     return f"\x1b[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m"
 
 
+def fade_fg_ansi(intensity: float) -> str:
+    """Foreground between DIM and TEXT.
+
+    ``intensity`` is 0 (DIM) to 1 (TEXT). Live-action glow uses this so
+    runtime code never builds a raw truecolor escape.
+    """
+    clamped = 0.0 if intensity < 0.0 else 1.0 if intensity > 1.0 else intensity
+    dim = _parse_hex_color(_ACTIVE_THEME.DIM)
+    text = _parse_hex_color(_ACTIVE_THEME.TEXT)
+    return _fg(
+        (
+            int(dim[0] + (text[0] - dim[0]) * clamped),
+            int(dim[1] + (text[1] - dim[1]) * clamped),
+            int(dim[2] + (text[2] - dim[2]) * clamped),
+        )
+    )
+
+
 def _parse_hex_color(value: str) -> tuple[int, int, int]:
     stripped = value.lstrip("#")
     return (int(stripped[0:2], 16), int(stripped[2:4], 16), int(stripped[4:6], 16))
@@ -462,6 +480,7 @@ __all__ = [
     "DIM_ANSI",
     "DIM_COUNTER_ANSI",
     "ERROR",
+    "fade_fg_ansi",
     "GLYPH_ACTIVE",
     "GLYPH_BULLET",
     "GLYPH_ERROR",

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -16,7 +16,11 @@ from surfaces.shared.terminal.components.token_format import (
     _CHARS_PER_TOKEN,
     format_token_count_short,
 )
-from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_line_width
+from surfaces.shared.terminal.prompt_layout import (
+    clip_prompt_text,
+    prompt_line_width,
+    prompt_text_width,
+)
 
 # How often prompt-toolkit refreshes prompt callbacks and confirmation polling.
 PROMPT_REFRESH_INTERVAL_S = 0.25
@@ -28,6 +32,15 @@ DEFAULT_CONFIRM_OPTIONS: tuple[tuple[str, str], ...] = (
     ("y", "Yes, allow"),
     ("n", "No, cancel"),
 )
+
+
+@dataclass
+class _InFlightAction:
+    """One still-running tool shown (or queued) on the live action row."""
+
+    action_id: str
+    text: str
+    started_at: float
 
 
 class TurnPhase(enum.Enum):
@@ -246,12 +259,10 @@ class SpinnerState:
     # Verbs picked twice as often as the rest of their pool (default weight 1).
     _VERB_WEIGHTS = {"jacking in": 2, "crawling the datastream": 2}
 
-    # White-glow shimmer for the running action line: a triangle wave over this
-    # period drives brightness between the two levels below (pure function of the
-    # clock, like the spinner glyph, so it never freezes on a busy render pass).
+    # Theme-token shimmer for the running action line: a triangle wave over this
+    # period fades DIM → TEXT → DIM (pure function of the clock, like the
+    # spinner glyph, so it never freezes on a busy render pass).
     _SHIMMER_PERIOD_SECONDS = 1.1
-    _SHIMMER_MIN_LEVEL = 150
-    _SHIMMER_MAX_LEVEL = 255
     _ACTION_GLYPH = "⟩"
 
     def __init__(self) -> None:
@@ -261,35 +272,67 @@ class SpinnerState:
         self._verb_tier: int = 0
         self._verb: str = self._VERB_TIERS[0][1][0]
         self.phase: str = ""
-        # The action currently running, shown shimmering in the live region and
-        # committed as a solid line to scrollback when it ends. Empty when none.
-        self.active_action: str = ""
-        self._action_started_at: float = 0.0
+        # In-flight tools in start order. The live row shows the first still
+        # running; the ReAct loop emits every start before any end, so a single
+        # slot would display the last tool and clear on the first completion.
+        self._in_flight_actions: list[_InFlightAction] = []
 
-    def set_active_action(self, text: str) -> None:
-        """Show ``text`` as the running action line (white-glow shimmer)."""
-        self.active_action = text.strip()
-        self._action_started_at = time.monotonic()
+    @property
+    def active_action(self) -> str:
+        """Text of the first still-running action, or empty."""
+        return self._in_flight_actions[0].text if self._in_flight_actions else ""
 
-    def clear_active_action(self) -> None:
-        self.active_action = ""
+    def set_active_action(self, text: str, *, action_id: str = "") -> None:
+        """Show ``text`` as a running action (theme-token shimmer).
+
+        Distinct ``action_id`` values stack so a batched start does not
+        overwrite an earlier tool. The same id updates that slot in place.
+        """
+        cleaned = text.strip()
+        started_at = time.monotonic()
+        if action_id:
+            for existing in self._in_flight_actions:
+                if existing.action_id == action_id:
+                    existing.text = cleaned
+                    existing.started_at = started_at
+                    return
+        self._in_flight_actions.append(
+            _InFlightAction(action_id=action_id, text=cleaned, started_at=started_at)
+        )
+
+    def clear_active_action(self, action_id: str | None = None) -> None:
+        """Drop one in-flight action, or all of them.
+
+        ``None`` clears every slot. A non-empty ``action_id`` removes that
+        tool only. An empty string pops the oldest slot (events that omitted
+        an id).
+        """
+        if action_id is None:
+            self._in_flight_actions.clear()
+            return
+        if action_id:
+            self._in_flight_actions = [
+                action for action in self._in_flight_actions if action.action_id != action_id
+            ]
+            return
+        if self._in_flight_actions:
+            del self._in_flight_actions[0]
 
     def active_action_ansi(self) -> str:
         """The indented, shimmering action line, or ``""`` when none is running.
 
-        The glow is a triangle wave on a white foreground, so the line reads as
-        live work in progress; scrollback holds the settled solid copy.
+        The glow fades DIM to TEXT on a triangle wave so the line reads as
+        live work; scrollback holds the settled solid copy.
         """
-        if not self.active_action:
+        current = self._in_flight_actions[0] if self._in_flight_actions else None
+        if current is None:
             return ""
-        elapsed = time.monotonic() - self._action_started_at
+        elapsed = time.monotonic() - current.started_at
         phase = (elapsed % self._SHIMMER_PERIOD_SECONDS) / self._SHIMMER_PERIOD_SECONDS
         triangle = 1.0 - abs(2.0 * phase - 1.0)  # 0 → 1 → 0 over the period
-        span = self._SHIMMER_MAX_LEVEL - self._SHIMMER_MIN_LEVEL
-        level = self._SHIMMER_MIN_LEVEL + int(triangle * span)
-        glow = f"\x1b[38;2;{level};{level};{level}m"
+        glow = ui_theme.fade_fg_ansi(triangle)
         lead = f"  {self._ACTION_GLYPH} "
-        text = clip_prompt_text(self.active_action, prompt_line_width() - len(lead))
+        text = clip_prompt_text(current.text, prompt_line_width() - prompt_text_width(lead))
         return f"{glow}{lead}{text}{ui_theme.ANSI_RESET}"
 
     def start(self) -> None:
@@ -299,6 +342,7 @@ class SpinnerState:
         self._verb_tier = 0
         self._verb = self._pick_verb()
         self.phase = self.EXECUTING_PHASE
+        self._in_flight_actions.clear()
 
     def advance_verb(self) -> None:
         """Pick a fresh thinking verb (the rotation cadence is the caller's).
@@ -353,6 +397,7 @@ class SpinnerState:
     def stop(self) -> None:
         self.streaming = False
         self.phase = ""
+        self._in_flight_actions.clear()
 
     def toolbar_ansi(self) -> str:
         # Always return an empty string so prompt_toolkit's ConditionalContainer
@@ -413,7 +458,7 @@ class SpinnerState:
         tail = f" {self._STOP_HINT}  {elapsed_badge}"
         accent = self._phase_accent_ansi()
         width = prompt_line_width()
-        reserved = len(lead) + len(tail)
+        reserved = prompt_text_width(lead) + prompt_text_width(tail)
         if reserved >= width:
             visible = clip_prompt_text(f"{lead}{label}{tail}", width)
             return f"{accent}{visible}{ui_theme.ANSI_RESET}"

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -193,7 +193,12 @@ class SpinnerState:
     # render pass (layout measurement + paint), so a per-call counter can land
     # on the same frame every visible render and freeze the animation.
     _FRAME_INTERVAL_SECONDS = 0.1
-    EXECUTING_PHASE = "Thinking…"
+    # Load-state labels for the live spinner, escalating with the turn stage:
+    # waiting on the model (THINKING) → dispatching / between tools (EXECUTING)
+    # → a tool is running (INVOKING_TOOLS). Each renders in a distinct accent so
+    # a glance tells LLM latency from tool work.
+    THINKING_PHASE = "Thinking…"
+    EXECUTING_PHASE = "Executing…"
     INVOKING_TOOLS_PHASE = "Invoking tools…"
     _STOP_HINT = "(Press ESC to stop)"
     # Netrunner verb pools, escalating with time spent in the net: the longer
@@ -241,6 +246,14 @@ class SpinnerState:
     # Verbs picked twice as often as the rest of their pool (default weight 1).
     _VERB_WEIGHTS = {"jacking in": 2, "crawling the datastream": 2}
 
+    # White-glow shimmer for the running action line: a triangle wave over this
+    # period drives brightness between the two levels below (pure function of the
+    # clock, like the spinner glyph, so it never freezes on a busy render pass).
+    _SHIMMER_PERIOD_SECONDS = 1.1
+    _SHIMMER_MIN_LEVEL = 150
+    _SHIMMER_MAX_LEVEL = 255
+    _ACTION_GLYPH = "⟩"
+
     def __init__(self) -> None:
         self.streaming: bool = False
         self.started_at: float = 0.0
@@ -248,6 +261,36 @@ class SpinnerState:
         self._verb_tier: int = 0
         self._verb: str = self._VERB_TIERS[0][1][0]
         self.phase: str = ""
+        # The action currently running, shown shimmering in the live region and
+        # committed as a solid line to scrollback when it ends. Empty when none.
+        self.active_action: str = ""
+        self._action_started_at: float = 0.0
+
+    def set_active_action(self, text: str) -> None:
+        """Show ``text`` as the running action line (white-glow shimmer)."""
+        self.active_action = text.strip()
+        self._action_started_at = time.monotonic()
+
+    def clear_active_action(self) -> None:
+        self.active_action = ""
+
+    def active_action_ansi(self) -> str:
+        """The indented, shimmering action line, or ``""`` when none is running.
+
+        The glow is a triangle wave on a white foreground, so the line reads as
+        live work in progress; scrollback holds the settled solid copy.
+        """
+        if not self.active_action:
+            return ""
+        elapsed = time.monotonic() - self._action_started_at
+        phase = (elapsed % self._SHIMMER_PERIOD_SECONDS) / self._SHIMMER_PERIOD_SECONDS
+        triangle = 1.0 - abs(2.0 * phase - 1.0)  # 0 → 1 → 0 over the period
+        span = self._SHIMMER_MAX_LEVEL - self._SHIMMER_MIN_LEVEL
+        level = self._SHIMMER_MIN_LEVEL + int(triangle * span)
+        glow = f"\x1b[38;2;{level};{level};{level}m"
+        lead = f"  {self._ACTION_GLYPH} "
+        text = clip_prompt_text(self.active_action, prompt_line_width() - len(lead))
+        return f"{glow}{lead}{text}{ui_theme.ANSI_RESET}"
 
     def start(self) -> None:
         self.streaming = True
@@ -336,14 +379,17 @@ class SpinnerState:
         )
 
     def _phase_accent_ansi(self) -> str:
-        """Accent for the spinner lead+label; tool phase uses brand, not highlight.
+        """Accent for the spinner lead+label, distinct per load-state phase.
 
-        ``Thinking…`` / stage labels stay on the prompt accent (bold highlight).
-        ``Invoking tools…`` uses bold brand so the line under the plan reads as a
-        distinct activity color — same stack as Droid, different hue from thinking.
+        ``Thinking…`` (and pipeline stage labels) stay on the prompt accent (bold
+        highlight); ``Executing…`` uses brand; ``Invoking tools…`` uses bold
+        brand — the same hue as executing but heavier, so tool work reads as the
+        hottest state while staying different from thinking.
         """
         if self.phase == self.INVOKING_TOOLS_PHASE:
             return ui_theme.BOLD_BRAND_ANSI
+        if self.phase == self.EXECUTING_PHASE:
+            return ui_theme.BRAND_ANSI
         return ui_theme.PROMPT_ACCENT_ANSI
 
     def inline_spinner_ansi(self) -> str:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -319,7 +319,7 @@ class ActionRenderObserver:
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         if kind == "llm_start":
-            self._set_spinner_phase(SpinnerState.EXECUTING_PHASE)
+            self._set_spinner_phase(SpinnerState.THINKING_PHASE)
             self._advance_spinner_verb(data)
             return
         if kind == "message_update":
@@ -341,6 +341,7 @@ class ActionRenderObserver:
             # update_plan is not painted into the transcript: the plan renders in
             # the pinned bottom overlay (``task_plan_overlay_ansi``) from session
             # state the tool committed.
+            self._clear_active_action()
             self._set_spinner_phase(SpinnerState.EXECUTING_PHASE)
             return
         if kind != "tool_start":
@@ -361,6 +362,7 @@ class ActionRenderObserver:
             self._render_tool_invocation(name, data)
         if name not in _SKIP_PLAN_WORK_TOOLS and not _is_internal_choice_command(name, data):
             self._record_plan_work(name, data)
+            self._set_active_action(name, data)
         if self.planned_count == 0 and name not in SELF_RECORDING_ACTION_TOOL_NAMES:
             self.session.record("cli_agent", self.message)
         self.planned_count += 1
@@ -381,6 +383,24 @@ class ActionRenderObserver:
         spinner = get_investigation_spinner()
         if spinner is not None and getattr(spinner, "streaming", False):
             spinner.set_phase(label)
+
+    def _set_active_action(self, name: str, data: dict[str, Any]) -> None:
+        """Show the running tool as a shimmering action line in the live region.
+
+        The line clears on ``tool_end``; scrollback keeps the settled solid copy.
+        Only relabels an already-running spinner (see ``_set_spinner_phase``).
+        """
+        spinner = get_investigation_spinner()
+        if spinner is None or not getattr(spinner, "streaming", False):
+            return
+        args = data.get("input")
+        label, content = tool_call_display(name, args if isinstance(args, dict) else {})
+        spinner.set_active_action(f"{label} · {content}" if content else label)
+
+    def _clear_active_action(self) -> None:
+        spinner = get_investigation_spinner()
+        if spinner is not None:
+            spinner.clear_active_action()
 
     def _advance_spinner_verb(self, data: dict[str, Any]) -> None:
         """Rotate the prompt spinner's thinking verb every two agent steps.

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -84,8 +84,19 @@ _SELF_RENDERING_TOOLS: frozenset[str] = frozenset(
     {
         ActionToolName.ASK_USER_CHOICE,
         ActionToolName.INVESTIGATION_START,
+        # shell_run / cli_exec stream their own ``$ <command>`` + output during
+        # execution, and the running action shows as the live shimmer line — so a
+        # static ``Execute``/``opensre`` header here would print the command a
+        # third time. Suppress it; the shimmer and the ``$`` line are enough.
+        ActionToolName.SHELL_RUN,
+        ActionToolName.CLI_EXEC,
     }
 )
+
+
+def _tool_event_id(data: dict[str, Any]) -> str:
+    """Stable id for one tool call, or empty when the event omitted it."""
+    return str(data.get("id") or data.get("tool_call_id") or "").strip()
 
 
 def _is_internal_choice_command(name: str, data: dict[str, Any]) -> bool:
@@ -341,8 +352,9 @@ class ActionRenderObserver:
             # update_plan is not painted into the transcript: the plan renders in
             # the pinned bottom overlay (``task_plan_overlay_ansi``) from session
             # state the tool committed.
-            self._clear_active_action()
-            self._set_spinner_phase(SpinnerState.EXECUTING_PHASE)
+            self._clear_active_action(data)
+            if not self._has_active_action():
+                self._set_spinner_phase(SpinnerState.EXECUTING_PHASE)
             return
         if kind != "tool_start":
             return
@@ -387,20 +399,30 @@ class ActionRenderObserver:
     def _set_active_action(self, name: str, data: dict[str, Any]) -> None:
         """Show the running tool as a shimmering action line in the live region.
 
-        The line clears on ``tool_end``; scrollback keeps the settled solid copy.
-        Only relabels an already-running spinner (see ``_set_spinner_phase``).
+        Stacked by tool-call id: the ReAct loop emits every ``tool_start``
+        before executing the batch, so a single slot would show the last
+        tool and clear on the first ``tool_end``. Scrollback keeps the
+        settled solid copy. Only relabels an already-running spinner
+        (see ``_set_spinner_phase``).
         """
         spinner = get_investigation_spinner()
         if spinner is None or not getattr(spinner, "streaming", False):
             return
         args = data.get("input")
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
-        spinner.set_active_action(f"{label} · {content}" if content else label)
+        spinner.set_active_action(
+            f"{label} · {content}" if content else label,
+            action_id=_tool_event_id(data),
+        )
 
-    def _clear_active_action(self) -> None:
+    def _clear_active_action(self, data: dict[str, Any]) -> None:
         spinner = get_investigation_spinner()
         if spinner is not None:
-            spinner.clear_active_action()
+            spinner.clear_active_action(_tool_event_id(data))
+
+    def _has_active_action(self) -> bool:
+        spinner = get_investigation_spinner()
+        return bool(spinner is not None and spinner.active_action)
 
     def _advance_spinner_verb(self, data: dict[str, Any]) -> None:
         """Rotate the prompt spinner's thinking verb every two agent steps.

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -109,9 +109,13 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
+    # The running action shimmers on its own row between the status line and the
+    # autonomy line; scrollback keeps the settled solid copy.
+    action = strip_cpr_sequences(spinner.active_action_ansi())
+    action_line = f"{action}\n" if action else ""
     # A blank row separates the plan block from the status line so the checklist
     # reads as its own element, not flush against the prompt.
-    return ANSI(f"\n{plan_prefix}{prefix}\n{auto_line}\n{base}")
+    return ANSI(f"\n{plan_prefix}{prefix}\n{action_line}{auto_line}\n{base}")
 
 
 _CONFIRM_HINT = "↑↓ Navigate • Enter confirm • Esc cancel"

--- a/surfaces/shared/terminal/prompt_layout.py
+++ b/surfaces/shared/terminal/prompt_layout.py
@@ -9,6 +9,7 @@ drifts, leaving stale frames in scrollback.
 from __future__ import annotations
 
 from prompt_toolkit.application.current import get_app_or_none
+from prompt_toolkit.utils import get_cwidth
 
 from infrastructure.safety.terminal_output import strip_terminal_controls
 
@@ -32,14 +33,38 @@ def prompt_line_width(cols: int | None = None) -> int:
     return max(width - 1, 1)
 
 
+def prompt_text_width(text: str) -> int:
+    """Terminal columns occupied by ``text`` after stripping controls.
+
+    Counts display width, not code points: CJK and emoji are typically two
+    columns, so a live row clipped by ``len()`` can still soft-wrap.
+    """
+    return get_cwidth(strip_terminal_controls(text))
+
+
 def clip_prompt_text(text: str, max_len: int) -> str:
-    """Truncate to ``max_len`` visible characters after stripping controls."""
+    """Truncate to ``max_len`` terminal columns after stripping controls."""
     visible = strip_terminal_controls(text)
     if max_len <= 0:
         return ""
-    if len(visible) <= max_len:
+    if prompt_text_width(visible) <= max_len:
         return visible
-    return visible[: max_len - 1] + "…"
+    budget = max_len - 1  # one column for the ellipsis
+    clipped: list[str] = []
+    used = 0
+    for char in visible:
+        width = get_cwidth(char)
+        if used + width > budget:
+            break
+        clipped.append(char)
+        used += width
+    return "".join(clipped) + "…"
 
 
-__all__ = ["DEFAULT_TERMINAL_COLUMNS", "clip_prompt_text", "prompt_line_width", "terminal_columns"]
+__all__ = [
+    "DEFAULT_TERMINAL_COLUMNS",
+    "clip_prompt_text",
+    "prompt_line_width",
+    "prompt_text_width",
+    "terminal_columns",
+]

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -83,6 +83,20 @@ def test_muted_tokens_are_readable_on_theme_background() -> None:
         assert _contrast(theme.DIM, theme.BG) >= 3.0, name
 
 
+def test_fade_fg_ansi_interpolates_dim_to_text() -> None:
+    """Live-action glow must come from theme tokens, not a raw RGB escape."""
+    from infrastructure.terminal import theme as ui_theme
+
+    ui_theme.set_active_theme("solarized")
+    assert ui_theme.fade_fg_ansi(0.0) == ui_theme.DIM_ANSI
+    assert ui_theme.fade_fg_ansi(1.0) == ui_theme.TEXT_ANSI
+    assert ui_theme.fade_fg_ansi(0.0) != ui_theme.fade_fg_ansi(1.0)
+    mid = ui_theme.fade_fg_ansi(0.5)
+    assert mid.startswith("\x1b[38;2;")
+    assert mid != ui_theme.DIM_ANSI
+    assert mid != ui_theme.TEXT_ANSI
+
+
 def test_palette_registry_keys_match_the_config_vocabulary() -> None:
     """The infra palettes must cover exactly the config-owned theme names.
 

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -109,32 +109,60 @@ def test_spinner_empty_when_not_streaming() -> None:
 
 def test_inline_spinner_clips_a_long_phase_to_one_prompt_row() -> None:
     """A long phase label must not soft-wrap past the one reserved prompt row."""
-    from surfaces.shared.terminal.prompt_layout import prompt_line_width
+    from surfaces.shared.terminal.prompt_layout import prompt_line_width, prompt_text_width
 
     spinner = SpinnerState()
     spinner.start()
     spinner.set_phase("X" * 400)
     rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
 
-    assert len(rendered) <= prompt_line_width()
+    assert prompt_text_width(rendered) <= prompt_line_width()
 
 
 def test_active_action_shimmer_renders_indented_glow_and_clears() -> None:
-    """The running action shows an indented white-glow line; cleared → blank."""
+    """The running action shows an indented theme-token glow; cleared → blank."""
+    from infrastructure.terminal.theme import fade_fg_ansi, set_active_theme
+
+    set_active_theme("solarized")
     spinner = SpinnerState()
     spinner.start()
     assert spinner.active_action_ansi() == ""  # none by default
 
     spinner.set_active_action("Execute · cd /tmp")
+    started = time.monotonic() - SpinnerState._SHIMMER_PERIOD_SECONDS / 2
+    spinner._in_flight_actions[0].started_at = started
     rendered = spinner.active_action_ansi()
+    elapsed = time.monotonic() - started
+    phase = (elapsed % SpinnerState._SHIMMER_PERIOD_SECONDS) / SpinnerState._SHIMMER_PERIOD_SECONDS
+    triangle = 1.0 - abs(2.0 * phase - 1.0)
     assert "Execute · cd /tmp" in rendered
     assert SpinnerState._ACTION_GLYPH in rendered
-    # White glow: a 24-bit grey foreground (R == G == B) within the shimmer band.
-    match = re.search(r"\x1b\[38;2;(\d+);(\d+);(\d+)m", rendered)
-    assert match is not None
-    red, green, blue = (int(match.group(i)) for i in (1, 2, 3))
-    assert red == green == blue
-    assert SpinnerState._SHIMMER_MIN_LEVEL <= red <= SpinnerState._SHIMMER_MAX_LEVEL
+    assert fade_fg_ansi(triangle) in rendered
 
     spinner.clear_active_action()
     assert spinner.active_action_ansi() == ""
+
+
+def test_active_action_stack_keeps_earlier_tools_until_they_end() -> None:
+    """A later start must not overwrite an earlier still-running tool."""
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_active_action("GitHub CLI · gh pr list", action_id="a")
+    spinner.set_active_action("Execute · true", action_id="b")
+    assert spinner.active_action.startswith("GitHub CLI")
+
+    spinner.clear_active_action("a")
+    assert spinner.active_action.startswith("Execute")
+    spinner.clear_active_action("b")
+    assert spinner.active_action == ""
+
+
+def test_active_action_row_clips_wide_glyphs_to_one_prompt_column_budget() -> None:
+    """CJK / emoji must be measured in terminal columns, not code points."""
+    from surfaces.shared.terminal.prompt_layout import prompt_line_width, prompt_text_width
+
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_active_action("查询 · " + "中" * 200)
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.active_action_ansi())
+    assert prompt_text_width(rendered) <= prompt_line_width()

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -69,24 +69,34 @@ def test_spinner_invoking_tools_phase_matches_factory_copy() -> None:
     assert "(Press ESC to stop)" in rendered
 
 
-def test_invoking_tools_uses_brand_accent_not_highlight() -> None:
-    """Tool phase is brand-colored so it contrasts with Thinking (highlight)."""
+def test_load_state_phases_use_distinct_accents() -> None:
+    """Thinking=highlight, Executing=brand, Invoking tools=bold brand — a glance
+    tells LLM latency (thinking) from tool work (invoking)."""
     from infrastructure.terminal.theme import set_active_theme
 
     set_active_theme("blue")
     spinner = SpinnerState()
     spinner.start()
-    thinking = spinner.inline_spinner_ansi()
+
+    spinner.set_phase(SpinnerState.THINKING_PHASE)
+    thinking = spinner.inline_spinner_ansi().split("(Press ESC")[0]
+    assert SpinnerState.THINKING_PHASE in thinking
     assert "168;212;255" in thinking  # highlight
-    assert "111;165;216" not in thinking.split("(Press ESC")[0]
+    assert "111;165;216" not in thinking  # not brand
+
+    spinner.set_phase(SpinnerState.EXECUTING_PHASE)
+    executing = spinner.inline_spinner_ansi().split("(Press ESC")[0]
+    assert SpinnerState.EXECUTING_PHASE in executing
+    assert "111;165;216" in executing  # brand
+    assert "168;212;255" not in executing  # not highlight
+    assert "\x1b[1m" not in executing  # brand is not bold in the executing phase
 
     spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
-    invoking = spinner.inline_spinner_ansi()
+    invoking = spinner.inline_spinner_ansi().split("(Press ESC")[0]
     assert SpinnerState.INVOKING_TOOLS_PHASE in invoking
     assert "111;165;216" in invoking  # brand
-    # Lead+label must not stay on highlight once tools are invoking.
-    lead = invoking.split("(Press ESC")[0]
-    assert "168;212;255" not in lead
+    assert "\x1b[1m" in invoking  # bold brand — the hottest state
+    assert "168;212;255" not in invoking  # not highlight
 
 
 def test_spinner_empty_when_not_streaming() -> None:
@@ -107,3 +117,24 @@ def test_inline_spinner_clips_a_long_phase_to_one_prompt_row() -> None:
     rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
 
     assert len(rendered) <= prompt_line_width()
+
+
+def test_active_action_shimmer_renders_indented_glow_and_clears() -> None:
+    """The running action shows an indented white-glow line; cleared → blank."""
+    spinner = SpinnerState()
+    spinner.start()
+    assert spinner.active_action_ansi() == ""  # none by default
+
+    spinner.set_active_action("Execute · cd /tmp")
+    rendered = spinner.active_action_ansi()
+    assert "Execute · cd /tmp" in rendered
+    assert SpinnerState._ACTION_GLYPH in rendered
+    # White glow: a 24-bit grey foreground (R == G == B) within the shimmer band.
+    match = re.search(r"\x1b\[38;2;(\d+);(\d+);(\d+)m", rendered)
+    assert match is not None
+    red, green, blue = (int(match.group(i)) for i in (1, 2, 3))
+    assert red == green == blue
+    assert SpinnerState._SHIMMER_MIN_LEVEL <= red <= SpinnerState._SHIMMER_MAX_LEVEL
+
+    spinner.clear_active_action()
+    assert spinner.active_action_ansi() == ""

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -713,14 +713,15 @@ class TestSpinnerState:
         assert spinner.streaming is False
         assert spinner.inline_spinner_ansi() == ""
 
-    def test_inline_spinner_uses_active_theme_highlight(self) -> None:
+    def test_inline_spinner_thinking_uses_active_theme_highlight(self) -> None:
         from infrastructure.terminal.theme import set_active_theme
 
         set_active_theme("blue")
         spinner = loop_state.SpinnerState()
         spinner.start()
+        spinner.set_phase(loop_state.SpinnerState.THINKING_PHASE)
         raw = spinner.inline_spinner_ansi()
-        assert "168;212;255" in raw
+        assert "168;212;255" in raw  # highlight — the Thinking accent
         assert "185;237;175" not in raw
 
     def test_inline_spinner_invoking_tools_uses_brand(self) -> None:

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -573,3 +573,33 @@ def test_update_plan_is_not_dumped_into_the_transcript() -> None:
     assert "Plan ready" not in output
     assert "Measure wait vs work" not in output
     assert "p99 up" not in output
+
+
+def test_observer_drives_load_state_phases_by_turn_stage() -> None:
+    """The spinner label tracks the stage: llm_start → Thinking, tool_start →
+    Invoking tools, tool_end → Executing. Never a stale label, never blank."""
+    from surfaces.interactive_shell.runtime.core.state import SpinnerState
+    from surfaces.shared.terminal.output.console_state import set_investigation_spinner
+
+    spinner = SpinnerState()
+    spinner.start()  # initial dispatch shows Executing
+    assert spinner.phase == SpinnerState.EXECUTING_PHASE
+    set_investigation_spinner(spinner)
+    try:
+        console = Console(file=io.StringIO(), force_terminal=False)
+        observer = ActionRenderObserver(session=Session(), console=console, message="do it")
+
+        observer("llm_start", {})
+        assert spinner.phase == SpinnerState.THINKING_PHASE
+
+        observer("tool_start", {"name": "shell_run", "input": {"command": "true"}})
+        assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
+        # The running action shows as a shimmering live line.
+        assert "Execute" in spinner.active_action
+        assert "true" in spinner.active_action
+
+        observer("tool_end", {"name": "shell_run"})
+        assert spinner.phase == SpinnerState.EXECUTING_PHASE
+        assert spinner.active_action == ""  # cleared; scrollback keeps the solid copy
+    finally:
+        set_investigation_spinner(None)

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -603,3 +603,84 @@ def test_observer_drives_load_state_phases_by_turn_stage() -> None:
         assert spinner.active_action == ""  # cleared; scrollback keeps the solid copy
     finally:
         set_investigation_spinner(None)
+
+
+def test_batched_tool_starts_keep_the_first_action_until_it_ends() -> None:
+    """The loop emits every tool_start before any tool_end.
+
+    The live row must keep the first still-running tool (not the last start)
+    and must stay on Invoking tools until the last in-flight call ends.
+    """
+    from surfaces.interactive_shell.runtime.core.state import SpinnerState
+    from surfaces.shared.terminal.output.console_state import set_investigation_spinner
+
+    spinner = SpinnerState()
+    spinner.start()
+    set_investigation_spinner(spinner)
+    try:
+        observer, _buffer = _observer_with_buffer("do both")
+        observer(
+            "tool_start",
+            {
+                "id": "a",
+                "name": "github_cli",
+                "input": {"repo": "acme/app", "args": ["pr", "list"]},
+            },
+        )
+        observer("tool_start", {"id": "b", "name": "shell_run", "input": {"command": "true"}})
+        assert "GitHub CLI" in spinner.active_action
+        assert "true" not in spinner.active_action
+        assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
+
+        observer("tool_end", {"id": "a", "name": "github_cli"})
+        assert "Execute" in spinner.active_action
+        assert "true" in spinner.active_action
+        assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
+
+        observer("tool_end", {"id": "b", "name": "shell_run"})
+        assert spinner.active_action == ""
+        assert spinner.phase == SpinnerState.EXECUTING_PHASE
+    finally:
+        set_investigation_spinner(None)
+
+
+def test_untracked_tool_end_does_not_clear_a_running_action() -> None:
+    """update_plan never owns the live row; its end must not wipe another tool."""
+    from surfaces.interactive_shell.runtime.core.state import SpinnerState
+    from surfaces.shared.terminal.output.console_state import set_investigation_spinner
+
+    spinner = SpinnerState()
+    spinner.start()
+    set_investigation_spinner(spinner)
+    try:
+        observer, _buffer = _observer_with_buffer("plan while running")
+        observer("tool_start", {"id": "a", "name": "shell_run", "input": {"command": "true"}})
+        observer(
+            "tool_end",
+            {"id": "p1", "name": "update_plan", "output": {"ok": True, "total": 1}},
+        )
+        assert "true" in spinner.active_action
+        assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
+    finally:
+        set_investigation_spinner(None)
+
+
+def test_command_tools_suppress_the_static_action_header() -> None:
+    """shell_run / cli_exec stream their own ``$ <cmd>`` + output; the observer
+    must not also print an Execute/opensre header (the running action shows as
+    the live shimmer, and scrollback keeps the ``$`` line)."""
+    for name, key, cmd in (
+        ("shell_run", "command", "echo hi"),
+        ("cli_exec", "payload", "integrations list"),
+    ):
+        buf = io.StringIO()
+        observer = ActionRenderObserver(
+            session=Session(),
+            console=Console(file=buf, force_terminal=False, highlight=False),
+            message="do it",
+        )
+        observer("tool_start", {"name": name, "input": {key: cmd}})
+        out = buf.getvalue()
+        assert "Execute" not in out
+        assert "opensre" not in out
+        assert cmd not in out  # header suppressed; the $cmd line comes from the presenter

--- a/tests/shared/terminal/test_prompt_layout.py
+++ b/tests/shared/terminal/test_prompt_layout.py
@@ -1,0 +1,16 @@
+"""Prompt-region width and clipping."""
+
+from __future__ import annotations
+
+from surfaces.shared.terminal.prompt_layout import clip_prompt_text, prompt_text_width
+
+
+def test_clip_prompt_text_limits_terminal_columns_not_codepoints() -> None:
+    """CJK and emoji occupy two columns; clipping by ``len()`` would wrap."""
+    clipped = clip_prompt_text("中" * 10, 10)
+    assert clipped == "中中中中…"
+    assert prompt_text_width(clipped) <= 10
+
+    emoji = clip_prompt_text("👋" * 8, 7)
+    assert emoji.endswith("…")
+    assert prompt_text_width(emoji) <= 7


### PR DESCRIPTION
Status labels: Thinking/Executing/Invoking phases + a live shimmer for the running action. Status labels: Thinking / Executing / Invoking + a live shimmer for the running action. 

## What

Differentiates the interactive-shell load-state spinner into three labelled,
distinctly-coloured phases, and adds a live white-glow shimmer for the action
currently running — so a glance tells LLM latency from tool work, and the
screen is never blank or stuck on a stale label.

## Why

The spinner had two effective states and a mislabeled constant
(`EXECUTING_PHASE = "Thinking…"`), so "waiting on the model" and "running a
tool" looked the same, and a running command showed only as static scrollback
with no live "this is happening now" signal.