### PR TITLE
docs: fix wrong tier anchor in tool-placement-policy link

### DIFF
--- a/docs/tool-placement-policy.md
+++ b/docs/tool-placement-policy.md
@@ -3,7 +3,7 @@
 Where a piece of agent-callable capability lives is decided by **how many
 vendor integrations its domain logic touches**, not by convenience or file
 size. This is the decision rule referenced from
-[ARCHITECTURE.md](ARCHITECTURE.md#tier-2--tools-and-integrations).
+[ARCHITECTURE.md](ARCHITECTURE.md#tier-3--tools-and-integrations).
 
 ## Decision rule
 


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

One-line documentation fix: `docs/tool-placement-policy.md` links to the wrong section anchor in `docs/ARCHITECTURE.md`.

**The problem.** Line 6 reads:

```
This is the decision rule referenced from
[ARCHITECTURE.md](ARCHITECTURE.md#tier-2--tools-and-integrations).
```

But in `ARCHITECTURE.md` the tiers are:

- `### Tier 2 — \`bootstrap\`` &rarr; anchor `#tier-2--bootstrap`
- `### Tier 3 — \`tools\` and \`integrations\`` &rarr; anchor `#tier-3--tools-and-integrations`

So `#tier-2--tools-and-integrations` matches **no** heading — GitHub resolves it to nothing and the link jumps nowhere. The intended target is clearly the *tools and integrations* tier (the anchor text already says `tools-and-integrations`), which is **Tier 3**, not Tier 2 (`bootstrap`). Only the tier number was off by one.

**The fix.** `#tier-2--tools-and-integrations` &rarr; `#tier-3--tools-and-integrations` (one character).

### Demo/Screenshot for feature changes and bug fixes -

Reproduce the broken anchor and confirm the fix against GitHub's heading-slug rules:

```
$ grep -n '^###' docs/ARCHITECTURE.md | grep -i tier
103:### Tier 2 — `bootstrap`
121:### Tier 3 — `tools` and `integrations`

# GitHub slug of "Tier 3 — `tools` and `integrations`"
#   lowercase, drop punctuation (—, backticks), spaces->hyphens
#   => tier-3--tools-and-integrations   (matches the corrected link)
#   => tier-2--tools-and-integrations   (old link) matches no heading
```

Before: the link in `tool-placement-policy.md` points at `#tier-2--tools-and-integrations` (dead — Tier 2 is `bootstrap`).
After: it points at `#tier-3--tools-and-integrations`, which jumps to the correct `### Tier 3 — \`tools\` and \`integrations\`` section.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

_(Documentation-only change: a single-character correction to one Markdown section anchor. No application code touched.)_

**Explain your implementation approach:**

- *What problem does your code solve?* A cross-doc link resolved to a non-existent anchor, so readers of the tool-placement policy who clicked through to the architecture tiers landed nowhere.
- *Why this implementation?* The anchor text already read `tools-and-integrations`, which is unambiguously Tier 3 in `ARCHITECTURE.md`; the only error was the tier number. Correcting `tier-2` to `tier-3` is the minimal, exact fix and needs no other edits.
