### PR TITLE
fix(shell): Fix: an untracked tool_end clears only an id-less action shimmer, never a named one

### DIFF
--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -304,8 +304,8 @@ class SpinnerState:
         """Drop one in-flight action, or all of them.
 
         ``None`` clears every slot. A non-empty ``action_id`` removes that
-        tool only. An empty string pops the oldest slot (events that omitted
-        an id).
+        tool only. An empty string pops the oldest slot that also omitted
+        an id, so an untracked ``tool_end`` cannot wipe a named action.
         """
         if action_id is None:
             self._in_flight_actions.clear()
@@ -315,8 +315,10 @@ class SpinnerState:
                 action for action in self._in_flight_actions if action.action_id != action_id
             ]
             return
-        if self._in_flight_actions:
-            del self._in_flight_actions[0]
+        for index, action in enumerate(self._in_flight_actions):
+            if not action.action_id:
+                del self._in_flight_actions[index]
+                return
 
     def active_action_ansi(self) -> str:
         """The indented, shimmering action line, or ``""`` when none is running.

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -166,3 +166,22 @@ def test_active_action_row_clips_wide_glyphs_to_one_prompt_column_budget() -> No
     spinner.set_active_action("查询 · " + "中" * 200)
     rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.active_action_ansi())
     assert prompt_text_width(rendered) <= prompt_line_width()
+
+
+def test_untracked_tool_end_pops_only_an_untracked_slot() -> None:
+    """Regression: an id-less tool_end popped the oldest slot (del[0]) and could
+    wipe a still-running named action. It must pop only an id-less slot."""
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_active_action("Execute · true", action_id="b")  # named, still running
+
+    spinner.clear_active_action("")  # an untracked tool_end (no id)
+    assert spinner.active_action.startswith("Execute")  # named action survives
+
+    # An id-less action is still cleared by an id-less end.
+    spinner.set_active_action("GitHub CLI · gh pr list")  # no id
+    spinner.clear_active_action("")
+    assert spinner.active_action.startswith("Execute")  # popped the id-less one, kept "b"
+
+    spinner.clear_active_action("b")
+    assert spinner.active_action == ""


### PR DESCRIPTION
## What
Harden the in-flight action-shimmer stack so an id-less `tool_end` can't clear a
named, still-running action.

## Why
`clear_active_action("")` — the path taken when a `tool_end` event omits a tool
id — popped the oldest slot unconditionally (`del self._in_flight_actions[0]`).
If a named action (started with an id) was oldest, that untracked end wiped its
shimmer while it was still running, so the live "⟩ …" line vanished mid-command.

## How
`clear_active_action("")` now scans for and removes the first slot that *also*
has no id, leaving named actions intact. `None` (clear-all) and a specific id
are unchanged.