### PR TITLE
feat(shell): emphasize key action words in the agent's live narration

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -35,6 +35,13 @@ Unless the user explicitly asks for a plan, asks a question about the code, is b
 
 ## Responsiveness
 
+While you work, narrate the next action in a short sentence and put the one or
+two words that carry the action — the verb or its target — in **bold**, so a
+long response is easy to skim (for example: "Now let me **trigger** the chaos
+experiment and **watch** the UI react."). Emphasize only those key words, never
+a whole phrase or sentence, and never bold a file path or command (those use
+inline code).
+
 ## Planning
 
 You have access to an `update_plan` tool which tracks steps and progress and renders them to the user. Using the tool helps demonstrate that you've understood the task and convey how you're approaching it. Plans can help to make complex, ambiguous, or multi-phase work clearer and more collaborative for the user. A good plan should break the task into meaningful, logically ordered steps that are easy to verify as you go.


### PR DESCRIPTION
## What / Why
In-progress agent narration read as a wall of text. Instruct the model to bold
the one or two words that carry each action so a long response scans quickly
(e.g. "Now let me **trigger** the chaos experiment and **watch** the UI react").

## How
Fill the previously-empty "Responsiveness" section of the single system prompt
with a tight rule: bold the verb or its target only — never a whole phrase or
sentence, and never a file path or command (those use inline code). No code
change needed: the narration path (`message_update` → `_render_intermediate_message`
→ `render_markdown_block`) already renders `**bold**` via rich Markdown.