### PR TITLE
feat(shell): Action shimmer: shimmer-in → solid, and no duplicate command during a run

### DIFF
--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -259,10 +259,12 @@ class SpinnerState:
     # Verbs picked twice as often as the rest of their pool (default weight 1).
     _VERB_WEIGHTS = {"jacking in": 2, "crawling the datastream": 2}
 
-    # Theme-token shimmer for the running action line: a triangle wave over this
-    # period fades DIM → TEXT → DIM (pure function of the clock, like the
-    # spinner glyph, so it never freezes on a busy render pass).
+    # The running action line shimmers in — a white glow rising DIM → TEXT over
+    # the lead window as the action is picked up — then holds a SOLID fill while
+    # it runs ("shimmer prior, solid in progress"). Level is a pure function of
+    # the clock, like the spinner glyph, so it never freezes on a busy render.
     _SHIMMER_PERIOD_SECONDS = 1.1
+    _SHIMMER_LEAD_SECONDS = _SHIMMER_PERIOD_SECONDS / 2  # rising half of the glow
     _ACTION_GLYPH = "⟩"
 
     def __init__(self) -> None:
@@ -321,21 +323,26 @@ class SpinnerState:
                 return
 
     def active_action_ansi(self) -> str:
-        """The indented, shimmering action line, or ``""`` when none is running.
+        """The indented action line, or ``""`` when none is running.
 
-        The glow fades DIM to TEXT on a triangle wave so the line reads as
-        live work; scrollback holds the settled solid copy.
+        Shimmers in (DIM → TEXT) over the lead window as the action is picked up,
+        then holds a solid fill (TEXT) while it runs; scrollback keeps the
+        settled copy.
         """
         current = self._in_flight_actions[0] if self._in_flight_actions else None
         if current is None:
             return ""
         elapsed = time.monotonic() - current.started_at
-        phase = (elapsed % self._SHIMMER_PERIOD_SECONDS) / self._SHIMMER_PERIOD_SECONDS
-        triangle = 1.0 - abs(2.0 * phase - 1.0)  # 0 → 1 → 0 over the period
-        glow = ui_theme.fade_fg_ansi(triangle)
+        if elapsed < self._SHIMMER_LEAD_SECONDS:
+            # Shimmer in: the rising half of the glow (0 → 1) as it is picked up.
+            phase = (elapsed % self._SHIMMER_PERIOD_SECONDS) / self._SHIMMER_PERIOD_SECONDS
+            level = 1.0 - abs(2.0 * phase - 1.0)
+        else:
+            level = 1.0  # solid fill once in progress
+        fill = ui_theme.fade_fg_ansi(level)
         lead = f"  {self._ACTION_GLYPH} "
         text = clip_prompt_text(current.text, prompt_line_width() - prompt_text_width(lead))
-        return f"{glow}{lead}{text}{ui_theme.ANSI_RESET}"
+        return f"{fill}{lead}{text}{ui_theme.ANSI_RESET}"
 
     def start(self) -> None:
         self.streaming = True

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -93,6 +93,16 @@ _SELF_RENDERING_TOOLS: frozenset[str] = frozenset(
     }
 )
 
+#: Tools that stream their own ``$ <command>`` line during execution. The live
+#: shimmer names the action only (``⟩ Execute``) rather than repeating the
+#: command, so the command is not shown twice while it runs.
+_COMMAND_STREAMING_TOOLS: frozenset[str] = frozenset(
+    {
+        ActionToolName.SHELL_RUN,
+        ActionToolName.CLI_EXEC,
+    }
+)
+
 
 def _tool_event_id(data: dict[str, Any]) -> str:
     """Stable id for one tool call, or empty when the event omitted it."""
@@ -410,10 +420,11 @@ class ActionRenderObserver:
             return
         args = data.get("input")
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
-        spinner.set_active_action(
-            f"{label} · {content}" if content else label,
-            action_id=_tool_event_id(data),
-        )
+        if name in _COMMAND_STREAMING_TOOLS:
+            text = label  # the ``$ <command>`` line already shows the command
+        else:
+            text = f"{label} · {content}" if content else label
+        spinner.set_active_action(text, action_id=_tool_event_id(data))
 
     def _clear_active_action(self, data: dict[str, Any]) -> None:
         spinner = get_investigation_spinner()

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -119,9 +119,10 @@ def test_inline_spinner_clips_a_long_phase_to_one_prompt_row() -> None:
     assert prompt_text_width(rendered) <= prompt_line_width()
 
 
-def test_active_action_shimmer_renders_indented_glow_and_clears() -> None:
-    """The running action shows an indented theme-token glow; cleared → blank."""
-    from infrastructure.terminal.theme import fade_fg_ansi, set_active_theme
+def test_active_action_renders_indented_line_and_clears() -> None:
+    """The running action shows an indented action line with a theme fill;
+    cleared → blank. (The shimmer→solid transition is pinned separately.)"""
+    from infrastructure.terminal.theme import set_active_theme
 
     set_active_theme("solarized")
     spinner = SpinnerState()
@@ -129,15 +130,10 @@ def test_active_action_shimmer_renders_indented_glow_and_clears() -> None:
     assert spinner.active_action_ansi() == ""  # none by default
 
     spinner.set_active_action("Execute · cd /tmp")
-    started = time.monotonic() - SpinnerState._SHIMMER_PERIOD_SECONDS / 2
-    spinner._in_flight_actions[0].started_at = started
     rendered = spinner.active_action_ansi()
-    elapsed = time.monotonic() - started
-    phase = (elapsed % SpinnerState._SHIMMER_PERIOD_SECONDS) / SpinnerState._SHIMMER_PERIOD_SECONDS
-    triangle = 1.0 - abs(2.0 * phase - 1.0)
     assert "Execute · cd /tmp" in rendered
     assert SpinnerState._ACTION_GLYPH in rendered
-    assert fade_fg_ansi(triangle) in rendered
+    assert "\x1b[38;2;" in rendered  # a 24-bit theme fill
 
     spinner.clear_active_action()
     assert spinner.active_action_ansi() == ""
@@ -185,3 +181,25 @@ def test_untracked_tool_end_pops_only_an_untracked_slot() -> None:
 
     spinner.clear_active_action("b")
     assert spinner.active_action == ""
+
+
+def test_action_line_shimmers_in_then_holds_solid() -> None:
+    """The action glows in over the lead window (shimmer prior), then holds a
+    solid fill while it runs (solid in progress)."""
+    from infrastructure.terminal.theme import fade_fg_ansi, set_active_theme
+
+    set_active_theme("solarized")
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_active_action("Execute · sleep 4")
+    action = spinner._in_flight_actions[0]
+
+    # Early in the lead window: still shimmering in (partial glow), not solid.
+    action.started_at = time.monotonic() - SpinnerState._SHIMMER_LEAD_SECONDS * 0.25
+    early = spinner.active_action_ansi()
+    assert fade_fg_ansi(1.0) not in early
+
+    # After the lead window: solid fill held for the rest of the run.
+    action.started_at = time.monotonic() - (SpinnerState._SHIMMER_LEAD_SECONDS + 0.3)
+    solid = spinner.active_action_ansi()
+    assert fade_fg_ansi(1.0) in solid

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -594,9 +594,9 @@ def test_observer_drives_load_state_phases_by_turn_stage() -> None:
 
         observer("tool_start", {"name": "shell_run", "input": {"command": "true"}})
         assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
-        # The running action shows as a shimmering live line.
-        assert "Execute" in spinner.active_action
-        assert "true" in spinner.active_action
+        # The running action shows as a shimmering live line; for shell_run the
+        # shimmer names the action only — the ``$ <cmd>`` line shows the command.
+        assert spinner.active_action == "Execute"
 
         observer("tool_end", {"name": "shell_run"})
         assert spinner.phase == SpinnerState.EXECUTING_PHASE
@@ -633,8 +633,7 @@ def test_batched_tool_starts_keep_the_first_action_until_it_ends() -> None:
         assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
 
         observer("tool_end", {"id": "a", "name": "github_cli"})
-        assert "Execute" in spinner.active_action
-        assert "true" in spinner.active_action
+        assert spinner.active_action == "Execute"  # shell_run shimmer names the action only
         assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
 
         observer("tool_end", {"id": "b", "name": "shell_run"})
@@ -659,7 +658,7 @@ def test_untracked_tool_end_does_not_clear_a_running_action() -> None:
             "tool_end",
             {"id": "p1", "name": "update_plan", "output": {"ok": True, "total": 1}},
         )
-        assert "true" in spinner.active_action
+        assert spinner.active_action == "Execute"  # shell_run still running, not wiped
         assert spinner.phase == SpinnerState.INVOKING_TOOLS_PHASE
     finally:
         set_investigation_spinner(None)


### PR DESCRIPTION
## What / Why
Two fixes to the live running-action row so it matches the spec (and droid):

1. **Shimmer prior → solid in progress.** The action line used to glow the whole
   time. Now it shimmers in (a white glow rising over ~0.55s as the action is
   picked up) then holds a **solid** fill while it runs — "shimmer prior, solid
   in progress".
2. **No duplicate command.** For `shell_run` / `cli_exec` the shimmer repeated
   the command that the `$ <cmd>` line already shows, so a running command
   appeared twice. The shimmer now names the action only (`⟩ Execute`); generic
   tools (no `$ cmd`) keep the full `label · content`.

## How
- `SpinnerState.active_action_ansi`: rising-glow over `_SHIMMER_LEAD_SECONDS`,
  then `fade_fg_ansi(1.0)` solid.
- `ActionRenderObserver._set_active_action`: `_COMMAND_STREAMING_TOOLS` show the
  label only.