### PR TITLE
feat(shell): User-prompt accent bar + command output indented under its action

### DIFF
--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -24,6 +24,8 @@ from surfaces.interactive_shell.ui.input_prompt.layout import (
 
 DEFAULT_PLACEHOLDER_TEXT = 'Try "Investigate this alert"'
 _PLAN_CONTINUE_PLACEHOLDER = "continue the plan, or type a message"
+# Left accent bar that marks a user-prompt row (agent responses use ``●``).
+_PROMPT_ACCENT_BAR = "▌"
 
 
 def _prompt_turn_number(session: Session) -> int:
@@ -107,17 +109,25 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
         )
     counter = _counter_text(session.terminal.claim_turn_number())
     lines = text.splitlines() or [""]
-    continuation_prefix = " " * (len(counter) + len("❯ "))
-    rendered = Text()
     # Rich's Style.parse() reads the bare str value of a _LazyRichStyle (""),
     # so resolve to a concrete string at the call site to keep palette colors.
     body_style = handoff_answer_style() if is_handoff_answer else str(ui_theme.TEXT)
-    rendered.append(counter, style=str(ui_theme.DIM))
-    rendered.append("❯ ", style=f"bold {ui_theme.HIGHLIGHT}")
-    rendered.append(lines[0], style=body_style)
-    for line in lines[1:]:
-        rendered.append("\n")
-        rendered.append(continuation_prefix, style=str(ui_theme.DIM))
+    # A colour accent bar down the left marks the row as the user's prompt —
+    # distinct from the agent response, which opens with the ``●`` glyph and no
+    # bar. The bar repeats on every wrapped line so the whole submission reads as
+    # one block.
+    bar_style = f"bold {ui_theme.HIGHLIGHT}"
+    continuation_prefix = " " * (len(counter) + len("❯ "))
+    rendered = Text()
+    for index, line in enumerate(lines):
+        if index:
+            rendered.append("\n")
+        rendered.append(f"{_PROMPT_ACCENT_BAR} ", style=bar_style)
+        if index == 0:
+            rendered.append(counter, style=str(ui_theme.DIM))
+            rendered.append("❯ ", style=bar_style)
+        else:
+            rendered.append(continuation_prefix, style=str(ui_theme.DIM))
         rendered.append(line, style=body_style)
     console.print(rendered)
 

--- a/surfaces/shared/terminal/tables/tables.py
+++ b/surfaces/shared/terminal/tables/tables.py
@@ -6,6 +6,7 @@ All rendering is delegated to the REPL TTY helpers in :mod:`rendering`.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -206,10 +207,31 @@ def render_tools_table(console: Console, entries: list[ToolCatalogEntry]) -> Non
     )
 
 
+_COMMAND_OUTPUT_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+_COMMAND_OUTPUT_INDENT = "    "  # aligns wrapped lines under the ``  ↳ `` marker
+
+
+def _command_output_fits_indented(text: str, width: int) -> bool:
+    """Whether ``text`` still fits after a 4-column indent (visible width)."""
+    longest = max(
+        (len(_COMMAND_OUTPUT_ANSI_RE.sub("", line)) for line in text.split("\n")),
+        default=0,
+    )
+    return longest + len(_COMMAND_OUTPUT_INDENT) <= max(width, 1)
+
+
 def print_command_output(console: Console, output: str, *, style: str | None = None) -> None:
     if not output:
         return
     text = output.rstrip()
+    # Indent the result under its `$ command` header with a ``↳`` marker so it
+    # reads as the command's child (parent → child hierarchy) — but only when it
+    # fits, so wide output (tables) stays flush and does not wrap.
+    if _command_output_fits_indented(text, console.width):
+        lines = text.split("\n")
+        text = "\n".join(
+            [f"  ↳ {lines[0]}", *(f"{_COMMAND_OUTPUT_INDENT}{line}" for line in lines[1:])]
+        )
     # Parse any ANSI the captured child emitted so its Rich styling (bold, colour)
     # survives being re-printed here instead of showing as raw escape codes.
     rendered = Text.from_ansi(text) if style is None else Text.from_ansi(text, style=style)

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -117,6 +117,18 @@ class TestPromptTurnCounter:
         render_submitted_prompt(console, session, "and again")
         assert _prompt_turn_number(session) == 3
 
+    def test_user_prompt_row_has_a_left_accent_bar(self) -> None:
+        """A user prompt is marked by a left colour accent bar before ``[N] ❯``."""
+        from surfaces.interactive_shell.ui.input_prompt.rendering import _PROMPT_ACCENT_BAR
+
+        session = Session()
+        console = _render_console()
+        render_submitted_prompt(console, session, "why does it show that?")
+        out = console.file.getvalue()  # type: ignore[union-attr]
+        assert _PROMPT_ACCENT_BAR in out
+        assert out.index(_PROMPT_ACCENT_BAR) < out.index("[1]")  # bar leads the row
+        assert "why does it show that?" in out
+
     def test_autosubmitted_goal_condition_gets_work_turn_marker(self) -> None:
         """``/goal set`` autosubmit must not look like part of the slash turn."""
         session = Session()

--- a/tests/shared/terminal/test_command_output_indent.py
+++ b/tests/shared/terminal/test_command_output_indent.py
@@ -1,0 +1,32 @@
+"""Command output is indented under its ``$ command`` header when it fits."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from surfaces.shared.terminal.tables.tables import print_command_output
+
+
+def _out(text: str, *, width: int) -> str:
+    console = Console(file=StringIO(), force_terminal=False, width=width)
+    print_command_output(console, text)
+    return console.file.getvalue()
+
+
+def test_short_result_is_indented_under_the_header_with_a_marker() -> None:
+    out = _out("done", width=80)
+    assert "↳ done" in out  # parent → child hierarchy
+
+
+def test_multiline_result_that_fits_indents_with_one_marker() -> None:
+    out = _out("first\nsecond", width=80)
+    assert "↳ first" in out
+    assert "second" in out
+    assert out.count("↳") == 1  # marker on the first line only
+
+
+def test_wide_output_stays_flush_so_it_does_not_wrap() -> None:
+    out = _out("x" * 40, width=20)
+    assert "↳" not in out  # too wide to indent — left flush


### PR DESCRIPTION
## What
- User-prompt rows open with a left colour accent bar (`▌`) so a prompt is
  visually distinct from the agent response (which opens with `●`).
- Shell/CLI command output is indented under its `$ command` header with a `↳`
  marker (parent → child), matching droid's readable hierarchy.

## How
- `render_submitted_prompt`: prepend a `▌` bar (bold highlight) on every line of
  the submission.
- `print_command_output`: indent the result with `  ↳ ` when it fits the
  terminal width; wide output (tables) stays flush so it does not wrap.