### PR TITLE
feat(shell): Syntax-highlight the command; remove the ⟩ action glyph

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -214,7 +214,7 @@ Your final message should read naturally, like an update from a concise teammate
 
 You can skip heavy formatting for single, simple actions or confirmations. In these cases, respond in plain sentences with any relevant next step or quick option. Reserve multi-section structured responses for results that need grouping or explanation.
 
-After running a command or action, always close the turn with a one-line confirmation of what happened: the concrete result (what was created, changed, or removed, and a nonzero exit if any) plus anything the user should know, such as a step you skipped or that was cancelled. Do not end a turn silently right after a tool call — the terminal shows the command ran, but not what it means.
+After running a command or action, always close the turn with a one-line confirmation of what happened: the concrete result (what was created, changed, or removed, and a nonzero exit if any) plus anything the user should know, such as a step you skipped or that was cancelled. Do not end a turn silently right after a tool call — the terminal shows the command ran, but not what it means. Keep it to that one line: the command's output is already on screen, so do not re-print or quote it (no fenced block of the stdout you just showed) — reference it, don't repeat it.
 
 The user is working on the same computer as you, and has access to your work. As such there's no need to show the contents of files you have already written unless the user explicitly asks for them. Similarly, if you've created or modified files using `apply_patch`, there's no need to tell users to "save the file" or "copy the code into a file"—just reference the file path.
 

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -265,7 +265,8 @@ class SpinnerState:
     # the clock, like the spinner glyph, so it never freezes on a busy render.
     _SHIMMER_PERIOD_SECONDS = 1.1
     _SHIMMER_LEAD_SECONDS = _SHIMMER_PERIOD_SECONDS / 2  # rising half of the glow
-    _ACTION_GLYPH = "⟩"
+    # The action line carries no leading glyph — just an indent under the header.
+    _ACTION_INDENT = "  "
 
     def __init__(self) -> None:
         self.streaming: bool = False
@@ -340,7 +341,7 @@ class SpinnerState:
         else:
             level = 1.0  # solid fill once in progress
         fill = ui_theme.fade_fg_ansi(level)
-        lead = f"  {self._ACTION_GLYPH} "
+        lead = self._ACTION_INDENT
         text = clip_prompt_text(current.text, prompt_line_width() - prompt_text_width(lead))
         return f"{fill}{lead}{text}{ui_theme.ANSI_RESET}"
 

--- a/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
@@ -11,11 +11,9 @@ from typing import Any
 
 from rich.console import Console
 from rich.markup import escape
-from rich.syntax import Syntax
 from rich.text import Text
 
 from infrastructure.scheduling.task_types import TaskKind
-from infrastructure.terminal.theme import MARKDOWN_CODE_THEME
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING, print_command_output
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
@@ -38,6 +36,26 @@ _MARKUP_STYLE_ALIASES: dict[str, str] = {
     "highlight": str(HIGHLIGHT),
     "warning": str(WARNING),
 }
+
+# Command-focused highlighting: colour the command word (first token and each
+# token after a pipeline operator), flags, and operators; leave bare arguments
+# in the base bold. A shell lexer mis-colours argument words that happen to be
+# bash keywords (e.g. ``echo done`` → ``done`` as the loop keyword).
+_SHELL_OPERATOR_RE = r"&&|\|\||[|;<>&]"
+_SHELL_FLAG_RE = r"(?<!\S)--?[A-Za-z][\w-]*"
+_SHELL_FIRST_COMMAND_RE = r"^\s*[\w./+-]+"
+_SHELL_PIPED_COMMAND_RE = r"(?<=[|&;]) *[\w./+-]+"
+
+
+def _highlight_command(command: str) -> Text:
+    """Return ``command`` as a Text with command/flag/operator colouring."""
+    text = Text(command, style="bold")
+    text.highlight_regex(_SHELL_OPERATOR_RE, style=str(DIM))
+    text.highlight_regex(_SHELL_FLAG_RE, style=str(WARNING))
+    text.highlight_regex(_SHELL_FIRST_COMMAND_RE, style=f"bold {HIGHLIGHT}")
+    text.highlight_regex(_SHELL_PIPED_COMMAND_RE, style=f"bold {HIGHLIGHT}")
+    return text
+
 
 # Intentional Rich markup tags used by subprocess presenters and action tools.
 _ALLOWED_MARKUP_TAG = re.compile(
@@ -135,17 +153,8 @@ class ReplSubprocessPresenter:
         # as one block; a blank between header and output would visually attach
         # the output to the following command instead.
         self._console.print()
-        # Syntax-highlight the command (bash lexer) so its keywords, arguments,
-        # and operators are coloured rather than a flat monochrome line.
-        highlighted = Syntax(
-            display_command,
-            "bash",
-            theme=MARKDOWN_CODE_THEME,
-            background_color="default",
-        ).highlight(display_command)
-        highlighted.rstrip()
         line = Text("$ ", style="bold")
-        line.append_text(highlighted)
+        line.append_text(_highlight_command(display_command))
         self._console.print(line)
 
     def print_command_output(self, text: str, *, style: str | None = None) -> None:

--- a/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
@@ -11,9 +11,11 @@ from typing import Any
 
 from rich.console import Console
 from rich.markup import escape
+from rich.syntax import Syntax
 from rich.text import Text
 
 from infrastructure.scheduling.task_types import TaskKind
+from infrastructure.terminal.theme import MARKDOWN_CODE_THEME
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING, print_command_output
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
@@ -133,7 +135,18 @@ class ReplSubprocessPresenter:
         # as one block; a blank between header and output would visually attach
         # the output to the following command instead.
         self._console.print()
-        self._console.print(f"[bold]$ {escape(display_command)}[/bold]")
+        # Syntax-highlight the command (bash lexer) so its keywords, arguments,
+        # and operators are coloured rather than a flat monochrome line.
+        highlighted = Syntax(
+            display_command,
+            "bash",
+            theme=MARKDOWN_CODE_THEME,
+            background_color="default",
+        ).highlight(display_command)
+        highlighted.rstrip()
+        line = Text("$ ", style="bold")
+        line.append_text(highlighted)
+        self._console.print(line)
 
     def print_command_output(self, text: str, *, style: str | None = None) -> None:
         resolved: str | None

--- a/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
@@ -40,20 +40,63 @@ _MARKUP_STYLE_ALIASES: dict[str, str] = {
 # Command-focused highlighting: colour the command word (first token and each
 # token after a pipeline operator), flags, and operators; leave bare arguments
 # in the base bold. A shell lexer mis-colours argument words that happen to be
-# bash keywords (e.g. ``echo done`` → ``done`` as the loop keyword).
+# bash keywords (e.g. ``echo done`` → ``done`` as the loop keyword). Quoted
+# spans are blanked before matching so ``echo "a && b"`` does not treat the
+# inner ``&&`` as an operator.
 _SHELL_OPERATOR_RE = r"&&|\|\||[|;<>&]"
 _SHELL_FLAG_RE = r"(?<!\S)--?[A-Za-z][\w-]*"
 _SHELL_FIRST_COMMAND_RE = r"^\s*[\w./+-]+"
 _SHELL_PIPED_COMMAND_RE = r"(?<=[|&;]) *[\w./+-]+"
 
 
+def _blank_quoted_regions(command: str) -> str:
+    """Replace quoted interiors with spaces so highlighter regexes skip them.
+
+    Length is preserved so match offsets apply to the original command.
+    Unbalanced quotes blank through the end. Backslash escapes the next
+    character outside quotes and inside double quotes; single quotes treat
+    it as literal.
+    """
+    chars = list(command)
+    quote: str | None = None
+    index = 0
+    length = len(command)
+    while index < length:
+        char = chars[index]
+        if quote is None:
+            if char == "\\" and index + 1 < length:
+                index += 2
+                continue
+            if char in ("'", '"'):
+                quote = char
+            index += 1
+            continue
+        if char == "\\" and quote == '"' and index + 1 < length:
+            chars[index] = " "
+            chars[index + 1] = " "
+            index += 2
+            continue
+        if char == quote:
+            quote = None
+            index += 1
+            continue
+        chars[index] = " "
+        index += 1
+    return "".join(chars)
+
+
 def _highlight_command(command: str) -> Text:
     """Return ``command`` as a Text with command/flag/operator colouring."""
     text = Text(command, style="bold")
-    text.highlight_regex(_SHELL_OPERATOR_RE, style=str(DIM))
-    text.highlight_regex(_SHELL_FLAG_RE, style=str(WARNING))
-    text.highlight_regex(_SHELL_FIRST_COMMAND_RE, style=f"bold {HIGHLIGHT}")
-    text.highlight_regex(_SHELL_PIPED_COMMAND_RE, style=f"bold {HIGHLIGHT}")
+    searchable = _blank_quoted_regions(command)
+    for pattern, style in (
+        (_SHELL_OPERATOR_RE, str(DIM)),
+        (_SHELL_FLAG_RE, str(WARNING)),
+        (_SHELL_FIRST_COMMAND_RE, f"bold {HIGHLIGHT}"),
+        (_SHELL_PIPED_COMMAND_RE, f"bold {HIGHLIGHT}"),
+    ):
+        for match in re.finditer(pattern, searchable):
+            text.stylize(style, *match.span())
     return text
 
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -30,7 +30,10 @@ from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, MARKDOWN_CODE_THEME
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
-from surfaces.interactive_shell.ui.streaming import render_markdown_block
+from surfaces.interactive_shell.ui.streaming import (
+    render_markdown_block,
+    render_response_header,
+)
 from surfaces.shared.terminal.output.console_state import get_investigation_spinner
 from tools.interactive_shell.action_names import ActionToolName
 from tools.interactive_shell.shell.display import format_shell_command_for_display
@@ -467,6 +470,9 @@ class ActionRenderObserver:
         if is_plan_diagnosis_prose(content):
             return
         self.console.print()
+        # Mark this as an agent message with the same ``●`` header the final
+        # response uses, so every message to the user carries the marker.
+        render_response_header(self.console, "OpenSRE")
         # ``render_markdown_block`` sanitizes model text at ``_build_markdown_block``.
         render_markdown_block(self.console, content)
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -30,10 +30,7 @@ from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, MARKDOWN_CODE_THEME
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
-from surfaces.interactive_shell.ui.streaming import (
-    render_markdown_block,
-    render_response_header,
-)
+from surfaces.interactive_shell.ui.streaming import render_markdown_block
 from surfaces.shared.terminal.output.console_state import get_investigation_spinner
 from tools.interactive_shell.action_names import ActionToolName
 from tools.interactive_shell.shell.display import format_shell_command_for_display
@@ -470,10 +467,9 @@ class ActionRenderObserver:
         if is_plan_diagnosis_prose(content):
             return
         self.console.print()
-        # Mark this as an agent message with the same ``●`` header the final
-        # response uses, so every message to the user carries the marker.
-        render_response_header(self.console, "OpenSRE")
         # ``render_markdown_block`` sanitizes model text at ``_build_markdown_block``.
+        # No ``∴`` header here: the turn's single marker sits on the final
+        # response, so a mid-turn narration must not add a second one.
         render_markdown_block(self.console, content)
 
     def _render_skill_start(self, data: dict[str, Any]) -> None:

--- a/surfaces/interactive_shell/ui/streaming/closer.py
+++ b/surfaces/interactive_shell/ui/streaming/closer.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from rich.console import Console
 
-import infrastructure.terminal.theme as ui_theme
 from core.agent_harness.spi.prompt_chrome import closer_tail_from
-from surfaces.interactive_shell.ui.streaming.loop import _CHARS_PER_TOKEN, _format_tokens
 from surfaces.interactive_shell.ui.streaming.renderer import render_markdown_block
 
 
@@ -17,11 +15,9 @@ def finish_deferred_closer(
     footer_elapsed_s: float | None = None,
     footer_total_bytes: int | None = None,
 ) -> None:
-    """Render the (possibly rewritten) Want-me-to closer + held stream footer."""
+    """Render the (possibly rewritten) Want-me-to closer."""
+    del footer_elapsed_s, footer_total_bytes  # per-turn footer meta line removed
     closer = closer_tail_from(final_text)
     if closer:
         render_markdown_block(console, closer)
-    if footer_elapsed_s is not None and footer_total_bytes is not None:
-        tokens = _format_tokens(footer_total_bytes // _CHARS_PER_TOKEN)
-        console.print(f"[{ui_theme.DIM}]· {footer_elapsed_s:.1f}s · ↓ {tokens}[/]")
     console.print()

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -42,11 +42,6 @@ from core.agent_harness.spi.session_goal import strip_session_goal_progress_tags
 from surfaces.interactive_shell.ui.streaming.renderer import (
     _build_markdown_block,
     render_markdown_block,
-    render_response_header,
-)
-from surfaces.shared.terminal.components.token_format import (
-    _CHARS_PER_TOKEN,
-    format_token_count_short,
 )
 
 # Throttle for the optional ``update_streaming_progress`` hook on the
@@ -58,6 +53,9 @@ _PROGRESS_INTERVAL_SECONDS = 0.1
 # external caller (e.g. agent_actions.py for the planned-actions
 # bullet header) stay in lock-step.
 _PARAGRAPH_BREAK = "\n\n"
+# Inline agent marker: a single ``∴`` leads the response's first line (no
+# separate ``∴ OpenSRE`` header row) so the turn carries one compact marker.
+_RESPONSE_MARKER = "∴ "
 _CODE_FENCE = "```"
 # Match a triple-backtick only when it opens a line. An inline mention
 # inside flowing text (e.g. "The ``` marker opens a code block") would
@@ -80,10 +78,6 @@ _SELF_SPACING_BLOCK_TOKEN_TYPES = frozenset(
         "table_open",
     }
 )
-
-
-def _format_tokens(token_count: int) -> str:
-    return f"{format_token_count_short(token_count)} tokens"
 
 
 def _paragraph_has_want_me_to(text: str) -> bool:
@@ -142,6 +136,7 @@ def stream_to_console_state(
     defer_want_me_to_closer: bool = False,
 ) -> StreamRenderResult:
     """Like :func:`stream_to_console` but returns render/defer metadata."""
+    del label  # the inline ∴ marker replaced the ``∴ OpenSRE`` header
     if not console.is_terminal:
         text = "".join(chunks)
         if suppress_if_starts_with is not None and text.lstrip().startswith(
@@ -155,8 +150,7 @@ def stream_to_console_state(
             # gather path can print the canonical rewrite once.
             return StreamRenderResult(text=text, deferred_closer=True)
         console.print()
-        render_response_header(console, label)
-        render_markdown_block(console, text)
+        render_markdown_block(console, f"{_RESPONSE_MARKER}{text.lstrip()}")
         console.print()
         return StreamRenderResult(text=text)
 
@@ -189,7 +183,6 @@ def stream_to_console_state(
             break
 
     console.print()
-    render_response_header(console, label)
 
     # Paragraph-level streaming: chunks accumulate in ``para_buffer``
     # until a paragraph boundary (``\n\n`` outside a code block) closes
@@ -234,6 +227,9 @@ def stream_to_console_state(
         visible = strip_session_goal_progress_tags(text)
         if not visible.strip():
             return
+        if rendered_paragraphs == 0:
+            # The first paragraph carries the inline ``∴`` marker.
+            visible = f"{_RESPONSE_MARKER}{visible.lstrip()}"
         markdown = _build_markdown_block(visible)
         starts_with_self_spacing_block = bool(
             markdown.parsed and markdown.parsed[0].type in _SELF_SPACING_BLOCK_TOKEN_TYPES
@@ -419,19 +415,16 @@ def stream_to_console_state(
             footer_elapsed_s=elapsed,
             footer_total_bytes=total_bytes,
         )
-    if buffer:
-        tokens = _format_tokens(total_bytes // _CHARS_PER_TOKEN)
-        console.print(f"[{ui_theme.DIM}]· {elapsed:.1f}s · ↓ {tokens}[/]")
     console.print()
     return StreamRenderResult(text=text, deferred_closer=False)
 
 
 def publish_full_response(console: Console, text: str, *, label: str = "assistant") -> None:
     """Render a complete assistant answer (non-TTY deferred gather path)."""
+    del label  # the inline ∴ marker replaced the ``∴ OpenSRE`` header
     body = (text or "").strip()
     if not body:
         return
     console.print()
-    render_response_header(console, label)
-    render_markdown_block(console, body)
+    render_markdown_block(console, f"{_RESPONSE_MARKER}{body}")
     console.print()

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -71,9 +71,10 @@ def render_markdown_block(console: Console, text: str) -> None:
 
 
 def render_response_header(console: Console, label: str) -> None:
-    """Print the ``●`` bullet row marker that opens every assistant
-    response (Claude Code-style row layout). Shared with
-    ``action_turn.run_action_tool_turn`` so the planned-actions path
-    and the streaming response path use the exact same prefix.
+    """Print the ``∴`` triangle row marker that opens every assistant response.
+
+    A single triangle is opensre's uniquely identifiable agent marker. Shared
+    with ``action_turn.run_action_tool_turn`` so the planned-actions path and the
+    streaming response path use the exact same prefix.
     """
-    console.print(f"[{ui_theme.BOLD_BRAND}]●[/] [{ui_theme.DIM}]{label}[/]")
+    console.print(f"[{ui_theme.BOLD_BRAND}]∴[/] [{ui_theme.DIM}]{label}[/]")

--- a/tests/interactive_shell/runtime/test_agent_harness_adapters.py
+++ b/tests/interactive_shell/runtime/test_agent_harness_adapters.py
@@ -121,6 +121,6 @@ def test_response_header_opens_with_a_blank_line() -> None:
     # Act
     ShellOutputSink(console).render_response_header("assistant")  # type: ignore[arg-type]
 
-    # Assert: blank line first, then the ● marker.
+    # Assert: blank line first, then the ∴ marker.
     assert console.lines[0] == ""
-    assert "●" in console.lines[1]
+    assert "∴" in console.lines[1]

--- a/tests/interactive_shell/runtime/test_repl_presenter.py
+++ b/tests/interactive_shell/runtime/test_repl_presenter.py
@@ -9,8 +9,14 @@ from rich.console import Console
 from surfaces.interactive_shell.runtime.subprocess_runner.repl_presenter import (
     ReplSubprocessPresenter,
     _escape_markup_message,
+    _highlight_command,
 )
 from surfaces.interactive_shell.session import Session
+
+
+def _styled_spans(command: str) -> set[str]:
+    text = _highlight_command(command)
+    return {text.plain[span.start : span.end].strip() for span in text.spans}
 
 
 def _presenter() -> tuple[ReplSubprocessPresenter, StringIO]:
@@ -68,3 +74,52 @@ def test_print_preserves_task_id_markup_with_escaped_brackets() -> None:
     output = buffer.getvalue()
     assert task_id in output
     assert "/tasks" in output
+
+
+def test_highlight_command_leaves_quoted_operators_plain() -> None:
+    styled = _styled_spans('echo "a && b"')
+    assert "echo" in styled
+    assert "&&" not in styled
+    assert "b" not in styled
+
+
+def test_highlight_command_leaves_quoted_flags_plain() -> None:
+    styled = _styled_spans('echo "use --force"')
+    assert "echo" in styled
+    assert "--force" not in styled
+
+
+def test_highlight_command_leaves_quoted_pipes_plain() -> None:
+    styled = _styled_spans('grep -E "(foo|bar)" file')
+    assert "grep" in styled
+    assert "-E" in styled
+    assert "|" not in styled
+    assert "bar" not in styled
+
+
+def test_highlight_command_still_colours_unquoted_syntax_after_quotes() -> None:
+    command = 'echo "a && b" && echo done'
+    quoted_and = command.index("&&")
+    unquoted_and = command.index("&&", quoted_and + 2)
+    text = _highlight_command(command)
+    operator_starts = {
+        span.start for span in text.spans if command[span.start : span.end].strip() == "&&"
+    }
+    assert unquoted_and in operator_starts
+    assert quoted_and not in operator_starts
+    styled = {command[span.start : span.end].strip() for span in text.spans}
+    assert "echo" in styled
+    assert "done" not in styled
+
+
+def test_highlight_command_leaves_single_quoted_syntax_plain() -> None:
+    styled = _styled_spans("echo 'a && b --force'")
+    assert "echo" in styled
+    assert "&&" not in styled
+    assert "--force" not in styled
+
+
+def test_highlight_command_ignores_escaped_quotes_inside_double_quotes() -> None:
+    styled = _styled_spans(r'echo "say \"--force\""')
+    assert "echo" in styled
+    assert "--force" not in styled

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -132,7 +132,7 @@ def test_active_action_renders_indented_line_and_clears() -> None:
     spinner.set_active_action("Execute · cd /tmp")
     rendered = spinner.active_action_ansi()
     assert "Execute · cd /tmp" in rendered
-    assert SpinnerState._ACTION_GLYPH in rendered
+    assert SpinnerState._ACTION_INDENT in rendered  # indented under the header, no glyph
     assert "\x1b[38;2;" in rendered  # a 24-bit theme fill
 
     spinner.clear_active_action()

--- a/tests/interactive_shell/runtime/test_subprocess_runner.py
+++ b/tests/interactive_shell/runtime/test_subprocess_runner.py
@@ -1761,3 +1761,17 @@ def test_start_background_cli_task_echoes_command_markup_literally(
 
     assert task is not None
     assert f"$ {display_command}" in buf.getvalue().replace("\n", "")
+
+
+def test_highlight_command_leaves_argument_keywords_plain() -> None:
+    """``done`` after ``echo`` is an argument, not the bash loop keyword — a shell
+    lexer mis-colours it. Command words are highlighted; ``done`` stays plain."""
+    from surfaces.interactive_shell.runtime.subprocess_runner.repl_presenter import (
+        _highlight_command,
+    )
+
+    text = _highlight_command("sleep 8 && echo done")
+    styled = {text.plain[s.start : s.end].strip() for s in text.spans}
+    assert "sleep" in styled  # first command highlighted
+    assert "echo" in styled  # command after the operator highlighted
+    assert "done" not in styled  # argument left in the base style, not recoloured

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -683,13 +683,3 @@ def test_command_tools_suppress_the_static_action_header() -> None:
         assert "Execute" not in out
         assert "opensre" not in out
         assert cmd not in out  # header suppressed; the $cmd line comes from the presenter
-
-
-def test_intermediate_narration_carries_the_agent_marker() -> None:
-    """An agent message to the user (intermediate narration) is marked with the
-    same ``●`` header as the final response, not left unmarked."""
-    observer, buffer = _observer_with_buffer("do it")
-    observer("message_update", {"content": "I'll run the command.", "has_tool_calls": True})
-    out = buffer.getvalue()
-    assert "●" in out
-    assert "I'll run the command." in out

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -683,3 +683,13 @@ def test_command_tools_suppress_the_static_action_header() -> None:
         assert "Execute" not in out
         assert "opensre" not in out
         assert cmd not in out  # header suppressed; the $cmd line comes from the presenter
+
+
+def test_intermediate_narration_carries_the_agent_marker() -> None:
+    """An agent message to the user (intermediate narration) is marked with the
+    same ``●`` header as the final response, not left unmarked."""
+    observer, buffer = _observer_with_buffer("do it")
+    observer("message_update", {"content": "I'll run the command.", "has_tool_calls": True})
+    out = buffer.getvalue()
+    assert "●" in out
+    assert "I'll run the command." in out

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -57,9 +57,9 @@ class TestNonTtyFallback:
         output = buf.getvalue()
         assert result == "Hello, world"
         # Bullet header + label + text reach piped output so captured
-        # logs are useful. ``●`` is the row marker; ``assistant`` is the
+        # logs are useful. ``∴`` is the row marker; ``assistant`` is the
         # dim label alongside it.
-        assert "●" in output
+        assert "∴" in output
         assert "assistant" in output
         assert "Hello, world" in output
         # No spinner / Live cursor-movement artifacts in non-TTY captures.
@@ -91,7 +91,7 @@ class TestNonTtyFallback:
         assert result == '{"actions":[]}'
         output = buf.getvalue()
         # No bullet header for suppressed responses.
-        assert "●" not in output
+        assert "∴" not in output
         assert '{"actions"' not in output
 
 
@@ -133,7 +133,7 @@ class TestTtyParagraphRender:
         output = _strip_ansi(buf.getvalue())
         assert result == "Run **opensre investigate** to start."
         # Bullet row marker pinned above the rendered paragraph.
-        assert "●" in output
+        assert "∴" in output
         # End-of-stream force-flush rendered Markdown — ``**`` stripped.
         assert "**opensre" not in output
         assert "opensre investigate" in output
@@ -572,7 +572,7 @@ class TestTtyParagraphRender:
         assert result == ""
         # Bullet still printed (header fires before chunk processing),
         # but no spinner residue at finalize.
-        assert "●" in _strip_ansi(buf.getvalue())
+        assert "∴" in _strip_ansi(buf.getvalue())
 
 
 class TestMidStreamError:
@@ -690,7 +690,7 @@ class TestRenderResponseHeader:
         console, buf = _tty_console()
         render_response_header(console, "assistant")
         output = _strip_ansi(buf.getvalue())
-        assert "●" in output
+        assert "∴" in output
         assert "assistant" in output
 
     def test_label_is_passthrough(self) -> None:
@@ -1002,7 +1002,7 @@ class TestSuppressionPeek:
         assert result == '{"actions":[]}'
         # No bullet header, no markdown, no live-region artifacts.
         output = _strip_ansi(buf.getvalue())
-        assert "●" not in output
+        assert "∴" not in output
         assert '{"actions"' not in output
 
     def test_renders_normally_when_first_char_does_not_match(self) -> None:
@@ -1016,7 +1016,7 @@ class TestSuppressionPeek:
 
         assert result == "Hello, world"
         output = _strip_ansi(buf.getvalue())
-        assert "●" in output
+        assert "∴" in output
         assert "Hello, world" in output
 
     def test_skips_leading_whitespace_before_deciding(self) -> None:
@@ -1031,7 +1031,7 @@ class TestSuppressionPeek:
 
         assert result == '  \n{"action":"slash"}'
         output = _strip_ansi(buf.getvalue())
-        assert "●" not in output
+        assert "∴" not in output
 
 
 class TestRenderMarkdownBlock:

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -56,11 +56,9 @@ class TestNonTtyFallback:
 
         output = buf.getvalue()
         assert result == "Hello, world"
-        # Bullet header + label + text reach piped output so captured
-        # logs are useful. ``∴`` is the row marker; ``assistant`` is the
-        # dim label alongside it.
+        # The inline ``∴`` marker + text reach piped output so captured logs
+        # are useful (the standalone label header was removed).
         assert "∴" in output
-        assert "assistant" in output
         assert "Hello, world" in output
         # No spinner / Live cursor-movement artifacts in non-TTY captures.
         assert "thinking" not in output
@@ -570,9 +568,9 @@ class TestTtyParagraphRender:
         )
 
         assert result == ""
-        # Bullet still printed (header fires before chunk processing),
-        # but no spinner residue at finalize.
-        assert "∴" in _strip_ansi(buf.getvalue())
+        # The marker is inline on the first paragraph, so an empty stream prints
+        # no marker at all — and no spinner residue at finalize.
+        assert "∴" not in _strip_ansi(buf.getvalue())
 
 
 class TestMidStreamError:
@@ -643,7 +641,8 @@ class TestMidStreamError:
 class TestTimingFooter:
     """A small dim ``· Ns`` footer appears after a rendered live response."""
 
-    def test_footer_printed_after_streamed_response(self) -> None:
+    def test_no_timing_footer_after_streamed_response(self) -> None:
+        """The per-turn ``· Ns · ↓ tokens`` footer was removed for compactness."""
         console, buf = _tty_console()
         stream_to_console(
             console,
@@ -652,7 +651,7 @@ class TestTimingFooter:
         )
 
         output = _strip_ansi(buf.getvalue())
-        assert re.search(r"·\s+\d+\.\d+s", output) is not None
+        assert re.search(r"·\s+\d+\.\d+s", output) is None
 
     def test_footer_skipped_when_stream_is_empty(self) -> None:
         """Empty stream must not print a timing footer under nothing."""


### PR DESCRIPTION
## What
- The `$ command` line is syntax-highlighted (bash lexer) so its keywords,
  arguments, and operators are coloured, not a flat monochrome bold line.
- The live running-action line dropped its leading glyph: `⟩` read as `)` and
  the arrow alternative was worse, so it's now just an indented `Execute`.

## How
- `ReplSubprocessPresenter.print_bold_command`: render the command via
  `rich.syntax.Syntax(...).highlight(...)` under the bold `$ ` prefix.
- `SpinnerState`: replace `_ACTION_GLYPH` with a plain `_ACTION_INDENT`.