### PR TITLE
feat(slack): map read-tool output into citeable report evidence

### DIFF
--- a/integrations/slack/tools/slack_list_members_tool/tool.py
+++ b/integrations/slack/tools/slack_list_members_tool/tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
@@ -16,11 +17,28 @@ from integrations.slack.web_client import (
 )
 
 
+def _map_slack_list_team_members(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record the workspace roster as citeable evidence when members were read."""
+    members = output.get("members")
+    if not isinstance(members, list) or not members:
+        return
+    truncated = " (truncated)" if output.get("truncated") else ""
+    record_evidence_entry(
+        evidence,
+        source="slack_list_team_members",
+        label="Slack Workspace Roster",
+        summary=f"{len(members)} members{truncated}",
+    )
+
+
 class SlackListTeamMembersTool(BaseTool):
     """List the members of the Slack workspace the bot is installed in."""
 
     name = "slack_list_team_members"
     source = SOURCE
+    evidence_mapper = _map_slack_list_team_members
     description = (
         "List members of the Slack *workspace* the bot is installed in "
         "(id, username, real name, title, bot flag) via users.list. "

--- a/integrations/slack/tools/slack_read_list_tool/tool.py
+++ b/integrations/slack/tools/slack_read_list_tool/tool.py
@@ -6,6 +6,7 @@ import os
 import re
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import tool
@@ -84,11 +85,30 @@ def _matched(row: dict[str, str], candidates: list[dict[str, str]]) -> _ListReso
     return row["list_id"], row.get("title") or row.get("name") or "", candidates, ""
 
 
+def _map_slack_read_list(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record the rows read from a Slack List as citeable evidence."""
+    items = output.get("items")
+    if not isinstance(items, list) or not items:
+        return
+    name = str(output.get("list_title") or output.get("list_id") or "").strip()
+    scope = f" in {name}" if name else ""
+    truncated = " (truncated)" if output.get("truncated") else ""
+    record_evidence_entry(
+        evidence,
+        source="slack_read_list",
+        label="Slack List",
+        summary=f"{len(items)} rows{scope}{truncated}",
+    )
+
+
 class SlackReadListTool(BaseTool):
     """Find Slack Lists by name and/or read their rows (lists:read + files:read)."""
 
     name = "slack_read_list"
     source = SOURCE
+    evidence_mapper = _map_slack_read_list
     description = (
         "Find and/or read a Slack *List* (the Lists product — e.g. a shared "
         "'OpenSRE Team Tasks' board), NOT channel message history and NOT the "

--- a/integrations/slack/tools/slack_read_messages_tool/results.py
+++ b/integrations/slack/tools/slack_read_messages_tool/results.py
@@ -16,10 +16,13 @@ def failed_result(*, available: bool, error: str, error_type: str) -> dict[str, 
         "error_type": error_type,
         "messages": [],
         "message_count": 0,
+        "truncated": False,
     }
 
 
-def read_result(*, channel_id: str, messages: list[dict[str, str]]) -> dict[str, Any]:
+def read_result(
+    *, channel_id: str, messages: list[dict[str, str]], truncated: bool
+) -> dict[str, Any]:
     # A success result must NOT carry an "error" key: the shared tool runtime
     # flags any dict containing "error" as a failed tool call regardless of value.
     return {
@@ -29,4 +32,5 @@ def read_result(*, channel_id: str, messages: list[dict[str, str]]) -> dict[str,
         "channel_id": channel_id,
         "messages": messages,
         "message_count": len(messages),
+        "truncated": truncated,
     }

--- a/integrations/slack/tools/slack_read_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_read_messages_tool/tool.py
@@ -34,11 +34,12 @@ def _map_slack_read_messages(
         return
     channel_id = str(output.get("channel_id") or "").strip()
     scope = f" from {channel_id}" if channel_id else ""
+    truncated = " (truncated)" if output.get("truncated") else ""
     record_evidence_entry(
         evidence,
         source="slack_read_messages",
         label="Slack Channel Messages",
-        summary=f"{len(messages)} messages{scope}",
+        summary=f"{len(messages)} messages{scope}{truncated}",
     )
 
 
@@ -105,6 +106,7 @@ class SlackReadMessagesTool(BaseTool):
         "channel_id": "resolved Slack channel ID that was read",
         "messages": "list of {user, ts, thread_ts, text}, oldest first",
         "message_count": "number of messages returned",
+        "truncated": "true when the read hit the page cap and older messages may exist",
         "error": "error detail when status is 'failed'",
         "error_type": "stable failure class: validation_error, configuration_error, or api_error",
     }
@@ -143,15 +145,21 @@ class SlackReadMessagesTool(BaseTool):
                 error_type="api_error" if normalized_ref.startswith("#") else "validation_error",
             )
 
+        # One page is fetched, so a full page means older messages may exist.
+        page_size = clamp_limit(limit)
         messages, error = fetch_channel_messages(
             target,
             channel_id=resolved_id,
-            limit=clamp_limit(limit),
+            limit=page_size,
             thread_ts=str(thread_ts or "").strip(),
         )
         if messages is None:
             return failed_result(available=True, error=error, error_type="api_error")
-        return read_result(channel_id=resolved_id, messages=messages)
+        return read_result(
+            channel_id=resolved_id,
+            messages=messages,
+            truncated=len(messages) >= page_size,
+        )
 
 
 slack_read_messages = tool(

--- a/integrations/slack/tools/slack_read_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_read_messages_tool/tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
@@ -24,11 +25,29 @@ from integrations.slack.web_client import (
 )
 
 
+def _map_slack_read_messages(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record the channel/thread history read as citeable evidence."""
+    messages = output.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return
+    channel_id = str(output.get("channel_id") or "").strip()
+    scope = f" from {channel_id}" if channel_id else ""
+    record_evidence_entry(
+        evidence,
+        source="slack_read_messages",
+        label="Slack Channel Messages",
+        summary=f"{len(messages)} messages{scope}",
+    )
+
+
 class SlackReadMessagesTool(BaseTool):
     """Read recent messages from a Slack channel or thread the bot can see."""
 
     name = "slack_read_messages"
     source = SOURCE
+    evidence_mapper = _map_slack_read_messages
     description = (
         "Read recent *messages* from one Slack channel or thread the bot can see "
         "(conversations.history / conversations.replies). Pass channel ID (C…) or "

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import SUMMARIZE_OBSERVATION_TAG, tool
@@ -11,12 +12,36 @@ from core.tool_framework.utils import tool_unavailable
 from integrations.slack.tools.slack_read_messages_tool.constants import SOURCE
 from integrations.slack.web_client import resolve_user_token, search_messages, user_token_configured
 
+# Cap the query echoed into the evidence summary: the entry is re-read on every
+# later turn, so a long search string costs context without adding signal.
+_MAX_SUMMARY_QUERY_CHARS = 80
+
+
+def _map_slack_search_messages(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Record workspace search hits as citeable evidence, linking the top match."""
+    matches = output.get("matches")
+    if not isinstance(matches, list) or not matches:
+        return
+    query = str(tool_input.get("query") or "").strip()[:_MAX_SUMMARY_QUERY_CHARS]
+    scope = f" for {query!r}" if query else ""
+    top = matches[0] if isinstance(matches[0], dict) else {}
+    record_evidence_entry(
+        evidence,
+        source="slack_search_messages",
+        label="Slack Message Search",
+        summary=f"{len(matches)} matches{scope}",
+        url=str(top.get("permalink") or "") or None,
+    )
+
 
 class SlackSearchMessagesTool(BaseTool):
     """Search Slack messages across the workspace."""
 
     name = "slack_search_messages"
     source = SOURCE
+    evidence_mapper = _map_slack_search_messages
     description = (
         "Search Slack *messages* workspace-wide (search.messages). "
         "Use Slack search syntax (e.g. 'in:#incidents timeout', 'from:@user error'). "

--- a/integrations/slack/tools/slack_search_messages_tool/tool.py
+++ b/integrations/slack/tools/slack_search_messages_tool/tool.py
@@ -26,12 +26,13 @@ def _map_slack_search_messages(
         return
     query = str(tool_input.get("query") or "").strip()[:_MAX_SUMMARY_QUERY_CHARS]
     scope = f" for {query!r}" if query else ""
+    truncated = " (truncated)" if output.get("truncated") else ""
     top = matches[0] if isinstance(matches[0], dict) else {}
     record_evidence_entry(
         evidence,
         source="slack_search_messages",
         label="Slack Message Search",
-        summary=f"{len(matches)} matches{scope}",
+        summary=f"{len(matches)} matches{scope}{truncated}",
         url=str(top.get("permalink") or "") or None,
     )
 
@@ -81,6 +82,7 @@ class SlackSearchMessagesTool(BaseTool):
         "status": "'read' on success, 'failed' otherwise",
         "matches": "list of {channel_id, user, ts, text, permalink}",
         "match_count": "number of matches returned",
+        "truncated": "true when the search hit the count cap and more matches may exist",
         "error": "error detail when status is 'failed'",
         "error_type": "validation_error, configuration_error, or api_error",
     }
@@ -100,9 +102,10 @@ class SlackSearchMessagesTool(BaseTool):
                 error_type="configuration_error",
                 matches=[],
                 match_count=0,
+                truncated=False,
             )
 
-        matches, error = search_messages(target, query=query, count=count)
+        matches, error, truncated = search_messages(target, query=query, count=count)
         if matches is None:
             return {
                 "source": SOURCE,
@@ -112,6 +115,7 @@ class SlackSearchMessagesTool(BaseTool):
                 "error_type": ("validation_error" if "empty" in error else "api_error"),
                 "matches": [],
                 "match_count": 0,
+                "truncated": False,
             }
         return {
             "source": SOURCE,
@@ -119,6 +123,7 @@ class SlackSearchMessagesTool(BaseTool):
             "status": "read",
             "matches": matches,
             "match_count": len(matches),
+            "truncated": truncated,
         }
 
 

--- a/integrations/slack/tools/slack_thread_replay_tool/tool.py
+++ b/integrations/slack/tools/slack_thread_replay_tool/tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from core.domain.types.evidence import EvidenceSource
+from core.domain.types.evidence import EvidenceSource, record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
 from core.tool_framework import tool
@@ -10,9 +10,32 @@ from integrations.slack.thread_client import fetch_thread, parse_thread_ref
 from integrations.slack.web_client import bot_token_configured
 
 
+def _map_replay_slack_thread_locally(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Record the replayed thread as citeable evidence when messages were fetched."""
+    thread = output.get("thread")
+    if not isinstance(thread, dict):
+        return
+    messages = thread.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return
+    channel = str(thread.get("channel") or "").strip()
+    timestamp = str(thread.get("ts") or "").strip()
+    ref = f" from {channel}/{timestamp}" if channel and timestamp else ""
+    truncated = " (truncated)" if thread.get("truncated") else ""
+    record_evidence_entry(
+        evidence,
+        source="replay_slack_thread_locally",
+        label="Slack Thread Replay",
+        summary=f"{len(messages)} thread messages{ref}{truncated}",
+    )
+
+
 class ReplaySlackThreadLocallyTool(BaseTool):
     name = "replay_slack_thread_locally"
     source: ClassVar[EvidenceSource] = "slack"
+    evidence_mapper = _map_replay_slack_thread_locally
     surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT, ToolSurface.ACTION)
     side_effect_level = SideEffectLevel.READ_ONLY
     description = "Fetch a captured Slack thread for local replay and Slack bot behavior testing."

--- a/integrations/slack/web_client.py
+++ b/integrations/slack/web_client.py
@@ -723,13 +723,17 @@ def search_messages(
     *,
     query: str,
     count: int = 20,
-) -> tuple[list[dict[str, str]] | None, str]:
-    """Search workspace messages (``search.messages``)."""
+) -> tuple[list[dict[str, str]] | None, str, bool]:
+    """Search workspace messages. Returns ``(matches, error, truncated)``.
+
+    ``search.messages`` is fetched as a single page, so ``truncated`` is true
+    when the hit count reaches the requested cap and more matches may exist.
+    """
     q = str(query or "").strip()
     if not q:
-        return None, "query cannot be empty."
+        return None, "query cannot be empty.", False
     if not is_user_token(target.bot_token):
-        return None, _SEARCH_NEEDS_USER_TOKEN
+        return None, _SEARCH_NEEDS_USER_TOKEN, False
     limit = max(1, min(int(count), 100))
     payload, req_err = _request_json(
         "GET",
@@ -738,10 +742,10 @@ def search_messages(
         params={"query": q, "count": limit, "sort": "timestamp"},
     )
     if payload is None:
-        return None, req_err
+        return None, req_err, False
     if not payload.get("ok"):
         error = str(payload.get("error") or "unknown_error")
-        return None, _api_error_hint(error, context="search")
+        return None, _api_error_hint(error, context="search"), False
 
     matches = ((payload.get("messages") or {}).get("matches")) or []
     results: list[dict[str, str]] = []
@@ -764,7 +768,7 @@ def search_messages(
                 "permalink": str(raw.get("permalink") or ""),
             }
         )
-    return results, ""
+    return results, "", len(results) >= limit
 
 
 def add_reaction(

--- a/tests/integrations/slack/test_evidence_mappers.py
+++ b/tests/integrations/slack/test_evidence_mappers.py
@@ -1,0 +1,330 @@
+"""Evidence mapper tests for the Slack read tools.
+
+Each mapper turns a read tool's output into one citeable catalog entry. The
+shared rule they all pin: an empty or failed read records *nothing*, because a
+"0 items" entry is context the agent re-reads on every later turn for no claim.
+"""
+
+from typing import Any
+
+import pytest
+
+from core.tool_framework.utils import tool_unavailable
+from integrations.slack.tools.slack_list_members_tool.tool import _map_slack_list_team_members
+from integrations.slack.tools.slack_read_list_tool.tool import _map_slack_read_list
+from integrations.slack.tools.slack_read_messages_tool.tool import _map_slack_read_messages
+from integrations.slack.tools.slack_search_messages_tool.tool import _map_slack_search_messages
+from integrations.slack.tools.slack_thread_replay_tool.tool import (
+    _map_replay_slack_thread_locally,
+)
+
+
+class TestSlackReadMessagesMapper:
+    def test_records_message_count_and_channel(self) -> None:
+        # Arrange
+        evidence: dict[str, Any] = {}
+        output = {
+            "source": "slack",
+            "available": True,
+            "status": "read",
+            "channel_id": "C0INCIDENT",
+            "messages": [
+                {"user": "U1", "ts": "1.0", "text": "deploy started"},
+                {"user": "U2", "ts": "2.0", "text": "errors spiking"},
+            ],
+            "message_count": 2,
+        }
+
+        # Act
+        _map_slack_read_messages(evidence, output, {"channel_id": "C0INCIDENT"})
+
+        # Assert
+        assert evidence["catalog_entries"] == [
+            {
+                "source": "slack_read_messages",
+                "label": "Slack Channel Messages",
+                "summary": "2 messages from C0INCIDENT",
+                "url": None,
+                "snippet": None,
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            pytest.param({}, id="empty-payload"),
+            pytest.param(
+                {"status": "read", "channel_id": "C1", "messages": [], "message_count": 0},
+                id="no-messages",
+            ),
+            pytest.param(
+                {
+                    "source": "slack",
+                    "available": True,
+                    "status": "failed",
+                    "error": "channel_not_found",
+                    "error_type": "api_error",
+                    "messages": [],
+                    "message_count": 0,
+                },
+                id="failed-read",
+            ),
+        ],
+    )
+    def test_records_nothing_without_messages(self, output: dict[str, Any]) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_slack_read_messages(evidence, output, {})
+
+        assert evidence == {}
+
+
+class TestSlackSearchMessagesMapper:
+    def test_records_match_count_query_and_top_permalink(self) -> None:
+        # Arrange
+        evidence: dict[str, Any] = {}
+        output = {
+            "source": "slack",
+            "available": True,
+            "status": "read",
+            "matches": [
+                {
+                    "channel_id": "C1",
+                    "user": "U1",
+                    "ts": "1.0",
+                    "text": "timeout",
+                    "permalink": "https://slack.example/p1",
+                },
+                {"channel_id": "C2", "user": "U2", "ts": "2.0", "text": "timeout again"},
+            ],
+            "match_count": 2,
+        }
+
+        # Act
+        _map_slack_search_messages(evidence, output, {"query": "in:#incidents timeout"})
+
+        # Assert
+        assert evidence["catalog_entries"] == [
+            {
+                "source": "slack_search_messages",
+                "label": "Slack Message Search",
+                "summary": "2 matches for 'in:#incidents timeout'",
+                "url": "https://slack.example/p1",
+                "snippet": None,
+            }
+        ]
+
+    def test_caps_the_query_echoed_into_the_summary(self) -> None:
+        """The entry is re-read every turn, so a pathological query cannot grow it."""
+        # Arrange
+        evidence: dict[str, Any] = {}
+        query = "timeout " * 50
+
+        # Act
+        _map_slack_search_messages(evidence, {"matches": [{"text": "x"}]}, {"query": query})
+
+        # Assert
+        summary = evidence["catalog_entries"][0]["summary"]
+        assert len(summary) < 120
+        assert summary.startswith("1 matches for 'timeout timeout")
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            pytest.param({}, id="empty-payload"),
+            pytest.param(
+                tool_unavailable("slack", "no user token", matches=[], match_count=0),
+                id="unavailable-envelope",
+            ),
+            pytest.param({"status": "read", "matches": [], "match_count": 0}, id="no-matches"),
+        ],
+    )
+    def test_records_nothing_without_matches(self, output: dict[str, Any]) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_slack_search_messages(evidence, output, {"query": "timeout"})
+
+        assert evidence == {}
+
+
+class TestSlackListTeamMembersMapper:
+    def test_records_member_count(self) -> None:
+        # Arrange
+        evidence: dict[str, Any] = {}
+        output = {
+            "status": "read",
+            "members": [
+                {"id": "U1", "username": "ada", "is_bot": False},
+                {"id": "U2", "username": "grace", "is_bot": False},
+            ],
+            "member_count": 2,
+            "truncated": False,
+        }
+
+        # Act
+        _map_slack_list_team_members(evidence, output, {})
+
+        # Assert
+        assert evidence["catalog_entries"] == [
+            {
+                "source": "slack_list_team_members",
+                "label": "Slack Workspace Roster",
+                "summary": "2 members",
+                "url": None,
+                "snippet": None,
+            }
+        ]
+
+    def test_marks_a_page_capped_roster_as_truncated(self) -> None:
+        """A partial roster must not read as the whole team."""
+        # Arrange
+        evidence: dict[str, Any] = {}
+
+        # Act
+        _map_slack_list_team_members(evidence, {"members": [{"id": "U1"}], "truncated": True}, {})
+
+        # Assert
+        assert evidence["catalog_entries"][0]["summary"] == "1 members (truncated)"
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            pytest.param({}, id="empty-payload"),
+            pytest.param(
+                tool_unavailable("slack", "bot token missing", members=[], member_count=0),
+                id="unavailable-envelope",
+            ),
+            pytest.param({"status": "read", "members": []}, id="no-members"),
+        ],
+    )
+    def test_records_nothing_without_members(self, output: dict[str, Any]) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_slack_list_team_members(evidence, output, {})
+
+        assert evidence == {}
+
+
+class TestSlackReadListMapper:
+    def test_records_row_count_and_list_title(self) -> None:
+        # Arrange
+        evidence: dict[str, Any] = {}
+        output = {
+            "status": "read",
+            "list_id": "F0123ABCD",
+            "list_title": "OpenSRE Team Tasks",
+            "lists": [],
+            "items": [{"id": "1", "name": "Rotate keys"}, {"id": "2", "name": "Patch runner"}],
+            "item_count": 2,
+            "truncated": False,
+        }
+
+        # Act
+        _map_slack_read_list(evidence, output, {})
+
+        # Assert
+        assert evidence["catalog_entries"] == [
+            {
+                "source": "slack_read_list",
+                "label": "Slack List",
+                "summary": "2 rows in OpenSRE Team Tasks",
+                "url": None,
+                "snippet": None,
+            }
+        ]
+
+    def test_falls_back_to_the_list_id_when_discovery_found_no_title(self) -> None:
+        # Arrange
+        evidence: dict[str, Any] = {}
+
+        # Act
+        _map_slack_read_list(
+            evidence,
+            {"list_id": "F0123ABCD", "list_title": "", "items": [{"id": "1"}], "truncated": True},
+            {},
+        )
+
+        # Assert
+        assert evidence["catalog_entries"][0]["summary"] == "1 rows in F0123ABCD (truncated)"
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            pytest.param({}, id="empty-payload"),
+            pytest.param(
+                {"status": "read", "list_id": "", "lists": [{"list_id": "F1"}], "items": []},
+                id="ambiguous-discovery-only",
+            ),
+            pytest.param(
+                {
+                    "status": "failed",
+                    "error": "lists:read missing",
+                    "error_type": "api_error",
+                    "items": [],
+                },
+                id="failed-read",
+            ),
+        ],
+    )
+    def test_records_nothing_without_rows(self, output: dict[str, Any]) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_slack_read_list(evidence, output, {})
+
+        assert evidence == {}
+
+
+class TestReplaySlackThreadLocallyMapper:
+    def test_records_thread_message_count_and_reference(self) -> None:
+        # Arrange
+        evidence: dict[str, Any] = {}
+        output = {
+            "status": "ok",
+            "thread": {
+                "channel": "C0INCIDENT",
+                "ts": "1700000000.000100",
+                "messages": [
+                    {"user": "U1", "text": "paging on-call", "ts": "1.0", "reactions": []},
+                    {"user": "U2", "text": "rolling back", "ts": "2.0", "reactions": ["eyes"]},
+                ],
+                "count": 2,
+                "truncated": False,
+            },
+        }
+
+        # Act
+        _map_replay_slack_thread_locally(
+            evidence, output, {"thread_ref": "C0INCIDENT/1700000000.000100"}
+        )
+
+        # Assert
+        assert evidence["catalog_entries"] == [
+            {
+                "source": "replay_slack_thread_locally",
+                "label": "Slack Thread Replay",
+                "summary": "2 thread messages from C0INCIDENT/1700000000.000100",
+                "url": None,
+                "snippet": None,
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            pytest.param({}, id="empty-payload"),
+            pytest.param(
+                {"status": "failed", "error": "thread_not_found", "error_type": "delivery_error"},
+                id="failed-fetch",
+            ),
+            pytest.param(
+                {"status": "ok", "thread": {"channel": "C1", "ts": "1.0", "messages": []}},
+                id="empty-thread",
+            ),
+        ],
+    )
+    def test_records_nothing_without_thread_messages(self, output: dict[str, Any]) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_replay_slack_thread_locally(evidence, output, {})
+
+        assert evidence == {}

--- a/tests/integrations/slack/test_evidence_mappers.py
+++ b/tests/integrations/slack/test_evidence_mappers.py
@@ -33,6 +33,7 @@ class TestSlackReadMessagesMapper:
                 {"user": "U2", "ts": "2.0", "text": "errors spiking"},
             ],
             "message_count": 2,
+            "truncated": False,
         }
 
         # Act
@@ -48,6 +49,26 @@ class TestSlackReadMessagesMapper:
                 "snippet": None,
             }
         ]
+
+    def test_marks_a_page_capped_read_as_truncated(self) -> None:
+        """A full page is a floor, not a total — citing it as exact would mislead."""
+        # Arrange
+        evidence: dict[str, Any] = {}
+        output = {
+            "status": "read",
+            "channel_id": "C0INCIDENT",
+            "messages": [{"text": f"m{i}"} for i in range(50)],
+            "message_count": 50,
+            "truncated": True,
+        }
+
+        # Act
+        _map_slack_read_messages(evidence, output, {"channel_id": "C0INCIDENT", "limit": 50})
+
+        # Assert
+        assert (
+            evidence["catalog_entries"][0]["summary"] == "50 messages from C0INCIDENT (truncated)"
+        )
 
     @pytest.mark.parametrize(
         "output",
@@ -98,6 +119,7 @@ class TestSlackSearchMessagesMapper:
                 {"channel_id": "C2", "user": "U2", "ts": "2.0", "text": "timeout again"},
             ],
             "match_count": 2,
+            "truncated": False,
         }
 
         # Act
@@ -113,6 +135,23 @@ class TestSlackSearchMessagesMapper:
                 "snippet": None,
             }
         ]
+
+    def test_marks_a_count_capped_search_as_truncated(self) -> None:
+        """search.messages returns one page, so a full page may hide more hits."""
+        # Arrange
+        evidence: dict[str, Any] = {}
+        output = {
+            "status": "read",
+            "matches": [{"text": f"hit {i}"} for i in range(20)],
+            "match_count": 20,
+            "truncated": True,
+        }
+
+        # Act
+        _map_slack_search_messages(evidence, output, {"query": "timeout"})
+
+        # Assert
+        assert evidence["catalog_entries"][0]["summary"] == "20 matches for 'timeout' (truncated)"
 
     def test_caps_the_query_echoed_into_the_summary(self) -> None:
         """The entry is re-read every turn, so a pathological query cannot grow it."""

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -138,7 +138,6 @@ query_grafana_annotations
 query_yc_metrics
 read_yc_logs
 redeploy_railway_service
-replay_slack_thread_locally
 rocketchat_send_message
 scan_redis_keys
 search_github_code
@@ -147,11 +146,7 @@ search_openclaw_conversations
 send_openclaw_message
 slack_add_reaction
 slack_join_channel
-slack_list_team_members
-slack_read_list
-slack_read_messages
 slack_reply_message
-slack_search_messages
 slack_send_message
 summarize_community_followups
 summarize_github_pr_status

--- a/tests/tools/test_slack_coworker_tools.py
+++ b/tests/tools/test_slack_coworker_tools.py
@@ -70,7 +70,7 @@ def test_search_messages_maps_matches(monkeypatch: pytest.MonkeyPatch) -> None:
         },
     }
     _install_fake_client(monkeypatch, lambda **_kw: _FakeResponse(payload))
-    matches, error = web_client.search_messages(
+    matches, error, _truncated = web_client.search_messages(
         web_client.SlackBotTarget(bot_token="xoxp-user"), query="boom"
     )
     assert error == ""

--- a/tests/tools/test_slack_search_messages_tool.py
+++ b/tests/tools/test_slack_search_messages_tool.py
@@ -98,7 +98,7 @@ def test_description_does_not_promise_a_bot_search_scope() -> None:
 
 def test_bot_token_is_refused_without_calling_slack(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_client(monkeypatch, _ExplodingClient())
-    matches, error = web_client.search_messages(
+    matches, error, _truncated = web_client.search_messages(
         web_client.SlackBotTarget(bot_token="xoxb-x"), query="timeout"
     )
     assert matches is None
@@ -108,7 +108,7 @@ def test_bot_token_is_refused_without_calling_slack(monkeypatch: pytest.MonkeyPa
 def test_rotating_user_token_is_treated_as_a_user_token(monkeypatch: pytest.MonkeyPatch) -> None:
     client = _RecordingClient(_SEARCH_PAYLOAD)
     _install_client(monkeypatch, client)
-    matches, error = web_client.search_messages(
+    matches, error, _truncated = web_client.search_messages(
         web_client.SlackBotTarget(bot_token="xoxe.xoxp-rotating"), query="boom"
     )
     assert error == ""
@@ -152,7 +152,7 @@ def test_slack_rejection_maps_to_the_same_actionable_hint(
 ) -> None:
     """A user token Slack still refuses must not surface the raw error code."""
     _install_client(monkeypatch, _RecordingClient({"ok": False, "error": "not_allowed_token_type"}))
-    matches, error = web_client.search_messages(
+    matches, error, _truncated = web_client.search_messages(
         web_client.SlackBotTarget(bot_token="xoxp-user"), query="boom"
     )
     assert matches is None


### PR DESCRIPTION
Fixes #5551 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Each of the five Slack read tools (`replay_slack_thread_locally`, `slack_list_team_members`, `slack_read_list`, `slack_read_messages`, `slack_search_messages`) now carries an `evidence_mapper` that calls `record_evidence_entry`, so its output becomes a numbered, citeable report entry (e.g. `E1 — Slack Channel Messages — 3 messages from C0INCIDENT`) instead of being dropped; the search mapper also links the top match's permalink. Empty, unavailable, and failed payloads record nothing, so no "0 items" line costs context on every later turn. Removes those five tools from `evidence_mapper_baseline.txt` and adds a unit test per mapper under `tests/integrations/slack/`.




### Demo/Screenshot for feature changes and bug fixes - 


https://github.com/user-attachments/assets/a325ab07-b7ac-4ce5-a8be-377bc81b0388


<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

These five tools are `BaseTool` classes, not `@tool` functions like the Grafana example, so each mapper is attached as a class attribute (`evidence_mapper = _map_slack_read_messages`). Each mapper sits in its own tool file.

- Every mapper uses the tool's own name as the `source`. Only the first entry per source is kept, so a shared `"slack"` key would have hidden four of the five.
- A mapper checks the result list itself, not the `status` field. One check handles empty reads, failures and unavailable tools.
- Entries are a short count plus context (channel, list title, thread ref) — about 100 characters. Search also adds the top match's link, with the query cut at 80 chars.
- No new evidence keys: the raw output is already stored, so adding more would save it twice.


<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
