### PR TITLE
fix(openclaw): map get/send wrappers to current MCP names

### DIFF
--- a/integrations/openclaw/delivery.py
+++ b/integrations/openclaw/delivery.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _OVERRIDABLE_KEYS = ("url", "mode", "auth_token", "command", "args", "headers", "timeout_seconds")
+_MISSING_CONVERSATION_ID = (
+    "OpenClaw write-back requires a conversation_id; creating a new conversation is not supported."
+)
 
 
 def _report_body(state: InvestigationState, report: str) -> str:
@@ -52,7 +55,6 @@ def _merge_openclaw_credentials(
 
 
 def _send_message(
-    tool_name: str,
     config_payload: dict[str, Any],
     arguments: dict[str, Any],
 ) -> tuple[bool, str | None]:
@@ -62,7 +64,7 @@ def _send_message(
         return False, runtime_error
 
     try:
-        result = call_openclaw_tool(config, tool_name, arguments)
+        result = call_openclaw_tool(config, "messages_send", arguments)
         if result.get("is_error"):
             return False, str(result.get("text") or "OpenClaw tool call failed.")
         return True, None
@@ -95,26 +97,16 @@ def send_openclaw_report(
     except Exception as exc:
         return False, f"OpenClaw config invalid: {exc}"
 
-    title = (
-        str(state.get("alert_name") or "OpenSRE Investigation").strip() or "OpenSRE Investigation"
-    )
     content = _report_body(state, report)
     conversation_id = str(openclaw_context.get("conversation_id") or "").strip()
+    if not conversation_id:
+        return False, _MISSING_CONVERSATION_ID
 
-    attempts: list[tuple[str, dict[str, Any]]] = []
-    if conversation_id:
-        attempts.append(("message_send", {"conversationId": conversation_id, "content": content}))
-    create_arguments: dict[str, Any] = {"title": title, "content": content}
-    if conversation_id:
-        create_arguments["conversationId"] = conversation_id
-    attempts.append(("conversations_create", create_arguments))
-
-    last_error: str | None = None
-    for tool_name, arguments in attempts:
-        posted, error = _send_message(tool_name, config_payload, arguments)
-        if posted:
-            return True, None
-        last_error = error
-        logger.debug("[openclaw_delivery] %s failed: %s", tool_name, error)
-
-    return False, last_error
+    posted, error = _send_message(
+        config_payload,
+        {"session_key": conversation_id, "text": content},
+    )
+    if posted:
+        return True, None
+    logger.debug("[openclaw_delivery] messages_send failed: %s", error)
+    return False, error

--- a/integrations/openclaw/delivery.py
+++ b/integrations/openclaw/delivery.py
@@ -18,8 +18,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _OVERRIDABLE_KEYS = ("url", "mode", "auth_token", "command", "args", "headers", "timeout_seconds")
-_MISSING_CONVERSATION_ID = (
-    "OpenClaw write-back requires a conversation_id; creating a new conversation is not supported."
+MISSING_CONVERSATION_ID = (
+    "OpenClaw write-back requires openclaw_conversation_id; "
+    "creating a new conversation is not supported."
 )
 
 
@@ -105,7 +106,7 @@ def send_openclaw_report(
         or ""
     ).strip()
     if not conversation_id:
-        return False, _MISSING_CONVERSATION_ID
+        return False, MISSING_CONVERSATION_ID
 
     posted, error = _send_message(
         config_payload,

--- a/integrations/openclaw/delivery.py
+++ b/integrations/openclaw/delivery.py
@@ -98,7 +98,12 @@ def send_openclaw_report(
         return False, f"OpenClaw config invalid: {exc}"
 
     content = _report_body(state, report)
-    conversation_id = str(openclaw_context.get("conversation_id") or "").strip()
+    conversation_id = str(
+        openclaw_context.get("conversation_id")
+        or merged_creds.get("openclaw_conversation_id")
+        or merged_creds.get("conversation_id")
+        or ""
+    ).strip()
     if not conversation_id:
         return False, _MISSING_CONVERSATION_ID
 

--- a/integrations/openclaw/reporting_adapter.py
+++ b/integrations/openclaw/reporting_adapter.py
@@ -51,8 +51,8 @@ class _OpenClawReportDeliveryAdapter:
         )
         logger.debug("[publish] openclaw delivery: posted=%s error=%s", posted, error)
         if not posted:
-            logger.debug("[publish] OpenClaw delivery failed: %s", error)
-        return True
+            logger.warning("[publish] OpenClaw delivery failed: %s", error)
+        return posted
 
 
 openclaw_delivery_adapter = _OpenClawReportDeliveryAdapter()

--- a/integrations/openclaw/reporting_adapter.py
+++ b/integrations/openclaw/reporting_adapter.py
@@ -37,7 +37,10 @@ class _OpenClawReportDeliveryAdapter:
             logger.debug("[publish] openclaw delivery: no openclaw integration configured")
             return False
 
-        from integrations.openclaw.delivery import send_openclaw_report
+        from integrations.openclaw.delivery import (
+            MISSING_CONVERSATION_ID,
+            send_openclaw_report,
+        )
 
         # ``state`` arrives as the platform-level ``DeliveryContext`` (a
         # ``Mapping``); the OpenClaw client wants the concrete
@@ -51,7 +54,7 @@ class _OpenClawReportDeliveryAdapter:
         )
         logger.debug("[publish] openclaw delivery: posted=%s error=%s", posted, error)
         if not posted:
-            if error and "conversation_id" in error.lower():
+            if error == MISSING_CONVERSATION_ID:
                 logger.debug("[publish] openclaw delivery: skipped - %s", error)
                 return False
             logger.warning("[publish] OpenClaw delivery failed: %s", error)

--- a/integrations/openclaw/reporting_adapter.py
+++ b/integrations/openclaw/reporting_adapter.py
@@ -51,8 +51,11 @@ class _OpenClawReportDeliveryAdapter:
         )
         logger.debug("[publish] openclaw delivery: posted=%s error=%s", posted, error)
         if not posted:
+            if error and "conversation_id" in error.lower():
+                logger.debug("[publish] openclaw delivery: skipped - %s", error)
+                return False
             logger.warning("[publish] OpenClaw delivery failed: %s", error)
-        return posted
+        return True
 
 
 openclaw_delivery_adapter = _OpenClawReportDeliveryAdapter()

--- a/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
+++ b/integrations/openclaw/tools/openclaw_mcp_tool/__init__.py
@@ -84,7 +84,7 @@ def _normalize_named_bridge_call(
 ) -> OpenClawBridgeResponse:
     """Invoke a named MCP tool and normalise its result.
 
-    ``tool_name`` is the MCP-side tool identifier (e.g. ``conversations_get``);
+    ``tool_name`` is the MCP-side tool identifier (e.g. ``conversation_get``);
     ``surface_tool_name`` is the OpenSRE registered tool name that this call
     is running on behalf of (e.g. ``get_openclaw_conversation``) so the Sentry
     ``tool_name`` tag matches the tool's declared metadata.
@@ -358,8 +358,8 @@ def get_openclaw_conversation(
 
     return _normalize_named_bridge_call(
         config,
-        tool_name="conversations_get",
-        arguments={"conversationId": normalized_conversation_id},
+        tool_name="conversation_get",
+        arguments={"session_key": normalized_conversation_id},
         surface_tool_name="get_openclaw_conversation",
     )
 
@@ -424,8 +424,8 @@ def send_openclaw_message(
 
     return _normalize_named_bridge_call(
         config,
-        tool_name="message_send",
-        arguments={"conversationId": normalized_conversation_id, "content": normalized_content},
+        tool_name="messages_send",
+        arguments={"session_key": normalized_conversation_id, "text": normalized_content},
         surface_tool_name="send_openclaw_message",
     )
 

--- a/tests/e2e/openclaw/fixtures/write_back_failure_alert.json
+++ b/tests/e2e/openclaw/fixtures/write_back_failure_alert.json
@@ -18,7 +18,7 @@
     "summary": "OpenSRE failed to write investigation report back to OpenClaw",
     "description": "After completing an RCA investigation for 'Checkout API Error Rate Spike', the publish_findings node attempted to call conversations_create on the OpenClaw MCP bridge but received an error. The investigation report was successfully delivered to Slack but is missing from OpenClaw. Engineers will not see the RCA findings in their AI assistant.",
     "investigation": "Checkout API Error Rate Spike",
-    "mcp_tool": "conversations_create",
+    "mcp_tool": "messages_send",
     "error": "OpenClaw tool call failed."
   },
   "externalURL": "http://alertmanager.monitoring.svc:9093",

--- a/tests/e2e/openclaw/test_openclaw_e2e.py
+++ b/tests/e2e/openclaw/test_openclaw_e2e.py
@@ -9,7 +9,7 @@ Test cases:
 1. Gateway Unavailable       — openclaw gateway process has crashed
 2. MCP Auth Failure          — bearer token rejected (401) on the HTTP MCP endpoint
 3. Stdio Command Not Found   — legacy openclaw-mcp binary replaced by 'openclaw mcp serve'
-4. Write-back Failure        — conversations_create returns is_error=True after investigation
+4. Write-back Failure        — messages_send returns is_error=True after investigation
 5. connection_verified Bug   — bridge tools permanently unavailable due to missing flag in catalog
 
 Run with:
@@ -373,14 +373,14 @@ class TestOpenClawStdioCommandNotFound:
 
 
 # ---------------------------------------------------------------------------
-# Test 4 — Write-back Failure (conversations_create returns is_error=True)
+# Test 4 — Write-back Failure (messages_send returns is_error=True)
 # ---------------------------------------------------------------------------
 
 
 class TestOpenClawWriteBackFailure:
     """
     Scenario: After a successful RCA investigation, publish_findings calls
-    send_openclaw_report() which in turn calls conversations_create on the MCP bridge.
+    send_openclaw_report() which in turn calls messages_send on the MCP bridge.
     The bridge returns is_error=True ('OpenClaw tool call failed.').
     OpenSRE must:
       - return (False, error_message) from send_openclaw_report
@@ -404,6 +404,7 @@ class TestOpenClawWriteBackFailure:
             root_cause="Increased 5xx rate due to upstream database timeouts",
             remediation_steps=["Scale RDS read replica", "Add circuit breaker"],
             validity_score=0.91,
+            openclaw_context={"conversation_id": "conv-1"},
         )
         creds = _openclaw_http_resolved()
 
@@ -429,6 +430,7 @@ class TestOpenClawWriteBackFailure:
             root_cause="Database connection pool exhausted",
             remediation_steps=["Increase max_connections to 1200"],
             validity_score=0.95,
+            openclaw_context={"conversation_id": "conv-1"},
         )
         creds = _openclaw_http_resolved()
 
@@ -448,6 +450,7 @@ class TestOpenClawWriteBackFailure:
         state = _minimal_investigation_state(
             alert_name="Test Alert",
             root_cause="Database connection pool exhausted",
+            openclaw_context={"conversation_id": "conv-1"},
         )
         creds = _openclaw_http_resolved()
 
@@ -468,7 +471,7 @@ class TestOpenClawWriteBackFailure:
 
         assert captured_arguments, "call_openclaw_tool must be invoked at least once"
         last_call = captured_arguments[-1]
-        body = last_call.get("content", "")
+        body = last_call.get("text", "")
         assert "Database connection pool exhausted" in body
 
     def test_send_report_includes_remediation_steps_in_body(self) -> None:
@@ -476,6 +479,7 @@ class TestOpenClawWriteBackFailure:
         state = _minimal_investigation_state(
             alert_name="Test Alert",
             remediation_steps=["Increase max_connections", "Restart connection pool"],
+            openclaw_context={"conversation_id": "conv-1"},
         )
         creds = _openclaw_http_resolved()
 
@@ -495,7 +499,7 @@ class TestOpenClawWriteBackFailure:
             send_openclaw_report(state, "RCA report", creds)
 
         last_call = captured_arguments[-1]
-        body = last_call.get("content", "")
+        body = last_call.get("text", "")
         assert "Increase max_connections" in body
         assert "Restart connection pool" in body
 
@@ -523,10 +527,9 @@ class TestOpenClawWriteBackFailure:
             send_openclaw_report(state, "RCA report", creds)
 
         assert captured, "No MCP calls were made"
-        # The first attempt should be message_send targeting the existing conversation
         first_tool, first_args = captured[0]
-        assert first_tool == "message_send"
-        assert first_args.get("conversationId") == "conv-existing-123"
+        assert first_tool == "messages_send"
+        assert first_args.get("session_key") == "conv-existing-123"
 
     def test_send_report_invalid_config_returns_false(self) -> None:
         """send_openclaw_report returns (False, error) when creds are invalid."""

--- a/tests/e2e/openclaw/test_openclaw_e2e.py
+++ b/tests/e2e/openclaw/test_openclaw_e2e.py
@@ -391,7 +391,7 @@ class TestOpenClawWriteBackFailure:
     def test_fixture_is_valid_json(self) -> None:
         alert = _load_fixture("write_back_failure_alert.json")
         assert alert["status"] == "firing"
-        assert "conversations_create" in alert["commonAnnotations"]["mcp_tool"]
+        assert "messages_send" in alert["commonAnnotations"]["mcp_tool"]
 
     def test_fixture_mentions_investigation_name(self) -> None:
         alert = _load_fixture("write_back_failure_alert.json")

--- a/tests/synthetic/mock_openclaw_backend/backend.py
+++ b/tests/synthetic/mock_openclaw_backend/backend.py
@@ -121,9 +121,8 @@ class FixtureOpenClawBackend:
     def _tool_handlers(self) -> dict[str, Any]:
         return {
             "conversations_list": self._handle_conversations_list,
-            "conversations_get": self._handle_conversations_get,
-            "conversations_create": self._handle_conversations_create,
-            "message_send": self._handle_message_send,
+            "conversation_get": self._handle_conversation_get,
+            "messages_send": self._handle_messages_send,
         }
 
     def _handle_conversations_list(self, arguments: dict[str, object]) -> dict[str, object]:
@@ -150,13 +149,13 @@ class FixtureOpenClawBackend:
             "structured_content": {"conversations": conversations},
         }
 
-    def _handle_conversations_get(self, arguments: dict[str, object]) -> dict[str, object]:
-        conversation_id = str(arguments.get("conversationId", ""))
+    def _handle_conversation_get(self, arguments: dict[str, object]) -> dict[str, object]:
+        conversation_id = str(arguments.get("session_key") or "").strip()
         for conv in self._scenario.fixture_conversations:
             if conv.get("id") == conversation_id:
                 return {
                     "is_error": False,
-                    "tool": "conversations_get",
+                    "tool": "conversation_get",
                     "arguments": arguments,
                     "text": conv.get("lastMessage", ""),
                     "content": [{"type": "text", "text": str(conv.get("lastMessage", ""))}],
@@ -164,27 +163,17 @@ class FixtureOpenClawBackend:
                 }
         return {
             "is_error": True,
-            "tool": "conversations_get",
+            "tool": "conversation_get",
             "arguments": arguments,
             "text": f"Conversation '{conversation_id}' not found.",
             "content": [],
             "structured_content": None,
         }
 
-    def _handle_conversations_create(self, arguments: dict[str, object]) -> dict[str, object]:
+    def _handle_messages_send(self, arguments: dict[str, object]) -> dict[str, object]:
         return {
             "is_error": False,
-            "tool": "conversations_create",
-            "arguments": arguments,
-            "text": "Conversation created successfully.",
-            "content": [{"type": "text", "text": "Conversation created successfully."}],
-            "structured_content": {"id": "fixture-conv-new", "title": arguments.get("title", "")},
-        }
-
-    def _handle_message_send(self, arguments: dict[str, object]) -> dict[str, object]:
-        return {
-            "is_error": False,
-            "tool": "message_send",
+            "tool": "messages_send",
             "arguments": arguments,
             "text": "Message sent.",
             "content": [{"type": "text", "text": "Message sent."}],

--- a/tests/synthetic/openclaw/scenario_loader.py
+++ b/tests/synthetic/openclaw/scenario_loader.py
@@ -55,17 +55,12 @@ def _load_fixture_tools(scenario_dir: Path) -> list[dict[str, Any]]:
                 "input_schema": None,
             },
             {
-                "name": "conversations_get",
-                "description": "Get a specific OpenClaw conversation by ID.",
+                "name": "conversation_get",
+                "description": "Get a specific OpenClaw conversation by session key.",
                 "input_schema": None,
             },
             {
-                "name": "conversations_create",
-                "description": "Create a new OpenClaw conversation.",
-                "input_schema": None,
-            },
-            {
-                "name": "message_send",
+                "name": "messages_send",
                 "description": "Send a message into an OpenClaw conversation.",
                 "input_schema": None,
             },

--- a/tests/tools/test_openclaw_mcp_tool.py
+++ b/tests/tools/test_openclaw_mcp_tool.py
@@ -371,13 +371,13 @@ def test_get_openclaw_conversation_happy_path() -> None:
             "integrations.openclaw.tools.openclaw_mcp_tool.invoke_openclaw_mcp_tool",
             return_value={
                 "is_error": False,
-                "tool": "conversations_get",
-                "arguments": {"conversationId": "conv-1"},
+                "tool": "conversation_get",
+                "arguments": {"session_key": "conv-1"},
                 "text": "ok",
                 "structured_content": {"id": "conv-1", "title": "Checkout debugging"},
                 "content": [],
             },
-        ),
+        ) as invoke,
     ):
         result = get_openclaw_conversation(
             conversation_id="conv-1",
@@ -387,7 +387,8 @@ def test_get_openclaw_conversation_happy_path() -> None:
         )
 
     assert result["available"] is True
-    assert result["tool"] == "conversations_get"
+    assert result["tool"] == "conversation_get"
+    invoke.assert_called_once_with(mock_config, "conversation_get", {"session_key": "conv-1"})
 
 
 def test_send_openclaw_message_happy_path() -> None:
@@ -410,13 +411,13 @@ def test_send_openclaw_message_happy_path() -> None:
             "integrations.openclaw.tools.openclaw_mcp_tool.invoke_openclaw_mcp_tool",
             return_value={
                 "is_error": False,
-                "tool": "message_send",
-                "arguments": {"conversationId": "conv-1", "content": "hello"},
+                "tool": "messages_send",
+                "arguments": {"session_key": "conv-1", "text": "hello"},
                 "text": "sent",
                 "structured_content": {"ok": True},
                 "content": [],
             },
-        ),
+        ) as invoke,
     ):
         result = send_openclaw_message(
             conversation_id="conv-1",
@@ -427,4 +428,9 @@ def test_send_openclaw_message_happy_path() -> None:
         )
 
     assert result["available"] is True
-    assert result["tool"] == "message_send"
+    assert result["tool"] == "messages_send"
+    invoke.assert_called_once_with(
+        mock_config,
+        "messages_send",
+        {"session_key": "conv-1", "text": "hello"},
+    )

--- a/tests/utils/test_openclaw_delivery.py
+++ b/tests/utils/test_openclaw_delivery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -204,3 +205,26 @@ def test_send_openclaw_report_merges_transport_overrides(monkeypatch: pytest.Mon
     assert posted is True
     assert error is None
     assert seen_configs[0] == ("stdio", "openclaw")
+
+
+def test_openclaw_adapter_warns_when_session_is_missing(caplog: pytest.LogCaptureFixture) -> None:
+    from integrations.openclaw.reporting_adapter import openclaw_delivery_adapter
+
+    with caplog.at_level(logging.WARNING, logger="integrations.openclaw.reporting_adapter"):
+        delivered = openclaw_delivery_adapter.deliver(
+            {
+                "resolved_integrations": {
+                    "openclaw": {
+                        "mode": "streamable-http",
+                        "url": "https://openclaw.example.com/mcp",
+                        "auth_token": "tok",
+                    }
+                },
+                "channel_contexts": {"openclaw": {}},
+            },
+            messages={"slack_text": "RCA report"},
+            blocks=[],
+        )
+
+    assert delivered is False
+    assert any("OpenClaw delivery failed" in rec.getMessage() for rec in caplog.records)

--- a/tests/utils/test_openclaw_delivery.py
+++ b/tests/utils/test_openclaw_delivery.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from integrations.openclaw.delivery import send_openclaw_report
+from integrations.openclaw.delivery import MISSING_CONVERSATION_ID, send_openclaw_report
 
 
 def _state(**overrides: Any) -> dict[str, Any]:
@@ -55,8 +55,7 @@ def test_send_openclaw_report_without_conversation_id_fails_closed(
     )
 
     assert posted is False
-    assert error is not None
-    assert "conversation_id" in error.lower()
+    assert error == MISSING_CONVERSATION_ID
     assert calls == []
 
 
@@ -270,7 +269,10 @@ def test_openclaw_adapter_returns_true_after_failed_send(
     )
     monkeypatch.setattr(
         "integrations.openclaw.delivery.call_openclaw_tool",
-        lambda *_args, **_kwargs: {"is_error": True, "text": "route missing"},
+        lambda *_args, **_kwargs: {
+            "is_error": True,
+            "text": "Unknown conversation_id 'conv-1' on this workspace.",
+        },
     )
 
     with caplog.at_level(logging.WARNING, logger="integrations.openclaw.reporting_adapter"):

--- a/tests/utils/test_openclaw_delivery.py
+++ b/tests/utils/test_openclaw_delivery.py
@@ -134,6 +134,33 @@ def test_send_openclaw_report_exception_returns_false(monkeypatch: pytest.Monkey
     assert "boom" in error
 
 
+def test_send_openclaw_report_uses_creds_conversation_id_when_context_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    monkeypatch.setattr(
+        "integrations.openclaw.delivery.openclaw_runtime_unavailable_reason",
+        lambda _config: None,
+    )
+
+    def _fake_call(_config: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        calls.append((tool_name, arguments))
+        return {"is_error": False, "tool": tool_name, "arguments": arguments}
+
+    monkeypatch.setattr("integrations.openclaw.delivery.call_openclaw_tool", _fake_call)
+
+    posted, error = send_openclaw_report(
+        _state(),
+        "report",
+        _creds(openclaw_conversation_id="conv-from-creds"),
+    )
+
+    assert posted is True
+    assert error is None
+    assert calls[0][1]["session_key"] == "conv-from-creds"
+
+
 def test_send_openclaw_report_forwards_conversation_id(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
 
@@ -207,10 +234,10 @@ def test_send_openclaw_report_merges_transport_overrides(monkeypatch: pytest.Mon
     assert seen_configs[0] == ("stdio", "openclaw")
 
 
-def test_openclaw_adapter_warns_when_session_is_missing(caplog: pytest.LogCaptureFixture) -> None:
+def test_openclaw_adapter_skips_when_session_is_missing(caplog: pytest.LogCaptureFixture) -> None:
     from integrations.openclaw.reporting_adapter import openclaw_delivery_adapter
 
-    with caplog.at_level(logging.WARNING, logger="integrations.openclaw.reporting_adapter"):
+    with caplog.at_level(logging.DEBUG, logger="integrations.openclaw.reporting_adapter"):
         delivered = openclaw_delivery_adapter.deliver(
             {
                 "resolved_integrations": {
@@ -227,4 +254,40 @@ def test_openclaw_adapter_warns_when_session_is_missing(caplog: pytest.LogCaptur
         )
 
     assert delivered is False
+    assert any("skipped" in rec.getMessage() for rec in caplog.records)
+    assert not any("OpenClaw delivery failed" in rec.getMessage() for rec in caplog.records)
+
+
+def test_openclaw_adapter_returns_true_after_failed_send(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from integrations.openclaw.reporting_adapter import openclaw_delivery_adapter
+
+    monkeypatch.setattr(
+        "integrations.openclaw.delivery.openclaw_runtime_unavailable_reason",
+        lambda _config: None,
+    )
+    monkeypatch.setattr(
+        "integrations.openclaw.delivery.call_openclaw_tool",
+        lambda *_args, **_kwargs: {"is_error": True, "text": "route missing"},
+    )
+
+    with caplog.at_level(logging.WARNING, logger="integrations.openclaw.reporting_adapter"):
+        delivered = openclaw_delivery_adapter.deliver(
+            {
+                "resolved_integrations": {
+                    "openclaw": {
+                        "mode": "streamable-http",
+                        "url": "https://openclaw.example.com/mcp",
+                        "auth_token": "tok",
+                    }
+                },
+                "channel_contexts": {"openclaw": {"conversation_id": "conv-1"}},
+            },
+            messages={"slack_text": "RCA report"},
+            blocks=[],
+        )
+
+    assert delivered is True
     assert any("OpenClaw delivery failed" in rec.getMessage() for rec in caplog.records)

--- a/tests/utils/test_openclaw_delivery.py
+++ b/tests/utils/test_openclaw_delivery.py
@@ -31,7 +31,9 @@ def _creds(**overrides: Any) -> dict[str, Any]:
     return base
 
 
-def test_send_openclaw_report_success_creates_conversation(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_send_openclaw_report_without_conversation_id_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
 
     monkeypatch.setattr(
@@ -51,21 +53,10 @@ def test_send_openclaw_report_success_creates_conversation(monkeypatch: pytest.M
         _creds(),
     )
 
-    assert posted is True
-    assert error is None
-    assert calls == [
-        (
-            "conversations_create",
-            {
-                "title": "Checkout API error rate spike",
-                "content": (
-                    "Full RCA report\n\nRoot cause: A bad deploy introduced 5xx errors.\n\n"
-                    "Remediation steps:\n- Roll back the deploy\n- Verify health checks\n\n"
-                    "Confidence: 92%"
-                ),
-            },
-        )
-    ]
+    assert posted is False
+    assert error is not None
+    assert "conversation_id" in error.lower()
+    assert calls == []
 
 
 def test_send_openclaw_report_invalid_config_returns_false() -> None:
@@ -89,7 +80,9 @@ def test_send_openclaw_report_runtime_unavailable_returns_false(
     )
 
     posted, error = send_openclaw_report(
-        _state(), "report", _creds(mode="stdio", command="openclaw")
+        _state(channel_contexts={"openclaw": {"conversation_id": "conv-1"}}),
+        "report",
+        _creds(mode="stdio", command="openclaw"),
     )
 
     assert posted is False
@@ -109,7 +102,11 @@ def test_send_openclaw_report_tool_error_returns_false(monkeypatch: pytest.Monke
         },
     )
 
-    posted, error = send_openclaw_report(_state(), "report", _creds())
+    posted, error = send_openclaw_report(
+        _state(channel_contexts={"openclaw": {"conversation_id": "conv-1"}}),
+        "report",
+        _creds(),
+    )
 
     assert posted is False
     assert error == "route missing"
@@ -125,7 +122,11 @@ def test_send_openclaw_report_exception_returns_false(monkeypatch: pytest.Monkey
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
-    posted, error = send_openclaw_report(_state(), "report", _creds())
+    posted, error = send_openclaw_report(
+        _state(channel_contexts={"openclaw": {"conversation_id": "conv-1"}}),
+        "report",
+        _creds(),
+    )
 
     assert posted is False
     assert error is not None
@@ -154,8 +155,19 @@ def test_send_openclaw_report_forwards_conversation_id(monkeypatch: pytest.Monke
 
     assert posted is True
     assert error is None
-    assert calls[0][0] == "message_send"
-    assert calls[0][1]["conversationId"] == "conv-1"
+    assert calls == [
+        (
+            "messages_send",
+            {
+                "session_key": "conv-1",
+                "text": (
+                    "report\n\nRoot cause: A bad deploy introduced 5xx errors.\n\n"
+                    "Remediation steps:\n- Roll back the deploy\n- Verify health checks\n\n"
+                    "Confidence: 92%"
+                ),
+            },
+        )
+    ]
 
 
 def test_send_openclaw_report_merges_transport_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -177,7 +189,12 @@ def test_send_openclaw_report_merges_transport_overrides(monkeypatch: pytest.Mon
     posted, error = send_openclaw_report(
         _state(
             channel_contexts={
-                "openclaw": {"mode": "stdio", "command": "openclaw", "args": ["mcp", "serve"]}
+                "openclaw": {
+                    "conversation_id": "conv-1",
+                    "mode": "stdio",
+                    "command": "openclaw",
+                    "args": ["mcp", "serve"],
+                }
             }
         ),
         "report",


### PR DESCRIPTION
Fixes #5890

#### Describe the changes you have made in this PR -

OpenClaw 2026.8+ no longer exposes `conversations_get`, `message_send`, or `conversations_create`. Public OpenSRE tools keep the same names and args (`get_openclaw_conversation(conversation_id=…)`, `send_openclaw_message(conversation_id=…, content=…)`); they now call live MCP `conversation_get` (`session_key`) and `messages_send` (`session_key` + `text`). RCA write-back uses `messages_send` only and fails closed when `conversation_id` is missing.

Live check against OpenClaw 2026.8.1: verify still finds 9 tools; retired names still return `Tool … not found`; wrappers hit `conversation_get` / `messages_send` (empty `--dev` gateway returns conversation-not-found, not tool-not-found).

### Demo/Screenshot for feature changes and bug fixes -

Live MCP catalog (2026.8.1): `conversation_get`, `messages_send` present; `conversations_get` / `message_send` / `conversations_create` absent.

Retired raw calls:
- `conversations_get` → `MCP error -32602: Tool conversations_get not found`
- `message_send` → `MCP error -32602: Tool message_send not found`

After fix:
- `get_openclaw_conversation` → `conversation_get` + `session_key`
- `send_openclaw_message` → `messages_send` + `session_key` / `text`

---


**Explain your implementation approach:**

The bug was a name/arg mismatch with current OpenClaw MCP, not a change to the OpenSRE public API. Mapping is inlined at the two call sites (bridge tools + write-back). Without a session, write-back cannot create a conversation because that MCP tool is gone, so it fails closed instead of retrying `conversations_create`. Tests pin the new MCP names/args; the synthetic fixture catalog matches live tools.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions