### PR TITLE
feat(shell): letter-key (A)(B)(C) clarification menus + local-scope default

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -125,6 +125,15 @@ arrow-key selection menu. Do not ask for free-form text, write a numbered
 "reply with 1, 2, or 3" list, or end the turn with prose asking the user to
 choose among those options.
 
+Read "my system", "on my machine", "my repos", or "my services" as the local
+environment — this machine's filesystem and local Git checkouts — unless the
+request names a connected account or integration. Do not silently reinterpret a
+local-scoped request as a hosted account (a request about repositories "on my
+system" is about local checkouts, not your GitHub account). Proceed with that
+default and state it in one short sentence. Only when a genuinely blocking
+choice remains — a small fixed set of materially different paths with no safe
+default — call `ask_user_choice` instead of guessing.
+
 For a demo or getting-started request, present the available skill demos as
 selectable options using `ask_user_choice`; use each demo prompt as the option
 that expresses that intent. This rule takes precedence over any assembled

--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -150,8 +150,9 @@ intent is explicit, when a safe default would not materially change the result,
 or when the possible answers are open-ended rather than a small fixed set.
 
 After calling `ask_user_choice`, end the turn with at most one short sentence of
-context. The user's selection arrives verbatim as the next message; resume from
-that selection. If the tool reports that the menu is unavailable **and the
+context — exactly one, never two variations of the same "pick one / or type your
+own" prompt. The user's selection arrives verbatim as the next message; resume
+from that selection. If the tool reports that the menu is unavailable **and the
 choice is required to continue**, fall back to a short numbered list and ask
 the user to reply with their choice. Use this numbered fallback only for
 required clarification when TURN INTERACTION reports the menu is unavailable.

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -66,6 +66,7 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         custom_label=CUSTOM_OPTION,
         multi_select=items[0].multi_select,
         header="Ask User",
+        letter_keys=True,
     )
     if picked_one is None:
         console.print(f"[{ui_theme.DIM}]Selection cancelled — type a reply instead.[/]")

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -30,7 +30,7 @@ from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, MARKDOWN_CODE_THEME
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
-from surfaces.interactive_shell.ui.streaming import render_markdown_block
+from surfaces.interactive_shell.ui.streaming import render_note_block
 from surfaces.shared.terminal.output.console_state import get_investigation_spinner
 from tools.interactive_shell.action_names import ActionToolName
 from tools.interactive_shell.shell.display import format_shell_command_for_display
@@ -467,10 +467,10 @@ class ActionRenderObserver:
         if is_plan_diagnosis_prose(content):
             return
         self.console.print()
-        # ``render_markdown_block`` sanitizes model text at ``_build_markdown_block``.
-        # No ``∴`` header here: the turn's single marker sits on the final
-        # response, so a mid-turn narration must not add a second one.
-        render_markdown_block(self.console, content)
+        # Intermediate narration is a working note: dim + indented, no glyph, so
+        # it reads apart from the recessed ``[n] ❯`` user row and bright ``∴`` reply.
+        # ``render_note_block`` sanitizes model text at ``_build_markdown_block``.
+        render_note_block(self.console, content)
 
     def _render_skill_start(self, data: dict[str, Any]) -> None:
         """Print ``Skill <name>`` when the agent starts loading a skill."""

--- a/surfaces/interactive_shell/ui/ask_user.py
+++ b/surfaces/interactive_shell/ui/ask_user.py
@@ -10,9 +10,9 @@ when that row is focused you type on it in place — the panel never leaves
 for a separate ``Your answer:`` or ``[N] ❯`` prompt.
 
 Options are labelled ``(A)``, ``(B)``, ``(C)`` and selected by the matching
-letter key or the arrows. Questions with ``multi_select`` show ``[ ]`` /
-``[x]`` checkboxes; Space, Enter, and the option letters toggle. Submit
-commits the checked set.
+letter key or the arrows. Questions with ``multi_select`` keep those letter
+labels next to ``[ ]`` / ``[x]`` checkboxes; Space, Enter, and the option
+letters toggle. Submit commits the checked set.
 """
 
 from __future__ import annotations
@@ -170,11 +170,13 @@ def _draw_ask_user(
             body = f"{custom_draft}{_CURSOR}"
         else:
             body = label
+        token = f"({chr(ord('A') + position)})"
         if multi:
             box = _CHECKED if position in checked else _UNCHECKED
-            _write_option_row(prefix=box, label=body, width=width, selected=is_selected)
+            _write_option_row(
+                prefix=box, label=f"{token} {body}", width=width, selected=is_selected
+            )
         else:
-            token = f"({chr(ord('A') + position)})"
             marker = "❯" if is_selected else " "
             _write_option_row(
                 prefix=marker, label=f"{token} {body}", width=width, selected=is_selected

--- a/surfaces/interactive_shell/ui/ask_user.py
+++ b/surfaces/interactive_shell/ui/ask_user.py
@@ -9,8 +9,10 @@ Free text is the last row of the same OpenSRE option array (Droid-style):
 when that row is focused you type on it in place — the panel never leaves
 for a separate ``Your answer:`` or ``[N] ❯`` prompt.
 
-Questions with ``multi_select`` show ``[ ]`` / ``[x]`` checkboxes; Space,
-Enter, and digits toggle. Submit commits the checked set.
+Options are labelled ``(A)``, ``(B)``, ``(C)`` and selected by the matching
+letter key or the arrows. Questions with ``multi_select`` show ``[ ]`` /
+``[x]`` checkboxes; Space, Enter, and the option letters toggle. Submit
+commits the checked set.
 """
 
 from __future__ import annotations
@@ -38,9 +40,18 @@ from surfaces.shared.terminal.components.key_reader import (
 CUSTOM_OPTION = "Or type your own answer..."
 _HEADER = "Ask User"
 _SUBMIT = "Submit"
-_HINT = "Tab/⇧Tab or ←/→ Questions    ↑/↓ Navigate    Enter/1-9 Select    Esc cancel"
-_HINT_MULTI = "Tab/⇧Tab or ←/→ Questions    ↑/↓ Navigate    Space/Enter/1-9 Toggle    Esc cancel"
 _HINT_TYPING = "Type on this row    Enter confirm    ↑/↓ leave    Esc cancel"
+_HINT_NAV = "Tab/⇧Tab or ←/→ Questions    ↑/↓ Navigate    "
+
+
+def _ask_user_hint(count: int, *, multi_select: bool) -> str:
+    """Key hint naming the ``A-…`` letter selectors for the visible options."""
+    keys = f"A-{chr(ord('A') + count - 1)}" if count > 1 else "A"
+    if multi_select:
+        return f"{_HINT_NAV}Space/Enter/{keys} Toggle    Esc cancel"
+    return f"{_HINT_NAV}Enter/{keys} Select    Esc cancel"
+
+
 _CURSOR = "█"
 _BREADCRUMB_SEP = " → "
 _FILLED = "●"
@@ -72,6 +83,11 @@ def _breadcrumb_items(
         label = strip_terminal_controls(question.label).strip() or f"Q{index + 1}"
         items.append((glyph, label))
     return items
+
+
+def _letter_index(action: str) -> int | None:
+    """Zero-based option index an ``(A)``/``(B)`` letter keystroke names, or ``None``."""
+    return ord(action.upper()) - ord("A") if len(action) == 1 and action.isalpha() else None
 
 
 def _option_labels(question: AskUserQuestion) -> list[str]:
@@ -158,9 +174,11 @@ def _draw_ask_user(
             box = _CHECKED if position in checked else _UNCHECKED
             _write_option_row(prefix=box, label=body, width=width, selected=is_selected)
         else:
-            numbered = f"{position + 1}. {body}"
+            token = f"({chr(ord('A') + position)})"
             marker = "❯" if is_selected else " "
-            _write_option_row(prefix=marker, label=numbered, width=width, selected=is_selected)
+            _write_option_row(
+                prefix=marker, label=f"{token} {body}", width=width, selected=is_selected
+            )
     submit_selected = option_index == submit_row and not typing
     submit_marker = "❯" if submit_selected else " "
     _write_option_row(
@@ -171,10 +189,8 @@ def _draw_ask_user(
     )
     if typing:
         hint = _HINT_TYPING
-    elif multi:
-        hint = _HINT_MULTI
     else:
-        hint = _HINT
+        hint = _ask_user_hint(len(labels), multi_select=multi)
     write_menu_line(f"{ui_theme.DIM_COUNTER_ANSI}{hint}{ui_theme.ANSI_RESET}")
     sys.stdout.flush()
 
@@ -286,7 +302,7 @@ def _run_ask_user(
             flush_pending_input()
             first = False
         current_height = _menu_height(question)
-        action = read_menu_or_char(allow_chars=on_custom)
+        action = read_menu_or_char(allow_chars=on_custom, alpha_keys=not on_custom)
         if action in ("tab", "right"):
             q_idx = min(q_idx + 1, len(items) - 1)
             opt_idx = 0
@@ -324,10 +340,12 @@ def _run_ask_user(
             toggle_index: int | None = None
             if action in (" ", "enter") and opt_idx < len(labels):
                 toggle_index = opt_idx
-            elif (not on_custom) and len(action) == 1 and action.isdigit():
-                picked = int(action) - 1
-                if 0 <= picked < len(labels):
-                    toggle_index = picked
+            elif (
+                not on_custom
+                and (picked := _letter_index(action)) is not None
+                and 0 <= picked < len(labels)
+            ):
+                toggle_index = picked
             if toggle_index is not None:
                 if toggle_index == custom_index and not drafts[q_idx].strip():
                     opt_idx = toggle_index
@@ -374,8 +392,7 @@ def _run_ask_user(
             selected = option_focus if opt_idx == submit_row else opt_idx
             if selected < len(labels):
                 option_focus = selected
-        elif (not on_custom) and len(action) == 1 and action.isdigit():
-            picked = int(action) - 1
+        elif not on_custom and (picked := _letter_index(action)) is not None:
             if 0 <= picked < len(labels):
                 selected = picked
 

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -24,8 +24,6 @@ from surfaces.interactive_shell.ui.input_prompt.layout import (
 
 DEFAULT_PLACEHOLDER_TEXT = 'Try "Investigate this alert"'
 _PLAN_CONTINUE_PLACEHOLDER = "continue the plan, or type a message"
-# Left accent bar that marks a user-prompt row (agent responses use ``●``).
-_PROMPT_ACCENT_BAR = "▌"
 
 
 def _prompt_turn_number(session: Session) -> int:
@@ -111,23 +109,22 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
     lines = text.splitlines() or [""]
     # Rich's Style.parse() reads the bare str value of a _LazyRichStyle (""),
     # so resolve to a concrete string at the call site to keep palette colors.
-    body_style = handoff_answer_style() if is_handoff_answer else str(ui_theme.TEXT)
-    # A colour accent bar down the left marks the row as the user's prompt —
-    # distinct from the agent response, which opens with the ``●`` glyph and no
-    # bar. The bar repeats on every wrapped line so the whole submission reads as
-    # one block.
-    bar_style = f"bold {ui_theme.HIGHLIGHT}"
+    # The user row is recessed grey (no bright accent): the agent's ``∴`` reply
+    # and working notes carry the visual weight, and SECONDARY keeps the ask
+    # readable while sitting a shade above the darker DIM notes so the three
+    # turn roles still read apart. The ``[N] ❯`` prefix is dimmer still.
+    body_style = handoff_answer_style() if is_handoff_answer else str(ui_theme.SECONDARY)
+    prefix_style = str(ui_theme.DIM)
     continuation_prefix = " " * (len(counter) + len("❯ "))
     rendered = Text()
     for index, line in enumerate(lines):
         if index:
             rendered.append("\n")
-        rendered.append(f"{_PROMPT_ACCENT_BAR} ", style=bar_style)
         if index == 0:
-            rendered.append(counter, style=str(ui_theme.DIM))
-            rendered.append("❯ ", style=bar_style)
+            rendered.append(counter, style=prefix_style)
+            rendered.append("❯ ", style=prefix_style)
         else:
-            rendered.append(continuation_prefix, style=str(ui_theme.DIM))
+            rendered.append(continuation_prefix, style=prefix_style)
         rendered.append(line, style=body_style)
     console.print(rendered)
 

--- a/surfaces/interactive_shell/ui/streaming/__init__.py
+++ b/surfaces/interactive_shell/ui/streaming/__init__.py
@@ -46,6 +46,7 @@ from surfaces.interactive_shell.ui.streaming.renderer import (
     STREAM_LABEL_ANSWER,
     STREAM_LABEL_ASSISTANT,
     render_markdown_block,
+    render_note_block,
     render_response_header,
 )
 from surfaces.shared.terminal.components.token_format import (
@@ -62,6 +63,7 @@ __all__ = [
     "format_token_count_short",
     "publish_full_response",
     "render_markdown_block",
+    "render_note_block",
     "render_response_header",
     "stream_to_console",
     "stream_to_console_state",

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -7,6 +7,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from rich.console import Console
+from rich.padding import Padding
 
 import infrastructure.terminal.theme as ui_theme
 from core.agent_harness.spi.prompt_chrome import normalize_three_tier_spacing
@@ -68,6 +69,23 @@ def render_markdown_block(console: Console, text: str) -> None:
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):
         console.print(_build_markdown_block(visible))
+
+
+def render_note_block(console: Console, text: str) -> None:
+    """Render intermediate agent narration as a dim, indented note.
+
+    Distinct from the bright ``∴`` reply and the recessed grey ``[n] ❯`` user
+    row: a note carries no glyph, only a dim left indent, so the three turn
+    roles — your ask, opensre's working notes, and its final reply — read apart.
+    Bold spans (the action words) stay bold within the dim base.
+    """
+    visible = strip_session_goal_progress_tags(text)
+    if not visible.strip():
+        return
+    with console.use_theme(ui_theme.MARKDOWN_THEME):
+        console.print(
+            Padding(_build_markdown_block(visible), (0, 0, 0, 3)), style=str(ui_theme.DIM)
+        )
 
 
 def render_response_header(console: Console, label: str) -> None:

--- a/surfaces/shared/terminal/components/choice_menu.py
+++ b/surfaces/shared/terminal/components/choice_menu.py
@@ -290,11 +290,11 @@ def _draw_menu(
     write_menu_line()
     for i, label in enumerate(labels):
         here = i == index
+        token = _option_token(i, letter_keys=letter_keys)
         if multi_select:
             box = _CHECKED if i in checked else _UNCHECKED
-            _write_option_row(prefix=box, label=label, width=w, selected=here)
+            _write_option_row(prefix=box, label=f"{token} {label}", width=w, selected=here)
         else:
-            token = _option_token(i, letter_keys=letter_keys)
             sym = "❯" if here else " "
             _write_option_row(prefix=sym, label=f"{token} {label}", width=w, selected=here)
     if multi_select:
@@ -343,7 +343,7 @@ def _pick(
 
     When ``multi_select`` is True, return a newline-joined string of checked
     **values** (``values[i]`` when provided, else ``labels[i]``). Submit commits.
-    Space/Enter/1-9 toggle checkboxes.
+    Space/Enter and the visible row keys (``1-9`` or ``A-…``) toggle checkboxes.
     """
     from surfaces.shared.terminal.components.key_reader import read_menu_or_char
 

--- a/surfaces/shared/terminal/components/choice_menu.py
+++ b/surfaces/shared/terminal/components/choice_menu.py
@@ -24,6 +24,32 @@ from surfaces.shared.terminal.components.key_reader import read_key_unix, read_k
 
 _HINT = "↑↓ Navigate • Enter/1-9 Select • Esc cancel"
 _HINT_MULTI = "↑↓ Navigate • Space/Enter/1-9 Toggle • Submit to confirm • Esc cancel"
+
+
+def _option_token(index: int, *, letter_keys: bool) -> str:
+    """Row prefix: ``(A)`` in letter mode, else ``1.`` (1-based)."""
+    return f"({chr(ord('A') + index)})" if letter_keys else f"{index + 1}."
+
+
+def _option_index_from_key(action: str, *, letter_keys: bool) -> int | None:
+    """Zero-based option index a select keystroke names, or ``None``."""
+    if len(action) != 1:
+        return None
+    if letter_keys:
+        return ord(action.upper()) - ord("A") if action.isalpha() else None
+    return int(action) - 1 if action.isdigit() else None
+
+
+def _select_hint(count: int, *, letter_keys: bool, multi_select: bool) -> str:
+    """Key hint reflecting letter vs numeric selectors and the option count."""
+    if not letter_keys:
+        return _HINT_MULTI if multi_select else _HINT
+    keys = f"A-{chr(ord('A') + count - 1)}" if count > 1 else "A"
+    if multi_select:
+        return f"↑↓ Navigate • Space/Enter/{keys} Toggle • Submit to confirm • Esc cancel"
+    return f"↑↓ Navigate • Enter/{keys} Select • Esc cancel"
+
+
 # Airy block indent so the panel is not flush against the left margin.
 _BLOCK_INDENT = "  "
 _SUBMIT = "Submit"
@@ -65,14 +91,19 @@ def repl_section_break(console: Console) -> None:
 # ── raw key reader ───────────────────────────────────────────────────────────
 
 
-def _read_action() -> MenuAction:
+def _read_action(*, alpha_keys: bool = False) -> MenuAction:
     """Map a raw keypress to a menu action.
 
     Delegates terminal I/O to :mod:`key_reader` and applies
     choice_menu-specific overrides: Tab → ``"down"``,
-    right-arrow → ``"enter"``, left-arrow → ``"ignore"``.
+    right-arrow → ``"enter"``, left-arrow → ``"ignore"``. With ``alpha_keys``
+    an option letter (``A``/``B``/…) is returned verbatim for letter select.
     """
-    key = read_key_windows() if os.name == "nt" else read_key_unix()
+    key = (
+        read_key_windows(alpha_keys=alpha_keys)
+        if os.name == "nt"
+        else read_key_unix(alpha_keys=alpha_keys)
+    )
     if key == "tab":
         return "down"
     if key == "right":
@@ -233,6 +264,7 @@ def _draw_menu(
     multi_select: bool = False,
     checked: set[int] | None = None,
     header: str = "",
+    letter_keys: bool = False,
 ) -> None:
     out = sys.stdout
     w = _cols()
@@ -262,9 +294,9 @@ def _draw_menu(
             box = _CHECKED if i in checked else _UNCHECKED
             _write_option_row(prefix=box, label=label, width=w, selected=here)
         else:
-            numbered = f"{i + 1}. {label}"
+            token = _option_token(i, letter_keys=letter_keys)
             sym = "❯" if here else " "
-            _write_option_row(prefix=sym, label=numbered, width=w, selected=here)
+            _write_option_row(prefix=sym, label=f"{token} {label}", width=w, selected=here)
     if multi_select:
         submit_selected = index == len(labels)
         _write_option_row(
@@ -273,9 +305,7 @@ def _draw_menu(
             width=w,
             selected=submit_selected,
         )
-        hint = _HINT_MULTI
-    else:
-        hint = _HINT
+    hint = _select_hint(len(labels), letter_keys=letter_keys, multi_select=multi_select)
     write_menu_line()
     write_menu_line(f"{_BLOCK_INDENT}{ui_theme.DIM_COUNTER_ANSI}{hint}{ui_theme.ANSI_RESET}")
     out.flush()
@@ -304,6 +334,7 @@ def _pick(
     multi_select: bool = False,
     values: list[str] | None = None,
     header: str = "",
+    letter_keys: bool = False,
 ) -> int | str | None:
     """Draw an inline menu; return index, custom typed string, or None on Esc.
 
@@ -343,14 +374,18 @@ def _pick(
             multi_select=multi_select,
             checked=checked if multi_select else None,
             header=header,
+            letter_keys=letter_keys,
         )
         first = False
         height = _menu_height(crumb, display, multi_select=multi_select, header=header)
-        action = (
-            read_menu_or_char(allow_chars=True)
-            if on_custom
-            else (read_menu_or_char(allow_chars=False) if multi_select else _read_action())
-        )
+        if on_custom:
+            action = read_menu_or_char(allow_chars=True)
+        elif multi_select:
+            action = read_menu_or_char(allow_chars=False, alpha_keys=letter_keys)
+        elif letter_keys:
+            action = _read_action(alpha_keys=True)
+        else:
+            action = _read_action()
         if on_custom and action == "backspace":
             draft = draft[:-1]
             if multi_select and custom_index >= 0 and not draft.strip():
@@ -371,9 +406,9 @@ def _pick(
             toggle_index: int | None = None
             if action in (" ", "enter") and idx < len(labels):
                 toggle_index = idx
-            elif len(action) == 1 and action.isdigit():
-                picked = int(action) - 1
-                if 0 <= picked < len(labels):
+            else:
+                picked = _option_index_from_key(action, letter_keys=letter_keys)
+                if picked is not None and 0 <= picked < len(labels):
                     toggle_index = picked
             if toggle_index is not None:
                 if toggle_index == custom_index and not draft.strip():
@@ -403,14 +438,16 @@ def _pick(
                 _erase_menu(crumb, display, multi_select=True, header=header)
                 return None
             continue
-        if (not on_custom) and len(action) == 1 and action.isdigit():
-            picked = int(action) - 1
-            if 0 <= picked < len(labels):
-                if picked == custom_index:
-                    idx = picked
+        select_index = (
+            None if on_custom else _option_index_from_key(action, letter_keys=letter_keys)
+        )
+        if select_index is not None:
+            if 0 <= select_index < len(labels):
+                if select_index == custom_index:
+                    idx = select_index
                     continue
                 _erase_menu(crumb, labels, header=header)
-                return picked
+                return select_index
             continue
         if action == "enter":
             if on_custom:
@@ -437,6 +474,7 @@ def repl_choose_one(
     custom_label: str | None = None,
     multi_select: bool = False,
     header: str = "",
+    letter_keys: bool = False,
 ) -> str | None:
     """Show an inline erasing arrow-key menu; return selected value or None on Esc.
 
@@ -478,6 +516,7 @@ def repl_choose_one(
             multi_select=multi_select,
             values=values,
             header=header,
+            letter_keys=letter_keys,
         )
         if picked is None:
             return None

--- a/surfaces/shared/terminal/components/key_reader.py
+++ b/surfaces/shared/terminal/components/key_reader.py
@@ -67,10 +67,21 @@ def restore_stdin_terminal() -> None:
         termios.tcflush(fd, termios.TCIFLUSH)  # type: ignore[attr-defined]
 
 
+def _alpha_option_key(byte: int) -> str | None:
+    """Uppercase letter for an ascii-letter byte, else ``None``.
+
+    Used by letter-select menus (the Ask User clarification picker), where an
+    option is chosen by its ``(A)``/``(B)`` letter instead of a digit.
+    """
+    char = chr(byte)
+    return char.upper() if char.isascii() and char.isalpha() else None
+
+
 def read_key_unix(
     *,
     also_cancel: tuple[bytes, ...] = (),
     space_confirms: bool = True,
+    alpha_keys: bool = False,
 ) -> str:
     """Read one logical keypress in raw mode; return a normalised key name.
 
@@ -99,13 +110,17 @@ def read_key_unix(
             return "enter"
         if b == 9:  # Tab
             return "tab"
-        if 0x31 <= b <= 0x39:  # 1-9
+        if alpha_keys:
+            letter = _alpha_option_key(b)
+            if letter is not None:  # (A)/(B)/… select; arrows still navigate
+                return letter
+        elif 0x31 <= b <= 0x39:  # 1-9
             return chr(b)
-        if ch in (b"j", b"J"):
+        if not alpha_keys and ch in (b"j", b"J"):
             return "down"
-        if ch in (b"k", b"K"):
+        if not alpha_keys and ch in (b"k", b"K"):
             return "up"
-        if ch in (b"q", b"Q"):
+        if not alpha_keys and ch in (b"q", b"Q"):
             return "cancel"
         if b == 27:  # ESC or arrow-key prefix
             if _sel.select([fd], [], [], 0.1)[0]:
@@ -140,6 +155,7 @@ def read_key_windows(
     *,
     also_cancel: tuple[bytes, ...] = (),
     space_confirms: bool = True,
+    alpha_keys: bool = False,
 ) -> str:
     """Read one logical keypress on Windows; return a normalised key name.
 
@@ -158,13 +174,17 @@ def read_key_windows(
         return "enter"
     if ch == b"\t":
         return "tab"
-    if len(ch) == 1 and b"1" <= ch <= b"9":
+    if alpha_keys and len(ch) == 1:
+        letter = _alpha_option_key(ch[0])
+        if letter is not None:  # (A)/(B)/… select; arrows still navigate
+            return letter
+    elif len(ch) == 1 and b"1" <= ch <= b"9":
         return str(ch.decode("ascii"))
-    if ch in (b"j", b"J"):
+    if not alpha_keys and ch in (b"j", b"J"):
         return "down"
-    if ch in (b"k", b"K"):
+    if not alpha_keys and ch in (b"k", b"K"):
         return "up"
-    if ch in (b"q", b"Q"):
+    if not alpha_keys and ch in (b"q", b"Q"):
         return "cancel"
     if ch in (b"\xe0", b"\x00"):
         ch2 = msvcrt.getch()  # type: ignore[attr-defined]
@@ -194,18 +214,20 @@ def read_typing_key() -> str:
     return _read_typing_key_unix()
 
 
-def read_menu_or_char(*, allow_chars: bool = False) -> str:
+def read_menu_or_char(*, allow_chars: bool = False, alpha_keys: bool = False) -> str:
     """Menu navigation keys, optionally plus printable chars / backspace.
 
     When ``allow_chars`` is True (custom option row focused), typing inserts
-    on that row in place; arrows/tab still move between options.
+    on that row in place; arrows/tab still move between options. When
+    ``alpha_keys`` is True (and not typing), an option is selected by its
+    ``(A)``/``(B)`` letter instead of a digit.
     """
     if os.name == "nt":
-        return _read_menu_or_char_windows(allow_chars=allow_chars)
-    return _read_menu_or_char_unix(allow_chars=allow_chars)
+        return _read_menu_or_char_windows(allow_chars=allow_chars, alpha_keys=alpha_keys)
+    return _read_menu_or_char_unix(allow_chars=allow_chars, alpha_keys=alpha_keys)
 
 
-def _read_menu_or_char_unix(*, allow_chars: bool) -> str:
+def _read_menu_or_char_unix(*, allow_chars: bool, alpha_keys: bool = False) -> str:
     import select as _sel
     import termios
     import tty
@@ -226,14 +248,19 @@ def _read_menu_or_char_unix(*, allow_chars: bool) -> str:
             return "backspace"
         if b == 9:
             return "tab"
-        # Digits stay as select shortcuts unless typing on the custom row.
-        if not allow_chars and 0x31 <= b <= 0x39:
+        # Letters select in alpha mode; otherwise digits stay as select
+        # shortcuts unless typing on the custom row.
+        if alpha_keys and not allow_chars:
+            letter = _alpha_option_key(b)
+            if letter is not None:
+                return letter
+        elif not allow_chars and 0x31 <= b <= 0x39:
             return chr(b)
-        if ch in (b"j", b"J") and not allow_chars:
+        if not alpha_keys and ch in (b"j", b"J") and not allow_chars:
             return "down"
-        if ch in (b"k", b"K") and not allow_chars:
+        if not alpha_keys and ch in (b"k", b"K") and not allow_chars:
             return "up"
-        if ch in (b"q", b"Q") and not allow_chars:
+        if not alpha_keys and ch in (b"q", b"Q") and not allow_chars:
             return "cancel"
         if b == 27:
             if _sel.select([fd], [], [], 0.1)[0]:
@@ -266,7 +293,7 @@ def _read_menu_or_char_unix(*, allow_chars: bool) -> str:
         termios.tcsetattr(fd, termios.TCSADRAIN, old)  # type: ignore[attr-defined]
 
 
-def _read_menu_or_char_windows(*, allow_chars: bool) -> str:
+def _read_menu_or_char_windows(*, allow_chars: bool, alpha_keys: bool = False) -> str:
     import msvcrt  # type: ignore[import,attr-defined]
 
     ch = msvcrt.getch()  # type: ignore[attr-defined]
@@ -280,13 +307,17 @@ def _read_menu_or_char_windows(*, allow_chars: bool) -> str:
         return "tab"
     if ch == b"\x1b":
         return "cancel"
-    if not allow_chars and len(ch) == 1 and b"1" <= ch <= b"9":
+    if alpha_keys and not allow_chars and len(ch) == 1:
+        letter = _alpha_option_key(ch[0])
+        if letter is not None:
+            return letter
+    elif not allow_chars and len(ch) == 1 and b"1" <= ch <= b"9":
         return str(ch.decode("ascii"))
-    if not allow_chars and ch in (b"j", b"J"):
+    if not alpha_keys and not allow_chars and ch in (b"j", b"J"):
         return "down"
-    if not allow_chars and ch in (b"k", b"K"):
+    if not alpha_keys and not allow_chars and ch in (b"k", b"K"):
         return "up"
-    if not allow_chars and ch in (b"q", b"Q"):
+    if not alpha_keys and not allow_chars and ch in (b"q", b"Q"):
         return "cancel"
     if ch in (b"\xe0", b"\x00"):
         ch2 = msvcrt.getch()  # type: ignore[attr-defined]

--- a/tests/interactive_shell/ui/test_ask_user.py
+++ b/tests/interactive_shell/ui/test_ask_user.py
@@ -258,6 +258,7 @@ def test_draw_ask_user_multi_uses_checkboxes(monkeypatch) -> None:
         checked={0},
     )
     plain = re.sub(r"\x1b\[[0-9;:]*[A-Za-z]", "", out.getvalue())
-    assert "[x] Unit tests" in plain
-    assert "[ ] Dockerfile" in plain
+    assert "[x] (A) Unit tests" in plain
+    assert "[ ] (B) Dockerfile" in plain
+    assert "Space/Enter/A-C Toggle" in plain
     assert "1. Unit tests" not in plain

--- a/tests/interactive_shell/ui/test_ask_user.py
+++ b/tests/interactive_shell/ui/test_ask_user.py
@@ -104,6 +104,46 @@ def test_wizard_esc_cancels(monkeypatch) -> None:
     assert repl_ask_user(_QUESTIONS) is None
 
 
+def test_wizard_labels_options_with_letters(monkeypatch) -> None:
+    # Arrange: capture the drawn panel for the first question.
+    import io
+    import re
+    import sys
+
+    from surfaces.interactive_shell.ui import ask_user
+
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(ask_user, "menu_columns", lambda: 80)
+
+    # Act
+    ask_user._draw_ask_user(
+        questions=_QUESTIONS,
+        current=0,
+        answers=[None, None, None],
+        option_index=0,
+        erase_lines=0,
+    )
+
+    # Assert: (A)/(B) chips and a letter-range hint, no numeric labels.
+    plain = re.sub(r"\x1b\[[0-9;:]*[A-Za-z]", "", out.getvalue())
+    assert "(A) Hypothetical/demo scenario, no real code" in plain
+    assert "(B) I'll point you at a repo" in plain
+    assert "Enter/A-C Select" in plain
+    assert "1." not in plain
+
+
+def test_wizard_selects_option_by_letter_key(monkeypatch) -> None:
+    # Pressing (B) on each question chooses the second option without arrows.
+    _patch_wizard(monkeypatch, ["B", "B", "B"])
+    picked = repl_ask_user(_QUESTIONS)
+    assert picked == (
+        "I'll point you at a repo",
+        "Query Datadog",
+        "Last 24 hours",
+    )
+
+
 def test_wizard_flushes_leftover_keys_before_reading(monkeypatch) -> None:
     flushed = {"count": 0}
 

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -117,17 +117,18 @@ class TestPromptTurnCounter:
         render_submitted_prompt(console, session, "and again")
         assert _prompt_turn_number(session) == 3
 
-    def test_user_prompt_row_has_a_left_accent_bar(self) -> None:
-        """A user prompt is marked by a left colour accent bar before ``[N] ❯``."""
-        from surfaces.interactive_shell.ui.input_prompt.rendering import _PROMPT_ACCENT_BAR
-
+    def test_user_prompt_row_is_recessed_grey_without_accent_bar(self) -> None:
+        """Droid-style: the user row is recessed SECONDARY grey with no bright ``▌``
+        accent bar, so the agent reply (``∴``) and notes carry the visual weight."""
         session = Session()
-        console = _render_console()
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=True, color_system="truecolor", highlight=False)
         render_submitted_prompt(console, session, "why does it show that?")
-        out = console.file.getvalue()  # type: ignore[union-attr]
-        assert _PROMPT_ACCENT_BAR in out
-        assert out.index(_PROMPT_ACCENT_BAR) < out.index("[1]")  # bar leads the row
-        assert "why does it show that?" in out
+        raw = buf.getvalue()
+        assert "▌" not in raw  # no bright accent bar
+        visible = re.sub(r"\x1b\[[0-9;]*m", "", raw)
+        assert "[1] ❯ why does it show that?" in visible  # turn number + text kept
+        assert "166;166;166" in raw  # body in SECONDARY (#A6A6A6) recessed grey
 
     def test_autosubmitted_goal_condition_gets_work_turn_marker(self) -> None:
         """``/goal set`` autosubmit must not look like part of the slash turn."""

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -14,6 +14,7 @@ from surfaces.interactive_shell.ui.streaming import (
     finish_deferred_closer,
     format_token_count_short,
     render_markdown_block,
+    render_note_block,
     render_response_header,
     stream_to_console,
     stream_to_console_state,
@@ -23,6 +24,24 @@ from surfaces.interactive_shell.ui.streaming import (
 def _strip_ansi(text: str) -> str:
     """Drop ANSI escapes so assertions check the visible output."""
     return re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", text)
+
+
+def test_render_note_block_is_dim_and_indented_but_keeps_bold() -> None:
+    # A working note reads as dim + indented (no glyph), distinct from the bright
+    # reply, while the bold action word stays bold within the dim base.
+    buf = io.StringIO()
+    console = Console(
+        file=buf, force_terminal=True, color_system="standard", width=80, highlight=False
+    )
+
+    render_note_block(console, "I'll **load** the workflow.")
+
+    raw = buf.getvalue()
+    assert "\x1b[90m" in raw  # dim grey base applied to the note body
+    assert re.search(r"\x1b\[[0-9;]*1[;m]", raw)  # bold action word survives the dim base
+    first_line = _strip_ansi(raw).splitlines()[0]
+    assert first_line.startswith("   ")  # three-space left indent, no glyph
+    assert "load the workflow" in first_line
 
 
 def _tty_console() -> tuple[Console, io.StringIO]:

--- a/tests/shared/terminal/test_choice_menu.py
+++ b/tests/shared/terminal/test_choice_menu.py
@@ -126,9 +126,35 @@ def test_draw_menu_multi_select_checkboxes(monkeypatch) -> None:
     )
 
     plain = _ANSI_RE.sub("", out.getvalue())
-    assert "[ ] Unit tests" in plain
-    assert "[x] Dockerfile" in plain
+    assert "[ ] 1. Unit tests" in plain
+    assert "[x] 2. Dockerfile" in plain
+    assert "Space/Enter/1-9 Toggle" in plain
     assert "Submit" in plain
+
+
+def test_draw_menu_multi_select_letter_keys_labels_options(monkeypatch) -> None:
+    # Multi-select still advertises A-…; the checkbox row must show the letter.
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+
+    choice_menu._draw_menu(
+        title="Extras",
+        crumb="",
+        labels=["Unit tests", "Dockerfile", "Or type your own answer..."],
+        index=0,
+        erase_lines=0,
+        multi_select=True,
+        checked={0},
+        letter_keys=True,
+    )
+
+    plain = _ANSI_RE.sub("", out.getvalue())
+    assert "[x] (A) Unit tests" in plain
+    assert "[ ] (B) Dockerfile" in plain
+    assert "[ ] (C) Or type your own answer..." in plain
+    assert "Space/Enter/A-C Toggle" in plain
+    assert "1." not in plain
 
 
 def test_pick_multi_select_returns_values_not_labels(monkeypatch) -> None:

--- a/tests/shared/terminal/test_choice_menu.py
+++ b/tests/shared/terminal/test_choice_menu.py
@@ -47,6 +47,69 @@ def test_draw_menu_uses_carriage_return_newlines(monkeypatch) -> None:
     assert "─" not in plain
 
 
+def test_draw_menu_letter_keys_labels_options_alphabetically(monkeypatch) -> None:
+    # The clarification (Ask User) picker labels options (A)/(B)/(C) and its hint
+    # advertises the letter-key range instead of digits.
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+
+    choice_menu._draw_menu(
+        title="How should I select repos?",
+        crumb="",
+        labels=["Local repos", "GitHub account", "Or type your own answer..."],
+        index=0,
+        erase_lines=0,
+        header="Ask User",
+        letter_keys=True,
+    )
+
+    plain = _ANSI_RE.sub("", out.getvalue())
+    assert "❯ (A) Local repos" in plain
+    assert "(B) GitHub account" in plain
+    assert "(C) Or type your own answer..." in plain
+    assert "Enter/A-C Select" in plain
+    assert "1." not in plain
+
+
+def test_pick_letter_key_selects_matching_option(monkeypatch) -> None:
+    # Pressing the option's letter returns that option's index (case-insensitive).
+    out = io.StringIO()
+    actions = iter(["b"])
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+    monkeypatch.setattr(choice_menu, "_read_action", lambda **_kwargs: next(actions))
+    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
+
+    result = choice_menu._pick(
+        title="Q",
+        crumb="",
+        labels=["Local", "GitHub", "Other"],
+        letter_keys=True,
+    )
+
+    assert result == 1
+
+
+def test_pick_letter_keys_still_navigates_with_arrows(monkeypatch) -> None:
+    # Requirement: letter menus stay navigable by up/down arrows, not only keys.
+    out = io.StringIO()
+    actions = iter(["down", "down", "enter"])
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+    monkeypatch.setattr(choice_menu, "_read_action", lambda **_kwargs: next(actions))
+    monkeypatch.setattr(choice_menu, "repl_tty_interactive", lambda: True)
+
+    result = choice_menu._pick(
+        title="Q",
+        crumb="",
+        labels=["Local", "GitHub", "Other"],
+        letter_keys=True,
+    )
+
+    assert result == 2
+
+
 def test_draw_menu_multi_select_checkboxes(monkeypatch) -> None:
     out = io.StringIO()
     monkeypatch.setattr(sys, "stdout", out)

--- a/tests/shared/terminal/test_key_reader.py
+++ b/tests/shared/terminal/test_key_reader.py
@@ -44,3 +44,42 @@ def test_restore_stdin_terminal_is_a_no_op_when_not_a_tty(monkeypatch: pytest.Mo
         SimpleNamespace(isatty=lambda: False, fileno=lambda: (_ for _ in ()).throw(AssertionError)),
     )
     key_reader.restore_stdin_terminal()  # returns without touching termios
+
+
+def test_alpha_option_key_maps_only_ascii_letters() -> None:
+    # Arrange / Act / Assert: letters map to their uppercase; anything else is None.
+    assert key_reader._alpha_option_key(ord("a")) == "A"
+    assert key_reader._alpha_option_key(ord("C")) == "C"
+    assert key_reader._alpha_option_key(ord("1")) is None
+    assert key_reader._alpha_option_key(ord("-")) is None
+
+
+def _drive_read_key_unix(monkeypatch: pytest.MonkeyPatch, byte: bytes, *, alpha_keys: bool) -> str:
+    """Run read_key_unix once with ``byte`` queued on a faked raw TTY."""
+    termios = pytest.importorskip("termios")
+    tty = pytest.importorskip("tty")
+    monkeypatch.setattr(key_reader.os, "name", "posix")
+    monkeypatch.setattr(key_reader.sys, "stdin", SimpleNamespace(fileno=lambda: 0))
+    monkeypatch.setattr(key_reader.os, "read", lambda _fd, _n: byte)
+    monkeypatch.setattr(termios, "tcgetattr", lambda _fd: [0, 0, 0, 0, 0, 0, []])
+    monkeypatch.setattr(termios, "tcsetattr", lambda _fd, _when, _attrs: None)
+    monkeypatch.setattr(tty, "setraw", lambda _fd: None)
+    return key_reader.read_key_unix(alpha_keys=alpha_keys)
+
+
+def test_read_key_unix_alpha_mode_surfaces_option_letter(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange / Act / Assert: in alpha mode a letter key IS the selection.
+    assert _drive_read_key_unix(monkeypatch, b"b", alpha_keys=True) == "B"
+
+
+def test_read_key_unix_alpha_mode_disables_vim_navigation(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 'j'/'k' are vim nav only when numeric; as an option letter they must select,
+    # otherwise pressing option (J) would scroll instead of choosing it.
+    assert _drive_read_key_unix(monkeypatch, b"j", alpha_keys=True) == "J"
+    assert _drive_read_key_unix(monkeypatch, b"j", alpha_keys=False) == "down"
+
+
+def test_read_key_unix_alpha_mode_ignores_digits(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Numbering is off in letter menus, so a digit is inert rather than a selector.
+    assert _drive_read_key_unix(monkeypatch, b"2", alpha_keys=True) == "ignore"
+    assert _drive_read_key_unix(monkeypatch, b"2", alpha_keys=False) == "2"


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

clarifying multiple-choice questions.

**UI: (A)(B)(C) labels + letter-key navigation**
- The Ask User clarification menus (single-decision `/choose` and the batch
  wizard) now label options `(A) (B) (C)` and select by the matching letter key
  (case-insensitive) as well as up/down arrows. The key hint shows the live
  letter range (e.g. `Enter/A-C Select`).
- New `alpha_keys` mode in the shared key reader surfaces option letters and
  suppresses the vim `j/k/q` bindings inside letter menus, so pressing an option
  letter selects it instead of scrolling.
- Scope: letters apply to clarification menus only; slash pickers
  (`/model`, `/template`, …) keep their numeric `1-9` selectors.

**Behaviour: local-scope default (droid parity)**
- The system prompt now reads "my system", "on my machine", "my repos", and
  "my services" as the local environment (this machine's filesystem and local
  Git checkouts) by default, proceeds with that default, and only opens
  `ask_user_choice` when a genuinely blocking fixed-set choice has no safe
  default. This fixes the reported misinterpretation where a local-scoped
  request was treated as the user's hosted GitHub account.

### Demo/Screenshot for feature changes and bug fixes -
Clarification menu (rendered live):

    Ask User
    How should I select "top 5 most committed" repositories?

    ❯ (A) Local Git repos under your home dir, ranked by commit count
      (B) GitHub repos ranked by your personal commit contributions
      (C) Or type your own answer...

    ↑↓ Navigate • Enter/A-C Select • Esc cancel

Behaviour (live, same prompt as the issue): opensre now responds
"use the safe defaults: search the home directory … scan local checkouts"
and proceeds — matching droid, which also interprets "on my system" as local
git repositories rather than a hosted account.