### PR TITLE
feat(shell): bold Ask User questions in the Q→A recap

### DIFF
--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -86,10 +86,12 @@ def render_choice_selection(console: Console, title: str, answer: str) -> None:
 
 
 def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:
-    """Print Ask User Q→A: orange header, numbered questions, brand answers.
+    """Print Ask User Q→A: accent header, bold numbered questions, brand answers.
 
-    Each pair is a two-line block with a blank row after the header and
-    between items so the list is scannable.
+    Each pair is a two-line block — a bold question, then its answer in the brand
+    colour indented beneath it — with a blank row after the header and between
+    items so the filled-in recap is scannable and the answer reads apart from the
+    question.
     """
     console.print()
     console.print(Text("Ask User", style=f"bold {ui_theme.HIGHLIGHT}"))
@@ -99,7 +101,7 @@ def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:
             console.print()
         qline = Text()
         qline.append(f"  {index + 1}.  ", style=str(ui_theme.DIM))
-        qline.append(_display_safe(question), style=str(ui_theme.TEXT))
+        qline.append(_display_safe(question), style=f"bold {ui_theme.TEXT}")
         console.print(qline)
         aline = Text()
         aline.append("      ", style=str(ui_theme.DIM))

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -72,6 +72,30 @@ def test_ask_user_answers_render_as_numbered_qa() -> None:
     assert session.terminal.submitted_turn_count == 1
 
 
+def test_ask_user_qa_highlights_answer_differently_from_question() -> None:
+    # 10.6 core contract: the answer must render in a distinct colour from the
+    # question, under a highlighted "Ask User" header, so a filled-in recap reads
+    # apart at a glance. Pin the colours, not just the text.
+    from infrastructure.terminal import theme as ui_theme
+
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=True, color_system="truecolor", highlight=False)
+    render_ask_user_qa(console, [("Which product should I demo?", "OpenSRE itself")])
+    raw = buffer.getvalue()
+
+    def _sgr(hex_color: str) -> str:
+        r, g, b = (int(hex_color[i : i + 2], 16) for i in (1, 3, 5))
+        return f"38;2;{r};{g};{b}"
+
+    question_sgr = _sgr(str(ui_theme.TEXT))
+    answer_sgr = _sgr(str(ui_theme.BRAND))
+    header_sgr = _sgr(str(ui_theme.HIGHLIGHT))
+    assert question_sgr != answer_sgr  # the two colours genuinely differ
+    assert header_sgr in raw  # "Ask User" header in the accent colour
+    assert f"1;{question_sgr}" in raw  # question is bold TEXT (droid-style emphasis)
+    assert answer_sgr in raw  # answer highlighted in BRAND, distinct from the question
+
+
 def test_ask_user_qa_leaves_blank_rows_between_pairs() -> None:
     buffer = io.StringIO()
     console = Console(file=buffer, force_terminal=False, highlight=False, width=80)

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -29,15 +29,22 @@ def _strip_ansi(text: str) -> str:
 def test_render_note_block_is_dim_and_indented_but_keeps_bold() -> None:
     # A working note reads as dim + indented (no glyph), distinct from the bright
     # reply, while the bold action word stays bold within the dim base.
+    from infrastructure.terminal import theme as ui_theme
+
     buf = io.StringIO()
     console = Console(
-        file=buf, force_terminal=True, color_system="standard", width=80, highlight=False
+        file=buf, force_terminal=True, color_system="truecolor", width=80, highlight=False
     )
 
     render_note_block(console, "I'll **load** the workflow.")
 
     raw = buf.getvalue()
-    assert "\x1b[90m" in raw  # dim grey base applied to the note body
+    dim = str(ui_theme.DIM)  # e.g. "#6E6E6E"
+    r, g, b = (int(dim[i : i + 2], 16) for i in (1, 3, 5))
+    # DIM may render as 8-colour (``90m``) or truecolor (``38;2;r;g;b``) depending
+    # on the color system the runner advertises — accept either so the test does
+    # not hinge on terminal capability.
+    assert f"38;2;{r};{g};{b}" in raw or "\x1b[90m" in raw  # dim base on the note body
     assert re.search(r"\x1b\[[0-9;]*1[;m]", raw)  # bold action word survives the dim base
     first_line = _strip_ansi(raw).splitlines()[0]
     assert first_line.startswith("   ")  # three-space left indent, no glyph


### PR DESCRIPTION
(Ask User Q→A recap). The recap already rendered a highlighted
"Ask User" header, numbered questions, and distinct-colour indented answers
(#5892). This finishes the hand-off layout by rendering the questions in
bold, matching the intended emphasis, and adds a test that pins the
header/question/answer colours and the bold question — the earlier tests ran
on a no-colour console and locked neither the colour contrast nor the weight.

Colours remain theme-driven (the amber theme reproduces the gold look);
nothing is hardcoded.