### PR TITLE
feat(shell): recess plain command output beneath the reply summary

### DIFF
--- a/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
@@ -15,7 +15,14 @@ from rich.text import Text
 
 from infrastructure.scheduling.task_types import TaskKind
 from surfaces.interactive_shell.session import Session
-from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING, print_command_output
+from surfaces.interactive_shell.ui import (
+    DIM,
+    ERROR,
+    HIGHLIGHT,
+    SECONDARY,
+    WARNING,
+    print_command_output,
+)
 from surfaces.interactive_shell.ui.execution_confirm import execution_allowed
 from surfaces.shared.error_handling.exception_reporting import report_exception
 from tools.interactive_shell.shared import ExecutionPolicyResult
@@ -205,7 +212,11 @@ class ReplSubprocessPresenter:
         if style in _MARKUP_STYLE_ALIASES:
             resolved = _MARKUP_STYLE_ALIASES[style]
         elif style is None:
-            resolved = None
+            # Recess plain command output beneath the bright reply summary: apply
+            # SECONDARY as the base so uncoloured stdout reads as supporting detail,
+            # while any colour the command emitted itself (red errors, etc.) still
+            # wins over the base.
+            resolved = str(SECONDARY)
         else:
             resolved = style
         print_command_output(self._console, text, style=resolved)

--- a/tests/interactive_shell/runtime/test_repl_presenter.py
+++ b/tests/interactive_shell/runtime/test_repl_presenter.py
@@ -26,6 +26,28 @@ def _presenter() -> tuple[ReplSubprocessPresenter, StringIO]:
     return ReplSubprocessPresenter(session, console), buffer
 
 
+def test_plain_command_output_is_recessed_but_keeps_command_colours() -> None:
+    # Raw stdout reads as supporting detail beneath the bright reply: plain output
+    # is recessed to SECONDARY, while colour the command emitted itself survives.
+    import io
+    import re
+
+    from infrastructure.terminal import theme as ui_theme
+
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=True, color_system="truecolor", width=80)
+    presenter = ReplSubprocessPresenter(Session(), console)
+
+    presenter.print_command_output("plain line of output")
+    presenter.print_command_output("\x1b[32mgreen success\x1b[0m")
+
+    raw = buffer.getvalue()
+    secondary = str(ui_theme.SECONDARY)
+    r, g, b = (int(secondary[i : i + 2], 16) for i in (1, 3, 5))
+    assert f"38;2;{r};{g};{b}" in raw  # plain output recessed to SECONDARY
+    assert re.search(r"\x1b\[[0-9;]*32m", raw)  # command's own green survives the base
+
+
 def test_escape_markup_message_preserves_intentional_tags() -> None:
     escaped = _escape_markup_message("[error]failed[/]")
     buffer = StringIO()


### PR DESCRIPTION
Render uncoloured shell stdout in SECONDARY so raw output reads as supporting detail under the bright reply, matching the intended focus hierarchy. Colour the command emits itself (errors, success) still wins over the base, so semantic output colours are preserved.

<img width="939" height="378" alt="image" src="https://github.com/user-attachments/assets/35dbbaea-b5db-4ab3-a5da-ff4c8ca4709c" />
