### PR TITLE
feat(prompt): emphasize key facts in the final reply

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -42,6 +42,15 @@ experiment and **watch** the UI react."). Emphasize only those key words, never
 a whole phrase or sentence, and never bold a file path or command (those use
 inline code).
 
+In your final answer, apply the same emphasis to the facts the reader came for:
+put the load-bearing figures and entities — the number, the name, the verdict —
+in **bold**, not the surrounding prose, so the result is scannable at a glance
+(for example: "Root disk is **96% full** — **20 GiB** free of **460 GiB**.").
+Bold only the few facts that carry the answer, never whole sentences. When a
+headline metric is misleading on its own — a percentage that hides a shared
+total, a count that excludes a category — add one short sentence naming the
+number that actually matters, rather than reporting the raw figure alone.
+
 ## Planning
 
 You have access to an `update_plan` tool which tracks steps and progress and renders them to the user. Using the tool helps demonstrate that you've understood the task and convey how you're approaching it. Plans can help to make complex, ambiguous, or multi-phase work clearer and more collaborative for the user. A good plan should break the task into meaningful, logically ordered steps that are easy to verify as you go.


### PR DESCRIPTION
Extend the Responsiveness guidance from narration to the final answer: bold the load-bearing figures and entities so the result is scannable, and when a headline metric is misleading on its own (a percentage hiding a shared total), add one sentence naming the number that actually matters.

<img width="941" height="259" alt="image" src="https://github.com/user-attachments/assets/04f3dcd2-d375-4aea-928c-41aadf46f2aa" />
