### PR TITLE
feat(shell): fix reply table rendering and add focus-aware sound notifications

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -330,6 +330,7 @@ from config.constants.repl_autonomy import (
     format_auto_status_plain,
     parse_auto_level,
 )
+from config.constants.repl_sound import SOUND_MIN_TURN_SECONDS, SOUND_NOTIFICATIONS_ENV
 from config.constants.repl_theme import DEFAULT_THEME_NAME, THEME_NAMES, Theme
 from config.constants.reporting import SLACK_LINK_RE
 from config.constants.runtime_metadata import (
@@ -536,6 +537,8 @@ __all__ = [
     "DEFAULT_AUTO_LEVEL",
     "format_auto_status_plain",
     "parse_auto_level",
+    "SOUND_MIN_TURN_SECONDS",
+    "SOUND_NOTIFICATIONS_ENV",
     "REMOTE_SYNC_BUCKET_ENV",
     "REMOTE_SYNC_ENDPOINT_URL_ENV",
     "REMOTE_SYNC_ENV",

--- a/config/constants/repl_sound.py
+++ b/config/constants/repl_sound.py
@@ -1,0 +1,13 @@
+"""Interactive-shell sound-notification settings."""
+
+from __future__ import annotations
+
+# Enable a short chime on turn completion / when input is needed. Off unless the
+# env var is truthy so the shell never makes an unexpected sound by default.
+SOUND_NOTIFICATIONS_ENV = "OPENSRE_SOUND"
+
+# Only chime on turn completion for turns longer than this, so quick interactive
+# replies stay silent and only a walk-away-length task announces itself.
+SOUND_MIN_TURN_SECONDS = 8.0
+
+__all__ = ["SOUND_NOTIFICATIONS_ENV", "SOUND_MIN_TURN_SECONDS"]

--- a/infrastructure/terminal/notify.py
+++ b/infrastructure/terminal/notify.py
@@ -17,12 +17,13 @@ import shutil
 import subprocess
 import sys
 
-from config.constants.repl_sound import SOUND_NOTIFICATIONS_ENV
+from config.constants import SOUND_NOTIFICATIONS_ENV
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
-# TERM_PROGRAM value -> the macOS app whose window hosts this terminal, so the
-# frontmost app can be matched against the one we run inside.
+# TERM_PROGRAM value -> the macOS app that hosts this process. A *different*
+# frontmost app means this window is not focused. The same app does not prove
+# this window is frontmost (another window of iTerm/Code/… may be).
 _TERM_PROGRAM_APP = {
     "Apple_Terminal": "Terminal",
     "iTerm.app": "iTerm2",
@@ -35,8 +36,6 @@ _TERM_PROGRAM_APP = {
     "alacritty": "Alacritty",
     "Tabby": "Tabby",
 }
-# When TERM_PROGRAM is unset, treat any of these frontmost apps as "our terminal".
-_KNOWN_TERMINAL_APPS = frozenset(_TERM_PROGRAM_APP.values()) | {"Electron"}
 _LSAPPINFO_NAME_RE = re.compile(r'"LSDisplayName"="([^"]+)"')
 
 # Distinct macOS system sounds so completion and a request for input are audibly
@@ -82,8 +81,10 @@ def _macos_frontmost_app() -> str | None:
 def terminal_is_focused() -> bool | None:
     """Whether this terminal's window is frontmost. ``None`` when undeterminable.
 
-    Only resolvable on macOS (via the frontmost app). Off macOS — or if the
-    lookup fails — returns ``None`` so the caller can degrade rather than guess.
+    On macOS a *different* frontmost app means this window is not focused.
+    Matching the host app — or an unknown ``TERM_PROGRAM`` — cannot identify the
+    window, so that is undeterminable rather than treated as focused. Off macOS
+    — or if the lookup fails — returns ``None`` so the caller can degrade.
     """
     if platform.system() != "Darwin":
         return None
@@ -91,16 +92,16 @@ def terminal_is_focused() -> bool | None:
     if front is None:
         return None
     ours = _TERM_PROGRAM_APP.get(os.environ.get("TERM_PROGRAM", ""))
-    if ours is not None:
-        return front == ours
-    return front in _KNOWN_TERMINAL_APPS
+    if ours is None or front == ours:
+        return None
+    return False
 
 
 def play_notification(event: NotifyEvent) -> None:
     """Play a short chime for ``event`` — opt-in, best-effort, non-blocking.
 
-    Stays silent while this terminal is the focused window (you are already
-    looking); chimes when it is unfocused, or when focus cannot be determined.
+    Stays silent only when this window is known focused; chimes when it is
+    unfocused, or when focus cannot be determined.
     """
     if not sound_enabled():
         return

--- a/infrastructure/terminal/notify.py
+++ b/infrastructure/terminal/notify.py
@@ -1,0 +1,131 @@
+"""Best-effort pleasant sound notifications for the interactive shell.
+
+A short chime signals that a long turn finished or that the agent is waiting on
+the user — useful when the terminal is not the focused window. Playback is
+best-effort and never blocks the REPL or raises: on macOS it plays a system
+sound, elsewhere it falls back to the terminal bell.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import enum
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+
+from config.constants.repl_sound import SOUND_NOTIFICATIONS_ENV
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# TERM_PROGRAM value -> the macOS app whose window hosts this terminal, so the
+# frontmost app can be matched against the one we run inside.
+_TERM_PROGRAM_APP = {
+    "Apple_Terminal": "Terminal",
+    "iTerm.app": "iTerm2",
+    "vscode": "Code",
+    "WarpTerminal": "Warp",
+    "Hyper": "Hyper",
+    "ghostty": "Ghostty",
+    "WezTerm": "WezTerm",
+    "kitty": "kitty",
+    "alacritty": "Alacritty",
+    "Tabby": "Tabby",
+}
+# When TERM_PROGRAM is unset, treat any of these frontmost apps as "our terminal".
+_KNOWN_TERMINAL_APPS = frozenset(_TERM_PROGRAM_APP.values()) | {"Electron"}
+_LSAPPINFO_NAME_RE = re.compile(r'"LSDisplayName"="([^"]+)"')
+
+# Distinct macOS system sounds so completion and a request for input are audibly
+# different: a soft resolved tone vs. a lighter attention ping.
+_MACOS_SOUNDS = {
+    "turn_complete": "/System/Library/Sounds/Glass.aiff",
+    "input_needed": "/System/Library/Sounds/Ping.aiff",
+}
+
+
+class NotifyEvent(enum.Enum):
+    """What the chime is announcing."""
+
+    TURN_COMPLETE = "turn_complete"
+    INPUT_NEEDED = "input_needed"
+
+
+def sound_enabled() -> bool:
+    """True when the user opted into shell sound notifications."""
+    return os.environ.get(SOUND_NOTIFICATIONS_ENV, "").strip().lower() in _TRUTHY
+
+
+def _macos_frontmost_app() -> str | None:
+    """Display name of the frontmost macOS app, or ``None`` (permission-free)."""
+    with contextlib.suppress(Exception):
+        front = subprocess.run(  # noqa: S603
+            ["lsappinfo", "front"], capture_output=True, text=True, timeout=1
+        ).stdout.strip()
+        if not front:
+            return None
+        info = subprocess.run(  # noqa: S603
+            ["lsappinfo", "info", "-only", "name", front],
+            capture_output=True,
+            text=True,
+            timeout=1,
+        ).stdout
+        match = _LSAPPINFO_NAME_RE.search(info)
+        if match:
+            return match.group(1)
+    return None
+
+
+def terminal_is_focused() -> bool | None:
+    """Whether this terminal's window is frontmost. ``None`` when undeterminable.
+
+    Only resolvable on macOS (via the frontmost app). Off macOS — or if the
+    lookup fails — returns ``None`` so the caller can degrade rather than guess.
+    """
+    if platform.system() != "Darwin":
+        return None
+    front = _macos_frontmost_app()
+    if front is None:
+        return None
+    ours = _TERM_PROGRAM_APP.get(os.environ.get("TERM_PROGRAM", ""))
+    if ours is not None:
+        return front == ours
+    return front in _KNOWN_TERMINAL_APPS
+
+
+def play_notification(event: NotifyEvent) -> None:
+    """Play a short chime for ``event`` — opt-in, best-effort, non-blocking.
+
+    Stays silent while this terminal is the focused window (you are already
+    looking); chimes when it is unfocused, or when focus cannot be determined.
+    """
+    if not sound_enabled():
+        return
+    # A notification must never disrupt the turn — swallow any focus-check or
+    # playback error, and stay silent only when the terminal is definitely focused.
+    with contextlib.suppress(Exception):
+        if terminal_is_focused() is not True:
+            _play(event)
+
+
+def _play(event: NotifyEvent) -> None:
+    if platform.system() == "Darwin":
+        sound = _MACOS_SOUNDS.get(event.value, _MACOS_SOUNDS["turn_complete"])
+        afplay = shutil.which("afplay")
+        if afplay and os.path.exists(sound):
+            # Detached and non-blocking: the REPL never waits on playback.
+            subprocess.Popen(  # noqa: S603
+                [afplay, sound],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return
+    # Portable fallback: the terminal bell (the terminal decides how it sounds).
+    sys.stdout.write("\a")
+    sys.stdout.flush()
+
+
+__all__ = ["NotifyEvent", "play_notification", "sound_enabled", "terminal_is_focused"]

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -15,6 +15,7 @@ from rich.console import Console
 
 from core.agent_harness.spi.handoff import format_ask_user_answers
 from infrastructure.terminal import theme as ui_theme
+from infrastructure.terminal.notify import NotifyEvent, play_notification
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.ask_user import CUSTOM_OPTION, repl_ask_user
@@ -47,6 +48,7 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
 
     items = pending.items()
     clear_live_prompt_paint(session)
+    play_notification(NotifyEvent.INPUT_NEEDED)  # the agent is now waiting on the user
     if pending.is_batch():
         picked = repl_ask_user(items)
         if picked is None:

--- a/surfaces/interactive_shell/runtime/agent_presentation.py
+++ b/surfaces/interactive_shell/runtime/agent_presentation.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 from rich.markup import escape
 
-from config.constants.repl_sound import SOUND_MIN_TURN_SECONDS
+from config.constants import SOUND_MIN_TURN_SECONDS
 from infrastructure.terminal.notify import NotifyEvent, play_notification
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.runtime.input_policy import turn_should_show_spinner

--- a/surfaces/interactive_shell/runtime/agent_presentation.py
+++ b/surfaces/interactive_shell/runtime/agent_presentation.py
@@ -12,12 +12,15 @@ draining from the turn's action-routing and prompt-construction logic.
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Literal
 
 from rich.markup import escape
 
+from config.constants.repl_sound import SOUND_MIN_TURN_SECONDS
+from infrastructure.terminal.notify import NotifyEvent, play_notification
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.runtime.input_policy import turn_should_show_spinner
 from surfaces.interactive_shell.session import Session
@@ -126,8 +129,11 @@ class ConsoleAgentEventSink:
         self.spinner = spinner
         self.console = console
         self.state = AgentPresentationState()
+        self._turn_started_at: float | None = None
 
     async def __call__(self, event: AgentEvent) -> None:
+        if event.type == "turn_start":
+            self._turn_started_at = time.monotonic()
         previous = self.state
         self.state = _reduce_agent_presentation(
             previous,
@@ -141,6 +147,15 @@ class ConsoleAgentEventSink:
             console=self.console,
             spinner=self.spinner,
         )
+        if event.type in {"turn_end", "turn_interrupted", "turn_error"}:
+            self._chime_if_long_turn()
+
+    def _chime_if_long_turn(self) -> None:
+        """Chime once a walk-away-length turn finishes; stay silent for quick ones."""
+        started = self._turn_started_at
+        self._turn_started_at = None
+        if started is not None and time.monotonic() - started >= SOUND_MIN_TURN_SECONDS:
+            play_notification(NotifyEvent.TURN_COMPLETE)
 
 
 __all__ = [

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -80,6 +80,37 @@ _SELF_SPACING_BLOCK_TOKEN_TYPES = frozenset(
 )
 
 
+# A leading Markdown block: table row, heading, bullet/ordered list, code fence,
+# or blockquote. Detected by first-line shape (no Markdown parse) so attaching the
+# response marker stays allocation-free on the hot streaming path.
+_BLOCK_LEAD_RE = re.compile(r"^\s*(?:\||#{1,6}\s|[-*+]\s|\d+[.)]\s|```|~~~|>)")
+
+
+def _body_leads_with_block(stripped: str) -> bool:
+    lines = stripped.split("\n", 2)
+    if _BLOCK_LEAD_RE.match(lines[0]):
+        return True
+    # A pipe-less GFM table: a header line followed by a ``---|---`` delimiter row.
+    if len(lines) > 1 and "|" in lines[0]:
+        delim = lines[1].strip()
+        return bool(delim) and set(delim) <= set("|:- ") and "-" in delim
+    return False
+
+
+def _prepend_response_marker(body: str) -> str:
+    """Attach the ``∴`` marker: inline for prose, on its own line before a block.
+
+    A ``∴ `` fused onto the first line of a Markdown block — a table row, heading,
+    list item, or code fence — breaks CommonMark block parsing, so the block then
+    renders as flattened raw text. Only a paragraph can carry the marker inline;
+    any other leading block takes the marker on the line above it.
+    """
+    stripped = body.lstrip()
+    if _body_leads_with_block(stripped):
+        return f"{_RESPONSE_MARKER.rstrip()}\n\n{stripped}"
+    return f"{_RESPONSE_MARKER}{stripped}"
+
+
 def _paragraph_has_want_me_to(text: str) -> bool:
     return WANT_ME_TO_MARKER in text.lower()
 
@@ -150,7 +181,7 @@ def stream_to_console_state(
             # gather path can print the canonical rewrite once.
             return StreamRenderResult(text=text, deferred_closer=True)
         console.print()
-        render_markdown_block(console, f"{_RESPONSE_MARKER}{text.lstrip()}")
+        render_markdown_block(console, _prepend_response_marker(text))
         console.print()
         return StreamRenderResult(text=text)
 
@@ -228,8 +259,9 @@ def stream_to_console_state(
         if not visible.strip():
             return
         if rendered_paragraphs == 0:
-            # The first paragraph carries the inline ``∴`` marker.
-            visible = f"{_RESPONSE_MARKER}{visible.lstrip()}"
+            # The first paragraph carries the ``∴`` marker — inline for prose, on
+            # its own line when it leads with a block (table/heading/list/fence).
+            visible = _prepend_response_marker(visible)
         markdown = _build_markdown_block(visible)
         starts_with_self_spacing_block = bool(
             markdown.parsed and markdown.parsed[0].type in _SELF_SPACING_BLOCK_TOKEN_TYPES
@@ -426,5 +458,5 @@ def publish_full_response(console: Console, text: str, *, label: str = "assistan
     if not body:
         return
     console.print()
-    render_markdown_block(console, f"{_RESPONSE_MARKER}{body}")
+    render_markdown_block(console, _prepend_response_marker(body))
     console.print()

--- a/tests/config/test_constants.py
+++ b/tests/config/test_constants.py
@@ -63,6 +63,16 @@ def test_the_organization_id_is_re_exported() -> None:
         assert name in constants.__all__
 
 
+def test_repl_sound_constants_are_re_exported() -> None:
+    """Callers may import the shell-sound names from the package root."""
+    from config import constants
+
+    assert constants.SOUND_NOTIFICATIONS_ENV == "OPENSRE_SOUND"
+    assert constants.SOUND_MIN_TURN_SECONDS == 8.0
+    assert "SOUND_NOTIFICATIONS_ENV" in constants.__all__
+    assert "SOUND_MIN_TURN_SECONDS" in constants.__all__
+
+
 def test_remote_sync_endpoint_url_env_is_re_exported() -> None:
     """Verify REMOTE_SYNC_ENDPOINT_URL_ENV is re-exported from config.constants."""
     # Arrange / Act

--- a/tests/infrastructure/terminal/test_notify.py
+++ b/tests/infrastructure/terminal/test_notify.py
@@ -7,6 +7,7 @@ import sys
 
 import pytest
 
+from config.constants import SOUND_NOTIFICATIONS_ENV
 from infrastructure.terminal import notify
 from infrastructure.terminal.notify import (
     NotifyEvent,
@@ -17,17 +18,17 @@ from infrastructure.terminal.notify import (
 
 
 def test_sound_is_disabled_unless_env_is_truthy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("OPENSRE_SOUND", raising=False)
+    monkeypatch.delenv(SOUND_NOTIFICATIONS_ENV, raising=False)
     assert not sound_enabled()
-    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setenv(SOUND_NOTIFICATIONS_ENV, "1")
     assert sound_enabled()
-    monkeypatch.setenv("OPENSRE_SOUND", "false")
+    monkeypatch.setenv(SOUND_NOTIFICATIONS_ENV, "false")
     assert not sound_enabled()
 
 
 def test_play_is_a_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     # Disabled: no bell, no subprocess — the shell stays silent by default.
-    monkeypatch.delenv("OPENSRE_SOUND", raising=False)
+    monkeypatch.delenv(SOUND_NOTIFICATIONS_ENV, raising=False)
     buf = io.StringIO()
     monkeypatch.setattr(sys, "stdout", buf)
     play_notification(NotifyEvent.TURN_COMPLETE)
@@ -36,7 +37,7 @@ def test_play_is_a_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_non_darwin_falls_back_to_the_terminal_bell(monkeypatch: pytest.MonkeyPatch) -> None:
     # When enabled off macOS, focus is undeterminable so it chimes (bell fallback).
-    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setenv(SOUND_NOTIFICATIONS_ENV, "1")
     monkeypatch.setattr(notify.platform, "system", lambda: "Linux")
     buf = io.StringIO()
     monkeypatch.setattr(sys, "stdout", buf)
@@ -46,7 +47,7 @@ def test_non_darwin_falls_back_to_the_terminal_bell(monkeypatch: pytest.MonkeyPa
 
 def test_stays_silent_when_the_terminal_is_focused(monkeypatch: pytest.MonkeyPatch) -> None:
     # No chime while you are already looking at the terminal.
-    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setenv(SOUND_NOTIFICATIONS_ENV, "1")
     monkeypatch.setattr(notify, "terminal_is_focused", lambda: True)
     buf = io.StringIO()
     monkeypatch.setattr(sys, "stdout", buf)
@@ -55,7 +56,7 @@ def test_stays_silent_when_the_terminal_is_focused(monkeypatch: pytest.MonkeyPat
 
 
 def test_chimes_when_the_terminal_is_unfocused(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setenv(SOUND_NOTIFICATIONS_ENV, "1")
     monkeypatch.setattr(notify, "terminal_is_focused", lambda: False)
     monkeypatch.setattr(notify.platform, "system", lambda: "Linux")
     buf = io.StringIO()
@@ -64,23 +65,52 @@ def test_chimes_when_the_terminal_is_unfocused(monkeypatch: pytest.MonkeyPatch) 
     assert buf.getvalue() == "\a"
 
 
-def test_focus_matches_our_terminal_against_the_frontmost_app(
+def test_focus_is_false_only_when_a_different_app_is_frontmost(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # macOS: our terminal (TERM_PROGRAM=vscode -> "Code") focused iff it is frontmost.
+    # App-name match cannot prove *this* window is focused (another Code/iTerm
+    # window may be), so same-host is undeterminable. A different app is not us.
     monkeypatch.setattr(notify.platform, "system", lambda: "Darwin")
     monkeypatch.setenv("TERM_PROGRAM", "vscode")
     monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: "Code")
-    assert terminal_is_focused() is True
+    assert terminal_is_focused() is None
     monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: "Safari")
     assert terminal_is_focused() is False
     monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: None)
     assert terminal_is_focused() is None
 
 
+def test_same_host_app_does_not_suppress_the_chime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Switching to another window of the same terminal must still chime: app
+    # matching cannot prove this OpenSRE window is the one in front.
+    played: list[NotifyEvent] = []
+    monkeypatch.setenv(SOUND_NOTIFICATIONS_ENV, "1")
+    monkeypatch.setattr(notify.platform, "system", lambda: "Darwin")
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+    monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: "Code")
+    monkeypatch.setattr(notify, "_play", played.append)
+    play_notification(NotifyEvent.TURN_COMPLETE)
+    assert played == [NotifyEvent.TURN_COMPLETE]
+
+
+def test_unknown_term_program_does_not_treat_any_terminal_as_focused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Without TERM_PROGRAM we cannot name our host, so a frontmost iTerm/Code/…
+    # must not suppress the opted-in chime (degrade to undeterminable).
+    monkeypatch.setattr(notify.platform, "system", lambda: "Darwin")
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: "iTerm2")
+    assert terminal_is_focused() is None
+    monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: "Safari")
+    assert terminal_is_focused() is None
+
+
 def test_playback_errors_never_raise(monkeypatch: pytest.MonkeyPatch) -> None:
     # A notification must never disrupt the turn — a failing player is swallowed.
-    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setenv(SOUND_NOTIFICATIONS_ENV, "1")
 
     def _boom() -> str:
         raise RuntimeError("no audio device")

--- a/tests/infrastructure/terminal/test_notify.py
+++ b/tests/infrastructure/terminal/test_notify.py
@@ -1,0 +1,89 @@
+"""Sound-notification gating and playback fallbacks."""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from infrastructure.terminal import notify
+from infrastructure.terminal.notify import (
+    NotifyEvent,
+    play_notification,
+    sound_enabled,
+    terminal_is_focused,
+)
+
+
+def test_sound_is_disabled_unless_env_is_truthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENSRE_SOUND", raising=False)
+    assert not sound_enabled()
+    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    assert sound_enabled()
+    monkeypatch.setenv("OPENSRE_SOUND", "false")
+    assert not sound_enabled()
+
+
+def test_play_is_a_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Disabled: no bell, no subprocess — the shell stays silent by default.
+    monkeypatch.delenv("OPENSRE_SOUND", raising=False)
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    play_notification(NotifyEvent.TURN_COMPLETE)
+    assert buf.getvalue() == ""
+
+
+def test_non_darwin_falls_back_to_the_terminal_bell(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When enabled off macOS, focus is undeterminable so it chimes (bell fallback).
+    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setattr(notify.platform, "system", lambda: "Linux")
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    play_notification(NotifyEvent.INPUT_NEEDED)
+    assert buf.getvalue() == "\a"
+
+
+def test_stays_silent_when_the_terminal_is_focused(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No chime while you are already looking at the terminal.
+    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setattr(notify, "terminal_is_focused", lambda: True)
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    play_notification(NotifyEvent.TURN_COMPLETE)
+    assert buf.getvalue() == ""
+
+
+def test_chimes_when_the_terminal_is_unfocused(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_SOUND", "1")
+    monkeypatch.setattr(notify, "terminal_is_focused", lambda: False)
+    monkeypatch.setattr(notify.platform, "system", lambda: "Linux")
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    play_notification(NotifyEvent.TURN_COMPLETE)
+    assert buf.getvalue() == "\a"
+
+
+def test_focus_matches_our_terminal_against_the_frontmost_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # macOS: our terminal (TERM_PROGRAM=vscode -> "Code") focused iff it is frontmost.
+    monkeypatch.setattr(notify.platform, "system", lambda: "Darwin")
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+    monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: "Code")
+    assert terminal_is_focused() is True
+    monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: "Safari")
+    assert terminal_is_focused() is False
+    monkeypatch.setattr(notify, "_macos_frontmost_app", lambda: None)
+    assert terminal_is_focused() is None
+
+
+def test_playback_errors_never_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A notification must never disrupt the turn — a failing player is swallowed.
+    monkeypatch.setenv("OPENSRE_SOUND", "1")
+
+    def _boom() -> str:
+        raise RuntimeError("no audio device")
+
+    monkeypatch.setattr(notify.platform, "system", _boom)
+    play_notification(NotifyEvent.TURN_COMPLETE)  # must not raise

--- a/tests/interactive_shell/runtime/test_agent_presentation.py
+++ b/tests/interactive_shell/runtime/test_agent_presentation.py
@@ -6,9 +6,11 @@ import asyncio
 from unittest.mock import MagicMock
 
 from core.llm.shared.llm_retry import LLMCreditExhaustedError
+from surfaces.interactive_shell.runtime import agent_presentation as ap
 from surfaces.interactive_shell.runtime.agent_presentation import (
     AgentEvent,
     AgentPresentationState,
+    ConsoleAgentEventSink,
     _render_agent_presentation_transition,
 )
 
@@ -19,6 +21,26 @@ class _RecordingConsole:
 
     def print(self, text: str = "") -> None:
         self.lines.append(text)
+
+
+def test_turn_complete_chimes_only_for_a_long_turn(monkeypatch) -> None:
+    # A walk-away-length turn chimes on completion; a quick reply stays silent so
+    # the shell does not beep on every short interactive turn.
+    calls: list[object] = []
+    monkeypatch.setattr(ap, "play_notification", lambda event: calls.append(event))
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(ap.time, "monotonic", lambda: clock["now"])
+    sink = ConsoleAgentEventSink(session=MagicMock(), spinner=MagicMock(), console=MagicMock())
+
+    sink._turn_started_at = 1000.0
+    clock["now"] = 1000.0 + ap.SOUND_MIN_TURN_SECONDS - 1
+    sink._chime_if_long_turn()
+    assert calls == []  # under the threshold: silent
+
+    sink._turn_started_at = 1000.0
+    clock["now"] = 1000.0 + ap.SOUND_MIN_TURN_SECONDS + 1
+    sink._chime_if_long_turn()
+    assert calls == [ap.NotifyEvent.TURN_COMPLETE]
 
 
 def _render_turn_error(error: Exception) -> str:

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from surfaces.interactive_shell.ui.streaming import (
     finish_deferred_closer,
     format_token_count_short,
+    publish_full_response,
     render_markdown_block,
     render_note_block,
     render_response_header,
@@ -49,6 +50,34 @@ def test_render_note_block_is_dim_and_indented_but_keeps_bold() -> None:
     first_line = _strip_ansi(raw).splitlines()[0]
     assert first_line.startswith("   ")  # three-space left indent, no glyph
     assert "load the workflow" in first_line
+
+
+def test_table_reply_renders_as_a_table_not_flattened_pipes() -> None:
+    # A reply that leads with a Markdown table must render as an aligned table. The
+    # inline ``∴ `` marker fused onto the header row breaks CommonMark block parsing
+    # and flattens the table to one line of raw pipes, so the marker goes on its own
+    # line before a leading block.
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=60, highlight=False)
+
+    publish_full_response(
+        console, "| Rank | Folder | Size |\n|---:|---|---:|\n| 1 | Library | 113G |"
+    )
+
+    out = buf.getvalue()
+    assert "| Rank | Folder |" not in out  # not the raw flattened markdown row
+    assert "Rank" in out and "Folder" in out and "Size" in out
+    assert "─" in out  # rendered as a table with a header rule
+
+
+def test_prose_reply_keeps_the_inline_marker() -> None:
+    # Prose still carries the marker inline on the first line.
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=60, highlight=False)
+
+    publish_full_response(console, "Root disk is 44% full.")
+
+    assert "∴ Root disk is 44% full." in buf.getvalue()
 
 
 def _tty_console() -> tuple[Console, io.StringIO]:


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Two shell-UX items surfaced by a live comparison with droid.

**1. Reply markdown tables render as tables, not raw pipes.**
A reply that led with a Markdown table rendered as one flattened line of raw
pipes instead of an aligned table: the inline `∴ ` response marker fused onto
the table's header row broke CommonMark block parsing, so the block was treated
as a paragraph and flattened. The marker now attaches inline only for prose;
when the reply leads with a block element (table, heading, list, code fence,
blockquote) it goes on its own line above it. Detection is a lightweight
first-line check, so the streaming path takes no extra Markdown parse.

**2. Opt-in, focus-aware sound notifications (`OPENSRE_SOUND=1`).**
A chime that fires only when the terminal is **not** the focused window — so it
alerts you when you've switched away, not while you're watching:
- Turn complete: chimes only for turns longer than ~8s (quick replies stay silent).
- Input needed: chimes when a clarification menu opens.

macOS focus is detected permission-free via `lsappinfo` (frontmost app vs. the
terminal we run in, from `TERM_PROGRAM`); off macOS, or when focus can't be
determined, it degrades to the duration gate. Playback uses macOS system sounds
via `afplay` with a terminal-bell fallback, never blocks the REPL or raises, and
is silent by default.

### Demo/Screenshot for feature changes and bug fixes -

Table — before: `∴ | Rank | Folder | Size | |---:|---|---:| | 1 | ~/Library | 113G | ...`
(one flattened, unreadable line). After:

    ∴
     Rank  Folder     Size
     ─────────────────────
        1  ~/Library  113G
        2  ~/DevBox    47G


Sound — `OPENSRE_SOUND=1 uv run opensre`, then `run: sleep 12; echo done` and
switch to another window before it finishes → a soft completion chime; stay
focused on the terminal → silent.