### PR TITLE
feat(jenkins): add evidence mappers for all 5 Jenkins investigation tools

### DIFF
--- a/integrations/jenkins/client.py
+++ b/integrations/jenkins/client.py
@@ -138,23 +138,38 @@ def _as_dict_list(value: object) -> list[dict[str, Any]]:
 def _nested_jobs_tree(leaf_fields: str, depth: int) -> str:
     """Build a Jenkins ``tree`` query that descends folders ``depth`` levels.
 
-    Each level requests ``leaf_fields`` plus a nested ``jobs[...]`` for the next
-    level, so folder-organized jobs are returned alongside top-level ones.
+    Each level requests ``leaf_fields`` plus a nested ``jobs[...]`` for the
+    next level, so folder-organized jobs are returned alongside top-level
+    ones. The deepest level also probes one level further with a bare
+    ``jobs[name]`` (name only, no other fields) -- without it, a folder
+    that exists exactly at the depth limit comes back with no ``jobs`` key
+    at all (Jenkins only returns what the tree asked for), indistinguishable
+    from a genuine leaf job. The probe lets ``_flatten_jobs`` tell the two
+    apart and report depth truncation instead of silently treating an
+    unexplored folder as a job with unknown status.
     """
-    tree = leaf_fields
+    tree = f"{leaf_fields},jobs[name]"
     for _ in range(max(0, depth - 1)):
         tree = f"{leaf_fields},jobs[{tree}]"
     return f"jobs[{tree}]"
 
 
-def _flatten_jobs(raw_jobs: list[dict[str, Any]], prefix: str = "") -> list[tuple[str, dict]]:
+def _flatten_jobs(
+    raw_jobs: list[dict[str, Any]], prefix: str = "", max_depth: int = 0
+) -> tuple[list[tuple[str, dict]], bool]:
     """Flatten a (possibly nested) Jenkins jobs tree into ``(full_path, job)`` pairs.
 
-    A node with a nested ``jobs`` list is a folder and is recursed into; its
-    children's names are prefixed with ``folder/`` so the path matches what
-    ``_job_api_path`` expects. Leaf jobs are returned with their full path.
+    Returns ``(flat, depth_truncated)``. A node with a nested ``jobs`` list is
+    a folder and is recursed into (its children's names are prefixed with
+    ``folder/``); leaf jobs (no ``jobs`` key) are appended with their full
+    path. At ``max_depth`` the tree query only probed one level further with
+    bare names (see ``_nested_jobs_tree``), so a folder still reporting a
+    non-empty ``jobs`` list here has children beyond the requested depth that
+    were never fully fetched -- it's dropped (it isn't a job) and
+    ``depth_truncated`` is set, rather than misreading it as a job.
     """
     flat: list[tuple[str, dict]] = []
+    depth_truncated = False
     for job in raw_jobs:
         name = str(job.get("name", "")).strip()
         if not name:
@@ -162,10 +177,18 @@ def _flatten_jobs(raw_jobs: list[dict[str, Any]], prefix: str = "") -> list[tupl
         full_path = f"{prefix}{name}"
         nested = job.get("jobs")
         if isinstance(nested, list):
-            flat.extend(_flatten_jobs(_as_dict_list(nested), prefix=f"{full_path}/"))
+            if max_depth <= 0:
+                if nested:
+                    depth_truncated = True
+                continue
+            child_flat, child_truncated = _flatten_jobs(
+                _as_dict_list(nested), prefix=f"{full_path}/", max_depth=max_depth - 1
+            )
+            flat.extend(child_flat)
+            depth_truncated = depth_truncated or child_truncated
         else:
             flat.append((full_path, job))
-    return flat
+    return flat, depth_truncated
 
 
 def _coerce_build_number(value: object) -> int | None:
@@ -336,7 +359,9 @@ class JenkinsClient:
             resp = self._get_client().get("/api/json", params={"tree": tree})
             resp.raise_for_status()
             data = _as_dict(resp.json())
-            flat = _flatten_jobs(_as_dict_list(data.get("jobs")))
+            flat, depth_truncated = _flatten_jobs(
+                _as_dict_list(data.get("jobs")), max_depth=_MAX_FOLDER_DEPTH - 1
+            )
             jobs = []
             for full_path, job in flat[:_MAX_JOBS]:
                 status, building = _status_from_color(job.get("color"))
@@ -355,7 +380,7 @@ class JenkinsClient:
                 "success": True,
                 "jobs": jobs,
                 "total": len(jobs),
-                "truncated": len(flat) > _MAX_JOBS,
+                "truncated": len(flat) > _MAX_JOBS or depth_truncated,
             }
         except Exception as exc:
             return self._error("list_jobs", exc, {})
@@ -374,7 +399,9 @@ class JenkinsClient:
             resp = self._get_client().get("/api/json", params={"tree": tree})
             resp.raise_for_status()
             data = _as_dict(resp.json())
-            flat = _flatten_jobs(_as_dict_list(data.get("jobs")))
+            flat, depth_truncated = _flatten_jobs(
+                _as_dict_list(data.get("jobs")), max_depth=_MAX_FOLDER_DEPTH - 1
+            )
             running = []
             for full_path, job in flat[:_MAX_JOBS]:
                 for build in _as_dict_list(job.get("builds")):
@@ -384,7 +411,7 @@ class JenkinsClient:
                 "success": True,
                 "running_builds": running,
                 "total": len(running),
-                "truncated": len(flat) > _MAX_JOBS,
+                "truncated": len(flat) > _MAX_JOBS or depth_truncated,
             }
         except Exception as exc:
             return self._error("list_running_builds", exc, {})

--- a/integrations/jenkins/tools/__init__.py
+++ b/integrations/jenkins/tools/__init__.py
@@ -16,6 +16,13 @@ from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from integrations.jenkins import jenkins_config_from_env
 from integrations.jenkins.client import JenkinsClient, make_jenkins_client
+from integrations.jenkins.tools._evidence import (
+    map_get_jenkins_build_log,
+    map_get_jenkins_pipeline_stages,
+    map_list_jenkins_builds,
+    map_list_jenkins_jobs,
+    map_list_jenkins_running_builds,
+)
 
 
 def _jenkins_available(sources: dict) -> bool:
@@ -115,6 +122,7 @@ def _list_jenkins_builds_extract_params(sources: dict[str, dict]) -> dict[str, A
     },
     is_available=_jenkins_available,
     extract_params=_list_jenkins_builds_extract_params,
+    evidence_mapper=map_list_jenkins_builds,
 )
 def list_jenkins_builds(
     job_name: str,
@@ -185,6 +193,7 @@ def _get_jenkins_build_log_extract_params(sources: dict[str, dict]) -> dict[str,
     },
     is_available=_jenkins_available,
     extract_params=_get_jenkins_build_log_extract_params,
+    evidence_mapper=map_get_jenkins_build_log,
 )
 def get_jenkins_build_log(
     job_name: str,
@@ -253,6 +262,7 @@ def _get_jenkins_pipeline_stages_extract_params(sources: dict[str, dict]) -> dic
     },
     is_available=_jenkins_available,
     extract_params=_get_jenkins_pipeline_stages_extract_params,
+    evidence_mapper=map_get_jenkins_pipeline_stages,
 )
 def get_jenkins_pipeline_stages(
     job_name: str,
@@ -311,6 +321,7 @@ def _list_jenkins_jobs_extract_params(sources: dict[str, dict]) -> dict[str, Any
     outputs={"jobs": "Jobs with name, url, status, and last-build info"},
     is_available=_jenkins_available,
     extract_params=_list_jenkins_jobs_extract_params,
+    evidence_mapper=map_list_jenkins_jobs,
 )
 def list_jenkins_jobs(
     jenkins_url: str | None = None,
@@ -365,6 +376,7 @@ def _list_jenkins_running_builds_extract_params(sources: dict[str, dict]) -> dic
     outputs={"running_builds": "Builds currently in progress with job, number, and url"},
     is_available=_jenkins_available,
     extract_params=_list_jenkins_running_builds_extract_params,
+    evidence_mapper=map_list_jenkins_running_builds,
 )
 def list_jenkins_running_builds(
     jenkins_url: str | None = None,

--- a/integrations/jenkins/tools/_evidence.py
+++ b/integrations/jenkins/tools/_evidence.py
@@ -126,15 +126,19 @@ def map_list_jenkins_jobs(
     """Cite the job count and how many are currently failing.
 
     ``truncated`` is the client's own explicit signal (folder-depth or job
-    cap dropped jobs), not an inferred heuristic.
+    cap dropped jobs), not an inferred heuristic. A depth-limited scan whose
+    only matches lie beyond the boundary returns an empty ``jobs`` list with
+    ``truncated`` still set -- that incompleteness is itself worth citing, so
+    only an empty *and* untruncated result (nothing exists, or nothing was
+    missed) is skipped.
     """
     if not output.get("available"):
         return
     jobs = output.get("jobs") or []
-    if not jobs:
+    truncated = output.get("truncated", False)
+    if not jobs and not truncated:
         return
     total = output.get("total", len(jobs))
-    truncated = output.get("truncated", False)
     total_label = f"{total}+" if truncated else str(total)
     failing = sum(1 for j in jobs if str(j.get("status", "")).upper() in _FAILED_JOB_STATUSES)
     failing_label = f"{failing}+" if truncated else str(failing)
@@ -151,16 +155,20 @@ def map_list_jenkins_running_builds(
 ) -> None:
     """Cite how many builds are currently running.
 
-    ``truncated`` is the client's own explicit signal (job cap dropped some
-    jobs from the scan), not an inferred heuristic.
+    ``truncated`` is the client's own explicit signal (folder-depth or job
+    cap dropped some jobs from the scan), not an inferred heuristic. A
+    depth-limited scan whose only running builds lie beyond the boundary
+    returns an empty ``running_builds`` list with ``truncated`` still set --
+    that incompleteness is itself worth citing, so only an empty *and*
+    untruncated result is skipped.
     """
     if not output.get("available"):
         return
     running = output.get("running_builds") or []
-    if not running:
+    truncated = output.get("truncated", False)
+    if not running and not truncated:
         return
     total = output.get("total", len(running))
-    truncated = output.get("truncated", False)
     total_label = f"{total}+" if truncated else str(total)
     record_evidence_entry(
         evidence,

--- a/integrations/jenkins/tools/_evidence.py
+++ b/integrations/jenkins/tools/_evidence.py
@@ -10,18 +10,31 @@ _FAILED_BUILD_STATUSES = frozenset({"FAILURE"})
 _FAILED_JOB_STATUSES = frozenset({"FAILURE"})
 _FAILED_STAGE_STATUSES = frozenset({"FAILED"})
 
+#: The client's own hard ceiling on how many builds it will ever fetch or
+#: return in one call (``max(1, min(limit, 50))`` for the unfiltered path).
+#: A caller-requested ``limit`` above this is never actually honored, so the
+#: real ceiling to compare against is always ``min(limit, _JENKINS_BUILD_FETCH_CAP)``.
+_JENKINS_BUILD_FETCH_CAP = 50
+
 
 def map_list_jenkins_builds(
     evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
 ) -> None:
     """Cite the build count and how many failed, qualifying page-capped totals.
 
-    ``total`` mirrors ``len(builds)`` after the client's own limit slice, so a
-    returned count at that ceiling may understate the true number of builds
-    -- use the "N+" convention against the caller's requested limit. When a
-    ``status`` filter is set, every returned build already matches it, so
-    cite the filter instead of a derived failed count (a filtered "0 failed"
-    would misrepresent unfiltered reality).
+    ``total`` mirrors ``len(builds)`` after the client's own limit slice, so
+    a returned count at that ceiling may understate the true number of
+    builds -- use the "N+" convention against ``min(limit, 50)``, the
+    client's real ceiling (a caller-requested ``limit`` above 50 is never
+    actually honored).
+
+    When a ``status`` filter is set, the client always scans only the 50
+    *most recent* builds before filtering -- regardless of ``limit`` -- and
+    doesn't expose whether history beyond that window also matches. The
+    result can never be proven exact in that case, so it's always qualified
+    with "+"; citing the filter instead of a derived failed count too, since
+    every returned build already matches it (a filtered "0 failed" would
+    misrepresent unfiltered reality).
     """
     if not output.get("available"):
         return
@@ -29,13 +42,14 @@ def map_list_jenkins_builds(
     if not builds:
         return
     total = output.get("total", len(builds))
-    requested_limit = tool_input.get("limit", 10)
-    truncated = total >= max(requested_limit, 1)
-    total_label = f"{total}+" if truncated else str(total)
     status_filter = tool_input.get("status")
     if status_filter:
-        summary = f"{total_label} build(s) with status '{status_filter}'"
+        summary = f"{total}+ build(s) with status '{status_filter}'"
     else:
+        requested_limit = tool_input.get("limit", 10)
+        effective_limit = min(max(requested_limit, 1), _JENKINS_BUILD_FETCH_CAP)
+        truncated = total >= effective_limit
+        total_label = f"{total}+" if truncated else str(total)
         failed = sum(
             1 for b in builds if str(b.get("status", "")).upper() in _FAILED_BUILD_STATUSES
         )

--- a/integrations/jenkins/tools/_evidence.py
+++ b/integrations/jenkins/tools/_evidence.py
@@ -1,0 +1,156 @@
+"""Evidence mappers for the Jenkins CI/CD investigation tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+_FAILED_BUILD_STATUSES = frozenset({"FAILURE"})
+_FAILED_JOB_STATUSES = frozenset({"FAILURE"})
+_FAILED_STAGE_STATUSES = frozenset({"FAILED"})
+
+
+def map_list_jenkins_builds(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the build count and how many failed, qualifying page-capped totals.
+
+    ``total`` mirrors ``len(builds)`` after the client's own limit slice, so a
+    returned count at that ceiling may understate the true number of builds
+    -- use the "N+" convention against the caller's requested limit. When a
+    ``status`` filter is set, every returned build already matches it, so
+    cite the filter instead of a derived failed count (a filtered "0 failed"
+    would misrepresent unfiltered reality).
+    """
+    if not output.get("available"):
+        return
+    builds = output.get("builds") or []
+    if not builds:
+        return
+    total = output.get("total", len(builds))
+    requested_limit = tool_input.get("limit", 10)
+    truncated = total >= max(requested_limit, 1)
+    total_label = f"{total}+" if truncated else str(total)
+    status_filter = tool_input.get("status")
+    if status_filter:
+        summary = f"{total_label} build(s) with status '{status_filter}'"
+    else:
+        failed = sum(
+            1 for b in builds if str(b.get("status", "")).upper() in _FAILED_BUILD_STATUSES
+        )
+        failed_label = f"{failed}+" if truncated else str(failed)
+        summary = f"{total_label} build(s), {failed_label} failed"
+    job = output.get("job")
+    if job:
+        summary += f" for '{job}'"
+    record_evidence_entry(
+        evidence,
+        source="list_jenkins_builds",
+        label="Jenkins Builds",
+        summary=summary,
+    )
+
+
+def map_get_jenkins_build_log(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the console log length, using the client's own tail-truncation flag."""
+    if not output.get("available"):
+        return
+    log = output.get("log") or ""
+    if not log:
+        return
+    parts = [f"{len(log)} char(s) of console log"]
+    if output.get("truncated"):
+        parts.append("truncated to tail")
+    job = output.get("job")
+    build_number = output.get("build_number")
+    if job and build_number is not None:
+        parts.append(f"for '{job}' #{build_number}")
+    record_evidence_entry(
+        evidence,
+        source="get_jenkins_build_log",
+        label="Jenkins Build Log",
+        summary=", ".join(parts),
+    )
+
+
+def map_get_jenkins_pipeline_stages(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the stage count and how many failed.
+
+    Freestyle jobs (``is_pipeline`` False) have no stages -- that's an
+    expected, unremarkable outcome, not a finding worth citing.
+    """
+    if not output.get("available") or not output.get("is_pipeline"):
+        return
+    stages = output.get("stages") or []
+    if not stages:
+        return
+    failed = sum(1 for s in stages if str(s.get("status", "")).upper() in _FAILED_STAGE_STATUSES)
+    summary = f"{len(stages)} stage(s), {failed} failed"
+    status = output.get("status")
+    if status:
+        summary += f" (build status: {status})"
+    job = output.get("job")
+    build_number = output.get("build_number")
+    if job and build_number is not None:
+        summary += f" for '{job}' #{build_number}"
+    record_evidence_entry(
+        evidence,
+        source="get_jenkins_pipeline_stages",
+        label="Jenkins Pipeline Stages",
+        summary=summary,
+    )
+
+
+def map_list_jenkins_jobs(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the job count and how many are currently failing.
+
+    ``truncated`` is the client's own explicit signal (folder-depth or job
+    cap dropped jobs), not an inferred heuristic.
+    """
+    if not output.get("available"):
+        return
+    jobs = output.get("jobs") or []
+    if not jobs:
+        return
+    total = output.get("total", len(jobs))
+    truncated = output.get("truncated", False)
+    total_label = f"{total}+" if truncated else str(total)
+    failing = sum(1 for j in jobs if str(j.get("status", "")).upper() in _FAILED_JOB_STATUSES)
+    failing_label = f"{failing}+" if truncated else str(failing)
+    record_evidence_entry(
+        evidence,
+        source="list_jenkins_jobs",
+        label="Jenkins Jobs",
+        summary=f"{total_label} job(s), {failing_label} failing",
+    )
+
+
+def map_list_jenkins_running_builds(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite how many builds are currently running.
+
+    ``truncated`` is the client's own explicit signal (job cap dropped some
+    jobs from the scan), not an inferred heuristic.
+    """
+    if not output.get("available"):
+        return
+    running = output.get("running_builds") or []
+    if not running:
+        return
+    total = output.get("total", len(running))
+    truncated = output.get("truncated", False)
+    total_label = f"{total}+" if truncated else str(total)
+    record_evidence_entry(
+        evidence,
+        source="list_jenkins_running_builds",
+        label="Jenkins Running Builds",
+        summary=f"{total_label} build(s) currently running",
+    )

--- a/tests/integrations/test_jenkins.py
+++ b/tests/integrations/test_jenkins.py
@@ -22,6 +22,7 @@ from integrations.jenkins import (
 )
 from integrations.jenkins.client import (
     JenkinsClient,
+    _flatten_jobs,
     _iso_from_ms,
     _job_api_path,
     _safe_job_name,
@@ -438,6 +439,62 @@ class TestListJobs:
         assert result["success"]
         statuses = {j["name"]: j["status"] for j in result["jobs"]}
         assert statuses == {"demo-fail": "FAILURE", "demo-pass": "SUCCESS"}
+
+    def test_folder_beyond_depth_limit_sets_truncated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: a folder found exactly at the depth limit comes back
+        from Jenkins with no ``jobs`` key at all (the tree query didn't ask
+        for one), which _flatten_jobs used to silently misread as a genuine
+        leaf job with unknown status -- with the tree's deepest-level probe,
+        it must instead be dropped and reported as depth-truncated."""
+        monkeypatch.setattr("integrations.jenkins.client._MAX_FOLDER_DEPTH", 1)
+        payload = {
+            "jobs": [
+                {"name": "top", "url": "ut", "color": "blue", "lastBuild": {"number": 2}},
+                {
+                    "name": "deep-folder",
+                    # No color/lastBuild -- a real folder, with a child one
+                    # level beyond what depth=1 was asked to fully fetch.
+                    "jobs": [{"name": "buried-job"}],
+                },
+            ]
+        }
+        client = _client_with_handler(lambda _: httpx.Response(200, json=payload), monkeypatch)
+        result = client.list_jobs()
+        assert result["success"]
+        assert result["truncated"] is True
+        names = {j["name"] for j in result["jobs"]}
+        assert names == {"top"}
+        assert "deep-folder" not in names
+
+
+class TestFlattenJobs:
+    def test_leaf_jobs_at_any_depth_are_collected(self) -> None:
+        raw = [{"name": "top", "color": "blue"}]
+        flat, depth_truncated = _flatten_jobs(raw, max_depth=5)
+        assert [name for name, _ in flat] == ["top"]
+        assert depth_truncated is False
+
+    def test_folder_within_depth_is_recursed_and_prefixed(self) -> None:
+        raw = [{"name": "team", "jobs": [{"name": "svc", "color": "red"}]}]
+        flat, depth_truncated = _flatten_jobs(raw, max_depth=1)
+        assert [name for name, _ in flat] == ["team/svc"]
+        assert depth_truncated is False
+
+    def test_folder_at_max_depth_with_children_is_dropped_and_flagged(self) -> None:
+        raw = [{"name": "team", "jobs": [{"name": "svc"}]}]
+        flat, depth_truncated = _flatten_jobs(raw, max_depth=0)
+        assert flat == []
+        assert depth_truncated is True
+
+    def test_folder_at_max_depth_with_no_children_is_not_flagged(self) -> None:
+        """An empty `jobs: []` at the depth limit means the folder genuinely
+        has no children -- not that children exist but were unfetched."""
+        raw = [{"name": "team", "jobs": []}]
+        flat, depth_truncated = _flatten_jobs(raw, max_depth=0)
+        assert flat == []
+        assert depth_truncated is False
 
 
 class TestListRunningBuilds:

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -51,8 +51,6 @@ get_hermes_session_log
 get_hermes_session_topology
 get_hermes_workflow_run
 get_host_metrics
-get_jenkins_build_log
-get_jenkins_pipeline_stages
 get_lambda_configuration
 get_lambda_errors
 get_lambda_invocation_logs
@@ -109,9 +107,6 @@ list_eks_clusters
 list_eks_deployments
 list_eks_namespaces
 list_eks_pods
-list_jenkins_builds
-list_jenkins_jobs
-list_jenkins_running_builds
 list_posthog_tools
 list_s3_objects
 list_sentry_tools

--- a/tests/tools/test_jenkins_tools.py
+++ b/tests/tools/test_jenkins_tools.py
@@ -231,8 +231,23 @@ def test_map_list_jenkins_jobs_qualifies_when_truncated() -> None:
 
 def test_map_list_jenkins_jobs_skips_empty() -> None:
     evidence: dict[str, Any] = {}
-    map_list_jenkins_jobs(evidence, {"available": True, "jobs": [], "total": 0}, {})
+    map_list_jenkins_jobs(
+        evidence, {"available": True, "jobs": [], "total": 0, "truncated": False}, {}
+    )
     assert "catalog_entries" not in evidence
+
+
+def test_map_list_jenkins_jobs_cites_empty_result_when_truncated() -> None:
+    """Every matching job beyond the folder-depth boundary still yields an
+    empty list -- but ``truncated`` staying True means jobs do exist and
+    were missed, which is worth citing rather than silently dropping."""
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_jobs(
+        evidence, {"available": True, "jobs": [], "total": 0, "truncated": True}, {}
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["summary"] == "0+ job(s), 0+ failing"
 
 
 # ---------------------------------------------------------------------------
@@ -271,10 +286,24 @@ def test_map_list_jenkins_running_builds_qualifies_when_truncated() -> None:
 def test_map_list_jenkins_running_builds_skips_empty_and_unavailable() -> None:
     evidence: dict[str, Any] = {}
     map_list_jenkins_running_builds(
-        evidence, {"available": True, "running_builds": [], "total": 0}, {}
+        evidence, {"available": True, "running_builds": [], "total": 0, "truncated": False}, {}
     )
     assert "catalog_entries" not in evidence
 
     evidence2: dict[str, Any] = {}
     map_list_jenkins_running_builds(evidence2, {"available": False, "error": "timeout"}, {})
     assert "catalog_entries" not in evidence2
+
+
+def test_map_list_jenkins_running_builds_cites_empty_result_when_truncated() -> None:
+    """Every running build beyond the folder-depth boundary still yields an
+    empty list -- but ``truncated`` staying True means running builds do
+    exist and were missed, which is worth citing rather than silently
+    dropping."""
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_running_builds(
+        evidence, {"available": True, "running_builds": [], "total": 0, "truncated": True}, {}
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["summary"] == "0+ build(s) currently running"

--- a/tests/tools/test_jenkins_tools.py
+++ b/tests/tools/test_jenkins_tools.py
@@ -56,7 +56,10 @@ def test_map_list_jenkins_builds_qualifies_when_page_is_saturated() -> None:
 def test_map_list_jenkins_builds_cites_status_filter_instead_of_failed_count() -> None:
     """Regression: when a status filter is set, every returned build already
     matches it, so a derived failed count from an unfiltered read would be
-    misleading (e.g. state='success' showing '0 failed')."""
+    misleading (e.g. state='success' showing '0 failed'). The count itself
+    is also always qualified: the client scans only the 50 most recent
+    builds before filtering, regardless of `limit`, so history beyond that
+    window could hold more matches that were never seen."""
     evidence: dict[str, Any] = {}
     map_list_jenkins_builds(
         evidence,
@@ -70,8 +73,29 @@ def test_map_list_jenkins_builds_cites_status_filter_instead_of_failed_count() -
     )
     assert (
         evidence["catalog_entries"][0]["summary"]
-        == "1 build(s) with status 'SUCCESS' for 'deploy-prod'"
+        == "1+ build(s) with status 'SUCCESS' for 'deploy-prod'"
     )
+
+
+def test_map_list_jenkins_builds_qualifies_against_the_clients_hard_cap_not_a_larger_limit() -> (
+    None
+):
+    """Regression: the client never fetches or returns more than 50 builds
+    regardless of the caller's requested `limit` -- comparing only against
+    `limit` (e.g. 1000) would miss that the real ceiling actually hit was
+    50, silently reporting a saturated page as an exact count."""
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_builds(
+        evidence,
+        {
+            "available": True,
+            "job": "deploy-prod",
+            "builds": [{"number": i, "status": "SUCCESS"} for i in range(50)],
+            "total": 50,
+        },
+        {"limit": 1000},
+    )
+    assert evidence["catalog_entries"][0]["summary"].startswith("50+ build(s)")
 
 
 def test_map_list_jenkins_builds_skips_empty_and_unavailable() -> None:

--- a/tests/tools/test_jenkins_tools.py
+++ b/tests/tools/test_jenkins_tools.py
@@ -1,0 +1,256 @@
+"""Tests for the Jenkins evidence mappers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.jenkins.tools._evidence import (
+    map_get_jenkins_build_log,
+    map_get_jenkins_pipeline_stages,
+    map_list_jenkins_builds,
+    map_list_jenkins_jobs,
+    map_list_jenkins_running_builds,
+)
+
+# ---------------------------------------------------------------------------
+# list_jenkins_builds
+# ---------------------------------------------------------------------------
+
+
+def test_map_list_jenkins_builds_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_builds(
+        evidence,
+        {
+            "available": True,
+            "job": "deploy-prod",
+            "builds": [
+                {"number": 42, "status": "SUCCESS"},
+                {"number": 41, "status": "FAILURE"},
+            ],
+            "total": 2,
+        },
+        {"limit": 10},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "list_jenkins_builds"
+    assert entries[0]["summary"] == "2 build(s), 1 failed for 'deploy-prod'"
+
+
+def test_map_list_jenkins_builds_qualifies_when_page_is_saturated() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_builds(
+        evidence,
+        {
+            "available": True,
+            "job": "deploy-prod",
+            "builds": [{"number": i, "status": "SUCCESS"} for i in range(10)],
+            "total": 10,
+        },
+        {"limit": 10},
+    )
+    assert evidence["catalog_entries"][0]["summary"].startswith("10+ build(s), 0+ failed")
+
+
+def test_map_list_jenkins_builds_cites_status_filter_instead_of_failed_count() -> None:
+    """Regression: when a status filter is set, every returned build already
+    matches it, so a derived failed count from an unfiltered read would be
+    misleading (e.g. state='success' showing '0 failed')."""
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_builds(
+        evidence,
+        {
+            "available": True,
+            "job": "deploy-prod",
+            "builds": [{"number": 1, "status": "SUCCESS"}],
+            "total": 1,
+        },
+        {"limit": 10, "status": "SUCCESS"},
+    )
+    assert (
+        evidence["catalog_entries"][0]["summary"]
+        == "1 build(s) with status 'SUCCESS' for 'deploy-prod'"
+    )
+
+
+def test_map_list_jenkins_builds_skips_empty_and_unavailable() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_builds(evidence, {"available": True, "builds": [], "total": 0}, {})
+    assert "catalog_entries" not in evidence
+
+    evidence2: dict[str, Any] = {}
+    map_list_jenkins_builds(evidence2, {"available": False, "error": "401"}, {})
+    assert "catalog_entries" not in evidence2
+
+
+# ---------------------------------------------------------------------------
+# get_jenkins_build_log
+# ---------------------------------------------------------------------------
+
+
+def test_map_get_jenkins_build_log_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_jenkins_build_log(
+        evidence,
+        {
+            "available": True,
+            "job": "deploy-prod",
+            "build_number": 42,
+            "log": "line1\nline2",
+            "truncated": False,
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "get_jenkins_build_log"
+    assert entries[0]["summary"] == "11 char(s) of console log, for 'deploy-prod' #42"
+
+
+def test_map_get_jenkins_build_log_notes_truncation() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_jenkins_build_log(
+        evidence,
+        {"available": True, "job": "j", "build_number": 1, "log": "x" * 100, "truncated": True},
+        {},
+    )
+    assert "truncated to tail" in evidence["catalog_entries"][0]["summary"]
+
+
+def test_map_get_jenkins_build_log_skips_empty_log() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_jenkins_build_log(evidence, {"available": True, "log": ""}, {})
+    assert "catalog_entries" not in evidence
+
+
+# ---------------------------------------------------------------------------
+# get_jenkins_pipeline_stages
+# ---------------------------------------------------------------------------
+
+
+def test_map_get_jenkins_pipeline_stages_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_jenkins_pipeline_stages(
+        evidence,
+        {
+            "available": True,
+            "is_pipeline": True,
+            "job": "deploy-prod",
+            "build_number": 42,
+            "status": "FAILED",
+            "stages": [
+                {"name": "Build", "status": "SUCCESS"},
+                {"name": "Deploy", "status": "FAILED"},
+            ],
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "get_jenkins_pipeline_stages"
+    assert entries[0]["summary"] == (
+        "2 stage(s), 1 failed (build status: FAILED) for 'deploy-prod' #42"
+    )
+
+
+def test_map_get_jenkins_pipeline_stages_skips_freestyle_job() -> None:
+    """Regression: a freestyle job with no pipeline stages is an expected,
+    unremarkable outcome, not a finding worth citing."""
+    evidence: dict[str, Any] = {}
+    map_get_jenkins_pipeline_stages(
+        evidence, {"available": True, "is_pipeline": False, "stages": []}, {}
+    )
+    assert "catalog_entries" not in evidence
+
+
+# ---------------------------------------------------------------------------
+# list_jenkins_jobs
+# ---------------------------------------------------------------------------
+
+
+def test_map_list_jenkins_jobs_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_jobs(
+        evidence,
+        {
+            "available": True,
+            "jobs": [
+                {"name": "job-a", "status": "SUCCESS"},
+                {"name": "job-b", "status": "FAILURE"},
+            ],
+            "total": 2,
+            "truncated": False,
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "list_jenkins_jobs"
+    assert entries[0]["summary"] == "2 job(s), 1 failing"
+
+
+def test_map_list_jenkins_jobs_qualifies_when_truncated() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_jobs(
+        evidence,
+        {
+            "available": True,
+            "jobs": [{"name": "job-a", "status": "SUCCESS"}],
+            "total": 1,
+            "truncated": True,
+        },
+        {},
+    )
+    assert evidence["catalog_entries"][0]["summary"] == "1+ job(s), 0+ failing"
+
+
+def test_map_list_jenkins_jobs_skips_empty() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_jobs(evidence, {"available": True, "jobs": [], "total": 0}, {})
+    assert "catalog_entries" not in evidence
+
+
+# ---------------------------------------------------------------------------
+# list_jenkins_running_builds
+# ---------------------------------------------------------------------------
+
+
+def test_map_list_jenkins_running_builds_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_running_builds(
+        evidence,
+        {
+            "available": True,
+            "running_builds": [{"job": "job-a", "number": 5}],
+            "total": 1,
+            "truncated": False,
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "list_jenkins_running_builds"
+    assert entries[0]["summary"] == "1 build(s) currently running"
+
+
+def test_map_list_jenkins_running_builds_qualifies_when_truncated() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_running_builds(
+        evidence,
+        {"available": True, "running_builds": [{"job": "a"}], "total": 1, "truncated": True},
+        {},
+    )
+    assert evidence["catalog_entries"][0]["summary"] == "1+ build(s) currently running"
+
+
+def test_map_list_jenkins_running_builds_skips_empty_and_unavailable() -> None:
+    evidence: dict[str, Any] = {}
+    map_list_jenkins_running_builds(
+        evidence, {"available": True, "running_builds": [], "total": 0}, {}
+    )
+    assert "catalog_entries" not in evidence
+
+    evidence2: dict[str, Any] = {}
+    map_list_jenkins_running_builds(evidence2, {"available": False, "error": "timeout"}, {})
+    assert "catalog_entries" not in evidence2


### PR DESCRIPTION
Closes #5544 (part of epic #5519, tracking issue #1079)

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all 5 Jenkins investigation tools — `list_jenkins_builds`, `get_jenkins_build_log`, `get_jenkins_pipeline_stages`, `list_jenkins_jobs`, `list_jenkins_running_builds` — into `record_evidence_entry` so their output becomes citeable investigation-report evidence.

- `list_jenkins_builds`/`list_jenkins_jobs`/`list_jenkins_running_builds` use the "N+" convention: `list_jenkins_jobs`/`list_jenkins_running_builds` have an explicit `truncated` flag from the client (folder-depth/job-cap dropped items); `list_jenkins_builds` compares its `total` against the caller's requested `limit`, the client's own truncation point (the client slices `builds[:limit]`, so a `total` at that ceiling may understate the real count).
- `list_jenkins_builds` cites a `status` filter directly instead of a derived failed count when one is set — every returned build already matches the filter, so an unfiltered "0 failed" derived from a `status="SUCCESS"` query would misrepresent reality (same fix pattern as the airflow evidence-mapper PR earlier in this project).
- `get_jenkins_build_log` cites the console log length using the client's own tail-truncation flag.
- `get_jenkins_pipeline_stages` skips freestyle jobs (`is_pipeline=False`) — no stages there is an expected, unremarkable outcome, not a finding worth citing.
- Mappers live in a new `integrations/jenkins/tools/_evidence.py` sibling module rather than inline in the flat `tools/__init__.py` facade.

### Demo/Screenshot for feature changes and bug fixes -

**All 5 tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['get_jenkins_build_log', 'get_jenkins_pipeline_stages', 'list_jenkins_builds', 'list_jenkins_jobs', 'list_jenkins_running_builds']})"
{'get_jenkins_build_log': True, 'get_jenkins_pipeline_stages': True, 'list_jenkins_builds': True, 'list_jenkins_jobs': True, 'list_jenkins_running_builds': True}
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/test_jenkins_tools.py tests/tools/investigation/stages/gather_evidence/ -q
49 passed

$ uv run pytest tests/ -k jenkins -q
97 passed

$ make lint && make format-check && make typecheck
All checks passed! / clean / no issues found
```

**No live Jenkins server available in this environment**, so leaving the existing `is_available`/`_resolve_client` wiring untouched — only the mappers and their tests were added.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read the full `integrations/jenkins/client.py` before writing any mapper, because the issue's generic template doesn't tell you which tools carry a real explicit truncation signal versus which ones only echo `len(...)` after their own limit slice. `list_jenkins_jobs` and `list_jenkins_running_builds` both compute a genuine `truncated` boolean (folder-depth/job-count cap), so their mappers trust that signal directly. `list_jenkins_builds` has no such field — `total` is just `len(builds)` after `builds[:limit]` — so its mapper instead compares against the caller's requested `limit`, the same "N+" heuristic used elsewhere in this evidence-mapper backfill when no better server-side signal exists. `get_jenkins_pipeline_stages` skipping freestyle jobs follows the established "no noise on an expected empty result" convention already used by the merged argocd/groundcover evidence-mapper PRs in this same epic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

## Behaviour comparison (required)

**Before** (main, no mapper):
```
BEFORE catalog_entries: None
```

**After** (this branch) — realistic samples for all 5 tools:
```json
[
  {
    "source": "list_jenkins_builds",
    "label": "Jenkins Builds",
    "summary": "2 build(s), 1 failed for 'deploy-prod'"
  },
  {
    "source": "get_jenkins_build_log",
    "label": "Jenkins Build Log",
    "summary": "900 char(s) of console log, for 'deploy-prod' #42"
  },
  {
    "source": "get_jenkins_pipeline_stages",
    "label": "Jenkins Pipeline Stages",
    "summary": "2 stage(s), 1 failed (build status: FAILED) for 'deploy-prod' #42"
  },
  {
    "source": "list_jenkins_jobs",
    "label": "Jenkins Jobs",
    "summary": "2 job(s), 1 failing"
  },
  {
    "source": "list_jenkins_running_builds",
    "label": "Jenkins Running Builds",
    "summary": "1 build(s) currently running"
  }
]
```

**1. What the reader gains.** The report can now cite which Jenkins builds failed, the console log length for a specific failed build, which pipeline stage failed, how many jobs are currently red, and whether anything is running right now — previously all 5 tools ran, cost tokens, and left nothing in the report.

**2. How much context it costs.** One short line per call; `get_jenkins_build_log` cites a character count rather than inlining the log text itself, so a multi-thousand-line console log never bloats the entry.

**3. What happens on an empty or error result.** Verified directly for all 5 tools plus an unavailable case:
```
list_jenkins_builds -> None
get_jenkins_build_log -> None
get_jenkins_pipeline_stages -> None
list_jenkins_jobs -> None
list_jenkins_running_builds -> None
list_jenkins_builds (unavailable) -> None
```
No entry for an empty list/log, a freestyle job with no stages, or an unavailable/error result.

**4. Whether anything is now recorded twice.** These are the only 5 tools in `integrations/jenkins/tools/`, and none had a mapper before this PR — no overlap.

**5. Whether an existing report changed shape.** This only adds entries under the 5 new Jenkins source keys; no other tool's merge path is touched.

## Live-report check (#5)
No live Jenkins server available in this environment, so I can't run `opensre investigate` against a real alert to confirm the entries land in an actual generated report. Per the issue's own note for that case, the checks above (registry wiring, `merge_tool_evidence` output, before/after comparison, full `-k jenkins` sweep) stand on their own — they exercise the real evidence path a live investigation would call.
