### PR TITLE
feat(helm): add evidence mappers for all 5 Helm CLI investigation tools

### DIFF
--- a/integrations/helm/tools/__init__.py
+++ b/integrations/helm/tools/__init__.py
@@ -8,6 +8,13 @@ from typing import Any
 
 from core.tool import BaseTool
 from integrations.helm.client_factory import helm_client_for_run
+from integrations.helm.tools._evidence import (
+    map_helm_get_release_manifest,
+    map_helm_get_release_values,
+    map_helm_list_releases,
+    map_helm_release_history,
+    map_helm_release_status,
+)
 from integrations.helm.unavailable import helm_base_unavailable
 
 
@@ -16,6 +23,7 @@ class HelmListReleasesTool(BaseTool):
 
     name = "helm_list_releases"
     source = "helm"
+    evidence_mapper = map_helm_list_releases
     description = (
         "List Helm releases (JSON metadata) using the local Helm CLI against the "
         "configured kubeconfig/context."
@@ -135,6 +143,7 @@ class HelmReleaseStatusTool(BaseTool):
 
     name = "helm_release_status"
     source = "helm"
+    evidence_mapper = map_helm_release_status
     description = "Fetch Helm release status (resources, hooks metadata, notes) as structured JSON."
     use_cases = [
         "Checking whether a Helm release is in failed/pending state",
@@ -224,6 +233,7 @@ class HelmReleaseHistoryTool(BaseTool):
 
     name = "helm_release_history"
     source = "helm"
+    evidence_mapper = map_helm_release_history
     description = "Fetch Helm revision history (status, chart version, description per revision)."
     use_cases = [
         "Seeing recent failed rollouts or rollbacks for a Helm release",
@@ -311,6 +321,7 @@ class HelmGetReleaseValuesTool(BaseTool):
 
     name = "helm_get_release_values"
     source = "helm"
+    evidence_mapper = map_helm_get_release_values
     description = "Fetch Helm values for a release as JSON. May include secrets — handle carefully."
     use_cases = [
         "Confirming image tags, replica counts, or feature flags shipped with a chart revision",
@@ -403,6 +414,7 @@ class HelmGetReleaseManifestTool(BaseTool):
 
     name = "helm_get_release_manifest"
     source = "helm"
+    evidence_mapper = map_helm_get_release_manifest
     description = (
         "Fetch the rendered Kubernetes manifest YAML for a Helm release (truncated if huge)."
     )

--- a/integrations/helm/tools/_evidence.py
+++ b/integrations/helm/tools/_evidence.py
@@ -1,0 +1,138 @@
+"""Evidence mappers for the Helm CLI investigation tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+
+_FAILED_REVISION_STATUS = "failed"
+
+
+def map_helm_list_releases(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the release count and scope, qualifying page-capped totals.
+
+    ``helm list --max`` silently caps the CLI's own output with no
+    truncation signal echoed back, so a returned count at that ceiling may
+    understate the true number of releases -- use the "N+" convention
+    against the caller's requested ``max_releases``.
+    """
+    if not output.get("available"):
+        return
+    releases = output.get("releases") or []
+    if not releases:
+        return
+    total = len(releases)
+    requested_max = tool_input.get("max_releases", 256)
+    truncated = total >= max(requested_max, 1)
+    total_label = f"{total}+" if truncated else str(total)
+    scope = "all namespaces" if output.get("all_namespaces") else (output.get("namespace") or "")
+    summary = f"{total_label} release(s)"
+    if scope:
+        summary += f" in {scope}"
+    record_evidence_entry(
+        evidence,
+        source="helm_list_releases",
+        label="Helm Releases",
+        summary=summary,
+    )
+
+
+def map_helm_release_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the release's deployment status (helm status's ``info.status``)."""
+    if not output.get("available"):
+        return
+    status = output.get("status") or {}
+    if not status:
+        return
+    info = status.get("info") if isinstance(status.get("info"), dict) else {}
+    deploy_status = (info or {}).get("status") or "unknown"
+    summary = f"status: {deploy_status}"
+    release = output.get("release")
+    if release:
+        summary += f" for '{release}'"
+    namespace = output.get("namespace")
+    if namespace:
+        summary += f" (ns: {namespace})"
+    record_evidence_entry(
+        evidence,
+        source="helm_release_status",
+        label="Helm Release Status",
+        summary=summary,
+    )
+
+
+def map_helm_release_history(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the revision count and how many are in a failed state."""
+    if not output.get("available"):
+        return
+    history = output.get("history") or []
+    if not history:
+        return
+    failed = sum(1 for h in history if str(h.get("status", "")).lower() == _FAILED_REVISION_STATUS)
+    summary = f"{len(history)} revision(s), {failed} failed"
+    release = output.get("release")
+    if release:
+        summary += f" for '{release}'"
+    record_evidence_entry(
+        evidence,
+        source="helm_release_history",
+        label="Helm Release History",
+        summary=summary,
+    )
+
+
+def map_helm_get_release_values(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite how many value keys were retrieved -- never the values themselves.
+
+    The tool's own docstring warns values "may include secrets"; citing a
+    key count (not the keys or values) keeps the evidence entry safe to
+    surface in a report without deciding per-key sensitivity.
+    """
+    if not output.get("available"):
+        return
+    values = output.get("values") or {}
+    if not values:
+        return
+    summary = f"{len(values)} top-level value key(s) retrieved"
+    if output.get("all_values"):
+        summary += " (including chart defaults)"
+    release = output.get("release")
+    if release:
+        summary += f" for '{release}'"
+    record_evidence_entry(
+        evidence,
+        source="helm_get_release_values",
+        label="Helm Release Values",
+        summary=summary,
+    )
+
+
+def map_helm_get_release_manifest(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the rendered manifest's length, using the client's own truncation flag."""
+    if not output.get("available"):
+        return
+    manifest = output.get("manifest") or ""
+    if not manifest:
+        return
+    count_label = f"{len(manifest)}+" if output.get("truncated") else str(len(manifest))
+    summary = f"{count_label} char(s) of rendered manifest"
+    release = output.get("release")
+    if release:
+        summary += f" for '{release}'"
+    record_evidence_entry(
+        evidence,
+        source="helm_get_release_manifest",
+        label="Helm Release Manifest",
+        summary=summary,
+    )

--- a/integrations/helm/tools/_evidence.py
+++ b/integrations/helm/tools/_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.domain.types.evidence import record_evidence_entry
+from infrastructure.delivery.notifications.limits import MAX_MESSAGE_SIZE
 
 _FAILED_REVISION_STATUS = "failed"
 
@@ -17,7 +18,10 @@ def map_helm_list_releases(
     ``helm list --max`` silently caps the CLI's own output with no
     truncation signal echoed back, so a returned count at that ceiling may
     understate the true number of releases -- use the "N+" convention
-    against the caller's requested ``max_releases``.
+    against ``min(max_releases, MAX_MESSAGE_SIZE)``, the client's real
+    ceiling (``list_releases`` clamps ``max_releases`` to
+    ``MAX_MESSAGE_SIZE`` before ever calling the CLI, so a caller-requested
+    value above that is never actually honored).
     """
     if not output.get("available"):
         return
@@ -26,7 +30,8 @@ def map_helm_list_releases(
         return
     total = len(releases)
     requested_max = tool_input.get("max_releases", 256)
-    truncated = total >= max(requested_max, 1)
+    effective_max = min(max(requested_max, 1), MAX_MESSAGE_SIZE)
+    truncated = total >= effective_max
     total_label = f"{total}+" if truncated else str(total)
     scope = "all namespaces" if output.get("all_namespaces") else (output.get("namespace") or "")
     summary = f"{total_label} release(s)"

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -80,11 +80,6 @@ get_tracer_run
 get_tracer_tasks
 get_yc_instance_diagnostics
 get_yc_lb_health
-helm_get_release_manifest
-helm_get_release_values
-helm_list_releases
-helm_release_history
-helm_release_status
 inspect_lambda_function
 inspect_s3_object
 jira_add_comment

--- a/tests/tools/test_helm_tools.py
+++ b/tests/tools/test_helm_tools.py
@@ -141,6 +141,27 @@ def test_map_helm_list_releases_qualifies_when_capped() -> None:
     assert evidence["catalog_entries"][0]["summary"].startswith("5+ release(s)")
 
 
+def test_map_helm_list_releases_qualifies_against_the_clients_hard_cap_not_a_larger_request() -> (
+    None
+):
+    """Regression: list_releases clamps max_releases to MAX_MESSAGE_SIZE
+    (4096) before ever calling the CLI, so a caller-requested value above
+    that is never actually honored -- comparing only against the raw
+    requested max would miss that the real ceiling hit was 4096, silently
+    reporting a saturated page as an exact count."""
+    evidence: dict[str, Any] = {}
+    map_helm_list_releases(
+        evidence,
+        {
+            "available": True,
+            "releases": [{"name": f"r{i}"} for i in range(4096)],
+            "all_namespaces": True,
+        },
+        {"max_releases": 1_000_000},
+    )
+    assert evidence["catalog_entries"][0]["summary"].startswith("4096+ release(s)")
+
+
 def test_map_helm_list_releases_skips_empty_and_unavailable() -> None:
     evidence: dict[str, Any] = {}
     map_helm_list_releases(evidence, {"available": True, "releases": []}, {})

--- a/tests/tools/test_helm_tools.py
+++ b/tests/tools/test_helm_tools.py
@@ -12,6 +12,13 @@ from integrations.helm.tools import (
     HelmListReleasesTool,
     HelmReleaseStatusTool,
 )
+from integrations.helm.tools._evidence import (
+    map_helm_get_release_manifest,
+    map_helm_get_release_values,
+    map_helm_list_releases,
+    map_helm_release_history,
+    map_helm_release_status,
+)
 
 
 class _FakeHelmClient:
@@ -100,3 +107,166 @@ def test_helm_get_manifest_tool_returns_yaml(monkeypatch: pytest.MonkeyPatch) ->
     result = tool.run(**tool.extract_params({"helm": _HELM_SOURCE}))
     assert result["available"] is True
     assert "kind: Service" in result["manifest"]
+
+
+# ---------------------------------------------------------------------------
+# Evidence mappers
+# ---------------------------------------------------------------------------
+
+
+def test_map_helm_list_releases_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_list_releases(
+        evidence,
+        {
+            "available": True,
+            "releases": [{"name": "demo"}, {"name": "other"}],
+            "all_namespaces": True,
+        },
+        {"max_releases": 256},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "helm_list_releases"
+    assert entries[0]["summary"] == "2 release(s) in all namespaces"
+
+
+def test_map_helm_list_releases_qualifies_when_capped() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_list_releases(
+        evidence,
+        {"available": True, "releases": [{"name": f"r{i}"} for i in range(5)], "namespace": "ns"},
+        {"max_releases": 5},
+    )
+    assert evidence["catalog_entries"][0]["summary"].startswith("5+ release(s)")
+
+
+def test_map_helm_list_releases_skips_empty_and_unavailable() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_list_releases(evidence, {"available": True, "releases": []}, {})
+    assert "catalog_entries" not in evidence
+
+    evidence2: dict[str, Any] = {}
+    map_helm_list_releases(evidence2, {"available": False, "error": "binary not found"}, {})
+    assert "catalog_entries" not in evidence2
+
+
+def test_map_helm_release_status_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_release_status(
+        evidence,
+        {
+            "available": True,
+            "release": "demo",
+            "namespace": "prod",
+            "status": {"info": {"status": "failed"}},
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "helm_release_status"
+    assert entries[0]["summary"] == "status: failed for 'demo' (ns: prod)"
+
+
+def test_map_helm_release_status_skips_empty_status() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_release_status(evidence, {"available": True, "status": {}}, {})
+    assert "catalog_entries" not in evidence
+
+
+def test_map_helm_release_history_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_release_history(
+        evidence,
+        {
+            "available": True,
+            "release": "demo",
+            "history": [
+                {"revision": 1, "status": "superseded"},
+                {"revision": 2, "status": "failed"},
+            ],
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "helm_release_history"
+    assert entries[0]["summary"] == "2 revision(s), 1 failed for 'demo'"
+
+
+def test_map_helm_release_history_skips_empty() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_release_history(evidence, {"available": True, "history": []}, {})
+    assert "catalog_entries" not in evidence
+
+
+def test_map_helm_get_release_values_records_key_count_not_values() -> None:
+    """Regression: values may include secrets -- the summary must cite a
+    count, never the actual keys or values."""
+    evidence: dict[str, Any] = {}
+    map_helm_get_release_values(
+        evidence,
+        {
+            "available": True,
+            "release": "demo",
+            "values": {"apiKey": "super-secret", "replicas": 3},
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "helm_get_release_values"
+    assert entries[0]["summary"] == "2 top-level value key(s) retrieved for 'demo'"
+    assert "super-secret" not in entries[0]["summary"]
+    assert "apiKey" not in entries[0]["summary"]
+
+
+def test_map_helm_get_release_values_notes_all_values() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_get_release_values(
+        evidence, {"available": True, "values": {"a": 1}, "all_values": True}, {}
+    )
+    assert "including chart defaults" in evidence["catalog_entries"][0]["summary"]
+
+
+def test_map_helm_get_release_values_skips_empty() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_get_release_values(evidence, {"available": True, "values": {}}, {})
+    assert "catalog_entries" not in evidence
+
+
+def test_map_helm_get_release_manifest_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_get_release_manifest(
+        evidence,
+        {
+            "available": True,
+            "release": "demo",
+            "manifest": "apiVersion: v1\nkind: Service",
+            "truncated": False,
+        },
+        {},
+    )
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "helm_get_release_manifest"
+    assert entries[0]["summary"] == "28 char(s) of rendered manifest for 'demo'"
+
+
+def test_map_helm_get_release_manifest_qualifies_when_truncated() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_get_release_manifest(
+        evidence, {"available": True, "manifest": "x" * 10, "truncated": True}, {}
+    )
+    assert evidence["catalog_entries"][0]["summary"].startswith("10+ char(s)")
+
+
+def test_map_helm_get_release_manifest_skips_empty_and_unavailable() -> None:
+    evidence: dict[str, Any] = {}
+    map_helm_get_release_manifest(evidence, {"available": True, "manifest": ""}, {})
+    assert "catalog_entries" not in evidence
+
+    evidence2: dict[str, Any] = {}
+    map_helm_get_release_manifest(evidence2, {"available": False, "error": "not found"}, {})
+    assert "catalog_entries" not in evidence2


### PR DESCRIPTION
Closes #5543 (part of epic #5519, tracking issue #1079)

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all 5 Helm CLI investigation tools — `helm_list_releases`, `helm_release_status`, `helm_release_history`, `helm_get_release_values`, `helm_get_release_manifest` — into `record_evidence_entry` so their output becomes citeable investigation-report evidence.

- `helm_list_releases` uses the "N+" convention against the caller's requested `max_releases` — `helm list --max` silently caps the CLI's own output with no truncation signal echoed back to the tool layer.
- `helm_get_release_manifest` uses the client's own explicit `truncated` flag (a real signal, not inferred).
- `helm_get_release_values` cites **only a top-level key count**, never the keys or values themselves — the tool's own docstring explicitly warns values "may include secrets", so the evidence entry stays safe to surface in a report without having to decide per-key sensitivity.
- `helm_release_status` cites the deployment status from `status.info.status` (helm's own status JSON shape).
- `helm_release_history` cites revision count and how many are in a `failed` state.
- Mappers live in a new `integrations/helm/tools/_evidence.py` sibling module rather than inline in the `tools/__init__.py` facade.

### Demo/Screenshot for feature changes and bug fixes -

**All 5 tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['helm_get_release_manifest', 'helm_get_release_values', 'helm_list_releases', 'helm_release_history', 'helm_release_status']})"
{'helm_get_release_manifest': True, 'helm_get_release_values': True, 'helm_list_releases': True, 'helm_release_history': True, 'helm_release_status': True}
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/test_helm_tools.py tests/tools/investigation/stages/gather_evidence/ -q
50 passed

$ uv run pytest tests/ -k helm -q
56 passed, 1 skipped

$ make lint && make format-check && make typecheck
All checks passed! / clean / no issues found
```

**No live Kubernetes cluster/Helm binary available in this environment**, so leaving the existing `is_available`/`helm_client_for_run` wiring untouched — only the mappers and their tests were added.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read the full `integrations/helm/client.py` before writing any mapper, because it's the only source of truth for which fields carry a real truncation signal. `helm_get_release_manifest` already tracks `truncated` explicitly (the client caps the manifest text and sets the flag itself), so its mapper trusts that directly. `helm_list_releases` has no such field — the CLI's own `--max` flag silently caps `releases` — so its mapper instead compares the returned count against the caller's requested `max_releases`, the same "N+" heuristic used elsewhere in this evidence-mapper backfill when no better server-side signal exists. The `helm_get_release_values` design decision (key count, not key names or values) came directly from the tool's own docstring warning about secrets — citing anything more specific would risk leaking a secret's name or shape into a report the security team might not expect evidence entries to carry.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

## Behaviour comparison (required)

**Before** (main, no mapper):
```
BEFORE catalog_entries: None
```

**After** (this branch) — realistic samples for all 5 tools:
```json
[
  {
    "source": "helm_list_releases",
    "label": "Helm Releases",
    "summary": "2 release(s) in all namespaces"
  },
  {
    "source": "helm_release_status",
    "label": "Helm Release Status",
    "summary": "status: failed for 'checkout' (ns: prod)"
  },
  {
    "source": "helm_release_history",
    "label": "Helm Release History",
    "summary": "2 revision(s), 1 failed for 'checkout'"
  },
  {
    "source": "helm_get_release_values",
    "label": "Helm Release Values",
    "summary": "2 top-level value key(s) retrieved for 'checkout'"
  },
  {
    "source": "helm_get_release_manifest",
    "label": "Helm Release Manifest",
    "summary": "160 char(s) of rendered manifest for 'checkout'"
  }
]
```

**1. What the reader gains.** The report can now cite which release is failed/deployed, how many prior rollouts failed, how many value keys were retrieved for a release (without leaking secret contents), and the size of the rendered manifest — previously all 5 tools ran, cost tokens, and left nothing in the report.

**2. How much context it costs.** One short line per call. `helm_get_release_values` cites a count, never the values, so a release with secret-shaped values never leaks anything into the report. `helm_get_release_manifest` cites a character count, not the manifest text itself.

**3. What happens on an empty or error result.** Verified directly for all 5 tools plus an unavailable case:
```
helm_list_releases -> None
helm_release_status -> None
helm_release_history -> None
helm_get_release_values -> None
helm_get_release_manifest -> None
helm_list_releases (unavailable) -> None
```
No entry for an empty releases list, an empty status/history/values, an empty manifest, or an unavailable/error result.

**4. Whether anything is now recorded twice.** These are the only 5 tools in `integrations/helm/tools/`, and none had a mapper before this PR — no overlap.

**5. Whether an existing report changed shape.** This only adds entries under the 5 new Helm source keys; no other tool's merge path is touched.

## Live-report check (#5)
No live Kubernetes cluster or Helm binary available in this environment, so I can't run `opensre investigate` against a real alert to confirm the entries land in an actual generated report. Per the issue's own note for that case, the checks above (registry wiring, `merge_tool_evidence` output, before/after comparison, full `-k helm` sweep) stand on their own — they exercise the real evidence path a live investigation would call.
