### PR TITLE
feat(knowledge): add evidence mappers for the 5 knowledge-source tools

### DIFF
--- a/core/domain/types/evidence.py
+++ b/core/domain/types/evidence.py
@@ -45,3 +45,25 @@ def record_evidence_entry(
     entries.append(
         {"source": source, "label": label, "summary": summary, "url": url, "snippet": snippet}
     )
+
+
+def unique_evidence_source(evidence: dict[str, Any], base: str) -> str:
+    """Disambiguate repeat calls to a tool that can run many times per investigation.
+
+    ``record_evidence_entry`` lets the first entry for a given ``source``
+    win, which silently drops every later call's evidence for a tool the
+    agent invokes repeatedly with different arguments (e.g. a generic
+    dispatcher or a recall/search tool called once per topic). Call this to
+    get ``base`` on the first use and an incrementing ``base#N`` suffix on
+    each repeat, so every call keeps its own citeable entry.
+    """
+    entries = evidence.get(CATALOG_ENTRIES_KEY)
+    if not isinstance(entries, list):
+        return base
+    existing = {e.get("source") for e in entries if isinstance(e, dict)}
+    if base not in existing:
+        return base
+    suffix = 2
+    while f"{base}#{suffix}" in existing:
+        suffix += 1
+    return f"{base}#{suffix}"

--- a/tests/core/domain/types/test_evidence.py
+++ b/tests/core/domain/types/test_evidence.py
@@ -1,0 +1,32 @@
+"""Tests for the shared evidence catalog helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry, unique_evidence_source
+
+
+def test_record_evidence_entry_appends_to_catalog() -> None:
+    evidence: dict[str, Any] = {}
+    record_evidence_entry(evidence, source="s1", label="Label", summary="summary")
+    assert evidence["catalog_entries"] == [
+        {"source": "s1", "label": "Label", "summary": "summary", "url": None, "snippet": None}
+    ]
+
+
+def test_unique_evidence_source_returns_base_when_unused() -> None:
+    evidence: dict[str, Any] = {}
+    assert unique_evidence_source(evidence, "foo") == "foo"
+
+
+def test_unique_evidence_source_increments_past_existing_suffixes() -> None:
+    evidence: dict[str, Any] = {}
+    record_evidence_entry(evidence, source="foo", label="L", summary="1")
+    record_evidence_entry(evidence, source="foo#2", label="L", summary="2")
+    assert unique_evidence_source(evidence, "foo") == "foo#3"
+
+
+def test_unique_evidence_source_tolerates_missing_or_malformed_catalog() -> None:
+    assert unique_evidence_source({}, "foo") == "foo"
+    assert unique_evidence_source({"catalog_entries": "not-a-list"}, "foo") == "foo"

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -21,7 +21,6 @@ check_s3_marker
 create_google_docs_incident_report
 describe_eks_addon
 describe_eks_cluster
-execute_python_code
 execute_yc_operation
 fetch_failed_run
 find_yc_api
@@ -75,7 +74,6 @@ get_redis_replication
 get_redis_server_info
 get_redis_slowlog
 get_s3_object
-get_sre_guidance
 get_tracer_run
 get_tracer_tasks
 get_yc_instance_diagnostics
@@ -119,7 +117,6 @@ list_x_tools
 list_yc_instances
 list_yc_log_groups
 list_yc_metrics
-memory_recall
 memory_remember
 pi_coding_task
 query_azure_monitor_logs
@@ -143,7 +140,5 @@ telegram_send_message
 twilio_notify
 work_task_add
 work_task_complete
-work_task_list
-work_task_prioritize
 work_task_schedule_checkin
 work_task_update

--- a/tests/tools/test_agent_memory.py
+++ b/tests/tools/test_agent_memory.py
@@ -11,6 +11,7 @@ from config.constants import OPENSRE_MEMORY_DIR_ENV, OPENSRE_MEMORY_DISABLED_ENV
 from core.tool_framework.tool_decorator import REGISTERED_TOOL_ATTR
 from tests.tools.conftest import BaseToolContract
 from tools.system.agent_memory import memory_forget, memory_recall, memory_remember
+from tools.system.agent_memory._evidence import map_memory_recall
 from tools.system.agent_memory.results import RECALL_BODY_CHAR_CAP
 from tools.system.agent_memory.validation import MAX_RECALL_LIMIT
 
@@ -186,3 +187,42 @@ class TestRecall:
         result = memory_recall(query="needle", limit=999)
         assert len(result["memories"]) == MAX_RECALL_LIMIT
         assert memory_recall(query=123)["error"] == "invalid_query"
+
+
+class TestMapMemoryRecall:
+    def test_records_named_recall(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_memory_recall(
+            evidence,
+            {"memories": [{"name": "prod-cluster"}], "total_stored": 5},
+            {"name": "prod-cluster"},
+        )
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "memory_recall"
+        assert entries[0]["summary"] == "recalled memory 'prod-cluster'"
+
+    def test_records_query_search(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_memory_recall(
+            evidence,
+            {"memories": [{"name": "a"}, {"name": "b"}], "total_stored": 10},
+            {"query": "cluster"},
+        )
+        assert evidence["catalog_entries"][0]["summary"] == (
+            "2 memory match(es) for query 'cluster' (of 10 stored)"
+        )
+
+    def test_records_index_listing(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_memory_recall(evidence, {"memories": [{"name": "a"}], "total_stored": 1}, {})
+        assert evidence["catalog_entries"][0]["summary"] == "1 memory index entries (of 1 stored)"
+
+    def test_skips_empty_and_error_results(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_memory_recall(evidence, {"memories": []}, {})
+        assert "catalog_entries" not in evidence
+
+        evidence2: dict[str, Any] = {}
+        map_memory_recall(evidence2, {"error": "not_found", "name": "x"}, {"name": "x"})
+        assert "catalog_entries" not in evidence2

--- a/tests/tools/test_agent_memory.py
+++ b/tests/tools/test_agent_memory.py
@@ -226,3 +226,10 @@ class TestMapMemoryRecall:
         evidence2: dict[str, Any] = {}
         map_memory_recall(evidence2, {"error": "not_found", "name": "x"}, {"name": "x"})
         assert "catalog_entries" not in evidence2
+
+    def test_disambiguates_repeat_calls(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_memory_recall(evidence, {"memories": [{"name": "a"}]}, {"name": "a"})
+        map_memory_recall(evidence, {"memories": [{"name": "b"}]}, {"name": "b"})
+        sources = [e["source"] for e in evidence["catalog_entries"]]
+        assert sources == ["memory_recall", "memory_recall#2"]

--- a/tests/tools/test_python_execution_tool.py
+++ b/tests/tools/test_python_execution_tool.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 from infrastructure.safety.sandbox.runner import SandboxResult
 from tests.tools.conftest import BaseToolContract
 from tools.registry import clear_tool_registry_cache, get_registered_tool_map
 from tools.system.python_execution_tool import execute_python_code
+from tools.system.python_execution_tool._evidence import map_execute_python_code
 
 
 class TestPythonExecutionToolContract(BaseToolContract):
@@ -184,3 +186,51 @@ class TestPythonExecutionToolCredentials:
         assert result["credentials_available"] == ["github"]
         assert "ghp_explicit_secret" not in result["stdout"]
         assert "[redacted]" in result["stdout"]
+
+
+class TestMapExecutePythonCode:
+    def test_records_stdout_on_success(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_execute_python_code(evidence, {"success": True, "stdout": "42\n"}, {})
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "execute_python_code"
+        assert entries[0]["summary"] == "42"
+
+    def test_skips_successful_run_with_no_output(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_execute_python_code(evidence, {"success": True, "stdout": ""}, {})
+        assert "catalog_entries" not in evidence
+
+    def test_records_failure_reason_even_without_output(self) -> None:
+        """A failure is diagnostic information by itself -- unlike an empty
+        successful run, it must not be silently dropped."""
+        evidence: dict[str, Any] = {}
+        map_execute_python_code(
+            evidence, {"success": False, "timed_out": True, "stdout": "", "stderr": ""}, {}
+        )
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["summary"] == "execution failed (timed out)"
+
+    def test_records_failure_with_stderr_detail(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_execute_python_code(
+            evidence,
+            {"success": False, "exit_code": 1, "stderr": "ZeroDivisionError: division by zero"},
+            {},
+        )
+        summary = evidence["catalog_entries"][0]["summary"]
+        assert summary.startswith("execution failed (exit code 1)")
+        assert "ZeroDivisionError" in summary
+
+    def test_disambiguates_repeat_calls(self) -> None:
+        """Regression: this tool can be called many times per investigation
+        with different code -- record_evidence_entry lets the first entry
+        for a source win, so reusing one source key would silently drop
+        every call after the first."""
+        evidence: dict[str, Any] = {}
+        map_execute_python_code(evidence, {"success": True, "stdout": "1"}, {})
+        map_execute_python_code(evidence, {"success": True, "stdout": "2"}, {})
+        sources = [e["source"] for e in evidence["catalog_entries"]]
+        assert sources == ["execute_python_code", "execute_python_code#2"]

--- a/tests/tools/test_sre_guidance_tool.py
+++ b/tests/tools/test_sre_guidance_tool.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from tests.tools.conftest import BaseToolContract
 from tools.system.sre_guidance_tool import get_sre_guidance
+from tools.system.sre_guidance_tool._evidence import map_get_sre_guidance
 
 
 class TestSREGuidanceToolContract(BaseToolContract):
@@ -35,3 +38,18 @@ def test_metadata_has_knowledge_source() -> None:
     rt = get_sre_guidance.__opensre_registered_tool__
     assert rt.source == "knowledge"
     assert rt.name == "get_sre_guidance"
+
+
+def test_map_get_sre_guidance_records_entry() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_sre_guidance(evidence, {"topics": ["failure_delayed_data", "slo_freshness"]}, {})
+    entries = evidence["catalog_entries"]
+    assert len(entries) == 1
+    assert entries[0]["source"] == "get_sre_guidance"
+    assert entries[0]["summary"] == "2 topic(s): failure_delayed_data, slo_freshness"
+
+
+def test_map_get_sre_guidance_skips_empty_topics() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_sre_guidance(evidence, {"topics": []}, {})
+    assert "catalog_entries" not in evidence

--- a/tests/tools/test_sre_guidance_tool.py
+++ b/tests/tools/test_sre_guidance_tool.py
@@ -53,3 +53,11 @@ def test_map_get_sre_guidance_skips_empty_topics() -> None:
     evidence: dict[str, Any] = {}
     map_get_sre_guidance(evidence, {"topics": []}, {})
     assert "catalog_entries" not in evidence
+
+
+def test_map_get_sre_guidance_disambiguates_repeat_calls() -> None:
+    evidence: dict[str, Any] = {}
+    map_get_sre_guidance(evidence, {"topics": ["slo_freshness"]}, {})
+    map_get_sre_guidance(evidence, {"topics": ["hotspotting"]}, {})
+    sources = [e["source"] for e in evidence["catalog_entries"]]
+    assert sources == ["get_sre_guidance", "get_sre_guidance#2"]

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -275,6 +275,15 @@ class TestMapWorkTaskList:
         map_work_task_list(evidence2, {"error": "invalid_status"}, {})
         assert "catalog_entries" not in evidence2
 
+    def test_disambiguates_repeat_calls(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_work_task_list(evidence, {"tasks": [{}], "returned": 1, "total": 1}, {"status": "open"})
+        map_work_task_list(
+            evidence, {"tasks": [{}], "returned": 1, "total": 1}, {"status": "closed"}
+        )
+        sources = [e["source"] for e in evidence["catalog_entries"]]
+        assert sources == ["work_task_list", "work_task_list#2"]
+
 
 class TestMapWorkTaskPrioritize:
     def test_records_entry(self) -> None:
@@ -298,3 +307,14 @@ class TestMapWorkTaskPrioritize:
         evidence: dict[str, Any] = {}
         map_work_task_prioritize(evidence, {"recommendations": []}, {})
         assert "catalog_entries" not in evidence
+
+    def test_disambiguates_repeat_calls(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_work_task_prioritize(
+            evidence, {"recommendations": [{"task": {"title": "Fix prod outage"}}]}, {}
+        )
+        map_work_task_prioritize(
+            evidence, {"recommendations": [{"task": {"title": "Update docs"}}]}, {}
+        )
+        sources = [e["source"] for e in evidence["catalog_entries"]]
+        assert sources == ["work_task_prioritize", "work_task_prioritize#2"]

--- a/tests/tools/test_work_items_tools.py
+++ b/tests/tools/test_work_items_tools.py
@@ -10,6 +10,7 @@ import pytest
 
 from core.domain.work_items import WorkItemChannelTarget, WorkItemPriority, make_work_item
 from infrastructure.scheduling.scheduler.types import Provider
+from tools.system.work_items._evidence import map_work_task_list, map_work_task_prioritize
 from tools.system.work_items.delivery import (
     delivery_targets,
     gateway_delivery_context,
@@ -243,3 +244,57 @@ def test_work_task_tools_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     # Verify list is now empty of open items
     list_after = work_task_list(status="open", project="infra")
     assert list_after["total"] == 0
+
+
+class TestMapWorkTaskList:
+    def test_records_entry(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_work_task_list(
+            evidence, {"tasks": [{}, {}], "returned": 2, "total": 2}, {"status": "open"}
+        )
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "work_task_list"
+        assert entries[0]["summary"] == "2 task(s) with status 'open'"
+
+    def test_notes_when_page_is_smaller_than_total(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_work_task_list(
+            evidence, {"tasks": [{}] * 5, "returned": 5, "total": 12}, {"status": "open"}
+        )
+        assert evidence["catalog_entries"][0]["summary"] == (
+            "12 task(s) with status 'open' (5 shown)"
+        )
+
+    def test_skips_empty_and_error(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_work_task_list(evidence, {"tasks": [], "returned": 0, "total": 0}, {})
+        assert "catalog_entries" not in evidence
+
+        evidence2: dict[str, Any] = {}
+        map_work_task_list(evidence2, {"error": "invalid_status"}, {})
+        assert "catalog_entries" not in evidence2
+
+
+class TestMapWorkTaskPrioritize:
+    def test_records_entry(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_work_task_prioritize(
+            evidence,
+            {
+                "recommendations": [
+                    {"rank": 1, "score": 9.5, "task": {"title": "Fix prod outage"}},
+                    {"rank": 2, "score": 5.0, "task": {"title": "Update docs"}},
+                ]
+            },
+            {},
+        )
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "work_task_prioritize"
+        assert entries[0]["summary"] == "2 task(s) ranked, top: 'Fix prod outage'"
+
+    def test_skips_empty(self) -> None:
+        evidence: dict[str, Any] = {}
+        map_work_task_prioritize(evidence, {"recommendations": []}, {})
+        assert "catalog_entries" not in evidence

--- a/tools/system/agent_memory/_evidence.py
+++ b/tools/system/agent_memory/_evidence.py
@@ -1,0 +1,41 @@
+"""Evidence mapper for memory_recall."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: Bound a caller-supplied query echoed into a report summary.
+_QUERY_SUMMARY_TRUNCATE_LEN = 60
+
+
+def map_memory_recall(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite what was recalled: a named memory, a search match count, or the index size."""
+    if output.get("error"):
+        return
+    memories = output.get("memories") or []
+    if not memories:
+        return
+    name = tool_input.get("name")
+    query = tool_input.get("query")
+    if name:
+        summary = f"recalled memory '{name}'"
+    elif query:
+        total_stored = output.get("total_stored", len(memories))
+        safe_query = truncate(str(query), _QUERY_SUMMARY_TRUNCATE_LEN)
+        summary = (
+            f"{len(memories)} memory match(es) for query '{safe_query}' (of {total_stored} stored)"
+        )
+    else:
+        total_stored = output.get("total_stored", len(memories))
+        summary = f"{len(memories)} memory index entries (of {total_stored} stored)"
+    record_evidence_entry(
+        evidence,
+        source="memory_recall",
+        label="Memory Recall",
+        summary=summary,
+    )

--- a/tools/system/agent_memory/_evidence.py
+++ b/tools/system/agent_memory/_evidence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
+from core.domain.types.evidence import record_evidence_entry, unique_evidence_source
 from infrastructure.text.truncation import truncate
 
 #: Bound a caller-supplied query echoed into a report summary.
@@ -35,7 +35,7 @@ def map_memory_recall(
         summary = f"{len(memories)} memory index entries (of {total_stored} stored)"
     record_evidence_entry(
         evidence,
-        source="memory_recall",
+        source=unique_evidence_source(evidence, "memory_recall"),
         label="Memory Recall",
         summary=summary,
     )

--- a/tools/system/agent_memory/tool.py
+++ b/tools/system/agent_memory/tool.py
@@ -20,6 +20,7 @@ from core.domain.memory import (
 from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel
 from core.tool_framework import tool
+from tools.system.agent_memory._evidence import map_memory_recall
 from tools.system.agent_memory.results import (
     deleted_result,
     index_result,
@@ -162,6 +163,7 @@ def memory_forget(name: str) -> dict[str, Any]:
         "required": [],
         "additionalProperties": False,
     },
+    evidence_mapper=map_memory_recall,
 )
 def memory_recall(
     name: str | None = None, query: str | None = None, limit: int = 5

--- a/tools/system/python_execution_tool/__init__.py
+++ b/tools/system/python_execution_tool/__init__.py
@@ -13,6 +13,7 @@ from core.domain.types.tools import ToolSurface
 from core.tool import BaseTool, SideEffectLevel
 from infrastructure.observability.trace.spans import component_span
 from infrastructure.safety.sandbox import python_interpreter_available
+from tools.system.python_execution_tool._evidence import map_execute_python_code
 from tools.system.python_execution_tool.credentials import execution_env, github_extract_params
 from tools.system.python_execution_tool.runner import run_python_execution
 
@@ -32,6 +33,7 @@ class PythonExecutionTool(BaseTool):
     name = "execute_python_code"
     display_name = "Python execution"
     source = "knowledge"
+    evidence_mapper = map_execute_python_code
     side_effect_level = SideEffectLevel.READ_ONLY
     surfaces = (ToolSurface.INVESTIGATION, ToolSurface.CHAT)
     injected_params = ["github_token"]

--- a/tools/system/python_execution_tool/_evidence.py
+++ b/tools/system/python_execution_tool/_evidence.py
@@ -1,0 +1,61 @@
+"""Evidence mapper for execute_python_code."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: Bound stdout/stderr echoed into a report summary -- generated code output
+#: is unbounded.
+_OUTPUT_SUMMARY_TRUNCATE_LEN = 120
+
+
+def _next_unique_source(evidence: dict[str, Any], base: str) -> str:
+    """Disambiguate repeat calls.
+
+    ``record_evidence_entry`` lets the first entry for a given ``source``
+    win, but the agent can call this tool many times per investigation with
+    different code -- reusing one source key would silently drop every call
+    after the first.
+    """
+    entries = evidence.get("catalog_entries")
+    if not isinstance(entries, list):
+        return base
+    existing = {e.get("source") for e in entries if isinstance(e, dict)}
+    if base not in existing:
+        return base
+    suffix = 2
+    while f"{base}#{suffix}" in existing:
+        suffix += 1
+    return f"{base}#{suffix}"
+
+
+def map_execute_python_code(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the execution result: stdout on success, the failure reason otherwise.
+
+    A successful run with no stdout has nothing to cite. A failed run is
+    cited even without output, since the failure itself (timeout, non-zero
+    exit) is diagnostic information the agent computed.
+    """
+    stdout = str(output.get("stdout") or "").strip()
+    stderr = str(output.get("stderr") or "").strip()
+    if output.get("success"):
+        if not stdout:
+            return
+        summary = truncate(stdout.replace("\n", " "), _OUTPUT_SUMMARY_TRUNCATE_LEN)
+    else:
+        reason = "timed out" if output.get("timed_out") else f"exit code {output.get('exit_code')}"
+        summary = f"execution failed ({reason})"
+        detail = (stderr or stdout).replace("\n", " ")
+        if detail:
+            summary += f": {truncate(detail, _OUTPUT_SUMMARY_TRUNCATE_LEN)}"
+    record_evidence_entry(
+        evidence,
+        source=_next_unique_source(evidence, "execute_python_code"),
+        label="Python Execution",
+        summary=summary,
+    )

--- a/tools/system/python_execution_tool/_evidence.py
+++ b/tools/system/python_execution_tool/_evidence.py
@@ -4,32 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
+from core.domain.types.evidence import record_evidence_entry, unique_evidence_source
 from infrastructure.text.truncation import truncate
 
 #: Bound stdout/stderr echoed into a report summary -- generated code output
 #: is unbounded.
 _OUTPUT_SUMMARY_TRUNCATE_LEN = 120
-
-
-def _next_unique_source(evidence: dict[str, Any], base: str) -> str:
-    """Disambiguate repeat calls.
-
-    ``record_evidence_entry`` lets the first entry for a given ``source``
-    win, but the agent can call this tool many times per investigation with
-    different code -- reusing one source key would silently drop every call
-    after the first.
-    """
-    entries = evidence.get("catalog_entries")
-    if not isinstance(entries, list):
-        return base
-    existing = {e.get("source") for e in entries if isinstance(e, dict)}
-    if base not in existing:
-        return base
-    suffix = 2
-    while f"{base}#{suffix}" in existing:
-        suffix += 1
-    return f"{base}#{suffix}"
 
 
 def map_execute_python_code(
@@ -55,7 +35,7 @@ def map_execute_python_code(
             summary += f": {truncate(detail, _OUTPUT_SUMMARY_TRUNCATE_LEN)}"
     record_evidence_entry(
         evidence,
-        source=_next_unique_source(evidence, "execute_python_code"),
+        source=unique_evidence_source(evidence, "execute_python_code"),
         label="Python Execution",
         summary=summary,
     )

--- a/tools/system/sre_guidance_tool/__init__.py
+++ b/tools/system/sre_guidance_tool/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.tool_framework import FALLBACK_PLANNING_TAG, tool
+from tools.system.sre_guidance_tool._evidence import map_get_sre_guidance
 from tools.system.sre_guidance_tool.knowledge_base import (
     get_sre_guidance as _get_sre_guidance,
 )
@@ -47,6 +48,7 @@ def _extract_guidance_params(sources: dict[str, dict[str, Any]]) -> dict[str, An
         "required": [],
     },
     extract_params=_extract_guidance_params,
+    evidence_mapper=map_get_sre_guidance,
 )
 def get_sre_guidance(
     topic: str | None = None,

--- a/tools/system/sre_guidance_tool/_evidence.py
+++ b/tools/system/sre_guidance_tool/_evidence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
+from core.domain.types.evidence import record_evidence_entry, unique_evidence_source
 from infrastructure.text.truncation import truncate
 
 #: Bound the joined topic list echoed into a report summary -- max_topics is
@@ -22,7 +22,7 @@ def map_get_sre_guidance(
     joined = truncate(", ".join(str(t) for t in topics), _TOPICS_SUMMARY_TRUNCATE_LEN)
     record_evidence_entry(
         evidence,
-        source="get_sre_guidance",
+        source=unique_evidence_source(evidence, "get_sre_guidance"),
         label="SRE Guidance",
         summary=f"{len(topics)} topic(s): {joined}",
     )

--- a/tools/system/sre_guidance_tool/_evidence.py
+++ b/tools/system/sre_guidance_tool/_evidence.py
@@ -1,0 +1,28 @@
+"""Evidence mapper for get_sre_guidance."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: Bound the joined topic list echoed into a report summary -- max_topics is
+#: caller-controlled and unbounded.
+_TOPICS_SUMMARY_TRUNCATE_LEN = 120
+
+
+def map_get_sre_guidance(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite which SRE guidance topics were retrieved."""
+    topics = output.get("topics") or []
+    if not topics:
+        return
+    joined = truncate(", ".join(str(t) for t in topics), _TOPICS_SUMMARY_TRUNCATE_LEN)
+    record_evidence_entry(
+        evidence,
+        source="get_sre_guidance",
+        label="SRE Guidance",
+        summary=f"{len(topics)} topic(s): {joined}",
+    )

--- a/tools/system/work_items/_evidence.py
+++ b/tools/system/work_items/_evidence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.domain.types.evidence import record_evidence_entry
+from core.domain.types.evidence import record_evidence_entry, unique_evidence_source
 from infrastructure.text.truncation import truncate
 
 #: Bound a task title echoed into a report summary.
@@ -34,7 +34,7 @@ def map_work_task_list(
         summary += f" ({returned} shown)"
     record_evidence_entry(
         evidence,
-        source="work_task_list",
+        source=unique_evidence_source(evidence, "work_task_list"),
         label="Work Tasks",
         summary=summary,
     )
@@ -55,7 +55,7 @@ def map_work_task_prioritize(
         summary += f", top: '{truncate(str(top_title), _TITLE_SUMMARY_TRUNCATE_LEN)}'"
     record_evidence_entry(
         evidence,
-        source="work_task_prioritize",
+        source=unique_evidence_source(evidence, "work_task_prioritize"),
         label="Work Task Priorities",
         summary=summary,
     )

--- a/tools/system/work_items/_evidence.py
+++ b/tools/system/work_items/_evidence.py
@@ -1,0 +1,61 @@
+"""Evidence mappers for work_task_list and work_task_prioritize."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
+from infrastructure.text.truncation import truncate
+
+#: Bound a task title echoed into a report summary.
+_TITLE_SUMMARY_TRUNCATE_LEN = 60
+
+
+def map_work_task_list(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite the task count and status filter.
+
+    ``total`` is the true count of matching items *before* the caller's
+    ``limit`` slice, so it needs no "N+" qualifier -- unlike ``returned``,
+    which is the (possibly smaller) page actually included in ``tasks``.
+    """
+    if output.get("error"):
+        return
+    total = output.get("total", 0)
+    if not total:
+        return
+    returned = output.get("returned", total)
+    status = tool_input.get("status", "open")
+    summary = f"{total} task(s)"
+    if status:
+        summary += f" with status '{status}'"
+    if returned < total:
+        summary += f" ({returned} shown)"
+    record_evidence_entry(
+        evidence,
+        source="work_task_list",
+        label="Work Tasks",
+        summary=summary,
+    )
+
+
+def map_work_task_prioritize(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite how many tasks were ranked and the top recommendation."""
+    recommendations = output.get("recommendations") or []
+    if not recommendations:
+        return
+    top = recommendations[0]
+    top_task = top.get("task") if isinstance(top, dict) else None
+    top_title = (top_task or {}).get("title") if isinstance(top_task, dict) else None
+    summary = f"{len(recommendations)} task(s) ranked"
+    if top_title:
+        summary += f", top: '{truncate(str(top_title), _TITLE_SUMMARY_TRUNCATE_LEN)}'"
+    record_evidence_entry(
+        evidence,
+        source="work_task_prioritize",
+        label="Work Task Priorities",
+        summary=summary,
+    )

--- a/tools/system/work_items/tool.py
+++ b/tools/system/work_items/tool.py
@@ -25,6 +25,7 @@ from core.tool import AgentToolContext, SideEffectLevel
 from core.tool_framework import tool
 from infrastructure.scheduling.scheduler.store import add_task as add_scheduled_task
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+from tools.system.work_items._evidence import map_work_task_list, map_work_task_prioritize
 from tools.system.work_items.delivery import delivery_targets, invalid_delivery_targets
 from tools.system.work_items.reminders import schedule_item_reminder
 from tools.system.work_items.results import (
@@ -216,6 +217,7 @@ def work_task_add(
         "required": [],
         "additionalProperties": False,
     },
+    evidence_mapper=map_work_task_list,
 )
 def work_task_list(
     status: str = "open",
@@ -446,6 +448,7 @@ def work_task_update(
         "required": [],
         "additionalProperties": False,
     },
+    evidence_mapper=map_work_task_prioritize,
 )
 def work_task_prioritize(
     project: str = "",


### PR DESCRIPTION
Closes #5545 (part of epic #5519, tracking issue #1079)

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Wires all 5 `knowledge`-source tools — `get_sre_guidance`, `execute_python_code`, `memory_recall`, `work_task_list`, `work_task_prioritize` — into `record_evidence_entry` so their output becomes citeable investigation-report evidence. Unlike the other evidence-mapper PRs in this backfill, these 5 tools live in 4 otherwise-unrelated packages under `tools/system/` with no shared output shape (no common `available` field, no common client), so each gets its own `_evidence.py` sibling module.

- **`get_sre_guidance`** cites which topics were retrieved.
- **`execute_python_code`** is a generic sandbox the agent can call many times per investigation with different code — like `call_posthog_tool` earlier in this same backfill, it gets a disambiguated source key (`execute_python_code`, then `#2`, `#3`, ...) so `record_evidence_entry`'s first-wins semantics don't silently drop every call after the first. A **failed** run is cited even with empty stdout/stderr (the failure itself — timeout, non-zero exit — is diagnostic information), while an empty **successful** run is not (nothing to say).
- **`memory_recall`** cites a named recall, a search match count, or the index size, depending on which of `name`/`query`/neither the caller passed.
- **`work_task_list`** cites `total`, the tool's true pre-`limit` count of matching tasks, not the possibly-smaller `returned` page — and notes when the page shown is smaller than the true total.
- **`work_task_prioritize`** cites how many tasks were ranked and the top recommendation's title.

### Demo/Screenshot for feature changes and bug fixes -

**All 5 tools carry their mapper (via the real registry):**
```
$ uv run python -c "from tools.registry import get_registered_tool as g; \
print({n: bool(g(n).evidence_mapper) for n in ['execute_python_code', 'get_sre_guidance', 'memory_recall', 'work_task_list', 'work_task_prioritize']})"
{'execute_python_code': True, 'get_sre_guidance': True, 'memory_recall': True, 'work_task_list': True, 'work_task_prioritize': True}
```

**Tests and quality gates:**
```
$ uv run pytest tests/tools/test_sre_guidance_tool.py tests/tools/test_python_execution_tool.py tests/tools/test_agent_memory.py tests/tools/test_work_items_tools.py tests/tools/investigation/stages/gather_evidence/ -q
130 passed

$ make lint && make format-check && make typecheck
All checks passed! / clean / no issues found
```

All 5 tools here are local/sandboxed (no external credentials needed), so every test above runs the real code path directly — no "no live account" caveat for this PR.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read each of the 4 tool files individually before writing anything, because unlike the other integrations in this evidence-mapper backfill (one client, one output convention), these 5 tools share nothing — `execute_python_code` returns `{success, stdout, stderr, exit_code, timed_out}`, `memory_recall` returns three different shapes depending on which argument was passed, `work_task_list` returns a true pre-limit `total`, and `get_sre_guidance`/`work_task_prioritize` have their own bespoke shapes again. The one design decision that generalizes from earlier work in this backfill is `execute_python_code`'s repeat-call disambiguation: it's a dispatcher-style tool exactly like `call_posthog_tool` (merged earlier in this backfill), so it needed the same "first-wins would silently drop every call after the first" fix. The decision to cite a failed execution even with no stdout/stderr, but skip an empty successful one, came from thinking about what's actually useful to a reader: "the analysis timed out" is a real finding; "printed nothing" is not.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

## Behaviour comparison (required)

**Before** (main, no mapper) — confirmed via `grep -c evidence_mapper` on all 4 files on main (all zero):
```
BEFORE catalog_entries: None
```

**After** (this branch) — realistic samples for all 5 tools:
```json
[
  {
    "source": "get_sre_guidance",
    "label": "SRE Guidance",
    "summary": "2 topic(s): failure_delayed_data, slo_freshness"
  },
  {
    "source": "execute_python_code",
    "label": "Python Execution",
    "summary": "windows_users_last_7d=271"
  },
  {
    "source": "memory_recall",
    "label": "Memory Recall",
    "summary": "recalled memory 'prod-cluster'"
  },
  {
    "source": "work_task_list",
    "label": "Work Tasks",
    "summary": "3 task(s) with status 'open'"
  },
  {
    "source": "work_task_prioritize",
    "label": "Work Task Priorities",
    "summary": "1 task(s) ranked, top: 'Fix prod outage'"
  }
]
```

**1. What the reader gains.** The report can now cite which SRE runbook topics were consulted, what a diagnostic Python snippet actually printed (or how it failed), which memory was recalled, how many open tasks exist, and which task the agent recommends tackling next — previously all 5 tools ran, cost tokens, and left nothing in the report.

**2. How much context it costs.** One short line per call; `execute_python_code`'s stdout/stderr are bounded to 120 chars, so a verbose script's output never bloats the entry.

**3. What happens on an empty or error result.** Verified directly for all 5 tools plus two error cases:
```
get_sre_guidance -> None
execute_python_code -> None
memory_recall -> None
memory_recall (error) -> None
work_task_list -> None
work_task_list (error) -> None
work_task_prioritize -> None
```
No entry for empty topics, a successful-but-silent script run, an empty memory/task list, or an error-shaped result.

**4. Whether anything is now recorded twice.** These 5 tools live in 4 separate packages with no other mapper touching any of them — no overlap.

**5. Whether an existing report changed shape.** This only adds entries under the 5 new source keys; no other tool's merge path is touched.

## Live-report check (#5)
All 5 tools here are local (no external account needed), so I ran the real code paths directly in the tests above rather than needing a synthetic `opensre investigate` walkthrough — `merge_tool_evidence` output shown above is the exact real path a live investigation calls.
