### PR TITLE
fix(yandex-cloud): rename the MDB catalog off the banned umbrella words

### DIFF
--- a/integrations/yandex_cloud/mdb_catalog.py
+++ b/integrations/yandex_cloud/mdb_catalog.py
@@ -16,8 +16,8 @@ from typing import Final
 
 
 @dataclass(frozen=True)
-class Engine:
-    """One managed database engine."""
+class ManagedDatabase:
+    """One managed database engine, and how to reach it."""
 
     key: str
     """What a caller names, e.g. ``postgresql``."""
@@ -71,9 +71,9 @@ class Engine:
     """
 
 
-ENGINES: Final[tuple[Engine, ...]] = (
+ENGINES: Final[tuple[ManagedDatabase, ...]] = (
     # PostgreSQL answers on 6432, not 5432 — connections go through a pooler.
-    Engine(
+    ManagedDatabase(
         "postgresql",
         "PostgreSQL",
         "managed-postgresql",
@@ -82,7 +82,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
         "postgresql",
         log_service_types=("POSTGRESQL", "POOLER", "REPACK"),
     ),
-    Engine(
+    ManagedDatabase(
         "mysql",
         "MySQL",
         "managed-mysql",
@@ -92,7 +92,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
         # Error log first: it is what explains a cluster that is misbehaving.
         log_service_types=("MYSQL_ERROR", "MYSQL_GENERAL", "MYSQL_SLOW_QUERY", "MYSQL_AUDIT"),
     ),
-    Engine(
+    ManagedDatabase(
         "clickhouse",
         "ClickHouse",
         "managed-clickhouse",
@@ -103,7 +103,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
         # Required here: without it the endpoint refuses the read.
         log_service_types=("CLICKHOUSE", "CLICKHOUSE_KEEPER"),
     ),
-    Engine(
+    ManagedDatabase(
         "valkey",
         "Valkey (was Redis)",
         "managed-redis",
@@ -113,7 +113,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
         plaintext_port=6379,
         log_service_types=("REDIS",),
     ),
-    Engine(
+    ManagedDatabase(
         "storedoc",
         "StoreDoc (was MongoDB)",
         "managed-mongodb",
@@ -123,7 +123,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
         plaintext_port=27017,
         log_service_types=("MONGOD", "MONGOS", "MONGOCFG", "AUDIT"),
     ),
-    Engine(
+    ManagedDatabase(
         "kafka",
         "Apache Kafka",
         "managed-kafka",
@@ -132,7 +132,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
         "kafka",
         plaintext_port=9092,
     ),
-    Engine(
+    ManagedDatabase(
         "opensearch",
         "OpenSearch",
         "managed-opensearch",
@@ -141,7 +141,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
         "opensearch",
         log_service_types=("OPENSEARCH", "DASHBOARDS"),
     ),
-    Engine(
+    ManagedDatabase(
         "greenplum",
         "MPP Analytics (was Greenplum)",
         "managed-greenplum",
@@ -155,7 +155,7 @@ ENGINES: Final[tuple[Engine, ...]] = (
     ),
     # Sharded PostgreSQL is its own service, not a mode of the one above: its
     # own API prefix, its own cluster type, and a router in front of the shards.
-    Engine(
+    ManagedDatabase(
         "spqr",
         "Sharded PostgreSQL (SPQR)",
         "managed-spqr",
@@ -180,10 +180,10 @@ _ALIASES: Final[dict[str, str]] = {
 }
 
 ENGINE_KEYS: Final[tuple[str, ...]] = tuple(engine.key for engine in ENGINES)
-_BY_KEY: Final[dict[str, Engine]] = {engine.key: engine for engine in ENGINES}
+_BY_KEY: Final[dict[str, ManagedDatabase]] = {engine.key: engine for engine in ENGINES}
 
 
-def resolve_engine(name: str) -> Engine | None:
+def resolve_engine(name: str) -> ManagedDatabase | None:
     """Return the engine *name* refers to, accepting former product names."""
     key = name.strip().lower()
     return _BY_KEY.get(_ALIASES.get(key, key))
@@ -194,4 +194,4 @@ def engine_choices() -> str:
     return ", ".join(ENGINE_KEYS)
 
 
-__all__ = ["ENGINES", "ENGINE_KEYS", "Engine", "engine_choices", "resolve_engine"]
+__all__ = ["ENGINES", "ENGINE_KEYS", "ManagedDatabase", "engine_choices", "resolve_engine"]

--- a/integrations/yandex_cloud/tools/yc_db_logs_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_db_logs_tool/__init__.py
@@ -27,7 +27,7 @@ from integrations.yandex_cloud.availability import (
     yc_available_or_backend,
     yc_credentials,
 )
-from integrations.yandex_cloud.mdb_engines import engine_choices, resolve_engine
+from integrations.yandex_cloud.mdb_catalog import engine_choices, resolve_engine
 
 SOURCE = "yandex_cloud"
 

--- a/integrations/yandex_cloud/tools/yc_db_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_db_tool/__init__.py
@@ -14,7 +14,7 @@ from integrations.yandex_cloud.availability import (
     yc_available_or_backend,
     yc_credentials,
 )
-from integrations.yandex_cloud.mdb_engines import Engine, engine_choices, resolve_engine
+from integrations.yandex_cloud.mdb_catalog import ManagedDatabase, engine_choices, resolve_engine
 from integrations.yandex_cloud.rest_client import YandexCloudClient
 
 SOURCE = "yandex_cloud"
@@ -35,7 +35,7 @@ def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     return yc_credentials(sources)
 
 
-def _summarize_cluster(cluster: dict[str, Any], engine: Engine) -> dict[str, Any]:
+def _summarize_cluster(cluster: dict[str, Any], engine: ManagedDatabase) -> dict[str, Any]:
     return {
         "id": cluster.get("id", ""),
         "name": cluster.get("name", ""),
@@ -84,7 +84,7 @@ def _summarize_operation(operation: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _connection_hint(engine: Engine, hosts: list[dict[str, Any]]) -> dict[str, Any]:
+def _connection_hint(engine: ManagedDatabase, hosts: list[dict[str, Any]]) -> dict[str, Any]:
     """Return how to reach the data plane, which is where the real answers are."""
     primary = next(
         (host for host in hosts if str(host.get("role", "")).upper() in {"MASTER", "PRIMARY"}),
@@ -114,7 +114,7 @@ _MAX_PAGES = 5
 
 
 def _list_clusters(
-    client: YandexCloudClient, engine: Engine
+    client: YandexCloudClient, engine: ManagedDatabase
 ) -> tuple[list[dict[str, Any]], str, bool]:
     """Return every cluster of *engine*, an error if the read failed, and completeness.
 
@@ -141,7 +141,7 @@ def _list_clusters(
 
 
 def _read_hosts(
-    client: YandexCloudClient, engine: Engine, cluster_id: str
+    client: YandexCloudClient, engine: ManagedDatabase, cluster_id: str
 ) -> tuple[list[dict[str, Any]], str]:
     """Return every host of *cluster_id* summarized, and why the list is empty if it is.
 
@@ -285,9 +285,9 @@ def list_yc_db_clusters(
     if yc_backend is not None:
         return dict(yc_backend.list_yc_db_clusters(engine))
 
-    from integrations.yandex_cloud.mdb_engines import ENGINES
+    from integrations.yandex_cloud.mdb_catalog import ENGINES
 
-    engines: tuple[Engine, ...] = ENGINES
+    engines: tuple[ManagedDatabase, ...] = ENGINES
     if engine.strip():
         resolved = resolve_engine(engine)
         if resolved is None:

--- a/tests/integrations/test_yc_db_logs.py
+++ b/tests/integrations/test_yc_db_logs.py
@@ -18,7 +18,7 @@ from typing import Any
 import httpx
 import pytest
 
-from integrations.yandex_cloud.mdb_engines import ENGINES, resolve_engine
+from integrations.yandex_cloud.mdb_catalog import ENGINES, resolve_engine
 from tools.registry import get_registered_tool_map
 
 _CREDENTIALS: dict[str, Any] = {"folder_id": "b1gfolder", "iam_token": "t1.token"}

--- a/tests/integrations/test_yc_db_tool.py
+++ b/tests/integrations/test_yc_db_tool.py
@@ -15,7 +15,7 @@ from typing import Any
 import httpx
 import pytest
 
-from integrations.yandex_cloud.mdb_engines import ENGINE_KEYS, resolve_engine
+from integrations.yandex_cloud.mdb_catalog import ENGINE_KEYS, resolve_engine
 from integrations.yandex_cloud.tools import get_yc_db_cluster, list_yc_db_clusters
 
 FOLDER = "b1gexamplefolder"
@@ -70,7 +70,7 @@ class TestManagedDatabases:
     def test_every_engine_resolves_to_a_known_endpoint(self) -> None:
         """A key the registry does not carry is refused before the read is sent."""
         from integrations.yandex_cloud.endpoints import STATIC_ENDPOINTS
-        from integrations.yandex_cloud.mdb_engines import ENGINES
+        from integrations.yandex_cloud.mdb_catalog import ENGINES
 
         for engine in ENGINES:
             assert engine.service in STATIC_ENDPOINTS, engine.key


### PR DESCRIPTION
Relates to #5362

#### Describe the changes you have made in this PR -

`main` is red. #5828 landed a module and a class named for "engine", which `tests/quality/test_no_umbrella_names.py` bans, so `test (integrations-and-misc-2)` fails on every push to main. Latest failure: [run 33491184790](https://github.com/Tracer-Cloud/opensre/actions/runs/33491184790).

Two renames, which is what the guard's own failure message asks for:

- `integrations/yandex_cloud/mdb_engines.py` -> `mdb_catalog.py`. It holds metadata and a lookup table, which the file-placement table in AGENTS.md calls a `*_catalog.py`.
- `class Engine` -> `class ManagedDatabase`.

`ENGINES`, `ENGINE_KEYS`, `resolve_engine` and `engine_choices` keep their names. The guard only reads module and class names, and `engine` is the parameter callers actually type in both tools' schemas and read back in their output. Renaming those would drift the internals away from the public contract for no gain. 26 insertions, 26 deletions.

### Demo/Screenshot for feature changes and bug fixes -

Before, on main at `12af3179f`:

```
$ uv run python -m pytest "tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[integrations]" -q

E   AssertionError: New umbrella name introduced (see docs/NAMING.md for the vocabulary
E   to use instead). Rename it - do not add it to
E   tests/quality/umbrella_names_allowlist.txt to silence this:
E     integrations/yandex_cloud/mdb_engines.py:class: Engine
E     integrations/yandex_cloud/mdb_engines.py:module: mdb_engines

FAILED tests/quality/test_no_umbrella_names.py::test_product_packages_have_no_umbrella_names[integrations]
1 failed in 2.83s
```

After:

```
$ uv run python -m pytest tests/quality/test_no_umbrella_names.py \
    tests/integrations/test_yc_db_tool.py tests/integrations/test_yc_db_logs.py -q

110 passed in 9.78s
```

The three MDB tools still register and the catalog still resolves, aliases included:

```
registered: list_yc_db_clusters: True
registered: get_yc_db_cluster: True
registered: read_yc_db_logs: True
engine keys: postgresql, mysql, clickhouse, valkey, storedoc, kafka, opensearch, greenplum, spqr
alias redis   -> valkey | label: Valkey (was Redis)
alias mongo   -> storedoc | label: StoreDoc (was MongoDB)
unknown 'foo' -> None
```

Nothing users type changed. Both tool schemas still take `engine`:

```
list_yc_db_clusters params: ['engine']
  required: []
read_yc_db_logs params: ['engine', 'cluster_id', 'service_type', 'filter', 'from_time', 'to_time', 'page_size', 'page_token']
  required: ['engine', 'cluster_id']
```

Local checks:

| Check | Result |
| --- | --- |
| `make lint` | passed |
| `make format-check` | 3771 files already formatted |
| `make typecheck` | no issues, 1968 source files |
| `tests/integrations` + `tests/quality` | 3907 passed, 11 skipped |
| `tests/shared bootstrap config packaging github_ci` | 713 passed |
| `check_imports.py --strict` | 3/3 passed |

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a red main branch, not a bug in the Yandex Cloud code. `test_no_umbrella_names.py` bans "engine" anywhere in a product module or top-level class name, and the new MDB work used it in both places.

I considered adding the two entries to `umbrella_names_allowlist.txt`, which would be a one-line fix. The test explicitly rejects that: the allowlist is shrink-only and its failure message says to rename instead. So renaming was the only option that respects the guard.

Picking the names was the real decision. For the module, AGENTS.md already has a slot for a file that holds metadata and a discovery table, and that slot is named `*_catalog.py`, so `mdb_catalog.py` is the repo's own vocabulary rather than something invented. For the class, `ManagedDatabase` says what one row is: a managed database product plus the endpoint key, REST prefix and data-plane port needed to reach it.

I deliberately stopped short of a full sweep. `ENGINES`, `ENGINE_KEYS`, `resolve_engine` and `engine_choices` are untouched because the guard does not read them, and because `engine` is the public parameter name in both tool schemas. Renaming the internals would have made `resolve_engine` and the tool argument disagree, which is worse than the inconsistency it removes. That keeps the diff net zero.

The edge case worth naming is the rename mechanics. I used a word-boundary replace for `Engine`, which is why `ENGINES` and `ENGINE_KEYS` survived untouched, and I checked the whole repo for stale references afterwards. `git mv` preserves history at 91% similarity.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
