### PR TITLE
feat(shell): grow the composer with input and treat modified Enter as newline

### DIFF
--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -13,8 +13,10 @@ from prompt_toolkit.layout.containers import (
     FloatContainer,
     HSplit,
     Window,
+    to_container,
 )
 from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.widgets import Frame
 
 from infrastructure.terminal import theme as ui_theme
@@ -31,9 +33,21 @@ from surfaces.interactive_shell.ui.input_prompt.rendering import (
 )
 from surfaces.interactive_shell.ui.input_prompt.style import _build_prompt_style
 
-# Frame (height 3) plus the help/status footer (height 1): the blank stand-in
-# shown while the composer is hidden must match this so the region height holds.
-_COMPOSER_ROWS = 4
+_COMPOSER_MAX_EDIT_ROWS = 8
+_COMPOSER_MIN_FRAME_ROWS = 3
+_COMPOSER_MAX_FRAME_ROWS = _COMPOSER_MAX_EDIT_ROWS + 2
+
+
+def _limit_editable_height(main_input: HSplit) -> HSplit:
+    """Return the editable prompt body capped to a chat-composer-sized viewport."""
+    editable_children = main_input.children[1:]
+    default_buffer_slot = editable_children[0]
+    if not isinstance(default_buffer_slot, ConditionalContainer) or not isinstance(
+        default_buffer_slot.content, Window
+    ):
+        raise RuntimeError("prompt-toolkit input container is missing its editable window")
+    default_buffer_slot.content.height = Dimension(min=1, max=_COMPOSER_MAX_EDIT_ROWS)
+    return HSplit(editable_children)
 
 
 def _install_prompt_frame(
@@ -60,8 +74,8 @@ def _install_prompt_frame(
         raise RuntimeError("prompt-toolkit input container is missing its buffer")
 
     before_input = main_input.content.children[0]
-    editable_body = HSplit(main_input.content.children[1:])
-    composer: AnyContainer = Frame(editable_body, style="class:composer", height=3)
+    editable_body = _limit_editable_height(main_input.content)
+    composer: AnyContainer = Frame(editable_body, style="class:composer")
     footer: AnyContainer = Window(
         FormattedTextControl(lambda: ANSI(composer_footer_ansi())),
         height=1,
@@ -71,14 +85,29 @@ def _install_prompt_frame(
     box_rows: list[AnyContainer] = [composer, footer]
     if hide_composer is not None:
         shown = Condition(lambda: not hide_composer())
+        composer_container = to_container(composer)
+
+        def _current_composer_rows() -> int:
+            preferred = composer_container.preferred_height(
+                prompt_line_width(),
+                _COMPOSER_MAX_FRAME_ROWS,
+            ).preferred
+            return max(
+                _COMPOSER_MIN_FRAME_ROWS,
+                min(preferred, _COMPOSER_MAX_FRAME_ROWS),
+            )
+
         # Swap the box for a blank pad of the SAME height while structured input
         # owns the keyboard. Collapsing to zero height shrinks the region, and a
         # shrinking prompt under patch_stdout leaves stale border fragments — a
-        # constant-height stand-in overwrites the box cleanly instead.
+        # same-height stand-in overwrites the growing box cleanly instead.
         box_rows = [
             ConditionalContainer(composer, filter=shown),
             ConditionalContainer(footer, filter=shown),
-            ConditionalContainer(Window(height=_COMPOSER_ROWS, char=" "), filter=~shown),
+            ConditionalContainer(
+                Window(height=lambda: _current_composer_rows() + 1, char=" "),
+                filter=~shown,
+            ),
         ]
     # Keep the final terminal column empty. Painting a frame border there puts
     # the cursor in pending-wrap, which makes patch_stdout redraws jump and

--- a/surfaces/interactive_shell/ui/input_prompt/key_bindings.py
+++ b/surfaces/interactive_shell/ui/input_prompt/key_bindings.py
@@ -7,8 +7,10 @@ from typing import Protocol
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.filters import has_completions
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from prompt_toolkit.keys import Keys
 
 from infrastructure.terminal.prompt_support import (
     CTRL_C_DOUBLE_PRESS_WINDOW_S,
@@ -33,8 +35,23 @@ class _DispatchCancelState(Protocol):
         """Clear the transient double-press exit hint."""
 
 
-# Keystroke escape (xterm modifyOtherKeys for Shift+Enter), not a colour code.
+# Keystroke escapes, not colour codes. Terminals use either xterm's
+# modifyOtherKeys encoding or the CSI-u keyboard protocol for modified Enter.
 _SHIFT_ENTER_SEQUENCE = "\x1b[27;2;13~"
+_MODIFIED_ENTER_SEQUENCES = frozenset(
+    {
+        *(f"\x1b[27;{modifier};13~" for modifier in range(2, 9)),
+        *(f"\x1b[13;{modifier}u" for modifier in range(2, 9)),
+        "\x1b\r",
+        "\x1b\n",
+    }
+)
+
+
+def _install_modified_enter_sequences() -> None:
+    """Teach prompt-toolkit's VT parser the modified Enter encodings it lacks."""
+    for sequence in _MODIFIED_ENTER_SEQUENCES:
+        ANSI_SEQUENCES.setdefault(sequence, Keys.ControlM)
 
 
 def _tab_expand_or_menu(buffer: Buffer) -> None:
@@ -62,14 +79,21 @@ def _tab_expand_or_menu(buffer: Buffer) -> None:
 
 
 def _build_prompt_key_bindings() -> KeyBindings:
+    _install_modified_enter_sequences()
     bindings = KeyBindings()
 
     @bindings.add("c-m")
     def _accept_turn(event: KeyPressEvent) -> None:
-        if event.data == _SHIFT_ENTER_SEQUENCE:
+        if event.data in _MODIFIED_ENTER_SEQUENCES:
             event.current_buffer.newline(copy_margin=False)
             return
         event.current_buffer.validate_and_handle()
+
+    @bindings.add("c-j")
+    def _insert_newline(event: KeyPressEvent) -> None:
+        # Several terminals encode Shift+Enter as LF while plain Enter is CR.
+        # Ctrl+J therefore remains a portable explicit-newline fallback too.
+        event.current_buffer.newline(copy_margin=False)
 
     @bindings.add("tab")
     def _tab_complete(event: object) -> None:

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -146,7 +146,7 @@ def ctrl_c_exit_hint_ansi() -> str:
 
 def composer_footer_ansi() -> str:
     """Return the help hint and terminal-mode label below the composer."""
-    left = "? for help"
+    left = "Enter send · Shift+Enter newline · ? help"
     right = "TERMINAL ■"
     width = prompt_line_width()
     if len(left) + len(right) + 2 > width:

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -167,7 +167,7 @@ def test_build_prompt_session_uses_persistent_history(
     assert prompt.app.key_bindings is not None
 
 
-def test_build_prompt_session_installs_single_row_bordered_composer() -> None:
+def test_build_prompt_session_installs_growing_bordered_composer() -> None:
     from prompt_toolkit.layout.containers import (
         FloatContainer,
         HSplit,
@@ -187,9 +187,43 @@ def test_build_prompt_session_installs_single_row_bordered_composer() -> None:
     composer = chrome.children[1]
     footer = chrome.children[2]
     assert isinstance(composer, HSplit)
-    assert composer.height == 3  # top border + one edit row + bottom border
+    assert composer.height is None
+    editable_row = composer.children[1]
+    editable_body = editable_row.children[1].get_container()
+    default_buffer_slot = editable_body.children[0]
+    assert default_buffer_slot.content.height.min == 1
+    assert default_buffer_slot.content.height.max == 8
     assert isinstance(footer, Window)
     assert chrome.preferred_width(80).preferred == 79
+
+
+@pytest.mark.asyncio
+async def test_bordered_composer_grows_with_input_up_to_eight_edit_rows() -> None:
+    with (
+        create_pipe_input() as pipe_input,
+        create_app_session(input=pipe_input, output=DummyOutput()),
+    ):
+        prompt = input_prompt.build_prompt_session()
+        task = asyncio.create_task(prompt.prompt_async(""))
+        await asyncio.sleep(0)
+
+        composer = prompt.layout.container.children[0].content.children[1]
+        prompt.default_buffer.text = "first"
+        single_line_height = composer.preferred_height(79, 30).preferred
+        prompt.default_buffer.text = "x" * 200
+        wrapped_line_height = composer.preferred_height(79, 30).preferred
+        prompt.default_buffer.text = "first\nsecond\nthird"
+        multiline_height = composer.preferred_height(79, 30).preferred
+        prompt.default_buffer.text = "\n".join(str(index) for index in range(12))
+        capped_height = composer.preferred_height(79, 30).preferred
+
+        pipe_input.send_text("\r")
+        await asyncio.wait_for(task, timeout=5.0)
+
+    assert single_line_height == 3
+    assert single_line_height < wrapped_line_height <= 10
+    assert multiline_height == 5
+    assert capped_height == 10
 
 
 def test_build_prompt_session_falls_back_to_memory_history(
@@ -233,9 +267,21 @@ def test_prompt_message_uses_accent_glyph() -> None:
     assert ANSI_RESET in rendered
 
 
-def test_shift_enter_inserts_newline_before_submit(
+@pytest.mark.parametrize(
+    "newline_sequence",
+    [
+        _SHIFT_ENTER_SEQUENCE,
+        "\x1b[13;2u",  # CSI-u Shift+Enter
+        "\x1b[27;5;13~",  # xterm Ctrl+Enter
+        "\x1b[13;5u",  # CSI-u Ctrl+Enter
+        "\x1b\r",  # Alt/Option+Enter
+        "\n",  # Shift+Enter in terminals that emit LF
+    ],
+)
+def test_modified_enter_inserts_newline_before_submit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    newline_sequence: str,
 ) -> None:
     import config.constants as const_module
 
@@ -253,7 +299,7 @@ def test_shift_enter_inserts_newline_before_submit(
             # under loaded ``test-cov`` (xdist + coverage) a 1s wait_for flakes.
             await asyncio.sleep(0)
             pipe_input.send_bytes(b"first line")
-            pipe_input.send_bytes(_SHIFT_ENTER_SEQUENCE.encode())
+            pipe_input.send_bytes(newline_sequence.encode())
             pipe_input.send_bytes(b"second line\r")
             return await asyncio.wait_for(task, timeout=5.0)
 

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -192,7 +192,7 @@ class TestComposerFooter:
     ) -> None:
         monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 79)
         footer = _strip_ansi(composer_footer_ansi())
-        assert footer.startswith("? for help")
+        assert footer.startswith("Enter send · Shift+Enter newline · ? help")
         assert footer.endswith("TERMINAL ■")
         assert len(footer) == 79
 
@@ -201,7 +201,7 @@ class TestComposerFooter:
     ) -> None:
         monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 6)
         footer = _strip_ansi(composer_footer_ansi())
-        assert footer == "? for…"
+        assert footer == "Enter…"
 
 
 class TestPromptMessage:


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

The interactive-shell composer stayed a single edit row, so wrapped or multiline drafts were hard to read, and Shift+Enter only worked for one xterm encoding. This grows the bordered input box with the buffer (capped at eight edit rows), keeps a same-height blank pad while structured input owns the keyboard, and treats the common modified-Enter encodings plus Ctrl+J as newline.

- Composer height follows the buffer from 1 to 8 edit rows (frame 3–10 rows).
- Shift+Enter / Ctrl+Enter / Alt+Enter / CSI-u / LF insert a newline; plain Enter still submits.
- Footer hint now reads `Enter send · Shift+Enter newline · ? help`.

### Demo/Screenshot for feature changes and bug fixes -
Composer grows with wrapped and multiline input up to eight edit rows; modified Enter inserts a newline instead of submitting.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The prompt-toolkit Frame already wraps the editable buffer; the previous layout fixed that Frame at three rows. Cap the inner Window at `Dimension(min=1, max=8)` so preferred height grows with content, then size the hide-composer blank pad from the Frame's current preferred height so `patch_stdout` does not leave stale borders. For newline, teach prompt-toolkit's VT parser the modified-Enter sequences it does not ship, then treat those encodings (and Ctrl+J / LF) as `newline()` while leaving unmodified Enter as submit.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

## Test plan
- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`
- [x] `uv run python -m pytest tests/interactive_shell/test_terminal_runtime.py tests/interactive_shell/ui/test_input_prompt.py tests/interactive_shell/`
- [ ] GitHub PR CI green

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.