### PR TITLE
refactor(analytics): break tracker/event_properties import cycle

### DIFF
--- a/infrastructure/analytics/capture.py
+++ b/infrastructure/analytics/capture.py
@@ -13,10 +13,12 @@ from infrastructure.analytics.event_properties import (
     _investigation_failed_properties,
     _investigation_outcome_properties,
     _onboard_completed_properties,
-    _with_investigation_loop_metrics,
 )
 from infrastructure.analytics.events import Event
-from infrastructure.analytics.investigation_tracker import InvestigationTracker
+from infrastructure.analytics.investigation_tracker_types import (
+    InvestigationTracker,
+    _with_investigation_loop_metrics,
+)
 from infrastructure.analytics.provider import Properties, get_analytics
 from infrastructure.observability.errors.sentry import capture_exception
 

--- a/infrastructure/analytics/event_properties.py
+++ b/infrastructure/analytics/event_properties.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from config.constants.investigation import MAX_INVESTIGATION_LOOPS
 from config.constants.llm import LLM_PROVIDER_ENV
 from config.llm_auth.provider_catalog import provider_spec
-from infrastructure.analytics.investigation_tracker import (
+from infrastructure.analytics.investigation_tracker_types import (
     InvestigationTracker,
     _with_investigation_loop_metrics,
 )

--- a/infrastructure/analytics/investigation_tracker.py
+++ b/infrastructure/analytics/investigation_tracker.py
@@ -3,22 +3,17 @@
 from __future__ import annotations
 
 import traceback
-from collections.abc import Generator, Mapping
+from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from config.constants.investigation import MAX_INVESTIGATION_LOOPS
 from infrastructure.analytics.investigation_loop import (
     begin_investigation_loop_metrics_scope,
-    bound_loop_metrics,
-    loop_metrics_from_state,
-    merge_loop_properties,
     reset_investigation_loop_metrics,
 )
-from infrastructure.analytics.provider import Properties
+from infrastructure.analytics.investigation_tracker_types import InvestigationTracker
 from infrastructure.analytics.source import (
     EntrypointSource,
     TriggerMode,
@@ -33,69 +28,6 @@ _INVESTIGATION_TRACKING_DEPTH: ContextVar[int] = ContextVar(
     "investigation_tracking_depth",
     default=0,
 )
-
-
-@dataclass
-class InvestigationTracker:
-    """Holds shared context for investigation lifecycle captures."""
-
-    shared_properties: Properties
-    enabled: bool
-    completed: bool = False
-    failed: bool = False
-    investigation_loop_count: int | None = None
-    investigation_iteration_cap: int = MAX_INVESTIGATION_LOOPS
-
-    def record_loop_metrics_from_state(self, state: Mapping[str, object] | None) -> None:
-        """Capture canonical loop metrics from the investigation final state."""
-        loop_count, iteration_cap = loop_metrics_from_state(state)
-        self.investigation_loop_count = loop_count
-        self.investigation_iteration_cap = iteration_cap
-
-
-def _resolve_investigation_loop_metrics(
-    *,
-    loop_count: int | None = None,
-    iteration_cap: int | None = None,
-    state: Mapping[str, object] | None = None,
-    tracker: InvestigationTracker | None = None,
-) -> tuple[int, int]:
-    if loop_count is not None:
-        resolved_cap = (
-            iteration_cap
-            if iteration_cap is not None
-            else (
-                tracker.investigation_iteration_cap
-                if tracker is not None
-                else MAX_INVESTIGATION_LOOPS
-            )
-        )
-        return max(0, int(loop_count)), max(1, int(resolved_cap))
-    bound = bound_loop_metrics()
-    if bound is not None:
-        return bound
-    if state is not None:
-        return loop_metrics_from_state(state)
-    if tracker is not None and tracker.investigation_loop_count is not None:
-        return tracker.investigation_loop_count, tracker.investigation_iteration_cap
-    return 0, MAX_INVESTIGATION_LOOPS
-
-
-def _with_investigation_loop_metrics(
-    properties: Properties,
-    *,
-    loop_count: int | None = None,
-    iteration_cap: int | None = None,
-    state: Mapping[str, object] | None = None,
-    tracker: InvestigationTracker | None = None,
-) -> Properties:
-    count, cap = _resolve_investigation_loop_metrics(
-        loop_count=loop_count,
-        iteration_cap=iteration_cap,
-        state=state,
-        tracker=tracker,
-    )
-    return merge_loop_properties(properties, loop_count=count, iteration_cap=cap)
 
 
 @contextmanager
@@ -175,3 +107,6 @@ def track_investigation(
             _INVESTIGATION_TRACKING_DEPTH.reset(token)
             if depth == 0 and loop_metrics_token is not None:
                 reset_investigation_loop_metrics(loop_metrics_token)
+
+
+__all__ = ["track_investigation"]

--- a/infrastructure/analytics/investigation_tracker_types.py
+++ b/infrastructure/analytics/investigation_tracker_types.py
@@ -1,0 +1,89 @@
+"""Shared record and metric-merge helpers for investigation tracking.
+
+Leaf module: importable from both ``investigation_tracker`` (which owns the
+``track_investigation`` context manager) and ``event_properties`` (which reads
+tracker fields when building payloads) without creating an import cycle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from config.constants.investigation import MAX_INVESTIGATION_LOOPS
+from infrastructure.analytics.investigation_loop import (
+    bound_loop_metrics,
+    loop_metrics_from_state,
+    merge_loop_properties,
+)
+from infrastructure.analytics.provider import Properties
+
+
+@dataclass
+class InvestigationTracker:
+    """Holds shared context for investigation lifecycle captures."""
+
+    shared_properties: Properties
+    enabled: bool
+    completed: bool = False
+    failed: bool = False
+    investigation_loop_count: int | None = None
+    investigation_iteration_cap: int = MAX_INVESTIGATION_LOOPS
+
+    def record_loop_metrics_from_state(self, state: Mapping[str, object] | None) -> None:
+        """Capture canonical loop metrics from the investigation final state."""
+        loop_count, iteration_cap = loop_metrics_from_state(state)
+        self.investigation_loop_count = loop_count
+        self.investigation_iteration_cap = iteration_cap
+
+
+def _resolve_investigation_loop_metrics(
+    *,
+    loop_count: int | None = None,
+    iteration_cap: int | None = None,
+    state: Mapping[str, object] | None = None,
+    tracker: InvestigationTracker | None = None,
+) -> tuple[int, int]:
+    if loop_count is not None:
+        resolved_cap = (
+            iteration_cap
+            if iteration_cap is not None
+            else (
+                tracker.investigation_iteration_cap
+                if tracker is not None
+                else MAX_INVESTIGATION_LOOPS
+            )
+        )
+        return max(0, int(loop_count)), max(1, int(resolved_cap))
+    bound = bound_loop_metrics()
+    if bound is not None:
+        return bound
+    if state is not None:
+        return loop_metrics_from_state(state)
+    if tracker is not None and tracker.investigation_loop_count is not None:
+        return tracker.investigation_loop_count, tracker.investigation_iteration_cap
+    return 0, MAX_INVESTIGATION_LOOPS
+
+
+def _with_investigation_loop_metrics(
+    properties: Properties,
+    *,
+    loop_count: int | None = None,
+    iteration_cap: int | None = None,
+    state: Mapping[str, object] | None = None,
+    tracker: InvestigationTracker | None = None,
+) -> Properties:
+    count, cap = _resolve_investigation_loop_metrics(
+        loop_count=loop_count,
+        iteration_cap=iteration_cap,
+        state=state,
+        tracker=tracker,
+    )
+    return merge_loop_properties(properties, loop_count=count, iteration_cap=cap)
+
+
+__all__ = [
+    "InvestigationTracker",
+    "_resolve_investigation_loop_metrics",
+    "_with_investigation_loop_metrics",
+]

--- a/surfaces/cli/investigation/investigate.py
+++ b/surfaces/cli/investigation/investigate.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger(__name__)
 _SESSION_EVENT_POLL_SECONDS = 0.25
 
 if TYPE_CHECKING:
-    from infrastructure.analytics.investigation_tracker import InvestigationTracker
+    from infrastructure.analytics.investigation_tracker_types import InvestigationTracker
 
 
 def _reraise_cli_investigation_failure(exc: BaseException) -> NoReturn:

--- a/tests/analytics/test_investigation_tracker_types.py
+++ b/tests/analytics/test_investigation_tracker_types.py
@@ -1,0 +1,53 @@
+"""Guards the acyclic edge between the tracker lifecycle and property builders.
+
+CodeQL alert #2263 (``py/cyclic-import``) fired when both
+``investigation_tracker`` and ``event_properties`` reached back into each other.
+The shared record and merge helpers were moved to ``investigation_tracker_types``
+so both modules import only from that leaf. This test pins that direction.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_ANALYTICS = Path(__file__).resolve().parents[2] / "infrastructure" / "analytics"
+
+
+def _module_level_imports(module_file: Path) -> set[str]:
+    tree = ast.parse(module_file.read_text())
+    imported: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+    return imported
+
+
+def test_event_properties_does_not_import_investigation_tracker() -> None:
+    imports = _module_level_imports(_ANALYTICS / "event_properties.py")
+    assert "infrastructure.analytics.investigation_tracker" not in imports
+
+
+def test_capture_does_not_import_investigation_tracker() -> None:
+    imports = _module_level_imports(_ANALYTICS / "capture.py")
+    assert "infrastructure.analytics.investigation_tracker" not in imports
+
+
+def test_investigation_tracker_types_is_a_leaf() -> None:
+    imports = _module_level_imports(_ANALYTICS / "investigation_tracker_types.py")
+    forbidden = {
+        "infrastructure.analytics.investigation_tracker",
+        "infrastructure.analytics.event_properties",
+        "infrastructure.analytics.capture",
+    }
+    assert not (imports & forbidden)
+
+
+def test_leaf_exports_shared_symbols() -> None:
+    from infrastructure.analytics import investigation_tracker_types as leaf
+
+    assert hasattr(leaf, "InvestigationTracker")
+    assert hasattr(leaf, "_with_investigation_loop_metrics")
+    assert hasattr(leaf, "_resolve_investigation_loop_metrics")


### PR DESCRIPTION
`investigation_tracker` and `event_properties` imported each other, which CodeQL flags as `py/cyclic-import` (alert #2263): the tracker owns the `track_investigation` lifecycle, while `event_properties` reaches back for the `InvestigationTracker` record and the loop-metric helpers when building payloads.

The shared symbols — the `InvestigationTracker` dataclass and the `_resolve_/_with_investigation_loop_metrics` helpers — move into a new leaf module `investigation_tracker_types`, which both sides (plus `capture` and the `investigate` CLI) import from instead of reaching into each other. The leaf imports only downward (`config.constants`, `investigation_loop`, `provider`, so no cycle can form. Pure move — no behaviour change.

A border test (`tests/analytics/test_investigation_tracker_types.py`) pins the acyclic direction so the alert can't regress.