### PR TITLE
feat(shell): redesign launch banner — canonical logo, 2-item status, product constants

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -298,10 +298,14 @@ from config.constants.posthog_mcp import (
     POSTHOG_MCP_URL_ENV,
 )
 from config.constants.product import (
+    PRODUCT_NAME,
     RELEASE_STAGE,
     RELEASE_STAGE_BANNER,
     RELEASES_API_URL_ENV,
+    SIGN_IN_PROMPT,
     UV_RUN_RECURSION_DEPTH_ENV,
+    WELCOME_DESCRIPTION,
+    WELCOME_TITLE,
 )
 from config.constants.rabbitmq import (
     RABBITMQ_HOST_ENV,
@@ -460,10 +464,14 @@ from config.constants.yandex_cloud import (
 )
 
 __all__ = [
+    "PRODUCT_NAME",
     "RELEASE_STAGE",
     "RELEASE_STAGE_BANNER",
     "RELEASES_API_URL_ENV",
+    "SIGN_IN_PROMPT",
     "UV_RUN_RECURSION_DEPTH_ENV",
+    "WELCOME_DESCRIPTION",
+    "WELCOME_TITLE",
     "ALERT_TEMPLATE_CHOICES",
     "ALERTMANAGER_BEARER_TOKEN_ENV",
     "ALERTMANAGER_PASSWORD_ENV",

--- a/config/constants/product.py
+++ b/config/constants/product.py
@@ -9,6 +9,17 @@ from __future__ import annotations
 
 from typing import Final
 
+#: The CLI identity shown on the launch banner and sign-in screen.
+PRODUCT_NAME: Final[str] = "opensre"
+
+#: Sign-in / welcome screen copy, shown when the shell requires login.
+WELCOME_TITLE: Final[str] = "Welcome to OpenSRE CLI"
+WELCOME_DESCRIPTION: Final[str] = (
+    "OpenSRE is an AI-powered DevOps assistant that diagnoses, fixes and "
+    "optimizes your production software."
+)
+SIGN_IN_PROMPT: Final[str] = "Please login with your OpenSRE account to continue."
+
 #: Release maturity, as users see it. Keep in step with the README badge.
 RELEASE_STAGE: Final[str] = "Public Alpha"
 
@@ -25,8 +36,12 @@ RELEASES_API_URL_ENV: Final[str] = "OPENSRE_RELEASES_API_URL"
 UV_RUN_RECURSION_DEPTH_ENV: Final[str] = "UV_RUN_RECURSION_DEPTH"
 
 __all__ = [
+    "PRODUCT_NAME",
     "RELEASES_API_URL_ENV",
     "RELEASE_STAGE",
     "RELEASE_STAGE_BANNER",
+    "SIGN_IN_PROMPT",
     "UV_RUN_RECURSION_DEPTH_ENV",
+    "WELCOME_DESCRIPTION",
+    "WELCOME_TITLE",
 ]

--- a/surfaces/shared/terminal/banner/banner.py
+++ b/surfaces/shared/terminal/banner/banner.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import enum
+
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
 from rich.padding import Padding
 from rich.table import Table
 from rich.text import Text
 
+from config.constants import PRODUCT_NAME
 from config.version import get_opensre_version
 from infrastructure.terminal.theme import BRAND, DIM, ERROR, HIGHLIGHT, SECONDARY, TEXT
 from surfaces.shared.terminal.banner.banner_state import LaunchStatus, load_launch_status
@@ -15,18 +18,35 @@ from surfaces.shared.terminal.banner.banner_state import LaunchStatus, load_laun
 _SIDE_BY_SIDE_MIN_WIDTH = 72
 _BANNER_VERTICAL_PADDING = 1
 
+#: Identity separator and version prefix on the ``opensre · vX`` line.
+_IDENTITY_SEPARATOR = "  ·  "
+_VERSION_PREFIX = "v"
+#: Capability-status glyphs: present/usable vs. absent.
+_STATUS_OK_GLYPH = "✓"
+_STATUS_MISSING_GLYPH = "✗"
+#: Spacing between status items.
+_STATUS_ITEM_GAP = "   "
+
+
+class LaunchStatusLabel(enum.StrEnum):
+    """Labels for the launch banner's capability status line."""
+
+    SKILLS = "Skills"
+    INTEGRATIONS = "Integrations"
+
+
+#: Braille rendering of the canonical OpenSRE mark (docs/images/opensre-mark.svg).
 _LOGO_ROWS: tuple[str, ...] = (
-    "    ••••••••••    ",
-    "  ••••••••••••••  ",
-    " ••••••    •••••• ",
-    " •• ••      •• •• ",
-    "•• ••        •• ••",
-    "•• ••        •• ••",
-    "•• ••        •• ••",
-    " •• ••      •• •• ",
-    " ••••••    •••••• ",
-    "  ••••••••••••••  ",
-    "    ••••••••••    ",
+    "⠀⠀⠀⢀⣤⣶⣾⣿⣿⣿⣿⣶⣦⣄⡈⠒⢦⣄⡀⠀⠀⠀",
+    "⠀⢀⣴⣿⠿⠋⢁⣤⣶⠖⠂⠉⠙⢿⣿⣦⠀⠙⣿⣦⡀⠀",
+    "⢀⣾⣿⠋⠀⣴⣿⡟⠁⠀⠀⠀⠀⠀⠹⣿⣷⠀⠘⣿⣷⡀",
+    "⣼⣿⡇⠀⣼⣿⡿⠀⠀⠀⠀⠀⠀⠀⠀⢹⣿⡇⠀⢹⣿⣇",
+    "⣿⣿⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⠀⢸⣿⣿",
+    "⣿⣿⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⠀⢸⣿⣿",
+    "⢻⣿⣇⠀⢻⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⣼⣿⡇⠀⣸⣿⡏",
+    "⠈⢿⣿⣄⠀⠻⣿⣧⡀⠀⠀⠀⠀⠀⣰⣿⡟⠀⢠⣿⡿⠁",
+    "⠀⠈⠻⣿⣷⣄⣈⠛⠻⠶⠄⣀⣤⣾⣿⠟⠀⣰⣿⠟⠀⠀",
+    "⠀⠀⠀⠈⠙⠻⠿⣿⣿⣿⡿⠿⠟⠋⠀⠴⠞⠋⠁⠀⠀⠀",
 )
 
 
@@ -43,39 +63,33 @@ def _append_status_item(
     available: bool,
 ) -> None:
     if line:
-        line.append("   ", style=DIM)
+        line.append(_STATUS_ITEM_GAP, style=DIM)
     line.append(label, style=f"bold {TEXT}")
     if count is not None:
         line.append(f" ({count})", style=SECONDARY)
-    glyph = "✓" if available else "✗"
+    glyph = _STATUS_OK_GLYPH if available else _STATUS_MISSING_GLYPH
     line.append(f" {glyph}", style=HIGHLIGHT if available else ERROR)
 
 
 def _build_details(status: LaunchStatus) -> Text:
     """Return the product/version line and compact capability summary."""
     identity = Text(no_wrap=True)
-    identity.append("opensre", style=f"bold {TEXT}")
-    identity.append("  ·  ", style=DIM)
-    identity.append(f"v{get_opensre_version()}", style=BRAND)
+    identity.append(PRODUCT_NAME, style=f"bold {TEXT}")
+    identity.append(_IDENTITY_SEPARATOR, style=DIM)
+    identity.append(f"{_VERSION_PREFIX}{get_opensre_version()}", style=BRAND)
 
     capabilities = Text(overflow="fold")
     _append_status_item(
         capabilities,
-        "Skills",
+        LaunchStatusLabel.SKILLS,
         status.skill_count,
         available=status.skill_count > 0,
     )
     _append_status_item(
         capabilities,
-        "MCPs",
-        status.mcp_count,
-        available=status.mcps_ready,
-    )
-    _append_status_item(
-        capabilities,
-        "AGENTS.md",
-        None,
-        available=status.agents_md_available,
+        LaunchStatusLabel.INTEGRATIONS,
+        status.integration_count,
+        available=status.integration_count > 0,
     )
     return Text("\n").join([identity, Text(), capabilities])
 

--- a/surfaces/shared/terminal/banner/banner_state.py
+++ b/surfaces/shared/terminal/banner/banner_state.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from config.constants.paths import REPO_ROOT
-from surfaces.shared.terminal.tables import MCP_INTEGRATION_SERVICES
-
 
 @dataclass(frozen=True)
 class LaunchStatus:
-    """Counts and availability flags displayed beside the OpenSRE mark."""
+    """Counts displayed beside the OpenSRE mark."""
 
     skill_count: int
-    mcp_count: int
-    mcps_ready: bool
-    agents_md_available: bool
+    integration_count: int
 
 
 def _count_loaded_skills() -> int:
@@ -28,37 +23,21 @@ def _count_loaded_skills() -> int:
         return 0
 
 
-def _mcp_health() -> tuple[int, bool]:
-    """Return the configured MCP count and whether every entry is usable."""
+def _count_configured_integrations() -> int:
+    """Return how many integrations are configured (any health state)."""
     try:
         from integrations.catalog import configured_integration_health
 
-        entries = [
-            status
-            for service, status in configured_integration_health()
-            if service in MCP_INTEGRATION_SERVICES
-        ]
+        return len(configured_integration_health())
     except Exception:
-        return 0, False
-    return len(entries), bool(entries) and all(status == "ok" for status in entries)
-
-
-def _has_agents_md() -> bool:
-    """Return whether the repository instructions used for grounding exist."""
-    try:
-        return (REPO_ROOT / "AGENTS.md").is_file()
-    except OSError:
-        return False
+        return 0
 
 
 def load_launch_status() -> LaunchStatus:
     """Load the startup-safe status summary without network calls."""
-    mcp_count, mcps_ready = _mcp_health()
     return LaunchStatus(
         skill_count=_count_loaded_skills(),
-        mcp_count=mcp_count,
-        mcps_ready=mcps_ready,
-        agents_md_available=_has_agents_md(),
+        integration_count=_count_configured_integrations(),
     )
 
 

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-from pathlib import Path
 
 from rich.console import Console
 
@@ -17,9 +16,7 @@ from surfaces.shared.terminal.banner.banner_state import LaunchStatus
 def _fixed_status() -> LaunchStatus:
     return LaunchStatus(
         skill_count=21,
-        mcp_count=2,
-        mcps_ready=True,
-        agents_md_available=True,
+        integration_count=2,
     )
 
 
@@ -36,10 +33,11 @@ def test_launch_banner_is_borderless_and_shows_only_compact_identity(
     output = console_file.getvalue()
     assert "opensre  ·  v2026.8.27+main.85fd865" in output
     assert "Skills (21) ✓" in output
-    assert "MCPs (2) ✓" in output
-    assert "AGENTS.md ✓" in output
-    assert "Welcome" not in output
-    assert "Integrations" not in output
+    assert "Integrations (2) ✓" in output
+    # Only the two capability items — no MCPs or AGENTS.md line.
+    assert "MCPs" not in output
+    assert "AGENTS.md" not in output
+    assert "Welcome" not in output  # welcome copy lives on the sign-in screen, not the banner
     assert not any(char in output for char in "╭╮╰╯│")
 
 
@@ -50,9 +48,8 @@ def test_launch_banner_draws_two_overlapping_equal_rings(monkeypatch: object) ->
     console.print(banner_module.build_launch_banner(console))
 
     output = console.export_text(styles=False)
-    assert "    ••••••••••    " in output
-    assert "•• ••        •• ••" in output
-    assert " ••••••    •••••• " in output
+    # Braille rendering of the canonical OpenSRE "O" mark: the two ring-wall rows.
+    assert "⣿⣿⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⠀⢸⣿⣿" in output
 
 
 def test_launch_banner_uses_active_theme_palette(monkeypatch: object) -> None:
@@ -90,9 +87,7 @@ def test_status_marks_empty_or_unavailable_capabilities(monkeypatch: object) -> 
         "load_launch_status",
         lambda: LaunchStatus(
             skill_count=0,
-            mcp_count=0,
-            mcps_ready=False,
-            agents_md_available=False,
+            integration_count=0,
         ),
     )
     console = Console(record=True, force_terminal=False, highlight=False, width=120)
@@ -101,17 +96,17 @@ def test_status_marks_empty_or_unavailable_capabilities(monkeypatch: object) -> 
 
     output = console.export_text(styles=False)
     assert "Skills (0) ✗" in output
-    assert "MCPs (0) ✗" in output
-    assert "AGENTS.md ✗" in output
+    assert "Integrations (0) ✗" in output
 
 
-def test_mcp_health_counts_only_mcp_integrations(monkeypatch: object) -> None:
+def test_integration_count_includes_all_configured(monkeypatch: object) -> None:
+    # Every configured integration counts (not just MCP ones), any health state.
     monkeypatch.setattr(
         "integrations.catalog.configured_integration_health",
         lambda: [("datadog", "ok"), ("github", "ok"), ("openclaw", "incomplete")],
     )
 
-    assert banner_state_module._mcp_health() == (2, False)
+    assert banner_state_module._count_configured_integrations() == 3
 
 
 def test_status_probes_survive_loader_failures(monkeypatch: object) -> None:
@@ -130,18 +125,7 @@ def test_status_probes_survive_loader_failures(monkeypatch: object) -> None:
     monkeypatch.setattr(builtins, "__import__", _fail_startup_probes)
 
     assert banner_state_module._count_loaded_skills() == 0
-    assert banner_state_module._mcp_health() == (0, False)
-
-
-def test_agents_md_status_tracks_repository_instructions(
-    monkeypatch: object,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setattr(banner_state_module, "REPO_ROOT", tmp_path)
-    assert banner_state_module._has_agents_md() is False
-
-    (tmp_path / "AGENTS.md").write_text("# instructions\n", encoding="utf-8")
-    assert banner_state_module._has_agents_md() is True
+    assert banner_state_module._count_configured_integrations() == 0
 
 
 def test_banner_uses_runtime_version(monkeypatch: object) -> None:


### PR DESCRIPTION
Redesigns the opening/launch banner toward the forced-sign-in screen (screen
scope; the Login → web-app auth flow lands separately).

- Logo: replace the sparse `•• ••` mark with a braille rendering of the
  canonical OpenSRE mark, derived from `docs/images/opensre-mark.svg` (the
  layered "O"), so the banner matches the brand.
- Status line: show exactly two items — `Skills (N) ✓` and `Integrations (N) ✓`
  — dropping the `MCPs` and `AGENTS.md` items. Integrations counts all
  configured integrations (any health state); ✓ when at least one is present.
- Version: unchanged source (`get_opensre_version()`), which already renders the
  full `v0.1.YYYY.M.D+main.<sha>` release string on release builds and bare
  `v0.1` on dev checkouts.
- No hardcoded literals: `PRODUCT_NAME`, `WELCOME_TITLE`, `WELCOME_DESCRIPTION`,
  and `SIGN_IN_PROMPT` move to `config/constants/product.py`; the banner uses a
  `LaunchStatusLabel` StrEnum plus named glyph/separator constants.