### PR TITLE
fix(harness): type PersistToolCalls as (name, input, output) tuples

### DIFF
--- a/core/agent_harness/turns/evidence_driver.py
+++ b/core/agent_harness/turns/evidence_driver.py
@@ -400,7 +400,7 @@ def gather_tool_evidence(
             log.debug("gather_evidence done: no tools executed")
             return None
         if persist is not None:
-            persist(result.executed)
+            persist([(call.name, call.input, output) for call, output in result.executed])
         log.debug("gather_evidence done tools_executed=%s", len(result.executed))
         return GatheredEvidence(
             observation=_format_observation(result.executed),

--- a/core/agent_harness/turns/gather_phase.py
+++ b/core/agent_harness/turns/gather_phase.py
@@ -6,15 +6,14 @@ the type without reaching through the turn machinery.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
 from core.agent_harness.ports import ToolEventObserver
-from core.llm.types import ToolCall
 
-#: Persists the tool calls a gather pass made: ``[(tool_call, result), ...]``.
-PersistToolCalls = Callable[[list[tuple[ToolCall, Any]]], None]
+#: Persists gathered tool calls as ``[(tool_name, tool_input, output), ...]``.
+PersistToolCalls = Callable[[list[tuple[str, Mapping[str, object], Any]]], None]
 
 #: Loop budget for headless metric reports (PostHog / digests): schema discovery plus
 #: one query per metric needs more than the chat default; passed as ``max_iterations``.

--- a/surfaces/interactive_shell/runtime/integration_tool_gathering.py
+++ b/surfaces/interactive_shell/runtime/integration_tool_gathering.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -109,8 +110,10 @@ def _truncate(text: str, limit: int) -> str:
     return text[:limit] + f"\n…[truncated, {len(text)} chars total]"
 
 
-def _persist_tool_calls(session: Session, executed: list[tuple[Any, Any]]) -> None:
-    """Record each gathered tool-call result into the session log.
+def _persist_tool_calls(
+    session: Session, executed: list[tuple[str, Mapping[str, object], Any]]
+) -> None:
+    """Record each gathered tool call into the session log.
 
     Arguments and results are redacted and bounded before writing; failures are
     swallowed so logging never breaks the turn.
@@ -119,20 +122,17 @@ def _persist_tool_calls(session: Session, executed: list[tuple[Any, Any]]) -> No
     from infrastructure.observability.trace.redaction import redact_sensitive
 
     store = default_session_store()
-    for tc, output in executed:
+    for tool_name, tool_input, output in executed:
         with contextlib.suppress(Exception):
             body = (
                 output
                 if isinstance(output, str)
                 else json.dumps(redact_sensitive(output), default=str)
             )
-            arguments = (
-                redact_sensitive(tc.input) if isinstance(tc.input, dict) else {"value": tc.input}
-            )
             store.append_tool_call(
                 session.session_id,
-                tool=str(tc.name),
-                arguments=arguments,
+                tool=tool_name,
+                arguments=dict(redact_sensitive(tool_input)),
                 result=_truncate(body, _MAX_PER_TOOL_CHARS),
                 ok=not (isinstance(output, dict) and "error" in output),
             )
@@ -181,7 +181,7 @@ def shell_gather_phase(session: SessionState, console: Console) -> GatherPhase:
     """
     session = cast(Session, session)
 
-    def persist(executed: list[tuple[Any, Any]]) -> None:
+    def persist(executed: list[tuple[str, Mapping[str, object], Any]]) -> None:
         _persist_tool_calls(session, executed)
 
     return GatherPhase(on_progress=ShellGatherProgress(console), persist=persist)

--- a/tests/core/agent_harness/test_gather_phase.py
+++ b/tests/core/agent_harness/test_gather_phase.py
@@ -8,6 +8,7 @@ harder to read the more surfaces it served.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import pytest
@@ -70,7 +71,7 @@ class TestAgentForwardsGatherPhase:
         def _on_progress(_kind: str, _data: dict[str, Any]) -> None:
             return None
 
-        def _persist(_executed: list[tuple[Any, Any]]) -> None:
+        def _persist(_executed: list[tuple[str, Mapping[str, object], Any]]) -> None:
             return None
 
         agent = InMemoryHeadlessBuild(session=headless_adapters.InMemorySessionState()).agent(

--- a/tests/interactive_shell/runtime/test_integration_tool_gathering.py
+++ b/tests/interactive_shell/runtime/test_integration_tool_gathering.py
@@ -1,0 +1,56 @@
+"""Tests for the shell's gather-phase session persistence."""
+
+from __future__ import annotations
+
+from core.agent_harness.session import InMemorySessionStore
+from surfaces.interactive_shell.runtime.integration_tool_gathering import _persist_tool_calls
+from surfaces.interactive_shell.session import Session
+
+
+def _open_session(monkeypatch) -> tuple[Session, InMemorySessionStore]:
+    storage = InMemorySessionStore()
+    session = Session(store=storage)
+    storage.open_session(session)
+    monkeypatch.setattr(
+        "core.agent_harness.spi.defaults.default_session_store",
+        lambda: storage,
+    )
+    return session, storage
+
+
+def test_persist_tool_calls_records_a_successful_result(monkeypatch) -> None:
+    session, storage = _open_session(monkeypatch)
+
+    _persist_tool_calls(
+        session,
+        [("search_github_issues", {"owner": "o", "repo": "r"}, {"issues": ["#1"]})],
+    )
+
+    records = storage.read(session.session_id)
+    tool_call = next(record for record in records if record["type"] == "tool_call")
+    tool_result = next(record for record in records if record["type"] == "tool_result")
+
+    assert tool_call["tool"] == "search_github_issues"
+    assert tool_call["arguments"] == {"owner": "o", "repo": "r"}
+    assert tool_result["tool"] == "search_github_issues"
+    assert tool_result["content"] == '{"issues": ["#1"]}'
+    assert tool_result["ok"] is True
+
+
+def test_persist_tool_calls_records_failed_result(monkeypatch) -> None:
+    session, storage = _open_session(monkeypatch)
+
+    _persist_tool_calls(
+        session,
+        [("test_tool", {"query": "something"}, {"error": "boom"})],
+    )
+
+    records = storage.read(session.session_id)
+    tool_call = next(record for record in records if record["type"] == "tool_call")
+    tool_result = next(record for record in records if record["type"] == "tool_result")
+
+    assert tool_call["tool"] == "test_tool"
+    assert tool_call["arguments"] == {"query": "something"}
+    assert tool_result["tool"] == "test_tool"
+    assert tool_result["content"] == '{"error": "boom"}'
+    assert tool_result["ok"] is False


### PR DESCRIPTION
Fixes #5784

#### Describe the changes you have made in this PR -

`PersistToolCalls` was typed as `Callable[[list[tuple[ToolCall, Any]]], None]`, and the real implementation in `surfaces/interactive_shell/runtime/integration_tool_gathering.py` independently re-declared the same payload as `list[tuple[Any, Any]]` — both hiding the stable shape actually flowing through the gather phase: the tool's name, its input mapping, and the raw output.

- `core/agent_harness/turns/gather_phase.py`: retyped `PersistToolCalls` to `Callable[[list[tuple[str, Mapping[str, object], Any]]], None]`; dropped the now-unused `ToolCall` import.
- `core/agent_harness/turns/evidence_driver.py`: the one production call site (`gather_tool_evidence`) now maps `result.executed` (`list[tuple[ToolCall, Any]]`) into the narrowed shape before calling `persist(...)`: `[(call.name, call.input, output) for call, output in result.executed]`.
- `surfaces/interactive_shell/runtime/integration_tool_gathering.py`: `_persist_tool_calls` and the `persist` closure in `shell_gather_phase` now take `list[tuple[str, Mapping[str, object], Any]]` directly, unpacking `tool_name, tool_input, output` instead of reaching into a `ToolCall`-shaped first element (`tc.name`/`tc.input`). Since `tool_input` is now always a mapping by type, the old `isinstance(tc.input, dict) else {"value": tc.input}` fallback is gone — `dict(redact_sensitive(tool_input))` is the only path.
- `tests/core/agent_harness/test_gather_phase.py`: retyped the local `_persist` test fixture to match.
- `tests/interactive_shell/runtime/test_integration_tool_gathering.py` (new): direct regression coverage for `_persist_tool_calls` — a successful call (asserts `ok=True`, correct `tool`/`arguments`/`content`) and a failed call (`{"error": ...}` output → `ok=False`), so the persistence path's actual session-log output is pinned, not just its call signature.

No behavior change: `result.executed` was always `[(ToolCall(id, name, input), output), ...]` — this only narrows the type at the boundary and removes the now-redundant attribute indirection.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/interactive_shell/runtime/test_integration_tool_gathering.py tests/interactive_shell/tools/test_tool_gathering.py tests/core/agent_harness/test_gather_phase.py tests/core/agent_harness/test_evidence_agent.py -q
....................................                                     [100%]
32 passed in 3.06s

$ uv run pytest -k gather -q
159 passed, 15812 deselected in 17.37s

$ uv run pytest -k persist -q
140 passed, 15831 deselected in 11.98s

$ uv run pytest tests/core/agent_harness/ tests/interactive_shell/ -q
2019 passed, 1 skipped in 34.20s

$ uv run mypy core/agent_harness/turns/gather_phase.py core/agent_harness/turns/evidence_driver.py surfaces/interactive_shell/runtime/integration_tool_gathering.py
Success: no issues found in 3 source files

$ uv run mypy tests/core/agent_harness/test_gather_phase.py tests/interactive_shell/runtime/test_integration_tool_gathering.py
Success: no issues found in 2 source files

$ uv run ruff check <changed files> && uv run ruff format --check <changed files>
All checks passed! / 5 files already formatted
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`PersistToolCalls` is a `GatherPhase` field: a surface (currently just the interactive shell) plugs in a callback that records each tool call the gather pass executed into session history. The type alias claimed `list[tuple[ToolCall, Any]]`, but the one real consumer (`_persist_tool_calls`) had already been re-declaring its own parameter as `list[tuple[Any, Any]]` rather than importing and using `ToolCall` — a sign the alias wasn't actually pulling its weight as a shared contract, and that the two sides could silently drift.

I traced the data from its source: `Agent`/`ReactLoop` build `executed: list[tuple[ToolCall, Any]]`, which `gather_tool_evidence` forwards unmodified into `persist(...)`. `_persist_tool_calls` then only ever reads `tc.name` and `tc.input` off the first element — never the full `ToolCall` (its `id` field goes unused here) — so the *actual* contract the callback relies on is `(name: str, input: Mapping[str, object], output: Any)`, not `(ToolCall, Any)`.

I considered keeping `ToolCall` in the type and just tightening `Any` → the input dict's real type, but that still exposes the `id` field to every implementer for no reason, and the closed PR #5406 for this same issue (redone as a fresh issue per its description, since #5406 was closed for unrelated conflict/process reasons, not the design itself) already validated this exact 3-tuple shape against the interactive shell's real persistence behavior — including the `ok=False`-on-error case — so I followed that shape rather than inventing a new one. I mapped `result.executed` into `(call.name, call.input, output)` tuples at the single call site in `evidence_driver.py`, which is the only place a `ToolCall` needs to be unpacked at all now.

Key files: `gather_phase.py` (the type alias itself, now importing `Mapping` instead of `ToolCall`), `evidence_driver.py` (the one production call site doing the mapping), and `integration_tool_gathering.py` (`_persist_tool_calls`, the real implementation, now unpacking the narrowed tuple directly instead of reading `.name`/`.input` off a positional `ToolCall`).

Edge case tested directly: a tool call whose output is `{"error": "..."}` must still be persisted (not dropped) with `ok=False` — this is the behavior the issue's own verification checklist calls out, and it's now pinned by a dedicated unit test on `_persist_tool_calls` rather than only indirectly exercised through the full gather pipeline.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions