### PR TITLE
fix(interactive-shell): escape /theme argument before Rich markup rendering

### DIFF
--- a/surfaces/interactive_shell/command_registry/theme.py
+++ b/surfaces/interactive_shell/command_registry/theme.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 
 from rich.console import Console
+from rich.markup import escape
 
 from infrastructure.terminal import theme as ui_theme
 from infrastructure.terminal.theme import (
@@ -61,7 +62,9 @@ def _cmd_theme(session: Session, console: Console, args: list[str]) -> bool:
         selected = args[0].strip().lower()
         if selected not in list_theme_names():
             supported = ", ".join(list_theme_names())
-            console.print(f"[{ui_theme.ERROR}]unknown theme:[/] {selected}  (choose: {supported})")
+            console.print(
+                f"[{ui_theme.ERROR}]unknown theme:[/] {escape(selected)}  (choose: {supported})"
+            )
             return True
         _persist_and_report_theme(session, console, selected)
         return True

--- a/tests/interactive_shell/command_registry/test_theme_cmd.py
+++ b/tests/interactive_shell/command_registry/test_theme_cmd.py
@@ -1,0 +1,43 @@
+"""/theme slash command: unknown-theme error path."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from surfaces.interactive_shell.command_registry.theme import _cmd_theme
+from surfaces.interactive_shell.session import Session
+
+
+def _console() -> tuple[Console, StringIO]:
+    buf = StringIO()
+    return Console(file=buf, force_terminal=False, width=120), buf
+
+
+def test_unknown_theme_prints_plain_name() -> None:
+    session = Session()
+    console, buf = _console()
+
+    assert _cmd_theme(session, console, ["not-a-real-theme"])
+    assert "unknown theme: not-a-real-theme" in buf.getvalue()
+
+
+def test_unknown_theme_with_markup_like_argument_does_not_raise() -> None:
+    """A theme name that looks like Rich markup must not crash the handler.
+
+    ``selected`` is interpolated into a Rich markup string to report the
+    error -- an unescaped ``[/]`` or unmatched ``[bold`` previously raised
+    ``rich.errors.MarkupError`` out of the command instead of printing the
+    intended message.
+    """
+    session = Session()
+    console, buf = _console()
+
+    assert _cmd_theme(session, console, ["[/]"])
+    assert "unknown theme: [/]" in buf.getvalue()
+
+    buf.truncate(0)
+    buf.seek(0)
+    assert _cmd_theme(session, console, ["[bold"])
+    assert "unknown theme: [bold" in buf.getvalue()

--- a/tests/interactive_shell/command_registry/test_theme_cmd.py
+++ b/tests/interactive_shell/command_registry/test_theme_cmd.py
@@ -24,13 +24,7 @@ def test_unknown_theme_prints_plain_name() -> None:
 
 
 def test_unknown_theme_with_markup_like_argument_does_not_raise() -> None:
-    """A theme name that looks like Rich markup must not crash the handler.
-
-    ``selected`` is interpolated into a Rich markup string to report the
-    error -- an unescaped ``[/]`` or unmatched ``[bold`` previously raised
-    ``rich.errors.MarkupError`` out of the command instead of printing the
-    intended message.
-    """
+    """A theme name that looks like Rich markup must not crash the handler."""
     session = Session()
     console, buf = _console()
 


### PR DESCRIPTION
Fixes #5300

#### Describe the changes you have made in this PR -

`_cmd_theme` interpolated the raw caller-supplied argument directly into a Rich markup string (`f"[{ui_theme.ERROR}]unknown theme:[/] {selected}  ..."`) to report an unknown theme. An argument that itself looks like Rich markup — `[/]`, `[bold` — broke the markup parser, so `rich.errors.MarkupError` propagated out of `dispatch_slash` instead of the intended "unknown theme: ..." message ever printing.

Fix: wrap `selected` with `rich.markup.escape` before interpolation, so it's always rendered as literal text regardless of what characters it contains. `supported` (the comma-joined list of real theme names) doesn't need escaping — it's built entirely from `list_theme_names()`, never from caller input.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`):
```
$ uv run python3 -c "
from io import StringIO
from rich.console import Console
from surfaces.interactive_shell.command_registry.theme import _cmd_theme
from surfaces.interactive_shell.session import Session
session = Session()
console = Console(file=StringIO(), force_terminal=False, width=120)
_cmd_theme(session, console, ['[/]'])
"
Traceback (most recent call last):
  ...
rich.errors.MarkupError: closing tag '[/]' at position 27 has nothing to close
```

After (this branch):
```
$ uv run python3 -c "
from io import StringIO
from rich.console import Console
from surfaces.interactive_shell.command_registry.theme import _cmd_theme
from surfaces.interactive_shell.session import Session
session = Session()
buf = StringIO()
console = Console(file=buf, force_terminal=False, width=120)
_cmd_theme(session, console, ['[/]'])
print(repr(buf.getvalue()))
"
'unknown theme: [/]  (choose: green, blue, amber, mono, red, pink, purple, orange, teal, lime, nord, dracula, solarized, \ngruvbox, webflux, sunset)\n'
```

```
$ uv run pytest tests/interactive_shell/command_registry/test_theme_cmd.py -q
..                                                                       [100%]
2 passed in 2.55s

$ uv run pytest -k theme -q
39 passed, 16921 deselected in 16.42s

$ uv run ruff check surfaces/interactive_shell/command_registry/theme.py tests/interactive_shell/command_registry/test_theme_cmd.py
All checks passed!

$ uv run ruff format --check surfaces/interactive_shell/command_registry/theme.py tests/interactive_shell/command_registry/test_theme_cmd.py
2 files already formatted

$ uv run mypy surfaces/interactive_shell/command_registry/theme.py tests/interactive_shell/command_registry/test_theme_cmd.py
Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a straightforward unescaped-user-input-into-markup issue: `console.print(f"... {selected} ...")` treats `selected` as part of the markup source, not as literal data, because f-string interpolation happens before Rich ever parses the string. Rich's own fix for exactly this is `rich.markup.escape`, which prefixes any `[` in the input with a backslash so Rich's parser treats it as a literal bracket rather than the start of a tag — the same pattern already used elsewhere in this codebase for user-controlled text going into a Rich-rendered string (e.g. `_format_gathering_progress_line` in `surfaces/interactive_shell/runtime/integration_tool_gathering.py`, which escapes both the display name and the input hint before printing).

I considered validating/rejecting theme names with bracket characters instead, but that changes user-facing behavior (a name like `[weird]` would need a different error path) for no real benefit — escaping preserves the exact existing message and only changes how it's rendered, which is the minimal fix for a rendering bug.

Key files: `theme.py`'s `_cmd_theme`, the one call site building this message. Added `tests/interactive_shell/command_registry/test_theme_cmd.py` since no test file existed yet for this command handler — one test for the ordinary unknown-theme path (unaffected by the escape) and one exercising two markup-like arguments (`[/]`, an unmatched closing tag; `[bold`, an unmatched opening tag) that would previously raise.

Edge case tested directly: both an unmatched closing bracket and an unmatched opening bracket, since Rich's parser can fail on either shape, and confirmed the printed text is the plain (unescaped-looking) string a user would expect, not a literal backslash-escaped one.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions