### PR TITLE
fix(terminal): roll magnitude formatters into the next unit at boundaries

### DIFF
--- a/infrastructure/evidence/metric_summary.py
+++ b/infrastructure/evidence/metric_summary.py
@@ -255,7 +255,14 @@ def _format_bytes(value: float) -> str:
     units = ("B", "KiB", "MiB", "GiB", "TiB")
     amount = abs(value)
     unit_index = 0
-    while amount >= 1024 and unit_index < len(units) - 1:
+    # Advance while the amount *rendered at its current unit's precision*
+    # would still show 1024 -- comparing the raw amount let e.g. 1023.5 stop
+    # at the B tier and round up to the four-digit "1024 B" instead of
+    # rolling into "1.00 KiB".
+    while unit_index < len(units) - 1:
+        precision = 0 if unit_index == 0 else 2
+        if round(amount, precision) < 1024:
+            break
         amount /= 1024
         unit_index += 1
     signed = -amount if value < 0 else amount

--- a/infrastructure/evidence/metric_summary.py
+++ b/infrastructure/evidence/metric_summary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -258,10 +259,12 @@ def _format_bytes(value: float) -> str:
     # Advance while the amount *rendered at its current unit's precision*
     # would still show 1024 -- comparing the raw amount let e.g. 1023.5 stop
     # at the B tier and round up to the four-digit "1024 B" instead of
-    # rolling into "1.00 KiB".
+    # rolling into "1.00 KiB". NaN compares False against everything
+    # (including "< 1024"), so without this guard it would advance through
+    # every unit and render "nan TiB" instead of stopping at "nan B".
     while unit_index < len(units) - 1:
         precision = 0 if unit_index == 0 else 2
-        if round(amount, precision) < 1024:
+        if math.isnan(amount) or round(amount, precision) < 1024:
             break
         amount /= 1024
         unit_index += 1

--- a/surfaces/shared/terminal/agents/agents_view.py
+++ b/surfaces/shared/terminal/agents/agents_view.py
@@ -67,11 +67,15 @@ def _format_tokens_per_min(value: float | None) -> str:
     if value is None:
         return _UNFILLED
     # Round-then-compare so ``999.6`` doesn't render as 4-digit ``"1000"``
-    # next to its 3-digit neighbors.
+    # next to its 3-digit neighbors -- and the same trap one unit up: a
+    # k-scale value that rounds to "1000.0" at .1f must roll into the M
+    # tier instead of rendering as four-digit "1000.0k".
     rounded = int(round(value))
     if rounded < 1000:
         return f"{rounded}"
-    return f"{value / 1000:.1f}k"
+    if round(value / 1000, 1) < 1000:
+        return f"{value / 1000:.1f}k"
+    return f"{value / 1_000_000:.1f}M"
 
 
 def _format_usd_per_hour(value: float | None) -> str:

--- a/surfaces/shared/terminal/components/token_format.py
+++ b/surfaces/shared/terminal/components/token_format.py
@@ -13,10 +13,16 @@ _CHARS_PER_TOKEN = 4
 
 
 def format_token_count_short(token_count: int) -> str:
-    """Format a token count as a short string — ``42`` / ``1.2k`` / ``5.2k``."""
-    if token_count >= 1000:
+    """Format a token count as a short string — ``42`` / ``1.2k`` / ``1.0M``."""
+    if token_count < 1000:
+        return str(token_count)
+    # Branch on the rounded-to-one-decimal magnitude, not the raw value: a
+    # count like 999_950 rounds to "1000.0" at .1f precision, and comparing
+    # the raw value against 1_000_000 let that render as the broken "1000.0k"
+    # instead of rolling into the M branch below.
+    if round(token_count / 1000, 1) < 1000:
         return f"{token_count / 1000:.1f}k"
-    return str(token_count)
+    return f"{token_count / 1_000_000:.1f}M"
 
 
 __all__ = ["_CHARS_PER_TOKEN", "format_token_count_short"]

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -769,6 +769,10 @@ class TestFormatTokenCountShort:
             (1234, "1.2k"),
             (10000, "10.0k"),
             (123456, "123.5k"),
+            (999949, "999.9k"),
+            (999950, "1.0M"),
+            (1000000, "1.0M"),
+            (2500000, "2.5M"),
         ],
     )
     def test_formats_at_boundaries(self, count: int, expected: str) -> None:

--- a/tests/shared/terminal/test_agents_view.py
+++ b/tests/shared/terminal/test_agents_view.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.table import Table
 
 from surfaces.shared.terminal.agents import agents_view as agents_view_mod
-from surfaces.shared.terminal.agents.agents_view import _build_agents_table
+from surfaces.shared.terminal.agents.agents_view import _build_agents_table, _format_tokens_per_min
 from tools.system.fleet_monitoring import config as config_mod
 from tools.system.fleet_monitoring.probe import ProcessSnapshot
 from tools.system.fleet_monitoring.registry import AgentRecord
@@ -359,3 +359,21 @@ def test_record_name_is_rich_escaped_so_markup_does_not_render() -> None:
 # Resilience to a schema-invalid ``agents.yaml`` is now enforced by
 # the sampler's catch-all around ``load_agents_config`` (see
 # ``test_sampler.py``); the view no longer touches the config.
+
+
+class TestFormatTokensPerMin:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (None, "-"),
+            (999.4, "999"),
+            (999.6, "1.0k"),
+            (1234.0, "1.2k"),
+            # Rounds up to the k-tier boundary at .1f precision -- must roll
+            # into the M tier rather than rendering four-digit "1000.0k".
+            (999950.0, "1.0M"),
+            (2500000.0, "2.5M"),
+        ],
+    )
+    def test_formats_at_boundaries(self, value: float | None, expected: str) -> None:
+        assert _format_tokens_per_min(value) == expected

--- a/tests/tools/utils/test_metric_summary.py
+++ b/tests/tools/utils/test_metric_summary.py
@@ -82,3 +82,9 @@ class TestFormatBytes:
     )
     def test_formats_at_boundaries(self, value: float, expected: str) -> None:
         assert _format_bytes(value) == expected
+
+    def test_nan_stays_at_the_byte_tier(self) -> None:
+        """NaN compares False against everything, including "< 1024" -- the
+        boundary check alone would advance it through every unit and render
+        the nonsensical "nan TiB" instead of stopping at "nan B"."""
+        assert _format_bytes(float("nan")) == "nan B"

--- a/tests/tools/utils/test_metric_summary.py
+++ b/tests/tools/utils/test_metric_summary.py
@@ -7,7 +7,9 @@ without misreading spikes and baselines.
 
 from __future__ import annotations
 
-from infrastructure.evidence.metric_summary import summarize_prometheus_metrics
+import pytest
+
+from infrastructure.evidence.metric_summary import _format_bytes, summarize_prometheus_metrics
 
 
 def _series(metric_name: str, points: list[tuple[float, float]]) -> dict[str, object]:
@@ -62,3 +64,21 @@ def test_empty_series_does_not_crash() -> None:
     # Optional enriched fields should not be present without datapoints.
     assert "mean" not in summary
     assert "p95" not in summary
+
+
+class TestFormatBytes:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (0, "0 B"),
+            (500, "500 B"),
+            (1024, "1.00 KiB"),
+            # Rounds up to the unit boundary at its current precision --
+            # must roll into the next unit rather than rendering 4 digits.
+            (1023.5, "1.00 KiB"),
+            (1048570.9, "1.00 MiB"),
+            (-1023.5, "-1.00 KiB"),
+        ],
+    )
+    def test_formats_at_boundaries(self, value: float, expected: str) -> None:
+        assert _format_bytes(value) == expected


### PR DESCRIPTION
Fixes #5312

#### Describe the changes you have made in this PR -

Three magnitude formatters have the round-before-branch bug already fixed in `format_token_count_compact` by #5179: each branches on the raw value but renders rounded, so a value just below a unit boundary displays with an oversized mantissa instead of rolling into the next unit.

- `surfaces/shared/terminal/components/token_format.py` `format_token_count_short` had no M tier at all, so `999_950` → `"1000.0k"` and `2_500_000` → `"2500.0k"`. Added the M tier and branch on `round(token_count / 1000, 1) < 1000` instead of comparing the raw count against `1_000_000`.
- `surfaces/shared/terminal/agents/agents_view.py` `_format_tokens_per_min` already round-then-compares for the `<1000` boundary (with a comment explaining why) but repeated the bug one unit up and had no M tier. Same fix pattern applied one level up.
- `infrastructure/evidence/metric_summary.py` `_format_bytes` advances the unit while the **raw** amount `>= 1024` but renders at `.0f`/`.2f`, so `1023.5` → `"1024 B"` and `1_048_570.9` → `"1024.00 KiB"`. Now advances while `round(amount, precision) >= 1024` at the *current* unit's display precision (0 decimals for B, 2 for KiB and up), so an amount that would only round up to the boundary still rolls into the next unit.

No other formatter in the repo has this bug — `format_token_count_compact` (the #5179 reference) was already correct.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`, from the issue's own repro):
```
$ uv run python -c "
from surfaces.shared.terminal.components.token_format import format_token_count_short
for v in (999949, 999950, 2500000): print(v, '->', format_token_count_short(v))
from infrastructure.evidence.metric_summary import _format_bytes
for v in (1023.5, 1048570.9): print(v, '->', _format_bytes(v))
"
999949 -> 999.9k
999950 -> 1000.0k
2500000 -> 2500.0k
1023.5 -> 1024 B
1048570.9 -> 1024.00 KiB
```

After (this branch, plus `_format_tokens_per_min`):
```
$ uv run python3 -c "
from surfaces.shared.terminal.components.token_format import format_token_count_short
for v in (999949, 999950, 2500000): print(v, '->', format_token_count_short(v))
from infrastructure.evidence.metric_summary import _format_bytes
for v in (1023.5, 1048570.9): print(v, '->', _format_bytes(v))
from surfaces.shared.terminal.agents.agents_view import _format_tokens_per_min
for v in (999.4, 999.6, 999950.0, 2500000.0): print(v, '->', _format_tokens_per_min(v))
"
999949 -> 999.9k
999950 -> 1.0M
2500000 -> 2.5M
1023.5 -> 1.00 KiB
1048570.9 -> 1.00 MiB
999.4 -> 999
999.6 -> 1.0k
999950.0 -> 1.0M
2500000.0 -> 2.5M
```

Visible in the terminal surfaces this feeds: `/cost`, `/context`, `/fleet` (token counters, KiB/MiB formatting), and RCA evidence metric summaries.

```
$ uv run pytest tests/interactive_shell/ui/test_streaming.py::TestFormatTokenCountShort tests/tools/utils/test_metric_summary.py tests/shared/terminal/test_agents_view.py -q
43 passed in 1.81s

$ uv run pytest -k "format_token or format_bytes or magnitude or tokens_per_min" -q
6 passed, 16968 deselected in 9.97s

$ uv run ruff check <changed files> && uv run ruff format --check <changed files>
All checks passed! / 6 files already formatted

$ uv run mypy surfaces/shared/terminal/components/token_format.py surfaces/shared/terminal/agents/agents_view.py infrastructure/evidence/metric_summary.py
Success: no issues found in 3 source files
```

Note: `uv run mypy tests/interactive_shell/ui/test_streaming.py` reports 21 pre-existing errors unrelated to this change (an `_SpyMarkdown` monkeypatch pattern elsewhere in the file, lines 289-571) — confirmed identical on `main` before this PR's changes via `git stash`. The two new/extended test files I touched directly (`test_agents_view.py`, `test_metric_summary.py`) are clean.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

All three bugs share one root cause: a formatter picks its unit/tier by comparing the *raw* value against a boundary, then renders that value *rounded* to some fixed precision — so a value that rounds up to the boundary (but doesn't reach it) still gets classified into the lower tier and displays with one extra digit than the tier's format was designed for. The already-merged `format_token_count_compact` (#5179) fixed this for one formatter by branching on `round(value / 1000, 1) < 1000` instead of `value < 1_000_000`; I applied the same principle to the other three call sites, since they're independent functions with their own display conventions (some strip trailing `.0`, some don't) rather than shared code, so each needed its own fix rather than a shared helper extraction — that would have been a larger, more invasive refactor than a three-line bug fix warrants (AGENTS.md: don't introduce abstractions beyond what the task requires).

For `_format_bytes` specifically, the fix is slightly different in shape because it's a *loop* advancing through multiple tiers (B → KiB → MiB → GiB → TiB), not a single two-way branch: I round at each tier's own display precision (`.0f` for B, `.2f` for the rest) before deciding whether to advance, rather than rounding once at a fixed precision, since the precision itself changes per tier.

I did not touch `format_token_count_compact` itself (already correct) or introduce a shared "round-then-branch" helper across all four functions, since AGENTS.md's file-placement rules keep each surface's own display formatting local to that surface, and the four functions live in three different packages (`surfaces/shared/terminal/components/`, `surfaces/shared/terminal/agents/`, `infrastructure/evidence/`) with no existing shared formatting module between them.

Edge cases tested directly: for `_format_bytes`, a negative value (`-1023.5` → `"-1.00 KiB"`, confirming the sign-handling `abs()`/`signed` logic still works after rounding); for the token formatters, values both just under and just over each of the two tier boundaries.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions