### PR TITLE
fix(yandex-cloud): normalize the service id once at the top of execute_yc_operation

### DIFF
--- a/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_operation_tool/__init__.py
@@ -126,6 +126,12 @@ def execute_yc_operation(
     **credentials: Any,
 ) -> dict[str, Any]:
     """Read a Yandex Cloud resource."""
+    # Canonicalise once, up front: host resolution case-folds the service, so a
+    # caller-supplied "Compute" or "Resource-Manager" must read as the same
+    # service everywhere below (the index gate, the folder-scope exception, and
+    # what gets sent) as its lowercase form -- not as an unknown service to one
+    # check and the real thing to another.
+    service = canonical_service(service)
     # Checked here rather than only in the client: the synthetic-backend path
     # never reaches the client, and a read-only guarantee that depends on which
     # branch the call took is not a guarantee.
@@ -144,11 +150,8 @@ def execute_yc_operation(
     # path that Yandex binds to GET, or a path the generator never listed.
     # Unknown services still fall through to the client, which names them as
     # unknown. A known service with a path the index does not list is refused
-    # here so a well-formed write never reaches the network. Canonicalise first:
-    # the caller may use the name the tools and the registry use, and asking the
-    # index about a name it does not carry would read as "unknown service" and
-    # skip the check.
-    if canonical_service(service) in known_services() and lookup(service, path) is None:
+    # here so a well-formed write never reaches the network.
+    if service in known_services() and lookup(service, path) is None:
         return {
             "success": False,
             "service": service,

--- a/tests/integrations/test_yc_operation_single_resource.py
+++ b/tests/integrations/test_yc_operation_single_resource.py
@@ -114,6 +114,25 @@ class TestFolderScope:
         assert "folderId" not in backend.query
         assert backend.query["cloudId"] == "b1gcloud"
 
+    def test_no_folder_is_added_however_resource_manager_is_spelled(self) -> None:
+        """Host resolution case-folds the service, so the folder-scope
+        exception must too -- otherwise a case-variant "Resource-Manager"
+        defeats it and gets a stray folderId injected, which Yandex answers
+        with a bare 404.
+        """
+        backend = _RecordingBackend()
+        tool = get_registered_tool_map()["execute_yc_operation"]
+        tool.run(
+            service="Resource-Manager",
+            path="/resource-manager/v1/folders",
+            params={"cloudId": "b1gcloud"},
+            yc_backend=backend,
+            folder_id="b1gtest",
+        )
+
+        assert "folderId" not in backend.query
+        assert backend.query["cloudId"] == "b1gcloud"
+
     def test_a_caller_scoping_by_cloud_is_left_alone(self) -> None:
         """cloudId means the caller already chose a scope, whatever the service."""
         backend = _RecordingBackend()


### PR DESCRIPTION
Fixes #5321

#### Describe the changes you have made in this PR -

`execute_yc_operation` checks its GET-only index allowlist and the Resource Manager folder-scope exception with the raw caller-supplied service id, but the client resolves the API host case-insensitively (`resolve_endpoint` lowercases). The index-gate half of this was already fixed on `main` (via `canonical_service(service) in known_services()`, with `lookup()` also canonicalizing internally, and a regression test — `test_the_gate_holds_however_the_service_is_spelled`). The remaining gap: `accepts_folder_scope(service)` still compared the raw string, so a case-variant `"Resource-Manager"` defeated the exception, got a stray `folderId` injected into an otherwise-valid folders list, and Yandex answered with a bare 404.

Fix: canonicalize `service = canonical_service(service)` once at the top of the function — the one entry point that accepts an arbitrary caller-supplied service string — so the index gate, `accepts_folder_scope`, and everything sent downstream (to `yc_backend` or the real client) all see the same id. This also let me drop the now-redundant `canonical_service(...)` call at the gate-check line, since `service` is already canonical by that point.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`, the still-live half of the issue's repro):
```
$ uv run python -c "
from integrations.yandex_cloud.rest_client import accepts_folder_scope
print(accepts_folder_scope('Resource-Manager'))
"
True
```

After (this branch):
```
$ uv run python3 -c "
from integrations.yandex_cloud.api_index import canonical_service
from integrations.yandex_cloud.rest_client import accepts_folder_scope
print(accepts_folder_scope(canonical_service('Resource-Manager')))
"
False
```

```
$ uv run pytest tests/integrations/test_yc_operation_single_resource.py tests/integrations/test_yc_operation_tool.py -q
52 passed in 2.24s

$ uv run pytest -k "yandex or yc_operation" -q
166 passed, 16793 deselected in 11.37s

$ uv run ruff check integrations/yandex_cloud/tools/yc_operation_tool/__init__.py tests/integrations/test_yc_operation_single_resource.py
All checks passed!

$ uv run ruff format --check integrations/yandex_cloud/tools/yc_operation_tool/__init__.py tests/integrations/test_yc_operation_single_resource.py
2 files already formatted

$ uv run mypy integrations/yandex_cloud/tools/yc_operation_tool/__init__.py tests/integrations/test_yc_operation_single_resource.py
Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Before touching anything, I re-ran the issue's exact repro against current `main` to confirm what was still broken — the index-gate half (`"Compute" in known_services()`) was already fixed, with `canonical_service()` doing `.strip().lower()` plus alias resolution and already wired into both the gate check and `lookup()`. Only the `accepts_folder_scope` call site was still passing the raw, un-canonicalized `service`.

Rather than patch just that one call site with a local `.lower()`, I moved the canonicalization to the top of the function, matching the issue's own proposed fix ("normalize `service` at the top of `execute_yc_operation` — the one entry point that accepts an arbitrary caller-supplied service string") and using the project's own `canonical_service` helper (which already handles aliasing, not just casing) instead of a plain `.lower()`. This means every use of `service` for the rest of the function body — the gate check, the folder-scope exception, and the value forwarded to the backend/client — operates on one consistent, already-canonical value, so no future call site added below can reintroduce the same class of bug by forgetting to canonicalize.

One behavioral note I considered: the function's error responses echo `"service": service` back to the caller. After this change, a caller passing `"Compute"` gets back `"service": "compute"` in an error payload instead of the original casing. I judged this acceptable and arguably more correct — the response should reflect what was actually treated as the service (the same value used to resolve the host and check the gate), not the arbitrary casing the caller happened to type. No test asserts on the raw-casing echo of that field, so this is not a behavior change any existing consumer depends on.

Key file: `integrations/yandex_cloud/tools/yc_operation_tool/__init__.py`, `execute_yc_operation` — the one function this bug lives in. `canonical_service`, `known_services`, `lookup`, and `accepts_folder_scope` (in `integrations/yandex_cloud/api_index.py` and `integrations/yandex_cloud/rest_client.py`) are all pre-existing and untouched; only the call site's inputs changed.

Edge case tested directly: `test_no_folder_is_added_however_resource_manager_is_spelled` runs `execute_yc_operation` end-to-end with `service="Resource-Manager"` (not lowercase) against a recording backend and asserts no `folderId` is injected — the exact failure mode from the issue, not just a unit check on `accepts_folder_scope` in isolation.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions