### PR TITLE
fix(slack): convert scheduled deliveries to mrkdwn before posting

### DIFF
--- a/integrations/slack/scheduled_delivery.py
+++ b/integrations/slack/scheduled_delivery.py
@@ -13,6 +13,7 @@ from infrastructure.scheduling.scheduler.delivery import (
 )
 from infrastructure.scheduling.scheduler.types import ScheduledTask
 from integrations.slack.delivery import send_slack_webhook_message
+from integrations.slack.formatting import markdown_to_slack_mrkdwn
 
 
 class SlackScheduledDelivery:
@@ -42,7 +43,10 @@ class SlackScheduledDelivery:
                 return False, "Missing chat_id or webhook_url for Slack delivery", ""
             return False, "Scheduled tasks require Slack bot access_token for chat_id delivery", ""
 
-        plain_message = strip_html(message)
+        # Strip any stray HTML first, then convert Markdown to mrkdwn -- the
+        # reverse order would have strip_html's <tag> regex eat the <url|label>
+        # links markdown_to_slack_mrkdwn just produced.
+        plain_message = markdown_to_slack_mrkdwn(strip_html(message))
 
         if access_token and chat_id:
             headers = {

--- a/tests/integrations/slack/test_scheduled_delivery.py
+++ b/tests/integrations/slack/test_scheduled_delivery.py
@@ -1,0 +1,68 @@
+"""Scheduled Slack deliveries must convert Markdown to mrkdwn before posting.
+
+Regression: the Telegram sibling converts Markdown to its channel's format
+(``markdown_to_telegram_html``), but the Slack adapter only stripped HTML tags
+and posted the LLM's raw Markdown verbatim -- ``**bold**``, ``## headings``,
+and ``[label](url)`` rendered literally in Slack.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+from integrations.slack.scheduled_delivery import SlackScheduledDelivery
+
+_MARKDOWN_MESSAGE = "## Loop report\n**3 pods failing** — see [runbook](https://example.com/rb)"
+_EXPECTED_MRKDWN = "*Loop report*\n*3 pods failing* — see <https://example.com/rb|runbook>"
+
+
+def _task(*, chat_id: str = "") -> ScheduledTask:
+    return ScheduledTask(
+        kind=TaskKind.DAILY_SUMMARY,
+        cron="0 9 * * *",
+        provider=Provider.SLACK,
+        chat_id=chat_id,
+    )
+
+
+def test_webhook_delivery_converts_markdown_to_mrkdwn() -> None:
+    with (
+        patch(
+            "integrations.slack.scheduled_delivery.resolve_slack_credentials",
+            return_value={"webhook_url": "https://hooks.slack.com/services/T/B/x"},
+        ),
+        patch(
+            "integrations.slack.scheduled_delivery.send_slack_webhook_message",
+            return_value=(True, ""),
+        ) as mock_hook,
+    ):
+        ok, error, _ts = SlackScheduledDelivery().deliver(_task(), _MARKDOWN_MESSAGE)
+
+    assert ok is True
+    assert error == ""
+    sent_text = mock_hook.call_args.args[0]
+    assert sent_text == _EXPECTED_MRKDWN
+    assert "**" not in sent_text
+    assert "##" not in sent_text
+
+
+def test_bot_token_delivery_converts_markdown_to_mrkdwn() -> None:
+    with (
+        patch(
+            "integrations.slack.scheduled_delivery.resolve_slack_credentials",
+            return_value={"access_token": "xoxb-test"},
+        ),
+        patch("integrations.slack.scheduled_delivery.post_json") as mock_post,
+    ):
+        mock_post.return_value.ok = True
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.data = {"ok": True, "ts": "123.456"}
+
+        ok, error, ts = SlackScheduledDelivery().deliver(_task(chat_id="C123"), _MARKDOWN_MESSAGE)
+
+    assert ok is True
+    assert error == ""
+    assert ts == "123.456"
+    sent_payload = mock_post.call_args.kwargs["payload"]
+    assert sent_payload["text"] == _EXPECTED_MRKDWN

--- a/tests/integrations/slack/test_scheduled_delivery.py
+++ b/tests/integrations/slack/test_scheduled_delivery.py
@@ -8,6 +8,7 @@ and ``[label](url)`` rendered literally in Slack.
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from unittest.mock import patch
 
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
@@ -56,7 +57,7 @@ def test_bot_token_delivery_converts_markdown_to_mrkdwn() -> None:
         patch("integrations.slack.scheduled_delivery.post_json") as mock_post,
     ):
         mock_post.return_value.ok = True
-        mock_post.return_value.status_code = 200
+        mock_post.return_value.status_code = HTTPStatus.OK
         mock_post.return_value.data = {"ok": True, "ts": "123.456"}
 
         ok, error, ts = SlackScheduledDelivery().deliver(_task(chat_id="C123"), _MARKDOWN_MESSAGE)


### PR DESCRIPTION
Fixes #5314

#### Describe the changes you have made in this PR -

`SlackScheduledDelivery.deliver` (`integrations/slack/scheduled_delivery.py`) only stripped HTML tags before posting the LLM's Markdown, so `**bold**`, `## headings`, and `[label](url)` rendered literally in Slack — for both the `chat.postMessage` and webhook branches, which share `plain_message`. The Telegram sibling (`integrations/telegram/scheduled_delivery.py`) already converts Markdown to its channel's format via `markdown_to_telegram_html`; the gateway's Slack turn path already converts via `markdown_to_slack_mrkdwn` (`gateway/transports/slack/delivery/turn_output.py`) — the scheduler's Slack path was the one delivery route that skipped conversion.

Fix: run the stripped message through `markdown_to_slack_mrkdwn` — `strip_html` first, then the mrkdwn conversion, in that order, since the reverse order would let `strip_html`'s `<[^>]+>` regex eat the `<url|label>` link syntax `markdown_to_slack_mrkdwn` just produced.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`, from the issue's own repro, adapted to the current module path — the issue references an older `platform/scheduling/scheduler/executor.py`; the delivery logic now lives in `integrations/slack/scheduled_delivery.py` / `integrations/telegram/scheduled_delivery.py`):
```
$ uv run python -c "
from infrastructure.scheduling.scheduler.delivery import strip_html
msg = '## Loop report\n**3 pods failing** — see [runbook](https://example.com/rb)'
print(repr(strip_html(msg)))
"
'## Loop report\n**3 pods failing** — see [runbook](https://example.com/rb)'
```

After (this branch):
```
$ uv run python3 -c "
from infrastructure.scheduling.scheduler.delivery import strip_html
from integrations.slack.formatting import markdown_to_slack_mrkdwn
msg = '## Loop report\n**3 pods failing** — see [runbook](https://example.com/rb)'
print(repr(markdown_to_slack_mrkdwn(strip_html(msg))))
"
'*Loop report*\n*3 pods failing* — see <https://example.com/rb|runbook>'
```

Same output the gateway's Slack turn path already produces for the identical input.

```
$ uv run pytest tests/integrations/slack/test_scheduled_delivery.py -q
2 passed in 1.78s

$ uv run pytest tests/scheduler/ -q
177 passed in 1.97s

$ uv run pytest -k "slack and (scheduled or delivery)" -q
96 passed, 16864 deselected in 9.81s

$ uv run ruff check integrations/slack/scheduled_delivery.py tests/integrations/slack/test_scheduled_delivery.py
All checks passed!

$ uv run ruff format --check integrations/slack/scheduled_delivery.py tests/integrations/slack/test_scheduled_delivery.py
2 files already formatted

$ uv run mypy integrations/slack/scheduled_delivery.py tests/integrations/slack/test_scheduled_delivery.py
Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue's own repro pointed at `platform/scheduling/scheduler/executor.py`, which no longer exists on `main` — the per-provider `_deliver_*` functions the issue described have since been refactored into one adapter class per vendor (`integrations/<vendor>/scheduled_delivery.py`, e.g. `SlackScheduledDelivery`, `TelegramScheduledDelivery`). I confirmed the bug is still present in the current code by reading both siblings directly: `TelegramScheduledDelivery.deliver` converts (`markdown_to_telegram_html`), `SlackScheduledDelivery.deliver` only had `strip_html` — same asymmetry the issue describes, just relocated.

The fix itself is the one-line change the issue proposes, but I paid attention to *ordering*: `strip_html` uses the regex `<[^>]+>`, and `markdown_to_slack_mrkdwn` converts `[label](url)` into Slack's `<url|label>` angle-bracket syntax. Composing them as `strip_html(markdown_to_slack_mrkdwn(message))` (mrkdwn first) would have `strip_html` immediately delete the `<url|label>` link the conversion just built, silently reintroducing a stripped-link bug alongside fixing the formatting one — so the order has to be `markdown_to_slack_mrkdwn(strip_html(message))`, stripping any stray HTML from the raw LLM Markdown *before* Slack's own bracket syntax exists in the string. I verified this by running both orderings against the exact repro and confirming only one preserves the `<https://example.com/rb|runbook>` link.

No existing test covered `SlackScheduledDelivery` or `TelegramScheduledDelivery` directly (only the executor's fan-out/routing, via a fake adapter bundle) — I added `tests/integrations/slack/test_scheduled_delivery.py` with a direct unit test per branch (bot-token `chat.postMessage` and incoming webhook), each asserting the *exact* posted payload text matches the mrkdwn-converted string, not just that delivery succeeded — since a test only checking `ok is True` would pass identically whether or not the conversion ran.

Key files: `integrations/slack/scheduled_delivery.py` (`SlackScheduledDelivery.deliver`, the one function this bug lives in) and the new test file. `markdown_to_slack_mrkdwn` (`integrations/slack/formatting.py`) is pre-existing and untouched — already used and tested by the gateway's Slack turn path.

Edge case tested directly: both delivery branches (webhook and bot-token), since they independently build their payload from the shared `plain_message` and either could regress separately.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions