### PR TITLE
fix(integrations): mark bitbucket and supabase as directly effective

### DIFF
--- a/integrations/effective_models.py
+++ b/integrations/effective_models.py
@@ -62,6 +62,7 @@ class EffectiveIntegrations(StrictConfigModel):
     postgresql: EffectiveIntegrationEntry | None = None
     azure_sql: EffectiveIntegrationEntry | None = None
     bitbucket: EffectiveIntegrationEntry | None = None
+    supabase: EffectiveIntegrationEntry | None = None
     trello: EffectiveIntegrationEntry | None = None
     discord: EffectiveIntegrationEntry | None = None
     telegram: EffectiveIntegrationEntry | None = None

--- a/integrations/registry.py
+++ b/integrations/registry.py
@@ -291,7 +291,7 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
         setup_order=21,
         verify_order=14,
     ),
-    IntegrationSpec(service="bitbucket", has_verifier=True, verify_order=24),
+    IntegrationSpec(service="bitbucket", has_verifier=True, direct_effective=True, verify_order=24),
     IntegrationSpec(
         service="snowflake",
         has_verifier=True,
@@ -417,6 +417,7 @@ _BUILTIN_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(
         service="supabase",
         has_verifier=True,
+        direct_effective=True,
         verify_order=99,
     ),
     IntegrationSpec(

--- a/integrations/supabase/verifier.py
+++ b/integrations/supabase/verifier.py
@@ -4,11 +4,30 @@ from __future__ import annotations
 
 from typing import Any
 
-from integrations.supabase import build_supabase_config, validate_supabase_config
+from integrations.supabase import (
+    SupabaseConfig,
+    build_supabase_config,
+    resolve_supabase_config,
+    validate_supabase_config,
+)
 from integrations.verification import (
     register_verifier,
     verify_with_validation_result,
 )
+
+
+def _build_verified_config(config: dict[str, Any]) -> SupabaseConfig:
+    """Build a config to verify from the resolved effective entry.
+
+    ``resolve_effective_integrations`` publishes Supabase as ``project_url``
+    only -- the service key never appears in a resolved config, by design, so
+    ``build_supabase_config`` can't validate this shape directly. Re-resolve
+    the full credentials from the store/env the same way the tools do.
+    """
+    project_url = str(config.get("project_url") or "").strip()
+    if project_url:
+        return resolve_supabase_config(project_url)
+    return build_supabase_config(config)
 
 
 @register_verifier("supabase")
@@ -17,6 +36,6 @@ def verify_supabase(source: str, config: dict[str, Any]) -> dict[str, str]:
         "supabase",
         source,
         config,
-        build_config=build_supabase_config,
+        build_config=_build_verified_config,
         validate_config=validate_supabase_config,
     )

--- a/tests/integrations/test_catalog_multi_instance.py
+++ b/tests/integrations/test_catalog_multi_instance.py
@@ -355,3 +355,49 @@ def test_resolve_effective_integrations_publishes_store_configured_prefect() -> 
     assert "prefect" in resolved
     assert resolved["prefect"]["source"] == "local store"
     assert resolved["prefect"]["config"]["api_url"] == "http://localhost:4200/api"
+
+
+def test_resolve_effective_integrations_publishes_store_configured_bitbucket() -> None:
+    """Same bug as prefect (#5147/#5216): bitbucket's spec was missing
+    direct_effective=True, so a store-saved bitbucket integration classified
+    correctly but resolve_effective_integrations() silently dropped it.
+    """
+    from integrations.catalog import resolve_effective_integrations
+
+    store_record = {
+        "id": "bitbucket-1",
+        "service": "bitbucket",
+        "status": "active",
+        "credentials": {
+            "workspace": "acme",
+            "username": "bot",
+            "app_password": "secret",
+        },
+    }
+    resolved = resolve_effective_integrations(store_integrations=[store_record])
+    assert "bitbucket" in resolved
+    assert resolved["bitbucket"]["source"] == "local store"
+    assert resolved["bitbucket"]["config"]["workspace"] == "acme"
+
+
+def test_resolve_effective_integrations_publishes_store_configured_supabase() -> None:
+    """Same bug as prefect (#5147/#5216): supabase's spec was missing
+    direct_effective=True. Unlike bitbucket, supabase's classify() publishes
+    only project_url (the service key never appears in a resolved config) --
+    that reduced shape is the input the supabase verifier must handle.
+    """
+    from integrations.catalog import resolve_effective_integrations
+
+    store_record = {
+        "id": "supabase-1",
+        "service": "supabase",
+        "status": "active",
+        "credentials": {"url": "https://proj.supabase.co", "service_key": "secret"},
+    }
+    resolved = resolve_effective_integrations(store_integrations=[store_record])
+    assert "supabase" in resolved
+    assert resolved["supabase"]["source"] == "local store"
+    assert resolved["supabase"]["config"] == {
+        "project_url": "https://proj.supabase.co",
+        "integration_id": "supabase-1",
+    }

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -74,7 +74,6 @@ def test_registry_preserves_aliases_and_special_case_buckets() -> None:
     assert "slack" not in SKIP_CLASSIFIED_SERVICES
     assert "slack" in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
     assert "grafana" in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
-    assert "bitbucket" not in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES
 
 
 def test_railway_is_registered_as_a_configurable_verified_integration() -> None:
@@ -107,6 +106,19 @@ def test_prefect_is_registered_as_a_directly_effective_integration() -> None:
     assert prefect.has_verifier is True
     assert prefect.direct_effective is True
     assert "prefect" not in SKIP_CLASSIFIED_SERVICES
+
+
+def test_bitbucket_and_supabase_are_registered_as_directly_effective() -> None:
+    # Same bug as prefect (#5147/#5216): both classify() correctly, but their
+    # specs were missing direct_effective=True, so a store-saved bitbucket or
+    # supabase integration silently never resolved via
+    # resolve_effective_integrations() -- breaking `opensre integrations
+    # verify bitbucket|supabase` and the tools' is_available() checks.
+    for service in ("bitbucket", "supabase"):
+        spec = next(s for s in INTEGRATION_SPECS if s.service == service)
+        assert spec.has_verifier is True
+        assert spec.direct_effective is True
+        assert service not in SKIP_CLASSIFIED_SERVICES
 
 
 def test_resolve_management_service_keeps_posthog_and_posthog_mcp_distinct() -> None:

--- a/tests/integrations/test_supabase.py
+++ b/tests/integrations/test_supabase.py
@@ -143,6 +143,63 @@ class TestResolveSupabaseConfig:
 
 
 # ---------------------------------------------------------------------------
+# verify_supabase — re-resolving the reduced effective config
+# ---------------------------------------------------------------------------
+
+
+class TestVerifySupabase:
+    """Regression: resolve_effective_integrations publishes Supabase as
+    ``{"project_url": ..., "integration_id": ...}`` -- the service key never
+    appears in a resolved config, by design. Feeding that shape straight into
+    build_supabase_config raised a pydantic "Unexpected field" error (the
+    model forbids extras), which verify_with_validation_result reported as
+    "missing" even with valid store credentials.
+    """
+
+    def test_reresolves_credentials_from_env_for_the_reduced_shape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from integrations.supabase.verifier import verify_supabase
+
+        monkeypatch.setenv("SUPABASE_URL", "https://proj.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_KEY", "svc")
+
+        with patch("integrations.supabase._make_request", return_value=(200, {})):
+            result = verify_supabase(
+                "local env", {"project_url": "https://proj.supabase.co", "integration_id": ""}
+            )
+
+        assert result["status"] == "passed"
+
+    def test_reduced_shape_without_matching_credentials_reports_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+        with patch("integrations.store.load_integrations", return_value=[]):
+            from integrations.supabase.verifier import verify_supabase
+
+            result = verify_supabase(
+                "local store", {"project_url": "https://proj.supabase.co", "integration_id": "x"}
+            )
+
+        assert result["status"] == "missing"
+
+    def test_a_full_config_without_project_url_still_validates_directly(self) -> None:
+        """Not every caller goes through the reduced effective shape -- a full
+        url/service_key dict must still build normally."""
+        from integrations.supabase.verifier import verify_supabase
+
+        with patch("integrations.supabase._make_request", return_value=(200, {})):
+            result = verify_supabase(
+                "local env",
+                {"url": "https://proj.supabase.co", "service_key": "svc"},
+            )
+
+        assert result["status"] == "passed"
+
+
+# ---------------------------------------------------------------------------
 # Availability and param extraction
 # ---------------------------------------------------------------------------
 

--- a/tests/integrations/test_supabase.py
+++ b/tests/integrations/test_supabase.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
 
@@ -164,7 +165,7 @@ class TestVerifySupabase:
         monkeypatch.setenv("SUPABASE_URL", "https://proj.supabase.co")
         monkeypatch.setenv("SUPABASE_SERVICE_KEY", "svc")
 
-        with patch("integrations.supabase._make_request", return_value=(200, {})):
+        with patch("integrations.supabase._make_request", return_value=(HTTPStatus.OK, {})):
             result = verify_supabase(
                 "local env", {"project_url": "https://proj.supabase.co", "integration_id": ""}
             )
@@ -190,7 +191,7 @@ class TestVerifySupabase:
         url/service_key dict must still build normally."""
         from integrations.supabase.verifier import verify_supabase
 
-        with patch("integrations.supabase._make_request", return_value=(200, {})):
+        with patch("integrations.supabase._make_request", return_value=(HTTPStatus.OK, {})):
             result = verify_supabase(
                 "local env",
                 {"url": "https://proj.supabase.co", "service_key": "svc"},


### PR DESCRIPTION
Fixes #5304

#### Describe the changes you have made in this PR -

`bitbucket` and `supabase` have the exact bug already fixed for prefect in #5147/#5216: both register classifiers (`integrations/_catalog_impl.py`) and env loaders, so `classify_integrations()` resolves their saved credentials correctly — but `resolve_effective_integrations()` only publishes services listed in `DIRECT_CLASSIFIED_EFFECTIVE_SERVICES`, which is built entirely from `spec.direct_effective`. Neither `IntegrationSpec` carried the flag, so a bitbucket or supabase record saved in the local store (or configured via `BITBUCKET_WORKSPACE…` / `SUPABASE_URL`+`SUPABASE_SERVICE_KEY` env vars) never resolved into an effective config — `opensre integrations verify bitbucket|supabase` always reported "missing" even with valid credentials, which also makes the open verification tasks #5109 and #5161 unfulfillable as-is.

Changes, mirroring #5216:
- `integrations/registry.py`: `direct_effective=True` on both specs.
- `integrations/effective_models.py`: added the missing `supabase` field to `EffectiveIntegrations` (bitbucket's was already there) — every other built-in service has its own field here for typo protection, even though the model's `extra="allow"` means nothing would silently break without it.
- `integrations/supabase/verifier.py`: **the one place bitbucket and supabase diverge.** Bitbucket's `classify()` returns the full config (workspace/username/app_password), so the registry flag alone is a complete, one-line fix there. Supabase's `classify()` deliberately publishes only `{"project_url": ..., "integration_id": ...}` — the service key never appears in a resolved config, by design — so feeding that reduced shape straight into `build_supabase_config` (a `StrictConfigModel`, `extra="forbid"`) raised a pydantic "Unexpected field 'project_url'" error, which `verify_with_validation_result` caught and reported as `"missing"` — the *right* status by accident, for the *wrong* reason, that would have looked like "the fix didn't work" without inspecting the detail message. `verify_supabase` now recognizes that shape and re-resolves full credentials via `resolve_supabase_config` (the same store/env lookup the Supabase tools already use), falling back to the direct `build_supabase_config` path for any other config shape.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`):
```
$ uv run python -c "
from integrations.catalog import resolve_effective_integrations
resolved = resolve_effective_integrations(store_integrations=[{
    'id': 'bb-1', 'service': 'bitbucket', 'status': 'active',
    'credentials': {'workspace': 'acme', 'username': 'bot', 'app_password': 'secret'},
}])
print('bitbucket' in resolved)
"
False
```

After (this branch):
```
$ uv run python3 -c "
from integrations.catalog import resolve_effective_integrations
from integrations.supabase.verifier import verify_supabase

resolved = resolve_effective_integrations(store_integrations=[{
    'id': 'bb-1', 'service': 'bitbucket', 'status': 'active',
    'credentials': {'workspace': 'acme', 'username': 'bot', 'app_password': 'secret'},
}])
print('bitbucket:', resolved.get('bitbucket'))

resolved2 = resolve_effective_integrations(store_integrations=[{
    'id': 'sb-1', 'service': 'supabase', 'status': 'active',
    'credentials': {'url': 'https://proj.supabase.co', 'service_key': 'secret'},
}])
print('supabase:', resolved2.get('supabase'))
"
bitbucket: {'source': 'local store', 'config': {'workspace': 'acme', 'app_password': 'secret', 'username': 'bot', 'base_url': 'https://api.bitbucket.org/2.0', 'timeout_seconds': 10.0, 'max_results': 25, 'integration_id': 'bb-1'}}
supabase: {'source': 'local store', 'config': {'project_url': 'https://proj.supabase.co', 'integration_id': 'sb-1'}}
```

And, with the store lookup mocked so `resolve_supabase_config` sees the same record (a real `opensre integrations verify supabase` reads the actual on-disk store):
```
$ uv run python3 -c "
from unittest.mock import patch
from integrations.catalog import resolve_effective_integrations
from integrations.supabase.verifier import verify_supabase

record = {'id': 'sb-1', 'service': 'supabase', 'status': 'active',
          'credentials': {'url': 'https://proj.supabase.co', 'service_key': 'secret'}}
resolved = resolve_effective_integrations(store_integrations=[record])
with patch('integrations.store.load_integrations', return_value=[record]):
    print(verify_supabase(resolved['supabase']['source'], resolved['supabase']['config']))
"
{'service': 'supabase', 'source': 'local store', 'status': 'failed', 'detail': 'Supabase connection failed: [Errno 8] nodename nor servname provided, or not known'}
```
Status moved from a validation-error "missing" to a real connection attempt (`failed` here only because `proj.supabase.co` isn't a real reachable host in this sandbox) — confirming the credentials were found and used, not skipped.

```
$ uv run pytest tests/integrations/test_registry.py tests/integrations/test_catalog_multi_instance.py tests/integrations/test_supabase.py -q
69 passed in 1.90s

$ uv run pytest -k "bitbucket or supabase or effective_integrations or effective_models" -q
170 passed, 16794 deselected in 11.15s

$ uv run pytest tests/integrations/ -q
3873 passed, 8 skipped in 55.45s

$ uv run ruff check <changed files> && uv run ruff format --check <changed files>
All checks passed! / 6 files already formatted

$ uv run mypy integrations/registry.py integrations/effective_models.py integrations/supabase/verifier.py tests/integrations/test_registry.py tests/integrations/test_catalog_multi_instance.py tests/integrations/test_supabase.py
Success: no issues found in 6 source files
```

Note: one pre-existing test (`test_registry_preserves_aliases_and_special_case_buckets`) asserted `"bitbucket" not in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES` — i.e. it pinned the bug as expected behavior. Removed that line (the new `test_bitbucket_and_supabase_are_registered_as_directly_effective` now covers this directly); the rest of that test (aliasing, slack/grafana's own `direct_effective` status) is untouched.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I started from the #5216 precedent (the merged prefect fix) since the issue explicitly names it as "the exact bug." Adding `direct_effective=True` to both specs and re-running the resolution confirmed bitbucket now resolves cleanly end-to-end — its `classify()` returns a full config object, so there was nothing else to fix there.

Supabase failed differently: `resolve_supabase_config`/`build_supabase_config` already existed in the codebase (the former specifically documented as "credentials are resolved internally and never appear in tool signatures" — a deliberate security boundary for LLM-facing tools), and `supabase/__init__.py`'s `classify()` already returns only `{"project_url", "integration_id"}` by the same design. I traced why `verify_supabase` then broke: `SupabaseConfig` extends `StrictConfigModel` (`extra="forbid"`), so `build_supabase_config({"project_url": ..., "integration_id": ...})` raises a pydantic validation error for the unrecognized `project_url` field — caught by `verify_with_validation_result`'s try/except and reported as `"missing"`, which is misleading: the integration *is* configured, the verifier just can't see it through the reduced shape it was handed.

I considered changing `classify()` to publish the full config for supabase (matching bitbucket), but that would leak the service key into every effective-integrations dump and diagnostic surface that reads this dict — a real security regression for the sake of a smaller diff. Instead I added `_build_verified_config` as the verifier's own `build_config` callback: it detects the reduced shape (`project_url` present) and calls `resolve_supabase_config` — the exact function the Supabase tools already use for the same "LLM knows the URL, not the secret" pattern — to re-hydrate the full config from the store/env before validating. A config that already carries `url`/`service_key` directly (any other caller of this verifier) still goes straight to `build_supabase_config`, unchanged.

Key files: `integrations/registry.py` (the two `IntegrationSpec` entries), `integrations/effective_models.py` (the missing `supabase` field — a pure documentation/typo-safety addition, `extra="allow"` means it wasn't strictly required), and `integrations/supabase/verifier.py` (`_build_verified_config`, the one new function).

Edge case tested directly: `test_reduced_shape_without_matching_credentials_reports_missing` confirms the re-resolution path still correctly reports `"missing"` (not a crash) when no matching store/env credentials exist, and `test_a_full_config_without_project_url_still_validates_directly` confirms the fallback path for a caller that already has the full config.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions