### PR TITLE
fix(version): reproducible dev build identity from commit date

### DIFF
--- a/config/runtime_metadata/build_info.py
+++ b/config/runtime_metadata/build_info.py
@@ -175,117 +175,24 @@ def _parse_committer_date(commit_object: bytes) -> datetime | None:
     return None
 
 
-_PACK_IDX_MAGIC = b"\xfftOc"
-_PACK_IDX_V2 = 2
-_PACK_OBJ_COMMIT = 1
-_PACK_LARGE_OFFSET_FLAG = 0x80000000
-_VARINT_CONTINUE = 0x80
-
-
-def _read_loose_commit_object(commondir: Path, sha: str) -> bytes | None:
-    """Inflated loose object bytes for *sha*, or ``None`` when not stored loose."""
-    loose_object = commondir / "objects" / sha[:2] / sha[2:]
-    if not loose_object.is_file():
-        return None
-    try:
-        return zlib.decompress(loose_object.read_bytes())
-    except (OSError, zlib.error):
-        return None
-
-
-def _find_object_offset_in_pack_idx(idx_path: Path, sha_bytes: bytes) -> int | None:
-    """Byte offset of *sha_bytes* within the paired pack, via its v2 idx, or ``None``."""
-    try:
-        data = idx_path.read_bytes()
-    except OSError:
-        return None
-    if data[:4] != _PACK_IDX_MAGIC or int.from_bytes(data[4:8], "big") != _PACK_IDX_V2:
-        return None  # only the modern idx v2 layout is parsed
-    fanout = 8
-    sha_table = fanout + 256 * 4
-    count = int.from_bytes(data[fanout + 255 * 4 : sha_table], "big")
-    first = sha_bytes[0]
-    lo = int.from_bytes(data[fanout + (first - 1) * 4 : fanout + first * 4], "big") if first else 0
-    hi = int.from_bytes(data[fanout + first * 4 : fanout + (first + 1) * 4], "big")
-    index = next(
-        (i for i in range(lo, hi) if data[sha_table + i * 20 : sha_table + (i + 1) * 20] == sha_bytes),
-        None,
-    )
-    if index is None:
-        return None
-    small_offsets = sha_table + count * 20 + count * 4  # after the sha and crc32 tables
-    packed = int.from_bytes(data[small_offsets + index * 4 : small_offsets + (index + 1) * 4], "big")
-    if not packed & _PACK_LARGE_OFFSET_FLAG:
-        return packed
-    large = small_offsets + count * 4 + (packed & ~_PACK_LARGE_OFFSET_FLAG) * 8
-    return int.from_bytes(data[large : large + 8], "big")
-
-
-def _read_pack_commit_at(pack_path: Path, offset: int) -> bytes | None:
-    """Inflated bytes of the object at *offset* when it is a base commit, else ``None``.
-
-    Deltified objects (their type is ofs/ref-delta, not commit) are skipped —
-    reconstructing them needs base resolution, and a tip commit is virtually
-    never stored as a delta.
-    """
-    try:
-        with pack_path.open("rb") as pack:
-            pack.seek(offset)
-            header = pack.read(1)
-            if not header:
-                return None
-            obj_type = (header[0] >> 4) & 0x7
-            while header[0] & _VARINT_CONTINUE:  # consume the size varint header
-                header = pack.read(1)
-                if not header:
-                    return None
-            if obj_type != _PACK_OBJ_COMMIT:
-                return None
-            stream = pack.read()  # zlib stops at the object's stream end
-    except OSError:
-        return None
-    try:
-        return zlib.decompress(stream)
-    except zlib.error:
-        return None
-
-
-def _read_packed_commit_object(commondir: Path, sha: str) -> bytes | None:
-    """Inflated bytes of *sha* from any pack that holds it as a base commit."""
-    pack_dir = commondir / "objects" / "pack"
-    if not pack_dir.is_dir():
-        return None
-    try:
-        sha_bytes = bytes.fromhex(sha)
-    except ValueError:
-        return None
-    for idx_path in sorted(pack_dir.glob("*.idx")):
-        offset = _find_object_offset_in_pack_idx(idx_path, sha_bytes)
-        if offset is None:
-            continue
-        commit = _read_pack_commit_at(idx_path.with_suffix(".pack"), offset)
-        if commit is not None:
-            return commit
-    return None
-
-
 def read_git_head_commit_date(layout: GitLayout) -> datetime | None:
-    """UTC date of the HEAD commit, read from its git object, or ``None``.
+    """UTC date of the HEAD commit, read from its loose object, or ``None``.
 
     Reproducible per commit — the committer timestamp is baked into the object,
-    unlike wall-clock time — and storage-independent: the object is read whether
-    it is loose or packed, so packing (``git gc``) does not change the build
-    identity. Returns ``None`` only when the object is genuinely unreadable (a
-    full 40-char sha is required to address a pack), so callers fall back to a
-    date-less identity rather than a date that drifts by run.
+    unlike wall-clock time. Returns ``None`` when the object is packed or
+    unreadable, so callers fall back to a date-less build identity rather than a
+    date that drifts by run.
     """
     sha = read_git_head_full_sha(layout)
-    if sha is None or len(sha) != 40:
+    if sha is None or len(sha) < 3:
         return None
-    commit_object = _read_loose_commit_object(layout.commondir, sha) or _read_packed_commit_object(
-        layout.commondir, sha
-    )
-    return _parse_committer_date(commit_object) if commit_object else None
+    loose_object = layout.commondir / "objects" / sha[:2] / sha[2:]
+    if not loose_object.is_file():
+        return None  # packed object: no cheap filesystem read
+    try:
+        return _parse_committer_date(zlib.decompress(loose_object.read_bytes()))
+    except (OSError, zlib.error):
+        return None
 
 
 def release_tag_sort_key(name: str) -> tuple[int, ...] | None:

--- a/config/runtime_metadata/build_info.py
+++ b/config/runtime_metadata/build_info.py
@@ -8,7 +8,9 @@ marker: ``""`` for installed wheels, ``dev, <tag> @ <sha>`` for checkouts.
 from __future__ import annotations
 
 import re
+import zlib
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
 _RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+(\.\d+){2,}$")
@@ -136,15 +138,61 @@ def _read_head(layout: GitLayout) -> str | None:
     return head_file.read_text(encoding="utf-8").strip() or None
 
 
-def read_git_head_sha(layout: GitLayout) -> str | None:
-    """Short SHA the working tree currently points at, or ``None``."""
+def read_git_head_full_sha(layout: GitLayout) -> str | None:
+    """Full SHA the working tree currently points at, or ``None``."""
     head = _read_head(layout)
     if head is None:
         return None
     if not head.startswith(_HEAD_SYMREF_PREFIX):
-        return head[:7]  # detached HEAD: the sha is HEAD itself
-    sha = read_ref_sha(layout, head.removeprefix(_HEAD_SYMREF_PREFIX).strip())
+        return head  # detached HEAD: HEAD is the full sha
+    return read_ref_sha(layout, head.removeprefix(_HEAD_SYMREF_PREFIX).strip())
+
+
+def read_git_head_sha(layout: GitLayout) -> str | None:
+    """Short SHA the working tree currently points at, or ``None``."""
+    sha = read_git_head_full_sha(layout)
     return sha[:7] if sha else None
+
+
+_COMMITTER_LINE_PREFIX = b"committer "
+
+
+def _parse_committer_date(commit_object: bytes) -> datetime | None:
+    """UTC datetime from a commit object's ``committer`` line, or ``None``.
+
+    The line ends ``… <unix_seconds> <tz>``; the trailing two tokens are the
+    epoch timestamp and the author's zone. UTC is used for a zone-independent,
+    reproducible build date.
+    """
+    for line in commit_object.split(b"\n"):
+        if not line.startswith(_COMMITTER_LINE_PREFIX):
+            continue
+        fields = line.split(b" ")
+        try:
+            return datetime.fromtimestamp(int(fields[-2]), tz=UTC)
+        except (IndexError, ValueError):
+            return None
+    return None
+
+
+def read_git_head_commit_date(layout: GitLayout) -> datetime | None:
+    """UTC date of the HEAD commit, read from its loose object, or ``None``.
+
+    Reproducible per commit — the committer timestamp is baked into the object,
+    unlike wall-clock time. Returns ``None`` when the object is packed or
+    unreadable, so callers fall back to a date-less build identity rather than a
+    date that drifts by run.
+    """
+    sha = read_git_head_full_sha(layout)
+    if sha is None or len(sha) < 3:
+        return None
+    loose_object = layout.commondir / "objects" / sha[:2] / sha[2:]
+    if not loose_object.is_file():
+        return None  # packed object: no cheap filesystem read
+    try:
+        return _parse_committer_date(zlib.decompress(loose_object.read_bytes()))
+    except (OSError, zlib.error):
+        return None
 
 
 def release_tag_sort_key(name: str) -> tuple[int, ...] | None:
@@ -207,6 +255,8 @@ __all__ = [
     "detect_build_info",
     "find_git_layout",
     "iter_release_tag_names",
+    "read_git_head_commit_date",
+    "read_git_head_full_sha",
     "read_git_head_sha",
     "read_latest_release_tag",
     "read_packed_refs",

--- a/config/runtime_metadata/build_info.py
+++ b/config/runtime_metadata/build_info.py
@@ -175,24 +175,117 @@ def _parse_committer_date(commit_object: bytes) -> datetime | None:
     return None
 
 
-def read_git_head_commit_date(layout: GitLayout) -> datetime | None:
-    """UTC date of the HEAD commit, read from its loose object, or ``None``.
+_PACK_IDX_MAGIC = b"\xfftOc"
+_PACK_IDX_V2 = 2
+_PACK_OBJ_COMMIT = 1
+_PACK_LARGE_OFFSET_FLAG = 0x80000000
+_VARINT_CONTINUE = 0x80
 
-    Reproducible per commit — the committer timestamp is baked into the object,
-    unlike wall-clock time. Returns ``None`` when the object is packed or
-    unreadable, so callers fall back to a date-less build identity rather than a
-    date that drifts by run.
-    """
-    sha = read_git_head_full_sha(layout)
-    if sha is None or len(sha) < 3:
-        return None
-    loose_object = layout.commondir / "objects" / sha[:2] / sha[2:]
+
+def _read_loose_commit_object(commondir: Path, sha: str) -> bytes | None:
+    """Inflated loose object bytes for *sha*, or ``None`` when not stored loose."""
+    loose_object = commondir / "objects" / sha[:2] / sha[2:]
     if not loose_object.is_file():
-        return None  # packed object: no cheap filesystem read
+        return None
     try:
-        return _parse_committer_date(zlib.decompress(loose_object.read_bytes()))
+        return zlib.decompress(loose_object.read_bytes())
     except (OSError, zlib.error):
         return None
+
+
+def _find_object_offset_in_pack_idx(idx_path: Path, sha_bytes: bytes) -> int | None:
+    """Byte offset of *sha_bytes* within the paired pack, via its v2 idx, or ``None``."""
+    try:
+        data = idx_path.read_bytes()
+    except OSError:
+        return None
+    if data[:4] != _PACK_IDX_MAGIC or int.from_bytes(data[4:8], "big") != _PACK_IDX_V2:
+        return None  # only the modern idx v2 layout is parsed
+    fanout = 8
+    sha_table = fanout + 256 * 4
+    count = int.from_bytes(data[fanout + 255 * 4 : sha_table], "big")
+    first = sha_bytes[0]
+    lo = int.from_bytes(data[fanout + (first - 1) * 4 : fanout + first * 4], "big") if first else 0
+    hi = int.from_bytes(data[fanout + first * 4 : fanout + (first + 1) * 4], "big")
+    index = next(
+        (i for i in range(lo, hi) if data[sha_table + i * 20 : sha_table + (i + 1) * 20] == sha_bytes),
+        None,
+    )
+    if index is None:
+        return None
+    small_offsets = sha_table + count * 20 + count * 4  # after the sha and crc32 tables
+    packed = int.from_bytes(data[small_offsets + index * 4 : small_offsets + (index + 1) * 4], "big")
+    if not packed & _PACK_LARGE_OFFSET_FLAG:
+        return packed
+    large = small_offsets + count * 4 + (packed & ~_PACK_LARGE_OFFSET_FLAG) * 8
+    return int.from_bytes(data[large : large + 8], "big")
+
+
+def _read_pack_commit_at(pack_path: Path, offset: int) -> bytes | None:
+    """Inflated bytes of the object at *offset* when it is a base commit, else ``None``.
+
+    Deltified objects (their type is ofs/ref-delta, not commit) are skipped —
+    reconstructing them needs base resolution, and a tip commit is virtually
+    never stored as a delta.
+    """
+    try:
+        with pack_path.open("rb") as pack:
+            pack.seek(offset)
+            header = pack.read(1)
+            if not header:
+                return None
+            obj_type = (header[0] >> 4) & 0x7
+            while header[0] & _VARINT_CONTINUE:  # consume the size varint header
+                header = pack.read(1)
+                if not header:
+                    return None
+            if obj_type != _PACK_OBJ_COMMIT:
+                return None
+            stream = pack.read()  # zlib stops at the object's stream end
+    except OSError:
+        return None
+    try:
+        return zlib.decompress(stream)
+    except zlib.error:
+        return None
+
+
+def _read_packed_commit_object(commondir: Path, sha: str) -> bytes | None:
+    """Inflated bytes of *sha* from any pack that holds it as a base commit."""
+    pack_dir = commondir / "objects" / "pack"
+    if not pack_dir.is_dir():
+        return None
+    try:
+        sha_bytes = bytes.fromhex(sha)
+    except ValueError:
+        return None
+    for idx_path in sorted(pack_dir.glob("*.idx")):
+        offset = _find_object_offset_in_pack_idx(idx_path, sha_bytes)
+        if offset is None:
+            continue
+        commit = _read_pack_commit_at(idx_path.with_suffix(".pack"), offset)
+        if commit is not None:
+            return commit
+    return None
+
+
+def read_git_head_commit_date(layout: GitLayout) -> datetime | None:
+    """UTC date of the HEAD commit, read from its git object, or ``None``.
+
+    Reproducible per commit — the committer timestamp is baked into the object,
+    unlike wall-clock time — and storage-independent: the object is read whether
+    it is loose or packed, so packing (``git gc``) does not change the build
+    identity. Returns ``None`` only when the object is genuinely unreadable (a
+    full 40-char sha is required to address a pack), so callers fall back to a
+    date-less identity rather than a date that drifts by run.
+    """
+    sha = read_git_head_full_sha(layout)
+    if sha is None or len(sha) != 40:
+        return None
+    commit_object = _read_loose_commit_object(layout.commondir, sha) or _read_packed_commit_object(
+        layout.commondir, sha
+    )
+    return _parse_committer_date(commit_object) if commit_object else None
 
 
 def release_tag_sort_key(name: str) -> tuple[int, ...] | None:

--- a/config/version.py
+++ b/config/version.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib.metadata
 import tomllib
-from datetime import UTC, datetime
 from pathlib import Path
 
 #: Base public version when no full release string is available.
@@ -37,10 +36,16 @@ def _dev_build_version(base: str) -> str:
     """Expand *base* to the release shape ``base.Y.M.D+main.<sha>`` from git.
 
     Mirrors the release version so a dev checkout reports the same specific
-    build shape. Falls back to *base* when git metadata is unreadable (a
-    stripped checkout / wheel without metadata).
+    build shape. The date is the HEAD commit's date, not wall-clock time, so an
+    unchanged commit reports the same version, telemetry, and release id on any
+    day. Falls back to ``base+main.<sha>`` when the commit date is unreadable,
+    and to *base* when git metadata is absent (a stripped checkout / wheel).
     """
-    from config.runtime_metadata.build_info import find_git_layout, read_git_head_sha
+    from config.runtime_metadata.build_info import (
+        find_git_layout,
+        read_git_head_commit_date,
+        read_git_head_sha,
+    )
 
     layout = find_git_layout()
     if layout is None:
@@ -48,8 +53,10 @@ def _dev_build_version(base: str) -> str:
     sha = read_git_head_sha(layout)
     if not sha:
         return base
-    today = datetime.now(tz=UTC)
-    return f"{base}.{today.year}.{today.month}.{today.day}+{_DEV_CHANNEL}.{sha}"
+    commit_date = read_git_head_commit_date(layout)
+    if commit_date is None:
+        return f"{base}+{_DEV_CHANNEL}.{sha}"
+    return f"{base}.{commit_date.year}.{commit_date.month}.{commit_date.day}+{_DEV_CHANNEL}.{sha}"
 
 
 def get_opensre_version() -> str:

--- a/tests/config/test_runtime_metadata_build_info.py
+++ b/tests/config/test_runtime_metadata_build_info.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import datetime as _dt
+import zlib
 from pathlib import Path
 
 from config.runtime_metadata.build_info import (
     GitLayout,
+    read_git_head_commit_date,
     read_git_head_sha,
     read_latest_release_tag,
     resolve_gitdir,
 )
+
+_DETACHED_HEAD_SHA = "abcdef0123456789abcdef0123456789abcdef01"
 
 
 def test_resolve_gitdir_follows_linked_worktree_pointer_file(tmp_path: Path) -> None:
@@ -83,6 +88,37 @@ def test_latest_release_tag_reads_from_commondir_in_linked_worktree(tmp_path: Pa
     (tags_dir / "v0.1.2026.7.11").write_text("sha\n", encoding="utf-8")
 
     assert read_latest_release_tag(commondir) == "v0.1.2026.7.11"
+
+
+def test_head_commit_date_reads_committer_timestamp_from_loose_object(tmp_path: Path) -> None:
+    """The dev build date is the commit's own date (reproducible per commit),
+    read from the committer line of the zlib-deflated loose commit object."""
+    committed = _dt.datetime(2026, 8, 27, 15, 30, tzinfo=_dt.UTC)
+    body = (
+        b"commit 0\x00tree 0\n"
+        b"author A <a@x> 1000 +0000\n"
+        b"committer C <c@x> " + str(int(committed.timestamp())).encode() + b" +0000\n"
+        b"\ncommit message\n"
+    )
+    (tmp_path / "HEAD").write_text(f"{_DETACHED_HEAD_SHA}\n", encoding="utf-8")
+    obj_dir = tmp_path / "objects" / _DETACHED_HEAD_SHA[:2]
+    obj_dir.mkdir(parents=True)
+    (obj_dir / _DETACHED_HEAD_SHA[2:]).write_bytes(zlib.compress(body))
+
+    result = read_git_head_commit_date(GitLayout(gitdir=tmp_path, commondir=tmp_path))
+
+    assert result is not None
+    assert result.date() == _dt.date(2026, 8, 27)
+
+
+def test_head_commit_date_is_none_when_object_is_packed(tmp_path: Path) -> None:
+    """A packed HEAD object has no loose file; the reader returns None so the
+    build version falls back to a sha-only id rather than guessing a date."""
+    (tmp_path / "HEAD").write_text(f"{_DETACHED_HEAD_SHA}\n", encoding="utf-8")
+
+    result = read_git_head_commit_date(GitLayout(gitdir=tmp_path, commondir=tmp_path))
+
+    assert result is None
 
 
 def test_latest_release_tag_sorts_numerically_not_lexicographically(tmp_path: Path) -> None:

--- a/tests/config/test_runtime_metadata_build_info.py
+++ b/tests/config/test_runtime_metadata_build_info.py
@@ -3,44 +3,18 @@
 from __future__ import annotations
 
 import datetime as _dt
-import os
-import subprocess
 import zlib
 from pathlib import Path
 
 from config.runtime_metadata.build_info import (
     GitLayout,
     read_git_head_commit_date,
-    read_git_head_full_sha,
     read_git_head_sha,
     read_latest_release_tag,
     resolve_gitdir,
 )
 
 _DETACHED_HEAD_SHA = "abcdef0123456789abcdef0123456789abcdef01"
-
-
-def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> None:
-    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, env=env)
-
-
-def _commit_repo(repo: Path, *, committed: str) -> GitLayout:
-    """Init *repo*, make one commit with a fixed committer date, return its layout."""
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "T",
-        "GIT_AUTHOR_EMAIL": "t@x",
-        "GIT_COMMITTER_NAME": "T",
-        "GIT_COMMITTER_EMAIL": "t@x",
-        "GIT_AUTHOR_DATE": committed,
-        "GIT_COMMITTER_DATE": committed,
-    }
-    repo.mkdir(parents=True, exist_ok=True)
-    _git(repo, "init", "-q")
-    (repo / "f.txt").write_text("hi", encoding="utf-8")
-    _git(repo, "add", "f.txt", env=env)
-    _git(repo, "commit", "-q", "-m", "c", env=env)
-    return GitLayout(gitdir=repo / ".git", commondir=repo / ".git")
 
 
 def test_resolve_gitdir_follows_linked_worktree_pointer_file(tmp_path: Path) -> None:
@@ -137,29 +111,9 @@ def test_head_commit_date_reads_committer_timestamp_from_loose_object(tmp_path: 
     assert result.date() == _dt.date(2026, 8, 27)
 
 
-def test_head_commit_date_is_storage_independent_across_git_gc(tmp_path: Path) -> None:
-    """The build identity must not change when git packs the HEAD object. The
-    committer date reads the same before and after repacking (loose → packed)."""
-    layout = _commit_repo(tmp_path / "repo", committed="2026-08-27T12:00:00 +0000")
-
-    loose_date = read_git_head_commit_date(layout)
-
-    _git(tmp_path / "repo", "repack", "-ad", "-q")  # pack all objects, drop loose
-    full_sha = read_git_head_full_sha(layout)
-    assert full_sha is not None
-    loose_path = layout.commondir / "objects" / full_sha[:2] / full_sha[2:]
-    assert not loose_path.exists()  # the packed reader is now what is under test
-
-    packed_date = read_git_head_commit_date(layout)
-
-    assert loose_date is not None
-    assert loose_date.date() == _dt.date(2026, 8, 27)
-    assert packed_date == loose_date
-
-
-def test_head_commit_date_is_none_when_object_is_absent(tmp_path: Path) -> None:
-    """A HEAD sha with no loose object and no pack is unreadable; the reader
-    returns None so the version falls back rather than guessing a date."""
+def test_head_commit_date_is_none_when_object_is_packed(tmp_path: Path) -> None:
+    """A packed HEAD object has no loose file; the reader returns None so the
+    build version falls back to a sha-only id rather than guessing a date."""
     (tmp_path / "HEAD").write_text(f"{_DETACHED_HEAD_SHA}\n", encoding="utf-8")
 
     result = read_git_head_commit_date(GitLayout(gitdir=tmp_path, commondir=tmp_path))

--- a/tests/config/test_runtime_metadata_build_info.py
+++ b/tests/config/test_runtime_metadata_build_info.py
@@ -3,18 +3,44 @@
 from __future__ import annotations
 
 import datetime as _dt
+import os
+import subprocess
 import zlib
 from pathlib import Path
 
 from config.runtime_metadata.build_info import (
     GitLayout,
     read_git_head_commit_date,
+    read_git_head_full_sha,
     read_git_head_sha,
     read_latest_release_tag,
     resolve_gitdir,
 )
 
 _DETACHED_HEAD_SHA = "abcdef0123456789abcdef0123456789abcdef01"
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, env=env)
+
+
+def _commit_repo(repo: Path, *, committed: str) -> GitLayout:
+    """Init *repo*, make one commit with a fixed committer date, return its layout."""
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "T",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "T",
+        "GIT_COMMITTER_EMAIL": "t@x",
+        "GIT_AUTHOR_DATE": committed,
+        "GIT_COMMITTER_DATE": committed,
+    }
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    (repo / "f.txt").write_text("hi", encoding="utf-8")
+    _git(repo, "add", "f.txt", env=env)
+    _git(repo, "commit", "-q", "-m", "c", env=env)
+    return GitLayout(gitdir=repo / ".git", commondir=repo / ".git")
 
 
 def test_resolve_gitdir_follows_linked_worktree_pointer_file(tmp_path: Path) -> None:
@@ -111,9 +137,29 @@ def test_head_commit_date_reads_committer_timestamp_from_loose_object(tmp_path: 
     assert result.date() == _dt.date(2026, 8, 27)
 
 
-def test_head_commit_date_is_none_when_object_is_packed(tmp_path: Path) -> None:
-    """A packed HEAD object has no loose file; the reader returns None so the
-    build version falls back to a sha-only id rather than guessing a date."""
+def test_head_commit_date_is_storage_independent_across_git_gc(tmp_path: Path) -> None:
+    """The build identity must not change when git packs the HEAD object. The
+    committer date reads the same before and after repacking (loose → packed)."""
+    layout = _commit_repo(tmp_path / "repo", committed="2026-08-27T12:00:00 +0000")
+
+    loose_date = read_git_head_commit_date(layout)
+
+    _git(tmp_path / "repo", "repack", "-ad", "-q")  # pack all objects, drop loose
+    full_sha = read_git_head_full_sha(layout)
+    assert full_sha is not None
+    loose_path = layout.commondir / "objects" / full_sha[:2] / full_sha[2:]
+    assert not loose_path.exists()  # the packed reader is now what is under test
+
+    packed_date = read_git_head_commit_date(layout)
+
+    assert loose_date is not None
+    assert loose_date.date() == _dt.date(2026, 8, 27)
+    assert packed_date == loose_date
+
+
+def test_head_commit_date_is_none_when_object_is_absent(tmp_path: Path) -> None:
+    """A HEAD sha with no loose object and no pack is unreadable; the reader
+    returns None so the version falls back rather than guessing a date."""
     (tmp_path / "HEAD").write_text(f"{_DETACHED_HEAD_SHA}\n", encoding="utf-8")
 
     result = read_git_head_commit_date(GitLayout(gitdir=tmp_path, commondir=tmp_path))

--- a/tests/packaging/test_version.py
+++ b/tests/packaging/test_version.py
@@ -16,18 +16,15 @@ def _no_git(monkeypatch) -> None:
     monkeypatch.setattr(build_info, "find_git_layout", lambda: None)
 
 
-class _FixedClock:
-    """A datetime stand-in whose ``now`` is fixed, so the build date is stable."""
-
-    @staticmethod
-    def now(tz: object = None) -> _dt.datetime:
-        return _dt.datetime(2026, 8, 27, tzinfo=tz)  # type: ignore[arg-type]
-
-
 def _git_head_at(monkeypatch, sha: str) -> None:
+    """Pin git HEAD to *sha* committed on a fixed date, so the build is stable."""
     monkeypatch.setattr(build_info, "find_git_layout", lambda: object())
     monkeypatch.setattr(build_info, "read_git_head_sha", lambda _layout: sha)
-    monkeypatch.setattr(version_module, "datetime", _FixedClock)
+    monkeypatch.setattr(
+        build_info,
+        "read_git_head_commit_date",
+        lambda _layout: _dt.datetime(2026, 8, 27, tzinfo=_dt.UTC),
+    )
 
 
 def test_release_version_string_is_returned_verbatim(monkeypatch) -> None:
@@ -76,8 +73,9 @@ def test_dev_checkout_expands_to_the_dated_main_build_shape(monkeypatch) -> None
     assert version_module.get_opensre_version() == "0.1.2026.8.27+main.85fd865"
 
 
-def test_dev_build_version_is_deterministic_for_a_fixed_commit_and_clock(monkeypatch) -> None:
-    # A fixed commit + clock yields one stable string across calls — no flake.
+def test_dev_build_version_is_deterministic_for_a_fixed_commit(monkeypatch) -> None:
+    # The date is the commit's, not wall-clock, so an unchanged commit yields
+    # the same string on any day — no telemetry/release-id churn.
     monkeypatch.setattr(version_module.importlib.metadata, "version", _raise_package_not_found)
     monkeypatch.setattr(version_module, "_pyproject_version", lambda: "0.1")
     _git_head_at(monkeypatch, "85fd865")
@@ -86,3 +84,15 @@ def test_dev_build_version_is_deterministic_for_a_fixed_commit_and_clock(monkeyp
     second = version_module.get_opensre_version()
 
     assert first == second == "0.1.2026.8.27+main.85fd865"
+
+
+def test_dev_build_falls_back_to_sha_only_when_commit_date_is_unreadable(monkeypatch) -> None:
+    # A packed / unreadable commit object drops the date but keeps the sha, so
+    # the identity is still reproducible (never a wall-clock-derived date).
+    monkeypatch.setattr(version_module.importlib.metadata, "version", _raise_package_not_found)
+    monkeypatch.setattr(version_module, "_pyproject_version", lambda: "0.1")
+    monkeypatch.setattr(build_info, "find_git_layout", lambda: object())
+    monkeypatch.setattr(build_info, "read_git_head_sha", lambda _layout: "85fd865")
+    monkeypatch.setattr(build_info, "read_git_head_commit_date", lambda _layout: None)
+
+    assert version_module.get_opensre_version() == "0.1+main.85fd865"


### PR DESCRIPTION
What: The development build version (0.1.Y.M.D+main.<sha>) took its date from datetime.now(UTC), so the same commit produced a different version / Sentry release / telemetry id on every calendar day.

Fix: _dev_build_version now reads the date from the HEAD commit's committer timestamp via a new read_git_head_commit_date() in build_info.py — a filesystem read of the zlib-deflated loose commit object, consistent with the module's existing no-subprocess design. Result is deterministic per commit. Fallbacks: base+main.<sha> when the commit object is packed/unreadable (still reproducible via sha), and bare base when git metadata is absent.

Tests: fixed-commit determinism, packed-object → sha-only fallback, and direct read_git_head_commit_date coverage (loose-object parse + packed → None).

Follow-up to the Greptile review on #5920.