### PR TITLE
fix(correlation): count threshold crossings, not elevated samples, in score_periodic_spikes

### DIFF
--- a/core/domain/correlation/scoring.py
+++ b/core/domain/correlation/scoring.py
@@ -144,7 +144,18 @@ def score_periodic_spikes(
     values: tuple[float, ...],
     spike_threshold: float,
 ) -> PeriodicityScore:
-    repeated_spikes = sum(1 for value in values if value >= spike_threshold)
+    """Score whether ``values`` shows a *repeated* spike pattern.
+
+    Counts below-to-above threshold crossings, not elevated samples: a
+    signal that crosses once and stays high for many samples is one
+    sustained spike, not a repeated pattern, even though many of its
+    samples individually sit at or above the threshold.
+    """
+    repeated_spikes = sum(
+        1
+        for previous, current in zip(values, values[1:], strict=False)
+        if previous < spike_threshold <= current
+    )
 
     if repeated_spikes <= 1:
         score = 0.0

--- a/tests/synthetic/rds_postgres/correlation/test_periodicity.py
+++ b/tests/synthetic/rds_postgres/correlation/test_periodicity.py
@@ -21,3 +21,19 @@ def test_periodic_spikes_score_low_when_not_repeated() -> None:
 
     assert result.repeated_spikes == 1
     assert result.score == 0.0
+
+
+def test_a_sustained_spike_counts_as_one_crossing_not_one_per_sample() -> None:
+    """One below-to-above crossing that stays elevated for several samples
+    is a single sustained spike, not a repeated pattern -- counting each
+    elevated sample would score it identically to genuinely recurring
+    spikes.
+    """
+    result = score_periodic_spikes(
+        signal_name="upstream_cpu",
+        values=(20.0, 90.0, 90.0, 90.0, 20.0),
+        spike_threshold=80.0,
+    )
+
+    assert result.repeated_spikes == 1
+    assert result.score == 0.0


### PR DESCRIPTION
Fixes #4249

#### Describe the changes you have made in this PR -

`score_periodic_spikes` counted every sample at or above `spike_threshold` (`sum(1 for value in values if value >= spike_threshold)`) instead of counting threshold *crossings*. A single sustained spike — one below-to-above transition that then stays elevated for several samples — was mis-scored as a repeated/periodic pattern: `repeated_spikes=3, score=1.0` for `(20.0, 90.0, 90.0, 90.0, 20.0)`, even though it's one spike, not three.

This feeds the periodicity evidence axis (weight `0.10`) in `score_candidate_correlation` → `final_confidence` → `most_likely_causal_drivers`, the ranked suspect list the investigation Planner reasons over. A sustained-high upstream service — the most common real-metric shape — got a flat, unearned `+0.10` confidence boost that could re-rank it above a better-correlated suspect or flip its confidence label across a cutoff.

Fix: count below-to-above crossings (`previous < spike_threshold <= current`) instead of elevated samples. Both existing fixtures in `test_periodicity.py` use one-sample-wide spikes, where crossing count and elevated-sample count coincide — exactly the blind spot the issue describes — so both pass unchanged.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`, the issue's own repro):
```
$ uv run python -c "
from core.domain.correlation.scoring import score_periodic_spikes
print(score_periodic_spikes(signal_name='upstream_cpu', values=(20.0, 90.0, 90.0, 90.0, 20.0), spike_threshold=80.0))
"
PeriodicityScore(signal_name='upstream_cpu', repeated_spikes=3, score=1.0, rationale='Detected repeated threshold crossings for upstream_cpu.')
```

After (this branch):
```
$ uv run python3 -c "
from core.domain.correlation.scoring import score_periodic_spikes
print(score_periodic_spikes(signal_name='upstream_cpu', values=(20.0, 90.0, 90.0, 90.0, 20.0), spike_threshold=80.0))
"
PeriodicityScore(signal_name='upstream_cpu', repeated_spikes=1, score=0.0, rationale='No repeated spike pattern detected.')
```

```
$ uv run pytest tests/synthetic/rds_postgres/correlation/ -q
25 passed in 1.60s

$ uv run pytest -k periodic -q
5 passed, 16986 deselected in 10.31s

$ uv run ruff check core/domain/correlation/scoring.py tests/synthetic/rds_postgres/correlation/test_periodicity.py
All checks passed!

$ uv run ruff format --check core/domain/correlation/scoring.py tests/synthetic/rds_postgres/correlation/test_periodicity.py
2 files already formatted

$ uv run mypy core/domain/correlation/scoring.py tests/synthetic/rds_postgres/correlation/test_periodicity.py
Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue's diagnosis is precise: the field name (`repeated_spikes`), the rationale string ("repeated threshold crossings"), and the existing test's name (`test_periodic_spikes_score_repeated_threshold_crossings`) all describe *crossings*, but the implementation counted *elevated samples* — they only agree when every spike is exactly one sample wide, which is the shape both existing test fixtures happen to use, so the divergence was never caught.

I traced the downstream impact before treating this as "just an off-by-N": `score_periodic_spikes` isn't a leaf display formatter, it's one of the weighted axes (`0.10`) feeding `score_candidate_correlation`, whose `final_confidence` output ranks suspects in `most_likely_causal_drivers` — the actual root-cause suspect list surfaced to the investigation Planner and, ultimately, the report reader. A flat `+0.10` on every sustained-high metric is a real correctness bug in ranking, not a cosmetic one — worth the trace before assuming this was low-stakes.

I implemented the exact fix the issue proposes (`zip(values, values[1:], strict=False)` pairing consecutive samples, counting `previous < spike_threshold <= current`) rather than inventing an alternative, since it was already verified against both existing fixtures in the issue body and matches the field/rationale semantics precisely. I re-derived both existing test cases by hand against the new logic before running them, to confirm the "both existing tests stay green" claim rather than taking it on faith, then ran the actual suite to verify.

I considered whether a signal that *starts* already above threshold (no preceding low sample in the window) should count as a spike — the crossing-based approach doesn't count it, since there's no `previous < threshold` sample to pair with. I left this as-is: it matches the "crossing" semantics the field name and rationale already commit to, and inventing a different rule for a window-boundary edge case not mentioned in the issue would be scope creep beyond what's asked.

Key file: `core/domain/correlation/scoring.py`, `score_periodic_spikes` — the one function this bug lives in. I also added a short docstring, since the crossing-vs-elevated-sample distinction is exactly the kind of non-obvious invariant that caused this bug in the first place and is worth documenting so it isn't reintroduced.

Edge case tested directly: the issue's own sustained-spike example (`test_a_sustained_spike_counts_as_one_crossing_not_one_per_sample`), alongside the two pre-existing tests which now serve as regression coverage for the "two separated single-sample spikes" and "no repeated pattern" cases.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions