### PR TITLE
fix(scheduler): make task-store writes crash-safe, preserve unreadable stores

### DIFF
--- a/infrastructure/scheduling/scheduler/store.py
+++ b/infrastructure/scheduling/scheduler/store.py
@@ -57,6 +57,25 @@ def _load_raw(store_path: Path) -> list[dict[str, object]]:
     return _read_raw(store_path)[0]
 
 
+def _fsync_parent_dir(path: Path) -> None:
+    """Best-effort directory fsync so an ``os.replace`` survives a power loss on Unix.
+
+    ``os.replace`` is atomic, but the directory entry change it makes is only
+    guaranteed durable once the directory itself is fsynced -- without this, a
+    crash immediately after replace can leave the directory pointing at the
+    old inode again, even though the new file's own contents were fsynced.
+    Windows has no equivalent operation, so this is a no-op there.
+    """
+    if os.name == "nt":
+        return
+    with contextlib.suppress(OSError):
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+
 def _quarantine_unreadable(store_path: Path) -> None:
     """Move an unparseable store aside so a write cannot destroy it.
 
@@ -71,7 +90,16 @@ def _quarantine_unreadable(store_path: Path) -> None:
     )
     os.close(fd)
     aside = Path(aside_str)
-    os.replace(store_path, aside)
+    try:
+        os.replace(store_path, aside)
+    except OSError:
+        # mkstemp already created the (empty) aside file; a failed replace
+        # would otherwise leave it behind as a misleading empty "recovery"
+        # artifact that isn't actually the quarantined data.
+        with contextlib.suppress(OSError):
+            aside.unlink()
+        raise
+    _fsync_parent_dir(aside)
     logger.error(
         "Scheduler store at %s was unreadable and has been preserved at %s. "
         "Scheduled tasks in it are recoverable from that file.",
@@ -99,7 +127,10 @@ def _save_raw(store_path: Path, data: list[dict[str, object]]) -> None:
     window leaves a half-written file that no longer parses. Every other
     local store in the repo writes through a temp file in the destination
     directory, fsyncs, then ``os.replace``; see
-    ``integrations/store.py::_atomic_write``.
+    ``integrations/store.py::_atomic_write``. The directory fsync afterward
+    (``_fsync_parent_dir``) mirrors
+    ``infrastructure/analytics/provider.py::_write_text_atomic``, so the
+    rename itself survives a power loss, not just the file's own contents.
     """
     store_path.parent.mkdir(parents=True, exist_ok=True)
     serialized = json.dumps(data, indent=2, default=str) + "\n"
@@ -111,6 +142,7 @@ def _save_raw(store_path: Path, data: list[dict[str, object]]) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp_path, store_path)
+        _fsync_parent_dir(store_path)
     except Exception:
         if tmp_path:
             with contextlib.suppress(OSError):

--- a/infrastructure/scheduling/scheduler/store.py
+++ b/infrastructure/scheduling/scheduler/store.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
+import tempfile
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -28,24 +32,90 @@ def _lock_path(store_path: Path) -> Path:
     return store_path.with_suffix(".lock")
 
 
-def _load_raw(store_path: Path) -> list[dict[str, object]]:
-    """Load raw task list from disk."""
+def _read_raw(store_path: Path) -> tuple[list[dict[str, object]], bool]:
+    """Load the raw task list; the flag reports whether the file was readable.
+
+    A missing store is readable and empty. A store that will not parse is
+    ``([], False)`` -- callers about to write must not treat that as "no
+    tasks" and silently overwrite it.
+    """
     if not store_path.exists():
-        return []
+        return [], True
     try:
         data = json.loads(store_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
         logger.warning("Failed to read scheduler store: %s", exc)
-        return []
+        return [], False
     if not isinstance(data, list):
-        return []
-    return data  # type: ignore[return-value]
+        logger.warning("Scheduler store is not a JSON list; treating it as unreadable")
+        return [], False
+    return data, True  # type: ignore[return-value]
+
+
+def _load_raw(store_path: Path) -> list[dict[str, object]]:
+    """Load the raw task list, treating an unreadable store as empty."""
+    return _read_raw(store_path)[0]
+
+
+def _quarantine_unreadable(store_path: Path) -> None:
+    """Move an unparseable store aside so a write cannot destroy it.
+
+    The name carries a timestamp for the operator and a unique suffix for
+    correctness: ``mkstemp`` reserves the destination atomically, so two
+    corruptions inside the same second cannot land on one name and have the
+    second ``os.replace`` erase the first casualty.
+    """
+    fd, aside_str = tempfile.mkstemp(
+        dir=store_path.parent,
+        prefix=f"{store_path.name}.corrupt-{int(time.time())}-",
+    )
+    os.close(fd)
+    aside = Path(aside_str)
+    os.replace(store_path, aside)
+    logger.error(
+        "Scheduler store at %s was unreadable and has been preserved at %s. "
+        "Scheduled tasks in it are recoverable from that file.",
+        store_path,
+        aside,
+    )
+
+
+def _load_for_write(store_path: Path) -> list[dict[str, object]]:
+    """Load the task list for a call about to write it back.
+
+    An unreadable store is moved aside first, so the write lands on a fresh
+    file and the damaged one stays on disk for recovery.
+    """
+    raw, readable = _read_raw(store_path)
+    if not readable:
+        _quarantine_unreadable(store_path)
+    return raw
 
 
 def _save_raw(store_path: Path, data: list[dict[str, object]]) -> None:
-    """Persist task list to disk."""
+    """Persist the task list by atomic rename.
+
+    ``Path.write_text`` truncates before rewriting, so a crash inside that
+    window leaves a half-written file that no longer parses. Every other
+    local store in the repo writes through a temp file in the destination
+    directory, fsyncs, then ``os.replace``; see
+    ``integrations/store.py::_atomic_write``.
+    """
     store_path.parent.mkdir(parents=True, exist_ok=True)
-    store_path.write_text(json.dumps(data, indent=2, default=str) + "\n", encoding="utf-8")
+    serialized = json.dumps(data, indent=2, default=str) + "\n"
+    tmp_path: str | None = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(dir=store_path.parent, prefix=store_path.name + ".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, store_path)
+    except Exception:
+        if tmp_path:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+        raise
 
 
 def list_tasks(store_path: Path | None = None) -> list[ScheduledTask]:
@@ -101,7 +171,7 @@ def add_task(task: ScheduledTask, store_path: Path | None = None) -> ScheduledTa
     path = store_path or _default_store_path()
     lock = FileLock(_lock_path(path))
     with lock:
-        raw = _load_raw(path)
+        raw = _load_for_write(path)
         wanted = _schedule_identity(task.model_dump(mode="json"))
         existing = next(
             (entry for entry in raw if _schedule_identity(entry) == wanted),

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -292,3 +292,101 @@ class TestReloadSignal:
         signals = self._capture(monkeypatch)
         assert remove_task("does-not-exist", store_path) is False
         assert signals == []
+
+
+class TestStoreSurvivesTornWrites:
+    """A crash mid-write, or a store that will not parse, must not lose tasks."""
+
+    @staticmethod
+    def _digest(hour: int) -> ScheduledTask:
+        return ScheduledTask(
+            name=f"digest-{hour}",
+            kind=TaskKind.DAILY_SUMMARY,
+            cron=f"0 {hour} * * *",
+            provider=Provider.TELEGRAM,
+            chat_id="-100",
+        )
+
+    def test_save_never_truncates_the_live_file(self, store_path: Path) -> None:
+        add_task(self._digest(7), store_path)
+        before = store_path.read_text(encoding="utf-8")
+
+        # A truncating writer would have already destroyed `before` by the
+        # time this raises -- os.replace is the last step, after the temp
+        # file is fully written and fsynced.
+        def _explode(_src: object, _dst: object) -> None:
+            raise OSError("crash during rename")
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr("infrastructure.scheduling.scheduler.store.os.replace", _explode)
+            with pytest.raises(OSError):
+                add_task(self._digest(8), store_path)
+
+        assert store_path.read_text(encoding="utf-8") == before
+        assert [task.name for task in list_tasks(store_path)] == ["digest-7"]
+        assert list(store_path.parent.glob(f"{store_path.name}.tmp*")) == []
+
+    def test_add_preserves_an_unreadable_store_instead_of_replacing_it(
+        self, store_path: Path
+    ) -> None:
+        # A store torn in half, exactly as an interrupted write leaves it.
+        for hour in (7, 8, 9):
+            add_task(self._digest(hour), store_path)
+        full = store_path.read_text(encoding="utf-8")
+        store_path.write_text(full[: len(full) // 2], encoding="utf-8")
+
+        add_task(self._digest(10), store_path)
+
+        # The new task is stored, and the damaged file still exists under a
+        # quarantine name rather than having been overwritten.
+        assert [task.name for task in list_tasks(store_path)] == ["digest-10"]
+        quarantined = list(store_path.parent.glob(f"{store_path.name}.corrupt-*"))
+        assert len(quarantined) == 1
+        assert quarantined[0].read_text(encoding="utf-8") == full[: len(full) // 2]
+
+    def test_remove_and_update_leave_an_unreadable_store_untouched(self, store_path: Path) -> None:
+        # Neither call finds its target in a store it cannot read, so
+        # neither has any business rewriting -- or quarantining -- the file.
+        task = self._digest(7)
+        add_task(task, store_path)
+        store_path.write_text("{ not json", encoding="utf-8")
+
+        removed = remove_task(task.id, store_path)
+        updated = update_task(task, store_path)
+
+        assert removed is False
+        assert updated is False
+        assert store_path.read_text(encoding="utf-8") == "{ not json"
+
+    def test_a_non_list_payload_is_treated_as_unreadable(self, store_path: Path) -> None:
+        # Valid JSON of the wrong shape is just as unusable as broken JSON,
+        # and previously fell through to the same silent-empty path.
+        store_path.write_text('{"tasks": []}', encoding="utf-8")
+
+        add_task(self._digest(7), store_path)
+
+        assert [task.name for task in list_tasks(store_path)] == ["digest-7"]
+        assert len(list(store_path.parent.glob(f"{store_path.name}.corrupt-*"))) == 1
+
+    def test_two_corruptions_in_one_second_keep_both_recovery_copies(
+        self, store_path: Path
+    ) -> None:
+        # Freeze the clock so both quarantines derive the same second -- a
+        # name built from the timestamp alone would collide here, and the
+        # second os.replace would erase the first casualty.
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(
+                "infrastructure.scheduling.scheduler.store.time.time", lambda: 1_700_000_000.0
+            )
+
+            store_path.write_text("first torn write", encoding="utf-8")
+            add_task(self._digest(7), store_path)
+            store_path.write_text("second torn write", encoding="utf-8")
+            add_task(self._digest(8), store_path)
+
+        quarantined = sorted(store_path.parent.glob(f"{store_path.name}.corrupt-*"))
+        assert len(quarantined) == 2
+        assert {path.read_text(encoding="utf-8") for path in quarantined} == {
+            "first torn write",
+            "second torn write",
+        }

--- a/tests/scheduler/test_store.py
+++ b/tests/scheduler/test_store.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
 from infrastructure.scheduling.scheduler.claim_store import get_runs, try_claim
 from infrastructure.scheduling.scheduler.store import (
+    _quarantine_unreadable,
     add_task,
     get_task,
     list_tasks,
@@ -390,3 +392,44 @@ class TestStoreSurvivesTornWrites:
             "first torn write",
             "second torn write",
         }
+
+    def test_save_fsyncs_the_parent_directory_after_replace(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The rename itself, not just the file's contents, must survive a
+        power loss -- os.replace alone only guarantees the latter.
+        """
+        fsync_calls: list[int] = []
+        real_fsync = os.fsync
+
+        def _counting_fsync(fd: int) -> None:
+            real_fsync(fd)
+            fsync_calls.append(fd)
+
+        monkeypatch.setattr("infrastructure.scheduling.scheduler.store.os.fsync", _counting_fsync)
+
+        add_task(self._digest(7), store_path)
+
+        # Two fsyncs per save: once for the temp file's contents, once for
+        # the parent directory so the rename itself is durable too.
+        assert len(fsync_calls) == 2
+
+    def test_quarantine_removes_the_empty_aside_file_if_replace_fails(
+        self, store_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed replace must not leave an empty file masquerading as
+        the quarantined data.
+        """
+        store_path.write_text("not valid json", encoding="utf-8")
+
+        def _explode(_src: object, _dst: object) -> None:
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr("infrastructure.scheduling.scheduler.store.os.replace", _explode)
+
+        with pytest.raises(OSError):
+            _quarantine_unreadable(store_path)
+
+        assert list(store_path.parent.glob(f"{store_path.name}.corrupt-*")) == []
+        # The original (unreadable) store is untouched -- os.replace never happened.
+        assert store_path.read_text(encoding="utf-8") == "not valid json"


### PR DESCRIPTION
Fixes #4927

#### Describe the changes you have made in this PR -

`infrastructure/scheduling/scheduler/store.py`'s `_save_raw` wrote the task store with a plain `Path.write_text`, which truncates the destination file before rewriting it. If the process died during that window (SIGKILL, container eviction, power loss, ENOSPC), the JSON was left truncated. `_load_raw` then swallowed the resulting `JSONDecodeError` and returned `[]`, so the scheduler silently reported **no tasks** — and the next `add_task` wrote a fresh list over the damaged file, making the loss permanent. Every other local store in the repo already writes by atomic rename (`integrations/store.py::_atomic_write` is the closest analog); the scheduler task store was the one that didn't.

Two changes, both from the issue's own suggested fix:

1. **`_save_raw` writes atomically.** Through a temp file in the destination directory (`tempfile.mkstemp`), `flush` + `os.fsync`, then `os.replace` — atomic on POSIX and Windows. A crash at any point before the final `os.replace` leaves the *previous* file completely untouched (verified with a test that fails `os.replace` mid-write and asserts the store is byte-identical to before, with no temp-file debris left behind).
2. **A store that cannot be parsed is never overwritten by a subsequent write.** Split `_load_raw` into `_read_raw` (returns `(data, readable)`) and `_load_for_write` (moves an unreadable store aside via `mkstemp`-reserved unique naming — `scheduler_tasks.json.corrupt-<timestamp>-<random>` — before returning `[]`, so schedules stay recoverable from the quarantined file instead of vanishing). Only `add_task` uses `_load_for_write`, since it's the one call that unconditionally writes after loading; `remove_task`/`update_task` only write when they find their target, so an unreadable store they can't search is correctly left completely untouched rather than quarantined for no reason.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`, the issue's own repro):
```
$ uv run python -c "
from pathlib import Path
import tempfile
from infrastructure.scheduling.scheduler.store import add_task, list_tasks
from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
store = Path(tempfile.mkdtemp()) / 'scheduler_tasks.json'
for hour in (7, 8, 9):
    add_task(ScheduledTask(name=f'digest-{hour}', kind=TaskKind.DAILY_SUMMARY, cron=f'0 {hour} * * *', timezone='UTC', provider=Provider.TELEGRAM, chat_id='-100', window_hours=24), store_path=store)
print('stored:', [t.name for t in list_tasks(store)])
full = store.read_text(encoding='utf-8')
store.write_text(full[: len(full) // 2], encoding='utf-8')
print('after torn write:', [t.name for t in list_tasks(store)])
add_task(ScheduledTask(name='digest-10', kind=TaskKind.DAILY_SUMMARY, cron='0 10 * * *', timezone='UTC', provider=Provider.TELEGRAM, chat_id='-100', window_hours=24), store_path=store)
print('after next add_task:', [t.name for t in list_tasks(store)])
"
stored: ['digest-7', 'digest-8', 'digest-9']
after torn write: []
after next add_task: ['digest-10']
```
The three original schedules are gone from disk, not merely unreadable.

After (this branch):
```
stored tasks: ['digest-7', 'digest-8', 'digest-9']
after partial write, list_tasks -> []
after next add_task -> ['digest-10']
quarantined files: ['/tmp/.../scheduler_tasks.json.corrupt-1788283816-cr7lylnd']
```
Same live-list behavior after the crash (the corrupt file genuinely can't be parsed, so `list_tasks` correctly can't recover it in place), but the original 3 tasks' data is now preserved byte-for-byte in the quarantined file rather than destroyed — recoverable by an operator, not gone.

```
$ uv run pytest tests/scheduler/test_store.py -q
27 passed in 1.59s

$ uv run pytest tests/scheduler/ -q
182 passed in 1.99s

$ uv run ruff check infrastructure/scheduling/scheduler/store.py tests/scheduler/test_store.py
All checks passed!

$ uv run ruff format --check infrastructure/scheduling/scheduler/store.py tests/scheduler/test_store.py
2 files already formatted

$ uv run mypy infrastructure/scheduling/scheduler/store.py tests/scheduler/test_store.py
Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I checked three prior closed PRs against this same issue before writing anything, to understand what had already been tried and why they didn't land. All three were closed the same day, in bulk, by a maintainer telling one contributor to "stop spamming with AI generated PRs" — a contributor-behavior issue, not a code-quality rejection. One of the three (the most refined iteration) had already reached Greptile 5/5 and included a real, reviewer-caught fix: an earlier version of the quarantine step built the aside filename from `time.time()` alone, which a reviewer pointed out would let two corruptions inside the same second collide on one filename and have the second `os.replace` erase the first casualty — exactly the class of loss this function exists to prevent. That got fixed with `tempfile.mkstemp`'s atomic-reservation guarantee instead of a bare timestamp string.

Given that design was already vetted to 5/5 and specifically addressed a subtle race a human reviewer had to point out once already, I implemented my own version of the same approach (read/write split, `mkstemp`-based unique quarantine naming, atomic write via temp-file+fsync+replace) rather than inventing a different one from scratch — but wrote it independently and verified every claim myself rather than copying: I ran the issue's exact repro against current `main` first to confirm the bug was still live (it was, unchanged), then re-derived the read/write-path distinction by tracing all four call sites (`list_tasks`, `add_task`, `remove_task`, `update_task`) — only `add_task` unconditionally calls `_save_raw` after loading, so only it needed the quarantine-before-write behavior; `remove_task`/`update_task` return early without writing when their target isn't found, and quarantining an unreadable store on a call that was never going to write to it would be a needless, surprising side effect.

Key files: `infrastructure/scheduling/scheduler/store.py` — `_read_raw` (the readability-reporting load), `_quarantine_unreadable` (the aside-move), `_load_for_write` (composes them for callers about to write), and the rewritten `_save_raw` (atomic write). `add_task`'s one changed line (`_load_raw` → `_load_for_write`) is the only call-site change; `list_tasks`, `remove_task`, and `update_task` are untouched.

Edge cases tested directly: a crash during `os.replace` itself (verifies the *previous* file survives byte-for-byte and no `.tmp` debris is left — not just "some file exists"); a store that's valid JSON but the wrong shape (`{"tasks": []}` instead of a list), which previously fell through to the same silent-empty path as broken JSON; `remove_task`/`update_task` against an unreadable store, confirming they leave it completely untouched (no quarantine, no write) since they have no target to act on; and two corruptions landing in the same wall-clock second, confirming both recovery copies survive independently rather than the second overwriting the first.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions