### PR TITLE
fix(shell): advertise Ctrl+P for the plan overlay instead of Alt/Option+P

### DIFF
--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -94,7 +94,7 @@ class PromptBuilder:
         # hook so a selection change repaints immediately.
         confirm_kb = install_confirmation_key_bindings(self.state, self._invalidate_prompt)
         install_session_key_bindings(self.pt_session, confirm_kb)
-        # Alt/Option+P (and Ctrl+P) expands/collapses the pinned plan while one
+        # Ctrl+P (and Alt/Option+P) expands/collapses the pinned plan while one
         # is on screen.
         plan_kb = install_plan_expand_key_bindings(
             self.state,

--- a/surfaces/interactive_shell/ui/hooks/plan_expand.py
+++ b/surfaces/interactive_shell/ui/hooks/plan_expand.py
@@ -1,8 +1,10 @@
-"""Alt/Option+P (and Ctrl+P) expand/collapse the pinned task-plan overlay.
+"""Ctrl+P (and Alt/Option+P) expand/collapse the pinned task-plan overlay.
 
 A long plan collapses to a window around the current step; this toggles the
-full checklist. Bindings are gated on a plan being present, so when there is
-no plan the keys fall through to their defaults (history for Ctrl+P).
+full checklist. Ctrl+P is the advertised key because it works on every terminal
+without Meta-key configuration; Alt/Option+P is bound too for those who prefer
+it. Bindings are gated on a plan being present, so when there is no plan the
+keys fall through to their defaults (history for Ctrl+P).
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ def install_plan_expand_key_bindings(
     has_plan: Callable[[], bool],
     redraw: Callable[[], None],
 ) -> KeyBindings:
-    """Bind Alt/Option+P and Ctrl+P to toggle the plan overlay while a plan is on screen."""
+    """Bind Ctrl+P and Alt/Option+P to toggle the plan overlay while a plan is on screen."""
     kb = KeyBindings()
     plan_shown = Condition(has_plan)
 
@@ -35,13 +37,14 @@ def install_plan_expand_key_bindings(
         state.toggle_plan_expanded()
         redraw()
 
-    # Alt/Option+P (ESC p in most terminals); Ctrl+P kept as a fallback.
-    @kb.add("escape", "p", filter=plan_shown, eager=True)
-    def _toggle_alt_p(event: KeyPressEvent) -> None:
-        _toggle(event)
-
+    # Ctrl+P works on every terminal without Meta-key setup — the advertised key.
     @kb.add("c-p", filter=plan_shown, eager=True)
     def _toggle_ctrl_p(event: KeyPressEvent) -> None:
+        _toggle(event)
+
+    # Alt/Option+P (ESC p) also bound, for terminals configured to send Meta.
+    @kb.add("escape", "p", filter=plan_shown, eager=True)
+    def _toggle_alt_p(event: KeyPressEvent) -> None:
         _toggle(event)
 
     return kb

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -24,7 +24,7 @@ _STEP_INDENT = "  "
 # Steps shown before the plan collapses; a longer plan folds to a window
 # around the current step until the user expands it.
 _COLLAPSED_MAX_STEPS = 3
-_EXPAND_HINT = "Alt/Option+P to view all"
+_EXPAND_HINT = "Ctrl+P to view all"
 
 
 def task_plan_from_tool_args(args: dict[str, object]) -> TaskPlan | None:

--- a/tests/interactive_shell/ui/hooks/test_plan_expand.py
+++ b/tests/interactive_shell/ui/hooks/test_plan_expand.py
@@ -1,4 +1,4 @@
-"""Alt/Option+P and Ctrl+P toggle the plan overlay only while a plan is on screen."""
+"""Ctrl+P and Alt/Option+P toggle the plan overlay only while a plan is on screen."""
 
 from __future__ import annotations
 

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -148,7 +148,7 @@ def test_long_plan_collapses_to_a_window_around_the_current_step() -> None:
     assert lines[2] == "  ✓ Read the config"
     assert lines[3] == "  ● Patch the bug"
     assert lines[4] == "  ○ Run the tests"
-    assert lines[5] == "  … 1 more · Alt/Option+P to view all"
+    assert lines[5] == "  … 1 more · Ctrl+P to view all"
     # The collapsed view hides the far ends.
     assert "Inspect the repo" not in overlay
     assert "Confirm green" not in overlay
@@ -162,7 +162,7 @@ def test_expanded_long_plan_shows_every_step() -> None:
     assert lines[1] == "  ✓ Inspect the repo"
     assert lines[5] == "  ○ Confirm green"
     assert "earlier" not in overlay
-    assert "Alt/Option+P" not in overlay
+    assert "to view all" not in overlay
     assert "Ctrl+P" not in overlay
 
 
@@ -183,7 +183,7 @@ def _other_long_plan():
 
 
 def test_replacing_a_plan_resets_expanded_state() -> None:
-    # Alt/Option+P on plan A must not stick when plan B is assigned without a
+    # Expanding plan A must not stick when plan B is assigned without a
     # None/empty gap — the replacement should open in its collapsed window.
     session = Session()
     session.task_plan = _long_plan()
@@ -196,7 +196,7 @@ def test_replacing_a_plan_resets_expanded_state() -> None:
     session.task_plan = _other_long_plan()
     second = _strip_ansi(render_prompt_region(session, state, SpinnerState()).value)
     assert state.plan_expanded is False
-    assert "Alt/Option+P to view all" in second
+    assert "Ctrl+P to view all" in second
     assert "Map the services" not in second
     assert "Verify p99" not in second
 


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

The pinned task-plan overlay hinted "Alt/Option+P to view all", but macOS
terminals don't send the Option key as Meta by default, so pressing it did
nothing and users couldn't expand a collapsed plan.

Both keys were already bound to toggle the overlay. This change makes Ctrl+P
the advertised, primary key — it emits a control code on every terminal and
keyboard layout with no Meta-key configuration — and keeps Alt/Option+P bound
as a secondary for terminals set up to send Meta.

Changes:
- Hint text now reads "Ctrl+P to view all".
- `plan_expand.py`: Ctrl+P binding listed first; docstring and comments explain
  why it is the advertised key. Alt/Option+P (`escape`, `p`) still bound.
- `prompt_builder.py`: wiring comment updated.
- Tests updated to assert the new hint and ordering.

No behavior change beyond the advertised key: the toggle is still gated on a
plan with steps being on screen, and both keys fall through to their defaults
(Ctrl+P → history) when no plan is pinned.