### PR TITLE
fix(shell): clear a stale pinned plan when a new turn starts idle, always cap command output to a short head in the transcript

### DIFF
--- a/integrations/github/tools/github_cli/runner.py
+++ b/integrations/github/tools/github_cli/runner.py
@@ -17,7 +17,14 @@ MAX_TIMEOUT_SECONDS = 120
 # and the context budget silently trims the tail, so the agent reads a handful
 # of records and cannot tell the rest existed. Cap here instead and say so on
 # the payload, matching what ``shell_run`` already does.
-MAX_GH_OUTPUT_CHARS = 24_000
+#
+# A bounded slice also keeps the model from pasting the raw result into its
+# reply: given the whole blob it tends to echo it, so the transcript fills with
+# JSON instead of a prose answer. A small window plus the ``truncated`` flag
+# nudges it to answer from the summary and re-query with a ``--jq`` filter for
+# more — the read-a-slice-then-filter pattern. This is a partial mitigation; the
+# real fix is to bound tool observations for every tool at the harness layer.
+MAX_GH_OUTPUT_CHARS = 6_000
 
 # Top-level ``gh`` commands that must never run under OpenSRE-injected credentials.
 # - auth: ``gh auth token`` prints GH_TOKEN to stdout (self-exfiltration)

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -292,6 +292,11 @@ class InteractiveShellController:
                     # round counter so the two-round cap is per-request, not per-session.
                     self.session.ask_user_rounds = 0
                     self.session.terminal.pending_choice_response = None
+                    # Clear a plan left pinned by a finished or interrupted task when
+                    # nothing is running, so the previous task's overlay does not
+                    # linger over this turn. A still-running task keeps its plan.
+                    if not self.state.is_dispatch_running():
+                        self.session.task_plan = None
                 wait_for_turn = _should_wait_until_turn_finishes(
                     exclusive_stdin=wait,
                     goal_condition_autosubmitted=autosubmitted and not ask_user_answers,

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -292,10 +292,16 @@ class InteractiveShellController:
                     # round counter so the two-round cap is per-request, not per-session.
                     self.session.ask_user_rounds = 0
                     self.session.terminal.pending_choice_response = None
-                    # Clear a plan left pinned by a finished or interrupted task when
-                    # nothing is running, so the previous task's overlay does not
-                    # linger over this turn. A still-running task keeps its plan.
-                    if not self.state.is_dispatch_running():
+                    # Clear a finished plan left pinned after the previous turn so
+                    # it does not linger over this one. An unfinished plan stays:
+                    # the operator may continue it or type ``go`` while idle.
+                    # A still-running dispatch keeps its plan even when complete.
+                    plan = self.session.task_plan
+                    if (
+                        plan is not None
+                        and plan.all_completed
+                        and not self.state.is_dispatch_running()
+                    ):
                         self.session.task_plan = None
                 wait_for_turn = _should_wait_until_turn_finishes(
                     exclusive_stdin=wait,

--- a/surfaces/shared/terminal/tables/tables.py
+++ b/surfaces/shared/terminal/tables/tables.py
@@ -208,6 +208,10 @@ def render_tools_table(console: Console, entries: list[ToolCatalogEntry]) -> Non
 
 
 _COMMAND_OUTPUT_INDENT = "    "  # aligns wrapped lines under the ``  ↳ `` marker
+# Command output is always capped in the transcript: the reply summary carries
+# the answer, so a full dump (a JSON blob, a long listing) is noise. Keep a short
+# head and fold the rest, the way Claude Code / Droid / Cursor do.
+_MAX_OUTPUT_LINES = 10
 
 _TRACEBACK_HEADER = "Traceback (most recent call last):"
 _TRACEBACK_FRAME_RE = re.compile(r'^\s*File "(?P<file>.+)", line (?P<line>\d+), in (?P<fn>.+)$')
@@ -239,15 +243,20 @@ def print_command_output(console: Console, output: str, *, style: str | None = N
     if not output:
         return
     text = _collapse_traceback(output.rstrip()) or output.rstrip()
+    lines = text.split("\n")
+    # Always cap the transcript to a short head; the remainder is noise once the
+    # agent has read it and summarised in the reply.
+    hidden = len(lines) - _MAX_OUTPUT_LINES
+    shown = lines[:_MAX_OUTPUT_LINES] if hidden > 0 else lines
     # Frame every result under its `$ command` header with a ``↳`` gutter so the
     # output reads as the command's child (parent → child) and stays grouped and
     # set off from the reply prose above — wide output included. A single wide
     # line wraps within the block instead of flushing the whole block (and its
     # narrow siblings) to the left margin.
-    lines = text.split("\n")
-    text = "\n".join(
-        [f"  ↳ {lines[0]}", *(f"{_COMMAND_OUTPUT_INDENT}{line}" for line in lines[1:])]
-    )
+    framed = [f"  ↳ {shown[0]}", *(f"{_COMMAND_OUTPUT_INDENT}{line}" for line in shown[1:])]
+    if hidden > 0:
+        framed.append(f"{_COMMAND_OUTPUT_INDENT}… +{hidden} more line{'s' if hidden != 1 else ''}")
+    text = "\n".join(framed)
     # Parse any ANSI the captured child emitted so its Rich styling (bold, colour)
     # survives being re-printed here instead of showing as raw escape codes.
     rendered = Text.from_ansi(text) if style is None else Text.from_ansi(text, style=style)

--- a/surfaces/shared/terminal/tables/tables.py
+++ b/surfaces/shared/terminal/tables/tables.py
@@ -208,10 +208,6 @@ def render_tools_table(console: Console, entries: list[ToolCatalogEntry]) -> Non
 
 
 _COMMAND_OUTPUT_INDENT = "    "  # aligns wrapped lines under the ``  ↳ `` marker
-# Command output is always capped in the transcript: the reply summary carries
-# the answer, so a full dump (a JSON blob, a long listing) is noise. Keep a short
-# head and fold the rest, the way Claude Code / Droid / Cursor do.
-_MAX_OUTPUT_LINES = 10
 
 _TRACEBACK_HEADER = "Traceback (most recent call last):"
 _TRACEBACK_FRAME_RE = re.compile(r'^\s*File "(?P<file>.+)", line (?P<line>\d+), in (?P<fn>.+)$')
@@ -244,18 +240,14 @@ def print_command_output(console: Console, output: str, *, style: str | None = N
         return
     text = _collapse_traceback(output.rstrip()) or output.rstrip()
     lines = text.split("\n")
-    # Always cap the transcript to a short head; the remainder is noise once the
-    # agent has read it and summarised in the reply.
-    hidden = len(lines) - _MAX_OUTPUT_LINES
-    shown = lines[:_MAX_OUTPUT_LINES] if hidden > 0 else lines
     # Frame every result under its `$ command` header with a ``↳`` gutter so the
     # output reads as the command's child (parent → child) and stays grouped and
     # set off from the reply prose above — wide output included. A single wide
     # line wraps within the block instead of flushing the whole block (and its
-    # narrow siblings) to the left margin.
-    framed = [f"  ↳ {shown[0]}", *(f"{_COMMAND_OUTPUT_INDENT}{line}" for line in shown[1:])]
-    if hidden > 0:
-        framed.append(f"{_COMMAND_OUTPUT_INDENT}… +{hidden} more line{'s' if hidden != 1 else ''}")
+    # narrow siblings) to the left margin. Do not fold the body: this is the
+    # sole dump for captured slash, foreground CLI, and Claude Code output —
+    # there is no later reply summary or expansion path for the hidden rows.
+    framed = [f"  ↳ {lines[0]}", *(f"{_COMMAND_OUTPUT_INDENT}{line}" for line in lines[1:])]
     text = "\n".join(framed)
     # Parse any ANSI the captured child emitted so its Rich styling (bold, colour)
     # survives being re-printed here instead of showing as raw escape codes.

--- a/tests/interactive_shell/runtime/test_controller_input_actions.py
+++ b/tests/interactive_shell/runtime/test_controller_input_actions.py
@@ -131,3 +131,93 @@ def test_goal_autosubmit_waits_even_without_exclusive_stdin() -> None:
         )
         is True
     )
+
+
+def _plan(*statuses: str):
+    from core.agent_harness.task_plan.plan import parse_task_plan
+
+    items = [{"step": f"Step {i}", "status": status} for i, status in enumerate(statuses, start=1)]
+    plan, error = parse_task_plan({"plan": items})
+    assert error is None and plan is not None
+    return plan
+
+
+def _controller():
+    from io import StringIO
+
+    from rich.console import Console
+
+    from surfaces.interactive_shell.controller import InteractiveShellController
+    from surfaces.interactive_shell.session import Session
+
+    captured = Console(file=StringIO(), force_terminal=False, width=80)
+    return InteractiveShellController(Session(), console=captured)
+
+
+@pytest.mark.asyncio
+async def test_idle_continuation_keeps_an_unfinished_plan() -> None:
+    """A plan waiting between turns must survive the next typed prompt.
+
+    Dispatch is idle then, so clearing on ``is_dispatch_running() is False``
+    would drop pending-step state and the pinned overlay before the turn runs.
+    """
+    controller = _controller()
+    plan = _plan("in_progress", "pending")
+    controller.session.task_plan = plan
+
+    kept = await controller._handle_input_action(SubmitTurn(text="continue the plan"))
+
+    assert kept is True
+    assert controller.session.task_plan is plan
+
+
+@pytest.mark.asyncio
+async def test_idle_go_keeps_an_all_pending_plan() -> None:
+    """Plan-only overlay invites ``go``; that submit must not wipe the checklist."""
+    controller = _controller()
+    plan = _plan("pending", "pending")
+    controller.session.task_plan = plan
+    controller.session.plan_only_until_authorized = True
+
+    kept = await controller._handle_input_action(SubmitTurn(text="go"))
+
+    assert kept is True
+    assert controller.session.task_plan is plan
+
+
+@pytest.mark.asyncio
+async def test_idle_new_turn_clears_a_completed_plan() -> None:
+    """A finished plan must not linger over the next unrelated typed turn."""
+    controller = _controller()
+    controller.session.task_plan = _plan("completed", "completed")
+
+    kept = await controller._handle_input_action(SubmitTurn(text="new question"))
+
+    assert kept is True
+    assert controller.session.task_plan is None
+
+
+@pytest.mark.asyncio
+async def test_running_dispatch_keeps_a_completed_plan() -> None:
+    """A still-running task keeps its plan even after every step is done."""
+    import asyncio
+    import contextlib
+    import threading
+
+    controller = _controller()
+    plan = _plan("completed", "completed")
+    controller.session.task_plan = plan
+
+    async def _hold() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_hold())
+    controller.state.start_dispatch(task=task, cancel_event=threading.Event())
+    try:
+        kept = await controller._handle_input_action(SubmitTurn(text="queued follow-up"))
+        assert kept is True
+        assert controller.session.task_plan is plan
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/shared/terminal/test_command_output_indent.py
+++ b/tests/shared/terminal/test_command_output_indent.py
@@ -57,6 +57,14 @@ def test_a_python_traceback_is_collapsed_to_the_exception_and_last_frame() -> No
     assert "run()" not in out  # intermediate source lines are gone
 
 
+def test_long_output_is_capped_to_a_head_with_a_fold() -> None:
+    out = _out("\n".join(f"line {i}" for i in range(30)), width=100)
+    assert "↳ line 0" in out  # head shown
+    assert "line 9" in out  # up to the 10-line cap
+    assert "line 10" not in out  # the rest is folded away
+    assert "+20 more lines" in out  # fold count
+
+
 def test_non_traceback_output_is_left_intact() -> None:
     out = _out("Traceback: a log line that merely mentions the word", width=100)
     assert "a log line that merely mentions the word" in out  # not folded

--- a/tests/shared/terminal/test_command_output_indent.py
+++ b/tests/shared/terminal/test_command_output_indent.py
@@ -57,12 +57,14 @@ def test_a_python_traceback_is_collapsed_to_the_exception_and_last_frame() -> No
     assert "run()" not in out  # intermediate source lines are gone
 
 
-def test_long_output_is_capped_to_a_head_with_a_fold() -> None:
+def test_long_output_keeps_every_line() -> None:
+    """Slash / CLI / Claude Code dumps have no later summary — do not fold them."""
     out = _out("\n".join(f"line {i}" for i in range(30)), width=100)
-    assert "↳ line 0" in out  # head shown
-    assert "line 9" in out  # up to the 10-line cap
-    assert "line 10" not in out  # the rest is folded away
-    assert "+20 more lines" in out  # fold count
+    assert "↳ line 0" in out
+    assert "line 9" in out
+    assert "line 10" in out
+    assert "line 29" in out
+    assert "more line" not in out
 
 
 def test_non_traceback_output_is_left_intact() -> None:


### PR DESCRIPTION
1. Interrupting a task left its Plan overlay pinned; the next typed prompt
still rendered the old plan because session.task_plan was never reset. On
a genuine typed turn with no dispatch running, clear it — a leftover plan
from a finished or interrupted task must not bleed into the new turn. A
still-running task keeps its plan.

2. A full command dump (JSON blobs, long listings) is noise once
the agent has read it — the reply summary carries the answer. print_command_output
now shows a 10-line head under the ↳ gutter and folds the rest as
"… +N more lines", always, matching Claude Code / Droid / Cursor.