### PR TITLE
fix(test): patch GitHub package API in account-gate tests

### DIFF
--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -22,9 +22,12 @@ def _console() -> Console:
 
 
 def test_account_is_signed_in_follows_saved_github_username(monkeypatch: Any) -> None:
-    monkeypatch.setattr("integrations.github.identity.saved_github_username", lambda: "octocat")
+    # Patch the package API (what account_gate imports). Patching only
+    # ``integrations.github.identity`` misses when another test has bound the
+    # name on ``integrations.github`` and shadowed ``__getattr__``.
+    monkeypatch.setattr("integrations.github.saved_github_username", lambda: "octocat")
     assert account_gate.account_is_signed_in() is True
-    monkeypatch.setattr("integrations.github.identity.saved_github_username", lambda: "")
+    monkeypatch.setattr("integrations.github.saved_github_username", lambda: "")
     assert account_gate.account_is_signed_in() is False
 
 
@@ -36,7 +39,7 @@ def test_account_login_returns_ok_from_github_device_flow(monkeypatch: Any) -> N
         return GitHubLoginResult(ok=True, username="octocat")
 
     monkeypatch.setattr(
-        "integrations.github.login.authenticate_and_configure_github",
+        "integrations.github.authenticate_and_configure_github",
         _auth,
     )
 
@@ -50,7 +53,7 @@ def test_account_login_returns_false_when_device_flow_fails(monkeypatch: Any) ->
         raise RuntimeError("denied")
 
     monkeypatch.setattr(
-        "integrations.github.login.authenticate_and_configure_github",
+        "integrations.github.authenticate_and_configure_github",
         _auth,
     )
     console = _console()


### PR DESCRIPTION
## Summary
- Account-gate tests now patch `integrations.github.saved_github_username` and `integrations.github.authenticate_and_configure_github` (the package API the gate imports).
- Patching only `identity` / `login` is ignored after another test binds those names on the package and shadows `__getattr__`.
- That left CI calling the real `saved_github_username` (empty → `False`) and the real GitHub device flow (600s timeouts).

## Test plan
- [x] ` run python -m pytest tests/interactive_shell/runtime/test_account_gate.py -q`
- [x] Same file after `tests/cli/wizard/test_factory_setup.py` + `tests/analytics/test_capture.py` (the tests that bind the package names)
- [ ] Confirm the `test (ubuntu-…)` shard that failed on main is green