### PR TITLE
test(harness): honour EvaluateFn contract in test_goal_and_run_until.py (#5191)

### DIFF
--- a/tests/core/agent_harness/session_goal/test_goal_and_run_until.py
+++ b/tests/core/agent_harness/session_goal/test_goal_and_run_until.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from core.agent_harness.session.session_core import SessionCore
 from core.agent_harness.session_goal.goal import (
     SessionGoal,
@@ -91,6 +93,11 @@ def test_five_step_outer_loop_continues_until_achieved() -> None:
     assert "session_goal:" not in (outcome.last_result.assistant_response_text or "")
 
 
+def _stay_active(goal: SessionGoal, result: Any, *, session: Any | None = None) -> str:
+    """Evaluate stub that never achieves, so only the turn budget stops the loop."""
+    return SessionGoalStatus.ACTIVE
+
+
 def test_outer_loop_disabled_fails_five_step_probe() -> None:
     session = SessionCore()
     turns: list[str] = []
@@ -117,7 +124,7 @@ def test_outer_loop_disabled_fails_five_step_probe() -> None:
             condition="complete all five steps",
             max_outer_turns=1,
         ),
-        evaluate=lambda *_a, **_k: SessionGoalStatus.ACTIVE,
+        evaluate=_stay_active,
     )
 
     assert len(turns) == 1


### PR DESCRIPTION
Fixes #5191

#### Describe the changes you have made in this PR -

Test-only refactor of `tests/core/agent_harness/session_goal/test_goal_and_run_until.py`.

The single swallow-all `evaluate=lambda *_a, **_k: SessionGoalStatus.ACTIVE` stage stub is replaced with a named function whose signature matches the `EvaluateFn` contract and `default_evaluate_session_goal` exactly:

```python
def _stay_active(goal: SessionGoal, result: Any, *, session: Any | None = None) -> str:
    """Evaluate stub that never achieves, so only the turn budget stops the loop."""
    return SessionGoalStatus.ACTIVE
```

Behaviour is identical: it always returns `ACTIVE`, so `test_outer_loop_disabled_fails_five_step_probe` still asserts `BUDGET_EXHAUSTED` from `max_outer_turns=1`. The difference is that a change to the evaluate contract now fails the test instead of passing silently. `result` and `session` stay typed as `Any` because that is what the production contract uses; a stricter type would break the signature match this issue asks for.

**Scope vs. the issue text.** The issue was written against a pre-#5761 version of this file that had 8 `lambda *_a, **_k` stage stubs and 2 `type("Run", ...)` result fakes (lines 90 to 168). PR #5761 ("Collapse chat into the shared ReAct agent") already rewrote those tests and removed all of them except the one `evaluate=` lambda addressed here. The shared helpers the issue references (`fake_llm_run`, `no_evidence`, `answer_with_text`, added by #5215) were also removed by #5761 and have no remaining consumers, so they are not reintroduced. The two earlier attempts at this issue (#5467, #5736) predate #5761 and are closed. A similar `type("R", ...)` fake exists in `test_progress.py`, but that file is out of scope per the issue ("Other files"); noted here for a separate follow-up.

Acceptance criteria, against the current state of the file:

- [x] No `lambda *_a, **_k` stage stubs remain
- [x] No `type("Run", ...)` result fakes remain
- [x] Stubs are named functions
- [x] Test intent unchanged (this file has no `answer=None` semantics to preserve)
- [x] `uv run pytest tests/core/agent_harness/session_goal/test_goal_and_run_until.py` green, no product change

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/core/agent_harness/session_goal/test_goal_and_run_until.py -q
7 passed

$ uv run pytest tests/core/agent_harness/session_goal/ -q
87 passed

$ make lint && make format-check && make typecheck
ruff check ...            All checks passed!
ruff format --check ...   3793 files already formatted
mypy ...                  Success: no issues found in 1982 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The test passed `evaluate` as `lambda *_a, **_k`, which accepts any signature and keeps the test green even if the `EvaluateFn` contract changes underneath it. The fix is a named function pinned to the real signature `(goal, result, *, session=None) -> str`, taken from `default_evaluate_session_goal`. `result` and `session` are kept as `Any` on purpose because that is the production contract (the evaluator reads `assistant_response_text` via `getattr`), so a narrower type would defeat the point of matching the signature. Alternative considered: reuse a shared helper as the issue suggests, but those helpers were deleted by #5761 and none was ever an `evaluate` helper, so a local named function is the minimal correct change. No new tests are added because there is no behaviour change to cover.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests. N/A, test-only refactor with no behaviour change
- [x] My code follows the project's style guidelines and conventions
