### PR TITLE
feat(shell): readable tool output — hide raw data dumps, one-line calls, plan overlay

### DIFF
--- a/core/agent_harness/prompts/skills/architecture_audit/SKILL.md
+++ b/core/agent_harness/prompts/skills/architecture_audit/SKILL.md
@@ -36,18 +36,16 @@ HARD RULES (violating any = failed turn):
   + save observations + final report.
 
 STEP LABELING RULES (UX) — this skill hides its shell output (quiet=true), so
-narrate the 9 steps of the compact sequence:
-- Before every step's tool calls, emit this exact header format as assistant
-  text in the SAME response as the tool calls, then one short status sentence:
-    ### [n/9] <step name>
-    <One-sentence status.>
-- Never start tool calls for a new step without its header.
-- After a step's tool results are in, state its outcome in one line (start it
-  with ✓ on success, ✗ plus what failed otherwise) before the next step's
-  header.
-- Use the step's own number as n and a short name (e.g. `### [2/9] Agent
-  scan`, `### [3/9] Import pass`), even when a step is skipped or trivial
-  (a ✓ line with no tool calls is fine); never renumber mid-run.
+the pinned plan overlay is the user's progress signal (Droid-style):
+- Call `update_plan` **once at the start** of the run with the 9 compact-
+  sequence steps below (pending). Mark the first step `in_progress`.
+- Before starting each next step's tool calls, call `update_plan` again:
+  mark the finished step `completed`, the next one `in_progress`. Never leave
+  the plan idle with every step still pending.
+- Do **not** dump `### [n/9]` headers into the transcript — the overlay already
+  shows `Plan · n/m`. One short status sentence per step is enough.
+- After the final report is ready, call `update_plan` with every step
+  `completed` (or leave the last step completed from the prior update).
 
 Compact sequence:
 1) architecture_clone_repo(owner, repo, ref?)

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -65,7 +65,12 @@ from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
 from infrastructure.observability.trace.prompts import persist_turn_system_prompt
 from infrastructure.observability.trace.spans import component_span
-from infrastructure.terminal.peek import build_output_peek, format_expand_marker
+from infrastructure.terminal.peek import (
+    DISPLAY_OUTPUT_MAX_CHARS,
+    DISPLAY_OUTPUT_MAX_LINES,
+    cap_output_for_display,
+    format_view_all_marker,
+)
 
 log = logging.getLogger(__name__)
 
@@ -342,10 +347,9 @@ def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
     ]
 
 
-_DISPLAY_OUTPUT_MAX_LINES = 4
-_DISPLAY_OUTPUT_MAX_CHARS = 240
-_OUTPUT_TRUNCATED_MARKER = "… (output truncated)"
-_EXPAND_MARKER_RE = re.compile(r"^… \d+ more lines?$")
+_DISPLAY_OUTPUT_MAX_LINES = DISPLAY_OUTPUT_MAX_LINES
+_DISPLAY_OUTPUT_MAX_CHARS = DISPLAY_OUTPUT_MAX_CHARS
+_EXPAND_MARKER_RE = re.compile(r"^… \d+ more, Ctrl\+O to view$")
 
 
 _PLAN_SNAPSHOT_RE = re.compile(r"Plan\s*[·.]\s*\d+\s*/\s*\d+(?:\s*[✓●○][^✓●○\n]*)*")
@@ -375,15 +379,14 @@ def _looks_like_json(text: str) -> bool:
 
 
 def _is_output_truncation_marker(line: str) -> bool:
-    return line == _OUTPUT_TRUNCATED_MARKER or bool(_EXPAND_MARKER_RE.fullmatch(line))
+    return line == format_view_all_marker() or bool(_EXPAND_MARKER_RE.fullmatch(line))
 
 
 def _split_output_truncation_markers(text: str) -> tuple[str, str]:
-    """Peel trailing truncation-marker lines from a capped preview.
+    """Peel the trailing expand marker from a capped preview.
 
-    Returns ``(body, markers)``. *markers* is the trailing marker block — the
-    character-cap line, the folded-line peek, or both — or empty when nothing
-    was truncated.
+    Returns ``(body, marker)``. *marker* is the single Droid-style line
+    (``… N more, Ctrl+O to view`` or ``Ctrl+O to view all``), or empty.
     """
     lines = text.split("\n")
     cut = len(lines)
@@ -396,26 +399,17 @@ def _cap_for_display(text: str) -> str:
     """Cap verbose tool output for the console so a large result cannot flood the
     transcript. The model and persisted history keep the full text; only the
     user-facing preview is truncated to a short head (Droid-style).
-
-    Line-fold and character-cap can both apply to the same preview; each one
-    that fires is reported so a mid-line cut is never silent behind a
-    ``… N more lines`` marker.
     """
-    if not text:
-        return text
-    peek, hidden = build_output_peek(text, max_lines=_DISPLAY_OUTPUT_MAX_LINES)
-    char_truncated = False
-    if len(peek) > _DISPLAY_OUTPUT_MAX_CHARS:
-        peek = peek[:_DISPLAY_OUTPUT_MAX_CHARS].rstrip()
-        char_truncated = True
-    markers: list[str] = []
-    if char_truncated:
-        markers.append(_OUTPUT_TRUNCATED_MARKER)
-    if hidden:
-        markers.append(format_expand_marker(hidden))
-    if markers:
-        return peek + "\n" + "\n".join(markers)
-    return peek
+    preview, _full = cap_output_for_display(text)
+    return preview
+
+
+def _stash_collapsed_tool_output(session: SessionState, text: str | None) -> None:
+    """Remember the full body so Ctrl+O can page it; no-op without a terminal."""
+    terminal = getattr(session, "terminal", None)
+    if terminal is None:
+        return
+    terminal.collapsed_tool_output = text
 
 
 def _is_data_blob(text: str) -> bool:
@@ -516,7 +510,7 @@ def _preferred_tool_response_text(tool_result: Any) -> str:
     if isinstance(details, dict):
         response_text = details.get("response_text")
         if isinstance(response_text, str) and response_text.strip():
-            return response_text.strip()
+            return _user_facing_tool_text(response_text)
     content = _content_to_text(getattr(tool_result, "content", "")).strip()
     if not content:
         return ""
@@ -527,7 +521,9 @@ def _preferred_tool_response_text(tool_result: Any) -> str:
     if not isinstance(parsed, dict):
         return ""
     response_text = parsed.get("response_text")
-    return response_text.strip() if isinstance(response_text, str) else ""
+    if not isinstance(response_text, str):
+        return ""
+    return _user_facing_tool_text(response_text)
 
 
 def _has_preferred_tool_response_text(result: Any) -> bool:
@@ -1029,6 +1025,7 @@ def _compose_response(
     is_json = _looks_like_json(generic_text)
     body, markers = _split_output_truncation_markers(display_generic)
     truncated = bool(markers)
+    _stash_collapsed_tool_output(session, generic_text if truncated else None)
     bulky = display_generic.count("\n") >= 4 or truncated
     if display_generic and (is_json or bulky):
         # Truncated JSON is invalid — fencing it as ``json`` makes Rich/Pygments

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -345,6 +345,7 @@ def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
 _DISPLAY_OUTPUT_MAX_LINES = 4
 _DISPLAY_OUTPUT_MAX_CHARS = 240
 _OUTPUT_TRUNCATED_MARKER = "… (output truncated)"
+_EXPAND_MARKER_RE = re.compile(r"^… \d+ more lines?$")
 
 
 _PLAN_SNAPSHOT_RE = re.compile(r"Plan\s*[·.]\s*\d+\s*/\s*\d+(?:\s*[✓●○][^✓●○\n]*)*")
@@ -373,10 +374,33 @@ def _looks_like_json(text: str) -> bool:
     return True
 
 
+def _is_output_truncation_marker(line: str) -> bool:
+    return line == _OUTPUT_TRUNCATED_MARKER or bool(_EXPAND_MARKER_RE.fullmatch(line))
+
+
+def _split_output_truncation_markers(text: str) -> tuple[str, str]:
+    """Peel trailing truncation-marker lines from a capped preview.
+
+    Returns ``(body, markers)``. *markers* is the trailing marker block — the
+    character-cap line, the folded-line peek, or both — or empty when nothing
+    was truncated.
+    """
+    lines = text.split("\n")
+    cut = len(lines)
+    while cut and _is_output_truncation_marker(lines[cut - 1]):
+        cut -= 1
+    return "\n".join(lines[:cut]), "\n".join(lines[cut:])
+
+
 def _cap_for_display(text: str) -> str:
     """Cap verbose tool output for the console so a large result cannot flood the
     transcript. The model and persisted history keep the full text; only the
-    user-facing preview is truncated to a short head (Droid-style)."""
+    user-facing preview is truncated to a short head (Droid-style).
+
+    Line-fold and character-cap can both apply to the same preview; each one
+    that fires is reported so a mid-line cut is never silent behind a
+    ``… N more lines`` marker.
+    """
     if not text:
         return text
     peek, hidden = build_output_peek(text, max_lines=_DISPLAY_OUTPUT_MAX_LINES)
@@ -384,10 +408,13 @@ def _cap_for_display(text: str) -> str:
     if len(peek) > _DISPLAY_OUTPUT_MAX_CHARS:
         peek = peek[:_DISPLAY_OUTPUT_MAX_CHARS].rstrip()
         char_truncated = True
-    if hidden:
-        return f"{peek}\n{format_expand_marker(hidden)}"
+    markers: list[str] = []
     if char_truncated:
-        return f"{peek}\n{_OUTPUT_TRUNCATED_MARKER}"
+        markers.append(_OUTPUT_TRUNCATED_MARKER)
+    if hidden:
+        markers.append(format_expand_marker(hidden))
+    if markers:
+        return peek + "\n" + "\n".join(markers)
     return peek
 
 
@@ -402,7 +429,20 @@ def _is_data_blob(text: str) -> bool:
     stripped = text.strip()
     if not stripped:
         return False
-    return stripped[0] in "{[" or stripped.count('":') >= 3
+    if stripped[0] in "{[":
+        return True
+    # Mid-object fragments (and short gh ``summary`` previews of JSON) still
+    # carry ``":`` key separators — two is enough once the text is clearly a
+    # record slice rather than prose.
+    return stripped.count('":') >= 2
+
+
+def _user_facing_tool_text(text: str) -> str:
+    """Return *text* for the transcript, or ``""`` when it is a data blob."""
+    stripped = text.strip()
+    if not stripped or _is_data_blob(stripped):
+        return ""
+    return stripped
 
 
 def _visible_stdout(stdout: str) -> str:
@@ -414,12 +454,7 @@ def _visible_stdout(stdout: str) -> str:
     Claude Code / Droid keep tool results out of the reply prose. Plain-text
     output (logs, a short listing) is still shown, capped later at display time.
     """
-    stripped = stdout.strip()
-    if not stripped:
-        return ""
-    if _is_data_blob(stripped):
-        return ""
-    return stripped
+    return _user_facing_tool_text(stdout)
 
 
 def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
@@ -428,12 +463,14 @@ def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
         return ""
     preferred_response = _preferred_tool_response_text(tool_result)
     if preferred_response:
-        return preferred_response
+        return _user_facing_tool_text(preferred_response)
     details = getattr(tool_result, "details", None)
     if isinstance(details, dict):
         summary = details.get("summary")
         if isinstance(summary, str) and summary.strip():
-            return summary.strip()
+            # gh ``summary`` for ``api`` used to be a sliced JSON string — hide
+            # that the same way as raw stdout so the transcript stays prose.
+            return _user_facing_tool_text(summary)
         stdout = details.get("stdout")
         if details.get("ok") and isinstance(stdout, str) and stdout.strip():
             return _visible_stdout(stdout)
@@ -453,10 +490,10 @@ def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
     if isinstance(parsed, dict):
         response_text = parsed.get("response_text")
         if isinstance(response_text, str) and response_text.strip():
-            return response_text.strip()
+            return _user_facing_tool_text(response_text)
         summary = parsed.get("summary")
         if isinstance(summary, str) and summary.strip():
-            return summary.strip()
+            return _user_facing_tool_text(summary)
         if parsed.get("ok") and isinstance(parsed.get("stdout"), str) and parsed["stdout"].strip():
             return _visible_stdout(str(parsed["stdout"]))
         if parsed.get("error"):
@@ -985,23 +1022,23 @@ def _compose_response(
     # github_cli / other registry tools without double-printing shell output.
     # response_text still includes history for persistence / non-TTY surfaces.
     display_generic = _cap_for_display(generic_text)
+    # Defense: never fence a data blob into the transcript (summary/stdout leaks
+    # used to pretty-print truncated JSON behind a text fence).
+    if _is_data_blob(generic_text):
+        display_generic = ""
     is_json = _looks_like_json(generic_text)
-    truncated = display_generic.endswith(_OUTPUT_TRUNCATED_MARKER) or (
-        "… " in display_generic and " more line" in display_generic
-    )
+    body, markers = _split_output_truncation_markers(display_generic)
+    truncated = bool(markers)
     bulky = display_generic.count("\n") >= 4 or truncated
     if display_generic and (is_json or bulky):
         # Truncated JSON is invalid — fencing it as ``json`` makes Rich/Pygments
         # paint error tokens (red blocks) on the cut. Use a text fence instead
-        # and keep the truncation marker outside the block.
+        # and keep truncation markers outside the block.
         if truncated:
-            # Marker is either the legacy char-cap line or a peek ``… N more``.
-            body, _, marker = display_generic.rpartition("\n")
-            if not body:
-                body, marker = display_generic, ""
-            fence_body = body if body else display_generic
-            suffix = f"\n{marker}" if marker else ""
-            display_generic = f"\n```text\n{fence_body}\n```{suffix}"
+            if body:
+                display_generic = f"\n```text\n{body}\n```\n{markers}"
+            else:
+                display_generic = f"\n```text\n{display_generic}\n```"
         else:
             lang = "json" if is_json else "text"
             display_generic = f"\n```{lang}\n{display_generic}\n```"

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -38,7 +38,6 @@ from core.agent_harness.prompts import (
     build_action_user_message,
 )
 from core.agent_harness.session.integration_resolution import resolve_and_cache_integrations
-from infrastructure.terminal.peek import build_output_peek, format_expand_marker
 from core.agent_harness.session.pending_choice import parse_ask_user_answers
 from core.agent_harness.session.terminal_access import execute_cli_onboard_on_missing_key
 from core.agent_harness.session_goal.goal import strip_session_goal_progress_tags
@@ -66,6 +65,7 @@ from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
 from infrastructure.observability.trace.prompts import persist_turn_system_prompt
 from infrastructure.observability.trace.spans import component_span
+from infrastructure.terminal.peek import build_output_peek, format_expand_marker
 
 log = logging.getLogger(__name__)
 

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -38,6 +38,7 @@ from core.agent_harness.prompts import (
     build_action_user_message,
 )
 from core.agent_harness.session.integration_resolution import resolve_and_cache_integrations
+from infrastructure.terminal.peek import build_output_peek, format_expand_marker
 from core.agent_harness.session.pending_choice import parse_ask_user_answers
 from core.agent_harness.session.terminal_access import execute_cli_onboard_on_missing_key
 from core.agent_harness.session_goal.goal import strip_session_goal_progress_tags
@@ -341,8 +342,8 @@ def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
     ]
 
 
-_DISPLAY_OUTPUT_MAX_LINES = 12
-_DISPLAY_OUTPUT_MAX_CHARS = 800
+_DISPLAY_OUTPUT_MAX_LINES = 4
+_DISPLAY_OUTPUT_MAX_CHARS = 240
 _OUTPUT_TRUNCATED_MARKER = "… (output truncated)"
 
 
@@ -375,30 +376,50 @@ def _looks_like_json(text: str) -> bool:
 def _cap_for_display(text: str) -> str:
     """Cap verbose tool output for the console so a large result cannot flood the
     transcript. The model and persisted history keep the full text; only the
-    user-facing preview is truncated."""
+    user-facing preview is truncated to a short head (Droid-style)."""
     if not text:
         return text
-    lines = text.splitlines()
-    capped = "\n".join(lines[:_DISPLAY_OUTPUT_MAX_LINES])
-    truncated = len(lines) > _DISPLAY_OUTPUT_MAX_LINES
-    if len(capped) > _DISPLAY_OUTPUT_MAX_CHARS:
-        capped = capped[:_DISPLAY_OUTPUT_MAX_CHARS].rstrip()
-        truncated = True
-    return f"{capped}\n{_OUTPUT_TRUNCATED_MARKER}" if truncated else capped
+    peek, hidden = build_output_peek(text, max_lines=_DISPLAY_OUTPUT_MAX_LINES)
+    char_truncated = False
+    if len(peek) > _DISPLAY_OUTPUT_MAX_CHARS:
+        peek = peek[:_DISPLAY_OUTPUT_MAX_CHARS].rstrip()
+        char_truncated = True
+    if hidden:
+        return f"{peek}\n{format_expand_marker(hidden)}"
+    if char_truncated:
+        return f"{peek}\n{_OUTPUT_TRUNCATED_MARKER}"
+    return peek
+
+
+def _is_data_blob(text: str) -> bool:
+    """Whether *text* is a JSON/record blob — valid, truncated, or a mid-object
+    fragment (a capped ``gh api`` response can arrive starting mid-value).
+
+    Detected by shape (opens an object/array) or by density of ``":`` key
+    separators, which URLs do not inflate and prose/logs almost never contain.
+    Such data is what the reply summarizes; it should not fill the transcript.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    return stripped[0] in "{[" or stripped.count('":') >= 3
 
 
 def _visible_stdout(stdout: str) -> str:
-    """Plain-text stdout is shown as-is; a JSON payload (e.g. a ``gh api``
-    response) is pretty-printed so it reads as formatted data, not a one-line
-    blob. Capping and fenced-block styling happen later, at display time."""
+    """Plain-text stdout is shown as-is; a JSON payload is hidden.
+
+    A ``gh api`` / structured response is data the reply already summarizes, so
+    dumping it into the transcript only adds a wall that reads as unattached to
+    the command. Hide the blob and let the summary carry the answer — the way
+    Claude Code / Droid keep tool results out of the reply prose. Plain-text
+    output (logs, a short listing) is still shown, capped later at display time.
+    """
     stripped = stdout.strip()
     if not stripped:
         return ""
-    try:
-        parsed = json.loads(stripped)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return stripped
-    return json.dumps(parsed, indent=2, ensure_ascii=False)
+    if _is_data_blob(stripped):
+        return ""
+    return stripped
 
 
 def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
@@ -440,11 +461,15 @@ def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
             return _visible_stdout(str(parsed["stdout"]))
         if parsed.get("error"):
             return str(parsed["error"]).strip()
-    if parsed is not None:
-        # An opaque JSON payload (a dict with no user-facing field, or a list):
-        # pretty-print it so raw data reads as formatted JSON rather than a
-        # one-line blob. Capping and fenced-block styling happen at display time.
-        return json.dumps(parsed, indent=2, ensure_ascii=False)
+    if isinstance(parsed, (dict, list)):
+        # An opaque JSON payload (no user-facing field — e.g. a raw ``gh api``
+        # response) is for the model, not the transcript: the reply summarizes
+        # it. Hide it rather than dump a wall of data unattached to the command.
+        return ""
+    # A truncated / fragmentary JSON blob (a capped ``gh api`` response) that
+    # failed to parse — hide it, same as valid JSON.
+    if _is_data_blob(content):
+        return ""
     # Non-JSON content is the tool's real text output; show it under the name.
     return f"{tool_call.name} result: {content}"
 
@@ -961,15 +986,22 @@ def _compose_response(
     # response_text still includes history for persistence / non-TTY surfaces.
     display_generic = _cap_for_display(generic_text)
     is_json = _looks_like_json(generic_text)
-    truncated = display_generic.endswith(_OUTPUT_TRUNCATED_MARKER)
+    truncated = display_generic.endswith(_OUTPUT_TRUNCATED_MARKER) or (
+        "… " in display_generic and " more line" in display_generic
+    )
     bulky = display_generic.count("\n") >= 4 or truncated
     if display_generic and (is_json or bulky):
         # Truncated JSON is invalid — fencing it as ``json`` makes Rich/Pygments
         # paint error tokens (red blocks) on the cut. Use a text fence instead
         # and keep the truncation marker outside the block.
         if truncated:
-            body = display_generic[: -len(_OUTPUT_TRUNCATED_MARKER)].rstrip("\n")
-            display_generic = f"\n```text\n{body}\n```\n{_OUTPUT_TRUNCATED_MARKER}"
+            # Marker is either the legacy char-cap line or a peek ``… N more``.
+            body, _, marker = display_generic.rpartition("\n")
+            if not body:
+                body, marker = display_generic, ""
+            fence_body = body if body else display_generic
+            suffix = f"\n{marker}" if marker else ""
+            display_generic = f"\n```text\n{fence_body}\n```{suffix}"
         else:
             lang = "json" if is_json else "text"
             display_generic = f"\n```{lang}\n{display_generic}\n```"

--- a/infrastructure/terminal/peek.py
+++ b/infrastructure/terminal/peek.py
@@ -1,12 +1,15 @@
 """Peek helpers for collapsed tool output in the transcript.
 
 Pure string logic so collapse behaviour is testable without a live TTY: a long
-tool result renders as a short head plus a ``… N more lines`` marker. Expansion
-(Ctrl+O) can reuse these helpers once a session buffer + keybinding land; this
-module owns only the text shaping.
+tool result renders as a short head plus a Droid-style expand marker
+(``… N more, Ctrl+O to view``). The shell binds Ctrl+O to page the full text.
 """
 
 from __future__ import annotations
+
+DISPLAY_OUTPUT_MAX_LINES = 4
+DISPLAY_OUTPUT_MAX_CHARS = 240
+_VIEW_ALL_MARKER = "Ctrl+O to view all"
 
 
 def build_output_peek(full_text: str, *, max_lines: int = 3) -> tuple[str, int]:
@@ -26,9 +29,47 @@ def build_output_peek(full_text: str, *, max_lines: int = 3) -> tuple[str, int]:
 
 
 def format_expand_marker(hidden: int) -> str:
-    """One-line marker for the folded remainder: ``… N more lines``."""
-    noun = "line" if hidden == 1 else "lines"
-    return f"… {hidden} more {noun}"
+    """Folded remainder: ``… N more, Ctrl+O to view``."""
+    return f"… {hidden} more, Ctrl+O to view"
 
 
-__all__ = ["build_output_peek", "format_expand_marker"]
+def format_view_all_marker() -> str:
+    """Character-cap with no hidden lines: ``Ctrl+O to view all``."""
+    return _VIEW_ALL_MARKER
+
+
+def cap_output_for_display(
+    text: str,
+    *,
+    max_lines: int = DISPLAY_OUTPUT_MAX_LINES,
+    max_chars: int = DISPLAY_OUTPUT_MAX_CHARS,
+) -> tuple[str, str | None]:
+    """Return ``(preview, full_if_folded)``.
+
+    *full_if_folded* is the original text when the preview was truncated (so
+    Ctrl+O can restore it), or None when the preview is the whole text. A
+    mid-line character-cap is an inline ``…``; hidden lines add one expand
+    marker. Never two marker lines.
+    """
+    if not text:
+        return text, None
+    peek, hidden = build_output_peek(text, max_lines=max_lines)
+    char_truncated = False
+    if len(peek) > max_chars:
+        peek = peek[:max_chars].rstrip() + "…"
+        char_truncated = True
+    if hidden:
+        return f"{peek}\n{format_expand_marker(hidden)}", text
+    if char_truncated:
+        return f"{peek}\n{format_view_all_marker()}", text
+    return peek, None
+
+
+__all__ = [
+    "DISPLAY_OUTPUT_MAX_CHARS",
+    "DISPLAY_OUTPUT_MAX_LINES",
+    "build_output_peek",
+    "cap_output_for_display",
+    "format_expand_marker",
+    "format_view_all_marker",
+]

--- a/infrastructure/terminal/peek.py
+++ b/infrastructure/terminal/peek.py
@@ -1,0 +1,34 @@
+"""Peek helpers for collapsed tool output in the transcript.
+
+Pure string logic so collapse behaviour is testable without a live TTY: a long
+tool result renders as a short head plus a ``… N more lines`` marker. Expansion
+(Ctrl+O) can reuse these helpers once a session buffer + keybinding land; this
+module owns only the text shaping.
+"""
+
+from __future__ import annotations
+
+
+def build_output_peek(full_text: str, *, max_lines: int = 3) -> tuple[str, int]:
+    """Return ``(peek, hidden_line_count)`` for *full_text*.
+
+    The peek is the first *max_lines* lines; ``hidden`` is how many lines were
+    dropped (0 when the text already fits, in which case *peek* is the whole
+    text). The caller appends :func:`format_expand_marker` when ``hidden > 0``.
+    """
+    if not full_text.strip():
+        return "", 0
+    body = full_text.rstrip("\n")
+    lines = body.split("\n")
+    if len(lines) <= max_lines:
+        return body, 0
+    return "\n".join(lines[:max_lines]), len(lines) - max_lines
+
+
+def format_expand_marker(hidden: int) -> str:
+    """One-line marker for the folded remainder: ``… N more lines``."""
+    noun = "line" if hidden == 1 else "lines"
+    return f"… {hidden} more {noun}"
+
+
+__all__ = ["build_output_peek", "format_expand_marker"]

--- a/integrations/github/tools/github_cli/runner.py
+++ b/integrations/github/tools/github_cli/runner.py
@@ -17,13 +17,6 @@ MAX_TIMEOUT_SECONDS = 120
 # and the context budget silently trims the tail, so the agent reads a handful
 # of records and cannot tell the rest existed. Cap here instead and say so on
 # the payload, matching what ``shell_run`` already does.
-#
-# A bounded slice also keeps the model from pasting the raw result into its
-# reply: given the whole blob it tends to echo it, so the transcript fills with
-# JSON instead of a prose answer. A small window plus the ``truncated`` flag
-# nudges it to answer from the summary and re-query with a ``--jq`` filter for
-# more — the read-a-slice-then-filter pattern. This is a partial mitigation; the
-# real fix is to bound tool observations for every tool at the harness layer.
 MAX_GH_OUTPUT_CHARS = 6_000
 
 # Top-level ``gh`` commands that must never run under OpenSRE-injected credentials.

--- a/integrations/github/tools/github_cli/summary.py
+++ b/integrations/github/tools/github_cli/summary.py
@@ -108,6 +108,13 @@ def summarize_gh_result(
     if url:
         return url
     if out:
+        # Raw JSON from ``gh api`` is for the model, not the transcript — a sliced
+        # JSON string still reads as a dump. Keep a short prose acknowledgement.
+        stripped = out.lstrip()
+        if stripped[:1] in "{[" or out.count('":') >= 2:
+            if command == "api":
+                return "GitHub API call succeeded."
+            return "GitHub command succeeded."
         lines = [line for line in out.splitlines() if line.strip()]
         if not lines:
             return "GitHub command succeeded."

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -57,6 +57,12 @@ def _decode_subprocess_stream(value: str | bytes | None) -> str:
     return value
 
 
+def _stash_collapsed_output(session: Session | None, body: str) -> None:
+    terminal = session_terminal(session) if session is not None else None
+    if terminal is not None:
+        terminal.collapsed_tool_output = body
+
+
 def _cli_command_succeeded(exit_code: int | None) -> bool:
     return exit_code == 0
 
@@ -136,8 +142,17 @@ def run_cli_command(
                 env=child_env,
             )
             exit_code = captured_result.returncode
-            print_command_output(console, captured_result.stdout or "")
-            print_command_output(console, captured_result.stderr or "", style=ERROR)
+            print_command_output(
+                console,
+                captured_result.stdout or "",
+                on_collapse=lambda body: _stash_collapsed_output(session, body),
+            )
+            print_command_output(
+                console,
+                captured_result.stderr or "",
+                style=ERROR,
+                on_collapse=lambda body: _stash_collapsed_output(session, body),
+            )
             if captured_result.returncode != 0:
                 console.print(
                     f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
@@ -166,8 +181,17 @@ def run_cli_command(
         # kill a hung install script, i.e. a streamed child mid-redraw of its own
         # progress bar.
         prepare_repl_output_line()
-        print_command_output(console, _decode_subprocess_stream(exc.stdout))
-        print_command_output(console, _decode_subprocess_stream(exc.stderr), style=ERROR)
+        print_command_output(
+            console,
+            _decode_subprocess_stream(exc.stdout),
+            on_collapse=lambda body: _stash_collapsed_output(session, body),
+        )
+        print_command_output(
+            console,
+            _decode_subprocess_stream(exc.stderr),
+            style=ERROR,
+            on_collapse=lambda body: _stash_collapsed_output(session, body),
+        )
         console.print(f"[{ERROR}]error:[/] CLI command timed out")
     except KeyboardInterrupt:
         exit_code = None

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Callable
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.application import Application
+from prompt_toolkit.application import Application, run_in_terminal
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.formatted_text import ANSI
@@ -21,8 +21,10 @@ from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui import input_prompt
 from surfaces.interactive_shell.ui.hooks import (
     install_confirmation_key_bindings,
+    install_output_expand_key_bindings,
     install_plan_expand_key_bindings,
 )
+from surfaces.interactive_shell.ui.hooks.output_expand import page_collapsed_output
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
 from surfaces.interactive_shell.ui.input_prompt.key_bindings import (
     build_cancel_key_bindings,
@@ -102,6 +104,23 @@ class PromptBuilder:
             self._invalidate_prompt,
         )
         install_session_key_bindings(self.pt_session, plan_kb)
+        output_kb = install_output_expand_key_bindings(
+            lambda: bool(self.session.terminal.collapsed_tool_output),
+            lambda: str(self.session.terminal.collapsed_tool_output or ""),
+            self._page_collapsed_output,
+        )
+        install_session_key_bindings(self.pt_session, output_kb)
+
+    def _page_collapsed_output(self, text: str) -> None:
+        """Suspend the prompt and page the last folded tool result (Ctrl+O)."""
+
+        async def _run() -> None:
+            await run_in_terminal(lambda: page_collapsed_output(text), in_executor=False)
+
+        if self.pt_app is not None and self.pt_app.is_running:
+            self.pt_app.create_background_task(_run())
+            return
+        page_collapsed_output(text)
 
     @property
     def invalidate_prompt(self) -> Callable[[], None]:

--- a/surfaces/interactive_shell/runtime/input/prompt_input_reader.py
+++ b/surfaces/interactive_shell/runtime/input/prompt_input_reader.py
@@ -25,6 +25,21 @@ from surfaces.shared.terminal.components.cpr_stdin import (
     strip_cpr_sequences,
 )
 
+# Stuck-key / paste-corruption spam (seen after CPR redraw glitches) — a long
+# run dominated by one character is never a real ask. Re-prompt instead of
+# sending it to the model.
+_SPAM_MIN_LEN = 40
+_SPAM_DOMINANT_RATIO = 0.9
+
+
+def _looks_like_key_spam(text: str) -> bool:
+    """True when *text* is almost entirely one repeated character."""
+    body = "".join(text.split())
+    if len(body) < _SPAM_MIN_LEN:
+        return False
+    dominant = max(body.count(ch) for ch in set(body))
+    return dominant / len(body) >= _SPAM_DOMINANT_RATIO
+
 
 class PromptInputReader:
     """Read prompt text and hide terminal-specific control flow from the loop."""
@@ -64,6 +79,9 @@ class PromptInputReader:
             raw_text = text
             text = strip_cpr_sequences(text)
             if not text.strip() and contains_cpr_sequence(raw_text):
+                continue
+            if _looks_like_key_spam(text):
+                # Accidental held-key / redraw garbage — do not spend a turn.
                 continue
             return InputSubmitted(text)
 

--- a/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
@@ -219,7 +219,12 @@ class ReplSubprocessPresenter:
             resolved = str(SECONDARY)
         else:
             resolved = style
-        print_command_output(self._console, text, style=resolved)
+        print_command_output(
+            self._console,
+            text,
+            style=resolved,
+            on_collapse=lambda body: setattr(self._session.terminal, "collapsed_tool_output", body),
+        )
 
     def print_plain(self, text: str) -> None:
         self._console.print(Text(text))

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -111,6 +111,12 @@ class TerminalSession:
     The response composer consumes the label to hide a pure acknowledgement
     while preserving meaningful follow-up the selected option unlocks."""
 
+    collapsed_tool_output: str | None = None
+    """Full text of the last display-capped tool result, for Ctrl+O paging.
+
+    Set by the action turn when the console preview is folded; cleared when
+    the next turn's preview fits. None when nothing is collapsed."""
+
     pending_confirm_options: tuple[tuple[str, str], ...] | None = None
     """Rows the next execution confirmation should offer, or None for Yes/No.
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -19,15 +19,13 @@ import shlex
 from typing import Any
 
 from rich.console import Console
-from rich.padding import Padding
-from rich.syntax import Syntax
 from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.spi.task_plan import is_plan_diagnosis_prose
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
-from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, MARKDOWN_CODE_THEME
+from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.ui.streaming import render_note_block
@@ -35,9 +33,12 @@ from surfaces.shared.terminal.output.console_state import get_investigation_spin
 from tools.interactive_shell.action_names import ActionToolName
 from tools.interactive_shell.shell.display import format_shell_command_for_display
 
-# Tool labels whose payload is a runnable command: render it as a highlighted
-# shell code block rather than plain inline text.
+# Tool labels whose payload is a runnable command.
 _COMMAND_TOOL_LABELS: frozenset[str] = frozenset({"Execute", "GitHub CLI", "opensre"})
+
+# Leads every tool-call line so a call reads apart from the ``∴`` reply and the
+# ``[n] ❯`` user row — the call → result → reply hierarchy Claude Code / Droid use.
+_TOOL_CALL_MARKER = "⏺"
 
 # Tools whose preview is just ``(label, single-arg)``. The display content is the
 # stripped string value of that single argument. Anything that needs to combine
@@ -487,31 +488,20 @@ class ActionRenderObserver:
         self.console.print(line)
 
     def _render_tool_invocation(self, name: str, data: dict[str, Any]) -> None:
-        """Show the running tool: orange verb, then payload."""
+        """Show the running tool as one marked line: ``⏺ Label · payload``."""
         args = data.get("input")
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
         self.console.print()
-        if content and label in _COMMAND_TOOL_LABELS:
-            # A runnable command reads as code: label line, then a syntax-
-            # highlighted shell block indented under it.
-            self.console.print(Text(label, style=str(HIGHLIGHT)))
-            self.console.print(
-                Padding(
-                    Syntax(
-                        content,
-                        "bash",
-                        theme=MARKDOWN_CODE_THEME,
-                        background_color="default",
-                        word_wrap=True,
-                    ),
-                    (0, 0, 0, 2),
-                )
-            )
-            return
+        # One line per call, led by ``⏺``: the label reads as the action and the
+        # payload (command / args) as its detail. A command tool separates the two
+        # with ``·`` so ``⏺ GitHub CLI · gh api …`` reads as a single unit.
         line = Text()
-        line.append(label, style=str(HIGHLIGHT))
+        line.append(f"{_TOOL_CALL_MARKER} ", style=str(HIGHLIGHT))
+        line.append(label, style=f"bold {HIGHLIGHT}")
         if content:
-            line.append(f" {content}", style=str(BRAND))
+            separator = " · " if label in _COMMAND_TOOL_LABELS else " "
+            line.append(separator, style=str(DIM))
+            line.append(content, style=str(BRAND))
         self.console.print(line)
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:

--- a/surfaces/interactive_shell/ui/hooks/__init__.py
+++ b/surfaces/interactive_shell/ui/hooks/__init__.py
@@ -9,6 +9,9 @@ from surfaces.interactive_shell.ui.hooks.confirmation_choice import (
     confirmation_choice_overlay_ansi,
     install_confirmation_key_bindings,
 )
+from surfaces.interactive_shell.ui.hooks.output_expand import (
+    install_output_expand_key_bindings,
+)
 from surfaces.interactive_shell.ui.hooks.plan_expand import (
     install_plan_expand_key_bindings,
 )
@@ -16,5 +19,6 @@ from surfaces.interactive_shell.ui.hooks.plan_expand import (
 __all__ = [
     "confirmation_choice_overlay_ansi",
     "install_confirmation_key_bindings",
+    "install_output_expand_key_bindings",
     "install_plan_expand_key_bindings",
 ]

--- a/surfaces/interactive_shell/ui/hooks/output_expand.py
+++ b/surfaces/interactive_shell/ui/hooks/output_expand.py
@@ -1,0 +1,52 @@
+"""Ctrl+O pages the last collapsed tool-output peek (Droid-style).
+
+A long tool result renders a short head plus ``… N more, Ctrl+O to view``.
+This hook opens the full text in the user's pager, then returns to the
+session. The binding is gated on a collapsed body being stashed, so Ctrl+O
+falls through when nothing was folded.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+
+
+def page_collapsed_output(text: str) -> None:
+    """Show *text* in ``$PAGER`` / ``less``, or print it when no pager exists."""
+    spec = os.environ.get("PAGER") or shutil.which("less") or ""
+    cmd = shlex.split(spec) if spec else []
+    if cmd:
+        subprocess.run(cmd, input=text.encode(), check=False)
+        return
+    sys.stdout.write(text if text.endswith("\n") else f"{text}\n")
+    sys.stdout.flush()
+
+
+def install_output_expand_key_bindings(
+    has_output: Callable[[], bool],
+    get_output: Callable[[], str],
+    page: Callable[[str], None],
+) -> KeyBindings:
+    """Bind Ctrl+O to page the stashed collapsed tool result."""
+    kb = KeyBindings()
+    output_shown = Condition(has_output)
+
+    @kb.add("c-o", filter=output_shown, eager=True)
+    def _page_output(_event: KeyPressEvent) -> None:
+        body = get_output()
+        if body:
+            page(body)
+
+    return kb
+
+
+__all__ = ["install_output_expand_key_bindings", "page_collapsed_output"]

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -46,11 +46,11 @@ def _limit_editable_height(main_input: HSplit) -> HSplit:
         default_buffer_slot.content, Window
     ):
         raise RuntimeError("prompt-toolkit input container is missing its editable window")
-    default_buffer_slot.content.height = Dimension(
-        min=1,
-        preferred=1,
-        max=_COMPOSER_MAX_EDIT_ROWS,
-    )
+    # No fixed ``preferred``: it pins the box to one row so it never grows with
+    # wrapped/multiline input. Let the buffer's own content height drive it,
+    # clamped to [1, max]; ``dont_extend_height`` below keeps it from eating
+    # leftover terminal rows.
+    default_buffer_slot.content.height = Dimension(min=1, max=_COMPOSER_MAX_EDIT_ROWS)
     # Grow with wrapped/multiline input only — never eat leftover terminal rows
     # (that made the bordered box jump as the status region above it changed).
     # Window stores a Filter, not a raw bool — assign via to_filter.

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.filters import Condition
+from prompt_toolkit.filters import Condition, to_filter
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.layout.containers import (
     AnyContainer,
@@ -46,7 +46,15 @@ def _limit_editable_height(main_input: HSplit) -> HSplit:
         default_buffer_slot.content, Window
     ):
         raise RuntimeError("prompt-toolkit input container is missing its editable window")
-    default_buffer_slot.content.height = Dimension(min=1, max=_COMPOSER_MAX_EDIT_ROWS)
+    default_buffer_slot.content.height = Dimension(
+        min=1,
+        preferred=1,
+        max=_COMPOSER_MAX_EDIT_ROWS,
+    )
+    # Grow with wrapped/multiline input only — never eat leftover terminal rows
+    # (that made the bordered box jump as the status region above it changed).
+    # Window stores a Filter, not a raw bool — assign via to_filter.
+    default_buffer_slot.content.dont_extend_height = to_filter(True)
     return HSplit(editable_children)
 
 

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -39,7 +39,7 @@ _COMPOSER_MAX_FRAME_ROWS = _COMPOSER_MAX_EDIT_ROWS + 2
 
 
 def _limit_editable_height(main_input: HSplit) -> HSplit:
-    """Return the editable prompt body capped to a chat-composer-sized viewport."""
+    """Return the editable prompt body sized to its text, capped to a chat viewport."""
     editable_children = main_input.children[1:]
     default_buffer_slot = editable_children[0]
     if not isinstance(default_buffer_slot, ConditionalContainer) or not isinstance(
@@ -47,13 +47,11 @@ def _limit_editable_height(main_input: HSplit) -> HSplit:
     ):
         raise RuntimeError("prompt-toolkit input container is missing its editable window")
     # No fixed ``preferred``: it pins the box to one row so it never grows with
-    # wrapped/multiline input. Let the buffer's own content height drive it,
-    # clamped to [1, max]; ``dont_extend_height`` below keeps it from eating
-    # leftover terminal rows.
+    # wrapped/multiline input. The buffer's own content height drives it,
+    # clamped to [1, max]; ``dont_extend_height`` keeps it from eating leftover
+    # terminal rows (that made the bordered box jump as the status region above
+    # it changed). Window stores a Filter, not a raw bool — assign via to_filter.
     default_buffer_slot.content.height = Dimension(min=1, max=_COMPOSER_MAX_EDIT_ROWS)
-    # Grow with wrapped/multiline input only — never eat leftover terminal rows
-    # (that made the bordered box jump as the status region above it changed).
-    # Window stores a Filter, not a raw bool — assign via to_filter.
     default_buffer_slot.content.dont_extend_height = to_filter(True)
     return HSplit(editable_children)
 

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -31,6 +31,59 @@ def _escape_markdown_dunder_filenames(text: str) -> str:
     return _DUNDER_FILENAME_RE.sub(r"\_\_\1\_\_", text)
 
 
+# The model sometimes pastes a tool's raw result (JSON, listings) into its reply
+# instead of answering in prose. Collapse such a block to a compact marker so the
+# reply reads like Claude Code / Droid, regardless of which model echoed it.
+_DUMP_TRUNCATED_MARKER = "output truncated"
+_DUMP_MIN_CHARS = 200
+_DUMP_MIN_JSON_KEYS = 3
+_DUMP_STRUCTURAL_RATIO = 0.15
+_DUMP_STRUCTURAL_CHARS = frozenset('{}[]":,')
+
+
+def _looks_like_raw_dump(text: str) -> bool:
+    """Whether *text* is an echoed tool result rather than prose.
+
+    True when it carries the ``output truncated`` marker a tool cap leaves, or
+    when it is large and reads as a record/JSON blob. The ``":`` key separator
+    is common in such a dump and rare in prose, and — unlike a raw char ratio —
+    long URL values do not dilute it (a GitHub API object stays URL-heavy yet
+    keeps many keys). A structural-char ratio still catches non-JSON dense data.
+    Prose and Markdown tables/lists trip neither test.
+    """
+    if len(text) < _DUMP_MIN_CHARS:
+        return False  # too small to be a wall — a short block is not a problem
+    if _DUMP_TRUNCATED_MARKER in text:
+        return True
+    if text.count('":') >= _DUMP_MIN_JSON_KEYS:
+        return True
+    structural = sum(1 for ch in text if ch in _DUMP_STRUCTURAL_CHARS)
+    return structural / len(text) >= _DUMP_STRUCTURAL_RATIO
+
+
+def _collapse_paragraph(paragraph: str) -> str:
+    """Collapse *paragraph* to a marker when it is a raw dump, else return it."""
+    stripped = paragraph.strip()
+    if not _looks_like_raw_dump(stripped):
+        return paragraph
+    lines = stripped.count("\n") + 1
+    noun = "line" if lines == 1 else "lines"
+    return f"_[tool output omitted — {lines} {noun}]_"
+
+
+def _collapse_raw_dumps(text: str) -> str:
+    """Replace echoed raw tool-output paragraphs with a one-line marker.
+
+    Fenced code is left untouched — a fence means the model meant to show it.
+    Works per blank-line-separated paragraph so a summary sentence beside a
+    pasted blob keeps the summary and collapses only the blob, whether the reply
+    arrives whole (finalize path) or paragraph-by-paragraph (streaming).
+    """
+    if "```" in text:  # fenced code — respect the model's intent
+        return text
+    return "\n\n".join(_collapse_paragraph(part) for part in re.split(r"\n[ \t]*\n", text))
+
+
 def _build_markdown_block(text: str) -> Markdown:
     """Build a Markdown renderable with the shared escaping and code theme.
 
@@ -49,6 +102,7 @@ def _build_markdown_block(text: str) -> Markdown:
     assert __package__  # always set for a package submodule
     package = sys.modules[__package__]
     safe = strip_terminal_controls(text, keep_whitespace=True)
+    safe = _collapse_raw_dumps(safe)
     spaced = normalize_three_tier_spacing(safe)
     return package.Markdown(  # type: ignore[no-any-return]
         _escape_markdown_dunder_filenames(spaced.rstrip()),

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -110,9 +110,14 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
             )
         )
     # The running action shimmers on its own row between the status line and the
-    # autonomy line; scrollback keeps the settled solid copy.
-    action = strip_cpr_sequences(spinner.active_action_ansi())
-    action_line = f"{action}\n" if action else ""
+    # autonomy line; scrollback keeps the settled solid copy. Reserve that row
+    # for the whole streaming turn — appearing/clearing mid-turn used to grow
+    # and shrink the prompt region, which made the composer box jump.
+    if spinner.streaming:
+        action = strip_cpr_sequences(spinner.active_action_ansi())
+        action_line = f"{action}\n"
+    else:
+        action_line = ""
     # A blank row separates the plan block from the status line so the checklist
     # reads as its own element, not flush against the prompt.
     return ANSI(f"\n{plan_prefix}{prefix}\n{action_line}{auto_line}\n{base}")

--- a/surfaces/shared/terminal/tables/tables.py
+++ b/surfaces/shared/terminal/tables/tables.py
@@ -7,6 +7,7 @@ All rendering is delegated to the REPL TTY helpers in :mod:`rendering`.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.text import Text
 
+from infrastructure.terminal.peek import cap_output_for_display
 from infrastructure.terminal.theme import (
     BOLD_BRAND,
     DIM,
@@ -235,18 +237,26 @@ def _collapse_traceback(text: str) -> str | None:
     return "\n".join(rendered)
 
 
-def print_command_output(console: Console, output: str, *, style: str | None = None) -> None:
+def print_command_output(
+    console: Console,
+    output: str,
+    *,
+    style: str | None = None,
+    on_collapse: Callable[[str], None] | None = None,
+) -> None:
     if not output:
         return
     text = _collapse_traceback(output.rstrip()) or output.rstrip()
-    lines = text.split("\n")
+    preview, folded = cap_output_for_display(text)
+    if folded is not None and on_collapse is not None:
+        on_collapse(folded)
+    lines = preview.split("\n")
     # Frame every result under its `$ command` header with a ``↳`` gutter so the
     # output reads as the command's child (parent → child) and stays grouped and
     # set off from the reply prose above — wide output included. A single wide
     # line wraps within the block instead of flushing the whole block (and its
-    # narrow siblings) to the left margin. Do not fold the body: this is the
-    # sole dump for captured slash, foreground CLI, and Claude Code output —
-    # there is no later reply summary or expansion path for the hidden rows.
+    # narrow siblings) to the left margin. Long bodies collapse to a Droid-style
+    # peek plus ``Ctrl+O to view``; the caller stashes *folded* for paging.
     framed = [f"  ↳ {lines[0]}", *(f"{_COMMAND_OUTPUT_INDENT}{line}" for line in lines[1:])]
     text = "\n".join(framed)
     # Parse any ANSI the captured child emitted so its Rich styling (bold, colour)

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -469,6 +469,28 @@ def test_truncated_json_uses_text_fence_not_json_highlight() -> None:
     assert "more lines" in joined[fence_end:]
 
 
+def test_character_and_line_truncation_markers_sit_outside_the_fence() -> None:
+    github = ToolCall(id="1", name="github_cli", input={"command": "run list"})
+    # Four-plus long lines so the display cap cuts the visible head *and* folds
+    # remainder — both markers must stay outside the fence.
+    bulky = "\n".join("y" * 80 for _ in range(10))
+    result = _Result(
+        tool_results=[(github, _ToolResult(_payload(bulky)))],
+        final_text="Here is the run history.",
+    )
+
+    _response_text, display_chunks, _use_final = _compose_response(result, _Session(), _counts(1))
+    joined = "\n".join(display_chunks)
+
+    fence_end = joined.index("```", joined.index("```text") + 1)
+    after = joined[fence_end:]
+    inside = joined[:fence_end]
+    assert "output truncated" in after
+    assert "more lines" in after
+    assert "output truncated" not in inside
+    assert "more lines" not in inside
+
+
 def test_plan_snapshots_are_stripped_from_the_reply() -> None:
     # The model sometimes restates the plan (or every historical snapshot) in its
     # closing text; the overlay already shows it, so display strips the snapshots

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -441,7 +441,7 @@ def test_bulky_tool_output_is_capped_and_fenced_for_display() -> None:
 
     # Display: capped + text-fenced (truncated content is not valid code to highlight).
     assert "```text" in joined
-    assert "… (output truncated)" in joined
+    assert "more lines" in joined
     assert joined.count("run ") <= 12
     assert "```text" not in response_text
     assert response_text.count("run ") == 30
@@ -463,10 +463,10 @@ def test_truncated_json_uses_text_fence_not_json_highlight() -> None:
 
     assert "```json" not in joined
     assert "```text" in joined
-    assert "… (output truncated)" in joined
+    assert "more lines" in joined
     # Marker sits outside the fence so it is not syntax-highlighted as an error.
     fence_end = joined.index("```", joined.index("```text") + 1)
-    assert "… (output truncated)" in joined[fence_end:]
+    assert "more lines" in joined[fence_end:]
 
 
 def test_plan_snapshots_are_stripped_from_the_reply() -> None:

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -436,21 +436,23 @@ def test_bulky_tool_output_is_capped_and_fenced_for_display() -> None:
         final_text="Here is the run history.",
     )
 
-    response_text, display_chunks, _use_final = _compose_response(result, _Session(), _counts(1))
+    session = _Session()
+    response_text, display_chunks, _use_final = _compose_response(result, session, _counts(1))
     joined = "\n".join(display_chunks)
 
     # Display: capped + text-fenced (truncated content is not valid code to highlight).
     assert "```text" in joined
-    assert "more lines" in joined
+    assert "Ctrl+O to view" in joined
     assert joined.count("run ") <= 12
     assert "```text" not in response_text
     assert response_text.count("run ") == 30
+    assert session.terminal.collapsed_tool_output == bulky
 
 
 def test_truncated_json_uses_text_fence_not_json_highlight() -> None:
-    """Broken mid-JSON must not use a ``json`` fence (Rich paints red error tokens)."""
+    """Broken mid-JSON must not paint as a dumped fence — hide the blob."""
     github = ToolCall(id="1", name="posthog_mcp", input={"tool_name": "list"})
-    # Valid JSON over the line/char caps so _cap_for_display truncates it.
+    # Valid JSON over the line/char caps so _cap_for_display would truncate it.
     bulky_obj = {"tools": [{"name": f"tool_{i}", "description": "x" * 40} for i in range(40)]}
     bulky = json.dumps(bulky_obj, indent=2)
     result = _Result(
@@ -462,17 +464,15 @@ def test_truncated_json_uses_text_fence_not_json_highlight() -> None:
     joined = "\n".join(display_chunks)
 
     assert "```json" not in joined
-    assert "```text" in joined
-    assert "more lines" in joined
-    # Marker sits outside the fence so it is not syntax-highlighted as an error.
-    fence_end = joined.index("```", joined.index("```text") + 1)
-    assert "more lines" in joined[fence_end:]
+    assert "followers_url" not in joined
+    assert '"tools"' not in joined
+    assert "Listed tools." in joined
 
 
 def test_character_and_line_truncation_markers_sit_outside_the_fence() -> None:
     github = ToolCall(id="1", name="github_cli", input={"command": "run list"})
     # Four-plus long lines so the display cap cuts the visible head *and* folds
-    # remainder — both markers must stay outside the fence.
+    # remainder — the single expand marker must stay outside the fence.
     bulky = "\n".join("y" * 80 for _ in range(10))
     result = _Result(
         tool_results=[(github, _ToolResult(_payload(bulky)))],
@@ -485,10 +485,10 @@ def test_character_and_line_truncation_markers_sit_outside_the_fence() -> None:
     fence_end = joined.index("```", joined.index("```text") + 1)
     after = joined[fence_end:]
     inside = joined[:fence_end]
-    assert "output truncated" in after
-    assert "more lines" in after
-    assert "output truncated" not in inside
-    assert "more lines" not in inside
+    assert "Ctrl+O to view" in after
+    assert "output truncated" not in joined
+    assert after.count("Ctrl+O to view") == 1
+    assert "Ctrl+O to view" not in inside
 
 
 def test_plan_snapshots_are_stripped_from_the_reply() -> None:

--- a/tests/core/agent_harness/turns/test_generic_tool_payload.py
+++ b/tests/core/agent_harness/turns/test_generic_tool_payload.py
@@ -29,18 +29,30 @@ def _call(name: str) -> ToolCall:
     return ToolCall(id="t1", name=name, input={"owner": "acme", "repo": "svc"})
 
 
-def test_opaque_json_object_is_pretty_printed() -> None:
-    # A GitHub-style payload with no summary field is pretty-printed, not a blob.
+def test_opaque_json_object_is_hidden() -> None:
+    # A raw JSON payload with no user-facing field (e.g. a gh-api response) is
+    # for the model, not the transcript — hide it; the reply summarizes it.
     payload = {"ok": True, "available": True, "repository": {"full_name": "acme/svc"}}
-    shown = _format_generic_tool_payload(_call("get_github_repository"), _result(payload))
-    assert '"full_name": "acme/svc"' in shown
-    assert "\n" in shown  # indented, multi-line
+    assert _format_generic_tool_payload(_call("get_github_repository"), _result(payload)) == ""
 
 
-def test_opaque_json_list_is_pretty_printed() -> None:
-    shown = _format_generic_tool_payload(_call("list_runs"), _result([{"id": 1}, {"id": 2}]))
-    assert '"id": 1' in shown
-    assert "\n" in shown
+def test_opaque_json_list_is_hidden() -> None:
+    assert _format_generic_tool_payload(_call("list_runs"), _result([{"id": 1}, {"id": 2}])) == ""
+
+
+def test_truncated_json_blob_is_hidden_not_dumped_raw() -> None:
+    # A capped gh-api response arrives as invalid (cut-off) JSON — it must not
+    # slip past the JSON check and dump raw. Detection is by shape, not parse.
+    trunc = '{"full_name":"Tracer-Cloud/opensre","followers_url":"https://api.github.com/users/Tr'
+    assert _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": trunc})) == ""
+    assert _format_generic_tool_payload(_call("github_cli"), _result(trunc)) == ""
+    # A mid-object fragment (starts on a value, not ``{``) is still a data blob:
+    # key-density detection catches it where a first-char check would not.
+    frag = (
+        'https://github.com/x","followers_url":"https://api.github.com/u",'
+        '"following_url":"https://api.github.com/f","gists_url":"https://api.github.com/g"'
+    )
+    assert _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": frag})) == ""
 
 
 def test_a_real_summary_is_still_shown() -> None:
@@ -54,13 +66,12 @@ def test_plain_text_output_is_still_shown() -> None:
     assert "build succeeded" in shown
 
 
-def test_json_stdout_is_pretty_printed_and_plain_stdout_is_shown() -> None:
-    # gh-api JSON stdout is pretty-printed (readable data). Plain-text command
-    # output (ls, git) is the user's real result and shows as-is.
+def test_json_stdout_is_hidden_and_plain_stdout_is_shown() -> None:
+    # gh-api JSON stdout is data the reply already summarizes — hide it rather
+    # than dump a wall unattached to the command. Plain-text output (ls, git) is
+    # the user's real result and shows as-is.
     json_stdout = _result({"ok": True, "stdout": '{"id": 18260225, "name": "main"}'})
-    shown = _format_generic_tool_payload(_call("github_cli"), json_stdout)
-    assert '"name": "main"' in shown
-    assert "\n" in shown  # pretty-printed
+    assert _format_generic_tool_payload(_call("github_cli"), json_stdout) == ""
 
     plain_stdout = _result({"ok": True, "stdout": "total 56\ndrwxr-xr-x  15 user"})
     assert "drwxr-xr-x" in _format_generic_tool_payload(_call("shell"), plain_stdout)
@@ -72,9 +83,9 @@ def test_verbose_output_is_capped_for_display_only() -> None:
     big = "\n".join(f"run {i} failure 2026-08-01T09:11:00Z" for i in range(50))
     capped = _cap_for_display(big)
 
-    # Display is bounded with a truncation marker; the full text is untouched.
-    assert capped.count("\n") + 1 <= 13
-    assert capped.endswith("… (output truncated)")
+    # Display is a short head + peek marker; the full text is untouched.
+    assert capped.count("\n") + 1 <= 6
+    assert "… 46 more lines" in capped
     assert big.count("\n") + 1 == 50  # source unchanged
 
 

--- a/tests/core/agent_harness/turns/test_generic_tool_payload.py
+++ b/tests/core/agent_harness/turns/test_generic_tool_payload.py
@@ -44,7 +44,10 @@ def test_truncated_json_blob_is_hidden_not_dumped_raw() -> None:
     # A capped gh-api response arrives as invalid (cut-off) JSON — it must not
     # slip past the JSON check and dump raw. Detection is by shape, not parse.
     trunc = '{"full_name":"Tracer-Cloud/opensre","followers_url":"https://api.github.com/users/Tr'
-    assert _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": trunc})) == ""
+    assert (
+        _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": trunc}))
+        == ""
+    )
     assert _format_generic_tool_payload(_call("github_cli"), _result(trunc)) == ""
     # A mid-object fragment (starts on a value, not ``{``) is still a data blob:
     # key-density detection catches it where a first-char check would not.
@@ -52,7 +55,10 @@ def test_truncated_json_blob_is_hidden_not_dumped_raw() -> None:
         'https://github.com/x","followers_url":"https://api.github.com/u",'
         '"following_url":"https://api.github.com/f","gists_url":"https://api.github.com/g"'
     )
-    assert _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": frag})) == ""
+    assert (
+        _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": frag}))
+        == ""
+    )
 
 
 def test_a_real_summary_is_still_shown() -> None:

--- a/tests/core/agent_harness/turns/test_generic_tool_payload.py
+++ b/tests/core/agent_harness/turns/test_generic_tool_payload.py
@@ -100,3 +100,44 @@ def test_short_output_is_not_truncated() -> None:
 
     text = "total 56\ndrwxr-xr-x  15 user"
     assert _cap_for_display(text) == text
+
+
+def test_character_cap_reports_truncation_when_lines_fit() -> None:
+    from core.agent_harness.turns.action_driver import (
+        _DISPLAY_OUTPUT_MAX_CHARS,
+        _OUTPUT_TRUNCATED_MARKER,
+        _cap_for_display,
+    )
+
+    text = "x" * (_DISPLAY_OUTPUT_MAX_CHARS + 40)
+    capped = _cap_for_display(text)
+    assert capped.endswith(_OUTPUT_TRUNCATED_MARKER)
+    body, _, marker = capped.rpartition("\n")
+    assert marker == _OUTPUT_TRUNCATED_MARKER
+    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS
+    assert "more line" not in capped
+
+
+def test_character_and_line_caps_both_report_truncation() -> None:
+    from core.agent_harness.turns.action_driver import (
+        _DISPLAY_OUTPUT_MAX_CHARS,
+        _DISPLAY_OUTPUT_MAX_LINES,
+        _OUTPUT_TRUNCATED_MARKER,
+        _cap_for_display,
+    )
+
+    # First N lines together exceed the character cap, and extra lines remain.
+    line = "y" * ((_DISPLAY_OUTPUT_MAX_CHARS // 2) + 1)
+    extra_lines = 3
+    text = "\n".join([line] * (_DISPLAY_OUTPUT_MAX_LINES + extra_lines))
+    capped = _cap_for_display(text)
+
+    assert _OUTPUT_TRUNCATED_MARKER in capped
+    assert f"… {extra_lines} more lines" in capped
+    body, _, _ = capped.partition(f"\n{_OUTPUT_TRUNCATED_MARKER}")
+    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS
+    # Character-cap is reported first (the visible head was cut); folded
+    # remainder follows so neither truncation is silent.
+    char_at = capped.index(_OUTPUT_TRUNCATED_MARKER)
+    fold_at = capped.index(" more lines")
+    assert char_at < fold_at

--- a/tests/core/agent_harness/turns/test_generic_tool_payload.py
+++ b/tests/core/agent_harness/turns/test_generic_tool_payload.py
@@ -36,6 +36,29 @@ def test_opaque_json_object_is_hidden() -> None:
     assert _format_generic_tool_payload(_call("get_github_repository"), _result(payload)) == ""
 
 
+def test_json_summary_preview_is_hidden() -> None:
+    """gh used to put a sliced JSON string in ``summary`` — that must not paint."""
+    sliced = (
+        '{"login": "Tracer-Cloud", "followers_url": '
+        '"https://api.github.com/users/Tracer-Cloud/followers", '
+        '"gists_url": "https://api.github.com/users/Tr...'
+    )
+    payload = {"ok": True, "stdout": sliced, "summary": sliced}
+    assert _format_generic_tool_payload(_call("github_cli"), _result(payload)) == ""
+
+
+def test_prose_summary_is_still_shown() -> None:
+    payload = {
+        "ok": True,
+        "stdout": '{"id": 1}',
+        "summary": "GitHub API call succeeded.",
+    }
+    assert (
+        _format_generic_tool_payload(_call("github_cli"), _result(payload))
+        == "GitHub API call succeeded."
+    )
+
+
 def test_opaque_json_list_is_hidden() -> None:
     assert _format_generic_tool_payload(_call("list_runs"), _result([{"id": 1}, {"id": 2}])) == ""
 
@@ -89,9 +112,10 @@ def test_verbose_output_is_capped_for_display_only() -> None:
     big = "\n".join(f"run {i} failure 2026-08-01T09:11:00Z" for i in range(50))
     capped = _cap_for_display(big)
 
-    # Display is a short head + peek marker; the full text is untouched.
+    # Display is a short head + one Droid-style peek marker; the full text is untouched.
     assert capped.count("\n") + 1 <= 6
-    assert "… 46 more lines" in capped
+    assert "… 46 more, Ctrl+O to view" in capped
+    assert "output truncated" not in capped
     assert big.count("\n") + 1 == 50  # source unchanged
 
 
@@ -105,26 +129,27 @@ def test_short_output_is_not_truncated() -> None:
 def test_character_cap_reports_truncation_when_lines_fit() -> None:
     from core.agent_harness.turns.action_driver import (
         _DISPLAY_OUTPUT_MAX_CHARS,
-        _OUTPUT_TRUNCATED_MARKER,
         _cap_for_display,
     )
+    from infrastructure.terminal.peek import format_view_all_marker
 
     text = "x" * (_DISPLAY_OUTPUT_MAX_CHARS + 40)
     capped = _cap_for_display(text)
-    assert capped.endswith(_OUTPUT_TRUNCATED_MARKER)
+    assert capped.endswith(format_view_all_marker())
     body, _, marker = capped.rpartition("\n")
-    assert marker == _OUTPUT_TRUNCATED_MARKER
-    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS
-    assert "more line" not in capped
+    assert marker == format_view_all_marker()
+    assert body.endswith("…")
+    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS + 1
+    assert "more, Ctrl+O" not in capped
 
 
-def test_character_and_line_caps_both_report_truncation() -> None:
+def test_character_and_line_caps_share_one_marker() -> None:
     from core.agent_harness.turns.action_driver import (
         _DISPLAY_OUTPUT_MAX_CHARS,
         _DISPLAY_OUTPUT_MAX_LINES,
-        _OUTPUT_TRUNCATED_MARKER,
         _cap_for_display,
     )
+    from infrastructure.terminal.peek import format_expand_marker, format_view_all_marker
 
     # First N lines together exceed the character cap, and extra lines remain.
     line = "y" * ((_DISPLAY_OUTPUT_MAX_CHARS // 2) + 1)
@@ -132,12 +157,10 @@ def test_character_and_line_caps_both_report_truncation() -> None:
     text = "\n".join([line] * (_DISPLAY_OUTPUT_MAX_LINES + extra_lines))
     capped = _cap_for_display(text)
 
-    assert _OUTPUT_TRUNCATED_MARKER in capped
-    assert f"… {extra_lines} more lines" in capped
-    body, _, _ = capped.partition(f"\n{_OUTPUT_TRUNCATED_MARKER}")
-    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS
-    # Character-cap is reported first (the visible head was cut); folded
-    # remainder follows so neither truncation is silent.
-    char_at = capped.index(_OUTPUT_TRUNCATED_MARKER)
-    fold_at = capped.index(" more lines")
-    assert char_at < fold_at
+    assert format_expand_marker(extra_lines) in capped
+    assert format_view_all_marker() not in capped
+    assert "output truncated" not in capped
+    body, _, marker = capped.rpartition("\n")
+    assert marker == format_expand_marker(extra_lines)
+    assert body.endswith("…")
+    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS + 1

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -22,9 +22,12 @@ def _console() -> Console:
 
 
 def test_account_is_signed_in_follows_saved_github_username(monkeypatch: Any) -> None:
-    monkeypatch.setattr("integrations.github.identity.saved_github_username", lambda: "octocat")
+    # Patch the package API (what account_gate imports). Patching only
+    # ``integrations.github.identity`` misses when another test has bound the
+    # name on ``integrations.github`` and shadowed ``__getattr__``.
+    monkeypatch.setattr("integrations.github.saved_github_username", lambda: "octocat")
     assert account_gate.account_is_signed_in() is True
-    monkeypatch.setattr("integrations.github.identity.saved_github_username", lambda: "")
+    monkeypatch.setattr("integrations.github.saved_github_username", lambda: "")
     assert account_gate.account_is_signed_in() is False
 
 
@@ -36,7 +39,7 @@ def test_account_login_returns_ok_from_github_device_flow(monkeypatch: Any) -> N
         return GitHubLoginResult(ok=True, username="octocat")
 
     monkeypatch.setattr(
-        "integrations.github.login.authenticate_and_configure_github",
+        "integrations.github.authenticate_and_configure_github",
         _auth,
     )
 
@@ -50,7 +53,7 @@ def test_account_login_returns_false_when_device_flow_fails(monkeypatch: Any) ->
         raise RuntimeError("denied")
 
     monkeypatch.setattr(
-        "integrations.github.login.authenticate_and_configure_github",
+        "integrations.github.authenticate_and_configure_github",
         _auth,
     )
     console = _console()

--- a/tests/interactive_shell/runtime/test_prompt_input_reader.py
+++ b/tests/interactive_shell/runtime/test_prompt_input_reader.py
@@ -167,3 +167,10 @@ async def test_prompt_input_reader_ignores_cpr_only_input() -> None:
     ).read()
 
     assert event == InputSubmitted("show status")
+
+
+@pytest.mark.asyncio
+async def test_prompt_input_reader_ignores_held_key_spam() -> None:
+    spam = "d" * 80 + "cs"
+    event = await _reader(SequencePrompt([spam, "real ask"])).read()
+    assert event == InputSubmitted("real ask")

--- a/tests/interactive_shell/runtime/test_repl_presenter.py
+++ b/tests/interactive_shell/runtime/test_repl_presenter.py
@@ -26,6 +26,20 @@ def _presenter() -> tuple[ReplSubprocessPresenter, StringIO]:
     return ReplSubprocessPresenter(session, console), buffer
 
 
+def test_long_command_output_is_stashed_for_ctrl_o() -> None:
+    presenter, buffer = _presenter()
+    body = "\n".join(f"line {i}" for i in range(30))
+    presenter.print_command_output(body)
+    assert presenter.session.terminal.collapsed_tool_output == body
+    assert "Ctrl+O to view" in buffer.getvalue()
+
+
+def test_short_command_output_is_not_stashed() -> None:
+    presenter, _buffer = _presenter()
+    presenter.print_command_output("ok")
+    assert presenter.session.terminal.collapsed_tool_output is None
+
+
 def test_plain_command_output_is_recessed_but_keeps_command_colours() -> None:
     # Raw stdout reads as supporting detail beneath the bright reply: plain output
     # is recessed to SECONDARY, while colour the command emitted itself survives.

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -2784,6 +2784,7 @@ class TestRunCliCommand:
             output: str,
             *,
             style: str | None = None,
+            on_collapse: object = None,
         ) -> None:
             replayed.append((output, style))
 

--- a/tests/interactive_shell/ui/hooks/test_output_expand.py
+++ b/tests/interactive_shell/ui/hooks/test_output_expand.py
@@ -1,0 +1,55 @@
+"""Ctrl+O pages the last collapsed tool result only while one is stashed."""
+
+from __future__ import annotations
+
+from surfaces.interactive_shell.ui.hooks import install_output_expand_key_bindings
+from surfaces.interactive_shell.ui.hooks.output_expand import page_collapsed_output
+
+
+def _binding_keys(kb) -> set[tuple[str, ...]]:
+    return {tuple(str(key) for key in binding.keys) for binding in kb.bindings}
+
+
+def test_expand_binding_is_ctrl_o() -> None:
+    kb = install_output_expand_key_bindings(lambda: True, lambda: "body", lambda _text: None)
+    assert ("Keys.ControlO",) in _binding_keys(kb)
+
+
+def test_ctrl_o_pages_the_stashed_body() -> None:
+    paged: list[str] = []
+    kb = install_output_expand_key_bindings(lambda: True, lambda: "full output", paged.append)
+    handler = next(
+        binding.handler
+        for binding in kb.bindings
+        if tuple(str(k) for k in binding.keys) == ("Keys.ControlO",)
+    )
+
+    handler(None)
+
+    assert paged == ["full output"]
+
+
+def test_binding_is_gated_on_collapsed_output_being_present() -> None:
+    kb = install_output_expand_key_bindings(lambda: False, lambda: "body", lambda _text: None)
+
+    assert all(binding.filter() is False for binding in kb.bindings)
+
+
+def test_page_collapsed_output_prints_when_no_pager(monkeypatch) -> None:
+    written: list[str] = []
+    monkeypatch.delenv("PAGER", raising=False)
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.output_expand.shutil.which",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.output_expand.sys.stdout.write",
+        written.append,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.output_expand.sys.stdout.flush", lambda: None
+    )
+
+    page_collapsed_output("hello")
+
+    assert written == ["hello\n"]

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -469,10 +469,31 @@ class TestResolvePromptPrefix:
         assert _strip_ansi(prefix) == ""
 
 
-def test_composer_frame_preferred_height_does_not_crash() -> None:
-    """dont_extend_height must be a Filter — a raw bool crashes on first redraw."""
+@pytest.mark.asyncio
+async def test_composer_frame_preferred_height_does_not_crash() -> None:
+    """dont_extend_height must be a Filter — a raw bool crashes on first redraw.
+
+    Measures under a running app: the composer height is content-driven, so
+    prompt-toolkit loads the buffer's history to size it, which needs a live
+    app loop — the only context a real redraw ever has.
+    """
+    import asyncio
+
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input.defaults import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
     from surfaces.interactive_shell.ui.input_prompt import build_prompt_session
 
-    prompt = build_prompt_session()
-    dim = prompt.layout.container.preferred_height(80, 40)
+    with (
+        create_pipe_input() as pipe_input,
+        create_app_session(input=pipe_input, output=DummyOutput()),
+    ):
+        prompt = build_prompt_session()
+        task = asyncio.create_task(prompt.prompt_async(""))
+        await asyncio.sleep(0)
+        dim = prompt.layout.container.preferred_height(80, 40)
+        pipe_input.send_text("\r")
+        await asyncio.wait_for(task, timeout=5.0)
+
     assert dim.preferred >= 1

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -467,3 +467,12 @@ class TestResolvePromptPrefix:
             idle_hint=resolve_idle_hint_ansi(Session()),
         )
         assert _strip_ansi(prefix) == ""
+
+
+def test_composer_frame_preferred_height_does_not_crash() -> None:
+    """dont_extend_height must be a Filter — a raw bool crashes on first redraw."""
+    from surfaces.interactive_shell.ui.input_prompt import build_prompt_session
+
+    prompt = build_prompt_session()
+    dim = prompt.layout.container.preferred_height(80, 40)
+    assert dim.preferred >= 1

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -111,6 +111,31 @@ def test_confirmation_region_height_is_stable_across_selection_changes() -> None
     assert yes_rows == no_rows
 
 
+def test_streaming_prompt_height_stable_when_action_row_fills_and_clears() -> None:
+    """Tool start/end must not resize the composer region mid-turn.
+
+    The shimmer action row is reserved for the whole streaming turn so filling
+    or clearing it cannot push the bordered input box up and down.
+    """
+    session = Session()
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_phase(SpinnerState.THINKING_PHASE)
+
+    empty_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
+
+    spinner.set_active_action("GitHub CLI · gh api repos/x", action_id="t1")
+    filled_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
+    assert filled_rows == empty_rows
+
+    spinner.clear_active_action("t1")
+    cleared_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
+    assert cleared_rows == empty_rows
+
+    rendered = _plain(render_prompt_region(session, ReplState(), spinner).value)
+    assert "Thinking" in rendered or "…" in rendered
+
+
 def test_confirmation_region_shows_stacked_yes_no_choice() -> None:
     session = Session()
     state = ReplState()

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -1131,6 +1131,80 @@ class TestRenderMarkdownBlock:
         assert "Phase" in plain
         assert "Checking the token" in plain
 
+    def test_collapses_url_heavy_json_the_model_pasted(self) -> None:
+        """The real gh case: URL-heavy JSON, no inline marker. Long URLs dilute a
+        char ratio, so detection keys off the ``":`` separators instead."""
+        console, buf = _non_tty_console()
+        dump = (
+            '"login":"Tracer-Cloud",'
+            '"followers_url":"https://api.github.com/users/Tracer-Cloud/followers",'
+            '"following_url":"https://api.github.com/users/Tracer-Cloud/following{/other_user}",'
+            '"gists_url":"https://api.github.com/users/Tracer-Cloud/gists{/gist_id}",'
+            '"organizations_url":"https://api.github.com/users/Tracer-Cloud/orgs",'
+            '"type":"Organization","site_admin":false'
+        )
+
+        render_markdown_block(console, dump)
+
+        out = _strip_ansi(buf.getvalue())
+        assert "tool output omitted" in out  # collapsed to a one-line marker
+        assert "followers_url" not in out  # the raw blob is gone
+
+    def test_collapses_a_dump_flagged_by_the_truncated_marker(self) -> None:
+        console, buf = _non_tty_console()
+        rows = "\n".join(f"repo-{i}\tmain\t2026-01-01\t{i}\t0\t0" for i in range(20))
+
+        render_markdown_block(console, f"{rows}\n… (output truncated)")
+
+        assert "tool output omitted" in _strip_ansi(buf.getvalue())
+
+    def test_keeps_the_summary_and_collapses_only_the_pasted_blob(self) -> None:
+        """When a summary sentence and a pasted blob arrive as one block, keep the
+        summary and collapse only the blob — never nuke the whole reply."""
+        console, buf = _non_tty_console()
+        reply = (
+            "Repository is public with 10,984 stars.\n\n"
+            '"login":"Tracer-Cloud","followers_url":"https://api.github.com/users/Tracer-Cloud/f",'
+            '"gists_url":"https://api.github.com/users/Tracer-Cloud/gists{/gist_id}",'
+            '"organizations_url":"https://api.github.com/users/Tracer-Cloud/orgs",'
+            '"type":"Organization","site_admin":false'
+        )
+
+        render_markdown_block(console, reply)
+
+        out = _strip_ansi(buf.getvalue())
+        assert "Repository is public" in out  # summary survives
+        assert "tool output omitted" in out  # blob collapsed
+        assert "followers_url" not in out
+
+    def test_keeps_a_short_inline_json_snippet(self) -> None:
+        console, buf = _non_tty_console()
+
+        render_markdown_block(console, 'The API returned `{"ok": true, "count": 3}`.')
+
+        out = _strip_ansi(buf.getvalue())
+        assert '"ok"' in out
+        assert "tool output omitted" not in out
+
+    def test_keeps_ordinary_prose(self) -> None:
+        console, buf = _non_tty_console()
+
+        render_markdown_block(console, "The repository is public and its default branch is main.")
+
+        out = _strip_ansi(buf.getvalue())
+        assert "default branch is main" in out
+        assert "tool output omitted" not in out
+
+    def test_keeps_fenced_code_the_model_meant_to_show(self) -> None:
+        """A fenced block signals intent — never collapse it."""
+        console, buf = _non_tty_console()
+
+        render_markdown_block(console, '```json\n{"stars": 10984, "forks": 1603}\n```')
+
+        out = _strip_ansi(buf.getvalue())
+        assert "10984" in out
+        assert "tool output omitted" not in out
+
 
 class TestDeferWantMeToCloser:
     """Gather path holds drifted Want-me-to until the canonical rewrite paints."""

--- a/tests/shared/terminal/test_command_output_indent.py
+++ b/tests/shared/terminal/test_command_output_indent.py
@@ -57,14 +57,13 @@ def test_a_python_traceback_is_collapsed_to_the_exception_and_last_frame() -> No
     assert "run()" not in out  # intermediate source lines are gone
 
 
-def test_long_output_keeps_every_line() -> None:
-    """Slash / CLI / Claude Code dumps have no later summary — do not fold them."""
+def test_long_output_collapses_to_a_peek_with_an_expand_marker() -> None:
+    """Droid-style: a short head plus ``Ctrl+O to view``; full text is stashed."""
     out = _out("\n".join(f"line {i}" for i in range(30)), width=100)
     assert "↳ line 0" in out
-    assert "line 9" in out
-    assert "line 10" in out
-    assert "line 29" in out
-    assert "more line" not in out
+    assert "line 3" in out
+    assert "line 29" not in out
+    assert "Ctrl+O to view" in out
 
 
 def test_non_traceback_output_is_left_intact() -> None:

--- a/tests/shared/terminal/test_output_peek.py
+++ b/tests/shared/terminal/test_output_peek.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from infrastructure.terminal.peek import build_output_peek, format_expand_marker
+from infrastructure.terminal.peek import (
+    build_output_peek,
+    cap_output_for_display,
+    format_expand_marker,
+    format_view_all_marker,
+)
 
 
 def test_short_output_is_returned_whole_with_nothing_hidden() -> None:
@@ -22,6 +27,19 @@ def test_empty_output_hides_nothing() -> None:
     assert build_output_peek("   \n  ") == ("", 0)
 
 
-def test_expand_marker_pluralizes() -> None:
-    assert format_expand_marker(7) == "… 7 more lines"
-    assert format_expand_marker(1) == "… 1 more line"
+def test_expand_marker_matches_droid_copy() -> None:
+    assert format_expand_marker(7) == "… 7 more, Ctrl+O to view"
+    assert format_expand_marker(1) == "… 1 more, Ctrl+O to view"
+    assert format_view_all_marker() == "Ctrl+O to view all"
+
+
+def test_cap_output_uses_one_marker_when_both_caps_apply() -> None:
+    line = "y" * 130
+    text = "\n".join([line] * 7)
+    preview, folded = cap_output_for_display(text)
+    assert folded == text
+    assert preview.count("Ctrl+O to view") == 1
+    assert "output truncated" not in preview
+    assert preview.rstrip().endswith("Ctrl+O to view")
+    body, _, _ = preview.rpartition("\n")
+    assert body.endswith("…")

--- a/tests/shared/terminal/test_output_peek.py
+++ b/tests/shared/terminal/test_output_peek.py
@@ -1,0 +1,27 @@
+"""Collapsed tool-output peek + expand marker."""
+
+from __future__ import annotations
+
+from infrastructure.terminal.peek import build_output_peek, format_expand_marker
+
+
+def test_short_output_is_returned_whole_with_nothing_hidden() -> None:
+    peek, hidden = build_output_peek("one\ntwo", max_lines=3)
+    assert peek == "one\ntwo"
+    assert hidden == 0
+
+
+def test_long_output_is_cut_to_the_head_and_reports_the_remainder() -> None:
+    full = "\n".join(f"line {i}" for i in range(10))
+    peek, hidden = build_output_peek(full, max_lines=3)
+    assert peek == "line 0\nline 1\nline 2"
+    assert hidden == 7
+
+
+def test_empty_output_hides_nothing() -> None:
+    assert build_output_peek("   \n  ") == ("", 0)
+
+
+def test_expand_marker_pluralizes() -> None:
+    assert format_expand_marker(7) == "… 7 more lines"
+    assert format_expand_marker(1) == "… 1 more line"

--- a/tests/tools/test_github_cli.py
+++ b/tests/tools/test_github_cli.py
@@ -339,6 +339,21 @@ def test_summarize_gh_result_auto_merge() -> None:
     assert summary == "Enabled auto-merge for PR #3996."
 
 
+def test_summarize_gh_api_json_is_prose_not_a_json_slice() -> None:
+    stdout = (
+        '{"login":"Tracer-Cloud","followers_url":'
+        '"https://api.github.com/users/Tracer-Cloud/followers",'
+        '"type":"Organization"}'
+    )
+    summary = summarize_gh_result(
+        args=["api", "repos/tracer-cloud/opensre"],
+        ok=True,
+        stdout=stdout,
+    )
+    assert summary == "GitHub API call succeeded."
+    assert "followers_url" not in summary
+
+
 def test_summarize_gh_result_auto_merge_flags_before_number() -> None:
     summary = summarize_gh_result(
         args=["pr", "merge", "--squash", "--auto", "3996"],


### PR DESCRIPTION
Make the interactive-shell turn read like Claude Code / Droid instead of a wall
of raw data. When the agent runs a tool (e.g. `gh api`), the transcript was
dumping the raw JSON response under the reply; this hides that noise and keeps
the turn to: the tool call, the `∴` prose summary, and (for plain-text tools)
the real output.

- **Hide raw data blobs from the console** (`action_driver.py`): a generic tool
  result that is a JSON/record blob — valid, truncated (capped `gh api`
  responses arrive as invalid JSON), or a mid-object fragment — is detected by
  shape plus `":` key density (`_is_data_blob`) and dropped from the transcript;
  the reply summary carries the answer. Genuine plain-text output (logs, `ls`,
  `git`) still shows. The generic display cap is tightened and shows a
  `… N more lines` peek.
- **Collapse echoed dumps in the reply** (`streaming/renderer.py`): if the model
  pastes a raw block into its prose, it folds per paragraph to a one-line marker
  and keeps the summary around it.
- **One-line tool call** (`action_rendering.py`): `⏺ GitHub CLI · gh api …`
  instead of a label line plus an indented block.
- **Plan overlay, not header dumps** (architecture_audit `SKILL.md`): the skill
  drives the pinned `update_plan` overlay rather than printing `### [n/9]`
  headers into the transcript.
- Adds `infrastructure/terminal/peek.py` (peek + expand-marker helpers).