### PR TITLE
refactor(turns): extract tool-output display text into its own module

### DIFF
--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -42,6 +42,15 @@ from core.agent_harness.session.pending_choice import parse_ask_user_answers
 from core.agent_harness.session.terminal_access import execute_cli_onboard_on_missing_key
 from core.agent_harness.session_goal.goal import strip_session_goal_progress_tags
 from core.agent_harness.turns.conversation_recording import record_conversation_turn
+from core.agent_harness.turns.display_text import (
+    cap_for_display,
+    format_generic_tool_payload,
+    is_data_blob,
+    looks_like_json,
+    preferred_tool_response_text,
+    split_output_truncation_markers,
+    strip_plan_snapshots,
+)
 from core.agent_harness.turns.goal_review import (
     build_goal_reviewer,
     tap_executed_tool_names,
@@ -65,12 +74,6 @@ from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
 from infrastructure.observability.trace.prompts import persist_turn_system_prompt
 from infrastructure.observability.trace.spans import component_span
-from infrastructure.terminal.peek import (
-    DISPLAY_OUTPUT_MAX_CHARS,
-    DISPLAY_OUTPUT_MAX_LINES,
-    cap_output_for_display,
-    format_view_all_marker,
-)
 
 log = logging.getLogger(__name__)
 
@@ -232,15 +235,12 @@ _EXECUTED_HISTORY_TYPES = {
 INVESTIGATION_DISPATCH_TOOL_NAMES: frozenset[str] = frozenset(
     {"investigation_start", "alert_sample"}
 )
+
+
 # Tools whose user-facing event is owned by the host UI, so the end-of-turn
 # generic formatter must stay silent: repeating their summary would double-print,
 # and their payload (e.g. the full skill body) is for the model only. update_plan
 # renders as the pinned plan overlay, so its summary must not also print as text.
-_HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset(
-    {"ask_user_choice", "skill_view", "update_plan"}
-)
-
-
 @dataclass(frozen=True)
 class ActionTurnPlan:
     agent: Agent[Any]
@@ -331,77 +331,12 @@ def _pop_turn_outcome_hint(session: SessionState) -> str:
     return hint.strip() if isinstance(hint, str) else ""
 
 
-def _content_to_text(content: Any) -> str:
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        return json.dumps(content, default=str)
-    return str(content)
-
-
 def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
     return [
         (tool_call, tool_result)
         for tool_call, tool_result in getattr(result, "tool_results", [])
         if tool_call.name not in SELF_RECORDING_ACTION_TOOL_NAMES
     ]
-
-
-_DISPLAY_OUTPUT_MAX_LINES = DISPLAY_OUTPUT_MAX_LINES
-_DISPLAY_OUTPUT_MAX_CHARS = DISPLAY_OUTPUT_MAX_CHARS
-_EXPAND_MARKER_RE = re.compile(r"^… \d+ more, Ctrl\+O to view$")
-
-
-_PLAN_SNAPSHOT_RE = re.compile(r"Plan\s*[·.]\s*\d+\s*/\s*\d+(?:\s*[✓●○][^✓●○\n]*)*")
-
-
-def _strip_plan_snapshots(text: str) -> str:
-    """Remove ``Plan · n/m`` checklist snapshots the model restates in its reply.
-
-    The plan lives in the pinned overlay, so echoing it — let alone every
-    historical step-completion state — is a redundant wall. Prose (``-``/``•``
-    bullets, sentences) is untouched."""
-    if "Plan" not in text:
-        return text
-    cleaned = _PLAN_SNAPSHOT_RE.sub("", text)
-    return re.sub(r"\n{3,}", "\n\n", cleaned).strip()
-
-
-def _looks_like_json(text: str) -> bool:
-    stripped = text.strip()
-    if not stripped or stripped[0] not in "[{":
-        return False
-    try:
-        json.loads(stripped)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return False
-    return True
-
-
-def _is_output_truncation_marker(line: str) -> bool:
-    return line == format_view_all_marker() or bool(_EXPAND_MARKER_RE.fullmatch(line))
-
-
-def _split_output_truncation_markers(text: str) -> tuple[str, str]:
-    """Peel the trailing expand marker from a capped preview.
-
-    Returns ``(body, marker)``. *marker* is the single Droid-style line
-    (``… N more, Ctrl+O to view`` or ``Ctrl+O to view all``), or empty.
-    """
-    lines = text.split("\n")
-    cut = len(lines)
-    while cut and _is_output_truncation_marker(lines[cut - 1]):
-        cut -= 1
-    return "\n".join(lines[:cut]), "\n".join(lines[cut:])
-
-
-def _cap_for_display(text: str) -> str:
-    """Cap verbose tool output for the console so a large result cannot flood the
-    transcript. The model and persisted history keep the full text; only the
-    user-facing preview is truncated to a short head (Droid-style).
-    """
-    preview, _full = cap_output_for_display(text)
-    return preview
 
 
 def _stash_collapsed_tool_output(session: SessionState, text: str | None) -> None:
@@ -412,123 +347,9 @@ def _stash_collapsed_tool_output(session: SessionState, text: str | None) -> Non
     terminal.collapsed_tool_output = text
 
 
-def _is_data_blob(text: str) -> bool:
-    """Whether *text* is a JSON/record blob — valid, truncated, or a mid-object
-    fragment (a capped ``gh api`` response can arrive starting mid-value).
-
-    Detected by shape (opens an object/array) or by density of ``":`` key
-    separators, which URLs do not inflate and prose/logs almost never contain.
-    Such data is what the reply summarizes; it should not fill the transcript.
-    """
-    stripped = text.strip()
-    if not stripped:
-        return False
-    if stripped[0] in "{[":
-        return True
-    # Mid-object fragments (and short gh ``summary`` previews of JSON) still
-    # carry ``":`` key separators — two is enough once the text is clearly a
-    # record slice rather than prose.
-    return stripped.count('":') >= 2
-
-
-def _user_facing_tool_text(text: str) -> str:
-    """Return *text* for the transcript, or ``""`` when it is a data blob."""
-    stripped = text.strip()
-    if not stripped or _is_data_blob(stripped):
-        return ""
-    return stripped
-
-
-def _visible_stdout(stdout: str) -> str:
-    """Plain-text stdout is shown as-is; a JSON payload is hidden.
-
-    A ``gh api`` / structured response is data the reply already summarizes, so
-    dumping it into the transcript only adds a wall that reads as unattached to
-    the command. Hide the blob and let the summary carry the answer — the way
-    Claude Code / Droid keep tool results out of the reply prose. Plain-text
-    output (logs, a short listing) is still shown, capped later at display time.
-    """
-    return _user_facing_tool_text(stdout)
-
-
-def _format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
-    """Build a user-visible summary for one non-self-recording tool result."""
-    if tool_call.name in _HOST_RENDERED_TOOL_NAMES and not getattr(tool_result, "is_error", False):
-        return ""
-    preferred_response = _preferred_tool_response_text(tool_result)
-    if preferred_response:
-        return _user_facing_tool_text(preferred_response)
-    details = getattr(tool_result, "details", None)
-    if isinstance(details, dict):
-        summary = details.get("summary")
-        if isinstance(summary, str) and summary.strip():
-            # gh ``summary`` for ``api`` used to be a sliced JSON string — hide
-            # that the same way as raw stdout so the transcript stays prose.
-            return _user_facing_tool_text(summary)
-        stdout = details.get("stdout")
-        if details.get("ok") and isinstance(stdout, str) and stdout.strip():
-            return _visible_stdout(stdout)
-        error = details.get("error")
-        if error:
-            return str(error).strip()
-    if getattr(tool_result, "is_error", False):
-        return ""
-    content = _content_to_text(getattr(tool_result, "content", "")).strip()
-    if not content:
-        return ""
-    # Prefer a nested summary when the tool returned a JSON object payload.
-    try:
-        parsed = json.loads(content)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        parsed = None
-    if isinstance(parsed, dict):
-        response_text = parsed.get("response_text")
-        if isinstance(response_text, str) and response_text.strip():
-            return _user_facing_tool_text(response_text)
-        summary = parsed.get("summary")
-        if isinstance(summary, str) and summary.strip():
-            return _user_facing_tool_text(summary)
-        if parsed.get("ok") and isinstance(parsed.get("stdout"), str) and parsed["stdout"].strip():
-            return _visible_stdout(str(parsed["stdout"]))
-        if parsed.get("error"):
-            return str(parsed["error"]).strip()
-    if isinstance(parsed, (dict, list)):
-        # An opaque JSON payload (no user-facing field — e.g. a raw ``gh api``
-        # response) is for the model, not the transcript: the reply summarizes
-        # it. Hide it rather than dump a wall of data unattached to the command.
-        return ""
-    # A truncated / fragmentary JSON blob (a capped ``gh api`` response) that
-    # failed to parse — hide it, same as valid JSON.
-    if _is_data_blob(content):
-        return ""
-    # Non-JSON content is the tool's real text output; show it under the name.
-    return f"{tool_call.name} result: {content}"
-
-
-def _preferred_tool_response_text(tool_result: Any) -> str:
-    details = getattr(tool_result, "details", None)
-    if isinstance(details, dict):
-        response_text = details.get("response_text")
-        if isinstance(response_text, str) and response_text.strip():
-            return _user_facing_tool_text(response_text)
-    content = _content_to_text(getattr(tool_result, "content", "")).strip()
-    if not content:
-        return ""
-    try:
-        parsed = json.loads(content)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return ""
-    if not isinstance(parsed, dict):
-        return ""
-    response_text = parsed.get("response_text")
-    if not isinstance(response_text, str):
-        return ""
-    return _user_facing_tool_text(response_text)
-
-
 def _has_preferred_tool_response_text(result: Any) -> bool:
     return any(
-        bool(_preferred_tool_response_text(tool_result))
+        bool(preferred_tool_response_text(tool_result))
         for _tool_call, tool_result in _generic_tool_results(result)
     )
 
@@ -602,7 +423,7 @@ def _has_quiet_shell_run(result: Any) -> bool:
 def _response_text_from_generic_results(result: Any) -> str:
     chunks: list[str] = []
     for tool_call, tool_result in _generic_tool_results(result):
-        formatted = _format_generic_tool_payload(tool_call, tool_result)
+        formatted = format_generic_tool_payload(tool_call, tool_result)
         if formatted:
             chunks.append(formatted)
     return "\n".join(chunks)
@@ -1012,20 +833,29 @@ def _compose_response(
     final_text_chunk = "" if suppress_final else final_text
     # The model sometimes restates the plan (or every historical snapshot) in its
     # reply; the pinned overlay already shows it, so strip snapshots from display.
-    display_final = _strip_plan_snapshots(final_text_chunk)
+    display_final = strip_plan_snapshots(final_text_chunk)
     # History entries are already rendered by self-recording tools (shell/slash/…).
     # Console display uses final_text + generic results + hints only so users see
     # github_cli / other registry tools without double-printing shell output.
     # response_text still includes history for persistence / non-TTY surfaces.
-    display_generic = _cap_for_display(generic_text)
+    display_generic = cap_for_display(generic_text)
     # Defense: never fence a data blob into the transcript (summary/stdout leaks
     # used to pretty-print truncated JSON behind a text fence).
-    if _is_data_blob(generic_text):
+    if is_data_blob(generic_text):
         display_generic = ""
-    is_json = _looks_like_json(generic_text)
-    body, markers = _split_output_truncation_markers(display_generic)
+    # The shell observer already nested user-facing results under each ``⏺``
+    # call (Droid / Claude Code / Cursor). Repeating them in the closing
+    # would float a second copy after the reply. Leave the Ctrl+O stash the
+    # observer wrote; do not clear it with an empty preview.
+    already_inline = bool(getattr(terminal, "inline_tool_results", False))
+    if already_inline and terminal is not None:
+        terminal.inline_tool_results = False
+        display_generic = ""
+    is_json = looks_like_json(generic_text)
+    body, markers = split_output_truncation_markers(display_generic)
     truncated = bool(markers)
-    _stash_collapsed_tool_output(session, generic_text if truncated else None)
+    if not already_inline:
+        _stash_collapsed_tool_output(session, generic_text if truncated else None)
     bulky = display_generic.count("\n") >= 4 or truncated
     if display_generic and (is_json or bulky):
         # Truncated JSON is invalid — fencing it as ``json`` makes Rich/Pygments

--- a/core/agent_harness/turns/display_text.py
+++ b/core/agent_harness/turns/display_text.py
@@ -1,0 +1,214 @@
+"""Turn tool-result and reply text as it is shown in the transcript.
+
+Formats a tool result into the user-facing line the transcript shows, caps
+verbose output to a short head, and hides raw data blobs the reply already
+summarizes. Kept apart from ``action_driver`` so the turn driver stays about
+driving the turn and this module is the one place display text is shaped.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from core.llm.types import ToolCall
+from infrastructure.terminal.peek import (
+    DISPLAY_OUTPUT_MAX_CHARS,
+    DISPLAY_OUTPUT_MAX_LINES,
+    cap_output_for_display,
+    format_view_all_marker,
+)
+
+# Tools whose result the host already rendered to the console; their payload is
+# not re-shown in the transcript.
+_HOST_RENDERED_TOOL_NAMES: frozenset[str] = frozenset(
+    {"ask_user_choice", "skill_view", "update_plan"}
+)
+
+_EXPAND_MARKER_RE = re.compile(r"^… \d+ more, Ctrl\+O to view$")
+_PLAN_SNAPSHOT_RE = re.compile(r"Plan\s*[·.]\s*\d+\s*/\s*\d+(?:\s*[✓●○][^✓●○\n]*)*")
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return json.dumps(content, default=str)
+    return str(content)
+
+
+def strip_plan_snapshots(text: str) -> str:
+    """Remove ``Plan · n/m`` checklist snapshots the model restates in its reply.
+
+    The plan lives in the pinned overlay, so echoing it — let alone every
+    historical step-completion state — is a redundant wall. Prose (``-``/``•``
+    bullets, sentences) is untouched."""
+    if "Plan" not in text:
+        return text
+    cleaned = _PLAN_SNAPSHOT_RE.sub("", text)
+    return re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+
+
+def looks_like_json(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped or stripped[0] not in "[{":
+        return False
+    try:
+        json.loads(stripped)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return False
+    return True
+
+
+def _is_output_truncation_marker(line: str) -> bool:
+    return line == format_view_all_marker() or bool(_EXPAND_MARKER_RE.fullmatch(line))
+
+
+def split_output_truncation_markers(text: str) -> tuple[str, str]:
+    """Peel the trailing expand marker from a capped preview.
+
+    Returns ``(body, marker)``. *marker* is the single Droid-style line
+    (``… N more, Ctrl+O to view`` or ``Ctrl+O to view all``), or empty.
+    """
+    lines = text.split("\n")
+    cut = len(lines)
+    while cut and _is_output_truncation_marker(lines[cut - 1]):
+        cut -= 1
+    return "\n".join(lines[:cut]), "\n".join(lines[cut:])
+
+
+def cap_for_display(text: str) -> str:
+    """Cap verbose tool output for the console so a large result cannot flood the
+    transcript. The model and persisted history keep the full text; only the
+    user-facing preview is truncated to a short head (Droid-style).
+    """
+    preview, _full = cap_output_for_display(text)
+    return preview
+
+
+def is_data_blob(text: str) -> bool:
+    """Whether *text* is a JSON/record blob — valid, truncated, or a mid-object
+    fragment (a capped ``gh api`` response can arrive starting mid-value).
+
+    Detected by shape (opens an object/array) or by density of ``":`` key
+    separators, which URLs do not inflate and prose/logs almost never contain.
+    Such data is what the reply summarizes; it should not fill the transcript.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if stripped[0] in "{[":
+        return True
+    # Mid-object fragments (and short gh ``summary`` previews of JSON) still
+    # carry ``":`` key separators — two is enough once the text is clearly a
+    # record slice rather than prose.
+    return stripped.count('":') >= 2
+
+
+def _user_facing_tool_text(text: str) -> str:
+    """Return *text* for the transcript, or ``""`` when it is a data blob."""
+    stripped = text.strip()
+    if not stripped or is_data_blob(stripped):
+        return ""
+    return stripped
+
+
+def _visible_stdout(stdout: str) -> str:
+    """Plain-text stdout is shown as-is; a JSON payload is hidden.
+
+    A ``gh api`` / structured response is data the reply already summarizes, so
+    dumping it into the transcript only adds a wall that reads as unattached to
+    the command. Hide the blob and let the summary carry the answer — the way
+    Claude Code / Droid keep tool results out of the reply prose. Plain-text
+    output (logs, a short listing) is still shown, capped later at display time.
+    """
+    return _user_facing_tool_text(stdout)
+
+
+def format_generic_tool_payload(tool_call: ToolCall, tool_result: Any) -> str:
+    """Build a user-visible summary for one non-self-recording tool result."""
+    if tool_call.name in _HOST_RENDERED_TOOL_NAMES and not getattr(tool_result, "is_error", False):
+        return ""
+    preferred_response = preferred_tool_response_text(tool_result)
+    if preferred_response:
+        return _user_facing_tool_text(preferred_response)
+    details = getattr(tool_result, "details", None)
+    if isinstance(details, dict):
+        summary = details.get("summary")
+        if isinstance(summary, str) and summary.strip():
+            # gh ``summary`` for ``api`` used to be a sliced JSON string — hide
+            # that the same way as raw stdout so the transcript stays prose.
+            return _user_facing_tool_text(summary)
+        stdout = details.get("stdout")
+        if details.get("ok") and isinstance(stdout, str) and stdout.strip():
+            return _visible_stdout(stdout)
+        error = details.get("error")
+        if error:
+            return str(error).strip()
+    if getattr(tool_result, "is_error", False):
+        return ""
+    content = _content_to_text(getattr(tool_result, "content", "")).strip()
+    if not content:
+        return ""
+    # Prefer a nested summary when the tool returned a JSON object payload.
+    try:
+        parsed = json.loads(content)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        parsed = None
+    if isinstance(parsed, dict):
+        response_text = parsed.get("response_text")
+        if isinstance(response_text, str) and response_text.strip():
+            return _user_facing_tool_text(response_text)
+        summary = parsed.get("summary")
+        if isinstance(summary, str) and summary.strip():
+            return _user_facing_tool_text(summary)
+        if parsed.get("ok") and isinstance(parsed.get("stdout"), str) and parsed["stdout"].strip():
+            return _visible_stdout(str(parsed["stdout"]))
+        if parsed.get("error"):
+            return str(parsed["error"]).strip()
+    if isinstance(parsed, (dict, list)):
+        # An opaque JSON payload (no user-facing field — e.g. a raw ``gh api``
+        # response) is for the model, not the transcript: the reply summarizes
+        # it. Hide it rather than dump a wall of data unattached to the command.
+        return ""
+    # A truncated / fragmentary JSON blob (a capped ``gh api`` response) that
+    # failed to parse — hide it, same as valid JSON.
+    if is_data_blob(content):
+        return ""
+    # Non-JSON content is the tool's real text output; show it under the name.
+    return f"{tool_call.name} result: {content}"
+
+
+def preferred_tool_response_text(tool_result: Any) -> str:
+    details = getattr(tool_result, "details", None)
+    if isinstance(details, dict):
+        response_text = details.get("response_text")
+        if isinstance(response_text, str) and response_text.strip():
+            return _user_facing_tool_text(response_text)
+    content = _content_to_text(getattr(tool_result, "content", "")).strip()
+    if not content:
+        return ""
+    try:
+        parsed = json.loads(content)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return ""
+    if not isinstance(parsed, dict):
+        return ""
+    response_text = parsed.get("response_text")
+    if not isinstance(response_text, str):
+        return ""
+    return _user_facing_tool_text(response_text)
+
+
+__all__ = [
+    "DISPLAY_OUTPUT_MAX_CHARS",
+    "DISPLAY_OUTPUT_MAX_LINES",
+    "cap_for_display",
+    "format_generic_tool_payload",
+    "is_data_blob",
+    "looks_like_json",
+    "preferred_tool_response_text",
+    "split_output_truncation_markers",
+    "strip_plan_snapshots",
+]

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -117,6 +117,12 @@ class TerminalSession:
     Set by the action turn when the console preview is folded; cleared when
     the next turn's preview fits. None when nothing is collapsed."""
 
+    inline_tool_results: bool = False
+    """True when this turn already printed tool results under their call lines.
+
+    The closing reply must not repeat those results. The response composer
+    reads and clears the flag."""
+
     pending_confirm_options: tuple[tuple[str, str], ...] | None = None
     """Rows the next execution confirmation should offer, or None for Yes/No.
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -30,6 +30,7 @@ from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.ui.streaming import render_note_block
 from surfaces.shared.terminal.output.console_state import get_investigation_spinner
+from surfaces.shared.terminal.tables import print_command_output
 from tools.interactive_shell.action_names import ActionToolName
 from tools.interactive_shell.shell.display import format_shell_command_for_display
 
@@ -124,6 +125,58 @@ def _bounded_preview(value: str, *, limit: int = _TOOL_PREVIEW_MAX_CHARS) -> str
     if len(collapsed) <= limit:
         return collapsed
     return collapsed[: limit - 1].rstrip() + "…"
+
+
+def _is_result_data_blob(text: str) -> bool:
+    """True when *text* is a JSON/record blob the reply will summarize.
+
+    Same shape test the action driver uses to hide ``gh api`` payloads: opens
+    an object/array, or is dense with ``":`` key separators.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if stripped[0] in "{[":
+        return True
+    return stripped.count('":') >= 2
+
+
+def _preview_from_result_fields(payload: dict[str, Any]) -> str:
+    """Pull the one user-facing field from a tool-result dict, or empty."""
+    for key in ("response_text", "summary"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip() and not _is_result_data_blob(value):
+            return value.strip()
+    stdout = payload.get("stdout")
+    if (
+        payload.get("ok")
+        and isinstance(stdout, str)
+        and stdout.strip()
+        and not _is_result_data_blob(stdout)
+    ):
+        return stdout.strip()
+    error = payload.get("error")
+    if error:
+        return str(error).strip()
+    return ""
+
+
+def _tool_result_preview(output: object) -> str:
+    """User-facing result text for a ``↳`` child, or empty for model-only data."""
+    if isinstance(output, dict):
+        return _preview_from_result_fields(output)
+    details = getattr(output, "details", None)
+    if isinstance(details, dict):
+        preview = _preview_from_result_fields(details)
+        if preview:
+            return preview
+    if isinstance(output, str):
+        stripped = output.strip()
+        return "" if not stripped or _is_result_data_blob(stripped) else stripped
+    content = getattr(output, "content", None)
+    if isinstance(content, str) and content.strip() and not _is_result_data_blob(content):
+        return content.strip()
+    return ""
 
 
 def _is_sensitive_key(key: object) -> bool:
@@ -338,6 +391,7 @@ class ActionRenderObserver:
         self.message = message
         self.planned_count = 0
         self._pending_skill_calls: dict[str, str] = {}
+        self._pending_result_tools: set[str] = set()
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         if kind == "llm_start":
@@ -360,6 +414,9 @@ class ActionRenderObserver:
             name = str(data.get("name", "")).strip()
             if name == ActionToolName.SKILL_VIEW:
                 self._render_skill_end(data)
+            elif _tool_event_id(data) in self._pending_result_tools:
+                self._render_tool_result(data)
+            self._pending_result_tools.discard(_tool_event_id(data))
             # update_plan is not painted into the transcript: the plan renders in
             # the pinned bottom overlay (``task_plan_overlay_ansi``) from session
             # state the tool committed.
@@ -383,6 +440,7 @@ class ActionRenderObserver:
             pass  # owns its UI; a generic preview would duplicate it
         else:
             self._render_tool_invocation(name, data)
+            self._pending_result_tools.add(_tool_event_id(data))
         if name not in _SKIP_PLAN_WORK_TOOLS and not _is_internal_choice_command(name, data):
             self._record_plan_work(name, data)
             self._set_active_action(name, data)
@@ -503,6 +561,22 @@ class ActionRenderObserver:
             line.append(separator, style=str(DIM))
             line.append(content, style=str(BRAND))
         self.console.print(line)
+
+    def _render_tool_result(self, data: dict[str, Any]) -> None:
+        """Nest the user-facing result under the ``⏺`` call as a ``↳`` child.
+
+        Droid / Claude Code / Cursor keep the result attached to the call.
+        JSON blobs stay hidden — the closing reply summarizes those.
+        """
+        preview = _tool_result_preview(data.get("output"))
+        if not preview:
+            return
+        print_command_output(
+            self.console,
+            preview,
+            on_collapse=lambda body: setattr(self.session.terminal, "collapsed_tool_output", body),
+        )
+        self.session.terminal.inline_tool_results = True
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:
         """Print the ``↳`` child line under the skill's ``tool_start`` parent."""

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -39,6 +39,9 @@ _DUMP_MIN_CHARS = 200
 _DUMP_MIN_JSON_KEYS = 3
 _DUMP_STRUCTURAL_RATIO = 0.15
 _DUMP_STRUCTURAL_CHARS = frozenset('{}[]":,')
+# Line-start fences only — matches the streaming splitter so an inline
+# ``Use ``` to fence code`` mention does not freeze dump collapsing.
+_FENCE_LINE_RE = re.compile(r"^```", re.MULTILINE)
 
 
 def _looks_like_raw_dump(text: str) -> bool:
@@ -74,14 +77,25 @@ def _collapse_paragraph(paragraph: str) -> str:
 def _collapse_raw_dumps(text: str) -> str:
     """Replace echoed raw tool-output paragraphs with a one-line marker.
 
-    Fenced code is left untouched — a fence means the model meant to show it.
-    Works per blank-line-separated paragraph so a summary sentence beside a
-    pasted blob keeps the summary and collapses only the blob, whether the reply
-    arrives whole (finalize path) or paragraph-by-paragraph (streaming).
+    Fenced regions stay intact — a fence means the model meant to show them.
+    Independent paragraphs still collapse, including when they sit beside a
+    fence in the same reply. Works per blank-line-separated paragraph so a
+    summary sentence beside a pasted blob keeps the summary and collapses
+    only the blob, whether the reply arrives whole (finalize path) or
+    paragraph-by-paragraph (streaming).
     """
-    if "```" in text:  # fenced code — respect the model's intent
-        return text
-    return "\n\n".join(_collapse_paragraph(part) for part in re.split(r"\n[ \t]*\n", text))
+    parts = re.split(r"\n[ \t]*\n", text)
+    collapsed: list[str] = []
+    inside_fence = False
+    for part in parts:
+        fence_count = len(_FENCE_LINE_RE.findall(part))
+        if inside_fence or fence_count:
+            collapsed.append(part)
+        else:
+            collapsed.append(_collapse_paragraph(part))
+        if fence_count % 2:
+            inside_fence = not inside_fence
+    return "\n\n".join(collapsed)
 
 
 def _build_markdown_block(text: str) -> Markdown:

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -426,6 +426,26 @@ def test_selected_choice_keeps_meaningful_follow_up_response() -> None:
     assert session.terminal.pending_choice_response is None
 
 
+def test_inline_tool_results_are_not_repeated_in_the_closing() -> None:
+    """When the shell already nested results under ``⏺``, the closing stays the reply."""
+    github = ToolCall(id="1", name="github_cli", input={"command": "api user"})
+    result = _Result(
+        tool_results=[(github, _ToolResult({"ok": True, "summary": "GitHub API call succeeded."}))],
+        final_text="The repository is public.",
+    )
+    session = _Session()
+    session.terminal.inline_tool_results = True
+    session.terminal.collapsed_tool_output = "stashed-by-observer"
+
+    _response_text, display_chunks, _use_final = _compose_response(result, session, _counts(1))
+    shown = "\n".join(display_chunks)
+
+    assert "The repository is public." in shown
+    assert "GitHub API call succeeded." not in shown
+    assert session.terminal.inline_tool_results is False
+    assert session.terminal.collapsed_tool_output == "stashed-by-observer"
+
+
 def test_bulky_tool_output_is_capped_and_fenced_for_display() -> None:
     # A large tool result must not flood the transcript or blend into the report:
     # it is capped and shown in its own fenced code block for the console.

--- a/tests/core/agent_harness/turns/test_generic_tool_payload.py
+++ b/tests/core/agent_harness/turns/test_generic_tool_payload.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 
-from core.agent_harness.turns.action_driver import _format_generic_tool_payload
+from core.agent_harness.turns.display_text import format_generic_tool_payload
 from core.llm.types import ToolCall
 
 
@@ -33,7 +33,7 @@ def test_opaque_json_object_is_hidden() -> None:
     # A raw JSON payload with no user-facing field (e.g. a gh-api response) is
     # for the model, not the transcript — hide it; the reply summarizes it.
     payload = {"ok": True, "available": True, "repository": {"full_name": "acme/svc"}}
-    assert _format_generic_tool_payload(_call("get_github_repository"), _result(payload)) == ""
+    assert format_generic_tool_payload(_call("get_github_repository"), _result(payload)) == ""
 
 
 def test_json_summary_preview_is_hidden() -> None:
@@ -44,7 +44,7 @@ def test_json_summary_preview_is_hidden() -> None:
         '"gists_url": "https://api.github.com/users/Tr...'
     )
     payload = {"ok": True, "stdout": sliced, "summary": sliced}
-    assert _format_generic_tool_payload(_call("github_cli"), _result(payload)) == ""
+    assert format_generic_tool_payload(_call("github_cli"), _result(payload)) == ""
 
 
 def test_prose_summary_is_still_shown() -> None:
@@ -54,13 +54,13 @@ def test_prose_summary_is_still_shown() -> None:
         "summary": "GitHub API call succeeded.",
     }
     assert (
-        _format_generic_tool_payload(_call("github_cli"), _result(payload))
+        format_generic_tool_payload(_call("github_cli"), _result(payload))
         == "GitHub API call succeeded."
     )
 
 
 def test_opaque_json_list_is_hidden() -> None:
-    assert _format_generic_tool_payload(_call("list_runs"), _result([{"id": 1}, {"id": 2}])) == ""
+    assert format_generic_tool_payload(_call("list_runs"), _result([{"id": 1}, {"id": 2}])) == ""
 
 
 def test_truncated_json_blob_is_hidden_not_dumped_raw() -> None:
@@ -68,10 +68,10 @@ def test_truncated_json_blob_is_hidden_not_dumped_raw() -> None:
     # slip past the JSON check and dump raw. Detection is by shape, not parse.
     trunc = '{"full_name":"Tracer-Cloud/opensre","followers_url":"https://api.github.com/users/Tr'
     assert (
-        _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": trunc}))
+        format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": trunc}))
         == ""
     )
-    assert _format_generic_tool_payload(_call("github_cli"), _result(trunc)) == ""
+    assert format_generic_tool_payload(_call("github_cli"), _result(trunc)) == ""
     # A mid-object fragment (starts on a value, not ``{``) is still a data blob:
     # key-density detection catches it where a first-char check would not.
     frag = (
@@ -79,19 +79,19 @@ def test_truncated_json_blob_is_hidden_not_dumped_raw() -> None:
         '"following_url":"https://api.github.com/f","gists_url":"https://api.github.com/g"'
     )
     assert (
-        _format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": frag}))
+        format_generic_tool_payload(_call("github_cli"), _result({"ok": True, "stdout": frag}))
         == ""
     )
 
 
 def test_a_real_summary_is_still_shown() -> None:
     payload = {"ok": True, "summary": "3 workflows, 12 runs"}
-    shown = _format_generic_tool_payload(_call("list_runs"), _result(payload))
+    shown = format_generic_tool_payload(_call("list_runs"), _result(payload))
     assert shown == "3 workflows, 12 runs"
 
 
 def test_plain_text_output_is_still_shown() -> None:
-    shown = _format_generic_tool_payload(_call("shell"), _result("build succeeded"))
+    shown = format_generic_tool_payload(_call("shell"), _result("build succeeded"))
     assert "build succeeded" in shown
 
 
@@ -100,17 +100,17 @@ def test_json_stdout_is_hidden_and_plain_stdout_is_shown() -> None:
     # than dump a wall unattached to the command. Plain-text output (ls, git) is
     # the user's real result and shows as-is.
     json_stdout = _result({"ok": True, "stdout": '{"id": 18260225, "name": "main"}'})
-    assert _format_generic_tool_payload(_call("github_cli"), json_stdout) == ""
+    assert format_generic_tool_payload(_call("github_cli"), json_stdout) == ""
 
     plain_stdout = _result({"ok": True, "stdout": "total 56\ndrwxr-xr-x  15 user"})
-    assert "drwxr-xr-x" in _format_generic_tool_payload(_call("shell"), plain_stdout)
+    assert "drwxr-xr-x" in format_generic_tool_payload(_call("shell"), plain_stdout)
 
 
 def test_verbose_output_is_capped_for_display_only() -> None:
-    from core.agent_harness.turns.action_driver import _cap_for_display
+    from core.agent_harness.turns.display_text import cap_for_display
 
     big = "\n".join(f"run {i} failure 2026-08-01T09:11:00Z" for i in range(50))
-    capped = _cap_for_display(big)
+    capped = cap_for_display(big)
 
     # Display is a short head + one Droid-style peek marker; the full text is untouched.
     assert capped.count("\n") + 1 <= 6
@@ -120,42 +120,42 @@ def test_verbose_output_is_capped_for_display_only() -> None:
 
 
 def test_short_output_is_not_truncated() -> None:
-    from core.agent_harness.turns.action_driver import _cap_for_display
+    from core.agent_harness.turns.display_text import cap_for_display
 
     text = "total 56\ndrwxr-xr-x  15 user"
-    assert _cap_for_display(text) == text
+    assert cap_for_display(text) == text
 
 
 def test_character_cap_reports_truncation_when_lines_fit() -> None:
-    from core.agent_harness.turns.action_driver import (
-        _DISPLAY_OUTPUT_MAX_CHARS,
-        _cap_for_display,
+    from core.agent_harness.turns.display_text import (
+        DISPLAY_OUTPUT_MAX_CHARS,
+        cap_for_display,
     )
     from infrastructure.terminal.peek import format_view_all_marker
 
-    text = "x" * (_DISPLAY_OUTPUT_MAX_CHARS + 40)
-    capped = _cap_for_display(text)
+    text = "x" * (DISPLAY_OUTPUT_MAX_CHARS + 40)
+    capped = cap_for_display(text)
     assert capped.endswith(format_view_all_marker())
     body, _, marker = capped.rpartition("\n")
     assert marker == format_view_all_marker()
     assert body.endswith("…")
-    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS + 1
+    assert len(body) <= DISPLAY_OUTPUT_MAX_CHARS + 1
     assert "more, Ctrl+O" not in capped
 
 
 def test_character_and_line_caps_share_one_marker() -> None:
-    from core.agent_harness.turns.action_driver import (
-        _DISPLAY_OUTPUT_MAX_CHARS,
-        _DISPLAY_OUTPUT_MAX_LINES,
-        _cap_for_display,
+    from core.agent_harness.turns.display_text import (
+        DISPLAY_OUTPUT_MAX_CHARS,
+        DISPLAY_OUTPUT_MAX_LINES,
+        cap_for_display,
     )
     from infrastructure.terminal.peek import format_expand_marker, format_view_all_marker
 
     # First N lines together exceed the character cap, and extra lines remain.
-    line = "y" * ((_DISPLAY_OUTPUT_MAX_CHARS // 2) + 1)
+    line = "y" * ((DISPLAY_OUTPUT_MAX_CHARS // 2) + 1)
     extra_lines = 3
-    text = "\n".join([line] * (_DISPLAY_OUTPUT_MAX_LINES + extra_lines))
-    capped = _cap_for_display(text)
+    text = "\n".join([line] * (DISPLAY_OUTPUT_MAX_LINES + extra_lines))
+    capped = cap_for_display(text)
 
     assert format_expand_marker(extra_lines) in capped
     assert format_view_all_marker() not in capped
@@ -163,4 +163,4 @@ def test_character_and_line_caps_share_one_marker() -> None:
     body, _, marker = capped.rpartition("\n")
     assert marker == format_expand_marker(extra_lines)
     assert body.endswith("…")
-    assert len(body) <= _DISPLAY_OUTPUT_MAX_CHARS + 1
+    assert len(body) <= DISPLAY_OUTPUT_MAX_CHARS + 1

--- a/tests/core/agent_harness/turns/test_skill_view_display.py
+++ b/tests/core/agent_harness/turns/test_skill_view_display.py
@@ -10,7 +10,7 @@ escaped JSON, box-drawing characters and all — onto the user's screen.
 
 from __future__ import annotations
 
-from core.agent_harness.turns.action_driver import _format_generic_tool_payload
+from core.agent_harness.turns.display_text import format_generic_tool_payload
 from core.llm.types import ToolCall
 from tools.interactive_shell.actions.skill_view import execute_skill_view_tool
 
@@ -36,7 +36,7 @@ def test_loading_a_skill_emits_nothing_from_the_generic_formatter() -> None:
         details = result
 
     # Act
-    shown = _format_generic_tool_payload(
+    shown = format_generic_tool_payload(
         ToolCall(id="t1", name="skill_view", input={"name": "morning-report"}), _Result()
     )
 

--- a/tests/core/agent_harness/turns/test_update_plan_display.py
+++ b/tests/core/agent_harness/turns/test_update_plan_display.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 
-from core.agent_harness.turns.action_driver import _format_generic_tool_payload
+from core.agent_harness.turns.display_text import format_generic_tool_payload
 from core.llm.types import ToolCall
 
 
@@ -33,7 +33,7 @@ def test_update_plan_emits_nothing_from_the_generic_formatter() -> None:
         is_error = False
 
     # Act
-    shown = _format_generic_tool_payload(
+    shown = format_generic_tool_payload(
         ToolCall(id="t1", name="update_plan", input={"plan": []}), _Result()
     )
 

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -424,8 +424,55 @@ def test_non_skill_tool_end_prints_nothing() -> None:
         {"id": "t1", "name": "shell_run", "input": {"command": "true"}, "output": {"ok": True}},
     )
 
-    # tool_end adds a child line only for skill_view; a non-skill tool_end is silent.
+    # Self-rendering tools (shell_run) already printed ``$ cmd`` + output;
+    # a generic tool_end child would duplicate that block.
     assert buffer.getvalue() == after_start
+
+
+def test_generic_tool_end_nests_the_result_under_the_call() -> None:
+    """Droid / Claude Code / Cursor attach the result to the call as a ``↳`` child."""
+    observer, buffer = _observer_with_buffer()
+
+    observer(
+        "tool_start",
+        {"id": "t1", "name": "github_cli", "input": {"args": ["api", "user"]}},
+    )
+    observer(
+        "tool_end",
+        {
+            "id": "t1",
+            "name": "github_cli",
+            "output": {"ok": True, "summary": "GitHub API call succeeded."},
+        },
+    )
+
+    out = buffer.getvalue()
+    assert "GitHub CLI" in out
+    assert "↳" in out
+    assert "GitHub API call succeeded" in out
+    assert observer.session.terminal.inline_tool_results is True
+
+
+def test_generic_tool_end_hides_a_json_blob() -> None:
+    """A ``gh api`` payload is for the model — nest nothing, leave the reply to summarize."""
+    observer, buffer = _observer_with_buffer()
+
+    observer(
+        "tool_start",
+        {"id": "t1", "name": "github_cli", "input": {"args": ["api", "user"]}},
+    )
+    after_start = buffer.getvalue()
+    observer(
+        "tool_end",
+        {
+            "id": "t1",
+            "name": "github_cli",
+            "output": {"ok": True, "stdout": '{"login":"Tracer-Cloud"}'},
+        },
+    )
+
+    assert buffer.getvalue() == after_start
+    assert observer.session.terminal.inline_tool_results is False
 
 
 def test_literal_slash_command_records_single_history_entry(

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -1205,6 +1205,45 @@ class TestRenderMarkdownBlock:
         assert "10984" in out
         assert "tool output omitted" not in out
 
+    def test_collapses_an_independent_dump_beside_a_fenced_block(self) -> None:
+        """A fence exempts only its region — a separate dump still collapses."""
+        console, buf = _non_tty_console()
+        dump = (
+            '"login":"Tracer-Cloud",'
+            '"followers_url":"https://api.github.com/users/Tracer-Cloud/followers",'
+            '"following_url":"https://api.github.com/users/Tracer-Cloud/following{/other_user}",'
+            '"gists_url":"https://api.github.com/users/Tracer-Cloud/gists{/gist_id}",'
+            '"organizations_url":"https://api.github.com/users/Tracer-Cloud/orgs",'
+            '"type":"Organization","site_admin":false'
+        )
+        reply = f'Use this snippet:\n\n```json\n{{"stars": 10984, "forks": 1603}}\n```\n\n{dump}'
+
+        render_markdown_block(console, reply)
+
+        out = _strip_ansi(buf.getvalue())
+        assert "10984" in out  # intentional fence survives
+        assert "tool output omitted" in out  # independent dump collapsed
+        assert "followers_url" not in out
+
+    def test_keeps_dump_like_content_inside_a_fenced_block(self) -> None:
+        """Blank lines inside a fence must not expose the inner body to collapsing."""
+        console, buf = _non_tty_console()
+        inner = (
+            '{"note":"inside-fence",'
+            '"homepage":"https://example.com/inside-fence/homepage",'
+            '"clone_url":"https://example.com/inside-fence.git",'
+            '"ssh_url":"git@example.com:inside-fence/repo.git",'
+            '"description":"kept because it sits inside the intentional fence"}'
+        )
+        reply = f'```json\n{{"stars": 10984}}\n\n{inner}\n```'
+
+        render_markdown_block(console, reply)
+
+        out = _strip_ansi(buf.getvalue())
+        assert "10984" in out
+        assert "inside-fence" in out
+        assert "tool output omitted" not in out
+
 
 class TestDeferWantMeToCloser:
     """Gather path holds drifted Want-me-to until the canonical rewrite paints."""


### PR DESCRIPTION
Moves the tool-result → transcript-text formatting out of the 1320-line
action_driver.py into a focused core/agent_harness/turns/display_text.py, so
the turn driver is about driving the turn and there is one obvious home for
"how a tool result becomes the line the user sees."

## Why

action_driver.py had accreted a cohesive cluster of display logic — hiding raw
data blobs, capping verbose output to a short head, peeling expand markers,
stripping echoed plan snapshots — interleaved with the tool-calling loop. It
was hard to find and mixed two concerns. The cluster is self-contained (its
only couplings, _content_to_text and _HOST_RENDERED_TOOL_NAMES, moved with it),
so it lifts out cleanly.

## Changes

- New module core/agent_harness/turns/display_text.py holding
  format_generic_tool_payload, cap_for_display, is_data_blob, looks_like_json,
  split_output_truncation_markers, strip_plan_snapshots,
  preferred_tool_response_text, the display-cap constants, and their private
  helpers. Public names lost the leading underscore now that they are a real
  module API; genuinely internal helpers keep it.
- action_driver.py imports from the new module and no longer imports peek
  directly (only the moved code used it).
- Three test modules import the display helpers from their new home.