### PR TITLE
refactor(text): share one data-blob detector across both hide policies

### DIFF
--- a/core/agent_harness/turns/display_text.py
+++ b/core/agent_harness/turns/display_text.py
@@ -19,6 +19,7 @@ from infrastructure.terminal.peek import (
     cap_output_for_display,
     format_view_all_marker,
 )
+from infrastructure.text import looks_like_data_blob
 
 # Tools whose result the host already rendered to the console; their payload is
 # not re-shown in the transcript.
@@ -88,22 +89,16 @@ def cap_for_display(text: str) -> str:
 
 
 def is_data_blob(text: str) -> bool:
-    """Whether *text* is a JSON/record blob — valid, truncated, or a mid-object
-    fragment (a capped ``gh api`` response can arrive starting mid-value).
+    """Whether a tool-result payload is a JSON/record blob to keep out of the
+    transcript — valid, truncated, or a mid-object fragment (a capped
+    ``gh api`` response can arrive starting mid-value).
 
-    Detected by shape (opens an object/array) or by density of ``":`` key
-    separators, which URLs do not inflate and prose/logs almost never contain.
-    Such data is what the reply summarizes; it should not fill the transcript.
+    Aggressive by design: any payload opening with ``{``/``[``, or carrying two
+    ``":`` key separators, is data the reply already summarizes. The reply-prose
+    collapse in the streaming renderer applies the *same* mechanism with a
+    larger floor so it never mistakes real prose for a dump.
     """
-    stripped = text.strip()
-    if not stripped:
-        return False
-    if stripped[0] in "{[":
-        return True
-    # Mid-object fragments (and short gh ``summary`` previews of JSON) still
-    # carry ``":`` key separators — two is enough once the text is clearly a
-    # record slice rather than prose.
-    return stripped.count('":') >= 2
+    return looks_like_data_blob(text, min_json_keys=2, honor_open_bracket=True)
 
 
 def _user_facing_tool_text(text: str) -> str:

--- a/infrastructure/text/__init__.py
+++ b/infrastructure/text/__init__.py
@@ -1,12 +1,14 @@
 """Small text/value helpers (truncate, coerce, URL checks, Markdown)."""
 
 from infrastructure.text.coercion import safe_int
+from infrastructure.text.data_blob import looks_like_data_blob
 from infrastructure.text.markdown import tighten_markdown_emphasis
 from infrastructure.text.truncation import truncate
 from infrastructure.text.url_validation import is_loopback_host, validate_https_or_loopback_http_url
 
 __all__ = [
     "is_loopback_host",
+    "looks_like_data_blob",
     "safe_int",
     "tighten_markdown_emphasis",
     "truncate",

--- a/infrastructure/text/data_blob.py
+++ b/infrastructure/text/data_blob.py
@@ -1,0 +1,49 @@
+"""Recognize JSON/record data blobs so callers can keep them out of prose.
+
+One detection mechanism; each caller passes its own policy. A tool-result
+payload is hidden aggressively (any short JSON is data), while a paragraph in a
+model reply is collapsed conservatively (only a large, dense block) so real
+prose is never mistaken for a dump. Keeping the mechanism here stops the two
+policies from drifting apart as they did when each hand-rolled its own check.
+"""
+
+from __future__ import annotations
+
+_KEY_SEPARATOR = '":'
+_STRUCTURAL_CHARS = frozenset('{}[]":,')
+
+
+def looks_like_data_blob(
+    text: str,
+    *,
+    min_json_keys: int,
+    min_chars: int = 0,
+    honor_open_bracket: bool = False,
+    structural_ratio: float | None = None,
+    truncation_marker: str | None = None,
+) -> bool:
+    """Whether *text* reads as a JSON/record blob under the caller's policy.
+
+    ``min_json_keys`` is the count of ``":`` key separators that marks it as
+    data; these survive long URL values that would dilute a raw character
+    ratio. ``honor_open_bracket`` treats text opening with ``{``/``[`` as data
+    outright. ``min_chars`` sets a size floor below which nothing is a blob.
+    ``structural_ratio`` catches non-JSON dense data by structural-char density.
+    ``truncation_marker`` matches the substring a tool output cap leaves behind.
+    """
+    stripped = text.strip()
+    if not stripped or len(stripped) < min_chars:
+        return False
+    if honor_open_bracket and stripped[0] in "{[":
+        return True
+    if truncation_marker and truncation_marker in stripped:
+        return True
+    if stripped.count(_KEY_SEPARATOR) >= min_json_keys:
+        return True
+    if structural_ratio is not None:
+        structural = sum(1 for ch in stripped if ch in _STRUCTURAL_CHARS)
+        return structural / len(stripped) >= structural_ratio
+    return False
+
+
+__all__ = ["looks_like_data_blob"]

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -25,7 +25,7 @@ from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.spi.task_plan import is_plan_diagnosis_prose
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
-from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT
+from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, SECONDARY
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.ui.streaming import render_note_block
@@ -574,19 +574,23 @@ class ActionRenderObserver:
         print_command_output(
             self.console,
             preview,
+            style=str(SECONDARY),
             on_collapse=lambda body: setattr(self.session.terminal, "collapsed_tool_output", body),
         )
         self.session.terminal.inline_tool_results = True
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:
-        """Print the ``↳`` child line under the skill's ``tool_start`` parent."""
+        """Print the ``↳`` child line under the skill's ``tool_start`` parent.
+
+        The next block (another call, a note, or the ``∴`` reply) opens with
+        its own blank line — do not add one here or the gap doubles.
+        """
         if self._pending_skill_calls.pop(str(data.get("id") or ""), None) is None:
             return
         output = data.get("output")
         activated = isinstance(output, dict) and bool(output.get("ok"))
         label = "Skill activated" if activated else "Skill failed to load"
         self.console.print(Text(f"  ↳ {label}", style=DIM))
-        self.console.print()
 
 
 __all__ = [

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -13,6 +13,7 @@ import infrastructure.terminal.theme as ui_theme
 from core.agent_harness.spi.prompt_chrome import normalize_three_tier_spacing
 from core.agent_harness.spi.session_goal import strip_session_goal_progress_tags
 from infrastructure.safety.terminal_output import strip_terminal_controls
+from infrastructure.text import looks_like_data_blob
 
 if TYPE_CHECKING:
     from rich.markdown import Markdown
@@ -38,30 +39,26 @@ _DUMP_TRUNCATED_MARKER = "output truncated"
 _DUMP_MIN_CHARS = 200
 _DUMP_MIN_JSON_KEYS = 3
 _DUMP_STRUCTURAL_RATIO = 0.15
-_DUMP_STRUCTURAL_CHARS = frozenset('{}[]":,')
 # Line-start fences only — matches the streaming splitter so an inline
 # ``Use ``` to fence code`` mention does not freeze dump collapsing.
 _FENCE_LINE_RE = re.compile(r"^```", re.MULTILINE)
 
 
 def _looks_like_raw_dump(text: str) -> bool:
-    """Whether *text* is an echoed tool result rather than prose.
+    """Whether a paragraph in the model's reply is an echoed tool result.
 
-    True when it carries the ``output truncated`` marker a tool cap leaves, or
-    when it is large and reads as a record/JSON blob. The ``":`` key separator
-    is common in such a dump and rare in prose, and — unlike a raw char ratio —
-    long URL values do not dilute it (a GitHub API object stays URL-heavy yet
-    keeps many keys). A structural-char ratio still catches non-JSON dense data.
-    Prose and Markdown tables/lists trip neither test.
+    Conservative by design: a paragraph collapses only when it is large and
+    dense (or carries the ``output truncated`` marker), so real prose is never
+    mistaken for a dump. The tool-result hider in ``display_text`` runs the same
+    mechanism with a smaller floor, since a raw payload is always data.
     """
-    if len(text) < _DUMP_MIN_CHARS:
-        return False  # too small to be a wall — a short block is not a problem
-    if _DUMP_TRUNCATED_MARKER in text:
-        return True
-    if text.count('":') >= _DUMP_MIN_JSON_KEYS:
-        return True
-    structural = sum(1 for ch in text if ch in _DUMP_STRUCTURAL_CHARS)
-    return structural / len(text) >= _DUMP_STRUCTURAL_RATIO
+    return looks_like_data_blob(
+        text,
+        min_chars=_DUMP_MIN_CHARS,
+        min_json_keys=_DUMP_MIN_JSON_KEYS,
+        structural_ratio=_DUMP_STRUCTURAL_RATIO,
+        truncation_marker=_DUMP_TRUNCATED_MARKER,
+    )
 
 
 def _collapse_paragraph(paragraph: str) -> str:

--- a/tests/infrastructure/text/test_data_blob.py
+++ b/tests/infrastructure/text/test_data_blob.py
@@ -1,0 +1,61 @@
+"""Shared data-blob detection under the two caller policies.
+
+The tool-result hider (``display_text.is_data_blob``) and the reply-prose
+collapse (streaming renderer ``_looks_like_raw_dump``) run this one mechanism
+with different thresholds. These tests pin each policy and lock in that they
+differ on purpose, so the two sites can never silently drift apart again.
+"""
+
+from __future__ import annotations
+
+from infrastructure.text import looks_like_data_blob
+
+# The two live policies, named here so a threshold change is a deliberate edit.
+_TOOL_PAYLOAD = {"min_json_keys": 2, "honor_open_bracket": True}
+_REPLY_PARAGRAPH = {
+    "min_chars": 200,
+    "min_json_keys": 3,
+    "structural_ratio": 0.15,
+    "truncation_marker": "output truncated",
+}
+
+
+def test_tool_policy_hides_a_short_mid_object_fragment() -> None:
+    # Arrange: a capped gh-api response cut mid-value — two keys, well under 200 chars.
+    fragment = 'foo","followers_url":"https://api.github.com/u","gists_url":"https://x"'
+
+    # Act / Assert: the aggressive tool policy treats it as data...
+    assert looks_like_data_blob(fragment, **_TOOL_PAYLOAD) is True
+    # ...while the conservative reply policy leaves it as prose (below its floor).
+    assert looks_like_data_blob(fragment, **_REPLY_PARAGRAPH) is False
+
+
+def test_tool_policy_honors_an_opening_bracket() -> None:
+    assert looks_like_data_blob('{"a": 1}', **_TOOL_PAYLOAD) is True
+    # The reply policy ignores shape and needs bulk before it collapses.
+    assert looks_like_data_blob('{"a": 1}', **_REPLY_PARAGRAPH) is False
+
+
+def test_reply_policy_collapses_a_large_dense_blob() -> None:
+    blob = "\n".join(f'"field_{i}": "value_{i}",' for i in range(40))
+    assert looks_like_data_blob(blob, **_REPLY_PARAGRAPH) is True
+    assert looks_like_data_blob(blob, **_TOOL_PAYLOAD) is True
+
+
+def test_reply_policy_keeps_prose_that_merely_mentions_a_colon() -> None:
+    prose = (
+        "The deploy finished and the health check passed. One note: the cache "
+        "warm-up ran twice, which is expected on a cold start after a release. "
+        "Nothing else looked off across the three services I checked just now."
+    )
+    assert looks_like_data_blob(prose, **_REPLY_PARAGRAPH) is False
+
+
+def test_reply_policy_collapses_on_the_truncation_marker() -> None:
+    text = "x" * 300 + " output truncated"
+    assert looks_like_data_blob(text, **_REPLY_PARAGRAPH) is True
+
+
+def test_empty_text_is_never_a_blob() -> None:
+    assert looks_like_data_blob("   ", **_TOOL_PAYLOAD) is False
+    assert looks_like_data_blob("", **_REPLY_PARAGRAPH) is False

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -154,7 +154,7 @@ def test_skill_view_renders_activation_event() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill install-code-review\n  ↳ Skill activated\n\n"
+    assert buffer.getvalue() == "\nSkill install-code-review\n  ↳ Skill activated\n"
 
 
 def test_skill_view_renders_bold_green_skill_label() -> None:
@@ -352,7 +352,7 @@ def test_skill_view_failure_renders_failure_child() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill no-such-skill\n  ↳ Skill failed to load\n\n"
+    assert buffer.getvalue() == "\nSkill no-such-skill\n  ↳ Skill failed to load\n"
 
 
 def test_skill_view_tool_end_without_start_prints_nothing() -> None:
@@ -448,8 +448,8 @@ def test_generic_tool_end_nests_the_result_under_the_call() -> None:
 
     out = buffer.getvalue()
     assert "GitHub CLI" in out
-    assert "↳" in out
-    assert "GitHub API call succeeded" in out
+    assert "\n  ↳ GitHub API call succeeded" in out  # tight child, 2-space gutter
+    assert "\n\n  ↳" not in out  # no blank inside the block
     assert observer.session.terminal.inline_tool_results is True
 
 
@@ -473,6 +473,32 @@ def test_generic_tool_end_hides_a_json_blob() -> None:
 
     assert buffer.getvalue() == after_start
     assert observer.session.terminal.inline_tool_results is False
+
+
+def test_one_blank_line_between_a_skill_block_and_the_next_call() -> None:
+    """Droid / Claude / Cursor: one gap BETWEEN blocks, never two stacked blanks."""
+    observer, buffer = _observer_with_buffer()
+
+    observer(
+        "tool_start",
+        {"id": "s1", "name": "skill_view", "input": {"name": "install_code_review"}},
+    )
+    observer(
+        "tool_end",
+        {
+            "id": "s1",
+            "name": "skill_view",
+            "output": {"ok": True, "name": "install-code-review"},
+        },
+    )
+    observer(
+        "tool_start",
+        {"id": "t1", "name": "github_cli", "input": {"args": ["api", "user"]}},
+    )
+
+    out = buffer.getvalue()
+    assert "\nSkill install-code-review\n  ↳ Skill activated\n\n⏺" in out
+    assert "\n\n\n" not in out
 
 
 def test_literal_slash_command_records_single_history_entry(


### PR DESCRIPTION
The interactive shell decided "is this text a JSON/record dump to keep out of
the transcript?" in two hand-rolled places with different thresholds:

- core `is_data_blob` (hides a tool-result payload): opens with `{`/`[`, or
  ≥ 2 `":` keys, no size floor.
- streaming renderer `_looks_like_raw_dump` (collapses a dump the model pasted
  into its reply): ≥ 200 chars and (≥ 3 `":` keys, or structural ratio ≥ 0.15,
  or the "output truncated" marker).

Same question, two divergent answers — a payload with 2 keys and 150 chars was
hidden by one and shown by the other. That drift is what made the raw-JSON
leak whack-a-mole to fix.

One detection mechanism in a dependency-free leaf,
infrastructure/text/data_blob.py — `looks_like_data_blob(text, *, min_json_keys,
min_chars=0, honor_open_bracket=False, structural_ratio=None,
truncation_marker=None)`. Each caller keeps its own policy, now stated
explicitly on top of the shared code, so the two sites cannot silently drift
apart again. The reply side stays deliberately more conservative than the
tool-payload side (collapsing real prose is worse than showing a small blob) —
that difference is now intentional and tested, not accidental.

No behavior change: each branch of the two originals was mapped before the
rewrite.