### PR TITLE
fix(yandex-cloud): carry the command hand-off into the database tool descriptions

### DIFF
--- a/integrations/yandex_cloud/mdb_catalog.py
+++ b/integrations/yandex_cloud/mdb_catalog.py
@@ -14,6 +14,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
+#: Carried in every tool description of this family rather than as the full
+#: SKILL.md slice: the slice is 2400 characters and would be duplicated into each
+#: description, while the one thing an investigation loses without it is this
+#: sentence. A read-only integration cannot change anything, so the command it
+#: writes out is the remediation - and an investigation that only touched these
+#: tools never saw the generic readers where the slice is attached.
+READ_ONLY_HANDOFF: Final = "These tools only read, so when the finding calls for a change, end with the exact `yc ...` command an operator can paste."
+
 
 @dataclass(frozen=True)
 class ManagedDatabase:
@@ -194,4 +202,11 @@ def engine_choices() -> str:
     return ", ".join(ENGINE_KEYS)
 
 
-__all__ = ["ENGINES", "ENGINE_KEYS", "ManagedDatabase", "engine_choices", "resolve_engine"]
+__all__ = [
+    "ENGINES",
+    "READ_ONLY_HANDOFF",
+    "ENGINE_KEYS",
+    "ManagedDatabase",
+    "engine_choices",
+    "resolve_engine",
+]

--- a/integrations/yandex_cloud/tools/yc_db_logs_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_db_logs_tool/__init__.py
@@ -15,7 +15,7 @@ one.
 
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Any
 
 from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
@@ -27,15 +27,13 @@ from integrations.yandex_cloud.availability import (
     yc_available_or_backend,
     yc_credentials,
 )
-from integrations.yandex_cloud.mdb_catalog import engine_choices, resolve_engine
+from integrations.yandex_cloud.mdb_catalog import (
+    READ_ONLY_HANDOFF,
+    engine_choices,
+    resolve_engine,
+)
 
 SOURCE = "yandex_cloud"
-
-
-#: See the note beside the same constant in yc_db_tool: one sentence rather than
-#: the full SKILL.md slice, because duplicating 2400 characters per tool buys
-#: nothing an investigation actually needs.
-_READ_ONLY_HANDOFF: Final = "These tools only read, so when the finding calls for a change, end with the exact `yc ...` command an operator can paste."
 
 #: Enough to see a pattern without flooding the prompt.
 DEFAULT_PAGE_SIZE = 100
@@ -90,7 +88,7 @@ def _map_db_logs(
         "read_yc_logs is not evidence a cluster logged nothing. Each engine keeps "
         "several streams and one is served at a time, so name the stream when the "
         "question is about slow queries or the pooler rather than general errors. "
-        + _READ_ONLY_HANDOFF
+        + READ_ONLY_HANDOFF
     ),
     use_cases=[
         "Finding why a managed database is erroring or restarting",

--- a/integrations/yandex_cloud/tools/yc_db_logs_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_db_logs_tool/__init__.py
@@ -15,7 +15,7 @@ one.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
@@ -30,6 +30,12 @@ from integrations.yandex_cloud.availability import (
 from integrations.yandex_cloud.mdb_catalog import engine_choices, resolve_engine
 
 SOURCE = "yandex_cloud"
+
+
+#: See the note beside the same constant in yc_db_tool: one sentence rather than
+#: the full SKILL.md slice, because duplicating 2400 characters per tool buys
+#: nothing an investigation actually needs.
+_READ_ONLY_HANDOFF: Final = "These tools only read, so when the finding calls for a change, end with the exact `yc ...` command an operator can paste."
 
 #: Enough to see a pattern without flooding the prompt.
 DEFAULT_PAGE_SIZE = 100
@@ -83,7 +89,8 @@ def _map_db_logs(
         "log is here and nowhere else unless export was switched on, so an empty "
         "read_yc_logs is not evidence a cluster logged nothing. Each engine keeps "
         "several streams and one is served at a time, so name the stream when the "
-        "question is about slow queries or the pooler rather than general errors."
+        "question is about slow queries or the pooler rather than general errors. "
+        + _READ_ONLY_HANDOFF
     ),
     use_cases=[
         "Finding why a managed database is erroring or restarting",

--- a/integrations/yandex_cloud/tools/yc_db_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_db_tool/__init__.py
@@ -14,22 +14,18 @@ from integrations.yandex_cloud.availability import (
     yc_available_or_backend,
     yc_credentials,
 )
-from integrations.yandex_cloud.mdb_catalog import ManagedDatabase, engine_choices, resolve_engine
+from integrations.yandex_cloud.mdb_catalog import (
+    READ_ONLY_HANDOFF,
+    ManagedDatabase,
+    engine_choices,
+    resolve_engine,
+)
 from integrations.yandex_cloud.rest_client import YandexCloudClient
 
 SOURCE = "yandex_cloud"
 
 #: The private CA managed clusters present, which is in no system trust store.
 CA_CERTIFICATE_URL = "https://storage.yandexcloud.net/cloud-certs/CA.pem"
-
-
-#: Attached to every tool of this family rather than the full SKILL.md slice:
-#: the slice is 2400 characters and would be duplicated into each description,
-#: while the one thing an investigation loses without it is this sentence. A
-#: read-only integration cannot change anything, so the command it writes out is
-#: the remediation - and an investigation that only touched these tools never
-#: saw the generic readers where the slice is attached.
-_READ_ONLY_HANDOFF: Final = "These tools only read, so when the finding calls for a change, end with the exact `yc ...` command an operator can paste."
 
 _HEALTHY = "ALIVE"
 _RUNNING = "RUNNING"
@@ -252,7 +248,7 @@ def _map_db_cluster(
         "List managed database clusters in the folder with their status and "
         "health. Covers PostgreSQL, MySQL, ClickHouse, Valkey (was Redis), "
         "StoreDoc (was MongoDB), Kafka, OpenSearch, and MPP Analytics (was "
-        "Greenplum). Omit the engine to search all of them. " + _READ_ONLY_HANDOFF
+        "Greenplum). Omit the engine to search all of them. " + READ_ONLY_HANDOFF
     ),
     use_cases=[
         "Finding a cluster id from its name",
@@ -365,7 +361,7 @@ def list_yc_db_clusters(
         "role and zone, and recent operations. Recent operations are where a "
         "failover, a restart, or a resize shows up — often the thing that "
         "explains an incident. Also returns how to connect the matching "
-        "data-plane integration for querying the database itself. " + _READ_ONLY_HANDOFF
+        "data-plane integration for querying the database itself. " + READ_ONLY_HANDOFF
     ),
     use_cases=[
         "Checking whether a failover happened around the time of an incident",

--- a/integrations/yandex_cloud/tools/yc_db_tool/__init__.py
+++ b/integrations/yandex_cloud/tools/yc_db_tool/__init__.py
@@ -22,6 +22,15 @@ SOURCE = "yandex_cloud"
 #: The private CA managed clusters present, which is in no system trust store.
 CA_CERTIFICATE_URL = "https://storage.yandexcloud.net/cloud-certs/CA.pem"
 
+
+#: Attached to every tool of this family rather than the full SKILL.md slice:
+#: the slice is 2400 characters and would be duplicated into each description,
+#: while the one thing an investigation loses without it is this sentence. A
+#: read-only integration cannot change anything, so the command it writes out is
+#: the remediation - and an investigation that only touched these tools never
+#: saw the generic readers where the slice is attached.
+_READ_ONLY_HANDOFF: Final = "These tools only read, so when the finding calls for a change, end with the exact `yc ...` command an operator can paste."
+
 _HEALTHY = "ALIVE"
 _RUNNING = "RUNNING"
 #: A cluster somebody switched off. Not a failure, and worth keeping apart from
@@ -243,7 +252,7 @@ def _map_db_cluster(
         "List managed database clusters in the folder with their status and "
         "health. Covers PostgreSQL, MySQL, ClickHouse, Valkey (was Redis), "
         "StoreDoc (was MongoDB), Kafka, OpenSearch, and MPP Analytics (was "
-        "Greenplum). Omit the engine to search all of them."
+        "Greenplum). Omit the engine to search all of them. " + _READ_ONLY_HANDOFF
     ),
     use_cases=[
         "Finding a cluster id from its name",
@@ -356,7 +365,7 @@ def list_yc_db_clusters(
         "role and zone, and recent operations. Recent operations are where a "
         "failover, a restart, or a resize shows up — often the thing that "
         "explains an incident. Also returns how to connect the matching "
-        "data-plane integration for querying the database itself."
+        "data-plane integration for querying the database itself. " + _READ_ONLY_HANDOFF
     ),
     use_cases=[
         "Checking whether a failover happened around the time of an incident",

--- a/tests/integrations/test_yc_db_tool.py
+++ b/tests/integrations/test_yc_db_tool.py
@@ -563,6 +563,6 @@ class TestTheHandoffToAnOperatorIsInEveryDescription:
 
     def test_it_stays_a_sentence_and_not_a_second_copy_of_the_skill(self) -> None:
         """Duplicating the 2400-character slice per tool buys nothing."""
-        from integrations.yandex_cloud.tools.yc_db_tool import _READ_ONLY_HANDOFF
+        from integrations.yandex_cloud.mdb_catalog import READ_ONLY_HANDOFF
 
-        assert len(_READ_ONLY_HANDOFF) < 200
+        assert len(READ_ONLY_HANDOFF) < 200

--- a/tests/integrations/test_yc_db_tool.py
+++ b/tests/integrations/test_yc_db_tool.py
@@ -539,3 +539,30 @@ class TestNothingIsDroppedOffTheEndOfAPage:
 
         assert [host["name"] for host in result["hosts"]] == ["master-1", "seg-1", "seg-2"]
         assert [host["name"] for host in result["unhealthy_hosts"]] == ["seg-2"]
+
+
+class TestTheHandoffToAnOperatorIsInEveryDescription:
+    """An investigation that only touched these tools must still be told.
+
+    The SKILL.md slice carrying that instruction attaches to the two generic
+    readers, so a database-only investigation never sees it - and ends with
+    "increase the timeout" instead of the command that does it.
+    """
+
+    @pytest.mark.parametrize(
+        "name", ["list_yc_db_clusters", "get_yc_db_cluster", "read_yc_db_logs"]
+    )
+    def test_the_description_asks_for_the_command(self, name: str) -> None:
+        from tools.registry import clear_tool_registry_cache, get_registered_tool_map
+
+        clear_tool_registry_cache()
+        description = get_registered_tool_map("investigation")[name].description
+
+        assert "yc ..." in description
+        assert "only read" in description
+
+    def test_it_stays_a_sentence_and_not_a_second_copy_of_the_skill(self) -> None:
+        """Duplicating the 2400-character slice per tool buys nothing."""
+        from integrations.yandex_cloud.tools.yc_db_tool import _READ_ONLY_HANDOFF
+
+        assert len(_READ_ONLY_HANDOFF) < 200


### PR DESCRIPTION
Part of #4605

#### Describe the changes you have made in this PR -

The Yandex Cloud SKILL.md says that when a finding calls for a change, the answer should end with the exact `yc ...` command an operator can paste. That slice attaches to the two generic readers, `find_yc_api` and `execute_yc_operation`, so an investigation that only touched the Managed Databases tools never sees it - and ends with "return the timeout to its previous value" instead of the line that does it.

For a read-only integration that is the whole deliverable. It cannot change anything, so the command it writes out is the only remediation it can produce.

This carries the one relevant sentence into the three database tool descriptions: `list_yc_db_clusters`, `get_yc_db_cluster`, `read_yc_db_logs`. A sentence rather than adding those tools to the SKILL frontmatter, which would attach the full 2400-character slice to each of them - three copies of a document to deliver one idea. A test keeps the constant short so nobody later replaces it with the slice after all.

### Demo/Screenshot for feature changes and bug fixes -

https://github.com/user-attachments/assets/defcbbc0-a45e-4294-bbe1-b547530b1b13

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The wider version of this change added a line to the shared investigation prompt, since the mitigation phase is where the final wording is decided and no integration has a hook into it. I dropped that on purpose. It would have changed how every investigation ends, for every integration, to fix something observed in one - and the wording I had drafted told the model to reach for "the CLI of whichever platform the evidence came from", which is wrong for the sources that have no CLI at all. A Sentry or Jira finding is fixed by a person, not an invocation.

So this stays inside the integration that has the problem.

It is worth being straight about what this does and does not fix, because I checked afterwards and it is less than I hoped. It closes the case where the instruction was absent: a database-only investigation now carries it, and the demo above shows that against `origin/main`. It does not change the answer in the run I have: with the sentence in place, and `execute_yc_operation` called alongside so the slice was in context too, the conclusion was prose again. The same question against the same cluster on a stronger model does produce the command. So the variable that moved the outcome was the model, not the delivery of the instruction.

I am proposing it anyway because absent guidance is still worth fixing on its own terms, and because the next lever is a different one: hand the command shape back as data in the tool result - the cluster id is already there - rather than as an instruction the model has to remember to follow. That is a larger change and belongs in its own PR, with this measurement behind it. Happy to hold this one if you would rather see them together.

Edge cases: the sentence says these tools only read, which keeps it from reading as permission to run anything - the same SKILL.md separately forbids shelling out to `yc`, and the integration holds a hard read-only guarantee. The constant is defined once per module with a comment explaining why it is a sentence and not the slice, and asserted under 200 characters so the reasoning survives the next person to touch it.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
