### PR TITLE
feat(shell): tighter prompt stack, consistent tool-output hiding

### DIFF
--- a/core/agent_harness/turns/action_dedup.py
+++ b/core/agent_harness/turns/action_dedup.py
@@ -1,0 +1,167 @@
+"""Suppress replayed action-tool calls within one turn.
+
+A guarded tool (``slash_invoke`` / ``shell_run`` / ``cli_exec``) that the model
+re-emits with identical arguments after it already succeeded this turn is
+blocked, so a stuttering model cannot run the same side-effecting command
+twice. Kept apart from the turn driver: this is a self-contained hook policy,
+not part of driving the loop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from core.llm.types import ToolCall
+from core.tool.execution import (
+    BeforeToolCallResult,
+    ToolExecutionHooks,
+    ToolExecutionPatch,
+    ToolExecutionRequest,
+    ToolExecutionResult,
+    public_tool_input,
+)
+
+# Local REPL tools covered by consecutive identical-batch suppress (oracle 202 /
+# 203): slash_invoke, shell_run, cli_exec. One rule — no per-tool carve-outs.
+_DEDUPE_ACTION_TOOL_NAMES: frozenset[str] = frozenset({"slash_invoke", "shell_run", "cli_exec"})
+
+# Hashable identity for one guarded call (no hot-path json.dumps).
+_ActionCallFingerprint = tuple[Any, ...]
+
+
+def coerce_fingerprint_quiet(value: Any) -> bool:
+    """Match ``shell_run`` quiet coercion so retries compare equal."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _action_call_fingerprint(name: str, args: Any) -> _ActionCallFingerprint:
+    """Stable identity for one guarded action call (schema fields only)."""
+    if not isinstance(args, dict):
+        args = {}
+
+    if name == "slash_invoke":
+        command = str(args.get("command", ""))
+        raw = args.get("args")
+        argv = tuple(str(item) for item in raw) if isinstance(raw, (list, tuple)) else ()
+        return (name, command, argv)
+
+    if name == "cli_exec":
+        return (name, str(args.get("payload", "")).strip())
+
+    # shell_run
+    return (
+        name,
+        str(args.get("command", "")),
+        coerce_fingerprint_quiet(args.get("quiet", False)),
+    )
+
+
+def with_duplicate_action_call_guard(
+    base: ToolExecutionHooks | None = None,
+) -> ToolExecutionHooks:
+    """Block replaying guarded action calls already covered by the success snapshot.
+
+    Suppress ``slash_invoke`` / ``shell_run`` / ``cli_exec`` when the call's
+    fingerprint is in ``last_fully_succeeded_batch`` *or* already succeeded
+    earlier in the current provider batch (same-batch duplicates). Guarded
+    tools are sequential, so ``batch_succeeded`` is visible to the next
+    ``before()`` in the batch.
+
+    Snapshot updates at the next batch boundary:
+
+    - Fully successful batch → replace snapshot with that batch (so A → B → A
+      still allows the second A after B replaces the snapshot).
+    - Mixed batch (suppressed replay + new success) → replace snapshot with
+      *only* the newly succeeded fingerprints. That blocks an immediate re-emit
+      of the new action without retaining suppressed members (which would block
+      a later intentional standalone replay of A after {A suppressed, C ran}).
+    - Pure suppress or total failure → leave the snapshot alone (a third
+      identical replay stays blocked; failed calls may still retry).
+
+    Limitation (intentional): the same batch twice in one turn — lone or
+    multi — is also suppressed; accidental replay and “run that again” are
+    indistinguishable without parsing the user message. Ask again next turn.
+    """
+    last_fully_succeeded_batch: frozenset[_ActionCallFingerprint] = frozenset()
+    current_batch: frozenset[_ActionCallFingerprint] = frozenset()
+    batch_succeeded: set[_ActionCallFingerprint] = set()
+    has_open_batch = False
+    base_before = base.before_tool_call if base is not None else None
+    base_after = base.after_tool_call if base is not None else None
+    base_update = base.on_tool_update if base is not None else None
+    base_batch = base.before_tool_batch if base is not None else None
+
+    def before_batch(tool_calls: Sequence[ToolCall]) -> None:
+        nonlocal last_fully_succeeded_batch, current_batch, batch_succeeded, has_open_batch
+        if base_batch is not None:
+            base_batch(tool_calls)
+        if has_open_batch and current_batch:
+            succeeded = frozenset(batch_succeeded)
+            if succeeded == current_batch:
+                last_fully_succeeded_batch = current_batch
+            elif succeeded:
+                # Mixed suppress/success: snapshot is only what newly ran.
+                # Do not retain suppressed members — that would block a later
+                # intentional standalone A after {A suppressed, C succeeded}.
+                last_fully_succeeded_batch = succeeded
+            # else: pure suppress or all-error — leave snapshot intact.
+        keys: list[_ActionCallFingerprint] = []
+        for tool_call in tool_calls:
+            if tool_call.name not in _DEDUPE_ACTION_TOOL_NAMES:
+                continue
+            keys.append(
+                _action_call_fingerprint(tool_call.name, public_tool_input(tool_call.input))
+            )
+        current_batch = frozenset(keys)
+        batch_succeeded = set()
+        has_open_batch = True
+
+    def before(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
+        name = request.tool_call.name
+        # Membership across the prior success snapshot *and* earlier successes
+        # in this batch. Interleaved A -> B -> A still runs, because a fully
+        # successful {B} replaces the snapshot. Same-batch duplicates (two
+        # identical cli_exec in one provider response) hit batch_succeeded.
+        if name in _DEDUPE_ACTION_TOOL_NAMES:
+            key = _action_call_fingerprint(name, public_tool_input(request.arguments))
+            if key in last_fully_succeeded_batch or key in batch_succeeded:
+                return BeforeToolCallResult(
+                    blocked=True,
+                    reason=(
+                        f"Already ran {name} with identical arguments "
+                        "this turn. Do not repeat it; finish with no further tool calls."
+                    ),
+                    metadata={"suppressed_duplicate": True},
+                )
+        if base_before is not None:
+            return base_before(request)
+        return None
+
+    def after(
+        request: ToolExecutionRequest,
+        result: ToolExecutionResult,
+    ) -> ToolExecutionPatch | None:
+        if request.tool_call.name in _DEDUPE_ACTION_TOOL_NAMES and not result.is_error:
+            batch_succeeded.add(
+                _action_call_fingerprint(
+                    request.tool_call.name, public_tool_input(request.arguments)
+                )
+            )
+        if base_after is not None:
+            return base_after(request, result)
+        return None
+
+    return ToolExecutionHooks(
+        before_tool_call=before,
+        after_tool_call=after,
+        on_tool_update=base_update,
+        before_tool_batch=before_batch,
+    )
+
+
+__all__ = ["coerce_fingerprint_quiet", "with_duplicate_action_call_guard"]

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -49,7 +49,6 @@ from core.agent_harness.turns.conversation_recording import record_conversation_
 from core.agent_harness.turns.display_text import (
     cap_for_display,
     format_generic_tool_payload,
-    is_data_blob,
     looks_like_json,
     preferred_tool_response_text,
     split_output_truncation_markers,
@@ -71,6 +70,7 @@ from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
 from infrastructure.observability.trace.prompts import persist_turn_system_prompt
 from infrastructure.observability.trace.spans import component_span
+from infrastructure.text import is_data_blob
 
 log = logging.getLogger(__name__)
 
@@ -195,11 +195,21 @@ def _generic_tool_results(result: Any) -> list[tuple[ToolCall, Any]]:
 
 
 def _stash_collapsed_tool_output(session: SessionState, text: str | None) -> None:
-    """Remember the full body so Ctrl+O can page it; no-op without a terminal."""
+    """Remember a capped peek so Ctrl+O can expand it; no-op without a terminal.
+
+    ``None`` never clears earlier peeks (same semantics as
+    ``TerminalSession.stash_collapsed_tool_output``).
+    """
     terminal = getattr(session, "terminal", None)
     if terminal is None:
         return
-    terminal.collapsed_tool_output = text
+    stash = getattr(terminal, "stash_collapsed_tool_output", None)
+    if callable(stash):
+        stash(text)
+        return
+    # Minimal test doubles without the ring API: only record a non-None peek.
+    if text is not None:
+        terminal.collapsed_tool_output = text
 
 
 def _has_preferred_tool_response_text(result: Any) -> bool:

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -41,6 +41,10 @@ from core.agent_harness.session.integration_resolution import resolve_and_cache_
 from core.agent_harness.session.pending_choice import parse_ask_user_answers
 from core.agent_harness.session.terminal_access import execute_cli_onboard_on_missing_key
 from core.agent_harness.session_goal.goal import strip_session_goal_progress_tags
+from core.agent_harness.turns.action_dedup import (
+    coerce_fingerprint_quiet,
+    with_duplicate_action_call_guard,
+)
 from core.agent_harness.turns.conversation_recording import record_conversation_turn
 from core.agent_harness.turns.display_text import (
     cap_for_display,
@@ -62,162 +66,13 @@ from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from core.agent_harness.turns.wal_recorder import with_wal_recording
 from core.events import runtime_event_callback_from_observer
 from core.llm.types import AgentLLMResponse, SchemaDescribedTool, ToolCall
-from core.tool.execution import (
-    BeforeToolCallResult,
-    ToolExecutionHooks,
-    ToolExecutionPatch,
-    ToolExecutionRequest,
-    ToolExecutionResult,
-    public_tool_input,
-)
+from core.tool.execution import ToolExecutionHooks, public_tool_input
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
 from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
 from infrastructure.observability.trace.prompts import persist_turn_system_prompt
 from infrastructure.observability.trace.spans import component_span
 
 log = logging.getLogger(__name__)
-
-# Local REPL tools covered by consecutive identical-batch suppress (oracle 202 /
-# 203): slash_invoke, shell_run, cli_exec. One rule — no per-tool carve-outs.
-_DEDUPE_ACTION_TOOL_NAMES: frozenset[str] = frozenset({"slash_invoke", "shell_run", "cli_exec"})
-
-# Hashable identity for one guarded call (no hot-path json.dumps).
-_ActionCallFingerprint = tuple[Any, ...]
-
-
-def _coerce_fingerprint_quiet(value: Any) -> bool:
-    """Match ``shell_run`` quiet coercion so retries compare equal."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
-
-
-def _action_call_fingerprint(name: str, args: Any) -> _ActionCallFingerprint:
-    """Stable identity for one guarded action call (schema fields only)."""
-    if not isinstance(args, dict):
-        args = {}
-
-    if name == "slash_invoke":
-        command = str(args.get("command", ""))
-        raw = args.get("args")
-        argv = tuple(str(item) for item in raw) if isinstance(raw, (list, tuple)) else ()
-        return (name, command, argv)
-
-    if name == "cli_exec":
-        return (name, str(args.get("payload", "")).strip())
-
-    # shell_run
-    return (
-        name,
-        str(args.get("command", "")),
-        _coerce_fingerprint_quiet(args.get("quiet", False)),
-    )
-
-
-def with_duplicate_action_call_guard(
-    base: ToolExecutionHooks | None = None,
-) -> ToolExecutionHooks:
-    """Block replaying guarded action calls already covered by the success snapshot.
-
-    Suppress ``slash_invoke`` / ``shell_run`` / ``cli_exec`` when the call's
-    fingerprint is in ``last_fully_succeeded_batch`` *or* already succeeded
-    earlier in the current provider batch (same-batch duplicates). Guarded
-    tools are sequential, so ``batch_succeeded`` is visible to the next
-    ``before()`` in the batch.
-
-    Snapshot updates at the next batch boundary:
-
-    - Fully successful batch → replace snapshot with that batch (so A → B → A
-      still allows the second A after B replaces the snapshot).
-    - Mixed batch (suppressed replay + new success) → replace snapshot with
-      *only* the newly succeeded fingerprints. That blocks an immediate re-emit
-      of the new action without retaining suppressed members (which would block
-      a later intentional standalone replay of A after {A suppressed, C ran}).
-    - Pure suppress or total failure → leave the snapshot alone (a third
-      identical replay stays blocked; failed calls may still retry).
-
-    Limitation (intentional): the same batch twice in one turn — lone or
-    multi — is also suppressed; accidental replay and “run that again” are
-    indistinguishable without parsing the user message. Ask again next turn.
-    """
-    last_fully_succeeded_batch: frozenset[_ActionCallFingerprint] = frozenset()
-    current_batch: frozenset[_ActionCallFingerprint] = frozenset()
-    batch_succeeded: set[_ActionCallFingerprint] = set()
-    has_open_batch = False
-    base_before = base.before_tool_call if base is not None else None
-    base_after = base.after_tool_call if base is not None else None
-    base_update = base.on_tool_update if base is not None else None
-    base_batch = base.before_tool_batch if base is not None else None
-
-    def before_batch(tool_calls: Sequence[ToolCall]) -> None:
-        nonlocal last_fully_succeeded_batch, current_batch, batch_succeeded, has_open_batch
-        if base_batch is not None:
-            base_batch(tool_calls)
-        if has_open_batch and current_batch:
-            succeeded = frozenset(batch_succeeded)
-            if succeeded == current_batch:
-                last_fully_succeeded_batch = current_batch
-            elif succeeded:
-                # Mixed suppress/success: snapshot is only what newly ran.
-                # Do not retain suppressed members — that would block a later
-                # intentional standalone A after {A suppressed, C succeeded}.
-                last_fully_succeeded_batch = succeeded
-            # else: pure suppress or all-error — leave snapshot intact.
-        keys: list[_ActionCallFingerprint] = []
-        for tool_call in tool_calls:
-            if tool_call.name not in _DEDUPE_ACTION_TOOL_NAMES:
-                continue
-            keys.append(
-                _action_call_fingerprint(tool_call.name, public_tool_input(tool_call.input))
-            )
-        current_batch = frozenset(keys)
-        batch_succeeded = set()
-        has_open_batch = True
-
-    def before(request: ToolExecutionRequest) -> BeforeToolCallResult | None:
-        name = request.tool_call.name
-        # Membership across the prior success snapshot *and* earlier successes
-        # in this batch. Interleaved A -> B -> A still runs, because a fully
-        # successful {B} replaces the snapshot. Same-batch duplicates (two
-        # identical cli_exec in one provider response) hit batch_succeeded.
-        if name in _DEDUPE_ACTION_TOOL_NAMES:
-            key = _action_call_fingerprint(name, public_tool_input(request.arguments))
-            if key in last_fully_succeeded_batch or key in batch_succeeded:
-                return BeforeToolCallResult(
-                    blocked=True,
-                    reason=(
-                        f"Already ran {name} with identical arguments "
-                        "this turn. Do not repeat it; finish with no further tool calls."
-                    ),
-                    metadata={"suppressed_duplicate": True},
-                )
-        if base_before is not None:
-            return base_before(request)
-        return None
-
-    def after(
-        request: ToolExecutionRequest,
-        result: ToolExecutionResult,
-    ) -> ToolExecutionPatch | None:
-        if request.tool_call.name in _DEDUPE_ACTION_TOOL_NAMES and not result.is_error:
-            batch_succeeded.add(
-                _action_call_fingerprint(
-                    request.tool_call.name, public_tool_input(request.arguments)
-                )
-            )
-        if base_after is not None:
-            return base_after(request, result)
-        return None
-
-    return ToolExecutionHooks(
-        before_tool_call=before,
-        after_tool_call=after,
-        on_tool_update=base_update,
-        before_tool_batch=before_batch,
-    )
-
 
 # This is an emergency ceiling, not the normal workflow budget. Productive
 # action turns may need many sequential calls; repeated observations are stopped
@@ -415,7 +270,7 @@ def _has_quiet_shell_run(result: Any) -> bool:
         raw = getattr(tool_call, "input", None)
         if not isinstance(raw, dict):
             continue
-        if _coerce_fingerprint_quiet(public_tool_input(raw).get("quiet", False)):
+        if coerce_fingerprint_quiet(public_tool_input(raw).get("quiet", False)):
             return True
     return False
 
@@ -1146,5 +1001,4 @@ __all__ = [
     "ActionTurnPlan",
     "ActionTurnRunner",
     "SELF_RECORDING_ACTION_TOOL_NAMES",
-    "with_duplicate_action_call_guard",
 ]

--- a/core/agent_harness/turns/display_text.py
+++ b/core/agent_harness/turns/display_text.py
@@ -19,6 +19,7 @@ from infrastructure.terminal.peek import (
     cap_output_for_display,
     format_view_all_marker,
 )
+from infrastructure.text import looks_like_data_blob
 
 # Tools whose result the host already rendered to the console; their payload is
 # not re-shown in the transcript.
@@ -88,22 +89,16 @@ def cap_for_display(text: str) -> str:
 
 
 def is_data_blob(text: str) -> bool:
-    """Whether *text* is a JSON/record blob — valid, truncated, or a mid-object
-    fragment (a capped ``gh api`` response can arrive starting mid-value).
+    """Whether a tool-result payload is a JSON/record blob to keep out of the
+    transcript — valid, truncated, or a mid-object fragment (a capped
+    ``gh api`` response can arrive starting mid-value).
 
-    Detected by shape (opens an object/array) or by density of ``":`` key
-    separators, which URLs do not inflate and prose/logs almost never contain.
-    Such data is what the reply summarizes; it should not fill the transcript.
+    Aggressive by design: any payload opening with ``{``/``[``, or carrying two
+    ``":`` key separators, is data the reply already summarizes. The reply-prose
+    collapse in the streaming renderer applies the *same* mechanism with a
+    larger floor so it never mistakes real prose for a dump.
     """
-    stripped = text.strip()
-    if not stripped:
-        return False
-    if stripped[0] in "{[":
-        return True
-    # Mid-object fragments (and short gh ``summary`` previews of JSON) still
-    # carry ``":`` key separators — two is enough once the text is clearly a
-    # record slice rather than prose.
-    return stripped.count('":') >= 2
+    return looks_like_data_blob(text, min_json_keys=2, honor_open_bracket=True)
 
 
 def _user_facing_tool_text(text: str) -> str:

--- a/core/agent_harness/turns/display_text.py
+++ b/core/agent_harness/turns/display_text.py
@@ -19,7 +19,7 @@ from infrastructure.terminal.peek import (
     cap_output_for_display,
     format_view_all_marker,
 )
-from infrastructure.text import looks_like_data_blob
+from infrastructure.text import is_data_blob
 
 # Tools whose result the host already rendered to the console; their payload is
 # not re-shown in the transcript.
@@ -86,19 +86,6 @@ def cap_for_display(text: str) -> str:
     """
     preview, _full = cap_output_for_display(text)
     return preview
-
-
-def is_data_blob(text: str) -> bool:
-    """Whether a tool-result payload is a JSON/record blob to keep out of the
-    transcript — valid, truncated, or a mid-object fragment (a capped
-    ``gh api`` response can arrive starting mid-value).
-
-    Aggressive by design: any payload opening with ``{``/``[``, or carrying two
-    ``":`` key separators, is data the reply already summarizes. The reply-prose
-    collapse in the streaming renderer applies the *same* mechanism with a
-    larger floor so it never mistakes real prose for a dump.
-    """
-    return looks_like_data_blob(text, min_json_keys=2, honor_open_bracket=True)
 
 
 def _user_facing_tool_text(text: str) -> str:
@@ -201,7 +188,6 @@ __all__ = [
     "DISPLAY_OUTPUT_MAX_LINES",
     "cap_for_display",
     "format_generic_tool_payload",
-    "is_data_blob",
     "looks_like_json",
     "preferred_tool_response_text",
     "split_output_truncation_markers",

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -271,6 +271,47 @@ def fade_fg_ansi(intensity: float) -> str:
     )
 
 
+def shimmer_text_ansi(
+    text: str,
+    *,
+    elapsed: float,
+    period: float = 1.5,
+    high_hex: str | None = None,
+) -> str:
+    """Paint *text* with a traveling light wave (Cursor / Droid style).
+
+    Brightness is a pure function of *elapsed* and character index so prompt
+    re-measure passes at the same clock stay visually stable. Whitespace is
+    left unstyled so the wave reads as light over the words, not the gaps.
+    """
+    if not text:
+        return ""
+    low = _parse_hex_color(_ACTIVE_THEME.DIM)
+    high = _parse_hex_color(high_hex or _ACTIVE_THEME.TEXT)
+    span = max(period, 0.05)
+    wave = (elapsed / span) % 1.0
+    n = len(text)
+    parts: list[str] = []
+    for index, char in enumerate(text):
+        if char.isspace():
+            parts.append(char)
+            continue
+        pos = index / max(n - 1, 1)
+        # Circular distance on the unit interval; peak is a ~quarter-string band.
+        distance = abs((pos - wave + 0.5) % 1.0 - 0.5)
+        peak = max(0.0, 1.0 - distance / 0.25)
+        # Floor keeps non-peak letters readable; square softens the band edges.
+        level = 0.38 + 0.62 * (peak * peak)
+        rgb = (
+            int(low[0] + (high[0] - low[0]) * level),
+            int(low[1] + (high[1] - low[1]) * level),
+            int(low[2] + (high[2] - low[2]) * level),
+        )
+        parts.append(f"{_fg(rgb)}{char}")
+    parts.append(ANSI_RESET)
+    return "".join(parts)
+
+
 def _parse_hex_color(value: str) -> tuple[int, int, int]:
     stripped = value.lstrip("#")
     return (int(stripped[0:2], 16), int(stripped[2:4], 16), int(stripped[4:6], 16))
@@ -481,6 +522,7 @@ __all__ = [
     "DIM_COUNTER_ANSI",
     "ERROR",
     "fade_fg_ansi",
+    "shimmer_text_ansi",
     "GLYPH_ACTIVE",
     "GLYPH_BULLET",
     "GLYPH_ERROR",

--- a/infrastructure/text/__init__.py
+++ b/infrastructure/text/__init__.py
@@ -1,12 +1,14 @@
 """Small text/value helpers (truncate, coerce, URL checks, Markdown)."""
 
 from infrastructure.text.coercion import safe_int
+from infrastructure.text.data_blob import looks_like_data_blob
 from infrastructure.text.markdown import tighten_markdown_emphasis
 from infrastructure.text.truncation import truncate
 from infrastructure.text.url_validation import is_loopback_host, validate_https_or_loopback_http_url
 
 __all__ = [
     "is_loopback_host",
+    "looks_like_data_blob",
     "safe_int",
     "tighten_markdown_emphasis",
     "truncate",

--- a/infrastructure/text/__init__.py
+++ b/infrastructure/text/__init__.py
@@ -1,12 +1,13 @@
 """Small text/value helpers (truncate, coerce, URL checks, Markdown)."""
 
 from infrastructure.text.coercion import safe_int
-from infrastructure.text.data_blob import looks_like_data_blob
+from infrastructure.text.data_blob import is_data_blob, looks_like_data_blob
 from infrastructure.text.markdown import tighten_markdown_emphasis
 from infrastructure.text.truncation import truncate
 from infrastructure.text.url_validation import is_loopback_host, validate_https_or_loopback_http_url
 
 __all__ = [
+    "is_data_blob",
     "is_loopback_host",
     "looks_like_data_blob",
     "safe_int",

--- a/infrastructure/text/data_blob.py
+++ b/infrastructure/text/data_blob.py
@@ -1,0 +1,49 @@
+"""Recognize JSON/record data blobs so callers can keep them out of prose.
+
+One detection mechanism; each caller passes its own policy. A tool-result
+payload is hidden aggressively (any short JSON is data), while a paragraph in a
+model reply is collapsed conservatively (only a large, dense block) so real
+prose is never mistaken for a dump. Keeping the mechanism here stops the two
+policies from drifting apart as they did when each hand-rolled its own check.
+"""
+
+from __future__ import annotations
+
+_KEY_SEPARATOR = '":'
+_STRUCTURAL_CHARS = frozenset('{}[]":,')
+
+
+def looks_like_data_blob(
+    text: str,
+    *,
+    min_json_keys: int,
+    min_chars: int = 0,
+    honor_open_bracket: bool = False,
+    structural_ratio: float | None = None,
+    truncation_marker: str | None = None,
+) -> bool:
+    """Whether *text* reads as a JSON/record blob under the caller's policy.
+
+    ``min_json_keys`` is the count of ``":`` key separators that marks it as
+    data; these survive long URL values that would dilute a raw character
+    ratio. ``honor_open_bracket`` treats text opening with ``{``/``[`` as data
+    outright. ``min_chars`` sets a size floor below which nothing is a blob.
+    ``structural_ratio`` catches non-JSON dense data by structural-char density.
+    ``truncation_marker`` matches the substring a tool output cap leaves behind.
+    """
+    stripped = text.strip()
+    if not stripped or len(stripped) < min_chars:
+        return False
+    if honor_open_bracket and stripped[0] in "{[":
+        return True
+    if truncation_marker and truncation_marker in stripped:
+        return True
+    if stripped.count(_KEY_SEPARATOR) >= min_json_keys:
+        return True
+    if structural_ratio is not None:
+        structural = sum(1 for ch in stripped if ch in _STRUCTURAL_CHARS)
+        return structural / len(stripped) >= structural_ratio
+    return False
+
+
+__all__ = ["looks_like_data_blob"]

--- a/infrastructure/text/data_blob.py
+++ b/infrastructure/text/data_blob.py
@@ -46,4 +46,16 @@ def looks_like_data_blob(
     return False
 
 
-__all__ = ["looks_like_data_blob"]
+def is_data_blob(text: str) -> bool:
+    """Whether a tool-result payload is a JSON/record blob to keep out of view.
+
+    The aggressive policy shared by the transcript hider and the inline result
+    preview: any payload opening with ``{``/``[``, or carrying two ``":`` key
+    separators, is data the reply already summarizes — valid, truncated, or a
+    mid-object fragment. The reply-prose collapse uses ``looks_like_data_blob``
+    directly with a larger floor so it never mistakes real prose for a dump.
+    """
+    return looks_like_data_blob(text, min_json_keys=2, honor_open_bracket=True)
+
+
+__all__ = ["is_data_blob", "looks_like_data_blob"]

--- a/integrations/github/tools/repository.py
+++ b/integrations/github/tools/repository.py
@@ -135,11 +135,19 @@ def get_github_repository(
             repository={},
         )
     repository = _normalize_repository(payload, owner=owner, repo_name=repo)
+    stars = repository["stargazers_count"] or 0
+    branch = repository["default_branch"] or "unknown"
+    visibility = repository["visibility"] or "unknown"
+    language = repository["language"]
+    parts = [f"{owner}/{repo}", f"{stars}★", branch, visibility]
+    if language:
+        parts.append(language)
     return {
         "source": "github",
         "available": True,
         "owner": owner,
         "repo": repo,
         "repository": repository,
-        "stargazers_count": repository["stargazers_count"] or 0,
+        "stargazers_count": stars,
+        "summary": " · ".join(str(p) for p in parts),
     }

--- a/integrations/grafana/tools/grafana_logs_tool/__init__.py
+++ b/integrations/grafana/tools/grafana_logs_tool/__init__.py
@@ -9,7 +9,10 @@ from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
 from infrastructure.evidence.evidence_compaction import summarize_counts
 from infrastructure.evidence.log_compaction import build_error_taxonomy, deduplicate_logs
-from integrations.opensre.grafana_backend_queries import query_logs_from_backend
+from integrations.opensre.grafana_backend_queries import (
+    format_grafana_logs_summary,
+    query_logs_from_backend,
+)
 
 _GRAFANA_RUNTIME_PARAMS = grafana_helpers.GRAFANA_RUNTIME_PARAMS
 
@@ -185,6 +188,10 @@ def query_grafana_logs(
 
     if summary:
         result_data["truncation_note"] = summary
+    log_count = result.get("total_logs", len(logs_data)) or len(logs_data)
+    result_data["summary"] = format_grafana_logs_summary(
+        log_count, error_count=len(error_logs), service_name=service_name
+    )
     return result_data
 
 

--- a/integrations/grafana/tools/grafana_metrics_tool/__init__.py
+++ b/integrations/grafana/tools/grafana_metrics_tool/__init__.py
@@ -11,7 +11,10 @@ from core.domain.types.evidence import record_evidence_entry
 from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
-from integrations.opensre.grafana_backend_queries import query_metrics_from_backend
+from integrations.opensre.grafana_backend_queries import (
+    format_grafana_metrics_summary,
+    query_metrics_from_backend,
+)
 
 _GRAFANA_RUNTIME_PARAMS = grafana_helpers.GRAFANA_RUNTIME_PARAMS
 
@@ -133,14 +136,19 @@ def query_grafana_metrics(
     if not result.get("success"):
         return tool_unavailable("grafana_mimir", result.get("error", "Unknown error"), metrics=[])
 
+    metrics = result.get("metrics", [])
+    total_series = result.get("total_series", 0) or len(metrics)
     return {
         "source": "grafana_mimir",
         "available": True,
-        "metrics": result.get("metrics", []),
-        "total_series": result.get("total_series", 0),
+        "metrics": metrics,
+        "total_series": total_series,
         "metric_name": metric_name,
         "service_name": service_name,
         "account_id": client.account_id,
+        "summary": format_grafana_metrics_summary(
+            metric_name, total_series, service_name=service_name
+        ),
     }
 
 

--- a/integrations/opensre/grafana_backend_queries.py
+++ b/integrations/opensre/grafana_backend_queries.py
@@ -14,6 +14,31 @@ from infrastructure.evidence.evidence_compaction import compact_traces, summariz
 from infrastructure.evidence.log_compaction import build_error_taxonomy, deduplicate_logs
 
 
+def format_grafana_metrics_summary(
+    metric_name: str,
+    total_series: int,
+    *,
+    service_name: str | None = None,
+) -> str:
+    """One-line user-facing summary for a Mimir metrics query result."""
+    scope = f" for {service_name}" if service_name else ""
+    return f"{total_series} series for `{metric_name}`{scope}"
+
+
+def format_grafana_logs_summary(
+    log_count: int,
+    *,
+    error_count: int = 0,
+    service_name: str | None = None,
+) -> str:
+    """One-line user-facing summary for a Loki logs query result."""
+    scope = f" for {service_name}" if service_name else ""
+    line = f"{log_count} log(s){scope}"
+    if error_count:
+        return f"{line}, {error_count} look like errors"
+    return line
+
+
 def query_logs_from_backend(
     backend: Any,
     *,
@@ -51,6 +76,9 @@ def query_logs_from_backend(
         "service_name": service_name,
         "execution_run_id": execution_run_id,
         "query": "",
+        "summary": format_grafana_logs_summary(
+            len(logs), error_count=len(error_logs), service_name=service_name
+        ),
     }
     summary = summarize_counts(len(logs), len(compacted_logs), "logs")
     if summary:
@@ -74,6 +102,9 @@ def query_metrics_from_backend(
         "total_series": len(metrics),
         "metric_name": metric_name,
         "service_name": service_name,
+        "summary": format_grafana_metrics_summary(
+            metric_name, len(metrics), service_name=service_name
+        ),
     }
 
 

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -60,7 +60,7 @@ def _decode_subprocess_stream(value: str | bytes | None) -> str:
 def _stash_collapsed_output(session: Session | None, body: str) -> None:
     terminal = session_terminal(session) if session is not None else None
     if terminal is not None:
-        terminal.collapsed_tool_output = body
+        terminal.stash_collapsed_tool_output(body)
 
 
 def _cli_command_succeeded(exit_code: int | None) -> bool:

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -24,7 +24,7 @@ from surfaces.interactive_shell.ui.hooks import (
     install_output_expand_key_bindings,
     install_plan_expand_key_bindings,
 )
-from surfaces.interactive_shell.ui.hooks.output_expand import page_collapsed_output
+from surfaces.interactive_shell.ui.hooks.output_expand import expand_collapsed_output
 from surfaces.interactive_shell.ui.input_prompt import rendering as prompt_rendering
 from surfaces.interactive_shell.ui.input_prompt.key_bindings import (
     build_cancel_key_bindings,
@@ -60,6 +60,7 @@ class PromptBuilder:
         self._invalidate_prompt: Callable[[], None] | None = None
         self._submitted: asyncio.Queue[str] = asyncio.Queue()
         self._prompt_task: asyncio.Task[str] | None = None
+        self._expand_in_flight: bool = False
 
     def _composer_hidden(self) -> bool:
         """True while structured input (confirmation, menus) owns the keyboard.
@@ -105,22 +106,35 @@ class PromptBuilder:
         )
         install_session_key_bindings(self.pt_session, plan_kb)
         output_kb = install_output_expand_key_bindings(
-            lambda: bool(self.session.terminal.collapsed_tool_output),
-            lambda: str(self.session.terminal.collapsed_tool_output or ""),
-            self._page_collapsed_output,
+            self.session.terminal.has_collapsed_tool_output,
+            self.session.terminal.next_collapsed_output_for_expand,
+            self._expand_collapsed_output,
         )
         install_session_key_bindings(self.pt_session, output_kb)
 
-    def _page_collapsed_output(self, text: str) -> None:
-        """Suspend the prompt and page the last folded tool result (Ctrl+O)."""
+    def _expand_collapsed_output(self, text: str) -> None:
+        """Suspend the prompt and expand the next folded tool result (Ctrl+O).
+
+        Single-flight: ignore further Ctrl+O while an expand is still running
+        so key-mash cannot interleave ``run_in_terminal`` sessions.
+        """
+        if self._expand_in_flight:
+            return
+        self._expand_in_flight = True
 
         async def _run() -> None:
-            await run_in_terminal(lambda: page_collapsed_output(text), in_executor=False)
+            try:
+                await run_in_terminal(lambda: expand_collapsed_output(text), in_executor=False)
+            finally:
+                self._expand_in_flight = False
 
         if self.pt_app is not None and self.pt_app.is_running:
             self.pt_app.create_background_task(_run())
             return
-        page_collapsed_output(text)
+        try:
+            expand_collapsed_output(text)
+        finally:
+            self._expand_in_flight = False
 
     @property
     def invalidate_prompt(self) -> Callable[[], None]:

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import enum
-import random
 import threading
 import time
 from dataclasses import dataclass, field
@@ -24,6 +23,33 @@ from surfaces.shared.terminal.prompt_layout import (
 
 # How often prompt-toolkit refreshes prompt callbacks and confirmation polling.
 PROMPT_REFRESH_INTERVAL_S = 0.25
+
+
+def ready_hint_ansi() -> str:
+    """One-line Ready chrome when no dispatch is running (clipped to one row)."""
+    hint = "/ for commands  ·  tab tool details  ·  ↑↓ history"
+    app = get_app_or_none()
+    if app is not None and app.current_buffer.text:
+        hint += "  ·  esc to clear"
+    lead = "Ready · "
+    width = prompt_line_width()
+    reserved = prompt_text_width(lead)
+    if reserved >= width:
+        visible = clip_prompt_text(f"{lead}{hint}", width)
+        # Keep accent on "Ready" when the clipped form still starts with it.
+        if visible.startswith("Ready"):
+            rest = visible[len("Ready") :]
+            return (
+                f"{ui_theme.PROMPT_ACCENT_ANSI}Ready{ui_theme.ANSI_RESET}"
+                f"{ui_theme.DIM_ANSI}{rest}{ui_theme.ANSI_RESET}"
+            )
+        return f"{ui_theme.DIM_ANSI}{visible}{ui_theme.ANSI_RESET}"
+    clipped_hint = clip_prompt_text(hint, width - reserved)
+    return (
+        f"{ui_theme.PROMPT_ACCENT_ANSI}Ready{ui_theme.ANSI_RESET}"
+        f"{ui_theme.DIM_ANSI} · {clipped_hint}{ui_theme.ANSI_RESET}"
+    )
+
 
 # Default confirmation rows: (answer, label). The execution gate reads "", "y",
 # "yes" as allow and "always" as allow-and-raise-auto; anything else cancels.
@@ -209,75 +235,24 @@ class SpinnerState:
     # Load-state labels for the live spinner, escalating with the turn stage:
     # waiting on the model (THINKING) → dispatching / between tools (EXECUTING)
     # → a tool is running (INVOKING_TOOLS). Each renders in a distinct accent so
-    # a glance tells LLM latency from tool work.
+    # a glance tells LLM latency from tool work. Phase labels are the product UX
+    # — no rotating “cyberpunk” verbs under them.
     THINKING_PHASE = "Thinking…"
     EXECUTING_PHASE = "Executing…"
     INVOKING_TOOLS_PHASE = "Invoking tools…"
     _STOP_HINT = "(Press ESC to stop)"
-    # Netrunner verb pools, escalating with time spent in the net: the longer
-    # the run, the hotter the trace. Each entry maps the minimum elapsed
-    # seconds to the pool active from that point on (tiers never de-escalate
-    # within a turn). Entries are ordered by ascending threshold.
-    _VERB_TIERS: tuple[tuple[float, tuple[str, ...]], ...] = (
-        (
-            0.0,  # calm run
-            (
-                "jacking in",
-                "scanning the grid",
-                "crawling the datastream",
-                "riding the signal",
-                "running the trace",
-                "decrypting",
-                "compiling daemons",
-                "ghosting the subnet",
-                "deep-diving the stack",
-            ),
-        ),
-        (
-            30.0,  # ICE contact
-            (
-                "cutting ice",
-                "ICE detected… rerouting",
-                "ghosting past the trace",
-                "pinging black ICE",
-                "running the icebreaker",
-                "uploading daemons",
-                "threading resonance",
-            ),
-        ),
-        (
-            90.0,  # deep run
-            (
-                "going past the Blackwall",
-                "black ICE closing… stay frosty",
-                "running Kuang Grade Mark Eleven",
-                "deep in the net… trace hot",
-                "riding the matrix",
-            ),
-        ),
-    )
-    # Verbs picked twice as often as the rest of their pool (default weight 1).
-    _VERB_WEIGHTS = {"jacking in": 2, "crawling the datastream": 2}
-
-    # The running action line shimmers in — a white glow rising DIM → TEXT over
-    # the lead window as the action is picked up — then holds a SOLID fill while
-    # it runs ("shimmer prior, solid in progress"). Level is a pure function of
-    # the clock, like the spinner glyph, so it never freezes on a busy render.
-    _SHIMMER_PERIOD_SECONDS = 1.1
-    _SHIMMER_LEAD_SECONDS = _SHIMMER_PERIOD_SECONDS / 2  # rising half of the glow
-    # The action line carries no leading glyph — just an indent under the header.
-    _ACTION_INDENT = "  "
+    # Traveling light wave across the status sentence (Cursor / Droid style).
+    _SHIMMER_PERIOD_SECONDS = 1.5
 
     def __init__(self) -> None:
         self.streaming: bool = False
         self.started_at: float = 0.0
         self.bytes_in: int = 0
-        self._verb_tier: int = 0
-        self._verb: str = self._VERB_TIERS[0][1][0]
         self.phase: str = ""
-        # In-flight tools in start order. The live row shows the first still
-        # running; the ReAct loop emits every start before any end, so a single
-        # slot would display the last tool and clear on the first completion.
+        # In-flight tools in start order. The live status row appends the first
+        # still-running tool after the phase label; the ReAct loop emits every
+        # start before any end, so a single slot would display the last tool
+        # and clear on the first completion.
         self._in_flight_actions: list[_InFlightAction] = []
 
     @property
@@ -286,7 +261,7 @@ class SpinnerState:
         return self._in_flight_actions[0].text if self._in_flight_actions else ""
 
     def set_active_action(self, text: str, *, action_id: str = "") -> None:
-        """Show ``text`` as a running action (theme-token shimmer).
+        """Record ``text`` as a running action for the compact status row.
 
         Distinct ``action_id`` values stack so a batched start does not
         overwrite an earlier tool. The same id updates that slot in place.
@@ -323,78 +298,18 @@ class SpinnerState:
                 del self._in_flight_actions[index]
                 return
 
-    def active_action_ansi(self) -> str:
-        """The indented action line, or ``""`` when none is running.
-
-        Shimmers in (DIM → TEXT) over the lead window as the action is picked up,
-        then holds a solid fill (TEXT) while it runs; scrollback keeps the
-        settled copy.
-        """
-        current = self._in_flight_actions[0] if self._in_flight_actions else None
-        if current is None:
-            return ""
-        elapsed = time.monotonic() - current.started_at
-        if elapsed < self._SHIMMER_LEAD_SECONDS:
-            # Shimmer in: the rising half of the glow (0 → 1) as it is picked up.
-            phase = (elapsed % self._SHIMMER_PERIOD_SECONDS) / self._SHIMMER_PERIOD_SECONDS
-            level = 1.0 - abs(2.0 * phase - 1.0)
-        else:
-            level = 1.0  # solid fill once in progress
-        fill = ui_theme.fade_fg_ansi(level)
-        lead = self._ACTION_INDENT
-        text = clip_prompt_text(current.text, prompt_line_width() - prompt_text_width(lead))
-        return f"{fill}{lead}{text}{ui_theme.ANSI_RESET}"
-
     def start(self) -> None:
         self.streaming = True
         self.started_at = time.monotonic()
         self.bytes_in = 0
-        self._verb_tier = 0
-        self._verb = self._pick_verb()
         self.phase = self.EXECUTING_PHASE
         self._in_flight_actions.clear()
 
-    def advance_verb(self) -> None:
-        """Pick a fresh thinking verb (the rotation cadence is the caller's).
-
-        The agent-loop observer calls this at its chosen step boundaries so
-        the label rotates during a long turn. Always picks a verb different
-        from the current one so the change is visible, staying within the
-        currently escalated tier.
-        """
-        self._verb = self._pick_verb(exclude=self._verb)
-
-    def _tier_for_elapsed(self, elapsed: float) -> int:
-        tier = 0
-        for index, (threshold, _pool) in enumerate(self._VERB_TIERS):
-            if elapsed >= threshold:
-                tier = index
-        return tier
-
-    def _escalate_for_elapsed(self, elapsed: float) -> None:
-        """Escalate the verb pool once *elapsed* crosses a tier threshold.
-
-        One-way within a turn: the tier only moves up (``start()`` resets it).
-        On a transition the verb re-rolls immediately from the new pool so
-        escalation shows even during a long single LLM call with no agent-step
-        events.
-        """
-        tier = self._tier_for_elapsed(elapsed)
-        if tier > self._verb_tier:
-            self._verb_tier = tier
-            self._verb = self._pick_verb()
-
-    def _pick_verb(self, exclude: str | None = None) -> str:
-        pool = self._VERB_TIERS[self._verb_tier][1]
-        candidates = [v for v in pool if v != exclude]
-        weights = [self._VERB_WEIGHTS.get(v, 1) for v in candidates]
-        return random.choices(candidates, weights=weights)[0]
-
     def set_phase(self, label: str) -> None:
-        """Animate a caller-supplied phase label instead of a thinking verb.
+        """Animate a caller-supplied phase label on the status row.
 
         Investigation stages (``/investigate``) dispatch deterministically, so
-        the turn-level "thinking" spinner never starts. The progress display
+        the turn-level spinner may not have been started. The progress display
         calls this to keep the prompt spinner cycling with the active pipeline
         stage; it can be called repeatedly to advance the phase.
         """
@@ -418,23 +333,23 @@ class SpinnerState:
         # unconditionally also keeps its height at zero in both streaming and
         # idle states, which prevents the one-row height delta that would cause
         # prompt_toolkit to misplace the cursor and leave stale spinner lines on
-        # screen.  Idle hints are surfaced through idle_hint_ansi() instead,
+        # screen.  Idle hints are surfaced through ready_hint_ansi() instead,
         # which is rendered in the prompt message's reserved first line.
         return ""
 
     def idle_hint_ansi(self) -> str:
-        """Dim hint line shown above the rule when no dispatch is running."""
-        hint = "/ for commands  ·  tab tool details  ·  ↑↓ history"
-        app = get_app_or_none()
-        if app is not None and app.current_buffer.text:
-            hint += "  ·  esc to clear"
-        return (
-            f"{ui_theme.PROMPT_ACCENT_ANSI}Ready{ui_theme.ANSI_RESET}"
-            f"{ui_theme.DIM_ANSI} · {hint}{ui_theme.ANSI_RESET}"
-        )
+        """One-line Ready chrome when no dispatch is running (clipped by caller)."""
+        return ready_hint_ansi()
+
+    def _phase_shimmer_high_hex(self) -> str:
+        """Peak color for the status-sentence light wave (matches phase accent)."""
+        theme = ui_theme.get_active_theme()
+        if self.phase in (self.INVOKING_TOOLS_PHASE, self.EXECUTING_PHASE):
+            return theme.BRAND
+        return theme.HIGHLIGHT
 
     def _phase_accent_ansi(self) -> str:
-        """Accent for the spinner lead+label, distinct per load-state phase.
+        """Accent for the spinner glyph, distinct per load-state phase.
 
         ``Thinking…`` (and pipeline stage labels) stay on the prompt accent (bold
         highlight); ``Executing…`` uses brand; ``Invoking tools…`` uses bold
@@ -448,10 +363,16 @@ class SpinnerState:
         return ui_theme.PROMPT_ACCENT_ANSI
 
     def inline_spinner_ansi(self) -> str:
+        """One status row: shimmering phase (+ live tool) · stop hint · elapsed.
+
+        When a tool is in flight the label becomes
+        ``Invoking tools… · GitHub CLI · gh api …`` so awareness stays on the
+        same row as the spinner — never a second reserved prompt row. A traveling
+        light wave runs across that sentence while work is in flight.
+        """
         if not self.streaming:
             return ""
         elapsed = time.monotonic() - self.started_at
-        self._escalate_for_elapsed(elapsed)
         token_count = self.bytes_in // _CHARS_PER_TOKEN
         frame_idx = int(elapsed / self._FRAME_INTERVAL_SECONDS)
         glyph = self._SPINNER_FRAMES[frame_idx % len(self._SPINNER_FRAMES)]
@@ -460,7 +381,10 @@ class SpinnerState:
             elapsed_badge = f"[ {elapsed:.0f}s · ↓ {tokens_str} tokens]"
         else:
             elapsed_badge = f"[ {elapsed:.0f}s]"
-        label = self.phase or f"{self._verb}…"
+        label = self.phase or self.THINKING_PHASE
+        action = self.active_action
+        if action:
+            label = f"{label} · {action}"
         # One prompt-region row only: a long phase (or a narrow terminal) must
         # not soft-wrap, which desyncs row height vs the one-row confirmation
         # prefix and leaves stale spinner/status lines.
@@ -473,8 +397,14 @@ class SpinnerState:
             visible = clip_prompt_text(f"{lead}{label}{tail}", width)
             return f"{accent}{visible}{ui_theme.ANSI_RESET}"
         clipped_label = clip_prompt_text(label, width - reserved)
+        shimmered = ui_theme.shimmer_text_ansi(
+            clipped_label,
+            elapsed=elapsed,
+            period=self._SHIMMER_PERIOD_SECONDS,
+            high_hex=self._phase_shimmer_high_hex(),
+        )
         return (
-            f"{accent}{lead}{clipped_label}{ui_theme.ANSI_RESET}"
+            f"{accent}{lead}{ui_theme.ANSI_RESET}{shimmered}"
             f"{ui_theme.ANSI_DIM}{tail}{ui_theme.ANSI_RESET}"
         )
 
@@ -506,4 +436,5 @@ __all__ = [
     "SpinnerState",
     "TurnPhase",
     "create_repl_mutable_state",
+    "ready_hint_ansi",
 ]

--- a/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
+++ b/surfaces/interactive_shell/runtime/subprocess_runner/repl_presenter.py
@@ -223,7 +223,7 @@ class ReplSubprocessPresenter:
             self._console,
             text,
             style=resolved,
-            on_collapse=lambda body: setattr(self._session.terminal, "collapsed_tool_output", body),
+            on_collapse=lambda body: self._session.terminal.stash_collapsed_tool_output(body),
         )
 
     def print_plain(self, text: str) -> None:

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -27,6 +27,17 @@ if TYPE_CHECKING:
     from prompt_toolkit.history import History
 
 
+#: How many capped tool peeks Ctrl+O can cycle through.
+COLLAPSED_OUTPUT_RING_SIZE = 5
+
+#: Bound each stashed peek so five ring slots cannot retain unbounded dumps.
+COLLAPSED_STASH_MAX_CHARS = 32_000
+
+#: Expand in-scrollback when the body fits; larger peeks open ``$PAGER`` / less.
+INLINE_EXPAND_MAX_CHARS = 8_000
+INLINE_EXPAND_MAX_LINES = 120
+
+
 @dataclass
 class TerminalSession:
     """Shell-surface session state, composed onto ``Session`` for the interactive shell."""
@@ -111,11 +122,11 @@ class TerminalSession:
     The response composer consumes the label to hide a pure acknowledgement
     while preserving meaningful follow-up the selected option unlocks."""
 
-    collapsed_tool_output: str | None = None
-    """Full text of the last display-capped tool result, for Ctrl+O paging.
+    collapsed_tool_outputs: list[str] = field(default_factory=list)
+    """Ring of the last N capped tool peeks (newest last). Ctrl+O cycles."""
 
-    Set by the action turn when the console preview is folded; cleared when
-    the next turn's preview fits. None when nothing is collapsed."""
+    _collapsed_expand_next: int = -1
+    """Index into :attr:`collapsed_tool_outputs` for the next Ctrl+O press."""
 
     inline_tool_results: bool = False
     """True when this turn already printed tool results under their call lines.
@@ -199,6 +210,58 @@ class TerminalSession:
         """Advance and return the 1-based ``[N]`` number for a just-submitted prompt."""
         self.submitted_turn_count += 1
         return self.submitted_turn_count
+
+    def has_collapsed_tool_output(self) -> bool:
+        """True when Ctrl+O can expand at least one stashed peek."""
+        return bool(self.collapsed_tool_outputs)
+
+    @property
+    def collapsed_tool_output(self) -> str | None:
+        """Newest capped peek, or ``None`` when the ring is empty."""
+        return self.collapsed_tool_outputs[-1] if self.collapsed_tool_outputs else None
+
+    @collapsed_tool_output.setter
+    def collapsed_tool_output(self, value: str | None) -> None:
+        """Compat for direct assignment; ``None`` is a no-op (keeps the ring)."""
+        if value is None:
+            return
+        self.stash_collapsed_tool_output(value)
+
+    def stash_collapsed_tool_output(self, text: str | None) -> None:
+        """Push a size-bounded peek onto the ring.
+
+        ``None`` means the latest preview was not folded — leave earlier peeks
+        reachable via Ctrl+O. Bodies longer than ``COLLAPSED_STASH_MAX_CHARS``
+        are truncated so the ring cannot retain unbounded API dumps.
+        """
+        if text is None:
+            return
+        body = text
+        if len(body) > COLLAPSED_STASH_MAX_CHARS:
+            marker = "\n… (truncated for Ctrl+O stash)\n"
+            keep = max(0, COLLAPSED_STASH_MAX_CHARS - len(marker))
+            body = body[:keep].rstrip() + marker
+        self.collapsed_tool_outputs.append(body)
+        overflow = len(self.collapsed_tool_outputs) - COLLAPSED_OUTPUT_RING_SIZE
+        if overflow > 0:
+            del self.collapsed_tool_outputs[:overflow]
+        self._collapsed_expand_next = len(self.collapsed_tool_outputs) - 1
+
+    def next_collapsed_output_for_expand(self) -> str:
+        """Return the next peek for Ctrl+O and advance toward older entries.
+
+        First press after a stash shows the newest body; repeated presses cycle
+        older peeks, then wrap back to newest.
+        """
+        ring = self.collapsed_tool_outputs
+        if not ring:
+            return ""
+        idx = self._collapsed_expand_next
+        if idx < 0 or idx >= len(ring):
+            idx = len(ring) - 1
+        body = ring[idx]
+        self._collapsed_expand_next = idx - 1 if idx > 0 else len(ring) - 1
+        return body
 
     def pop_pending_prompt_default(self) -> str:
         """Return pre-filled text for the next prompt line, if any, and clear it."""

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -23,10 +23,10 @@ from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.spi.task_plan import is_plan_diagnosis_prose
-from core.agent_harness.turns.display_text import is_data_blob
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, SECONDARY
+from infrastructure.text import is_data_blob
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.ui.streaming import render_note_block
@@ -46,8 +46,6 @@ _TOOL_CALL_MARKER = "⏺"
 # stripped string value of that single argument. Anything that needs to combine
 # multiple arguments (``slash_invoke``, ``synthetic_run``) keeps a custom branch
 # in :func:`tool_call_display`.
-# The spinner's thinking verb re-rolls once per this many agent-loop steps.
-_VERB_ROTATION_STEP_INTERVAL = 2
 _TOOL_PREVIEW_MAX_CHARS = 180
 _TOOL_VALUE_MAX_CHARS = 64
 _GH_VERBOSE_VALUE_FLAGS = frozenset({"--jq", "--template", "-t"})
@@ -88,16 +86,16 @@ _SELF_RENDERING_TOOLS: frozenset[str] = frozenset(
         ActionToolName.ASK_USER_CHOICE,
         ActionToolName.INVESTIGATION_START,
         # shell_run / cli_exec stream their own ``$ <command>`` + output during
-        # execution, and the running action shows as the live shimmer line — so a
-        # static ``Execute``/``opensre`` header here would print the command a
-        # third time. Suppress it; the shimmer and the ``$`` line are enough.
+        # execution, and the running tool is folded into the status spinner row —
+        # so a static ``Execute``/``opensre`` header here would print the command
+        # a third time. Suppress it; the status row and the ``$`` line are enough.
         ActionToolName.SHELL_RUN,
         ActionToolName.CLI_EXEC,
     }
 )
 
 #: Tools that stream their own ``$ <command>`` line during execution. The live
-#: shimmer names the action only (``⟩ Execute``) rather than repeating the
+#: status row names the action only (``Execute``) rather than repeating the
 #: command, so the command is not shown twice while it runs.
 _COMMAND_STREAMING_TOOLS: frozenset[str] = frozenset(
     {
@@ -383,7 +381,6 @@ class ActionRenderObserver:
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
         if kind == "llm_start":
             self._set_spinner_phase(SpinnerState.THINKING_PHASE)
-            self._advance_spinner_verb(data)
             return
         if kind == "message_update":
             self._render_intermediate_message(data)
@@ -453,12 +450,12 @@ class ActionRenderObserver:
             spinner.set_phase(label)
 
     def _set_active_action(self, name: str, data: dict[str, Any]) -> None:
-        """Show the running tool as a shimmering action line in the live region.
+        """Fold the running tool into the spinner status row (same line).
 
         Stacked by tool-call id: the ReAct loop emits every ``tool_start``
         before executing the batch, so a single slot would show the last
         tool and clear on the first ``tool_end``. Scrollback keeps the
-        settled solid copy. Only relabels an already-running spinner
+        settled ``⏺`` copy. Only relabels an already-running spinner
         (see ``_set_spinner_phase``).
         """
         spinner = get_investigation_spinner()
@@ -480,21 +477,6 @@ class ActionRenderObserver:
     def _has_active_action(self) -> bool:
         spinner = get_investigation_spinner()
         return bool(spinner is not None and spinner.active_action)
-
-    def _advance_spinner_verb(self, data: dict[str, Any]) -> None:
-        """Rotate the prompt spinner's thinking verb every two agent steps.
-
-        ``llm_start`` fires once per think→act iteration of the agent loop.
-        The verb picked at ``SpinnerState.start()`` covers the first two
-        iterations; each pair after that re-rolls it, so the label changes
-        during a long turn without flickering on every step.
-        """
-        iteration = int(data.get("iteration", 0) or 0)
-        if iteration < _VERB_ROTATION_STEP_INTERVAL or iteration % _VERB_ROTATION_STEP_INTERVAL:
-            return
-        spinner = get_investigation_spinner()
-        if spinner is not None:
-            spinner.advance_verb()
 
     def _render_intermediate_message(self, data: dict[str, Any]) -> None:
         """Render the model's commentary preceding this iteration's tool calls.
@@ -562,7 +544,7 @@ class ActionRenderObserver:
             self.console,
             preview,
             style=str(SECONDARY),
-            on_collapse=lambda body: setattr(self.session.terminal, "collapsed_tool_output", body),
+            on_collapse=lambda body: self.session.terminal.stash_collapsed_tool_output(body),
         )
         self.session.terminal.inline_tool_results = True
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -23,6 +23,7 @@ from rich.text import Text
 
 from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.spi.task_plan import is_plan_diagnosis_prose
+from core.agent_harness.turns.display_text import is_data_blob
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, SECONDARY
@@ -127,32 +128,18 @@ def _bounded_preview(value: str, *, limit: int = _TOOL_PREVIEW_MAX_CHARS) -> str
     return collapsed[: limit - 1].rstrip() + "…"
 
 
-def _is_result_data_blob(text: str) -> bool:
-    """True when *text* is a JSON/record blob the reply will summarize.
-
-    Same shape test the action driver uses to hide ``gh api`` payloads: opens
-    an object/array, or is dense with ``":`` key separators.
-    """
-    stripped = text.strip()
-    if not stripped:
-        return False
-    if stripped[0] in "{[":
-        return True
-    return stripped.count('":') >= 2
-
-
 def _preview_from_result_fields(payload: dict[str, Any]) -> str:
     """Pull the one user-facing field from a tool-result dict, or empty."""
     for key in ("response_text", "summary"):
         value = payload.get(key)
-        if isinstance(value, str) and value.strip() and not _is_result_data_blob(value):
+        if isinstance(value, str) and value.strip() and not is_data_blob(value):
             return value.strip()
     stdout = payload.get("stdout")
     if (
         payload.get("ok")
         and isinstance(stdout, str)
         and stdout.strip()
-        and not _is_result_data_blob(stdout)
+        and not is_data_blob(stdout)
     ):
         return stdout.strip()
     error = payload.get("error")
@@ -172,9 +159,9 @@ def _tool_result_preview(output: object) -> str:
             return preview
     if isinstance(output, str):
         stripped = output.strip()
-        return "" if not stripped or _is_result_data_blob(stripped) else stripped
+        return "" if not stripped or is_data_blob(stripped) else stripped
     content = getattr(output, "content", None)
-    if isinstance(content, str) and content.strip() and not _is_result_data_blob(content):
+    if isinstance(content, str) and content.strip() and not is_data_blob(content):
         return content.strip()
     return ""
 

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -25,7 +25,7 @@ from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.spi.task_plan import is_plan_diagnosis_prose
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
-from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT
+from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, SECONDARY
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 from surfaces.interactive_shell.ui.streaming import render_note_block
@@ -574,19 +574,23 @@ class ActionRenderObserver:
         print_command_output(
             self.console,
             preview,
+            style=str(SECONDARY),
             on_collapse=lambda body: setattr(self.session.terminal, "collapsed_tool_output", body),
         )
         self.session.terminal.inline_tool_results = True
 
     def _render_skill_end(self, data: dict[str, Any]) -> None:
-        """Print the ``↳`` child line under the skill's ``tool_start`` parent."""
+        """Print the ``↳`` child line under the skill's ``tool_start`` parent.
+
+        The next block (another call, a note, or the ``∴`` reply) opens with
+        its own blank line — do not add one here or the gap doubles.
+        """
         if self._pending_skill_calls.pop(str(data.get("id") or ""), None) is None:
             return
         output = data.get("output")
         activated = isinstance(output, dict) and bool(output.get("ok"))
         label = "Skill activated" if activated else "Skill failed to load"
         self.console.print(Text(f"  ↳ {label}", style=DIM))
-        self.console.print()
 
 
 __all__ = [

--- a/surfaces/interactive_shell/ui/hooks/output_expand.py
+++ b/surfaces/interactive_shell/ui/hooks/output_expand.py
@@ -1,9 +1,10 @@
-"""Ctrl+O pages the last collapsed tool-output peek (Droid-style).
+"""Ctrl+O expands stashed collapsed tool-output peeks (Droid-style).
 
 A long tool result renders a short head plus ``… N more, Ctrl+O to view``.
-This hook opens the full text in the user's pager, then returns to the
-session. The binding is gated on a collapsed body being stashed, so Ctrl+O
-falls through when nothing was folded.
+This hook expands the full text — inline into scrollback when modest, or in
+``$PAGER`` / ``less`` when large — then returns to the session. The binding is
+gated on a collapsed body being stashed, so Ctrl+O falls through when nothing
+was folded. Repeated presses cycle the last N peeks (newest first).
 """
 
 from __future__ import annotations
@@ -19,34 +20,67 @@ from prompt_toolkit.filters import Condition
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
+from infrastructure.safety.terminal_output import strip_terminal_controls
+from rich.text import Text
+from surfaces.interactive_shell.session.terminal_session import (
+    INLINE_EXPAND_MAX_CHARS,
+    INLINE_EXPAND_MAX_LINES,
+)
 
-def page_collapsed_output(text: str) -> None:
-    """Show *text* in ``$PAGER`` / ``less``, or print it when no pager exists."""
+
+def _fits_inline(text: str) -> bool:
+    if len(text) > INLINE_EXPAND_MAX_CHARS:
+        return False
+    return text.count("\n") <= INLINE_EXPAND_MAX_LINES
+
+
+def _safe_expand_text(text: str) -> str:
+    """Strip ANSI/CSI and leftover controls so expand cannot trash the live TUI."""
+    plain = Text.from_ansi(text).plain
+    return strip_terminal_controls(plain, keep_whitespace=True)
+
+
+def _print_inline_expand(text: str) -> None:
+    """Paint the peek into scrollback so everyday peeks never leave the TUI."""
+    body = _safe_expand_text(text)
+    if not body.endswith("\n"):
+        body = f"{body}\n"
+    # Framed like other tool output: dim gutter, no pager chrome.
+    sys.stdout.write(f"\n  ↳ expanded\n{body}")
+    sys.stdout.flush()
+
+
+def expand_collapsed_output(text: str) -> None:
+    """Show *text* inline when modest; otherwise ``$PAGER`` / ``less`` / print."""
+    safe = _safe_expand_text(text)
+    if _fits_inline(safe):
+        _print_inline_expand(safe)
+        return
     spec = os.environ.get("PAGER") or shutil.which("less") or ""
     cmd = shlex.split(spec) if spec else []
     if cmd:
-        subprocess.run(cmd, input=text.encode(), check=False)
+        subprocess.run(cmd, input=safe.encode(), check=False)
         return
-    sys.stdout.write(text if text.endswith("\n") else f"{text}\n")
+    sys.stdout.write(safe if safe.endswith("\n") else f"{safe}\n")
     sys.stdout.flush()
 
 
 def install_output_expand_key_bindings(
     has_output: Callable[[], bool],
     get_output: Callable[[], str],
-    page: Callable[[str], None],
+    expand: Callable[[str], None],
 ) -> KeyBindings:
-    """Bind Ctrl+O to page the stashed collapsed tool result."""
+    """Bind Ctrl+O to expand the next stashed collapsed tool result."""
     kb = KeyBindings()
     output_shown = Condition(has_output)
 
     @kb.add("c-o", filter=output_shown, eager=True)
-    def _page_output(_event: KeyPressEvent) -> None:
+    def _expand_output(_event: KeyPressEvent) -> None:
         body = get_output()
         if body:
-            page(body)
+            expand(body)
 
     return kb
 
 
-__all__ = ["install_output_expand_key_bindings", "page_collapsed_output"]
+__all__ = ["expand_collapsed_output", "install_output_expand_key_bindings"]

--- a/surfaces/interactive_shell/ui/hooks/output_expand.py
+++ b/surfaces/interactive_shell/ui/hooks/output_expand.py
@@ -19,9 +19,9 @@ from collections.abc import Callable
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from rich.text import Text
 
 from infrastructure.safety.terminal_output import strip_terminal_controls
-from rich.text import Text
 from surfaces.interactive_shell.session.terminal_session import (
     INLINE_EXPAND_MAX_CHARS,
     INLINE_EXPAND_MAX_LINES,

--- a/surfaces/interactive_shell/ui/input_prompt/key_bindings.py
+++ b/surfaces/interactive_shell/ui/input_prompt/key_bindings.py
@@ -135,6 +135,10 @@ def build_cancel_key_bindings(state: _DispatchCancelState) -> KeyBindings:
             event.app.exit(result="")
             return
         state.arm_ctrl_c_exit_hint(CTRL_C_DOUBLE_PRESS_WINDOW_S)
+        # Full repaint, not a diff: the transient hint replaces the idle
+        # "Ready…" line in place, and the renderer's line diff can skip an
+        # in-place text→text swap on that row, leaving the hint unshown.
+        event.app.renderer.reset()
         event.app.invalidate()
 
     @kb.add("escape", eager=True)

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -134,9 +134,11 @@ def resolve_prompt_prefix_ansi(*, inline_spinner: str, idle_hint: str) -> str:
 
 
 def resolve_idle_hint_ansi(session: Session) -> str:
-    """Return the idle spacer used by the fixed-height prompt region."""
+    """Return the one-line Ready/commands hint for the fixed-height status row."""
+    from surfaces.interactive_shell.runtime.core.state import ready_hint_ansi
+
     del session
-    return ""
+    return ready_hint_ansi()
 
 
 def ctrl_c_exit_hint_ansi() -> str:
@@ -145,19 +147,11 @@ def ctrl_c_exit_hint_ansi() -> str:
 
 
 def composer_footer_ansi() -> str:
-    """Return the help hint and terminal-mode label below the composer."""
+    """Return the help hint below the composer (no competing mode chrome)."""
     left = "Enter send · Shift+Enter newline · ? help"
-    right = "TERMINAL ■"
     width = prompt_line_width()
-    if len(left) + len(right) + 2 > width:
-        clipped = clip_prompt_text(left, width)
-        return f"{ui_theme.DIM_ANSI}{clipped}{ui_theme.ANSI_RESET}"
-    pad = width - len(left) - len(right)
-    return (
-        f"{ui_theme.DIM_ANSI}{left}{ui_theme.ANSI_RESET}"
-        f"{' ' * pad}{ui_theme.BRAND_ANSI}TERMINAL "
-        f"{ui_theme.HIGHLIGHT_ANSI}■{ui_theme.ANSI_RESET}"
-    )
+    clipped = clip_prompt_text(left, width)
+    return f"{ui_theme.DIM_ANSI}{clipped}{ui_theme.ANSI_RESET}"
 
 
 def resolve_prompt_placeholder(session: Session) -> ANSI:

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -13,6 +13,7 @@ import infrastructure.terminal.theme as ui_theme
 from core.agent_harness.spi.prompt_chrome import normalize_three_tier_spacing
 from core.agent_harness.spi.session_goal import strip_session_goal_progress_tags
 from infrastructure.safety.terminal_output import strip_terminal_controls
+from infrastructure.text import looks_like_data_blob
 
 if TYPE_CHECKING:
     from rich.markdown import Markdown
@@ -38,30 +39,26 @@ _DUMP_TRUNCATED_MARKER = "output truncated"
 _DUMP_MIN_CHARS = 200
 _DUMP_MIN_JSON_KEYS = 3
 _DUMP_STRUCTURAL_RATIO = 0.15
-_DUMP_STRUCTURAL_CHARS = frozenset('{}[]":,')
 # Line-start fences only — matches the streaming splitter so an inline
 # ``Use ``` to fence code`` mention does not freeze dump collapsing.
 _FENCE_LINE_RE = re.compile(r"^```", re.MULTILINE)
 
 
 def _looks_like_raw_dump(text: str) -> bool:
-    """Whether *text* is an echoed tool result rather than prose.
+    """Whether a paragraph in the model's reply is an echoed tool result.
 
-    True when it carries the ``output truncated`` marker a tool cap leaves, or
-    when it is large and reads as a record/JSON blob. The ``":`` key separator
-    is common in such a dump and rare in prose, and — unlike a raw char ratio —
-    long URL values do not dilute it (a GitHub API object stays URL-heavy yet
-    keeps many keys). A structural-char ratio still catches non-JSON dense data.
-    Prose and Markdown tables/lists trip neither test.
+    Conservative by design: a paragraph collapses only when it is large and
+    dense (or carries the ``output truncated`` marker), so real prose is never
+    mistaken for a dump. The tool-result hider in ``display_text`` runs the same
+    mechanism with a smaller floor, since a raw payload is always data.
     """
-    if len(text) < _DUMP_MIN_CHARS:
-        return False  # too small to be a wall — a short block is not a problem
-    if _DUMP_TRUNCATED_MARKER in text:
-        return True
-    if text.count('":') >= _DUMP_MIN_JSON_KEYS:
-        return True
-    structural = sum(1 for ch in text if ch in _DUMP_STRUCTURAL_CHARS)
-    return structural / len(text) >= _DUMP_STRUCTURAL_RATIO
+    return looks_like_data_blob(
+        text,
+        min_chars=_DUMP_MIN_CHARS,
+        min_json_keys=_DUMP_MIN_JSON_KEYS,
+        structural_ratio=_DUMP_STRUCTURAL_RATIO,
+        truncation_marker=_DUMP_TRUNCATED_MARKER,
+    )
 
 
 def _collapse_paragraph(paragraph: str) -> str:

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -95,10 +95,10 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     plan_prefix = f"{plan_overlay}\n\n" if plan_overlay else ""
 
     # A pending confirmation renders a stacked, arrow-navigable Yes/No choice
-    # (box hidden) with blank rows above and below so it reads as its own block.
+    # (box hidden). Density matches the streaming stack: status → Auto → composer.
     if state.is_awaiting_confirmation():
         choice = _confirmation_block(state)
-        return ANSI(f"\n{plan_prefix}{choice}\n\n{auto_line}\n{base}")
+        return ANSI(f"\n{plan_prefix}{choice}\n{auto_line}\n{base}")
 
     if state.is_ctrl_c_exit_hint_visible():
         prefix = prompt_rendering.ctrl_c_exit_hint_ansi()
@@ -109,10 +109,10 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
-    # Tools already paint a ``⏺`` line into scrollback; do not reserve a second
-    # shimmer row here. A blank reserved slot made the stack look sparse (Droid
-    # is Plan → Thinking → Auto with no empty gap), and filling it mid-turn was
-    # the old composer-height jump. Spinner phase alone carries "Invoking tools…".
+    # Tools already paint a ``⏺`` line into scrollback; the live tool name is
+    # folded into the spinner status row (same line as ``Invoking tools…``).
+    # Do not reserve a second action row here — that blank slot made the stack
+    # look sparse and filled mid-turn as the old composer-height jump.
     return ANSI(f"\n{plan_prefix}{prefix}\n{auto_line}\n{base}")
 
 
@@ -122,8 +122,8 @@ _CONFIRM_HINT = "↑↓ Navigate • Enter confirm • Esc cancel"
 def _confirmation_block(state: ReplState) -> str:
     """Header, the stacked ``[a] Yes`` / ``[b] No`` choice, and a nav hint.
 
-    Blank rows separate the header, the options, and the hint so the pending
-    decision reads as a clear, self-contained block above the status line.
+    Dense like the streaming stack: header, choice, and hint on consecutive
+    lines so confirm doesn't feel taller than Thinking/Invoking.
     """
     header = clip_prompt_text(state.confirm_prompt_text.strip(), prompt_line_width())
     header_ansi = f"{ui_theme.SECONDARY_ANSI}{header}{ui_theme.ANSI_RESET}"
@@ -131,7 +131,7 @@ def _confirmation_block(state: ReplState) -> str:
         confirmation_choice_overlay_ansi(state.confirm_selected, state.confirm_options)
     )
     hint = f"{ui_theme.DIM_ANSI}{_CONFIRM_HINT}{ui_theme.ANSI_RESET}"
-    return f"{header_ansi}\n\n{choice}\n\n{hint}"
+    return f"{header_ansi}\n{choice}\n{hint}"
 
 
 __all__ = ["render_prompt_region", "render_terminal_ui"]

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -109,18 +109,11 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
-    # The running action shimmers on its own row between the status line and the
-    # autonomy line; scrollback keeps the settled solid copy. Reserve that row
-    # for the whole streaming turn — appearing/clearing mid-turn used to grow
-    # and shrink the prompt region, which made the composer box jump.
-    if spinner.streaming:
-        action = strip_cpr_sequences(spinner.active_action_ansi())
-        action_line = f"{action}\n"
-    else:
-        action_line = ""
-    # A blank row separates the plan block from the status line so the checklist
-    # reads as its own element, not flush against the prompt.
-    return ANSI(f"\n{plan_prefix}{prefix}\n{action_line}{auto_line}\n{base}")
+    # Tools already paint a ``⏺`` line into scrollback; do not reserve a second
+    # shimmer row here. A blank reserved slot made the stack look sparse (Droid
+    # is Plan → Thinking → Auto with no empty gap), and filling it mid-turn was
+    # the old composer-height jump. Spinner phase alone carries "Invoking tools…".
+    return ANSI(f"\n{plan_prefix}{prefix}\n{auto_line}\n{base}")
 
 
 _CONFIRM_HINT = "↑↓ Navigate • Enter confirm • Esc cancel"

--- a/tests/core/agent/orchestration/test_duplicate_action_guard.py
+++ b/tests/core/agent/orchestration/test_duplicate_action_guard.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness.turns.action_driver import with_duplicate_action_call_guard
+from core.agent_harness.turns.action_dedup import with_duplicate_action_call_guard
 from core.llm.types import ToolCall
 from core.tool.execution import ToolExecutionResult
 

--- a/tests/core/agent_harness/turns/test_generic_tool_payload.py
+++ b/tests/core/agent_harness/turns/test_generic_tool_payload.py
@@ -63,6 +63,26 @@ def test_opaque_json_list_is_hidden() -> None:
     assert format_generic_tool_payload(_call("list_runs"), _result([{"id": 1}, {"id": 2}])) == ""
 
 
+def test_github_repository_summary_is_shown_not_blob() -> None:
+    payload = {
+        "available": True,
+        "summary": "Tracer-Cloud/opensre · 42★ · main · public · Python",
+        "repository": {"full_name": "Tracer-Cloud/opensre", "stargazers_count": 42},
+    }
+    shown = format_generic_tool_payload(_call("get_github_repository"), _result(payload))
+    assert shown == "Tracer-Cloud/opensre · 42★ · main · public · Python"
+
+
+def test_grafana_metrics_summary_is_shown_not_blob() -> None:
+    payload = {
+        "available": True,
+        "summary": "3 series for `http_requests_total` for api",
+        "metrics": [{"metric": {}, "values": []}],
+    }
+    shown = format_generic_tool_payload(_call("query_grafana_metrics"), _result(payload))
+    assert shown == "3 series for `http_requests_total` for api"
+
+
 def test_truncated_json_blob_is_hidden_not_dumped_raw() -> None:
     # A capped gh-api response arrives as invalid (cut-off) JSON — it must not
     # slip past the JSON check and dump raw. Detection is by shape, not parse.

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from rich.console import Console
 from rich.text import Text
 
@@ -95,6 +97,21 @@ def test_fade_fg_ansi_interpolates_dim_to_text() -> None:
     assert mid.startswith("\x1b[38;2;")
     assert mid != ui_theme.DIM_ANSI
     assert mid != ui_theme.TEXT_ANSI
+
+
+def test_shimmer_text_ansi_paints_a_traveling_wave() -> None:
+    """Status sentence shimmer: per-glyph truecolor that moves with elapsed time."""
+    from infrastructure.terminal import theme as ui_theme
+
+    ui_theme.set_active_theme("solarized")
+    early = ui_theme.shimmer_text_ansi("Thinking…", elapsed=0.0)
+    later = ui_theme.shimmer_text_ansi("Thinking…", elapsed=0.75)
+    assert early.count("\x1b[38;2;") >= 5
+    assert early.endswith(ui_theme.ANSI_RESET)
+    assert early != later
+    # Whitespace is not individually coloured.
+    spaced = ui_theme.shimmer_text_ansi("Invoking tools", elapsed=0.1)
+    assert " tools" in spaced or "tools" in re.sub(r"\x1b\[[0-9;]*m", "", spaced)
 
 
 def test_palette_registry_keys_match_the_config_vocabulary() -> None:

--- a/tests/infrastructure/text/test_data_blob.py
+++ b/tests/infrastructure/text/test_data_blob.py
@@ -1,0 +1,61 @@
+"""Shared data-blob detection under the two caller policies.
+
+The tool-result hider (``display_text.is_data_blob``) and the reply-prose
+collapse (streaming renderer ``_looks_like_raw_dump``) run this one mechanism
+with different thresholds. These tests pin each policy and lock in that they
+differ on purpose, so the two sites can never silently drift apart again.
+"""
+
+from __future__ import annotations
+
+from infrastructure.text import looks_like_data_blob
+
+# The two live policies, named here so a threshold change is a deliberate edit.
+_TOOL_PAYLOAD = {"min_json_keys": 2, "honor_open_bracket": True}
+_REPLY_PARAGRAPH = {
+    "min_chars": 200,
+    "min_json_keys": 3,
+    "structural_ratio": 0.15,
+    "truncation_marker": "output truncated",
+}
+
+
+def test_tool_policy_hides_a_short_mid_object_fragment() -> None:
+    # Arrange: a capped gh-api response cut mid-value — two keys, well under 200 chars.
+    fragment = 'foo","followers_url":"https://api.github.com/u","gists_url":"https://x"'
+
+    # Act / Assert: the aggressive tool policy treats it as data...
+    assert looks_like_data_blob(fragment, **_TOOL_PAYLOAD) is True
+    # ...while the conservative reply policy leaves it as prose (below its floor).
+    assert looks_like_data_blob(fragment, **_REPLY_PARAGRAPH) is False
+
+
+def test_tool_policy_honors_an_opening_bracket() -> None:
+    assert looks_like_data_blob('{"a": 1}', **_TOOL_PAYLOAD) is True
+    # The reply policy ignores shape and needs bulk before it collapses.
+    assert looks_like_data_blob('{"a": 1}', **_REPLY_PARAGRAPH) is False
+
+
+def test_reply_policy_collapses_a_large_dense_blob() -> None:
+    blob = "\n".join(f'"field_{i}": "value_{i}",' for i in range(40))
+    assert looks_like_data_blob(blob, **_REPLY_PARAGRAPH) is True
+    assert looks_like_data_blob(blob, **_TOOL_PAYLOAD) is True
+
+
+def test_reply_policy_keeps_prose_that_merely_mentions_a_colon() -> None:
+    prose = (
+        "The deploy finished and the health check passed. One note: the cache "
+        "warm-up ran twice, which is expected on a cold start after a release. "
+        "Nothing else looked off across the three services I checked just now."
+    )
+    assert looks_like_data_blob(prose, **_REPLY_PARAGRAPH) is False
+
+
+def test_reply_policy_collapses_on_the_truncation_marker() -> None:
+    text = "x" * 300 + " output truncated"
+    assert looks_like_data_blob(text, **_REPLY_PARAGRAPH) is True
+
+
+def test_empty_text_is_never_a_blob() -> None:
+    assert looks_like_data_blob("   ", **_TOOL_PAYLOAD) is False
+    assert looks_like_data_blob("", **_REPLY_PARAGRAPH) is False

--- a/tests/infrastructure/text/test_data_blob.py
+++ b/tests/infrastructure/text/test_data_blob.py
@@ -1,9 +1,10 @@
 """Shared data-blob detection under the two caller policies.
 
-The tool-result hider (``display_text.is_data_blob``) and the reply-prose
-collapse (streaming renderer ``_looks_like_raw_dump``) run this one mechanism
-with different thresholds. These tests pin each policy and lock in that they
-differ on purpose, so the two sites can never silently drift apart again.
+The tool-result hider (``display_text.is_data_blob``, also used by action
+rendering for ``↳`` child previews) and the reply-prose collapse (streaming
+renderer ``_looks_like_raw_dump``) run this one mechanism with different
+thresholds. These tests pin each policy and lock in that they differ on
+purpose, so the two sites can never silently drift apart again.
 """
 
 from __future__ import annotations

--- a/tests/interactive_shell/runtime/test_spinner_state.py
+++ b/tests/interactive_shell/runtime/test_spinner_state.py
@@ -1,4 +1,4 @@
-"""Tests for the inline turn spinner in runtime.core.state."""
+"""SpinnerState: phase status row, live tool fold-in, idle Ready hint."""
 
 from __future__ import annotations
 
@@ -8,115 +8,20 @@ import time
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
 
 
-def _rgb(hex_color: str) -> str:
-    """``"#RRGGBB"`` → the ``"r;g;b"`` triple as it appears in a truecolor escape."""
-    h = hex_color.lstrip("#")
-    return f"{int(h[0:2], 16)};{int(h[2:4], 16)};{int(h[4:6], 16)}"
+def test_inline_spinner_empty_when_idle() -> None:
+    assert SpinnerState().inline_spinner_ansi() == ""
 
 
-_GLYPHS = SpinnerState._SPINNER_FRAMES
-
-
-def _glyph(spinner: SpinnerState) -> str:
-    rendered = spinner.inline_spinner_ansi()
-    match = re.search("|".join(map(re.escape, _GLYPHS)), rendered)
-    assert match is not None, f"no spinner glyph in {rendered!r}"
-    return match.group(0)
-
-
-def test_spinner_frame_is_a_function_of_elapsed_time_not_call_count() -> None:
-    """Regression: the glyph must animate no matter how often it is rendered.
-
-    prompt_toolkit evaluates the prompt message callable several times per
-    render pass. A per-call frame counter advanced exactly one full cycle per
-    visible render (10 evals x 10 frames), so the on-screen glyph never
-    changed. Deriving the frame from elapsed time makes repeated evaluations
-    idempotent and guarantees the animation advances between renders.
-    """
+def test_inline_spinner_includes_phase_and_stop_hint() -> None:
     spinner = SpinnerState()
     spinner.start()
-
-    # Repeated evaluations inside one render pass: same frame every time.
-    first = _glyph(spinner)
-    assert all(_glyph(spinner) == first for _ in range(10))
-
-    # A frame interval later the glyph must have advanced.
-    spinner.started_at -= SpinnerState._FRAME_INTERVAL_SECONDS * 1.01
-    assert _glyph(spinner) != first
-
-    # Over a full cycle of elapsed time, every frame is visited in order.
-    spinner.start()
-    seen = []
-    for step in range(len(_GLYPHS)):
-        spinner.started_at = time.monotonic() - step * SpinnerState._FRAME_INTERVAL_SECONDS * 1.001
-        seen.append(_glyph(spinner))
-    assert seen == list(_GLYPHS)
-
-
-def test_spinner_renders_elapsed_seconds_and_cancel_hint() -> None:
-    spinner = SpinnerState()
-    spinner.start()
-    spinner.started_at = time.monotonic() - 8.2
-
-    rendered = spinner.inline_spinner_ansi()
-
-    assert "[ 8s]" in rendered
-    assert "(Press ESC to stop)" in rendered
-    assert SpinnerState.EXECUTING_PHASE in rendered
-
-
-def test_spinner_invoking_tools_phase_matches_factory_copy() -> None:
-    spinner = SpinnerState()
-    spinner.start()
-    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
-
-    rendered = spinner.inline_spinner_ansi()
-
-    assert SpinnerState.INVOKING_TOOLS_PHASE in rendered
-    assert "(Press ESC to stop)" in rendered
-
-
-def test_load_state_phases_use_distinct_accents() -> None:
-    """Thinking=highlight, Executing=brand, Invoking tools=bold brand — a glance
-    tells LLM latency (thinking) from tool work (invoking)."""
-    from infrastructure.terminal.theme import THEME_REGISTRY, set_active_theme
-
-    set_active_theme("blue")
-    highlight = _rgb(THEME_REGISTRY["blue"].HIGHLIGHT)
-    brand = _rgb(THEME_REGISTRY["blue"].BRAND)
-    spinner = SpinnerState()
-    spinner.start()
-
     spinner.set_phase(SpinnerState.THINKING_PHASE)
-    thinking = spinner.inline_spinner_ansi().split("(Press ESC")[0]
-    assert SpinnerState.THINKING_PHASE in thinking
-    assert highlight in thinking
-    assert brand not in thinking
-
-    spinner.set_phase(SpinnerState.EXECUTING_PHASE)
-    executing = spinner.inline_spinner_ansi().split("(Press ESC")[0]
-    assert SpinnerState.EXECUTING_PHASE in executing
-    assert brand in executing
-    assert highlight not in executing
-    assert "\x1b[1m" not in executing  # brand is not bold in the executing phase
-
-    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
-    invoking = spinner.inline_spinner_ansi().split("(Press ESC")[0]
-    assert SpinnerState.INVOKING_TOOLS_PHASE in invoking
-    assert brand in invoking
-    assert "\x1b[1m" in invoking  # bold brand — the hottest state
-    assert highlight not in invoking
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
+    assert SpinnerState.THINKING_PHASE in rendered
+    assert "Press ESC to stop" in rendered
 
 
-def test_spinner_empty_when_not_streaming() -> None:
-    spinner = SpinnerState()
-    assert spinner.inline_spinner_ansi() == ""
-    spinner.start()
-    spinner.stop()
-    assert spinner.inline_spinner_ansi() == ""
-
-
-def test_inline_spinner_clips_a_long_phase_to_one_prompt_row() -> None:
+def test_long_phase_clips_to_one_prompt_column_budget() -> None:
     """A long phase label must not soft-wrap past the one reserved prompt row."""
     from surfaces.shared.terminal.prompt_layout import prompt_line_width, prompt_text_width
 
@@ -128,24 +33,22 @@ def test_inline_spinner_clips_a_long_phase_to_one_prompt_row() -> None:
     assert prompt_text_width(rendered) <= prompt_line_width()
 
 
-def test_active_action_renders_indented_line_and_clears() -> None:
-    """The running action shows an indented action line with a theme fill;
-    cleared → blank. (The shimmer→solid transition is pinned separately.)"""
-    from infrastructure.terminal.theme import set_active_theme
-
-    set_active_theme("solarized")
+def test_live_tool_folds_into_spinner_row_and_clears() -> None:
+    """Running tool appears on the same status row as the phase; clear drops it."""
     spinner = SpinnerState()
     spinner.start()
-    assert spinner.active_action_ansi() == ""  # none by default
+    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
+    before = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
+    assert "Execute · cd /tmp" not in before
 
     spinner.set_active_action("Execute · cd /tmp")
-    rendered = spinner.active_action_ansi()
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
+    assert "Invoking tools…" in rendered
     assert "Execute · cd /tmp" in rendered
-    assert SpinnerState._ACTION_INDENT in rendered  # indented under the header, no glyph
-    assert "\x1b[38;2;" in rendered  # a 24-bit theme fill
 
     spinner.clear_active_action()
-    assert spinner.active_action_ansi() == ""
+    cleared = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
+    assert "Execute · cd /tmp" not in cleared
 
 
 def test_active_action_stack_keeps_earlier_tools_until_they_end() -> None:
@@ -162,14 +65,15 @@ def test_active_action_stack_keeps_earlier_tools_until_they_end() -> None:
     assert spinner.active_action == ""
 
 
-def test_active_action_row_clips_wide_glyphs_to_one_prompt_column_budget() -> None:
+def test_status_row_with_tool_clips_wide_glyphs_to_one_column_budget() -> None:
     """CJK / emoji must be measured in terminal columns, not code points."""
     from surfaces.shared.terminal.prompt_layout import prompt_line_width, prompt_text_width
 
     spinner = SpinnerState()
     spinner.start()
+    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
     spinner.set_active_action("查询 · " + "中" * 200)
-    rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.active_action_ansi())
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
     assert prompt_text_width(rendered) <= prompt_line_width()
 
 
@@ -192,23 +96,56 @@ def test_untracked_tool_end_pops_only_an_untracked_slot() -> None:
     assert spinner.active_action == ""
 
 
-def test_action_line_shimmers_in_then_holds_solid() -> None:
-    """The action glows in over the lead window (shimmer prior), then holds a
-    solid fill while it runs (solid in progress)."""
-    from infrastructure.terminal.theme import fade_fg_ansi, set_active_theme
+def test_idle_hint_ready_line() -> None:
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", SpinnerState().idle_hint_ansi())
+    assert rendered.startswith("Ready")
+    assert "/ for commands" in rendered
+
+
+def test_ready_hint_ansi_matches_spinner_idle_hint() -> None:
+    from surfaces.interactive_shell.runtime.core.state import ready_hint_ansi
+
+    assert ready_hint_ansi() == SpinnerState().idle_hint_ansi()
+
+
+def test_ready_hint_clips_to_one_prompt_column_budget(monkeypatch) -> None:
+    from surfaces.interactive_shell.runtime.core.state import ready_hint_ansi
+    from surfaces.shared.terminal.prompt_layout import prompt_text_width
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.runtime.core.state.prompt_line_width",
+        lambda: 24,
+    )
+    rendered = re.sub(r"\x1b\[[0-9;]*m", "", ready_hint_ansi())
+    assert prompt_text_width(rendered) <= 24
+    assert rendered.startswith("Ready")
+
+
+def test_status_sentence_shimmers_with_elapsed_time() -> None:
+    """Live status text carries a traveling light wave (still one prompt row)."""
+    from infrastructure.terminal.theme import set_active_theme
+    from surfaces.shared.terminal.prompt_layout import prompt_line_width, prompt_text_width
 
     set_active_theme("solarized")
     spinner = SpinnerState()
     spinner.start()
-    spinner.set_active_action("Execute · sleep 4")
-    action = spinner._in_flight_actions[0]
+    spinner.set_phase(SpinnerState.THINKING_PHASE)
+    early = spinner.inline_spinner_ansi()
+    spinner.started_at = time.monotonic() - 0.8
+    later = spinner.inline_spinner_ansi()
+    assert early.count("\x1b[38;2;") >= 5
+    assert early != later
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", later)
+    assert "Thinking…" in plain
+    assert prompt_text_width(plain) <= prompt_line_width()
 
-    # Early in the lead window: still shimmering in (partial glow), not solid.
-    action.started_at = time.monotonic() - SpinnerState._SHIMMER_LEAD_SECONDS * 0.25
-    early = spinner.active_action_ansi()
-    assert fade_fg_ansi(1.0) not in early
 
-    # After the lead window: solid fill held for the rest of the run.
-    action.started_at = time.monotonic() - (SpinnerState._SHIMMER_LEAD_SECONDS + 0.3)
-    solid = spinner.active_action_ansi()
-    assert fade_fg_ansi(1.0) in solid
+def test_status_shimmer_includes_live_tool_on_same_row() -> None:
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
+    spinner.set_active_action("GitHub CLI · gh api repos/x")
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
+    assert "Invoking tools…" in plain
+    assert "GitHub CLI" in plain
+    assert plain.count("\n") == 0

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -796,11 +796,6 @@ class TestSpinnerState:
         assert _rgb(THEME_REGISTRY["blue"].BRAND) in raw  # blue BRAND
         assert _rgb(THEME_REGISTRY["blue"].HIGHLIGHT) not in raw.split("(Press ESC")[0]
 
-    @staticmethod
-    def _all_verbs(spinner: loop_state.SpinnerState) -> tuple[str, ...]:
-        """Union of every tier's verb pool."""
-        return tuple(verb for _threshold, pool in spinner._VERB_TIERS for verb in pool)
-
     def test_streaming_inline_spinner_includes_glyph_and_token_count(self) -> None:
         spinner = loop_state.SpinnerState()
         spinner.start()
@@ -836,87 +831,22 @@ class TestSpinnerState:
         rendered = _strip_ansi(spinner.inline_spinner_ansi())
         assert "tokens" in rendered
 
-    def test_streaming_inline_spinner_verb_stays_constant_across_calls(self) -> None:
-        """A turn's verb is fixed at ``start()`` so the indicator
-        doesn't flicker between words mid-stream. The visible label is the
-        executing phase; the verb is kept for investigation-stage fallback.
-        """
+    def test_streaming_inline_spinner_phase_stays_stable_across_calls(self) -> None:
+        """Phase labels are the product UX — no rotating verbs mid-stream."""
         spinner = loop_state.SpinnerState()
         spinner.start()
-        first = spinner._verb
         for _ in range(20):
             rendered = _strip_ansi(spinner.inline_spinner_ansi())
-            assert spinner._verb == first
             assert loop_state.SpinnerState.EXECUTING_PHASE in rendered
 
-    def test_advance_verb_changes_verb_between_agent_steps(self) -> None:
-        """``advance_verb`` re-rolls the verb and never repeats the current one."""
+    def test_inline_spinner_folds_live_tool_onto_status_row(self) -> None:
         spinner = loop_state.SpinnerState()
         spinner.start()
-        for _ in range(20):
-            before = spinner._verb
-            spinner.advance_verb()
-            assert spinner._verb != before
-            assert spinner._verb in spinner._VERB_TIERS[0][1]
-
-    def test_weighted_verbs_are_picked_about_twice_as_often(self) -> None:
-        """Verbs in ``_VERB_WEIGHTS`` (weight 2) beat the unweighted average."""
-        import random as _random
-
-        _random.seed(20260807)
-        spinner = loop_state.SpinnerState()
-        counts: dict[str, int] = dict.fromkeys(spinner._VERB_TIERS[0][1], 0)
-        for _ in range(6000):
-            spinner.start()
-            counts[spinner._verb] += 1
-        plain = [count for verb, count in counts.items() if verb not in spinner._VERB_WEIGHTS]
-        plain_avg = sum(plain) / len(plain)
-        for verb in spinner._VERB_WEIGHTS:
-            assert counts[verb] > 1.5 * plain_avg, (
-                f"{verb!r} picked {counts[verb]}x vs plain avg {plain_avg:.0f}"
-            )
-
-    def test_spinner_verb_escalates_through_tiers_with_elapsed_time(self) -> None:
-        """The verb pool escalates as the run goes hot, and never de-escalates."""
-        spinner = loop_state.SpinnerState()
-        spinner.start()
-        tier0, tier1, tier2 = (pool for _threshold, pool in spinner._VERB_TIERS)
-        assert spinner._verb in tier0
-
-        spinner.started_at -= 45  # elapsed ≈ 45s → ICE contact
-        _strip_ansi(spinner.inline_spinner_ansi())
-        assert spinner._verb in tier1
-        assert spinner._verb_tier == 1
-
-        spinner.started_at -= 75  # elapsed ≈ 120s → deep run
-        _strip_ansi(spinner.inline_spinner_ansi())
-        assert spinner._verb in tier2
-        assert spinner._verb_tier == 2
-
-        # Re-rendering at the same elapsed time keeps the deep-run tier.
-        _strip_ansi(spinner.inline_spinner_ansi())
-        assert spinner._verb in tier2
-
-    def test_advance_verb_after_escalation_picks_within_escalated_tier(self) -> None:
-        spinner = loop_state.SpinnerState()
-        spinner.start()
-        spinner.started_at -= 45  # escalate to the ICE-contact tier
-        spinner.inline_spinner_ansi()
-        tier1 = spinner._VERB_TIERS[1][1]
-        for _ in range(10):
-            spinner.advance_verb()
-            assert spinner._verb in tier1
-
-    def test_start_resets_escalation_to_calm_tier(self) -> None:
-        spinner = loop_state.SpinnerState()
-        spinner.start()
-        spinner.started_at -= 120
-        spinner.inline_spinner_ansi()
-        assert spinner._verb_tier == 2
-
-        spinner.start()
-        assert spinner._verb_tier == 0
-        assert spinner._verb in spinner._VERB_TIERS[0][1]
+        spinner.set_phase(loop_state.SpinnerState.INVOKING_TOOLS_PHASE)
+        spinner.set_active_action("GitHub CLI · gh api repos/x")
+        rendered = _strip_ansi(spinner.inline_spinner_ansi())
+        assert "Invoking tools…" in rendered
+        assert "GitHub CLI · gh api repos/x" in rendered
 
     def test_inline_spinner_glyph_animates_with_elapsed_time(self) -> None:
         """The frame is a function of elapsed time, not of render-call count.

--- a/tests/interactive_shell/ui/hooks/test_output_expand.py
+++ b/tests/interactive_shell/ui/hooks/test_output_expand.py
@@ -1,9 +1,15 @@
-"""Ctrl+O pages the last collapsed tool result only while one is stashed."""
+"""Ctrl+O expands stashed peeks: ring cycle + inline-vs-pager."""
 
 from __future__ import annotations
 
+from surfaces.interactive_shell.session.terminal_session import (
+    COLLAPSED_OUTPUT_RING_SIZE,
+    COLLAPSED_STASH_MAX_CHARS,
+    INLINE_EXPAND_MAX_CHARS,
+    TerminalSession,
+)
 from surfaces.interactive_shell.ui.hooks import install_output_expand_key_bindings
-from surfaces.interactive_shell.ui.hooks.output_expand import page_collapsed_output
+from surfaces.interactive_shell.ui.hooks.output_expand import expand_collapsed_output
 
 
 def _binding_keys(kb) -> set[tuple[str, ...]]:
@@ -15,9 +21,9 @@ def test_expand_binding_is_ctrl_o() -> None:
     assert ("Keys.ControlO",) in _binding_keys(kb)
 
 
-def test_ctrl_o_pages_the_stashed_body() -> None:
-    paged: list[str] = []
-    kb = install_output_expand_key_bindings(lambda: True, lambda: "full output", paged.append)
+def test_ctrl_o_expands_the_stashed_body() -> None:
+    expanded: list[str] = []
+    kb = install_output_expand_key_bindings(lambda: True, lambda: "full output", expanded.append)
     handler = next(
         binding.handler
         for binding in kb.bindings
@@ -26,7 +32,7 @@ def test_ctrl_o_pages_the_stashed_body() -> None:
 
     handler(None)
 
-    assert paged == ["full output"]
+    assert expanded == ["full output"]
 
 
 def test_binding_is_gated_on_collapsed_output_being_present() -> None:
@@ -35,7 +41,7 @@ def test_binding_is_gated_on_collapsed_output_being_present() -> None:
     assert all(binding.filter() is False for binding in kb.bindings)
 
 
-def test_page_collapsed_output_prints_when_no_pager(monkeypatch) -> None:
+def test_expand_collapsed_output_prints_inline_when_modest(monkeypatch) -> None:
     written: list[str] = []
     monkeypatch.delenv("PAGER", raising=False)
     monkeypatch.setattr(
@@ -50,6 +56,87 @@ def test_page_collapsed_output_prints_when_no_pager(monkeypatch) -> None:
         "surfaces.interactive_shell.ui.hooks.output_expand.sys.stdout.flush", lambda: None
     )
 
-    page_collapsed_output("hello")
+    expand_collapsed_output("hello")
 
-    assert written == ["hello\n"]
+    assert written == ["\n  ↳ expanded\nhello\n"]
+
+
+def test_expand_collapsed_output_strips_csi_before_inline_write(monkeypatch) -> None:
+    written: list[str] = []
+    monkeypatch.delenv("PAGER", raising=False)
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.output_expand.shutil.which",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.output_expand.sys.stdout.write",
+        written.append,
+    )
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.output_expand.sys.stdout.flush", lambda: None
+    )
+
+    expand_collapsed_output("ok\x1b[2J\x1b[Hdone")
+
+    assert written == ["\n  ↳ expanded\nokdone\n"]
+    assert "\x1b[" not in written[0]
+
+
+def test_expand_collapsed_output_uses_pager_when_large(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setenv("PAGER", "less")
+
+    def _fake_run(cmd, input, check):
+        calls.append({"cmd": list(cmd), "input": input, "check": check})
+
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.hooks.output_expand.subprocess.run",
+        _fake_run,
+    )
+    huge = "x" * (INLINE_EXPAND_MAX_CHARS + 1)
+    expand_collapsed_output(huge)
+
+    assert len(calls) == 1
+    assert calls[0]["cmd"] == ["less"]  # routed to the pager
+    assert isinstance(calls[0]["input"], bytes) and calls[0]["input"]  # content piped in
+    assert calls[0]["check"] is False
+
+
+def test_stash_ring_keeps_last_n_and_ctrl_o_cycles_newest_first() -> None:
+    terminal = TerminalSession()
+    for i in range(COLLAPSED_OUTPUT_RING_SIZE + 2):
+        terminal.stash_collapsed_tool_output(f"peek-{i}")
+
+    assert len(terminal.collapsed_tool_outputs) == COLLAPSED_OUTPUT_RING_SIZE
+    assert terminal.collapsed_tool_output == "peek-6"
+
+    seen = [terminal.next_collapsed_output_for_expand() for _ in range(COLLAPSED_OUTPUT_RING_SIZE)]
+    assert seen[0] == "peek-6"
+    assert seen[1] == "peek-5"
+    assert seen[-1] == "peek-2"
+    # Wrap back to newest.
+    assert terminal.next_collapsed_output_for_expand() == "peek-6"
+
+
+def test_none_stash_does_not_wipe_earlier_peeks() -> None:
+    terminal = TerminalSession()
+    terminal.stash_collapsed_tool_output("keep-me")
+    terminal.stash_collapsed_tool_output(None)
+    assert terminal.has_collapsed_tool_output()
+    assert terminal.next_collapsed_output_for_expand() == "keep-me"
+
+
+def test_collapsed_tool_output_is_ring_newest_only() -> None:
+    terminal = TerminalSession()
+    terminal.collapsed_tool_output = "via-setter"
+    assert terminal.collapsed_tool_outputs == ["via-setter"]
+    terminal.collapsed_tool_output = None  # no-op
+    assert terminal.collapsed_tool_output == "via-setter"
+
+
+def test_stash_truncates_unbounded_bodies() -> None:
+    terminal = TerminalSession()
+    terminal.stash_collapsed_tool_output("x" * (COLLAPSED_STASH_MAX_CHARS + 500))
+    body = terminal.collapsed_tool_output or ""
+    assert len(body) <= COLLAPSED_STASH_MAX_CHARS
+    assert "truncated for Ctrl+O stash" in body

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -154,7 +154,7 @@ def test_skill_view_renders_activation_event() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill install-code-review\n  ↳ Skill activated\n\n"
+    assert buffer.getvalue() == "\nSkill install-code-review\n  ↳ Skill activated\n"
 
 
 def test_skill_view_renders_bold_green_skill_label() -> None:
@@ -352,7 +352,7 @@ def test_skill_view_failure_renders_failure_child() -> None:
         },
     )
 
-    assert buffer.getvalue() == "\nSkill no-such-skill\n  ↳ Skill failed to load\n\n"
+    assert buffer.getvalue() == "\nSkill no-such-skill\n  ↳ Skill failed to load\n"
 
 
 def test_skill_view_tool_end_without_start_prints_nothing() -> None:
@@ -448,8 +448,8 @@ def test_generic_tool_end_nests_the_result_under_the_call() -> None:
 
     out = buffer.getvalue()
     assert "GitHub CLI" in out
-    assert "↳" in out
-    assert "GitHub API call succeeded" in out
+    assert "\n  ↳ GitHub API call succeeded" in out  # tight child, 2-space gutter
+    assert "\n\n  ↳" not in out  # no blank inside the block
     assert observer.session.terminal.inline_tool_results is True
 
 
@@ -473,6 +473,32 @@ def test_generic_tool_end_hides_a_json_blob() -> None:
 
     assert buffer.getvalue() == after_start
     assert observer.session.terminal.inline_tool_results is False
+
+
+def test_one_blank_line_between_a_skill_block_and_the_next_call() -> None:
+    """Droid / Claude / Cursor: one gap BETWEEN blocks, never two stacked blanks."""
+    observer, buffer = _observer_with_buffer()
+
+    observer(
+        "tool_start",
+        {"id": "s1", "name": "skill_view", "input": {"name": "install_code_review"}},
+    )
+    observer(
+        "tool_end",
+        {
+            "id": "s1",
+            "name": "skill_view",
+            "output": {"ok": True, "name": "install-code-review"},
+        },
+    )
+    observer(
+        "tool_start",
+        {"id": "t1", "name": "github_cli", "input": {"args": ["api", "user"]}},
+    )
+
+    out = buffer.getvalue()
+    assert "\nSkill install-code-review\n  ↳ Skill activated\n\n⏺" in out
+    assert "\n\n\n" not in out
 
 
 def test_literal_slash_command_records_single_history_entry(

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import re
 from unittest.mock import Mock
 
 import pytest
@@ -371,27 +372,21 @@ def test_skill_view_tool_end_without_start_prints_nothing() -> None:
     assert buffer.getvalue() == ""
 
 
-def test_llm_start_advances_spinner_verb_every_two_steps() -> None:
-    """The spinner verb re-rolls once per two agent steps, not every step."""
+def test_llm_start_sets_thinking_phase_without_verb_rotation() -> None:
+    """``llm_start`` labels the status row Thinking…; phase labels are the UX."""
     from surfaces.interactive_shell.runtime.core.state import SpinnerState
     from surfaces.shared.terminal.output.console_state import set_investigation_spinner
 
     observer, _buffer = _observer_with_buffer()
     spinner = SpinnerState()
     spinner.start()
-    initial = spinner._verb
     set_investigation_spinner(spinner)
     try:
         observer("llm_start", {"iteration": 0})
-        observer("llm_start", {"iteration": 1})
-        assert spinner._verb == initial, "steps 0-1 must keep the verb picked at start()"
+        assert spinner.phase == SpinnerState.THINKING_PHASE
         observer("llm_start", {"iteration": 2})
-        second = spinner._verb
-        assert second != initial, "step 2 must rotate the verb"
-        observer("llm_start", {"iteration": 3})
-        assert spinner._verb == second, "step 3 must keep step 2's verb"
-        observer("llm_start", {"iteration": 4})
-        assert spinner._verb != second, "step 4 must rotate again"
+        assert spinner.phase == SpinnerState.THINKING_PHASE
+        assert "Thinking…" in re.sub(r"\x1b\[[0-9;]*m", "", spinner.inline_spinner_ansi())
     finally:
         set_investigation_spinner(None)
 

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -178,23 +178,24 @@ class TestPromptTurnCounter:
 
 
 class TestResolveIdleHint:
-    def test_idle_hint_is_a_spacer_because_help_lives_below_the_composer(self) -> None:
+    def test_idle_hint_shows_ready_and_commands(self) -> None:
         session = Session()
         session.configured_integrations_known = True
         session.configured_integrations = ("datadog", "github", "grafana")
         rendered = _strip_ansi(resolve_idle_hint_ansi(session))
-        assert rendered == ""
+        assert "Ready" in rendered
+        assert "/ for commands" in rendered
 
 
 class TestComposerFooter:
-    def test_places_help_and_terminal_mode_at_opposite_edges(
+    def test_places_help_hint_without_terminal_mode_chrome(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 79)
         footer = _strip_ansi(composer_footer_ansi())
         assert footer.startswith("Enter send · Shift+Enter newline · ? help")
-        assert footer.endswith("TERMINAL ■")
-        assert len(footer) == 79
+        assert "TERMINAL" not in footer
+        assert "■" not in footer
 
     def test_narrow_footer_keeps_only_a_clipped_help_hint(
         self, monkeypatch: pytest.MonkeyPatch
@@ -466,7 +467,9 @@ class TestResolvePromptPrefix:
             inline_spinner=spinner.inline_spinner_ansi(),
             idle_hint=resolve_idle_hint_ansi(Session()),
         )
-        assert _strip_ansi(prefix) == ""
+        rendered = _strip_ansi(prefix)
+        assert "Ready" in rendered
+        assert "/ for commands" in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/interactive_shell/ui/test_prompt_stdout.py
+++ b/tests/interactive_shell/ui/test_prompt_stdout.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import re
 
 import pytest
 from prompt_toolkit.application import create_app_session
@@ -22,11 +23,26 @@ from surfaces.interactive_shell.ui.input_prompt.key_bindings import (
 from surfaces.interactive_shell.ui.input_prompt.stdout import patch_prompt_stdout
 from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
 
+# prompt_toolkit skips rewriting a space when the previous cell was already a
+# space (``ESC[C`` / ``ESC[nC``). After Ready fills the status row, the Ctrl+C
+# hint lands on those columns as cursor-forward — correct on a real TTY, but
+# absent as literal `` `` in the VT100 capture.
+_CURSOR_FORWARD_RE = re.compile(r"\x1b\[(\d*)C")
+
+
+def _visible_prompt_text(raw: str) -> str:
+    """Expand cursor-forward skips so markers match what the user sees."""
+
+    def _expand(match: re.Match[str]) -> str:
+        return " " * int(match.group(1) or "1")
+
+    return _CURSOR_FORWARD_RE.sub(_expand, raw)
+
 
 async def _wait_for_output(buffer: io.StringIO, marker: str, *, count: int = 1) -> str:
     for _ in range(200):
         rendered = buffer.getvalue()
-        if rendered.count(marker) >= count:
+        if _visible_prompt_text(rendered).count(marker) >= count:
             return rendered
         await asyncio.sleep(0.01)
     pytest.fail(f"prompt output never rendered {marker!r} {count} time(s)")

--- a/tests/interactive_shell/ui/test_prompt_stdout.py
+++ b/tests/interactive_shell/ui/test_prompt_stdout.py
@@ -56,14 +56,14 @@ async def test_background_output_is_inserted_above_the_redrawn_composer(
                     refresh_interval=0,
                 )
             )
-            await _wait_for_output(terminal, "TERMINAL ")
+            await _wait_for_output(terminal, "Auto (")
 
             print("assistant response")
-            rendered = await _wait_for_output(terminal, "TERMINAL ", count=2)
+            rendered = await _wait_for_output(terminal, "Auto (", count=2)
 
-            assert rendered.rfind("assistant response") < rendered.rfind("TERMINAL ")
+            assert rendered.rfind("assistant response") < rendered.rfind("Auto (")
             assert rendered.rfind("\x1b[?2026h") < rendered.rfind("assistant response")
-            assert rendered.rfind("\x1b[?2026l") > rendered.rfind("TERMINAL ")
+            assert rendered.rfind("\x1b[?2026l") > rendered.rfind("Auto (")
             pipe_input.send_bytes(b"\x04")
             with pytest.raises(EOFError):
                 await asyncio.wait_for(prompt_task, timeout=2)
@@ -106,7 +106,7 @@ async def test_ctrl_c_updates_the_live_prompt_before_second_press_exits(
                     refresh_interval=0,
                 )
             )
-            await _wait_for_output(terminal, "TERMINAL ")
+            await _wait_for_output(terminal, "Auto (")
 
             pipe_input.send_bytes(b"\x03")
             await _wait_for_output(terminal, "(Press Ctrl+C again to exit)")

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -111,29 +111,29 @@ def test_confirmation_region_height_is_stable_across_selection_changes() -> None
     assert yes_rows == no_rows
 
 
-def test_streaming_prompt_height_stable_when_action_row_fills_and_clears() -> None:
-    """Tool start/end must not resize the composer region mid-turn.
+def test_streaming_prompt_height_matches_idle_and_ignores_action_shimmer() -> None:
+    """Prompt stack is Plan → status → Auto (Droid); no reserved action gap.
 
-    The shimmer action row is reserved for the whole streaming turn so filling
-    or clearing it cannot push the bordered input box up and down.
+    Tools paint ``⏺`` into scrollback. Keeping a blank/shimmer row in the prompt
+    region made Thinking→Auto look sparse and used to resize the composer when
+    the row filled. Height must match idle, with or without an in-flight action.
     """
     session = Session()
+    idle = SpinnerState()
+    idle_rows = render_prompt_region(session, ReplState(), idle).value.count("\n")
+
     spinner = SpinnerState()
     spinner.start()
     spinner.set_phase(SpinnerState.THINKING_PHASE)
-
-    empty_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
+    thinking_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
+    assert thinking_rows == idle_rows
 
     spinner.set_active_action("GitHub CLI · gh api repos/x", action_id="t1")
-    filled_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
-    assert filled_rows == empty_rows
-
-    spinner.clear_active_action("t1")
-    cleared_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
-    assert cleared_rows == empty_rows
-
-    rendered = _plain(render_prompt_region(session, ReplState(), spinner).value)
-    assert "Thinking" in rendered or "…" in rendered
+    filled = render_prompt_region(session, ReplState(), spinner).value
+    assert filled.count("\n") == idle_rows
+    plain = _plain(filled)
+    assert "GitHub CLI" not in plain  # action stays out of the prompt region
+    assert "Thinking" in plain or "…" in plain
 
 
 def test_confirmation_region_shows_stacked_yes_no_choice() -> None:

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -111,12 +111,12 @@ def test_confirmation_region_height_is_stable_across_selection_changes() -> None
     assert yes_rows == no_rows
 
 
-def test_streaming_prompt_height_matches_idle_and_ignores_action_shimmer() -> None:
+def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> None:
     """Prompt stack is Plan → status → Auto (Droid); no reserved action gap.
 
-    Tools paint ``⏺`` into scrollback. Keeping a blank/shimmer row in the prompt
-    region made Thinking→Auto look sparse and used to resize the composer when
-    the row filled. Height must match idle, with or without an in-flight action.
+    Live tool awareness folds into the spinner row
+    (``Invoking tools… · GitHub CLI · …``). Height must match idle whether or
+    not a tool is in flight — never a second reserved prompt row.
     """
     session = Session()
     idle = SpinnerState()
@@ -128,12 +128,21 @@ def test_streaming_prompt_height_matches_idle_and_ignores_action_shimmer() -> No
     thinking_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
     assert thinking_rows == idle_rows
 
+    spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
     spinner.set_active_action("GitHub CLI · gh api repos/x", action_id="t1")
     filled = render_prompt_region(session, ReplState(), spinner).value
     assert filled.count("\n") == idle_rows
     plain = _plain(filled)
-    assert "GitHub CLI" not in plain  # action stays out of the prompt region
-    assert "Thinking" in plain or "…" in plain
+    assert "GitHub CLI" in plain
+    assert "Invoking tools" in plain
+    assert plain.count("\n") == idle_rows or filled.count("\n") == idle_rows
+
+
+def test_idle_status_row_shows_ready_hint() -> None:
+    session = Session()
+    rendered = _plain(render_prompt_region(session, ReplState(), SpinnerState()).value)
+    assert "Ready" in rendered
+    assert "/ for commands" in rendered
 
 
 def test_confirmation_region_shows_stacked_yes_no_choice() -> None:

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -97,15 +97,17 @@ def test_prompt_region_keeps_the_checklist_above_invoking_tools() -> None:
     assert rendered.index(SpinnerState.INVOKING_TOOLS_PHASE) < rendered.index("Auto (High)")
 
 
-def test_idle_prompt_region_keeps_status_spacer_not_thinking() -> None:
+def test_idle_prompt_region_keeps_ready_hint_not_thinking() -> None:
     session = Session()
     session.task_plan = _sample_plan()
     rendered = _strip_ansi(render_prompt_region(session, ReplState(), SpinnerState()).value)
-    assert "Ready" not in rendered
+    assert "Ready" in rendered
+    assert "/ for commands" in rendered
     assert "Thinking" not in rendered
     assert SpinnerState.EXECUTING_PHASE not in rendered
     assert "Plan · 2/3" in rendered
-    assert rendered.index("Plan · 2/3") < rendered.index("Auto (High)")
+    assert rendered.index("Plan · 2/3") < rendered.index("Ready")
+    assert rendered.index("Ready") < rendered.index("Auto (High)")
 
 
 def test_clearing_the_plan_resets_expanded_state() -> None:

--- a/tests/tools/test_github_repository_tool.py
+++ b/tests/tools/test_github_repository_tool.py
@@ -71,6 +71,7 @@ def test_run_happy_path() -> None:
     assert result["stargazers_count"] == 42
     assert result["repository"]["forks_count"] == 7
     assert result["repository"]["license"] == "MIT"
+    assert result["summary"] == "Tracer-Cloud/opensre · 42★ · main · public · Python"
 
 
 def test_run_api_error() -> None:

--- a/tests/tools/test_grafana_logs_tool.py
+++ b/tests/tools/test_grafana_logs_tool.py
@@ -105,6 +105,7 @@ def test_run_with_backend_returns_logs() -> None:
     assert result["available"] is True
     assert result["total_logs"] == 2
     assert len(result["error_logs"]) == 1
+    assert result["summary"] == "2 log(s) for svc, 1 look like errors"
 
 
 def test_run_returns_unavailable_when_no_client() -> None:
@@ -155,6 +156,7 @@ def test_run_happy_path() -> None:
     assert result["available"] is True
     assert result["total_logs"] == 2
     assert len(result["error_logs"]) == 1
+    assert result["summary"] == "2 log(s) for svc, 1 look like errors"
 
 
 def test_run_fallback_to_pipeline_name() -> None:

--- a/tests/tools/test_grafana_metrics_tool.py
+++ b/tests/tools/test_grafana_metrics_tool.py
@@ -116,3 +116,13 @@ def test_run_happy_path() -> None:
         )
     assert result["available"] is True
     assert result["total_series"] == 1
+    assert result["summary"] == "1 series for `pipeline_runs_total`"
+
+
+def test_run_with_backend_includes_prose_summary() -> None:
+    mock_backend = MagicMock()
+    mock_backend.query_timeseries.return_value = {
+        "data": {"result": [{"metric": {}, "values": [[1000, "42"]]}]}
+    }
+    result = query_grafana_metrics(metric_name="pipeline_runs_total", grafana_backend=mock_backend)
+    assert result["summary"] == "1 series for `pipeline_runs_total`"


### PR DESCRIPTION
Two interactive-shell readability improvements.

- Tighter prompt stack. The prompt region no longer reserves a shimmer row for   the running action. Tools already paint a ⏺ line into scrollback, so the   reserved row only left a sparse gap (Plan → Thinking → Auto with  none) and made the bordered input box jump up and down as the row filled and  cleared mid-turn. The stack now stays put for the whole turn, and the spinner  phase carries "Invoking tools…" on its own.

- Consistent tool-output hiding. The inline ⏺ result preview decided "is this a  JSON/record blob to hide?" with its own private copy of the check, a third  one beside the two the shared detector already replaced. It now uses the same
  is_data_blob, so a payload is hidden or shown the same way everywhere in the  shell — no more a blob hidden in one spot and shown in another.

- Live status is one row: `Thinking…` / `Invoking tools… · {tool}` with a light-wave shimmer; no reserved blank action row or composer height jump.
- Idle shows a clipped `Ready · / for commands…` hint; footer drops competing `TERMINAL ■` chrome; confirm block density matches the streaming stack.
- Ctrl+O cycles a bounded peek ring (inline expand vs pager), strips CSI before painting, and single-flights expands; GitHub repo + Grafana metrics/logs get short prose `summary` fields.
- Retires unused cyberpunk verbs / dead shimmer paint; shares the aggressive `is_data_blob` policy for transcript hide.

