### PR TITLE
fix(shell): refresh history across concurrent sessions

### DIFF
--- a/docs/interactive-shell-privacy.mdx
+++ b/docs/interactive-shell-privacy.mdx
@@ -6,9 +6,11 @@ description: "How OpenSRE redacts secrets from command history and LLM prompt/re
 ## Overview
 
 The interactive shell saves every line you type to a history file so up-arrow
-recall and `/history` work across sessions. Separately, it records each LLM
-prompt/response turn for local debugging and `/resume`. Incident prompts can
-include sensitive identifiers and tokens, so the shell:
+recall and `/history` work across sessions. Each new prompt reloads the file
+when another running shell has changed it, so concurrent sessions share recent
+commands without a restart. Separately, it records each LLM prompt/response turn
+for local debugging and `/resume`. Incident prompts can include sensitive
+identifiers and tokens, so the shell:
 
 - Redacts known token shapes before each entry is written to disk
 - Supports disabling persistence entirely (memory-only mode)

--- a/surfaces/interactive_shell/prompt_history/__init__.py
+++ b/surfaces/interactive_shell/prompt_history/__init__.py
@@ -8,6 +8,7 @@ from surfaces.interactive_shell.prompt_history.policy import (
     HistoryPolicy,
     RedactingFileHistory,
     RedactionRule,
+    RefreshingFileHistory,
     redact_text,
 )
 from surfaces.interactive_shell.prompt_history.storage import (
@@ -21,6 +22,7 @@ __all__ = [
     "DEFAULT_MAX_ENTRIES",
     "DEFAULT_REDACTION_RULES",
     "HistoryPolicy",
+    "RefreshingFileHistory",
     "RedactingFileHistory",
     "RedactionRule",
     "clear_persisted_history",

--- a/surfaces/interactive_shell/prompt_history/policy.py
+++ b/surfaces/interactive_shell/prompt_history/policy.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Iterator
+from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
 from typing import Any, ClassVar
 
+from filelock import BaseFileLock, FileLock
 from prompt_toolkit.history import FileHistory
 from pydantic import ConfigDict
 
@@ -126,7 +127,60 @@ def _parse_int(env_val: str | None, file_val: Any, default: int) -> int:
     return default
 
 
-class RedactingFileHistory(FileHistory):
+def history_file_lock(
+    filename: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+) -> BaseFileLock:
+    """Return the cross-process lock for a prompt-history file."""
+    return FileLock(f"{os.fsdecode(filename)}.lock")
+
+
+class RefreshingFileHistory(FileHistory):
+    """File history that reloads when another shell changes the backing file."""
+
+    def __init__(self, filename: str) -> None:
+        super().__init__(filename)
+        self._loaded_signature: tuple[int, int, int] | None = None
+
+    def _file_signature(self) -> tuple[int, int, int] | None:
+        try:
+            stat = os.stat(self.filename)
+        except OSError:
+            return None
+        return stat.st_ino, stat.st_size, stat.st_mtime_ns
+
+    def _load_history_strings_unlocked(self) -> list[str]:
+        return list(super().load_history_strings())
+
+    def _store_string_unlocked(self, string: str) -> None:
+        super().store_string(string)
+        self._loaded_signature = self._file_signature()
+
+    async def load(self) -> AsyncGenerator[str]:
+        """Yield current entries, reloading after a peer modifies the file."""
+        with history_file_lock(self.filename):
+            signature = self._file_signature()
+            if not self._loaded or signature != self._loaded_signature:
+                self._loaded_strings = self._load_history_strings_unlocked()
+                self._loaded = True
+                self._loaded_signature = self._file_signature()
+            entries = tuple(self._loaded_strings)
+
+        for item in entries:
+            yield item
+
+    def load_history_strings(self) -> Iterator[str]:
+        """Yield a consistent snapshot of entries while writers are excluded."""
+        with history_file_lock(self.filename):
+            entries = self._load_history_strings_unlocked()
+        yield from entries
+
+    def store_string(self, string: str) -> None:
+        """Append one entry while excluding concurrent readers and writers."""
+        with history_file_lock(self.filename):
+            self._store_string_unlocked(string)
+
+
+class RedactingFileHistory(RefreshingFileHistory):
     """``FileHistory`` that redacts known token shapes before persisting.
 
     Also enforces a max-entry retention cap by rewriting the file when
@@ -165,17 +219,22 @@ class RedactingFileHistory(FileHistory):
         if self.paused:
             return
         cleaned = redact_text(string, self._rules) if self._rules else string
-        super().store_string(cleaned)
-        if self._max_entries <= 0:
-            return
-        if self._entry_count is None:
-            self._entry_count = self._count_entries()
-        else:
-            self._entry_count += 1
-        if self._entry_count > self._max_entries:
-            self._prune_to_cap()
+        with history_file_lock(self.filename):
+            self._store_string_unlocked(cleaned)
+            if self._max_entries <= 0:
+                return
+            if self._entry_count is None:
+                self._entry_count = self._count_entries_unlocked()
+            else:
+                self._entry_count += 1
+            if self._entry_count > self._max_entries:
+                self._prune_to_cap_unlocked()
 
     def _prune_to_cap(self) -> None:
+        with history_file_lock(self.filename):
+            self._prune_to_cap_unlocked()
+
+    def _prune_to_cap_unlocked(self) -> None:
         if self._max_entries <= 0:
             return
         path = Path(os.fsdecode(self.filename))
@@ -197,10 +256,11 @@ class RedactingFileHistory(FileHistory):
         try:
             path.write_text("".join(lines[keep_from:]), encoding="utf-8")
             self._entry_count = self._max_entries
+            self._loaded_signature = self._file_signature()
         except OSError:
             return
 
-    def _count_entries(self) -> int:
+    def _count_entries_unlocked(self) -> int:
         path = Path(os.fsdecode(self.filename))
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
@@ -213,7 +273,9 @@ __all__ = [
     "DEFAULT_MAX_ENTRIES",
     "DEFAULT_REDACTION_RULES",
     "HistoryPolicy",
+    "RefreshingFileHistory",
     "RedactingFileHistory",
     "RedactionRule",
+    "history_file_lock",
     "redact_text",
 ]

--- a/surfaces/interactive_shell/prompt_history/storage.py
+++ b/surfaces/interactive_shell/prompt_history/storage.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from prompt_toolkit.history import FileHistory, History, InMemoryHistory
+from prompt_toolkit.history import History, InMemoryHistory
 
 from surfaces.interactive_shell.prompt_history.policy import (
     HistoryPolicy,
     RedactingFileHistory,
+    RefreshingFileHistory,
+    history_file_lock,
 )
 
 _HISTORY_FILENAME = "interactive_history"
@@ -37,7 +39,7 @@ def load_prompt_history(policy: HistoryPolicy | None = None) -> History:
         path.parent.mkdir(parents=True, exist_ok=True)
         if settings.redact:
             return RedactingFileHistory(str(path), max_entries=settings.max_entries)
-        return FileHistory(str(path))
+        return RefreshingFileHistory(str(path))
     except OSError:
         return InMemoryHistory()
 
@@ -47,7 +49,7 @@ def load_command_history_entries() -> list[str]:
     try:
         path = prompt_history_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        history = FileHistory(str(path))
+        history = RefreshingFileHistory(str(path))
         raw = list(reversed(list(history.load_history_strings())))
         return [line.rstrip("\r\n") for line in raw]
     except OSError:
@@ -58,8 +60,9 @@ def clear_persisted_history() -> bool:
     """Truncate the on-disk history file. Returns True if the file is gone or empty."""
     path = prompt_history_path()
     try:
-        if path.exists():
-            path.write_text("", encoding="utf-8")
+        with history_file_lock(path):
+            if path.exists():
+                path.write_text("", encoding="utf-8")
         return True
     except OSError:
         return False

--- a/tests/interactive_shell/history/test_history_policy.py
+++ b/tests/interactive_shell/history/test_history_policy.py
@@ -11,6 +11,7 @@ from surfaces.interactive_shell.prompt_history.policy import (
     DEFAULT_REDACTION_RULES,
     HistoryPolicy,
     RedactingFileHistory,
+    RefreshingFileHistory,
     redact_text,
 )
 
@@ -114,6 +115,26 @@ def test_redacting_file_history_writes_redacted_only(tmp_path: Path) -> None:
     contents = history_file.read_text(encoding="utf-8")
     assert "AKIAIOSFODNN7EXAMPLE" not in contents
     assert "[REDACTED:aws_key]" in contents
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("history_type", [RefreshingFileHistory, RedactingFileHistory])
+async def test_file_history_reloads_entries_written_by_peer(
+    tmp_path: Path,
+    history_type: type[RefreshingFileHistory],
+) -> None:
+    history_file = tmp_path / "history"
+    writer = history_type(str(history_file))
+    reader = history_type(str(history_file))
+
+    writer.store_string("first session command")
+    assert [entry async for entry in reader.load()] == ["first session command"]
+
+    writer.store_string("second session command")
+    assert [entry async for entry in reader.load()] == [
+        "second session command",
+        "first session command",
+    ]
 
 
 def test_paused_backend_does_not_persist(tmp_path: Path) -> None:


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

- Refresh prompt history before each new prompt when another OpenSRE process changes the shared history file.
- Use a cross-process file lock for reads, appends, retention pruning, and clearing.
- Apply live refresh in both redacted and raw-history modes, with regression coverage and updated privacy documentation.

### Demo/Screenshot for feature changes and bug fixes -

Regression proof:

```text
Before: reader.load() returned only [\"first session command\"] after a peer wrote a second command.
After:  test_file_history_reloads_entries_written_by_peer passes for RefreshingFileHistory and RedactingFileHistory.
Full interactive-shell suite: 1661 passed, 1 skipped.
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`prompt_toolkit.History.load()` caches file contents after its first read, so running shells never observe later appends from peer processes. `RefreshingFileHistory` tracks the backing file's inode, size, and nanosecond modification time and reloads only when that signature changes. A shared sidecar file lock keeps reloads consistent with appends, retention rewrites, and history clearing. The redacting backend subclasses this implementation so both privacy modes have identical refresh behavior.

A timer was avoided because prompt-toolkit already calls `load()` whenever it resets the input buffer for a new prompt. Checking the file signature there provides timely refresh without a background task or repeated full-file reads.

---

## Checklist before requesting a review
- [x] I have added proper PR title
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

### Test plan

- `make lint`
- `make format-check`
- `make typecheck`
- `env -u NO_COLOR -u FORCE_COLOR TERM=xterm-256color COLORTERM=truecolor uv run python -m pytest tests/interactive_shell/`

Made with [Cursor](https://cursor.com)