### PR TITLE
feat(cli): make one-shot  answers render and denials actionable

### DIFF
--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -198,6 +198,21 @@ def _successful_turn(result: TurnResult) -> bool:
     )
 
 
+def _approval_denied_message(denied_tools: tuple[str, ...]) -> str:
+    """Name the denied tools and the exact flags that authorize them.
+
+    A one-shot ``ask`` has no prompt to approve at, so a bare "denied" is a
+    dead end; point the user straight at the flags that unblock the run.
+    """
+    tools = ", ".join(denied_tools)
+    allow = " ".join(f"--allowed-tool {tool}" for tool in denied_tools)
+    return (
+        f"Approval denied for: {tools}\n"
+        f"Re-run with {allow} to authorize these, "
+        "or --dangerously-bypass-approvals to allow all."
+    )
+
+
 def _approval_denied_outcome(
     tracker: ApprovalTracker,
     *,
@@ -208,7 +223,7 @@ def _approval_denied_outcome(
         return None
     return AskOutcome(
         status=AskStatus.APPROVAL_DENIED,
-        response=response or "Approval denied for: " + ", ".join(denied_tools),
+        response=response or _approval_denied_message(denied_tools),
         denied_tools=denied_tools,
         exit_code=AskExitCode.APPROVAL_DENIED,
     )

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -27,12 +27,34 @@ def _resolve_prompt(value: str) -> str:
     return prompt
 
 
+def _echo_answer(text: str) -> None:
+    """Print the answer as Markdown on a TTY, plain when piped or redirected.
+
+    A terminal reader gets the same rendered prose as the interactive shell
+    (bold, lists, fenced code); a script consuming ``opensre ask`` still gets
+    clean, ANSI-free text it can parse.
+    """
+    if not sys.stdout.isatty():
+        click.echo(text)
+        return
+    from rich.console import Console
+    from rich.markdown import Markdown
+
+    from infrastructure.safety.terminal_output import strip_terminal_controls
+    from infrastructure.terminal.theme import MARKDOWN_CODE_THEME, MARKDOWN_THEME
+
+    console = Console()
+    safe = strip_terminal_controls(text, keep_whitespace=True)
+    with console.use_theme(MARKDOWN_THEME):
+        console.print(Markdown(safe, code_theme=MARKDOWN_CODE_THEME))
+
+
 def _render_outcome(outcome: AskOutcome) -> None:
     if is_json_output():
         click.echo(json.dumps(outcome.as_dict(), ensure_ascii=False))
         return
     if outcome.status is AskStatus.SUCCESS:
-        click.echo(outcome.response)
+        _echo_answer(outcome.response)
         return
     if outcome.response:
         click.echo(outcome.response, err=True)

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -13,11 +13,35 @@ from surfaces.cli.ask.service import (
     AskSignal,
     AskStatus,
 )
-from surfaces.cli.commands.ask import ask_command
+from surfaces.cli.commands.ask import _echo_answer, ask_command
 
 
 def _success(response: str = "done") -> AskOutcome:
     return AskOutcome(status=AskStatus.SUCCESS, response=response)
+
+
+def test_ask_answer_stays_plain_when_piped(monkeypatch, capsys) -> None:
+    # Arrange: stdout is not a terminal (piped into a script / another command).
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+
+    # Act
+    _echo_answer("Branch is **main**.")
+
+    # Assert: raw Markdown is preserved so a consuming script can parse it.
+    assert "**main**" in capsys.readouterr().out
+
+
+def test_ask_answer_renders_markdown_on_a_tty(monkeypatch, capsys) -> None:
+    # Arrange: stdout is an interactive terminal.
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    # Act
+    _echo_answer("Branch is **main**.")
+
+    # Assert: the emphasis is rendered, not echoed as literal ``**`` syntax.
+    out = capsys.readouterr().out
+    assert "**main**" not in out
+    assert "main" in out
 
 
 def test_ask_passes_prompt_and_invocation_authority(monkeypatch) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -174,6 +174,9 @@ def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:
     assert outcome.denied_tools == ("shell_run",)
     assert outcome.exit_code is AskExitCode.APPROVAL_DENIED
     assert "downstream detail" not in outcome.response
+    # The denial is actionable: it names the exact flags that unblock the run.
+    assert "--allowed-tool shell_run" in outcome.response
+    assert "--dangerously-bypass-approvals" in outcome.response
 
 
 def test_run_ask_maps_incomplete_and_cancelled_turns(monkeypatch) -> None:


### PR DESCRIPTION
The `opensre ask` one-shot printed answers as raw Markdown and dead-ended on a bare "Approval denied for: <tool>". Now, on a TTY, the answer renders as Markdown through the shared theme (bold/lists/code) like the interactive shell,
while piped/--json output stays plain for scripts; and a denial names the exact flags that authorize the blocked tools