### PR TITLE
feat(azure_sql): add evidence mappers for all five diagnostic tools

### DIFF
--- a/integrations/azure_sql/tools/azure_sql_current_queries_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_current_queries_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,31 @@ from integrations.azure_sql import (
     get_current_queries,
     resolve_azure_sql_config,
 )
+
+
+def _map_get_azure_sql_current_queries(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the count of long-running queries and their longest duration."""
+    if not output.get("available"):
+        return
+    queries = output.get("queries") or []
+    if not isinstance(queries, list) or not queries:
+        return
+    parts = [f"{len(queries)} running query/queries"]
+    durations = [
+        q.get("duration_seconds")
+        for q in queries
+        if isinstance(q.get("duration_seconds"), (int, float))
+    ]
+    if durations:
+        parts.append(f"max duration {max(durations)}s")
+    record_evidence_entry(
+        evidence,
+        source="get_azure_sql_current_queries",
+        label="Azure SQL Current Queries",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -29,6 +55,7 @@ from integrations.azure_sql import (
     is_available=azure_sql_is_available,
     injected_params=("server",),
     extract_params=azure_sql_extract_params,
+    evidence_mapper=_map_get_azure_sql_current_queries,
 )
 def get_azure_sql_current_queries(
     server: str,

--- a/integrations/azure_sql/tools/azure_sql_resource_stats_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_resource_stats_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from integrations.azure_sql import (
@@ -10,6 +11,27 @@ from integrations.azure_sql import (
     get_resource_stats,
     resolve_azure_sql_config,
 )
+
+
+def _map_get_azure_sql_resource_stats(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the throttling risk and sample count over the rolling window."""
+    if not output.get("available"):
+        return
+    total = output.get("total_samples")
+    if not isinstance(total, int) or total <= 0:
+        return
+    risk = output.get("throttling_risk") or "none"
+    parts = [f"{total} sample(s)"]
+    if risk != "none":
+        parts.append(f"throttling risk {risk}")
+    record_evidence_entry(
+        evidence,
+        source="get_azure_sql_resource_stats",
+        label="Azure SQL Resource Stats",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -25,6 +47,7 @@ from integrations.azure_sql import (
     is_available=azure_sql_is_available,
     injected_params=("server",),
     extract_params=azure_sql_extract_params,
+    evidence_mapper=_map_get_azure_sql_resource_stats,
 )
 def get_azure_sql_resource_stats(
     server: str,

--- a/integrations/azure_sql/tools/azure_sql_server_status_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_server_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from integrations.azure_sql import (
@@ -10,6 +11,38 @@ from integrations.azure_sql import (
     get_server_status,
     resolve_azure_sql_config,
 )
+
+
+def _map_get_azure_sql_server_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite connection counts, service tier, and resource saturation."""
+    if not output.get("available"):
+        return
+    tier = output.get("service_tier") or {}
+    connections = output.get("connections") or {}
+    resources = output.get("resource_utilization") or {}
+    parts = []
+    total_conns = connections.get("total")
+    if isinstance(total_conns, int):
+        parts.append(f"{total_conns} connection(s)")
+    if isinstance(connections.get("active"), int):
+        parts.append(f"{connections.get('active')} active")
+    if isinstance(resources.get("avg_cpu_percent"), (int, float)):
+        parts.append(f"CPU {resources.get('avg_cpu_percent')}%")
+    if isinstance(resources.get("avg_memory_usage_percent"), (int, float)):
+        parts.append(f"memory {resources.get('avg_memory_usage_percent')}%")
+    tier_label = tier.get("service_objective") or tier.get("edition")
+    if tier_label:
+        parts.append(f"tier {tier_label}")
+    if not parts:
+        return
+    record_evidence_entry(
+        evidence,
+        source="get_azure_sql_server_status",
+        label="Azure SQL Server Status",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -25,6 +58,7 @@ from integrations.azure_sql import (
     is_available=azure_sql_is_available,
     injected_params=("server",),
     extract_params=azure_sql_extract_params,
+    evidence_mapper=_map_get_azure_sql_server_status,
 )
 def get_azure_sql_server_status(
     server: str,

--- a/integrations/azure_sql/tools/azure_sql_slow_queries_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_slow_queries_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,29 @@ from integrations.azure_sql import (
     get_slow_queries,
     resolve_azure_sql_config,
 )
+
+
+def _map_get_azure_sql_slow_queries(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the slow-query count and the slowest average elapsed time."""
+    if not output.get("available"):
+        return
+    queries = output.get("queries") or []
+    if not isinstance(queries, list) or not queries:
+        return
+    parts = [f"{len(queries)} slow query/queries"]
+    averages = [
+        q.get("avg_time_ms") for q in queries if isinstance(q.get("avg_time_ms"), (int, float))
+    ]
+    if averages:
+        parts.append(f"slowest avg {max(averages):.0f}ms")
+    record_evidence_entry(
+        evidence,
+        source="get_azure_sql_slow_queries",
+        label="Azure SQL Slow Queries",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -29,6 +53,7 @@ from integrations.azure_sql import (
     is_available=azure_sql_is_available,
     injected_params=("server",),
     extract_params=azure_sql_extract_params,
+    evidence_mapper=_map_get_azure_sql_slow_queries,
 )
 def get_azure_sql_slow_queries(
     server: str,

--- a/integrations/azure_sql/tools/azure_sql_wait_stats_tool/__init__.py
+++ b/integrations/azure_sql/tools/azure_sql_wait_stats_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from integrations.azure_sql import (
@@ -10,6 +11,34 @@ from integrations.azure_sql import (
     get_wait_stats,
     resolve_azure_sql_config,
 )
+
+
+def _map_get_azure_sql_wait_stats(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the wait-type count and the top wait by total wait time."""
+    if not output.get("available"):
+        return
+    waits = output.get("waits") or []
+    if not isinstance(waits, list) or not waits:
+        return
+    parts = [f"{len(waits)} wait type(s)"]
+    top = max(
+        waits,
+        key=lambda w: (
+            w.get("wait_time_ms") if isinstance(w.get("wait_time_ms"), (int, float)) else -1
+        ),
+    )
+    top_type = top.get("wait_type")
+    top_ms = top.get("wait_time_ms")
+    if top_type and isinstance(top_ms, (int, float)):
+        parts.append(f"top {top_type} {top_ms:.0f}ms")
+    record_evidence_entry(
+        evidence,
+        source="get_azure_sql_wait_stats",
+        label="Azure SQL Wait Stats",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -25,6 +54,7 @@ from integrations.azure_sql import (
     is_available=azure_sql_is_available,
     injected_params=("server",),
     extract_params=azure_sql_extract_params,
+    evidence_mapper=_map_get_azure_sql_wait_stats,
 )
 def get_azure_sql_wait_stats(
     server: str,

--- a/tests/integrations/azure_sql/test_evidence_mappers.py
+++ b/tests/integrations/azure_sql/test_evidence_mappers.py
@@ -1,0 +1,175 @@
+"""Evidence mapper coverage for the Azure SQL integration tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.azure_sql.tools.azure_sql_current_queries_tool import (
+    _map_get_azure_sql_current_queries,
+)
+from integrations.azure_sql.tools.azure_sql_resource_stats_tool import (
+    _map_get_azure_sql_resource_stats,
+)
+from integrations.azure_sql.tools.azure_sql_server_status_tool import (
+    _map_get_azure_sql_server_status,
+)
+from integrations.azure_sql.tools.azure_sql_slow_queries_tool import (
+    _map_get_azure_sql_slow_queries,
+)
+from integrations.azure_sql.tools.azure_sql_wait_stats_tool import (
+    _map_get_azure_sql_wait_stats,
+)
+from tools.registry import get_registered_tool
+
+
+def _entry(evidence: dict[str, Any]) -> Any:
+    entries = evidence.get("catalog_entries")
+    assert isinstance(entries, list) and entries
+    return entries[0]
+
+
+class TestCurrentQueries:
+    def test_records_query_count_and_longest_duration(self) -> None:
+        evidence: dict[str, Any] = {}
+        output = {
+            "available": True,
+            "threshold_seconds": 1,
+            "total_queries": 2,
+            "queries": [
+                {"session_id": 1, "duration_seconds": 5, "status": "running"},
+                {"session_id": 2, "duration_seconds": 12, "status": "running"},
+            ],
+        }
+
+        _map_get_azure_sql_current_queries(evidence, output, {})
+
+        entry = _entry(evidence)
+        assert entry["source"] == "get_azure_sql_current_queries"
+        assert entry["label"] == "Azure SQL Current Queries"
+        assert entry["summary"] == "2 running query/queries, max duration 12s"
+
+    def test_no_entry_when_unavailable_or_empty(self) -> None:
+        for output in (
+            {"available": False},
+            {"available": True, "queries": []},
+            {"available": True, "queries": "not-a-list"},
+            {},
+        ):
+            evidence: dict[str, Any] = {}
+            _map_get_azure_sql_current_queries(evidence, output, {})
+            assert evidence == {}
+
+
+class TestResourceStats:
+    def test_records_sample_count_and_throttling_risk(self) -> None:
+        evidence: dict[str, Any] = {}
+        output = {
+            "available": True,
+            "window_minutes": 30,
+            "total_samples": 29,
+            "throttling_risk": "high",
+            "samples": [{"avg_cpu_percent": 88.0}],
+        }
+
+        _map_get_azure_sql_resource_stats(evidence, output, {})
+
+        entry = _entry(evidence)
+        assert entry["source"] == "get_azure_sql_resource_stats"
+        assert entry["summary"] == "29 sample(s), throttling risk high"
+
+    def test_no_entry_when_no_samples(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_azure_sql_resource_stats(evidence, {"available": True, "total_samples": 0}, {})
+        assert evidence == {}
+
+
+class TestServerStatus:
+    def test_records_connections_cpu_and_tier(self) -> None:
+        evidence: dict[str, Any] = {}
+        output = {
+            "available": True,
+            "service_tier": {"edition": "Standard", "service_objective": "S1"},
+            "connections": {"total": 42, "active": 7, "idle": 35},
+            "resource_utilization": {
+                "avg_cpu_percent": 15.5,
+                "avg_memory_usage_percent": 22.0,
+            },
+            "database_size_mb": 1024.0,
+        }
+
+        _map_get_azure_sql_server_status(evidence, output, {})
+
+        entry = _entry(evidence)
+        assert entry["source"] == "get_azure_sql_server_status"
+        assert entry["summary"] == "42 connection(s), 7 active, CPU 15.5%, memory 22.0%, tier S1"
+
+    def test_no_entry_when_unavailable(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_azure_sql_server_status(evidence, {"available": False}, {})
+        assert evidence == {}
+
+
+class TestSlowQueries:
+    def test_records_count_and_slowest_average(self) -> None:
+        evidence: dict[str, Any] = {}
+        output = {
+            "available": True,
+            "threshold_ms": 1000,
+            "total_queries": 2,
+            "queries": [
+                {"query_hash": "a", "avg_time_ms": 1500.0},
+                {"query_hash": "b", "avg_time_ms": 3400.5},
+            ],
+        }
+
+        _map_get_azure_sql_slow_queries(evidence, output, {})
+
+        entry = _entry(evidence)
+        assert entry["source"] == "get_azure_sql_slow_queries"
+        assert entry["summary"] == "2 slow query/queries, slowest avg 3400ms"
+
+    def test_no_entry_when_no_queries(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_azure_sql_slow_queries(evidence, {"available": True, "queries": []}, {})
+        assert evidence == {}
+
+
+class TestWaitStats:
+    def test_records_wait_count_and_top_wait(self) -> None:
+        evidence: dict[str, Any] = {}
+        output = {
+            "available": True,
+            "total_wait_types": 2,
+            "waits": [
+                {"wait_type": "PAGEIOLATCH_SH", "wait_time_ms": 5000, "waiting_tasks_count": 3},
+                {"wait_type": "LCK_M_S", "wait_time_ms": 12000, "waiting_tasks_count": 1},
+            ],
+        }
+
+        _map_get_azure_sql_wait_stats(evidence, output, {})
+
+        entry = _entry(evidence)
+        assert entry["source"] == "get_azure_sql_wait_stats"
+        assert entry["summary"] == "2 wait type(s), top LCK_M_S 12000ms"
+
+    def test_no_entry_when_no_waits(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_azure_sql_wait_stats(evidence, {"available": True, "waits": []}, {})
+        assert evidence == {}
+
+
+class TestToolRegistration:
+    """Every azure_sql investigation tool carries its evidence mapper."""
+
+    def test_all_tools_carry_mappers(self) -> None:
+        mapping = {
+            "get_azure_sql_current_queries": _map_get_azure_sql_current_queries,
+            "get_azure_sql_resource_stats": _map_get_azure_sql_resource_stats,
+            "get_azure_sql_server_status": _map_get_azure_sql_server_status,
+            "get_azure_sql_slow_queries": _map_get_azure_sql_slow_queries,
+            "get_azure_sql_wait_stats": _map_get_azure_sql_wait_stats,
+        }
+        for name, mapper in mapping.items():
+            registered = get_registered_tool(name)
+            assert registered is not None
+            assert registered.evidence_mapper is mapper

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -26,11 +26,6 @@ fetch_failed_run
 find_yc_api
 fix_sentry_issue
 get_airflow_metrics
-get_azure_sql_current_queries
-get_azure_sql_resource_stats
-get_azure_sql_server_status
-get_azure_sql_slow_queries
-get_azure_sql_wait_stats
 get_batch_statistics
 get_cloudwatch_batch_metrics
 get_cloudwatch_logs


### PR DESCRIPTION
Fixes #5541

#### Describe the changes you have made in this PR -

- Add evidence mappers to all five `azure_sql` diagnostic tools so their output becomes citeable in incident reports.
- `get_azure_sql_server_status` — cite connection counts, active sessions, CPU/memory utilization, and service tier.
- `get_azure_sql_current_queries` — cite the running-query count and the longest observed duration.
- `get_azure_sql_resource_stats` — cite the sample count and throttling risk over the rolling window.
- `get_azure_sql_slow_queries` — cite the slow-query count and the slowest average elapsed time.
- `get_azure_sql_wait_stats` — cite the wait-type count and the top wait by total wait time.
- Skip unavailable output and empty result sets (no citeable evidence when there is nothing to report).
- Remove all five tools from the evidence-mapper known-gap baseline and add focused per-tool coverage.

### Demo/Screenshot for feature changes and bug fixes -

```text
>>> from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
>>> evidence = {}
>>> merge_tool_evidence(evidence, "get_azure_sql_server_status",
...     {"available": True, "service_tier": {"service_objective": "S1"},
...      "connections": {"total": 42, "active": 7},
...      "resource_utilization": {"avg_cpu_percent": 15.5}}, {})
>>> evidence["catalog_entries"][0]["summary"]
'42 connection(s), 7 active, CPU 15.5%, tier S1'
```

Validation:

- `make lint` — passed (ruff, no findings)
- `make format-check` — passed
- `make typecheck` — passed (mypy on `integrations/azure_sql/`: 9 files, no issues)
- `uv run python -m pytest tests/integrations/azure_sql/test_evidence_mappers.py -q` — 11 passed
- `uv run python -m pytest tests/tools/investigation/stages/gather_evidence/test_evidence_mapper_coverage.py -q` — 11 passed
- `uv run python -m pytest tests/integrations/test_azure_sql.py -q` — 35 passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Each mapper lives beside its owning tool and follows the existing in-repo convention (e.g. `mariadb`, `sqs`, `x_mcp`): a `_map_*` function that checks `output.get("available")`, ignores empty result sets, and calls `record_evidence_entry` to mint a citeable catalog entry. Summaries are compact and self-contained so the agent can point the reader at the relevant diagnostic signal (saturation, throttling risk, slow queries, dominant wait).

I considered storing raw output dicts verbatim as canonical evidence. I kept the raw-output path unchanged and instead emit the bounded catalog summary, matching how the other accepted evidence-mapper PRs in this epic behave.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
