### PR TITLE
fix(tests): stop the recessed-output assertion depending on Rich's style cache

### DIFF
--- a/tests/interactive_shell/runtime/test_repl_presenter.py
+++ b/tests/interactive_shell/runtime/test_repl_presenter.py
@@ -56,9 +56,19 @@ def test_plain_command_output_is_recessed_but_keeps_command_colours() -> None:
     presenter.print_command_output("\x1b[32mgreen success\x1b[0m")
 
     raw = buffer.getvalue()
-    secondary = str(ui_theme.SECONDARY)
-    r, g, b = (int(secondary[i : i + 2], 16) for i in (1, 3, 5))
-    assert f"38;2;{r};{g};{b}" in raw  # plain output recessed to SECONDARY
+    # Compare against SECONDARY rendered through an identical console rather than
+    # hard-coding the truecolor SGR. Rich caches the rendered ANSI on the Style
+    # object, and ``Style.parse`` is process-wide lru_cached, so whichever test
+    # renders this colour first fixes its escape sequence for the whole run --
+    # an 8-colour console elsewhere in the shard would otherwise make this assert
+    # a stale ``\x1b[37m``. Both sides here share that cache, so the check holds
+    # at any colour depth.
+    reference = io.StringIO()
+    Console(file=reference, force_terminal=True, color_system="truecolor", width=80).print(
+        "x", style=str(ui_theme.SECONDARY)
+    )
+    secondary_sgr = reference.getvalue().split("x")[0]
+    assert secondary_sgr and secondary_sgr in raw  # plain output recessed to SECONDARY
     assert re.search(r"\x1b\[[0-9;]*32m", raw)  # command's own green survives the base
 
 


### PR DESCRIPTION
Fixes the red `main`: `CI Gate` has been failing since cd03ccb60 on `test (cli-runtime-3)`.

#### Describe the changes you have made in this PR -

`test_plain_command_output_is_recessed_but_keeps_command_colours` hard-coded the truecolor SGR for `SECONDARY` and asserted it appeared in the presenter's output. On `main` it gets `\x1b[37m` instead.

The presenter is fine. This is a Rich caching footgun: `Style.parse` is process-wide `lru_cache`d, and each `Style` caches its rendered ANSI on the object the first time it is rendered. Whichever test renders `#A6A6A6` first therefore fixes that colour's escape sequence for the whole process.

`tests/cli/test_health_view.py:141` builds `Console(file=StringIO(), force_terminal=True, width=80)` with no explicit `color_system`, so Rich auto-detects, and with no `COLORTERM`/`TERM` that lands on 8-colour. It caches `37`. When it sorts ahead of this test in the duration-balanced shard, the later truecolor console still gets `37`.

Standalone proof, clean interpreter:

```
standard FIRST  : '\x1b[37mx\x1b[0m\n'
truecolor after : '\x1b[37mx\x1b[0m\n'    <- poisoned
```

Nothing about the presenter or the theme changed. Shard membership is duration-balanced by file, so recent commits simply reshuffled which file renders that colour first, which is why this went red at cd03ccb60 with no related diff.

The fix derives the expected sequence by rendering `SECONDARY` through an identical console rather than hard-coding bytes. Both sides then share whatever cache state exists, so the assertion holds at any colour depth.

### Demo/Screenshot for feature changes and bug fixes -

Before, on `main` (run 33631834698):

```
FAILED tests/interactive_shell/runtime/test_repl_presenter.py::test_plain_command_output_is_recessed_but_keeps_command_colours
E  AssertionError: assert '38;2;166;166;166' in '\x1b[37m  ↳ plain line of output\x1b[0m\n...'
1 failed, 1021 passed, 1 skipped in 29.39s
```

After, same shard command locally:

```
1022 passed, 1 skipped, 16 warnings in 16.28s
```

Ordering checks, including the exact poisoning order:

```
alone                          : 1 passed
test_health_view.py + target   : 8 passed
health + reader + target       : 17 passed
whole test_repl_presenter.py   : 15 passed
```

Mutation check - with `resolved = str(SECONDARY)` replaced by `resolved = None` in the presenter, the test fails, so it has not gone vacuous:

```
MUTANT   : 1 failed
RESTORED : 1 passed
```

Broad suite: `16661 passed, 74 skipped, 2 xfailed in 113.77s`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The failing assertion depends on process-global state that no test controls, so it fails based on what else happens to run first in the shard.

The alternative was to give `test_health_view.py` an explicit `color_system="truecolor"`. That turns `main` green too, but it only changes who wins the cache race - any future test that renders a theme colour through an 8-colour console breaks this again. Removing the dependency is what actually fixes it.

I bisected to the polluter rather than guessing: the shard reproduces locally at `-n 0`, and from there it is a binary search over the group's file list down to a single file plus the target.

Because rewriting an assertion risks making it vacuous, I ran a mutation check: dropping the `SECONDARY` styling in the presenter still fails the test.

Known follow-up, deliberately not in this diff: `tests/interactive_shell/ui/test_rendering.py:297`, `tests/interactive_shell/ui/test_handoff_questions.py:88` and `tests/infrastructure/terminal/test_theme.py` hard-code the same truecolor sequences and are latent in the same way. They pass today. `tests/interactive_shell/ui/test_streaming.py:48` already carries a manual `38;2;...` or `\x1b[90m` workaround for this exact problem, so it has bitten before.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
