### PR TITLE
feat(shell): refine the getting-started experience

### DIFF
--- a/core/agent_harness/prompts/action/assemble.py
+++ b/core/agent_harness/prompts/action/assemble.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from core.agent_harness.prompts.action.text import _SYSTEM_PROMPT_BASE
 from core.agent_harness.prompts.action.turn_interaction import turn_interaction_facts_block
+from core.agent_harness.prompts.getting_started import load_getting_started_block
 from core.agent_harness.prompts.kernel.envelope import (
     PromptBlock,
     PromptBlockId,
@@ -20,7 +21,7 @@ from core.agent_harness.prompts.memory.conversation import (
     format_recent_conversation,
 )
 from core.agent_harness.prompts.runtime_facts import render_static_runtime_facts
-from core.agent_harness.prompts.skills.loader import load_skills_demo_block, load_skills_index
+from core.agent_harness.prompts.skills.loader import load_skills_index
 from core.agent_harness.task_plan.prompt import (
     ask_user_answered_block,
     current_task_plan_block,
@@ -118,7 +119,7 @@ def build_action_system_prompt_envelope(turn_snapshot: TurnSnapshot) -> PromptEn
             suffix="\n\n",
         )
     )
-    skills_index = "\n\n".join(filter(None, (load_skills_index(), load_skills_demo_block())))
+    skills_index = "\n\n".join(filter(None, (load_skills_index(), load_getting_started_block())))
     blocks.extend(
         _optional_block(
             id=PromptBlockId.ACTION_SKILLS,

--- a/core/agent_harness/prompts/getting_started.py
+++ b/core/agent_harness/prompts/getting_started.py
@@ -1,0 +1,30 @@
+"""Stable getting-started choices for the interactive agent."""
+
+from __future__ import annotations
+
+GETTING_STARTED_OPTIONS: tuple[str, ...] = (
+    "Explore a repo and analyze its CI/CD performance (recommended)",
+    "Set up an agent that improves CI/CD reliability over time",
+    "Connect OpenSRE to Slack and hand off DevOps chores for your team",
+)
+
+_GETTING_STARTED_RULE = (
+    "When the user asks what you can do, what you're capable of, how you can "
+    "help, what tools you have, or for a demo / getting-started suggestion: "
+    "call `ask_user_choice` with ONLY the getting-started options below, in "
+    "the order shown. Use each option verbatim; do not rephrase, add, remove, "
+    "or reorder options. The interactive surface adds `Or type your own "
+    "answer...` automatically, so do not include a custom-answer option. Do "
+    "not list platform features, slash commands, AGENTS.md capabilities, or "
+    "add a Want-me-to closer that invents another action."
+)
+
+
+def load_getting_started_block() -> str:
+    """Return the agent rule and exact selectable starter prompts."""
+    lines = [_GETTING_STARTED_RULE, ""]
+    lines.extend(f"- {option}" for option in GETTING_STARTED_OPTIONS)
+    return "\n".join(lines)
+
+
+__all__ = ["GETTING_STARTED_OPTIONS", "load_getting_started_block"]

--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -143,14 +143,14 @@ default and state it in one short sentence. Only when a genuinely blocking
 choice remains — a small fixed set of materially different paths with no safe
 default — call `ask_user_choice` instead of guessing.
 
-For a demo or getting-started request, present the available skill demos as
-selectable options using `ask_user_choice`; use each demo prompt as the option
-that expresses that intent. This rule takes precedence over any assembled
-capability-overview instruction to answer a demo request directly or merely
-offer copy-pasteable prompts; that overview supplies the menu options only. The
-user's selection arrives verbatim as the next message. Treat it as the clarified
+For a demo or getting-started request, present the assembled getting-started
+prompts as selectable options using `ask_user_choice`; use each prompt verbatim
+and in the supplied order. This rule takes precedence over any assembled
+getting-started instruction to answer the request directly or merely offer
+copy-pasteable prompts; that block supplies the menu options only. The user's
+selection arrives verbatim as the next message. Treat it as the clarified
 request, then resolve the selected skill or goal and continue. Do not choose a
-demo or resolve a skill before the selection arrives.
+goal or resolve a skill before the selection arrives.
 
 When several independent finite clarifications all block the same request,
 batch them in one `ask_user_choice` call using the `questions` payload. Do not

--- a/core/agent_harness/prompts/skills/__init__.py
+++ b/core/agent_harness/prompts/skills/__init__.py
@@ -8,7 +8,6 @@ from core.agent_harness.prompts.skills.loader import (
     list_action_skills,
     load_skill_body,
     load_skills_block,
-    load_skills_demo_block,
     load_skills_index,
     skills_dir,
 )
@@ -19,7 +18,6 @@ __all__ = [
     "list_action_skills",
     "load_skill_body",
     "load_skills_block",
-    "load_skills_demo_block",
     "load_skills_index",
     "skills_dir",
 ]

--- a/core/agent_harness/prompts/skills/_template/SKILL_TEMPLATE.md
+++ b/core/agent_harness/prompts/skills/_template/SKILL_TEMPLATE.md
@@ -13,12 +13,9 @@ To create a new skill:
    "Multi-step; load before acting." for data-dependent chains.
 5. Add `recurring: <human schedule>` (e.g. "weekdays 09:00") only when the
    skill ends with a propose_scheduled_delivery offer.
-6. Add `demo: <copy-pasteable user prompt>` when this skill should appear in
-   the "what can you do?" answer. Omit it for prerequisite or generic-tool
-   skills.
-7. Optional report template: a sibling file named <folder>_report.md is
+6. Optional report template: a sibling file named <folder>_report.md is
    appended automatically to the body that skill_view returns.
-8. Section order below is the house style (see github_ci_fix for a
+7. Section order below is the house style (see github_ci_fix for a
    single-tool skill, architecture_audit for a multi-pass one). Keep the
    whole body tight — it is loaded into the planner's context on demand.
 -->
@@ -27,7 +24,6 @@ name: <kebab-case-name>
 description: >-
   <One or two lines for the compact index: what the skill does and the main
   tool(s) it uses. Add "Multi-step; load before acting." if data-dependent.>
-demo: <Copy-pasteable prompt a user can send to run this skill. Omit if none.>
 ---
 ══════════════════════════════════════════════════════════
 <UPPERCASE SKILL TITLE> SKILL — interactive-shell action agent:

--- a/core/agent_harness/prompts/skills/architecture_audit/SKILL.md
+++ b/core/agent_harness/prompts/skills/architecture_audit/SKILL.md
@@ -3,7 +3,6 @@ name: architecture-audit
 description: >-
   Architecture audit / layering scan of a repo with AGENT SCAN, heuristic
   passes, and a filled REPORT TEMPLATE
-demo: Audit this repo's architecture and give me a sequenced refactor plan
 ---
 ══════════════════════════════════════════════════════════
 ARCHITECTURE AUDIT SKILL — interactive-shell action agent:

--- a/core/agent_harness/prompts/skills/github_ci_fix/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_ci_fix/SKILL.md
@@ -3,7 +3,6 @@ name: github-ci-fix
 description: >-
   Fix failing GitHub CI / Actions checks via fix_github_pr_ci and push to the
   existing PR head, or fix a branch's failing CI via a linked repair worktree
-demo: Find open PRs with failing CI and fix them
 
 
 

--- a/core/agent_harness/prompts/skills/github_security_fix/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_security_fix/SKILL.md
@@ -3,7 +3,6 @@ name: github-security-fix
 description: >-
   Remediate GitHub security / Dependabot / CodeQL / code-quality alerts via
   fix_github_security_alert
-demo: Remediate the open Dependabot and CodeQL alerts
 ---
 ══════════════════════════════════════════════════════════
 GITHUB SECURITY AND QUALITY FIX SKILL — interactive-shell action agent:

--- a/core/agent_harness/prompts/skills/loader.py
+++ b/core/agent_harness/prompts/skills/loader.py
@@ -9,10 +9,9 @@ Layout (either form is supported):
   with an optional sibling ``<name>_report.md`` report template.
 - Flat: ``skills/<name>.md`` with optional ``skills/<name>_report.md``.
 
-Optional YAML frontmatter (``name``, ``description``, optional ``recurring``,
-optional ``demo``) feeds the compact index and capability overview. Without
-frontmatter, the name is derived from the path and the description from the
-first ``WHEN TO USE`` / subtitle lines.
+Optional YAML frontmatter (``name``, ``description``, optional ``recurring``)
+feeds the compact index. Without frontmatter, the name is derived from the path
+and the description from the first ``WHEN TO USE`` / subtitle lines.
 
 The harness prompt carries only :func:`load_skills_index` (~hundreds of
 chars). Full bodies load through the ``skill_view`` tool via
@@ -35,7 +34,6 @@ __all__ = (
     "list_action_skills",
     "load_skill_body",
     "load_skills_block",
-    "load_skills_demo_block",
     "load_skills_index",
     "skills_dir",
 )
@@ -58,7 +56,6 @@ class ActionSkill:
     description: str
     path: Path
     recurring: str | None = None
-    demo: str | None = None
 
 
 def skills_dir() -> Path:
@@ -198,13 +195,11 @@ def _load_action_skill(skill_path: Path) -> ActionSkill | None:
         name = _name_from_path(skill_path)
     description = _string_field(frontmatter.get("description")) or _derive_description(body)
     recurring = _string_field(frontmatter.get("recurring")) or None
-    demo = _string_field(frontmatter.get("demo")) or None
     return ActionSkill(
         name=name,
         description=description,
         path=skill_path,
         recurring=recurring,
-        demo=demo,
     )
 
 
@@ -254,28 +249,6 @@ def load_skills_index() -> str:
     return "".join(("\n".join(lines), "\n\n"))
 
 
-_CAPABILITY_OVERVIEW_RULE = (
-    "When the user asks what you can do, what you're capable of, how you can "
-    "help, what tools you have, or for a demo / getting-started suggestion: "
-    "answer with ONLY the skill demos below. Do not list platform features, "
-    "slash commands, AGENTS.md capabilities, or a generic coding-agent menu. "
-    "Do not add a Want-me-to closer that invents a fifth action (no open-PR "
-    "check, no /health, no /investigate). Offer the demos as copy-pasteable "
-    "prompts the user can send next."
-)
-
-
-@lru_cache(maxsize=1)
-def load_skills_demo_block() -> str:
-    """Return the capability-overview rule and copy-pasteable skill demos."""
-    demos = tuple(skill for skill in list_action_skills() if skill.demo)
-    if not demos:
-        return ""
-    lines = [_CAPABILITY_OVERVIEW_RULE, ""]
-    lines.extend(f"- {skill.demo}" for skill in demos)
-    return "\n".join(lines)
-
-
 def load_skills_block() -> str:
     """Return the skills section for the action envelope (the compact index).
 
@@ -302,7 +275,6 @@ def clear_skills_caches() -> None:
     """Drop cached discovery/index (tests mutate on-disk skills)."""
     list_action_skills.cache_clear()
     load_skills_index.cache_clear()
-    load_skills_demo_block.cache_clear()
 
 
 # Back-compat for tests that call ``load_skills_block.cache_clear()``.

--- a/core/agent_harness/prompts/skills/morning_report/SKILL.md
+++ b/core/agent_harness/prompts/skills/morning_report/SKILL.md
@@ -4,7 +4,6 @@ description: >-
   Weather + news morning briefing: fetch live weather and headlines, compose
   a plain-text briefing, deliver it. Multi-step; load before acting.
 recurring: weekdays 08:00
-demo: Set up a weekday morning briefing with weather and news
 ---
 ══════════════════════════════════════════════════════════
 MORNING REPORT SKILL #1 — weather + daily news briefing:

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -253,6 +253,28 @@ def _fg(rgb: tuple[int, int, int]) -> str:
     return f"\x1b[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m"
 
 
+def _mix_rgb(
+    start: tuple[int, int, int],
+    end: tuple[int, int, int],
+    amount: float,
+) -> tuple[int, int, int]:
+    clamped = 0.0 if amount < 0.0 else 1.0 if amount > 1.0 else amount
+    return (
+        int(start[0] + (end[0] - start[0]) * clamped),
+        int(start[1] + (end[1] - start[1]) * clamped),
+        int(start[2] + (end[2] - start[2]) * clamped),
+    )
+
+
+def _sample_cyclic_gradient(
+    stops: tuple[tuple[int, int, int], ...],
+    position: float,
+) -> tuple[int, int, int]:
+    scaled = (position % 1.0) * len(stops)
+    index = int(scaled)
+    return _mix_rgb(stops[index], stops[(index + 1) % len(stops)], scaled - index)
+
+
 def fade_fg_ansi(intensity: float) -> str:
     """Foreground between DIM and TEXT.
 
@@ -262,13 +284,7 @@ def fade_fg_ansi(intensity: float) -> str:
     clamped = 0.0 if intensity < 0.0 else 1.0 if intensity > 1.0 else intensity
     dim = _parse_hex_color(_ACTIVE_THEME.DIM)
     text = _parse_hex_color(_ACTIVE_THEME.TEXT)
-    return _fg(
-        (
-            int(dim[0] + (text[0] - dim[0]) * clamped),
-            int(dim[1] + (text[1] - dim[1]) * clamped),
-            int(dim[2] + (text[2] - dim[2]) * clamped),
-        )
-    )
+    return _fg(_mix_rgb(dim, text, clamped))
 
 
 def shimmer_text_ansi(
@@ -278,16 +294,31 @@ def shimmer_text_ansi(
     period: float = 1.5,
     high_hex: str | None = None,
 ) -> str:
-    """Paint *text* with a traveling light wave (Cursor / Droid style).
+    """Paint *text* with a traveling metallic, iridescent wave.
 
     Brightness is a pure function of *elapsed* and character index so prompt
     re-measure passes at the same clock stay visually stable. Whitespace is
-    left unstyled so the wave reads as light over the words, not the gaps.
+    left unstyled so the wave reads as light over the words, not the gaps. The
+    narrow accent reflections are softened with TEXT to avoid a saturated
+    rainbow while neutral TEXT and SECONDARY stops provide a silver sheen.
     """
     if not text:
         return ""
-    low = _parse_hex_color(_ACTIVE_THEME.DIM)
-    high = _parse_hex_color(high_hex or _ACTIVE_THEME.TEXT)
+    dim = _parse_hex_color(_ACTIVE_THEME.DIM)
+    secondary = _parse_hex_color(_ACTIVE_THEME.SECONDARY)
+    text_rgb = _parse_hex_color(_ACTIVE_THEME.TEXT)
+    accent = _parse_hex_color(high_hex or _ACTIVE_THEME.HIGHLIGHT)
+    brand = _parse_hex_color(_ACTIVE_THEME.BRAND)
+    stops = (
+        dim,
+        secondary,
+        _mix_rgb(text_rgb, brand, 0.38),
+        text_rgb,
+        _mix_rgb(text_rgb, accent, 0.52),
+        text_rgb,
+        secondary,
+        dim,
+    )
     span = max(period, 0.05)
     wave = (elapsed / span) % 1.0
     n = len(text)
@@ -297,16 +328,7 @@ def shimmer_text_ansi(
             parts.append(char)
             continue
         pos = index / max(n - 1, 1)
-        # Circular distance on the unit interval; peak is a ~quarter-string band.
-        distance = abs((pos - wave + 0.5) % 1.0 - 0.5)
-        peak = max(0.0, 1.0 - distance / 0.25)
-        # Floor keeps non-peak letters readable; square softens the band edges.
-        level = 0.38 + 0.62 * (peak * peak)
-        rgb = (
-            int(low[0] + (high[0] - low[0]) * level),
-            int(low[1] + (high[1] - low[1]) * level),
-            int(low[2] + (high[2] - low[2]) * level),
-        )
+        rgb = _sample_cyclic_gradient(stops, pos - wave)
         parts.append(f"{_fg(rgb)}{char}")
     parts.append(ANSI_RESET)
     return "".join(parts)

--- a/surfaces/interactive_shell/runtime/input/actions.py
+++ b/surfaces/interactive_shell/runtime/input/actions.py
@@ -16,9 +16,6 @@ from surfaces.interactive_shell.runtime.input.events import (
     InputEvent,
     InputSubmitted,
 )
-from surfaces.interactive_shell.ui.input_prompt.rendering import (
-    DEFAULT_PLACEHOLDER_TEXT,
-)
 
 QUEUE_DURING_CONFIRMATION_WARNING = (
     "[dim](type y/N to confirm the pending action; your input has been queued for after)[/]"
@@ -82,10 +79,6 @@ def decide_input_action(
             # turn, SessionGoal condition, or a doubled ``[n] ❯ [n] ❯`` echo.
             stripped = strip_shell_prompt_chrome(text)
             if not stripped:
-                return IgnoreInput()
-            # Placeholder text stuck in the buffer (not dim placeholder styling)
-            # must not submit as a real turn.
-            if stripped == DEFAULT_PLACEHOLDER_TEXT:
                 return IgnoreInput()
 
             if snapshot.dispatch_running and looks_like_cancel_request(stripped):

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -21,7 +21,7 @@ from surfaces.interactive_shell.ui.input_prompt.layout import (
     prompt_line_width,
 )
 
-DEFAULT_PLACEHOLDER_TEXT = 'Try "Investigate this alert"'
+DEFAULT_PLACEHOLDER_TEXT = "see what you can do"
 _PLAN_CONTINUE_PLACEHOLDER = "continue the plan, or type a message"
 
 
@@ -158,7 +158,7 @@ def resolve_prompt_placeholder(session: Session) -> ANSI:
     """Contextual ghost text when the input buffer is empty.
 
     Built per redraw (not at import) so theme ANSI cannot freeze stale, and so
-    an unfinished live plan can replace the default Investigate hint.
+    an unfinished live plan can replace the default exploratory hint.
     """
     parts: list[str] = []
     if session.terminal.trust_mode:

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -1,35 +1,30 @@
-"""Capability answers list skill demos instead of platform features."""
+"""Capability answers offer the stable getting-started choices."""
 
 from __future__ import annotations
 
 from core.agent_harness.prompts.action import build_action_system_prompt
-from core.agent_harness.prompts.skills.loader import (
-    clear_skills_caches,
-    list_action_skills,
-    load_skills_demo_block,
-    load_skills_index,
+from core.agent_harness.prompts.getting_started import (
+    GETTING_STARTED_OPTIONS,
+    load_getting_started_block,
 )
+from core.agent_harness.prompts.skills.loader import clear_skills_caches, load_skills_index
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 
 
-def test_skills_demo_block_lists_frontmatter_demos_only() -> None:
-    clear_skills_caches()
-    demos = {skill.name: skill.demo for skill in list_action_skills() if skill.demo}
-
-    assert demos == {
-        "architecture-audit": "Audit this repo's architecture and give me a sequenced refactor plan",
-        "github-ci-fix": "Find open PRs with failing CI and fix them",
-        "github-security-fix": "Remediate the open Dependabot and CodeQL alerts",
-        "morning-report": "Set up a weekday morning briefing with weather and news",
-    }
-    block = load_skills_demo_block()
-    assert "ONLY the skill demos" in block
-    assert "Do not list platform features" in block
-    for prompt in demos.values():
-        assert prompt in block
+def test_getting_started_block_lists_exact_options() -> None:
+    assert GETTING_STARTED_OPTIONS == (
+        "Explore a repo and analyze its CI/CD performance (recommended)",
+        "Set up an agent that improves CI/CD reliability over time",
+        "Connect OpenSRE to Slack and hand off DevOps chores for your team",
+    )
+    block = load_getting_started_block()
+    assert "Use each option verbatim" in block
+    assert "Or type your own answer..." in block
+    for option in GETTING_STARTED_OPTIONS:
+        assert f"- {option}" in block
 
 
-def test_agent_prompt_includes_skill_demos() -> None:
+def test_agent_prompt_includes_getting_started_options() -> None:
     clear_skills_caches()
     prompt = build_action_system_prompt(
         TurnSnapshot(
@@ -43,14 +38,13 @@ def test_agent_prompt_includes_skill_demos() -> None:
         )
     )
 
-    assert "ONLY the skill demos" in prompt
-    assert "Audit this repo's architecture and give me a sequenced refactor plan" in prompt
-    assert "Find open PRs with failing CI and fix them" in prompt
-    assert "Remediate the open Dependabot and CodeQL alerts" in prompt
-    assert "Set up a weekday morning briefing with weather and news" in prompt
+    for option in GETTING_STARTED_OPTIONS:
+        assert option in prompt
+    assert "Remediate the open Dependabot and CodeQL alerts" not in prompt
+    assert "Set up a weekday morning briefing with weather and news" not in prompt
 
 
-def test_agent_prompt_combines_demo_catalog_with_selectable_choice_contract() -> None:
+def test_agent_prompt_combines_starter_options_with_selectable_choice_contract() -> None:
     clear_skills_caches()
     prompt = build_action_system_prompt(
         TurnSnapshot(
@@ -69,12 +63,11 @@ def test_agent_prompt_combines_demo_catalog_with_selectable_choice_contract() ->
 
     assert "ask_user_choice menu: available" in prompt
     assert "For a demo or getting-started request" in collapsed
-    assert "available skill demos as selectable options" in collapsed
-    assert "ONLY the skill demos below" in collapsed
-    assert "that overview supplies the menu options only" in collapsed
-    for skill in list_action_skills():
-        if skill.demo:
-            assert skill.demo in prompt
+    assert "assembled getting-started prompts as selectable options" in collapsed
+    assert "call `ask_user_choice` with ONLY the getting-started options" in collapsed
+    assert "that block supplies the menu options only" in collapsed
+    for option in GETTING_STARTED_OPTIONS:
+        assert option in prompt
 
 
 def test_skills_index_routes_capability_questions_to_direct_answer() -> None:

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -39,12 +39,12 @@ def test_finite_material_ambiguity_requires_selectable_clarification() -> None:
 def test_demo_requests_require_selection_before_skill_resolution() -> None:
     collapsed = " ".join(_SYSTEM_PROMPT_BASE.split())
     assert "For a demo or getting-started request" in collapsed
-    assert "available skill demos as selectable options" in collapsed
-    assert "takes precedence over any assembled capability-overview instruction" in collapsed
-    assert "that overview supplies the menu options only" in collapsed
+    assert "assembled getting-started prompts as selectable options" in collapsed
+    assert "takes precedence over any assembled getting-started instruction" in collapsed
+    assert "that block supplies the menu options only" in collapsed
     assert "selection arrives verbatim as the next message" in collapsed
     assert "then resolve the selected skill or goal" in collapsed
-    assert "Do not choose a demo or resolve a skill before the selection arrives" in collapsed
+    assert "Do not choose a goal or resolve a skill before the selection arrives" in collapsed
 
 
 def test_finite_clarifications_are_batched_without_over_questioning() -> None:

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -99,16 +99,33 @@ def test_fade_fg_ansi_interpolates_dim_to_text() -> None:
     assert mid != ui_theme.TEXT_ANSI
 
 
-def test_shimmer_text_ansi_paints_a_traveling_wave() -> None:
-    """Status sentence shimmer: per-glyph truecolor that moves with elapsed time."""
+def test_shimmer_text_ansi_paints_a_traveling_metallic_wave() -> None:
+    """Status shimmer mixes neutral silver stops with muted accent reflections."""
     from infrastructure.terminal import theme as ui_theme
 
-    ui_theme.set_active_theme("solarized")
+    ui_theme.set_active_theme("blue")
     early = ui_theme.shimmer_text_ansi("Thinking…", elapsed=0.0)
     later = ui_theme.shimmer_text_ansi("Thinking…", elapsed=0.75)
     assert early.count("\x1b[38;2;") >= 5
     assert early.endswith(ui_theme.ANSI_RESET)
     assert early != later
+    assert ui_theme.TEXT_ANSI in early
+    assert ui_theme.SECONDARY_ANSI in early
+    colors = re.findall(r"\x1b\[38;2;(\d+);(\d+);(\d+)m", early)
+    assert len(set(colors)) >= 5
+
+    highlight_wave = ui_theme.shimmer_text_ansi(
+        "Thinking…",
+        elapsed=0.0,
+        high_hex=ui_theme.get_active_theme().HIGHLIGHT,
+    )
+    brand_wave = ui_theme.shimmer_text_ansi(
+        "Thinking…",
+        elapsed=0.0,
+        high_hex=ui_theme.get_active_theme().BRAND,
+    )
+    assert highlight_wave != brand_wave
+
     # Whitespace is not individually coloured.
     spaced = ui_theme.shimmer_text_ansi("Invoking tools", elapsed=0.1)
     assert " tools" in spaced or "tools" in re.sub(r"\x1b\[[0-9;]*m", "", spaced)

--- a/tests/interactive_shell/runtime/test_controller_input_actions.py
+++ b/tests/interactive_shell/runtime/test_controller_input_actions.py
@@ -93,10 +93,8 @@ def test_decide_strips_pasted_shell_prompt_chrome() -> None:
     )
 
 
-def test_decide_ignores_placeholder_text_stuck_in_buffer() -> None:
-    from surfaces.interactive_shell.ui.input_prompt.rendering import DEFAULT_PLACEHOLDER_TEXT
-
-    assert _decide(InputSubmitted(DEFAULT_PLACEHOLDER_TEXT)) == IgnoreInput()
+def test_decide_submits_text_matching_the_placeholder() -> None:
+    assert _decide(InputSubmitted("see what you can do")) == SubmitTurn(text="see what you can do")
 
 
 def test_decide_submits_normal_turn_with_exclusive_stdin_wait() -> None:

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -213,7 +213,7 @@ class TestPromptMessage:
 class TestResolvePromptPlaceholder:
     def test_default_when_no_session_context(self) -> None:
         session = Session()
-        assert DEFAULT_PLACEHOLDER_TEXT in _placeholder_text(session)
+        assert _strip_ansi(_placeholder_text(session)) == "see what you can do"
 
     def test_placeholder_prompts_to_continue_an_unfinished_plan(self) -> None:
         from core.agent_harness.task_plan.plan import parse_task_plan


### PR DESCRIPTION
Fixes: N/A

#### Describe the changes you have made in this PR -

- Replace dynamic skill-demo suggestions with three stable getting-started choices.
- Give the status text a muted metallic shimmer derived from the active terminal theme.
- Change the composer placeholder to `see what you can do` and allow that exact phrase to be submitted.

### Demo/Screenshot for feature changes and bug fixes -

Terminal behavior validated locally:
- Empty composer displays `see what you can do`.
- Submitting `see what you can do` creates a normal user turn.
- `Thinking…` and tool-status labels use the moving metallic gradient.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The getting-started menu now comes from a focused prompt module rather than optional metadata spread across skills, which keeps onboarding choices stable while preserving skill discovery. The terminal shimmer samples a cyclic gradient made only from semantic theme colors, mixing neutral text colors with softened brand and highlight reflections. The input controller no longer compares submitted text with display-only placeholder copy, so users can submit the suggested phrase normally.

Alternatives considered included keeping demos in skill frontmatter and retaining a content-based stale-placeholder guard. The dedicated starter catalog makes the intended onboarding contract explicit, and prompt-toolkit placeholders are presentation-only, so filtering real input by copy is unnecessary and prevents a valid request.

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/core/ tests/interactive_shell/ tests/infrastructure/terminal/test_theme.py -q` (3,727 passed; four ANSI assertions blocked by the host's `NO_COLOR=1`)
- `env -u NO_COLOR -u FORCE_COLOR uv run python -m pytest tests/interactive_shell/runtime/test_repl_presenter.py tests/interactive_shell/ui/test_handoff_questions.py tests/interactive_shell/ui/test_sign_in.py tests/interactive_shell/ui/test_streaming.py -q` (96 passed)
- `env -u NO_COLOR -u FORCE_COLOR uv run python -m pytest tests/core/agent/prompts/ tests/infrastructure/terminal/test_theme.py tests/interactive_shell/runtime/test_controller_input_actions.py tests/interactive_shell/ui/test_input_prompt.py -q` (92 passed after rebase)

---

## Checklist before requesting a review
- [x] I have added proper PR title; no issue applies to this UX refinement
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows this project's style guidelines and conventions

---

Made with [Cursor](https://cursor.com)