### PR TITLE
refactor(analytics): ReactPhase / ReactStopReason as StrEnums (#4520)

### DIFF
--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -67,7 +67,7 @@ from core.events import runtime_event_callback_from_observer
 from core.llm.types import AgentLLMResponse, SchemaDescribedTool, ToolCall
 from core.tool.execution import ToolExecutionHooks, public_tool_input
 from core.tool_framework.tags import SUMMARIZE_OBSERVATION_TAG
-from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
+from infrastructure.analytics.react_turn import ReactPhase, run_react_agent_with_telemetry
 from infrastructure.observability.trace.prompts import persist_turn_system_prompt
 from infrastructure.observability.trace.spans import component_span
 from infrastructure.text import is_data_blob
@@ -913,7 +913,7 @@ def _run_action_turn(
         result = run_react_agent_with_telemetry(
             built.agent,
             [{"role": "user", "content": built.user_message}],
-            phase="action",
+            phase=ReactPhase.ACTION,
             iteration_cap=built.max_iterations,
             llm=built.llm,
             session=session,

--- a/infrastructure/analytics/react_turn.py
+++ b/infrastructure/analytics/react_turn.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Any
 
 from core.agent import Agent
 from core.agent.run_io import AgentRunResult
@@ -28,8 +29,22 @@ from infrastructure.analytics.repl_context import (
     get_prompt_turn_id,
 )
 
-ReactPhase = Literal["action", "gather"]
-ReactStopReason = Literal["completed", "iteration_cap", "error", "cancelled", "no_tools_needed"]
+
+class ReactPhase(StrEnum):
+    """ReAct turn phase. String values are a public analytics vocabulary."""
+
+    ACTION = "action"
+    GATHER = "gather"
+
+
+class ReactStopReason(StrEnum):
+    """Why a ReAct turn ended. String values are a public analytics vocabulary."""
+
+    COMPLETED = "completed"
+    ITERATION_CAP = "iteration_cap"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+    NO_TOOLS_NEEDED = "no_tools_needed"
 
 
 def resolve_react_stop_reason(
@@ -41,14 +56,14 @@ def resolve_react_stop_reason(
 ) -> ReactStopReason:
     """Map a finished or failed Agent.run to the public stop-reason enum."""
     if cancelled:
-        return "cancelled"
+        return ReactStopReason.CANCELLED
     if error is not None:
-        return "error"
+        return ReactStopReason.ERROR
     if hit_iteration_cap:
-        return "iteration_cap"
+        return ReactStopReason.ITERATION_CAP
     if tool_calls_executed == 0:
-        return "no_tools_needed"
-    return "completed"
+        return ReactStopReason.NO_TOOLS_NEEDED
+    return ReactStopReason.COMPLETED
 
 
 def _session_investigation_id(session: SessionState | None) -> str | None:
@@ -120,7 +135,7 @@ def emit_react_turn_completed(
         error=error,
         cancelled=cancelled,
     )
-    hit_iteration_cap = stop_reason == "iteration_cap"
+    hit_iteration_cap = stop_reason == ReactStopReason.ITERATION_CAP
 
     cli_turn_kind = get_cli_turn_kind() or "agent"
     investigation_id = _session_investigation_id(session)

--- a/infrastructure/analytics/react_turn.py
+++ b/infrastructure/analytics/react_turn.py
@@ -141,12 +141,13 @@ def emit_react_turn_completed(
     investigation_id = _session_investigation_id(session)
     investigation_loop_count = _session_investigation_loop_count(session)
 
+    # Analytics is an external boundary: emit plain strings, not enum members
     capture_react_turn_completed(
-        phase=phase,
+        phase=phase.value,
         llm_iterations_used=llm_iterations_used,
         llm_iteration_cap=iteration_cap,
         hit_iteration_cap=hit_iteration_cap,
-        stop_reason=stop_reason,
+        stop_reason=stop_reason.value,
         tool_calls_executed=tool_calls_executed,
         duration_ms=duration_ms,
         cli_session_id=_resolve_cli_session_id(session),

--- a/tests/analytics/test_react_turn.py
+++ b/tests/analytics/test_react_turn.py
@@ -5,7 +5,12 @@ import pytest
 from core.agent.run_io import AgentRunResult
 from infrastructure.analytics import capture
 from infrastructure.analytics.events import Event
-from infrastructure.analytics.react_turn import emit_react_turn_completed, resolve_react_stop_reason
+from infrastructure.analytics.react_turn import (
+    ReactPhase,
+    ReactStopReason,
+    emit_react_turn_completed,
+    resolve_react_stop_reason,
+)
 
 
 class _StubLLM:
@@ -24,15 +29,30 @@ class _StubAnalytics:
 @pytest.mark.parametrize(
     ("kwargs", "expected"),
     [
-        ({"hit_iteration_cap": False, "tool_calls_executed": 2}, "completed"),
-        ({"hit_iteration_cap": True, "tool_calls_executed": 2}, "iteration_cap"),
-        ({"hit_iteration_cap": False, "tool_calls_executed": 0}, "no_tools_needed"),
-        ({"hit_iteration_cap": False, "tool_calls_executed": 0, "error": RuntimeError()}, "error"),
-        ({"hit_iteration_cap": False, "tool_calls_executed": 0, "cancelled": True}, "cancelled"),
+        ({"hit_iteration_cap": False, "tool_calls_executed": 2}, ReactStopReason.COMPLETED),
+        ({"hit_iteration_cap": True, "tool_calls_executed": 2}, ReactStopReason.ITERATION_CAP),
+        ({"hit_iteration_cap": False, "tool_calls_executed": 0}, ReactStopReason.NO_TOOLS_NEEDED),
+        (
+            {"hit_iteration_cap": False, "tool_calls_executed": 0, "error": RuntimeError()},
+            ReactStopReason.ERROR,
+        ),
+        (
+            {"hit_iteration_cap": False, "tool_calls_executed": 0, "cancelled": True},
+            ReactStopReason.CANCELLED,
+        ),
     ],
 )
-def test_resolve_react_stop_reason(kwargs: dict[str, object], expected: str) -> None:
-    assert resolve_react_stop_reason(**kwargs) == expected  # type: ignore[arg-type]
+def test_resolve_react_stop_reason(kwargs: dict[str, object], expected: ReactStopReason) -> None:
+    result = resolve_react_stop_reason(**kwargs)  # type: ignore[arg-type]
+    assert result is expected
+
+
+def test_react_stop_reason_round_trips_from_analytics_string() -> None:
+    for member in ReactStopReason:
+        assert ReactStopReason(str(member)) is member
+        assert member == member.value
+
+    assert ReactPhase("action") is ReactPhase.ACTION
 
 
 def test_capture_react_turn_completed_emits_required_properties(
@@ -91,7 +111,7 @@ def test_emit_react_turn_completed_sets_hit_iteration_cap_from_stop_reason(
     )
 
     emit_react_turn_completed(
-        phase="gather",
+        phase=ReactPhase.GATHER,
         result=AgentRunResult(
             messages=[],
             final_text="",

--- a/tests/core/agent_harness/test_react_turn_telemetry.py
+++ b/tests/core/agent_harness/test_react_turn_telemetry.py
@@ -75,6 +75,11 @@ def test_run_react_agent_with_telemetry_emits_one_completed_event(
     assert properties["stop_reason"] == "no_tools_needed"
     assert properties["llm_iterations_used"] == 1
 
+    # Dashboards key on the exact strings; the event must carry plain str, not
+    # enum members, so the serialized payload stays byte-for-byte identical
+    assert type(properties["phase"]) is str
+    assert type(properties["stop_reason"]) is str
+
 
 def test_run_react_agent_with_telemetry_emits_error_event(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/agent_harness/test_react_turn_telemetry.py
+++ b/tests/core/agent_harness/test_react_turn_telemetry.py
@@ -7,7 +7,7 @@ import pytest
 from core.agent.run_io import AgentRunResult
 from infrastructure.analytics import capture
 from infrastructure.analytics.events import Event
-from infrastructure.analytics.react_turn import run_react_agent_with_telemetry
+from infrastructure.analytics.react_turn import ReactPhase, run_react_agent_with_telemetry
 
 
 class _StubAnalytics:
@@ -61,7 +61,7 @@ def test_run_react_agent_with_telemetry_emits_one_completed_event(
     result = run_react_agent_with_telemetry(
         agent,  # type: ignore[arg-type]
         [{"role": "user", "content": "hello"}],
-        phase="action",
+        phase=ReactPhase.ACTION,
         iteration_cap=6,
         llm=_StubLLM(),
     )
@@ -87,7 +87,7 @@ def test_run_react_agent_with_telemetry_emits_error_event(
         run_react_agent_with_telemetry(
             agent,  # type: ignore[arg-type]
             [{"role": "user", "content": "hello"}],
-            phase="gather",
+            phase=ReactPhase.GATHER,
             iteration_cap=4,
             llm=_StubLLM(),
         )
@@ -112,7 +112,7 @@ def test_run_react_agent_with_telemetry_reports_partial_iterations_on_error(
         run_react_agent_with_telemetry(
             agent,  # type: ignore[arg-type]
             [{"role": "user", "content": "hello"}],
-            phase="action",
+            phase=ReactPhase.ACTION,
             iteration_cap=6,
             llm=_StubLLM(),
         )


### PR DESCRIPTION
Fixes #4520

#### Describe the changes you have made in this PR -

`infrastructure/analytics/react_turn.py` defined the ReAct turn telemetry
vocabulary as `Literal` aliases:

```python
ReactPhase = Literal["action", "gather"]
ReactStopReason = Literal["completed", "iteration_cap", "error", "cancelled", "no_tools_needed"]
```

`stop_reason` is a public property on the `react_turn_completed` PostHog event,
so a `Literal` gives no runtime enforcement and no single source of truth.

This PR converts both to `enum.StrEnum` with the **exact same string values**
(dashboards key on them):

- `ReactPhase` / `ReactStopReason` are now `StrEnum` classes.
- `resolve_react_stop_reason` returns enum members instead of bare strings.
- `emit_react_turn_completed` compares against `ReactStopReason.ITERATION_CAP`
  internally and passes `.value` (plain `str`) at the `capture_react_turn_completed`
  boundary, since analytics is an external API - so the emitted event stays
  byte-for-byte identical.
- `core/agent_harness/turns/action_driver.py` (the only production caller) now
  passes `ReactPhase.ACTION`.

Tests were updated as well:

- `test_resolve_react_stop_reason` now covers every stop-reason branch with
  member-identity assertions, and a new
  `test_react_stop_reason_round_trips_from_analytics_string` pins the members and
  the `Enum(value)` round-trips (per the issue's reference to
  `tests/filestorage/test_enums.py`).
- `test_react_turn_telemetry.py` is migrated to `ReactPhase` members and now
  asserts the emitted event properties are plain `str`, not enum members, so a
  future serializer change cannot drift the PostHog representation.

No behaviour change: the wire format of the analytics event is unchanged.

### Demo/Screenshot for feature changes and bug fixes -

Behaviour-preserving refactor. Focused checks:

```
$ uv run ruff check infrastructure/analytics/react_turn.py core/agent_harness/turns/action_driver.py tests/analytics/test_react_turn.py tests/core/agent_harness/test_react_turn_telemetry.py
All checks passed!

$ uv run mypy infrastructure/analytics/react_turn.py core/agent_harness/turns/action_driver.py
Success: no issues found in 2 source files

$ uv run pytest tests/analytics/ tests/core/agent_harness/ -q
642 passed, 1 xfailed
```

The `react_turn_completed` event still carries `"stop_reason": "completed"` /
`"phase": "action"` as plain strings (verified by
`tests/core/agent_harness/test_react_turn_telemetry.py`).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `ReactStopReason` / `ReactPhase` were `Literal` string aliases, which
only exist for the type checker. There was no runtime object, no enumerable set
of valid values, and no way to reference a value by name.

Alternative considered: a plain `enum.Enum`. Rejected because its members do not
compare equal to their string values, so `model_dump` / `json.dumps` and the
analytics event would change shape, and every equality check downstream would
break. `StrEnum` keeps each member usable as a `str`, so the emitted PostHog
payload stays identical - which the issue explicitly requires.

Internally the code works with enum members (`resolve_react_stop_reason` returns
them, comparisons use them). At the `capture_react_turn_completed` call - the
external analytics boundary - the members are converted with `.value` to plain
`str`, matching that function's declared signature and the issue's guidance
("use `.value` only when an external API needs a plain `str`").

Key pieces:
- `ReactPhase` / `ReactStopReason` (`StrEnum`): the enumerated vocabularies, in
  the same leaf module (no import cycles).
- `resolve_react_stop_reason`: maps a finished/failed `Agent.run` to a
  `ReactStopReason` member; return-annotation already promised the enum type.
- `action_driver._run_action_turn`: updated the single production call site to
  pass `ReactPhase.ACTION` so `make typecheck` stays green over `core/`.
- Tests: `test_resolve_react_stop_reason` (one case per stop-reason branch,
  asserting member identity), `test_react_stop_reason_round_trips_from_analytics_string`
  (pins members and `Enum(value)` round-trips), and a hardened telemetry test that
  pins the emitted event to plain `str`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

> _Note: the "core feature" item is left unchecked because this is a
> behaviour-preserving refactor, not a new feature. Test coverage was still
> updated - see the description above._
