### PR TITLE
feat(postgresql): add evidence mappers for postgresql tools (#5540)

### DIFF
--- a/integrations/postgresql/tools/postgresql_current_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_current_queries_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,31 @@ from integrations.postgresql import (
     postgresql_is_available,
     resolve_postgresql_config,
 )
+
+
+def _map_get_postgresql_current_queries(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the count of long-running queries and their longest duration."""
+    if not output.get("available"):
+        return
+    queries = output.get("queries") or []
+    if not isinstance(queries, list) or not queries:
+        return
+    parts = [f"{len(queries)} running query/queries"]
+    durations = [
+        q.get("duration_seconds")
+        for q in queries
+        if isinstance(q.get("duration_seconds"), (int, float))
+    ]
+    if durations:
+        parts.append(f"max duration {max(durations)}s")
+    record_evidence_entry(
+        evidence,
+        source="get_postgresql_current_queries",
+        label="PostgreSQL Current Queries",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -28,6 +54,7 @@ from integrations.postgresql import (
     is_available=postgresql_is_available,
     injected_params=("host",),
     extract_params=postgresql_extract_params,
+    evidence_mapper=_map_get_postgresql_current_queries,
 )
 def get_postgresql_current_queries(
     host: str,

--- a/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_locks_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework import tool
@@ -12,6 +13,29 @@ from integrations.postgresql import (
     postgresql_is_available,
     resolve_postgresql_config,
 )
+
+
+def _map_get_postgresql_lock_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite blocked-query count and the longest blocking wait."""
+    if not output.get("available"):
+        return
+    blocked = output.get("blocked_queries") or []
+    if not isinstance(blocked, list) or not blocked:
+        return
+    parts = [f"{len(blocked)} blocked query/queries"]
+    waits = [
+        q.get("wait_seconds") for q in blocked if isinstance(q.get("wait_seconds"), (int, float))
+    ]
+    if waits:
+        parts.append(f"longest wait {max(waits)}s")
+    record_evidence_entry(
+        evidence,
+        source="get_postgresql_lock_status",
+        label="PostgreSQL Lock Status",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -38,6 +62,7 @@ from integrations.postgresql import (
     is_available=postgresql_is_available,
     injected_params=("host",),
     extract_params=postgresql_extract_params,
+    evidence_mapper=_map_get_postgresql_lock_status,
 )
 def get_postgresql_lock_status(
     host: str,

--- a/integrations/postgresql/tools/postgresql_replication_status_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_replication_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,35 @@ from integrations.postgresql import (
     postgresql_is_available,
     resolve_postgresql_config,
 )
+
+
+def _map_get_postgresql_replication_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite primary/replica role and streaming replica count."""
+    if not output.get("available"):
+        return
+    if not output.get("is_primary", False):
+        record_evidence_entry(
+            evidence,
+            source="get_postgresql_replication_status",
+            label="PostgreSQL Replication Status",
+            summary="server is a replica, not a primary",
+        )
+        return
+    replicas = output.get("replicas") or []
+    count = output.get("replica_count")
+    if not isinstance(count, int) or count <= 0:
+        count = len(replicas) if isinstance(replicas, list) else 0
+    if count <= 0:
+        return
+    parts = [f"{count} streaming replica(s)"]
+    record_evidence_entry(
+        evidence,
+        source="get_postgresql_replication_status",
+        label="PostgreSQL Replication Status",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -26,6 +56,7 @@ from integrations.postgresql import (
     is_available=postgresql_is_available,
     injected_params=("host",),
     extract_params=postgresql_extract_params,
+    evidence_mapper=_map_get_postgresql_replication_status,
 )
 def get_postgresql_replication_status(
     host: str,

--- a/integrations/postgresql/tools/postgresql_server_status_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_server_status_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,36 @@ from integrations.postgresql import (
     postgresql_is_available,
     resolve_postgresql_config,
 )
+
+
+def _map_get_postgresql_server_status(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite connections, cache hit ratio, and uptime."""
+    if not output.get("available"):
+        return
+    connections = output.get("connections") or {}
+    db_stats = output.get("database_stats") or {}
+    parts = []
+    total = connections.get("total")
+    if isinstance(total, int):
+        parts.append(f"{total} connection(s)")
+    if isinstance(connections.get("active"), int):
+        parts.append(f"{connections.get('active')} active")
+    hit_ratio = db_stats.get("cache_hit_ratio_percent")
+    if isinstance(hit_ratio, (int, float)):
+        parts.append(f"cache hit {hit_ratio}%")
+    uptime = output.get("uptime")
+    if uptime:
+        parts.append(f"uptime {uptime}")
+    if not parts:
+        return
+    record_evidence_entry(
+        evidence,
+        source="get_postgresql_server_status",
+        label="PostgreSQL Server Status",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -26,6 +57,7 @@ from integrations.postgresql import (
     is_available=postgresql_is_available,
     injected_params=("host",),
     extract_params=postgresql_extract_params,
+    evidence_mapper=_map_get_postgresql_server_status,
 )
 def get_postgresql_server_status(
     host: str,

--- a/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_slow_queries_tool/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool import EvidenceType, SideEffectLevel
 from core.tool_framework import tool
@@ -16,6 +17,37 @@ from integrations.postgresql import (
     postgresql_is_available,
     resolve_postgresql_config,
 )
+
+
+def _map_get_postgresql_slow_queries(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the slow-query count and the slowest mean execution time."""
+    if not output.get("available"):
+        return
+    if not output.get("extension_available", True):
+        record_evidence_entry(
+            evidence,
+            source="get_postgresql_slow_queries",
+            label="PostgreSQL Slow Queries",
+            summary="pg_stat_statements extension not installed",
+        )
+        return
+    queries = output.get("queries") or []
+    if not isinstance(queries, list) or not queries:
+        return
+    parts = [f"{len(queries)} slow query/queries"]
+    means = [
+        q.get("mean_time_ms") for q in queries if isinstance(q.get("mean_time_ms"), (int, float))
+    ]
+    if means:
+        parts.append(f"slowest mean {max(means):.0f}ms")
+    record_evidence_entry(
+        evidence,
+        source="get_postgresql_slow_queries",
+        label="PostgreSQL Slow Queries",
+        summary=", ".join(parts),
+    )
 
 
 class PostgreSQLSlowQueriesInput(BaseModel):
@@ -74,6 +106,7 @@ class PostgreSQLSlowQueriesOutput(BaseModel):
     is_available=postgresql_is_available,
     injected_params=("host",),
     extract_params=postgresql_extract_params,
+    evidence_mapper=_map_get_postgresql_slow_queries,
 )
 def get_postgresql_slow_queries(
     host: str,

--- a/integrations/postgresql/tools/postgresql_table_stats_tool/__init__.py
+++ b/integrations/postgresql/tools/postgresql_table_stats_tool/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
 from core.tool_framework.utils import call_db_tool_with_default_db_warning
@@ -11,6 +12,36 @@ from integrations.postgresql import (
     postgresql_is_available,
     resolve_postgresql_config,
 )
+
+
+def _map_get_postgresql_table_stats(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the table count and the largest table by total size."""
+    if not output.get("available"):
+        return
+    tables = output.get("tables") or []
+    if not isinstance(tables, list) or not tables:
+        return
+    parts = [f"{len(tables)} table(s)"]
+    largest = max(
+        tables,
+        key=lambda t: (
+            t.get("size", {}).get("total_mb")
+            if isinstance(t.get("size", {}).get("total_mb"), (int, float))
+            else -1
+        ),
+    )
+    largest_name = largest.get("table_name")
+    largest_mb = largest.get("size", {}).get("total_mb")
+    if largest_name and isinstance(largest_mb, (int, float)):
+        parts.append(f"largest {largest_name} {largest_mb:.0f}MB")
+    record_evidence_entry(
+        evidence,
+        source="get_postgresql_table_stats",
+        label="PostgreSQL Table Stats",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -26,6 +57,7 @@ from integrations.postgresql import (
     is_available=postgresql_is_available,
     injected_params=("host",),
     extract_params=postgresql_extract_params,
+    evidence_mapper=_map_get_postgresql_table_stats,
 )
 def get_postgresql_table_stats(
     host: str,

--- a/tests/integrations/postgresql/test_evidence_mappers.py
+++ b/tests/integrations/postgresql/test_evidence_mappers.py
@@ -1,0 +1,231 @@
+"""Evidence mapper coverage for the postgresql tools (#5540)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.postgresql.tools.postgresql_current_queries_tool import (
+    _map_get_postgresql_current_queries,
+)
+from integrations.postgresql.tools.postgresql_locks_tool import (
+    _map_get_postgresql_lock_status,
+)
+from integrations.postgresql.tools.postgresql_replication_status_tool import (
+    _map_get_postgresql_replication_status,
+)
+from integrations.postgresql.tools.postgresql_server_status_tool import (
+    _map_get_postgresql_server_status,
+)
+from integrations.postgresql.tools.postgresql_slow_queries_tool import (
+    _map_get_postgresql_slow_queries,
+)
+from integrations.postgresql.tools.postgresql_table_stats_tool import (
+    _map_get_postgresql_table_stats,
+)
+
+
+class TestMapPostgresqlCurrentQueries:
+    def test_records_count_and_longest_duration(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_current_queries(
+            evidence,
+            {
+                "available": True,
+                "total_queries": 2,
+                "queries": [
+                    {"pid": 1, "state": "active", "duration_seconds": 8},
+                    {"pid": 2, "state": "active", "duration_seconds": 21},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_postgresql_current_queries"
+        assert entries[0]["summary"] == "2 running query/queries, max duration 21s"
+
+    def test_records_nothing_when_unavailable_or_empty(self) -> None:
+        for output in (
+            {"available": False, "error": "boom"},
+            {"available": True, "queries": []},
+            {"available": True, "queries": "not-a-list"},
+        ):
+            evidence: dict[str, Any] = {}
+            _map_get_postgresql_current_queries(evidence, output, {})
+            assert "catalog_entries" not in evidence
+
+
+class TestMapPostgresqlLockStatus:
+    def test_records_blocked_count_and_longest_wait(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_lock_status(
+            evidence,
+            {
+                "available": True,
+                "blocked_queries": [
+                    {"blocked_pid": 1, "wait_seconds": 15, "locktype": "relation"},
+                    {"blocked_pid": 2, "wait_seconds": 40, "locktype": "tuple"},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_postgresql_lock_status"
+        assert entries[0]["summary"] == "2 blocked query/queries, longest wait 40s"
+
+    def test_records_nothing_when_no_blocked_queries(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_postgresql_lock_status(
+            evidence, {"available": True, "blocked_queries": [], "lock_summary": []}, {}
+        )
+        assert "catalog_entries" not in evidence
+
+
+class TestMapPostgresqlReplicationStatus:
+    def test_records_replica_count(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_replication_status(
+            evidence,
+            {
+                "available": True,
+                "is_primary": True,
+                "replica_count": 2,
+                "replicas": [{"client_addr": "10.0.0.1"}, {"client_addr": "10.0.0.2"}],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_postgresql_replication_status"
+        assert entries[0]["summary"] == "2 streaming replica(s)"
+
+    def test_records_replica_not_primary(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_replication_status(
+            evidence,
+            {"available": True, "is_primary": False, "pg_is_in_recovery": True},
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert "replica" in entries[0]["summary"]
+
+    def test_records_nothing_when_primary_with_no_replicas(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_postgresql_replication_status(
+            evidence, {"available": True, "is_primary": True, "replica_count": 0}, {}
+        )
+        assert "catalog_entries" not in evidence
+
+
+class TestMapPostgresqlServerStatus:
+    def test_records_connections_and_cache_hit(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_server_status(
+            evidence,
+            {
+                "available": True,
+                "connections": {"total": 42, "active": 7},
+                "database_stats": {"cache_hit_ratio_percent": 99.3},
+                "uptime": "3 days",
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_postgresql_server_status"
+        assert "42 connection(s)" in entries[0]["summary"]
+        assert "cache hit 99.3%" in entries[0]["summary"]
+
+    def test_records_nothing_when_no_metric_fields(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_postgresql_server_status(evidence, {"available": True}, {})
+        assert "catalog_entries" not in evidence
+
+
+class TestMapPostgresqlSlowQueries:
+    def test_records_count_and_slowest_mean(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_slow_queries(
+            evidence,
+            {
+                "available": True,
+                "extension_available": True,
+                "total_queries": 2,
+                "queries": [
+                    {"queryid": "1", "mean_time_ms": 1500.0},
+                    {"queryid": "2", "mean_time_ms": 3200.0},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_postgresql_slow_queries"
+        assert entries[0]["summary"] == "2 slow query/queries, slowest mean 3200ms"
+
+    def test_records_note_when_extension_missing(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_slow_queries(
+            evidence,
+            {
+                "available": True,
+                "extension_available": False,
+                "note": "pg_stat_statements extension is not installed.",
+                "queries": [],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert "extension" in entries[0]["summary"]
+
+    def test_records_nothing_when_no_slow_queries(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_postgresql_slow_queries(
+            evidence, {"available": True, "extension_available": True, "queries": []}, {}
+        )
+        assert "catalog_entries" not in evidence
+
+
+class TestMapPostgresqlTableStats:
+    def test_records_count_and_largest_table(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_postgresql_table_stats(
+            evidence,
+            {
+                "available": True,
+                "total_tables": 2,
+                "tables": [
+                    {"schema": "public", "table_name": "users", "size": {"total_mb": 120.0}},
+                    {"schema": "public", "table_name": "orders", "size": {"total_mb": 540.0}},
+                ],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_postgresql_table_stats"
+        assert entries[0]["summary"] == "2 table(s), largest orders 540MB"
+
+    def test_records_nothing_when_no_tables(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_postgresql_table_stats(evidence, {"available": True, "tables": []}, {})
+        assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -54,12 +54,6 @@ get_lambda_configuration
 get_lambda_errors
 get_lambda_invocation_logs
 get_pods_on_node
-get_postgresql_current_queries
-get_postgresql_lock_status
-get_postgresql_replication_status
-get_postgresql_server_status
-get_postgresql_slow_queries
-get_postgresql_table_stats
 get_redis_client_list
 get_redis_latency_doctor
 get_redis_list_depth


### PR DESCRIPTION
Fixes #5540

<!-- Tracking epic #5519 (part of #1079) -->

#### Describe the changes you have made in this PR -

Wires the six PostgreSQL diagnostic tools into the incident report as citable evidence by attaching an `evidence_mapper` (via `evidence_mapper=` on each `@tool` decorator) that calls `record_evidence_entry`:

- `get_postgresql_current_queries` — running query count and longest duration
- `get_postgresql_lock_status` — blocked query count and longest wait
- `get_postgresql_replication_status` — streaming replica count / replica role
- `get_postgresql_server_status` — connections, cache hit ratio, uptime
- `get_postgresql_slow_queries` — slow query count and slowest mean time (also records a note when `pg_stat_statements` is missing)
- `get_postgresql_table_stats` — table count and largest table size

Each mapper guards on `output.get("available")`, ignores empty results, and only records when there is something worth citing. Adds a unit test per mapper under `tests/integrations/postgresql/` and removes the six tools from `evidence_mapper_baseline.txt`.

### Demo/Screenshot for feature changes and bug fixes -

Check 2 — tools carry their mapper:

```
{'get_postgresql_current_queries': True, 'get_postgresql_lock_status': True, 'get_postgresql_replication_status': True, 'get_postgresql_server_status': True, 'get_postgresql_slow_queries': True, 'get_postgresql_table_stats': True}
```

Check 3 — tool output becomes report evidence through the real path:

```
$ merge_tool_evidence(ev, 'get_postgresql_current_queries', {'available': True, 'queries': [{'pid':1,'state':'active','duration_seconds':3}]}, {})
[{'source': 'get_postgresql_current_queries', 'label': 'PostgreSQL Current Queries', 'summary': '1 running query/queries, max duration 3s', 'url': None, 'snippet': None}]
```

Check 4 — nothing broke:
- 14 new mapper unit tests pass
- `test_evidence_mapper_coverage.py`: 11 passed
- `pytest tests/ -k postgresql`: 134 passed
- `ruff check` / `ruff format --check` / `mypy`: all clean

Note on the issue's fifth check: no PostgreSQL credentials are available in this environment, so the end-to-end `opensre investigate` run is left unticked. Checks 1–4 stand; a reviewer with an account can complete it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Each tool's mapper is a small pure function `_map_get_postgresql_<tool>(evidence, output, _tool_input)` that:
- Returns immediately when `output.get("available")` is falsy (tool not configured or errored), so failures never produce noise evidence.
- Ignores empty result lists so an empty query/table set doesn't clutter the report.
- Calls `record_evidence_entry` with `source=` set to the tool name, a short human `label`, and a `summary` built from the most decision-relevant fields (counts + an extreme value, e.g. longest wait / slowest mean / largest table).

I followed the shipped Grafana example and the pattern already used by the merged azure_sql/SQS evidence-mapper PRs. I chose summary phrasing that reports counts the tool actually returned rather than implying uncounted totals.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
