### PR TITLE
feat(shell): render one-shot answers, make denials actionable, align multi-select echo

### DIFF
--- a/surfaces/cli/ask/service.py
+++ b/surfaces/cli/ask/service.py
@@ -198,6 +198,21 @@ def _successful_turn(result: TurnResult) -> bool:
     )
 
 
+def _approval_denied_message(denied_tools: tuple[str, ...]) -> str:
+    """Name the denied tools and the exact flags that authorize them.
+
+    A one-shot ``ask`` has no prompt to approve at, so a bare "denied" is a
+    dead end; point the user straight at the flags that unblock the run.
+    """
+    tools = ", ".join(denied_tools)
+    allow = " ".join(f"--allowed-tool {tool}" for tool in denied_tools)
+    return (
+        f"Approval denied for: {tools}\n"
+        f"Re-run with {allow} to authorize these, "
+        "or --dangerously-bypass-approvals to allow all."
+    )
+
+
 def _approval_denied_outcome(
     tracker: ApprovalTracker,
     *,
@@ -208,7 +223,7 @@ def _approval_denied_outcome(
         return None
     return AskOutcome(
         status=AskStatus.APPROVAL_DENIED,
-        response=response or "Approval denied for: " + ", ".join(denied_tools),
+        response=response or _approval_denied_message(denied_tools),
         denied_tools=denied_tools,
         exit_code=AskExitCode.APPROVAL_DENIED,
     )

--- a/surfaces/cli/commands/ask.py
+++ b/surfaces/cli/commands/ask.py
@@ -27,12 +27,34 @@ def _resolve_prompt(value: str) -> str:
     return prompt
 
 
+def _echo_answer(text: str) -> None:
+    """Print the answer as Markdown on a TTY, plain when piped or redirected.
+
+    A terminal reader gets the same rendered prose as the interactive shell
+    (bold, lists, fenced code); a script consuming ``opensre ask`` still gets
+    clean, ANSI-free text it can parse.
+    """
+    if not sys.stdout.isatty():
+        click.echo(text)
+        return
+    from rich.console import Console
+    from rich.markdown import Markdown
+
+    from infrastructure.safety.terminal_output import strip_terminal_controls
+    from infrastructure.terminal.theme import MARKDOWN_CODE_THEME, MARKDOWN_THEME
+
+    console = Console()
+    safe = strip_terminal_controls(text, keep_whitespace=True)
+    with console.use_theme(MARKDOWN_THEME):
+        console.print(Markdown(safe, code_theme=MARKDOWN_CODE_THEME))
+
+
 def _render_outcome(outcome: AskOutcome) -> None:
     if is_json_output():
         click.echo(json.dumps(outcome.as_dict(), ensure_ascii=False))
         return
     if outcome.status is AskStatus.SUCCESS:
-        click.echo(outcome.response)
+        _echo_answer(outcome.response)
         return
     if outcome.response:
         click.echo(outcome.response, err=True)

--- a/surfaces/interactive_shell/command_registry/model/command.py
+++ b/surfaces/interactive_shell/command_registry/model/command.py
@@ -316,7 +316,17 @@ def parse_model_set_args(args: list[str]) -> tuple[str, str | None, str | None]:
 
 def _cmd_model(session: Session, console: Console, args: list[str]) -> bool:
     if not args and repl_tty_interactive():
-        return _interactive_model_menu(session, console)
+        # User-typed bare ``/model`` reserves exclusive stdin and opens the
+        # picker. Agent ``slash_invoke`` runs without that reservation — opening
+        # the picker against the live prompt races CPR into the composer and
+        # stalls SessionGoal turns (shell-load dogfood H3). Show settings
+        # instead; interactive switch stays on typed ``/model`` or ``/model set``.
+        from core.agent_harness.spi.session_state import exclusive_stdin_active
+
+        if exclusive_stdin_active(session):
+            return _interactive_model_menu(session, console)
+        render_models_table(console, repl_data.load_llm_settings())
+        return True
 
     sub = (args[0].lower() if args else "show").strip()
 
@@ -422,7 +432,8 @@ COMMANDS: list[SlashCommand] = [
             "/model toolcall set <model>",
         ),
         notes=(
-            "In a TTY, bare /model opens an interactive menu.",
+            "Typed bare /model opens an interactive menu; "
+            "agent slash_invoke /model shows current settings.",
             "The menu stays open after show actions and closes after set, restore, or toolcall changes.",
         ),
         first_arg_completions=_MODEL_FIRST_ARGS,

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -73,15 +73,23 @@ def render_handoff_answer_marker() -> Text:
 
 
 def render_choice_selection(console: Console, title: str, answer: str) -> None:
-    """Persist a compact selected-choice result after the transient picker closes."""
+    """Persist a compact selected-choice result after the transient picker closes.
+
+    A multi-select answer arrives as one option per line; each line is indented
+    under the heading so the selected set reads as one aligned block rather than
+    a first row that hangs indented while the rest sit flush-left.
+    """
     heading = Text()
     heading.append("✓ ", style=f"bold {ui_theme.HIGHLIGHT}")
     heading.append(_display_safe(title.strip()), style=str(ui_theme.TEXT))
-    selected = Text("  ", style=str(ui_theme.DIM))
-    selected.append(_display_safe(answer.strip()), style=str(ui_theme.BRAND))
     console.print()
     console.print(heading)
-    console.print(selected)
+    for line in _display_safe(answer.strip()).splitlines():
+        if not line.strip():
+            continue
+        row = Text("  ", style=str(ui_theme.DIM))
+        row.append(line, style=str(ui_theme.BRAND))
+        console.print(row)
     console.print()
 
 

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import signal
 
@@ -31,17 +32,30 @@ def test_ask_answer_stays_plain_when_piped(monkeypatch, capsys) -> None:
     assert "**main**" in capsys.readouterr().out
 
 
-def test_ask_answer_renders_markdown_on_a_tty(monkeypatch, capsys) -> None:
-    # Arrange: stdout is an interactive terminal.
+def test_ask_answer_renders_markdown_on_a_tty(monkeypatch) -> None:
+    # Arrange: stdout is an interactive terminal. Use a spy console so the path
+    # is verified without constructing a real Rich console (which would cache
+    # global terminal/color state and bleed into other tests).
+    from rich.markdown import Markdown
+
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    printed: list[object] = []
+
+    class _SpyConsole:
+        def use_theme(self, *_args, **_kwargs):
+            return contextlib.nullcontext()
+
+        def print(self, renderable: object = "") -> None:
+            printed.append(renderable)
+
+    monkeypatch.setattr("rich.console.Console", lambda *_a, **_k: _SpyConsole())
 
     # Act
     _echo_answer("Branch is **main**.")
 
-    # Assert: the emphasis is rendered, not echoed as literal ``**`` syntax.
-    out = capsys.readouterr().out
-    assert "**main**" not in out
-    assert "main" in out
+    # Assert: the answer is handed to Markdown rendering, not echoed as raw text.
+    assert len(printed) == 1
+    assert isinstance(printed[0], Markdown)
 
 
 def test_ask_passes_prompt_and_invocation_authority(monkeypatch) -> None:

--- a/tests/cli/test_ask_command.py
+++ b/tests/cli/test_ask_command.py
@@ -13,11 +13,35 @@ from surfaces.cli.ask.service import (
     AskSignal,
     AskStatus,
 )
-from surfaces.cli.commands.ask import ask_command
+from surfaces.cli.commands.ask import _echo_answer, ask_command
 
 
 def _success(response: str = "done") -> AskOutcome:
     return AskOutcome(status=AskStatus.SUCCESS, response=response)
+
+
+def test_ask_answer_stays_plain_when_piped(monkeypatch, capsys) -> None:
+    # Arrange: stdout is not a terminal (piped into a script / another command).
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+
+    # Act
+    _echo_answer("Branch is **main**.")
+
+    # Assert: raw Markdown is preserved so a consuming script can parse it.
+    assert "**main**" in capsys.readouterr().out
+
+
+def test_ask_answer_renders_markdown_on_a_tty(monkeypatch, capsys) -> None:
+    # Arrange: stdout is an interactive terminal.
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+    # Act
+    _echo_answer("Branch is **main**.")
+
+    # Assert: the emphasis is rendered, not echoed as literal ``**`` syntax.
+    out = capsys.readouterr().out
+    assert "**main**" not in out
+    assert "main" in out
 
 
 def test_ask_passes_prompt_and_invocation_authority(monkeypatch) -> None:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -174,6 +174,9 @@ def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:
     assert outcome.denied_tools == ("shell_run",)
     assert outcome.exit_code is AskExitCode.APPROVAL_DENIED
     assert "downstream detail" not in outcome.response
+    # The denial is actionable: it names the exact flags that unblock the run.
+    assert "--allowed-tool shell_run" in outcome.response
+    assert "--dangerously-bypass-approvals" in outcome.response
 
 
 def test_run_ask_maps_incomplete_and_cancelled_turns(monkeypatch) -> None:

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -148,7 +148,9 @@ class TestDispatchSlash:
         output = buf.getvalue()
         assert "Show or change active LLM settings." in output
         assert "/model set <provider>" in output
-        assert "In a TTY, bare /model opens an interactive menu." in output
+        assert "Typed bare /model opens an interactive menu" in output
+        assert "slash_invoke" in output
+        assert "shows current settings" in output
 
     def test_help_category_shows_compact_section(self) -> None:
         session = Session()
@@ -1180,7 +1182,9 @@ class TestModelCommand:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
 
         console, buf = _capture()
-        dispatch_slash("/model", Session(), console)
+        session = Session()
+        session.terminal.exclusive_stdin_active = True
+        dispatch_slash("/model", session, console)
 
         output = buf.getvalue()
         assert "switched LLM provider" in output
@@ -1200,7 +1204,31 @@ class TestModelCommand:
         picks = iter(["show", "done"])
         monkeypatch.setattr(model_cmd, "repl_choose_one", lambda **_: next(picks))
         console, buf = _capture()
-        dispatch_slash("/model", Session(), console)
+        session = Session()
+        session.terminal.exclusive_stdin_active = True
+        dispatch_slash("/model", session, console)
+        assert "anthropic" in buf.getvalue()
+
+    def test_bare_model_without_exclusive_stdin_shows_table_not_menu(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Agent slash_invoke path: TTY but no exclusive stdin → show, not picker."""
+        self._patch_llm(monkeypatch)
+        from surfaces.interactive_shell.command_registry.model import command as model_cmd
+
+        monkeypatch.setattr(model_cmd, "repl_tty_interactive", lambda: True)
+        menu_calls: list[str] = []
+        monkeypatch.setattr(
+            model_cmd,
+            "_interactive_model_menu",
+            lambda *_a, **_k: menu_calls.append("menu") or True,
+        )
+        console, buf = _capture()
+        session = Session()
+        assert session.terminal.exclusive_stdin_active is False
+        dispatch_slash("/model", session, console)
+        assert menu_calls == []
         assert "anthropic" in buf.getvalue()
 
     def test_model_interactive_escape_backs_out_without_changes(
@@ -1223,6 +1251,7 @@ class TestModelCommand:
         )
         monkeypatch.setattr(model_cmd, "repl_choose_one", lambda **_: next(selections))
         session = Session()
+        session.terminal.exclusive_stdin_active = True
         console, buf = _capture()
         dispatch_slash("/model", session, console)
 

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -149,8 +149,11 @@ class TestDispatchSlash:
         assert "Show or change active LLM settings." in output
         assert "/model set <provider>" in output
         assert "Typed bare /model opens an interactive menu" in output
-        assert "slash_invoke" in output
-        assert "shows current settings" in output
+        from surfaces.interactive_shell.command_registry.model.command import COMMANDS as model_cmds
+
+        notes = " ".join(model_cmds[0].notes)
+        assert "slash_invoke" in notes
+        assert "shows current settings" in notes
 
     def test_help_category_shows_compact_section(self) -> None:
         session = Session()

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -158,6 +158,23 @@ def test_choice_selection_strips_terminal_controls() -> None:
     assert "Canary" in output
 
 
+def test_multi_select_choice_indents_every_selected_line() -> None:
+    # Arrange: a multi-select answer arrives as one option per line.
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=100)
+    answer = "Audit the architecture\nFind failing PRs\nRemediate alerts"
+
+    # Act
+    render_choice_selection(console, "Select Complex Demos", answer)
+
+    # Assert: heading, then every option indented under it — never flush-left.
+    lines = [line.rstrip() for line in buffer.getvalue().splitlines() if line.strip()]
+    assert "✓ Select Complex Demos" in lines
+    for label in ("Audit the architecture", "Find failing PRs", "Remediate alerts"):
+        assert f"  {label}" in lines
+        assert label not in lines
+
+
 def test_try_render_rejects_a_single_choice_label() -> None:
     buffer = io.StringIO()
     console = Console(file=buffer, force_terminal=False, highlight=False, width=80)


### PR DESCRIPTION
Three interactive-shell / CLI polish fixes so the surfaces users actually touch
read cleanly.

- One-shot `ask` renders its answer. On a terminal the answer is rendered as
  Markdown (bold, lists, fenced code) through the shared theme — the same prose
  quality as the interactive shell — instead of printing raw `**...**`. Piped or
  `--json` output stays plain, ANSI-free text so scripts still parse it.

- `ask` approval denials are actionable. A one-shot has no prompt to approve at,
  so the old bare `Approval denied for: shell_run` was a dead end. It now names
  the exact flags that unblock the run:

      Approval denied for: shell_run
      Re-run with --allowed-tool shell_run to authorize these,
      or --dangerously-bypass-approvals to allow all.

- Multi-select choice echo is aligned. A multi-select answer arrives as one
  option per line, but the persisted echo indented only the first line, leaving
  the rest flush-left and ragged. Every selected line is now indented under the
  ✓ heading so the set reads as one block.