### PR TITLE
feat(tracer_web): add evidence mapper for get_tracer_tasks (#5538)

### DIFF
--- a/integrations/tracer/tools/tracer_tasks_tool/__init__.py
+++ b/integrations/tracer/tools/tracer_tasks_tool/__init__.py
@@ -2,9 +2,37 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry
 from core.domain.types.tools import ToolSurface
 from core.tool_framework import tool
-from integrations.tracer import TracerTaskResult, get_tracer_client
+from integrations.tracer import get_tracer_client
+
+
+def _map_get_tracer_tasks(
+    evidence: dict[str, Any], output: dict[str, Any], _tool_input: dict[str, Any]
+) -> None:
+    """Cite the task count and how many failed for a pipeline run."""
+    if not output.get("found"):
+        return
+    total = output.get("total_tasks", 0)
+    if not total:
+        return
+    failed = output.get("failed_tasks", 0)
+    completed = output.get("completed_tasks", 0)
+    parts = [f"{total} task(s)"]
+    if failed:
+        parts.append(f"{failed} failed")
+    if completed:
+        parts.append(f"{completed} completed")
+    record_evidence_entry(
+        evidence,
+        source="get_tracer_tasks",
+        label="Tracer Run Tasks",
+        summary=", ".join(parts),
+    )
 
 
 @tool(
@@ -28,8 +56,9 @@ from integrations.tracer import TracerTaskResult, get_tracer_client
     },
     is_available=lambda sources: bool(sources.get("tracer_web")),
     surfaces=(ToolSurface.INVESTIGATION, ToolSurface.CHAT),
+    evidence_mapper=_map_get_tracer_tasks,
 )
-def get_tracer_tasks(run_id: str) -> TracerTaskResult:
+def get_tracer_tasks(run_id: str) -> dict[str, Any]:
     """Get tasks for a specific pipeline run from the Tracer API."""
     client = get_tracer_client()
-    return client.get_run_tasks(run_id)
+    return asdict(client.get_run_tasks(run_id))

--- a/tests/integrations/tracer/test_evidence_mappers.py
+++ b/tests/integrations/tracer/test_evidence_mappers.py
@@ -1,0 +1,39 @@
+"""Evidence mapper coverage for the tracer_web tools (#5538)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.tracer.tools.tracer_tasks_tool import _map_get_tracer_tasks
+
+
+class TestMapTracerTasks:
+    def test_records_count_and_failed(self) -> None:
+        evidence: dict[str, Any] = {}
+
+        _map_get_tracer_tasks(
+            evidence,
+            {
+                "found": True,
+                "total_tasks": 5,
+                "failed_tasks": 2,
+                "completed_tasks": 3,
+                "tasks": [],
+            },
+            {},
+        )
+
+        entries = evidence["catalog_entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "get_tracer_tasks"
+        assert entries[0]["summary"] == "5 task(s), 2 failed, 3 completed"
+
+    def test_records_nothing_when_not_found(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_tracer_tasks(evidence, {"found": False}, {})
+        assert "catalog_entries" not in evidence
+
+    def test_records_nothing_when_no_tasks(self) -> None:
+        evidence: dict[str, Any] = {}
+        _map_get_tracer_tasks(evidence, {"found": True, "total_tasks": 0}, {})
+        assert "catalog_entries" not in evidence

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -68,7 +68,6 @@ get_redis_server_info
 get_redis_slowlog
 get_s3_object
 get_tracer_run
-get_tracer_tasks
 get_yc_instance_diagnostics
 get_yc_lb_health
 helm_get_release_manifest

--- a/tests/tools/test_tracer_tasks_tool.py
+++ b/tests/tools/test_tracer_tasks_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from integrations.tracer import TracerTaskResult
 from integrations.tracer.tools.tracer_tasks_tool import get_tracer_tasks
 from tests.tools.conftest import BaseToolContract
 
@@ -25,13 +26,26 @@ def test_metadata() -> None:
     assert rt.source == "tracer_web"
 
 
-def test_run_returns_task_result() -> None:
+def test_run_returns_task_result_dict() -> None:
     mock_client = MagicMock()
-    mock_result = MagicMock()
-    mock_client.get_run_tasks.return_value = mock_result
+    mock_client.get_run_tasks.return_value = TracerTaskResult(
+        found=True,
+        total_tasks=5,
+        failed_tasks=2,
+        completed_tasks=3,
+        tasks=[{"tool_name": "run_scrape"}],
+        failed_task_details=[{"tool_name": "run_scrape", "exit_code": 1}],
+    )
     with patch(
         "integrations.tracer.tools.tracer_tasks_tool.get_tracer_client", return_value=mock_client
     ):
         result = get_tracer_tasks(run_id="run-123")
-    assert result is mock_result
+    assert result == {
+        "found": True,
+        "total_tasks": 5,
+        "failed_tasks": 2,
+        "completed_tasks": 3,
+        "tasks": [{"tool_name": "run_scrape"}],
+        "failed_task_details": [{"tool_name": "run_scrape", "exit_code": 1}],
+    }
     mock_client.get_run_tasks.assert_called_once_with("run-123")


### PR DESCRIPTION
Fixes #5538

<!-- Tracking epic #5519 (part of #1079) -->

#### Describe the changes you have made in this PR -

Wires the `get_tracer_tasks` tool into the incident report as citable evidence.

- Added `_map_get_tracer_tasks` which records an evidence entry citing the task count, how many failed, and how many completed for a pipeline run.
- Serialized the tool's `TracerTaskResult` dataclass into a dict before returning it. This is required because the report evidence path (`merge_tool_evidence`) only routes dict outputs to a tool's `evidence_mapper`; a dataclass output would otherwise be dropped before the mapper ever runs.
- Attached the mapper via `evidence_mapper=` on the `@tool` decorator.
- Added unit tests for the mapper under `tests/integrations/tracer/` and updated the existing tool contract test for the dict return shape.
- Removed `get_tracer_tasks` from `evidence_mapper_baseline.txt`.

Note: `get_tracer_run` is still in the baseline and is out of scope here — it is covered by #5537.

### Demo/Screenshot for feature changes and bug fixes -

Check 2 — the tool carries its mapper:

```
{'get_tracer_tasks': True}
```

Check 3 — tool output becomes report evidence through the real path:

```
$ merge_tool_evidence(ev, 'get_tracer_tasks', {'found': True, 'total_tasks': 5, 'failed_tasks': 2, 'completed_tasks': 3}, {})
[{'source': 'get_tracer_tasks', 'label': 'Tracer Run Tasks', 'summary': '5 task(s), 2 failed, 3 completed', 'url': None, 'snippet': None}]
```

Check 4 — nothing broke:
- New mapper unit tests: 3 passed
- Existing `test_tracer_tasks_tool.py`: 9 passed
- `test_evidence_mapper_coverage.py`: 11 passed
- `ruff check` / `ruff format --check` / `mypy`: all clean

Note on the issue's fifth check: no tracer_web credentials are available in this environment, so the end-to-end `opensre investigate` run is left unticked. Checks 1–4 stand; a reviewer with an account can complete it.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The mapper is a small pure function that:
- Returns immediately when `output.get("found")` is falsy (the Tracer API reported the run was not found).
- Ignores runs with no tasks (`total_tasks` falsy) so empty results don't clutter the report.
- Records an entry whose `summary` cites the total task count plus the failed and completed counts, which are the fields an incident investigator needs to decide whether the run is the source of a failure.

The key non-obvious decision was serializing `TracerTaskResult` to a dict. `merge_tool_evidence` (tools/investigation/stages/gather_evidence/tools.py) returns early for non-dict output before ever calling the mapper, so a dataclass-returning tool would never produce evidence. I used `dataclasses.asdict` at the tool boundary so the LLM-facing content also becomes proper JSON instead of a `repr` string.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
