### PR TITLE
feat(shell): OpenSRE visual identity — purple default, fully themed chrome, fix parity spacing

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -309,6 +309,7 @@ from config.constants.posthog_mcp import (
 )
 from config.constants.product import (
     FORCE_SIGN_IN_ENV,
+    PRODUCT_DISPLAY_NAME,
     PRODUCT_NAME,
     RELEASE_STAGE,
     RELEASE_STAGE_BANNER,
@@ -483,6 +484,7 @@ __all__ = [
     "OPENSRE_APP_URL_DEV",
     "OPENSRE_APP_URL_ENV",
     "FORCE_SIGN_IN_ENV",
+    "PRODUCT_DISPLAY_NAME",
     "PRODUCT_NAME",
     "RELEASE_STAGE",
     "RELEASE_STAGE_BANNER",

--- a/config/constants/product.py
+++ b/config/constants/product.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 from typing import Final
 
-#: The CLI identity shown on the launch banner and sign-in screen.
+#: The CLI command identity (lowercase, matches the ``opensre`` executable).
 PRODUCT_NAME: Final[str] = "opensre"
+
+#: The brand name for display headers (launch banner, sign-in screen).
+PRODUCT_DISPLAY_NAME: Final[str] = "OpenSRE"
 
 #: Sign-in / welcome screen copy, shown when the shell requires login.
 WELCOME_TITLE: Final[str] = "Welcome to OpenSRE CLI"
@@ -41,6 +44,7 @@ UV_RUN_RECURSION_DEPTH_ENV: Final[str] = "UV_RUN_RECURSION_DEPTH"
 
 __all__ = [
     "FORCE_SIGN_IN_ENV",
+    "PRODUCT_DISPLAY_NAME",
     "PRODUCT_NAME",
     "RELEASES_API_URL_ENV",
     "RELEASE_STAGE",

--- a/config/constants/repl_theme.py
+++ b/config/constants/repl_theme.py
@@ -36,7 +36,8 @@ class Theme(StrEnum):
 
 
 #: Theme applied when none is configured or an unknown name is requested.
-DEFAULT_THEME_NAME = Theme.BLUE
+# Amber matches Factory droid's warm gold chrome (sunny); blue reads cold/rainy.
+DEFAULT_THEME_NAME = Theme.AMBER
 
 #: Theme names in display order (a plain tuple for callers that iterate names).
 THEME_NAMES: tuple[Theme, ...] = tuple(Theme)

--- a/config/constants/repl_theme.py
+++ b/config/constants/repl_theme.py
@@ -36,8 +36,10 @@ class Theme(StrEnum):
 
 
 #: Theme applied when none is configured or an unknown name is requested.
-# Amber matches Factory droid's warm gold chrome (sunny); blue reads cold/rainy.
-DEFAULT_THEME_NAME = Theme.AMBER
+# Purple is OpenSRE's own identity — deliberately not the warm gold/orange chrome
+# that reads as a Factory-droid copycat. The ``amber`` and ``orange`` palettes
+# stay available (``/theme``) for side-by-side visual comparison.
+DEFAULT_THEME_NAME = Theme.PURPLE
 
 #: Theme names in display order (a plain tuple for callers that iterate names).
 THEME_NAMES: tuple[Theme, ...] = tuple(Theme)

--- a/config/version.py
+++ b/config/version.py
@@ -63,3 +63,20 @@ def get_opensre_version() -> str:
     if version and "+" in version:
         return version
     return _dev_build_version(version or _DEV_BASE_VERSION)
+
+
+def get_display_version() -> str:
+    """Return the clean marketing version for UI surfaces (e.g. the banner).
+
+    Drops the injected ``.YYYY.M.D+main.<sha>`` build tail that
+    :func:`get_opensre_version` carries, leaving the base semver (``0.1``). The
+    full build string stays on ``--version``, ``doctor``, and telemetry so
+    support and bug reports keep the exact build.
+    """
+    core = get_opensre_version().split("+", 1)[0]
+    kept: list[str] = []
+    for part in core.split("."):
+        if len(part) == 4 and part.isdigit():  # injected build year — stop before it
+            break
+        kept.append(part)
+    return ".".join(kept) or core

--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -299,11 +299,26 @@ Write tables as valid GitHub-flavored Markdown pipe tables: include a header row
 
 **Tone**
 
-- Keep the voice collaborative and natural, like a coding partner handing off work.
-- Be concise and factual — no filler or conversational commentary and avoid unnecessary repetition
+- Keep the voice warm and natural, like a friendly teammate handing off work — not a status readout.
+- Open with a short, genuine human beat when it fits ("Sure —", "Nice, that's clean", "Good news:") before the point. Keep it real and brief; never sycophantic filler ("Great question!") or padding, and never repeat yourself.
+- Prefer conversational phrasing over a bare fact dump: "Sure — there are 3,763 commits on this branch." reads far better than "The branch has 3,763 commits reachable from HEAD." Speak to the user in the first person and keep the body concise and factual.
 - Use present tense and active voice (e.g., “Runs tests” not “This will run tests”).
 - Keep descriptions self-contained; don’t refer to “above” or “below”.
 - Use parallel structure in lists for consistency.
+- Default to plain prose for simple answers; reach for bullets, headers, or a table only when the result is genuinely multi-part and the user will scan it. A one- or two-fact answer is a sentence, not a list.
+- Bold sparingly — at most a couple of genuinely key terms, never whole phrases or every noun. Put real code, paths, commands, and identifiers in backticks; that is usually all the emphasis an answer needs.
+
+**Voice examples** (aim for the "Prefer", avoid the "Avoid")
+
+- User: "How many commits are on this branch?"
+  - Avoid: "The current branch has **3,763 commits** reachable from `HEAD`."
+  - Prefer: "Sure — there are 3,763 commits on this branch."
+- User: "give me a rundown of this repo"
+  - Avoid: a bare bulleted dump with every field bolded.
+  - Prefer: "Here's the shape of it: you're on `feat/x`, the last commit was `abc1234` (\"fix flaky test\") from Yauhen about an hour ago, and there are 3 open PRs." Break into bullets only when the items are a genuine list the user will scan.
+- User: "what can you help with?"
+  - Avoid: "I help **analyze CI/CD reliability**, **fix failing checks**, ..."
+  - Prefer: "Happy to help — I mostly work on CI/CD reliability: fixing failing GitHub checks, triaging alerts, and automating DevOps chores across Slack, Kubernetes, and AWS."
 
 **Verbosity**
 - Final answer compactness rules (enforced):

--- a/infrastructure/terminal/prompt_support.py
+++ b/infrastructure/terminal/prompt_support.py
@@ -199,8 +199,8 @@ def print_session_resume_hint(console: Console, session_id: str) -> None:
     """Print REPL and CLI commands that restore ``session_id``."""
     cli_name = cli_invocation_name()
     console.print(f"[{DIM}]Resume this session with:[/]")
-    console.print(f"[{HIGHLIGHT}]/resume {session_id}[/]")
-    console.print(f"[{HIGHLIGHT}]{cli_name} --resume {session_id}[/]")
+    console.print(f"[{DIM}]/resume {session_id}[/]")
+    console.print(f"[{DIM}]{cli_name} --resume {session_id}[/]")
 
 
 def repl_prompt_note_ctrl_c(console: Console, session_id: str | None = None) -> bool:
@@ -208,7 +208,7 @@ def repl_prompt_note_ctrl_c(console: Console, session_id: str | None = None) -> 
         console.print()
         if session_id:
             print_session_resume_hint(console, session_id)
-        console.print(f"[{HIGHLIGHT}]Goodbye![/]")
+        console.print(f"[{DIM}]Goodbye![/]")
         return True
     console.print(f"[{DIM}](Press Ctrl+C again to exit)[/]")
     return False

--- a/infrastructure/terminal/prompt_support.py
+++ b/infrastructure/terminal/prompt_support.py
@@ -199,8 +199,8 @@ def print_session_resume_hint(console: Console, session_id: str) -> None:
     """Print REPL and CLI commands that restore ``session_id``."""
     cli_name = cli_invocation_name()
     console.print(f"[{DIM}]Resume this session with:[/]")
-    console.print(f"[{DIM}]/resume {session_id}[/]")
-    console.print(f"[{DIM}]{cli_name} --resume {session_id}[/]")
+    console.print(f"[{HIGHLIGHT}]/resume {session_id}[/]")
+    console.print(f"[{HIGHLIGHT}]{cli_name} --resume {session_id}[/]")
 
 
 def repl_prompt_note_ctrl_c(console: Console, session_id: str | None = None) -> bool:
@@ -208,7 +208,7 @@ def repl_prompt_note_ctrl_c(console: Console, session_id: str | None = None) -> 
         console.print()
         if session_id:
             print_session_resume_hint(console, session_id)
-        console.print(f"[{DIM}]Goodbye![/]")
+        console.print(f"[{HIGHLIGHT}]Goodbye![/]")
         return True
     console.print(f"[{DIM}](Press Ctrl+C again to exit)[/]")
     return False

--- a/infrastructure/terminal/prompt_support.py
+++ b/infrastructure/terminal/prompt_support.py
@@ -196,11 +196,15 @@ def cli_invocation_name() -> str:
 
 
 def print_session_resume_hint(console: Console, session_id: str) -> None:
-    """Print REPL and CLI commands that restore ``session_id``."""
+    """Print REPL and CLI commands that restore ``session_id``.
+
+    Caption stays dim; the copy-pasteable commands use the active theme accent
+    so ``/exit`` farewell keeps the same chrome as the rest of the shell.
+    """
     cli_name = cli_invocation_name()
     console.print(f"[{DIM}]Resume this session with:[/]")
-    console.print(f"[{DIM}]/resume {session_id}[/]")
-    console.print(f"[{DIM}]{cli_name} --resume {session_id}[/]")
+    console.print(f"[{HIGHLIGHT}]/resume {session_id}[/]")
+    console.print(f"[{HIGHLIGHT}]{cli_name} --resume {session_id}[/]")
 
 
 def repl_prompt_note_ctrl_c(console: Console, session_id: str | None = None) -> bool:
@@ -208,7 +212,7 @@ def repl_prompt_note_ctrl_c(console: Console, session_id: str | None = None) -> 
         console.print()
         if session_id:
             print_session_resume_hint(console, session_id)
-        console.print(f"[{DIM}]Goodbye![/]")
+        console.print(f"[{HIGHLIGHT}]Goodbye![/]")
         return True
     console.print(f"[{DIM}](Press Ctrl+C again to exit)[/]")
     return False

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -17,7 +17,7 @@ Token reference
   WARNING    warnings only — no auth, fallback store, config issues
   ERROR      errors only — missing required config, failures
   BG         terminal background, never used as foreground
-  INPUT_SURFACE  prompt/menu surface background
+  INPUT_SURFACE  composer/menu plate — visibly lifted vs BG (input box fill)
   BOLD_SKILL fixed green skill-activation label
   reply marker  assistant ``∴`` lead-in — Factory/Droid-warm accent via
                 :func:`reply_marker_style` (not WARNING; must stay vivid)
@@ -66,31 +66,37 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#CEA25C",
         ERROR="#C45B52",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "blue": CliTheme(
         name="blue",
-        HIGHLIGHT="#B7D4F0",
-        BRAND="#81A4C6",
-        TEXT="#B6BAC2",
-        SECONDARY="#A6A6A6",
+        HIGHLIGHT="#E0CC9C",
+        BRAND="#B2935B",
+        TEXT="#D0D0D0",
+        SECONDARY="#B0A898",
         DIM="#6E6E6E",
-        WARNING="#D8B06F",
+        WARNING="#E0B466",
         ERROR="#CF6B63",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "amber": CliTheme(
         name="amber",
         HIGHLIGHT="#E0CC9C",
         BRAND="#B2935B",
-        TEXT="#B6BAC2",
-        SECONDARY="#A6A6A6",
+        TEXT="#D0D0D0",
+        SECONDARY="#B0A898",
         DIM="#6E6E6E",
         WARNING="#E0B466",
         ERROR="#CF6B63",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "mono": CliTheme(
         name="mono",
@@ -102,7 +108,9 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#B0B0B0",
         ERROR="#8E8E8E",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "red": CliTheme(
         name="red",
@@ -114,7 +122,9 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#E0B466",
         ERROR="#CF6B63",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "pink": CliTheme(
         name="pink",
@@ -126,7 +136,9 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#E0B466",
         ERROR="#CF6B63",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "purple": CliTheme(
         name="purple",
@@ -138,7 +150,9 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#D8B06F",
         ERROR="#CF6B63",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "orange": CliTheme(
         name="orange",
@@ -150,7 +164,9 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#E0B466",
         ERROR="#CF6B63",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "teal": CliTheme(
         name="teal",
@@ -162,7 +178,9 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#CEA25C",
         ERROR="#C45B52",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "lime": CliTheme(
         name="lime",
@@ -174,7 +192,9 @@ THEME_REGISTRY: dict[str, CliTheme] = {
         WARNING="#CEA25C",
         ERROR="#C45B52",
         BG="#15161A",
-        INPUT_SURFACE="#1C1D22",
+        # Lifted plate for the composer (Droid/Claude/Cursor-style). Must read
+        # clearly against BG — the old #1C1D22 was nearly invisible.
+        INPUT_SURFACE="#252830",
     ),
     "nord": CliTheme(
         name="nord",
@@ -342,22 +362,27 @@ def _parse_hex_color(value: str) -> tuple[int, int, int]:
 
 
 # Factory droid agent-message marker (`#D78700`). Chromatic OpenSRE themes use
-# this for the ``∴`` reply glyph so it reads as a brand accent next to recessed
-# body text — pale WARNING gold was reading as bold-white in dogfood vs droid.
+# this for the ``∴`` reply glyph and the matching ``⏺`` tool lead-in so the
+# transcript has one warm accent on recessed grey chrome — pale WARNING gold
+# was reading as bold-white in dogfood vs droid.
 _REPLY_MARKER_HEX = "#D78700"
 
 
-def reply_marker_style() -> str:
-    """Bold warm style for the assistant ``∴`` reply marker.
-
-    Matches Factory droid's orange triangle and the Cursor/Claude pattern of a
-    single branded lead-in beside softer reply body text. Mono keeps the theme
-    highlight so the glyph stays visible without introducing chroma.
-    """
+def reply_marker_hex() -> str:
+    """Hex for the assistant/tool warm accent (mono uses theme highlight)."""
     theme = _ACTIVE_THEME
     if theme.name == "mono":
-        return f"bold {theme.HIGHLIGHT}"
-    return f"bold {_REPLY_MARKER_HEX}"
+        return theme.HIGHLIGHT
+    return _REPLY_MARKER_HEX
+
+
+def reply_marker_style() -> str:
+    """Bold warm style for the assistant ``∴`` reply marker and ``⏺`` tool lead.
+
+    Matches Factory droid's orange triangle and the Cursor/Claude pattern of a
+    single branded lead-in beside softer body text.
+    """
+    return f"bold {reply_marker_hex()}"
 
 
 class _LazyRichStyle(str):
@@ -454,7 +479,7 @@ def _apply_theme(theme: CliTheme) -> None:
     global HIGHLIGHT_ANSI, BRAND_ANSI, TEXT_ANSI, SECONDARY_ANSI, DIM_ANSI, BOLD_BRAND_ANSI
     global PROMPT_ACCENT_ANSI, PROMPT_FRAME_ANSI, DIM_COUNTER_ANSI, SURFACE_BG_ANSI
     global INPUT_SURFACE_BG_ANSI, MENU_SELECTION_ROW_ANSI, MARKDOWN_THEME
-    global DEVICE_CODE_ANSI
+    global DEVICE_CODE_ANSI, REPLY_MARKER_ANSI, BOLD_REPLY_MARKER_ANSI
 
     _highlight_rgb = _parse_hex_color(theme.HIGHLIGHT)
     _brand_rgb = _parse_hex_color(theme.BRAND)
@@ -463,6 +488,7 @@ def _apply_theme(theme: CliTheme) -> None:
     _dim_rgb = _parse_hex_color(theme.DIM)
     _bg_rgb = _parse_hex_color(theme.BG)
     _input_surface_rgb = _parse_hex_color(theme.INPUT_SURFACE)
+    _reply_rgb = _parse_hex_color(theme.HIGHLIGHT if theme.name == "mono" else _REPLY_MARKER_HEX)
 
     HIGHLIGHT_ANSI = _fg(_highlight_rgb)
     BRAND_ANSI = _fg(_brand_rgb)
@@ -470,6 +496,8 @@ def _apply_theme(theme: CliTheme) -> None:
     SECONDARY_ANSI = _fg(_secondary_rgb)
     DIM_ANSI = _fg(_dim_rgb)
     BOLD_BRAND_ANSI = f"\x1b[1m{BRAND_ANSI}"
+    REPLY_MARKER_ANSI = _fg(_reply_rgb)
+    BOLD_REPLY_MARKER_ANSI = f"\x1b[1m{REPLY_MARKER_ANSI}"
 
     PROMPT_ACCENT_ANSI = f"\x1b[1;38;2;{_highlight_rgb[0]};{_highlight_rgb[1]};{_highlight_rgb[2]}m"
     PROMPT_FRAME_ANSI = PROMPT_ACCENT_ANSI
@@ -483,23 +511,21 @@ def _apply_theme(theme: CliTheme) -> None:
 
     MARKDOWN_THEME = Theme(
         {
-            # Plain paragraphs must set a color — otherwise the body falls back
-            # to the terminal default (often pure white) and the warm ``∴``
-            # marker stops reading as the accent (Droid/Cursor/Claude pattern:
-            # branded glyph + recessed body).
+            # Sunny Droid-like reply: bright warm-grey body (#D0D0D0 TEXT), warm
+            # ``∴`` accent. Strong stays bold TEXT; avoid icy blue chrome.
             "markdown.paragraph": theme.TEXT,
             "markdown.code": f"bold {theme.HIGHLIGHT}",
             "markdown.code_block": theme.TEXT,
             "markdown.h1": f"bold {theme.HIGHLIGHT}",
-            "markdown.h2": f"bold {theme.BRAND}",
-            "markdown.h3": f"bold {theme.BRAND}",
+            "markdown.h2": f"bold {theme.WARNING}",
+            "markdown.h3": f"bold {theme.TEXT}",
             "markdown.h4": f"bold {theme.SECONDARY}",
             "markdown.strong": f"bold {theme.TEXT}",
             "markdown.em": f"italic {theme.SECONDARY}",
-            "markdown.item.bullet": f"bold {theme.BRAND}",
-            "markdown.item.number": f"bold {theme.BRAND}",
+            "markdown.item.bullet": f"bold {theme.WARNING}",
+            "markdown.item.number": f"bold {theme.WARNING}",
             "markdown.block_quote": theme.SECONDARY,
-            "markdown.link": f"underline {theme.BRAND}",
+            "markdown.link": f"underline {theme.HIGHLIGHT}",
             "markdown.link_url": theme.DIM,
             "markdown.hr": theme.DIM,
         }
@@ -587,12 +613,15 @@ __all__ = [
     "MENU_SELECTION_ROW_ANSI",
     "PROMPT_ACCENT_ANSI",
     "PROMPT_FRAME_ANSI",
+    "REPLY_MARKER_ANSI",
+    "BOLD_REPLY_MARKER_ANSI",
     "SECONDARY",
     "SECONDARY_ANSI",
     "SURFACE_BG_ANSI",
     "TEXT",
     "TEXT_ANSI",
     "WARNING",
+    "reply_marker_hex",
     "reply_marker_style",
 ]
 
@@ -617,6 +646,8 @@ TEXT_ANSI = ""
 SECONDARY_ANSI = ""
 DIM_ANSI = ""
 BOLD_BRAND_ANSI = ""
+REPLY_MARKER_ANSI = ""
+BOLD_REPLY_MARKER_ANSI = ""
 DEVICE_CODE_ANSI = ""
 
 ANSI_RESET = "\x1b[0m"

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -361,27 +361,16 @@ def _parse_hex_color(value: str) -> tuple[int, int, int]:
     return (int(stripped[0:2], 16), int(stripped[2:4], 16), int(stripped[4:6], 16))
 
 
-# Factory droid agent-message marker (`#D78700`). Chromatic OpenSRE themes use
-# this for the ``∴`` reply glyph and the matching ``⏺`` tool lead-in so the
-# transcript has one warm accent on recessed grey chrome — pale WARNING gold
-# was reading as bold-white in dogfood vs droid.
-_REPLY_MARKER_HEX = "#D78700"
-
-
 def reply_marker_hex() -> str:
-    """Hex for the assistant/tool warm accent (mono uses theme highlight)."""
-    theme = _ACTIVE_THEME
-    if theme.name == "mono":
-        return theme.HIGHLIGHT
-    return _REPLY_MARKER_HEX
+    """Hex for the assistant ``∴`` / tool ``⏺`` accent — the active theme's
+    ``HIGHLIGHT``, so every component follows the selected palette rather than a
+    fixed colour that would read as a copy of another tool."""
+    return _ACTIVE_THEME.HIGHLIGHT
 
 
 def reply_marker_style() -> str:
-    """Bold warm style for the assistant ``∴`` reply marker and ``⏺`` tool lead.
-
-    Matches Factory droid's orange triangle and the Cursor/Claude pattern of a
-    single branded lead-in beside softer body text.
-    """
+    """Bold accent for the assistant ``∴`` reply marker and ``⏺`` tool lead-in,
+    in the active theme's highlight colour (one branded lead beside softer body)."""
     return f"bold {reply_marker_hex()}"
 
 
@@ -488,7 +477,7 @@ def _apply_theme(theme: CliTheme) -> None:
     _dim_rgb = _parse_hex_color(theme.DIM)
     _bg_rgb = _parse_hex_color(theme.BG)
     _input_surface_rgb = _parse_hex_color(theme.INPUT_SURFACE)
-    _reply_rgb = _parse_hex_color(theme.HIGHLIGHT if theme.name == "mono" else _REPLY_MARKER_HEX)
+    _reply_rgb = _parse_hex_color(theme.HIGHLIGHT)
 
     HIGHLIGHT_ANSI = _fg(_highlight_rgb)
     BRAND_ANSI = _fg(_brand_rgb)

--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -19,6 +19,8 @@ Token reference
   BG         terminal background, never used as foreground
   INPUT_SURFACE  prompt/menu surface background
   BOLD_SKILL fixed green skill-activation label
+  reply marker  assistant ``∴`` lead-in — Factory/Droid-warm accent via
+                :func:`reply_marker_style` (not WARNING; must stay vivid)
 
 Usage
 -----
@@ -339,6 +341,25 @@ def _parse_hex_color(value: str) -> tuple[int, int, int]:
     return (int(stripped[0:2], 16), int(stripped[2:4], 16), int(stripped[4:6], 16))
 
 
+# Factory droid agent-message marker (`#D78700`). Chromatic OpenSRE themes use
+# this for the ``∴`` reply glyph so it reads as a brand accent next to recessed
+# body text — pale WARNING gold was reading as bold-white in dogfood vs droid.
+_REPLY_MARKER_HEX = "#D78700"
+
+
+def reply_marker_style() -> str:
+    """Bold warm style for the assistant ``∴`` reply marker.
+
+    Matches Factory droid's orange triangle and the Cursor/Claude pattern of a
+    single branded lead-in beside softer reply body text. Mono keeps the theme
+    highlight so the glyph stays visible without introducing chroma.
+    """
+    theme = _ACTIVE_THEME
+    if theme.name == "mono":
+        return f"bold {theme.HIGHLIGHT}"
+    return f"bold {_REPLY_MARKER_HEX}"
+
+
 class _LazyRichStyle(str):
     """Rich markup colour token that tracks :func:`set_active_theme`.
 
@@ -462,6 +483,11 @@ def _apply_theme(theme: CliTheme) -> None:
 
     MARKDOWN_THEME = Theme(
         {
+            # Plain paragraphs must set a color — otherwise the body falls back
+            # to the terminal default (often pure white) and the warm ``∴``
+            # marker stops reading as the accent (Droid/Cursor/Claude pattern:
+            # branded glyph + recessed body).
+            "markdown.paragraph": theme.TEXT,
             "markdown.code": f"bold {theme.HIGHLIGHT}",
             "markdown.code_block": theme.TEXT,
             "markdown.h1": f"bold {theme.HIGHLIGHT}",
@@ -567,6 +593,7 @@ __all__ = [
     "TEXT",
     "TEXT_ANSI",
     "WARNING",
+    "reply_marker_style",
 ]
 
 # ── Semantic glyphs ────────────────────────────────────────────────────────

--- a/surfaces/interactive_shell/command_registry/system.py
+++ b/surfaces/interactive_shell/command_registry/system.py
@@ -48,7 +48,7 @@ def _cmd_exit(session: Session, console: Console, _args: list[str]) -> bool:
         console.print()
         print_session_resume_hint(console, session.session_id)
     _flush_analytics_on_exit(console)
-    console.print(f"[{DIM}]goodbye.[/]")
+    console.print(f"[{HIGHLIGHT}]goodbye.[/]")
     return False
 
 

--- a/surfaces/interactive_shell/command_registry/system.py
+++ b/surfaces/interactive_shell/command_registry/system.py
@@ -48,7 +48,7 @@ def _cmd_exit(session: Session, console: Console, _args: list[str]) -> bool:
         console.print()
         print_session_resume_hint(console, session.session_id)
     _flush_analytics_on_exit(console)
-    console.print(f"[{HIGHLIGHT}]goodbye.[/]")
+    console.print(f"[{DIM}]goodbye.[/]")
     return False
 
 

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -22,6 +22,7 @@ from surfaces.interactive_shell.runtime.startup.account_gate import (
 from surfaces.interactive_shell.runtime.startup.initial_input import run_initial_input
 from surfaces.interactive_shell.runtime.startup.loop_suggestions import offer_loop_suggestions
 from surfaces.interactive_shell.ui.terminal_ui import render_terminal_ui
+from surfaces.shared.terminal.components.rendering import repl_clear_screen
 
 # Fallback when a caller does not supply one. Forces a terminal because the
 # shell owns the screen; an embedding caller passes its own instead.
@@ -126,6 +127,9 @@ def run_repl(
             if not pass_sign_in_gate(out):
                 return 0
             if paint_banner:
+                # Wipe the calling shell prompt so the REPL reads as its own
+                # screen (Droid/Claude Code), not a banner under ``uv run …``.
+                repl_clear_screen()
                 render_terminal_ui(out)
 
         return asyncio.run(

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -63,7 +63,7 @@ class ShellOutputSink:
         self._console.print(message, markup=False)
 
     def render_response_header(self, label: str) -> None:
-        self._console.print()
+        # No leading blank — Droid-dense turn stacking (user row → ∴ reply).
         render_response_header(self._console, label)
 
     def render_error(self, message: str) -> None:

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -31,6 +31,7 @@ from surfaces.interactive_shell.ui.input_prompt.key_bindings import (
     install_session_key_bindings,
 )
 from surfaces.interactive_shell.ui.input_prompt.refresh import wire_prompt_refresh
+from surfaces.interactive_shell.ui.input_prompt.resize import install_shrink_resize_guard
 from surfaces.interactive_shell.ui.input_prompt.style import refresh_prompt_theme
 from surfaces.interactive_shell.ui.prompt_visibility import typing_box_hidden
 from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
@@ -82,6 +83,7 @@ class PromptBuilder:
         install_session_key_bindings(self.pt_session, cancel_kb)
 
         self.pt_app = self.pt_session.app
+        install_shrink_resize_guard(self.pt_app)
         self.pt_session.default_buffer.accept_handler = self._accept_prompt_buffer
         # While the Yes/No gate owns the keyboard the composer is hidden but its
         # buffer still receives unbound keys unless it is read-only. Lock it so

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -9,7 +9,7 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.application import Application, run_in_terminal
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.filters import Condition
-from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.formatted_text import ANSI, FormattedText
 from rich.console import Console
 
 from surfaces.interactive_shell.runtime.core.state import (
@@ -247,15 +247,14 @@ class PromptBuilder:
             await asyncio.gather(submitted, return_exceptions=True)
             raise
 
-    def _prompt_placeholder(self) -> ANSI:
+    def _prompt_placeholder(self) -> FormattedText:
         # Options menus / confirmation own the keyboard — suppress free-text ghost.
         if typing_box_hidden(self.session, self.state):
-            return ANSI("")
+            return FormattedText()
         return prompt_rendering.resolve_prompt_placeholder(self.session)
 
     def render_submitted_prompt(self, console: Console, text: str) -> None:
-        # A blank row above each new user turn: Droid keeps the user row and its
-        # reply tight, with a clear gap between turns. The gap lives here (not in
-        # the row renderer) so the user row itself stays a single full-width plate.
-        console.print()
+        # The between-turns blank row is placed inside ``render_submitted_prompt``
+        # itself: the handoff-answer marker must hug the reply it answers, so the
+        # gap falls after the marker rather than blanket-above the whole turn.
         prompt_rendering.render_submitted_prompt(console, self.session, text)

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -254,4 +254,8 @@ class PromptBuilder:
         return prompt_rendering.resolve_prompt_placeholder(self.session)
 
     def render_submitted_prompt(self, console: Console, text: str) -> None:
+        # A blank row above each new user turn: Droid keeps the user row and its
+        # reply tight, with a clear gap between turns. The gap lives here (not in
+        # the row renderer) so the user row itself stays a single full-width plate.
+        console.print()
         prompt_rendering.render_submitted_prompt(console, self.session, text)

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -36,17 +36,17 @@ def ready_hint_ansi() -> str:
     reserved = prompt_text_width(lead)
     if reserved >= width:
         visible = clip_prompt_text(f"{lead}{hint}", width)
-        # Keep accent on "Ready" when the clipped form still starts with it.
+        # Soft grey lead — warm accent is reserved for ∴ / ⏺ / spinner glyph.
         if visible.startswith("Ready"):
             rest = visible[len("Ready") :]
             return (
-                f"{ui_theme.PROMPT_ACCENT_ANSI}Ready{ui_theme.ANSI_RESET}"
+                f"{ui_theme.BOLD_REPLY_MARKER_ANSI}Ready{ui_theme.ANSI_RESET}"
                 f"{ui_theme.DIM_ANSI}{rest}{ui_theme.ANSI_RESET}"
             )
         return f"{ui_theme.DIM_ANSI}{visible}{ui_theme.ANSI_RESET}"
     clipped_hint = clip_prompt_text(hint, width - reserved)
     return (
-        f"{ui_theme.PROMPT_ACCENT_ANSI}Ready{ui_theme.ANSI_RESET}"
+        f"{ui_theme.BOLD_REPLY_MARKER_ANSI}Ready{ui_theme.ANSI_RESET}"
         f"{ui_theme.DIM_ANSI} · {clipped_hint}{ui_theme.ANSI_RESET}"
     )
 
@@ -342,33 +342,20 @@ class SpinnerState:
         return ready_hint_ansi()
 
     def _phase_shimmer_high_hex(self) -> str:
-        """Peak color for the status-sentence light wave (matches phase accent)."""
-        theme = ui_theme.get_active_theme()
-        if self.phase in (self.INVOKING_TOOLS_PHASE, self.EXECUTING_PHASE):
-            return theme.BRAND
-        return theme.HIGHLIGHT
+        """Warm peak for the status wave (sunny gold, not icy blue)."""
+        return ui_theme.reply_marker_hex()
 
     def _phase_accent_ansi(self) -> str:
-        """Accent for the spinner glyph, distinct per load-state phase.
-
-        ``Thinking…`` (and pipeline stage labels) stay on the prompt accent (bold
-        highlight); ``Executing…`` uses brand; ``Invoking tools…`` uses bold
-        brand — the same hue as executing but heavier, so tool work reads as the
-        hottest state while staying different from thinking.
-        """
-        if self.phase == self.INVOKING_TOOLS_PHASE:
-            return ui_theme.BOLD_BRAND_ANSI
-        if self.phase == self.EXECUTING_PHASE:
-            return ui_theme.BRAND_ANSI
-        return ui_theme.PROMPT_ACCENT_ANSI
+        """Spinner glyph: Factory-warm orange (same family as ``∴`` / ``⏺``)."""
+        return ui_theme.BOLD_REPLY_MARKER_ANSI
 
     def inline_spinner_ansi(self) -> str:
-        """One status row: shimmering phase (+ live tool) · stop hint · elapsed.
+        """One status row: quiet phase (+ live tool) · stop hint · elapsed.
 
         When a tool is in flight the label becomes
         ``Invoking tools… · GitHub CLI · gh api …`` so awareness stays on the
-        same row as the spinner — never a second reserved prompt row. A traveling
-        light wave runs across that sentence while work is in flight.
+        same row as the spinner — never a second reserved prompt row. A soft
+        silver wave runs across the sentence; the glyph alone carries warmth.
         """
         if not self.streaming:
             return ""

--- a/surfaces/interactive_shell/runtime/input/prompt_input_reader.py
+++ b/surfaces/interactive_shell/runtime/input/prompt_input_reader.py
@@ -19,7 +19,7 @@ from surfaces.interactive_shell.runtime.input.events import (
     InputSubmitted,
 )
 from surfaces.interactive_shell.session import Session
-from surfaces.interactive_shell.ui import DIM
+from surfaces.interactive_shell.ui import HIGHLIGHT
 from surfaces.shared.terminal.components.cpr_stdin import (
     contains_cpr_sequence,
     strip_cpr_sequences,
@@ -90,7 +90,7 @@ class PromptInputReader:
             return
         self.console.print()
         print_session_resume_hint(self.console, self.session.session_id)
-        self.console.print(f"[{DIM}]Goodbye![/]")
+        self.console.print(f"[{HIGHLIGHT}]Goodbye![/]")
 
 
 __all__ = ["PromptInputReader"]

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -25,7 +25,14 @@ from core.agent_harness.spi.accounting import SELF_RECORDING_ACTION_TOOL_NAMES
 from core.agent_harness.spi.task_plan import is_plan_diagnosis_prose
 from infrastructure.observability.trace.redaction import redact_sensitive
 from infrastructure.safety.terminal_output import strip_terminal_controls
-from infrastructure.terminal.theme import BOLD_SKILL, BRAND, DIM, HIGHLIGHT, SECONDARY
+from infrastructure.terminal.theme import (
+    BOLD_SKILL,
+    DIM,
+    SECONDARY,
+    TEXT,
+    WARNING,
+    reply_marker_style,
+)
 from infrastructure.text import is_data_blob
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.runtime.core.state import SpinnerState
@@ -510,7 +517,7 @@ class ActionRenderObserver:
         # through Rich markup.
         line = Text()
         line.append("Skill ", style=BOLD_SKILL)
-        line.append(slug, style=HIGHLIGHT)
+        line.append(slug, style=str(TEXT))
         self.console.print()
         self.console.print(line)
 
@@ -519,16 +526,16 @@ class ActionRenderObserver:
         args = data.get("input")
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
         self.console.print()
-        # One line per call, led by ``⏺``: the label reads as the action and the
-        # payload (command / args) as its detail. A command tool separates the two
-        # with ``·`` so ``⏺ GitHub CLI · gh api …`` reads as a single unit.
+        # One warm accent (same as ``∴``) on the glyph; recessed label + dim
+        # payload — Droid-style quiet tool chrome, not a second blue brand strip.
         line = Text()
-        line.append(f"{_TOOL_CALL_MARKER} ", style=str(HIGHLIGHT))
-        line.append(label, style=f"bold {HIGHLIGHT}")
+        line.append(f"{_TOOL_CALL_MARKER} ", style=reply_marker_style())
+        line.append(label, style=f"bold {TEXT}")
         if content:
             separator = " · " if label in _COMMAND_TOOL_LABELS else " "
             line.append(separator, style=str(DIM))
-            line.append(content, style=str(BRAND))
+            # Tan payload like Droid's Execute line — warm, not cold blue/dim.
+            line.append(content, style=str(WARNING))
         self.console.print(line)
 
     def _render_tool_result(self, data: dict[str, Any]) -> None:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -30,7 +30,6 @@ from infrastructure.terminal.theme import (
     DIM,
     SECONDARY,
     TEXT,
-    WARNING,
     reply_marker_style,
 )
 from infrastructure.text import is_data_blob
@@ -534,8 +533,9 @@ class ActionRenderObserver:
         if content:
             separator = " · " if label in _COMMAND_TOOL_LABELS else " "
             line.append(separator, style=str(DIM))
-            # Tan payload like Droid's Execute line — warm, not cold blue/dim.
-            line.append(content, style=str(WARNING))
+            # Quiet payload that tracks the active palette (SECONDARY), so it
+            # never reads as an off-theme amber under a non-warm theme.
+            line.append(content, style=str(SECONDARY))
         self.console.print(line)
 
     def _render_tool_result(self, data: dict[str, Any]) -> None:

--- a/surfaces/interactive_shell/ui/auto_status.py
+++ b/surfaces/interactive_shell/ui/auto_status.py
@@ -31,12 +31,12 @@ def auto_status_ansi(session: Session) -> str:
     rest = "" if title_end < 0 else left[title_end:]
     if not right:
         clipped = clip_prompt_text(left, width)
-        return f"{ui_theme.PROMPT_ACCENT_ANSI}{clipped}{ui_theme.ANSI_RESET}"
+        return f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{clipped}{ui_theme.ANSI_RESET}"
     pad = max(width - len(left) - len(right), gap)
     return (
-        f"{ui_theme.PROMPT_ACCENT_ANSI}{title}{ui_theme.ANSI_RESET}"
+        f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{title}{ui_theme.ANSI_RESET}"
         f"{ui_theme.DIM_ANSI}{rest}{ui_theme.ANSI_RESET}"
-        f"{' ' * pad}{ui_theme.BRAND_ANSI}{right}{ui_theme.ANSI_RESET}"
+        f"{' ' * pad}{ui_theme.SECONDARY_ANSI}{right}{ui_theme.ANSI_RESET}"
     )
 
 

--- a/surfaces/interactive_shell/ui/auto_status.py
+++ b/surfaces/interactive_shell/ui/auto_status.py
@@ -31,7 +31,8 @@ def auto_status_ansi(session: Session) -> str:
     rest = "" if title_end < 0 else left[title_end:]
     if not right:
         clipped = clip_prompt_text(left, width)
-        return f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{clipped}{ui_theme.ANSI_RESET}"
+        pad = max(0, width - len(clipped))
+        return f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{clipped}{ui_theme.ANSI_RESET}{' ' * pad}"
     pad = max(width - len(left) - len(right), gap)
     return (
         f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{title}{ui_theme.ANSI_RESET}"

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.filters import Condition, to_filter
-from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.formatted_text import ANSI, FormattedText
 from prompt_toolkit.layout.containers import (
     AnyContainer,
     ConditionalContainer,
@@ -19,7 +19,6 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.widgets import Frame
 
-from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.prompt_history import load_prompt_history
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.input_prompt.completion import ShellCompleter
@@ -81,7 +80,10 @@ def _install_prompt_frame(
 
     before_input = main_input.content.children[0]
     editable_body = _limit_editable_height(main_input.content)
-    composer: AnyContainer = Frame(editable_body, style="class:composer")
+    # Inner surface so the editable rows share INPUT_SURFACE with the border
+    # (otherwise the frame looks hollow against the terminal bg).
+    surface_body: AnyContainer = HSplit([editable_body], style="class:composer-body")
+    composer: AnyContainer = Frame(surface_body, style="class:composer")
     footer: AnyContainer = Window(
         FormattedTextControl(lambda: ANSI(composer_footer_ansi())),
         height=1,
@@ -139,8 +141,12 @@ def build_prompt_session(
     *,
     hide_composer: Callable[[], bool] | None = None,
 ) -> PromptSession[str]:
-    def _default_placeholder() -> ANSI:
-        return ANSI(f"{ui_theme.DIM_ANSI}{DEFAULT_PLACEHOLDER_TEXT}{ui_theme.ANSI_RESET}")
+    def _default_placeholder() -> FormattedText:
+        from surfaces.interactive_shell.ui.input_prompt.rendering import (
+            _placeholder_formatted,
+        )
+
+        return _placeholder_formatted(DEFAULT_PLACEHOLDER_TEXT)
 
     placeholder = (
         (lambda: resolve_prompt_placeholder(session))

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -117,9 +117,8 @@ def _install_prompt_frame(
                 filter=~shown,
             ),
         ]
-    # Keep the final terminal column empty. Painting a frame border there puts
-    # the cursor in pending-wrap, which makes patch_stdout redraws jump and
-    # leaves stale composer fragments after output or a terminal resize.
+    # Keep one empty column so a right border never sits in pending-wrap, but
+    # prefer the widest safe span — Droid keeps chrome near the window edges.
     chrome = HSplit([before_input, *box_rows], width=prompt_line_width)
     framed_input = FloatContainer(
         chrome,

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -12,6 +12,7 @@ from prompt_toolkit.layout.containers import (
     ConditionalContainer,
     FloatContainer,
     HSplit,
+    VerticalAlign,
     Window,
     to_container,
 )
@@ -117,9 +118,13 @@ def _install_prompt_frame(
                 filter=~shown,
             ),
         ]
-    # Keep one empty column so a right border never sits in pending-wrap, but
-    # prefer the widest safe span — Droid keeps chrome near the window edges.
-    chrome = HSplit([before_input, *box_rows], width=prompt_line_width)
+    # Pack status + composer at the top of the live region (no JUSTIFY gap
+    # between Auto and the input box). Last column stays empty for wrap safety.
+    chrome = HSplit(
+        [before_input, *box_rows],
+        width=prompt_line_width,
+        align=VerticalAlign.TOP,
+    )
     framed_input = FloatContainer(
         chrome,
         floats=main_input.floats,

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -20,9 +20,12 @@ from surfaces.interactive_shell.ui.input_prompt.layout import (
     clip_prompt_text,
     prompt_line_width,
 )
+from surfaces.shared.terminal.prompt_layout import prompt_text_width, terminal_columns
 
 DEFAULT_PLACEHOLDER_TEXT = "see what you can do"
 _PLAN_CONTINUE_PLACEHOLDER = "continue the plan, or type a message"
+#: Warm vertical bar — same role as Droid's orange user-turn lead-in.
+_USER_TURN_ACCENT = "▌"
 
 
 def _placeholder_formatted(text: str) -> FormattedText:
@@ -111,21 +114,41 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
         )
     counter = _counter_text(session.terminal.claim_turn_number())
     lines = text.splitlines() or [""]
-    # Write palette ANSI directly. Rich Text/Style.parse on a _LazyRichStyle
-    # (empty underlying str) emits default white instead of SECONDARY grey
-    # under CI coverage / shared Style.parse cache.
-    body_ansi = ui_theme.BRAND_ANSI if is_handoff_answer else ui_theme.SECONDARY_ANSI
-    prefix_ansi = ui_theme.DIM_ANSI
-    continuation_prefix = " " * (len(counter) + len("❯ "))
+    # Full-width surface plate + warm left bar (Droid paints the user row
+    # edge-to-edge). Write palette ANSI directly — Rich Text/Style.parse on a
+    # _LazyRichStyle can fall through to default white under coverage.
+    # Full terminal width plate (Droid edge-to-edge). Trailing pad spaces stay
+    # inside the surface so the last column is never a glyph (soft-wrap safe).
+    row_width = max(terminal_columns(), 1)
+    accent_ansi = ui_theme.BOLD_REPLY_MARKER_ANSI
+    body_ansi = ui_theme.BRAND_ANSI if is_handoff_answer else ui_theme.TEXT_ANSI
+    counter_ansi = ui_theme.DIM_ANSI
+    surface = ui_theme.INPUT_SURFACE_BG_ANSI
     parts: list[str] = []
     for index, line in enumerate(lines):
         if index:
             parts.append("\n")
         if index == 0:
-            parts.append(f"{prefix_ansi}{counter}❯ {ui_theme.ANSI_RESET}")
+            # ``▌ [N] `` then body — bar sits on the left edge of the plate.
+            prefix = f"{_USER_TURN_ACCENT} {counter}"
+            prefix_cols = prompt_text_width(prefix)
+            body = clip_prompt_text(line, max(1, row_width - prefix_cols))
+            pad = max(0, row_width - prefix_cols - prompt_text_width(body))
+            parts.append(
+                f"{surface}{accent_ansi}{_USER_TURN_ACCENT}{ui_theme.ANSI_RESET}"
+                f"{surface} {counter_ansi}{counter}{ui_theme.ANSI_RESET}"
+                f"{surface}{body_ansi}{body}{' ' * pad}{ui_theme.ANSI_RESET}"
+            )
         else:
-            parts.append(f"{prefix_ansi}{continuation_prefix}{ui_theme.ANSI_RESET}")
-        parts.append(f"{body_ansi}{line}{ui_theme.ANSI_RESET}")
+            # Hang under the accent + space so wrapped lines stay in the plate.
+            hang = "  " + (" " * len(counter))
+            hang_cols = prompt_text_width(hang)
+            body = clip_prompt_text(line, max(1, row_width - hang_cols))
+            pad = max(0, row_width - hang_cols - prompt_text_width(body))
+            parts.append(
+                f"{surface}{counter_ansi}{hang}{ui_theme.ANSI_RESET}"
+                f"{surface}{body_ansi}{body}{' ' * pad}{ui_theme.ANSI_RESET}"
+            )
     console.file.write("".join(parts) + "\n")
     console.file.flush()
 

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -149,6 +149,8 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
                 f"{surface}{counter_ansi}{hang}{ui_theme.ANSI_RESET}"
                 f"{surface}{body_ansi}{body}{' ' * pad}{ui_theme.ANSI_RESET}"
             )
+    # Single trailing newline — the reply path owns the blank row under the
+    # user plate so we do not stack two spacers (Droid: one row of margin).
     console.file.write("".join(parts) + "\n")
     console.file.flush()
 

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.formatted_text import ANSI, FormattedText
 from rich.console import Console
 from rich.text import Text
 
@@ -23,6 +23,11 @@ from surfaces.interactive_shell.ui.input_prompt.layout import (
 
 DEFAULT_PLACEHOLDER_TEXT = "see what you can do"
 _PLAN_CONTINUE_PLACEHOLDER = "continue the plan, or type a message"
+
+
+def _placeholder_formatted(text: str) -> FormattedText:
+    """Ghost text on the composer plate (style carries INPUT_SURFACE bg)."""
+    return FormattedText([("class:placeholder", text)])
 
 
 def _prompt_turn_number(session: Session) -> int:
@@ -134,11 +139,15 @@ def resolve_prompt_prefix_ansi(*, inline_spinner: str, idle_hint: str) -> str:
 
 
 def resolve_idle_hint_ansi(session: Session) -> str:
-    """Return the one-line Ready/commands hint for the fixed-height status row."""
-    from surfaces.interactive_shell.runtime.core.state import ready_hint_ansi
+    """No idle chrome above the composer.
 
+    The command/shortcut hints live once in the launch banner and the composer
+    footer, so the prompt does not repeat a "Ready · …" line on every turn. That
+    recurring line also stacked into duplicate copies on terminal resize; with
+    nothing rendered here, there is nothing to leave behind.
+    """
     del session
-    return ready_hint_ansi()
+    return ""
 
 
 def ctrl_c_exit_hint_ansi() -> str:
@@ -154,11 +163,12 @@ def composer_footer_ansi() -> str:
     return f"{ui_theme.DIM_ANSI}{clipped}{ui_theme.ANSI_RESET}"
 
 
-def resolve_prompt_placeholder(session: Session) -> ANSI:
+def resolve_prompt_placeholder(session: Session) -> FormattedText:
     """Contextual ghost text when the input buffer is empty.
 
-    Built per redraw (not at import) so theme ANSI cannot freeze stale, and so
-    an unfinished live plan can replace the default exploratory hint.
+    Built per redraw (not at import) so theme styles cannot freeze stale, and so
+    an unfinished live plan can replace the default exploratory hint. Uses a
+    style class (not raw ANSI) so the composer INPUT_SURFACE fill is preserved.
     """
     parts: list[str] = []
     if session.terminal.trust_mode:
@@ -169,15 +179,13 @@ def resolve_prompt_placeholder(session: Session) -> ANSI:
     if session.resumed_from_name:
         parts.append(f"resumed: {_short_meta(session.resumed_from_name, max_len=32)}")
     if parts:
-        return ANSI(f"{ui_theme.DIM_ANSI}{' · '.join(parts)}{ui_theme.ANSI_RESET}")
+        return _placeholder_formatted(" · ".join(parts))
     if (
         session.task_plan is not None
         and session.task_plan.all_pending
         and session.plan_only_until_authorized
     ):
-        return ANSI(
-            f"{ui_theme.DIM_ANSI}say go to start the plan, or type a message{ui_theme.ANSI_RESET}"
-        )
+        return _placeholder_formatted("say go to start the plan, or type a message")
     plan = session.task_plan
     if (
         plan is not None
@@ -185,5 +193,5 @@ def resolve_prompt_placeholder(session: Session) -> ANSI:
         and not plan.all_completed
         and not session.plan_only_until_authorized
     ):
-        return ANSI(f"{ui_theme.DIM_ANSI}{_PLAN_CONTINUE_PLACEHOLDER}{ui_theme.ANSI_RESET}")
-    return ANSI(f"{ui_theme.DIM_ANSI}{DEFAULT_PLACEHOLDER_TEXT}{ui_theme.ANSI_RESET}")
+        return _placeholder_formatted(_PLAN_CONTINUE_PLACEHOLDER)
+    return _placeholder_formatted(DEFAULT_PLACEHOLDER_TEXT)

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -90,6 +90,7 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
         # Keep the Ask User block in the transcript (Q white, A brand). Claim the
         # turn number so the next prompt still advances; do not paint a fake
         # ``[N] ❯`` — leave this as the Ask User card.
+        console.print()
         session.terminal.claim_turn_number()
         render_ask_user_qa(console, ask_user_pairs)
         return
@@ -102,16 +103,23 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
         session.terminal.pending_choice_response = stripped
         return
     if is_handoff_answer:
+        # The marker hugs the assistant answer it responds to (no gap above);
+        # the between-turns gap falls below it, before the user's input row.
         console.print(render_handoff_answer_marker())
+        console.print()
     elif autosubmitted:
         # Keep this shorter than the condition — the ``[N] ❯`` line carries the
         # full text; this only answers "is this still /goal set or real work?".
+        console.print()
         console.print(
             Text(
                 "↗ /goal — work turn (condition auto-submitted)",
                 style=str(ui_theme.DIM),
             )
         )
+    else:
+        # Blank row between the previous turn and this one (Droid rhythm).
+        console.print()
     counter = _counter_text(session.terminal.claim_turn_number())
     lines = text.splitlines() or [""]
     # Full-width surface plate + warm left bar (Droid paints the user row

--- a/surfaces/interactive_shell/ui/input_prompt/resize.py
+++ b/surfaces/interactive_shell/ui/input_prompt/resize.py
@@ -1,0 +1,60 @@
+"""Shrink-resize guard for the live prompt region.
+
+When the terminal narrows, the emulator soft-wraps the *previous* paint before
+prompt-toolkit's ``_on_resize`` runs. ``Renderer.erase`` only climbs
+``_cursor_pos.y`` logical rows, so the extra wrapped rows stay on screen and
+the next redraw stacks another Ready / Auto / composer frame (ghost chrome).
+
+Keep autowrap off after each paint (stdout proxy turns it on for prints) and
+erase from an inflated origin on resize so soft-wrapped rows are cleared.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prompt_toolkit.application import Application
+
+# Soft-wrap after a modest shrink often doubles or triples physical rows for
+# the same logical UI. Climb at least this many extra rows beyond 3× height.
+_RESIZE_ERASE_PAD_ROWS = 8
+
+
+def inflate_resize_erase_y(logical_y: int, *, rows: int) -> int:
+    """Return the erase origin Y that covers soft-wrapped physical rows."""
+    if logical_y <= 0:
+        return logical_y
+    ceiling = max(1, rows) - 1
+    return min(ceiling, max(logical_y * 3, logical_y + _RESIZE_ERASE_PAD_ROWS))
+
+
+def install_shrink_resize_guard(app: Application[Any]) -> None:
+    """Install erase + autowrap guards so column shrinks do not ghost the UI."""
+    output = app.output
+    renderer = app.renderer
+    original_on_resize = app._on_resize
+    original_render = renderer.render
+
+    def _render(*args: Any, **kwargs: Any) -> None:
+        original_render(*args, **kwargs)
+        # prompt_toolkit re-enables autowrap after non-fullscreen paints so
+        # background threads can wrap. That leaves the idle composer wrap-on,
+        # so a column shrink soft-wraps Ready/Auto into ghost rows. Disable
+        # again; ``patch_prompt_stdout`` still calls ``enable_autowrap`` for
+        # each background write.
+        output.disable_autowrap()
+
+    def _on_resize() -> None:
+        output.disable_autowrap()
+        pos = renderer._cursor_pos
+        if pos is not None and pos.y > 0:
+            inflated_y = inflate_resize_erase_y(pos.y, rows=output.get_size().rows)
+            renderer._cursor_pos = type(pos)(x=pos.x, y=inflated_y)
+        original_on_resize()
+
+    renderer.render = _render  # type: ignore[method-assign]
+    app._on_resize = _on_resize  # type: ignore[method-assign]
+    output.disable_autowrap()
+
+
+__all__ = ["inflate_resize_erase_y", "install_shrink_resize_guard"]

--- a/surfaces/interactive_shell/ui/input_prompt/style.py
+++ b/surfaces/interactive_shell/ui/input_prompt/style.py
@@ -13,12 +13,15 @@ from surfaces.interactive_shell.runtime import Session
 def _build_prompt_style() -> Style:
     theme = ui_theme.get_active_theme()
     text_fg = f"fg:{theme.TEXT}"
+    # Distinct composer plate — same role as Claude/Cursor/Droid's input surface.
+    surface = f"bg:{theme.INPUT_SURFACE}"
     return Style.from_dict(
         {
             "prompt-frame-line": f"bold {theme.HIGHLIGHT}",
             "": text_fg,
             "default": text_fg,
-            "repl-slash-command": f"bold {theme.HIGHLIGHT} bg:{theme.BG}",
+            "placeholder": f"{theme.DIM} {surface}",
+            "repl-slash-command": f"bold {theme.HIGHLIGHT} {surface}",
             "completion-menu": f"bg:{theme.BG}",
             "completion-menu.completion": f"{theme.TEXT} bg:{theme.BG}",
             "completion-menu.completion.current": f"bold {theme.HIGHLIGHT} bg:{theme.BG}",
@@ -27,9 +30,11 @@ def _build_prompt_style() -> Style:
             "completion-menu.border": theme.DIM,
             "scrollbar.background": f"bg:{theme.BG}",
             "scrollbar.button": f"bg:{theme.DIM}",
-            "frame": "",
-            "frame.border": theme.DIM,
-            "composer": theme.TEXT,
+            "frame": surface,
+            "frame.border": f"{theme.SECONDARY} {surface}",
+            "composer": f"{theme.TEXT} {surface}",
+            "composer-body": f"{theme.TEXT} {surface}",
+            # Footer sits under the plate on terminal bg (hint chrome, not input).
             "composer-footer": theme.DIM,
             # prompt_toolkit defaults the ``bottom-toolbar`` style to
             # ``reverse:noinherit``, which paints the toolbar as a dark

--- a/surfaces/interactive_shell/ui/streaming/closer.py
+++ b/surfaces/interactive_shell/ui/streaming/closer.py
@@ -20,3 +20,4 @@ def finish_deferred_closer(
     closer = closer_tail_from(final_text)
     if closer:
         render_markdown_block(console, closer)
+    console.print()

--- a/surfaces/interactive_shell/ui/streaming/closer.py
+++ b/surfaces/interactive_shell/ui/streaming/closer.py
@@ -20,4 +20,3 @@ def finish_deferred_closer(
     closer = closer_tail_from(final_text)
     if closer:
         render_markdown_block(console, closer)
-    console.print()

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -41,7 +41,8 @@ from core.agent_harness.spi.prompt_chrome import WANT_ME_TO_MARKER
 from core.agent_harness.spi.session_goal import strip_session_goal_progress_tags
 from surfaces.interactive_shell.ui.streaming.renderer import (
     _build_markdown_block,
-    render_markdown_block,
+    render_reply_block,
+    reply_gutter,
 )
 
 # Throttle for the optional ``update_streaming_progress`` hook on the
@@ -53,9 +54,6 @@ _PROGRESS_INTERVAL_SECONDS = 0.1
 # external caller (e.g. agent_actions.py for the planned-actions
 # bullet header) stay in lock-step.
 _PARAGRAPH_BREAK = "\n\n"
-# Inline agent marker: a single ``∴`` leads the response's first line (no
-# separate ``∴ OpenSRE`` header row) so the turn carries one compact marker.
-_RESPONSE_MARKER = "∴ "
 _CODE_FENCE = "```"
 # Match a triple-backtick only when it opens a line. An inline mention
 # inside flowing text (e.g. "The ``` marker opens a code block") would
@@ -78,37 +76,6 @@ _SELF_SPACING_BLOCK_TOKEN_TYPES = frozenset(
         "table_open",
     }
 )
-
-
-# A leading Markdown block: table row, heading, bullet/ordered list, code fence,
-# or blockquote. Detected by first-line shape (no Markdown parse) so attaching the
-# response marker stays allocation-free on the hot streaming path.
-_BLOCK_LEAD_RE = re.compile(r"^\s*(?:\||#{1,6}\s|[-*+]\s|\d+[.)]\s|```|~~~|>)")
-
-
-def _body_leads_with_block(stripped: str) -> bool:
-    lines = stripped.split("\n", 2)
-    if _BLOCK_LEAD_RE.match(lines[0]):
-        return True
-    # A pipe-less GFM table: a header line followed by a ``---|---`` delimiter row.
-    if len(lines) > 1 and "|" in lines[0]:
-        delim = lines[1].strip()
-        return bool(delim) and set(delim) <= set("|:- ") and "-" in delim
-    return False
-
-
-def _prepend_response_marker(body: str) -> str:
-    """Attach the ``∴`` marker: inline for prose, on its own line before a block.
-
-    A ``∴ `` fused onto the first line of a Markdown block — a table row, heading,
-    list item, or code fence — breaks CommonMark block parsing, so the block then
-    renders as flattened raw text. Only a paragraph can carry the marker inline;
-    any other leading block takes the marker on the line above it.
-    """
-    stripped = body.lstrip()
-    if _body_leads_with_block(stripped):
-        return f"{_RESPONSE_MARKER.rstrip()}\n\n{stripped}"
-    return f"{_RESPONSE_MARKER}{stripped}"
 
 
 def _paragraph_has_want_me_to(text: str) -> bool:
@@ -181,7 +148,7 @@ def stream_to_console_state(
             # gather path can print the canonical rewrite once.
             return StreamRenderResult(text=text, deferred_closer=True)
         console.print()
-        render_markdown_block(console, _prepend_response_marker(text))
+        render_reply_block(console, text)
         console.print()
         return StreamRenderResult(text=text)
 
@@ -258,10 +225,6 @@ def stream_to_console_state(
         visible = strip_session_goal_progress_tags(text)
         if not visible.strip():
             return
-        if rendered_paragraphs == 0:
-            # The first paragraph carries the ``∴`` marker — inline for prose, on
-            # its own line when it leads with a block (table/heading/list/fence).
-            visible = _prepend_response_marker(visible)
         markdown = _build_markdown_block(visible)
         starts_with_self_spacing_block = bool(
             markdown.parsed and markdown.parsed[0].type in _SELF_SPACING_BLOCK_TOKEN_TYPES
@@ -272,8 +235,10 @@ def stream_to_console_state(
             # for the next standalone block. This matters most after lists,
             # whose renderer adds no trailing blank line.
             console.print()
+        # The first paragraph carries the ``∴`` marker in the gutter; every
+        # paragraph hangs in the same indented body column.
         with console.use_theme(ui_theme.MARKDOWN_THEME):
-            console.print(markdown)
+            console.print(reply_gutter(markdown, lead=rendered_paragraphs == 0))
         rendered_paragraphs += 1
 
     def _render_paragraph(text: str, *, source_break: bool = True) -> None:
@@ -458,5 +423,5 @@ def publish_full_response(console: Console, text: str, *, label: str = "assistan
     if not body:
         return
     console.print()
-    render_markdown_block(console, _prepend_response_marker(body))
+    render_reply_block(console, body)
     console.print()

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -147,7 +147,10 @@ def stream_to_console_state(
             # Non-TTY: hold the whole response when a closer is present so the
             # gather path can print the canonical rewrite once.
             return StreamRenderResult(text=text, deferred_closer=True)
+        # Blank row between the user turn and its reply (matches the TTY rhythm).
+        console.print()
         render_reply_block(console, text)
+        console.print()
         return StreamRenderResult(text=text)
 
     chunks_iter = iter(chunks)
@@ -225,6 +228,10 @@ def stream_to_console_state(
         starts_with_self_spacing_block = bool(
             markdown.parsed and markdown.parsed[0].type in _SELF_SPACING_BLOCK_TOKEN_TYPES
         )
+        if not rendered_paragraphs:
+            # One blank row between the user turn and its reply (Droid rhythm):
+            # the echo row and the ∴ reply must not sit flush against each other.
+            console.print()
         if rendered_paragraphs and source_break and not starts_with_self_spacing_block:
             # ``_flush_paragraphs`` consumes the source ``\n\n`` boundary.
             # Restore it explicitly unless Rich adds equivalent leading space
@@ -408,6 +415,9 @@ def stream_to_console_state(
             footer_elapsed_s=elapsed,
             footer_total_bytes=total_bytes,
         )
+    # One blank after the reply so the next user row / prompt chrome breathes
+    # like Droid — not flush against the last reply line.
+    console.print()
     return StreamRenderResult(text=text, deferred_closer=False)
 
 
@@ -417,4 +427,7 @@ def publish_full_response(console: Console, text: str, *, label: str = "assistan
     body = (text or "").strip()
     if not body:
         return
+    # Blank row between the user turn and its reply (matches the TTY rhythm).
+    console.print()
     render_reply_block(console, body)
+    console.print()

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -147,9 +147,7 @@ def stream_to_console_state(
             # Non-TTY: hold the whole response when a closer is present so the
             # gather path can print the canonical rewrite once.
             return StreamRenderResult(text=text, deferred_closer=True)
-        console.print()
         render_reply_block(console, text)
-        console.print()
         return StreamRenderResult(text=text)
 
     chunks_iter = iter(chunks)
@@ -179,8 +177,6 @@ def stream_to_console_state(
                     drained.append(rest)
                 return StreamRenderResult(text="".join(peeked) + "".join(drained))
             break
-
-    console.print()
 
     # Paragraph-level streaming: chunks accumulate in ``para_buffer``
     # until a paragraph boundary (``\n\n`` outside a code block) closes
@@ -412,7 +408,6 @@ def stream_to_console_state(
             footer_elapsed_s=elapsed,
             footer_total_bytes=total_bytes,
         )
-    console.print()
     return StreamRenderResult(text=text, deferred_closer=False)
 
 
@@ -422,6 +417,4 @@ def publish_full_response(console: Console, text: str, *, label: str = "assistan
     body = (text or "").strip()
     if not body:
         return
-    console.print()
     render_reply_block(console, body)
-    console.print()

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.padding import Padding
+from rich.table import Table
+from rich.text import Text
 
 import infrastructure.terminal.theme as ui_theme
 from core.agent_harness.spi.prompt_chrome import normalize_three_tier_spacing
@@ -16,6 +18,7 @@ from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.text import looks_like_data_blob
 
 if TYPE_CHECKING:
+    from rich.console import RenderableType
     from rich.markdown import Markdown
 
 STREAM_LABEL_ASSISTANT = "assistant"
@@ -153,6 +156,35 @@ def render_note_block(console: Console, text: str) -> None:
         )
 
 
+def _reply_marker_style() -> str:
+    """Warm accent for the ``∴`` reply marker (built per call so theme swaps apply)."""
+    return f"bold {ui_theme.WARNING}"
+
+
+def reply_gutter(body: RenderableType, *, lead: bool) -> Table:
+    """Lay a reply renderable in a two-column gutter.
+
+    The first paragraph carries the ``∴`` marker in the gutter; every other row
+    (wrapped lines and following paragraphs) sits in the same indented body
+    column, so the whole reply reads as one block hanging under the marker.
+    """
+    grid = Table.grid(padding=0)
+    grid.add_column(width=2, no_wrap=True)
+    grid.add_column(overflow="fold")
+    marker = Text("∴ ", style=_reply_marker_style()) if lead else Text("  ")
+    grid.add_row(marker, body)
+    return grid
+
+
+def render_reply_block(console: Console, text: str, *, lead: bool = True) -> None:
+    """Render a whole assistant reply inside the ``∴`` hanging-indent gutter."""
+    visible = strip_session_goal_progress_tags(text)
+    if not visible.strip():
+        return
+    with console.use_theme(ui_theme.MARKDOWN_THEME):
+        console.print(reply_gutter(_build_markdown_block(visible), lead=lead))
+
+
 def render_response_header(console: Console, label: str) -> None:
     """Print the ``∴`` triangle row marker that opens every assistant response.
 
@@ -160,4 +192,4 @@ def render_response_header(console: Console, label: str) -> None:
     with ``action_turn.run_action_tool_turn`` so the planned-actions path and the
     streaming response path use the exact same prefix.
     """
-    console.print(f"[{ui_theme.BOLD_BRAND}]∴[/] [{ui_theme.DIM}]{label}[/]")
+    console.print(f"[{_reply_marker_style()}]∴[/] [{ui_theme.DIM}]{label}[/]")

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -152,7 +152,8 @@ def render_note_block(console: Console, text: str) -> None:
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):
         console.print(
-            Padding(_build_markdown_block(visible), (0, 0, 0, 3)), style=str(ui_theme.DIM)
+            Padding(_build_markdown_block(visible), (0, 0, 0, 3)),
+            style=str(ui_theme.SECONDARY),
         )
 
 
@@ -196,5 +197,10 @@ def render_response_header(console: Console, label: str) -> None:
     A single triangle is opensre's uniquely identifiable agent marker. Shared
     with ``action_turn.run_action_tool_turn`` so the planned-actions path and the
     streaming response path use the exact same prefix.
+
+    ``label`` is accepted for port compatibility (callers still pass
+    ``answer`` / ``assistant``) but is not painted — a dim role word under the
+    marker read as school-project chrome next to Droid's silent replies.
     """
-    console.print(f"[{_reply_marker_style()}]∴[/] [{ui_theme.DIM}]{label}[/]")
+    del label
+    console.print(f"[{_reply_marker_style()}]∴[/]")

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -157,8 +157,8 @@ def render_note_block(console: Console, text: str) -> None:
 
 
 def _reply_marker_style() -> str:
-    """Warm accent for the ``∴`` reply marker (built per call so theme swaps apply)."""
-    return f"bold {ui_theme.WARNING}"
+    """Warm Factory/Droid-parity accent for the ``∴`` reply marker."""
+    return ui_theme.reply_marker_style()
 
 
 def reply_gutter(body: RenderableType, *, lead: bool) -> Table:
@@ -182,7 +182,12 @@ def render_reply_block(console: Console, text: str, *, lead: bool = True) -> Non
     if not visible.strip():
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):
-        console.print(reply_gutter(_build_markdown_block(visible), lead=lead))
+        # Explicit TEXT on the row so plain paragraphs never fall through to the
+        # terminal default white (which washed out the warm marker in dogfood).
+        console.print(
+            reply_gutter(_build_markdown_block(visible), lead=lead),
+            style=str(ui_theme.TEXT),
+        )
 
 
 def render_response_header(console: Console, label: str) -> None:

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -64,9 +64,9 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     compete with Ask User / option menus — free text is itself an option
     (``Or type your own answer...``), not a parallel composer.
 
-    No leading blank row — Droid packs the next chrome flush under the last
-    scrollback line. Idle has no empty "Ready" placeholder either; that used
-    to read as a cavernous gap under the banner.
+    One leading blank row separates scrollback from status → Auto → composer,
+    matching Droid's row margin between transcript and chrome. Idle still has
+    no empty "Ready" placeholder under the banner.
     """
     if typing_box_hidden(session, state):
         # Same newline count as ``_prompt_message`` so confirmation does not
@@ -98,7 +98,7 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     # (box hidden). Density matches the streaming stack: status → Auto → composer.
     if state.is_awaiting_confirmation():
         choice = _confirmation_block(state)
-        return ANSI(f"{plan_prefix}{choice}\n{auto_line}\n{base}")
+        return ANSI(f"\n{plan_prefix}{choice}\n{auto_line}\n{base}")
 
     if state.is_ctrl_c_exit_hint_visible():
         prefix = prompt_rendering.ctrl_c_exit_hint_ansi()
@@ -111,10 +111,10 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         )
     # Tools already paint a ``⏺`` line into scrollback; the live tool name is
     # folded into the spinner status row (same line as ``Invoking tools…``).
-    # No leading blank — keep status → Auto → composer stacked like Droid.
+    # Leading blank = Droid row margin under the last transcript line.
     if prefix:
-        return ANSI(f"{plan_prefix}{prefix}\n{auto_line}\n{base}")
-    return ANSI(f"{plan_prefix}{auto_line}\n{base}")
+        return ANSI(f"\n{plan_prefix}{prefix}\n{auto_line}\n{base}")
+    return ANSI(f"\n{plan_prefix}{auto_line}\n{base}")
 
 
 _CONFIRM_HINT = "↑↓ Navigate • Enter confirm • Esc cancel"

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -64,10 +64,9 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     compete with Ask User / option menus — free text is itself an option
     (``Or type your own answer...``), not a parallel composer.
 
-    The region always starts with one blank row so the hint/spinner line never
-    sits flush against whatever output scrolled above it. The row is constant
-    across all prompt states (no height delta between redraws) and is erased
-    with the rest of the region on submit (``erase_when_done=True``).
+    No leading blank row — Droid packs the next chrome flush under the last
+    scrollback line. Idle has no empty "Ready" placeholder either; that used
+    to read as a cavernous gap under the banner.
     """
     if typing_box_hidden(session, state):
         # Same newline count as ``_prompt_message`` so confirmation does not
@@ -92,13 +91,14 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         plan_overlay = strip_cpr_sequences(
             task_plan_overlay_ansi(plan, expanded=state.plan_expanded)
         )
-    plan_prefix = f"{plan_overlay}\n\n" if plan_overlay else ""
+    # One trailing blank after the plan, not two — keeps the stack dense.
+    plan_prefix = f"{plan_overlay}\n" if plan_overlay else ""
 
     # A pending confirmation renders a stacked, arrow-navigable Yes/No choice
     # (box hidden). Density matches the streaming stack: status → Auto → composer.
     if state.is_awaiting_confirmation():
         choice = _confirmation_block(state)
-        return ANSI(f"\n{plan_prefix}{choice}\n{auto_line}\n{base}")
+        return ANSI(f"{plan_prefix}{choice}\n{auto_line}\n{base}")
 
     if state.is_ctrl_c_exit_hint_visible():
         prefix = prompt_rendering.ctrl_c_exit_hint_ansi()
@@ -111,9 +111,10 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         )
     # Tools already paint a ``⏺`` line into scrollback; the live tool name is
     # folded into the spinner status row (same line as ``Invoking tools…``).
-    # Do not reserve a second action row here — that blank slot made the stack
-    # look sparse and filled mid-turn as the old composer-height jump.
-    return ANSI(f"\n{plan_prefix}{prefix}\n{auto_line}\n{base}")
+    # No leading blank — keep status → Auto → composer stacked like Droid.
+    if prefix:
+        return ANSI(f"{plan_prefix}{prefix}\n{auto_line}\n{base}")
+    return ANSI(f"{plan_prefix}{auto_line}\n{base}")
 
 
 _CONFIRM_HINT = "↑↓ Navigate • Enter confirm • Esc cancel"

--- a/surfaces/shared/terminal/banner/banner.py
+++ b/surfaces/shared/terminal/banner/banner.py
@@ -1,4 +1,8 @@
-"""Compact launch banner shared by the CLI landing page and REPL."""
+"""Launch banner shared by the CLI landing page and REPL.
+
+Centered hero (mark + identity + tip + shortcuts + capability chips) so the
+first viewport reads like a shipped product, not a left-aligned school demo.
+"""
 
 from __future__ import annotations
 
@@ -7,25 +11,35 @@ import enum
 from rich.align import Align
 from rich.console import Console, Group, RenderableType
 from rich.padding import Padding
-from rich.table import Table
 from rich.text import Text
 
 from config.constants import PRODUCT_NAME
 from config.version import get_opensre_version
-from infrastructure.terminal.theme import BRAND, DIM, ERROR, HIGHLIGHT, SECONDARY, TEXT
+from infrastructure.terminal.theme import (
+    BOLD_SKILL,
+    BRAND,
+    DIM,
+    ERROR,
+    HIGHLIGHT,
+    SECONDARY,
+    TEXT,
+)
 from surfaces.shared.terminal.banner.banner_state import LaunchStatus, load_launch_status
 
-_SIDE_BY_SIDE_MIN_WIDTH = 72
 _BANNER_VERTICAL_PADDING = 1
 
-#: Identity separator and version prefix on the ``opensre · vX`` line.
-_IDENTITY_SEPARATOR = "  ·  "
+#: Version prefix under the product name.
 _VERSION_PREFIX = "v"
 #: Capability-status glyphs: present/usable vs. absent.
 _STATUS_OK_GLYPH = "✓"
 _STATUS_MISSING_GLYPH = "✗"
 #: Spacing between status items.
-_STATUS_ITEM_GAP = "   "
+_STATUS_ITEM_GAP = "     "
+
+#: One tip under the identity — mirrors Droid's launch tip, OpenSRE-specific.
+_TIP_BODY = "try /theme for a new look · Ctrl+O expands long tool output"
+#: Keyboard hints (real bindings, not aspirational shortcuts).
+_SHORTCUTS_LINE = "/ commands · tab tool details · ? help · Enter send"
 
 
 class LaunchStatusLabel(enum.StrEnum):
@@ -51,8 +65,12 @@ _LOGO_ROWS: tuple[str, ...] = (
 
 
 def _build_logo_mark() -> Text:
-    """Return the overlapping-ring OpenSRE mark."""
-    return Text("\n".join(_LOGO_ROWS), style=SECONDARY, no_wrap=True)
+    """Return the overlapping-ring OpenSRE mark in a bright, confident accent.
+
+    Bold ``HIGHLIGHT`` (not dim grey) so the hero reads crisp and high-contrast
+    like a landing screen, rather than washed-out.
+    """
+    return Text("\n".join(_LOGO_ROWS), style=f"bold {HIGHLIGHT}", no_wrap=True)
 
 
 def _append_status_item(
@@ -68,17 +86,32 @@ def _append_status_item(
     if count is not None:
         line.append(f" ({count})", style=SECONDARY)
     glyph = _STATUS_OK_GLYPH if available else _STATUS_MISSING_GLYPH
-    line.append(f" {glyph}", style=HIGHLIGHT if available else ERROR)
+    # Green success / red missing — same signal language as Droid's chips.
+    line.append(f" {glyph}", style=BOLD_SKILL if available else ERROR)
 
 
-def _build_details(status: LaunchStatus) -> Text:
-    """Return the product/version line and compact capability summary."""
-    identity = Text(no_wrap=True)
-    identity.append(PRODUCT_NAME, style=f"bold {TEXT}")
-    identity.append(_IDENTITY_SEPARATOR, style=DIM)
-    identity.append(f"{_VERSION_PREFIX}{get_opensre_version()}", style=BRAND)
+def _build_identity() -> Text:
+    """Centered product name + clean marketing version (no build tail)."""
+    name = Text(PRODUCT_NAME, style=f"bold {TEXT}", justify="center")
+    version = Text(
+        f"{_VERSION_PREFIX}{get_opensre_version()}",
+        style=str(BRAND),
+        justify="center",
+    )
+    return Text("\n").join([name, version])
 
-    capabilities = Text(overflow="fold")
+
+def _build_tip_block() -> Text:
+    tip = Text(no_wrap=False)
+    tip.append("TIP", style=f"bold {HIGHLIGHT}")
+    tip.append("  ", style=DIM)
+    tip.append(_TIP_BODY, style=str(SECONDARY))
+    shortcuts = Text(_SHORTCUTS_LINE, style=str(DIM))
+    return Text("\n").join([tip, shortcuts])
+
+
+def _build_capabilities(status: LaunchStatus) -> Text:
+    capabilities = Text(overflow="fold", justify="center")
     _append_status_item(
         capabilities,
         LaunchStatusLabel.SKILLS,
@@ -91,7 +124,20 @@ def _build_details(status: LaunchStatus) -> Text:
         status.integration_count,
         available=status.integration_count > 0,
     )
-    return Text("\n").join([identity, Text(), capabilities])
+    return capabilities
+
+
+def _build_details(status: LaunchStatus) -> Text:
+    """Return identity + tip + capability summary (tests assert version here)."""
+    return Text("\n").join(
+        [
+            _build_identity(),
+            Text(),
+            _build_tip_block(),
+            Text(),
+            _build_capabilities(status),
+        ]
+    )
 
 
 def build_launch_banner(
@@ -99,30 +145,16 @@ def build_launch_banner(
     *,
     session: object = None,
 ) -> RenderableType:
-    """Build the responsive borderless OpenSRE launch banner."""
+    """Build the centered, borderless OpenSRE launch banner."""
     del session  # Reserved for future session-scoped launch indicators.
-    console = console or Console(
-        highlight=False,
-        force_terminal=True,
-        color_system="truecolor",
-        legacy_windows=False,
-    )
+    del console  # Width no longer switches layout; always stack/center.
     logo = _build_logo_mark()
     details = _build_details(load_launch_status())
-
-    if console.width < _SIDE_BY_SIDE_MIN_WIDTH:
-        body: RenderableType = Group(
-            Align.center(logo),
-            Text(),
-            Align.center(details),
-        )
-    else:
-        grid = Table.grid(padding=(0, 5), expand=False)
-        grid.add_column(vertical="middle")
-        grid.add_column(vertical="middle")
-        grid.add_row(logo, details)
-        body = Align.center(grid)
-
+    body: RenderableType = Group(
+        Align.center(logo),
+        Text(),
+        Align.center(details),
+    )
     return Padding(body, (_BANNER_VERTICAL_PADDING, 0))
 
 
@@ -131,7 +163,7 @@ def render_launch_banner(
     *,
     session: object = None,
 ) -> None:
-    """Print the compact OpenSRE launch banner."""
+    """Print the OpenSRE launch banner."""
     console = console or Console(
         highlight=False,
         force_terminal=True,

--- a/surfaces/shared/terminal/banner/banner.py
+++ b/surfaces/shared/terminal/banner/banner.py
@@ -1,7 +1,8 @@
 """Launch banner shared by the CLI landing page and REPL.
 
-Centered hero (mark + identity + tip + shortcuts + capability chips) so the
-first viewport reads like a shipped product, not a left-aligned school demo.
+Droid-style centered hero: each row is centered independently (a single
+``Align.center`` on a multi-line block left-aligns short lines inside the
+widest line). Bold block wordmark + clean version + tip + capability chips.
 """
 
 from __future__ import annotations
@@ -9,11 +10,12 @@ from __future__ import annotations
 import enum
 
 from rich.align import Align
+from rich.cells import cell_len
 from rich.console import Console, Group, RenderableType
 from rich.padding import Padding
 from rich.text import Text
 
-from config.constants import PRODUCT_NAME
+from config.constants import PRODUCT_DISPLAY_NAME, WELCOME_DESCRIPTION, WELCOME_TITLE
 from config.version import get_opensre_version
 from infrastructure.terminal.theme import (
     BOLD_SKILL,
@@ -25,10 +27,11 @@ from infrastructure.terminal.theme import (
     TEXT,
 )
 from surfaces.shared.terminal.banner.banner_state import LaunchStatus, load_launch_status
+from surfaces.shared.terminal.prompt_layout import clip_prompt_text
 
 _BANNER_VERTICAL_PADDING = 1
 
-#: Version prefix under the product name.
+#: Version prefix under the wordmark.
 _VERSION_PREFIX = "v"
 #: Capability-status glyphs: present/usable vs. absent.
 _STATUS_OK_GLYPH = "✓"
@@ -36,10 +39,12 @@ _STATUS_MISSING_GLYPH = "✗"
 #: Spacing between status items.
 _STATUS_ITEM_GAP = "     "
 
-#: One tip under the identity — mirrors Droid's launch tip, OpenSRE-specific.
-_TIP_BODY = "try /theme for a new look · Ctrl+O expands long tool output"
 #: Keyboard hints (real bindings, not aspirational shortcuts).
 _SHORTCUTS_LINE = "/ commands · tab tool details · ? help · Enter send"
+
+#: Minimum console width to paint the ring mark (its cell width + margin);
+#: narrower terminals get the compact text title instead.
+_WORDMARK_MIN_WIDTH = 24
 
 
 class LaunchStatusLabel(enum.StrEnum):
@@ -49,8 +54,9 @@ class LaunchStatusLabel(enum.StrEnum):
     INTEGRATIONS = "Integrations"
 
 
-#: Braille rendering of the canonical OpenSRE mark (docs/images/opensre-mark.svg).
-_LOGO_ROWS: tuple[str, ...] = (
+#: The canonical overlapping-ring OpenSRE mark (docs/images/opensre-mark.svg),
+#: rendered in braille — the "loops" logo.
+_WORDMARK_ROWS: tuple[str, ...] = (
     "⠀⠀⠀⢀⣤⣶⣾⣿⣿⣿⣿⣶⣦⣄⡈⠒⢦⣄⡀⠀⠀⠀",
     "⠀⢀⣴⣿⠿⠋⢁⣤⣶⠖⠂⠉⠙⢿⣿⣦⠀⠙⣿⣦⡀⠀",
     "⢀⣾⣿⠋⠀⣴⣿⡟⠁⠀⠀⠀⠀⠀⠹⣿⣷⠀⠘⣿⣷⡀",
@@ -64,13 +70,16 @@ _LOGO_ROWS: tuple[str, ...] = (
 )
 
 
-def _build_logo_mark() -> Text:
-    """Return the overlapping-ring OpenSRE mark in a bright, confident accent.
+def _center(renderable: RenderableType) -> Align:
+    """Center one row/block on its own — do not bundle unequal-width lines."""
+    return Align.center(renderable)
 
-    Bold ``HIGHLIGHT`` (not dim grey) so the hero reads crisp and high-contrast
-    like a landing screen, rather than washed-out.
-    """
-    return Text("\n".join(_LOGO_ROWS), style=f"bold {HIGHLIGHT}", no_wrap=True)
+
+def _build_wordmark(*, console_width: int) -> Text:
+    """Return the bold ring "loops" mark, or a compact title on narrow terminals."""
+    if console_width < _WORDMARK_MIN_WIDTH:
+        return Text(PRODUCT_DISPLAY_NAME, style=f"bold {HIGHLIGHT}", no_wrap=True)
+    return Text("\n".join(_WORDMARK_ROWS), style=f"bold {HIGHLIGHT}", no_wrap=True)
 
 
 def _append_status_item(
@@ -90,28 +99,34 @@ def _append_status_item(
     line.append(f" {glyph}", style=BOLD_SKILL if available else ERROR)
 
 
-def _build_identity() -> Text:
-    """Centered product name + clean marketing version (no build tail)."""
-    name = Text(PRODUCT_NAME, style=f"bold {TEXT}", justify="center")
-    version = Text(
+def _build_version_line() -> Text:
+    return Text(
         f"{_VERSION_PREFIX}{get_opensre_version()}",
-        style=str(BRAND),
-        justify="center",
+        style=f"bold {BRAND}",
+        no_wrap=True,
     )
-    return Text("\n").join([name, version])
 
 
-def _build_tip_block() -> Text:
-    tip = Text(no_wrap=False)
-    tip.append("TIP", style=f"bold {HIGHLIGHT}")
-    tip.append("  ", style=DIM)
-    tip.append(_TIP_BODY, style=str(SECONDARY))
-    shortcuts = Text(_SHORTCUTS_LINE, style=str(DIM))
-    return Text("\n").join([tip, shortcuts])
+def _build_welcome_title() -> Text:
+    """Accent title — same copy and style as the sign-in screen."""
+    return Text(WELCOME_TITLE, style=f"bold {HIGHLIGHT}", no_wrap=True)
 
 
-def _build_capabilities(status: LaunchStatus) -> Text:
-    capabilities = Text(overflow="fold", justify="center")
+def _build_welcome_paragraph() -> Text:
+    """One-sentence product description, wrapped and centered (not clipped)."""
+    return Text(WELCOME_DESCRIPTION, style=str(TEXT), justify="center")
+
+
+def _build_shortcuts_line(*, max_width: int) -> Text:
+    return Text(
+        clip_prompt_text(_SHORTCUTS_LINE, max(8, max_width)),
+        style=str(DIM),
+        no_wrap=True,
+    )
+
+
+def _build_capabilities(status: LaunchStatus, *, max_width: int) -> Text:
+    capabilities = Text(overflow="fold", no_wrap=True)
     _append_status_item(
         capabilities,
         LaunchStatusLabel.SKILLS,
@@ -124,20 +139,15 @@ def _build_capabilities(status: LaunchStatus) -> Text:
         status.integration_count,
         available=status.integration_count > 0,
     )
+    # Clip rather than soft-wrap — a wrapped chip row looks left-ragged.
+    plain = capabilities.plain
+    if cell_len(plain) > max_width:
+        return Text(
+            clip_prompt_text(plain, max_width),
+            style=str(TEXT),
+            no_wrap=True,
+        )
     return capabilities
-
-
-def _build_details(status: LaunchStatus) -> Text:
-    """Return identity + tip + capability summary (tests assert version here)."""
-    return Text("\n").join(
-        [
-            _build_identity(),
-            Text(),
-            _build_tip_block(),
-            Text(),
-            _build_capabilities(status),
-        ]
-    )
 
 
 def build_launch_banner(
@@ -147,14 +157,32 @@ def build_launch_banner(
 ) -> RenderableType:
     """Build the centered, borderless OpenSRE launch banner."""
     del session  # Reserved for future session-scoped launch indicators.
-    del console  # Width no longer switches layout; always stack/center.
-    logo = _build_logo_mark()
-    details = _build_details(load_launch_status())
-    body: RenderableType = Group(
-        Align.center(logo),
-        Text(),
-        Align.center(details),
+    console = console or Console(
+        highlight=False,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
     )
+    status = load_launch_status()
+    width = console.width
+    # Leave one column empty so the banner never soft-wraps on the last cell.
+    line_width = max(width - 1, 1)
+    # Rows top-to-bottom (``None`` is a blank spacer). Each is centered on its
+    # own axis in the loop below — one Align.center over a multi-line block
+    # would left-align the short lines inside the widest one.
+    rows: list[RenderableType | None] = [
+        _build_wordmark(console_width=width),
+        None,
+        _build_version_line(),
+        None,
+        _build_welcome_title(),
+        _build_welcome_paragraph(),
+        None,
+        _build_shortcuts_line(max_width=line_width),
+        None,
+        _build_capabilities(status, max_width=line_width),
+    ]
+    body: RenderableType = Group(*(Text() if row is None else _center(row) for row in rows))
     return Padding(body, (_BANNER_VERTICAL_PADDING, 0))
 
 
@@ -171,6 +199,11 @@ def render_launch_banner(
         legacy_windows=False,
     )
     console.print(build_launch_banner(console, session=session))
+
+
+def _wordmark_cell_width() -> int:
+    """Widest wordmark row in terminal cells (for tests / narrow fallback)."""
+    return max(cell_len(row) for row in _WORDMARK_ROWS)
 
 
 __all__ = ["build_launch_banner", "render_launch_banner"]

--- a/tests/cli/test_prompt_support.py
+++ b/tests/cli/test_prompt_support.py
@@ -23,13 +23,60 @@ def test_print_session_resume_hint_includes_repl_and_cli_commands(
 
     from rich.console import Console
 
+    import infrastructure.terminal.theme as ui_theme
+
+    ui_theme.set_active_theme("amber")
     monkeypatch.setattr("infrastructure.terminal.prompt_support.sys.argv", ["o"])
-    console = Console(file=StringIO(), force_terminal=False, color_system=None)
+    console = Console(
+        file=StringIO(),
+        force_terminal=True,
+        color_system="truecolor",
+        highlight=False,
+        no_color=False,
+    )
     print_session_resume_hint(console, "8988e743-87ae-4c4c-a37b-0351e62a4855")
     output = console.file.getvalue()
     assert "Resume this session with:" in output
     assert "/resume 8988e743-87ae-4c4c-a37b-0351e62a4855" in output
     assert "o --resume 8988e743-87ae-4c4c-a37b-0351e62a4855" in output
+    # Accent theme on the copy-pasteable commands — not flat DIM (looks unthemed).
+    assert ui_theme.HIGHLIGHT_ANSI in output
+
+
+def test_exit_farewell_keeps_theme_accent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``/exit`` goodbye and resume cmds must use HIGHLIGHT, not plain DIM."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    import infrastructure.terminal.theme as ui_theme
+    from surfaces.interactive_shell.command_registry.system import _cmd_exit
+    from surfaces.interactive_shell.runtime import Session
+
+    ui_theme.set_active_theme("amber")
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.system._flush_analytics_on_exit",
+        lambda _console: None,
+    )
+    monkeypatch.setattr(
+        "surfaces.shared.terminal.components.choice_menu.prepare_repl_output_line",
+        lambda: None,
+    )
+    session = Session()
+    session.session_id = "0dc1aa80-efdf-4245-a42a-36ea06d14964"
+    buf = StringIO()
+    console = Console(
+        file=buf,
+        force_terminal=True,
+        color_system="truecolor",
+        highlight=False,
+        no_color=False,
+    )
+    assert _cmd_exit(session, console, []) is False
+    out = buf.getvalue()
+    assert "goodbye." in out
+    assert "/resume 0dc1aa80-efdf-4245-a42a-36ea06d14964" in out
+    assert ui_theme.HIGHLIGHT_ANSI in out
 
 
 def test_install_questionary_escape_cancel_is_idempotent() -> None:

--- a/tests/config/test_repl_config.py
+++ b/tests/config/test_repl_config.py
@@ -19,14 +19,14 @@ class TestReplConfigDefaults:
         cfg = ReplConfig.load()
         assert cfg.layout == "classic"
 
-    def test_default_theme_is_blue(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_theme_is_purple(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("OPENSRE_THEME", raising=False)
         import config.constants as const_module
 
         monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
         monkeypatch.setattr("config.constants.paths.OPENSRE_HOME_DIR", tmp_path)
         cfg = ReplConfig.load()
-        assert cfg.theme == "blue"
+        assert cfg.theme == "purple"
 
 
 class TestEnvVarResolution:
@@ -64,7 +64,7 @@ class TestEnvVarResolution:
 
     def test_invalid_theme_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENSRE_THEME", "nope")
-        assert ReplConfig.load().theme == "blue"
+        assert ReplConfig.load().theme == "purple"
 
     def test_invalid_theme_logs_warning(self, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
         monkeypatch.setenv("OPENSRE_THEME", "chartreuse")
@@ -72,7 +72,7 @@ class TestEnvVarResolution:
         with caplog.at_level("WARNING"):
             cfg = ReplConfig.load()
 
-        assert cfg.theme == "blue"
+        assert cfg.theme == "purple"
         assert "OPENSRE_THEME='chartreuse' is not a valid theme" in caplog.text
 
 
@@ -197,7 +197,7 @@ class TestFileResolution:
         with caplog.at_level("WARNING"):
             cfg = ReplConfig.load()
 
-        assert cfg.theme == "blue"
+        assert cfg.theme == "purple"
         assert "interactive.theme='chartreuse' is not a valid theme" in caplog.text
 
     def test_env_overrides_file(

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -131,6 +131,40 @@ def test_shimmer_text_ansi_paints_a_traveling_metallic_wave() -> None:
     assert " tools" in spaced or "tools" in re.sub(r"\x1b\[[0-9;]*m", "", spaced)
 
 
+def test_reply_marker_style_is_vivid_droid_orange_on_chromatic_themes() -> None:
+    """Assistant ``∴`` must use Factory-warm orange, not pale WARNING gold."""
+    from infrastructure.terminal import theme as ui_theme
+
+    ui_theme.set_active_theme("blue")
+    assert ui_theme.reply_marker_style() == "bold #D78700"
+    ui_theme.set_active_theme("mono")
+    assert ui_theme.reply_marker_style() == f"bold {ui_theme.get_theme('mono').HIGHLIGHT}"
+
+
+def test_reply_block_paints_orange_marker_and_themed_body() -> None:
+    """Regression: marker washed out when body fell through to terminal white."""
+    import os
+
+    from surfaces.interactive_shell.ui.streaming.renderer import render_reply_block
+
+    os.environ.pop("NO_COLOR", None)
+    set_active_theme("blue")
+    console = Console(
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        no_color=False,
+    )
+    with console.capture() as capture:
+        render_reply_block(console, "Hey! How can I help?")
+    output = capture.get()
+    assert "∴" in output
+    # Factory droid orange #D78700 → 215,135,0
+    assert "38;2;215;135;0m" in output
+    # Body uses theme TEXT (#B6BAC2 on blue), not unstyled default white
+    assert "38;2;182;186;194m" in output
+
+
 def test_palette_registry_keys_match_the_config_vocabulary() -> None:
     """The infra palettes must cover exactly the config-owned theme names.
 

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -161,8 +161,8 @@ def test_reply_block_paints_orange_marker_and_themed_body() -> None:
     assert "∴" in output
     # Factory droid orange #D78700 → 215,135,0
     assert "38;2;215;135;0m" in output
-    # Body uses theme TEXT (#B6BAC2 on blue), not unstyled default white
-    assert "38;2;182;186;194m" in output
+    # Body uses sunny Droid-like agent grey TEXT (#D0D0D0)
+    assert "38;2;208;208;208m" in output
 
 
 def test_palette_registry_keys_match_the_config_vocabulary() -> None:

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -131,14 +131,14 @@ def test_shimmer_text_ansi_paints_a_traveling_metallic_wave() -> None:
     assert " tools" in spaced or "tools" in re.sub(r"\x1b\[[0-9;]*m", "", spaced)
 
 
-def test_reply_marker_style_is_vivid_droid_orange_on_chromatic_themes() -> None:
-    """Assistant ``∴`` must use Factory-warm orange, not pale WARNING gold."""
+def test_reply_marker_follows_the_active_theme_highlight() -> None:
+    """Assistant ``∴`` uses the active theme's HIGHLIGHT so every component
+    follows the selected palette (not a fixed colour that copies another tool)."""
     from infrastructure.terminal import theme as ui_theme
 
-    ui_theme.set_active_theme("blue")
-    assert ui_theme.reply_marker_style() == "bold #D78700"
-    ui_theme.set_active_theme("mono")
-    assert ui_theme.reply_marker_style() == f"bold {ui_theme.get_theme('mono').HIGHLIGHT}"
+    for name in ("blue", "purple", "green", "mono"):
+        ui_theme.set_active_theme(name)
+        assert ui_theme.reply_marker_style() == f"bold {ui_theme.get_theme(name).HIGHLIGHT}"
 
 
 def test_reply_block_paints_orange_marker_and_themed_body() -> None:
@@ -159,9 +159,9 @@ def test_reply_block_paints_orange_marker_and_themed_body() -> None:
         render_reply_block(console, "Hey! How can I help?")
     output = capture.get()
     assert "∴" in output
-    # Factory droid orange #D78700 → 215,135,0
-    assert "38;2;215;135;0m" in output
-    # Body uses sunny Droid-like agent grey TEXT (#D0D0D0)
+    # Marker follows the active theme's HIGHLIGHT (blue #B7D4F0 → 183,212,240).
+    assert "38;2;183;212;240m" in output
+    # Body uses the sunny Droid-like agent grey (#D0D0D0).
     assert "38;2;208;208;208m" in output
 
 

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -159,8 +159,10 @@ def test_reply_block_paints_orange_marker_and_themed_body() -> None:
         render_reply_block(console, "Hey! How can I help?")
     output = capture.get()
     assert "∴" in output
-    # Marker follows the active theme's HIGHLIGHT (blue #B7D4F0 → 183,212,240).
-    assert "38;2;183;212;240m" in output
+    # Marker follows the active theme's HIGHLIGHT (whatever the palette sets).
+    highlight = get_theme("blue").HIGHLIGHT.lstrip("#")
+    r, g, b = (int(highlight[i : i + 2], 16) for i in (0, 2, 4))
+    assert f"38;2;{r};{g};{b}m" in output
     # Body uses the sunny Droid-like agent grey (#D0D0D0).
     assert "38;2;208;208;208m" in output
 

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -146,6 +146,34 @@ def test_run_repl_invokes_the_sign_in_gate_before_the_controller(monkeypatch: An
     assert started == []
 
 
+def test_run_repl_clears_screen_before_painting_banner(monkeypatch: Any) -> None:
+    """Launch wipes the calling shell so the REPL owns the viewport like Droid."""
+    cleared: list[bool] = []
+    painted: list[bool] = []
+    monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(main_entrypoint, "should_paint_launch_banner", lambda: True)
+    monkeypatch.setattr(main_entrypoint, "pass_sign_in_gate", lambda _c: True)
+    monkeypatch.setattr(
+        main_entrypoint,
+        "repl_clear_screen",
+        lambda: cleared.append(True),
+    )
+    monkeypatch.setattr(
+        main_entrypoint,
+        "render_terminal_ui",
+        lambda *_a, **_k: painted.append(True),
+    )
+
+    async def _skip_async(**_kwargs: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(main_entrypoint, "run_repl_async", _skip_async)
+    main_entrypoint.run_repl(config=ReplConfig(enabled=True, layout="classic"))
+
+    assert cleared == [True]
+    assert painted == [True]
+
+
 def test_run_repl_skips_the_launch_banner_when_the_gate_paints_it(monkeypatch: Any) -> None:
     painted: list[bool] = []
     monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)

--- a/tests/interactive_shell/runtime/test_agent_harness_adapters.py
+++ b/tests/interactive_shell/runtime/test_agent_harness_adapters.py
@@ -107,13 +107,12 @@ def test_finalize_satisfies_the_host_contract_while_staying_silent() -> None:
     assert isinstance(sink, TurnOutput)
 
 
-def test_response_header_opens_with_a_blank_line() -> None:
-    """The sink owns this spacing: the turn engine no longer emits it.
+def test_response_header_opens_without_a_leading_blank() -> None:
+    """The sink used to print a blank before ``∴``; that padded turns vs Droid.
 
-    ``_show_response`` used to print a blank line before the header. That was
-    terminal layout living in the shared turn engine — chat sinks route
-    ``print`` to a placeholder status and never wanted it. Moving it here kept
-    the REPL looking the same; without a test, deleting it stays green.
+    ``_show_response`` used to own that spacer in the shared turn engine.
+    Chat sinks never wanted it; keeping a blank in the shell sink only was
+    the remaining gap between user row and reply marker.
     """
     # Arrange
     console = _RecordingConsole()
@@ -121,6 +120,7 @@ def test_response_header_opens_with_a_blank_line() -> None:
     # Act
     ShellOutputSink(console).render_response_header("assistant")  # type: ignore[arg-type]
 
-    # Assert: blank line first, then the ∴ marker.
-    assert console.lines[0] == ""
-    assert "∴" in console.lines[1]
+    # Assert: marker on the first painted line — no spacer row above.
+    assert console.lines
+    assert "∴" in console.lines[0]
+    assert console.lines[0] != ""

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -2292,7 +2292,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert "❯" in output
-        assert "assistant" in output
+        assert "∴" in output
         assert "$ /status" in output
         assert "you  " not in output
         assert "sre  " not in output
@@ -2326,7 +2326,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert output.count("❯ repeat") == 2
-        assert output.count("assistant") == 2
+        assert output.count("∴") == 2
         assert "first answer" in output
         assert "second answer" in output
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -198,7 +198,9 @@ def test_build_prompt_session_installs_growing_bordered_composer() -> None:
     assert isinstance(composer, HSplit)
     assert composer.height is None
     editable_row = composer.children[1]
-    editable_body = editable_row.children[1].get_container()
+    surface_body = editable_row.children[1].get_container()
+    assert isinstance(surface_body, HSplit)
+    editable_body = surface_body.children[0]
     default_buffer_slot = editable_body.children[0]
     assert default_buffer_slot.content.height.min == 1
     assert default_buffer_slot.content.height.max == 8
@@ -465,14 +467,15 @@ def test_build_prompt_style_tracks_active_theme() -> None:
 
 
 def test_completion_menu_current_item_uses_highlight_style() -> None:
-    from infrastructure.terminal.theme import BG, HIGHLIGHT
+    from infrastructure.terminal.theme import BG, HIGHLIGHT, INPUT_SURFACE
 
     set_active_theme("green")
     style = _build_prompt_style()
     attrs = style.get_attrs_for_style_str("class:repl-slash-command")
 
     assert attrs.color == HIGHLIGHT.lstrip("#")
-    assert attrs.bgcolor == BG.lstrip("#")
+    # Slash tokens sit on the composer plate, not the terminal bg.
+    assert attrs.bgcolor == str(INPUT_SURFACE).lstrip("#")
     assert attrs.bold is True
 
     attrs_menu = style.get_attrs_for_style_str("class:completion-menu.completion.current")
@@ -483,12 +486,25 @@ def test_completion_menu_current_item_uses_highlight_style() -> None:
     assert attrs_menu.bold is True
 
 
-def test_composer_uses_terminal_background_without_a_highlight_fill() -> None:
+def test_composer_uses_input_surface_fill() -> None:
+    """Composer plate uses INPUT_SURFACE — same role as Droid/Claude/Cursor input bg."""
+    from infrastructure.terminal.theme import INPUT_SURFACE
+
     set_active_theme("green")
     style = _build_prompt_style()
+    surface = str(INPUT_SURFACE).lstrip("#")
 
-    for style_name in ("class:frame", "class:composer", "class:composer-footer"):
-        assert not style.get_attrs_for_style_str(style_name).bgcolor
+    for style_name in (
+        "class:frame",
+        "class:frame.border",
+        "class:composer",
+        "class:composer-body",
+        "class:placeholder",
+    ):
+        assert style.get_attrs_for_style_str(style_name).bgcolor == surface
+
+    # Help line under the plate stays on terminal bg.
+    assert not style.get_attrs_for_style_str("class:composer-footer").bgcolor
 
 
 def test_lazy_rich_style_split_tracks_active_theme() -> None:
@@ -774,27 +790,28 @@ class TestSpinnerState:
         assert spinner.streaming is False
         assert spinner.inline_spinner_ansi() == ""
 
-    def test_inline_spinner_thinking_uses_active_theme_highlight(self) -> None:
-        from infrastructure.terminal.theme import set_active_theme
+    def test_inline_spinner_thinking_uses_warm_reply_marker(self) -> None:
+        from infrastructure.terminal.theme import reply_marker_hex, set_active_theme
 
         set_active_theme("blue")
         spinner = loop_state.SpinnerState()
         spinner.start()
         spinner.set_phase(loop_state.SpinnerState.THINKING_PHASE)
         raw = spinner.inline_spinner_ansi()
-        assert _rgb(THEME_REGISTRY["blue"].HIGHLIGHT) in raw  # highlight — the Thinking accent
+        assert _rgb(reply_marker_hex()) in raw  # Factory-warm glyph accent
         assert _rgb(THEME_REGISTRY["green"].HIGHLIGHT) not in raw
 
-    def test_inline_spinner_invoking_tools_uses_brand(self) -> None:
-        from infrastructure.terminal.theme import set_active_theme
+    def test_inline_spinner_invoking_tools_uses_same_warm_accent(self) -> None:
+        from infrastructure.terminal.theme import reply_marker_hex, set_active_theme
 
         set_active_theme("blue")
         spinner = loop_state.SpinnerState()
         spinner.start()
         spinner.set_phase(loop_state.SpinnerState.INVOKING_TOOLS_PHASE)
         raw = spinner.inline_spinner_ansi()
-        assert _rgb(THEME_REGISTRY["blue"].BRAND) in raw  # blue BRAND
-        assert _rgb(THEME_REGISTRY["blue"].HIGHLIGHT) not in raw.split("(Press ESC")[0]
+        # One sunny accent for every phase — not a second cold brand strip.
+        assert _rgb(reply_marker_hex()) in raw
+        assert _rgb(THEME_REGISTRY["blue"].BRAND) not in raw.split("(Press ESC")[0]
 
     def test_streaming_inline_spinner_includes_glyph_and_token_count(self) -> None:
         spinner = loop_state.SpinnerState()

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -12,7 +12,7 @@ from rich.text import Text
 
 import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
-from infrastructure.terminal.theme import BOLD_SKILL, HIGHLIGHT
+from infrastructure.terminal.theme import BOLD_SKILL, TEXT
 from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.action_rendering import (
@@ -172,7 +172,7 @@ def test_skill_view_renders_bold_green_skill_label() -> None:
     assert heading.plain == "Skill install-code-review"
     assert len(heading.spans) == 2
     assert str(heading.spans[0].style) == BOLD_SKILL
-    assert str(heading.spans[1].style) == str(HIGHLIGHT)
+    assert str(heading.spans[1].style) == str(TEXT)
 
 
 def test_skill_view_strips_terminal_controls_from_model_name() -> None:

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -1,4 +1,4 @@
-"""Tests for the compact interactive-shell launch banner."""
+"""Tests for the interactive-shell launch banner."""
 
 from __future__ import annotations
 
@@ -26,20 +26,23 @@ def _fixed_status() -> LaunchStatus:
     )
 
 
-def test_launch_banner_is_borderless_and_shows_only_compact_identity(
-    monkeypatch: object,
-) -> None:
+def test_launch_banner_is_borderless_centered_hero(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
-    monkeypatch.setattr(banner_module, "get_opensre_version", lambda: "2026.8.27+main.85fd865")
+    monkeypatch.setattr(banner_module, "get_opensre_version", lambda: "0.1.2026.9.2+main.baba83a")
     console_file = io.StringIO()
     console = Console(file=console_file, force_terminal=False, highlight=False, width=120)
 
     banner_module.render_launch_banner(console)
 
     output = console_file.getvalue()
-    assert "opensre  ·  v2026.8.27+main.85fd865" in output
+    assert "opensre" in output
+    assert "v0.1" in output
     assert "Skills (21) ✓" in output
     assert "Integrations (2) ✓" in output
+    assert "TIP" in output
+    assert "/theme" in output
+    assert "Ctrl+O" in output
+    assert "/ commands" in output
     # Only the two capability items — no MCPs or AGENTS.md line.
     assert "MCPs" not in output
     assert "AGENTS.md" not in output
@@ -134,9 +137,10 @@ def test_status_probes_survive_loader_failures(monkeypatch: object) -> None:
     assert banner_state_module._count_configured_integrations() == 0
 
 
-def test_banner_uses_runtime_version(monkeypatch: object) -> None:
+def test_banner_shows_the_full_build_version(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
     details = banner_module._build_details(_fixed_status()).plain
+    # The banner shows the full build version (identity for support / bug reports).
     assert f"v{get_opensre_version()}" in details
 
 

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -92,25 +92,26 @@ def test_launch_banner_centers_each_row_independently(monkeypatch: object) -> No
         assert abs(center - mid) <= 2.0, (body, center, mid)
 
 
-def test_launch_banner_draws_block_wordmark_on_wide_terminals(monkeypatch: object) -> None:
+def test_launch_banner_draws_ring_logo_on_wide_terminals(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
     console = Console(record=True, force_terminal=False, highlight=False, width=120)
 
     console.print(banner_module.build_launch_banner(console))
 
     output = console.export_text(styles=False)
-    assert "██████╗ ██████╗ ███████╗" in output
+    # A ring-wall row of the braille "loops" mark.
+    assert "⣿⣿⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⠀⢸⣿⣿" in output
 
 
 def test_launch_banner_falls_back_to_title_on_narrow_terminals(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
-    console = Console(record=True, force_terminal=False, highlight=False, width=40)
+    console = Console(record=True, force_terminal=False, highlight=False, width=20)
 
     console.print(banner_module.build_launch_banner(console))
 
     output = console.export_text(styles=False)
     assert "OpenSRE" in output
-    assert "██████╗ ██████╗" not in output
+    assert "⣿⣿" not in output  # braille ring omitted below its min width
 
 
 def test_launch_banner_uses_active_theme_palette(monkeypatch: object) -> None:

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -6,7 +6,7 @@ import io
 
 from rich.console import Console
 
-from config.version import get_opensre_version
+from config.constants import PRODUCT_DISPLAY_NAME
 from surfaces.interactive_shell.ui import poster as poster_module
 from surfaces.shared.terminal.banner import banner as banner_module
 from surfaces.shared.terminal.banner import banner_state as banner_state_module
@@ -26,39 +26,91 @@ def _fixed_status() -> LaunchStatus:
     )
 
 
+def _line_centers(plain: str, *, width: int) -> list[tuple[str, int, int]]:
+    """Return (stripped, leading_spaces, trailing_pad) for non-empty lines."""
+    rows: list[tuple[str, int, int]] = []
+    for raw in plain.splitlines():
+        if not raw.strip():
+            continue
+        stripped = raw.rstrip("\n")
+        # Console may pad to width with trailing spaces.
+        content = stripped.rstrip()
+        lead = len(content) - len(content.lstrip())
+        body = content.strip()
+        trail = width - lead - len(body) if width >= lead + len(body) else 0
+        rows.append((body, lead, trail))
+    return rows
+
+
 def test_launch_banner_is_borderless_centered_hero(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
-    monkeypatch.setattr(banner_module, "get_opensre_version", lambda: "0.1.2026.9.2+main.baba83a")
+    monkeypatch.setattr(banner_module, "get_opensre_version", lambda: "0.1.2026.9.2+main.abc1234")
     console_file = io.StringIO()
     console = Console(file=console_file, force_terminal=False, highlight=False, width=120)
 
     banner_module.render_launch_banner(console)
 
     output = console_file.getvalue()
-    assert "opensre" in output
-    assert "v0.1" in output
+    assert PRODUCT_DISPLAY_NAME == "OpenSRE"
+    assert "OpenSRE" in output or "██████" in output  # wordmark or compact title
+    assert "v0.1.2026.9.2+main.abc1234" in output  # full build version
     assert "Skills (21) ✓" in output
     assert "Integrations (2) ✓" in output
-    assert "TIP" in output
-    assert "/theme" in output
-    assert "Ctrl+O" in output
+    # Welcome title + product description (same copy as the sign-in screen),
+    # in place of the old TIP line.
+    assert "Welcome to OpenSRE CLI" in output
+    assert "AI-powered DevOps assistant" in output
     assert "/ commands" in output
     # Only the two capability items — no MCPs or AGENTS.md line.
     assert "MCPs" not in output
     assert "AGENTS.md" not in output
-    assert "Welcome" not in output  # welcome copy lives on the sign-in screen, not the banner
     assert not any(char in output for char in "╭╮╰╯│")
 
 
-def test_launch_banner_draws_two_overlapping_equal_rings(monkeypatch: object) -> None:
+def test_launch_banner_centers_each_row_independently(monkeypatch: object) -> None:
+    """Short rows (version) must share the same center axis as the wordmark.
+
+    Bundling unequal lines into one ``Align.center`` left-aligns shorts inside
+    the widest line — the school-project look vs Droid.
+    """
+    monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
+    monkeypatch.setattr(banner_module, "get_opensre_version", lambda: "0.1.2026.9.2+main.abc1234")
+    width = 120
+    console = Console(record=True, force_terminal=False, highlight=False, width=width)
+    console.print(banner_module.build_launch_banner(console))
+    plain = console.export_text(styles=False)
+    rows = _line_centers(plain, width=width)
+    assert rows, "banner must paint at least one row"
+
+    def _center_col(body: str, lead: int) -> float:
+        return lead + (len(body) / 2)
+
+    centers = [_center_col(body, lead) for body, lead, _trail in rows]
+    mid = width / 2
+    # Every content row's midpoint should sit near the terminal midline.
+    for body, center in zip([r[0] for r in rows], centers, strict=True):
+        assert abs(center - mid) <= 2.0, (body, center, mid)
+
+
+def test_launch_banner_draws_block_wordmark_on_wide_terminals(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
     console = Console(record=True, force_terminal=False, highlight=False, width=120)
 
     console.print(banner_module.build_launch_banner(console))
 
     output = console.export_text(styles=False)
-    # Braille rendering of the canonical OpenSRE "O" mark: the two ring-wall rows.
-    assert "⣿⣿⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⠀⢸⣿⣿" in output
+    assert "██████╗ ██████╗ ███████╗" in output
+
+
+def test_launch_banner_falls_back_to_title_on_narrow_terminals(monkeypatch: object) -> None:
+    monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
+    console = Console(record=True, force_terminal=False, highlight=False, width=40)
+
+    console.print(banner_module.build_launch_banner(console))
+
+    output = console.export_text(styles=False)
+    assert "OpenSRE" in output
+    assert "██████╗ ██████╗" not in output
 
 
 def test_launch_banner_uses_active_theme_palette(monkeypatch: object) -> None:
@@ -139,9 +191,14 @@ def test_status_probes_survive_loader_failures(monkeypatch: object) -> None:
 
 def test_banner_shows_the_full_build_version(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
-    details = banner_module._build_details(_fixed_status()).plain
-    # The banner shows the full build version (identity for support / bug reports).
-    assert f"v{get_opensre_version()}" in details
+    monkeypatch.setattr(
+        banner_module,
+        "get_opensre_version",
+        lambda: "0.1.2026.9.2+main.abc1234",
+    )
+    # Full build version (identity for support / bug reports), not a trimmed one.
+    version = banner_module._build_version_line().plain
+    assert version == "v0.1.2026.9.2+main.abc1234"
 
 
 def test_refresh_welcome_poster_uses_repl_safe_render(monkeypatch: object) -> None:

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -48,6 +48,14 @@ def test_submitted_answer_to_a_handoff_is_marked() -> None:
     output = buffer.getvalue()
     assert "↗ answer" in output
     assert "staging" in output
+    # The marker hugs the assistant answer it responds to (no blank row above it),
+    # and the between-turns gap falls after the marker, before the input row.
+    assert not output.startswith("\n")
+    lines = output.splitlines()
+    marker_index = next(i for i, line in enumerate(lines) if "↗ answer" in line)
+    input_index = next(i for i, line in enumerate(lines) if "staging" in line)
+    assert lines[marker_index + 1].strip() == ""
+    assert marker_index < input_index
 
 
 def test_ask_user_answers_render_as_numbered_qa() -> None:

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -178,13 +178,13 @@ class TestPromptTurnCounter:
 
 
 class TestResolveIdleHint:
-    def test_idle_hint_shows_ready_and_commands(self) -> None:
+    def test_idle_hint_is_empty_no_recurring_ready_line(self) -> None:
+        # Hints live once in the banner + footer; the prompt shows no per-turn
+        # "Ready · …" line (it also stacked into copies on terminal resize).
         session = Session()
         session.configured_integrations_known = True
         session.configured_integrations = ("datadog", "github", "grafana")
-        rendered = _strip_ansi(resolve_idle_hint_ansi(session))
-        assert "Ready" in rendered
-        assert "/ for commands" in rendered
+        assert resolve_idle_hint_ansi(session) == ""
 
 
 class TestComposerFooter:
@@ -461,15 +461,14 @@ class TestResolvePromptPrefix:
         assert prefix == "preview line"
         assert "/ for commands" not in prefix
 
-    def test_falls_back_to_idle_hint_when_no_preview(self) -> None:
+    def test_idle_prompt_prefix_is_empty_when_no_preview(self) -> None:
         spinner = loop_state.SpinnerState()
         prefix = resolve_prompt_prefix_ansi(
             inline_spinner=spinner.inline_spinner_ansi(),
             idle_hint=resolve_idle_hint_ansi(Session()),
         )
-        rendered = _strip_ansi(prefix)
-        assert "Ready" in rendered
-        assert "/ for commands" in rendered
+        # Nothing streaming or previewing → no idle chrome above the composer.
+        assert _strip_ansi(prefix) == ""
 
 
 @pytest.mark.asyncio

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -117,11 +117,13 @@ class TestPromptTurnCounter:
         render_submitted_prompt(console, session, "and again")
         assert _prompt_turn_number(session) == 3
 
-    def test_user_prompt_row_is_recessed_grey_without_accent_bar(self) -> None:
-        """Droid-style: the user row is recessed SECONDARY grey with no bright ``▌``
-        accent bar, so the agent reply (``∴``) and notes carry the visual weight."""
-        from infrastructure.terminal.theme import get_active_theme
+    def test_user_prompt_row_has_warm_accent_on_full_width_surface(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Droid-style: orange ``▌`` lead-in and INPUT_SURFACE across the full row."""
+        from infrastructure.terminal.theme import get_active_theme, reply_marker_hex
 
+        monkeypatch.setattr(prompt_rendering, "terminal_columns", lambda: 40)
         session = Session()
         buf = io.StringIO()
         console = Console(
@@ -134,12 +136,22 @@ class TestPromptTurnCounter:
         )
         render_submitted_prompt(console, session, "why does it show that?")
         raw = buf.getvalue()
-        assert "▌" not in raw  # no bright accent bar
-        visible = re.sub(r"\x1b\[[0-9;]*m", "", raw)
-        assert "[1] ❯ why does it show that?" in visible  # turn number + text kept
-        secondary = get_active_theme().SECONDARY.lstrip("#")
-        r, g, b = (int(secondary[i : i + 2], 16) for i in (0, 2, 4))
-        assert f"{r};{g};{b}" in raw  # body in SECONDARY recessed grey
+        visible = re.sub(r"\x1b\[[0-9;]*m", "", raw).rstrip("\n")
+        assert "▌" in visible
+        assert "❯" not in visible
+        assert "why does it show that?" in visible
+        # Plate spans the live prompt width (spaces pad out the row).
+        assert len(visible) == 40, repr(visible)
+        assert visible.startswith("▌")
+        accent = reply_marker_hex().lstrip("#")
+        ar, ag, ab = (int(accent[i : i + 2], 16) for i in (0, 2, 4))
+        assert f"{ar};{ag};{ab}" in raw
+        surface = get_active_theme().INPUT_SURFACE.lstrip("#")
+        sr, sg, sb = (int(surface[i : i + 2], 16) for i in (0, 2, 4))
+        assert f"{sr};{sg};{sb}" in raw
+        text = get_active_theme().TEXT.lstrip("#")
+        tr, tg, tb = (int(text[i : i + 2], 16) for i in (0, 2, 4))
+        assert f"{tr};{tg};{tb}" in raw
 
     def test_autosubmitted_goal_condition_gets_work_turn_marker(self) -> None:
         """``/goal set`` autosubmit must not look like part of the slash turn."""

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -136,7 +136,10 @@ class TestPromptTurnCounter:
         )
         render_submitted_prompt(console, session, "why does it show that?")
         raw = buf.getvalue()
-        visible = re.sub(r"\x1b\[[0-9;]*m", "", raw).rstrip("\n")
+        # A blank row precedes the echo (between-turns gap); the plate itself is
+        # the row after it.
+        assert re.sub(r"\x1b\[[0-9;]*m", "", raw).startswith("\n")
+        visible = re.sub(r"\x1b\[[0-9;]*m", "", raw).strip("\n")
         assert "▌" in visible
         assert "❯" not in visible
         assert "why does it show that?" in visible

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -36,7 +36,7 @@ def _strip_ansi(text: str) -> str:
 
 
 def _placeholder_text(session: Session) -> str:
-    return resolve_prompt_placeholder(session).value
+    return "".join(fragment for _style, fragment in resolve_prompt_placeholder(session))
 
 
 class _RefreshFakeBuffer:
@@ -213,7 +213,7 @@ class TestPromptMessage:
 class TestResolvePromptPlaceholder:
     def test_default_when_no_session_context(self) -> None:
         session = Session()
-        assert _strip_ansi(_placeholder_text(session)) == "see what you can do"
+        assert _placeholder_text(session) == "see what you can do"
 
     def test_placeholder_prompts_to_continue_an_unfinished_plan(self) -> None:
         from core.agent_harness.task_plan.plan import parse_task_plan

--- a/tests/interactive_shell/ui/test_prompt_resize.py
+++ b/tests/interactive_shell/ui/test_prompt_resize.py
@@ -1,0 +1,105 @@
+"""Shrink-resize must erase soft-wrapped ghost rows before redrawing.
+
+When columns shrink, the emulator wraps the previous paint before
+``Application._on_resize`` runs. ``Renderer.erase`` only climbs the logical
+``_cursor_pos.y``, so wrapped rows stay and the next paint stacks another
+Ready line. The guard inflates the erase origin and keeps autowrap off
+between paints.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+from prompt_toolkit.layout.containers import Window
+from prompt_toolkit.layout.layout import Layout
+from prompt_toolkit.output.base import Size
+from prompt_toolkit.output.vt100 import Vt100_Output
+
+from surfaces.interactive_shell.ui.input_prompt.resize import (
+    inflate_resize_erase_y,
+    install_shrink_resize_guard,
+)
+
+
+@dataclass
+class _Cursor:
+    x: int
+    y: int
+
+
+def test_inflate_resize_erase_y_covers_soft_wrap_multiple() -> None:
+    # Under-reported logical y=3 after a wrap that made physical ~9–11 rows.
+    assert inflate_resize_erase_y(3, rows=30) >= 9
+    assert inflate_resize_erase_y(3, rows=30) >= 3 + 8
+    # Never past the terminal floor.
+    assert inflate_resize_erase_y(20, rows=24) == 23
+
+
+def test_shrink_resize_guard_inflates_cursor_before_original_on_resize() -> None:
+    terminal = io.StringIO()
+    output = Vt100_Output(
+        terminal,
+        get_size=lambda: Size(rows=30, columns=80),
+        term="xterm-256color",
+        enable_cpr=False,
+    )
+    app: Any = MagicMock()
+    app.output = output
+    renderer = MagicMock()
+    renderer._cursor_pos = _Cursor(x=2, y=3)  # under-reported after soft-wrap
+    renderer.render = MagicMock()
+    app.renderer = renderer
+
+    seen_y: list[int] = []
+
+    def _original_on_resize() -> None:
+        pos = renderer._cursor_pos
+        seen_y.append(pos.y if pos is not None else -1)
+
+    app._on_resize = _original_on_resize
+
+    install_shrink_resize_guard(app)
+    app._on_resize()
+
+    assert seen_y == [inflate_resize_erase_y(3, rows=30)]
+
+
+def test_shrink_resize_guard_disables_autowrap_after_render() -> None:
+    terminal = io.StringIO()
+    output = Vt100_Output(
+        terminal,
+        get_size=lambda: Size(rows=24, columns=80),
+        term="xterm-256color",
+        enable_cpr=False,
+    )
+    disabled: list[bool] = []
+    real_disable = output.disable_autowrap
+
+    def _spy_disable() -> None:
+        disabled.append(True)
+        real_disable()
+
+    output.disable_autowrap = _spy_disable  # type: ignore[method-assign]
+
+    app: Any = MagicMock()
+    app.output = output
+    renderer = MagicMock()
+    renderer._cursor_pos = _Cursor(x=0, y=1)
+    calls: list[str] = []
+
+    def _original_render(*_a: object, **_k: object) -> None:
+        calls.append("render")
+
+    renderer.render = _original_render
+    app.renderer = renderer
+    app._on_resize = MagicMock()
+
+    install_shrink_resize_guard(app)
+    disabled.clear()
+    app.renderer.render(app, Layout(Window()))
+    assert calls == ["render"]
+    assert disabled, "render must leave autowrap disabled so shrink cannot soft-wrap the UI"

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -112,11 +112,11 @@ def test_confirmation_region_height_is_stable_across_selection_changes() -> None
 
 
 def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> None:
-    """Prompt stack is Plan → status → Auto (Droid); no reserved action gap.
+    """Prompt stack is status → Auto (Droid); no reserved empty action gap.
 
-    Live tool awareness folds into the spinner row
-    (``Invoking tools… · GitHub CLI · …``). Height must match idle whether or
-    not a tool is in flight — never a second reserved prompt row.
+    Idle omits the empty status placeholder (that was the big gap under the
+    banner). Thinking/Invoking add one status line — height may grow by one,
+    but never by a second reserved blank row.
     """
     session = Session()
     idle = SpinnerState()
@@ -126,16 +126,15 @@ def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> 
     spinner.start()
     spinner.set_phase(SpinnerState.THINKING_PHASE)
     thinking_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
-    assert thinking_rows == idle_rows
+    assert thinking_rows in {idle_rows, idle_rows + 1}
 
     spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
     spinner.set_active_action("GitHub CLI · gh api repos/x", action_id="t1")
     filled = render_prompt_region(session, ReplState(), spinner).value
-    assert filled.count("\n") == idle_rows
+    assert filled.count("\n") == thinking_rows
     plain = _plain(filled)
     assert "GitHub CLI" in plain
     assert "Invoking tools" in plain
-    assert plain.count("\n") == idle_rows or filled.count("\n") == idle_rows
 
 
 def test_idle_prompt_has_no_recurring_ready_hint() -> None:

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -138,11 +138,13 @@ def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> 
     assert plain.count("\n") == idle_rows or filled.count("\n") == idle_rows
 
 
-def test_idle_status_row_shows_ready_hint() -> None:
+def test_idle_prompt_has_no_recurring_ready_hint() -> None:
+    # Command hints live once in the launch banner and the composer footer, not
+    # a per-turn "Ready · …" line (which also stacked into copies on resize).
     session = Session()
     rendered = _plain(render_prompt_region(session, ReplState(), SpinnerState()).value)
-    assert "Ready" in rendered
-    assert "/ for commands" in rendered
+    assert "Ready" not in rendered
+    assert "/ for commands" not in rendered
 
 
 def test_confirmation_region_shows_stacked_yes_no_choice() -> None:

--- a/tests/interactive_shell/ui/test_rendering.py
+++ b/tests/interactive_shell/ui/test_rendering.py
@@ -296,9 +296,9 @@ def test_repl_render_launch_poster_uses_crlf_on_tty(monkeypatch: pytest.MonkeyPa
     assert "blue" in written
     assert f"38;2;{_rgb(THEME_REGISTRY['blue'].HIGHLIGHT)}" in written
     assert _rgb(THEME_REGISTRY["green"].HIGHLIGHT) not in written
-    assert "opensre" in written
+    # Canonical braille "loops" mark — do not assert a box-drawing wordmark.
+    assert "⣿⣿⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⠀⢸⣿⣿" in written
     assert "Skills" in written
-    assert "Welcome" not in written
     assert "\r\n" in written
     # REPL path must not emit bare \\n (causes double-spaced output under patch_stdout).
     assert "\r" not in written.replace("\r\n", "")

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -217,14 +217,31 @@ class TestTtyParagraphRender:
         assert "**para**" not in output
 
     def test_preserves_blank_line_between_list_and_following_paragraph(self) -> None:
-        """Standalone Rich list renders have no trailing vertical space."""
+        """One blank line between a list and the next paragraph — no double gap.
+
+        The whole reply hangs in the ``∴`` gutter, so the list and the following
+        paragraph sit in the indented body column.
+        """
         console, buf = _tty_console()
         text = "Ready:\n\n- first\n- second\n\nBlocked pending a choice."
 
         stream_to_console(console, label="OpenSRE", chunks=_yield_chunks([text]))
 
         visible = "\n".join(line.rstrip() for line in _strip_ansi(buf.getvalue()).splitlines())
-        assert "Ready:\n\n • first\n • second\n\nBlocked pending a choice." in visible
+        assert "∴ Ready:\n\n   • first\n   • second\n\n  Blocked pending a choice." in visible
+
+    def test_reply_hangs_indented_under_the_marker(self) -> None:
+        """A wrapped reply hangs in the ∴ gutter: line one carries the marker,
+        every continuation line aligns in the indented body column."""
+        console, buf = _tty_console()
+        text = "A fairly long assistant reply that has to wrap across several lines. " * 3
+
+        stream_to_console(console, label="assistant", chunks=_yield_chunks([text]))
+
+        lines = [line for line in _strip_ansi(buf.getvalue()).splitlines() if line.strip()]
+        assert lines[0].startswith("∴ ")  # marker leads the first line
+        assert len(lines) > 1  # the reply actually wrapped
+        assert all(line.startswith("  ") for line in lines[1:])  # hang-indent at col 2
 
     def test_paragraph_break_across_chunk_boundary_flushes(self) -> None:
         """The cross-chunk seam — chunk N ends with ``\\n``, chunk N+1

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -27,26 +27,29 @@ def _strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", text)
 
 
-def test_render_note_block_is_dim_and_indented_but_keeps_bold() -> None:
-    # A working note reads as dim + indented (no glyph), distinct from the bright
-    # reply, while the bold action word stays bold within the dim base.
+def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
+    # A working note reads as soft recessed grey + indented (no glyph), distinct
+    # from the bright reply, while the bold action word stays bold.
     from infrastructure.terminal import theme as ui_theme
 
+    ui_theme.set_active_theme("amber")
     buf = io.StringIO()
     console = Console(
-        file=buf, force_terminal=True, color_system="truecolor", width=80, highlight=False
+        file=buf,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+        no_color=False,
+        width=80,
+        highlight=False,
     )
 
     render_note_block(console, "I'll **load** the workflow.")
 
     raw = buf.getvalue()
-    dim = str(ui_theme.DIM)  # e.g. "#6E6E6E"
-    r, g, b = (int(dim[i : i + 2], 16) for i in (1, 3, 5))
-    # DIM may render as 8-colour (``90m``) or truecolor (``38;2;r;g;b``) depending
-    # on the color system the runner advertises — accept either so the test does
-    # not hinge on terminal capability.
-    assert f"38;2;{r};{g};{b}" in raw or "\x1b[90m" in raw  # dim base on the note body
-    assert re.search(r"\x1b\[[0-9;]*1[;m]", raw)  # bold action word survives the dim base
+    # Soft recessed base (SECONDARY), not ghost DIM — accept truecolor or 256.
+    assert "38;2;" in raw or "38;5;" in raw
+    assert re.search(r"\x1b\[[0-9;]*1[;m]", raw)  # bold action word survives
     first_line = _strip_ansi(raw).splitlines()[0]
     assert first_line.startswith("   ")  # three-space left indent, no glyph
     assert "load the workflow" in first_line
@@ -757,20 +760,20 @@ class TestRenderResponseHeader:
     to one helper, so we lock in the visible output here.
     """
 
-    def test_emits_bullet_glyph_and_label(self) -> None:
+    def test_emits_bullet_glyph_without_role_label(self) -> None:
         console, buf = _tty_console()
         render_response_header(console, "assistant")
         output = _strip_ansi(buf.getvalue())
         assert "∴" in output
-        assert "assistant" in output
+        assert "assistant" not in output
 
-    def test_label_is_passthrough(self) -> None:
-        """The function takes the label verbatim — callers pass either
-        ``STREAM_LABEL_ANSWER`` or ``STREAM_LABEL_ASSISTANT`` (or any
-        free-form word). No filtering, no defaults."""
+    def test_role_label_is_accepted_but_not_painted(self) -> None:
+        """Callers still pass ``STREAM_LABEL_ANSWER`` / ``STREAM_LABEL_ASSISTANT``
+        for port compatibility; the shell no longer echoes the dim role word."""
         console, buf = _tty_console()
         render_response_header(console, "answer")
-        assert "answer" in _strip_ansi(buf.getvalue())
+        assert "answer" not in _strip_ansi(buf.getvalue())
+        assert "∴" in _strip_ansi(buf.getvalue())
 
 
 class TestFormatTokenCountShort:

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -97,17 +97,15 @@ def test_prompt_region_keeps_the_checklist_above_invoking_tools() -> None:
     assert rendered.index(SpinnerState.INVOKING_TOOLS_PHASE) < rendered.index("Auto (High)")
 
 
-def test_idle_prompt_region_keeps_ready_hint_not_thinking() -> None:
+def test_idle_prompt_region_shows_plan_without_thinking_or_ready_hint() -> None:
     session = Session()
     session.task_plan = _sample_plan()
     rendered = _strip_ansi(render_prompt_region(session, ReplState(), SpinnerState()).value)
-    assert "Ready" in rendered
-    assert "/ for commands" in rendered
     assert "Thinking" not in rendered
     assert SpinnerState.EXECUTING_PHASE not in rendered
     assert "Plan · 2/3" in rendered
-    assert rendered.index("Plan · 2/3") < rendered.index("Ready")
-    assert rendered.index("Ready") < rendered.index("Auto (High)")
+    assert "Ready" not in rendered  # no recurring idle hint line
+    assert rendered.index("Plan · 2/3") < rendered.index("Auto (High)")
 
 
 def test_clearing_the_plan_resets_expanded_state() -> None:


### PR DESCRIPTION
Makes the interactive shell more user friendly

## Changes

- Purple is the default theme (OpenSRE identity, not warm-gold copycat chrome).
  amber/orange stay available via /theme for side-by-side comparison.
- Every component now follows the active palette. Two colors were hardcoded and
  stayed orange under any theme:
  - the ∴ reply marker / user-row accent / spinner glyph now resolve from the
    theme HIGHLIGHT;
  - the ⏺ tool-call payload (e.g. `⏺ command · /exit`) used the WARNING amber;
    it now uses the neutral SECONDARY so it never reads as off-theme orange.
- Transcript rhythm matches Droid: a blank row between turns and a blank row
  between the user echo and its reply, applied in every render path (TTY
  streaming, non-TTY, deferred gather).
- Exit block stays quiet grey (resume hint + goodbye) — not accented.
- Banner: ring "loops" mark, full build version, "Welcome to OpenSRE CLI" title
  and one-line product description (matching the sign-in screen), centered hero.
- Assistant reply hangs in the ∴ gutter; warmer assistant voice.