### PR TITLE
chore(ci): drop ensureLabelsExist from PR size label workflow

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -33,27 +33,15 @@ jobs:
             // references PR size labels.
             const EXCLUDED_FILES = new Set(["uv.lock"]);
 
+            // Labels already exist in the repo (size:small #0E8A16, size:medium
+            // #FBCA04, size:large #D93F0B, size:extra-large #B60205) — recreate
+            // manually with `gh label create` if one is ever deleted.
             const SIZES = [
-              { name: "size:small", color: "0E8A16", max: 99 },
-              { name: "size:medium", color: "FBCA04", max: 499 },
-              { name: "size:large", color: "D93F0B", max: 1999 },
-              { name: "size:extra-large", color: "B60205", max: Infinity },
+              { name: "size:small", max: 99 },
+              { name: "size:medium", max: 499 },
+              { name: "size:large", max: 1999 },
+              { name: "size:extra-large", max: Infinity },
             ];
-
-            async function ensureLabelsExist() {
-              for (const { name, color } of SIZES) {
-                try {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name,
-                    color,
-                  });
-                } catch (error) {
-                  if (error.status !== 422) throw error; // already exists
-                }
-              }
-            }
 
             async function countChangedLines(pullNumber) {
               const files = await github.paginate(
@@ -71,8 +59,6 @@ jobs:
             }
 
             const pullNumber = context.payload.pull_request.number;
-            await ensureLabelsExist();
-
             const changedLines = await countChangedLines(pullNumber);
             const size = SIZES.find((candidate) => changedLines <= candidate.max);
 


### PR DESCRIPTION
Fixes #

<!-- Maintainer-initiated tooling follow-up, no linked issue. -->

#### Describe the changes you have made in this PR -

Follow-up to #5943. Removes `ensureLabelsExist()` from `pr-size-label.yml`: the
`size:small`/`size:medium`/`size:large`/`size:extra-large` labels were created by
that PR's first workflow run and are now permanent repo-level state — they don't
go away when a PR merges. Every subsequent run of the workflow was paying for 4
`createLabel` API calls that all 422'd for nothing. Also dropped the now-unused
`color` field from the `SIZES` table (only `ensureLabelsExist` read it), moving
the color reference into a comment instead.

Behavior change: if a `size:*` label is ever deleted from the repo, the workflow
will now fail loudly on `addLabels` (404) instead of silently recreating it.
Recreate with `gh label create` if that happens — acceptable since label deletion
is a rare, human-visible action, not something worth defending against on every run.

### Demo/Screenshot for feature changes and bug fixes -

CI-only change, no behavior change for the common case. `size:*` labels already
exist on the repo (verified via `gh label list --search size`), so future PRs
keep getting labeled exactly as before.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Deleted the `ensureLabelsExist` function and its call site, then removed the
`color` field from `SIZES` since it had no remaining reader — kept the color
values as a comment so a human recreating a deleted label knows what to pick.
Considered keeping `ensureLabelsExist` for self-healing if a label is ever
deleted, but the cost (4 wasted API calls on every single PR event, forever)
outweighs the benefit (silently surviving an already-rare manual deletion);
a loud failure on `addLabels` is an acceptable trade since it points a human
straight at the fix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

https://claude.ai/code/session_01Vehpg4FvxPTbaowigFpkHB