### PR TITLE
Docs: replace door with public API in the tool-framework entry points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ The tool registry auto-discovers modules under `tools/`, so the normal path is t
 
 Steps:
 
-1. Pick the simplest shape that fits the tool. Use a `BaseTool` subclass (from `core.tool`) for richer behavior; use `@tool(...)` from `core.tool_framework` for a lightweight function tool. Import through those tier doors, not their internal submodules — the border test in `tests/shared/test_tool_api_border.py` enforces it.
+1. Pick the simplest shape that fits the tool. Use a `BaseTool` subclass (from `core.tool`) for richer behavior; use `@tool(...)` from `core.tool_framework` for a lightweight function tool. Import through those tier public APIs, not their internal submodules — the border test in `tests/shared/test_tool_api_border.py` enforces it.
 2. Declare clear metadata: `name`, `description`, `source`, `input_schema`, and any `use_cases`, `requires`, `outputs`, or `retrieval_controls` you need.
 3. Before opening or approving the PR, follow [docs/adding-tools-and-integrations.md](docs/adding-tools-and-integrations.md).
 

--- a/core/tool_framework/__init__.py
+++ b/core/tool_framework/__init__.py
@@ -1,7 +1,7 @@
 """Tool authoring helpers: the ``@tool`` decorator, planning tags, skill guidance.
 
-The tier's door for consumers above it. Schema and payload utilities live behind
-the sibling ``core.tool_framework.utils`` door; the tool contract itself (what a
+The tier's public API for consumers above it. Schema and payload utilities live behind
+the sibling ``core.tool_framework.utils`` package entry; the tool contract itself (what a
 tool is, how it runs, where it is registered) is ``core.tool``.
 """
 

--- a/core/tool_framework/utils/__init__.py
+++ b/core/tool_framework/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Tool utilities — the one door consumers import these helpers through.
+"""Tool utilities — the one public API consumers use to import these helpers.
 
 Schema builders, MCP payload readers, code-host and availability envelopes, and
 database-warning wrappers. Importing the submodules directly still works inside


### PR DESCRIPTION
Fixes #5626

#### Describe the changes you have made in this PR -
Replaced the "door" metaphor with plain, non-metaphorical terms in the four
locations flagged in the issue — three docstrings and one AGENTS.md line —
per .cursor/rules/no-jargon-names.mdc and docs/NAMING.md, which ask for
behaviour nouns a first-time reader already knows.

- core/tool_framework/__init__.py: "door" → "public API" and "package entry"
  (two separate sentences, worded individually rather than mechanically
  substituted)
- core/tool_framework/utils/__init__.py: "door" → "public API"
- AGENTS.md (adding a tool, step 1): "tier doors" → "tier public APIs"

This is a prose-only change. No module, import structure, or test logic was
touched. The import rule each sentence describes is unchanged and is still
enforced by tests/shared/test_tool_api_border.py.

### Demo/Screenshot for feature changes and bug fixes - 
This is a documentation/docstring-only change with no UI or runtime behavior. Verification output instead:

$ grep -rn "door" --include='*.py' --include='*.md' core/ AGENTS.md docs/
(no output - no occurrences remain)

$ uv run python -m pytest tests/shared/test_tool_api_border.py -q
tests\shared\test_tool_api_border.py .......                       [100%]
7 passed in 8.90s

$ make lint format
All checks passed!
3804 files left unchanged

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Replaced "door" with plain terms per sentence - "public API" where the
sentence names what the package exposes, "package entry" where it's about
location relative to a sibling module. Avoided new metaphors (gateway,
portal, etc.) as the issue asked.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
