### PR TITLE
feat(cloudwatch): add citeable Lambda inspection evidence

### DIFF
--- a/integrations/aws_lambda/tools/lambda_inspect_tool/__init__.py
+++ b/integrations/aws_lambda/tools/lambda_inspect_tool/__init__.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from core.tool_framework import tool
 from integrations.aws.lambda_client import get_function_code, get_function_configuration
 from integrations.aws_lambda.availability import lambda_available, lambda_name
+from integrations.aws_lambda.tools.lambda_inspect_tool._evidence import (
+    map_inspect_lambda_function,
+)
 
 
 def _extract_inspect_lambda_params(sources: dict[str, dict]) -> dict:
@@ -33,6 +36,7 @@ def _extract_inspect_lambda_params(sources: dict[str, dict]) -> dict:
     },
     is_available=lambda_available,
     extract_params=_extract_inspect_lambda_params,
+    evidence_mapper=map_inspect_lambda_function,
 )
 def inspect_lambda_function(function_name: str, include_code: bool = True) -> dict:
     """Inspect a Lambda function's configuration and optionally its code."""

--- a/integrations/aws_lambda/tools/lambda_inspect_tool/_evidence.py
+++ b/integrations/aws_lambda/tools/lambda_inspect_tool/_evidence.py
@@ -36,7 +36,11 @@ def map_inspect_lambda_function(
     code = output.get("code")
     if isinstance(code, dict):
         file_count = code.get("file_count")
-        if isinstance(file_count, int) and not isinstance(file_count, bool) and file_count >= 0:
+        if (
+            isinstance(file_count, int)
+            and not isinstance(file_count, bool)
+            and file_count >= 0
+        ):
             file_label = "code file" if file_count == 1 else "code files"
             parts.append(f"{file_count} {file_label}")
 

--- a/integrations/aws_lambda/tools/lambda_inspect_tool/_evidence.py
+++ b/integrations/aws_lambda/tools/lambda_inspect_tool/_evidence.py
@@ -36,11 +36,7 @@ def map_inspect_lambda_function(
     code = output.get("code")
     if isinstance(code, dict):
         file_count = code.get("file_count")
-        if (
-            isinstance(file_count, int)
-            and not isinstance(file_count, bool)
-            and file_count >= 0
-        ):
+        if isinstance(file_count, int) and not isinstance(file_count, bool) and file_count >= 0:
             file_label = "code file" if file_count == 1 else "code files"
             parts.append(f"{file_count} {file_label}")
 

--- a/integrations/aws_lambda/tools/lambda_inspect_tool/_evidence.py
+++ b/integrations/aws_lambda/tools/lambda_inspect_tool/_evidence.py
@@ -1,0 +1,54 @@
+"""Evidence mapper for Lambda function inspection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import record_evidence_entry, unique_evidence_source
+
+
+def map_inspect_lambda_function(
+    evidence: dict[str, Any], output: dict[str, Any], tool_input: dict[str, Any]
+) -> None:
+    """Cite safe Lambda configuration metadata from a successful inspection."""
+    if output.get("error") or output.get("found") is not True:
+        return
+
+    function_name = output.get("function_name") or tool_input.get("function_name")
+    parts: list[str] = []
+
+    runtime = output.get("runtime")
+    if runtime:
+        parts.append(f"runtime {runtime}")
+
+    state = output.get("state")
+    if state:
+        parts.append(f"state {state}")
+
+    memory_size = output.get("memory_size")
+    if memory_size is not None:
+        parts.append(f"{memory_size} MB")
+
+    timeout = output.get("timeout")
+    if timeout is not None:
+        parts.append(f"{timeout}s timeout")
+
+    code = output.get("code")
+    if isinstance(code, dict):
+        file_count = code.get("file_count")
+        if isinstance(file_count, int) and not isinstance(file_count, bool) and file_count >= 0:
+            file_label = "code file" if file_count == 1 else "code files"
+            parts.append(f"{file_count} {file_label}")
+
+    name = str(function_name).strip() if function_name else ""
+    if parts:
+        summary = f"{name}: {', '.join(parts)}" if name else ", ".join(parts)
+    else:
+        summary = f"{name}: configuration inspected" if name else "configuration inspected"
+
+    record_evidence_entry(
+        evidence,
+        source=unique_evidence_source(evidence, "inspect_lambda_function"),
+        label="Lambda Function",
+        summary=summary,
+    )

--- a/tests/integrations/cloudwatch/test_lambda_inspect_evidence_mapper.py
+++ b/tests/integrations/cloudwatch/test_lambda_inspect_evidence_mapper.py
@@ -43,8 +43,7 @@ def test_mapper_records_compact_safe_lambda_metadata() -> None:
             "source": "inspect_lambda_function",
             "label": "Lambda Function",
             "summary": (
-                "orders-worker: runtime python3.13, state Active, 512 MB, "
-                "30s timeout, 2 code files"
+                "orders-worker: runtime python3.13, state Active, 512 MB, 30s timeout, 2 code files"
             ),
             "url": None,
             "snippet": None,

--- a/tests/integrations/cloudwatch/test_lambda_inspect_evidence_mapper.py
+++ b/tests/integrations/cloudwatch/test_lambda_inspect_evidence_mapper.py
@@ -1,0 +1,137 @@
+"""Regression coverage for Lambda inspection evidence mapping."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.evidence import CATALOG_ENTRIES_KEY
+from integrations.aws_lambda.tools.lambda_inspect_tool._evidence import (
+    map_inspect_lambda_function,
+)
+from tools.investigation.stages.gather_evidence.tools import merge_tool_evidence
+from tools.registry import get_registered_tool
+
+
+def test_mapper_records_compact_safe_lambda_metadata() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "found": True,
+        "function_name": "orders-worker",
+        "function_arn": "arn:aws:lambda:us-east-1:123456789012:function:orders-worker",
+        "runtime": "python3.13",
+        "handler": "app.handler",
+        "timeout": 30,
+        "memory_size": 512,
+        "state": "Active",
+        "environment_variables": {"DATABASE_PASSWORD": "do-not-cite"},
+        "description": "internal deployment detail",
+        "layers": [{"arn": "secret-ish-layer-detail"}],
+        "code": {
+            "file_count": 2,
+            "files": {"app.py": "print('sensitive source')", "config.py": "TOKEN='secret'"},
+        },
+    }
+
+    map_inspect_lambda_function(evidence, output, {"function_name": "orders-worker"})
+
+    entries = evidence[CATALOG_ENTRIES_KEY]
+    assert entries == [
+        {
+            "source": "inspect_lambda_function",
+            "label": "Lambda Function",
+            "summary": "orders-worker: runtime python3.13, state Active, 512 MB, 30s timeout, 2 code files",
+            "url": None,
+            "snippet": None,
+        }
+    ]
+    rendered = repr(entries)
+    assert "do-not-cite" not in rendered
+    assert "sensitive source" not in rendered
+    assert "secret-ish-layer-detail" not in rendered
+    assert "123456789012" not in rendered
+
+
+def test_mapper_records_sparse_configuration_without_code() -> None:
+    evidence: dict[str, Any] = {}
+
+    map_inspect_lambda_function(
+        evidence,
+        {"found": True, "function_name": None},
+        {"function_name": "requested-function", "include_code": False},
+    )
+
+    entry = evidence[CATALOG_ENTRIES_KEY][0]
+    assert entry["source"] == "inspect_lambda_function"
+    assert entry["summary"] == "requested-function: configuration inspected"
+
+
+def test_mapper_skips_failed_inspection() -> None:
+    evidence: dict[str, Any] = {}
+
+    map_inspect_lambda_function(
+        evidence,
+        {"error": "AccessDenied", "function_name": "orders-worker"},
+        {"function_name": "orders-worker"},
+    )
+
+    assert CATALOG_ENTRIES_KEY not in evidence
+
+
+def test_registered_tool_carries_lambda_inspect_mapper() -> None:
+    tool = get_registered_tool("inspect_lambda_function")
+
+    assert tool is not None
+    assert tool.evidence_mapper is not None
+
+
+def test_merge_path_preserves_raw_output_and_records_evidence() -> None:
+    evidence: dict[str, Any] = {}
+    output = {
+        "found": True,
+        "function_name": "orders-worker",
+        "runtime": "python3.13",
+        "state": "Active",
+    }
+
+    merge_tool_evidence(
+        evidence,
+        "inspect_lambda_function",
+        output,
+        {"function_name": "orders-worker"},
+    )
+
+    assert evidence["inspect_lambda_function"] == output
+    entry = evidence[CATALOG_ENTRIES_KEY][0]
+    assert entry["source"] == "inspect_lambda_function"
+    assert entry["summary"] == "orders-worker: runtime python3.13, state Active"
+
+
+def test_repeated_merge_calls_keep_independent_citeable_entries() -> None:
+    evidence: dict[str, Any] = {}
+
+    merge_tool_evidence(
+        evidence,
+        "inspect_lambda_function",
+        {"found": True, "function_name": "orders-worker", "runtime": "python3.13"},
+        {"function_name": "orders-worker"},
+    )
+    second_output = {
+        "found": True,
+        "function_name": "billing-worker",
+        "runtime": "nodejs22.x",
+    }
+    merge_tool_evidence(
+        evidence,
+        "inspect_lambda_function",
+        second_output,
+        {"function_name": "billing-worker"},
+    )
+
+    entries = evidence[CATALOG_ENTRIES_KEY]
+    assert [entry["source"] for entry in entries] == [
+        "inspect_lambda_function",
+        "inspect_lambda_function#2",
+    ]
+    assert entries[0]["summary"] == "orders-worker: runtime python3.13"
+    assert entries[1]["summary"] == "billing-worker: runtime nodejs22.x"
+    assert evidence["inspect_lambda_function"] == second_output

--- a/tests/integrations/cloudwatch/test_lambda_inspect_evidence_mapper.py
+++ b/tests/integrations/cloudwatch/test_lambda_inspect_evidence_mapper.py
@@ -28,7 +28,10 @@ def test_mapper_records_compact_safe_lambda_metadata() -> None:
         "layers": [{"arn": "secret-ish-layer-detail"}],
         "code": {
             "file_count": 2,
-            "files": {"app.py": "print('sensitive source')", "config.py": "TOKEN='secret'"},
+            "files": {
+                "app.py": "print('sensitive source')",
+                "config.py": "TOKEN='secret'",
+            },
         },
     }
 
@@ -39,7 +42,10 @@ def test_mapper_records_compact_safe_lambda_metadata() -> None:
         {
             "source": "inspect_lambda_function",
             "label": "Lambda Function",
-            "summary": "orders-worker: runtime python3.13, state Active, 512 MB, 30s timeout, 2 code files",
+            "summary": (
+                "orders-worker: runtime python3.13, state Active, 512 MB, "
+                "30s timeout, 2 code files"
+            ),
             "url": None,
             "snippet": None,
         }
@@ -112,7 +118,11 @@ def test_repeated_merge_calls_keep_independent_citeable_entries() -> None:
     merge_tool_evidence(
         evidence,
         "inspect_lambda_function",
-        {"found": True, "function_name": "orders-worker", "runtime": "python3.13"},
+        {
+            "found": True,
+            "function_name": "orders-worker",
+            "runtime": "python3.13",
+        },
         {"function_name": "orders-worker"},
     )
     second_output = {

--- a/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
+++ b/tests/tools/investigation/stages/gather_evidence/evidence_mapper_baseline.txt
@@ -76,7 +76,6 @@ helm_get_release_values
 helm_list_releases
 helm_release_history
 helm_release_status
-inspect_lambda_function
 inspect_s3_object
 jira_add_comment
 jira_create_issue


### PR DESCRIPTION
Fixes #5534

Tracking epic: #5519 (part of #1079)

#### Describe the changes you have made in this PR -

`inspect_lambda_function` returns useful Lambda configuration and optional code-inspection metadata, but it did not have an evidence mapper, so successful inspection results could not become citeable report evidence.

This PR:
- adds an AWS Lambda-owned mapper in `integrations/aws_lambda/tools/lambda_inspect_tool/_evidence.py`
- attaches it to `inspect_lambda_function` through the existing `@tool(..., evidence_mapper=...)` contract
- records one compact `Lambda Function` catalog entry for each successful inspection
- uses `unique_evidence_source` so repeated inspections remain independently citeable (`inspect_lambda_function`, `inspect_lambda_function#2`, ...), without trying to aggregate raw tool output
- deliberately excludes environment variables, source-code contents, ARNs, descriptions, layers, and other potentially sensitive or oversized fields from report metadata
- still records configuration evidence when code inspection is disabled or unavailable
- skips failed inspections
- removes `inspect_lambda_function` from the evidence-mapper known-gap baseline
- adds focused mapper, registry, real merge-path, sensitive-field, sparse-output, error, and repeated-call regression coverage under `tests/integrations/cloudwatch/`

The mapper does not change `merge_tool_evidence` or the raw `evidence["inspect_lambda_function"]` contract. The shared merge stage still owns that value; the mapper only appends compact report catalog metadata.

### Demo/Screenshot for feature changes and bug fixes -

Backend-only change; no UI screenshot applies.

Focused mapper proof from an isolated harness using the current `record_evidence_entry` / `unique_evidence_source` behavior and the real merge ordering contract:

```text
4 passed in 0.05s
[{'source': 'inspect_lambda_function', 'label': 'Lambda Function', 'summary': 'orders-worker: runtime python3.13, state Active, 512 MB, 30s timeout, 2 code files', 'url': None, 'snippet': None}]
```

Upstream verification on exact head `35bbe29bfd9f8d0459836eb8ac8b9dba08fb23a0` is green:
- `CI` — passed
- `Synthetic Deterministic Tests` — passed
- `Interactive Shell Live (PR + post-merge)` — passed
- Windows label workflow — skipped by repository conditions

The credential-dependent live CloudWatch report check remains outside this PR's executable verification unless credentials are available; no live credentials were used.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-assisted code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The mapper treats each successful Lambda inspection as one small report entry. It requires `found=True` and rejects error outputs. It builds the summary only from bounded, non-secret configuration metadata: function name, runtime, state, memory, timeout, and code-file count when present. It never copies environment variables or file contents into the evidence catalog.

For repeated calls, the implementation uses the repository's `unique_evidence_source` helper instead of accumulating through `evidence["inspect_lambda_function"]`. That matters because `merge_tool_evidence` replaces the raw tool-output slot before invoking the mapper. Each call therefore gets a distinct citeable source while the existing raw-output semantics stay unchanged.

Sparse successful output falls back to the requested function name from tool input and records `configuration inspected`, so configuration-only success remains evidence even when code retrieval is disabled or unavailable.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions — upstream CI/format checks passed

---

Allow edits from maintainers: enabled.