### PR TITLE
feat: add falsifiable CI durability demo skill

### DIFF
--- a/core/agent_harness/prompts/skills/github_ci_durability_demo/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_ci_durability_demo/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: github-ci-durability-demo
+description: >-
+  Run a disposable, falsifiable GitHub CI durability demo: create a same-repo
+  PR with two sequential failures, invoke fix_github_pr_ci exactly once,
+  classify the result, and clean up. Multi-step; load before acting.
+---
+══════════════════════════════════════════════════════════
+GITHUB CI DURABILITY DEMO SKILL — interactive-shell action agent:
+══════════════════════════════════════════════════════════
+
+WHEN TO USE:
+- The user explicitly asks to demonstrate, test, or reproduce whether the
+  GitHub CI fixer stops after one repair when a later dependent check fails.
+- The user asks for the "CI durability demo" or to create a deliberately
+  broken, disposable CI pull request for this experiment.
+
+DO NOT USE THIS SKILL FOR:
+- Fixing a real failing PR. Load `github-ci-fix` instead.
+- CI onboarding. Load `github-ci-fix-onboarding` instead.
+- Creating a broken PR without an explicit demo request.
+
+EXPERIMENT CONTRACT:
+- This is an opt-in synthetic experiment, not evidence manufactured to force
+  a predetermined conclusion. Stage two is ordinary, fixable code and is
+  visible in the PR, but its CI job waits for stage one to pass.
+- Invoke `fix_github_pr_ci` exactly once. Never prompt it to ignore stage two,
+  never hide repository files from it, and never rerun it inside the same
+  experiment. A fixer that repairs both stages has disproved the limitation for
+  this run.
+- Run only against a checkout whose authenticated user has write access. Never
+  target a fork, protected branch, existing PR, or existing branch.
+- The fixture helper accepts only the generated
+  `codex/ci-durability-demo-*` branch and an OpenSRE marker in the PR body.
+- Cleanup is mandatory after evidence collection, including setup, tool, or
+  verification failures. Do not leave the intentionally red PR open.
+- Keep tokens out of commands and output. Use existing `gh` authentication and
+  OpenSRE's configured GitHub integration.
+
+Step labeling rules (UX):
+- Before every numbered step's tool calls, emit `### [n/8] <step name>` and one
+  short status sentence in the same response.
+- After results arrive, start the outcome line with ✓ or ✗ before moving
+  to the next step. Never renumber or skip the cleanup header.
+
+Steps, in order:
+
+1. **Readiness**
+   Use `shell_run` for read-only checks: `gh --version`, `gh auth status`, the
+   checkout's GitHub origin, and the coding-agent readiness probe from
+   `github-ci-fix-onboarding`. Stop before mutation if any prerequisite fails.
+
+2. **Create disposable PR**
+   Explain that this step creates and pushes a unique branch and opens an
+   intentionally failing PR. Then call one approval-gated `shell_run` from the
+   target checkout:
+
+   `uv run python core/agent_harness/prompts/skills/github_ci_durability_demo/demo_fixture.py create --repo-root "$(git rev-parse --show-toplevel)"`
+
+   Parse the JSON result. Preserve `state_file`, `worktree`, `pr_number`,
+   `pr_url`, `branch`, `baseline_sha`, and `repo` for later steps. If creation
+   fails after returning a `state_file`, continue directly to cleanup.
+
+3. **Observe first failure**
+   Call exactly `github_cli(args=["pr", "checks", "<pr_number>", "--json",
+   "name,state,bucket,link"], repo="<repo>")`. Repeat only while
+   `durability-stage-one` is pending. Proceed as soon as that check is terminal;
+   do not wait for Greptile or other review apps. Require
+   `durability-stage-one` to fail and `durability-stage-two` to be skipped or
+   absent. If a completed repository CI check unrelated to the demo fails,
+   classify the run inconclusive and continue to cleanup without invoking the
+   fixer. Never request a `checkSuites` field; `gh pr view` does not support it.
+
+4. **Capture baseline**
+   Call exactly `github_cli(args=["pr", "view", "<pr_number>", "--json",
+   "headRefOid,commits", "--jq", "{headRefOid: .headRefOid, commitCount:
+   (.commits | length)}"], repo="<repo>")`. Record the SHA and commit count;
+   do not change the PR and do not substitute unsupported JSON fields.
+
+5. **Run one fixer attempt**
+   Explain that the tested operation edits, commits, and pushes. Call exactly:
+   `fix_github_pr_ci(pr_url="<pr_url>", workspace="<worktree>")`.
+   This skill owns the surrounding experiment, so do not apply the
+   `github-ci-fix` skill's "output response_text and stop" rule here.
+
+6. **Collect final evidence**
+   After the fixer returns, call the same exact `pr checks` command from step 3
+   and the same exact `pr view` command from step 4. The fixer already waits for
+   post-push checks; do not add `--watch`, do not request `checkSuites`, and do
+   not call `fix_github_pr_ci` again.
+
+7. **Clean up**
+   Always call the approval-gated helper, even when an earlier step failed:
+
+   `uv run python core/agent_harness/prompts/skills/github_ci_durability_demo/demo_fixture.py cleanup --state-file "<state_file>"`
+
+   The helper refuses cleanup unless the branch prefix, temporary worktree,
+   repository, and PR marker all identify this demo. It closes the PR, deletes
+   the generated remote/local branch, removes its worktree, and deletes the
+   temporary state file.
+
+8. **Report verdict**
+   Report one of these exact verdict labels, followed by PR URL, before/after
+   SHAs, commits added, first and final check states, fixer response, and cleanup
+   result:
+   - `LIMITATION REPRODUCED`: one fixer commit made stage one pass, stage two
+     then failed, and the single fixer invocation returned without another fix.
+   - `LIMITATION NOT REPRODUCED`: all demo stages passed after the one fixer
+     invocation (for example, it anticipated and fixed both defects).
+   - `INCONCLUSIVE`: setup/tool/infra/unrelated-CI failure prevented the
+     experiment from distinguishing those outcomes.
+
+Never generalize one run into "the agent cannot make durable fixes." State only
+what this run demonstrates and link the evidence PR, even though it is closed.

--- a/core/agent_harness/prompts/skills/github_ci_durability_demo/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_ci_durability_demo/SKILL.md
@@ -97,7 +97,9 @@ Steps, in order:
    The helper refuses cleanup unless the branch prefix, temporary worktree,
    repository, and PR marker all identify this demo. It closes the PR, deletes
    the generated remote/local branch, removes its worktree, and deletes the
-   temporary state file.
+   temporary state file. If one operation fails, it still attempts every
+   independent cleanup step and retains the state file for a safe retry. Resolve
+   the reported blocker and repeat cleanup until the result has `ok=true`.
 
 8. **Report verdict**
    Report one of these exact verdict labels, followed by PR URL, before/after

--- a/core/agent_harness/prompts/skills/github_ci_durability_demo/demo_fixture.py
+++ b/core/agent_harness/prompts/skills/github_ci_durability_demo/demo_fixture.py
@@ -236,56 +236,87 @@ def cleanup(state_file: Path) -> dict[str, Any]:
     branch = str(state["branch"])
     repo = str(state["repo"])
     pr_number = state.get("pr_number")
+    errors: list[str] = []
+    pr_closed = False
+    remote_branch_deleted = False
+    local_branch_deleted = False
+    worktree_removed = False
 
-    if pr_number is not None:
-        pr = json.loads(
+    try:
+        if pr_number is not None:
+            pr = json.loads(
+                _run(
+                    "gh",
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "body,headRefName,state",
+                    cwd=root,
+                )
+            )
+            if pr.get("headRefName") != branch or PR_MARKER not in str(pr.get("body") or ""):
+                raise DemoError("refusing to close a PR without matching demo markers")
+        else:
+            pr = _matching_open_pr(root, repo, branch)
+            pr_number = pr.get("number") if pr is not None else None
+        if pr_number is not None and pr is not None and pr.get("state") == "OPEN":
             _run(
                 "gh",
                 "pr",
-                "view",
+                "close",
                 str(pr_number),
                 "--repo",
                 repo,
-                "--json",
-                "body,headRefName,state",
+                "--delete-branch",
                 cwd=root,
             )
-        )
-        if pr.get("headRefName") != branch or PR_MARKER not in str(pr.get("body") or ""):
-            raise DemoError("refusing to close a PR without matching demo markers")
-    else:
-        pr = _matching_open_pr(root, repo, branch)
-        pr_number = pr.get("number") if pr is not None else None
-    if pr_number is not None and pr is not None and pr.get("state") == "OPEN":
-        _run(
-            "gh",
-            "pr",
-            "close",
-            str(pr_number),
-            "--repo",
-            repo,
-            "--delete-branch",
-            cwd=root,
-        )
+        pr_closed = pr is None or pr.get("state") != "OPEN" or pr_number is not None
+    except (DemoError, json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+        errors.append(f"pull request cleanup failed: {exc}")
 
-    remote_ref = _run("git", "ls-remote", "--heads", "origin", branch, cwd=root)
-    if remote_ref:
-        _run("git", "push", "origin", "--delete", branch, cwd=root)
-    registered_worktrees = _run("git", "worktree", "list", "--porcelain", cwd=root)
-    if worktree.exists() and f"worktree {worktree}" in registered_worktrees:
-        _run("git", "worktree", "remove", "--force", str(worktree), cwd=root)
-    elif worktree.exists():
-        worktree.rmdir()
-    local_branches = _run("git", "branch", "--list", branch, cwd=root)
-    if local_branches:
-        _run("git", "branch", "-D", branch, cwd=root)
-    state_file.unlink()
+    try:
+        remote_ref = _run("git", "ls-remote", "--heads", "origin", branch, cwd=root)
+        if remote_ref:
+            _run("git", "push", "origin", "--delete", branch, cwd=root)
+        remote_branch_deleted = True
+    except DemoError as exc:
+        errors.append(f"remote branch cleanup failed: {exc}")
+
+    try:
+        registered_worktrees = _run("git", "worktree", "list", "--porcelain", cwd=root)
+        if worktree.exists() and f"worktree {worktree}" in registered_worktrees:
+            _run("git", "worktree", "remove", "--force", str(worktree), cwd=root)
+        elif worktree.exists():
+            worktree.rmdir()
+        worktree_removed = True
+    except (DemoError, OSError) as exc:
+        errors.append(f"worktree cleanup failed: {exc}")
+
+    try:
+        local_branches = _run("git", "branch", "--list", branch, cwd=root)
+        if local_branches:
+            _run("git", "branch", "-D", branch, cwd=root)
+        local_branch_deleted = True
+    except DemoError as exc:
+        errors.append(f"local branch cleanup failed: {exc}")
+
+    if not errors:
+        try:
+            state_file.unlink()
+        except OSError as exc:
+            errors.append(f"state file cleanup failed: {exc}")
     return {
-        "ok": True,
-        "branch_deleted": True,
-        "pr_closed": pr_number is not None,
-        "state_file_deleted": True,
-        "worktree_removed": True,
+        "ok": not errors,
+        "branch_deleted": remote_branch_deleted and local_branch_deleted,
+        "errors": errors,
+        "local_branch_deleted": local_branch_deleted,
+        "pr_closed": pr_closed,
+        "remote_branch_deleted": remote_branch_deleted,
+        "state_file_deleted": not state_file.exists(),
+        "worktree_removed": worktree_removed,
     }
 
 
@@ -303,7 +334,7 @@ def main() -> int:
     args = _parser().parse_args()
     result = create(args.repo_root) if args.command == "create" else cleanup(args.state_file)
     print(json.dumps(result, sort_keys=True))
-    return 0
+    return 0 if result.get("ok") else 1
 
 
 if __name__ == "__main__":

--- a/core/agent_harness/prompts/skills/github_ci_durability_demo/demo_fixture.py
+++ b/core/agent_harness/prompts/skills/github_ci_durability_demo/demo_fixture.py
@@ -1,0 +1,310 @@
+"""Create and clean up the disposable GitHub CI durability demo fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Final
+
+BRANCH_PREFIX: Final = "codex/ci-durability-demo-"
+PR_MARKER: Final = "<!-- opensre-ci-durability-demo -->"
+STATE_PREFIX: Final = "opensre-ci-durability-demo-state-"
+WORKTREE_PREFIX: Final = "opensre-ci-durability-demo-worktree-"
+
+_WORKFLOW = """name: OpenSRE CI Durability Demo
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/opensre-ci-durability-demo.yml"
+      - ".opensre-ci-durability-demo/**"
+
+permissions:
+  contents: read
+
+jobs:
+  durability-stage-one:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Exercise the first defect
+        run: python .opensre-ci-durability-demo/retry_delay.py
+
+  durability-stage-two:
+    needs: durability-stage-one
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Exercise the dependent defect
+        run: python .opensre-ci-durability-demo/service_slug.py
+"""
+
+_STAGE_ONE = """def retry_delay(attempt: int) -> int:
+    \"\"\"Return the cumulative delay before a retry attempt.\"\"\"
+    return attempt
+
+
+if __name__ == \"__main__\":
+    assert retry_delay(3) == 6, \"three attempts should accumulate to six seconds\"
+"""
+
+_STAGE_TWO = """def service_slug(value: str) -> str:
+    \"\"\"Return the canonical slug used in service URLs.\"\"\"
+    return value.strip().lower()
+
+
+if __name__ == \"__main__\":
+    assert service_slug(\"Open SRE\") == \"open-sre\", \"spaces must become hyphens\"
+"""
+
+
+class DemoError(RuntimeError):
+    """Raised when fixture safety or a subprocess operation fails."""
+
+
+def _run(*args: str, cwd: Path | None = None) -> str:
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise DemoError(f"{' '.join(args[:3])} failed: {detail}")
+    return completed.stdout.strip()
+
+
+def _repo_scope(origin: str) -> str:
+    match = re.search(r"github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?$", origin.strip())
+    if match is None:
+        raise DemoError("origin must be a github.com repository")
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def _default_branch(repo_root: Path) -> str:
+    try:
+        symbolic = _run("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD", cwd=repo_root)
+    except DemoError:
+        symbolic = "origin/main"
+    branch = symbolic.removeprefix("origin/")
+    _run("git", "rev-parse", "--verify", f"origin/{branch}", cwd=repo_root)
+    return branch
+
+
+def _write_state(path: Path, state: dict[str, Any]) -> None:
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def create(repo_root: Path) -> dict[str, Any]:
+    """Create one uniquely marked same-repository demo PR."""
+    root = Path(_run("git", "rev-parse", "--show-toplevel", cwd=repo_root)).resolve()
+    repo = _repo_scope(_run("git", "remote", "get-url", "origin", cwd=root))
+    base = _default_branch(root)
+    _run("git", "fetch", "origin", base, cwd=root)
+
+    identifier = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    branch = f"{BRANCH_PREFIX}{identifier}"
+    worktree = Path(tempfile.mkdtemp(prefix=WORKTREE_PREFIX)).resolve()
+    state_file = Path(tempfile.gettempdir()) / f"{STATE_PREFIX}{identifier}.json"
+    state: dict[str, Any] = {
+        "base": base,
+        "branch": branch,
+        "pr_number": None,
+        "pr_url": "",
+        "repo": repo,
+        "repo_root": str(root),
+        "state_file": str(state_file),
+        "worktree": str(worktree),
+    }
+    _write_state(state_file, state)
+
+    try:
+        _run("git", "worktree", "add", "-b", branch, str(worktree), f"origin/{base}", cwd=root)
+        workflow = worktree / ".github/workflows/opensre-ci-durability-demo.yml"
+        fixture = worktree / ".opensre-ci-durability-demo"
+        workflow.parent.mkdir(parents=True, exist_ok=True)
+        fixture.mkdir(parents=True, exist_ok=True)
+        workflow.write_text(_WORKFLOW, encoding="utf-8")
+        (fixture / "retry_delay.py").write_text(_STAGE_ONE, encoding="utf-8")
+        (fixture / "service_slug.py").write_text(_STAGE_TWO, encoding="utf-8")
+        _run(
+            "git",
+            "add",
+            str(workflow.relative_to(worktree)),
+            str(fixture.relative_to(worktree)),
+            cwd=worktree,
+        )
+        _run("git", "commit", "-m", "demo: add staged CI durability fixture", cwd=worktree)
+        baseline_sha = _run("git", "rev-parse", "HEAD", cwd=worktree)
+        state["baseline_sha"] = baseline_sha
+        _write_state(state_file, state)
+        _run("git", "push", "--set-upstream", "origin", branch, cwd=worktree)
+        body = "\n".join(
+            (
+                PR_MARKER,
+                "Disposable synthetic PR for the OpenSRE CI durability demo.",
+                "It is closed and deleted automatically after evidence collection.",
+            )
+        )
+        pr_url = _run(
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            repo,
+            "--base",
+            base,
+            "--head",
+            branch,
+            "--title",
+            "Demo: staged CI durability experiment",
+            "--body",
+            body,
+            cwd=worktree,
+        )
+        pr_number = int(pr_url.rstrip("/").rsplit("/", 1)[-1])
+        state.update({"pr_number": pr_number, "pr_url": pr_url})
+        _write_state(state_file, state)
+        return {"ok": True, **state}
+    except Exception:
+        print(json.dumps({"ok": False, **state}), flush=True)
+        raise
+
+
+def _validated_state(state_file: Path) -> dict[str, Any]:
+    if not state_file.name.startswith(STATE_PREFIX):
+        raise DemoError("refusing a state file not created by this demo")
+    raw = json.loads(state_file.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise DemoError("demo state must be a JSON object")
+    branch = str(raw.get("branch") or "")
+    worktree = Path(str(raw.get("worktree") or "")).resolve()
+    if not branch.startswith(BRANCH_PREFIX):
+        raise DemoError("refusing to clean a branch outside the demo prefix")
+    if not worktree.name.startswith(WORKTREE_PREFIX):
+        raise DemoError("refusing to remove a worktree outside the demo prefix")
+    resolved_repo = _repo_scope(
+        _run("git", "remote", "get-url", "origin", cwd=Path(str(raw["repo_root"])))
+    )
+    if resolved_repo != raw.get("repo"):
+        raise DemoError("refusing cleanup because the repository no longer matches demo state")
+    return raw
+
+
+def _matching_open_pr(root: Path, repo: str, branch: str) -> dict[str, Any] | None:
+    payload = json.loads(
+        _run(
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--limit",
+            "2",
+            "--json",
+            "number,body,headRefName,state",
+            cwd=root,
+        )
+    )
+    matches = [
+        pr
+        for pr in payload
+        if pr.get("headRefName") == branch and PR_MARKER in str(pr.get("body") or "")
+    ]
+    if len(matches) > 1:
+        raise DemoError("refusing cleanup because multiple marked demo PRs use this branch")
+    return matches[0] if matches else None
+
+
+def cleanup(state_file: Path) -> dict[str, Any]:
+    """Close and remove only resources carrying the demo's safety markers."""
+    state = _validated_state(state_file.resolve())
+    root = Path(str(state["repo_root"])).resolve()
+    worktree = Path(str(state["worktree"])).resolve()
+    branch = str(state["branch"])
+    repo = str(state["repo"])
+    pr_number = state.get("pr_number")
+
+    if pr_number is not None:
+        pr = json.loads(
+            _run(
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--json",
+                "body,headRefName,state",
+                cwd=root,
+            )
+        )
+        if pr.get("headRefName") != branch or PR_MARKER not in str(pr.get("body") or ""):
+            raise DemoError("refusing to close a PR without matching demo markers")
+    else:
+        pr = _matching_open_pr(root, repo, branch)
+        pr_number = pr.get("number") if pr is not None else None
+    if pr_number is not None and pr is not None and pr.get("state") == "OPEN":
+        _run(
+            "gh",
+            "pr",
+            "close",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--delete-branch",
+            cwd=root,
+        )
+
+    remote_ref = _run("git", "ls-remote", "--heads", "origin", branch, cwd=root)
+    if remote_ref:
+        _run("git", "push", "origin", "--delete", branch, cwd=root)
+    registered_worktrees = _run("git", "worktree", "list", "--porcelain", cwd=root)
+    if worktree.exists() and f"worktree {worktree}" in registered_worktrees:
+        _run("git", "worktree", "remove", "--force", str(worktree), cwd=root)
+    elif worktree.exists():
+        worktree.rmdir()
+    local_branches = _run("git", "branch", "--list", branch, cwd=root)
+    if local_branches:
+        _run("git", "branch", "-D", branch, cwd=root)
+    state_file.unlink()
+    return {
+        "ok": True,
+        "branch_deleted": True,
+        "pr_closed": pr_number is not None,
+        "state_file_deleted": True,
+        "worktree_removed": True,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    create_parser = subparsers.add_parser("create")
+    create_parser.add_argument("--repo-root", type=Path, required=True)
+    cleanup_parser = subparsers.add_parser("cleanup")
+    cleanup_parser.add_argument("--state-file", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    result = create(args.repo_root) if args.command == "create" else cleanup(args.state_file)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/agent/orchestration/test_action_prompt.py
+++ b/tests/core/agent/orchestration/test_action_prompt.py
@@ -264,6 +264,25 @@ def test_skills_loader_bundles_github_ci_fix_skill() -> None:
     cached_load_skills_block.cache_clear()
 
 
+def test_skills_loader_bundles_github_ci_durability_demo_skill() -> None:
+    cached_load_skills_block.cache_clear()
+    skill = skills_dir() / "github_ci_durability_demo" / "SKILL.md"
+    helper = skill.with_name("demo_fixture.py")
+    assert skill.is_file()
+    assert helper.is_file()
+
+    assert "github-ci-durability-demo" in load_skills_index()
+    body = load_skill_body("github-ci-durability-demo")
+    assert "GITHUB CI DURABILITY DEMO SKILL" in body
+    assert "fix_github_pr_ci" in body
+    assert "exactly once" in body
+    assert "LIMITATION REPRODUCED" in body
+    assert "LIMITATION NOT REPRODUCED" in body
+    assert "INCONCLUSIVE" in body
+    assert "Cleanup is mandatory" in body
+    cached_load_skills_block.cache_clear()
+
+
 def test_skill_matches_take_priority_over_generic_docs_answer() -> None:
     cached_load_skills_block.cache_clear()
 

--- a/tests/core/agent/orchestration/test_ci_durability_demo_fixture.py
+++ b/tests/core/agent/orchestration/test_ci_durability_demo_fixture.py
@@ -1,0 +1,49 @@
+"""Contract tests for the disposable CI durability demo fixture."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.agent_harness.prompts.skills.loader import skills_dir
+
+
+def _fixture_module() -> dict[str, Any]:
+    path = skills_dir() / "github_ci_durability_demo" / "demo_fixture.py"
+    return runpy.run_path(str(path))
+
+
+def test_fixture_exposes_second_defect_only_after_first_job_passes() -> None:
+    module = _fixture_module()
+    workflow = str(module["_WORKFLOW"])
+
+    assert "durability-stage-one:" in workflow
+    assert "durability-stage-two:" in workflow
+    assert "needs: durability-stage-one" in workflow
+    assert "return attempt\n" in str(module["_STAGE_ONE"])
+    assert 'service_slug("Open SRE") == "open-sre"' in str(module["_STAGE_TWO"])
+
+
+@pytest.mark.parametrize(
+    ("origin", "expected"),
+    [
+        ("https://github.com/Tracer-Cloud/opensre.git", "Tracer-Cloud/opensre"),
+        ("git@github.com:Tracer-Cloud/opensre.git", "Tracer-Cloud/opensre"),
+    ],
+)
+def test_repo_scope_accepts_common_github_remote_forms(origin: str, expected: str) -> None:
+    module = _fixture_module()
+
+    assert module["_repo_scope"](origin) == expected
+
+
+def test_cleanup_state_rejects_non_demo_filename(tmp_path: Path) -> None:
+    module = _fixture_module()
+    state_file = tmp_path / "ordinary-state.json"
+    state_file.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(module["DemoError"], match="not created by this demo"):
+        module["_validated_state"](state_file)

--- a/tests/core/agent/orchestration/test_ci_durability_demo_fixture.py
+++ b/tests/core/agent/orchestration/test_ci_durability_demo_fixture.py
@@ -47,3 +47,45 @@ def test_cleanup_state_rejects_non_demo_filename(tmp_path: Path) -> None:
 
     with pytest.raises(module["DemoError"], match="not created by this demo"):
         module["_validated_state"](state_file)
+
+
+def test_cleanup_continues_after_pr_failure_and_retains_retry_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_values = _fixture_module()
+    cleanup = module_values["cleanup"]
+    branch = "codex/ci-durability-demo-test"
+    state_file = tmp_path / "opensre-ci-durability-demo-state-test.json"
+    state_file.write_text("{}", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+
+    def _validated_state(_path: Path) -> dict[str, Any]:
+        return {
+            "branch": branch,
+            "pr_number": 123,
+            "repo": "owner/repo",
+            "repo_root": str(tmp_path),
+            "worktree": str(tmp_path / "opensre-ci-durability-demo-worktree-test"),
+        }
+
+    def _run(*args: str, cwd: Path | None = None) -> str:
+        _ = cwd
+        calls.append(args)
+        if args[:3] == ("gh", "pr", "view"):
+            raise module_values["DemoError"]("simulated GitHub outage")
+        if args[:3] == ("git", "ls-remote", "--heads"):
+            return "remote branch exists"
+        if args[:3] == ("git", "branch", "--list"):
+            return branch
+        return ""
+
+    monkeypatch.setitem(cleanup.__globals__, "_validated_state", _validated_state)
+    monkeypatch.setitem(cleanup.__globals__, "_run", _run)
+
+    result = cleanup(state_file)
+
+    assert result["ok"] is False
+    assert result["state_file_deleted"] is False
+    assert state_file.exists()
+    assert ("git", "push", "origin", "--delete", branch) in calls
+    assert ("git", "branch", "-D", branch) in calls


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Adds the discoverable `github-ci-durability-demo` action skill. The skill creates a disposable same-repository PR with two dependent, independently fixable CI failures, invokes `fix_github_pr_ci` exactly once, records a falsifiable verdict, and cleans up every generated resource.

The bundled helper enforces a unique branch prefix, PR body marker, repository match, and temporary-worktree prefix before cleanup. Cleanup attempts each independent resource removal even after an earlier failure and retains its state file for a safe retry until every operation succeeds. Contract tests pin discovery, verdict language, staged-job dependency, GitHub remote parsing, cleanup refusal for unrelated state, and best-effort cleanup after an injected GitHub failure.

### Demo/Screenshot for feature changes and bug fixes -

Live run: https://github.com/Tracer-Cloud/opensre/pull/5970

- Baseline `b2862b58aa05`: `durability-stage-one` failed; `durability-stage-two` skipped.
- Single fixer commit `6c7f8ce32417`: stage one passed; stage two failed.
- The fixer returned `checks_failed` without a second repair attempt.
- The demo PR was closed and its branch/worktree/state file were deleted by the skill cleanup.

Local verification:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/core/agent/orchestration/test_action_prompt.py tests/core/agent/orchestration/test_ci_durability_demo_fixture.py` (32 passed)
- skill-creator `quick_validate.py` (valid)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The demo is intentionally falsifiable rather than rigged: both defects are ordinary visible source files, but GitHub exposes the second check only after the first job passes. The production fixer receives only the observed first failure. If it anticipates both defects, the skill reports that the limitation was not reproduced; if it stops after the newly unblocked second failure, the skill reports only that this run reproduced the limitation.

A small Python helper was chosen over model-generated shell because setup and cleanup need exact, reusable safety invariants and state transfer. It creates a linked worktree from the remote default branch and refuses cleanup unless all demo ownership markers match. Cleanup isolates failures, continues with independent removals, and preserves retry state until all resources are gone. The skill wraps it with exact GitHub reads, one fixer call, evidence collection, mandatory cleanup, and a three-way verdict.

---

## Checklist before requesting a review
- [x] I have added proper PR title
- [x] I have performed a self-review of this code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why these changes work and have tested them thoroughly
- [x] I have considered partial setup, unrelated PRs/branches, unsupported GitHub fields, and inconclusive experiment outcomes
- [x] I added focused tests for the skill and cleanup guardrails
- [x] My code follows the project's style guidelines and conventions
