### PR TITLE
feat(shell): OpenSRE visual identity — purple default, fully themed chrome, user friendly spacing

### DIFF
--- a/config/constants/product.py
+++ b/config/constants/product.py
@@ -18,7 +18,7 @@ PRODUCT_DISPLAY_NAME: Final[str] = "OpenSRE"
 #: Sign-in / welcome screen copy, shown when the shell requires login.
 WELCOME_TITLE: Final[str] = "Welcome to OpenSRE CLI"
 WELCOME_DESCRIPTION: Final[str] = (
-    "OpenSRE is an AI-powered DevOps assistant that diagnoses, fixes and "
+    "OpenSRE is an AI-powered DevOps agent that diagnoses, fixes and "
     "optimizes your production software."
 )
 SIGN_IN_PROMPT: Final[str] = "Please login with your OpenSRE account to continue."

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -1,9 +1,8 @@
-"""Detect and style human hand-off questions vs the user's answers.
+"""Style the user's answers to a structured hand-off (picker / Ask-User).
 
-Questions the agent asks the user (a closing ``?``, or a Want-me-to offer)
-render in the highlight colour. The user's reply to that question uses the
-brand colour so the two are visually distinct in the transcript — the same
-split used for hand-off vs continuation.
+A turn is treated as a hand-off answer only when the harness flagged that a
+picker or Ask-User handoff issued the question; the answer text then uses the
+brand colour so it reads apart from the assistant's questions in the transcript.
 """
 
 from __future__ import annotations
@@ -12,59 +11,13 @@ from rich.console import Console
 from rich.text import Text
 
 from core.agent_harness.spi.handoff import parse_ask_user_answers
-from core.agent_harness.spi.prompt_chrome import WANT_ME_TO_MARKER
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal import theme as ui_theme
-
-_QUESTION_MAX_CHARS = 400
 
 
 def _display_safe(text: str) -> str:
     """Strip terminal controls while keeping newlines for multi-line questions."""
     return "\n".join(strip_terminal_controls(line) for line in text.splitlines())
-
-
-def is_handoff_question(text: str) -> bool:
-    """True when ``text`` is a short question waiting on the user.
-
-    Structural only: a Want-me-to closer, or a short block whose last line
-    ends with ``?``. Does not scan user prose for intent keywords.
-    """
-    stripped = text.strip()
-    if not stripped or stripped.startswith("```"):
-        return False
-    if WANT_ME_TO_MARKER in stripped.lower():
-        return True
-    if len(stripped) > _QUESTION_MAX_CHARS:
-        return False
-    last = ""
-    for line in reversed(stripped.splitlines()):
-        candidate = line.strip().strip("*").strip()
-        if candidate:
-            last = candidate
-            break
-    return last.endswith("?")
-
-
-def last_assistant_asked_handoff(messages: list[tuple[str, str]]) -> bool:
-    """True when the most recent assistant turn is a hand-off question."""
-    for role, content in reversed(messages):
-        if role == "assistant":
-            return is_handoff_question(content)
-        if role == "user":
-            return False
-    return False
-
-
-def render_handoff_question(console: Console, text: str) -> None:
-    """Print a hand-off question in highlight, prefixed with ``?``."""
-    body = _display_safe(text.strip())
-    line = Text()
-    line.append("  ?  ", style=f"bold {ui_theme.HIGHLIGHT}")
-    line.append(body, style=str(ui_theme.HIGHLIGHT))
-    console.print()
-    console.print(line)
-    console.print()
 
 
 def render_handoff_answer_marker() -> Text:
@@ -127,18 +80,9 @@ def try_render_ask_user_submission(console: Console, text: str) -> bool:
     return True
 
 
-def handoff_answer_style() -> str:
-    """Brand colour for the user's answer text."""
-    return str(ui_theme.BRAND)
-
-
 __all__ = [
-    "handoff_answer_style",
-    "is_handoff_question",
-    "last_assistant_asked_handoff",
     "render_ask_user_qa",
     "render_choice_selection",
     "render_handoff_answer_marker",
-    "render_handoff_question",
     "try_render_ask_user_submission",
 ]

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -10,7 +10,6 @@ from core.agent_harness.spi.handoff import parse_ask_user_answers
 from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.handoff_questions import (
-    last_assistant_asked_handoff,
     render_ask_user_qa,
     render_handoff_answer_marker,
 )
@@ -79,11 +78,11 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
     if stripped == "/choose" or stripped.startswith("/choose "):
         session.terminal.last_input_autosubmitted = False
         return
+    # A turn is an answer to a hand-off only when a structured picker/Ask-User
+    # actually issued one (the harness sets this flag). Do not infer it from the
+    # assistant's prose ending in ``?`` — a plain opener like "How can I help?"
+    # would then paint every ordinary follow-up as a brand-coloured answer.
     is_handoff_answer = bool(session.terminal.awaiting_handoff_answer)
-    if not is_handoff_answer:
-        is_handoff_answer = last_assistant_asked_handoff(
-            list(getattr(session, "cli_agent_messages", []) or [])
-        )
     session.terminal.awaiting_handoff_answer = False
     ask_user_pairs = parse_ask_user_answers(stripped) if is_handoff_answer else []
     if len(ask_user_pairs) >= 2:

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -59,7 +59,7 @@ def test_launch_banner_is_borderless_centered_hero(monkeypatch: object) -> None:
     # Welcome title + product description (same copy as the sign-in screen),
     # in place of the old TIP line.
     assert "Welcome to OpenSRE CLI" in output
-    assert "AI-powered DevOps assistant" in output
+    assert "AI-powered DevOps agent" in output
     assert "/ commands" in output
     # Only the two capability items — no MCPs or AGENTS.md line.
     assert "MCPs" not in output

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -8,22 +8,12 @@ from rich.console import Console
 
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.handoff_questions import (
-    is_handoff_question,
-    last_assistant_asked_handoff,
     render_ask_user_qa,
     render_choice_selection,
-    render_handoff_question,
     try_render_ask_user_submission,
 )
 from surfaces.interactive_shell.ui.input_prompt.rendering import render_submitted_prompt
 from surfaces.interactive_shell.ui.streaming.renderer import render_markdown_block
-
-
-def test_short_closing_question_is_a_handoff() -> None:
-    assert is_handoff_question("Which environment should I investigate first?")
-    assert is_handoff_question("**Want me to:** run a full investigation?")
-    assert not is_handoff_question("checkout is returning 502s")
-    assert not is_handoff_question("### [1/8] Prerequisite checks")
 
 
 def test_render_markdown_block_highlights_a_question() -> None:
@@ -37,13 +27,11 @@ def test_render_markdown_block_highlights_a_question() -> None:
 
 def test_submitted_answer_to_a_handoff_is_marked() -> None:
     session = Session()
-    session.cli_agent_messages = [
-        ("user", "checkout is 502ing"),
-        ("assistant", "Which environment should I investigate first?"),
-    ]
+    # Only a structured picker / Ask-User handoff sets this flag; a plain
+    # assistant question in prose must not trigger the answer treatment.
+    session.terminal.awaiting_handoff_answer = True
     buffer = io.StringIO()
     console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
-    assert last_assistant_asked_handoff(list(session.cli_agent_messages))
     render_submitted_prompt(console, session, "staging")
     output = buffer.getvalue()
     assert "↗ answer" in output
@@ -190,12 +178,20 @@ def test_try_render_rejects_a_single_choice_label() -> None:
     assert buffer.getvalue() == ""
 
 
-def test_render_handoff_question_strips_terminal_controls() -> None:
+def test_plain_assistant_question_does_not_tag_the_next_turn() -> None:
+    """A conversational opener ending in ``?`` must not paint the follow-up.
+
+    Without the ``awaiting_handoff_answer`` flag the turn is an ordinary user
+    turn: no ``↗ answer`` marker and the input keeps the neutral row treatment.
+    """
+    session = Session()
+    session.cli_agent_messages = [
+        ("user", "good evening"),
+        ("assistant", "Good evening! How can I help?"),
+    ]
     buffer = io.StringIO()
     console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
-    render_handoff_question(console, "Which env?\x1b]0;pwn\x07\x1b[2K staging")
+    render_submitted_prompt(console, session, "how many open PRs in opensre?")
     output = buffer.getvalue()
-    assert "\x1b" not in output
-    assert "\x07" not in output
-    assert "Which env?" in output
-    assert "staging" in output
+    assert "↗ answer" not in output
+    assert "how many open PRs in opensre?" in output


### PR DESCRIPTION
Makes the interactive shell read as OpenSRE's own product — as polished with its own identity rather than a look-alike — and fixes two transcript bugs that made ordinary turns render wrong.

## Changes

- Purple is the default theme (OpenSRE identity, not warm-gold copycat chrome);  amber/orange remain available via /theme for comparison.
- Every component now follows the active palette. Two colors were hardcoded and
  stayed orange under any theme:
  - the ∴ reply marker / user-row accent / spinner glyph resolve from HIGHLIGHT;
  - the ⏺ tool-call payload (e.g. `⏺ command · /exit`) used the WARNING amber
    and now uses the neutral SECONDARY, so it never reads as off-theme.
- Transcript rhythm: a blank row between turns and a blank row between the user echo and its reply, applied in every render path (TTY  streaming, non-TTY, deferred gather). Gap placement now lives inside  render_submitted_prompt so each path (plain turn, autosubmit, handoff answer)  places it correctly.