### PR TITLE
fix: resolve all open CodeQL findings

### DIFF
--- a/core/agent_harness/turns/goal_review.py
+++ b/core/agent_harness/turns/goal_review.py
@@ -26,7 +26,6 @@ vs metric ``call_*_tool`` can be distinguished).
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -40,8 +39,6 @@ from core.agent_harness.turns.gather_discovery_budget import (
 )
 from core.events import RuntimeEvent, RuntimeEventCallback, ToolExecutionEndEvent
 from core.llm.types import AgentLLMClient
-
-log = logging.getLogger(__name__)
 
 # One rejection is enough to catch a stopped-short turn; the follow-up work is
 # then accepted as-is. More reviews only amplify the damage when the reviewer

--- a/surfaces/interactive_shell/ui/input_prompt/key_bindings.py
+++ b/surfaces/interactive_shell/ui/input_prompt/key_bindings.py
@@ -40,7 +40,8 @@ class _DispatchCancelState(Protocol):
 _SHIFT_ENTER_SEQUENCE = "\x1b[27;2;13~"
 _MODIFIED_ENTER_SEQUENCES = frozenset(
     {
-        *(f"\x1b[27;{modifier};13~" for modifier in range(2, 9)),
+        _SHIFT_ENTER_SEQUENCE,
+        *(f"\x1b[27;{modifier};13~" for modifier in range(3, 9)),
         *(f"\x1b[13;{modifier}u" for modifier in range(2, 9)),
         "\x1b\r",
         "\x1b\n",

--- a/tests/core/agent_harness/test_headless_build.py
+++ b/tests/core/agent_harness/test_headless_build.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 
 from rich.console import Console
 
-from core.agent_harness.runtime import TurnBinding
+import core.agent_harness.runtime as runtime
 from core.agent_harness.session import SessionCore
 from core.agent_harness.session.persistence.memory import InMemorySessionStore
 from core.agent_harness.turns.headless_adapters import BufferOutputSink
@@ -36,7 +36,6 @@ def test_default_headless_build_sets_gateway_surface() -> None:
 
 def test_default_headless_build_is_exported_from_runtime_and_the_buffer_sink_is_not() -> None:
     import core.agent_harness as pkg
-    import core.agent_harness.runtime as runtime
 
     assert runtime.DefaultHeadlessBuild is DefaultHeadlessBuild
     assert not hasattr(pkg, "DefaultHeadlessBuild")
@@ -136,7 +135,7 @@ def test_default_headless_build_takes_the_hosts_tool_provider_and_forwards_the_l
     agent = DefaultHeadlessBuild(session=session, output=BufferOutputSink()).agent(
         tools=tools, llm_factory=llm_factory
     )
-    agent.bind_turn(TurnBinding(tool_hooks=hooks))
+    agent.bind_turn(runtime.TurnBinding(tool_hooks=hooks))
     bare = DefaultHeadlessBuild(session=session, output=BufferOutputSink()).agent()
 
     # Assert — the host's provider is used as-is; the factory and hooks reach the

--- a/tests/integrations/test_yandex_cloud_catalog.py
+++ b/tests/integrations/test_yandex_cloud_catalog.py
@@ -24,7 +24,7 @@ from integrations.catalog import (
     load_env_integrations,
     resolve_effective_integrations,
 )
-from integrations.yandex_cloud import classify
+from integrations.yandex_cloud import classify, endpoints
 from integrations.yandex_cloud.availability import (
     yc_available_or_backend,
     yc_credentials,
@@ -322,8 +322,6 @@ class TestEndpointRegistryBackoff:
     def test_a_failed_fetch_is_not_retried_before_the_cache_period(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        import integrations.yandex_cloud.endpoints as endpoints
-
         endpoints.reset_endpoint_cache()
         attempts = {"n": 0}
 
@@ -374,14 +372,12 @@ class TestObjectStorageResolvesToItsControlPlane:
     """
 
     def test_storage_reads_go_to_the_control_plane(self) -> None:
-        from integrations.yandex_cloud.endpoints import resolve_endpoint
-
-        assert resolve_endpoint("storage", refresh=False) == "storage.api.cloud.yandex.net"
+        assert (
+            endpoints.resolve_endpoint("storage", refresh=False) == "storage.api.cloud.yandex.net"
+        )
 
     def test_the_alias_survives_a_registry_refresh(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A refresh brings back Yandex's own mapping; the alias must outlive it."""
-        from integrations.yandex_cloud import endpoints
-
         monkeypatch.setattr(
             endpoints, "_fetch_endpoints", lambda: {"storage": "storage.yandexcloud.net"}
         )
@@ -393,8 +389,6 @@ class TestObjectStorageResolvesToItsControlPlane:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """An operator overrides the name they call, not the one the registry uses."""
-        from integrations.yandex_cloud import endpoints
-
         monkeypatch.setenv(YC_ENDPOINT_OVERRIDES_ENV, '{"storage": "storage.internal"}')
         endpoints.reset_endpoint_cache()
 
@@ -404,8 +398,6 @@ class TestObjectStorageResolvesToItsControlPlane:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Either name is a fair thing to override, so both have to take effect."""
-        from integrations.yandex_cloud import endpoints
-
         monkeypatch.setenv(YC_ENDPOINT_OVERRIDES_ENV, '{"storage-api": "storage.internal"}')
         endpoints.reset_endpoint_cache()
 

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -203,7 +203,7 @@ def test_run_repl_async_does_not_run_the_gate_itself(monkeypatch: Any) -> None:
 
     class _Controller:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
-            del _args, _kwargs
+            pass
 
         async def start_interactive_shell(self) -> None:
             started.append(True)

--- a/tests/interactive_shell/runtime/test_controller_input_actions.py
+++ b/tests/interactive_shell/runtime/test_controller_input_actions.py
@@ -218,4 +218,4 @@ async def test_running_dispatch_keeps_a_completed_plan() -> None:
     finally:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
-            await task
+            _ = await task

--- a/tests/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -432,7 +432,8 @@ def test_package_facade_exposes_every_runtime_parameter() -> None:
     import inspect
 
     from surfaces.interactive_shell import run_repl as facade
-    from surfaces.interactive_shell.main import run_repl as runtime
+
+    runtime = main_entrypoint.run_repl
 
     # Act
     facade_params = inspect.signature(facade).parameters

--- a/tests/interactive_shell/runtime/test_prompt_builder.py
+++ b/tests/interactive_shell/runtime/test_prompt_builder.py
@@ -23,7 +23,7 @@ async def _wait_until_running(builder: PromptBuilder) -> asyncio.Task[str]:
         if task is not None and builder.pt_app is not None and builder.pt_app.is_running:
             return task
         await asyncio.sleep(0.01)
-    pytest.fail("prompt application did not start")
+    raise AssertionError("prompt application did not start")
 
 
 def _terminal_output() -> Vt100_Output:

--- a/tests/interactive_shell/test_terminal_runtime_turns.py
+++ b/tests/interactive_shell/test_terminal_runtime_turns.py
@@ -255,12 +255,12 @@ async def test_queued_literal_quit_requests_runtime_exit(
         # deadlock; stubbing the analytics flush above keeps ``/quit`` off the
         # PostHog network path under xdist + coverage.
         await state.queue.join()
-        await worker
+        _ = await worker
     finally:
         if not worker.done():
             worker.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await worker
+                _ = await worker
 
     assert state.exit_requested is True
 

--- a/tests/interactive_shell/ui/test_prompt_stdout.py
+++ b/tests/interactive_shell/ui/test_prompt_stdout.py
@@ -45,7 +45,7 @@ async def _wait_for_output(buffer: io.StringIO, marker: str, *, count: int = 1) 
         if _visible_prompt_text(rendered).count(marker) >= count:
             return rendered
         await asyncio.sleep(0.01)
-    pytest.fail(f"prompt output never rendered {marker!r} {count} time(s)")
+    raise AssertionError(f"prompt output never rendered {marker!r} {count} time(s)")
 
 
 @pytest.mark.asyncio

--- a/tests/packaging/test_version.py
+++ b/tests/packaging/test_version.py
@@ -25,7 +25,7 @@ class _FixedClock:
 
 
 def _git_head_at(monkeypatch, sha: str) -> None:
-    monkeypatch.setattr(build_info, "find_git_layout", lambda: object())
+    monkeypatch.setattr(build_info, "find_git_layout", object)
     monkeypatch.setattr(build_info, "read_git_head_sha", lambda _layout: sha)
     monkeypatch.setattr(version_module, "datetime", _FixedClock)
 


### PR DESCRIPTION
Fixes the 12 open CodeQL code-scanning alerts on main: 2267, 2266, 2265, 2264, 2258, 2257, 2256, 2255, 2252, 2199, 2130, and 2076.

#### Describe the changes you have made in this PR -

- Preserve async task-reaping semantics while binding awaited results so CodeQL models the side effect.
- Replace mixed implicit/explicit test helper returns with explicit assertion failures.
- Consolidate mixed module import styles and remove unused production logging state.
- Keep the Shift+Enter compatibility constant as an explicit member of the sequence registry.
- Remove unnecessary test-only lambda and local-variable deletion patterns.

### Demo/Screenshot for feature changes and bug fixes -

Equivalent verification output:

- make lint: passed
- make format-check: passed
- make typecheck: passed (1,989 source files)
- branch-scoped pytest: 3,763 passed, 17 skipped, 2 expected xfails

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this projects coding standards and conventions

**Explain your implementation approach:**

The change directly addresses each CodeQL diagnostic without suppressions or behavior-changing shortcuts. Existing cleanup awaits remain intact, import changes use one consistent module style per file, and the Shift+Enter symbol remains available to its cross-module compatibility test while becoming visibly used in its defining module. The alternatives considered were alert suppressions and deleting apparently unused compatibility code; both were rejected because they would either hide diagnostics or break established behavior.

---

## Checklist before requesting a review
- [x] I have added a proper PR title; these findings are GitHub code-scanning alerts rather than a repository issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (not applicable; existing regression coverage exercises these behavior-preserving changes)
- [x] My code follows the projects style guidelines and conventions

---