### PR TITLE
fix(ci): reconcile legacy CodeQL alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: /language:${{ matrix.language }}/full
+          # Preserve the canonical category so each full scan supersedes the
+          # repository's historical results instead of leaving stale alerts open.
+          category: /language:${{ matrix.language }}
 
   analyze-pr-benchmark:
     if: >-

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -35,6 +35,10 @@ def test_full_codeql_is_post_merge_and_pr_profile_is_manual() -> None:
     ]
     full_init = next(step for step in full["steps"] if step.get("name") == "Initialize CodeQL")
     assert full_init["with"]["queries"] == "security-and-quality"
+    full_analyze = next(
+        step for step in full["steps"] if step.get("name") == "Perform CodeQL Analysis"
+    )
+    assert full_analyze["with"]["category"] == "/language:${{ matrix.language }}"
 
     benchmark = jobs["analyze-pr-benchmark"]
     benchmark_init = next(

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -46,6 +46,10 @@ def test_full_codeql_is_post_merge_and_pr_profile_is_manual() -> None:
     )
     assert benchmark_init["with"]["config-file"] == ".github/codeql/codeql-pr-config.yml"
     assert "queries" not in benchmark_init["with"]
+    benchmark_analyze = next(
+        step for step in benchmark["steps"] if step.get("name") == "Perform CodeQL Analysis"
+    )
+    assert benchmark_analyze["with"]["category"] == "/language:python/pr-fast"
 
 
 def test_heavy_test_suites_are_duration_balanced_with_measured_headroom() -> None:


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Keep the full CodeQL scan on the canonical per-language analysis category. This lets each post-merge scan supersede results produced before the full/pr-fast workflow split, so fixed findings do not remain globally open through a retired category. The manual pr-fast profile keeps its separate category.

Add a workflow contract assertion to prevent future category drift from recreating stale alert instances.

### Demo/Screenshot for feature changes and bug fixes -

Local verification:
- `make lint`
- `make format-check`
- `make typecheck`
- `env -u NO_COLOR TERM=xterm-256color uv run python -m pytest tests/github_ci/test_pr_pipeline_slo.py` (5 passed)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project coding standards and conventions

**Explain your implementation approach:**

The four remaining alerts have fixed instances in the active `/full` scan but open instances in the retired canonical category. Reusing the canonical category for full scans preserves continuity without deleting scan history or dismissing genuine findings. The benchmark profile remains isolated under `/pr-fast`. A targeted YAML contract test pins that invariant.

---

## Checklist before requesting a review
- [x] I have added proper PR title; no tracking issue is available
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project style guidelines and conventions
