### PR TITLE
feat(prompt): define proactive messaging policy

### DIFF
--- a/core/agent_harness/prompts/opensre_system_prompt.md
+++ b/core/agent_harness/prompts/opensre_system_prompt.md
@@ -348,3 +348,11 @@ When using the shell, you must adhere to the following guidelines:
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
 - Do not use python scripts to attempt to output larger chunks of a file.
 - Parallelize tool calls whenever possible - especially file reads, such as `cat`, `rg`, `sed`, `ls`, `git show`, `nl`, `wc`. Use `multi_tool_use.parallel` to parallelize tool calls and only this.
+
+# Proactive messaging
+
+Treat the following as the standing policy for unsolicited messages:
+
+- Send one only when it reports verified information not previously shared, names a clear owner and next action (or explicitly says no action is required), and has timing that can materially affect the outcome.
+- Use a direct message for a blocker owned by a specific person or team. Broadcast only decisions, anomalies, or milestones relevant to the full audience.
+- Suppress scheduled or recurring messages when the underlying state has not changed. Do not ask whether to adopt this policy or send a low-value update.

--- a/tests/core/agent/prompts/test_system_prompt_markdown.py
+++ b/tests/core/agent/prompts/test_system_prompt_markdown.py
@@ -66,3 +66,15 @@ def test_optional_choice_protections_follow_turn_interaction_facts() -> None:
     assert "Always leave the user a selectable next step" not in text
     assert "TURN INTERACTION says the ask_user_choice menu is available" in collapsed
     assert "headless, scheduled, or gateway" not in collapsed
+
+
+def test_proactive_messages_are_new_actionable_and_time_sensitive() -> None:
+    collapsed = " ".join(_SYSTEM_PROMPT_BASE.split())
+    assert "standing policy for unsolicited messages" in collapsed
+    assert "verified information not previously shared" in collapsed
+    assert "names a clear owner and next action" in collapsed
+    assert "timing that can materially affect the outcome" in collapsed
+    assert "Use a direct message for a blocker owned by a specific person or team" in collapsed
+    assert "Broadcast only decisions, anomalies, or milestones" in collapsed
+    assert "when the underlying state has not changed" in collapsed
+    assert "Do not ask whether to adopt this policy" in collapsed


### PR DESCRIPTION
Fixes N/A

#### Describe the changes you have made in this PR -

- Add a standing proactive-messaging policy to the end of the shared OpenSRE system prompt.
- Require new verified information, an explicit owner/action, and material timing.
- Route targeted blockers to DMs, limit broadcasts to audience-relevant decisions/anomalies/milestones, and suppress unchanged recurring updates.
- Add a focused prompt-contract regression test.

### Demo/Screenshot for feature changes and bug fixes -

`uv run python -m pytest tests/core/agent/prompts/test_system_prompt_markdown.py` — 7 passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this projects coding standards and conventions

**Explain your implementation approach:**

The change keeps the policy in the canonical bundled Markdown prompt rather than adding runtime branching. It turns the source guidance into explicit, testable conditions and treats the policy as already adopted so the agent does not ask a redundant follow-up. A focused contract test pins each behavioral requirement.

---

## Checklist before requesting a review
- [x] I have added proper PR title; no issue was provided to link
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the projects style guidelines and conventions

---