### PR TITLE
fix: remove post-refactor CodeQL findings

### DIFF
--- a/core/agent_harness/session/persistence/jsonl_store.py
+++ b/core/agent_harness/session/persistence/jsonl_store.py
@@ -40,7 +40,6 @@ def _session_file_lock_enabled() -> bool:
     }
 
 
-_TRIGGER_MAX_CHARS = 200
 # Cold tip scan keeps at most this many trailing bytes resident (then grows by the
 # same step only while the window still contains nothing but skippable rows).
 _TAIL_SCAN_CHUNK_BYTES = 64 * 1024

--- a/core/agent_harness/session/persistence/memory.py
+++ b/core/agent_harness/session/persistence/memory.py
@@ -8,8 +8,6 @@ from typing import Any
 
 from core.agent_harness.session.persistence.contracts import SessionPersistenceSource
 
-_TRIGGER_MAX_CHARS = 200
-
 
 def _now() -> str:
     return datetime.now(UTC).isoformat()

--- a/gateway/web/webapp.py
+++ b/gateway/web/webapp.py
@@ -9,7 +9,6 @@ standalone via ``uvicorn gateway.web.webapp:app``.
 
 from __future__ import annotations
 
-import logging
 from http import HTTPStatus
 
 from fastapi import FastAPI, Response
@@ -25,8 +24,6 @@ from infrastructure.alert_intake import router as alert_router
 from infrastructure.request_body_limit import RequestBodyLimitMiddleware
 
 configure_process(WEB_PROFILE)  # env → sentry → adapters
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["app"]
 

--- a/surfaces/shared/terminal/output/renderers.py
+++ b/surfaces/shared/terminal/output/renderers.py
@@ -12,7 +12,6 @@ from infrastructure.terminal.theme import (
     HIGHLIGHT,
     SECONDARY,
     TEXT,
-    WARNING,
 )
 from surfaces.shared.terminal.components.time_format import _elapsed_hms
 from surfaces.shared.terminal.output.console_state import _get_console


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Remove four unused symbols left behind by the investigation-product removal in #5981:

- obsolete session-store trigger preview constants in both persistence backends
- an unused gateway web logger
- an unused terminal warning-style import

This resolves CodeQL alerts #2270 through #2273 without changing runtime behavior.

### Demo/Screenshot for feature changes and bug fixes -

Local verification:
- `make lint`
- `make format-check`
- `make typecheck`
- `env -u NO_COLOR TERM=xterm-256color uv run python .github/ci/run_test_scope.py --base origin/main` (829 passed, 1 expected xfail)
- `env -u NO_COLOR TERM=xterm-256color OPENSRE_SESSION_FILE_LOCK=1 uv run python -m pytest tests/core/agent_harness/session/ -v --timeout=120` (84 passed, 1 expected xfail)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project coding standards and conventions

**Explain your implementation approach:**

Each alert was checked against current usage after #5981. The reported import, logger, and constants had no remaining readers, so the safest fix is deletion rather than compatibility aliases or scanner suppression. No behavior or package boundary changes were introduced.

---

## Checklist before requesting a review
- [x] I have added proper PR title; no tracking issue is available
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project style guidelines and conventions
