### PR TITLE
feat(shell): polish terminal identity and startup animation

### DIFF
--- a/infrastructure/terminal/theme.py
+++ b/infrastructure/terminal/theme.py
@@ -19,7 +19,7 @@ Token reference
   BG         terminal background, never used as foreground
   INPUT_SURFACE  composer/menu plate — visibly lifted vs BG (input box fill)
   BOLD_SKILL fixed green skill-activation label
-  reply marker  assistant ``∴`` lead-in — Factory/Droid-warm accent via
+  reply marker  assistant ``Ω`` lead-in — Factory/Droid-warm accent via
                 :func:`reply_marker_style` (not WARNING; must stay vivid)
 
 Usage
@@ -362,15 +362,14 @@ def _parse_hex_color(value: str) -> tuple[int, int, int]:
 
 
 def reply_marker_hex() -> str:
-    """Hex for the assistant ``∴`` / tool ``⏺`` accent — the active theme's
+    """Hex for the assistant ``Ω`` / tool ``⏺`` accent — the active theme's
     ``HIGHLIGHT``, so every component follows the selected palette rather than a
     fixed colour that would read as a copy of another tool."""
     return _ACTIVE_THEME.HIGHLIGHT
 
 
 def reply_marker_style() -> str:
-    """Bold accent for the assistant ``∴`` reply marker and ``⏺`` tool lead-in,
-    in the active theme's highlight colour (one branded lead beside softer body)."""
+    """Bold tool-lead accent using the reply marker's active highlight colour."""
     return f"bold {reply_marker_hex()}"
 
 
@@ -501,7 +500,7 @@ def _apply_theme(theme: CliTheme) -> None:
     MARKDOWN_THEME = Theme(
         {
             # Sunny Droid-like reply: bright warm-grey body (#D0D0D0 TEXT), warm
-            # ``∴`` accent. Strong stays bold TEXT; avoid icy blue chrome.
+            # ``Ω`` accent. Strong stays bold TEXT; avoid icy blue chrome.
             "markdown.paragraph": theme.TEXT,
             "markdown.code": f"bold {theme.HIGHLIGHT}",
             "markdown.code_block": theme.TEXT,

--- a/surfaces/interactive_shell/runtime/agent_harness_adapters.py
+++ b/surfaces/interactive_shell/runtime/agent_harness_adapters.py
@@ -63,7 +63,7 @@ class ShellOutputSink:
         self._console.print(message, markup=False)
 
     def render_response_header(self, label: str) -> None:
-        # No leading blank — Droid-dense turn stacking (user row → ∴ reply).
+        # No leading blank — Droid-dense turn stacking (user row → Ω reply).
         render_response_header(self._console, label)
 
     def render_error(self, message: str) -> None:

--- a/surfaces/interactive_shell/runtime/core/state.py
+++ b/surfaces/interactive_shell/runtime/core/state.py
@@ -36,7 +36,7 @@ def ready_hint_ansi() -> str:
     reserved = prompt_text_width(lead)
     if reserved >= width:
         visible = clip_prompt_text(f"{lead}{hint}", width)
-        # Soft grey lead — warm accent is reserved for ∴ / ⏺ / spinner glyph.
+        # Soft grey lead — warm accent is reserved for Ω / ⏺ / spinner glyph.
         if visible.startswith("Ready"):
             rest = visible[len("Ready") :]
             return (
@@ -346,7 +346,7 @@ class SpinnerState:
         return ui_theme.reply_marker_hex()
 
     def _phase_accent_ansi(self) -> str:
-        """Spinner glyph: Factory-warm orange (same family as ``∴`` / ``⏺``)."""
+        """Spinner glyph: Factory-warm orange (same family as ``Ω`` / ``⏺``)."""
         return ui_theme.BOLD_REPLY_MARKER_ANSI
 
     def inline_spinner_ansi(self) -> str:

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -517,7 +517,7 @@ class ActionRenderObserver:
         args = data.get("input")
         label, content = tool_call_display(name, args if isinstance(args, dict) else {})
         self.console.print()
-        # One warm accent (same as ``∴``) on the glyph; recessed label + dim
+        # One warm accent (same as ``Ω``) on the glyph; recessed label + dim
         # payload — Droid-style quiet tool chrome, not a second blue brand strip.
         line = Text()
         line.append(f"{_TOOL_CALL_MARKER} ", style=reply_marker_style())

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -13,12 +13,12 @@ from prompt_toolkit.layout.containers import (
     FloatContainer,
     HSplit,
     VerticalAlign,
+    VSplit,
     Window,
     to_container,
 )
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
-from prompt_toolkit.widgets import Frame
 
 from surfaces.interactive_shell.prompt_history import load_prompt_history
 from surfaces.interactive_shell.runtime import Session
@@ -36,6 +36,44 @@ from surfaces.interactive_shell.ui.input_prompt.style import _build_prompt_style
 _COMPOSER_MAX_EDIT_ROWS = 8
 _COMPOSER_MIN_FRAME_ROWS = 3
 _COMPOSER_MAX_FRAME_ROWS = _COMPOSER_MAX_EDIT_ROWS + 2
+
+
+def _rounded_composer_frame(body: AnyContainer) -> HSplit:
+    """Wrap the composer in the terminal's smallest rounded border."""
+
+    def _border(*, char: str, width: int | None = None) -> Window:
+        return Window(
+            width=width,
+            height=1 if width == 1 else None,
+            char=char,
+            style="class:frame.border",
+        )
+
+    top = VSplit(
+        [
+            _border(char="╭", width=1),
+            _border(char="─"),
+            _border(char="╮", width=1),
+        ],
+        height=1,
+    )
+    middle = VSplit(
+        [
+            Window(width=1, char="│", style="class:frame.border"),
+            body,
+            Window(width=1, char="│", style="class:frame.border"),
+        ],
+        padding=0,
+    )
+    bottom = VSplit(
+        [
+            _border(char="╰", width=1),
+            _border(char="─"),
+            _border(char="╯", width=1),
+        ],
+        height=1,
+    )
+    return HSplit([top, middle, bottom], style="class:frame class:composer")
 
 
 def _limit_editable_height(main_input: HSplit) -> HSplit:
@@ -84,7 +122,7 @@ def _install_prompt_frame(
     # Inner surface so the editable rows share INPUT_SURFACE with the border
     # (otherwise the frame looks hollow against the terminal bg).
     surface_body: AnyContainer = HSplit([editable_body], style="class:composer-body")
-    composer: AnyContainer = Frame(surface_body, style="class:composer")
+    composer: AnyContainer = _rounded_composer_frame(surface_body)
     footer: AnyContainer = Window(
         FormattedTextControl(lambda: ANSI(composer_footer_ansi())),
         height=1,

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -13,7 +13,6 @@ from prompt_toolkit.layout.containers import (
     FloatContainer,
     HSplit,
     VerticalAlign,
-    VSplit,
     Window,
     to_container,
 )
@@ -23,6 +22,7 @@ from prompt_toolkit.layout.dimension import Dimension
 from surfaces.interactive_shell.prompt_history import load_prompt_history
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.input_prompt.completion import ShellCompleter
+from surfaces.interactive_shell.ui.input_prompt.frame import rounded_composer_frame
 from surfaces.interactive_shell.ui.input_prompt.key_bindings import _build_prompt_key_bindings
 from surfaces.interactive_shell.ui.input_prompt.layout import prompt_line_width
 from surfaces.interactive_shell.ui.input_prompt.lexer import ReplInputLexer
@@ -36,44 +36,6 @@ from surfaces.interactive_shell.ui.input_prompt.style import _build_prompt_style
 _COMPOSER_MAX_EDIT_ROWS = 8
 _COMPOSER_MIN_FRAME_ROWS = 3
 _COMPOSER_MAX_FRAME_ROWS = _COMPOSER_MAX_EDIT_ROWS + 2
-
-
-def _rounded_composer_frame(body: AnyContainer) -> HSplit:
-    """Wrap the composer in the terminal's smallest rounded border."""
-
-    def _border(*, char: str, width: int | None = None) -> Window:
-        return Window(
-            width=width,
-            height=1 if width == 1 else None,
-            char=char,
-            style="class:frame.border",
-        )
-
-    top = VSplit(
-        [
-            _border(char="╭", width=1),
-            _border(char="─"),
-            _border(char="╮", width=1),
-        ],
-        height=1,
-    )
-    middle = VSplit(
-        [
-            Window(width=1, char="│", style="class:frame.border"),
-            body,
-            Window(width=1, char="│", style="class:frame.border"),
-        ],
-        padding=0,
-    )
-    bottom = VSplit(
-        [
-            _border(char="╰", width=1),
-            _border(char="─"),
-            _border(char="╯", width=1),
-        ],
-        height=1,
-    )
-    return HSplit([top, middle, bottom], style="class:frame class:composer")
 
 
 def _limit_editable_height(main_input: HSplit) -> HSplit:
@@ -122,7 +84,7 @@ def _install_prompt_frame(
     # Inner surface so the editable rows share INPUT_SURFACE with the border
     # (otherwise the frame looks hollow against the terminal bg).
     surface_body: AnyContainer = HSplit([editable_body], style="class:composer-body")
-    composer: AnyContainer = _rounded_composer_frame(surface_body)
+    composer: AnyContainer = rounded_composer_frame(surface_body)
     footer: AnyContainer = Window(
         FormattedTextControl(lambda: ANSI(composer_footer_ansi())),
         height=1,
@@ -215,4 +177,5 @@ def build_prompt_session(
 __all__ = [
     "_install_prompt_frame",
     "build_prompt_session",
+    "rounded_composer_frame",
 ]

--- a/surfaces/interactive_shell/ui/input_prompt/frame.py
+++ b/surfaces/interactive_shell/ui/input_prompt/frame.py
@@ -1,0 +1,46 @@
+"""Rounded prompt-toolkit composer frame."""
+
+from __future__ import annotations
+
+from prompt_toolkit.layout.containers import AnyContainer, HSplit, VSplit, Window
+
+
+def rounded_composer_frame(body: AnyContainer) -> HSplit:
+    """Wrap the composer in the terminal's smallest rounded border."""
+
+    def _border(*, char: str, width: int | None = None) -> Window:
+        return Window(
+            width=width,
+            height=1 if width == 1 else None,
+            char=char,
+            style="class:frame.border",
+        )
+
+    top = VSplit(
+        [
+            _border(char="╭", width=1),
+            _border(char="─"),
+            _border(char="╮", width=1),
+        ],
+        height=1,
+    )
+    middle = VSplit(
+        [
+            Window(width=1, char="│", style="class:frame.border"),
+            body,
+            Window(width=1, char="│", style="class:frame.border"),
+        ],
+        padding=0,
+    )
+    bottom = VSplit(
+        [
+            _border(char="╰", width=1),
+            _border(char="─"),
+            _border(char="╯", width=1),
+        ],
+        height=1,
+    )
+    return HSplit([top, middle, bottom], style="class:frame class:composer")
+
+
+__all__ = ["rounded_composer_frame"]

--- a/surfaces/interactive_shell/ui/poster.py
+++ b/surfaces/interactive_shell/ui/poster.py
@@ -10,6 +10,7 @@ from rich.markup import escape
 from rich.text import Text
 
 import infrastructure.terminal.theme as ui_theme
+from surfaces.shared.terminal.banner import animate_launch_wordmark
 from surfaces.shared.terminal.components.rendering import (
     _console_is_capturing,
     _console_print_prepared,
@@ -49,6 +50,7 @@ def repl_render_launch_poster(
         )
         render_terminal_ui(buf_console, session=session)
         prefix = _theme_notice_line(theme_notice) if theme_notice else ""
+        animate_launch_wordmark(console)
         _repl_write_buffer(prefix + buf.getvalue())
         _feed_record_buffer(console, Text.from_ansi(buf.getvalue()).plain)
         return

--- a/surfaces/interactive_shell/ui/sign_in.py
+++ b/surfaces/interactive_shell/ui/sign_in.py
@@ -25,7 +25,7 @@ from config.constants import (
     WELCOME_TITLE,
 )
 from infrastructure.terminal.theme import DIM, HIGHLIGHT, SECONDARY, TEXT
-from surfaces.shared.terminal.banner.banner import build_launch_banner
+from surfaces.shared.terminal.banner import animate_launch_wordmark, build_launch_banner
 from surfaces.shared.terminal.components.choice_menu import repl_choose_one, repl_tty_interactive
 
 _TRUTHY = {"1", "true", "yes", "on"}
@@ -55,14 +55,14 @@ def build_welcome_box() -> RenderableType:
 
 def render_sign_in_screen(console: Console) -> None:
     """Paint the launch banner, the welcome box, and the sign-in prompt line."""
-    console.print(
-        Group(
-            build_launch_banner(console),
-            build_welcome_box(),
-            Text(),
-            Text(SIGN_IN_PROMPT, style=str(SECONDARY)),
-        )
+    screen = Group(
+        build_launch_banner(console),
+        build_welcome_box(),
+        Text(),
+        Text(SIGN_IN_PROMPT, style=str(SECONDARY)),
     )
+    animate_launch_wordmark(console)
+    console.print(screen)
 
 
 def prompt_login_or_exit() -> SignInChoice | None:

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -134,7 +134,7 @@ def stream_to_console_state(
     defer_want_me_to_closer: bool = False,
 ) -> StreamRenderResult:
     """Like :func:`stream_to_console` but returns render/defer metadata."""
-    del label  # the inline ∴ marker replaced the ``∴ OpenSRE`` header
+    del label  # the inline Ω marker replaced the ``Ω OpenSRE`` header
     if not console.is_terminal:
         text = "".join(chunks)
         if suppress_if_starts_with is not None and text.lstrip().startswith(
@@ -230,7 +230,7 @@ def stream_to_console_state(
         )
         if not rendered_paragraphs:
             # One blank row between the user turn and its reply (Droid rhythm):
-            # the echo row and the ∴ reply must not sit flush against each other.
+            # the echo row and the Ω reply must not sit flush against each other.
             console.print()
         if rendered_paragraphs and source_break and not starts_with_self_spacing_block:
             # ``_flush_paragraphs`` consumes the source ``\n\n`` boundary.
@@ -238,7 +238,7 @@ def stream_to_console_state(
             # for the next standalone block. This matters most after lists,
             # whose renderer adds no trailing blank line.
             console.print()
-        # The first paragraph carries the ``∴`` marker in the gutter; every
+        # The first paragraph carries the ``Ω`` marker in the gutter; every
         # paragraph hangs in the same indented body column.
         with console.use_theme(ui_theme.MARKDOWN_THEME):
             console.print(reply_gutter(markdown, lead=rendered_paragraphs == 0))
@@ -423,7 +423,7 @@ def stream_to_console_state(
 
 def publish_full_response(console: Console, text: str, *, label: str = "assistant") -> None:
     """Render a complete assistant answer (non-TTY deferred gather path)."""
-    del label  # the inline ∴ marker replaced the ``∴ OpenSRE`` header
+    del label  # the inline Ω marker replaced the ``Ω OpenSRE`` header
     body = (text or "").strip()
     if not body:
         return

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -139,10 +139,13 @@ def render_markdown_block(console: Console, text: str) -> None:
         console.print(_build_markdown_block(visible))
 
 
+_REPLY_MARKER = "Ω"
+
+
 def render_note_block(console: Console, text: str) -> None:
     """Render intermediate agent narration as a dim, indented note.
 
-    Distinct from the bright ``∴`` reply and the recessed grey ``[n] ❯`` user
+    Distinct from the bright ``Ω`` reply and the recessed grey ``[n] ❯`` user
     row: a note carries no glyph, only a dim left indent, so the three turn
     roles — your ask, opensre's working notes, and its final reply — read apart.
     Bold spans (the action words) stay bold within the dim base.
@@ -158,27 +161,27 @@ def render_note_block(console: Console, text: str) -> None:
 
 
 def _reply_marker_style() -> str:
-    """Warm Factory/Droid-parity accent for the ``∴`` reply marker."""
-    return ui_theme.reply_marker_style()
+    """Unbolded warm accent for the ``Ω`` reply marker."""
+    return ui_theme.reply_marker_hex()
 
 
 def reply_gutter(body: RenderableType, *, lead: bool) -> Table:
     """Lay a reply renderable in a two-column gutter.
 
-    The first paragraph carries the ``∴`` marker in the gutter; every other row
+    The first paragraph carries the ``Ω`` marker in the gutter; every other row
     (wrapped lines and following paragraphs) sits in the same indented body
     column, so the whole reply reads as one block hanging under the marker.
     """
     grid = Table.grid(padding=0)
-    grid.add_column(width=2, no_wrap=True)
+    grid.add_column(width=3, no_wrap=True)
     grid.add_column(overflow="fold")
-    marker = Text("∴ ", style=_reply_marker_style()) if lead else Text("  ")
+    marker = Text(f"{_REPLY_MARKER}  ", style=_reply_marker_style()) if lead else Text("   ")
     grid.add_row(marker, body)
     return grid
 
 
 def render_reply_block(console: Console, text: str, *, lead: bool = True) -> None:
-    """Render a whole assistant reply inside the ``∴`` hanging-indent gutter."""
+    """Render a whole assistant reply inside the ``Ω`` hanging-indent gutter."""
     visible = strip_session_goal_progress_tags(text)
     if not visible.strip():
         return
@@ -192,9 +195,9 @@ def render_reply_block(console: Console, text: str, *, lead: bool = True) -> Non
 
 
 def render_response_header(console: Console, label: str) -> None:
-    """Print the ``∴`` triangle row marker that opens every assistant response.
+    """Print the ``Ω`` row marker that opens every assistant response.
 
-    A single triangle is opensre's uniquely identifiable agent marker. Shared
+    A single omega is opensre's uniquely identifiable agent marker. Shared
     with ``action_turn.run_action_tool_turn`` so the planned-actions path and the
     streaming response path use the exact same prefix.
 
@@ -203,4 +206,4 @@ def render_response_header(console: Console, label: str) -> None:
     marker read as school-project chrome next to Droid's silent replies.
     """
     del label
-    console.print(f"[{_reply_marker_style()}]∴[/]")
+    console.print(f"[{_reply_marker_style()}]{_REPLY_MARKER}[/]")

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -57,7 +57,8 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
 
     The top line is the pending confirmation prompt when one is active,
     otherwise the spinner, completion preview, or idle hint, followed by the
-    autonomy status line showing the active ``/auto`` level.
+    autonomy status line showing the active ``/auto`` level. A rendered task
+    plan has one blank row beneath it before this status chrome.
 
     When confirmation or exclusive-stdin structured input owns the keyboard,
     the free-text typing box (rule + ``[N] ❯``) is omitted so it does not
@@ -91,8 +92,8 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         plan_overlay = strip_cpr_sequences(
             task_plan_overlay_ansi(plan, expanded=state.plan_expanded)
         )
-    # One trailing blank after the plan, not two — keeps the stack dense.
-    plan_prefix = f"{plan_overlay}\n" if plan_overlay else ""
+    # Keep one empty row between the pinned plan and the live status chrome.
+    plan_prefix = f"{plan_overlay}\n\n" if plan_overlay else ""
 
     # A pending confirmation renders a stacked, arrow-navigable Yes/No choice
     # (box hidden). Density matches the streaming stack: status → Auto → composer.
@@ -103,9 +104,10 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     if state.is_ctrl_c_exit_hint_visible():
         prefix = prompt_rendering.ctrl_c_exit_hint_ansi()
     else:
+        inline_spinner = spinner.inline_spinner_ansi()
         prefix = strip_cpr_sequences(
             prompt_rendering.resolve_prompt_prefix_ansi(
-                inline_spinner=spinner.inline_spinner_ansi(),
+                inline_spinner=inline_spinner,
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )

--- a/surfaces/shared/terminal/banner/__init__.py
+++ b/surfaces/shared/terminal/banner/__init__.py
@@ -1,11 +1,17 @@
 """OpenSRE launch banner."""
 
 from surfaces.shared.terminal.banner.banner import (
+    WordmarkSpinFrame,
+    animate_launch_wordmark,
     build_launch_banner,
+    build_wordmark_spin_frames,
     render_launch_banner,
 )
 
 __all__ = [
+    "WordmarkSpinFrame",
+    "animate_launch_wordmark",
     "build_launch_banner",
+    "build_wordmark_spin_frames",
     "render_launch_banner",
 ]

--- a/surfaces/shared/terminal/banner/banner.py
+++ b/surfaces/shared/terminal/banner/banner.py
@@ -81,12 +81,10 @@ _WORDMARK_SPIN_FRAME_INTERVAL_SECONDS = 1 / 60
 _MIN_PROJECTED_SCALE = 0.08
 _BRAILLE_BASE = 0x2800
 _BRAILLE_LIMIT = 0x28FF
-_LOGO_FIRST_ROW = 2
-_SAVE_CURSOR = "\x1b7"
-_RESTORE_CURSOR = "\x1b8"
 _HIDE_CURSOR = "\x1b[?25l"
 _SHOW_CURSOR = "\x1b[?25h"
 _ERASE_LINE = "\x1b[2K"
+_COLUMN_ONE = "\x1b[1G"
 _SYNCED_OUTPUT_START = "\x1b[?2026h"
 _SYNCED_OUTPUT_END = "\x1b[?2026l"
 
@@ -184,26 +182,30 @@ def _frame_style(frame: WordmarkSpinFrame) -> str:
     return ui_theme.HIGHLIGHT_ANSI
 
 
-def _animation_frame(frame: WordmarkSpinFrame, *, width: int) -> str:
-    """Paint one frame on the banner rows while preserving the cursor."""
+def _animation_frame(
+    frame: WordmarkSpinFrame,
+    *,
+    width: int,
+    rewind: bool,
+) -> str:
+    """Paint one frame in the temporary startup region."""
     style = _frame_style(frame)
-    rows = []
-    for offset, row in enumerate(frame.rows):
+    rows = [""]
+    for row in frame.rows:
         left_pad = max((width - cell_len(row)) // 2, 0)
-        rows.append(
-            f"\x1b[{_LOGO_FIRST_ROW + offset};1H"
-            f"{_ERASE_LINE}{' ' * left_pad}{style}\x1b[1m"
-            f"{row}{ui_theme.ANSI_RESET}"
-        )
-    return (
-        f"{_SYNCED_OUTPUT_START}{_SAVE_CURSOR}{''.join(rows)}{_RESTORE_CURSOR}{_SYNCED_OUTPUT_END}"
-    )
+        rows.append(f"{' ' * left_pad}{style}\x1b[1m{row}{ui_theme.ANSI_RESET}")
+    frame_text = f"{_COLUMN_ONE}{_ERASE_LINE}" + (f"\r\n{_COLUMN_ONE}{_ERASE_LINE}".join(rows))
+    move_to_top = f"{_COLUMN_ONE}\x1b[{len(rows) - 1}A" if rewind else ""
+    return f"{_SYNCED_OUTPUT_START}{move_to_top}{frame_text}{_SYNCED_OUTPUT_END}"
 
 
 def _clear_animation(frame: WordmarkSpinFrame) -> str:
-    rows = (f"\x1b[{_LOGO_FIRST_ROW + offset};1H{_ERASE_LINE}" for offset in range(len(frame.rows)))
+    row_count = len(frame.rows) + 1
+    move_to_top = f"{_COLUMN_ONE}\x1b[{row_count - 1}A"
+    clear_rows = _ERASE_LINE + (f"\x1b[1B{_COLUMN_ONE}{_ERASE_LINE}" * (row_count - 1))
     return (
-        f"{_SYNCED_OUTPUT_START}{_SAVE_CURSOR}{''.join(rows)}{_RESTORE_CURSOR}{_SYNCED_OUTPUT_END}"
+        f"{_SYNCED_OUTPUT_START}{move_to_top}{clear_rows}"
+        f"\x1b[{row_count - 1}A{_COLUMN_ONE}{_SYNCED_OUTPUT_END}"
     )
 
 
@@ -221,8 +223,14 @@ def animate_launch_wordmark(console: Console) -> None:
     stream = sys.stdout
     try:
         stream.write(_HIDE_CURSOR)
-        for frame in frames:
-            stream.write(_animation_frame(frame, width=console.width))
+        for index, frame in enumerate(frames):
+            stream.write(
+                _animation_frame(
+                    frame,
+                    width=console.width,
+                    rewind=index > 0,
+                )
+            )
             stream.flush()
             time.sleep(_WORDMARK_SPIN_FRAME_INTERVAL_SECONDS)
     finally:

--- a/surfaces/shared/terminal/banner/banner.py
+++ b/surfaces/shared/terminal/banner/banner.py
@@ -8,6 +8,10 @@ widest line). Bold block wordmark + clean version + tip + capability chips.
 from __future__ import annotations
 
 import enum
+import math
+import sys
+import time
+from dataclasses import dataclass
 
 from rich.align import Align
 from rich.cells import cell_len
@@ -17,6 +21,7 @@ from rich.text import Text
 
 from config.constants import PRODUCT_DISPLAY_NAME, WELCOME_DESCRIPTION, WELCOME_TITLE
 from config.version import get_opensre_version
+from infrastructure.terminal import theme as ui_theme
 from infrastructure.terminal.theme import (
     BOLD_SKILL,
     BRAND,
@@ -27,6 +32,7 @@ from infrastructure.terminal.theme import (
     TEXT,
 )
 from surfaces.shared.terminal.banner.banner_state import LaunchStatus, load_launch_status
+from surfaces.shared.terminal.components.rendering import _console_is_capturing
 from surfaces.shared.terminal.prompt_layout import clip_prompt_text
 
 _BANNER_VERTICAL_PADDING = 1
@@ -69,10 +75,160 @@ _WORDMARK_ROWS: tuple[str, ...] = (
     "⠀⠀⠀⠈⠙⠻⠿⣿⣿⣿⡿⠿⠟⠋⠀⠴⠞⠋⠁⠀⠀⠀",
 )
 
+# A short 60 FPS startup turn; animation stops before the prompt becomes live.
+_WORDMARK_SPIN_FRAME_COUNT = 48
+_WORDMARK_SPIN_FRAME_INTERVAL_SECONDS = 1 / 60
+_MIN_PROJECTED_SCALE = 0.08
+_BRAILLE_BASE = 0x2800
+_BRAILLE_LIMIT = 0x28FF
+_LOGO_FIRST_ROW = 2
+_SAVE_CURSOR = "\x1b7"
+_RESTORE_CURSOR = "\x1b8"
+_HIDE_CURSOR = "\x1b[?25l"
+_SHOW_CURSOR = "\x1b[?25h"
+_ERASE_LINE = "\x1b[2K"
+_SYNCED_OUTPUT_START = "\x1b[?2026h"
+_SYNCED_OUTPUT_END = "\x1b[?2026l"
+
+
+@dataclass(frozen=True, slots=True)
+class WordmarkSpinFrame:
+    """One projected frame of the terminal wordmark's Y-axis turn."""
+
+    rows: tuple[str, ...]
+    scale: float
+    back_facing: bool
+
 
 def _center(renderable: RenderableType) -> Align:
     """Center one row/block on its own — do not bundle unequal-width lines."""
     return Align.center(renderable)
+
+
+def _braille_dot_columns(row: str) -> list[int]:
+    """Decode braille cells into four-bit vertical dot columns."""
+    columns: list[int] = []
+    for cell in row:
+        codepoint = ord(cell)
+        dots = codepoint - _BRAILLE_BASE if _BRAILLE_BASE <= codepoint <= _BRAILLE_LIMIT else 0
+        left = dots & 0x07 | ((dots & 0x40) >> 3)
+        right = ((dots & 0x38) >> 3) | ((dots & 0x80) >> 4)
+        columns.extend((left, right))
+    return columns
+
+
+def _encode_braille_columns(columns: list[int]) -> str:
+    """Encode four-bit vertical dot columns back into braille cells."""
+    cells: list[str] = []
+    for index in range(0, len(columns), 2):
+        left = columns[index]
+        right = columns[index + 1] if index + 1 < len(columns) else 0
+        dots = (left & 0x07) | ((left & 0x08) << 3) | ((right & 0x07) << 3) | ((right & 0x08) << 4)
+        cells.append(chr(_BRAILLE_BASE + dots))
+    return "".join(cells)
+
+
+def _turn_wordmark_row(row: str, *, scale: float, mirrored: bool) -> str:
+    """Project one logo row onto a narrower plane for a 3D turn frame."""
+    source = _braille_dot_columns(row)
+    if mirrored:
+        source.reverse()
+    # A braille cell is two dot columns wide. An odd projected width cannot be
+    # centered on the even-width source canvas, so its extra dot alternates
+    # sides as the logo turns and makes the mark appear to wobble.
+    target_width = max(2, 2 * round(len(source) * scale / 2))
+    if target_width >= len(source):
+        projected = source
+    else:
+        last_source_index = len(source) - 1
+        last_target_index = target_width - 1
+        projected = [
+            source[round(index * last_source_index / last_target_index)]
+            for index in range(target_width)
+        ]
+    # Keep the encoded row width fixed. Re-centering a shorter string on every
+    # frame moves it by whole terminal cells, producing a visible side-to-side
+    # jump even though the dot projection itself changes smoothly.
+    canvas = [0] * len(source)
+    start = (len(canvas) - len(projected)) // 2
+    canvas[start : start + len(projected)] = projected
+    return _encode_braille_columns(canvas)
+
+
+def build_wordmark_spin_frames() -> tuple[WordmarkSpinFrame, ...]:
+    """Build one full Y-axis revolution of the terminal wordmark."""
+    frames: list[WordmarkSpinFrame] = []
+    for frame_index in range(_WORDMARK_SPIN_FRAME_COUNT):
+        angle = math.tau * frame_index / _WORDMARK_SPIN_FRAME_COUNT
+        cosine = math.cos(angle)
+        scale = max(abs(cosine), _MIN_PROJECTED_SCALE)
+        mirrored = cosine < 0
+        frames.append(
+            WordmarkSpinFrame(
+                rows=tuple(
+                    _turn_wordmark_row(row, scale=scale, mirrored=mirrored)
+                    for row in _WORDMARK_ROWS
+                ),
+                scale=scale,
+                back_facing=mirrored,
+            )
+        )
+    return tuple(frames)
+
+
+def _frame_style(frame: WordmarkSpinFrame) -> str:
+    if frame.scale <= 0.18:
+        return ui_theme.DIM_ANSI
+    if frame.back_facing:
+        return ui_theme.SECONDARY_ANSI
+    return ui_theme.HIGHLIGHT_ANSI
+
+
+def _animation_frame(frame: WordmarkSpinFrame, *, width: int) -> str:
+    """Paint one frame on the banner rows while preserving the cursor."""
+    style = _frame_style(frame)
+    rows = []
+    for offset, row in enumerate(frame.rows):
+        left_pad = max((width - cell_len(row)) // 2, 0)
+        rows.append(
+            f"\x1b[{_LOGO_FIRST_ROW + offset};1H"
+            f"{_ERASE_LINE}{' ' * left_pad}{style}\x1b[1m"
+            f"{row}{ui_theme.ANSI_RESET}"
+        )
+    return (
+        f"{_SYNCED_OUTPUT_START}{_SAVE_CURSOR}{''.join(rows)}{_RESTORE_CURSOR}{_SYNCED_OUTPUT_END}"
+    )
+
+
+def _clear_animation(frame: WordmarkSpinFrame) -> str:
+    rows = (f"\x1b[{_LOGO_FIRST_ROW + offset};1H{_ERASE_LINE}" for offset in range(len(frame.rows)))
+    return (
+        f"{_SYNCED_OUTPUT_START}{_SAVE_CURSOR}{''.join(rows)}{_RESTORE_CURSOR}{_SYNCED_OUTPUT_END}"
+    )
+
+
+def animate_launch_wordmark(console: Console) -> None:
+    """Turn the terminal wordmark once before the interactive prompt starts."""
+    if (
+        console.file is not sys.stdout
+        or not sys.stdout.isatty()
+        or _console_is_capturing(console)
+        or console.width <= _wordmark_cell_width()
+    ):
+        return
+
+    frames = build_wordmark_spin_frames()
+    stream = sys.stdout
+    try:
+        stream.write(_HIDE_CURSOR)
+        for frame in frames:
+            stream.write(_animation_frame(frame, width=console.width))
+            stream.flush()
+            time.sleep(_WORDMARK_SPIN_FRAME_INTERVAL_SECONDS)
+    finally:
+        stream.write(_clear_animation(frames[0]))
+        stream.write(_SHOW_CURSOR)
+        stream.flush()
 
 
 def _build_wordmark(*, console_width: int) -> Text:
@@ -198,7 +354,9 @@ def render_launch_banner(
         color_system="truecolor",
         legacy_windows=False,
     )
-    console.print(build_launch_banner(console, session=session))
+    banner = build_launch_banner(console, session=session)
+    animate_launch_wordmark(console)
+    console.print(banner)
 
 
 def _wordmark_cell_width() -> int:
@@ -206,4 +364,10 @@ def _wordmark_cell_width() -> int:
     return max(cell_len(row) for row in _WORDMARK_ROWS)
 
 
-__all__ = ["build_launch_banner", "render_launch_banner"]
+__all__ = [
+    "WordmarkSpinFrame",
+    "animate_launch_wordmark",
+    "build_launch_banner",
+    "build_wordmark_spin_frames",
+    "render_launch_banner",
+]

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -131,9 +131,8 @@ def test_shimmer_text_ansi_paints_a_traveling_metallic_wave() -> None:
     assert " tools" in spaced or "tools" in re.sub(r"\x1b\[[0-9;]*m", "", spaced)
 
 
-def test_reply_marker_follows_the_active_theme_highlight() -> None:
-    """Assistant ``∴`` uses the active theme's HIGHLIGHT so every component
-    follows the selected palette (not a fixed colour that copies another tool)."""
+def test_tool_marker_follows_the_active_theme_highlight() -> None:
+    """The bold tool marker follows each palette's highlight colour."""
     from infrastructure.terminal import theme as ui_theme
 
     for name in ("blue", "purple", "green", "mono"):
@@ -145,7 +144,10 @@ def test_reply_block_paints_orange_marker_and_themed_body() -> None:
     """Regression: marker washed out when body fell through to terminal white."""
     import os
 
-    from surfaces.interactive_shell.ui.streaming.renderer import render_reply_block
+    from surfaces.interactive_shell.ui.streaming.renderer import (
+        _reply_marker_style,
+        render_reply_block,
+    )
 
     os.environ.pop("NO_COLOR", None)
     set_active_theme("blue")
@@ -158,7 +160,8 @@ def test_reply_block_paints_orange_marker_and_themed_body() -> None:
     with console.capture() as capture:
         render_reply_block(console, "Hey! How can I help?")
     output = capture.get()
-    assert "∴" in output
+    assert "Ω" in output
+    assert _reply_marker_style() == get_theme("blue").HIGHLIGHT
     # Marker follows the active theme's HIGHLIGHT (whatever the palette sets).
     highlight = get_theme("blue").HIGHLIGHT.lstrip("#")
     r, g, b = (int(highlight[i : i + 2], 16) for i in (0, 2, 4))

--- a/tests/interactive_shell/runtime/test_agent_harness_adapters.py
+++ b/tests/interactive_shell/runtime/test_agent_harness_adapters.py
@@ -76,7 +76,7 @@ def test_finalize_satisfies_the_host_contract_while_staying_silent() -> None:
 
 
 def test_response_header_opens_without_a_leading_blank() -> None:
-    """The sink used to print a blank before ``∴``; that padded turns vs Droid.
+    """The sink used to print a blank before ``Ω``; that padded turns vs Droid.
 
     ``_show_response`` used to own that spacer in the shared turn engine.
     Chat sinks never wanted it; keeping a blank in the shell sink only was
@@ -90,5 +90,5 @@ def test_response_header_opens_without_a_leading_blank() -> None:
 
     # Assert: marker on the first painted line — no spacer row above.
     assert console.lines
-    assert "∴" in console.lines[0]
+    assert "Ω" in console.lines[0]
     assert console.lines[0] != ""

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -1478,7 +1478,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert "❯" in output
-        assert "∴" in output
+        assert "Ω" in output
         assert "$ /status" in output
         assert "you  " not in output
         assert "sre  " not in output
@@ -1512,7 +1512,7 @@ class TestResumeCommand:
 
         output = buf.getvalue()
         assert output.count("❯ repeat") == 2
-        assert output.count("∴") == 2
+        assert output.count("Ω") == 2
         assert "first answer" in output
         assert "second answer" in output
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -177,6 +177,7 @@ def test_build_prompt_session_installs_growing_bordered_composer() -> None:
     from prompt_toolkit.layout.containers import (
         FloatContainer,
         HSplit,
+        VSplit,
         Window,
     )
 
@@ -195,7 +196,8 @@ def test_build_prompt_session_installs_growing_bordered_composer() -> None:
     assert isinstance(composer, HSplit)
     assert composer.height is None
     editable_row = composer.children[1]
-    surface_body = editable_row.children[1].get_container()
+    assert isinstance(editable_row, VSplit)
+    surface_body = editable_row.children[1]
     assert isinstance(surface_body, HSplit)
     editable_body = surface_body.children[0]
     default_buffer_slot = editable_body.children[0]

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -148,9 +148,12 @@ def test_launch_banner_spins_once_in_place_on_tty(monkeypatch: object) -> None:
 
     written = "".join(fake_stdout.writes)
     animation_end = written.index("\x1b[?25h") + len("\x1b[?25h")
-    assert written.count("\x1b[2;1H") > 10
-    assert "\n" not in written[:animation_end]
-    assert written.index("\x1b[?25l") < written.index("\x1b[2;1H")
+    animation = written[:animation_end]
+    assert written.count("\x1b[10A") > 10
+    assert "\x1b[2;1H" not in animation
+    assert "\x1b[H" not in animation
+    assert "\n" not in animation.replace("\r\n", "")
+    assert written.index("\x1b[?25l") < written.index("\x1b[1G")
     assert written.index("\x1b[?25h") < written.index("Welcome to OpenSRE CLI")
 
 

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -103,6 +103,57 @@ def test_launch_banner_draws_ring_logo_on_wide_terminals(monkeypatch: object) ->
     assert "⣿⣿⠀⠀⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⠀⢸⣿⣿" in output
 
 
+def test_wordmark_spin_frames_complete_a_full_revolution() -> None:
+    frames = banner_module.build_wordmark_spin_frames()
+    blank = "\u2800"
+
+    assert len(frames) > 10
+    assert frames[0].rows == frames[-1].rows
+    assert any(frame.back_facing for frame in frames)
+    assert all(tuple(map(len, frame.rows)) == tuple(map(len, frames[0].rows)) for frame in frames)
+    edge = min(frames, key=lambda frame: frame.scale)
+    assert max(len(row.strip(blank)) for row in edge.rows) < max(
+        len(row.strip(blank)) for row in frames[0].rows
+    )
+
+
+def test_launch_banner_spins_once_in_place_on_tty(monkeypatch: object) -> None:
+    class _FakeStdout:
+        def __init__(self) -> None:
+            self.writes: list[str] = []
+
+        def write(self, text: str) -> int:
+            self.writes.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+        def isatty(self) -> bool:
+            return True
+
+    fake_stdout = _FakeStdout()
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+    monkeypatch.setattr(banner_module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
+    console = Console(
+        file=fake_stdout,
+        force_terminal=True,
+        highlight=False,
+        color_system="truecolor",
+        width=120,
+    )
+
+    banner_module.render_launch_banner(console)
+
+    written = "".join(fake_stdout.writes)
+    animation_end = written.index("\x1b[?25h") + len("\x1b[?25h")
+    assert written.count("\x1b[2;1H") > 10
+    assert "\n" not in written[:animation_end]
+    assert written.index("\x1b[?25l") < written.index("\x1b[2;1H")
+    assert written.index("\x1b[?25h") < written.index("Welcome to OpenSRE CLI")
+
+
 def test_launch_banner_falls_back_to_title_on_narrow_terminals(monkeypatch: object) -> None:
     monkeypatch.setattr(banner_module, "load_launch_status", _fixed_status)
     console = Console(record=True, force_terminal=False, highlight=False, width=20)

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -519,9 +519,9 @@ async def test_composer_frame_preferred_height_does_not_crash() -> None:
 def test_composer_frame_uses_subtle_rounded_corners() -> None:
     from prompt_toolkit.layout.containers import VSplit, Window
 
-    from surfaces.interactive_shell.ui.input_prompt import _rounded_composer_frame
+    from surfaces.interactive_shell.ui.input_prompt import rounded_composer_frame
 
-    frame = _rounded_composer_frame(Window())
+    frame = rounded_composer_frame(Window())
     top, _middle, bottom = frame.children
 
     assert isinstance(top, VSplit)

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -514,3 +514,20 @@ async def test_composer_frame_preferred_height_does_not_crash() -> None:
         await asyncio.wait_for(task, timeout=5.0)
 
     assert dim.preferred >= 1
+
+
+def test_composer_frame_uses_subtle_rounded_corners() -> None:
+    from prompt_toolkit.layout.containers import VSplit, Window
+
+    from surfaces.interactive_shell.ui.input_prompt import _rounded_composer_frame
+
+    frame = _rounded_composer_frame(Window())
+    top, _middle, bottom = frame.children
+
+    assert isinstance(top, VSplit)
+    assert isinstance(bottom, VSplit)
+    assert [corner.char for corner in (top.children[0], top.children[-1])] == ["╭", "╮"]
+    assert [corner.char for corner in (bottom.children[0], bottom.children[-1])] == [
+        "╰",
+        "╯",
+    ]

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -112,11 +112,11 @@ def test_confirmation_region_height_is_stable_across_selection_changes() -> None
 
 
 def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> None:
-    """Prompt stack is status → Auto (Droid); no reserved empty action gap.
+    """Prompt stack is status → Auto; no reserved empty action gap.
 
     Idle omits the empty status placeholder (that was the big gap under the
-    banner). Thinking/Invoking add one status line — height may grow by one,
-    but never by a second reserved blank row.
+    banner). Thinking/Invoking add one status line, but never a second reserved
+    action row.
     """
     session = Session()
     idle = SpinnerState()

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -57,7 +57,7 @@ def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
 
 def test_table_reply_renders_as_a_table_not_flattened_pipes() -> None:
     # A reply that leads with a Markdown table must render as an aligned table. The
-    # inline ``∴ `` marker fused onto the header row breaks CommonMark block parsing
+    # inline ``Ω `` marker fused onto the header row breaks CommonMark block parsing
     # and flattens the table to one line of raw pipes, so the marker goes on its own
     # line before a leading block.
     buf = io.StringIO()
@@ -80,7 +80,7 @@ def test_prose_reply_keeps_the_inline_marker() -> None:
 
     publish_full_response(console, "Root disk is 44% full.")
 
-    assert "∴ Root disk is 44% full." in buf.getvalue()
+    assert "Ω  Root disk is 44% full." in buf.getvalue()
 
 
 def _tty_console() -> tuple[Console, io.StringIO]:
@@ -114,9 +114,9 @@ class TestNonTtyFallback:
 
         output = buf.getvalue()
         assert result == "Hello, world"
-        # The inline ``∴`` marker + text reach piped output so captured logs
+        # The inline ``Ω`` marker + text reach piped output so captured logs
         # are useful (the standalone label header was removed).
-        assert "∴" in output
+        assert "Ω" in output
         assert "Hello, world" in output
         # No spinner / Live cursor-movement artifacts in non-TTY captures.
         assert "thinking" not in output
@@ -147,7 +147,7 @@ class TestNonTtyFallback:
         assert result == '{"actions":[]}'
         output = buf.getvalue()
         # No bullet header for suppressed responses.
-        assert "∴" not in output
+        assert "Ω" not in output
         assert '{"actions"' not in output
 
 
@@ -189,7 +189,7 @@ class TestTtyParagraphRender:
         output = _strip_ansi(buf.getvalue())
         assert result == "Run **opensre setup** to start."
         # Bullet row marker pinned above the rendered paragraph.
-        assert "∴" in output
+        assert "Ω" in output
         # End-of-stream force-flush rendered Markdown — ``**`` stripped.
         assert "**opensre" not in output
         assert "opensre setup" in output
@@ -222,7 +222,7 @@ class TestTtyParagraphRender:
     def test_preserves_blank_line_between_list_and_following_paragraph(self) -> None:
         """One blank line between a list and the next paragraph — no double gap.
 
-        The whole reply hangs in the ``∴`` gutter, so the list and the following
+        The whole reply hangs in the ``Ω`` gutter, so the list and the following
         paragraph sit in the indented body column.
         """
         console, buf = _tty_console()
@@ -231,10 +231,10 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="OpenSRE", chunks=_yield_chunks([text]))
 
         visible = "\n".join(line.rstrip() for line in _strip_ansi(buf.getvalue()).splitlines())
-        assert "∴ Ready:\n\n   • first\n   • second\n\n  Blocked pending a choice." in visible
+        assert "Ω  Ready:\n\n    • first\n    • second\n\n   Blocked pending a choice." in visible
 
     def test_reply_hangs_indented_under_the_marker(self) -> None:
-        """A wrapped reply hangs in the ∴ gutter: line one carries the marker,
+        """A wrapped reply hangs in the Ω gutter: line one carries the marker,
         every continuation line aligns in the indented body column."""
         console, buf = _tty_console()
         text = "A fairly long assistant reply that has to wrap across several lines. " * 3
@@ -242,7 +242,7 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="assistant", chunks=_yield_chunks([text]))
 
         lines = [line for line in _strip_ansi(buf.getvalue()).splitlines() if line.strip()]
-        assert lines[0].startswith("∴ ")  # marker leads the first line
+        assert lines[0].startswith("Ω  ")  # marker leads the first line
         assert len(lines) > 1  # the reply actually wrapped
         assert all(line.startswith("  ") for line in lines[1:])  # hang-indent at col 2
 
@@ -645,7 +645,7 @@ class TestTtyParagraphRender:
         assert result == ""
         # The marker is inline on the first paragraph, so an empty stream prints
         # no marker at all — and no spinner residue at finalize.
-        assert "∴" not in _strip_ansi(buf.getvalue())
+        assert "Ω" not in _strip_ansi(buf.getvalue())
 
 
 class TestMidStreamError:
@@ -764,7 +764,7 @@ class TestRenderResponseHeader:
         console, buf = _tty_console()
         render_response_header(console, "assistant")
         output = _strip_ansi(buf.getvalue())
-        assert "∴" in output
+        assert "Ω" in output
         assert "assistant" not in output
 
     def test_role_label_is_accepted_but_not_painted(self) -> None:
@@ -773,7 +773,7 @@ class TestRenderResponseHeader:
         console, buf = _tty_console()
         render_response_header(console, "answer")
         assert "answer" not in _strip_ansi(buf.getvalue())
-        assert "∴" in _strip_ansi(buf.getvalue())
+        assert "Ω" in _strip_ansi(buf.getvalue())
 
 
 class TestFormatTokenCountShort:
@@ -1076,7 +1076,7 @@ class TestSuppressionPeek:
         assert result == '{"actions":[]}'
         # No bullet header, no markdown, no live-region artifacts.
         output = _strip_ansi(buf.getvalue())
-        assert "∴" not in output
+        assert "Ω" not in output
         assert '{"actions"' not in output
 
     def test_renders_normally_when_first_char_does_not_match(self) -> None:
@@ -1090,7 +1090,7 @@ class TestSuppressionPeek:
 
         assert result == "Hello, world"
         output = _strip_ansi(buf.getvalue())
-        assert "∴" in output
+        assert "Ω" in output
         assert "Hello, world" in output
 
     def test_skips_leading_whitespace_before_deciding(self) -> None:
@@ -1105,7 +1105,7 @@ class TestSuppressionPeek:
 
         assert result == '  \n{"action":"slash"}'
         output = _strip_ansi(buf.getvalue())
-        assert "∴" not in output
+        assert "Ω" not in output
 
 
 class TestRenderMarkdownBlock:

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -95,6 +95,11 @@ def test_prompt_region_keeps_the_checklist_above_invoking_tools() -> None:
     assert rendered.index("Plan · 2/3") < rendered.index(SpinnerState.INVOKING_TOOLS_PHASE)
     assert "Auto (High)" in rendered
     assert rendered.index(SpinnerState.INVOKING_TOOLS_PHASE) < rendered.index("Auto (High)")
+    assert re.search(
+        rf"  ○ Confirm checkout returns 2xx\n\n[^\n]*"
+        rf"{re.escape(SpinnerState.INVOKING_TOOLS_PHASE)}",
+        rendered,
+    )
 
 
 def test_idle_prompt_region_shows_plan_without_thinking_or_ready_hint() -> None:
@@ -106,6 +111,7 @@ def test_idle_prompt_region_shows_plan_without_thinking_or_ready_hint() -> None:
     assert "Plan · 2/3" in rendered
     assert "Ready" not in rendered  # no recurring idle hint line
     assert rendered.index("Plan · 2/3") < rendered.index("Auto (High)")
+    assert "  ○ Confirm checkout returns 2xx\n\nAuto (High)" in rendered
 
 
 def test_clearing_the_plan_resets_expanded_state() -> None:


### PR DESCRIPTION
Fixes: N/A

#### Describe the changes you have made in this PR -

- Add a centered, in-place 3D startup turn for the braille OpenSRE mark, with fixed-width/even-dot projection to avoid wobble.
- Refine the terminal identity with an Omega response marker, rounded composer chrome, themed streaming output, and denser plan/status spacing.
- Update terminal and interactive-shell tests for the new rendering structures and visual contracts.

### Demo/Screenshot for feature changes and bug fixes -

Run `uv run opensre`. Before the prompt appears, the OpenSRE mark performs one smooth 0.8-second, 60 FPS Y-axis revolution in place and settles into the static launch banner. Assistant responses then use the themed `Ω` gutter marker and the composer uses rounded corners.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The startup animation decodes the existing braille logo into dot columns, projects those columns using a cosine-based Y-axis rotation, mirrors the back-facing half, and re-encodes each frame. Every frame stays on a fixed-width canvas and uses an even projected dot count, preventing whole-cell recentering and half-cell wobble. Relative cursor movement and synchronized-output sequences repaint only a temporary startup region, restore the cursor in `finally`, and run only for a short TTY startup burst; non-TTY and narrow terminals retain static fallback behavior.

The composer uses explicit prompt-toolkit row/column containers for rounded borders, while response rendering uses a themed Omega gutter with matching tests.

---

## Test plan

- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`
- [x] `uv run python -m pytest tests/interactive_shell/ -q` — 1493 passed, 1 skipped
- [x] `uv run python -m pytest tests/infrastructure/terminal/ -q` — 17 passed

## Checklist before requesting a review
- [x] I have added proper PR title
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Made with [Cursor](https://cursor.com)