### PR TITLE
fix(messaging): remove outbound send approval gates

### DIFF
--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -170,7 +170,7 @@ SERVICE    │ SOURCE    │ STATUS   │ DETAIL
 rocketchat │ local env │ ✓ passed │ Connected to Rocket.Chat as @verifyadmin.
 ```
 
-Send a real message through the supported watchdog delivery path (see [Watchdog alarms](#watchdog-alarms) below) rather than calling the tool class directly — this exercises the same threshold-detection, cooldown, and provider-routing code a production alarm uses. Rocket.Chat's one registered tool, `rocketchat_send_message`, is a delivery action (`side_effect_level: EXTERNAL`) that needs interactive approval when the agent calls it, which doesn't complete in one non-interactive demo run; `watchdog` triggers a real delivery autonomously by design.
+Send a real message through the supported watchdog delivery path (see [Watchdog alarms](#watchdog-alarms) below) rather than calling the tool class directly — this exercises the same threshold-detection, cooldown, and provider-routing code a production alarm uses.
 
 ```bash
 sleep 30 &

--- a/docs/messaging/rocketchat.mdx
+++ b/docs/messaging/rocketchat.mdx
@@ -215,7 +215,7 @@ unset ROCKETCHAT_USER_ID ROCKETCHAT_DEFAULT_CHANNEL
 
 The tool resolves credentials internally from the integration store, then the same env/keyring rules as setup (PAT via `resolve_env_credential`; webhook URL via plain env) — the agent never sees them. In token mode an explicit `channel` (or the configured `default_channel`) is targeted via `chat.postMessage`; in webhook-only mode messages go to the webhook's fixed destination, and an explicit `channel` returns a configuration error instead of being silently ignored.
 
-Delivery is an external side effect and requires approval. The result includes a stable `status`, `sent`, `error_type`, `channel`, and `message_length` shape so follow-up tool calls can tell configuration failures from Rocket.Chat delivery failures.
+Delivery is an external side effect but does not require a separate approval. The result includes a stable `status`, `sent`, `error_type`, `channel`, and `message_length` shape so follow-up tool calls can tell configuration failures from Rocket.Chat delivery failures.
 
 ### Watchdog alarms
 

--- a/docs/messaging/slack.mdx
+++ b/docs/messaging/slack.mdx
@@ -146,8 +146,8 @@ Teammate tools (bot token) plus webhook blast. Credentials resolve inside the to
 
 | Tool | What it does | Needs | Approval |
 | --- | --- | --- | --- |
-| `slack_send_message` | Post to the webhook's fixed channel | `SLACK_WEBHOOK_URL` | Yes |
-| `slack_reply_message` | Post to any channel/thread (`C…` or `#name`) | bot token, `chat:write` | Yes |
+| `slack_send_message` | Post to the webhook's fixed channel | `SLACK_WEBHOOK_URL` | No |
+| `slack_reply_message` | Post to any channel/thread (`C…` or `#name`) | bot token, `chat:write` | No |
 | `slack_read_messages` | Read channel history or a thread (`thread_ts`) | bot token, history + list scopes | No |
 | `slack_search_messages` | Workspace message search | **user** token (`SLACK_ACCESS_TOKEN`), `search:read` | No |
 | `slack_list_team_members` | List workspace members | bot token, `users:read` | No |
@@ -173,8 +173,8 @@ Example prompts:
 The last two need [GitHub configured](/github) and name the repository explicitly
 (`your-org/your-repo`) so the GitHub tools can resolve it — see
 [GitHub workflow tools](/github-workflow-tools) for what they can report on.
-`slack_send_message` requires approval before it posts; confirm the prompt when
-it appears, then check the channel for the message.
+Message tools post without a separate approval prompt; check the target channel
+for the delivered message.
 
 ### Production Engineer schedules (Slack)
 

--- a/gateway/tests/slack/test_channel_intro.py
+++ b/gateway/tests/slack/test_channel_intro.py
@@ -46,7 +46,7 @@ def test_bot_join_posts_intro_to_the_channel() -> None:
     # trial and error, using the real mention token.
     assert "<@UBOT>" in post["text"]
     assert "follow the conversation" in post["text"]
-    assert "approval" in post["text"]
+    assert "High-impact actions" in post["text"]
 
 
 def test_rejoining_the_same_channel_greets_once() -> None:

--- a/gateway/transports/slack/delivery/channel_intro.py
+++ b/gateway/transports/slack/delivery/channel_intro.py
@@ -32,8 +32,8 @@ def _intro_text(bot_user_id: str) -> str:
         "logs.\n"
         "• Once you mention me in a thread, I follow the conversation — no "
         "need to re-tag every message.\n"
-        "• Anything that writes (posting messages, joining channels, code "
-        "fixes) asks for your approval first."
+        "• High-impact actions such as joining channels or applying code "
+        "fixes ask for your approval first."
     )
 
 

--- a/integrations/buzz/tools/buzz_send_message_tool/tool.py
+++ b/integrations/buzz/tools/buzz_send_message_tool/tool.py
@@ -37,8 +37,6 @@ class BuzzSendMessageTool(BaseTool):
     ]
     requires = ["buzz"]
     side_effect_level = SideEffectLevel.EXTERNAL
-    requires_approval = True
-    approval_reason = "Sends a message via Buzz on your behalf."
     input_schema = {
         "type": "object",
         "properties": {

--- a/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
+++ b/integrations/rocketchat/tools/rocketchat_send_message_tool/tool.py
@@ -40,8 +40,6 @@ class RocketChatSendMessageTool(BaseTool):
     ]
     requires = ["rocketchat"]
     side_effect_level = SideEffectLevel.EXTERNAL
-    requires_approval = True
-    approval_reason = "Sends a message via Rocket.Chat on your behalf."
     input_schema = {
         "type": "object",
         "properties": {

--- a/integrations/slack/tools/slack_reply_message_tool/tool.py
+++ b/integrations/slack/tools/slack_reply_message_tool/tool.py
@@ -42,8 +42,6 @@ class SlackReplyMessageTool(BaseTool):
     ]
     requires = ["slack"]
     side_effect_level = SideEffectLevel.EXTERNAL
-    requires_approval = True
-    approval_reason = "Posts a message to a Slack channel on your behalf."
     input_schema = {
         "type": "object",
         "properties": {

--- a/integrations/slack/tools/slack_send_message_tool/tool.py
+++ b/integrations/slack/tools/slack_send_message_tool/tool.py
@@ -45,8 +45,6 @@ class SlackSendMessageTool(BaseTool):
     ]
     requires = ["slack"]
     side_effect_level = SideEffectLevel.EXTERNAL
-    requires_approval = True
-    approval_reason = "Sends a message to Slack on your behalf."
     input_schema = {
         "type": "object",
         "properties": {

--- a/integrations/telegram/tools/telegram_send_message_tool/tool.py
+++ b/integrations/telegram/tools/telegram_send_message_tool/tool.py
@@ -40,8 +40,6 @@ class TelegramSendMessageTool(BaseTool):
     ]
     requires = ["telegram"]
     side_effect_level = SideEffectLevel.EXTERNAL
-    requires_approval = True
-    approval_reason = "Sends a message via Telegram on your behalf."
     input_schema = {
         "type": "object",
         "properties": {

--- a/tests/interactive_shell/runtime/test_repl_presenter.py
+++ b/tests/interactive_shell/runtime/test_repl_presenter.py
@@ -49,7 +49,13 @@ def test_plain_command_output_is_recessed_but_keeps_command_colours() -> None:
     from infrastructure.terminal import theme as ui_theme
 
     buffer = io.StringIO()
-    console = Console(file=buffer, force_terminal=True, color_system="truecolor", width=80)
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        color_system="truecolor",
+        width=80,
+        no_color=False,
+    )
     presenter = ReplSubprocessPresenter(Session(), console)
 
     presenter.print_command_output("plain line of output")
@@ -64,9 +70,13 @@ def test_plain_command_output_is_recessed_but_keeps_command_colours() -> None:
     # a stale ``\x1b[37m``. Both sides here share that cache, so the check holds
     # at any colour depth.
     reference = io.StringIO()
-    Console(file=reference, force_terminal=True, color_system="truecolor", width=80).print(
-        "x", style=str(ui_theme.SECONDARY)
-    )
+    Console(
+        file=reference,
+        force_terminal=True,
+        color_system="truecolor",
+        width=80,
+        no_color=False,
+    ).print("x", style=str(ui_theme.SECONDARY))
     secondary_sgr = reference.getvalue().split("x")[0]
     assert secondary_sgr and secondary_sgr in raw  # plain output recessed to SECONDARY
     assert re.search(r"\x1b\[[0-9;]*32m", raw)  # command's own green survives the base

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -75,7 +75,13 @@ def test_ask_user_qa_highlights_answer_differently_from_question() -> None:
     from infrastructure.terminal import theme as ui_theme
 
     buffer = io.StringIO()
-    console = Console(file=buffer, force_terminal=True, color_system="truecolor", highlight=False)
+    console = Console(
+        file=buffer,
+        force_terminal=True,
+        color_system="truecolor",
+        highlight=False,
+        no_color=False,
+    )
     render_ask_user_qa(console, [("Which product should I demo?", "OpenSRE itself")])
     raw = buffer.getvalue()
 

--- a/tests/interactive_shell/ui/test_sign_in.py
+++ b/tests/interactive_shell/ui/test_sign_in.py
@@ -49,7 +49,13 @@ def test_welcome_title_renders_in_the_accent_colour() -> None:
     from infrastructure.terminal.theme import HIGHLIGHT
 
     buf = io.StringIO()
-    console = Console(file=buf, force_terminal=True, color_system="truecolor", highlight=False)
+    console = Console(
+        file=buf,
+        force_terminal=True,
+        color_system="truecolor",
+        highlight=False,
+        no_color=False,
+    )
     console.print(sign_in.build_welcome_box())
     raw = buf.getvalue()
     hex_color = str(HIGHLIGHT).lstrip("#")

--- a/tests/tools/test_buzz_send_message_tool.py
+++ b/tests/tools/test_buzz_send_message_tool.py
@@ -1,0 +1,16 @@
+"""Tests for the Buzz message action surface."""
+
+from integrations.buzz.tools.buzz_send_message_tool import (
+    BuzzSendMessageTool,
+    buzz_send_message,
+)
+
+
+def test_metadata_allows_external_send_without_approval() -> None:
+    metadata = BuzzSendMessageTool.metadata()
+
+    assert metadata.name == "buzz_send_message"
+    assert metadata.source == "buzz"
+    assert metadata.side_effect_level == "external"
+    assert buzz_send_message.requires_approval is False
+    assert buzz_send_message.__opensre_registered_tool__.surfaces == ("action",)

--- a/tests/tools/test_rocketchat_send_message_tool.py
+++ b/tests/tools/test_rocketchat_send_message_tool.py
@@ -55,7 +55,7 @@ def test_metadata_declares_rocketchat_source() -> None:
     assert metadata.name == "rocketchat_send_message"
     assert metadata.source == "rocketchat"
     assert metadata.side_effect_level == "external"
-    assert rocketchat_send_message.requires_approval is True
+    assert rocketchat_send_message.requires_approval is False
 
 
 def test_registered_tool_is_scoped_off_the_chat_surface() -> None:
@@ -63,7 +63,7 @@ def test_registered_tool_is_scoped_off_the_chat_surface() -> None:
     # so exposing a send tool there lets the agent target the wrong platform.
     registered = rocketchat_send_message.__opensre_registered_tool__
     assert registered.surfaces == ("action",)
-    assert registered.requires_approval is True
+    assert registered.requires_approval is False
 
 
 def test_init_is_only_registry_entrypoint() -> None:

--- a/tests/tools/test_slack_reply_message_tool.py
+++ b/tests/tools/test_slack_reply_message_tool.py
@@ -43,11 +43,11 @@ def _install_fake_client(monkeypatch: Any, responder: Any) -> None:
     )
 
 
-def test_metadata_requires_approval_for_external_send() -> None:
+def test_metadata_allows_external_send_without_approval() -> None:
     metadata = SlackReplyMessageTool.metadata()
     assert metadata.name == "slack_reply_message"
     assert metadata.side_effect_level == "external"
-    assert slack_reply_message.requires_approval is True
+    assert slack_reply_message.requires_approval is False
 
 
 def test_post_includes_thread_ts_only_when_given(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_slack_send_message_tool.py
+++ b/tests/tools/test_slack_send_message_tool.py
@@ -29,7 +29,7 @@ def test_metadata_declares_slack_source() -> None:
     assert metadata.name == "slack_send_message"
     assert metadata.source == "slack"
     assert metadata.side_effect_level == "external"
-    assert slack_send_message.requires_approval is True
+    assert slack_send_message.requires_approval is False
 
 
 def test_registered_tool_is_scoped_off_the_chat_surface() -> None:
@@ -37,7 +37,7 @@ def test_registered_tool_is_scoped_off_the_chat_surface() -> None:
     # so exposing a send tool there lets the agent target the wrong platform.
     registered = slack_send_message.__opensre_registered_tool__
     assert registered.surfaces == ("action",)
-    assert registered.requires_approval is True
+    assert registered.requires_approval is False
 
 
 def test_is_available_true_when_webhook_configured(

--- a/tests/tools/test_telegram_send_message_tool.py
+++ b/tests/tools/test_telegram_send_message_tool.py
@@ -30,7 +30,7 @@ def test_metadata_declares_telegram_source() -> None:
     assert metadata.name == "telegram_send_message"
     assert metadata.source == "telegram"
     assert metadata.side_effect_level == "external"
-    assert telegram_send_message.requires_approval is True
+    assert telegram_send_message.requires_approval is False
 
 
 def test_registered_tool_is_scoped_off_the_chat_surface() -> None:
@@ -38,7 +38,7 @@ def test_registered_tool_is_scoped_off_the_chat_surface() -> None:
     # so exposing a send tool there lets the agent target the wrong platform.
     registered = telegram_send_message.__opensre_registered_tool__
     assert registered.surfaces == ("action",)
-    assert registered.requires_approval is True
+    assert registered.requires_approval is False
 
 
 def test_is_available_true_when_bot_token_configured(telegram_source: dict[str, Any]) -> None:


### PR DESCRIPTION
Fixes: N/A — requested directly by maintainers.

#### Describe the changes you have made in this PR -

- Remove interactive approval requirements from Slack, Telegram, Rocket.Chat, and Buzz outbound message tools.
- Keep message tools classified as external side effects and scoped to the action surface.
- Preserve approval gates for non-messaging high-impact operations such as Slack channel joins, deployments, and code/security fixes.
- Update Slack/Rocket.Chat guidance and Slack channel-intro copy to match the new behavior.
- Add/adjust regression coverage for the message-tool approval policy.
- Make three terminal true-colour assertions explicit about overriding `NO_COLOR`, which the full-suite validation exposed.

### Demo/Screenshot for feature changes and bug fixes -

Before: `slack_reply_message` posted an Approve/Deny prompt and expired after 180 seconds if unanswered.

After: all outbound messaging tools report `requires_approval is False` and execute without the approval hook blocking them.

Validation:

```text
make lint         — passed
make format-check — passed
make typecheck    — passed
make test-cov     — 14,855 passed, 54 skipped, 2 xfailed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Message delivery already passes through the shared tool hook, which only prompts when a registered tool declares `requires_approval=True`. Removing that opt-in metadata from the five outbound send tools therefore removes the prompt without bypassing or weakening approval handling for unrelated high-impact tools. Tests assert the resulting registered metadata directly. Documentation and Slack onboarding copy were updated so users are no longer told that messages require confirmation.

The approval infrastructure remains intact because deployments, channel membership changes, and code/security fixes still use it. The full suite also revealed that three true-colour tests were affected by the caller's `NO_COLOR=1`; setting `no_color=False` on those explicitly colour-testing consoles makes their test contract deterministic without changing product behavior.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue (no issue exists for this direct maintainer request)
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
