### PR TITLE
fix(ci): gate rolling main-build publication on same-SHA CI Gate success

### DIFF
--- a/.github/ci/test_scope_rules.py
+++ b/.github/ci/test_scope_rules.py
@@ -580,6 +580,8 @@ RULES: tuple[PathRule, ...] = (
     PathRule("uv.lock", (), always_escalate=True),
     PathRule("pytest.ini", (), always_escalate=True),
     PathRule("Makefile", (), always_escalate=True),
+    PathRule(".github/workflows/", ("tests/github_ci/",)),
+    PathRule(".github/scripts/", ("tests/github_ci/",)),
     PathRule(".github/ci/", ("tests/github_ci/",)),
 )
 

--- a/.github/scripts/wait_for_ci_gate.py
+++ b/.github/scripts/wait_for_ci_gate.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Wait until the CI workflow's CI Gate job succeeds for a commit SHA."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+CI_WORKFLOW_FILE = "ci.yml"
+CI_GATE_JOB_NAME = "CI Gate"
+CI_PUSH_EVENT = "push"
+DEFAULT_TIMEOUT_SECONDS = 4800
+DEFAULT_POLL_SECONDS = 30
+GITHUB_API = "https://api.github.com"
+_TRANSIENT_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+JsonGetter = Callable[[str, Mapping[str, str]], dict[str, Any]]
+Verdict = Literal["success", "failure", "wait"]
+
+
+class CiGateNotSuccessful(Exception):
+    """CI Gate did not succeed for the requested SHA."""
+
+
+class CiGateWaitTimeout(CiGateNotSuccessful):
+    """Timed out before CI Gate reached a terminal result."""
+
+
+class TransientApiError(Exception):
+    """GitHub API returned a retryable error."""
+
+
+@dataclass(frozen=True, slots=True)
+class GateObservation:
+    """One poll of the CI Gate job for a single SHA."""
+
+    run_id: int | None
+    job_status: str | None
+    job_conclusion: str | None
+
+
+def verdict(observation: GateObservation) -> Verdict:
+    """Classify a poll: publish, refuse, or keep waiting."""
+    if observation.run_id is None or observation.job_status is None:
+        return "wait"
+    if observation.job_status != "completed":
+        return "wait"
+    if observation.job_conclusion == "success":
+        return "success"
+    return "failure"
+
+
+def newest_push_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the newest CI workflow run, or None when the SHA has none yet."""
+    if not runs:
+        return None
+    return max(runs, key=lambda run: int(run.get("id") or 0))
+
+
+def ci_gate_job(jobs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the CI Gate job from a workflow run, if it has been queued."""
+    return next((job for job in jobs if job.get("name") == CI_GATE_JOB_NAME), None)
+
+
+def observe_ci_gate(
+    *,
+    sha: str,
+    get_json: JsonGetter,
+    repo: str,
+) -> GateObservation:
+    """Load the newest push-event CI run for ``sha`` and read its CI Gate job."""
+    runs_payload = get_json(
+        f"/repos/{repo}/actions/workflows/{CI_WORKFLOW_FILE}/runs",
+        {
+            "head_sha": sha,
+            "event": CI_PUSH_EVENT,
+            "per_page": "20",
+        },
+    )
+    run = newest_push_run(list(runs_payload.get("workflow_runs") or []))
+    if run is None:
+        return GateObservation(run_id=None, job_status=None, job_conclusion=None)
+
+    run_id = int(run["id"])
+    jobs_payload = get_json(
+        f"/repos/{repo}/actions/runs/{run_id}/jobs",
+        {"per_page": "100", "filter": "latest"},
+    )
+    job = ci_gate_job(list(jobs_payload.get("jobs") or []))
+    if job is None:
+        if run.get("status") == "completed":
+            return GateObservation(
+                run_id=run_id,
+                job_status="completed",
+                job_conclusion="missing",
+            )
+        return GateObservation(run_id=run_id, job_status=None, job_conclusion=None)
+
+    conclusion = job.get("conclusion")
+    return GateObservation(
+        run_id=run_id,
+        job_status=job.get("status"),
+        job_conclusion=str(conclusion) if conclusion is not None else None,
+    )
+
+
+def wait_for_ci_gate(
+    *,
+    fetch: Callable[[], GateObservation],
+    sleep: Callable[[float], None],
+    monotonic: Callable[[], float],
+    timeout_seconds: float,
+    poll_seconds: float,
+    log: Callable[[str], None] = print,
+) -> GateObservation:
+    """Poll ``fetch`` until CI Gate succeeds, or raise ``CiGateNotSuccessful``."""
+    deadline = monotonic() + timeout_seconds
+    while True:
+        try:
+            observation = fetch()
+        except TransientApiError as exc:
+            log(f"transient GitHub API error; retrying: {exc}")
+            observation = GateObservation(run_id=None, job_status=None, job_conclusion=None)
+        decision = verdict(observation)
+        log(
+            "CI Gate "
+            f"run={observation.run_id} status={observation.job_status} "
+            f"conclusion={observation.job_conclusion} verdict={decision}"
+        )
+        if decision == "success":
+            return observation
+        if decision == "failure":
+            conclusion = observation.job_conclusion or "unknown"
+            raise CiGateNotSuccessful(
+                f"CI Gate concluded {conclusion!r} for this SHA; refusing to publish main-build"
+            )
+        if monotonic() >= deadline:
+            raise CiGateWaitTimeout("timed out waiting for CI Gate to succeed for this SHA")
+        sleep(poll_seconds)
+
+
+def github_json_getter(token: str) -> JsonGetter:
+    """Return a GET helper authenticated with ``token``."""
+
+    def get_json(path: str, query: Mapping[str, str]) -> dict[str, Any]:
+        url = f"{GITHUB_API}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "opensre-wait-for-ci-gate",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.loads(response.read().decode())
+        except urllib.error.HTTPError as exc:
+            if exc.code in _TRANSIENT_HTTP_STATUSES:
+                raise TransientApiError(f"HTTP {exc.code}") from exc
+            raise
+        except urllib.error.URLError as exc:
+            raise TransientApiError(str(exc.reason)) from exc
+        if not isinstance(payload, dict):
+            raise TransientApiError("GitHub API returned a non-object payload")
+        return payload
+
+    return get_json
+
+
+def main() -> int:
+    """Poll CI Gate for ``WAIT_SHA``/``GITHUB_SHA`` and exit 0 only on success."""
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    sha = os.environ.get("WAIT_SHA") or os.environ.get("GITHUB_SHA", "")
+    timeout_seconds = int(os.environ.get("WAIT_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+    poll_seconds = int(os.environ.get("WAIT_POLL_SECONDS", DEFAULT_POLL_SECONDS))
+
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 1
+    if not repo or "/" not in repo:
+        print("GITHUB_REPOSITORY must be owner/repo", file=sys.stderr)
+        return 1
+    if not sha:
+        print("WAIT_SHA or GITHUB_SHA is required", file=sys.stderr)
+        return 1
+
+    getter = github_json_getter(token)
+    try:
+        wait_for_ci_gate(
+            fetch=lambda: observe_ci_gate(sha=sha, get_json=getter, repo=repo),
+            sleep=time.sleep,
+            monotonic=time.monotonic,
+            timeout_seconds=timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+    except CiGateNotSuccessful as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -718,12 +718,26 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "latest-known"  # avoid live ndjson "latest" fetch flakes
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - name: Wait for CI Gate on this SHA
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           WAIT_SHA: ${{ github.sha }}
-        run: python3 .github/scripts/wait_for_ci_gate.py
+        run: uv run python .github/scripts/wait_for_ci_gate.py
 
   publish-main-release:
     if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -706,8 +706,31 @@ jobs:
           export VERSION="${VERSION#v}"
           bash .github/scripts/sync-homebrew-tap-formula.sh
 
+  wait-for-ci-gate:
+    # Rolling main-build must not replace public installer assets unless the
+    # CI workflow's required "CI Gate" job succeeded for this exact SHA.
+    # Binary builds still run in parallel; only publication waits.
+    if: needs.prepare.outputs.channel == 'main'
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Wait for CI Gate on this SHA
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WAIT_SHA: ${{ github.sha }}
+        run: python3 .github/scripts/wait_for_ci_gate.py
+
   publish-main-release:
-    if: always() && needs.prepare.outputs.channel == 'main' && needs.build-binaries.result == 'success'
+    if: >-
+      always()
+      && needs.prepare.outputs.channel == 'main'
+      && needs.build-binaries.result == 'success'
+      && needs.wait-for-ci-gate.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -715,6 +738,7 @@ jobs:
     needs:
       - prepare
       - build-binaries
+      - wait-for-ci-gate
 
     steps:
       - uses: actions/checkout@v5

--- a/tests/github_ci/test_release_workflow.py
+++ b/tests/github_ci/test_release_workflow.py
@@ -25,7 +25,9 @@ def test_publish_main_release_requires_same_sha_ci_gate_success() -> None:
     wait_step = next(
         step for step in wait["steps"] if step.get("name") == "Wait for CI Gate on this SHA"
     )
-    assert wait_step["run"] == f"python3 {_WAIT_SCRIPT}"
+    assert wait_step["run"] == f"uv run python {_WAIT_SCRIPT}"
+    assert "Install uv" in {step.get("name") for step in wait["steps"]}
+    assert "Set up Python" in {step.get("name") for step in wait["steps"]}
     assert wait_step["env"]["WAIT_SHA"] == "${{ github.sha }}"
     assert "continue-on-error" not in wait
     assert "continue-on-error" not in wait_step

--- a/tests/github_ci/test_release_workflow.py
+++ b/tests/github_ci/test_release_workflow.py
@@ -1,0 +1,72 @@
+"""Workflow contracts for rolling main-build publication."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WAIT_SCRIPT = ".github/scripts/wait_for_ci_gate.py"
+
+
+def _workflow(name: str) -> dict[str, Any]:
+    return yaml.safe_load(_ROOT.joinpath(".github", "workflows", name).read_text(encoding="utf-8"))
+
+
+def test_publish_main_release_requires_same_sha_ci_gate_success() -> None:
+    jobs = _workflow("release.yml")["jobs"]
+    wait = jobs["wait-for-ci-gate"]
+    publish = jobs["publish-main-release"]
+
+    assert wait["needs"] == "prepare"
+    assert wait["if"] == "needs.prepare.outputs.channel == 'main'"
+    wait_step = next(
+        step for step in wait["steps"] if step.get("name") == "Wait for CI Gate on this SHA"
+    )
+    assert wait_step["run"] == f"python3 {_WAIT_SCRIPT}"
+    assert wait_step["env"]["WAIT_SHA"] == "${{ github.sha }}"
+    assert "continue-on-error" not in wait
+    assert "continue-on-error" not in wait_step
+
+    assert set(publish["needs"]) == {"prepare", "build-binaries", "wait-for-ci-gate"}
+    publish_if = " ".join(publish["if"].split())
+    assert "needs.wait-for-ci-gate.result == 'success'" in publish_if
+    assert "needs.build-binaries.result == 'success'" in publish_if
+    assert "needs.prepare.outputs.channel == 'main'" in publish_if
+    assert "needs.wait-for-ci-gate.result == 'skipped'" not in publish_if
+    assert "needs.wait-for-ci-gate.result == 'failure'" not in publish_if
+    assert "needs.wait-for-ci-gate.result == 'cancelled'" not in publish_if
+
+
+def test_failed_wait_does_not_move_main_build_assets() -> None:
+    jobs = _workflow("release.yml")["jobs"]
+    publish = jobs["publish-main-release"]
+    tag_step = next(
+        step
+        for step in publish["steps"]
+        if step.get("name") == "Move main build tag to the latest commit"
+    )
+    notes_step = next(
+        step for step in publish["steps"] if step.get("name") == "Publish rolling main release"
+    )
+
+    assert "git tag -f" in tag_step["run"]
+    assert "gh release upload" in notes_step["run"]
+    assert "gh release create" in notes_step["run"]
+    assert "wait-for-ci-gate" in publish["needs"]
+    assert "needs.wait-for-ci-gate.result == 'success'" in " ".join(publish["if"].split())
+
+
+def test_stable_releases_remain_independent_of_the_ci_gate_wait() -> None:
+    jobs = _workflow("release.yml")["jobs"]
+    triggers = _workflow("release.yml")[True]
+
+    assert "schedule" in triggers
+    assert "workflow_dispatch" in triggers
+    assert jobs["verify"]["if"] == "github.event_name != 'push'"
+    assert jobs["publish-release"]["if"] == "needs.prepare.outputs.channel == 'release'"
+    assert "wait-for-ci-gate" not in jobs["publish-release"]["needs"]
+    assert "wait-for-ci-gate" not in jobs["verify"].get("needs", [])
+    assert "wait-for-ci-gate" not in jobs["build-python-dist"]["needs"]

--- a/tests/github_ci/test_wait_for_ci_gate.py
+++ b/tests/github_ci/test_wait_for_ci_gate.py
@@ -1,0 +1,158 @@
+"""Decision contracts for same-SHA CI Gate gating of main-build publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from config.constants.paths import REPO_ROOT
+
+_MODULE_PATH = REPO_ROOT / ".github" / "scripts" / "wait_for_ci_gate.py"
+_spec = importlib.util.spec_from_file_location("wait_for_ci_gate", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+_script = importlib.util.module_from_spec(_spec)
+sys.modules["wait_for_ci_gate"] = _script
+_spec.loader.exec_module(_script)
+
+CiGateNotSuccessful = _script.CiGateNotSuccessful
+CiGateWaitTimeout = _script.CiGateWaitTimeout
+GateObservation = _script.GateObservation
+TransientApiError = _script.TransientApiError
+observe_ci_gate = _script.observe_ci_gate
+verdict = _script.verdict
+wait_until = _script.wait_for_ci_gate
+
+_SHA = "4b20a0d0123456789abcdef0123456789abcdef0"
+_REPO = "Tracer-Cloud/opensre"
+
+
+def _get_json_for(
+    runs: list[dict[str, Any]],
+    jobs_by_run: Mapping[int, list[dict[str, Any]]],
+) -> _script.JsonGetter:
+    def get_json(path: str, query: Mapping[str, str]) -> dict[str, Any]:
+        if path.endswith("/runs"):
+            assert query["head_sha"] == _SHA
+            assert query["event"] == "push"
+            return {"workflow_runs": runs}
+        run_id = int(path.split("/")[-2])
+        return {"jobs": list(jobs_by_run[run_id])}
+
+    return get_json
+
+
+def test_verdict_waits_until_ci_gate_completes() -> None:
+    assert verdict(GateObservation(None, None, None)) == "wait"
+    assert verdict(GateObservation(1, "in_progress", None)) == "wait"
+    assert verdict(GateObservation(1, "completed", "success")) == "success"
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "skipped", "timed_out", "missing"])
+def test_verdict_refuses_terminal_non_success(conclusion: str) -> None:
+    assert verdict(GateObservation(1, "completed", conclusion)) == "failure"
+
+
+def test_observe_uses_newest_push_run_for_the_requested_sha() -> None:
+    runs = [
+        {"id": 10, "status": "completed", "head_sha": _SHA},
+        {"id": 20, "status": "completed", "head_sha": _SHA},
+    ]
+    jobs = {
+        10: [{"name": "CI Gate", "status": "completed", "conclusion": "failure"}],
+        20: [{"name": "CI Gate", "status": "completed", "conclusion": "success"}],
+    }
+
+    observation = observe_ci_gate(sha=_SHA, get_json=_get_json_for(runs, jobs), repo=_REPO)
+
+    assert observation == GateObservation(20, "completed", "success")
+    assert verdict(observation) == "success"
+
+
+def test_observe_fail_closes_when_completed_run_has_no_ci_gate_job() -> None:
+    runs = [{"id": 7, "status": "completed"}]
+    observation = observe_ci_gate(sha=_SHA, get_json=_get_json_for(runs, {7: []}), repo=_REPO)
+
+    assert observation == GateObservation(7, "completed", "missing")
+    assert verdict(observation) == "failure"
+
+
+def test_observe_waits_while_ci_gate_has_not_queued() -> None:
+    runs = [{"id": 7, "status": "in_progress"}]
+    observation = observe_ci_gate(sha=_SHA, get_json=_get_json_for(runs, {7: []}), repo=_REPO)
+
+    assert observation == GateObservation(7, None, None)
+    assert verdict(observation) == "wait"
+
+
+def test_wait_succeeds_after_in_progress_polls() -> None:
+    polls = iter(
+        [
+            GateObservation(1, "in_progress", None),
+            GateObservation(1, "completed", "success"),
+        ]
+    )
+    sleeps: list[float] = []
+    clock = iter([0.0, 1.0, 2.0])
+
+    result = wait_until(
+        fetch=lambda: next(polls),
+        sleep=sleeps.append,
+        monotonic=lambda: next(clock),
+        timeout_seconds=30,
+        poll_seconds=5,
+        log=lambda _message: None,
+    )
+
+    assert result.job_conclusion == "success"
+    assert sleeps == [5]
+
+
+def test_wait_refuses_cancelled_or_failed_ci_gate() -> None:
+    with pytest.raises(CiGateNotSuccessful, match="cancelled"):
+        wait_until(
+            fetch=lambda: GateObservation(1, "completed", "cancelled"),
+            sleep=lambda _seconds: None,
+            monotonic=lambda: 0.0,
+            timeout_seconds=30,
+            poll_seconds=5,
+            log=lambda _message: None,
+        )
+
+
+def test_wait_times_out_when_ci_gate_never_appears() -> None:
+    clock = iter([0.0, 30.0])
+
+    with pytest.raises(CiGateWaitTimeout):
+        wait_until(
+            fetch=lambda: GateObservation(None, None, None),
+            sleep=lambda _seconds: None,
+            monotonic=lambda: next(clock),
+            timeout_seconds=30,
+            poll_seconds=5,
+            log=lambda _message: None,
+        )
+
+
+def test_wait_retries_transient_api_errors_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    def fetch() -> GateObservation:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TransientApiError("HTTP 502")
+        return GateObservation(3, "completed", "success")
+
+    result = wait_until(
+        fetch=fetch,
+        sleep=lambda _seconds: None,
+        monotonic=lambda: 0.0,
+        timeout_seconds=30,
+        poll_seconds=5,
+        log=lambda _message: None,
+    )
+
+    assert result.run_id == 3

--- a/tests/tools/selection/test_live_llm_gate.py
+++ b/tests/tools/selection/test_live_llm_gate.py
@@ -1,0 +1,11 @@
+"""Keep the live selection suite gated, and this shard collectable on fork PRs."""
+
+from __future__ import annotations
+
+from tests.tools.selection import test_tool_selection as selection_tests
+
+
+def test_tool_selection_suite_is_marked_live_llm() -> None:
+    """Fork CI skips ``live_llm``; this unmarked pin keeps the shard from collecting 0 tests."""
+    names = {mark.name for mark in selection_tests.pytestmark}
+    assert "live_llm" in names


### PR DESCRIPTION
Fixes #5965

#### Describe the changes you have made in this PR -

Rolling `main-build` publication is no longer independent of CI. `publish-main-release` now waits for the `CI Gate` job in `.github/workflows/ci.yml` to succeed on the **same SHA** before it can move the `main-build` tag or replace installer assets.

- Added a `wait-for-ci-gate` job on the `main` channel only. It polls `ci.yml` for this commit and requires the `CI Gate` job conclusion to be `success`.
- `publish-main-release` now also needs `wait-for-ci-gate` and runs only when that job succeeds. Failed, cancelled, skipped, or timed-out CI does not publish.
- Binary builds still run in parallel with the wait. Only publication is gated.
- Manual and scheduled stable (`release` channel) publishes are unchanged: they still go through `verify` → `build-python-dist` / `build-binaries` → `publish-release`.
- Contract tests live under `tests/github_ci/` for the workflow wiring and the wait script’s success / fail / cancel / timeout / retry behavior.

This closes the failure mode in #5965, where commits such as `4b20a0d` and `cd03ccb` published rolling artifacts while their CI Gate runs had already failed.

### Demo/Screenshot for feature changes and bug fixes -

Local contract suite (34 passed):

```
uv run python -m pytest -q tests/github_ci/
============================= 34 passed in 16.92s =============================
```

Focused coverage for this change:

```
uv run python -m pytest -q tests/github_ci/test_wait_for_ci_gate.py tests/github_ci/test_release_workflow.py tests/packaging/test_release_manifest.py
============================= 26 passed in 8.00s ==============================
```

Pinned contracts:

- `publish-main-release` requires `needs.wait-for-ci-gate.result == 'success'` for `${{ github.sha }}`
- cancelled / failed / skipped CI Gate refuses publication and does not move `main-build`
- `schedule` and `workflow_dispatch` stable releases do not depend on `wait-for-ci-gate`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a race between two workflows on `push` to `main`. `release.yml` built binaries and published `main-build` without checking whether `ci.yml`’s required `CI Gate` job had passed for that commit. Broken SHAs could replace the public rolling installer.

I considered `workflow_run` (Release starts only after CI finishes), a marketplace wait action, and putting publish behind `needs` inside `ci.yml`. `workflow_run` would serialize the whole release behind CI and still needs extra SHA matching. Merging into `ci.yml` would couple a long binary matrix to the PR gate. A third-party wait action adds an extra supply-chain pin.

I kept Release as a separate workflow and added a same-SHA poll so binaries can still build while CI runs, but publication cannot proceed unless CI Gate succeeded:

- `wait-for-ci-gate` runs only when `prepare` resolves the `main` channel.
- `.github/scripts/wait_for_ci_gate.py` lists push-event `ci.yml` runs for `WAIT_SHA`, reads the `CI Gate` job, and returns success / wait / refuse. Transient GitHub API errors retry; failure, cancelled, skipped, timeout, or a completed run with no CI Gate job fail closed.
- `publish-main-release` uses `always()` so a failed wait does not skip the job by accident, then requires `channel == main`, successful binaries, **and** a successful wait. Tag move and asset upload therefore never run on a red SHA.
- Stable releases never take this job, so `workflow_dispatch` / cron `release` publishes stay available.

Key pieces:

- `verdict` / `observe_ci_gate` / `wait_for_ci_gate` — poll and classify the same-SHA CI Gate result
- `wait-for-ci-gate` job — Release-side gate that does not block binary builds
- `tests/github_ci/test_release_workflow.py` — YAML contract: publish needs a successful wait; stable path is independent
- `tests/github_ci/test_wait_for_ci_gate.py` — success after in-progress polls, refuse on cancelled/failed, timeout, newest-run selection, missing job fail-closed, transient API retry

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.