### PR TITLE
test(sandbox): cover Windows SystemRoot forwarding

### DIFF
--- a/tests/sandbox/test_runner.py
+++ b/tests/sandbox/test_runner.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from config.constants import OPENSRE_TMP_DIR, ensure_opensre_tmp_dir
+from infrastructure.safety.sandbox import runner as sandbox_runner
 from infrastructure.safety.sandbox.runner import (
     MAX_TIMEOUT,
     SandboxResult,
@@ -248,6 +249,31 @@ class TestSandboxRunnerInputInjection:
         result = run_python_sandbox("x = 1", inputs=None)
         assert result.success
         assert result.inputs == {}
+
+
+class TestSandboxRunnerEnvironment:
+    def test_systemroot_is_forwarded_to_subprocess_environment(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+        captured_env: dict[str, str] = {}
+
+        def fake_run(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            captured_env.update(kwargs["env"])
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        monkeypatch.setattr(sandbox_runner.subprocess, "run", fake_run)
+
+        result = run_python_sandbox("pass")
+
+        assert result.success
+        assert captured_env["SYSTEMROOT"] == r"C:\Windows"
 
 
 class TestSandboxNetworkRestrictions:


### PR DESCRIPTION
Fixes #4937

#### Describe the changes you have made in this PR -

- Add a focused regression test for the Windows sandbox subprocess environment.
- Verify that `SYSTEMROOT` reaches the actual `subprocess.run(..., env=...)` call used by `run_python_sandbox`.
- Keep production behavior unchanged because current `main` already contains the allowlist fix from #5850.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run pytest tests/sandbox/test_runner.py tests/tools/test_python_execution_tool.py::TestPythonExecutionToolRestrictions::test_network_access_can_be_enabled tests/tools/test_python_execution_runtime_inputs.py::test_socket_reachability_check_works_with_allow_network
============================= 30 passed in 28.04s =============================

uv run python -m ruff check bootstrap config core gateway integrations infrastructure surfaces tools tests
All checks passed!

uv run python -m ruff format --check bootstrap config core gateway integrations infrastructure surfaces tools tests
3105 files already formatted

uv run mypy bootstrap config core gateway integrations infrastructure surfaces tools
Success: no issues found in 1800 source files

uv run python -m build
Successfully built opensre-0.1.tar.gz and opensre-0.1-py3-none-any.whl
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The Windows failure was caused by the sandbox's narrow environment omitting the Windows root variable. Current `main` already forwards `SYSTEMROOT`, so this PR avoids duplicating production code and instead protects that contract. The test sets a deterministic Windows-style value, replaces only the runner's subprocess boundary, executes `run_python_sandbox`, and asserts that the exact environment supplied to the child contains the value. This remains platform-independent while directly covering the regression point.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions