### PR TITLE
fix(ci): skip live-only shard for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,7 +565,14 @@ jobs:
           esac
 
       - name: Run tests
-        if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
+        # Fork PRs cannot access live LLM credentials. Their marker excludes
+        # every test in cli-live-agent, so skip that live-only matrix entry
+        # instead of invoking pytest with an empty collection (exit code 5).
+        if: >-
+          (steps.changes.outputs.source == 'true' || github.event_name == 'push') &&
+          (matrix.shard != 'cli-live-agent' ||
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.fork == false)
         env:
           COVERAGE_FILE: .coverage.${{ matrix.shard }}
           # PRs do not consume coverage artifacts. Avoid instrumenting every

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -101,6 +101,18 @@ def test_heavy_test_suites_are_duration_balanced_with_measured_headroom() -> Non
     assert "github.event_name == 'push'" in run_step["env"]["PYTEST_COVERAGE_ARGS"]
 
 
+def test_fork_pull_requests_skip_only_the_live_agent_shard() -> None:
+    test_job = _workflow("ci.yml")["jobs"]["test"]
+    run_step = next(step for step in test_job["steps"] if step.get("name") == "Run tests")
+    condition = " ".join(run_step["if"].split())
+
+    assert condition == (
+        "(steps.changes.outputs.source == 'true' || github.event_name == 'push') && "
+        "(matrix.shard != 'cli-live-agent' || github.event_name != 'pull_request' || "
+        "github.event.pull_request.head.repo.fork == false)"
+    )
+
+
 def test_quality_jobs_start_in_parallel_and_gate_aggregates_them() -> None:
     workflow = _workflow("ci.yml")
     jobs = workflow["jobs"]


### PR DESCRIPTION
Fixes #5994

#### Describe the changes you have made in this PR -

- Skip the credentialed `cli-live-agent` test step only for fork pull requests, where repository secrets are unavailable.
- Preserve the live shard for internal pull requests and pushes to `main`.
- Extend the existing CI workflow contract test to lock the fork guard in place.

### Demo/Screenshot for feature changes and bug fixes -

```text
Before (#5991 fork PR):
PYTEST_MARKER_EXPR=not live_llm
2 workers [0 items]
no tests ran
Process completed with exit code 5

After (local workflow-contract verification):
uv run pytest -q tests/github_ci/test_pr_pipeline_slo.py tests/github_ci/test_empty_collection_guard.py
9 passed in 5.07s

uv run python -m ruff check tests/github_ci/test_pr_pipeline_slo.py
All checks passed!

uv run python -m ruff format --check tests/github_ci/test_pr_pipeline_slo.py
1 file already formatted
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Fork pull requests intentionally set `PYTEST_MARKER_EXPR` to `not live_llm` because they cannot receive repository LLM credentials. The `cli-live-agent` matrix entry contains only file-level `live_llm` tests, so running that entry on a fork deterministically produces an empty collection and pytest exit code 5. The step condition now skips only that combination. The other fork shards still run, while internal PRs and main pushes keep the credentialed live gate. The existing workflow test reads the YAML and asserts both parts of this condition.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions