### PR TITLE
perf(ci): pre-partition pytest shards and refresh timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
         run: uv sync --frozen --extra dev
 
+      - name: Report pytest timing snapshot health
+        if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
+        run: |
+          uv run python -m tests.ci_sharding report --label=tools-runtime tests/tools tests/core tests/infrastructure tests/filestorage tests/utils tests/masking tests/watch_dog --ignore=tests/core/agent --ignore=tests/core/tool/test_contracts.py --ignore=tests/tools/test_registry_index.py --ignore=tests/tools/selection
+          uv run python -m tests.ci_sharding report --label=cli-runtime tests/cli tests/interactive_shell tests/surfaces tests/core/agent tests/fleet_monitoring tests/analytics tests/sandbox --ignore=tests/cli/test_smoke.py
+          uv run python -m tests.ci_sharding report --label=integrations-and-misc tests/integrations tests/bootstrap tests/benchmarks tests/shared tests/config tests/github_ci tests/quality tests/packaging tests/scheduler gateway/tests
+
       - name: Lint
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
         run: uv run python -m ruff check $PYTHON_SOURCE_PATHS tests/
@@ -149,9 +156,8 @@ jobs:
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
               --ignore=tests/tools/selection
-            split_args: >-
-              --ci-splits=6 --ci-group=1
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=1
             pytest_paths: >-
               tests/tools
               tests/core
@@ -167,9 +173,8 @@ jobs:
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
               --ignore=tests/tools/selection
-            split_args: >-
-              --ci-splits=6 --ci-group=2
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=2
             pytest_paths: >-
               tests/tools
               tests/core
@@ -185,9 +190,8 @@ jobs:
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
               --ignore=tests/tools/selection
-            split_args: >-
-              --ci-splits=6 --ci-group=3
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=3
             pytest_paths: >-
               tests/tools
               tests/core
@@ -203,9 +207,8 @@ jobs:
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
               --ignore=tests/tools/selection
-            split_args: >-
-              --ci-splits=6 --ci-group=4
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=4
             pytest_paths: >-
               tests/tools
               tests/core
@@ -221,9 +224,8 @@ jobs:
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
               --ignore=tests/tools/selection
-            split_args: >-
-              --ci-splits=6 --ci-group=5
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=5
             pytest_paths: >-
               tests/tools
               tests/core
@@ -239,9 +241,8 @@ jobs:
               --ignore=tests/core/tool/test_contracts.py
               --ignore=tests/tools/test_registry_index.py
               --ignore=tests/tools/selection
-            split_args: >-
-              --ci-splits=6 --ci-group=6
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=6
             pytest_paths: >-
               tests/tools
               tests/core
@@ -264,9 +265,8 @@ jobs:
             llm_provider: openai
             extra_pytest_args: >-
               --ignore=tests/cli/test_smoke.py
-            split_args: >-
-              --ci-splits=6 --ci-group=1
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=1
             pytest_paths: >-
               tests/cli
               tests/interactive_shell
@@ -280,9 +280,8 @@ jobs:
             llm_provider: openai
             extra_pytest_args: >-
               --ignore=tests/cli/test_smoke.py
-            split_args: >-
-              --ci-splits=6 --ci-group=2
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=2
             pytest_paths: >-
               tests/cli
               tests/interactive_shell
@@ -296,9 +295,8 @@ jobs:
             llm_provider: openai
             extra_pytest_args: >-
               --ignore=tests/cli/test_smoke.py
-            split_args: >-
-              --ci-splits=6 --ci-group=3
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=3
             pytest_paths: >-
               tests/cli
               tests/interactive_shell
@@ -312,9 +310,8 @@ jobs:
             llm_provider: openai
             extra_pytest_args: >-
               --ignore=tests/cli/test_smoke.py
-            split_args: >-
-              --ci-splits=6 --ci-group=4
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=4
             pytest_paths: >-
               tests/cli
               tests/interactive_shell
@@ -328,9 +325,8 @@ jobs:
             llm_provider: openai
             extra_pytest_args: >-
               --ignore=tests/cli/test_smoke.py
-            split_args: >-
-              --ci-splits=6 --ci-group=5
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=5
             pytest_paths: >-
               tests/cli
               tests/interactive_shell
@@ -344,9 +340,8 @@ jobs:
             llm_provider: openai
             extra_pytest_args: >-
               --ignore=tests/cli/test_smoke.py
-            split_args: >-
-              --ci-splits=6 --ci-group=6
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=6
             pytest_paths: >-
               tests/cli
               tests/interactive_shell
@@ -389,9 +384,8 @@ jobs:
               test_onboard_interactive_smoke_cli_provider))'
           - os: ubuntu-latest
             shard: integrations-and-misc-1
-            split_args: >-
-              --ci-splits=6 --ci-group=1
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=1
             pytest_paths: >-
               tests/integrations
               tests/bootstrap
@@ -405,9 +399,8 @@ jobs:
               gateway/tests
           - os: ubuntu-latest
             shard: integrations-and-misc-2
-            split_args: >-
-              --ci-splits=6 --ci-group=2
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=2
             pytest_paths: >-
               tests/integrations
               tests/bootstrap
@@ -421,9 +414,8 @@ jobs:
               gateway/tests
           - os: ubuntu-latest
             shard: integrations-and-misc-3
-            split_args: >-
-              --ci-splits=6 --ci-group=3
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=3
             pytest_paths: >-
               tests/integrations
               tests/bootstrap
@@ -437,9 +429,8 @@ jobs:
               gateway/tests
           - os: ubuntu-latest
             shard: integrations-and-misc-4
-            split_args: >-
-              --ci-splits=6 --ci-group=4
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=4
             pytest_paths: >-
               tests/integrations
               tests/bootstrap
@@ -453,9 +444,8 @@ jobs:
               gateway/tests
           - os: ubuntu-latest
             shard: integrations-and-misc-5
-            split_args: >-
-              --ci-splits=6 --ci-group=5
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=5
             pytest_paths: >-
               tests/integrations
               tests/bootstrap
@@ -469,9 +459,8 @@ jobs:
               gateway/tests
           - os: ubuntu-latest
             shard: integrations-and-misc-6
-            split_args: >-
-              --ci-splits=6 --ci-group=6
-              --ci-durations-path=.github/ci/pytest-file-durations.json
+            shard_args: >-
+              --splits=6 --group=6
             pytest_paths: >-
               tests/integrations
               tests/bootstrap
@@ -558,6 +547,19 @@ jobs:
               ;;
           esac
 
+      - name: Pre-partition pytest files
+        id: shard
+        if: >-
+          (steps.changes.outputs.source == 'true' || github.event_name == 'push') &&
+          matrix.shard_args
+        run: >
+          uv run python -m tests.ci_sharding select
+          --output=.pytest-shard-files
+          ${{ matrix.shard_args }}
+          ${{ matrix.pytest_paths }}
+          ${{ matrix.extra_pytest_args }}
+          && echo "pytest_paths=$(tr '\n' ' ' < .pytest-shard-files)" >> "$GITHUB_OUTPUT"
+
       - name: Run tests
         if: >-
           (steps.changes.outputs.source == 'true' || github.event_name == 'push') &&
@@ -579,10 +581,10 @@ jobs:
         # ``N workers [0 items]`` even when the marker is correct.
         run: >
           uv run python -m pytest -p tests.ci_sharding -n auto -v
-          ${{ matrix.pytest_paths }}
+          ${{ steps.shard.outputs.pytest_paths || matrix.pytest_paths }}
           ${PYTEST_COVERAGE_ARGS}
           ${{ matrix.extra_pytest_args }}
-          ${{ matrix.split_args }}
+          --ci-durations-output=.pytest-file-durations-${{ matrix.shard }}.json
           -m "${PYTEST_MARKER_EXPR}"
 
       - name: Upload shard coverage data
@@ -595,6 +597,19 @@ jobs:
           name: coverage-data-${{ matrix.shard }}
           path: .coverage.${{ matrix.shard }}*
           if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 7
+
+      - name: Upload shard timing data
+        if: >-
+          always() &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-timings-${{ matrix.shard }}
+          path: .pytest-file-durations-${{ matrix.shard }}.json
+          if-no-files-found: warn
           include-hidden-files: true
           retention-days: 7
 
@@ -638,10 +653,23 @@ jobs:
           path: ./
           merge-multiple: true
 
+      - name: Download shard timing artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pytest-timings-*
+          path: .pytest-timings
+          merge-multiple: true
+
       - name: Combine coverage and build report
         run: |
           uv run python -m coverage combine .
           uv run python -m coverage html
+
+      - name: Merge pytest timing snapshot
+        run: >-
+          uv run python -m tests.ci_sharding merge
+          --output=.pytest-timings/pytest-file-durations.json
+          .pytest-timings/.pytest-file-durations-*.json
 
       - name: Upload combined coverage
         uses: actions/upload-artifact@v4
@@ -650,6 +678,13 @@ jobs:
           path: |
             htmlcov/
             .coverage
+          retention-days: 7
+
+      - name: Upload reviewable pytest timing snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-file-durations-snapshot
+          path: .pytest-timings/pytest-file-durations.json
           retention-days: 7
 
   session-store-locked:

--- a/tests/ci_sharding.py
+++ b/tests/ci_sharding.py
@@ -1,15 +1,25 @@
-"""Duration-balanced file sharding used by the pull-request test matrix."""
+"""Pre-collection CI sharding and per-file timing snapshots."""
 
 from __future__ import annotations
 
+import argparse
 import json
+import subprocess
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+DEFAULT_TIMINGS_PATH = Path(".github/ci/pytest-file-durations.json")
+DEFAULT_MAX_SNAPSHOT_AGE_DAYS = 14.0
+DEFAULT_MAX_MISSING_PERCENT = 5.0
+_TEST_FILE_PATTERNS = ("test_*.py", "*_test.py")
+_duration_seconds: defaultdict[str, float] = defaultdict(float)
+_duration_nodeids: defaultdict[str, set[str]] = defaultdict(set)
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,7 +31,7 @@ class FileTiming:
 
 
 def assign_file_groups(
-    file_test_counts: Mapping[str, int],
+    file_paths: Collection[str],
     timings: Mapping[str, FileTiming],
     splits: int,
 ) -> dict[str, int]:
@@ -29,18 +39,13 @@ def assign_file_groups(
     if splits < 1:
         raise ValueError("splits must be at least one")
 
-    recorded_tests = sum(timing.tests for timing in timings.values())
-    recorded_seconds = sum(timing.seconds for timing in timings.values())
-    default_test_seconds = recorded_seconds / recorded_tests if recorded_tests else 1.0
-
-    estimates: dict[str, float] = {}
-    for path, test_count in file_test_counts.items():
-        timing = timings.get(path)
-        if timing is None:
-            estimates[path] = test_count * default_test_seconds
-            continue
-        new_tests = max(0, test_count - timing.tests)
-        estimates[path] = timing.seconds + new_tests * default_test_seconds
+    recorded_seconds = [timings[path].seconds for path in file_paths if path in timings]
+    default_file_seconds = (
+        sum(recorded_seconds) / len(recorded_seconds) if recorded_seconds else 1.0
+    )
+    estimates = {
+        path: timings.get(path, FileTiming(default_file_seconds, 0)).seconds for path in file_paths
+    }
 
     totals = [0.0] * splits
     assignments: dict[str, int] = {}
@@ -51,70 +56,211 @@ def assign_file_groups(
     return assignments
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    """Register CI-only sharding options."""
-    group = parser.getgroup("OpenSRE CI sharding")
-    group.addoption("--ci-splits", type=int)
-    group.addoption("--ci-group", type=int)
-    group.addoption("--ci-durations-path", type=Path)
+def discover_test_files(roots: Sequence[Path], ignored: Sequence[Path] = ()) -> list[str]:
+    """Return test files below existing roots without importing or collecting them."""
+    repository_root = Path.cwd().resolve()
+    ignored_paths = [_repository_path(path, repository_root) for path in ignored]
+    files: set[str] = set()
+
+    for root in roots:
+        absolute_root = _repository_path(root, repository_root)
+        if not absolute_root.exists():
+            raise FileNotFoundError(f"pytest path does not exist: {root}")
+        candidates = [absolute_root] if absolute_root.is_file() else absolute_root.rglob("*.py")
+        for candidate in candidates:
+            if any(candidate == item or item in candidate.parents for item in ignored_paths):
+                continue
+            if any(candidate.match(pattern) for pattern in _TEST_FILE_PATTERNS):
+                files.add(candidate.relative_to(repository_root).as_posix())
+
+    return sorted(files)
 
 
-def pytest_collection_modifyitems(
-    config: pytest.Config,
-    items: list[pytest.Item],
-) -> None:
-    """Select the duration-balanced file group requested by CI."""
-    splits = config.getoption("--ci-splits")
-    selected_group = config.getoption("--ci-group")
-    durations_path = config.getoption("--ci-durations-path")
-    if splits is None and selected_group is None and durations_path is None:
-        return
-    if not isinstance(splits, int) or splits < 1:
-        raise pytest.UsageError("--ci-splits must be at least one")
-    if not isinstance(selected_group, int) or not 1 <= selected_group <= splits:
-        raise pytest.UsageError("--ci-group must be between one and --ci-splits")
-    if not isinstance(durations_path, Path):
-        raise pytest.UsageError("--ci-durations-path is required with CI sharding")
+def merge_timing_files(
+    base: Mapping[str, FileTiming], paths: Sequence[Path]
+) -> dict[str, FileTiming]:
+    """Merge shard timing files, summing files split by test expression."""
+    fresh_seconds: defaultdict[str, float] = defaultdict(float)
+    fresh_tests: defaultdict[str, int] = defaultdict(int)
+    for path in sorted(paths):
+        for file_path, timing in _load_timings(path).items():
+            fresh_seconds[file_path] += timing.seconds
+            fresh_tests[file_path] += timing.tests
 
-    file_items: dict[str, list[pytest.Item]] = defaultdict(list)
-    root = Path(config.rootpath).resolve()
-    for item in items:
-        try:
-            path = Path(item.path).resolve().relative_to(root).as_posix()
-        except ValueError:
-            path = item.nodeid.split("::", maxsplit=1)[0]
-        file_items[path].append(item)
-
-    timings = _load_timings(durations_path)
-    assignments = assign_file_groups(
-        {path: len(grouped) for path, grouped in file_items.items()},
-        timings,
-        splits,
+    merged = dict(base)
+    merged.update(
+        {
+            path: FileTiming(seconds=seconds, tests=fresh_tests[path])
+            for path, seconds in fresh_seconds.items()
+        }
     )
-    selected = [
-        item
-        for path, grouped in file_items.items()
-        if assignments[path] == selected_group
-        for item in grouped
-    ]
-    selected_items = set(selected)
-    deselected = [item for item in items if item not in selected_items]
-    items[:] = selected
-    config.hook.pytest_deselected(items=deselected)
+    return merged
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the CI timing output option."""
+    group = parser.getgroup("OpenSRE CI sharding")
+    group.addoption("--ci-durations-output", type=Path)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Reset timing state for this pytest process."""
+    _duration_seconds.clear()
+    _duration_nodeids.clear()
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Aggregate every test phase by repository-relative file."""
+    file_path = report.nodeid.split("::", maxsplit=1)[0]
+    _duration_seconds[file_path] += report.duration
+    _duration_nodeids[file_path].add(report.nodeid)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Write one timing fragment from the xdist controller."""
+    del exitstatus
+    config = session.config
+    output = config.getoption("--ci-durations-output")
+    if not isinstance(output, Path) or hasattr(config, "workerinput"):
+        return
+    timings = {
+        path: FileTiming(seconds=_duration_seconds[path], tests=len(nodeids))
+        for path, nodeids in _duration_nodeids.items()
+    }
+    _write_timings(output, timings)
+
+
+def _repository_path(path: Path, repository_root: Path) -> Path:
+    absolute = path.resolve() if path.is_absolute() else repository_root.joinpath(path).resolve()
+    try:
+        absolute.relative_to(repository_root)
+    except ValueError as exc:
+        raise ValueError(f"path is outside the repository: {path}") from exc
+    return absolute
 
 
 def _load_timings(path: Path) -> dict[str, FileTiming]:
-    """Load the checked-in aggregate timing snapshot."""
+    """Load a timing snapshot or shard fragment."""
     raw: Any = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
-        raise pytest.UsageError(f"CI durations file must be an object: {path}")
+        raise ValueError(f"CI durations file must be an object: {path}")
     timings: dict[str, FileTiming] = {}
     for file_path, value in raw.items():
         if not isinstance(file_path, str) or not isinstance(value, dict):
-            raise pytest.UsageError(f"Invalid CI duration entry in {path}")
+            raise ValueError(f"Invalid CI duration entry in {path}")
         seconds = value.get("seconds")
         tests = value.get("tests")
-        if not isinstance(seconds, int | float) or not isinstance(tests, int):
-            raise pytest.UsageError(f"Invalid CI duration entry for {file_path}")
+        if (
+            not isinstance(seconds, int | float)
+            or isinstance(seconds, bool)
+            or seconds < 0
+            or not isinstance(tests, int)
+            or isinstance(tests, bool)
+            or tests < 0
+        ):
+            raise ValueError(f"Invalid CI duration entry for {file_path}")
         timings[file_path] = FileTiming(seconds=float(seconds), tests=tests)
     return timings
+
+
+def _write_timings(path: Path, timings: Mapping[str, FileTiming]) -> None:
+    payload = {
+        file_path: {"seconds": round(timing.seconds, 3), "tests": timing.tests}
+        for file_path, timing in sorted(timings.items())
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _snapshot_age_days(path: Path) -> float | None:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%ct", "--", path.as_posix()],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    timestamp = result.stdout.strip()
+    if result.returncode != 0 or not timestamp.isdigit():
+        return None
+    updated = datetime.fromtimestamp(int(timestamp), tz=UTC)
+    return (datetime.now(tz=UTC) - updated).total_seconds() / 86_400
+
+
+def _select(args: argparse.Namespace) -> int:
+    files = discover_test_files(args.paths, args.ignore)
+    assignments = assign_file_groups(files, _load_timings(args.timings), args.splits)
+    if not 1 <= args.group <= args.splits:
+        raise ValueError("group must be between one and splits")
+    selected = [path for path in files if assignments[path] == args.group]
+    if not selected:
+        raise ValueError(f"CI shard {args.group}/{args.splits} selected no test files")
+    args.output.write_text("\n".join(selected) + "\n", encoding="utf-8")
+    print(f"selected {len(selected)}/{len(files)} files for shard {args.group}/{args.splits}")
+    return 0
+
+
+def _report(args: argparse.Namespace) -> int:
+    files = discover_test_files(args.paths, args.ignore)
+    timings = _load_timings(args.timings)
+    missing = sorted(set(files) - timings.keys())
+    missing_percent = (100.0 * len(missing) / len(files)) if files else 0.0
+    age_days = _snapshot_age_days(args.timings)
+    age = "unknown" if age_days is None else f"{age_days:.1f} days"
+    summary = (
+        f"{args.label}: age {age} (limit {args.max_age_days:g}); "
+        f"missing {len(missing)}/{len(files)} files "
+        f"({missing_percent:.1f}%, limit {args.max_missing_percent:g}%)"
+    )
+    print(summary)
+    if age_days is None or age_days > args.max_age_days:
+        print(f"::warning title=Stale pytest timing snapshot::{summary}")
+    if missing_percent > args.max_missing_percent:
+        print(f"::warning title=Incomplete pytest timing snapshot::{summary}")
+    return 0
+
+
+def _merge(args: argparse.Namespace) -> int:
+    _write_timings(args.output, merge_timing_files(_load_timings(args.base), args.fragments))
+    print(f"wrote merged timing snapshot to {args.output}")
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    select = commands.add_parser("select", help="write the file list for one shard")
+    select.add_argument("paths", nargs="+", type=Path)
+    select.add_argument("--ignore", action="append", default=[], type=Path)
+    select.add_argument("--splits", required=True, type=int)
+    select.add_argument("--group", required=True, type=int)
+    select.add_argument("--timings", default=DEFAULT_TIMINGS_PATH, type=Path)
+    select.add_argument("--output", required=True, type=Path)
+    select.set_defaults(handler=_select)
+
+    report = commands.add_parser("report", help="report snapshot freshness and coverage")
+    report.add_argument("paths", nargs="+", type=Path)
+    report.add_argument("--ignore", action="append", default=[], type=Path)
+    report.add_argument("--timings", default=DEFAULT_TIMINGS_PATH, type=Path)
+    report.add_argument("--label", required=True)
+    report.add_argument("--max-age-days", default=DEFAULT_MAX_SNAPSHOT_AGE_DAYS, type=float)
+    report.add_argument("--max-missing-percent", default=DEFAULT_MAX_MISSING_PERCENT, type=float)
+    report.set_defaults(handler=_report)
+
+    merge = commands.add_parser("merge", help="merge timing fragments into a snapshot")
+    merge.add_argument("fragments", nargs="+", type=Path)
+    merge.add_argument("--base", default=DEFAULT_TIMINGS_PATH, type=Path)
+    merge.add_argument("--output", required=True, type=Path)
+    merge.set_defaults(handler=_merge)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CI sharding utility."""
+    args = _parser().parse_args(argv)
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/filestorage/test_service_and_registry.py
+++ b/tests/filestorage/test_service_and_registry.py
@@ -73,6 +73,11 @@ def _restore_registry() -> Iterator[None]:
     from infrastructure.filestorage.providers import registry as reg
 
     with reg._REGISTRY_LOCK:
+        # Import every built-in before snapshotting. Restoring an empty
+        # registry after a lazy import leaves the module cached but its
+        # import-time registration missing for later tests.
+        for provider in reg._BUILTIN_MODULES:
+            reg._load_builtin(provider)
         snap = dict(reg._REGISTRY)
         # Restored alongside the factories: a declared upload cap outliving its
         # registration would silently re-tune a later test's push.

--- a/tests/github_ci/test_ci_sharding.py
+++ b/tests/github_ci/test_ci_sharding.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from pathlib import Path
 
-from tests.ci_sharding import FileTiming, assign_file_groups
+import pytest
+
+from tests.ci_sharding import (
+    FileTiming,
+    assign_file_groups,
+    discover_test_files,
+    merge_timing_files,
+)
 
 
 def test_slow_files_are_balanced_across_groups() -> None:
@@ -24,10 +32,69 @@ def test_slow_files_are_balanced_across_groups() -> None:
     assert max(totals.values()) - min(totals.values()) <= 1.0
 
 
-def test_new_files_use_the_recorded_per_test_average() -> None:
-    counts = {"tests/known.py": 2, "tests/new.py": 4}
-    timings = {"tests/known.py": FileTiming(seconds=2.0, tests=2)}
+def test_new_files_use_the_recorded_per_file_average() -> None:
+    files = {"tests/slow.py", "tests/fast.py", "tests/new.py"}
+    timings = {
+        "tests/slow.py": FileTiming(seconds=8.0, tests=2),
+        "tests/fast.py": FileTiming(seconds=2.0, tests=20),
+    }
 
-    assignments = assign_file_groups(counts, timings, splits=2)
+    assignments = assign_file_groups(files, timings, splits=2)
 
-    assert assignments == {"tests/new.py": 1, "tests/known.py": 2}
+    assert assignments == {
+        "tests/slow.py": 1,
+        "tests/new.py": 2,
+        "tests/fast.py": 2,
+    }
+
+
+def test_precollection_discovery_assigns_every_eligible_file_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tests = tmp_path / "tests"
+    ignored = tests / "ignored"
+    ignored.mkdir(parents=True)
+    (tests / "test_one.py").touch()
+    (tests / "helper.py").touch()
+    (ignored / "two_test.py").touch()
+    (ignored / "test_three.py").touch()
+    monkeypatch.chdir(tmp_path)
+
+    files = discover_test_files([Path("tests")], [Path("tests/ignored/two_test.py")])
+    assignments = assign_file_groups(files, {}, splits=2)
+
+    assert files == ["tests/ignored/test_three.py", "tests/test_one.py"]
+    assert set(assignments) == set(files)
+    assert sorted(assignments.values()) == [1, 2]
+
+
+def test_precollection_discovery_rejects_missing_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="pytest path does not exist"):
+        discover_test_files([Path("tests/missing")])
+
+
+def test_merge_sums_split_file_fragments_and_retains_unobserved_base(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first.json"
+    first.write_text(
+        '{"tests/test_split.py": {"seconds": 1.25, "tests": 2}}',
+        encoding="utf-8",
+    )
+    second = tmp_path / "second.json"
+    second.write_text(
+        '{"tests/test_split.py": {"seconds": 2.75, "tests": 3}}',
+        encoding="utf-8",
+    )
+    base = {"tests/test_skipped.py": FileTiming(seconds=4.0, tests=1)}
+
+    merged = merge_timing_files(base, [second, first])
+
+    assert merged == {
+        "tests/test_skipped.py": FileTiming(seconds=4.0, tests=1),
+        "tests/test_split.py": FileTiming(seconds=4.0, tests=5),
+    }

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -67,7 +67,7 @@ def test_heavy_test_suites_are_duration_balanced_with_measured_headroom() -> Non
         assert [entry["shard"] for entry in groups] == [
             f"{base}-{group}" for group in range(1, splits + 1)
         ]
-        assert all(f"--ci-splits={splits}" in entry["split_args"] for entry in groups)
+        assert all(f"--splits={splits}" in entry["shard_args"] for entry in groups)
 
     live_agent = next(entry for entry in entries if entry["shard"] == "cli-live-agent")
     assert live_agent["llm_provider"] == "openai"
@@ -97,8 +97,39 @@ def test_heavy_test_suites_are_duration_balanced_with_measured_headroom() -> Non
 
     run_step = next(step for step in test_job["steps"] if step.get("name") == "Run tests")
     assert "-p tests.ci_sharding" in run_step["run"]
+    assert "steps.shard.outputs.pytest_paths || matrix.pytest_paths" in run_step["run"]
+    assert "--ci-durations-output=" in run_step["run"]
     assert "--cov=config" not in run_step["run"]
     assert "github.event_name == 'push'" in run_step["env"]["PYTEST_COVERAGE_ARGS"]
+
+    prepartition = next(
+        step for step in test_job["steps"] if step.get("name") == "Pre-partition pytest files"
+    )
+    assert "tests.ci_sharding select" in prepartition["run"]
+    assert "matrix.shard_args" in prepartition["if"]
+    assert "matrix.pytest_paths" in prepartition["run"]
+
+
+def test_main_builds_a_reviewable_timing_snapshot_artifact() -> None:
+    jobs = _workflow("ci.yml")["jobs"]
+    test_steps = jobs["test"]["steps"]
+    timing_upload = next(
+        step for step in test_steps if step.get("name") == "Upload shard timing data"
+    )
+    assert "github.event_name == 'push'" in timing_upload["if"]
+    assert timing_upload["with"]["name"] == "pytest-timings-${{ matrix.shard }}"
+
+    coverage_steps = jobs["coverage-report"]["steps"]
+    merge = next(
+        step for step in coverage_steps if step.get("name") == "Merge pytest timing snapshot"
+    )
+    assert "tests.ci_sharding merge" in merge["run"]
+    snapshot = next(
+        step
+        for step in coverage_steps
+        if step.get("name") == "Upload reviewable pytest timing snapshot"
+    )
+    assert snapshot["with"]["path"] == ".pytest-timings/pytest-file-durations.json"
 
 
 def test_quality_jobs_start_in_parallel_and_gate_aggregates_them() -> None:


### PR DESCRIPTION
Fixes #5967

#### Describe the changes you have made in this PR -

- Pre-compute duration-balanced pytest file lists before collection for all 18 split matrix legs.
- Keep missing-path and zero-selection failures explicit while assigning every discovered file to exactly one group.
- Record per-file timings from xdist reports and merge main-branch shard fragments deterministically.
- Upload the merged snapshot as a reviewable artifact; CI retains read-only repository permissions and never commits it.
- Report snapshot age against a 14-day threshold and missing-file coverage against a 5% threshold.
- Harden the file-storage registry fixture exposed by the new shard ordering so cached built-in modules retain their import-time registrations.

### Demo/Screenshot for feature changes and bug fixes -

Local pre-collection proof:

```text
tools 439 Counter({4: 75, 3: 74, 2: 73, 5: 73, 6: 73, 1: 71})
cli 230 Counter({5: 47, 3: 46, 4: 46, 6: 46, 2: 44, 1: 1})
misc 413 Counter({6: 70, 3: 69, 4: 69, 5: 69, 1: 68, 2: 68})
```

The verification asserted that each of the 1,082 eligible files appeared exactly once across its family's six groups. A real two-worker pytest run also produced a valid per-file timing fragment.

### CI execution evidence

These links open the exact successful steps introduced by this PR:

- [Snapshot freshness and missing-file report](https://github.com/Tracer-Cloud/opensre/actions/runs/33756758343/job/100652958419#step:7:1)
- [Pre-partition tools-runtime shard](https://github.com/Tracer-Cloud/opensre/actions/runs/33756758343/job/100652958685#step:8:1)
- [Pre-partition cli-runtime shard](https://github.com/Tracer-Cloud/opensre/actions/runs/33756758343/job/100652958698#step:8:1)
- [Pre-partition integrations-and-misc shard](https://github.com/Tracer-Cloud/opensre/actions/runs/33756758343/job/100652958683#step:8:1)
- [Successful final CI Gate](https://github.com/Tracer-Cloud/opensre/actions/runs/33756758343/job/100653342221)

Validation:

```text
make lint
make format-check
make typecheck
uv run python -m pytest -q tests/github_ci/test_ci_sharding.py tests/github_ci/test_pr_pipeline_slo.py
# 37 passed
```

### PR CI verification

- [Successful CI run #11926](https://github.com/Tracer-Cloud/opensre/actions/runs/33756758343)
- [Successful CI Gate job](https://github.com/Tracer-Cloud/opensre/actions/runs/33756758343/job/100653342221)

The required aggregate runner-time and p90 comparison over at least 10 representative runs still needs to be collected from CI during review; this PR does not claim that evidence from a single run.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The selector walks only pytest-named files under the matrix roots, applies the same explicit ignores as pytest, and uses longest-processing-time assignment from the checked-in file-duration snapshot. Unknown files use the recorded mean file duration for that family, avoiding the old per-test fallback without importing test modules just to count tests.

The pytest plugin no longer deselects after collection. It only aggregates setup/call/teardown report durations by file, including reports forwarded by xdist to the controller. The merge command sorts fragment inputs and output keys, sums files intentionally split by `-k`, and retains base entries for tests skipped in a particular main run.

I considered dynamically generating the entire GitHub matrix, but retained the existing named jobs and only changed how each receives paths so branch protection, secrets, and current job ownership remain stable.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.