### PR TITLE
fix(install): preflight glibc compatibility on Linux before download

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ curl -fsSL https://install.opensre.com | bash
 
 The macOS/Linux installer does not require sudo. If no writable bin directory is already on `PATH`, it installs to `~/.local/bin` and prints the shell command to apply the PATH update.
 
+The Linux binary requires **glibc 2.35+** (Ubuntu 22.04+, Debian 12+, Fedora 36+, or similarly current distributions). On an older system (e.g. Ubuntu 20.04), the installer stops with a clear error instead of downloading a binary that won't start — build and run from source instead (see [Quick setup](SETUP.md#quick-setup-all-platforms)).
+
 Equivalent explicit main-channel form:
 
 ```bash

--- a/docs/environments/linux-local.mdx
+++ b/docs/environments/linux-local.mdx
@@ -20,6 +20,8 @@ brew install tracer-cloud/tap/opensre
 
 You usually don't need `sudo`. If `opensre` isn't found after install, open a new terminal or add the bin directory the installer printed (often `~/.local/bin`) to your PATH.
 
+The prebuilt Linux binary needs **glibc 2.35+** (Ubuntu 22.04+, Debian 12+, Fedora 36+, or similarly current releases). On an older distribution (e.g. Ubuntu 20.04), the installer detects this and stops before downloading — clone the repo and run it from source with `uv` instead (see [SETUP.md](https://github.com/Tracer-Cloud/opensre/blob/main/SETUP.md)).
+
 In a normal interactive terminal, install may start onboard for you. To skip that:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -916,9 +916,8 @@ detect_glibc_version() {
   # getconf reports "glibc X.Y" on glibc systems and is part of the C library
   # itself, so prefer it; fall back to parsing `ldd --version` when getconf
   # is missing, or present but unable to report a version (e.g. a non-glibc
-  # getconf that doesn't know GNU_LIBC_VERSION). Empty output (not an error)
-  # means neither could determine a version, e.g. on musl/other libc systems
-  # where this check does not apply.
+  # getconf that doesn't know GNU_LIBC_VERSION). Empty output means no glibc
+  # version was found; the caller distinguishes known musl from an unknown libc.
   local version=""
 
   if command -v getconf >/dev/null 2>&1; then
@@ -935,6 +934,17 @@ detect_glibc_version() {
   fi
 }
 
+is_musl_linux() {
+  local ldd_output
+
+  command -v ldd >/dev/null 2>&1 || return 1
+  ldd_output="$(ldd --version 2>&1 || true)"
+  case "$ldd_output" in
+    *musl*|*MUSL*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 version_ge() {
   [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n 1)" = "$1" ]
 }
@@ -945,14 +955,23 @@ check_linux_glibc_compatibility() {
   [ "$platform" = "linux" ] || return 0
 
   glibc_version="$(detect_glibc_version)"
-  # Can't determine the version (non-glibc libc, or missing getconf/ldd) —
-  # don't block install on a check we can't perform.
-  [ -n "$glibc_version" ] || return 0
+  if [ -z "$glibc_version" ]; then
+    if is_musl_linux; then
+      die "$(cat <<EOF
+The OpenSRE Linux binary requires glibc ${LINUX_MIN_GLIBC}+, but this system uses musl libc, so the prebuilt binary will not start here.
+Use a glibc-based distribution or container, or run OpenSRE from source: clone https://github.com/${REPO}, install uv (https://docs.astral.sh/uv/getting-started/installation/), then run 'make install' followed by 'uv run opensre'.
+EOF
+)"
+    fi
+
+    warn "Could not determine this Linux system's libc version. The prebuilt binary requires glibc ${LINUX_MIN_GLIBC}+; continuing without a compatibility guarantee."
+    return 0
+  fi
 
   if ! version_ge "$glibc_version" "$LINUX_MIN_GLIBC"; then
     die "$(cat <<EOF
 The OpenSRE Linux binary requires glibc ${LINUX_MIN_GLIBC}+ (Ubuntu 22.04+, Debian 12+, Fedora 36+, or similarly current distributions). This system reports glibc ${glibc_version}, so the prebuilt binary will not start here.
-Run OpenSRE from source instead: clone https://github.com/${REPO}, install uv (https://docs.astral.sh/uv/getting-started/installation/), then run 'make install' followed by 'uv run opensre'.
+Upgrade to a supported distribution rather than replacing the system glibc manually, or run OpenSRE from source: clone https://github.com/${REPO}, install uv (https://docs.astral.sh/uv/getting-started/installation/), then run 'make install' followed by 'uv run opensre'.
 EOF
 )"
   fi

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,9 @@ else
   SUCCESS_MARK="Success:"
 fi
 
+# Release binaries are built (and glibc-symbol-capped) on ubuntu-22.04 in
+# .github/workflows/release.yml — keep this in sync with that cap.
+LINUX_MIN_GLIBC="2.35"
 REPO="${OPENSRE_INSTALL_REPO:-Tracer-Cloud/opensre}"
 DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
 USER_INSTALL_DIR_CANDIDATES="${OPENSRE_USER_INSTALL_DIR_CANDIDATES:-$HOME/.local/bin:$HOME/bin}"
@@ -909,6 +912,45 @@ detect_platform() {
   esac
 }
 
+detect_glibc_version() {
+  # getconf reports "glibc X.Y" on glibc systems and is part of the C library
+  # itself, so prefer it; fall back to parsing `ldd --version`. Both are
+  # empty (not an error) on musl/other libc systems, where this check does
+  # not apply.
+  if command -v getconf >/dev/null 2>&1; then
+    getconf GNU_LIBC_VERSION 2>/dev/null | sed -n 's/^glibc \([0-9][0-9.]*\)/\1/p'
+    return 0
+  fi
+
+  if command -v ldd >/dev/null 2>&1; then
+    ldd --version 2>/dev/null | sed -n '1s/.*[^0-9]\([0-9][0-9]*\.[0-9][0-9]*\)$/\1/p'
+    return 0
+  fi
+}
+
+version_ge() {
+  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n 1)" = "$1" ]
+}
+
+check_linux_glibc_compatibility() {
+  local glibc_version
+
+  [ "$platform" = "linux" ] || return 0
+
+  glibc_version="$(detect_glibc_version)"
+  # Can't determine the version (non-glibc libc, or missing getconf/ldd) —
+  # don't block install on a check we can't perform.
+  [ -n "$glibc_version" ] || return 0
+
+  if ! version_ge "$glibc_version" "$LINUX_MIN_GLIBC"; then
+    die "$(cat <<EOF
+The OpenSRE Linux binary requires glibc ${LINUX_MIN_GLIBC}+ (Ubuntu 22.04+, Debian 12+, Fedora 36+, or similarly current distributions). This system reports glibc ${glibc_version}, so the prebuilt binary will not start here.
+Run OpenSRE from source instead: clone https://github.com/${REPO}, install uv (https://docs.astral.sh/uv/getting-started/installation/), then run 'make install' followed by 'uv run opensre'.
+EOF
+)"
+  fi
+}
+
 resolve_release_metadata() {
   version="$requested_version"
   release_tag=""
@@ -1090,6 +1132,7 @@ main() {
   parse_args "$@"
   require_prerequisites
   detect_platform
+  check_linux_glibc_compatibility
   resolve_install_dir
   resolve_release_metadata
   select_archive_asset

--- a/install.sh
+++ b/install.sh
@@ -914,12 +914,19 @@ detect_platform() {
 
 detect_glibc_version() {
   # getconf reports "glibc X.Y" on glibc systems and is part of the C library
-  # itself, so prefer it; fall back to parsing `ldd --version`. Both are
-  # empty (not an error) on musl/other libc systems, where this check does
-  # not apply.
+  # itself, so prefer it; fall back to parsing `ldd --version` when getconf
+  # is missing, or present but unable to report a version (e.g. a non-glibc
+  # getconf that doesn't know GNU_LIBC_VERSION). Empty output (not an error)
+  # means neither could determine a version, e.g. on musl/other libc systems
+  # where this check does not apply.
+  local version=""
+
   if command -v getconf >/dev/null 2>&1; then
-    getconf GNU_LIBC_VERSION 2>/dev/null | sed -n 's/^glibc \([0-9][0-9.]*\)/\1/p'
-    return 0
+    version="$(getconf GNU_LIBC_VERSION 2>/dev/null | sed -n 's/^glibc \([0-9][0-9.]*\)/\1/p')"
+    if [ -n "$version" ]; then
+      printf '%s\n' "$version"
+      return 0
+    fi
   fi
 
   if command -v ldd >/dev/null 2>&1; then

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -486,6 +486,55 @@ def test_install_sh_rejects_incompatible_glibc(tmp_path: Path) -> None:
     assert "uv run opensre" in combined
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="glibc preflight only runs when install.sh detects platform=linux",
+)
+def test_install_sh_falls_back_to_ldd_when_getconf_cannot_report_version(tmp_path: Path) -> None:
+    """A present-but-uninformative getconf (no GNU_LIBC_VERSION) must not skip ldd.
+
+    Regression for a review finding on the fix for #5993: the preferred
+    (getconf) detection branch used to return unconditionally, so a host
+    where getconf exists but can't report a glibc version silently bypassed
+    the check instead of falling back to `ldd --version`.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    (fake_bin / "getconf").write_text(
+        "#!/usr/bin/env bash\nexit 1\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "getconf").chmod(
+        (fake_bin / "getconf").stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    (fake_bin / "ldd").write_text(
+        "#!/usr/bin/env bash\nprintf 'ldd (Ubuntu GLIBC 2.31-0ubuntu1) 2.31\\n'\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "ldd").chmod(
+        (fake_bin / "ldd").stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH), "--main"],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0, combined
+    assert "glibc 2.31" in combined
+
+
 def test_install_sh_skip_gh_and_no_auto_launch_env(tmp_path: Path) -> None:
     """Documented CI/provisioning knobs must keep install non-interactive."""
     result = _run_install_sh(

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -434,6 +434,58 @@ def test_install_sh_unknown_flag_fails(tmp_path: Path) -> None:
     assert "Unknown argument" in (result.stdout + result.stderr)
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="glibc preflight only runs when install.sh detects platform=linux",
+)
+def test_install_sh_rejects_incompatible_glibc(tmp_path: Path) -> None:
+    """An old-glibc host fails fast with an actionable message, before any download.
+
+    Regression for https://github.com/Tracer-Cloud/opensre/issues/5993: the
+    release binary is built (and glibc-symbol-capped) on ubuntu-22.04, so it
+    cannot start on Ubuntu 20.04 (glibc 2.31). Without this preflight, users
+    only saw a cryptic PyInstaller loader error after downloading the archive.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    getconf_shim = fake_bin / "getconf"
+    getconf_shim.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            if [ "${1:-}" = "GNU_LIBC_VERSION" ]; then
+              printf 'glibc 2.31\\n'
+              exit 0
+            fi
+            exit 1
+            """
+        ),
+        encoding="utf-8",
+    )
+    getconf_shim.chmod(getconf_shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH), "--main"],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0, combined
+    assert "glibc 2.35" in combined
+    assert "glibc 2.31" in combined
+    assert "uv run opensre" in combined
+
+
 def test_install_sh_skip_gh_and_no_auto_launch_env(tmp_path: Path) -> None:
     """Documented CI/provisioning knobs must keep install non-interactive."""
     result = _run_install_sh(

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -535,6 +535,62 @@ def test_install_sh_falls_back_to_ldd_when_getconf_cannot_report_version(tmp_pat
     assert "glibc 2.31" in combined
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="libc preflight only runs when install.sh detects platform=linux",
+)
+def test_install_sh_rejects_musl_before_download(tmp_path: Path) -> None:
+    """A known non-glibc host must fail before fetching an incompatible binary."""
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    network_marker = tmp_path / "network-reached"
+
+    (fake_bin / "getconf").write_text(
+        "#!/usr/bin/env bash\nexit 1\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "getconf").chmod(
+        (fake_bin / "getconf").stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    (fake_bin / "ldd").write_text(
+        "#!/usr/bin/env bash\nprintf 'musl libc (x86_64)\\nVersion 1.2.5\\n' >&2\nexit 1\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "ldd").chmod(
+        (fake_bin / "ldd").stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    (fake_bin / "curl").write_text(
+        '#!/usr/bin/env bash\nprintf reached > "$NETWORK_MARKER"\nexit 1\n',
+        encoding="utf-8",
+    )
+    (fake_bin / "curl").chmod(
+        (fake_bin / "curl").stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["NETWORK_MARKER"] = str(network_marker)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH), "--main"],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0, combined
+    assert "musl libc" in combined
+    assert "glibc 2.35" in combined
+    assert "uv run opensre" in combined
+    assert not network_marker.exists()
+
+
 def test_install_sh_skip_gh_and_no_auto_launch_env(tmp_path: Path) -> None:
     """Documented CI/provisioning knobs must keep install non-interactive."""
     result = _run_install_sh(


### PR DESCRIPTION
Fixes #5993

#### Describe the changes you have made in this PR -

The linux-x64/arm64 release binaries are built on `ubuntu-22.04` in `release.yml`, which itself already asserts (`Check Linux binary glibc compatibility`) that the binary must not require newer than `GLIBC_2.35`. That step confirms the binary's floor is exactly glibc 2.35 — but nothing told the *installer* or the *user* about it, so on an older host (e.g. Ubuntu 20.04, glibc 2.31) `install.sh` happily downloaded, extracted, and then failed with a cryptic PyInstaller loader error (`Failed to load Python shared library ... GLIBC_2.35' not found`) exactly as reported in the issue.

This PR adds a preflight check to `install.sh`:
- `detect_glibc_version()` reads the host's glibc version via `getconf GNU_LIBC_VERSION` (falling back to `ldd --version`); known musl systems fail before download, while genuinely inconclusive detection warns and continues.
- `check_linux_glibc_compatibility()` runs right after `detect_platform` in `main()`, before any network call, and `die()`s with an actionable message (detected version, required floor, and a source-install fallback) if the host's glibc is older than `LINUX_MIN_GLIBC="2.35"`.
- Documented the floor in `README.md` and `docs/environments/linux-local.mdx`, next to the existing install instructions.

Rebuilding the release binaries against an older glibc floor (e.g. a manylinux-style container) would be a much larger infra change with its own risk (recompiling every native dependency against an older toolchain); this PR takes the fix the issue itself proposed as sufficient — fail fast with a clear message instead of a cryptic post-download crash.

### Demo/Screenshot for feature changes and bug fixes -

Simulated on this machine by shimming `getconf` to report an old glibc version (real repro requires an actual Ubuntu 20.04 host, which isn't available here):

```
$ bash install.sh --main
Error: The OpenSRE Linux binary requires glibc 2.35+ (Ubuntu 22.04+, Debian 12+, Fedora 36+, or similarly current distributions). This system reports glibc 2.31, so the prebuilt binary will not start here.
Run OpenSRE from source instead: clone https://github.com/Tracer-Cloud/opensre, install uv (https://docs.astral.sh/uv/getting-started/installation/), then run 'make install' followed by 'uv run opensre'.
```

Exits immediately (before any download), vs. today's flow which downloads ~100MB+ and fails deep inside the PyInstaller loader.

Added regression coverage for incompatible glibc, failed-`getconf` fallback, and musl rejection before network access. The focused installer suite passes on this glibc 2.39 host, confirming compatible installations remain unchanged.

`make lint`, `make format-check`, and `make typecheck` all pass.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a distribution-compatibility gap, not a logic bug: the release pipeline intentionally targets glibc 2.35 (documented by its own CI assertion), and nothing surfaced that requirement to users before they hit a crash. The fix is a shell preflight check placed as early as possible in `main()` (right after platform detection, before any network I/O), using `getconf`/`ldd` — both already broadly available on any glibc Linux host without new dependencies — and comparing against a named constant (`LINUX_MIN_GLIBC`) kept next to a comment pointing back at the CI check it must stay in sync with. It rejects known musl/Alpine hosts because the glibc-linked binary cannot start there, and warns but continues only when the libc cannot be identified. I considered instead rebuilding the release binaries in an older-glibc container (e.g. manylinux2014), but that's a much larger, riskier infra change (recompiling every native wheel dependency against an older toolchain) than what the issue itself calls sufficient — clearly documenting/enforcing the existing floor.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

https://claude.ai/code/session_016xigdmudH12x1BhZtfXJ4o
