### PR TITLE
fix(installer): preserve Windows command name

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -973,6 +973,15 @@ function Test-OpenSreAutoLaunchEnabled {
     return -not ($value -eq "0" -or $value -eq "false" -or $value -eq "FALSE" -or $value -eq "no" -or $value -eq "NO" -or $value -eq "off" -or $value -eq "OFF")
 }
 
+function Get-OpenSreCommandName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BinaryName
+    )
+
+    return [System.IO.Path]::GetFileNameWithoutExtension($BinaryName)
+}
+
 function Start-OpenSreOnboardingAfterInstall {
     param(
         [string]$BinaryPath,
@@ -1153,7 +1162,7 @@ function Install-OpenSre {
 
     Ensure-OpenSreGithubCli
 
-    $exe = [System.IO.Path]::GetFileNameWithoutExtension($binaryName)
+    $exe = Get-OpenSreCommandName -BinaryName $binaryName
     $sep = "────────────────────────────────────────────"
 
     Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -1153,7 +1153,7 @@ function Install-OpenSre {
 
     Ensure-OpenSreGithubCli
 
-    $exe = $binaryName.TrimEnd(".exe")
+    $exe = [System.IO.Path]::GetFileNameWithoutExtension($binaryName)
     $sep = "────────────────────────────────────────────"
 
     Write-Host ""

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -86,6 +86,13 @@ def test_install_ps1_contains_auto_onboarding_launch_hook() -> None:
     assert "[System.Console]::IsInputRedirected" in source
 
 
+def test_install_ps1_preserves_full_binary_name_in_next_steps() -> None:
+    source = INSTALL_PS1.read_text()
+
+    assert "$exe = [System.IO.Path]::GetFileNameWithoutExtension($binaryName)" in source
+    assert '$binaryName.TrimEnd(".exe")' not in source
+
+
 def test_install_ps1_soft_installs_github_cli_via_winget() -> None:
     source = INSTALL_PS1.read_text()
 

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -87,10 +87,25 @@ def test_install_ps1_contains_auto_onboarding_launch_hook() -> None:
 
 
 def test_install_ps1_preserves_full_binary_name_in_next_steps() -> None:
-    source = INSTALL_PS1.read_text()
+    shell = _powershell()
+    if shell is None:
+        pytest.skip("PowerShell is not installed in this environment.")
 
-    assert "$exe = [System.IO.Path]::GetFileNameWithoutExtension($binaryName)" in source
-    assert '$binaryName.TrimEnd(".exe")' not in source
+    script = textwrap.dedent(
+        f"""
+        . '{INSTALL_PS1}' -SkipMain
+        Get-OpenSreCommandName -BinaryName 'opensre.exe'
+        """
+    )
+
+    result = subprocess.run(
+        [shell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "opensre"
 
 
 def test_install_ps1_soft_installs_github_cli_via_winget() -> None:


### PR DESCRIPTION
Fixes #5992

#### Describe the changes you have made in this PR -

- Derive the Windows installer command name with a focused helper backed by `Path.GetFileNameWithoutExtension` instead of `TrimEnd`.
- Add a regression test that prevents the executable suffix from being treated as a character set and truncating `opensre` to `opensr`.

### Demo/Screenshot for feature changes and bug fixes -

Regression test output:

```text
tests/cli/test_install_ps1_progress.py::test_install_ps1_preserves_full_binary_name_in_next_steps PASSED
```

With `opensre.exe`, the next-steps display name now resolves to `opensre`, so the installer prints `opensre setup`, `opensre`, and `opensre investigate ...`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

PowerShell's `TrimEnd(".exe")` removes any trailing characters contained in that argument, not the literal `.exe` suffix, so it also removes the final `e` from `opensre.exe`. I considered removing a fixed four-character suffix, but that would couple the display logic to one extension shape. Using the .NET path API states the intent directly, remains compatible with Windows PowerShell, and safely returns `opensre` for `opensre.exe`. A focused helper keeps the transformation directly testable, and the regression test executes it under PowerShell to verify `opensre.exe` renders as `opensre`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Validation:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/cli/test_install_matrix.py tests/cli/test_install_ps1_progress.py` with PowerShell 7.6.5 on `PATH` (28 passed, 1 skipped)
