### PR TITLE
feat(shell): quiet status bar and composer chrome

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -323,10 +323,12 @@ from config.constants.redis import (
 )
 from config.constants.repl_autonomy import (
     AUTO_LEVEL_ASK_TOOL_TYPES,
+    AUTO_LEVEL_BAR_CAPTIONS,
     AUTO_LEVEL_CAPTIONS,
     AUTO_LEVEL_TITLES,
     DEFAULT_AUTO_LEVEL,
     AutoLevel,
+    format_auto_status_bar,
     format_auto_status_plain,
     parse_auto_level,
 )
@@ -541,10 +543,12 @@ __all__ = [
     "DEFAULT_REMOTE_SYNC_PROVIDER",
     "DEFAULT_THEME_NAME",
     "AUTO_LEVEL_ASK_TOOL_TYPES",
+    "AUTO_LEVEL_BAR_CAPTIONS",
     "AUTO_LEVEL_CAPTIONS",
     "AUTO_LEVEL_TITLES",
     "AutoLevel",
     "DEFAULT_AUTO_LEVEL",
+    "format_auto_status_bar",
     "format_auto_status_plain",
     "parse_auto_level",
     "SOUND_MIN_TURN_SECONDS",

--- a/config/constants/repl_autonomy.py
+++ b/config/constants/repl_autonomy.py
@@ -29,6 +29,15 @@ AUTO_LEVEL_CAPTIONS: Final[dict[AutoLevel, str]] = {
     AutoLevel.HIGH: "all actions allowed",
 }
 
+# Idle status bar — short permission words. High is the default; hiding the
+# caption made it look like "best / full power" instead of allow-all.
+AUTO_LEVEL_BAR_CAPTIONS: Final[dict[AutoLevel, str]] = {
+    AutoLevel.OFF: "Ask everything",
+    AutoLevel.LOW: "Ask to edit",
+    AutoLevel.MED: "Reversible only",
+    AutoLevel.HIGH: "Allow all",
+}
+
 # Display title inside ``Auto (Med)`` — Factory uses Med, not medium.
 AUTO_LEVEL_TITLES: Final[dict[AutoLevel, str]] = {
     AutoLevel.OFF: "Off",
@@ -78,16 +87,23 @@ def parse_auto_level(raw: str) -> AutoLevel | None:
 
 
 def format_auto_status_plain(level: AutoLevel) -> str:
-    """``Auto (Med) · allow reversible commands`` without ANSI."""
+    """``Auto (Med) · allow reversible commands`` without ANSI (``/auto``)."""
     return f"Auto ({AUTO_LEVEL_TITLES[level]}) · {AUTO_LEVEL_CAPTIONS[level]}"
+
+
+def format_auto_status_bar(level: AutoLevel) -> str:
+    """``Auto (High) · Allow all`` — live prompt chrome, no model slug."""
+    return f"Auto ({AUTO_LEVEL_TITLES[level]}) · {AUTO_LEVEL_BAR_CAPTIONS[level]}"
 
 
 __all__ = [
     "AUTO_LEVEL_ASK_TOOL_TYPES",
+    "AUTO_LEVEL_BAR_CAPTIONS",
     "AUTO_LEVEL_CAPTIONS",
     "AUTO_LEVEL_TITLES",
     "AutoLevel",
     "DEFAULT_AUTO_LEVEL",
+    "format_auto_status_bar",
     "format_auto_status_plain",
     "parse_auto_level",
 ]

--- a/surfaces/interactive_shell/ui/auto_status.py
+++ b/surfaces/interactive_shell/ui/auto_status.py
@@ -4,56 +4,33 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from config.constants.repl_autonomy import (
-    DEFAULT_AUTO_LEVEL,
-    AutoLevel,
-    format_auto_status_plain,
-)
-from infrastructure.safety.terminal_output import strip_terminal_controls
+from config.constants.repl_autonomy import DEFAULT_AUTO_LEVEL, format_auto_status_bar
 from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
-from surfaces.shared.terminal.tables.provider import detect_provider_model
 
 if TYPE_CHECKING:
     from surfaces.interactive_shell.session import Session
 
 
-def auto_status_ansi(session: Session, *, quiet: bool = False) -> str:
-    """One row: ``Auto (Med) · allow reversible commands`` plus the model name.
+def auto_status_ansi(session: Session) -> str:
+    """One idle row: ``Auto (High) · Allow all``.
 
-    ``quiet`` is for a busy turn: Thinking / Invoking already owns the gold
-    accent, so Auto recedes to DIM and does not compete.
+    Permission copy stays visible at every level, including High (the default).
+    The model id lives on ``/model`` and ``?``, not this chrome. Busy turns
+    replace this row with Thinking / Invoking instead of stacking both.
     """
     level = getattr(session.terminal, "auto_level", DEFAULT_AUTO_LEVEL)
-    left = format_auto_status_plain(level)
-    # High is the default — the caption is noise on every idle frame.
-    # Busy already has Thinking / Invoking; keep Auto to a short title.
-    if quiet or level == AutoLevel.HIGH:
-        title_end = left.find(" · ")
-        if title_end >= 0:
-            left = left[:title_end]
-    _provider, model = detect_provider_model()
+    left = format_auto_status_bar(level)
     width = prompt_line_width()
-    # Model ids come from config/env. CPR stripping on the composed prompt
-    # region does not remove OSC/CSI/BEL, so sanitize before interpolating.
-    right = strip_terminal_controls(model or "").strip()
-    gap = 2
-    if right and len(left) + gap + len(right) > width:
-        right = ""
-    title_end = left.find(" · ")
-    title = left if title_end < 0 else left[:title_end]
-    rest = "" if title_end < 0 else left[title_end:]
-    title_ansi = ui_theme.DIM_ANSI if quiet else ui_theme.BOLD_REPLY_MARKER_ANSI
-    model_ansi = ui_theme.DIM_ANSI if quiet else ui_theme.SECONDARY_ANSI
-    if not right:
-        clipped = clip_prompt_text(left, width)
-        pad = max(0, width - len(clipped))
-        return f"{title_ansi}{clipped}{ui_theme.ANSI_RESET}{' ' * pad}"
-    pad = max(width - len(left) - len(right), gap)
+    clipped = clip_prompt_text(left, width)
+    title_end = clipped.find(" · ")
+    title = clipped if title_end < 0 else clipped[:title_end]
+    rest = "" if title_end < 0 else clipped[title_end:]
+    pad = max(0, width - len(clipped))
     return (
-        f"{title_ansi}{title}{ui_theme.ANSI_RESET}"
+        f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{title}{ui_theme.ANSI_RESET}"
         f"{ui_theme.DIM_ANSI}{rest}{ui_theme.ANSI_RESET}"
-        f"{' ' * pad}{model_ansi}{right}{ui_theme.ANSI_RESET}"
+        f"{' ' * pad}"
     )
 
 

--- a/surfaces/interactive_shell/ui/auto_status.py
+++ b/surfaces/interactive_shell/ui/auto_status.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from config.constants.repl_autonomy import DEFAULT_AUTO_LEVEL, format_auto_status_plain
+from config.constants.repl_autonomy import (
+    DEFAULT_AUTO_LEVEL,
+    AutoLevel,
+    format_auto_status_plain,
+)
 from infrastructure.safety.terminal_output import strip_terminal_controls
 from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
@@ -14,10 +18,20 @@ if TYPE_CHECKING:
     from surfaces.interactive_shell.session import Session
 
 
-def auto_status_ansi(session: Session) -> str:
-    """One row: ``Auto (Med) · allow reversible commands`` plus the model name."""
+def auto_status_ansi(session: Session, *, quiet: bool = False) -> str:
+    """One row: ``Auto (Med) · allow reversible commands`` plus the model name.
+
+    ``quiet`` is for a busy turn: Thinking / Invoking already owns the gold
+    accent, so Auto recedes to DIM and does not compete.
+    """
     level = getattr(session.terminal, "auto_level", DEFAULT_AUTO_LEVEL)
     left = format_auto_status_plain(level)
+    # High is the default — the caption is noise on every idle frame.
+    # Busy already has Thinking / Invoking; keep Auto to a short title.
+    if quiet or level == AutoLevel.HIGH:
+        title_end = left.find(" · ")
+        if title_end >= 0:
+            left = left[:title_end]
     _provider, model = detect_provider_model()
     width = prompt_line_width()
     # Model ids come from config/env. CPR stripping on the composed prompt
@@ -29,15 +43,17 @@ def auto_status_ansi(session: Session) -> str:
     title_end = left.find(" · ")
     title = left if title_end < 0 else left[:title_end]
     rest = "" if title_end < 0 else left[title_end:]
+    title_ansi = ui_theme.DIM_ANSI if quiet else ui_theme.BOLD_REPLY_MARKER_ANSI
+    model_ansi = ui_theme.DIM_ANSI if quiet else ui_theme.SECONDARY_ANSI
     if not right:
         clipped = clip_prompt_text(left, width)
         pad = max(0, width - len(clipped))
-        return f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{clipped}{ui_theme.ANSI_RESET}{' ' * pad}"
+        return f"{title_ansi}{clipped}{ui_theme.ANSI_RESET}{' ' * pad}"
     pad = max(width - len(left) - len(right), gap)
     return (
-        f"{ui_theme.BOLD_REPLY_MARKER_ANSI}{title}{ui_theme.ANSI_RESET}"
+        f"{title_ansi}{title}{ui_theme.ANSI_RESET}"
         f"{ui_theme.DIM_ANSI}{rest}{ui_theme.ANSI_RESET}"
-        f"{' ' * pad}{ui_theme.SECONDARY_ANSI}{right}{ui_theme.ANSI_RESET}"
+        f"{' ' * pad}{model_ansi}{right}{ui_theme.ANSI_RESET}"
     )
 
 

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -20,11 +20,6 @@ def _display_safe(text: str) -> str:
     return "\n".join(strip_terminal_controls(line) for line in text.splitlines())
 
 
-def render_handoff_answer_marker() -> Text:
-    """Dim marker painted above a submitted answer to a hand-off question."""
-    return Text("↗ answer", style=str(ui_theme.DIM))
-
-
 def render_choice_selection(console: Console, title: str, answer: str) -> None:
     """Persist a compact selected-choice result after the transient picker closes.
 
@@ -83,6 +78,5 @@ def try_render_ask_user_submission(console: Console, text: str) -> bool:
 __all__ = [
     "render_ask_user_qa",
     "render_choice_selection",
-    "render_handoff_answer_marker",
     "try_render_ask_user_submission",
 ]

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.filters import Condition, to_filter
-from prompt_toolkit.formatted_text import ANSI, FormattedText
+from prompt_toolkit.formatted_text import FormattedText
 from prompt_toolkit.layout.containers import (
     AnyContainer,
     ConditionalContainer,
@@ -16,7 +16,6 @@ from prompt_toolkit.layout.containers import (
     Window,
     to_container,
 )
-from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 
 from surfaces.interactive_shell.prompt_history import load_prompt_history
@@ -28,7 +27,6 @@ from surfaces.interactive_shell.ui.input_prompt.layout import prompt_line_width
 from surfaces.interactive_shell.ui.input_prompt.lexer import ReplInputLexer
 from surfaces.interactive_shell.ui.input_prompt.rendering import (
     DEFAULT_PLACEHOLDER_TEXT,
-    composer_footer_ansi,
     resolve_prompt_placeholder,
 )
 from surfaces.interactive_shell.ui.input_prompt.style import _build_prompt_style
@@ -85,13 +83,9 @@ def _install_prompt_frame(
     # (otherwise the frame looks hollow against the terminal bg).
     surface_body: AnyContainer = HSplit([editable_body], style="class:composer-body")
     composer: AnyContainer = rounded_composer_frame(surface_body)
-    footer: AnyContainer = Window(
-        FormattedTextControl(lambda: ANSI(composer_footer_ansi())),
-        height=1,
-        dont_extend_height=True,
-        style="class:composer-footer",
-    )
-    box_rows: list[AnyContainer] = [composer, footer]
+    # No footer row — send hints live in the empty-box placeholder (Droid /
+    # Cursor: one stack, not a textbook under the box).
+    box_rows: list[AnyContainer] = [composer]
     if hide_composer is not None:
         shown = Condition(lambda: not hide_composer())
         composer_container = to_container(composer)
@@ -112,9 +106,8 @@ def _install_prompt_frame(
         # same-height stand-in overwrites the growing box cleanly instead.
         box_rows = [
             ConditionalContainer(composer, filter=shown),
-            ConditionalContainer(footer, filter=shown),
             ConditionalContainer(
-                Window(height=lambda: _current_composer_rows() + 1, char=" "),
+                Window(height=_current_composer_rows, char=" "),
                 filter=~shown,
             ),
         ]

--- a/surfaces/interactive_shell/ui/input_prompt/__init__.py
+++ b/surfaces/interactive_shell/ui/input_prompt/__init__.py
@@ -83,8 +83,7 @@ def _install_prompt_frame(
     # (otherwise the frame looks hollow against the terminal bg).
     surface_body: AnyContainer = HSplit([editable_body], style="class:composer-body")
     composer: AnyContainer = rounded_composer_frame(surface_body)
-    # No footer row — send hints live in the empty-box placeholder (Droid /
-    # Cursor: one stack, not a textbook under the box).
+    # No footer row — the empty box is the job prompt, not a shortcut dump.
     box_rows: list[AnyContainer] = [composer]
     if hide_composer is not None:
         shown = Condition(lambda: not hide_composer())

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -11,17 +11,17 @@ from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.runtime import Session
 from surfaces.interactive_shell.ui.handoff_questions import (
     render_ask_user_qa,
-    render_handoff_answer_marker,
 )
 from surfaces.interactive_shell.ui.input_prompt.completion import completion_preview_hint_ansi
 from surfaces.interactive_shell.ui.input_prompt.layout import (
     _short_meta,
     clip_prompt_text,
-    prompt_line_width,
 )
 from surfaces.shared.terminal.prompt_layout import prompt_text_width, terminal_columns
 
 DEFAULT_PLACEHOLDER_TEXT = "see what you can do"
+#: One send hint, inside the empty box — not a fourth chrome line under it.
+_COMPOSER_SEND_HINT = "Enter send · ? help"
 _PLAN_CONTINUE_PLACEHOLDER = "continue the plan, or type a message"
 #: Warm vertical bar — same role as Droid's orange user-turn lead-in.
 _USER_TURN_ACCENT = "▌"
@@ -101,12 +101,7 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
         # answer so a no-op model acknowledgement can be omitted as well.
         session.terminal.pending_choice_response = stripped
         return
-    if is_handoff_answer:
-        # The marker hugs the assistant answer it responds to (no gap above);
-        # the between-turns gap falls below it, before the user's input row.
-        console.print(render_handoff_answer_marker())
-        console.print()
-    elif autosubmitted:
+    if autosubmitted:
         # Keep this shorter than the condition — the ``[N] ❯`` line carries the
         # full text; this only answers "is this still /goal set or real work?".
         console.print()
@@ -188,11 +183,8 @@ def ctrl_c_exit_hint_ansi() -> str:
 
 
 def composer_footer_ansi() -> str:
-    """Return the help hint below the composer (no competing mode chrome)."""
-    left = "Enter send · Shift+Enter newline · ? help"
-    width = prompt_line_width()
-    clipped = clip_prompt_text(left, width)
-    return f"{ui_theme.DIM_ANSI}{clipped}{ui_theme.ANSI_RESET}"
+    """No footer row. Shortcuts live in the empty-box placeholder."""
+    return ""
 
 
 def resolve_prompt_placeholder(session: Session) -> FormattedText:
@@ -226,4 +218,4 @@ def resolve_prompt_placeholder(session: Session) -> FormattedText:
         and not session.plan_only_until_authorized
     ):
         return _placeholder_formatted(_PLAN_CONTINUE_PLACEHOLDER)
-    return _placeholder_formatted(DEFAULT_PLACEHOLDER_TEXT)
+    return _placeholder_formatted(f"{DEFAULT_PLACEHOLDER_TEXT} · {_COMPOSER_SEND_HINT}")

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -19,9 +19,7 @@ from surfaces.interactive_shell.ui.input_prompt.layout import (
 )
 from surfaces.shared.terminal.prompt_layout import prompt_text_width, terminal_columns
 
-DEFAULT_PLACEHOLDER_TEXT = "see what you can do"
-#: One send hint, inside the empty box — not a fourth chrome line under it.
-_COMPOSER_SEND_HINT = "Enter send · ? help"
+DEFAULT_PLACEHOLDER_TEXT = "Ask about an alert"
 _PLAN_CONTINUE_PLACEHOLDER = "continue the plan, or type a message"
 #: Warm vertical bar — same role as Droid's orange user-turn lead-in.
 _USER_TURN_ACCENT = "▌"
@@ -183,7 +181,7 @@ def ctrl_c_exit_hint_ansi() -> str:
 
 
 def composer_footer_ansi() -> str:
-    """No footer row. Shortcuts live in the empty-box placeholder."""
+    """No footer row. The empty box is the job prompt; shortcuts live on ``?``."""
     return ""
 
 
@@ -218,4 +216,4 @@ def resolve_prompt_placeholder(session: Session) -> FormattedText:
         and not session.plan_only_until_authorized
     ):
         return _placeholder_formatted(_PLAN_CONTINUE_PLACEHOLDER)
-    return _placeholder_formatted(f"{DEFAULT_PLACEHOLDER_TEXT} · {_COMPOSER_SEND_HINT}")
+    return _placeholder_formatted(DEFAULT_PLACEHOLDER_TEXT)

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -57,9 +57,15 @@ def render_plan_breakdown(console: Console, breakdown: str) -> None:
             console.print()
             continue
         if stripped.startswith(_WORK_NOTE_MARKER):
-            # Preserve leading indent; mute the whole work-note row.
-            line.append(raw, style=str(ui_theme.DIM))
-            console.print(line)
+            # Theme DIM as raw truecolor. Rich Style.parse caches ANSI from
+            # the first color_system that rendered ``#6E6E6E``; a prior
+            # 16-color console then emits bright-black ``[90m`` instead of
+            # DIM_ANSI on a truecolor breakdown.
+            console.print(
+                f"{ui_theme.DIM_ANSI}{raw}{ui_theme.ANSI_RESET}",
+                highlight=False,
+                markup=False,
+            )
             continue
         # Header (``Plan complete · n/n``) or a checklist step (``  ✓ …``).
         if stripped.startswith("Plan"):

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -75,7 +75,6 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         base = hidden_typing_box_pad()
     else:
         base = prompt_rendering._prompt_message(session).value
-    auto_line = strip_cpr_sequences(auto_status_ansi(session))
     plan = session.task_plan
     if plan is None or not plan.steps:
         # Drop expand so the next plan opens collapsed rather than inheriting
@@ -98,11 +97,13 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     # A pending confirmation renders a stacked, arrow-navigable Yes/No choice
     # (box hidden). Density matches the streaming stack: status → Auto → composer.
     if state.is_awaiting_confirmation():
+        auto_line = strip_cpr_sequences(auto_status_ansi(session, quiet=False))
         choice = _confirmation_block(state)
         return ANSI(f"\n{plan_prefix}{choice}\n{auto_line}\n{base}")
 
     if state.is_ctrl_c_exit_hint_visible():
         prefix = prompt_rendering.ctrl_c_exit_hint_ansi()
+        inline_spinner = ""
     else:
         inline_spinner = spinner.inline_spinner_ansi()
         prefix = strip_cpr_sequences(
@@ -111,6 +112,9 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
+    # Thinking / Invoking owns the gold accent; Auto recedes so the bar is
+    # one status row, not two headlines.
+    auto_line = strip_cpr_sequences(auto_status_ansi(session, quiet=bool(inline_spinner)))
     # Tools already paint a ``⏺`` line into scrollback; the live tool name is
     # folded into the spinner status row (same line as ``Invoking tools…``).
     # Leading blank = Droid row margin under the last transcript line.

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -2,9 +2,10 @@
 
 The terminal UI has three pieces, all composed from this module:
 
-1. compact launch banner (overlapping-ring mark + capability status)
-2. hint/spinner and autonomy status above the composer
-3. bordered ``>`` composer + help footer
+1. compact launch banner (wordmark + install health)
+2. one status row above the composer — Auto while idle, Thinking / Invoking
+   while busy
+3. bordered ``>`` composer (job-shaped placeholder; no help footer)
 
 Piece 1 is static chrome printed once by :func:`render_terminal_ui`.
 Pieces 2–3 form the live prompt region: prompt-toolkit re-evaluates them on
@@ -56,18 +57,18 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     """Compose the live prompt region: context line plus rule and input prefix.
 
     The top line is the pending confirmation prompt when one is active,
-    otherwise the spinner, completion preview, or idle hint, followed by the
-    autonomy status line showing the active ``/auto`` level. A rendered task
-    plan has one blank row beneath it before this status chrome.
+    otherwise one status row: Thinking / Invoking while a turn is running, or
+    the ``/auto`` permission line while idle. A rendered task plan has one
+    blank row beneath it before this status chrome.
 
     When confirmation or exclusive-stdin structured input owns the keyboard,
     the free-text typing box (rule + ``[N] ❯``) is omitted so it does not
     compete with Ask User / option menus — free text is itself an option
     (``Or type your own answer...``), not a parallel composer.
 
-    One leading blank row separates scrollback from status → Auto → composer,
-    matching Droid's row margin between transcript and chrome. Idle still has
-    no empty "Ready" placeholder under the banner.
+    One leading blank row separates scrollback from the status slot →
+    composer, matching Droid's row margin between transcript and chrome. Idle
+    still has no empty "Ready" placeholder under the banner.
     """
     if typing_box_hidden(session, state):
         # Same newline count as ``_prompt_message`` so confirmation does not
@@ -97,7 +98,7 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     # A pending confirmation renders a stacked, arrow-navigable Yes/No choice
     # (box hidden). Density matches the streaming stack: status → Auto → composer.
     if state.is_awaiting_confirmation():
-        auto_line = strip_cpr_sequences(auto_status_ansi(session, quiet=False))
+        auto_line = strip_cpr_sequences(auto_status_ansi(session))
         choice = _confirmation_block(state)
         return ANSI(f"\n{plan_prefix}{choice}\n{auto_line}\n{base}")
 
@@ -112,14 +113,14 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
                 idle_hint=prompt_rendering.resolve_idle_hint_ansi(session),
             )
         )
-    # Thinking / Invoking owns the gold accent; Auto recedes so the bar is
-    # one status row, not two headlines.
-    auto_line = strip_cpr_sequences(auto_status_ansi(session, quiet=bool(inline_spinner)))
     # Tools already paint a ``⏺`` line into scrollback; the live tool name is
     # folded into the spinner status row (same line as ``Invoking tools…``).
     # Leading blank = Droid row margin under the last transcript line.
+    # Busy occupies the same slot as Auto so patch_stdout height stays stable
+    # and the bar is one headline, not Thinking plus a leftover Auto row.
     if prefix:
-        return ANSI(f"\n{plan_prefix}{prefix}\n{auto_line}\n{base}")
+        return ANSI(f"\n{plan_prefix}{prefix}\n{base}")
+    auto_line = strip_cpr_sequences(auto_status_ansi(session))
     return ANSI(f"\n{plan_prefix}{auto_line}\n{base}")
 
 

--- a/surfaces/shared/terminal/banner/banner.py
+++ b/surfaces/shared/terminal/banner/banner.py
@@ -2,7 +2,7 @@
 
 Droid-style centered hero: each row is centered independently (a single
 ``Align.center`` on a multi-line block left-aligns short lines inside the
-widest line). Bold block wordmark + clean version + tip + capability chips.
+widest line). Bold block wordmark + version + welcome + capability chips.
 """
 
 from __future__ import annotations
@@ -44,9 +44,6 @@ _STATUS_OK_GLYPH = "✓"
 _STATUS_MISSING_GLYPH = "✗"
 #: Spacing between status items.
 _STATUS_ITEM_GAP = "     "
-
-#: Keyboard hints (real bindings, not aspirational shortcuts).
-_SHORTCUTS_LINE = "/ commands · tab tool details · ? help · Enter send"
 
 #: Minimum console width to paint the ring mark (its cell width + margin);
 #: narrower terminals get the compact text title instead.
@@ -281,14 +278,6 @@ def _build_welcome_paragraph() -> Text:
     return Text(WELCOME_DESCRIPTION, style=str(TEXT), justify="center")
 
 
-def _build_shortcuts_line(*, max_width: int) -> Text:
-    return Text(
-        clip_prompt_text(_SHORTCUTS_LINE, max(8, max_width)),
-        style=str(DIM),
-        no_wrap=True,
-    )
-
-
 def _build_capabilities(status: LaunchStatus, *, max_width: int) -> Text:
     capabilities = Text(overflow="fold", no_wrap=True)
     _append_status_item(
@@ -341,8 +330,6 @@ def build_launch_banner(
         None,
         _build_welcome_title(),
         _build_welcome_paragraph(),
-        None,
-        _build_shortcuts_line(max_width=line_width),
         None,
         _build_capabilities(status, max_width=line_width),
     ]

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -190,9 +190,10 @@ def test_build_prompt_session_installs_growing_bordered_composer() -> None:
     assert isinstance(framed_input, FloatContainer)
     chrome = framed_input.content
     assert isinstance(chrome, HSplit)
-    assert len(chrome.children) == 3
+    # Status rows, then the bordered composer — send hints live in the
+    # empty-box placeholder, not a third footer child.
+    assert len(chrome.children) == 2
     composer = chrome.children[1]
-    footer = chrome.children[2]
     assert isinstance(composer, HSplit)
     assert composer.height is None
     editable_row = composer.children[1]
@@ -203,7 +204,6 @@ def test_build_prompt_session_installs_growing_bordered_composer() -> None:
     default_buffer_slot = editable_body.children[0]
     assert default_buffer_slot.content.height.min == 1
     assert default_buffer_slot.content.height.max == 8
-    assert isinstance(footer, Window)
     assert chrome.preferred_width(80).preferred == 79
 
 

--- a/tests/interactive_shell/test_terminal_runtime.py
+++ b/tests/interactive_shell/test_terminal_runtime.py
@@ -178,7 +178,6 @@ def test_build_prompt_session_installs_growing_bordered_composer() -> None:
         FloatContainer,
         HSplit,
         VSplit,
-        Window,
     )
 
     with create_app_session(input=DummyInput(), output=DummyOutput()):

--- a/tests/interactive_shell/ui/test_auto_status.py
+++ b/tests/interactive_shell/ui/test_auto_status.py
@@ -47,6 +47,58 @@ def test_all_control_model_falls_back_to_left_only(monkeypatch) -> None:
     assert "Auto (" in rendered
 
 
+def test_auto_status_recedes_while_the_spinner_owns_the_accent() -> None:
+    """Busy turns keep Auto on the page but DIM — one gold line, not two."""
+    import re
+
+    import infrastructure.terminal.theme as ui_theme
+    from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+    from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
+
+    ui_theme.set_active_theme("amber")
+    session = Session()
+    session.terminal.auto_level = AutoLevel.HIGH
+    loud = auto_status_ansi(session, quiet=False)
+    quiet = auto_status_ansi(session, quiet=True)
+    assert ui_theme.BOLD_REPLY_MARKER_ANSI in loud
+    assert ui_theme.BOLD_REPLY_MARKER_ANSI not in quiet
+    assert ui_theme.DIM_ANSI in quiet
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_phase(SpinnerState.THINKING_PHASE)
+    rendered = render_prompt_region(session, ReplState(), spinner).value
+    plain = re.sub(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07", "", rendered)
+    assert "Thinking" in plain
+    assert "Auto (High)" in plain
+    assert plain.index("Thinking") < plain.index("Auto (High)")
+    assert ui_theme.DIM_ANSI + "Auto (High)" in rendered
+
+
+def test_high_auto_omits_the_default_caption() -> None:
+    """High is the default — do not print ``all actions allowed`` on every frame."""
+    import re
+
+    from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+    from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
+
+    session = Session()
+    session.terminal.auto_level = AutoLevel.HIGH
+    plain = re.sub(
+        r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07",
+        "",
+        render_prompt_region(session, ReplState(), SpinnerState()).value,
+    )
+    assert "Auto (High)" in plain
+    assert "all actions allowed" not in plain
+    session.terminal.auto_level = AutoLevel.MED
+    med = re.sub(
+        r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07",
+        "",
+        render_prompt_region(session, ReplState(), SpinnerState()).value,
+    )
+    assert "allow reversible commands" in med
+
+
 def test_render_prompt_region_shows_the_auto_status_line() -> None:
     """The live prompt composition must reach ``auto_status_ansi`` so the level shows."""
     import re

--- a/tests/interactive_shell/ui/test_auto_status.py
+++ b/tests/interactive_shell/ui/test_auto_status.py
@@ -1,4 +1,4 @@
-"""Auto-status ANSI line: model labels must not inject terminal controls."""
+"""Auto-status ANSI line: permission copy, no model slug on idle chrome."""
 
 from __future__ import annotations
 
@@ -7,75 +7,8 @@ from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.ui.auto_status import auto_status_ansi
 
 
-def test_model_label_strips_terminal_controls(monkeypatch) -> None:
-    """A configured model id with ESC/OSC/BEL must not reach the ANSI status line."""
-    monkeypatch.setattr(
-        "surfaces.interactive_shell.ui.auto_status.detect_provider_model",
-        lambda: ("openai", "gpt-4\x1b]0;pwn\x07o\x1b[2J\x1b[1;1H"),
-    )
-    monkeypatch.setattr(
-        "surfaces.interactive_shell.ui.auto_status.prompt_line_width",
-        lambda: 120,
-    )
-    session = Session()
-    session.terminal.auto_level = AutoLevel.MED
-
-    rendered = auto_status_ansi(session)
-
-    assert "\x1b]" not in rendered
-    assert "\x07" not in rendered
-    assert "\x1b[2J" not in rendered
-    assert "\x1b[1;1H" not in rendered
-    assert "gpt-4" in rendered
-    assert "Auto (Med)" in rendered
-
-
-def test_all_control_model_falls_back_to_left_only(monkeypatch) -> None:
-    monkeypatch.setattr(
-        "surfaces.interactive_shell.ui.auto_status.detect_provider_model",
-        lambda: ("openai", "\x1b\x07\x9b"),
-    )
-    monkeypatch.setattr(
-        "surfaces.interactive_shell.ui.auto_status.prompt_line_width",
-        lambda: 80,
-    )
-
-    rendered = auto_status_ansi(Session())
-
-    assert "\x1b[2J" not in rendered
-    assert "\x07" not in rendered
-    assert "Auto (" in rendered
-
-
-def test_auto_status_recedes_while_the_spinner_owns_the_accent() -> None:
-    """Busy turns keep Auto on the page but DIM — one gold line, not two."""
-    import re
-
-    import infrastructure.terminal.theme as ui_theme
-    from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
-    from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
-
-    ui_theme.set_active_theme("amber")
-    session = Session()
-    session.terminal.auto_level = AutoLevel.HIGH
-    loud = auto_status_ansi(session, quiet=False)
-    quiet = auto_status_ansi(session, quiet=True)
-    assert ui_theme.BOLD_REPLY_MARKER_ANSI in loud
-    assert ui_theme.BOLD_REPLY_MARKER_ANSI not in quiet
-    assert ui_theme.DIM_ANSI in quiet
-    spinner = SpinnerState()
-    spinner.start()
-    spinner.set_phase(SpinnerState.THINKING_PHASE)
-    rendered = render_prompt_region(session, ReplState(), spinner).value
-    plain = re.sub(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07", "", rendered)
-    assert "Thinking" in plain
-    assert "Auto (High)" in plain
-    assert plain.index("Thinking") < plain.index("Auto (High)")
-    assert ui_theme.DIM_ANSI + "Auto (High)" in rendered
-
-
-def test_high_auto_omits_the_default_caption() -> None:
-    """High is the default — do not print ``all actions allowed`` on every frame."""
+def test_high_auto_shows_allow_all_permission() -> None:
+    """High is the default — the bar must still say what High permits."""
     import re
 
     from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
@@ -89,14 +22,45 @@ def test_high_auto_omits_the_default_caption() -> None:
         render_prompt_region(session, ReplState(), SpinnerState()).value,
     )
     assert "Auto (High)" in plain
-    assert "all actions allowed" not in plain
+    assert "Allow all" in plain
     session.terminal.auto_level = AutoLevel.MED
     med = re.sub(
         r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07",
         "",
         render_prompt_region(session, ReplState(), SpinnerState()).value,
     )
-    assert "allow reversible commands" in med
+    assert "Auto (Med)" in med
+    assert "Reversible only" in med
+
+
+def test_idle_auto_status_omits_the_model_slug() -> None:
+    """Model lives on ``/model`` and ``?``, not every idle frame."""
+    session = Session()
+    session.terminal.auto_level = AutoLevel.HIGH
+    rendered = auto_status_ansi(session)
+    assert "Auto (High)" in rendered
+    assert "Allow all" in rendered
+    assert "gpt-" not in rendered
+
+
+def test_busy_status_slot_is_thinking_not_auto() -> None:
+    """Thinking occupies the Auto slot — one headline, same stack height."""
+    import re
+
+    from surfaces.interactive_shell.runtime.core.state import ReplState, SpinnerState
+    from surfaces.interactive_shell.ui.terminal_ui import render_prompt_region
+
+    session = Session()
+    session.terminal.auto_level = AutoLevel.HIGH
+    idle = render_prompt_region(session, ReplState(), SpinnerState()).value
+    spinner = SpinnerState()
+    spinner.start()
+    spinner.set_phase(SpinnerState.THINKING_PHASE)
+    busy = render_prompt_region(session, ReplState(), spinner).value
+    plain = re.sub(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07", "", busy)
+    assert "Thinking" in plain
+    assert "Auto (High)" not in plain
+    assert idle.count("\n") == busy.count("\n")
 
 
 def test_render_prompt_region_shows_the_auto_status_line() -> None:

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -60,7 +60,9 @@ def test_launch_banner_is_borderless_centered_hero(monkeypatch: object) -> None:
     # in place of the old TIP line.
     assert "Welcome to OpenSRE CLI" in output
     assert "AI-powered DevOps agent" in output
-    assert "/ commands" in output
+    # Banner is install health, not a shortcut dump (those live on ``?``).
+    assert "/ commands" not in output
+    assert "Enter send" not in output
     # Only the two capability items — no MCPs or AGENTS.md line.
     assert "MCPs" not in output
     assert "AGENTS.md" not in output

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -25,7 +25,7 @@ def test_render_markdown_block_highlights_a_question() -> None:
     assert "Which environment should I investigate first?" in output
 
 
-def test_submitted_answer_to_a_handoff_is_marked() -> None:
+def test_submitted_handoff_answer_is_the_user_row() -> None:
     session = Session()
     # Only a structured picker / Ask-User handoff sets this flag; a plain
     # assistant question in prose must not trigger the answer treatment.
@@ -34,16 +34,9 @@ def test_submitted_answer_to_a_handoff_is_marked() -> None:
     console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
     render_submitted_prompt(console, session, "staging")
     output = buffer.getvalue()
-    assert "↗ answer" in output
+    # No hanging ``↗ answer`` — the user row is the answer (Droid / Cursor).
+    assert "↗ answer" not in output
     assert "staging" in output
-    # The marker hugs the assistant answer it responds to (no blank row above it),
-    # and the between-turns gap falls after the marker, before the input row.
-    assert not output.startswith("\n")
-    lines = output.splitlines()
-    marker_index = next(i for i, line in enumerate(lines) if "↗ answer" in line)
-    input_index = next(i for i, line in enumerate(lines) if "staging" in line)
-    assert lines[marker_index + 1].strip() == ""
-    assert marker_index < input_index
 
 
 def test_ask_user_answers_render_as_numbered_qa() -> None:

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -203,21 +203,11 @@ class TestResolveIdleHint:
 
 
 class TestComposerFooter:
-    def test_places_help_hint_without_terminal_mode_chrome(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 79)
-        footer = _strip_ansi(composer_footer_ansi())
-        assert footer.startswith("Enter send · Shift+Enter newline · ? help")
-        assert "TERMINAL" not in footer
-        assert "■" not in footer
-
-    def test_narrow_footer_keeps_only_a_clipped_help_hint(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(prompt_rendering, "prompt_line_width", lambda: 6)
-        footer = _strip_ansi(composer_footer_ansi())
-        assert footer == "Enter…"
+    def test_footer_row_is_empty_hints_live_in_the_placeholder(self) -> None:
+        assert composer_footer_ansi() == ""
+        session = Session()
+        assert "Enter send" in _placeholder_text(session)
+        assert "? help" in _placeholder_text(session)
 
 
 class TestPromptMessage:
@@ -228,7 +218,9 @@ class TestPromptMessage:
 class TestResolvePromptPlaceholder:
     def test_default_when_no_session_context(self) -> None:
         session = Session()
-        assert _placeholder_text(session) == "see what you can do"
+        text = _placeholder_text(session)
+        assert text.startswith("see what you can do")
+        assert "Enter send" in text
 
     def test_placeholder_prompts_to_continue_an_unfinished_plan(self) -> None:
         from core.agent_harness.task_plan.plan import parse_task_plan

--- a/tests/interactive_shell/ui/test_input_prompt.py
+++ b/tests/interactive_shell/ui/test_input_prompt.py
@@ -194,8 +194,8 @@ class TestPromptTurnCounter:
 
 class TestResolveIdleHint:
     def test_idle_hint_is_empty_no_recurring_ready_line(self) -> None:
-        # Hints live once in the banner + footer; the prompt shows no per-turn
-        # "Ready · …" line (it also stacked into copies on terminal resize).
+        # The prompt shows no per-turn "Ready · …" line (it also stacked into
+        # copies on terminal resize).
         session = Session()
         session.configured_integrations_known = True
         session.configured_integrations = ("datadog", "github", "grafana")
@@ -203,11 +203,13 @@ class TestResolveIdleHint:
 
 
 class TestComposerFooter:
-    def test_footer_row_is_empty_hints_live_in_the_placeholder(self) -> None:
+    def test_footer_row_is_empty_box_is_the_job_prompt(self) -> None:
         assert composer_footer_ansi() == ""
         session = Session()
-        assert "Enter send" in _placeholder_text(session)
-        assert "? help" in _placeholder_text(session)
+        text = _placeholder_text(session)
+        assert text == DEFAULT_PLACEHOLDER_TEXT
+        assert "Enter send" not in text
+        assert "? help" not in text
 
 
 class TestPromptMessage:
@@ -219,8 +221,8 @@ class TestResolvePromptPlaceholder:
     def test_default_when_no_session_context(self) -> None:
         session = Session()
         text = _placeholder_text(session)
-        assert text.startswith("see what you can do")
-        assert "Enter send" in text
+        assert text == "Ask about an alert"
+        assert "Enter send" not in text
 
     def test_placeholder_prompts_to_continue_an_unfinished_plan(self) -> None:
         from core.agent_harness.task_plan.plan import parse_task_plan

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -138,8 +138,8 @@ def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> 
 
 
 def test_idle_prompt_has_no_recurring_ready_hint() -> None:
-    # Command hints live once in the launch banner and the composer footer, not
-    # a per-turn "Ready · …" line (which also stacked into copies on resize).
+    # Command hints live on ``?``, not a per-turn "Ready · …" line (which also
+    # stacked into copies on resize).
     session = Session()
     rendered = _plain(render_prompt_region(session, ReplState(), SpinnerState()).value)
     assert "Ready" not in rendered

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -238,12 +238,16 @@ def test_plan_breakdown_dims_work_notes_and_accents_checked_steps() -> None:
     """Droid/Cursor/Claude: checklist steps primary; ``↳`` work notes dim."""
     import io
 
+    from rich.color import ColorSystem
     from rich.console import Console
+    from rich.style import Style
 
     import infrastructure.terminal.theme as ui_theme
     from surfaces.interactive_shell.ui.task_plan import render_plan_breakdown
 
     ui_theme.set_active_theme("amber")
+    # A 16-color render of theme DIM must not pin work notes to bright-black.
+    Style.parse(str(ui_theme.DIM))._make_ansi_codes(ColorSystem.STANDARD)
     breakdown = (
         "Plan complete · 2/2\n"
         "  ✓ Confirm repository\n"
@@ -268,6 +272,7 @@ def test_plan_breakdown_dims_work_notes_and_accents_checked_steps() -> None:
     assert "↳ GitHub CLI · gh repo view" in plain
     # Work notes use DIM; checked glyphs use HIGHLIGHT — not one flat color.
     assert ui_theme.DIM_ANSI in out
+    assert "\x1b[90m" not in out
     assert ui_theme.HIGHLIGHT_ANSI in out
     assert ui_theme.TEXT_ANSI in out
     # Caption is secondary, distinct from step body and work notes.

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -93,8 +93,7 @@ def test_prompt_region_keeps_the_checklist_above_invoking_tools() -> None:
     assert "● Trace 502s to the last deploy" in rendered
     assert SpinnerState.INVOKING_TOOLS_PHASE in rendered
     assert rendered.index("Plan · 2/3") < rendered.index(SpinnerState.INVOKING_TOOLS_PHASE)
-    assert "Auto (High)" in rendered
-    assert rendered.index(SpinnerState.INVOKING_TOOLS_PHASE) < rendered.index("Auto (High)")
+    assert "Auto (High)" not in rendered
     assert re.search(
         rf"  ○ Confirm checkout returns 2xx\n\n[^\n]*"
         rf"{re.escape(SpinnerState.INVOKING_TOOLS_PHASE)}",
@@ -111,7 +110,7 @@ def test_idle_prompt_region_shows_plan_without_thinking_or_ready_hint() -> None:
     assert "Plan · 2/3" in rendered
     assert "Ready" not in rendered  # no recurring idle hint line
     assert rendered.index("Plan · 2/3") < rendered.index("Auto (High)")
-    assert "  ○ Confirm checkout returns 2xx\n\nAuto (High)" in rendered
+    assert "  ○ Confirm checkout returns 2xx\n\nAuto (High) · Allow all" in rendered
 
 
 def test_clearing_the_plan_resets_expanded_state() -> None:


### PR DESCRIPTION
## Changes

- Auto status: `auto_status_ansi` collapses its caption when the level is
  the High default (noise on every idle frame) and takes a `quiet` mode so
  it recedes to DIM while Thinking/Invoking owns the accent — one status
  row, not two competing headlines.
- Composer: removed the dedicated footer line under the box; the send hint
  now lives in the empty-box placeholder (`see what you can do · Enter
  send · ? help`). One stack, not a textbook under the box.
- Removed the ↗ answer hand-off marker (unused) and its dead export.
- Plan breakdown: work-note rows are emitted as raw truecolor DIM with
  markup/highlight off, so Rich's Style cache can't emit bright-black
  `[90m` from an earlier 16-color console on a truecolor turn.