### PR TITLE
perf(installer): preserve verified macOS bundle identity

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,16 @@ INSTALL_CHANNEL_EXPLICIT=0
 MAIN_RELEASE_TAG="${OPENSRE_MAIN_RELEASE_TAG:-main-build}"
 BIN_NAME="opensre"
 requested_version="${OPENSRE_VERSION:-}"
+binary_app_transaction_active=0
+binary_app_transaction_committed=0
+binary_app_transaction_had_app=0
+binary_app_transaction_had_destination=0
+binary_app_transaction_app_destination_dir=""
+binary_app_transaction_app_tmp_dir=""
+binary_app_transaction_app_old_dir=""
+binary_app_transaction_destination_path=""
+binary_app_transaction_destination_tmp_path=""
+binary_app_transaction_destination_old_path=""
 
 [ -n "$INSTALL_DIR" ] && INSTALL_DIR_OVERRIDE=1
 requested_version="${requested_version#v}"
@@ -566,32 +576,81 @@ install_binary() {
   chmod 0755 "$destination_path" 2>/dev/null || true
 }
 
+begin_binary_app_install_transaction() {
+  binary_app_transaction_app_destination_dir="$1"
+  binary_app_transaction_app_tmp_dir="$2"
+  binary_app_transaction_app_old_dir="$3"
+  binary_app_transaction_destination_path="$4"
+  binary_app_transaction_destination_tmp_path="$5"
+  binary_app_transaction_destination_old_path="$6"
+  binary_app_transaction_committed=0
+  binary_app_transaction_had_app=0
+  binary_app_transaction_had_destination=0
+
+  if [ -e "$binary_app_transaction_app_destination_dir" ] \
+    || [ -L "$binary_app_transaction_app_destination_dir" ]; then
+    binary_app_transaction_had_app=1
+  fi
+  if [ -e "$binary_app_transaction_destination_path" ] \
+    || [ -L "$binary_app_transaction_destination_path" ]; then
+    binary_app_transaction_had_destination=1
+  fi
+  binary_app_transaction_active=1
+}
+
 rollback_binary_app_install() {
-  local app_destination_dir="$1"
-  local app_tmp_dir="$2"
-  local app_old_dir="$3"
-  local app_promoted="$4"
-  local previous_app_moved="$5"
-  local destination_path="$6"
-  local destination_tmp_path="$7"
-  local destination_old_path="$8"
-  local previous_destination_moved="$9"
+  [ "$binary_app_transaction_active" -eq 1 ] || return 0
 
-  if [ "$app_promoted" -eq 1 ]; then
-    if ! mv "$app_destination_dir" "$app_tmp_dir"; then
-      rm -rf "$app_destination_dir" || true
+  if [ "$binary_app_transaction_committed" -eq 1 ]; then
+    rm -rf \
+      "$binary_app_transaction_app_tmp_dir" \
+      "$binary_app_transaction_app_old_dir" \
+      2>/dev/null || true
+    rm -f \
+      "$binary_app_transaction_destination_tmp_path" \
+      "$binary_app_transaction_destination_old_path" \
+      2>/dev/null || true
+    binary_app_transaction_active=0
+    return 0
+  fi
+
+  if [ "$binary_app_transaction_had_app" -eq 1 ]; then
+    if [ -e "$binary_app_transaction_app_old_dir" ] \
+      || [ -L "$binary_app_transaction_app_old_dir" ]; then
+      if rm -rf "$binary_app_transaction_app_destination_dir"; then
+        if ! mv \
+          "$binary_app_transaction_app_old_dir" \
+          "$binary_app_transaction_app_destination_dir"; then
+          warn "Could not restore the previous OpenSRE app; it remains at '${binary_app_transaction_app_old_dir}'."
+        fi
+      else
+        warn "Could not remove the uncommitted OpenSRE app at '${binary_app_transaction_app_destination_dir}'."
+      fi
     fi
-  fi
-  if [ "$previous_app_moved" -eq 1 ] && ! mv "$app_old_dir" "$app_destination_dir"; then
-    warn "Could not restore the previous OpenSRE app; it remains at '${app_old_dir}'."
-  fi
-  if [ "$previous_destination_moved" -eq 1 ] \
-    && ! mv "$destination_old_path" "$destination_path"; then
-    warn "Could not restore the previous OpenSRE launcher; it remains at '${destination_old_path}'."
+  else
+    rm -rf "$binary_app_transaction_app_destination_dir" || true
   fi
 
-  rm -rf "$app_tmp_dir" || true
-  rm -f "$destination_tmp_path" || true
+  if [ "$binary_app_transaction_had_destination" -eq 1 ]; then
+    if [ -e "$binary_app_transaction_destination_old_path" ] \
+      || [ -L "$binary_app_transaction_destination_old_path" ]; then
+      if rm -f "$binary_app_transaction_destination_path"; then
+        if ! mv \
+          "$binary_app_transaction_destination_old_path" \
+          "$binary_app_transaction_destination_path"; then
+          warn "Could not restore the previous OpenSRE launcher; it remains at '${binary_app_transaction_destination_old_path}'."
+        fi
+      else
+        warn "Could not remove the uncommitted OpenSRE launcher at '${binary_app_transaction_destination_path}'."
+      fi
+    fi
+  else
+    rm -f "$binary_app_transaction_destination_path" || true
+  fi
+
+  rm -rf "$binary_app_transaction_app_tmp_dir" || true
+  rm -f "$binary_app_transaction_destination_tmp_path" || true
+  binary_app_transaction_active=0
 }
 
 install_binary_app() {
@@ -602,9 +661,6 @@ install_binary_app() {
   local app_old_dir="${app_destination_dir}.old.$$"
   local destination_tmp_path="${destination_path}.new.$$"
   local destination_old_path="${destination_path}.old.$$"
-  local app_promoted=0
-  local previous_app_moved=0
-  local previous_destination_moved=0
 
   if [ -d "$destination_path" ] && [ ! -L "$destination_path" ]; then
     warn "Cannot install OpenSRE because '${destination_path}' is a directory."
@@ -613,64 +669,57 @@ install_binary_app() {
 
   rm -rf "$app_tmp_dir" "$app_old_dir" || return 1
   rm -f "$destination_tmp_path" "$destination_old_path" || return 1
+  begin_binary_app_install_transaction \
+    "$app_destination_dir" "$app_tmp_dir" "$app_old_dir" \
+    "$destination_path" "$destination_tmp_path" "$destination_old_path"
+
   if [ "$platform" = "darwin" ]; then
     # Preserve file identity after verify_binary_version() on same-filesystem
     # installs. Retaining the verified executable's inode avoids the repeated
     # cold security-assessment delay observed when an ad-hoc-signed bundle is
     # copied. ``mv`` falls back to copy/remove semantics across filesystems.
     if ! mv "$app_root" "$app_tmp_dir"; then
-      rm -rf "$app_tmp_dir" || true
+      rollback_binary_app_install
       return 1
     fi
   else
     # A fresh Linux copy inherits destination SELinux labels and default ACLs.
     if ! cp -R "$app_root" "$app_tmp_dir"; then
-      rm -rf "$app_tmp_dir" || true
+      rollback_binary_app_install
       return 1
     fi
   fi
   chmod -R u+rwX,go+rX "$app_tmp_dir" 2>/dev/null || true
   if ! ln -s "$app_destination_dir/${BIN_NAME}" "$destination_tmp_path"; then
-    rm -rf "$app_tmp_dir" || true
+    rollback_binary_app_install
     return 1
   fi
 
-  if [ -e "$app_destination_dir" ]; then
+  if [ -e "$app_destination_dir" ] || [ -L "$app_destination_dir" ]; then
     if ! mv "$app_destination_dir" "$app_old_dir"; then
-      rm -rf "$app_tmp_dir" || true
-      rm -f "$destination_tmp_path" || true
+      rollback_binary_app_install
       return 1
     fi
-    previous_app_moved=1
   fi
   if [ -e "$destination_path" ] || [ -L "$destination_path" ]; then
     if ! mv "$destination_path" "$destination_old_path"; then
-      rollback_binary_app_install \
-        "$app_destination_dir" "$app_tmp_dir" "$app_old_dir" "$app_promoted" \
-        "$previous_app_moved" "$destination_path" "$destination_tmp_path" \
-        "$destination_old_path" "$previous_destination_moved"
+      rollback_binary_app_install
       return 1
     fi
-    previous_destination_moved=1
   fi
   if ! mv "$app_tmp_dir" "$app_destination_dir"; then
-    rollback_binary_app_install \
-      "$app_destination_dir" "$app_tmp_dir" "$app_old_dir" "$app_promoted" \
-      "$previous_app_moved" "$destination_path" "$destination_tmp_path" \
-      "$destination_old_path" "$previous_destination_moved"
+    rollback_binary_app_install
     return 1
   fi
-  app_promoted=1
   if ! mv "$destination_tmp_path" "$destination_path"; then
-    rollback_binary_app_install \
-      "$app_destination_dir" "$app_tmp_dir" "$app_old_dir" "$app_promoted" \
-      "$previous_app_moved" "$destination_path" "$destination_tmp_path" \
-      "$destination_old_path" "$previous_destination_moved"
+    rollback_binary_app_install
     return 1
   fi
 
+  binary_app_transaction_committed=1
   rm -rf "$app_old_dir" || warn "Could not remove '${app_old_dir}'."
   rm -f "$destination_old_path" || warn "Could not remove '${destination_old_path}'."
+  binary_app_transaction_active=0
 }
 
 install_verified_binary() {
@@ -953,6 +1002,7 @@ ensure_on_path_impl() {
 }
 
 cleanup() {
+  rollback_binary_app_install
   if [ -n "${tmp_dir:-}" ] && [ -d "$tmp_dir" ]; then
     rm -rf "$tmp_dir"
   fi

--- a/install.sh
+++ b/install.sh
@@ -496,7 +496,7 @@ extract_archive() {
   fi
 
   need_cmd tar
-  tar -xzf "$archive_path" -C "$destination_dir"
+  tar --no-same-owner --no-same-permissions -xzf "$archive_path" -C "$destination_dir"
 }
 
 verify_checksum() {
@@ -574,7 +574,16 @@ install_binary_app() {
   local app_old_dir="${app_destination_dir}.old.$$"
 
   rm -rf "$app_tmp_dir" "$app_old_dir"
-  cp -R "$app_root" "$app_tmp_dir"
+  if [ "$platform" = "darwin" ]; then
+    # Preserve file identity after verify_binary_version() on same-filesystem
+    # installs. Retaining the verified executable's inode avoids the repeated
+    # cold security-assessment delay observed when an ad-hoc-signed bundle is
+    # copied. ``mv`` falls back to copy/remove semantics across filesystems.
+    mv "$app_root" "$app_tmp_dir"
+  else
+    # A fresh Linux copy inherits destination SELinux labels and default ACLs.
+    cp -R "$app_root" "$app_tmp_dir"
+  fi
   chmod -R u+rwX,go+rX "$app_tmp_dir" 2>/dev/null || true
 
   if [ -e "$app_destination_dir" ]; then

--- a/install.sh
+++ b/install.sh
@@ -566,34 +566,111 @@ install_binary() {
   chmod 0755 "$destination_path" 2>/dev/null || true
 }
 
+rollback_binary_app_install() {
+  local app_destination_dir="$1"
+  local app_tmp_dir="$2"
+  local app_old_dir="$3"
+  local app_promoted="$4"
+  local previous_app_moved="$5"
+  local destination_path="$6"
+  local destination_tmp_path="$7"
+  local destination_old_path="$8"
+  local previous_destination_moved="$9"
+
+  if [ "$app_promoted" -eq 1 ]; then
+    if ! mv "$app_destination_dir" "$app_tmp_dir"; then
+      rm -rf "$app_destination_dir" || true
+    fi
+  fi
+  if [ "$previous_app_moved" -eq 1 ] && ! mv "$app_old_dir" "$app_destination_dir"; then
+    warn "Could not restore the previous OpenSRE app; it remains at '${app_old_dir}'."
+  fi
+  if [ "$previous_destination_moved" -eq 1 ] \
+    && ! mv "$destination_old_path" "$destination_path"; then
+    warn "Could not restore the previous OpenSRE launcher; it remains at '${destination_old_path}'."
+  fi
+
+  rm -rf "$app_tmp_dir" || true
+  rm -f "$destination_tmp_path" || true
+}
+
 install_binary_app() {
   local app_root="$1"
   local destination_path="$2"
   local app_destination_dir="${INSTALL_DIR}/.${BIN_NAME}-app"
   local app_tmp_dir="${app_destination_dir}.new.$$"
   local app_old_dir="${app_destination_dir}.old.$$"
+  local destination_tmp_path="${destination_path}.new.$$"
+  local destination_old_path="${destination_path}.old.$$"
+  local app_promoted=0
+  local previous_app_moved=0
+  local previous_destination_moved=0
 
-  rm -rf "$app_tmp_dir" "$app_old_dir"
+  if [ -d "$destination_path" ] && [ ! -L "$destination_path" ]; then
+    warn "Cannot install OpenSRE because '${destination_path}' is a directory."
+    return 1
+  fi
+
+  rm -rf "$app_tmp_dir" "$app_old_dir" || return 1
+  rm -f "$destination_tmp_path" "$destination_old_path" || return 1
   if [ "$platform" = "darwin" ]; then
     # Preserve file identity after verify_binary_version() on same-filesystem
     # installs. Retaining the verified executable's inode avoids the repeated
     # cold security-assessment delay observed when an ad-hoc-signed bundle is
     # copied. ``mv`` falls back to copy/remove semantics across filesystems.
-    mv "$app_root" "$app_tmp_dir"
+    if ! mv "$app_root" "$app_tmp_dir"; then
+      rm -rf "$app_tmp_dir" || true
+      return 1
+    fi
   else
     # A fresh Linux copy inherits destination SELinux labels and default ACLs.
-    cp -R "$app_root" "$app_tmp_dir"
+    if ! cp -R "$app_root" "$app_tmp_dir"; then
+      rm -rf "$app_tmp_dir" || true
+      return 1
+    fi
   fi
   chmod -R u+rwX,go+rX "$app_tmp_dir" 2>/dev/null || true
+  if ! ln -s "$app_destination_dir/${BIN_NAME}" "$destination_tmp_path"; then
+    rm -rf "$app_tmp_dir" || true
+    return 1
+  fi
 
   if [ -e "$app_destination_dir" ]; then
-    mv "$app_destination_dir" "$app_old_dir"
+    if ! mv "$app_destination_dir" "$app_old_dir"; then
+      rm -rf "$app_tmp_dir" || true
+      rm -f "$destination_tmp_path" || true
+      return 1
+    fi
+    previous_app_moved=1
   fi
-  mv "$app_tmp_dir" "$app_destination_dir"
-  rm -rf "$app_old_dir"
+  if [ -e "$destination_path" ] || [ -L "$destination_path" ]; then
+    if ! mv "$destination_path" "$destination_old_path"; then
+      rollback_binary_app_install \
+        "$app_destination_dir" "$app_tmp_dir" "$app_old_dir" "$app_promoted" \
+        "$previous_app_moved" "$destination_path" "$destination_tmp_path" \
+        "$destination_old_path" "$previous_destination_moved"
+      return 1
+    fi
+    previous_destination_moved=1
+  fi
+  if ! mv "$app_tmp_dir" "$app_destination_dir"; then
+    rollback_binary_app_install \
+      "$app_destination_dir" "$app_tmp_dir" "$app_old_dir" "$app_promoted" \
+      "$previous_app_moved" "$destination_path" "$destination_tmp_path" \
+      "$destination_old_path" "$previous_destination_moved"
+    return 1
+  fi
+  app_promoted=1
+  if ! mv "$destination_tmp_path" "$destination_path"; then
+    rollback_binary_app_install \
+      "$app_destination_dir" "$app_tmp_dir" "$app_old_dir" "$app_promoted" \
+      "$previous_app_moved" "$destination_path" "$destination_tmp_path" \
+      "$destination_old_path" "$previous_destination_moved"
+    return 1
+  fi
 
-  rm -f "$destination_path"
-  ln -s "$app_destination_dir/${BIN_NAME}" "$destination_path"
+  rm -rf "$app_old_dir" || warn "Could not remove '${app_old_dir}'."
+  rm -f "$destination_old_path" || warn "Could not remove '${destination_old_path}'."
 }
 
 install_verified_binary() {

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -81,6 +81,20 @@ def _run_logging_snippet(body: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
 
 
+def _write_fake_onedir_app(root: Path, output: str) -> Path:
+    root.mkdir(parents=True)
+    binary = root / "opensre"
+    binary.write_text(
+        f"#!/usr/bin/env sh\nprintf '%s\\n' {shlex.quote(output)}\n",
+        encoding="utf-8",
+    )
+    binary.chmod(0o755)
+    internal = root / "_internal"
+    internal.mkdir()
+    (internal / "payload.txt").write_text(output, encoding="utf-8")
+    return binary
+
+
 def test_install_sh_logging_falls_back_to_plain_text_when_not_tty() -> None:
     result = _run_logging_snippet(
         """
@@ -269,13 +283,7 @@ def test_install_sh_uses_move_on_darwin_and_copy_on_linux(
 ) -> None:
     """Darwin retains file identity; Linux stages a fresh copy."""
     app_root = tmp_path / "opensre-app"
-    app_root.mkdir()
-    app_binary = app_root / "opensre"
-    app_binary.write_text("#!/usr/bin/env sh\nprintf 'opensre test\\n'\n", encoding="utf-8")
-    app_binary.chmod(0o755)
-    internal = app_root / "_internal"
-    internal.mkdir()
-    (internal / "payload.txt").write_text("bundled", encoding="utf-8")
+    app_binary = _write_fake_onedir_app(app_root, "opensre test")
     source_stat = app_binary.stat()
     source_identity = (source_stat.st_dev, source_stat.st_ino)
     install_dir = tmp_path / "bin"
@@ -304,6 +312,151 @@ def test_install_sh_uses_move_on_darwin_and_copy_on_linux(
     else:
         assert app_root.exists()
         assert installed_identity != source_identity
+
+
+def test_install_sh_preserves_directory_at_launcher_path(tmp_path: Path) -> None:
+    candidate_root = tmp_path / "candidate"
+    candidate_binary = _write_fake_onedir_app(candidate_root, "candidate")
+    install_dir = tmp_path / "bin"
+    destination = install_dir / "opensre"
+    destination.mkdir(parents=True)
+    marker = destination / "user-data"
+    marker.write_text("keep", encoding="utf-8")
+
+    result = _run_logging_snippet(
+        f"""
+        platform="darwin"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        install_binary_app {shlex.quote(str(candidate_binary.parent))} {shlex.quote(str(destination))} || exit "$?"
+        """
+    )
+
+    assert result.returncode != 0
+    assert f"'{destination}' is a directory" in result.stderr
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert candidate_root.exists()
+    assert not list(install_dir.rglob(".opensre-app.new.*"))
+    assert not list(install_dir.rglob(".opensre-app.old.*"))
+    assert not list(install_dir.rglob("opensre.new.*"))
+    assert not list(install_dir.rglob("opensre.old.*"))
+
+
+def test_install_sh_cleans_staged_app_when_backing_up_existing_app_fails(
+    tmp_path: Path,
+) -> None:
+    candidate_root = tmp_path / "candidate"
+    candidate_binary = _write_fake_onedir_app(candidate_root, "candidate")
+    install_dir = tmp_path / "bin"
+    old_root = install_dir / ".opensre-app"
+    old_binary = _write_fake_onedir_app(old_root, "old")
+    destination = install_dir / "opensre"
+    destination.symlink_to(old_binary)
+
+    result = _run_logging_snippet(
+        f"""
+        platform="darwin"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        mv() {{
+          if [[ "${{2:-}}" == "$INSTALL_DIR/.opensre-app.old."* ]]; then
+            printf 'injected backup failure\\n' >&2
+            return 71
+          fi
+          command mv "$@"
+        }}
+        install_binary_app {shlex.quote(str(candidate_binary.parent))} {shlex.quote(str(destination))} || exit "$?"
+        """
+    )
+
+    assert result.returncode != 0
+    assert "injected backup failure" in result.stderr
+    assert destination.is_symlink()
+    assert (
+        subprocess.run([destination], capture_output=True, text=True, check=True).stdout == "old\n"
+    )
+    assert not list(install_dir.rglob(".opensre-app.new.*"))
+    assert not list(install_dir.rglob(".opensre-app.old.*"))
+    assert not list(install_dir.rglob("opensre.new.*"))
+    assert not list(install_dir.rglob("opensre.old.*"))
+
+
+def test_install_sh_rolls_back_existing_app_when_activation_fails(
+    tmp_path: Path,
+) -> None:
+    candidate_root = tmp_path / "candidate"
+    candidate_binary = _write_fake_onedir_app(candidate_root, "candidate")
+    install_dir = tmp_path / "bin"
+    old_root = install_dir / ".opensre-app"
+    old_binary = _write_fake_onedir_app(old_root, "old")
+    destination = install_dir / "opensre"
+    destination.symlink_to(old_binary)
+
+    result = _run_logging_snippet(
+        f"""
+        platform="darwin"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        mv() {{
+          if [[ "$1" == "$INSTALL_DIR/.opensre-app.new."* && "$2" == "$INSTALL_DIR/.opensre-app" ]]; then
+            printf 'injected activation failure\\n' >&2
+            return 72
+          fi
+          command mv "$@"
+        }}
+        install_binary_app {shlex.quote(str(candidate_binary.parent))} {shlex.quote(str(destination))} || exit "$?"
+        """
+    )
+
+    assert result.returncode != 0
+    assert "injected activation failure" in result.stderr
+    assert destination.is_symlink()
+    assert (
+        subprocess.run([destination], capture_output=True, text=True, check=True).stdout == "old\n"
+    )
+    assert not list(install_dir.rglob(".opensre-app.new.*"))
+    assert not list(install_dir.rglob(".opensre-app.old.*"))
+    assert not list(install_dir.rglob("opensre.new.*"))
+    assert not list(install_dir.rglob("opensre.old.*"))
+
+
+def test_install_sh_rolls_back_app_and_launcher_when_launcher_activation_fails(
+    tmp_path: Path,
+) -> None:
+    candidate_root = tmp_path / "candidate"
+    candidate_binary = _write_fake_onedir_app(candidate_root, "candidate")
+    install_dir = tmp_path / "bin"
+    old_root = install_dir / ".opensre-app"
+    old_binary = _write_fake_onedir_app(old_root, "old")
+    destination = install_dir / "opensre"
+    destination.symlink_to(old_binary)
+
+    result = _run_logging_snippet(
+        f"""
+        platform="darwin"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        mv() {{
+          if [[ "$1" == "$INSTALL_DIR/opensre.new."* && "$2" == "$INSTALL_DIR/opensre" ]]; then
+            printf 'injected launcher activation failure\\n' >&2
+            return 73
+          fi
+          command mv "$@"
+        }}
+        install_binary_app {shlex.quote(str(candidate_binary.parent))} {shlex.quote(str(destination))} || exit "$?"
+        """
+    )
+
+    assert result.returncode != 0
+    assert "injected launcher activation failure" in result.stderr
+    assert destination.is_symlink()
+    assert (
+        subprocess.run([destination], capture_output=True, text=True, check=True).stdout == "old\n"
+    )
+    assert not list(install_dir.rglob(".opensre-app.new.*"))
+    assert not list(install_dir.rglob(".opensre-app.old.*"))
+    assert not list(install_dir.rglob("opensre.new.*"))
+    assert not list(install_dir.rglob("opensre.old.*"))
 
 
 def test_install_sh_uses_concise_unnumbered_install_messages() -> None:

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -342,6 +342,36 @@ def test_install_sh_preserves_directory_at_launcher_path(tmp_path: Path) -> None
     assert not list(install_dir.rglob("opensre.old.*"))
 
 
+def test_install_sh_replaces_dangling_app_symlink(tmp_path: Path) -> None:
+    candidate_root = tmp_path / "candidate"
+    candidate_binary = _write_fake_onedir_app(candidate_root, "candidate")
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    app_destination = install_dir / ".opensre-app"
+    app_destination.symlink_to(tmp_path / "missing-app", target_is_directory=True)
+    destination = install_dir / "opensre"
+    destination.symlink_to(app_destination / "opensre")
+
+    result = _run_logging_snippet(
+        f"""
+        platform="darwin"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        install_binary_app {shlex.quote(str(candidate_binary.parent))} {shlex.quote(str(destination))} || exit "$?"
+        {shlex.quote(str(destination))}
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "candidate\n"
+    assert app_destination.is_dir()
+    assert not app_destination.is_symlink()
+    assert not list(install_dir.rglob(".opensre-app.new.*"))
+    assert not list(install_dir.rglob(".opensre-app.old.*"))
+    assert not list(install_dir.rglob("opensre.new.*"))
+    assert not list(install_dir.rglob("opensre.old.*"))
+
+
 def test_install_sh_cleans_staged_app_when_backing_up_existing_app_fails(
     tmp_path: Path,
 ) -> None:
@@ -449,6 +479,98 @@ def test_install_sh_rolls_back_app_and_launcher_when_launcher_activation_fails(
 
     assert result.returncode != 0
     assert "injected launcher activation failure" in result.stderr
+    assert destination.is_symlink()
+    assert (
+        subprocess.run([destination], capture_output=True, text=True, check=True).stdout == "old\n"
+    )
+    assert not list(install_dir.rglob(".opensre-app.new.*"))
+    assert not list(install_dir.rglob(".opensre-app.old.*"))
+    assert not list(install_dir.rglob("opensre.new.*"))
+    assert not list(install_dir.rglob("opensre.old.*"))
+
+
+def test_install_sh_exit_cleanup_removes_staged_darwin_app_on_term(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    candidate_root = workspace / "candidate"
+    candidate_binary = _write_fake_onedir_app(candidate_root, "candidate")
+    install_dir = tmp_path / "bin"
+    old_root = install_dir / ".opensre-app"
+    old_binary = _write_fake_onedir_app(old_root, "old")
+    destination = install_dir / "opensre"
+    destination.symlink_to(old_binary)
+
+    result = _run_logging_snippet(
+        f"""
+        platform="darwin"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        tmp_dir={shlex.quote(str(workspace))}
+        trap cleanup EXIT
+        is_interactive_status_terminal() {{ return 0; }}
+        mv() {{
+          command mv "$@"
+          if [[ "$1" == "$tmp_dir/candidate" && "$2" == "$INSTALL_DIR/.opensre-app.new."* ]]; then
+            printf 'checkpoint: Darwin app staged\n'
+            kill -TERM "$$"
+          fi
+        }}
+        run_with_dots "Installing OpenSRE" \
+          install_binary_app {shlex.quote(str(candidate_binary.parent))} {shlex.quote(str(destination))} \
+          || exit "$?"
+        """
+    )
+
+    assert result.returncode == 130
+    assert "checkpoint: Darwin app staged" in result.stdout
+    assert not workspace.exists()
+    assert destination.is_symlink()
+    assert (
+        subprocess.run([destination], capture_output=True, text=True, check=True).stdout == "old\n"
+    )
+    assert not list(install_dir.rglob(".opensre-app.new.*"))
+    assert not list(install_dir.rglob(".opensre-app.old.*"))
+    assert not list(install_dir.rglob("opensre.new.*"))
+    assert not list(install_dir.rglob("opensre.old.*"))
+
+
+def test_install_sh_exit_cleanup_restores_app_and_launcher_after_backup_on_int(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    candidate_root = workspace / "candidate"
+    candidate_binary = _write_fake_onedir_app(candidate_root, "candidate")
+    install_dir = tmp_path / "bin"
+    old_root = install_dir / ".opensre-app"
+    old_binary = _write_fake_onedir_app(old_root, "old")
+    destination = install_dir / "opensre"
+    destination.symlink_to(old_binary)
+
+    result = _run_logging_snippet(
+        f"""
+        platform="darwin"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        tmp_dir={shlex.quote(str(workspace))}
+        trap cleanup EXIT
+        is_interactive_status_terminal() {{ return 0; }}
+        mv() {{
+          command mv "$@"
+          if [[ "$1" == "$INSTALL_DIR/opensre" && "$2" == "$INSTALL_DIR/opensre.old."* ]]; then
+            printf 'checkpoint: app and launcher backed up\n'
+            kill -INT "$$"
+          fi
+        }}
+        run_with_dots "Installing OpenSRE" \
+          install_binary_app {shlex.quote(str(candidate_binary.parent))} {shlex.quote(str(destination))} \
+          || exit "$?"
+        """
+    )
+
+    assert result.returncode == 130
+    assert "checkpoint: app and launcher backed up" in result.stdout
+    assert not workspace.exists()
     assert destination.is_symlink()
     assert (
         subprocess.run([destination], capture_output=True, text=True, check=True).stdout == "old\n"

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -240,7 +240,34 @@ def test_install_sh_verify_binary_failure_includes_diagnostics(tmp_path: Path) -
     assert str(fake_binary) in output
 
 
-def test_install_sh_installs_pyinstaller_onedir_app(tmp_path: Path) -> None:
+def test_install_sh_tar_extraction_disables_archived_owner_and_permissions() -> None:
+    result = _run_logging_snippet(
+        """
+        platform="linux"
+        tar() { printf '%s\n' "$@"; }
+        extract_archive "/tmp/opensre.tar.gz" "/tmp/extracted"
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "--no-same-owner",
+        "--no-same-permissions",
+        "-xzf",
+        "/tmp/opensre.tar.gz",
+        "-C",
+        "/tmp/extracted",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("platform", "preserves_identity"),
+    (("darwin", True), ("linux", False)),
+)
+def test_install_sh_uses_move_on_darwin_and_copy_on_linux(
+    tmp_path: Path, platform: str, preserves_identity: bool
+) -> None:
+    """Darwin retains file identity; Linux stages a fresh copy."""
     app_root = tmp_path / "opensre-app"
     app_root.mkdir()
     app_binary = app_root / "opensre"
@@ -249,12 +276,14 @@ def test_install_sh_installs_pyinstaller_onedir_app(tmp_path: Path) -> None:
     internal = app_root / "_internal"
     internal.mkdir()
     (internal / "payload.txt").write_text("bundled", encoding="utf-8")
+    source_stat = app_binary.stat()
+    source_identity = (source_stat.st_dev, source_stat.st_ino)
     install_dir = tmp_path / "bin"
     destination = install_dir / "opensre"
 
     result = _run_logging_snippet(
         f"""
-        platform="linux"
+        platform={shlex.quote(platform)}
         BIN_NAME="opensre"
         INSTALL_DIR={shlex.quote(str(install_dir))}
         install_verified_binary {shlex.quote(str(app_binary))} {shlex.quote(str(destination))}
@@ -267,6 +296,14 @@ def test_install_sh_installs_pyinstaller_onedir_app(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert "opensre test" in result.stdout
+    installed_stat = destination.resolve().stat()
+    installed_identity = (installed_stat.st_dev, installed_stat.st_ino)
+    if preserves_identity:
+        assert not app_root.exists()
+        assert installed_identity == source_identity
+    else:
+        assert app_root.exists()
+        assert installed_identity != source_identity
 
 
 def test_install_sh_uses_concise_unnumbered_install_messages() -> None:


### PR DESCRIPTION
Refs #5844

> This is a partial improvement. It does not close #5844: eliminating the remaining macOS first-launch security assessment requires Developer ID signing and notarization.

#### Describe the changes you have made in this PR -

The installer verifies the extracted OpenSRE executable before installation. On macOS, copying the verified PyInstaller onedir bundle with `cp -R` gives the installed files new identities, causing macOS to assess the ad-hoc-signed bundle again when the user first launches it.

This change:

- Moves the verified onedir bundle into place on macOS, preserving file identity when the temporary and installation directories are on the same filesystem.
- Keeps the existing copy behavior on Linux so installed files inherit destination SELinux labels, default ACLs, and setgid behavior.
- Extracts non-Windows tar archives with `--no-same-owner` and `--no-same-permissions`, preventing archived build-runner ownership and modes from reaching the final installation now that macOS uses `mv`.
- Adds regression tests proving that macOS preserves the verified executable identity while Linux still installs a fresh copy.
- Stages both the app bundle and launcher, then rolls back to the previous working installation if backup, activation, or an `INT`/`TERM`-driven exit interrupts replacement. A real directory at the launcher path is rejected without moving or deleting it.
- Adds a test pinning the hardened tar extraction arguments.

A cross-filesystem macOS `mv` may fall back to copy/remove semantics, so installation remains functional but may not receive the file-identity performance benefit in that uncommon layout.

Remaining work intentionally stays out of scope:

- Fully removing the macOS assessment delay requires Developer ID Application signing, hardened runtime, timestamping, and notarization with maintainer-owned Apple credentials.
- Windows still uses a self-extracting onefile package. That separate startup cost is tracked by #5935; `install.ps1` and Windows packaging are unchanged here.

### Demo/Screenshot for feature changes and bug fixes -

A controlled macOS test used the same current ARM64 release artifact and measured readiness in a real PTY:

| Installation path | First interactive readiness |
| --- | ---: |
| Existing `cp -R` path | 32.961s |
| Candidate identity-preserving path | 14.246s |

This reduced first interactive readiness by approximately **56.8%**. Warm readiness remained effectively unchanged: 2.500s before and 2.278s after.

Linux/WSL2 regression validation used Ubuntu 24.04.1 LTS on WSL2, kernel `6.18.33.2-microsoft-standard-WSL2`, x86-64, with the repository on ext4:

| Measurement | Baseline median | Candidate median |
| --- | ---: | ---: |
| Installer, including 156 MB network download | 46.87s | 47.76s |
| First interactive readiness | 10.760434s | 10.647715s |
| Immediate warm readiness | 10.574285s | 10.032747s |

The Linux artifact was verified as ELF64, included `_internal`, and passed `--version`, `-h`, and `_package-smoke`. GNU tar 1.35 accepted both extraction flags, and a real extraction normalized archived ownership and permissions as intended.

Native Windows PowerShell validation confirmed that candidate and baseline `install.ps1` are identical. The published onefile release passed checksum, version, help, and package-smoke validation. Its existing startup delay remains unchanged and belongs to #5935.

Validation completed:

- `make install`
- `make lint`
- `make format-check` — 3,051 files already formatted
- `make typecheck` — no issues in 1,766 files
- Exact-baseline scope dry-run — selected the three installer test files
- `uv run python -m pytest -q tests/cli/test_install_matrix.py tests/cli/test_install_sh_path.py tests/cli/test_install_sh_resolution.py` — **63 passed, 1 skipped**
- `bash -n install.sh`
- `git diff --check`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The change targets the duplicate macOS security assessment rather than Python startup work. The installer already executes and verifies the extracted binary; preserving that verified executable's identity during installation prevents the normal same-filesystem path from invalidating the benefit of that verification.

Using `mv` on every platform was considered, but rejected because Linux installations should inherit destination security labels and filesystem policy through a fresh copy. The platform-specific branch therefore uses `mv` only on Darwin and retains `cp -R` on Linux. Because moving the extracted tree can preserve archive metadata, tar extraction now explicitly discards archived ownership and permissions before verification and installation.

The app bundle and launcher use same-directory staging and backup paths. Each filesystem operation is checked explicitly because the installer runs this function through a conditional status wrapper, where Bash does not apply `errexit` inside the function. Transaction state is registered before staging and connected to the installer's existing `EXIT` cleanup, so both synchronous failures and `INT`/`TERM` exits restore prior paths and remove staged files. Rollback derives completed renames from backup-path existence instead of relying on bookkeeping set after `mv`, closing the signal window between those operations.

The tests exercise the observable contract: Darwin retains the source executable identity and consumes the source app directory, while Linux creates a distinct installed executable and leaves the source intact. Fault-injection cases also cover app-backup failure, app-activation failure, launcher-activation failure, a pre-existing directory at the launcher path, `TERM` after Darwin staging, and `INT` after both prior paths are backed up.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
