### PR TITLE
test(e2e): remove stale installer copy assertion

### DIFF
--- a/tests/e2e/install/test_live_installers.py
+++ b/tests/e2e/install/test_live_installers.py
@@ -119,7 +119,6 @@ def test_live_install_sh_main_to_temp_dir(tmp_path: Path) -> None:
     )
     assert version.returncode == 0, version.stderr
     assert "opensre" in version.stdout.lower() or "0." in version.stdout
-    assert "opensre onboard" in combined
     if venv_before is not None:
         assert venv_opensre.exists(), "live install must not remove .venv/bin/opensre"
         assert venv_opensre.resolve() == venv_before, (


### PR DESCRIPTION
Related to #6007

#### Describe the changes you have made in this PR -

Removes the stale `opensre onboard` output assertion from the live shell-installer test. The installer intentionally now prints `Run 'opensre' to get started!`, and user-facing completion copy is not part of the installation contract.

The canary continues to validate the durable behavior: successful installation, an executable at the requested path, and a working `--version` invocation.

### Demo/Screenshot for feature changes and bug fixes - 

The failing canary showed a successful install followed only by the obsolete copy assertion:

```text
OpenSRE v2026.9.3 installed successfully
Run 'opensre' to get started!
E assert 'opensre onboard' in combined
```

Static validation:

```text
make lint         # passed
make format-check # passed
make typecheck    # passed: 1766 source files
```

The live test was not rerun locally at the request of the maintainer. The Installer Canary workflow will be dispatched against this PR branch for hosted verification.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The test already checks the installer's exit status, installed executable, executable bit, and `--version`. Rather than replacing one brittle user-facing string assertion with another, this change removes the copy assertion and retains the functional contract. This prevents harmless wording changes from creating installer incidents while preserving detection of real installation failures.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
