### PR TITLE
fix(packaging): bundle lazy CLI commands in PyInstaller

### DIFF
--- a/infrastructure/deployment/packaging/release_manifest.py
+++ b/infrastructure/deployment/packaging/release_manifest.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 _RUNTIME_PACKAGE_NAMES = (
     "integrations",
+    # Lazy-loaded via ``COMMAND_SPECS`` / ``importlib`` — Analysis cannot see
+    # these edges, so the frozen binary must list every command module here
+    # (including hidden ``_package-smoke`` for release artifact checks).
+    "surfaces.cli.commands",
     "surfaces.interactive_shell",
     "tools",
 )

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -27,6 +27,21 @@ def test_hidden_imports_cover_runtime_discovered_tool_packages() -> None:
     assert "tools.system.work_items.tool" in hidden_imports
 
 
+def test_hidden_imports_cover_lazy_cli_command_modules() -> None:
+    """CLI commands load via importlib from COMMAND_SPECS; freeze must list them.
+
+    Without this, ``opensre _package-smoke`` (and every other top-level command)
+    fails in the PyInstaller binary with ModuleNotFoundError before Click runs.
+    """
+    from surfaces.cli.commands.command_specs import COMMAND_SPECS
+
+    hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
+    command_modules = {spec.import_path.split(":", 1)[0] for spec in COMMAND_SPECS}
+
+    assert command_modules <= hidden_imports
+    assert "surfaces.cli.commands.package_smoke" in hidden_imports
+
+
 def test_hidden_imports_exclude_non_runtime_discovery_modules() -> None:
     hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
 


### PR DESCRIPTION
## Summary
- Add `surfaces.cli.commands` to PyInstaller `runtime_hidden_imports` so lazy `COMMAND_SPECS` modules (including `_package-smoke`) ship in the frozen binary.
- Pin that every `COMMAND_SPECS` import path is covered by a packaging test.

## Why
After #6009, CLI commands load via `importlib`. Release smoke (`opensre _package-smoke`) crashed with `ModuleNotFoundError: surfaces.cli.commands.package_smoke` on Linux/Windows artifacts.

## Test plan
- [x] `pytest tests/packaging/test_release_manifest.py`
- [ ] Re-run release job / local `opensre.exe --version` then `opensre.exe _package-smoke`