### PR TITLE
perf(install): warm the frozen bundle at install time and bake the tool index

### DIFF
--- a/.github/ci/test_scope_rules.py
+++ b/.github/ci/test_scope_rules.py
@@ -551,6 +551,7 @@ RULES: tuple[PathRule, ...] = (
     ),
     PathRule("infrastructure/safety/guardrails/", ("tests/infrastructure/safety/guardrails/",)),
     PathRule("infrastructure/safety/masking/", ("tests/masking/",)),
+    PathRule("opensre.spec", ("tests/packaging/",)),
     PathRule("infrastructure/deployment/packaging/", ("tests/packaging/",)),
     PathRule("infrastructure/safety/sandbox/", ("tests/sandbox/",)),
     PathRule(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,10 +384,17 @@ jobs:
             echo "No onedir binary at ${APP_BIN}; skip re-sign"
             exit 0
           fi
+          # Nested libs are independent — parallelize with a small cap, then
+          # sign the main binary last (same order as install.sh).
+          JOBS="$(sysctl -n hw.ncpu 2>/dev/null || printf '4')"
+          if [ "$JOBS" -gt 4 ]; then
+            JOBS=4
+          fi
+          if [ "$JOBS" -lt 1 ]; then
+            JOBS=1
+          fi
           find "$APP_DIR" -type f \( -name '*.dylib' -o -name '*.so' -o -name '*.so.*' \) -print0 \
-            | while IFS= read -r -d '' lib; do
-                codesign --force --sign - "$lib"
-              done
+            | xargs -0 -P "$JOBS" -n 1 codesign --force --sign -
           codesign --force --sign - "$APP_BIN"
           codesign --verify --strict "$APP_BIN"
           echo "Re-signed onedir libs + ${APP_BIN} (adhoc) after post-build mutations"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,6 +439,14 @@ jobs:
             echo "LiteLLM package data missing from Unix onedir bundle: ${LITELLM_DATA}" >&2
             exit 1
           fi
+          # Baked tool index: without this file the frozen binary imports every
+          # vendor module on the first turn. _package-smoke fail-closed covers
+          # onefile (Windows); onedir can also assert the path on disk.
+          BAKED_INDEX="./dist/opensre/_internal/tools/descriptor_index.json"
+          if [ ! -f "$BAKED_INDEX" ]; then
+            echo "Baked descriptor index missing from Unix onedir bundle: ${BAKED_INDEX}" >&2
+            exit 1
+          fi
 
       - name: Check Linux binary glibc compatibility
         if: runner.os == 'Linux'

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -800,24 +800,21 @@ def _show_response(
     """Show the turn's answer, or leave a blank line after silent tool work.
 
     ``final_text`` arrives empty unless the closing message reads like a real
-    reply; only then is it streamed as the assistant speaking. Progress tags
-    are scrubbed for display only — ``response_text`` keeps them for evaluate.
+    reply; only then is it preferred over joined ``display_chunks``. Either way
+    visible prose streams through the sink (``Ω`` gutter on the shell). Progress
+    tags are scrubbed for display only — ``response_text`` keeps them for evaluate.
     """
-    if final_text:
-        visible = strip_session_goal_progress_tags(final_text)
+    # Both branches stream through the sink so the shell paints the ``Ω`` gutter
+    # (Droid / Claude Code rhythm). Bare ``print`` after a lone header left
+    # agent prose unmarked and flush against Thinking chrome.
+    body = final_text or ("\n".join(display_chunks) if display_chunks else "")
+    if body:
+        visible = strip_session_goal_progress_tags(body)
         if visible.strip():
             output.stream(label="OpenSRE", chunks=iter([visible]))
-        return
-    if display_chunks:
-        visible = strip_session_goal_progress_tags("\n".join(display_chunks))
-        if not visible.strip():
-            if handled:
-                _end_silent_tool_turn(output)
             return
-        output.render_response_header("assistant")
-        # Literal text: the sink decides how to render it safely. The harness
-        # must not reach for terminal-markup helpers.
-        output.print(visible)
+        if handled:
+            _end_silent_tool_turn(output)
         return
     if handled:
         _end_silent_tool_turn(output)

--- a/infrastructure/deployment/packaging/release_manifest.py
+++ b/infrastructure/deployment/packaging/release_manifest.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 _RUNTIME_PACKAGE_NAMES = (
     "integrations",
+    # Lazy-loaded via ``COMMAND_SPECS`` / ``importlib`` — Analysis cannot see
+    # these edges, so the frozen binary must list every command module here
+    # (including hidden ``_package-smoke`` for release artifact checks).
+    "surfaces.cli.commands",
     "surfaces.interactive_shell",
     "tools",
 )

--- a/install.ps1
+++ b/install.ps1
@@ -111,6 +111,11 @@ function Get-OpenSreFriendlyProgressLabel {
         return "fetching metadata"
     }
 
+    # More specific than ``*Preparing opensre*`` below (install warm-up step).
+    if ($Label -like "*first launch*") {
+        return "preparing first launch"
+    }
+
     if ($Label -like "*Preparing opensre*") {
         return "resolving build"
     }
@@ -938,6 +943,33 @@ function Get-OpenSreBinaryVersionInfo {
     }
 }
 
+function Invoke-OpenSreFirstLaunchWarmup {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BinaryPath
+    )
+
+    # Windows Defender / Smart App Control often scan a freshly installed
+    # onedir tree on first execution. ``--version`` is a fast path and loads
+    # little of the bundle; ``_package-smoke`` imports the tool registry,
+    # verifiers and skills so that cost lands under the installer instead of
+    # the user's first real ``opensre``. (POSIX ``install.sh`` only warms on
+    # Darwin for codesign-cache reasons.) Best-effort: binary already passed
+    # ``--version``, so a smoke failure warns rather than aborts the install.
+    Write-OpenSreLine -Message "Preparing OpenSRE for first launch" -Color "Cyan"
+    try {
+        $null = & $BinaryPath _package-smoke 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-OpenSreLine -Message "  OK Preparing OpenSRE for first launch" -Color "Green"
+            return
+        }
+    }
+    catch {
+        # Fall through to the warning below.
+    }
+    Write-Warning "First-launch warm-up did not complete; the first opensre may start slowly."
+}
+
 function Ensure-OpenSreGithubCli {
     # Soft dependency for github_cli chat tools. Never fails the OpenSRE install.
     if (Get-Command gh -ErrorAction SilentlyContinue) {
@@ -1124,6 +1156,8 @@ function Install-OpenSre {
         $binaryVersionText = [string]$verifiedBinary.VersionText
         $binaryVersion = [string]$verifiedBinary.Version
         $version = [string]$verifiedBinary.InstallVersion
+
+        Invoke-OpenSreFirstLaunchWarmup -BinaryPath $binaryPath
 
         Invoke-OpenSreStep -Name "[6/6] Installing binary" -Detail (Join-Path $installDir $binaryName) -Operation {
             New-Item -ItemType Directory -Force -Path $installDir | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -633,6 +633,10 @@ prepare_and_verify_binary() {
 warm_first_launch() {
   local binary_path="$1"
 
+  # Codesign-cache warm-up is Darwin-only; Linux/Windows have no equivalent
+  # and would otherwise pay for a full registry/verifier/skills import.
+  [ "$(uname -s 2>/dev/null || true)" = "Darwin" ] || return 0
+
   # macOS validates the code signature of every Mach-O image on its first
   # dlopen and caches the result. The re-sign above resets that cache for all
   # ~300 bundled libs, and ``--version`` (the fast path) loads only a few of

--- a/install.sh
+++ b/install.sh
@@ -626,6 +626,28 @@ prepare_and_verify_binary() {
   else
     verify_binary_version "$binary_path"
   fi
+
+  warm_first_launch "$binary_path"
+}
+
+warm_first_launch() {
+  local binary_path="$1"
+
+  # macOS validates the code signature of every Mach-O image on its first
+  # dlopen and caches the result. The re-sign above resets that cache for all
+  # ~300 bundled libs, and ``--version`` (the fast path) loads only a few of
+  # them, so the user's first real ``opensre`` would pay ~10s of validation.
+  # ``_package-smoke`` imports the full tool registry, verifiers and skills,
+  # which loads essentially the whole set — so pay that cost here, under the
+  # installer spinner, instead of on the first launch. Best-effort: the binary
+  # already passed ``--version``, so a smoke failure warns rather than aborts.
+  run_with_dots "Preparing OpenSRE for first launch" package_smoke_quiet "$binary_path" \
+    || printf 'warning: first-launch warm-up did not complete; the first "%s" may start slowly.\n' "$BIN_NAME" >&2
+}
+
+package_smoke_quiet() {
+  # The smoke prints a JSON summary; only its exit status matters here.
+  "$1" _package-smoke >/dev/null 2>&1
 }
 
 extract_and_verify_binary() {

--- a/install.sh
+++ b/install.sh
@@ -783,6 +783,7 @@ clear_macos_quarantine() {
 resign_macos_onedir_adhoc() {
   local binary_path="$1"
   local bundle_dir
+  local jobs
 
   # PyInstaller onedir: post-build dylib rewrites (or a stale CI signature) leave
   # Invalid Page codesign faults. Consumer Macs SIGKILL --version (exit 137).
@@ -792,10 +793,18 @@ resign_macos_onedir_adhoc() {
   [ -f "$binary_path" ] || return 0
   bundle_dir="$(cd "$(dirname "$binary_path")" && pwd)"
   clear_macos_quarantine "$bundle_dir"
+  # Nested libs are independent; parallelize with a small cap so large hosts
+  # do not stampede the disk. The main binary stays serial and last.
+  jobs="$(sysctl -n hw.ncpu 2>/dev/null || printf '4')"
+  if [ "$jobs" -gt 4 ]; then
+    jobs=4
+  fi
+  if [ "$jobs" -lt 1 ]; then
+    jobs=1
+  fi
   find "$bundle_dir" -type f \( -name '*.dylib' -o -name '*.so' -o -name '*.so.*' \) -print0 \
-    | while IFS= read -r -d '' lib; do
-        codesign --force --sign - "$lib" >/dev/null 2>&1 || true
-      done
+    | xargs -0 -P "$jobs" -n 1 codesign --force --sign - >/dev/null 2>&1 \
+    || true
   codesign --force --sign - "$binary_path" >/dev/null 2>&1 || true
 }
 

--- a/integrations/github/mcp.py
+++ b/integrations/github/mcp.py
@@ -562,7 +562,7 @@ async def _open_github_mcp_session(config: GitHubMCPConfig) -> AsyncIterator[Cli
                     timeout=httpx.Timeout(config.timeout_seconds, read=read_timeout),
                 )
             )
-            transport_streams = await stack.enter_async_context(
+            read_stream, write_stream, _ = await stack.enter_async_context(
                 streamable_http_client(
                     session_url,
                     http_client=http_client,
@@ -571,12 +571,6 @@ async def _open_github_mcp_session(config: GitHubMCPConfig) -> AsyncIterator[Cli
                     sse_read_timeout=read_timeout,
                 )
             )
-            if len(transport_streams) not in {2, 3}:
-                raise ValueError(
-                    "GitHub MCP streamable HTTP transport returned an unexpected "
-                    f"stream count: {len(transport_streams)} (expected 2 or 3)."
-                )
-            read_stream, write_stream = transport_streams[:2]
         else:
             raise ValueError(
                 f"Unsupported GitHub MCP mode '{config.mode}'. "

--- a/integrations/github/mcp.py
+++ b/integrations/github/mcp.py
@@ -562,7 +562,7 @@ async def _open_github_mcp_session(config: GitHubMCPConfig) -> AsyncIterator[Cli
                     timeout=httpx.Timeout(config.timeout_seconds, read=read_timeout),
                 )
             )
-            read_stream, write_stream, _ = await stack.enter_async_context(
+            transport_streams = await stack.enter_async_context(
                 streamable_http_client(
                     session_url,
                     http_client=http_client,
@@ -571,6 +571,12 @@ async def _open_github_mcp_session(config: GitHubMCPConfig) -> AsyncIterator[Cli
                     sse_read_timeout=read_timeout,
                 )
             )
+            if len(transport_streams) not in {2, 3}:
+                raise ValueError(
+                    "GitHub MCP streamable HTTP transport returned an unexpected "
+                    f"stream count: {len(transport_streams)} (expected 2 or 3)."
+                )
+            read_stream, write_stream = transport_streams[:2]
         else:
             raise ValueError(
                 f"Unsupported GitHub MCP mode '{config.mode}'. "

--- a/integrations/harness_adapters.py
+++ b/integrations/harness_adapters.py
@@ -2,9 +2,29 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+
+def _setupable_services() -> tuple[str, ...]:
+    """Services with a setup wizard; imported on first use.
+
+    ``integrations.cli`` pulls every vendor's setup flow (~2,000 modules).
+    Registration must stay cheap at process boot, so the import waits until
+    the port is actually read (``/integrations setup``).
+    """
+    from integrations.cli import setup_services
+
+    return tuple(setup_services())
+
+
+def _fetch_webapp_vault() -> list[dict[str, Any]] | None:
+    """Webapp org integrations; the vault client imports on first use."""
+    import integrations.webapp_vault as webapp_vault
+
+    return webapp_vault.fetch_webapp_org_integrations()
+
 
 def register_harness_adapters() -> None:
-    import integrations.webapp_vault as webapp_vault
     from infrastructure.harness_providers import IntegrationResolutionAdapters
     from integrations.catalog import (
         classify_integrations,
@@ -13,7 +33,6 @@ def register_harness_adapters() -> None:
         merge_integrations_by_service,
         merge_local_integrations,
     )
-    from integrations.cli import setup_services
     from integrations.store import load_integrations, resolve_store_path
 
     IntegrationResolutionAdapters(
@@ -24,8 +43,8 @@ def register_harness_adapters() -> None:
         merge_local_integrations=merge_local_integrations,
         merge_integrations_by_service=merge_integrations_by_service,
         configured_services=lambda: tuple(configured_integration_services()),
-        setupable_services=lambda: tuple(setup_services()),
-        fetch_webapp_vault=lambda: webapp_vault.fetch_webapp_org_integrations(),
+        setupable_services=_setupable_services,
+        fetch_webapp_vault=_fetch_webapp_vault,
     ).install()
 
     _register_vcs_repo_scope_providers()
@@ -197,7 +216,6 @@ def _register_preferred_evidence_sources() -> None:
 
 
 def _register_cli_llm_adapters() -> None:
-    from typing import Any
 
     from core.llm.types import CliLLMClient, ModelType
     from infrastructure.harness_providers import CliLlmAdapters

--- a/integrations/mcp_streamable_http_compat.py
+++ b/integrations/mcp_streamable_http_compat.py
@@ -21,6 +21,26 @@ def _load_streamable_http_clients() -> tuple[Any, Any]:
     return modern_client, legacy_client
 
 
+def _as_transport_triple(streams: Any) -> tuple[Any, Any, Any]:
+    """Normalize SDK stream tuples to ``(read, write, session_id_callback)``.
+
+    Modern ``mcp`` yields three values. Older clients yield only the two
+    streams; callers that unpack exactly three values then fail while opening
+    a session.
+    """
+    try:
+        count = len(streams)
+    except TypeError:
+        count = -1
+    if count not in {2, 3}:
+        raise ValueError(
+            "Streamable HTTP transport returned an unexpected stream count: "
+            f"{count if count >= 0 else type(streams).__name__} (expected 2 or 3)."
+        )
+    read_stream, write_stream, *rest = streams
+    return read_stream, write_stream, rest[0] if rest else None
+
+
 @asynccontextmanager
 async def streamable_http_client(
     url: str,
@@ -38,8 +58,8 @@ async def streamable_http_client(
             url,
             http_client=http_client,
             terminate_on_close=terminate_on_close,
-        ) as triple:
-            yield triple
+        ) as streams:
+            yield _as_transport_triple(streams)
         return
 
     del http_client
@@ -49,5 +69,5 @@ async def streamable_http_client(
         timeout=timeout,
         sse_read_timeout=sse_read_timeout,
         terminate_on_close=terminate_on_close,
-    ) as triple:
-        yield triple
+    ) as streams:
+        yield _as_transport_triple(streams)

--- a/opensre.spec
+++ b/opensre.spec
@@ -30,6 +30,22 @@ datas += collect_data_files("litellm")
 datas += copy_metadata("opensre")
 datas += list(skill_data_entries(ROOT))
 
+# Bake the tool descriptor index. The bundle carries bytecode only, so the
+# registry's AST scan finds no source there; without this the frozen binary
+# falls back to importing every vendor tool module (~1,900 extra modules) on
+# the first turn. Built from the checkout here and shipped as data.
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, str(ROOT))
+from tools.registry_index import (  # noqa: E402
+    BAKED_INDEX_RELATIVE_PATH,
+    dump_descriptor_index,
+)
+
+_baked_index = ROOT / "build" / "baked" / BAKED_INDEX_RELATIVE_PATH
+dump_descriptor_index(_baked_index)
+datas.append((str(_baked_index), str(BAKED_INDEX_RELATIVE_PATH.parent)))
+
 hiddenimports = [
     "tiktoken_ext",
     "tiktoken_ext.openai_public",

--- a/surfaces/cli/commands/package_smoke.py
+++ b/surfaces/cli/commands/package_smoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 
 import click
 
@@ -38,6 +39,17 @@ def package_smoke_command() -> None:
     from integrations._verifiers_loader import register_all_verifiers
     from integrations.verification import list_verifiers
     from tools.registry import get_registered_tool_map
+    from tools.registry_index import BAKED_INDEX_RELATIVE_PATH, baked_index_available
+
+    # Frozen builds silently fall back to importing every vendor module when
+    # the bake is missing. Fail before the slow path so release smoke cannot
+    # pass on an artifact that restored the first-turn delay.
+    frozen = bool(getattr(sys, "frozen", False))
+    if frozen and not baked_index_available():
+        baked_failures = {"missing_baked_descriptor_index": [BAKED_INDEX_RELATIVE_PATH.as_posix()]}
+        raise click.ClickException(
+            f"PyInstaller package smoke failed: {json.dumps(baked_failures)}"
+        )
 
     register_all_verifiers()
     tool_map = get_registered_tool_map()
@@ -70,17 +82,15 @@ def package_smoke_command() -> None:
     if any(failures.values()):
         raise click.ClickException(f"PyInstaller package smoke failed: {json.dumps(failures)}")
 
-    click.echo(
-        json.dumps(
-            {
-                "action_skills": len(action_skill_names),
-                "integration_verifiers": len(integration_verifier_names),
-                "registered_tools": len(tool_names),
-                "status": "ok",
-            },
-            sort_keys=True,
-        )
-    )
+    payload: dict[str, object] = {
+        "action_skills": len(action_skill_names),
+        "integration_verifiers": len(integration_verifier_names),
+        "registered_tools": len(tool_names),
+        "status": "ok",
+    }
+    if frozen:
+        payload["baked_descriptor_index"] = True
+    click.echo(json.dumps(payload, sort_keys=True))
 
 
 __all__ = ["package_smoke_command"]

--- a/surfaces/cli/commands/package_smoke.py
+++ b/surfaces/cli/commands/package_smoke.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from core.tool import RegisteredTool
 
 _REQUIRED_TOOL_NAMES = frozenset(
     {
@@ -32,13 +37,35 @@ _GUIDED_TOOL_NAMES = frozenset({"execute_python_code", "generate_work_status_rep
 _ACTION_SKILL_BODY_MARKERS = {"architecture-audit": "REPORT TEMPLATE from"}
 
 
+def _load_required_tools() -> tuple[dict[str, RegisteredTool], int]:
+    """Import only modules that define the smoke-required tools.
+
+    Catalog size comes from the descriptor index (baked or AST) so release
+    smoke still proves hundreds of tools are discoverable without importing
+    every vendor module.
+    """
+    from tools.registry_discovery import collect_registered_tools_from_module
+    from tools.registry_index import build_descriptor_index
+    from tools.registry_skill_guidance import apply_skill_guidance
+
+    index = build_descriptor_index()
+    modules = sorted({index[name].module for name in _REQUIRED_TOOL_NAMES if name in index})
+    tools_by_name: dict[str, RegisteredTool] = {}
+    for dotted in modules:
+        module = importlib.import_module(dotted)
+        for tool in collect_registered_tools_from_module(module):
+            if tool.name in _REQUIRED_TOOL_NAMES:
+                tools_by_name.setdefault(tool.name, tool)
+    apply_skill_guidance(tools_by_name, known_tool_names=frozenset(index))
+    return tools_by_name, len(index)
+
+
 @click.command(name="_package-smoke", hidden=True)
 def package_smoke_command() -> None:
     """Fail unless essential dynamically bundled code and data are available."""
     from core.agent_harness.spi.grounding import list_action_skills, load_skill_body
     from integrations._verifiers_loader import register_all_verifiers
     from integrations.verification import list_verifiers
-    from tools.registry import get_registered_tool_map
     from tools.registry_index import BAKED_INDEX_RELATIVE_PATH, baked_index_available
 
     # Frozen builds silently fall back to importing every vendor module when
@@ -52,7 +79,7 @@ def package_smoke_command() -> None:
         )
 
     register_all_verifiers()
-    tool_map = get_registered_tool_map()
+    tool_map, catalog_size = _load_required_tools()
     tool_names = set(tool_map)
     action_skill_names = {skill.name for skill in list_action_skills()}
     integration_verifier_names = set(list_verifiers())
@@ -84,8 +111,9 @@ def package_smoke_command() -> None:
 
     payload: dict[str, object] = {
         "action_skills": len(action_skill_names),
+        "checked_tools": len(tool_names),
         "integration_verifiers": len(integration_verifier_names),
-        "registered_tools": len(tool_names),
+        "registered_tools": catalog_size,
         "status": "ok",
     }
     if frozen:

--- a/surfaces/cli/startup.py
+++ b/surfaces/cli/startup.py
@@ -19,9 +19,14 @@ Order is load-bearing:
 
 from __future__ import annotations
 
+import importlib.util
+import logging
+import threading
 from typing import Any
 
 from surfaces.cli.invocation import resolve_command_parts
+
+_LOG = logging.getLogger(__name__)
 
 # Everything else is imported inside run(). Importing this module must stay
 # cheap: the entry point imports it at module scope, and ``opensre --version``
@@ -51,13 +56,27 @@ def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
     briefly absent mid-upgrade. Anywhere else its absence is a broken install and
     must surface.
     """
+    # Presence check stays synchronous so a missing SDK surfaces here (the
+    # ``update`` exemption above); the init itself (~0.3s: SDK setup plus the
+    # llm_cli exception classes it registers) runs on a thread so it never
+    # sits between the user and the prompt. An error raised in that window is
+    # the accepted trade for a launch that does not wait on telemetry.
+    if importlib.util.find_spec("sentry_sdk") is None:
+        if command != "update":
+            raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
+        return
+
     from infrastructure.observability.errors.sentry import init_sentry
 
-    try:
-        init_sentry(entrypoint=sentry_entrypoint_for(group, argv))
-    except ModuleNotFoundError as exc:
-        if exc.name != "sentry_sdk" or command != "update":
-            raise
+    entrypoint = sentry_entrypoint_for(group, argv)
+
+    def _init() -> None:
+        try:
+            init_sentry(entrypoint=entrypoint)
+        except Exception:  # noqa: BLE001 - telemetry must never take the CLI down
+            _LOG.debug("Sentry init failed; continuing without error reporting", exc_info=True)
+
+    threading.Thread(target=_init, name="sentry-init", daemon=True).start()
 
 
 def run(group: Any, argv: list[str]) -> None:

--- a/surfaces/cli/startup.py
+++ b/surfaces/cli/startup.py
@@ -56,19 +56,26 @@ def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
     briefly absent mid-upgrade. Anywhere else its absence is a broken install and
     must surface.
     """
-    # Presence check stays synchronous so a missing SDK surfaces here (the
-    # ``update`` exemption above); the init itself (~0.3s: SDK setup plus the
-    # llm_cli exception classes it registers) runs on a thread so it never
-    # sits between the user and the prompt. An error raised in that window is
-    # the accepted trade for a launch that does not wait on telemetry.
-    if importlib.util.find_spec("sentry_sdk") is None:
-        if command != "update":
-            raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
-        return
-
     from infrastructure.observability.errors.sentry import init_sentry
 
     entrypoint = sentry_entrypoint_for(group, argv)
+    if command:
+        # Subcommands keep the init synchronous: ``debug sentry`` sends an
+        # event right after boot and must find the SDK ready.
+        try:
+            init_sentry(entrypoint=entrypoint)
+        except ModuleNotFoundError as exc:
+            if exc.name != "sentry_sdk" or command != "update":
+                raise
+        return
+
+    # Bare ``opensre`` opens the shell. The init (~0.3s: SDK setup plus the
+    # llm_cli exception classes it registers) runs on a thread so it never sits
+    # between the user and the prompt; only the presence check stays in line so
+    # a broken install still surfaces here. An error raised in that window is
+    # the accepted trade for a launch that does not wait on telemetry.
+    if not _sentry_sdk_installed():
+        raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
 
     def _init() -> None:
         try:
@@ -77,6 +84,15 @@ def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
             _LOG.debug("Sentry init failed; continuing without error reporting", exc_info=True)
 
     threading.Thread(target=_init, name="sentry-init", daemon=True).start()
+
+
+def _sentry_sdk_installed() -> bool:
+    """Whether ``sentry_sdk`` can be imported, without paying for the import."""
+    try:
+        return importlib.util.find_spec("sentry_sdk") is not None
+    except ValueError:
+        # Already in ``sys.modules`` without a spec (test doubles): present.
+        return True
 
 
 def run(group: Any, argv: list[str]) -> None:

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
+from collections.abc import Callable
 
 import click
 from rich.console import Console
@@ -22,6 +24,7 @@ from surfaces.interactive_shell.runtime.startup.account_gate import (
 from surfaces.interactive_shell.runtime.startup.initial_input import run_initial_input
 from surfaces.interactive_shell.runtime.startup.loop_suggestions import offer_loop_suggestions
 from surfaces.interactive_shell.ui.terminal_ui import render_terminal_ui
+from surfaces.shared.terminal.banner import animate_launch_wordmark
 from surfaces.shared.terminal.components.rendering import repl_clear_screen
 
 # Fallback when a caller does not supply one. Forces a terminal because the
@@ -37,6 +40,7 @@ async def run_repl_async(
     resume_session_id: str | None = None,
     console: Console | None = None,
     cli_command_group: click.Command | None = None,
+    finish_banner: Callable[[], None] | None = None,
 ) -> int:
     """Run the shell on an existing event loop and return its exit code.
 
@@ -71,6 +75,10 @@ async def run_repl_async(
 
     # Open the session file now that we know this is an interactive REPL run.
     SessionManager.for_session(session).open_store(session)
+    # The runtime is booted; nothing has printed yet. Stop the launch spin and
+    # paint the static banner before anything below can write to the screen.
+    if finish_banner is not None:
+        finish_banner()
 
     try:
         if resume_session_id:
@@ -102,6 +110,31 @@ async def run_repl_async(
         SessionManager.for_session(session).close(session)
 
 
+def _start_launch_banner(console: Console) -> Callable[[], None]:
+    """Spin the wordmark on a thread while the runtime boots; return the finisher.
+
+    The finisher stops the spin (after its minimum frames), waits for it, and
+    prints the static banner — call it before anything else writes to the
+    screen. Off a TTY the spin is a no-op and only the static banner prints.
+    """
+    stop = threading.Event()
+    spinner = threading.Thread(
+        target=animate_launch_wordmark,
+        args=(console,),
+        kwargs={"stop": stop},
+        name="launch-banner-spin",
+        daemon=True,
+    )
+    spinner.start()
+
+    def finish() -> None:
+        stop.set()
+        spinner.join()
+        render_terminal_ui(console, animate=False)
+
+    return finish
+
+
 def run_repl(
     initial_input: str | None = None,
     config: ReplConfig | None = None,
@@ -119,6 +152,7 @@ def run_repl(
     if not sys.stdin.isatty() and initial_input is None:
         return 0
 
+    finish_banner: Callable[[], None] | None = None
     try:
         if not initial_input:
             # Unsigned TTY: the gate paints the banner as part of the sign-in
@@ -130,7 +164,9 @@ def run_repl(
                 # Wipe the calling shell prompt so the REPL reads as its own
                 # screen (Droid/Claude Code), not a banner under ``uv run …``.
                 repl_clear_screen()
-                render_terminal_ui(out)
+                # Spin on a thread so the runtime boots under the animation;
+                # run_repl_async stops it and paints the banner once ready.
+                finish_banner = _start_launch_banner(out)
 
         return asyncio.run(
             run_repl_async(
@@ -139,6 +175,7 @@ def run_repl(
                 resume_session_id=resume_session_id,
                 console=out,
                 cli_command_group=cli_command_group,
+                finish_banner=finish_banner,
             )
         )
     except (EOFError, KeyboardInterrupt):

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -503,8 +503,9 @@ class ActionRenderObserver:
         if is_plan_diagnosis_prose(content):
             return
         self.console.print()
-        # Intermediate narration is a working note: dim + indented, no glyph, so
-        # it reads apart from the recessed ``[n] ❯`` user row and bright ``Ω`` reply.
+        # Intermediate narration is a working note: recessed body + dim ``·`` in
+        # the same gutter column as ``Ω``, so it reads apart from the user row
+        # and the bright final reply without floating as unmarked prose.
         # ``render_note_block`` sanitizes model text at ``_build_markdown_block``.
         render_note_block(self.console, content)
 

--- a/surfaces/interactive_shell/ui/ask_user.py
+++ b/surfaces/interactive_shell/ui/ask_user.py
@@ -95,8 +95,8 @@ def _option_labels(question: AskUserQuestion) -> list[str]:
 
 
 def _menu_height(question: AskUserQuestion) -> int:
-    # header, breadcrumb, rule, question, choices, Submit, hint (tight, no blank gaps)
-    return 1 + 1 + 1 + 1 + len(_option_labels(question)) + 1 + 1
+    # blank (section gap), header, breadcrumb, rule, question, choices, Submit, hint
+    return 1 + 1 + 1 + 1 + 1 + len(_option_labels(question)) + 1 + 1
 
 
 def _row_count(question: AskUserQuestion) -> int:
@@ -156,6 +156,9 @@ def _draw_ask_user(
     checked = checked or set()
     if erase_lines:
         erase_menu_lines(erase_lines)
+    # Blank above the header so Ask User reads as a new section after Plan
+    # complete / reply text (same rhythm as headered choice_menu).
+    write_menu_line()
     write_menu_line(f"{ui_theme.PROMPT_ACCENT_ANSI}{_HEADER}{ui_theme.ANSI_RESET}")
     write_menu_line(breadcrumb)
     write_menu_line(f"{ui_theme.DIM_COUNTER_ANSI}{'─' * width}{ui_theme.ANSI_RESET}")

--- a/surfaces/interactive_shell/ui/streaming/loop.py
+++ b/surfaces/interactive_shell/ui/streaming/loop.py
@@ -239,9 +239,13 @@ def stream_to_console_state(
             # whose renderer adds no trailing blank line.
             console.print()
         # The first paragraph carries the ``Ω`` marker in the gutter; every
-        # paragraph hangs in the same indented body column.
+        # paragraph hangs in the same indented body column. Explicit TEXT so
+        # body never falls through to terminal white and washes the marker out.
         with console.use_theme(ui_theme.MARKDOWN_THEME):
-            console.print(reply_gutter(markdown, lead=rendered_paragraphs == 0))
+            console.print(
+                reply_gutter(markdown, lead=rendered_paragraphs == 0),
+                style=str(ui_theme.TEXT),
+            )
         rendered_paragraphs += 1
 
     def _render_paragraph(text: str, *, source_break: bool = True) -> None:

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -7,7 +7,6 @@ import sys
 from typing import TYPE_CHECKING
 
 from rich.console import Console
-from rich.padding import Padding
 from rich.table import Table
 from rich.text import Text
 
@@ -140,43 +139,58 @@ def render_markdown_block(console: Console, text: str) -> None:
 
 
 _REPLY_MARKER = "Ω"
+# Quiet lead for mid-turn narration — same gutter width as ``Ω``, so notes align
+# with replies the way Droid keeps one marker column on every agent line.
+_NOTE_MARKER = "·"
 
 
 def render_note_block(console: Console, text: str) -> None:
-    """Render intermediate agent narration as a dim, indented note.
+    """Render intermediate agent narration in the recessed note gutter.
 
     Distinct from the bright ``Ω`` reply and the recessed grey ``[n] ❯`` user
-    row: a note carries no glyph, only a dim left indent, so the three turn
-    roles — your ask, opensre's working notes, and its final reply — read apart.
-    Bold spans (the action words) stay bold within the dim base.
+    row: a note keeps a dim ``·`` lead (same column as ``Ω``) so it does not
+    float as unmarked white prose against Thinking chrome. Bold spans (the
+    action words) stay bold within the recessed base.
     """
     visible = strip_session_goal_progress_tags(text)
     if not visible.strip():
         return
     with console.use_theme(ui_theme.MARKDOWN_THEME):
         console.print(
-            Padding(_build_markdown_block(visible), (0, 0, 0, 3)),
+            reply_gutter(
+                _build_markdown_block(visible),
+                lead=True,
+                marker=_NOTE_MARKER,
+                marker_style=str(ui_theme.DIM),
+            ),
             style=str(ui_theme.SECONDARY),
         )
 
 
 def _reply_marker_style() -> str:
-    """Unbolded warm accent for the ``Ω`` reply marker."""
-    return ui_theme.reply_marker_hex()
+    """Bold warm accent for the ``Ω`` reply marker — same weight as ``⏺`` / Thinking."""
+    return ui_theme.reply_marker_style()
 
 
-def reply_gutter(body: RenderableType, *, lead: bool) -> Table:
+def reply_gutter(
+    body: RenderableType,
+    *,
+    lead: bool,
+    marker: str = _REPLY_MARKER,
+    marker_style: str | None = None,
+) -> Table:
     """Lay a reply renderable in a two-column gutter.
 
-    The first paragraph carries the ``Ω`` marker in the gutter; every other row
+    The first paragraph carries the lead marker in the gutter; every other row
     (wrapped lines and following paragraphs) sits in the same indented body
     column, so the whole reply reads as one block hanging under the marker.
     """
     grid = Table.grid(padding=0)
     grid.add_column(width=3, no_wrap=True)
     grid.add_column(overflow="fold")
-    marker = Text(f"{_REPLY_MARKER}  ", style=_reply_marker_style()) if lead else Text("   ")
-    grid.add_row(marker, body)
+    style = marker_style if marker_style is not None else _reply_marker_style()
+    lead_cell = Text(f"{marker}  ", style=style) if lead else Text("   ")
+    grid.add_row(lead_cell, body)
     return grid
 
 

--- a/surfaces/interactive_shell/ui/streaming/renderer.py
+++ b/surfaces/interactive_shell/ui/streaming/renderer.py
@@ -139,18 +139,18 @@ def render_markdown_block(console: Console, text: str) -> None:
 
 
 _REPLY_MARKER = "Ω"
-# Quiet lead for mid-turn narration — same gutter width as ``Ω``, so notes align
-# with replies the way Droid keeps one marker column on every agent line.
+# Quiet lead for mid-turn narration — same 2-cell gutter as ``Ω `` / ``⏺ ``
+# (Droid: one marker column, body text shares a left edge).
 _NOTE_MARKER = "·"
+_GUTTER_WIDTH = 2
 
 
 def render_note_block(console: Console, text: str) -> None:
-    """Render intermediate agent narration in the recessed note gutter.
+    """Render intermediate agent narration in the agent marker gutter.
 
-    Distinct from the bright ``Ω`` reply and the recessed grey ``[n] ❯`` user
-    row: a note keeps a dim ``·`` lead (same column as ``Ω``) so it does not
-    float as unmarked white prose against Thinking chrome. Bold spans (the
-    action words) stay bold within the recessed base.
+    Droid puts a warm accent on every agent line. Notes use a dimmer ``·`` in
+    that same column as ``Ω`` / Thinking so the left edge stays straight; bold
+    spans (action words) stay bold within the recessed body.
     """
     visible = strip_session_goal_progress_tags(text)
     if not visible.strip():
@@ -161,7 +161,9 @@ def render_note_block(console: Console, text: str) -> None:
                 _build_markdown_block(visible),
                 lead=True,
                 marker=_NOTE_MARKER,
-                marker_style=str(ui_theme.DIM),
+                # Warm accent like Droid's agent marker — not ghost DIM, or notes
+                # vanish next to Thinking / plan chrome.
+                marker_style=ui_theme.reply_marker_style(),
             ),
             style=str(ui_theme.SECONDARY),
         )
@@ -186,10 +188,11 @@ def reply_gutter(
     column, so the whole reply reads as one block hanging under the marker.
     """
     grid = Table.grid(padding=0)
-    grid.add_column(width=3, no_wrap=True)
+    grid.add_column(width=_GUTTER_WIDTH, no_wrap=True)
     grid.add_column(overflow="fold")
     style = marker_style if marker_style is not None else _reply_marker_style()
-    lead_cell = Text(f"{marker}  ", style=style) if lead else Text("   ")
+    pad = " " * (_GUTTER_WIDTH - 1)
+    lead_cell = Text(f"{marker}{pad}", style=style) if lead else Text(" " * _GUTTER_WIDTH)
     grid.add_row(lead_cell, body)
     return grid
 

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -143,12 +143,12 @@ def _collapsed_window(plan: TaskPlan) -> tuple[int, int]:
 
 
 def task_plan_overlay_ansi(plan: TaskPlan, *, expanded: bool = False) -> str:
-    """ANSI plan overlay pinned above the prompt: a checklist indented under its
-    header, with ✓ done / ● current / ○ pending.
+    """ANSI plan overlay pinned above the prompt (Droid checklist rhythm).
 
-    A short plan (or ``expanded``) shows every step. A longer one collapses to a
-    window around the current step with ``… N earlier`` / ``… N more`` markers
-    and a hint to expand, so the prompt region stays short while output streams.
+    Header flush left; steps indented two spaces under it (``✓`` / ``●`` /
+    ``○``). Same left edge as note ``·`` / Thinking glyphs in column 0; step
+    glyphs sit under note body text. A short plan (or ``expanded``) shows every
+    step; a longer one collapses to a window around the current step.
     """
     width = prompt_line_width()
     header = _overlay_line(format_plan_header(plan), ui_theme.SECONDARY_ANSI, width)

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -70,9 +70,9 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     compete with Ask User / option menus — free text is itself an option
     (``Or type your own answer...``), not a parallel composer.
 
-    The stream already prints one blank after the last reply. This region
-    starts on the next row — a second leading ``\\n`` stacked a hole under
-    Ask User recaps. Idle still has no empty "Ready" placeholder.
+    The stream already prints one blank after a *finished* reply. Mid-turn
+    Thinking sits under still-streaming text with no that margin, so the busy
+    path leads with one blank row. Idle still has no empty "Ready" placeholder.
     """
     if typing_box_hidden(session, state):
         # Same newline count as ``_prompt_message`` so confirmation does not
@@ -122,8 +122,13 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
     # Auto stays on the page while busy (DIM) so permission chrome does not
     # vanish for the length of the turn.
     auto_line = strip_cpr_sequences(auto_status_ansi(session, quiet=bool(inline_spinner)))
+    # Mid-turn stream text has no trailing blank (that lands only when the
+    # reply finishes). One lead row under Thinking/Invoking so status chrome
+    # does not sit flush on the last assistant line. Skip when a plan overlay
+    # already supplies the gap, and skip when idle (no status prefix).
+    status_lead = "\n" if prefix and not plan_prefix else ""
     if prefix:
-        return ANSI(f"{plan_prefix}{prefix}\n{auto_line}\n{base}")
+        return ANSI(f"{plan_prefix}{status_lead}{prefix}\n{auto_line}\n{base}")
     return ANSI(f"{plan_prefix}{auto_line}\n{base}")
 
 

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -96,8 +96,9 @@ def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerSta
         plan_overlay = strip_cpr_sequences(
             task_plan_overlay_ansi(plan, expanded=state.plan_expanded)
         )
-    # Keep one empty row between the pinned plan and the live status chrome.
-    plan_prefix = f"{plan_overlay}\n\n" if plan_overlay else ""
+    # Droid block rhythm: blank row above the checklist (separates scrollback
+    # notes from the pinned plan) and one blank beneath before status chrome.
+    plan_prefix = f"\n{plan_overlay}\n\n" if plan_overlay else ""
 
     # A pending confirmation renders a stacked, arrow-navigable Yes/No choice
     # (box hidden). Density matches the streaming stack: status → Auto → composer.

--- a/surfaces/interactive_shell/ui/terminal_ui.py
+++ b/surfaces/interactive_shell/ui/terminal_ui.py
@@ -41,15 +41,20 @@ def render_terminal_ui(
     console: Console | None = None,
     *,
     session: object = None,
+    animate: bool = True,
 ) -> None:
-    """Render the static terminal chrome: the compact launch banner."""
+    """Render the static terminal chrome: the compact launch banner.
+
+    ``animate=False`` prints the banner without the startup spin — used when
+    the spin already ran on its own thread while the runtime booted.
+    """
     console = console or Console(
         highlight=False,
         force_terminal=True,
         color_system="truecolor",
         legacy_windows=False,
     )
-    render_launch_banner(console, session=session)
+    render_launch_banner(console, session=session, animate=animate)
 
 
 def render_prompt_region(session: Session, state: ReplState, spinner: SpinnerState) -> ANSI:

--- a/surfaces/shared/terminal/banner/banner.py
+++ b/surfaces/shared/terminal/banner/banner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import enum
 import math
 import sys
+import threading
 import time
 from dataclasses import dataclass
 
@@ -75,6 +76,9 @@ _WORDMARK_ROWS: tuple[str, ...] = (
 # A short 60 FPS startup turn; animation stops before the prompt becomes live.
 _WORDMARK_SPIN_FRAME_COUNT = 48
 _WORDMARK_SPIN_FRAME_INTERVAL_SECONDS = 1 / 60
+# When the spin runs under startup work and is asked to stop, it still shows
+# at least this many frames so it always reads as a turn, never a flicker.
+_WORDMARK_SPIN_MIN_FRAMES = 24
 _MIN_PROJECTED_SCALE = 0.08
 _BRAILLE_BASE = 0x2800
 _BRAILLE_LIMIT = 0x28FF
@@ -206,8 +210,18 @@ def _clear_animation(frame: WordmarkSpinFrame) -> str:
     )
 
 
-def animate_launch_wordmark(console: Console) -> None:
-    """Turn the terminal wordmark once before the interactive prompt starts."""
+def animate_launch_wordmark(
+    console: Console,
+    *,
+    stop: threading.Event | None = None,
+    min_frames: int = _WORDMARK_SPIN_MIN_FRAMES,
+) -> None:
+    """Turn the terminal wordmark once before the interactive prompt starts.
+
+    With ``stop``, the turn ends early once the event is set and at least
+    ``min_frames`` have shown — so the runtime can boot under the animation and
+    the prompt appears as soon as it is ready instead of after a fixed delay.
+    """
     if (
         console.file is not sys.stdout
         or not sys.stdout.isatty()
@@ -221,6 +235,8 @@ def animate_launch_wordmark(console: Console) -> None:
     try:
         stream.write(_HIDE_CURSOR)
         for index, frame in enumerate(frames):
+            if stop is not None and stop.is_set() and index >= min_frames:
+                break
             stream.write(
                 _animation_frame(
                     frame,

--- a/surfaces/shared/terminal/components/choice_menu.py
+++ b/surfaces/shared/terminal/components/choice_menu.py
@@ -65,8 +65,11 @@ _SUBMIT = "Submit"
 _CHECKED = "[x]"
 _UNCHECKED = "[ ]"
 CRUMB_SEP = "  ›  "
-# Tight Droid-style panel: no blank line above the title.
+# Tight Droid-style panel: no blank line above slash-command titles.
 _MENU_LEADING_LINES = 0
+# Headered menus (Ask User) need one blank above so the accent header reads as
+# a new section after Plan complete / reply text, not a continuation line.
+_HEADER_SECTION_GAP = 1
 _TERMINAL_NEWLINE = "\r\n"
 MenuAction = Literal["up", "down", "enter", "cancel", "eof", "ignore"]
 
@@ -183,9 +186,10 @@ def _sanitize_menu(
 def _menu_height(
     crumb: str, labels: list[str], *, multi_select: bool = False, header: str = ""
 ) -> int:
-    # [header], title, [crumb], blank, choices, [Submit], blank, hint (airy)
+    # [gap], [header], title, [crumb], blank, choices, [Submit], blank, hint
     submit = 1 if multi_select else 0
-    lead = _MENU_LEADING_LINES + (1 if header else 0)
+    gap = _HEADER_SECTION_GAP if header else 0
+    lead = _MENU_LEADING_LINES + gap + (1 if header else 0)
     return lead + 1 + (1 if crumb else 0) + 1 + len(labels) + submit + 1 + 1
 
 
@@ -331,6 +335,8 @@ def _draw_menu(
     # title reads as the plain question below it; otherwise the title is the
     # accent header (slash-command pickers).
     if header:
+        for _ in range(_HEADER_SECTION_GAP):
+            write_menu_line()
         write_menu_line(
             f"{ui_theme.PROMPT_ACCENT_ANSI}{_clip_to_row(f'{_BLOCK_INDENT}{header}', w)}{ui_theme.ANSI_RESET}"
         )

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -324,6 +324,9 @@ def test_install_sh_source_exposes_env_knobs() -> None:
         "OPENSRE_INSTALL_REPO",
         'INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-main}"',
         "ensure_github_cli",
+        "warm_first_launch",
+        "package_smoke_quiet",
+        "_package-smoke",
     ):
         assert needle in source, f"install.sh missing {needle!r}"
 
@@ -345,6 +348,8 @@ def test_install_ps1_source_exposes_all_windows_install_knobs() -> None:
         'else { "main" }',
         "main-build",
         "$exe setup",
+        "Invoke-OpenSreFirstLaunchWarmup",
+        "_package-smoke",
     ):
         assert needle in source, f"install.ps1 missing {needle!r}"
 

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -28,6 +28,7 @@ def test_install_ps1_defines_branded_progress_helpers() -> None:
         "function Get-OpenSreProgressFrame",
         "function New-OpenSreProgressBar",
         "function Invoke-OpenSreStep",
+        "function Invoke-OpenSreFirstLaunchWarmup",
         "function Invoke-OpenSreDownloadFileWithProgress",
     ):
         assert helper in source

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -570,3 +570,37 @@ def test_ensure_github_cli_respects_skip_env(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "OPENSRE_SKIP_GH_INSTALL" in result.stderr
     assert "OpenSRE GitHub chat tools" in result.stderr
+
+
+def test_warm_first_launch_skips_package_smoke_off_darwin() -> None:
+    """Linux/Windows have no codesign cache; the installer must not pay for smoke."""
+    result = _run_logging_snippet(
+        """
+        uname() { printf 'Linux\\n'; }
+        package_smoke_quiet() { printf 'SMOKE_RAN\\n'; return 0; }
+        BIN_NAME=opensre
+        warm_first_launch /tmp/opensre
+        printf 'done\\n'
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "SMOKE_RAN" not in combined
+    assert "Preparing OpenSRE for first launch" not in combined
+    assert "done" in result.stdout
+
+
+def test_warm_first_launch_runs_package_smoke_on_darwin() -> None:
+    result = _run_logging_snippet(
+        """
+        uname() { printf 'Darwin\\n'; }
+        package_smoke_quiet() { printf 'SMOKE_RAN\\n'; return 0; }
+        BIN_NAME=opensre
+        warm_first_launch /tmp/opensre
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SMOKE_RAN" in result.stdout
+    assert "Preparing OpenSRE for first launch" in result.stderr

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -604,3 +604,12 @@ def test_warm_first_launch_runs_package_smoke_on_darwin() -> None:
     assert result.returncode == 0, result.stderr
     assert "SMOKE_RAN" in result.stdout
     assert "Preparing OpenSRE for first launch" in result.stderr
+
+
+def test_resign_macos_onedir_parallelizes_nested_libs() -> None:
+    """Nested dylib/so signs are independent; main binary stays serial and last."""
+    source = INSTALL_SH.read_text(encoding="utf-8")
+    assert 'xargs -0 -P "$jobs" -n 1 codesign --force --sign -' in source
+    assert 'codesign --force --sign - "$binary_path"' in source
+    # Cap avoids disk stampede on large hosts.
+    assert 'if [ "$jobs" -gt 4 ]; then' in source

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import importlib
+import importlib.machinery
 import sys
+import types
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import click
@@ -16,6 +17,14 @@ from infrastructure.analytics.events import Event
 from surfaces.cli.app import cli
 from surfaces.cli.startup import sentry_entrypoint_for
 from surfaces.entrypoint import main
+
+
+def _fake_sentry_sdk(*, flush: object) -> types.ModuleType:
+    """A ``sys.modules`` double that ``find_spec`` can tolerate."""
+    mod = types.ModuleType("sentry_sdk")
+    mod.__spec__ = importlib.machinery.ModuleSpec("sentry_sdk", loader=None)
+    mod.flush = flush  # type: ignore[attr-defined]
+    return mod
 
 
 def _stub_analytics_httpx(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
@@ -267,7 +276,7 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     monkeypatch.setitem(
         sys.modules,
         "sentry_sdk",
-        SimpleNamespace(flush=lambda timeout: flush_calls.append(timeout)),
+        _fake_sentry_sdk(flush=lambda timeout: flush_calls.append(timeout)),
     )
 
     exit_code = main(["debug", "sentry"])
@@ -320,11 +329,7 @@ def test_main_debug_sentry_exits_nonzero_when_flush_fails(monkeypatch, capsys) -
         assert timeout == 5
         return False
 
-    monkeypatch.setitem(
-        sys.modules,
-        "sentry_sdk",
-        SimpleNamespace(flush=flush_stub),
-    )
+    monkeypatch.setitem(sys.modules, "sentry_sdk", _fake_sentry_sdk(flush=flush_stub))
 
     exit_code = main(["debug", "sentry"])
 

--- a/tests/cli/test_package_smoke.py
+++ b/tests/cli/test_package_smoke.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from surfaces.cli.app import cli
+from tools.registry_index import BAKED_INDEX_RELATIVE_PATH
 
 
 def test_package_smoke_finds_essential_tools_and_skills() -> None:
@@ -26,3 +30,17 @@ def test_package_smoke_command_is_hidden_from_help() -> None:
 
     assert result.exit_code == 0, result.output
     assert "_package-smoke" not in result.output
+
+
+def test_package_smoke_fails_when_frozen_bundle_lacks_baked_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Release smoke must not pass on a frozen artifact that fell back to the slow path."""
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    result = CliRunner().invoke(cli, ["_package-smoke"])
+
+    assert result.exit_code != 0, result.output
+    assert BAKED_INDEX_RELATIVE_PATH.as_posix() in result.output
+    assert "missing_baked_descriptor_index" in result.output

--- a/tests/cli/test_package_smoke.py
+++ b/tests/cli/test_package_smoke.py
@@ -47,3 +47,25 @@ def test_package_smoke_fails_when_frozen_bundle_lacks_baked_index(
     assert result.exit_code != 0, result.output
     assert BAKED_INDEX_RELATIVE_PATH.as_posix() in result.output
     assert "missing_baked_descriptor_index" in result.output
+
+
+def test_package_smoke_reports_baked_index_on_frozen_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Frozen smoke must prove it loaded the bake, not the every-vendor fallback."""
+    from tools.registry_index import clear_descriptor_index_cache, dump_descriptor_index
+
+    dump_descriptor_index(tmp_path / BAKED_INDEX_RELATIVE_PATH)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+    clear_descriptor_index_cache()
+    try:
+        result = CliRunner().invoke(cli, ["_package-smoke"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "ok"
+        assert payload["baked_descriptor_index"] is True
+        assert payload["registered_tools"] >= 250
+    finally:
+        clear_descriptor_index_cache()

--- a/tests/cli/test_package_smoke.py
+++ b/tests/cli/test_package_smoke.py
@@ -19,7 +19,10 @@ def test_package_smoke_finds_essential_tools_and_skills() -> None:
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["status"] == "ok"
+    # Catalog size from the descriptor index (no full vendor import).
     assert payload["registered_tools"] >= 250
+    # Deep-checked essentials only (required name set).
+    assert payload["checked_tools"] == 7
     assert payload["action_skills"] >= 5
     assert payload["integration_verifiers"] >= 60
     assert "planning_instructions" not in payload

--- a/tests/cli/test_startup.py
+++ b/tests/cli/test_startup.py
@@ -131,9 +131,38 @@ def test_missing_sentry_module_still_raises_for_other_commands(
     _silence_all(monkeypatch)
     monkeypatch.setattr(_SENTRY, _raise_missing_sentry)
 
-    # Act / Assert
+    # Act / Assert — subcommands init Sentry synchronously so the raise
+    # reaches the caller (background init would swallow it on a daemon thread).
     with pytest.raises(ModuleNotFoundError):
         startup.run(cli, ["doctor"])
+
+
+def test_sentry_sdk_installed_tolerates_modules_without_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test doubles in ``sys.modules`` must not make presence checks raise."""
+    from types import SimpleNamespace
+
+    from surfaces.cli import startup
+
+    monkeypatch.setitem(sys.modules, "sentry_sdk", SimpleNamespace())
+
+    assert startup._sentry_sdk_installed() is True
+
+
+def test_bare_shell_raises_when_sentry_sdk_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare ``opensre`` checks presence inline before background init."""
+    from bootstrap.process import reset_process_runtime_for_tests
+    from surfaces.cli import startup
+
+    reset_process_runtime_for_tests()
+    _silence_all(monkeypatch)
+    monkeypatch.setattr(startup, "_sentry_sdk_installed", lambda: False)
+
+    with pytest.raises(ModuleNotFoundError, match="sentry_sdk"):
+        startup.run(cli, [])
 
 
 def test_importing_the_entry_point_does_not_load_the_terminal_stack() -> None:

--- a/tests/infrastructure/terminal/test_theme.py
+++ b/tests/infrastructure/terminal/test_theme.py
@@ -161,7 +161,7 @@ def test_reply_block_paints_orange_marker_and_themed_body() -> None:
         render_reply_block(console, "Hey! How can I help?")
     output = capture.get()
     assert "Ω" in output
-    assert _reply_marker_style() == get_theme("blue").HIGHLIGHT
+    assert _reply_marker_style() == f"bold {get_theme('blue').HIGHLIGHT}"
     # Marker follows the active theme's HIGHLIGHT (whatever the palette sets).
     highlight = get_theme("blue").HIGHLIGHT.lstrip("#")
     r, g, b = (int(highlight[i : i + 2], 16) for i in (0, 2, 4))

--- a/tests/integrations/test_github_mcp_validation.py
+++ b/tests/integrations/test_github_mcp_validation.py
@@ -1055,3 +1055,51 @@ def test_github_integration_is_configured_true_when_store_has_token(
     monkeypatch.setattr(github_mcp_module, "github_mcp_config_from_env", lambda: None)
 
     assert github_mcp_module.github_integration_is_configured() is True
+
+
+@pytest.mark.asyncio
+async def test_open_session_accepts_legacy_two_stream_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older streamable-HTTP clients yield ``(read, write)`` only."""
+    read, write = object(), object()
+    opened: list[object] = []
+
+    @asynccontextmanager
+    async def _two_stream_client(*_args: Any, **_kwargs: Any):
+        yield (read, write)
+
+    class _HttpClient:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        async def __aenter__(self) -> _HttpClient:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _Session:
+        def __init__(self, read_stream: Any, write_stream: Any) -> None:
+            assert read_stream is read
+            assert write_stream is write
+            opened.append(self)
+            self.initialize = AsyncMock()
+
+        async def __aenter__(self) -> _Session:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    monkeypatch.setattr(github_mcp_module, "streamable_http_client", _two_stream_client)
+    monkeypatch.setattr(github_mcp_module.httpx, "AsyncClient", _HttpClient)
+    monkeypatch.setattr("mcp.client.session.ClientSession", _Session)
+
+    config = github_mcp_module.GitHubMCPConfig(
+        url="https://mcp.example.test/mcp",
+        mode="streamable-http",
+    )
+    async with github_mcp_module._open_github_mcp_session(config) as session:
+        assert session is opened[0]
+        session.initialize.assert_awaited_once()

--- a/tests/integrations/test_mcp_streamable_http_compat.py
+++ b/tests/integrations/test_mcp_streamable_http_compat.py
@@ -1,0 +1,55 @@
+"""Legacy streamable-HTTP clients yield two streams; callers unpack three."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from integrations import mcp_streamable_http_compat as compat
+
+
+def _clear_client_cache() -> None:
+    loader = compat._load_streamable_http_clients
+    if hasattr(loader, "cache_clear"):
+        loader.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_cache() -> None:
+    _clear_client_cache()
+    yield
+    _clear_client_cache()
+
+
+@asynccontextmanager
+async def _yield_streams(streams: Any):
+    yield streams
+
+
+@pytest.mark.asyncio
+async def test_legacy_two_stream_result_normalizes_to_a_triple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    read, write = object(), object()
+
+    def _legacy_only() -> tuple[Any, Any]:
+        def _client(*_args: Any, **_kwargs: Any):
+            return _yield_streams((read, write))
+
+        return None, _client
+
+    monkeypatch.setattr(compat, "_load_streamable_http_clients", _legacy_only)
+
+    async with compat.streamable_http_client(
+        "https://mcp.example.test/mcp",
+        http_client=MagicMock(),
+    ) as triple:
+        assert triple == (read, write, None)
+
+
+def test_as_transport_triple_rejects_unexpected_stream_counts() -> None:
+    with pytest.raises(ValueError, match="expected 2 or 3"):
+        compat._as_transport_triple((object(),))

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -180,8 +180,6 @@ def test_run_repl_clears_screen_before_painting_banner(monkeypatch: Any) -> None
     assert cleared == [True]
     assert finishers and finishers[0] is not None
     assert painted == [True]
-    # Clear happens on the sync entrypoint before the async finisher paints.
-    assert cleared[0] is True
 
 
 def test_run_repl_skips_the_launch_banner_when_the_gate_paints_it(monkeypatch: Any) -> None:

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -147,9 +147,10 @@ def test_run_repl_invokes_the_sign_in_gate_before_the_controller(monkeypatch: An
 
 
 def test_run_repl_clears_screen_before_painting_banner(monkeypatch: Any) -> None:
-    """Launch wipes the calling shell so the REPL owns the viewport like Droid."""
+    """Launch wipes the calling shell, then paints once the runtime finisher runs."""
     cleared: list[bool] = []
     painted: list[bool] = []
+    finishers: list[object] = []
     monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(main_entrypoint, "should_paint_launch_banner", lambda: True)
     monkeypatch.setattr(main_entrypoint, "pass_sign_in_gate", lambda _c: True)
@@ -163,15 +164,24 @@ def test_run_repl_clears_screen_before_painting_banner(monkeypatch: Any) -> None
         "render_terminal_ui",
         lambda *_a, **_k: painted.append(True),
     )
+    # Unit path: no real wordmark thread; finisher still paints the static banner.
+    monkeypatch.setattr(main_entrypoint, "animate_launch_wordmark", lambda *_a, **_k: None)
 
     async def _skip_async(**_kwargs: Any) -> int:
+        finish = _kwargs.get("finish_banner")
+        finishers.append(finish)
+        if finish is not None:
+            finish()
         return 0
 
     monkeypatch.setattr(main_entrypoint, "run_repl_async", _skip_async)
     main_entrypoint.run_repl(config=ReplConfig(enabled=True, layout="classic"))
 
     assert cleared == [True]
+    assert finishers and finishers[0] is not None
     assert painted == [True]
+    # Clear happens on the sync entrypoint before the async finisher paints.
+    assert cleared[0] is True
 
 
 def test_run_repl_skips_the_launch_banner_when_the_gate_paints_it(monkeypatch: Any) -> None:

--- a/tests/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -252,6 +252,20 @@ def test_run_repl_async_failed_resume_flushes_starter_session(
     assert not (sessions_dir / f"{session.session_id}.jsonl").exists()
 
 
+def _finish_banner_then_stop(**kwargs: Any) -> int:
+    """Invoke the launch-banner finisher the real ``run_repl_async`` would.
+
+    ``run_repl`` spins the wordmark on a thread and paints the static banner
+    only when the async half calls ``finish_banner``. Stubs that skip the
+    shell must still run that finisher or startup chrome never reaches the
+    injected console.
+    """
+    finish = kwargs.get("finish_banner")
+    if finish is not None:
+        finish()
+    return 0
+
+
 def test_run_repl_writes_startup_output_to_the_supplied_console(monkeypatch: Any) -> None:
     """An embedding caller can capture the shell's output.
 
@@ -267,16 +281,16 @@ def test_run_repl_writes_startup_output_to_the_supplied_console(monkeypatch: Any
 
     captured = Console(file=StringIO(), force_terminal=False, width=80)
     monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(main_entrypoint, "animate_launch_wordmark", lambda *_a, **_k: None)
 
     def _fake_terminal_ui(console: Any, **_kwargs: Any) -> None:
         console.print("SPLASH")
         console.print("READY")
 
-    async def _skip_async(**_kwargs: Any) -> int:
-        return 0
+    async def _skip_async(**kwargs: Any) -> int:
+        return _finish_banner_then_stop(**kwargs)
 
     monkeypatch.setattr(main_entrypoint, "render_terminal_ui", _fake_terminal_ui)
-    # Stop before the event loop; the startup renders are what this pins.
     monkeypatch.setattr(main_entrypoint, "run_repl_async", _skip_async)
 
     # Act
@@ -297,12 +311,13 @@ def test_run_repl_defaults_to_the_module_console(monkeypatch: Any) -> None:
     # Arrange
     seen: list[object] = []
     monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(main_entrypoint, "animate_launch_wordmark", lambda *_a, **_k: None)
 
     def _record_console(console: Any, **_kwargs: Any) -> None:
         seen.append(console)
 
-    async def _skip_async(**_kwargs: Any) -> int:
-        return 0
+    async def _skip_async(**kwargs: Any) -> int:
+        return _finish_banner_then_stop(**kwargs)
 
     monkeypatch.setattr(main_entrypoint, "render_terminal_ui", _record_console)
     monkeypatch.setattr(main_entrypoint, "run_repl_async", _skip_async)
@@ -436,12 +451,13 @@ def test_console_injection_works_through_the_package_facade(monkeypatch: Any) ->
     from surfaces.interactive_shell import run_repl as facade
 
     monkeypatch.setattr(main_entrypoint.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(main_entrypoint, "animate_launch_wordmark", lambda *_a, **_k: None)
 
     def _fake_terminal_ui(console: Any, **_kwargs: Any) -> None:
         console.print("SPLASH")
 
-    async def _skip_async(**_kwargs: Any) -> int:
-        return 0
+    async def _skip_async(**kwargs: Any) -> int:
+        return _finish_banner_then_stop(**kwargs)
 
     monkeypatch.setattr(main_entrypoint, "render_terminal_ui", _fake_terminal_ui)
     monkeypatch.setattr(main_entrypoint, "run_repl_async", _skip_async)

--- a/tests/interactive_shell/ui/test_prompt_visibility.py
+++ b/tests/interactive_shell/ui/test_prompt_visibility.py
@@ -126,7 +126,8 @@ def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> 
     spinner.start()
     spinner.set_phase(SpinnerState.THINKING_PHASE)
     thinking_rows = render_prompt_region(session, ReplState(), spinner).value.count("\n")
-    assert thinking_rows in {idle_rows, idle_rows + 1}
+    # Busy adds the Thinking row and one lead blank under mid-turn text.
+    assert thinking_rows == idle_rows + 2
 
     spinner.set_phase(SpinnerState.INVOKING_TOOLS_PHASE)
     spinner.set_active_action("GitHub CLI · gh api repos/x", action_id="t1")
@@ -137,17 +138,28 @@ def test_streaming_prompt_height_matches_idle_with_live_tool_on_status_row() -> 
     assert "Invoking tools" in plain
 
 
-def test_prompt_region_does_not_lead_with_a_blank_row() -> None:
-    """The stream already owns the one-row margin; a second ``\\n`` is a hole."""
+def test_prompt_region_idle_does_not_lead_with_a_blank_row() -> None:
+    """Idle chrome stays flush; a leading blank under the banner is a hole."""
     session = Session()
     idle = render_prompt_region(session, ReplState(), SpinnerState()).value
     assert not idle.startswith("\n")
+    assert "\n\n" not in idle
+
+
+def test_prompt_region_thinking_leads_with_a_blank_row() -> None:
+    """Thinking sits under mid-turn assistant text — one blank so it breathes."""
+    session = Session()
     spinner = SpinnerState()
     spinner.start()
     spinner.set_phase(SpinnerState.THINKING_PHASE)
     busy = render_prompt_region(session, ReplState(), spinner).value
-    assert not busy.startswith("\n")
-    assert "\n\n" not in busy
+    assert busy.startswith("\n")
+    plain = _plain(busy)
+    assert "Thinking" in plain
+    # Lead blank, then the status row (spinner glyph + Thinking…) — not flush.
+    first_content_line = plain.split("\n", 1)[1]
+    assert "Thinking" in first_content_line
+    assert not plain.startswith("\n\n")
 
 
 def test_idle_prompt_has_no_recurring_ready_hint() -> None:

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -28,8 +28,8 @@ def _strip_ansi(text: str) -> str:
 
 
 def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
-    # A working note reads as soft recessed grey under a dim ``·`` gutter lead,
-    # distinct from the bright ``Ω`` reply, while the bold action word stays bold.
+    # Droid rhythm: warm ``·`` in the shared agent column, recessed body, bold
+    # action words still bold.
     from infrastructure.terminal import theme as ui_theme
 
     ui_theme.set_active_theme("amber")
@@ -51,7 +51,7 @@ def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
     assert "38;2;" in raw or "38;5;" in raw
     assert re.search(r"\x1b\[[0-9;]*1[;m]", raw)  # bold action word survives
     first_line = _strip_ansi(raw).splitlines()[0]
-    assert first_line.startswith("·  ")  # dim note marker in the Ω gutter column
+    assert first_line.startswith("· ")  # warm · in the shared agent marker column
     assert "load the workflow" in first_line
 
 
@@ -80,7 +80,7 @@ def test_prose_reply_keeps_the_inline_marker() -> None:
 
     publish_full_response(console, "Root disk is 44% full.")
 
-    assert "Ω  Root disk is 44% full." in buf.getvalue()
+    assert "Ω Root disk is 44% full." in buf.getvalue()
 
 
 def _tty_console() -> tuple[Console, io.StringIO]:
@@ -231,7 +231,7 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="OpenSRE", chunks=_yield_chunks([text]))
 
         visible = "\n".join(line.rstrip() for line in _strip_ansi(buf.getvalue()).splitlines())
-        assert "Ω  Ready:\n\n    • first\n    • second\n\n   Blocked pending a choice." in visible
+        assert "Ω Ready:\n\n   • first\n   • second\n\n  Blocked pending a choice." in visible
 
     def test_reply_hangs_indented_under_the_marker(self) -> None:
         """A wrapped reply hangs in the Ω gutter: line one carries the marker,
@@ -242,7 +242,7 @@ class TestTtyParagraphRender:
         stream_to_console(console, label="assistant", chunks=_yield_chunks([text]))
 
         lines = [line for line in _strip_ansi(buf.getvalue()).splitlines() if line.strip()]
-        assert lines[0].startswith("Ω  ")  # marker leads the first line
+        assert lines[0].startswith("Ω ")  # marker leads the first line
         assert len(lines) > 1  # the reply actually wrapped
         assert all(line.startswith("  ") for line in lines[1:])  # hang-indent at col 2
 

--- a/tests/interactive_shell/ui/test_streaming.py
+++ b/tests/interactive_shell/ui/test_streaming.py
@@ -28,8 +28,8 @@ def _strip_ansi(text: str) -> str:
 
 
 def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
-    # A working note reads as soft recessed grey + indented (no glyph), distinct
-    # from the bright reply, while the bold action word stays bold.
+    # A working note reads as soft recessed grey under a dim ``·`` gutter lead,
+    # distinct from the bright ``Ω`` reply, while the bold action word stays bold.
     from infrastructure.terminal import theme as ui_theme
 
     ui_theme.set_active_theme("amber")
@@ -51,7 +51,7 @@ def test_render_note_block_is_recessed_and_indented_but_keeps_bold() -> None:
     assert "38;2;" in raw or "38;5;" in raw
     assert re.search(r"\x1b\[[0-9;]*1[;m]", raw)  # bold action word survives
     first_line = _strip_ansi(raw).splitlines()[0]
-    assert first_line.startswith("   ")  # three-space left indent, no glyph
+    assert first_line.startswith("·  ")  # dim note marker in the Ω gutter column
     assert "load the workflow" in first_line
 
 

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -108,6 +108,8 @@ def test_idle_prompt_region_shows_plan_without_thinking_or_ready_hint() -> None:
     assert "Ready" not in rendered  # no recurring idle hint line
     assert rendered.index("Plan · 2/3") < rendered.index("Auto (High)")
     assert "  ○ Confirm checkout returns 2xx\n\nAuto (High) · Allow all" in rendered
+    # Blank row above the plan separates it from scrollback notes (Droid blocks).
+    assert rendered.lstrip().startswith("Plan · 2/3") or "\nPlan · 2/3" in rendered
 
 
 def test_clearing_the_plan_resets_expanded_state() -> None:

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -12,6 +12,7 @@ from infrastructure.deployment.packaging.release_manifest import (
     runtime_hidden_imports,
 )
 from tools.registry_discovery import INTEGRATION_TOOL_PACKAGES
+from tools.registry_index import BAKED_INDEX_RELATIVE_PATH
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
@@ -100,6 +101,22 @@ def test_release_build_uses_checked_in_spec() -> None:
     assert "OPENSRE_PYINSTALLER_MODE: ${{ matrix.pyinstaller_mode }}" in workflow
     assert "release_manifest.py" in spec
     assert "skill_data_entries(ROOT)" in spec
+
+
+def test_spec_bakes_the_descriptor_index_into_the_bundle() -> None:
+    """The frozen fallback imports every vendor module when this file is missing.
+
+    A unit test that writes the JSON into a fake ``_MEIPASS`` cannot catch a
+    spec that omits or misplaces it. Pin the PyInstaller data entry: dump at
+    build time, ship under ``BAKED_INDEX_RELATIVE_PATH.parent`` so the runtime
+    path ``sys._MEIPASS / tools / descriptor_index.json`` is what the bundle
+    actually contains.
+    """
+    spec = _SPEC_FILE.read_text(encoding="utf-8")
+
+    assert "dump_descriptor_index(_baked_index)" in spec
+    assert "datas.append((str(_baked_index), str(BAKED_INDEX_RELATIVE_PATH.parent)))" in spec
+    assert BAKED_INDEX_RELATIVE_PATH.as_posix() == "tools/descriptor_index.json"
 
 
 def test_release_workflow_does_not_run_on_pull_requests() -> None:

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -119,6 +119,15 @@ def test_spec_bakes_the_descriptor_index_into_the_bundle() -> None:
     assert BAKED_INDEX_RELATIVE_PATH.as_posix() == "tools/descriptor_index.json"
 
 
+def test_release_workflow_parallelizes_macos_onedir_resign() -> None:
+    """Nested lib signs are independent; main binary stays serial and last."""
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'xargs -0 -P "$JOBS" -n 1 codesign --force --sign -' in workflow
+    assert 'codesign --force --sign - "$APP_BIN"' in workflow
+    assert 'if [ "$JOBS" -gt 4 ]; then' in workflow
+
+
 def test_release_workflow_does_not_run_on_pull_requests() -> None:
     workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
     triggers = yaml.load(workflow, Loader=yaml.BaseLoader)["on"]

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -114,9 +114,25 @@ def test_spec_bakes_the_descriptor_index_into_the_bundle() -> None:
     """
     spec = _SPEC_FILE.read_text(encoding="utf-8")
 
+    assert '_baked_index = ROOT / "build" / "baked" / BAKED_INDEX_RELATIVE_PATH' in spec
     assert "dump_descriptor_index(_baked_index)" in spec
     assert "datas.append((str(_baked_index), str(BAKED_INDEX_RELATIVE_PATH.parent)))" in spec
     assert BAKED_INDEX_RELATIVE_PATH.as_posix() == "tools/descriptor_index.json"
+
+
+def test_release_smoke_asserts_onedir_contains_the_baked_index() -> None:
+    """Unix onedir smoke must see the file on disk, not only via ``_package-smoke``.
+
+    A unit test that writes JSON into a fake ``_MEIPASS`` cannot catch a spec
+    that omits or misplaces the bake. ``_package-smoke`` fail-closed covers
+    onefile (Windows), where datas live inside the archive. Onedir can assert
+    the path PyInstaller materializes under ``_internal/``, same as LiteLLM.
+    """
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    baked_onedir = f"./dist/opensre/_internal/{BAKED_INDEX_RELATIVE_PATH.as_posix()}"
+
+    assert baked_onedir in workflow
+    assert "_package-smoke" in workflow
 
 
 def test_release_workflow_parallelizes_macos_onedir_resign() -> None:

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -27,6 +27,21 @@ def test_hidden_imports_cover_runtime_discovered_tool_packages() -> None:
     assert "tools.system.work_items.tool" in hidden_imports
 
 
+def test_hidden_imports_cover_lazy_cli_command_modules() -> None:
+    """CLI commands load via importlib from COMMAND_SPECS; freeze must list them.
+
+    Without this, ``opensre _package-smoke`` (and every other top-level command)
+    fails in the PyInstaller binary with ModuleNotFoundError before Click runs.
+    """
+    from surfaces.cli.commands.command_specs import COMMAND_SPECS
+
+    hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
+    command_modules = {spec.import_path.split(":", 1)[0] for spec in COMMAND_SPECS}
+
+    assert command_modules <= hidden_imports
+    assert "surfaces.cli.commands.package_smoke" in hidden_imports
+
+
 def test_hidden_imports_exclude_non_runtime_discovery_modules() -> None:
     hidden_imports = set(runtime_hidden_imports(_REPO_ROOT))
 

--- a/tests/shared/terminal/test_choice_menu.py
+++ b/tests/shared/terminal/test_choice_menu.py
@@ -65,11 +65,34 @@ def test_draw_menu_letter_keys_labels_options_alphabetically(monkeypatch) -> Non
     )
 
     plain = _ANSI_RE.sub("", out.getvalue())
+    # Section gap before the accent header so Ask User is not flush under
+    # Plan complete / reply text above.
+    assert plain.startswith("\r\n\r  Ask User")
+    assert "\r  Ask User\r\n\r  How should I select repos?" in plain
     assert "❯ (A) Local repos" in plain
     assert "(B) GitHub account" in plain
     assert "(C) Or type your own answer..." in plain
     assert "Enter/A-C Select" in plain
     assert "1." not in plain
+
+
+def test_draw_menu_without_header_stays_tight(monkeypatch) -> None:
+    """Slash pickers keep no blank above the title."""
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(choice_menu, "_cols", lambda: 80)
+
+    choice_menu._draw_menu(
+        title="integrations",
+        crumb="/integrations",
+        labels=["list"],
+        index=0,
+        erase_lines=0,
+    )
+
+    plain = _ANSI_RE.sub("", out.getvalue())
+    assert plain.startswith("\r  integrations")
+    assert not plain.startswith("\r\n\r  integrations")
 
 
 def test_pick_letter_key_selects_matching_option(monkeypatch) -> None:

--- a/tests/tools/test_registry_index.py
+++ b/tests/tools/test_registry_index.py
@@ -9,7 +9,9 @@ drifts, a tool changed shape: make its metadata literal, or update the pinned
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -119,3 +121,38 @@ def test_surfaces_attribute_resolution() -> None:
         ctx=ast.Load(),
     )
     assert _string_constant(node) == "chat"
+
+
+def test_baked_index_round_trips_and_serves_frozen_builds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A frozen bundle loads the build-time JSON index instead of scanning source.
+
+    Without it a frozen binary imports every vendor tool module (~1,900 extra
+    modules) on the first turn; with it the surface-scoped load is intact.
+    """
+    from tools import registry_index as ri
+    from tools.registry import _load_surface_snapshot, clear_tool_registry_cache
+
+    # Arrange: bake the index from source into a fake bundle root.
+    reference = ri.build_descriptor_index()
+    baked = tmp_path / ri.BAKED_INDEX_RELATIVE_PATH
+    ri.dump_descriptor_index(baked)
+    assert ri._load_baked_index(baked) == reference
+
+    # Act: pretend to be that frozen bundle.
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+    ri.clear_descriptor_index_cache()
+    clear_tool_registry_cache()
+    try:
+        # Assert: the baked file is what the index serves, and the frozen
+        # surface load stays scoped (not the every-vendor fallback).
+        assert ri.baked_index_available()
+        assert ri.build_descriptor_index() == reference
+        action = _load_surface_snapshot(ToolSurface.ACTION)
+        assert 0 < len(action) < len(reference)
+        assert all(ToolSurface.ACTION in tool.surfaces for tool in action)
+    finally:
+        ri.clear_descriptor_index_cache()
+        clear_tool_registry_cache()

--- a/tests/tools/test_registry_index.py
+++ b/tests/tools/test_registry_index.py
@@ -130,6 +130,11 @@ def test_baked_index_round_trips_and_serves_frozen_builds(
 
     Without it a frozen binary imports every vendor tool module (~1,900 extra
     modules) on the first turn; with it the surface-scoped load is intact.
+
+    This plants the JSON to exercise the load path only. The spec and release
+    onedir smoke own the "bundle actually ships the file" contract
+    (``test_spec_bakes_the_descriptor_index_into_the_bundle``,
+    ``test_release_smoke_asserts_onedir_contains_the_baked_index``).
     """
     from tools import registry_index as ri
     from tools.registry import _load_surface_snapshot, clear_tool_registry_cache

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -126,17 +126,16 @@ def _load_surface_snapshot(surface: ToolSurface) -> tuple[RegisteredTool, ...]:
     imported, so they are collected directly. Equivalent to the full snapshot
     filtered by ``surface`` (pinned by the registry-index contract test).
 
-    In a PyInstaller frozen binary the AST scanner cannot locate ``.py`` source
-    files (they are compiled to bytecode and not extracted), so
-    ``build_descriptor_index`` returns only the hand-written fallback entries and
-    Grafana / other integration tools are never discovered.  Fall back to the
-    full dynamic snapshot — which imports via ``importlib`` and works correctly
-    with the bundled bytecode — and filter by surface there.
+    A PyInstaller frozen binary carries bytecode only, so the AST scanner finds
+    no source; the build bakes the descriptor index into the bundle instead
+    (``dump_descriptor_index``) and this loads it. Only a frozen build that
+    shipped without that index falls back to the full dynamic snapshot, which
+    imports every vendor tool module.
     """
-    if getattr(sys, "frozen", False):
-        return tuple(t for t in _load_registry_snapshot() if surface in t.surfaces)
+    from tools.registry_index import baked_index_available, build_descriptor_index
 
-    from tools.registry_index import build_descriptor_index
+    if getattr(sys, "frozen", False) and not baked_index_available():
+        return tuple(t for t in _load_registry_snapshot() if surface in t.surfaces)
 
     index = build_descriptor_index()
     modules = sorted({d.module for d in index.values() if surface in d.surfaces})

--- a/tools/registry_index.py
+++ b/tools/registry_index.py
@@ -14,9 +14,12 @@ those the existing way. ``tests/tools/test_registry_index.py`` pins that gap.
 from __future__ import annotations
 
 import ast
+import json
+import sys
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from config.constants.paths import REPO_ROOT
 from core.domain.types.tools import ToolSurface
@@ -328,9 +331,73 @@ def _scan_roots() -> list[Path]:
     return roots
 
 
+#: Where a frozen build ships the index, relative to the bundle root
+#: (``sys._MEIPASS``). ``opensre.spec`` writes it at build time.
+BAKED_INDEX_RELATIVE_PATH = Path("tools") / "descriptor_index.json"
+
+
+def _baked_index_path() -> Path | None:
+    """Path of the build-time index inside a frozen bundle, else ``None``."""
+    if not getattr(sys, "frozen", False):
+        return None
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if bundle_root is None:
+        return None
+    return Path(bundle_root) / BAKED_INDEX_RELATIVE_PATH
+
+
+def baked_index_available() -> bool:
+    """True when this frozen build shipped a descriptor index."""
+    path = _baked_index_path()
+    return path is not None and path.is_file()
+
+
+def _descriptor_to_json(descriptor: ToolDescriptor) -> dict[str, Any]:
+    return {
+        "name": descriptor.name,
+        "surfaces": [surface.value for surface in descriptor.surfaces],
+        "source": descriptor.source,
+        "display_name": descriptor.display_name,
+        "module": descriptor.module,
+    }
+
+
+def _descriptor_from_json(raw: dict[str, Any]) -> ToolDescriptor:
+    return ToolDescriptor(
+        name=str(raw["name"]),
+        surfaces=tuple(ToolSurface(surface) for surface in raw["surfaces"]),
+        source=raw.get("source"),
+        display_name=raw.get("display_name"),
+        module=str(raw["module"]),
+    )
+
+
+def dump_descriptor_index(path: Path) -> None:
+    """Write the source-scanned index as JSON for a frozen build to load.
+
+    A PyInstaller bundle carries bytecode only, so the AST scan finds nothing
+    there; the build runs this against the checkout and ships the result.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = [_descriptor_to_json(d) for d in build_descriptor_index().values()]
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _load_baked_index(path: Path) -> dict[str, ToolDescriptor]:
+    entries = json.loads(path.read_text(encoding="utf-8"))
+    return {d.name: d for d in (_descriptor_from_json(entry) for entry in entries)}
+
+
 @lru_cache(maxsize=1)
 def build_descriptor_index() -> dict[str, ToolDescriptor]:
-    """Map tool name -> descriptor, first definition wins (registry order)."""
+    """Map tool name -> descriptor, first definition wins (registry order).
+
+    A frozen build loads the index baked at build time instead of scanning
+    source (which it does not carry).
+    """
+    baked = _baked_index_path()
+    if baked is not None and baked.is_file():
+        return _load_baked_index(baked)
     index: dict[str, ToolDescriptor] = {}
     for root in _scan_roots():
         for path in sorted(root.rglob("*.py")):
@@ -349,7 +416,10 @@ def clear_descriptor_index_cache() -> None:
 
 
 __all__ = [
+    "BAKED_INDEX_RELATIVE_PATH",
     "ToolDescriptor",
+    "baked_index_available",
     "build_descriptor_index",
     "clear_descriptor_index_cache",
+    "dump_descriptor_index",
 ]


### PR DESCRIPTION
## Problem

A fresh install's first `opensre` took 7–14s to reach the prompt (up to
18s on a cold machine). Every launch after that is ~1s. A 3s load-time
increase costs ~30% of users, so this is the single biggest drop-off in
the funnel.

## Root cause

The `curl` installer ships a PyInstaller onedir bundle: 781 MB, 301
native Mach-O libraries, all ad-hoc signed. macOS validates each image's
code signature on its first dlopen and caches the result. Two things
combine on the user's first launch:

1. The installer re-signs all 301 libs (to fix Invalid-Page SIGKILLs),
   which resets that cache — then verifies with `--version`, the fast path,
   which loads almost none of them. So the user's first real launch pays
   the whole validation bill. Measured on the bundle: re-sign then launch
   = 11.8s to first byte (`real 11.6s` vs `user 1.5s` — the process is
   waiting on the kernel, not computing); the run after = 1.0s.
2. Frozen builds imported every vendor tool module on the first turn
   (+1,881 modules: boto3, botocore, kubernetes, google) because the
   descriptor index is an AST scan of `.py` source the bundle does not
   carry, so it fell back to the full dynamic snapshot.

Ruled out along the way: `configure_process` (CLI profile = env only), the
sign-in gate, banner counters (filesystem only), version resolution (reads
git HEAD from files), integration warming (lazy), the tiktoken bootstrap
(only loads with litellm). Warm imports are 0.67s; dev `uv run opensre` is
3.4s to prompt.

## Fix

- **Install-time warm-up** (`install.sh`): after the re-sign, run the
  hidden `opensre _package-smoke` under the installer spinner. It imports
  the full tool registry, all verifiers and skills, so it dlopens
  essentially the whole library set and absorbs the validation while the
  user is already waiting on the installer. Quiet (JSON suppressed) and
  best-effort — `--version` already gates correctness, so a smoke failure
  warns rather than aborts.
- **Baked descriptor index**: `opensre.spec` runs `dump_descriptor_index()`
  against the checkout at build time and ships the result as
  `tools/descriptor_index.json`; `build_descriptor_index()` loads it when
  `sys.frozen`. `_load_surface_snapshot` now uses the index in frozen
  builds, keeping the surface-scoped load (54 action tools, 840 modules)
  instead of importing all 266 tools. The every-vendor fallback remains only
  for a bundle that shipped without the index.

## Results (rebuilt bundle, real PTY, macOS)

| Scenario | First byte → prompt |
|---|---|
| Before: first launch after install | 11.8–18.2s → 13–19.5s |
| After: first launch (installer ran the warm-up) | 1.56s → 2.8s |
