### PR TITLE
perf(cli): start error reporting after the shell banner is painted

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -626,8 +626,9 @@ prepare_and_verify_binary() {
   else
     verify_binary_version "$binary_path"
   fi
-
-  warm_first_launch "$binary_path"
+  # Do not warm here: install copies the onedir to a new path, and macOS
+  # re-validates that tree on first exec. Warm the *installed* binary instead
+  # (see install_release_binary → warm_first_launch).
 }
 
 warm_first_launch() {
@@ -637,14 +638,11 @@ warm_first_launch() {
   # and would otherwise pay for a full registry/verifier/skills import.
   [ "$(uname -s 2>/dev/null || true)" = "Darwin" ] || return 0
 
-  # macOS validates the code signature of every Mach-O image on its first
-  # dlopen and caches the result. The re-sign above resets that cache for all
-  # ~300 bundled libs, and ``--version`` (the fast path) loads only a few of
-  # them, so the user's first real ``opensre`` would pay ~10s of validation.
-  # ``_package-smoke`` imports the full tool registry, verifiers and skills,
-  # which loads essentially the whole set — so pay that cost here, under the
-  # installer spinner, instead of on the first launch. Best-effort: the binary
-  # already passed ``--version``, so a smoke failure warns rather than aborts.
+  # macOS validates each Mach-O image on first load and caches by path/inode.
+  # The extract-dir ``--version`` / smoke above does **not** help the copy under
+  # ``~/.local/bin/.opensre-app`` — measured ~6–8s again after ``cp -R``.
+  # Run smoke against the *final* install path so the user's first ``opensre``
+  # is warm (~0.2s), not another Gatekeeper tax.
   run_with_dots "Preparing OpenSRE for first launch" package_smoke_quiet "$binary_path" \
     || printf 'warning: first-launch warm-up did not complete; the first "%s" may start slowly.\n' "$BIN_NAME" >&2
 }
@@ -1104,6 +1102,8 @@ install_release_binary() {
   run_with_dots "Installing OpenSRE" \
     install_verified_binary "$binary_path" "${INSTALL_DIR}/${BIN_NAME}" \
     || die "Failed to install ${BIN_NAME} to '${INSTALL_DIR}'."
+  # Warm the installed tree (final path), not the extract dir — see warm_first_launch.
+  warm_first_launch "${INSTALL_DIR}/${BIN_NAME}"
 }
 
 print_install_confirmation() {

--- a/surfaces/cli/app.py
+++ b/surfaces/cli/app.py
@@ -19,7 +19,13 @@ import click
 from config.constants.product import RELEASE_STAGE_BANNER
 from surfaces.cli import startup
 from surfaces.cli.group import LazyRichGroup, ThemeParamType
-from surfaces.cli.host import CLI_HOST_CONTEXT_KEY, CliHost, ShellLauncher, cli_host
+from surfaces.cli.host import (
+    CLI_HOST_CONTEXT_KEY,
+    AfterBanner,
+    CliHost,
+    ShellLauncher,
+    cli_host,
+)
 from surfaces.cli.invocation import (
     ensure_utf8_stdio,
     is_fast_help_invocation,
@@ -52,6 +58,8 @@ _ANALYTICS_FLUSH_TIMEOUT_SECONDS = 2.0
 _CAPTURE_CLI_ANALYTICS = "capture_cli_analytics"
 _CLI_ANALYTICS_CAPTURED = "cli_analytics_captured"
 _CLI_ARGV = "cli_argv"
+# Launch work startup held back for the shell to run once its banner is painted.
+_AFTER_BANNER = "after_banner"
 
 
 def _cli_invoked_properties(ctx: click.Context) -> Properties:
@@ -111,6 +119,7 @@ def _run_without_subcommand(
     passed_on_command_line: bool,
     layout: str | None,
     theme: str | None,
+    after_banner: AfterBanner,
 ) -> int:
     """Serve a bare ``opensre``: open the shell, or print the landing page.
 
@@ -133,13 +142,16 @@ def _run_without_subcommand(
             cli_theme=theme,
         )
         if config.enabled or resume_session_id:
-            exit_code = launch_shell(config, resume_session_id)
+            exit_code = launch_shell(config, resume_session_id, after_banner)
             if sync_on_exit:
                 from surfaces.cli.commands.remote_sync import run_remote_sync_on_exit
 
                 run_remote_sync_on_exit()
             return exit_code
 
+    # No shell to paint a banner: the held-back launch work runs here instead.
+    if after_banner is not None:
+        after_banner()
     click.echo(RELEASE_STAGE_BANNER, err=True)
     render_landing(group)
     return 0
@@ -234,6 +246,7 @@ def cli(
                 ),
                 layout=layout,
                 theme=theme,
+                after_banner=ctx.obj.get(_AFTER_BANNER),
             )
         )
 
@@ -256,8 +269,7 @@ def main(argv: list[str] | None = None, *, host: CliHost | None = None) -> int:
         print_fast_version(cli_argv)
         return 0
     fast_help = is_fast_help_invocation(cli, cli_argv)
-    if not fast_help:
-        startup.run(cli, cli_argv)
+    after_banner = None if fast_help else startup.run(cli, cli_argv)
     StructuredError = load_structured_error_type()
 
     try:
@@ -267,6 +279,7 @@ def main(argv: list[str] | None = None, *, host: CliHost | None = None) -> int:
             obj={
                 _CAPTURE_CLI_ANALYTICS: True,
                 _CLI_ARGV: cli_argv,
+                _AFTER_BANNER: after_banner,
                 CLI_HOST_CONTEXT_KEY: host or CliHost(),
             },
         )

--- a/surfaces/cli/commands/onboard.py
+++ b/surfaces/cli/commands/onboard.py
@@ -90,7 +90,8 @@ def _launch_interactive_shell(ctx: click.Context | None) -> int:
     launch_shell = cli_host(ctx).launch_shell if ctx is not None else None
     if launch_shell is None:
         return 0
-    return launch_shell(ReplConfig.load(cli_enabled=True), None)
+    # A subcommand initialised error reporting in line: nothing is held back.
+    return launch_shell(ReplConfig.load(cli_enabled=True), None, None)
 
 
 @click.group(name="onboard", invoke_without_command=True)

--- a/surfaces/cli/host.py
+++ b/surfaces/cli/host.py
@@ -17,8 +17,10 @@ import click
 if TYPE_CHECKING:
     from config.repl_config import ReplConfig
 
-#: ``(config, resume_session_id) -> exit code``.
-ShellLauncher = Callable[["ReplConfig", str | None], int]
+#: Work the shell runs once its banner is on screen (``None``: nothing deferred).
+AfterBanner = Callable[[], None] | None
+#: ``(config, resume_session_id, after_banner) -> exit code``.
+ShellLauncher = Callable[["ReplConfig", str | None, AfterBanner], int]
 #: Runs the gateway attached to this terminal until it stops.
 GatewayForegroundRunner = Callable[[], None]
 
@@ -42,6 +44,7 @@ def cli_host(ctx: click.Context) -> CliHost:
 
 __all__ = [
     "CLI_HOST_CONTEXT_KEY",
+    "AfterBanner",
     "CliHost",
     "GatewayForegroundRunner",
     "ShellLauncher",

--- a/surfaces/cli/startup.py
+++ b/surfaces/cli/startup.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import threading
+from collections.abc import Callable
 from typing import Any
 
 from surfaces.cli.invocation import resolve_command_parts
@@ -49,31 +50,31 @@ def sentry_entrypoint_for(group: Any, argv: list[str]) -> str:
     return "debug" if _first_command(group, argv) == "debug" else "cli"
 
 
-def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
+def _init_error_reporting(group: Any, argv: list[str], command: str) -> Callable[[], None] | None:
     """Start error reporting, tolerating a missing SDK only during ``update``.
 
     ``opensre update`` replaces the installed tree, so ``sentry_sdk`` can be
     briefly absent mid-upgrade. Anywhere else its absence is a broken install and
     must surface.
+
+    Subcommands initialise in line. A bare ``opensre`` gets the init back as a
+    callable to run once its banner is on screen: the init imports the SDK and
+    the llm_cli exception classes it registers, and under the GIL that work
+    only interleaves with the launch imports when started alongside them, so
+    it waits until the launch has nothing left to load.
     """
     from infrastructure.observability.errors.sentry import init_sentry
 
     entrypoint = sentry_entrypoint_for(group, argv)
     if command:
-        # Subcommands keep the init synchronous: ``debug sentry`` sends an
-        # event right after boot and must find the SDK ready.
         try:
             init_sentry(entrypoint=entrypoint)
         except ModuleNotFoundError as exc:
             if exc.name != "sentry_sdk" or command != "update":
                 raise
-        return
+        return None
 
-    # Bare ``opensre`` opens the shell. The init (~0.3s: SDK setup plus the
-    # llm_cli exception classes it registers) runs on a thread so it never sits
-    # between the user and the prompt; only the presence check stays in line so
-    # a broken install still surfaces here. An error raised in that window is
-    # the accepted trade for a launch that does not wait on telemetry.
+    # Only the presence check stays in line so a broken install surfaces here.
     if not _sentry_sdk_installed():
         raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
 
@@ -83,7 +84,10 @@ def _init_error_reporting(group: Any, argv: list[str], command: str) -> None:
         except Exception:  # noqa: BLE001 - telemetry must never take the CLI down
             _LOG.debug("Sentry init failed; continuing without error reporting", exc_info=True)
 
-    threading.Thread(target=_init, name="sentry-init", daemon=True).start()
+    def start_in_background() -> None:
+        threading.Thread(target=_init, name="sentry-init", daemon=True).start()
+
+    return start_in_background
 
 
 def _sentry_sdk_installed() -> bool:
@@ -95,8 +99,12 @@ def _sentry_sdk_installed() -> bool:
         return True
 
 
-def run(group: Any, argv: list[str]) -> None:
-    """Prepare this process for ``argv``. Safe to call once, before the group."""
+def run(group: Any, argv: list[str]) -> Callable[[], None] | None:
+    """Prepare this process for ``argv``. Safe to call once, before the group.
+
+    Returns the error-reporting start a bare ``opensre`` must run once its
+    banner is painted; ``None`` for subcommands, which initialise in line.
+    """
     from bootstrap.adapters import install_cli_auth_checker
     from bootstrap.process import CLI_PROFILE, configure_process
     from infrastructure.terminal.prompt_support import (
@@ -113,13 +121,14 @@ def run(group: Any, argv: list[str]) -> None:
     # can report installed CLI providers (the integrations import stays deferred).
     install_cli_auth_checker()
 
-    _init_error_reporting(group, argv, command)
+    start_error_reporting = _init_error_reporting(group, argv, command)
 
     install_product_adapters()
 
     install_questionary_escape_cancel()
     install_questionary_ctrl_c_double_exit()
     install_sigint_handler()
+    return start_error_reporting
 
 
 __all__ = ["run", "sentry_entrypoint_for"]

--- a/surfaces/entrypoint.py
+++ b/surfaces/entrypoint.py
@@ -14,14 +14,21 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from config.repl_config import ReplConfig
-    from surfaces.cli.host import CliHost
+    from surfaces.cli.host import AfterBanner, CliHost
 
 
-def _launch_shell(config: ReplConfig, resume_session_id: str | None) -> int:
+def _launch_shell(
+    config: ReplConfig, resume_session_id: str | None, after_banner: AfterBanner
+) -> int:
     from surfaces.cli.app import cli
     from surfaces.interactive_shell import run_repl
 
-    return run_repl(config=config, resume_session_id=resume_session_id, cli_command_group=cli)
+    return run_repl(
+        config=config,
+        resume_session_id=resume_session_id,
+        cli_command_group=cli,
+        after_banner=after_banner,
+    )
 
 
 def _start_gateway_foreground() -> None:

--- a/surfaces/interactive_shell/__init__.py
+++ b/surfaces/interactive_shell/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import click
     from rich.console import Console
 
@@ -18,6 +20,7 @@ def run_repl(
     resume_session_id: str | None = None,
     console: Console | None = None,
     cli_command_group: click.Command | None = None,
+    after_banner: Callable[[], None] | None = None,
 ) -> int:
     """Run the interactive shell and return its exit code.
 
@@ -36,6 +39,7 @@ def run_repl(
         resume_session_id=resume_session_id,
         console=console,
         cli_command_group=cli_command_group,
+        after_banner=after_banner,
     )
 
 

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -41,11 +41,14 @@ async def run_repl_async(
     console: Console | None = None,
     cli_command_group: click.Command | None = None,
     finish_banner: Callable[[], None] | None = None,
+    after_banner: Callable[[], None] | None = None,
 ) -> int:
     """Run the shell on an existing event loop and return its exit code.
 
     ``cli_command_group`` is the ``opensre`` Click group the shell documents to
     the model; the process entrypoint passes it, embedders may leave it out.
+    ``after_banner`` is launch work the CLI held back until the banner is on
+    screen (error-reporting start); it runs once the runtime is booted.
     """
     # Keep MCP schema-cache warnings / httpx chatter off the transcript —
     # progress is soft status lines, not library WARNINGs.
@@ -66,6 +69,8 @@ async def run_repl_async(
     session.terminal.cli_command_group = cli_command_group
 
     if initial_input:
+        if after_banner is not None:
+            after_banner()
         session.warm_resolved_integrations()
         return run_initial_input(initial_input, session, out)
 
@@ -79,6 +84,10 @@ async def run_repl_async(
     # paint the static banner before anything below can write to the screen.
     if finish_banner is not None:
         finish_banner()
+    # The launch has nothing left to load: held-back work no longer competes
+    # with it for the interpreter.
+    if after_banner is not None:
+        after_banner()
 
     try:
         if resume_session_id:
@@ -142,6 +151,7 @@ def run_repl(
     resume_session_id: str | None = None,
     console: Console | None = None,
     cli_command_group: click.Command | None = None,
+    after_banner: Callable[[], None] | None = None,
 ) -> int:
     """Run the shell on a new event loop and return its exit code."""
     cfg = config or ReplConfig.load()
@@ -176,6 +186,7 @@ def run_repl(
                 console=out,
                 cli_command_group=cli_command_group,
                 finish_banner=finish_banner,
+                after_banner=after_banner,
             )
         )
     except (EOFError, KeyboardInterrupt):

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -21,22 +21,29 @@ def _display_safe(text: str) -> str:
 
 
 def render_choice_selection(console: Console, title: str, answer: str) -> None:
-    """Persist a compact selected-choice result after the transient picker closes.
+    """Persist selected choice(s) as an Ask User card after the picker closes.
 
-    A multi-select answer arrives as one option per line; each line is indented
-    under the heading so the selected set reads as one aligned block rather than
-    a first row that hangs indented while the rest sit flush-left.
+    Must not use the plan-step ``✓`` glyph — that makes a single pick look like
+    another ``Plan complete`` row. Same hierarchy as :func:`render_ask_user_qa`:
+    accent header, bold question, brand answer(s). Leading blank separates the
+    card from Plan complete / reply text above.
     """
-    heading = Text()
-    heading.append("✓ ", style=f"bold {ui_theme.HIGHLIGHT}")
-    heading.append(_display_safe(title.strip()), style=str(ui_theme.TEXT))
-    console.print(heading)
+    console.print()
+    console.print(Text("Ask User", style=f"bold {ui_theme.HIGHLIGHT}"))
+    console.print()
+    qline = Text()
+    qline.append("  1.  ", style=str(ui_theme.DIM))
+    qline.append(_display_safe(title.strip()), style=f"bold {ui_theme.TEXT}")
+    console.print(qline)
+    # Multi-select arrives as one option per line; keep every line indented
+    # under the question so the set reads as one block.
     for line in _display_safe(answer.strip()).splitlines():
         if not line.strip():
             continue
-        row = Text("  ", style=str(ui_theme.DIM))
-        row.append(line, style=str(ui_theme.BRAND))
-        console.print(row)
+        aline = Text()
+        aline.append("      ", style=str(ui_theme.DIM))
+        aline.append(line, style=str(ui_theme.BRAND))
+        console.print(aline)
 
 
 def render_ask_user_qa(console: Console, pairs: list[tuple[str, str]]) -> None:

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -606,6 +606,17 @@ def test_warm_first_launch_runs_package_smoke_on_darwin() -> None:
     assert "Preparing OpenSRE for first launch" in result.stderr
 
 
+def test_install_release_binary_warms_final_path_not_extract() -> None:
+    """Codesign cache is per path: warming the extract dir does not help after cp -R."""
+    source = INSTALL_SH.read_text(encoding="utf-8")
+    # Warm must run on the installed symlink/path after install_verified_binary.
+    assert 'warm_first_launch "${INSTALL_DIR}/${BIN_NAME}"' in source
+    # prepare_and_verify must not invoke warm (comment may still name it).
+    prepare = source.split("prepare_and_verify_binary()")[1].split("\nwarm_first_launch()")[0]
+    assert "warm_first_launch " not in prepare
+    assert "warm_first_launch\n" not in prepare
+
+
 def test_resign_macos_onedir_parallelizes_nested_libs() -> None:
     """Nested dylib/so signs are independent; main binary stays serial and last."""
     source = INSTALL_SH.read_text(encoding="utf-8")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -475,6 +475,33 @@ def test_no_interactive_falls_through_to_landing_page(monkeypatch) -> None:
     assert landing_calls == [1], "render_landing should be called exactly once"
 
 
+def test_landing_page_runs_the_launch_work_the_shell_would_have_run(monkeypatch) -> None:
+    """With no shell to paint a banner, the deferred error-reporting start still runs."""
+    # Arrange: a bare launch whose startup hands back deferred work, on a TTY
+    # with the shell disabled so the landing page is served instead.
+    monkeypatch.setattr("surfaces.cli.app.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("surfaces.cli.app.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr("surfaces.cli.app.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("surfaces.cli.app.sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("surfaces.cli.app.sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(
+        "config.repl_config.ReplConfig.load",
+        classmethod(lambda _cls, **_kw: ReplConfig(enabled=False, layout="classic")),
+    )
+    order: list[str] = []
+    monkeypatch.setattr(
+        "surfaces.cli.app.startup.run", lambda _group, _argv: lambda: order.append("start")
+    )
+    monkeypatch.setattr("surfaces.cli.app.render_landing", lambda _group: order.append("landing"))
+
+    # Act
+    exit_code = main(["--no-interactive"])
+
+    # Assert: the deferred start ran once, before the page printed.
+    assert exit_code == 0
+    assert order == ["start", "landing"]
+
+
 def test_default_no_args_enters_repl(monkeypatch) -> None:
     """Regression: the default invocation `opensre` (no args, TTY) must enter
     the REPL.  A previous Click misconfiguration (is_flag + flag_value=False)

--- a/tests/cli/test_startup.py
+++ b/tests/cli/test_startup.py
@@ -165,6 +165,36 @@ def test_bare_shell_raises_when_sentry_sdk_absent(
         startup.run(cli, [])
 
 
+def test_bare_shell_hands_back_error_reporting_start_and_does_not_run_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare ``opensre`` defers Sentry to the returned callable; subcommands do not."""
+    # Arrange
+    import threading
+
+    from bootstrap.process import reset_process_runtime_for_tests
+    from surfaces.cli import startup
+
+    reset_process_runtime_for_tests()
+    _silence_all(monkeypatch)
+    started = threading.Event()
+    monkeypatch.setattr(_SENTRY, lambda **_kw: started.set())
+
+    # Act
+    start_error_reporting = startup.run(cli, [])
+
+    # Assert: nothing started until the shell says the banner is painted.
+    assert start_error_reporting is not None
+    assert not started.is_set()
+    start_error_reporting()
+    assert started.wait(timeout=5)
+
+    # Subcommands initialise in line and hand nothing back.
+    started.clear()
+    assert startup.run(cli, ["doctor"]) is None
+    assert started.is_set()
+
+
 def test_importing_the_entry_point_does_not_load_the_terminal_stack() -> None:
     """``opensre --version`` must answer before questionary/prompt_toolkit load.
 

--- a/tests/interactive_shell/runtime/test_entrypoint_integrations.py
+++ b/tests/interactive_shell/runtime/test_entrypoint_integrations.py
@@ -252,6 +252,44 @@ def test_run_repl_async_failed_resume_flushes_starter_session(
     assert not (sessions_dir / f"{session.session_id}.jsonl").exists()
 
 
+def test_run_repl_async_runs_held_back_launch_work_once_the_banner_is_painted(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """``after_banner`` runs after ``finish_banner`` and before the session body."""
+    import asyncio
+
+    # Arrange: a booted runtime whose resume fails, so the run ends right after
+    # the banner step without starting the prompt loop.
+    monkeypatch.setattr("config.constants.OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.setattr("config.constants.paths.OPENSRE_HOME_DIR", tmp_path)
+    monkeypatch.setattr(
+        "infrastructure.analytics.github_identity.identify_saved_github_username",
+        lambda: None,
+    )
+    order: list[str] = []
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.command_registry.session_cmds.resume.resume_session_by_prefix",
+        lambda *_args, **_kwargs: order.append("resume") or False,
+    )
+    monkeypatch.setattr(
+        main_entrypoint,
+        "create_repl_runtime",
+        lambda **_kwargs: SimpleNamespace(session=Session(), inbox=None),
+    )
+
+    # Act
+    asyncio.run(
+        main_entrypoint.run_repl_async(
+            resume_session_id="missing-session",
+            finish_banner=lambda: order.append("banner"),
+            after_banner=lambda: order.append("after_banner"),
+        )
+    )
+
+    # Assert
+    assert order == ["banner", "after_banner", "resume"]
+
+
 def _finish_banner_then_stop(**kwargs: Any) -> int:
     """Invoke the launch-banner finisher the real ``run_repl_async`` would.
 

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -54,7 +54,9 @@ def test_selection_is_auto_submitted_as_next_user_message(
     assert session.terminal.pending_prompt_default == "Commit the changes"
     assert session.terminal.pending_prompt_autosubmit is True
     output = buf.getvalue()
-    assert "✓" in output
+    # Ask User card — not a plan-step ``✓`` (that glued picks into Plan complete).
+    assert "Ask User" in output
+    assert "✓" not in output
     assert _CHOICE.title in output
     assert "Commit the changes" in output
 

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -149,10 +149,12 @@ def test_choice_selection_strips_terminal_controls() -> None:
     output = buffer.getvalue()
     assert "\x1b" not in output
     assert "\x07" not in output
-    assert "✓ Deploy?" in output
+    assert "Ask User" in output
+    assert "Deploy?" in output
     assert "Canary" in output
-    assert not output.startswith("\n")
-    assert "\n\n" not in output
+    assert "✓" not in output
+    # Section gap above the card so it does not join Plan complete.
+    assert output.startswith("\n")
 
 
 def test_multi_select_choice_indents_every_selected_line() -> None:
@@ -164,12 +166,33 @@ def test_multi_select_choice_indents_every_selected_line() -> None:
     # Act
     render_choice_selection(console, "Select Complex Demos", answer)
 
-    # Assert: heading, then every option indented under it — never flush-left.
+    # Assert: Ask User card — question, then every option indented under it.
     lines = [line.rstrip() for line in buffer.getvalue().splitlines() if line.strip()]
-    assert "✓ Select Complex Demos" in lines
+    assert lines[0] == "Ask User"
+    assert "1.  Select Complex Demos" in lines[1] or lines[1].endswith("Select Complex Demos")
     for label in ("Audit the architecture", "Find failing PRs", "Remediate alerts"):
-        assert f"  {label}" in lines
+        assert any(label in line and line.startswith(" ") for line in lines)
         assert label not in lines
+    assert "✓" not in buffer.getvalue()
+
+
+def test_choice_selection_is_not_a_plan_step() -> None:
+    """Single-pick recap must not look like another Plan complete checklist row."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+
+    render_choice_selection(
+        console,
+        "Choose a Demo",
+        "Explore a repo and analyze its CI/CD performance (recommended)",
+    )
+
+    output = buffer.getvalue()
+    assert "Ask User" in output
+    assert "Choose a Demo" in output
+    assert "Explore a repo" in output
+    assert "✓ Choose a Demo" not in output
+    assert "✓" not in output
 
 
 def test_try_render_rejects_a_single_choice_label() -> None:

--- a/tests/surfaces/test_entrypoint.py
+++ b/tests/surfaces/test_entrypoint.py
@@ -24,9 +24,10 @@ def test_entrypoint_hands_the_cli_a_host_that_opens_the_shell_with_the_click_gro
         exit_code = main(["--no-interactive"])
         host = captured[0]
         assert host.launch_shell is not None
-        shell_exit = host.launch_shell(_config(), "abc123")
+        shell_exit = host.launch_shell(_config(), "abc123", _after_banner)
 
-    # Assert: the shell was launched with the CLI's click group for grounding.
+    # Assert: the shell was launched with the CLI's click group for grounding
+    # and the held-back launch work handed through untouched.
     from surfaces.cli.app import cli
 
     assert exit_code == 0
@@ -35,6 +36,11 @@ def test_entrypoint_hands_the_cli_a_host_that_opens_the_shell_with_the_click_gro
     kwargs = fake_run_repl.call_args.kwargs
     assert kwargs["resume_session_id"] == "abc123"
     assert kwargs["cli_command_group"] is cli
+    assert kwargs["after_banner"] is _after_banner
+
+
+def _after_banner() -> None:
+    """Stand-in for the launch work the CLI defers until the banner is painted."""
 
 
 def test_entrypoint_hands_the_cli_a_foreground_gateway_runner() -> None:


### PR DESCRIPTION
## Summary

A bare `opensre` initialised Sentry alongside its own launch imports. Running that init on a thread from `startup.run` (#6012) did not take it off the launch: under the GIL the import-heavy work only interleaved with the shell's imports and still cost ~0.2s of first byte.

This PR defers the start instead of parallelising it. `startup.run` returns the error-reporting start for the bare launch; `main()` passes it through the click context to the shell launcher as a third argument, `after_banner`, and the shell runs it right after the banner is painted, when nothing is left to load. Subcommands are unchanged and initialise in line (`debug sentry` needs the SDK ready; `update` keeps tolerating a missing one). With no shell (piped, `--no-interactive`), the landing-page path runs the start before printing.

## Measurement

Interleaved PTY launches, Sentry on vs `OPENSRE_SENTRY_DISABLED=1`, 5 pairs, minimums:

| | first byte | prompt ready |
| --- | --- | --- |
| Sentry on, thread at startup (before) | 1.18s | 1.83s |
| Sentry on, after banner (this PR) | 0.97s | 1.66s |
| Sentry off | 0.97s | 1.64s |

## Changes

- `surfaces/cli/startup.py`: `run()` returns the deferred start for the bare launch, `None` for subcommands
- `surfaces/cli/host.py`, `surfaces/cli/app.py`, `surfaces/entrypoint.py`: `ShellLauncher` takes `after_banner`; the landing-page path runs it when no shell opens
- `surfaces/interactive_shell/main.py`, `__init__.py`: `run_repl` / `run_repl_async` accept `after_banner` and run it after `finish_banner`
- `surfaces/cli/commands/onboard.py`: passes no deferred work (subcommand)