### PR TITLE
perf(launch): install the bundle by rename and keep the banner off the skill harness

### DIFF
--- a/infrastructure/terminal/__init__.py
+++ b/infrastructure/terminal/__init__.py
@@ -1,14 +1,12 @@
-"""Shared terminal presentation primitives (theme, prompts, error rendering)."""
+"""Shared terminal presentation primitives (theme, prompts, error rendering).
 
-from infrastructure.terminal.errors import render_error
-from infrastructure.terminal.prompt_support import (
-    CTRL_C_DOUBLE_PRESS_WINDOW_S,
-    handle_ctrl_c_press,
-    install_questionary_ctrl_c_double_exit,
-    install_questionary_escape_cancel,
-    repl_prompt_note_ctrl_c,
-    repl_reset_ctrl_c_gate,
-)
+Package import stays cheap: prompt_toolkit lives behind :mod:`prompt_support` and
+is only loaded when a caller asks for those names (or imports that submodule).
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = [
     "CTRL_C_DOUBLE_PRESS_WINDOW_S",
@@ -19,3 +17,26 @@ __all__ = [
     "repl_prompt_note_ctrl_c",
     "repl_reset_ctrl_c_gate",
 ]
+
+_PROMPT_EXPORTS = frozenset(
+    {
+        "CTRL_C_DOUBLE_PRESS_WINDOW_S",
+        "handle_ctrl_c_press",
+        "install_questionary_ctrl_c_double_exit",
+        "install_questionary_escape_cancel",
+        "repl_prompt_note_ctrl_c",
+        "repl_reset_ctrl_c_gate",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    if name == "render_error":
+        from infrastructure.terminal.errors import render_error
+
+        return render_error
+    if name in _PROMPT_EXPORTS:
+        from infrastructure.terminal import prompt_support
+
+        return getattr(prompt_support, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/install.sh
+++ b/install.sh
@@ -566,39 +566,78 @@ install_binary() {
   chmod 0755 "$destination_path" 2>/dev/null || true
 }
 
-install_binary_app() {
+# Install is two renames with the checks in between: stage the extracted tree
+# under INSTALL_DIR, verify and warm it there, then swap it into place. A binary
+# that fails its checks never replaces a working install, and nothing is
+# copied: macOS caches signature validation per file, so a renamed tree keeps
+# what the checks paid for while a copied tree is validated again on the
+# user's first launch.
+
+stage_binary() {
+  local source_path="$1"
+  local app_root=""
+
+  mkdir -p "$INSTALL_DIR"
+  if [ "$platform" != "windows" ] && app_root="$(binary_app_root "$source_path")"; then
+    stage_binary_app "$app_root"
+    return
+  fi
+
+  stage_single_binary "$source_path"
+}
+
+stage_binary_app() {
   local app_root="$1"
+  local staged_dir="${INSTALL_DIR}/.${BIN_NAME}-app.new.$$"
+
+  rm -rf "$staged_dir"
+  mv "$app_root" "$staged_dir"
+  chmod -R u+rwX,go+rX "$staged_dir" 2>/dev/null || true
+  printf '%s\n' "${staged_dir}/${BIN_NAME}"
+}
+
+stage_single_binary() {
+  local source_path="$1"
+  local staged_path="${INSTALL_DIR}/${BIN_NAME}.new.$$"
+
+  install_binary "$source_path" "$staged_path"
+  printf '%s\n' "$staged_path"
+}
+
+staged_binary_is_app() {
+  [ "${1%/*}" != "$INSTALL_DIR" ]
+}
+
+activate_staged_binary() {
+  local staged_path="$1"
   local destination_path="$2"
   local app_destination_dir="${INSTALL_DIR}/.${BIN_NAME}-app"
-  local app_tmp_dir="${app_destination_dir}.new.$$"
   local app_old_dir="${app_destination_dir}.old.$$"
 
-  rm -rf "$app_tmp_dir" "$app_old_dir"
-  cp -R "$app_root" "$app_tmp_dir"
-  chmod -R u+rwX,go+rX "$app_tmp_dir" 2>/dev/null || true
+  if ! staged_binary_is_app "$staged_path"; then
+    mv -f "$staged_path" "$destination_path"
+    return
+  fi
 
+  rm -rf "$app_old_dir"
   if [ -e "$app_destination_dir" ]; then
     mv "$app_destination_dir" "$app_old_dir"
   fi
-  mv "$app_tmp_dir" "$app_destination_dir"
+  mv "${staged_path%/*}" "$app_destination_dir"
   rm -rf "$app_old_dir"
 
   rm -f "$destination_path"
   ln -s "$app_destination_dir/${BIN_NAME}" "$destination_path"
 }
 
-install_verified_binary() {
-  local source_path="$1"
-  local destination_path="$2"
-  local app_root=""
+discard_staged_binary() {
+  local staged_path="$1"
 
-  mkdir -p "$INSTALL_DIR"
-  if [ "$platform" != "windows" ] && app_root="$(binary_app_root "$source_path")"; then
-    install_binary_app "$app_root" "$destination_path"
-    return
+  if staged_binary_is_app "$staged_path"; then
+    rm -rf "${staged_path%/*}"
+  else
+    rm -f "$staged_path"
   fi
-
-  install_binary "$source_path" "$destination_path"
 }
 
 download_and_verify_checksum() {
@@ -626,9 +665,9 @@ prepare_and_verify_binary() {
   else
     verify_binary_version "$binary_path"
   fi
-  # Do not warm here: install copies the onedir to a new path, and macOS
-  # re-validates that tree on first exec. Warm the *installed* binary instead
-  # (see install_release_binary → warm_first_launch).
+  # Runs on the staged tree under INSTALL_DIR, which is renamed into place
+  # afterwards, so the validation paid here is the validation the user's
+  # first launch would otherwise pay.
 }
 
 warm_first_launch() {
@@ -638,11 +677,11 @@ warm_first_launch() {
   # and would otherwise pay for a full registry/verifier/skills import.
   [ "$(uname -s 2>/dev/null || true)" = "Darwin" ] || return 0
 
-  # macOS validates each Mach-O image on first load and caches by path/inode.
-  # The extract-dir ``--version`` / smoke above does **not** help the copy under
-  # ``~/.local/bin/.opensre-app`` — measured ~6–8s again after ``cp -R``.
-  # Run smoke against the *final* install path so the user's first ``opensre``
-  # is warm (~0.2s), not another Gatekeeper tax.
+  # macOS validates each Mach-O image on first load and caches the result per
+  # file. ``--version`` loads only a few images; the smoke imports the whole
+  # tool registry and loads nearly all of them, so the user's first ``opensre``
+  # starts warm (~0.2s) instead of paying ~6s of validation. The staged tree
+  # is renamed into place afterwards, which keeps the cache.
   run_with_dots "Preparing OpenSRE for first launch" package_smoke_quiet "$binary_path" \
     || printf 'warning: first-launch warm-up did not complete; the first "%s" may start slowly.\n' "$BIN_NAME" >&2
 }
@@ -652,32 +691,14 @@ package_smoke_quiet() {
   "$1" _package-smoke >/dev/null 2>&1
 }
 
-extract_and_verify_binary() {
-  local archive_path="$1"
-  local extraction_dir="$2"
-  local extracted_binary_path
-  local extracted_version
+verify_staged_binary() {
+  local staged_path="$1"
 
-  run_with_dots "Extracting OpenSRE" extract_archive "$archive_path" "$extraction_dir" \
-    || return "$?"
-
-  extracted_binary_path="$(
-    run_with_dots "Locating ${BIN_NAME} binary" \
-      get_binary_path_from_archive "$extraction_dir" "$BIN_NAME"
-  )" || return "$?"
   if [ "$INSTALL_CHANNEL" = "main" ]; then
-    extracted_version="$(
-      run_with_dots "Found ${BIN_NAME} binary, verifying it runs" \
-        prepare_and_verify_binary "$extracted_binary_path" "$extraction_dir"
-    )" || return "$?"
+    prepare_and_verify_binary "$staged_path" "${staged_path%/*}"
   else
-    extracted_version="$(
-      run_with_dots "Found ${BIN_NAME} binary, verifying it runs" \
-        prepare_and_verify_binary "$extracted_binary_path" "$extraction_dir" "$version"
-    )" || return "$?"
+    prepare_and_verify_binary "$staged_path" "${staged_path%/*}" "$version"
   fi
-
-  printf '%s\n%s\n' "$extracted_binary_path" "$extracted_version"
 }
 
 get_binary_path_from_archive() {
@@ -1090,20 +1111,28 @@ verify_release_checksum() {
 }
 
 extract_release_binary() {
-  local verified_binary
-
-  verified_binary="$(extract_and_verify_binary "$archive_path" "$tmp_dir")" \
-    || die "Failed to extract or verify '${archive}'."
-  binary_path="${verified_binary%%$'\n'*}"
-  installed_version="${verified_binary#*$'\n'}"
+  run_with_dots "Extracting OpenSRE" extract_archive "$archive_path" "$tmp_dir" \
+    || die "Failed to extract '${archive}'."
+  binary_path="$(
+    run_with_dots "Locating ${BIN_NAME} binary" \
+      get_binary_path_from_archive "$tmp_dir" "$BIN_NAME"
+  )" || die "Failed to locate ${BIN_NAME} in '${archive}'."
 }
 
 install_release_binary() {
-  run_with_dots "Installing OpenSRE" \
-    install_verified_binary "$binary_path" "${INSTALL_DIR}/${BIN_NAME}" \
+  local staged_path
+
+  staged_path="$(run_with_dots "Installing OpenSRE" stage_binary "$binary_path")" \
     || die "Failed to install ${BIN_NAME} to '${INSTALL_DIR}'."
-  # Warm the installed tree (final path), not the extract dir — see warm_first_launch.
-  warm_first_launch "${INSTALL_DIR}/${BIN_NAME}"
+  if ! installed_version="$(
+    run_with_dots "Found ${BIN_NAME} binary, verifying it runs" verify_staged_binary "$staged_path"
+  )"; then
+    discard_staged_binary "$staged_path"
+    die "Failed to verify '${archive}'."
+  fi
+  warm_first_launch "$staged_path"
+  activate_staged_binary "$staged_path" "${INSTALL_DIR}/${BIN_NAME}" \
+    || die "Failed to install ${BIN_NAME} to '${INSTALL_DIR}'."
 }
 
 print_install_confirmation() {

--- a/surfaces/shared/terminal/banner/__init__.py
+++ b/surfaces/shared/terminal/banner/__init__.py
@@ -1,12 +1,13 @@
-"""OpenSRE launch banner."""
+"""OpenSRE launch banner.
 
-from surfaces.shared.terminal.banner.banner import (
-    WordmarkSpinFrame,
-    animate_launch_wordmark,
-    build_launch_banner,
-    build_wordmark_spin_frames,
-    render_launch_banner,
-)
+Eager imports stay off this package ``__init__`` so
+``banner_state.load_launch_status`` (two integer chips) does not pull Rich,
+prompt_toolkit, or the wordmark animation stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = [
     "WordmarkSpinFrame",
@@ -15,3 +16,11 @@ __all__ = [
     "build_wordmark_spin_frames",
     "render_launch_banner",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        from surfaces.shared.terminal.banner import banner as _banner
+
+        return getattr(_banner, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/surfaces/shared/terminal/banner/banner_state.py
+++ b/surfaces/shared/terminal/banner/banner_state.py
@@ -1,8 +1,16 @@
-"""Offline status probes for the compact launch banner."""
+"""Offline status probes for the compact launch banner.
+
+Counts only — no skill bodies, no vendor SDKs, no prompt_toolkit. The chips are
+decorative startup chrome; loading the action-skill harness or full catalog
+health graph here made first paint pay hundreds of milliseconds for two integers.
+"""
 
 from __future__ import annotations
 
+import json
+import os
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass(frozen=True)
@@ -13,24 +21,96 @@ class LaunchStatus:
     integration_count: int
 
 
-def _count_loaded_skills() -> int:
-    """Return the number of discovered action-agent skills."""
-    try:
-        from core.agent_harness.spi.grounding import list_action_skills
+# ``surfaces/shared/terminal/banner/banner_state.py`` → package root (opensre/).
+_PACKAGE_ROOT = Path(__file__).resolve().parents[4]
+_BUNDLED_SKILLS_DIR = _PACKAGE_ROOT / "core" / "agent_harness" / "prompts" / "skills"
 
-        return len(list_action_skills())
+
+def _count_bundled_skill_files(directory: Path) -> int:
+    """Count discoverable skill recipes without importing the skill loader.
+
+    Mirrors ``loader._iter_skill_paths`` (package dirs then top-level ``*.md``)
+    and dedupes by skill name the way ``list_action_skills`` does — without
+    reading file bodies or importing harness package ``__init__`` graphs.
+    """
+    if not directory.is_dir():
+        return 0
+    names: set[str] = set()
+
+    def _add(name: str) -> None:
+        key = name.replace("_", "-").lower()
+        if key:
+            names.add(key)
+
+    for child in sorted(directory.iterdir()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if (child / "SKILL.md").is_file() or (child / f"{child.name}.md").is_file():
+            _add(child.name)
+    for path in sorted(directory.glob("*.md")):
+        _add(path.stem)
+    return len(names)
+
+
+def _count_loaded_skills() -> int:
+    """Return the number of bundled action-agent skills (filesystem only)."""
+    try:
+        return _count_bundled_skill_files(_BUNDLED_SKILLS_DIR)
     except Exception:
         return 0
+
+
+def _integrations_store_file() -> Path:
+    """Best-effort path to ``integrations.json`` without importing the store stack."""
+    override = os.getenv("OPENSRE_INTEGRATIONS_STORE_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    home = os.getenv("OPENSRE_HOME", "").strip()
+    root = Path(home).expanduser() if home else Path.home() / ".opensre"
+    return root / "integrations.json"
+
+
+def _count_active_store_services(path: Path) -> int:
+    """Count active services in the local store JSON (no filelock / migration)."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+    records = data.get("integrations", []) if isinstance(data, dict) else []
+    if not isinstance(records, list):
+        return 0
+    services: set[str] = set()
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        if str(record.get("status", "active")).strip().lower() != "active":
+            continue
+        service = str(record.get("service", "")).strip().lower()
+        if service:
+            services.add(service)
+    return len(services)
 
 
 def _count_configured_integrations() -> int:
-    """Return how many integrations are configured (any health state)."""
-    try:
-        from integrations.catalog import configured_integration_health
+    """Prefer the catalog SoT; fall back to a cheap store JSON count.
 
-        return len(configured_integration_health())
+    The catalog path matches env + store (banner must not disagree with
+    ``/integrations``). When that import is too heavy or fails, the store file
+    alone still lights the chip.
+    """
+    try:
+        from integrations.catalog import configured_integration_services
+
+        return len(configured_integration_services())
     except Exception:
-        return 0
+        try:
+            return _count_active_store_services(_integrations_store_file())
+        except Exception:
+            return 0
 
 
 def load_launch_status() -> LaunchStatus:

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -173,7 +173,8 @@ def test_install_sh_defines_progress_helpers() -> None:
         "finish_dots()",
         "run_with_dots()",
         "binary_app_root()",
-        "install_binary_app()",
+        "stage_binary_app()",
+        "activate_staged_binary()",
         "print_binary_diagnostics()",
     ):
         assert helper in source
@@ -257,7 +258,12 @@ def test_install_sh_installs_pyinstaller_onedir_app(tmp_path: Path) -> None:
         platform="linux"
         BIN_NAME="opensre"
         INSTALL_DIR={shlex.quote(str(install_dir))}
-        install_verified_binary {shlex.quote(str(app_binary))} {shlex.quote(str(destination))}
+        staged="$(stage_binary {shlex.quote(str(app_binary))})"
+        test -f "$staged"
+        test ! -e {shlex.quote(str(app_root))}
+        test ! -e {shlex.quote(str(destination))}
+        activate_staged_binary "$staged" {shlex.quote(str(destination))}
+        test ! -e "$staged"
         test -L {shlex.quote(str(destination))}
         test -x {shlex.quote(str(destination))}
         test -f {shlex.quote(str(install_dir / ".opensre-app" / "_internal" / "payload.txt"))}
@@ -606,15 +612,54 @@ def test_warm_first_launch_runs_package_smoke_on_darwin() -> None:
     assert "Preparing OpenSRE for first launch" in result.stderr
 
 
-def test_install_release_binary_warms_final_path_not_extract() -> None:
-    """Codesign cache is per path: warming the extract dir does not help after cp -R."""
+def test_install_release_binary_verifies_and_warms_the_staged_tree_before_activation() -> None:
+    """Signature validation is cached per file: check and warm the tree that gets renamed
+    into place, and never copy it afterwards (a copy is validated all over again)."""
     source = INSTALL_SH.read_text(encoding="utf-8")
-    # Warm must run on the installed symlink/path after install_verified_binary.
-    assert 'warm_first_launch "${INSTALL_DIR}/${BIN_NAME}"' in source
+    pipeline = source.split("install_release_binary()")[1].split("\nprint_install_confirmation()")[
+        0
+    ]
+    assert pipeline.index('verify_staged_binary "$staged_path"') < pipeline.index(
+        'warm_first_launch "$staged_path"'
+    )
+    assert pipeline.index('warm_first_launch "$staged_path"') < pipeline.index(
+        'activate_staged_binary "$staged_path"'
+    )
+    assert "cp -R" not in source
     # prepare_and_verify must not invoke warm (comment may still name it).
     prepare = source.split("prepare_and_verify_binary()")[1].split("\nwarm_first_launch()")[0]
     assert "warm_first_launch " not in prepare
     assert "warm_first_launch\n" not in prepare
+
+
+def test_discarding_a_staged_app_leaves_the_existing_install_alone(tmp_path: Path) -> None:
+    app_root = tmp_path / "opensre-app"
+    (app_root / "_internal").mkdir(parents=True)
+    app_binary = app_root / "opensre"
+    app_binary.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+    app_binary.chmod(0o755)
+    install_dir = tmp_path / "bin"
+    existing_app = install_dir / ".opensre-app"
+    (existing_app / "_internal").mkdir(parents=True)
+    (existing_app / "opensre").write_text("#!/usr/bin/env sh\nprintf 'old\\n'\n", encoding="utf-8")
+    (existing_app / "opensre").chmod(0o755)
+    destination = install_dir / "opensre"
+    destination.symlink_to(existing_app / "opensre")
+
+    result = _run_logging_snippet(
+        f"""
+        platform="linux"
+        BIN_NAME="opensre"
+        INSTALL_DIR={shlex.quote(str(install_dir))}
+        staged="$(stage_binary {shlex.quote(str(app_binary))})"
+        discard_staged_binary "$staged"
+        test ! -e "$staged"
+        {shlex.quote(str(destination))}
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "old" in result.stdout
 
 
 def test_resign_macos_onedir_parallelizes_nested_libs() -> None:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -489,9 +489,14 @@ def test_landing_page_runs_the_launch_work_the_shell_would_have_run(monkeypatch)
         classmethod(lambda _cls, **_kw: ReplConfig(enabled=False, layout="classic")),
     )
     order: list[str] = []
-    monkeypatch.setattr(
-        "surfaces.cli.app.startup.run", lambda _group, _argv: lambda: order.append("start")
-    )
+
+    def _start_error_reporting() -> None:
+        order.append("start")
+
+    def _hand_back_error_reporting_start(_group: object, _argv: object) -> object:
+        return _start_error_reporting
+
+    monkeypatch.setattr("surfaces.cli.app.startup.run", _hand_back_error_reporting_start)
     monkeypatch.setattr("surfaces.cli.app.render_landing", lambda _group: order.append("landing"))
 
     # Act

--- a/tests/interactive_shell/ui/test_banner.py
+++ b/tests/interactive_shell/ui/test_banner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from pathlib import Path
 
 from rich.console import Console
 
@@ -218,10 +219,10 @@ def test_status_marks_empty_or_unavailable_capabilities(monkeypatch: object) -> 
 
 
 def test_integration_count_includes_all_configured(monkeypatch: object) -> None:
-    # Every configured integration counts (not just MCP ones), any health state.
+    # Every configured integration counts (not just MCP ones).
     monkeypatch.setattr(
-        "integrations.catalog.configured_integration_health",
-        lambda: [("datadog", "ok"), ("github", "ok")],
+        "integrations.catalog.configured_integration_services",
+        lambda: ["datadog", "github"],
     )
 
     assert banner_state_module._count_configured_integrations() == 2
@@ -234,13 +235,22 @@ def test_status_probes_survive_loader_failures(monkeypatch: object) -> None:
 
     def _fail_startup_probes(name: str, *args: object, **kwargs: object) -> object:
         if name in {
-            "core.agent_harness.spi.grounding",
             "integrations.catalog",
         }:
             raise ImportError("simulated startup probe failure")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", _fail_startup_probes)
+    monkeypatch.setattr(
+        banner_state_module,
+        "_BUNDLED_SKILLS_DIR",
+        Path("/nonexistent/skills-dir"),
+    )
+    monkeypatch.setattr(
+        banner_state_module,
+        "_integrations_store_file",
+        lambda: Path("/nonexistent/integrations.json"),
+    )
 
     assert banner_state_module._count_loaded_skills() == 0
     assert banner_state_module._count_configured_integrations() == 0

--- a/tests/interactive_shell/ui/test_banner_launch_status_imports.py
+++ b/tests/interactive_shell/ui/test_banner_launch_status_imports.py
@@ -1,0 +1,28 @@
+"""Launch banner status must not import the action-skill harness graph."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_load_launch_status_does_not_import_skill_harness() -> None:
+    """Skills chip is a filesystem count — not ``list_action_skills`` / prompt_toolkit."""
+    probe = (
+        "import sys; "
+        "from surfaces.shared.terminal.banner.banner_state import load_launch_status; "
+        "status = load_launch_status(); "
+        "heavy = [n for n in sys.modules if n == 'prompt_toolkit' "
+        "or n.startswith('core.agent_harness.prompts.skills.loader') "
+        "or n.startswith('core.agent_harness.spi')]; "
+        "print('STATUS', status.skill_count, status.integration_count); "
+        "print('HEAVY', ','.join(sorted(heavy)[:12]) or 'none')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "HEAVY none" in result.stdout, result.stdout + result.stderr
+    assert "STATUS" in result.stdout


### PR DESCRIPTION
Two launch-path cuts, both measured on the same machine.

**Install by rename, not copy.** The installer verified the extracted bundle, copied it into `.opensre-app`, then ran the first-launch warm-up on the copy. macOS caches signature validation per file, so the copy paid the whole cold validation again. The extracted tree is now renamed to a staged directory under the install dir, where the re-sign, version check and warm-up run, and then renamed into place. A binary that fails verification is discarded and the existing install stays as it was (`stage_binary` / `verify_staged_binary` / `activate_staged_binary` / `discard_staged_binary`).

**Banner status without the skill harness.** The Skills and Integrations chips on the launch banner were computed through `list_action_skills`, which imports the action-skill harness and prompt_toolkit on the launch path. They now count bundled skill files and active store services from the filesystem, and `infrastructure.terminal`'s prompt exports are lazy, so the banner prints its two numbers without loading the prompt stack. This part was pushed to main by mistake as 635053593 and reverted in dea43449f; it lands here as intended.

## Measurement (same machine, same 17s download)

| | main | this PR |
| --- | --- | --- |
| Local install work after download | 31s | 21s |
| Total install | 47s | 38s |
| First `--version` after install | 0.23s | 0.23s |