### PR TITLE
fix(installer): preflight Linux glibc compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ curl -fsSL https://install.opensre.com | bash
 
 The macOS/Linux installer does not require sudo. If no writable bin directory is already on `PATH`, it installs to `~/.local/bin` and prints the shell command to apply the PATH update.
 
+Linux release binaries require glibc **2.35 or newer** (for example, Ubuntu 22.04+). The installer checks this before downloading; on older systems, install from source with `uv` or use Docker.
+
 Equivalent explicit main-channel form:
 
 ```bash

--- a/docs/environments/linux-local.mdx
+++ b/docs/environments/linux-local.mdx
@@ -5,6 +5,8 @@ description: "Install OpenSRE on a local Linux machine and ask your first questi
 
 Install OpenSRE on Linux (laptop, desktop, or a local VM), set up your LLM, then ask the agent your first question.
 
+> The prebuilt Linux release requires glibc **2.35 or newer** (Ubuntu 22.04+). The installer checks this before downloading. For Ubuntu 20.04 or another older distribution, use the source-install or Docker instructions instead.
+
 ## 1. Install
 
 ```bash

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -15,6 +15,8 @@ After install, you have:
 
 No sudo required on macOS/Linux in the usual case — the installer puts the binary somewhere writable (often `~/.local/bin`) and tells you if you need a PATH tweak.
 
+Linux release binaries require glibc **2.35 or newer** (for example, Ubuntu 22.04+). The installer checks this before downloading. On Ubuntu 20.04 or another older glibc system, install from source with `uv` or use Docker instead.
+
 ## Install
 
 Pick one method.

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ INSTALL_CHANNEL_EXPLICIT=0
 MAIN_RELEASE_TAG="${OPENSRE_MAIN_RELEASE_TAG:-main-build}"
 BIN_NAME="opensre"
 requested_version="${OPENSRE_VERSION:-}"
+MIN_GLIBC_VERSION="2.35"
 
 [ -n "$INSTALL_DIR" ] && INSTALL_DIR_OVERRIDE=1
 requested_version="${requested_version#v}"
@@ -963,6 +964,50 @@ detect_platform() {
   esac
 }
 
+glibc_version_at_least() {
+  local actual_version="$1"
+  local required_version="$2"
+  local actual_major actual_minor required_major required_minor
+
+  IFS=. read -r actual_major actual_minor _ <<< "$actual_version"
+  IFS=. read -r required_major required_minor _ <<< "$required_version"
+  case "${actual_major:-}${actual_minor:-}${required_major:-}${required_minor:-}" in
+    *[!0-9]*|"")
+      return 2
+      ;;
+  esac
+
+  if [ "$actual_major" -ne "$required_major" ]; then
+    [ "$actual_major" -gt "$required_major" ]
+    return
+  fi
+  [ "$actual_minor" -ge "$required_minor" ]
+}
+
+check_linux_glibc_compatibility() {
+  local reported_version=""
+  local detected_version=""
+
+  [ "$platform" = "linux" ] || return 0
+
+  if command -v getconf >/dev/null 2>&1; then
+    reported_version="$(getconf GNU_LIBC_VERSION 2>/dev/null || true)"
+  fi
+  if [ -z "$reported_version" ] && command -v ldd >/dev/null 2>&1; then
+    reported_version="$(ldd --version 2>&1 | sed -n '1s/.*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
+  fi
+  detected_version="$(printf '%s\n' "$reported_version" | sed -n 's/.*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
+
+  if [ -z "$detected_version" ]; then
+    warn "Could not determine the host glibc version; the Linux release requires glibc >= ${MIN_GLIBC_VERSION}."
+    return 0
+  fi
+
+  if ! glibc_version_at_least "$detected_version" "$MIN_GLIBC_VERSION"; then
+    die "This Linux release requires glibc >= ${MIN_GLIBC_VERSION}; detected ${detected_version}. Use a newer distribution (Ubuntu 22.04+), install from source with uv, or use Docker."
+  fi
+}
+
 resolve_release_metadata() {
   version="$requested_version"
   release_tag=""
@@ -1154,6 +1199,7 @@ main() {
   parse_args "$@"
   require_prerequisites
   detect_platform
+  check_linux_glibc_compatibility
   resolve_install_dir
   resolve_release_metadata
   select_archive_asset

--- a/tests/cli/test_install_matrix.py
+++ b/tests/cli/test_install_matrix.py
@@ -245,6 +245,7 @@ def _run_install_sh(
                 "brew tap tracer-cloud/tap",
                 "brew install tracer-cloud/tap/opensre",
                 "irm https://install.opensre.com | iex",
+                "glibc **2.35 or newer**",
             ),
         ),
         (
@@ -262,6 +263,7 @@ def _run_install_sh(
                 "curl -fsSL https://install.opensre.com | bash",
                 "irm https://install.opensre.com | iex",
                 "opensre onboard",
+                "glibc **2.35 or newer**",
             ),
         ),
         (
@@ -273,6 +275,7 @@ def _run_install_sh(
                 "OPENSRE_AUTO_LAUNCH=0",
                 "OPENSRE_SKIP_GH_INSTALL=1",
                 "Homebrew installs pull in `gh` automatically.",
+                "glibc",
             ),
         ),
         (
@@ -329,6 +332,17 @@ def test_install_sh_source_exposes_env_knobs() -> None:
         "_package-smoke",
     ):
         assert needle in source, f"install.sh missing {needle!r}"
+
+
+def test_install_sh_checks_linux_glibc_before_download() -> None:
+    source = INSTALL_SH.read_text(encoding="utf-8")
+    for needle in (
+        'MIN_GLIBC_VERSION="2.35"',
+        "check_linux_glibc_compatibility",
+        "glibc >= ${MIN_GLIBC_VERSION}",
+        "install from source with uv, or use Docker",
+    ):
+        assert needle in source, f"install.sh missing glibc guard {needle!r}"
 
 
 def test_install_ps1_source_exposes_all_windows_install_knobs() -> None:

--- a/tests/cli/test_install_sh_glibc.py
+++ b/tests/cli/test_install_sh_glibc.py
@@ -1,0 +1,53 @@
+"""Regression tests for the Linux release glibc preflight."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="install.sh is POSIX-only; run the guard tests on Linux/macOS.",
+)
+
+INSTALL_SH = Path(__file__).parents[2] / "install.sh"
+
+
+def _run_glibc_guard(tmp_path: Path, version: str) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    getconf = fake_bin / "getconf"
+    getconf.write_text(
+        f"#!/usr/bin/env sh\nprintf 'glibc {version}\\n'\n",
+        encoding="utf-8",
+    )
+    getconf.chmod(0o755)
+
+    source = INSTALL_SH.read_text(encoding="utf-8").rsplit('main "$@"', 1)[0]
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        ["bash", "-c", f"{source}\nplatform=linux\ncheck_linux_glibc_compatibility"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_install_sh_glibc_guard_rejects_unsupported_host(tmp_path: Path) -> None:
+    result = _run_glibc_guard(tmp_path, "2.31")
+
+    assert result.returncode != 0
+    assert "requires glibc >= 2.35" in result.stderr
+    assert "detected 2.31" in result.stderr
+
+
+def test_install_sh_glibc_guard_accepts_supported_host(tmp_path: Path) -> None:
+    result = _run_glibc_guard(tmp_path, "2.35")
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Fixes #5993

#### Describe the changes you have made in this PR -

- Add a Linux installer preflight that detects the host glibc version before downloading a release binary.
- Fail clearly on hosts below glibc 2.35 and point users to Ubuntu 22.04+, source installation with uv, or Docker.
- Document the Linux release compatibility floor in the README and install guides.
- Add regression coverage for unsupported and supported glibc versions.

### Demo/Screenshot for feature changes and bug fixes -

Shell verification on the available WSL Ubuntu host:

```text
Error: This Linux release requires glibc >= 2.35; detected 2.31. Use a newer distribution (Ubuntu 22.04+), install from source with uv, or use Docker.
```

Windows-side validation:

- `uv run ruff check bootstrap config core gateway integrations infrastructure surfaces tools tests`
- `uv run ruff format --check bootstrap config core gateway integrations infrastructure surfaces tools tests`
- `uv run mypy bootstrap config core gateway integrations infrastructure surfaces tools`
- `uv run pytest -q tests/cli/test_install_readme.py` (1 passed)
- `uv run pytest -q tests/cli/test_install_ps1_progress.py` (10 passed)
- `bash -n install.sh`

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The release workflow currently builds Linux artifacts with a glibc 2.35 compatibility floor. The installer now checks the host before resolving release metadata or downloading an archive, using getconf when available and ldd as a fallback. A small numeric major/minor comparison avoids relying on GNU-only version sorting. Unknown libc output is reported as a warning so unusual environments are not blocked without evidence. The docs state the same floor and provide source/Docker alternatives. Focused tests cover the rejection message and the exact minimum boundary.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---