### PR TITLE
refactor(scheduler): isolate schema migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Report pytest timing snapshot health
         if: steps.changes.outputs.source == 'true' || github.event_name == 'push'
         run: |
-          uv run python -m tests.ci_sharding report --label=tools-runtime tests/tools tests/core tests/infrastructure tests/filestorage tests/utils tests/masking tests/watch_dog --ignore=tests/core/agent --ignore=tests/core/tool/test_contracts.py --ignore=tests/tools/test_registry_index.py --ignore=tests/tools/selection
+          uv run python -m tests.ci_sharding report --label=tools-runtime tests/tools tests/core tests/infrastructure tests/filestorage tests/utils tests/masking --ignore=tests/core/agent --ignore=tests/core/tool/test_contracts.py --ignore=tests/tools/test_registry_index.py --ignore=tests/tools/selection
           uv run python -m tests.ci_sharding report --label=cli-runtime tests/cli tests/interactive_shell tests/surfaces tests/core/agent tests/fleet_monitoring tests/analytics tests/sandbox --ignore=tests/cli/test_smoke.py
           uv run python -m tests.ci_sharding report --label=integrations-and-misc tests/integrations tests/bootstrap tests/benchmarks tests/shared tests/config tests/github_ci tests/quality tests/packaging tests/scheduler gateway/tests
 

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -96,8 +96,10 @@ destinations it is about to re-deliver to before it sends.
 
 ### `opensre cron logs <task_id>`
 
-Show execution history for a task (newest first). Displays start time, status,
-delivered targets, message ID, and any errors.
+Show execution history for a task (newest first). Displays start time, attempt,
+status, delivered targets, message ID, and any errors. A status such as
+`reclaimed/success` means a later worker recovered an expired claim;
+`abandoned` means the earlier worker stopped before completing.
 
 A task with more than one destination delivers to all of them at once, so one
 slow channel does not delay the rest. The **Targets** column counts how many
@@ -148,20 +150,23 @@ Cron expressions are validated at `cron add` time using APScheduler's
 
 ## Dedup Semantics
 
-The scheduler uses a SQLite-backed claim store with a
-`UNIQUE(task_id, fire_time)` constraint:
+The scheduler uses a SQLite-backed claim store with a unique task, fire-time,
+and attempt key. Each attempt has a 30-minute lease and a random owner token:
 
 1. When a cron tick fires, `EVENT_JOB_SUBMITTED` captures
    `scheduled_run_times[0]` and the job uses that UTC-normalized `fire_time`
    for the claim key
-2. The executor attempts an `INSERT OR IGNORE` into the claim table
-3. If the insert succeeds (rowcount = 1), this instance won the claim and
-   delivers
-4. If the insert is ignored (rowcount = 0), another instance already claimed
-   it — skip
+2. The executor creates an attempt with a 30-minute lease and owner token
+3. If the current attempt is still leased, another instance skips the tick
+4. If the lease expired, the old attempt is marked `abandoned` and one new
+   worker creates the next attempt
+5. Completion is accepted only from the attempt's owner token, so an old
+   worker cannot overwrite a reclaimed attempt
 
-This ensures exactly-once delivery even when multiple scheduler instances run
-concurrently (for example on a laptop and a hosted process).
+This prevents concurrent duplicate claims and recovers ticks after worker
+crashes. A crash after an external provider accepts a message but before the
+completion is recorded can still result in a duplicate on reclaim; preventing
+that case requires provider-specific idempotency support.
 
 ## Credential Resolution
 

--- a/infrastructure/scheduling/scheduler/claim_store.py
+++ b/infrastructure/scheduling/scheduler/claim_store.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -14,18 +13,12 @@ from typing import Any
 from uuid import uuid4
 
 from config.constants import OPENSRE_HOME_DIR
+from infrastructure.scheduling.scheduler.migrations import apply_migrations
 from infrastructure.scheduling.scheduler.types import DeliveryOutcome, TaskRun, TaskStatus
 
 logger = logging.getLogger(__name__)
 
 _DB_FILENAME = "scheduler.db"
-
-#: How long to keep retrying a column add while a competing process holds the
-#: write lock. Each attempt re-reads the schema first, so a winner's commit
-#: ends the loop immediately; this only bounds how long a *stuck* writer is
-#: tolerated before the real error surfaces.
-_MIGRATION_TIMEOUT_SECONDS = 30.0
-_MIGRATION_RETRY_DELAY_SECONDS = 0.1
 
 #: How far back to look for a run with readable per-target history before
 #: reporting none. Only a bound on work, not on correctness: exhausting it
@@ -33,24 +26,6 @@ _MIGRATION_RETRY_DELAY_SECONDS = 0.1
 #: than widening to every destination.
 _TARGETED_RUN_SCAN_LIMIT = 50
 _CLAIM_LEASE_SECONDS = 30 * 60
-_TASK_RUNS_SCHEMA = """
-    CREATE TABLE task_runs (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        task_id TEXT NOT NULL,
-        fire_time TEXT NOT NULL,
-        attempt INTEGER NOT NULL DEFAULT 1,
-        started_at TEXT NOT NULL,
-        finished_at TEXT,
-        status TEXT NOT NULL DEFAULT 'pending',
-        posted_message_id TEXT DEFAULT '',
-        error TEXT DEFAULT '',
-        provider TEXT DEFAULT '',
-        targets TEXT DEFAULT '',
-        owner_token TEXT NOT NULL DEFAULT '',
-        lease_expires_at TEXT NOT NULL DEFAULT '',
-        UNIQUE(task_id, fire_time, attempt)
-    )
-"""
 _RUN_COLUMNS = (
     "task_id, fire_time, started_at, finished_at, status, posted_message_id, "
     "error, provider, targets, attempt"
@@ -80,90 +55,12 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     return conn
 
 
-def _ensure_schema(conn: sqlite3.Connection) -> None:
-    """Create or migrate task runs, rechecking under a write lock before changes."""
-    columns = _table_columns(conn)
-    if {"attempt", "targets"} <= columns:
-        return
-
-    conn.execute("BEGIN IMMEDIATE")
-    try:
-        columns = _table_columns(conn)
-        if not columns:
-            conn.execute(_TASK_RUNS_SCHEMA)
-        elif "attempt" not in columns:
-            _migrate_legacy_claim_table(conn, columns)
-        _add_missing_columns(conn)
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
-
-
-def _table_columns(conn: sqlite3.Connection, table: str = "task_runs") -> set[str]:
-    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
-
-
-def _has_targets_column(conn: sqlite3.Connection) -> bool:
-    return "targets" in _table_columns(conn)
-
-
-def _migrate_legacy_claim_table(conn: sqlite3.Connection, legacy_columns: set[str]) -> None:
-    """Rebuild the pre-lease table so reclaimed attempts retain their history."""
-    conn.execute("ALTER TABLE task_runs RENAME TO task_runs_legacy")
-    conn.execute(_TASK_RUNS_SCHEMA)
-    targets = "targets" if "targets" in legacy_columns else "''"
-    conn.execute(
-        "INSERT INTO task_runs "
-        "(id, task_id, fire_time, attempt, started_at, finished_at, status, "
-        "posted_message_id, error, provider, targets, owner_token, lease_expires_at) "
-        f"SELECT id, task_id, fire_time, 1, started_at, finished_at, status, "
-        f"posted_message_id, error, provider, {targets}, '', started_at "
-        "FROM task_runs_legacy"
-    )
-    conn.execute("DROP TABLE task_runs_legacy")
-
-
-def _add_missing_columns(conn: sqlite3.Connection) -> None:
-    """Add columns introduced after a database was first created.
-
-    Two processes can both see the column missing before either commits its
-    ``ALTER TABLE``, so the loser's own write fails — with "duplicate column"
-    if the winner already committed, or with a lock-timeout if the winner is
-    still in flight and outlasts ``busy_timeout``. Rechecking the schema
-    (rather than matching the error text) covers the first case, and retrying
-    covers the second: at timeout the winner's column is not visible yet, so
-    a single recheck would wrongly conclude the migration failed. Each retry
-    re-reads the schema first, so the loser returns the moment the winner's
-    commit lands.
-
-    Adding a column to this table is sub-millisecond work, so a writer still
-    holding the lock after ``_MIGRATION_TIMEOUT_SECONDS`` is stuck rather than
-    slow. Raising then is deliberate: retrying forever would hide a wedged
-    database behind a scheduler that never fires.
-    """
-    deadline = time.monotonic() + _MIGRATION_TIMEOUT_SECONDS
-    while True:
-        if _has_targets_column(conn):
-            return
-        try:
-            conn.execute("ALTER TABLE task_runs ADD COLUMN targets TEXT DEFAULT ''")
-        except sqlite3.OperationalError:
-            if _has_targets_column(conn):
-                return
-            if time.monotonic() >= deadline:
-                raise
-            time.sleep(_MIGRATION_RETRY_DELAY_SECONDS)
-        else:
-            return
-
-
 def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> ExecutionClaim | None:
     """Claim a task tick or reclaim it when the current lease has expired."""
     path = db_path or _default_db_path()
     conn = _connect(path)
     try:
-        _ensure_schema(conn)
+        apply_migrations(conn)
         conn.execute("BEGIN IMMEDIATE")
         now = datetime.now(UTC)
         now_text = now.isoformat()
@@ -240,7 +137,7 @@ def complete_run(
     path = db_path or _default_db_path()
     conn = _connect(path)
     try:
-        _ensure_schema(conn)
+        apply_migrations(conn)
         now = datetime.now(UTC).isoformat()
         cursor = conn.execute(
             "UPDATE task_runs SET finished_at = ?, status = ?, "
@@ -325,7 +222,7 @@ def get_runs(task_id: str, limit: int = 20, db_path: Path | None = None) -> list
     path = db_path or _default_db_path()
     conn = _connect(path)
     try:
-        _ensure_schema(conn)
+        apply_migrations(conn)
         cursor = conn.execute(
             f"SELECT {_RUN_COLUMNS} "
             "FROM task_runs WHERE task_id = ? ORDER BY started_at DESC LIMIT ?",
@@ -345,7 +242,7 @@ def get_latest_finished_run(task_id: str, db_path: Path | None = None) -> TaskRu
     path = db_path or _default_db_path()
     conn = _connect(path)
     try:
-        _ensure_schema(conn)
+        apply_migrations(conn)
         cursor = conn.execute(
             f"SELECT {_RUN_COLUMNS} "
             "FROM task_runs WHERE task_id = ? AND status IN (?, ?) "
@@ -375,7 +272,7 @@ def get_latest_targeted_run(task_id: str, db_path: Path | None = None) -> TaskRu
     path = db_path or _default_db_path()
     conn = _connect(path)
     try:
-        _ensure_schema(conn)
+        apply_migrations(conn)
         cursor = conn.execute(
             f"SELECT {_RUN_COLUMNS} "
             "FROM task_runs WHERE task_id = ? AND status IN (?, ?) "
@@ -408,7 +305,7 @@ def delete_runs(task_id: str, db_path: Path | None = None) -> int:
         return 0
     conn = _connect(path)
     try:
-        _ensure_schema(conn)
+        apply_migrations(conn)
         cursor = conn.execute(
             "DELETE FROM task_runs WHERE task_id = ?",
             (task_id,),

--- a/infrastructure/scheduling/scheduler/claim_store.py
+++ b/infrastructure/scheduling/scheduler/claim_store.py
@@ -81,14 +81,23 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
-    """Create or migrate the task-runs table."""
+    """Create or migrate task runs, rechecking under a write lock before changes."""
     columns = _table_columns(conn)
-    if not columns:
-        conn.execute(_TASK_RUNS_SCHEMA)
-    elif "attempt" not in columns:
-        _migrate_legacy_claim_table(conn, columns)
-    _add_missing_columns(conn)
-    conn.commit()
+    if {"attempt", "targets"} <= columns:
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        columns = _table_columns(conn)
+        if not columns:
+            conn.execute(_TASK_RUNS_SCHEMA)
+        elif "attempt" not in columns:
+            _migrate_legacy_claim_table(conn, columns)
+        _add_missing_columns(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
 
 
 def _table_columns(conn: sqlite3.Connection, table: str = "task_runs") -> set[str]:

--- a/infrastructure/scheduling/scheduler/claim_store.py
+++ b/infrastructure/scheduling/scheduler/claim_store.py
@@ -1,8 +1,4 @@
-"""SQLite-backed execution claims and run history.
-
-The UNIQUE(task_id, fire_time) constraint prevents double-posting when
-multiple scheduler instances race for the same tick.
-"""
+"""SQLite-backed leased execution claims and run history."""
 
 from __future__ import annotations
 
@@ -11,9 +7,11 @@ import logging
 import sqlite3
 import time
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from config.constants import OPENSRE_HOME_DIR
 from infrastructure.scheduling.scheduler.types import DeliveryOutcome, TaskRun, TaskStatus
@@ -34,6 +32,39 @@ _MIGRATION_RETRY_DELAY_SECONDS = 0.1
 #: reads as "history unknown", and a failed-only retry refuses to run rather
 #: than widening to every destination.
 _TARGETED_RUN_SCAN_LIMIT = 50
+_CLAIM_LEASE_SECONDS = 30 * 60
+_TASK_RUNS_SCHEMA = """
+    CREATE TABLE task_runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL,
+        fire_time TEXT NOT NULL,
+        attempt INTEGER NOT NULL DEFAULT 1,
+        started_at TEXT NOT NULL,
+        finished_at TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        posted_message_id TEXT DEFAULT '',
+        error TEXT DEFAULT '',
+        provider TEXT DEFAULT '',
+        targets TEXT DEFAULT '',
+        owner_token TEXT NOT NULL DEFAULT '',
+        lease_expires_at TEXT NOT NULL DEFAULT '',
+        UNIQUE(task_id, fire_time, attempt)
+    )
+"""
+_RUN_COLUMNS = (
+    "task_id, fire_time, started_at, finished_at, status, posted_message_id, "
+    "error, provider, targets, attempt"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionClaim:
+    """Fenced identity for one scheduled execution attempt."""
+
+    task_id: str
+    fire_time: str
+    attempt: int
+    owner_token: str
 
 
 def _default_db_path() -> Path:
@@ -50,28 +81,38 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
-    """Create the task_runs table if it does not exist."""
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS task_runs (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            task_id TEXT NOT NULL,
-            fire_time TEXT NOT NULL,
-            started_at TEXT NOT NULL,
-            finished_at TEXT,
-            status TEXT NOT NULL DEFAULT 'pending',
-            posted_message_id TEXT DEFAULT '',
-            error TEXT DEFAULT '',
-            provider TEXT DEFAULT '',
-            targets TEXT DEFAULT '',
-            UNIQUE(task_id, fire_time)
-        )
-    """)
+    """Create or migrate the task-runs table."""
+    columns = _table_columns(conn)
+    if not columns:
+        conn.execute(_TASK_RUNS_SCHEMA)
+    elif "attempt" not in columns:
+        _migrate_legacy_claim_table(conn, columns)
     _add_missing_columns(conn)
     conn.commit()
 
 
+def _table_columns(conn: sqlite3.Connection, table: str = "task_runs") -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
 def _has_targets_column(conn: sqlite3.Connection) -> bool:
-    return "targets" in {str(row[1]) for row in conn.execute("PRAGMA table_info(task_runs)")}
+    return "targets" in _table_columns(conn)
+
+
+def _migrate_legacy_claim_table(conn: sqlite3.Connection, legacy_columns: set[str]) -> None:
+    """Rebuild the pre-lease table so reclaimed attempts retain their history."""
+    conn.execute("ALTER TABLE task_runs RENAME TO task_runs_legacy")
+    conn.execute(_TASK_RUNS_SCHEMA)
+    targets = "targets" if "targets" in legacy_columns else "''"
+    conn.execute(
+        "INSERT INTO task_runs "
+        "(id, task_id, fire_time, attempt, started_at, finished_at, status, "
+        "posted_message_id, error, provider, targets, owner_token, lease_expires_at) "
+        f"SELECT id, task_id, fire_time, 1, started_at, finished_at, status, "
+        f"posted_message_id, error, provider, {targets}, '', started_at "
+        "FROM task_runs_legacy"
+    )
+    conn.execute("DROP TABLE task_runs_legacy")
 
 
 def _add_missing_columns(conn: sqlite3.Connection) -> None:
@@ -108,34 +149,72 @@ def _add_missing_columns(conn: sqlite3.Connection) -> None:
             return
 
 
-def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> bool:
-    """Attempt to claim a task execution slot.
-
-    Returns True if this instance won the claim (INSERT succeeded).
-    Returns False if another instance already claimed it (UNIQUE violation).
-    """
+def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> ExecutionClaim | None:
+    """Claim a task tick or reclaim it when the current lease has expired."""
     path = db_path or _default_db_path()
     conn = _connect(path)
     try:
         _ensure_schema(conn)
-        now = datetime.now(UTC).isoformat()
-        cursor = conn.execute(
-            "INSERT OR IGNORE INTO task_runs (task_id, fire_time, started_at, status) "
-            "VALUES (?, ?, ?, ?)",
-            (task_id, fire_time, now, TaskStatus.RUNNING.value),
+        conn.execute("BEGIN IMMEDIATE")
+        now = datetime.now(UTC)
+        now_text = now.isoformat()
+        lease_text = (now + timedelta(seconds=_CLAIM_LEASE_SECONDS)).isoformat()
+        row = conn.execute(
+            "SELECT attempt, status, lease_expires_at FROM task_runs "
+            "WHERE task_id = ? AND fire_time = ? ORDER BY attempt DESC LIMIT 1",
+            (task_id, fire_time),
+        ).fetchone()
+
+        if row is not None:
+            attempt = int(row[0])
+            status = TaskStatus(row[1])
+            lease = _parse_datetime(row[2])
+            if status is not TaskStatus.RUNNING or (lease is not None and lease >= now):
+                conn.rollback()
+                return None
+            conn.execute(
+                "UPDATE task_runs SET status = ?, finished_at = ?, error = ? "
+                "WHERE task_id = ? AND fire_time = ? AND attempt = ? AND status = ?",
+                (
+                    TaskStatus.ABANDONED.value,
+                    now_text,
+                    "claim lease expired",
+                    task_id,
+                    fire_time,
+                    attempt,
+                    TaskStatus.RUNNING.value,
+                ),
+            )
+            attempt += 1
+        else:
+            attempt = 1
+
+        owner_token = uuid4().hex
+        conn.execute(
+            "INSERT INTO task_runs "
+            "(task_id, fire_time, attempt, started_at, status, owner_token, "
+            "lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                task_id,
+                fire_time,
+                attempt,
+                now_text,
+                TaskStatus.RUNNING.value,
+                owner_token,
+                lease_text,
+            ),
         )
         conn.commit()
-        # rowcount == 1 means our INSERT went through; 0 means IGNORE fired
-        return cursor.rowcount == 1
+        return ExecutionClaim(task_id, fire_time, attempt, owner_token)
     except sqlite3.IntegrityError:
-        return False
+        conn.rollback()
+        return None
     finally:
         conn.close()
 
 
 def complete_run(
-    task_id: str,
-    fire_time: str,
+    claim: ExecutionClaim,
     *,
     status: TaskStatus,
     posted_message_id: str = "",
@@ -143,7 +222,7 @@ def complete_run(
     provider: str = "",
     targets: Sequence[DeliveryOutcome] = (),
     db_path: Path | None = None,
-) -> None:
+) -> bool:
     """Mark a claimed run as completed, recording each destination's outcome.
 
     ``targets`` is stored in the order it is given, which is the order the run
@@ -154,10 +233,11 @@ def complete_run(
     try:
         _ensure_schema(conn)
         now = datetime.now(UTC).isoformat()
-        conn.execute(
+        cursor = conn.execute(
             "UPDATE task_runs SET finished_at = ?, status = ?, "
             "posted_message_id = ?, error = ?, provider = ?, targets = ? "
-            "WHERE task_id = ? AND fire_time = ?",
+            "WHERE task_id = ? AND fire_time = ? AND attempt = ? "
+            "AND owner_token = ? AND status = ?",
             (
                 now,
                 status.value,
@@ -165,11 +245,23 @@ def complete_run(
                 error,
                 provider,
                 _encode_targets(targets),
-                task_id,
-                fire_time,
+                claim.task_id,
+                claim.fire_time,
+                claim.attempt,
+                claim.owner_token,
+                TaskStatus.RUNNING.value,
             ),
         )
         conn.commit()
+        completed = cursor.rowcount == 1
+        if not completed:
+            logger.warning(
+                "Completion rejected for reclaimed task %s fire_time=%s attempt=%d",
+                claim.task_id,
+                claim.fire_time,
+                claim.attempt,
+            )
+        return completed
     finally:
         conn.close()
 
@@ -205,7 +297,18 @@ def _row_to_task_run(row: tuple[Any, ...]) -> TaskRun:
         error=row[6] or "",
         provider=row[7] or "",
         targets=_decode_targets(row[8]),
+        attempt=int(row[9] or 1),
     )
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
 
 
 def get_runs(task_id: str, limit: int = 20, db_path: Path | None = None) -> list[TaskRun]:
@@ -215,8 +318,7 @@ def get_runs(task_id: str, limit: int = 20, db_path: Path | None = None) -> list
     try:
         _ensure_schema(conn)
         cursor = conn.execute(
-            "SELECT task_id, fire_time, started_at, finished_at, status, "
-            "posted_message_id, error, provider, targets "
+            f"SELECT {_RUN_COLUMNS} "
             "FROM task_runs WHERE task_id = ? ORDER BY started_at DESC LIMIT ?",
             (task_id, limit),
         )
@@ -236,8 +338,7 @@ def get_latest_finished_run(task_id: str, db_path: Path | None = None) -> TaskRu
     try:
         _ensure_schema(conn)
         cursor = conn.execute(
-            "SELECT task_id, fire_time, started_at, finished_at, status, "
-            "posted_message_id, error, provider, targets "
+            f"SELECT {_RUN_COLUMNS} "
             "FROM task_runs WHERE task_id = ? AND status IN (?, ?) "
             "ORDER BY COALESCE(finished_at, started_at) DESC LIMIT 1",
             (task_id, TaskStatus.SUCCESS.value, TaskStatus.FAILED.value),
@@ -267,8 +368,7 @@ def get_latest_targeted_run(task_id: str, db_path: Path | None = None) -> TaskRu
     try:
         _ensure_schema(conn)
         cursor = conn.execute(
-            "SELECT task_id, fire_time, started_at, finished_at, status, "
-            "posted_message_id, error, provider, targets "
+            f"SELECT {_RUN_COLUMNS} "
             "FROM task_runs WHERE task_id = ? AND status IN (?, ?) "
             "AND targets IS NOT NULL AND targets != '' "
             "ORDER BY COALESCE(finished_at, started_at) DESC LIMIT ?",
@@ -313,6 +413,7 @@ def delete_runs(task_id: str, db_path: Path | None = None) -> int:
 __all__ = [
     "complete_run",
     "delete_runs",
+    "ExecutionClaim",
     "get_latest_finished_run",
     "get_latest_targeted_run",
     "get_runs",

--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import logging
 
-from infrastructure.scheduling.scheduler.claim_store import complete_run, try_claim
+from infrastructure.scheduling.scheduler.claim_store import (
+    ExecutionClaim,
+    complete_run,
+    try_claim,
+)
 from infrastructure.scheduling.scheduler.delivery_bundle import resolve_delivery_adapter
 from infrastructure.scheduling.scheduler.delivery_plan import (
     DeliveryTarget,
@@ -48,7 +52,8 @@ def execute_task(
         False if the claim was lost (another instance handled it) or delivery failed.
     """
     # Attempt to claim this execution slot
-    if not try_claim(task.id, fire_time):
+    claim = try_claim(task.id, fire_time)
+    if claim is None:
         logger.info(
             "Task %s fire_time=%s already claimed by another instance",
             task.id,
@@ -77,10 +82,11 @@ def execute_task(
         message = build_message(task, runners)
     except RuntimeError as exc:
         # Pipeline failures — record without leaking details to chat
-        _record_failure(task, fire_time, str(exc), stage="message_build")
+        _record_failure(claim, task, fire_time, str(exc), stage="message_build")
         return False
     except Exception as exc:
         _record_failure(
+            claim,
             task,
             fire_time,
             f"Message build error: {type(exc).__name__}",
@@ -90,13 +96,13 @@ def execute_task(
 
     # Quiet ticks (e.g. uptime watch with no transitions) skip delivery.
     if not message.strip():
-        complete_run(
-            task.id,
-            fire_time,
+        if not complete_run(
+            claim,
             status=TaskStatus.SUCCESS,
             posted_message_id="",
             provider=_run_provider_label(task),
-        )
+        ):
+            return False
         _emit_analytics(task, TaskStatus.SUCCESS)
         logger.info("Task %s produced no message; delivery skipped", task.id)
         record_scheduler_execution_operation(
@@ -116,6 +122,7 @@ def execute_task(
 
     if result.status is DeliveryStatus.FAILED:
         _record_failure(
+            claim,
             task,
             fire_time,
             error,
@@ -125,15 +132,15 @@ def execute_task(
         )
         return False
 
-    complete_run(
-        task.id,
-        fire_time,
+    if not complete_run(
+        claim,
         status=TaskStatus.SUCCESS,
         posted_message_id=message_id,
         error=error,
         provider=_run_provider_label(task),
         targets=result.outcomes,
-    )
+    ):
+        return False
     _emit_analytics(task, TaskStatus.SUCCESS, error=error)
     _record_work_item_reminder_delivery(task)
     record_scheduler_execution_operation(
@@ -217,6 +224,7 @@ def _run_provider_label(task: ScheduledTask) -> str:
 
 
 def _record_failure(
+    claim: ExecutionClaim,
     task: ScheduledTask,
     fire_time: str,
     error: str,
@@ -227,14 +235,14 @@ def _record_failure(
 ) -> None:
     """Record a failed execution in the claim store and emit analytics."""
     outcomes = result.outcomes if result is not None else ()
-    complete_run(
-        task.id,
-        fire_time,
+    if not complete_run(
+        claim,
         status=TaskStatus.FAILED,
         error=error,
         provider=_run_provider_label(task),
         targets=outcomes,
-    )
+    ):
+        return
     _emit_analytics(task, TaskStatus.FAILED, error=error)
     extra: dict[str, object] = {"stage": stage}
     if result is not None:

--- a/infrastructure/scheduling/scheduler/migrations.py
+++ b/infrastructure/scheduling/scheduler/migrations.py
@@ -1,0 +1,105 @@
+"""Schema changesets for the scheduler claim database."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+#: How long to keep retrying a column add while a competing process holds the
+#: write lock. Each attempt re-reads the schema first, so a winner's commit
+#: ends the loop immediately; this only bounds how long a stuck writer is
+#: tolerated before the real error surfaces.
+_MIGRATION_TIMEOUT_SECONDS = 30.0
+_MIGRATION_RETRY_DELAY_SECONDS = 0.1
+
+_TASK_RUNS_SCHEMA = """
+    CREATE TABLE task_runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL,
+        fire_time TEXT NOT NULL,
+        attempt INTEGER NOT NULL DEFAULT 1,
+        started_at TEXT NOT NULL,
+        finished_at TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        posted_message_id TEXT DEFAULT '',
+        error TEXT DEFAULT '',
+        provider TEXT DEFAULT '',
+        targets TEXT DEFAULT '',
+        owner_token TEXT NOT NULL DEFAULT '',
+        lease_expires_at TEXT NOT NULL DEFAULT '',
+        UNIQUE(task_id, fire_time, attempt)
+    )
+"""
+
+
+def apply_migrations(conn: sqlite3.Connection) -> None:
+    """Bring the scheduler claim schema to its current shape."""
+    columns = _table_columns(conn)
+    if {"attempt", "targets"} <= columns:
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        columns = _table_columns(conn)
+        if not columns:
+            conn.execute(_TASK_RUNS_SCHEMA)
+        elif "attempt" not in columns:
+            _migrate_legacy_claim_table(conn, columns)
+        _add_missing_columns(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _table_columns(conn: sqlite3.Connection, table: str = "task_runs") -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _has_targets_column(conn: sqlite3.Connection) -> bool:
+    return "targets" in _table_columns(conn)
+
+
+def _migrate_legacy_claim_table(conn: sqlite3.Connection, legacy_columns: set[str]) -> None:
+    """Rebuild the pre-lease table while retaining its run history."""
+    conn.execute("ALTER TABLE task_runs RENAME TO task_runs_legacy")
+    conn.execute(_TASK_RUNS_SCHEMA)
+    targets = "targets" if "targets" in legacy_columns else "''"
+    conn.execute(
+        "INSERT INTO task_runs "
+        "(id, task_id, fire_time, attempt, started_at, finished_at, status, "
+        "posted_message_id, error, provider, targets, owner_token, lease_expires_at) "
+        f"SELECT id, task_id, fire_time, 1, started_at, finished_at, status, "
+        f"posted_message_id, error, provider, {targets}, '', started_at "
+        "FROM task_runs_legacy"
+    )
+    conn.execute("DROP TABLE task_runs_legacy")
+
+
+def _add_missing_columns(conn: sqlite3.Connection) -> None:
+    """Add compatible columns, tolerating another process winning the race.
+
+    A competing migration can commit after this process checks the schema but
+    before its own ``ALTER TABLE`` completes. Rechecking after an error covers
+    an already-committed winner; retrying covers a winner that still held the
+    lock when this connection reached its busy timeout. The retry remains
+    bounded so a genuinely stuck writer surfaces instead of blocking the
+    scheduler forever.
+    """
+    deadline = time.monotonic() + _MIGRATION_TIMEOUT_SECONDS
+    while True:
+        if _has_targets_column(conn):
+            return
+        try:
+            conn.execute("ALTER TABLE task_runs ADD COLUMN targets TEXT DEFAULT ''")
+        except sqlite3.OperationalError:
+            if _has_targets_column(conn):
+                return
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(_MIGRATION_RETRY_DELAY_SECONDS)
+        else:
+            return
+
+
+__all__ = ["apply_migrations"]

--- a/infrastructure/scheduling/scheduler/types.py
+++ b/infrastructure/scheduling/scheduler/types.py
@@ -29,6 +29,7 @@ class TaskStatus(StrEnum):
     SUCCESS = "success"
     FAILED = "failed"
     SKIPPED = "skipped"
+    ABANDONED = "abandoned"
 
 
 class DeliveryStatus(StrEnum):
@@ -116,6 +117,7 @@ class TaskRun(BaseModel):
     error: str = ""
     provider: str = ""
     targets: tuple[DeliveryOutcome, ...] = ()
+    attempt: int = 1
 
 
 __all__ = [

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from rich.table import Table
 
 from infrastructure.scheduling.scheduler.credentials import requires_explicit_chat_id
-from infrastructure.scheduling.scheduler.types import Provider, TaskKind, TaskRun
+from infrastructure.scheduling.scheduler.types import Provider, TaskKind, TaskRun, TaskStatus
 from infrastructure.terminal.theme import GLYPH_ERROR, GLYPH_SUCCESS
 from surfaces.cli.commands.scheduling import validate_cron_and_timezone
 
@@ -282,6 +282,15 @@ def _delivered_targets(run: TaskRun) -> str:
     return f"{sum(1 for outcome in run.targets if outcome.ok)}/{len(run.targets)}"
 
 
+def _run_status_label(run: TaskRun) -> str:
+    """Describe whether a run was abandoned or recovered by a later attempt."""
+    if run.status is TaskStatus.ABANDONED:
+        return "abandoned"
+    if run.attempt > 1:
+        return f"reclaimed/{run.status.value}"
+    return run.status.value
+
+
 @cron_command.command(name="logs")
 @click.argument("task_id")
 @click.option(
@@ -308,6 +317,7 @@ def cron_logs(task_id: str, limit: int) -> None:
 
     table = Table(show_header=True, header_style="bold")
     table.add_column("Started")
+    table.add_column("Attempt")
     table.add_column("Status")
     table.add_column("Targets")
     table.add_column("Message ID")
@@ -318,14 +328,14 @@ def cron_logs(task_id: str, limit: int) -> None:
             "green"
             if run.status.value == "success"
             else "red"
-            if run.status.value == "failed"
+            if run.status.value in {"failed", "abandoned"}
             else ""
         )
+        status_label = _run_status_label(run)
         table.add_row(
             run.started_at,
-            f"[{status_style}]{run.status.value}[/{status_style}]"
-            if status_style
-            else run.status.value,
+            str(run.attempt),
+            f"[{status_style}]{status_label}[/{status_style}]" if status_style else status_label,
             _delivered_targets(run),
             run.posted_message_id or "—",
             run.error[:50] if run.error else "—",

--- a/tests/cli/test_cron_command.py
+++ b/tests/cli/test_cron_command.py
@@ -7,8 +7,13 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from infrastructure.scheduling.scheduler.types import Provider, TaskKind
-from surfaces.cli.commands.cron import _KIND_CHOICES, _PROVIDER_CHOICES, cron_command
+from infrastructure.scheduling.scheduler.types import Provider, TaskKind, TaskRun, TaskStatus
+from surfaces.cli.commands.cron import (
+    _KIND_CHOICES,
+    _PROVIDER_CHOICES,
+    _run_status_label,
+    cron_command,
+)
 
 
 def test_cron_add_provider_choices_match_full_provider_enum() -> None:
@@ -51,6 +56,25 @@ def test_cron_logs_rejects_non_positive_limit() -> None:
     result = runner.invoke(cron_command, ["logs", "task-123", "--limit", "0"])
     assert result.exit_code != 0
     assert "not in the range" in result.output
+
+
+def test_cron_log_status_identifies_reclaimed_attempts() -> None:
+    assert _run_status_label(TaskRun(task_id="t", fire_time="f")) == "pending"
+    assert (
+        _run_status_label(
+            TaskRun(
+                task_id="t",
+                fire_time="f",
+                status=TaskStatus.SUCCESS,
+                attempt=2,
+            )
+        )
+        == "reclaimed/success"
+    )
+    assert (
+        _run_status_label(TaskRun(task_id="t", fire_time="f", status=TaskStatus.ABANDONED))
+        == "abandoned"
+    )
 
 
 def test_cron_add_allows_slack_without_chat_id(

--- a/tests/infrastructure/test_setup_state.py
+++ b/tests/infrastructure/test_setup_state.py
@@ -154,7 +154,7 @@ class TestLatestDeliveryOrdering:
     ) -> None:
         # Arrange: Greptile P1 — more than five newer RUNNING rows (by start)
         # must not hide an earlier-started finished delivery.
-        from infrastructure.scheduling.scheduler import claim_store
+        from infrastructure.scheduling.scheduler import claim_store, migrations
         from infrastructure.scheduling.scheduler.types import TaskStatus
 
         db = tmp_path / "scheduler.db"
@@ -162,7 +162,7 @@ class TestLatestDeliveryOrdering:
 
         conn = claim_store._connect(db)
         try:
-            claim_store._ensure_schema(conn)
+            migrations.apply_migrations(conn)
             conn.execute(
                 "INSERT INTO task_runs "
                 "(task_id, fire_time, started_at, finished_at, status) "

--- a/tests/scheduler/test_claim_store.py
+++ b/tests/scheduler/test_claim_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -9,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from infrastructure.scheduling.scheduler import claim_store
+from infrastructure.scheduling.scheduler import claim_store, migrations
 from infrastructure.scheduling.scheduler.claim_store import (
     ExecutionClaim,
     complete_run,
@@ -59,6 +60,15 @@ class _AlterFailsConnection:
         if sql.strip().startswith("ALTER TABLE"):
             raise sqlite3.OperationalError("database is locked")
         return self._conn.execute(sql, *args)
+
+
+def test_schema_ddl_is_owned_by_the_migration_module() -> None:
+    """Keep runtime claim queries separate from schema evolution."""
+    claim_store_source = inspect.getsource(claim_store).upper()
+
+    assert "CREATE TABLE" not in claim_store_source
+    assert "ALTER TABLE" not in claim_store_source
+    assert "DROP TABLE" not in claim_store_source
 
 
 class TestClaimStore:
@@ -182,7 +192,7 @@ class TestClaimStore:
         # start-ordered lookback of five would drop the finished row.
         conn = claim_store._connect(db_path)
         try:
-            claim_store._ensure_schema(conn)
+            migrations.apply_migrations(conn)
             conn.execute(
                 "INSERT INTO task_runs "
                 "(task_id, fire_time, started_at, finished_at, status) "
@@ -281,7 +291,7 @@ class TestConcurrency:
         conn.commit()
         conn.close()
 
-        real_table_columns = claim_store._table_columns
+        real_table_columns = migrations._table_columns
         unlocked_reads = threading.Barrier(2)
 
         def _synchronize_unlocked_reads(
@@ -293,7 +303,7 @@ class TestConcurrency:
                 unlocked_reads.wait(timeout=5)
             return columns
 
-        real_migrate = claim_store._migrate_legacy_claim_table
+        real_migrate = migrations._migrate_legacy_claim_table
         migration_count = 0
         count_lock = threading.Lock()
 
@@ -306,8 +316,8 @@ class TestConcurrency:
                 migration_count += 1
             real_migrate(migration_conn, columns)
 
-        monkeypatch.setattr(claim_store, "_table_columns", _synchronize_unlocked_reads)
-        monkeypatch.setattr(claim_store, "_migrate_legacy_claim_table", _count_migration)
+        monkeypatch.setattr(migrations, "_table_columns", _synchronize_unlocked_reads)
+        monkeypatch.setattr(migrations, "_migrate_legacy_claim_table", _count_migration)
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             claims = list(
@@ -450,7 +460,7 @@ class TestPerTargetOutcomes:
         conn.execute("ALTER TABLE task_runs ADD COLUMN targets TEXT DEFAULT ''")
         conn.commit()
 
-        real_has_column = claim_store._has_targets_column
+        real_has_column = migrations._has_targets_column
         calls = {"count": 0}
 
         def _lie_on_first_call(check_conn: sqlite3.Connection) -> bool:
@@ -460,9 +470,9 @@ class TestPerTargetOutcomes:
             # nothing about the recovery path.
             return False if calls["count"] == 1 else real_has_column(check_conn)
 
-        monkeypatch.setattr(claim_store, "_has_targets_column", _lie_on_first_call)
+        monkeypatch.setattr(migrations, "_has_targets_column", _lie_on_first_call)
 
-        claim_store._add_missing_columns(conn)  # must not raise
+        migrations._add_missing_columns(conn)  # must not raise
         assert calls["count"] == 2
 
     def test_a_winner_committing_after_our_timeout_is_picked_up_on_retry(
@@ -501,9 +511,9 @@ class TestPerTargetOutcomes:
             checks["count"] += 1
             return checks["count"] > 2
 
-        monkeypatch.setattr(claim_store, "_has_targets_column", _column_appears_on_the_retry)
+        monkeypatch.setattr(migrations, "_has_targets_column", _column_appears_on_the_retry)
 
-        claim_store._add_missing_columns(_AlterFailsConnection(conn))  # must not raise
+        migrations._add_missing_columns(_AlterFailsConnection(conn))  # must not raise
 
         # Pre-check, post-timeout recheck, then the retry's own pre-check.
         assert checks["count"] == 3
@@ -513,7 +523,7 @@ class TestPerTargetOutcomes:
     ) -> None:
         """A writer stuck past the budget surfaces the real error rather than
         retrying forever."""
-        monkeypatch.setattr(claim_store, "_MIGRATION_TIMEOUT_SECONDS", 0.2)
+        monkeypatch.setattr(migrations, "_MIGRATION_TIMEOUT_SECONDS", 0.2)
         conn = sqlite3.connect(str(db_path))
         conn.execute("""
             CREATE TABLE task_runs (
@@ -532,7 +542,7 @@ class TestPerTargetOutcomes:
         conn.commit()
 
         with pytest.raises(sqlite3.OperationalError, match="database is locked"):
-            claim_store._add_missing_columns(_AlterFailsConnection(conn))
+            migrations._add_missing_columns(_AlterFailsConnection(conn))
 
 
 class TestLatestTargetedRun:

--- a/tests/scheduler/test_claim_store.py
+++ b/tests/scheduler/test_claim_store.py
@@ -257,6 +257,71 @@ class TestClaimStore:
 class TestConcurrency:
     """Verify transaction fencing prevents duplicate claims."""
 
+    def test_concurrent_legacy_migration_rebuilds_once(
+        self,
+        db_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("""
+            CREATE TABLE task_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id TEXT NOT NULL,
+                fire_time TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT,
+                status TEXT NOT NULL DEFAULT 'pending',
+                posted_message_id TEXT DEFAULT '',
+                error TEXT DEFAULT '',
+                provider TEXT DEFAULT '',
+                UNIQUE(task_id, fire_time)
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        real_table_columns = claim_store._table_columns
+        unlocked_reads = threading.Barrier(2)
+
+        def _synchronize_unlocked_reads(
+            read_conn: sqlite3.Connection,
+            table: str = "task_runs",
+        ) -> set[str]:
+            columns = real_table_columns(read_conn, table)
+            if "attempt" not in columns and not read_conn.in_transaction:
+                unlocked_reads.wait(timeout=5)
+            return columns
+
+        real_migrate = claim_store._migrate_legacy_claim_table
+        migration_count = 0
+        count_lock = threading.Lock()
+
+        def _count_migration(
+            migration_conn: sqlite3.Connection,
+            columns: set[str],
+        ) -> None:
+            nonlocal migration_count
+            with count_lock:
+                migration_count += 1
+            real_migrate(migration_conn, columns)
+
+        monkeypatch.setattr(claim_store, "_table_columns", _synchronize_unlocked_reads)
+        monkeypatch.setattr(claim_store, "_migrate_legacy_claim_table", _count_migration)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            claims = list(
+                pool.map(
+                    lambda _: try_claim("task1", "2026-01-01T09:00", db_path=db_path),
+                    range(2),
+                )
+            )
+
+        assert migration_count == 1
+        assert sum(claim is not None for claim in claims) == 1
+        claim = next(claim for claim in claims if claim is not None)
+        assert complete_run(claim, status=TaskStatus.SUCCESS, db_path=db_path)
+
     def test_concurrent_reclaimers_only_one_wins(self, db_path: Path) -> None:
         _claimed(db_path, "task1", "2026-01-01T09:00")
         _expire_claim(db_path, "task1", "2026-01-01T09:00")

--- a/tests/scheduler/test_claim_store.py
+++ b/tests/scheduler/test_claim_store.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
 from infrastructure.scheduling.scheduler import claim_store
 from infrastructure.scheduling.scheduler.claim_store import (
+    ExecutionClaim,
     complete_run,
     delete_runs,
     get_latest_finished_run,
@@ -22,6 +25,22 @@ from infrastructure.scheduling.scheduler.types import DeliveryOutcome, Provider,
 @pytest.fixture()
 def db_path(tmp_path: Path) -> Path:
     return tmp_path / "scheduler.db"
+
+
+def _claimed(db_path: Path, task_id: str, fire_time: str) -> ExecutionClaim:
+    claim = try_claim(task_id, fire_time, db_path=db_path)
+    assert claim is not None
+    return claim
+
+
+def _expire_claim(db_path: Path, task_id: str, fire_time: str) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "UPDATE task_runs SET lease_expires_at = ? WHERE task_id = ? AND fire_time = ?",
+        ("2020-01-01T00:00:00+00:00", task_id, fire_time),
+    )
+    conn.commit()
+    conn.close()
 
 
 class _AlterFailsConnection:
@@ -44,25 +63,66 @@ class _AlterFailsConnection:
 
 class TestClaimStore:
     def test_first_claim_succeeds(self, db_path: Path) -> None:
-        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is True
+        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is not None
 
     def test_duplicate_claim_fails(self, db_path: Path) -> None:
-        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is True
-        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is False
+        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is not None
+        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is None
+
+    def test_active_lease_cannot_be_reclaimed(self, db_path: Path) -> None:
+        first = try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+
+        assert first is not None
+        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is None
+
+    def test_expired_lease_is_abandoned_and_reclaimed(self, db_path: Path) -> None:
+        first = try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        assert first is not None
+
+        _expire_claim(db_path, "task1", "2026-01-01T09:00")
+
+        second = try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+
+        assert second is not None
+        assert second.attempt == 2
+        assert second.owner_token != first.owner_token
+        assert get_runs("task1", db_path=db_path)[0].status is TaskStatus.RUNNING
+        assert get_runs("task1", db_path=db_path)[1].status is TaskStatus.ABANDONED
+
+    def test_stale_owner_cannot_complete_after_reclaim(self, db_path: Path) -> None:
+        first = try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        assert first is not None
+        _expire_claim(db_path, "task1", "2026-01-01T09:00")
+        second = try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        assert second is not None
+
+        assert (
+            complete_run(
+                first,
+                status=TaskStatus.SUCCESS,
+                db_path=db_path,
+            )
+            is False
+        )
+        assert get_runs("task1", db_path=db_path)[0].status is TaskStatus.RUNNING
+        assert complete_run(
+            second,
+            status=TaskStatus.SUCCESS,
+            db_path=db_path,
+        )
 
     def test_different_fire_times_both_succeed(self, db_path: Path) -> None:
-        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is True
-        assert try_claim("task1", "2026-01-01T10:00", db_path=db_path) is True
+        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is not None
+        assert try_claim("task1", "2026-01-01T10:00", db_path=db_path) is not None
 
     def test_different_tasks_same_fire_time(self, db_path: Path) -> None:
-        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is True
-        assert try_claim("task2", "2026-01-01T09:00", db_path=db_path) is True
+        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is not None
+        assert try_claim("task2", "2026-01-01T09:00", db_path=db_path) is not None
 
     def test_complete_run_success(self, db_path: Path) -> None:
-        try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        claim = _claimed(db_path, "task1", "2026-01-01T09:00")
         complete_run(
-            "task1",
-            "2026-01-01T09:00",
+            claim,
             status=TaskStatus.SUCCESS,
             posted_message_id="msg123",
             provider="telegram",
@@ -75,10 +135,9 @@ class TestClaimStore:
         assert runs[0].finished_at is not None
 
     def test_complete_run_failed(self, db_path: Path) -> None:
-        try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        claim = _claimed(db_path, "task1", "2026-01-01T09:00")
         complete_run(
-            "task1",
-            "2026-01-01T09:00",
+            claim,
             status=TaskStatus.FAILED,
             error="Connection timeout",
             provider="slack",
@@ -92,10 +151,9 @@ class TestClaimStore:
     def test_get_runs_ordered_newest_first(self, db_path: Path) -> None:
         for i in range(5):
             fire_time = f"2026-01-01T0{i}:00"
-            try_claim("task1", fire_time, db_path=db_path)
+            claim = _claimed(db_path, "task1", fire_time)
             complete_run(
-                "task1",
-                fire_time,
+                claim,
                 status=TaskStatus.SUCCESS,
                 db_path=db_path,
             )
@@ -109,8 +167,8 @@ class TestClaimStore:
     def test_get_runs_respects_limit(self, db_path: Path) -> None:
         for i in range(10):
             fire_time = f"2026-01-01T{i:02d}:00"
-            try_claim("task1", fire_time, db_path=db_path)
-            complete_run("task1", fire_time, status=TaskStatus.SUCCESS, db_path=db_path)
+            claim = _claimed(db_path, "task1", fire_time)
+            complete_run(claim, status=TaskStatus.SUCCESS, db_path=db_path)
 
         runs = get_runs("task1", limit=3, db_path=db_path)
         assert len(runs) == 3
@@ -166,7 +224,7 @@ class TestClaimStore:
         )
 
     def test_delete_runs_removes_only_matching_task(self, db_path: Path) -> None:
-        try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        _claimed(db_path, "task1", "2026-01-01T09:00")
         try_claim("task2", "2026-01-01T09:00", db_path=db_path)
         assert len(get_runs("task1", db_path=db_path)) == 1
         assert len(get_runs("task2", db_path=db_path)) == 1
@@ -197,28 +255,34 @@ class TestClaimStore:
 
 
 class TestConcurrency:
-    """Verify the UNIQUE constraint prevents double-posting."""
+    """Verify transaction fencing prevents duplicate claims."""
 
-    def test_concurrent_claims_only_one_wins(self, db_path: Path) -> None:
-        """Simulate two instances racing for the same (task_id, fire_time)."""
-        # First claim wins
-        result1 = try_claim("task1", "2026-01-01T09:00", db_path=db_path)
-        # Second claim loses (same key)
-        result2 = try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+    def test_concurrent_reclaimers_only_one_wins(self, db_path: Path) -> None:
+        _claimed(db_path, "task1", "2026-01-01T09:00")
+        _expire_claim(db_path, "task1", "2026-01-01T09:00")
+        barrier = threading.Barrier(3)
 
-        assert result1 is True
-        assert result2 is False
+        def _reclaim() -> ExecutionClaim | None:
+            barrier.wait()
+            return try_claim("task1", "2026-01-01T09:00", db_path=db_path)
 
-        # Only one run record exists
-        runs = get_runs("task1", db_path=db_path)
-        assert len(runs) == 1
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(_reclaim) for _ in range(2)]
+            barrier.wait()
+            claims = [future.result() for future in futures]
+
+        assert sum(claim is not None for claim in claims) == 1
+        assert [run.status for run in get_runs("task1", db_path=db_path)] == [
+            TaskStatus.RUNNING,
+            TaskStatus.ABANDONED,
+        ]
 
 
 class TestPerTargetOutcomes:
     """Fan-out run history keeps one row per destination, in plan order."""
 
     def test_target_outcomes_round_trip_in_the_order_written(self, db_path: Path) -> None:
-        try_claim("task1", "2026-01-01T09:00", db_path=db_path)
+        claim = _claimed(db_path, "task1", "2026-01-01T09:00")
         outcomes = (
             DeliveryOutcome(
                 provider=Provider.INTERACTIVE_SHELL, ok=True, message_id="local:1", attempts=1
@@ -232,8 +296,7 @@ class TestPerTargetOutcomes:
             ),
         )
         complete_run(
-            "task1",
-            "2026-01-01T09:00",
+            claim,
             status=TaskStatus.SUCCESS,
             targets=outcomes,
             db_path=db_path,
@@ -242,8 +305,8 @@ class TestPerTargetOutcomes:
         assert get_runs("task1", db_path=db_path)[0].targets == outcomes
 
     def test_runs_without_target_outcomes_read_back_empty(self, db_path: Path) -> None:
-        try_claim("task1", "2026-01-01T09:00", db_path=db_path)
-        complete_run("task1", "2026-01-01T09:00", status=TaskStatus.SUCCESS, db_path=db_path)
+        claim = _claimed(db_path, "task1", "2026-01-01T09:00")
+        complete_run(claim, status=TaskStatus.SUCCESS, db_path=db_path)
 
         assert get_runs("task1", db_path=db_path)[0].targets == ()
 
@@ -268,13 +331,16 @@ class TestPerTargetOutcomes:
             "INSERT INTO task_runs (task_id, fire_time, started_at, status) VALUES (?, ?, ?, ?)",
             ("legacy", "2026-01-01T08:00", "2026-01-01T08:00:00+00:00", TaskStatus.SUCCESS.value),
         )
+        conn.execute(
+            "INSERT INTO task_runs (task_id, fire_time, started_at, status) VALUES (?, ?, ?, ?)",
+            ("stale", "2020-01-01T08:00", "2020-01-01T08:00:00+00:00", TaskStatus.RUNNING.value),
+        )
         conn.commit()
         conn.close()
 
-        assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is True
+        claim = _claimed(db_path, "task1", "2026-01-01T09:00")
         complete_run(
-            "task1",
-            "2026-01-01T09:00",
+            claim,
             status=TaskStatus.SUCCESS,
             targets=(DeliveryOutcome(provider=Provider.SLACK, ok=True, message_id="ts_1"),),
             db_path=db_path,
@@ -282,6 +348,9 @@ class TestPerTargetOutcomes:
 
         assert get_runs("legacy", db_path=db_path)[0].targets == ()
         assert get_runs("task1", db_path=db_path)[0].targets[0].message_id == "ts_1"
+        reclaimed = try_claim("stale", "2020-01-01T08:00", db_path=db_path)
+        assert reclaimed is not None
+        assert reclaimed.attempt == 2
 
     def test_a_concurrent_migration_landing_first_does_not_raise(
         self, db_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -412,8 +481,8 @@ class TestLatestTargetedRun:
         targets: tuple[DeliveryOutcome, ...],
         status: TaskStatus = TaskStatus.SUCCESS,
     ) -> None:
-        try_claim("task1", fire_time, db_path=db_path)
-        complete_run("task1", fire_time, status=status, targets=targets, db_path=db_path)
+        claim = _claimed(db_path, "task1", fire_time)
+        complete_run(claim, status=status, targets=targets, db_path=db_path)
 
     def test_a_later_run_without_targets_does_not_shadow_the_partial_failure(
         self, db_path: Path

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -9,6 +9,7 @@ the real bundle and patching that vendor's ``scheduled_delivery`` adapter.
 from __future__ import annotations
 
 import json
+import sqlite3
 import threading
 from pathlib import Path
 from typing import Any
@@ -22,7 +23,7 @@ from infrastructure.observability.operations_log import read_operations
 from infrastructure.scheduling.scheduler.executor import execute_task
 from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
 from infrastructure.scheduling.scheduler.loop_constants import LOOP_CHANNELS_PARAM
-from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind, TaskStatus
 from tests.scheduler._bundle import real_runners
 
 #: Generous enough to survive a loaded CI shard; a real hang still fails fast.
@@ -47,6 +48,21 @@ class _FakeAdapter:
     def deliver(self, task: ScheduledTask, message: str) -> tuple[bool, str, str]:
         self.calls.append((task, message))
         return self.result
+
+
+class _CrashOnceAdapter:
+    """Raises once to simulate a worker dying in the delivery call."""
+
+    def __init__(self) -> None:
+        self.crashed = False
+        self.calls = 0
+
+    def deliver(self, _task: ScheduledTask, _message: str) -> tuple[bool, str, str]:
+        self.calls += 1
+        if not self.crashed:
+            self.crashed = True
+            raise KeyboardInterrupt
+        return True, "", "recovered-message"
 
 
 def _install_fake_bundle() -> dict[Provider, _FakeAdapter]:
@@ -83,8 +99,80 @@ def _tmp_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _expire_claim(db_path: Path, task_id: str, fire_time: str) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "UPDATE task_runs SET lease_expires_at = ? WHERE task_id = ? AND fire_time = ?",
+        ("2020-01-01T00:00:00+00:00", task_id, fire_time),
+    )
+    conn.commit()
+    conn.close()
+
+
 @pytest.mark.usefixtures("_tmp_stores")
 class TestExecutor:
+    def test_crash_before_build_is_recovered_by_a_new_attempt(self, tmp_path: Path) -> None:
+        from infrastructure.scheduling.scheduler.claim_store import get_runs, try_claim
+
+        task = ScheduledTask(
+            id="test_build_crash",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+        fire_time = "2026-01-01T09:00"
+        assert try_claim(task.id, fire_time, db_path=tmp_path / "scheduler.db") is not None
+        _expire_claim(tmp_path / "scheduler.db", task.id, fire_time)
+        adapters = _install_fake_bundle()
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
+        ):
+            assert execute_task(task, fire_time, real_runners()) is True
+
+        runs = get_runs(task.id)
+        assert [run.status for run in runs] == [TaskStatus.SUCCESS, TaskStatus.ABANDONED]
+        assert runs[0].attempt == 2
+        assert len(adapters[Provider.SLACK].calls) == 1
+
+    def test_crash_during_delivery_is_recovered_by_a_new_attempt(self, tmp_path: Path) -> None:
+        from infrastructure.scheduling.scheduler.claim_store import get_runs
+
+        adapter = _CrashOnceAdapter()
+        _install_bundle({Provider.SLACK: adapter})
+        task = ScheduledTask(
+            id="test_delivery_crash",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+        fire_time = "2026-01-01T09:00"
+
+        with (
+            patch(
+                "infrastructure.scheduling.scheduler.executor.build_message",
+                return_value="Scheduled report",
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            execute_task(task, fire_time, real_runners())
+
+        _expire_claim(tmp_path / "scheduler.db", task.id, fire_time)
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
+        ):
+            assert execute_task(task, fire_time, real_runners()) is True
+
+        runs = get_runs(task.id)
+        assert [run.status for run in runs] == [TaskStatus.SUCCESS, TaskStatus.ABANDONED]
+        assert runs[0].attempt == 2
+        assert adapter.calls == 2
+
     def test_telegram_delivery_success(self) -> None:
         adapters = _install_fake_bundle()
         adapters[Provider.TELEGRAM].result = (True, "", "msg_42")

--- a/tests/scheduler/test_types.py
+++ b/tests/scheduler/test_types.py
@@ -79,3 +79,4 @@ class TestTaskRun:
         assert TaskStatus.SUCCESS == "success"
         assert TaskStatus.FAILED == "failed"
         assert TaskStatus.SKIPPED == "skipped"
+        assert TaskStatus.ABANDONED == "abandoned"


### PR DESCRIPTION
Fixes #6021

Depends on #6017. This is intentionally a stacked draft; once #6017 lands, the remaining diff is the schema-migration extraction requested in its review.\n\n> **Blocked:** review of the stacked diff found that #6017 has no production trigger to retry an expired claim with its original fire-time key. That recovery-path issue must be fixed in #6017 before this PR is rebased and marked ready.

#### Describe the changes you have made in this PR -

- Move scheduler table DDL, schema inspection, legacy-table reconstruction, and migration retry/locking behavior into `infrastructure/scheduling/scheduler/migrations.py`.
- Expose one narrow `apply_migrations(sqlite3.Connection)` entry point to the runtime claim store.
- Keep claim acquisition, completion, and history queries in `claim_store.py`.
- Retarget the existing migration/concurrency tests to the owning module.
- Add a boundary regression test that rejects schema DDL in `claim_store.py`.

No database shape, migration order, locking behavior, or user-visible scheduler behavior changes.

### Demo/Screenshot for feature changes and bug fixes -

Equivalent test evidence:

```text
uv run python -m pytest tests/scheduler/test_claim_store.py tests/infrastructure/test_setup_state.py
49 passed in 1.18s
```

Additional local gates:

```text
make lint          -> passed
make format-check  -> passed (3063 files formatted)
make typecheck     -> passed (1773 source files)
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I considered raw `.sql` changesets and introducing Alembic. Raw SQL alone cannot safely own this migration because it relies on Python-controlled SQLite write locking, schema rechecks, conditional legacy data copying, and bounded retry behavior. Alembic would add unnecessary machinery and a dependency for one local SQLite database.

The chosen package-local `migrations.py` module follows the repository's existing gateway storage separation: schema evolution has one owner and the runtime store delegates through a small API. Existing migration behavior was moved without changing its order or conditions.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Maintainers may modify the branch.