### PR TITLE
fix(scheduler): preserve recurring morning-report payloads

### DIFF
--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -19,8 +19,10 @@ from core.agent_harness.ports import OutputSink
 from core.agent_harness.prompts.skills.schedule import (
     is_recurring_skill,
     normalize_skill_name,
+
     pin_recurring_skill,
     resolve_scheduled_skill,
+    validate_skill_inputs,
 )
 from core.agent_harness.session import SessionCore, SessionManager
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
@@ -37,4 +39,5 @@ __all__ = [
     "normalize_skill_name",
     "pin_recurring_skill",
     "resolve_scheduled_skill",
+    "validate_skill_inputs",
 ]

--- a/core/agent_harness/__init__.py
+++ b/core/agent_harness/__init__.py
@@ -19,7 +19,6 @@ from core.agent_harness.ports import OutputSink
 from core.agent_harness.prompts.skills.schedule import (
     is_recurring_skill,
     normalize_skill_name,
-
     pin_recurring_skill,
     resolve_scheduled_skill,
     validate_skill_inputs,

--- a/core/agent_harness/prompts/skills/schedule.py
+++ b/core/agent_harness/prompts/skills/schedule.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from core.agent_harness.prompts.skills.loader import (
@@ -97,13 +98,15 @@ def resolve_scheduled_skill(name: str, pinned_revision: str) -> ScheduledSkillRe
     return ScheduledSkillResolution(skill=skill, body=body, revision=current)
 
 
-def validate_skill_inputs(raw: dict[str, object] | None) -> dict[str, str]:
+def validate_skill_inputs(raw: Mapping[str, object] | None) -> dict[str, str]:
     """Return string-only skill inputs or raise ``ValueError``."""
     if not raw:
         return {}
     validated: dict[str, str] = {}
     for key, value in raw.items():
-        name = str(key).strip()
+        if not isinstance(key, str):
+            raise ValueError("skill input keys must be strings.")
+        name = key.strip()
         if not name:
             raise ValueError("skill input keys must be non-empty strings.")
         if not isinstance(value, str):

--- a/core/agent_harness/session/pending_offer.py
+++ b/core/agent_harness/session/pending_offer.py
@@ -81,7 +81,11 @@ class PendingScheduleOffer:
             skill = self.skill_name.strip()
             if skill:
                 args.extend(["--skill", skill])
-            if skill == "github-ci-health":
+            if skill == "morning-report":
+                city = self.skill_inputs.get("city", "").strip()
+                if city:
+                    args.extend(["--city", city])
+            elif skill == "github-ci-health":
                 for key, flag in (
                     ("owner", "--owner"),
                     ("repo", "--repo"),

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -22,9 +22,9 @@ When you open the interactive shell (`opensre`) and no scheduled tasks exist yet
 ## Quick Start
 
 ```bash
-# Add a recurring prompt loop to Telegram at 09:00 IST on weekdays
+# Add a free-form recurring ops digest to Telegram at 09:00 IST on weekdays
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --name "Morning report" --tz Asia/Kolkata --provider telegram --chat-id <chat_id>
+  --name "Ops digest" --tz Asia/Kolkata --provider telegram --chat-id <chat_id>
 
 # Same kind to Slack via incoming webhook (omit --chat-id; webhook is channel-bound)
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
@@ -44,9 +44,14 @@ opensre cron add --kind recurring_skill --skill github-ci-health \
   --tz Europe/London --provider slack --owner Tracer-Cloud --repo opensre \
   --branch main
 
+# Morning-report skill with its previewed city → local inbox
+opensre cron add --kind recurring_skill --skill morning-report \
+  --cron "0 8 * * 1-5" --tz Asia/Kolkata \
+  --provider interactive_shell --city "New Delhi"
+
 # Local interactive-shell inbox delivery, useful for debugging
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --name "Local morning report" --provider interactive_shell
+  --name "Local ops digest" --provider interactive_shell
 
 # List configured tasks
 opensre cron list
@@ -78,6 +83,7 @@ Create a new scheduled delivery task.
 | `--repo` | Cond. | GitHub repository name; required for the `github-ci-health` recurring skill |
 | `--branch` | No | Branch filter for `github-ci-health`; cannot be combined with `--pr` |
 | `--pr` | No | Pull-request filter for `github-ci-health`; cannot be combined with `--branch` |
+| `--city` | No | City for `morning-report`; omitted to use its default-location behavior |
 
 ### `opensre cron list`
 
@@ -192,7 +198,7 @@ from your existing integration configuration.
 | Kind | Behavior |
 |------|----------|
 | `manual_loop` | Runs a stored prompt as one headless agent turn and delivers the answer. This is what `/loops` creates. |
-| `recurring_skill` | Runs a named, revision-pinned recurring skill. `github-ci-health` produces a read-only failing-check report for one repository, optionally narrowed to a branch or PR, with links, age, ownership, and an interactive repair handoff. |
+| `recurring_skill` | Runs a named, revision-pinned recurring skill. `morning-report` preserves its optional city; `github-ci-health` requires repository scope and can be narrowed to a branch or PR. |
 | `github_pr_sweep` | Headless GitHub PR standup (mergeable / stale / conflicted). Requires GitHub configured; posts via the chosen provider. |
 | `posthog_metric_report` | Headless PostHog metric report over the configured window. Requires PostHog configured. |
 | `work_item_reminder` | Reminder for a single work item at its `--remind-at` time. Created by `opensre work add --remind-at …`. |

--- a/infrastructure/scheduling/scheduler/loops.py
+++ b/infrastructure/scheduling/scheduler/loops.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from core.agent_harness import pin_recurring_skill
 from infrastructure.scheduling.scheduler.credentials import (
     resolve_slack_credentials,
     resolve_slack_default_chat_id,
@@ -38,6 +39,10 @@ from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, T
 _ONBOARDING_LOOP_SOURCE = "onboarding"
 _MANUAL_LOOP_SOURCE = "manual"
 _MANUAL_LOOP_CREATED_BY = "interactive_shell"
+_LEGACY_MORNING_REPORT_PROMPT = (
+    "Summarize the reliability picture for the last 24 hours: notable "
+    "alerts, error spikes, and anything on-call should know this morning."
+)
 _TIME_RE = re.compile(
     r"^(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<meridiem>am|pm)?$",
     re.IGNORECASE,
@@ -62,6 +67,7 @@ class StarterLoop:
     timezone: str
     window_hours: int
     prompt: str = ""
+    skill_name: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,15 +126,12 @@ STARTER_LOOPS: tuple[StarterLoop, ...] = (
     StarterLoop(
         slug="morning-report",
         name="Morning report",
-        description="Weekday reliability digest for the last 24 hours.",
-        kind=TaskKind.MANUAL_LOOP,
+        description="Weekday weather and news briefing.",
+        kind=TaskKind.RECURRING_SKILL,
         cron="0 8 * * 1-5",
         timezone="UTC",
         window_hours=24,
-        prompt=(
-            "Summarize the reliability picture for the last 24 hours: notable "
-            "alerts, error spikes, and anything on-call should know this morning."
-        ),
+        skill_name="morning-report",
     ),
     StarterLoop(
         slug="weekly-alert-audit",
@@ -159,6 +162,7 @@ _KIND_LABELS: dict[TaskKind, str] = {
     TaskKind.SENTRY_MORNING_DIGEST: "Sentry morning digest",
     TaskKind.SENTRY_UPTIME_WATCH: "Sentry uptime watch",
     TaskKind.GITHUB_PR_SWEEP: "GitHub PR sweep",
+    TaskKind.RECURRING_SKILL: "Recurring skill",
 }
 
 
@@ -498,14 +502,18 @@ def seed_starter_loops(store_path: Path | None = None) -> list[ScheduledTask]:
     posting to a user's chat destination. Users can create an active loop with
     ``/loops add`` or the natural-language schedule flow.
     """
-    existing_slugs = {
-        task.params.get(LOOP_SLUG_PARAM, "").strip()
+    existing_by_slug = {
+        task.params.get(LOOP_SLUG_PARAM, "").strip(): task
         for task in list_tasks(store_path)
         if task.params.get(LOOP_SOURCE_PARAM) == _ONBOARDING_LOOP_SOURCE
     }
     added: list[ScheduledTask] = []
     for starter in STARTER_LOOPS:
-        if starter.slug in existing_slugs:
+        existing = existing_by_slug.get(starter.slug)
+        if existing is not None:
+            upgraded = _upgrade_legacy_skill_starter(existing, starter, store_path=store_path)
+            if upgraded is not None:
+                added.append(upgraded)
             continue
         params = {
             LOOP_SLUG_PARAM: starter.slug,
@@ -515,6 +523,10 @@ def seed_starter_loops(store_path: Path | None = None) -> list[ScheduledTask]:
         }
         if starter.prompt:
             params[LOOP_PROMPT_PARAM] = starter.prompt
+        skill_name = ""
+        skill_revision = ""
+        if starter.skill_name:
+            skill_name, skill_revision = pin_recurring_skill(starter.skill_name)
         task = ScheduledTask(
             name=starter.name,
             kind=starter.kind,
@@ -524,11 +536,47 @@ def seed_starter_loops(store_path: Path | None = None) -> list[ScheduledTask]:
             window_hours=starter.window_hours,
             enabled=False,
             params=params,
+            skill_name=skill_name,
+            skill_revision=skill_revision,
         )
         stored_task = add_task(task, store_path)
         record_scheduler_task_operation("scheduled_loop_seeded", stored_task)
         added.append(stored_task)
     return added
+
+
+def _upgrade_legacy_skill_starter(
+    task: ScheduledTask,
+    starter: StarterLoop,
+    *,
+    store_path: Path | None,
+) -> ScheduledTask | None:
+    """Upgrade only an untouched disabled onboarding prompt to its named skill."""
+    if (
+        not starter.skill_name
+        or task.enabled
+        or task.kind is not TaskKind.MANUAL_LOOP
+        or task.params.get(LOOP_SOURCE_PARAM) != _ONBOARDING_LOOP_SOURCE
+        or task.params.get(LOOP_PROMPT_PARAM) != _LEGACY_MORNING_REPORT_PROMPT
+        or task.skill_name
+    ):
+        return None
+
+    skill_name, skill_revision = pin_recurring_skill(starter.skill_name)
+    task.kind = TaskKind.RECURRING_SKILL
+    task.skill_name = skill_name
+    task.skill_revision = skill_revision
+    task.skill_inputs = {}
+    task.params.pop(LOOP_PROMPT_PARAM, None)
+    task.params[LOOP_DESCRIPTION_PARAM] = starter.description
+    if not update_task(task, store_path):
+        return None
+    record_scheduler_task_operation(
+        "scheduled_loop_upgraded",
+        task,
+        extra={"from_kind": TaskKind.MANUAL_LOOP.value},
+    )
+    return task
 
 
 def _summarize_group(

--- a/integrations/scheduled_skill_runner.py
+++ b/integrations/scheduled_skill_runner.py
@@ -7,6 +7,7 @@ import logging
 from core.agent_harness import (
     AgentSession,
     resolve_scheduled_skill,
+    validate_skill_inputs,
 )
 from infrastructure.scheduling.scheduler.agent_runner import AgentPayload
 
@@ -46,13 +47,17 @@ def run_scheduled_recurring_skill(payload: AgentPayload) -> str:
         str(payload.get("skill_revision") or ""),
     )
     raw_inputs = payload.get("skill_inputs") or {}
-    inputs = raw_inputs if isinstance(raw_inputs, dict) else {}
+    if not isinstance(raw_inputs, dict):
+        raise RuntimeError(f"Scheduled skill {resolved.name!r} has invalid inputs.")
+    try:
+        inputs = validate_skill_inputs(raw_inputs)
+    except ValueError as exc:
+        raise RuntimeError(f"Scheduled skill {resolved.name!r} has invalid inputs.") from exc
     input_block = ""
     if inputs:
         rendered = "\n".join(f"- {key}: {value}" for key, value in sorted(inputs.items()))
         input_block = f"\nValidated inputs:\n{rendered}\n"
-    typed_inputs = {str(key): str(value) for key, value in inputs.items()}
-    fetch_block = _prefetched_context(resolved.name, typed_inputs)
+    fetch_block = _prefetched_context(resolved.name, inputs)
     if resolved.name == "github-ci-health":
         # The prefetcher renders the complete final report. Returning it
         # directly preserves every scoped failure instead of sending it

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -11,7 +11,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from core.agent_harness import pin_recurring_skill
+from core.agent_harness import pin_recurring_skill, validate_skill_inputs
 from infrastructure.scheduling.scheduler.credentials import requires_explicit_chat_id
 from infrastructure.scheduling.scheduler.types import Provider, TaskKind, TaskRun
 from infrastructure.terminal.theme import GLYPH_ERROR, GLYPH_SUCCESS
@@ -106,6 +106,7 @@ def cron_command() -> None:
 @click.option(
     "--pr", "pr_number", type=click.IntRange(min=1), default=None, help="Optional GitHub PR filter."
 )
+@click.option("--city", type=str, default="", help="Optional city for the morning-report skill.")
 def cron_add(
     name: str,
     kind: str,
@@ -119,6 +120,7 @@ def cron_add(
     repo: str,
     branch: str,
     pr_number: int | None,
+    city: str,
 ) -> None:
     """Add a new scheduled delivery task."""
     from infrastructure.scheduling.scheduler.types import ScheduledTask
@@ -139,8 +141,13 @@ def cron_add(
             raise click.ClickException(str(exc)) from exc
     elif skill_name.strip():
         raise click.ClickException("--skill is only valid with --kind recurring_skill.")
-    skill_inputs = _github_ci_health_inputs(
-        pinned_name, owner=owner, repo=repo, branch=branch, pr_number=pr_number
+    skill_inputs = _recurring_skill_inputs(
+        pinned_name,
+        city=city,
+        owner=owner,
+        repo=repo,
+        branch=branch,
+        pr_number=pr_number,
     )
 
     task = ScheduledTask(
@@ -178,23 +185,36 @@ def cron_add(
     _console.print(f"  Provider: {added.provider.value}  Chat: {added.chat_id}")
 
 
-def _github_ci_health_inputs(
+def _recurring_skill_inputs(
     skill_name: str,
     *,
+    city: str,
     owner: str,
     repo: str,
     branch: str,
     pr_number: int | None,
 ) -> dict[str, str]:
-    """Validate and serialize inputs for the recurring GitHub CI health skill."""
+    """Validate and serialize inputs for the selected recurring skill."""
+    normalized_city = city.strip()
     values_supplied = bool(owner.strip() or repo.strip() or branch.strip() or pr_number)
+    if skill_name == "morning-report":
+        if values_supplied:
+            raise click.UsageError(
+                "--owner, --repo, --branch, and --pr are only valid with "
+                "--kind recurring_skill --skill github-ci-health."
+            )
+        return validate_skill_inputs({"city": normalized_city} if normalized_city else {})
+    if normalized_city:
+        raise click.UsageError(
+            "--city is only valid with --kind recurring_skill --skill morning-report."
+        )
     if skill_name != "github-ci-health":
         if values_supplied:
             raise click.UsageError(
                 "--owner, --repo, --branch, and --pr are only valid with "
                 "--kind recurring_skill --skill github-ci-health."
             )
-        return {}
+        return validate_skill_inputs({})
     if not owner.strip() or not repo.strip():
         raise click.UsageError("--owner and --repo are required for skill github-ci-health.")
     if branch.strip() and pr_number is not None:
@@ -204,7 +224,7 @@ def _github_ci_health_inputs(
         params["branch"] = branch.strip()
     if pr_number is not None:
         params["pr_number"] = str(pr_number)
-    return params
+    return validate_skill_inputs(params)
 
 
 @cron_command.command(name="list")

--- a/tests/cli/test_cron_command.py
+++ b/tests/cli/test_cron_command.py
@@ -157,6 +157,65 @@ def test_cron_add_persists_github_ci_health_scope(
     }
 
 
+def test_cron_add_persists_morning_report_city(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from infrastructure.scheduling.scheduler import store as scheduler_store
+    from infrastructure.scheduling.scheduler.store import list_tasks
+
+    store = tmp_path / "scheduler_tasks.json"
+    monkeypatch.setattr(scheduler_store, "_default_store_path", lambda: store)
+
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "recurring_skill",
+            "--skill",
+            "morning-report",
+            "--cron",
+            "0 8 * * 1-5",
+            "--provider",
+            "interactive_shell",
+            "--city",
+            "New Delhi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    task = list_tasks(store)[0]
+    assert task.skill_name == "morning-report"
+    assert task.skill_revision
+    assert task.skill_inputs == {"city": "New Delhi"}
+
+
+def test_cron_add_rejects_city_for_unrelated_skill() -> None:
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "recurring_skill",
+            "--skill",
+            "github-ci-health",
+            "--cron",
+            "0 8 * * 1-5",
+            "--provider",
+            "interactive_shell",
+            "--owner",
+            "acme",
+            "--repo",
+            "api",
+            "--city",
+            "Paris",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--city is only valid" in result.output
+
+
 def test_cron_add_requires_repository_scope_for_github_ci_health() -> None:
     result = CliRunner().invoke(
         cron_command,

--- a/tests/core/agent_harness/prompts/skills/test_schedule.py
+++ b/tests/core/agent_harness/prompts/skills/test_schedule.py
@@ -55,6 +55,9 @@ def test_validate_skill_inputs_rejects_non_strings() -> None:
     with pytest.raises(ValueError, match="must be a string"):
         validate_skill_inputs({"city": 123})
 
+    with pytest.raises(ValueError, match="keys must be strings"):
+        validate_skill_inputs({1: "Paris"})
+
 
 def test_skill_revision_changes_when_body_changes() -> None:
     skill = find_action_skill("morning-report")

--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -29,6 +29,22 @@ def test_pending_recurring_skill_offer_includes_skill_flag() -> None:
     )
 
 
+def test_pending_morning_report_offer_preserves_city() -> None:
+    offer = PendingScheduleOffer(
+        kind="recurring_skill",
+        skill_name="morning-report",
+        skill_inputs={"city": "New Delhi"},
+        cron="0 8 * * 1-5",
+        timezone="Asia/Kolkata",
+        provider="slack",
+    )
+
+    assert offer.to_slash_command() == (
+        "/cron add --kind recurring_skill --cron '0 8 * * 1-5' "
+        "--tz Asia/Kolkata --provider slack --skill morning-report --city 'New Delhi'"
+    )
+
+
 def test_pending_github_ci_health_offer_preserves_repository_scope() -> None:
     offer = PendingScheduleOffer(
         kind="recurring_skill",
@@ -164,6 +180,7 @@ def test_propose_tool_sets_session_pending_offer() -> None:
     assert session.pending_schedule_offer.kind == "recurring_skill"
     assert session.pending_schedule_offer.skill_name == "morning-report"
     assert session.pending_schedule_offer.skill_inputs == {"city": "Amsterdam"}
+    assert "--city Amsterdam" in result["slash_preview"]
     assert result["closer"].startswith("**Want me to:**")
     assert "Weather — Amsterdam" in result["response_text"]
     assert result["closer"] in result["response_text"]

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -36,6 +36,7 @@ ROOT_API = frozenset(
         "normalize_skill_name",
         "pin_recurring_skill",
         "resolve_scheduled_skill",
+        "validate_skill_inputs",
     }
 )
 

--- a/tests/integrations/test_scheduled_skill_runner.py
+++ b/tests/integrations/test_scheduled_skill_runner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from core.agent_harness import AgentSession, pin_recurring_skill
+from core.agent_harness import AgentSession, ToolCallingTurnResult, TurnResult, pin_recurring_skill
 from core.agent_harness.tools.tool_provider import tool_allowed_for_unattended_run
 from core.tool import SideEffectLevel
 from integrations import scheduled_skill_runner
@@ -86,3 +86,63 @@ def test_github_ci_health_skill_returns_complete_prefetched_report_without_agent
     assert len(report) > 512
     assert report == complete_report
     assert prefetched == [("github-ci-health", {"owner": "acme", "repo": "api", "branch": "main"})]
+
+
+def test_morning_report_runs_the_pinned_recipe_with_prefetched_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill_name, revision = pin_recurring_skill("morning-report")
+    prompts: list[str] = []
+
+    def fake_prefetch(name: str, inputs: dict[str, str]) -> str:
+        assert name == "morning-report"
+        assert inputs == {"city": "New Delhi"}
+        return "Weather: New Delhi: sunny\nHeadlines:\n- One headline"
+
+    def fake_headless(message: str, **kwargs: object) -> TurnResult:
+        prompts.append(message)
+        assert kwargs["unattended"] is True
+        return TurnResult(
+            final_intent="handled",
+            action_result=ToolCallingTurnResult(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+                has_unhandled_clause=False,
+                handled=True,
+            ),
+            assistant_response_text=(
+                "Good morning! Here is your briefing.\n"
+                "Weather — New Delhi: sunny\n"
+                "Top headlines:\n- One headline"
+            ),
+        )
+
+    monkeypatch.setattr(scheduled_skill_runner, "_prefetched_context", fake_prefetch)
+    monkeypatch.setattr(AgentSession, "run_headless_turn", fake_headless)
+
+    report = scheduled_skill_runner.run_scheduled_recurring_skill(
+        {
+            "skill_name": skill_name,
+            "skill_revision": revision,
+            "skill_inputs": {"city": "New Delhi"},
+        }
+    )
+
+    assert "MORNING REPORT SKILL" in prompts[0]
+    assert "Weather: New Delhi: sunny" in prompts[0]
+    assert "Daily Reliability Summary" not in prompts[0]
+    assert report.startswith("Good morning!")
+
+
+def test_scheduled_skill_rejects_unvalidated_inputs() -> None:
+    skill_name, revision = pin_recurring_skill("morning-report")
+
+    with pytest.raises(RuntimeError, match="invalid inputs"):
+        scheduled_skill_runner.run_scheduled_recurring_skill(
+            {
+                "skill_name": skill_name,
+                "skill_revision": revision,
+                "skill_inputs": {"city": 123},
+            }
+        )

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -19,10 +19,16 @@ import pytest
 import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
 from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
 from infrastructure.observability.operations_log import read_operations
+from infrastructure.scheduling.scheduler.claim_store import get_runs
 from infrastructure.scheduling.scheduler.executor import execute_task
 from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
 from infrastructure.scheduling.scheduler.loop_constants import LOOP_CHANNELS_PARAM
-from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+from infrastructure.scheduling.scheduler.types import (
+    Provider,
+    ScheduledTask,
+    TaskKind,
+    TaskStatus,
+)
 from tests.scheduler._bundle import real_runners
 
 #: Generous enough to survive a loaded CI shard; a real hang still fails fast.
@@ -441,6 +447,36 @@ class TestExecutor:
             result = execute_task(task, "2026-01-01T09:00", real_runners())
 
         assert result is False
+
+    @pytest.mark.parametrize(
+        ("skill_name", "skill_revision", "error_text"),
+        [
+            ("missing-skill-xyz", "abc123", "not installed"),
+            ("morning-report", "0" * 64, "changed since it was scheduled"),
+        ],
+    )
+    def test_invalid_recurring_skill_is_visible_in_run_history(
+        self,
+        skill_name: str,
+        skill_revision: str,
+        error_text: str,
+    ) -> None:
+        task = ScheduledTask(
+            id=f"invalid-{skill_name}",
+            kind=TaskKind.RECURRING_SKILL,
+            cron="0 8 * * 1-5",
+            provider=Provider.INTERACTIVE_SHELL,
+            skill_name=skill_name,
+            skill_revision=skill_revision,
+        )
+
+        result = execute_task(task, "2026-01-01T09:00", real_runners())
+
+        assert result is False
+        runs = get_runs(task.id)
+        assert len(runs) == 1
+        assert runs[0].status is TaskStatus.FAILED
+        assert error_text in runs[0].error
 
     def test_delivery_failure_records_error(self) -> None:
         adapters = _install_fake_bundle()

--- a/tests/scheduler/test_loops.py
+++ b/tests/scheduler/test_loops.py
@@ -2,10 +2,103 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
+from infrastructure.scheduling.scheduler import loops as loop_mod
+from infrastructure.scheduling.scheduler.loop_constants import (
+    LOOP_CHANNELS_PARAM,
+    LOOP_DESCRIPTION_PARAM,
+    LOOP_PROMPT_PARAM,
+    LOOP_SLUG_PARAM,
+    LOOP_SOURCE_PARAM,
+)
 from infrastructure.scheduling.scheduler.loops import default_loop_channels, normalize_loop_channels
-from infrastructure.scheduling.scheduler.types import Provider
+from infrastructure.scheduling.scheduler.store import add_task, list_tasks
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+
+_LEGACY_MORNING_REPORT_PROMPT = (
+    "Summarize the reliability picture for the last 24 hours: notable "
+    "alerts, error spikes, and anything on-call should know this morning."
+)
+
+
+def test_morning_report_starter_is_a_pinned_recurring_skill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store_path = tmp_path / "tasks.json"
+    monkeypatch.setattr(loop_mod, "record_scheduler_task_operation", lambda *_a, **_kw: None)
+
+    loop_mod.seed_starter_loops(store_path)
+
+    morning = next(task for task in list_tasks(store_path) if task.name == "Morning report")
+    assert morning.kind is TaskKind.RECURRING_SKILL
+    assert morning.skill_name == "morning-report"
+    assert morning.skill_revision
+    assert LOOP_PROMPT_PARAM not in morning.params
+    assert morning.enabled is False
+
+
+def test_legacy_disabled_morning_report_starter_is_upgraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store_path = tmp_path / "tasks.json"
+    monkeypatch.setattr(loop_mod, "record_scheduler_task_operation", lambda *_a, **_kw: None)
+    legacy = ScheduledTask(
+        id="legacy-morning",
+        name="Morning report",
+        kind=TaskKind.MANUAL_LOOP,
+        cron="0 8 * * 1-5",
+        provider=Provider.INTERACTIVE_SHELL,
+        enabled=False,
+        params={
+            LOOP_SLUG_PARAM: "morning-report",
+            LOOP_SOURCE_PARAM: "onboarding",
+            LOOP_DESCRIPTION_PARAM: "Weekday reliability digest for the last 24 hours.",
+            LOOP_CHANNELS_PARAM: Provider.INTERACTIVE_SHELL.value,
+            LOOP_PROMPT_PARAM: _LEGACY_MORNING_REPORT_PROMPT,
+        },
+    )
+    add_task(legacy, store_path)
+
+    loop_mod.seed_starter_loops(store_path)
+
+    upgraded = next(task for task in list_tasks(store_path) if task.id == legacy.id)
+    assert upgraded.kind is TaskKind.RECURRING_SKILL
+    assert upgraded.skill_name == "morning-report"
+    assert upgraded.skill_revision
+    assert LOOP_PROMPT_PARAM not in upgraded.params
+
+
+def test_active_legacy_morning_report_loop_is_not_reinterpreted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store_path = tmp_path / "tasks.json"
+    monkeypatch.setattr(loop_mod, "record_scheduler_task_operation", lambda *_a, **_kw: None)
+    legacy = ScheduledTask(
+        id="active-legacy-morning",
+        name="Morning report",
+        kind=TaskKind.MANUAL_LOOP,
+        cron="0 8 * * 1-5",
+        provider=Provider.INTERACTIVE_SHELL,
+        enabled=True,
+        params={
+            LOOP_SLUG_PARAM: "morning-report",
+            LOOP_SOURCE_PARAM: "onboarding",
+            LOOP_DESCRIPTION_PARAM: "Weekday reliability digest for the last 24 hours.",
+            LOOP_CHANNELS_PARAM: Provider.INTERACTIVE_SHELL.value,
+            LOOP_PROMPT_PARAM: _LEGACY_MORNING_REPORT_PROMPT,
+        },
+    )
+    add_task(legacy, store_path)
+
+    loop_mod.seed_starter_loops(store_path)
+
+    unchanged = next(task for task in list_tasks(store_path) if task.id == legacy.id)
+    assert unchanged.kind is TaskKind.MANUAL_LOOP
+    assert unchanged.skill_name == ""
+    assert unchanged.params[LOOP_PROMPT_PARAM] == _LEGACY_MORNING_REPORT_PROMPT
 
 
 class TestDefaultLoopChannels:

--- a/tests/scheduler/test_recurring_skill_acceptance.py
+++ b/tests/scheduler/test_recurring_skill_acceptance.py
@@ -1,0 +1,117 @@
+"""Acceptance coverage for first-class recurring morning-report schedules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
+from core.agent_harness import AgentSession, ToolCallingTurnResult, TurnResult
+from infrastructure.scheduling.scheduler.claim_store import get_runs
+from infrastructure.scheduling.scheduler.executor import execute_task
+from infrastructure.scheduling.scheduler.store import list_tasks
+from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind, TaskStatus
+from integrations import scheduled_skill_runner
+from surfaces.cli.commands.cron import cron_command
+from tests.scheduler._bundle import runners_with_agent
+
+
+class _RecordingDelivery:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def deliver(self, _task: ScheduledTask, message: str) -> tuple[bool, str, str]:
+        self.messages.append(message)
+        return True, "", "local-1"
+
+
+def test_scheduled_morning_report_runs_the_skill_and_delivers_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cron tick repeats the previewed skill instead of an investigation summary."""
+    store_path = tmp_path / "scheduler_tasks.json"
+    db_path = tmp_path / "scheduler.db"
+    delivery = _RecordingDelivery()
+    prompts: list[str] = []
+
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.store._default_store_path",
+        lambda: store_path,
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.claim_store._default_db_path",
+        lambda: db_path,
+    )
+
+    def fake_prefetch(name: str, inputs: dict[str, str]) -> str:
+        assert name == "morning-report"
+        assert inputs == {"city": "New Delhi"}
+        return "Weather: New Delhi: sunny\nHeadlines:\n- Skill headline"
+
+    def fake_headless(message: str, **kwargs: object) -> TurnResult:
+        prompts.append(message)
+        assert kwargs["unattended"] is True
+        return TurnResult(
+            final_intent="handled",
+            action_result=ToolCallingTurnResult(
+                planned_count=0,
+                executed_count=0,
+                executed_success_count=0,
+                has_unhandled_clause=False,
+                handled=True,
+            ),
+            assistant_response_text=(
+                "Good morning! Here is your briefing.\n"
+                "Weather — New Delhi: sunny\n"
+                "Top headlines:\n- Skill headline"
+            ),
+        )
+
+    monkeypatch.setattr(scheduled_skill_runner, "_prefetched_context", fake_prefetch)
+    monkeypatch.setattr(AgentSession, "run_headless_turn", fake_headless)
+    delivery_bundle.ScheduledDeliveryAdapters({Provider.INTERACTIVE_SHELL: delivery}).install()
+
+    created = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "recurring_skill",
+            "--skill",
+            "morning-report",
+            "--cron",
+            "0 8 * * 1-5",
+            "--provider",
+            "interactive_shell",
+            "--city",
+            "New Delhi",
+        ],
+    )
+    assert created.exit_code == 0, created.output
+    task = list_tasks(store_path)[0]
+    assert task.kind is TaskKind.RECURRING_SKILL
+    assert task.skill_name == "morning-report"
+    assert task.skill_revision
+    assert task.skill_inputs == {"city": "New Delhi"}
+
+    success = execute_task(
+        task,
+        "2026-09-05T08:00Z",
+        runners_with_agent(scheduled_skill_runner.run_scheduled_recurring_skill),
+    )
+
+    assert success is True
+    assert len(prompts) == 1
+    assert "MORNING REPORT SKILL" in prompts[0]
+    assert "Daily Reliability Summary" not in prompts[0]
+    assert delivery.messages == [
+        "Good morning! Here is your briefing.\n"
+        "Weather — New Delhi: sunny\n"
+        "Top headlines:\n- Skill headline"
+    ]
+    runs = get_runs(task.id)
+    assert len(runs) == 1
+    assert runs[0].status is TaskStatus.SUCCESS

--- a/tools/interactive_shell/actions/propose_scheduled_delivery.py
+++ b/tools/interactive_shell/actions/propose_scheduled_delivery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness import is_recurring_skill, normalize_skill_name
+from core.agent_harness import is_recurring_skill, normalize_skill_name, validate_skill_inputs
 from core.agent_harness.spi.session_state import (
     PendingScheduleOffer,
     clear_competing_pending_offers,
@@ -206,6 +206,11 @@ def execute_propose_scheduled_delivery_tool(
             "ok": False,
             "error": "city is only valid for morning-report.",
         }
+
+    try:
+        skill_inputs = validate_skill_inputs(skill_inputs)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
 
     offer = PendingScheduleOffer(
         kind=kind,


### PR DESCRIPTION
  Fixes #5960

  #### Describe the changes you have made in this PR -

  Completes first-class scheduling for recurring skills so scheduled runs repeat the skill the user previewed.

  - Persists and validates recurring-skill inputs during creation and execution.
  - Preserves the `morning-report` city through the interactive confirmation and `/cron add` flow.
  - Seeds `morning-report` as a revision-pinned `RECURRING_SKILL` instead of a free-form reliability summary.
  - Safely upgrades only untouched, disabled legacy morning-report starter drafts.
  - Leaves active and user-created manual loops unchanged.
  - Records missing or revision-drifted skills as visible failed scheduler runs.
  - Keeps network fetching under `integrations/` and delivery outside the unattended agent turn.
  - Documents the `morning-report` cron workflow and `--city` option.

  ### Demo/Screenshot for feature changes and bug fixes -

  Issue-level acceptance regression:

  ```text
  $ uv run python -m pytest -q tests/scheduler/test_recurring_skill_acceptance.py

  tests/scheduler/test_recurring_skill_acceptance.py .                     [100%]
  1 passed

  The regression creates and persists a morning-report schedule, executes the real recurring-skill scheduler path, and verifies that:

  - the actual MORNING REPORT SKILL recipe is loaded;
  - the selected city and pinned revision are retained;
  - no Daily Reliability Summary is produced;
  - the resulting briefing is delivered exactly once;
  - the run is recorded as successful.

  Additional validation:

  145 focused tests passed
  make lint          # passed
  make format-check  # passed
  make typecheck     # passed
  make check-imports # passed
  git diff --check   # passed

  ———
```
