### PR TITLE
ci: add wheel and sdist preflight to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -739,9 +739,74 @@ jobs:
           -v
           --timeout=120
 
+  package-preflight:
+    name: package-preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Detect packaging changes
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            packaging:
+              - "pyproject.toml"
+              - "uv.lock"
+              - "bootstrap/**"
+              - "config/**"
+              - "core/**"
+              - "gateway/**"
+              - "infrastructure/**"
+              - "integrations/**"
+              - "surfaces/**"
+              - "tools/**"
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/release.yml"
+              - "infrastructure/deployment/packaging/**"
+
+      - name: Install uv
+        if: steps.changes.outputs.packaging == 'true'
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "latest-known"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python
+        if: steps.changes.outputs.packaging == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build and validate distributions
+        if: steps.changes.outputs.packaging == 'true'
+        run: |
+          uv sync --frozen --extra release-dist
+          uv run python -m build --outdir dist
+          uv run twine check dist/*
+          uv run python infrastructure/deployment/packaging/validate_wheel.py dist/*.whl
+
+      - name: Smoke the installed wheel
+        if: steps.changes.outputs.packaging == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_env="$(mktemp -d)"
+          uv venv --python 3.13 "$smoke_env"
+          uv pip install --python "$smoke_env/bin/python" dist/*.whl
+          cd "$RUNNER_TEMP"
+          "$smoke_env/bin/opensre" --version
+          "$smoke_env/bin/opensre" _package-smoke
+
   ci-gate:
     name: CI Gate
-    needs: [quality-static, quality-typecheck, test, coverage-report, session-store-locked]
+    needs:
+      [quality-static, quality-typecheck, test, coverage-report, session-store-locked, package-preflight]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -757,8 +822,9 @@ jobs:
           test_result='${{ needs.test.result }}'
           coverage='${{ needs.coverage-report.result }}'
           session_locked='${{ needs.session-store-locked.result }}'
+          package_preflight='${{ needs.package-preflight.result }}'
           session_persistence_changed='${{ needs.session-store-locked.outputs.session_persistence }}'
-          echo "static=$static typecheck=$typecheck test=$test_result coverage-report=$coverage session-store-locked=$session_locked session_persistence=$session_persistence_changed"
+          echo "static=$static typecheck=$typecheck test=$test_result coverage-report=$coverage session-store-locked=$session_locked package-preflight=$package_preflight session_persistence=$session_persistence_changed"
 
           # Source jobs always start. On docs-only PRs their setup and test
           # steps skip after the per-job classifier, leaving a successful job.
@@ -775,6 +841,11 @@ jobs:
             success|skipped) ;;
             *) echo "::error::coverage-report is $coverage"; exit 1 ;;
           esac
+
+          [ "$package_preflight" = success ] || {
+            echo "::error::package-preflight is $package_preflight"
+            exit 1
+          }
 
           # session-store-locked is required for session/persistence/ changes,
           # and non-blocking elsewhere.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,6 +753,8 @@ jobs:
         with:
           filters: |
             packaging:
+              - "README.md"
+              - "LICENSE"
               - "pyproject.toml"
               - "uv.lock"
               - "bootstrap/**"
@@ -762,6 +764,7 @@ jobs:
               - "infrastructure/**"
               - "integrations/**"
               - "surfaces/**"
+              - "tests/**"
               - "tools/**"
               - ".github/workflows/ci.yml"
               - ".github/workflows/release.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,7 +755,10 @@ jobs:
             packaging:
               - "README.md"
               - "LICENSE"
+              - "MANIFEST.in"
               - "pyproject.toml"
+              - "setup.cfg"
+              - "setup.py"
               - "uv.lock"
               - "bootstrap/**"
               - "config/**"

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -179,19 +179,42 @@ def test_package_preflight_builds_and_smokes_changed_distribution_artifacts() ->
 
     changes = next(step for step in job["steps"] if step.get("id") == "changes")
     filters = yaml.safe_load(changes["with"]["filters"])
-    assert {"pyproject.toml", "uv.lock", "surfaces/**", "tools/**"} <= set(filters["packaging"])
+    assert {
+        "README.md",
+        "LICENSE",
+        "pyproject.toml",
+        "uv.lock",
+        "surfaces/**",
+        "tests/**",
+        "tools/**",
+    } <= set(filters["packaging"])
+
+    install_uv = next(step for step in job["steps"] if step.get("name") == "Install uv")
+    assert install_uv["if"] == "steps.changes.outputs.packaging == 'true'"
+    setup_python = next(step for step in job["steps"] if step.get("name") == "Set up Python")
+    assert setup_python["if"] == "steps.changes.outputs.packaging == 'true'"
 
     build = next(
         step for step in job["steps"] if step.get("name") == "Build and validate distributions"
     )
+    assert build["if"] == "steps.changes.outputs.packaging == 'true'"
     assert "python -m build --outdir dist" in build["run"]
     assert "twine check dist/*" in build["run"]
     assert "validate_wheel.py dist/*.whl" in build["run"]
 
     smoke = next(step for step in job["steps"] if step.get("name") == "Smoke the installed wheel")
+    assert smoke["if"] == "steps.changes.outputs.packaging == 'true'"
     assert "uv pip install --python" in smoke["run"]
     assert '"$smoke_env/bin/opensre" --version' in smoke["run"]
     assert '"$smoke_env/bin/opensre" _package-smoke' in smoke["run"]
+
+    gate_run = next(
+        step["run"]
+        for step in workflow["jobs"]["ci-gate"]["steps"]
+        if step.get("name") == "Require green upstream jobs"
+    )
+    assert "package_preflight='${{ needs.package-preflight.result }}'" in gate_run
+    assert '[ "$package_preflight" = success ]' in gate_run
 
 
 def test_source_filter_defaults_to_running_ci_for_new_file_types() -> None:

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -142,6 +142,7 @@ def test_quality_jobs_start_in_parallel_and_gate_aggregates_them() -> None:
     assert "needs" not in jobs["quality-typecheck"]
     assert "needs" not in jobs["test"]
     assert "needs" not in jobs["session-store-locked"]
+    assert "needs" not in jobs["package-preflight"]
     assert "Restore mypy cache" in {step.get("name") for step in jobs["quality-typecheck"]["steps"]}
     assert "Verify typed tool contracts" in {
         step.get("name") for step in jobs["quality-typecheck"]["steps"]
@@ -168,7 +169,29 @@ def test_quality_jobs_start_in_parallel_and_gate_aggregates_them() -> None:
         "test",
         "coverage-report",
         "session-store-locked",
+        "package-preflight",
     }
+
+
+def test_package_preflight_builds_and_smokes_changed_distribution_artifacts() -> None:
+    workflow = _workflow("ci.yml")
+    job = workflow["jobs"]["package-preflight"]
+
+    changes = next(step for step in job["steps"] if step.get("id") == "changes")
+    filters = yaml.safe_load(changes["with"]["filters"])
+    assert {"pyproject.toml", "uv.lock", "surfaces/**", "tools/**"} <= set(filters["packaging"])
+
+    build = next(
+        step for step in job["steps"] if step.get("name") == "Build and validate distributions"
+    )
+    assert "python -m build --outdir dist" in build["run"]
+    assert "twine check dist/*" in build["run"]
+    assert "validate_wheel.py dist/*.whl" in build["run"]
+
+    smoke = next(step for step in job["steps"] if step.get("name") == "Smoke the installed wheel")
+    assert "uv pip install --python" in smoke["run"]
+    assert '"$smoke_env/bin/opensre" --version' in smoke["run"]
+    assert '"$smoke_env/bin/opensre" _package-smoke' in smoke["run"]
 
 
 def test_source_filter_defaults_to_running_ci_for_new_file_types() -> None:

--- a/tests/github_ci/test_pr_pipeline_slo.py
+++ b/tests/github_ci/test_pr_pipeline_slo.py
@@ -182,7 +182,10 @@ def test_package_preflight_builds_and_smokes_changed_distribution_artifacts() ->
     assert {
         "README.md",
         "LICENSE",
+        "MANIFEST.in",
         "pyproject.toml",
+        "setup.cfg",
+        "setup.py",
         "uv.lock",
         "surfaces/**",
         "tests/**",


### PR DESCRIPTION
Fixes #5966

  #### Describe the changes you have made in this PR -

  - Added a path-scoped `package-preflight` CI job for packaging-relevant changes.
  - The job builds wheel and sdist artifacts, runs `twine check`, validates wheel data, and installs the wheel in a clean environment.
  - Added installed-artifact smoke checks for `opensre --version` and `opensre _package-smoke`.
  - Made `CI Gate` fail if the preflight fails.
  - Added a workflow-contract test for the new job.

  Explain your implementation approach:

  The existing PR test matrix validates a source checkout but does not build distributable artifacts. The new job runs only when packaging-relevant paths change, keeping unrelated PRs fast.

  It uses the existing release build commands for artifact creation and metadata validation. The wheel is then installed into a separate environment and invoked from outside the checkout, ensuring the smoke test exercises the installed artifact rather than local
  source files. CI Gate requires the job to succeed, while unchanged packaging paths complete without running the build.

 