### PR TITLE
ci(test-scope): cover scheduler-dependent test suites

### DIFF
--- a/.github/ci/test_scope_rules.py
+++ b/.github/ci/test_scope_rules.py
@@ -542,7 +542,16 @@ RULES: tuple[PathRule, ...] = (
     PathRule("gateway/", ("gateway/tests/",)),
     PathRule("tools/", ("tests/tools/",)),
     PathRule("infrastructure/analytics/", ("tests/analytics/",)),
-    PathRule("infrastructure/scheduling/", ("tests/scheduler/",)),
+    PathRule(
+        "infrastructure/scheduling/",
+        (
+            "tests/scheduler/",
+            "tests/cli/",
+            "tests/tools/",
+            "tests/interactive_shell/",
+            "tests/infrastructure/",
+        ),
+    ),
     # Without this rule a change under infrastructure/filestorage/ matches nothing,
     # and the credential deny-list tests only run via the no-targets fallback —
     # which a diff that also touches any test file silently defeats.

--- a/.github/ci/test_scope_rules.py
+++ b/.github/ci/test_scope_rules.py
@@ -542,6 +542,7 @@ RULES: tuple[PathRule, ...] = (
     PathRule("gateway/", ("gateway/tests/",)),
     PathRule("tools/", ("tests/tools/",)),
     PathRule("infrastructure/analytics/", ("tests/analytics/",)),
+    PathRule("infrastructure/scheduling/", ("tests/scheduler/",)),
     # Without this rule a change under infrastructure/filestorage/ matches nothing,
     # and the credential deny-list tests only run via the no-targets fallback —
     # which a diff that also touches any test file silently defeats.

--- a/tests/github_ci/test_test_scope_rules.py
+++ b/tests/github_ci/test_test_scope_rules.py
@@ -16,7 +16,13 @@ def test_scheduler_source_changes_run_scheduler_suite() -> None:
     escalate, targets, areas = classify(["infrastructure/scheduling/scheduler/runner.py"])
 
     assert escalate is False
-    assert targets == ["tests/scheduler/"]
+    assert targets == [
+        "tests/scheduler/",
+        "tests/cli/",
+        "tests/tools/",
+        "tests/interactive_shell/",
+        "tests/infrastructure/",
+    ]
     assert areas == ["infrastructure/scheduling/"]
 
 
@@ -29,5 +35,12 @@ def test_scheduler_source_with_specific_test_still_runs_scheduler_suite() -> Non
     )
 
     assert escalate is False
-    assert targets == ["tests/scheduler/", "tests/scheduler/test_task_store.py"]
+    assert targets == [
+        "tests/scheduler/",
+        "tests/cli/",
+        "tests/tools/",
+        "tests/interactive_shell/",
+        "tests/infrastructure/",
+        "tests/scheduler/test_task_store.py",
+    ]
     assert areas == ["infrastructure/scheduling/"]

--- a/tests/github_ci/test_test_scope_rules.py
+++ b/tests/github_ci/test_test_scope_rules.py
@@ -1,0 +1,33 @@
+"""Regression tests for changed-path test target selection."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parents[2] / ".github" / "ci"
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+from test_scope_rules import classify  # noqa: E402
+
+
+def test_scheduler_source_changes_run_scheduler_suite() -> None:
+    escalate, targets, areas = classify(["infrastructure/scheduling/scheduler/runner.py"])
+
+    assert escalate is False
+    assert targets == ["tests/scheduler/"]
+    assert areas == ["infrastructure/scheduling/"]
+
+
+def test_scheduler_source_with_specific_test_still_runs_scheduler_suite() -> None:
+    escalate, targets, areas = classify(
+        [
+            "infrastructure/scheduling/scheduler/storage/task_store.py",
+            "tests/scheduler/test_task_store.py",
+        ]
+    )
+
+    assert escalate is False
+    assert targets == ["tests/scheduler/", "tests/scheduler/test_task_store.py"]
+    assert areas == ["infrastructure/scheduling/"]


### PR DESCRIPTION
<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Adds a `make test-scope` mapping from `infrastructure/scheduling/` changes to the scheduler test suite and its directly dependent test suites:

- `tests/scheduler/`
- `tests/cli/`
- `tests/tools/`
- `tests/interactive_shell/`
- `tests/infrastructure/`

Previously, scheduler source changes had no dedicated scope rule and could rely on the broad fallback behavior. This mapping keeps scheduler changes focused while ensuring dependent CLI, tool, interactive-shell, and infrastructure tests are also executed.

Added regression tests covering scheduler-only and mixed scheduler source/test changes.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<img width="979" height="339" alt="Screenshot 2026-09-06 at 12 00 39 AM" src="https://github.com/user-attachments/assets/c0ddbfa0-9ef6-42de-b698-d1ef6e22aa6e" />

<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The CI test-scope classifier maps changed source paths to the pytest targets that should run. Scheduler code previously had no mapping, so scheduler changes could be under-tested when dependent tests outside `tests/scheduler/` were not selected.

I added a focused `infrastructure/scheduling/` mapping to the scheduler suite and its known dependent test suites. Regression tests verify scheduler-only and mixed scheduler source/test changes. The change is isolated to CI test selection and does not alter application runtime behavior.
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
