### PR TITLE
fix(telegram): redact bot tokens from gateway poller errors

### DIFF
--- a/gateway/tests/telegram/test_telegram_client.py
+++ b/gateway/tests/telegram/test_telegram_client.py
@@ -33,3 +33,28 @@ def test_send_message_success_with_mapping_proxy_data(mock_post: MagicMock) -> N
     assert ok is True
     assert error == ""
     assert message_id == "42"
+
+
+@patch("gateway.transports.telegram.poller.client.post_json")
+def test_send_message_redacts_bot_token_from_transport_exception(
+    mock_post: MagicMock, caplog: object
+) -> None:
+    import logging
+
+    token = "123:SECRET"
+    safe_error = "Connection refused for https://api.telegram.org/bot<redacted>/sendMessage"
+    mock_post.return_value = DeliveryResponse(
+        ok=False,
+        error=f"Connection refused for https://api.telegram.org/bot{token}/sendMessage",
+        exc_type="ConnectError",
+    )
+    caplog.set_level(logging.WARNING, logger="gateway.transports.telegram.poller.client")
+
+    ok, error, message_id = TelegramBotClient(token).send_message("123", "hello")
+
+    assert ok is False
+    assert message_id == ""
+    assert error == safe_error
+    assert token not in error
+    assert token not in caplog.text
+    assert safe_error in caplog.text

--- a/gateway/tests/telegram/test_telegram_client.py
+++ b/gateway/tests/telegram/test_telegram_client.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from types import MappingProxyType
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from gateway.transports.telegram.poller.client import TelegramBotClient
 from infrastructure.delivery.notifications.delivery_transport import DeliveryResponse
 
@@ -37,7 +39,7 @@ def test_send_message_success_with_mapping_proxy_data(mock_post: MagicMock) -> N
 
 @patch("gateway.transports.telegram.poller.client.post_json")
 def test_send_message_redacts_bot_token_from_transport_exception(
-    mock_post: MagicMock, caplog: object
+    mock_post: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     import logging
 

--- a/gateway/tests/telegram/test_telegram_poller.py
+++ b/gateway/tests/telegram/test_telegram_poller.py
@@ -129,3 +129,27 @@ def test_poll_once_parses_callback_query(mock_get: MagicMock, mock_sleep: MagicM
     # Ensure getUpdates asked for callback_query updates.
     assert "callback_query" in mock_get.call_args.kwargs["params"]["allowed_updates"]
     mock_sleep.assert_not_called()
+
+
+@patch("gateway.transports.telegram.poller.poller.time.sleep")
+@patch("gateway.transports.telegram.poller.poller.httpx.get")
+def test_poll_once_redacts_bot_token_from_transport_exception(
+    mock_get: MagicMock,
+    mock_sleep: MagicMock,
+    caplog: object,
+) -> None:
+    import logging
+
+    token = "123:SECRET"
+    mock_get.side_effect = httpx.ConnectError(
+        f"Connection refused for https://api.telegram.org/bot{token}/getUpdates"
+    )
+    caplog.set_level(logging.DEBUG, logger="gateway.transports.telegram.poller.poller")
+
+    result = TelegramPoller(token).poll_once()
+
+    assert result == TelegramPollResult()
+    mock_sleep.assert_called_once_with(2.0)
+    assert token not in caplog.text
+    assert "https://api.telegram.org/bot<redacted>/getUpdates" in caplog.text
+    assert "ConnectError" in caplog.text

--- a/gateway/tests/telegram/test_telegram_poller.py
+++ b/gateway/tests/telegram/test_telegram_poller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from gateway.transports.telegram.poller.poller import (
     TelegramPoller,
@@ -136,7 +137,7 @@ def test_poll_once_parses_callback_query(mock_get: MagicMock, mock_sleep: MagicM
 def test_poll_once_redacts_bot_token_from_transport_exception(
     mock_get: MagicMock,
     mock_sleep: MagicMock,
-    caplog: object,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     import logging
 

--- a/gateway/transports/telegram/poller/client.py
+++ b/gateway/transports/telegram/poller/client.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 from typing import Any
 
 from infrastructure.delivery.notifications.delivery_transport import post_json
+from infrastructure.delivery.notifications.redaction import redact_token
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class TelegramBotClient:
             payload=payload,
         )
         if not response.ok:
-            return False, {}, response.error
+            return False, {}, redact_token(response.error, self._token)
         if response.status_code != HTTPStatus.OK or not isinstance(response.data, Mapping):
             return False, {}, response.text or f"HTTP {response.status_code}"
         if not response.data.get("ok"):

--- a/gateway/transports/telegram/poller/poller.py
+++ b/gateway/transports/telegram/poller/poller.py
@@ -18,6 +18,7 @@ from gateway.transports.telegram.settings import (
     TelegramCallbackQuery,
     TelegramInboundMessage,
 )
+from infrastructure.delivery.notifications.redaction import redact_token
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,12 @@ class TelegramPoller:
         try:
             response = httpx.get(url, params=params, timeout=float(self._timeout + 5))
         except Exception as exc:
-            self._log_transient("[telegram-gateway] getUpdates failed: %s", exc)
+            safe_error = redact_token(str(exc), self._token)
+            self._log_transient(
+                "[telegram-gateway] getUpdates failed (%s): %s",
+                type(exc).__name__,
+                safe_error,
+            )
             time.sleep(_DEFAULT_RETRY_SECONDS)
             return TelegramPollResult()
 


### PR DESCRIPTION
Fixes #4769

Telegram gateway poller errors could expose a live bot token because transient HTTP exceptions may include the full `https://api.telegram.org/bot{token}/...` URL.

This PR redacts the token at the two leak points identified in the issue:

* `TelegramPoller.poll_once()` now redacts the exception message before logging it, while keeping the exception type for debugging.
* `TelegramBotClient._call()` now redacts transport errors before returning them to callers.

The change uses the existing shared `redact_token` helper and keeps the current retry, backoff, HTTP response, and success-path behavior unchanged.

Added regression tests covering both cases:

* token must not appear in `getUpdates` exception logs
* token must not appear in caller-visible client errors

### Demo/Screenshot for feature changes and bug fixes -

Focused Telegram tests:

```text
9 passed in 2.91s
```

Validation:

```text
ruff check      -> All checks passed
ruff format     -> 4 files already formatted
mypy            -> Success: no issues found in 2 source files
```

The full `gateway/tests` suite was also run locally. It reported 9 failures and 2 teardown errors that reproduce unchanged on a clean `upstream/main` worktree on Windows, including POSIX file permission assertions, `os.WNOHANG`, and existing import-boundary checks. The Telegram tests affected by this PR remain fully green.

---

**Explain your implementation approach:**

The fix is intentionally scoped to the two credential leak boundaries described in #4769. Instead of changing the shared HTTP transport or Telegram retry behavior, the token is redacted where Telegram-specific errors are logged or returned.

This keeps the existing behavior intact while ensuring transient transport exceptions cannot expose the bot token through gateway logs or caller-visible error strings.

---

