### PR TITLE
fix(guardrails): load no rules instead of raising when the rules key is empty

### DIFF
--- a/infrastructure/safety/guardrails/rules.py
+++ b/infrastructure/safety/guardrails/rules.py
@@ -61,8 +61,17 @@ def load_rules(path: Path | None = None) -> list[GuardrailRule]:
         logger.warning("Guardrails config missing 'rules' key at %s", rules_path)
         return []
 
+    entries = raw["rules"]
+    if not isinstance(entries, list):
+        logger.warning(
+            "Guardrails config 'rules' must be a list at %s, got %s; ignoring",
+            rules_path,
+            type(entries).__name__,
+        )
+        return []
+
     rules: list[GuardrailRule] = []
-    for entry in raw["rules"]:
+    for entry in entries:
         if not isinstance(entry, dict):
             continue
         parsed = _parse_rule(entry)

--- a/tests/infrastructure/safety/guardrails/test_rules.py
+++ b/tests/infrastructure/safety/guardrails/test_rules.py
@@ -26,6 +26,16 @@ class TestLoadRules:
         path = _write_config(tmp_path, {"version": 1})
         assert load_rules(path) == []
 
+    def test_returns_empty_when_rules_key_is_empty(self, tmp_path: Path) -> None:
+        # "rules:" with every entry commented out parses as None, not a list.
+        path = tmp_path / "guardrails.yml"
+        path.write_text("rules:", encoding="utf-8")
+        assert load_rules(path) == []
+
+    def test_returns_empty_when_rules_key_is_not_a_list(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, {"rules": "aws_key"})
+        assert load_rules(path) == []
+
     def test_parses_pattern_rule(self, tmp_path: Path) -> None:
         path = _write_config(
             tmp_path,


### PR DESCRIPTION
Fixes #6033

#### Describe the changes you have made in this PR -

`load_rules` says it returns an empty list for a missing or malformed config, and it guards the missing-key case. It does not guard the key being present with nothing under it. A `rules:` block with every entry commented out parses as `None`, and `for entry in raw["rules"]` then raises `TypeError`. The `try` only covers `yaml.safe_load`, so nothing catches it.

Commenting out your rules is the obvious way to turn guardrails off for a moment, so this is easy to hit by hand. The exception escapes `load_rules`, which means `get_guardrail_evaluator()` cannot build its singleton, and `opensre health` raises while rendering the guardrails row.

The fix checks that the value is a list before iterating it. That also closes a quieter hole next to it: `rules: aws_key` was already returning `[]`, but only because iterating a string yields characters that each fail the per-entry `isinstance(entry, dict)` test. The wrong shape was accepted in silence; it is now rejected explicitly and logged, so a typo in the config says so instead of behaving like an empty rule set.

### Demo/Screenshot for feature changes and bug fixes -

Before:

```
  rules: (empty)             -> TypeError: 'NoneType' object is not iterable
  rules: with only comments  -> TypeError: 'NoneType' object is not iterable
  rules: []                  -> []
```

After:

```
  rules: (empty)             -> []
  rules: with only comments  -> []
  rules: []                  -> []
```

The new test fails on `main`:

```
$ git stash push -- infrastructure/safety/guardrails/rules.py
$ uv run pytest tests/infrastructure/safety/guardrails/test_rules.py -k "is_empty"
FAILED tests/.../test_rules.py::TestLoadRules::test_returns_empty_when_rules_key_is_empty
E   TypeError: 'NoneType' object is not iterable
```

Local checks:

```
$ uv run pytest tests/infrastructure/safety/guardrails/ -q
115 passed
$ uv run ruff check infrastructure/safety/guardrails/rules.py tests/infrastructure/safety/guardrails/test_rules.py
All checks passed!
$ uv run ruff format --check ...
2 files already formatted
$ uv run mypy infrastructure/safety/guardrails/rules.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The function's contract is that a bad config degrades to "no rules" rather than propagating, and the existing guard only covers one of the two ways the `rules` key can be unusable. Rather than widen the `try` to swallow `TypeError`, I validated the shape, because catching the exception would also swallow a genuine bug inside `_parse_rule` and report it as an empty rule set.

There is one new branch: after confirming `rules` is present, check `isinstance(entries, list)` and return `[]` with a warning naming the type that was found. Everything downstream is unchanged; the loop now iterates a value that has been proven to be a list.

Edge cases I checked: `rules:` with nothing under it and with only comments (both `None`, both now `[]`), `rules: []` (already correct, still correct), `rules: aws_key` (a string, previously iterated character by character in silence, now rejected and logged), and `rules: {name: x}` (a dict, previously iterated as keys, now rejected). The missing-file, malformed-YAML and missing-key paths are untouched and still covered by the existing tests.

I added two tests. The empty-key one is the regression test and fails on `main`. The non-list one passes on `main` as well, since the old code happened to reach the same return value by a different route; I kept it because it pins the new explicit branch, and I have called out that it is not a failing-before test rather than implying otherwise.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
