### PR TITLE
fix(aws): stop a malformed Lambda START line aborting get_recent_invocations

### DIFF
--- a/integrations/aws/lambda_client.py
+++ b/integrations/aws/lambda_client.py
@@ -156,6 +156,21 @@ def get_function_code(
         return {"success": False, "error": str(e)}
 
 
+def _token_after(message: str, label: str) -> str | None:
+    """First whitespace-delimited token following *label* in *message*, or None.
+
+    ``filter_log_events`` returns every event in the function's log group,
+    including the function's own stdout, so a line can carry a label without
+    the value that normally follows it. Both the label-value separator and the
+    value itself are therefore treated as optional.
+    """
+    _, separator, rest = message.partition(label)
+    if not separator:
+        return None
+    tokens = rest.split()
+    return tokens[0] if tokens else None
+
+
 def get_recent_invocations(
     function_name: str,
     limit: int = 50,
@@ -204,9 +219,7 @@ def get_recent_invocations(
             if "START RequestId:" in message:
                 if current_invocation:
                     invocations.append(current_invocation)
-                request_id = (
-                    message.split("RequestId: ")[1].split()[0] if "RequestId:" in message else None
-                )
+                request_id = _token_after(message, "RequestId:")
                 current_invocation = {
                     "request_id": request_id,
                     "start_time": timestamp,
@@ -219,13 +232,13 @@ def get_recent_invocations(
             elif "REPORT RequestId:" in message:
                 if current_invocation:
                     current_invocation["logs"].append(message)
-                    if "Duration:" in message:
-                        with suppress(IndexError, ValueError):
-                            duration_part = message.split("Duration: ")[1].split()[0]
+                    duration_part = _token_after(message, "Duration:")
+                    if duration_part is not None:
+                        with suppress(ValueError):
                             current_invocation["duration_ms"] = float(duration_part)
-                    if "Memory Used:" in message:
-                        with suppress(IndexError, ValueError):
-                            memory_part = message.split("Memory Used: ")[1].split()[0]
+                    memory_part = _token_after(message, "Memory Used:")
+                    if memory_part is not None:
+                        with suppress(ValueError):
                             current_invocation["memory_used_mb"] = int(memory_part)
                     invocations.append(current_invocation)
                     current_invocation = None

--- a/tests/integrations/aws/test_lambda_client.py
+++ b/tests/integrations/aws/test_lambda_client.py
@@ -262,6 +262,49 @@ def test_get_function_code_corrupt_zip(mock_lambda_client) -> None:
     assert "extract_error" in result["data"]
 
 
+def test_get_recent_invocations_start_line_without_a_value(mock_logs_client) -> None:
+    # The log group also carries the function's own stdout, so a START-shaped
+    # line can arrive with no request id after the label.
+    mock_logs_client.filter_log_events.return_value = {
+        "events": [
+            {"timestamp": 1000, "message": "START RequestId: \n"},
+            {"timestamp": 1050, "message": "log line\n"},
+        ]
+    }
+
+    result = get_recent_invocations("test-func")
+
+    assert result["success"] is True
+    assert result["data"]["invocations"][0]["request_id"] is None
+
+
+def test_get_recent_invocations_start_line_without_a_space(mock_logs_client) -> None:
+    mock_logs_client.filter_log_events.return_value = {
+        "events": [{"timestamp": 1000, "message": "START RequestId:req9 Version: $LATEST\n"}]
+    }
+
+    result = get_recent_invocations("test-func")
+
+    assert result["success"] is True
+    assert result["data"]["invocations"][0]["request_id"] == "req9"
+
+
+def test_get_recent_invocations_report_line_without_values(mock_logs_client) -> None:
+    mock_logs_client.filter_log_events.return_value = {
+        "events": [
+            {"timestamp": 1000, "message": "START RequestId: req1\n"},
+            {"timestamp": 1100, "message": "REPORT RequestId: req1\tDuration:\tMemory Used:\n"},
+        ]
+    }
+
+    result = get_recent_invocations("test-func")
+
+    assert result["success"] is True
+    invocation = result["data"]["invocations"][0]
+    assert "duration_ms" not in invocation
+    assert "memory_used_mb" not in invocation
+
+
 def test_get_recent_invocations_multiple(mock_logs_client) -> None:
     # Test grouping of multiple overlapping/sequential invocations
     mock_logs_client.filter_log_events.return_value = {


### PR DESCRIPTION
Fixes #6035

#### Describe the changes you have made in this PR -

The request-id parse in `get_recent_invocations` splits on `RequestId: ` but guards on `RequestId:`, so the guard cannot prevent the failure it looks like it is there for. Two shapes break it: a `START` line with no space after the colon leaves `split()` returning a single element, and a `START` line with nothing after the label leaves `[1]` empty so `.split()[0]` raises. Either way it is an `IndexError`.

`get_recent_invocations` catches only `ClientError`, so that `IndexError` escapes the function. One malformed line does not cost you a request id, it costs you the entire tool call, including the invocations that parsed correctly before it.

Worth noting where the input comes from: `filter_log_events` returns every event in `/aws/lambda/<function>`, which includes whatever the function itself wrote to stdout, not just the `START`, `END` and `REPORT` preamble AWS generates. The parser is reading untrusted text. The two sibling parses in the same block already treat it that way, both wrapped in `suppress(IndexError, ValueError)`; the request-id parse is the only one that does not.

Since all three parses are the same operation, I pulled it into `_token_after(message, label)` rather than adding a third guard. It partitions on the label, so the separating space is optional, and returns `None` when the label is absent or carries no value. The numeric parses keep `suppress(ValueError)` for the conversion itself, which is a different failure from a missing token and still needs handling.

Behavior on well-formed AWS lines is unchanged. `Duration:` still resolves to the real duration rather than `Billed Duration:`, and `Memory Used:` still resolves to the value in `Max Memory Used:`, because `partition` matches the first occurrence exactly as the previous `split` did.

### Demo/Screenshot for feature changes and bug fixes -

Before:

```
  normal AWS line          -> ok, request_id='8f1d2c3b-0000'
  no space after colon     -> IndexError: list index out of range
  nothing after the label  -> IndexError: list index out of range
```

After:

```
  normal AWS line          -> ok, request_id='8f1d2c3b-0000'
  no space after colon     -> ok, request_id='8f1d2c3b-0000'
  nothing after the label  -> ok, request_id=None
```

Two of the three new tests fail on `main`. The third covers the `REPORT` line and passes on both sides, which is what shows the refactor of the already-guarded parses is behavior preserving:

```
$ git stash push -- integrations/aws/lambda_client.py
$ uv run pytest tests/integrations/aws/test_lambda_client.py -k "without_a_value or without_a_space or without_values"
FAILED ...::test_get_recent_invocations_start_line_without_a_value
FAILED ...::test_get_recent_invocations_start_line_without_a_space
PASSED ...::test_get_recent_invocations_report_line_without_values
E   IndexError: list index out of range
```

Local checks:

```
$ uv run pytest tests/integrations/aws/ tests/tools/test_lambda_invocation_logs_tool.py tests/tools/test_lambda_errors_tool.py -q
172 passed
$ uv run ruff check integrations/aws/lambda_client.py tests/integrations/aws/test_lambda_client.py
All checks passed!
$ uv run ruff format --check ...
2 files already formatted
$ uv run mypy integrations/aws/lambda_client.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The narrow fix would have been a third `suppress(IndexError)` around the request-id line. I did not do that, because the block would then contain three copies of `split(label)[1].split()[0]`, each with its own guard, and the shared bug is that the expression is unsafe rather than that one caller forgot to wrap it. One helper removes the failure mode from all three sites at once and leaves nothing to forget at the fourth.

`_token_after(message, label)` uses `str.partition`, which returns a three-tuple and never raises. The empty separator is what says the label was absent, which is why the check is on `separator` rather than on the remainder; a label sitting at the very end of the line yields an empty remainder, and that is a real match with no value, not a miss. `rest.split()` then collapses any run of whitespace, so it handles the tab-delimited `REPORT` lines AWS emits as well as the space-delimited `START` lines, and returns `[]` rather than raising when nothing follows.

Passing the label without its trailing space is what fixes the no-space input: `partition` finds `RequestId:` in both `RequestId: req9` and `RequestId:req9`, and `split()` discards the separating whitespace when there is any.

Edge cases I checked: label absent entirely, label at end of line with no value, label with no space before the value, tab-separated `REPORT` fields, `Duration:` appearing again inside `Billed Duration:` (first match wins, same as before), `Memory Used:` appearing inside `Max Memory Used:` (same), and a non-numeric value after `Duration:`, which `suppress(ValueError)` still drops.

The one behavior change beyond the crash is intentional: a `START` line with no space after the colon now yields the request id instead of raising, rather than yielding `None`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
