### PR TITLE
fix(scheduler): preserve concurrent task edits and failed-only recovery scope

### DIFF
--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -182,7 +182,14 @@ and attempt key. Each attempt has a 30-minute lease and a random owner token:
 
 The scheduler also runs a recovery sweep every minute, including after a
 restart. It finds expired running attempts and resubmits their original
-fire-time keys through the same claim path.
+fire-time keys through the same claim path. Recovery preserves the destination
+restriction of a `--failed-only` retry, so it does not resend to destinations
+outside that retry's scope.
+
+Attempts created before delivery scopes were persisted cannot safely recover
+automatically. They appear as failed runs with a delivery-scope error; use
+`opensre cron run <task-id> --failed-only` when readable per-target history exists,
+or explicitly rerun the task for all destinations after checking its logs.
 
 This prevents concurrent duplicate claims and recovers ticks after worker
 crashes. A crash after an external provider accepts a message but before the

--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -52,7 +52,7 @@ def execute_task(
         False if the claim was lost (another instance handled it) or delivery failed.
     """
     # Attempt to claim this execution slot
-    claim = try_claim(task.id, fire_time)
+    claim = try_claim(task.id, fire_time, target_filter=target_filter)
     if claim is None:
         logger.info(
             "Task %s fire_time=%s already claimed by another instance",
@@ -76,6 +76,16 @@ def execute_task(
         status=TaskStatus.RUNNING,
     )
     _emit_analytics_started(task)
+
+    if claim.target_filter == frozenset():
+        _record_failure(
+            claim,
+            task,
+            fire_time,
+            "No delivery destinations authorized for this attempt; run the task explicitly.",
+            stage="delivery_scope",
+        )
+        return False
 
     # Build the message
     try:
@@ -116,7 +126,7 @@ def execute_task(
         return True
 
     # Fan out to every destination the task resolves to, concurrently.
-    result = _deliver_all(task, message, target_filter=target_filter)
+    result = _deliver_all(task, message, target_filter=claim.target_filter)
     message_id = result.message_id()
     error = result.error()
 

--- a/infrastructure/scheduling/scheduler/runner.py
+++ b/infrastructure/scheduling/scheduler/runner.py
@@ -31,6 +31,7 @@ from infrastructure.scheduling.scheduler.storage import (
     get_expired_claims,
     get_task,
     list_tasks,
+    record_task_success,
     update_task,
 )
 from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskStatus
@@ -134,10 +135,7 @@ def _scheduled_job(task_id: str, runners: SchedulerRunners) -> None:
     result = execute_task(task, fire_time, runners)
 
     if result:
-        task.last_run = datetime.now(UTC).isoformat()
-        if task.params.get("disable_after_success", "").strip().lower() == "true":
-            task.enabled = False
-        update_task(task)
+        record_task_success(task.id)
 
 
 def _recover_expired_tasks(

--- a/infrastructure/scheduling/scheduler/storage/__init__.py
+++ b/infrastructure/scheduling/scheduler/storage/__init__.py
@@ -20,6 +20,7 @@ from infrastructure.scheduling.scheduler.storage.task_store import (
     default_task_store_path,
     get_task,
     list_tasks,
+    record_task_success,
     remove_task,
     update_task,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "get_runs",
     "get_task",
     "list_tasks",
+    "record_task_success",
     "remove_task",
     "run_database_path",
     "try_claim",

--- a/infrastructure/scheduling/scheduler/storage/migrations.py
+++ b/infrastructure/scheduling/scheduler/storage/migrations.py
@@ -25,6 +25,7 @@ _TASK_RUNS_SCHEMA = """
         targets TEXT DEFAULT '',
         owner_token TEXT NOT NULL DEFAULT '',
         lease_expires_at TEXT NOT NULL DEFAULT '',
+        target_filter TEXT NOT NULL DEFAULT '[]',
         UNIQUE(task_id, fire_time, attempt)
     )
 """
@@ -91,7 +92,7 @@ def _add_missing_columns(conn: sqlite3.Connection) -> None:
 def apply_migrations(conn: sqlite3.Connection) -> None:
     """Create or migrate the task-runs schema under one SQLite write lock."""
     columns = _table_columns(conn)
-    if {"attempt", "targets"} <= columns:
+    if {"attempt", "targets", "target_filter"} <= columns:
         return
 
     conn.execute("BEGIN IMMEDIATE")
@@ -102,6 +103,12 @@ def apply_migrations(conn: sqlite3.Connection) -> None:
         elif "attempt" not in columns:
             _migrate_legacy_claim_table(conn, columns)
         _add_missing_columns(conn)
+        if "target_filter" not in _table_columns(conn):
+            # Old attempts did not record whether delivery was restricted.
+            # An empty scope prevents automatic recovery from widening it.
+            conn.execute(
+                "ALTER TABLE task_runs ADD COLUMN target_filter TEXT NOT NULL DEFAULT '[]'"
+            )
         conn.commit()
     except Exception:
         conn.rollback()

--- a/infrastructure/scheduling/scheduler/storage/run_store.py
+++ b/infrastructure/scheduling/scheduler/storage/run_store.py
@@ -13,7 +13,7 @@ from typing import Any
 from uuid import uuid4
 
 import infrastructure.scheduling.scheduler.storage.database as database
-from infrastructure.scheduling.scheduler.types import DeliveryOutcome, TaskRun, TaskStatus
+from infrastructure.scheduling.scheduler.types import DeliveryOutcome, Provider, TaskRun, TaskStatus
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,7 @@ class ExecutionClaim:
     fire_time: str
     attempt: int
     owner_token: str
+    target_filter: frozenset[tuple[Provider, str]] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,7 +49,13 @@ class ExpiredClaim:
     fire_time: str
 
 
-def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> ExecutionClaim | None:
+def try_claim(
+    task_id: str,
+    fire_time: str,
+    db_path: Path | None = None,
+    *,
+    target_filter: frozenset[tuple[Provider, str]] | None = None,
+) -> ExecutionClaim | None:
     """Claim a task tick or reclaim it when the current lease has expired."""
     try:
         with database.transaction(db_path, immediate=True) as conn:
@@ -56,7 +63,7 @@ def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> Exec
             now_text = now.isoformat()
             lease_text = (now + timedelta(seconds=_CLAIM_LEASE_SECONDS)).isoformat()
             row = conn.execute(
-                "SELECT attempt, status, lease_expires_at FROM task_runs "
+                "SELECT attempt, status, lease_expires_at, target_filter FROM task_runs "
                 "WHERE task_id = ? AND fire_time = ? ORDER BY attempt DESC LIMIT 1",
                 (task_id, fire_time),
             ).fetchone()
@@ -80,6 +87,7 @@ def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> Exec
                         TaskStatus.RUNNING.value,
                     ),
                 )
+                target_filter = _decode_target_filter(row[3])
                 attempt += 1
             else:
                 attempt = 1
@@ -88,7 +96,7 @@ def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> Exec
             conn.execute(
                 "INSERT INTO task_runs "
                 "(task_id, fire_time, attempt, started_at, status, owner_token, "
-                "lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "lease_expires_at, target_filter) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     task_id,
                     fire_time,
@@ -97,11 +105,35 @@ def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> Exec
                     TaskStatus.RUNNING.value,
                     owner_token,
                     lease_text,
+                    json.dumps(sorted(target_filter) if target_filter is not None else None),
                 ),
             )
-            return ExecutionClaim(task_id, fire_time, attempt, owner_token)
+            return ExecutionClaim(task_id, fire_time, attempt, owner_token, target_filter)
     except sqlite3.IntegrityError:
         return None
+
+
+def _decode_target_filter(raw: str) -> frozenset[tuple[Provider, str]] | None:
+    """Read durable delivery scope; unknown or malformed scope never widens."""
+    try:
+        entries = json.loads(raw)
+        if entries is None:
+            return None
+        if not isinstance(entries, list):
+            raise ValueError("delivery scope must be a list")
+        targets: set[tuple[Provider, str]] = set()
+        for entry in entries:
+            if (
+                not isinstance(entry, list)
+                or len(entry) != 2
+                or not all(isinstance(value, str) for value in entry)
+            ):
+                raise ValueError("invalid delivery scope entry")
+            targets.add((Provider(entry[0]), entry[1]))
+        return frozenset(targets)
+    except (ValueError, TypeError):
+        logger.warning("Refusing recovery delivery with unreadable scope")
+        return frozenset()
 
 
 def get_expired_claims(

--- a/infrastructure/scheduling/scheduler/storage/task_store.py
+++ b/infrastructure/scheduling/scheduler/storage/task_store.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import time
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -281,11 +282,28 @@ def update_task(task: ScheduledTask, store_path: Path | None = None) -> bool:
     return False
 
 
+def record_task_success(task_id: str, store_path: Path | None = None) -> bool:
+    """Update completion fields on the latest task while preserving user edits."""
+    path = store_path or default_task_store_path()
+    with FileLock(_lock_path(path)):
+        raw = _load_raw(path)
+        for entry in raw:
+            if entry.get("id") == task_id:
+                task = ScheduledTask.model_validate(entry)
+                entry["last_run"] = datetime.now(UTC).isoformat()
+                if task.params.get("disable_after_success", "").strip().lower() == "true":
+                    entry["enabled"] = False
+                _save_raw(path, raw)
+                return True
+    return False
+
+
 __all__ = [
     "add_task",
     "default_task_store_path",
     "get_task",
     "list_tasks",
+    "record_task_success",
     "remove_task",
     "update_task",
 ]

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -119,6 +119,114 @@ def _expire_claim(db_path: Path, task_id: str, fire_time: str) -> None:
 
 @pytest.mark.usefixtures("_tmp_stores")
 class TestExecutor:
+    @pytest.mark.parametrize("mutation", ["pause_and_edit", "delete"])
+    def test_completion_preserves_concurrent_task_changes(self, mutation: str) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        from infrastructure.scheduling.scheduler.runner import _scheduled_job
+        from infrastructure.scheduling.scheduler.storage import get_task, remove_task, update_task
+
+        task = add_task(
+            ScheduledTask(
+                kind=TaskKind.MANUAL_LOOP,
+                cron="0 9 * * *",
+                provider=Provider.SLACK,
+                chat_id="original",
+            )
+        )
+        started = threading.Event()
+        release = threading.Event()
+
+        def build_while_editing(*_args: object) -> str:
+            started.set()
+            assert release.wait(_SYNC_TIMEOUT_SECONDS)
+            return "report"
+
+        _install_fake_bundle()
+        with (
+            patch(
+                "infrastructure.scheduling.scheduler.executor.build_message", build_while_editing
+            ),
+            ThreadPoolExecutor(max_workers=1) as pool,
+        ):
+            future = pool.submit(_scheduled_job, task.id, real_runners())
+            try:
+                assert started.wait(_SYNC_TIMEOUT_SECONDS)
+                if mutation == "delete":
+                    assert remove_task(task.id)
+                else:
+                    edited = get_task(task.id)
+                    assert edited is not None
+                    edited.enabled = False
+                    edited.chat_id = "edited"
+                    edited.cron = "0 10 * * *"
+                    edited.params = {"loop_prompt": "new prompt"}
+                    assert update_task(edited)
+            finally:
+                release.set()
+            future.result(timeout=_SYNC_TIMEOUT_SECONDS)
+        stored = get_task(task.id)
+        if mutation == "delete":
+            assert stored is None
+        else:
+            assert stored is not None
+            assert stored.enabled is False
+            assert stored.chat_id == "edited"
+            assert stored.cron == "0 10 * * *"
+            assert stored.params == {"loop_prompt": "new prompt"}
+            assert stored.last_run is not None
+
+    def test_failed_only_retry_retains_scope_after_crash(self, tmp_path: Path) -> None:
+        from infrastructure.scheduling.scheduler.runner import run_task_now
+
+        task = add_task(
+            ScheduledTask(
+                kind=TaskKind.MANUAL_LOOP,
+                cron="0 9 * * *",
+                provider=Provider.SLACK,
+                params={
+                    "delivery_targets": json.dumps(
+                        [
+                            {"provider": "slack", "chat_id": "C123"},
+                            {"provider": "telegram", "chat_id": "456"},
+                        ]
+                    )
+                },
+            )
+        )
+        adapters = _install_fake_bundle()
+        adapters[Provider.TELEGRAM].result = (False, "unavailable", "")
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message", return_value="report"
+        ):
+            assert execute_task(task, "2026-01-01T09:00Z", real_runners())
+        assert len(adapters[Provider.SLACK].calls) == 1
+        with (
+            patch(
+                "infrastructure.scheduling.scheduler.executor.build_message",
+                side_effect=KeyboardInterrupt,
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            run_task_now(task.id, real_runners(), only_failed=True)
+        crashed = get_runs(task.id)[0]
+        assert crashed.status is TaskStatus.RUNNING
+        _expire_claim(tmp_path / "scheduler.db", task.id, crashed.fire_time)
+        adapters[Provider.TELEGRAM].calls.clear()
+        adapters[Provider.TELEGRAM].result = (True, "", "recovered")
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message", return_value="report"
+        ):
+            _recover_expired_tasks(real_runners())
+        assert len(adapters[Provider.SLACK].calls) == 1
+        assert len(adapters[Provider.TELEGRAM].calls) == 1
+        recovered = get_runs(task.id)[0]
+        assert recovered.attempt == 2
+        assert recovered.status is TaskStatus.SUCCESS
+        assert [(target.provider, target.chat_id) for target in recovered.targets] == [
+            (Provider.TELEGRAM, "456")
+        ]
+
     def test_crash_before_build_is_recovered_by_a_new_attempt(self, tmp_path: Path) -> None:
         from infrastructure.scheduling.scheduler.storage.run_store import get_runs, try_claim
 

--- a/tests/scheduler/test_run_store.py
+++ b/tests/scheduler/test_run_store.py
@@ -627,3 +627,66 @@ class TestLatestTargetedRun:
         conn.close()
 
         assert get_latest_targeted_run("task1", db_path=db_path) is None
+
+
+@pytest.mark.parametrize("scope", [None, frozenset(), frozenset({(Provider.SLACK, "C123")})])
+def test_reclaim_preserves_original_delivery_scope(
+    db_path: Path, scope: frozenset[tuple[Provider, str]] | None
+) -> None:
+    first = try_claim("task", "tick", db_path=db_path, target_filter=scope)
+    assert first is not None
+    _expire_claim(db_path, "task", "tick")
+    reclaimed = try_claim(
+        "task", "tick", db_path=db_path, target_filter=frozenset({(Provider.TELEGRAM, "other")})
+    )
+    assert reclaimed is not None
+    assert reclaimed.target_filter == scope
+
+
+def test_scope_migration_preserves_claims_and_refuses_unknown_delivery(db_path: Path) -> None:
+    claim = _claimed(db_path, "task", "tick")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("ALTER TABLE task_runs DROP COLUMN target_filter")
+    _expire_claim(db_path, "task", "tick")
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(lambda _: get_runs("task", db_path=db_path), range(4)))
+    assert all(len(runs) == 1 for runs in results)
+    reclaimed = try_claim("task", "tick", db_path=db_path)
+    assert reclaimed is not None
+    assert reclaimed.target_filter == frozenset()
+    assert not complete_run(claim, status=TaskStatus.SUCCESS, db_path=db_path)
+
+
+@pytest.mark.parametrize("raw", ['{"provider":"slack"}', '[["unknown", "chat"]]', "broken"])
+def test_malformed_scope_cannot_widen_recovery(db_path: Path, raw: str) -> None:
+    _claimed(db_path, "task", "tick")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE task_runs SET target_filter = ?", (raw,))
+    _expire_claim(db_path, "task", "tick")
+    reclaimed = try_claim("task", "tick", db_path=db_path)
+    assert reclaimed is not None
+    assert reclaimed.target_filter == frozenset()
+
+
+def test_delivery_scope_migration_rolls_back_on_failure(db_path: Path) -> None:
+    class FailScopeMigration(sqlite3.Connection):
+        def execute(self, sql: str, parameters: object = (), /) -> sqlite3.Cursor:
+            if sql.startswith("ALTER TABLE task_runs ADD COLUMN target_filter"):
+                raise sqlite3.OperationalError("injected migration failure")
+            return super().execute(sql, parameters)
+
+    _claimed(db_path, "task", "tick")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("ALTER TABLE task_runs DROP COLUMN target_filter")
+        conn.execute("ALTER TABLE task_runs DROP COLUMN targets")
+    conn = sqlite3.connect(db_path, factory=FailScopeMigration)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="injected migration failure"):
+            migrations.apply_migrations(conn)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        assert "targets" not in columns
+        assert "target_filter" not in columns
+        assert conn.execute("SELECT COUNT(*) FROM task_runs").fetchone()[0] == 1
+    finally:
+        conn.close()
+    assert len(get_runs("task", db_path=db_path)) == 1


### PR DESCRIPTION
Fixes #6039
Fixes #6040

#### Describe the changes you have made in this PR -

A successful scheduled run currently replaces the stored task with the definition it read before execution, undoing pauses or edits made while it ran. A crashed failed-only retry also loses its destination filter during recovery and can resend to channels that already received the report.

- Update only completion fields while holding the task-store lock and reading the latest task. Concurrent edits survive, and deleted tasks are not recreated.
- Persist delivery scope with the initial SQLite claim and carry it forward across reclaimed attempts. The executor delivers using the claim's authoritative scope.
- Preserve the distinction between unrestricted and explicitly empty scopes. Unknown legacy or malformed scopes fail visibly before message generation or delivery; the operator can explicitly rerun after checking history.
- Apply the additive migration transactionally under the existing startup lock; document the upgrade behavior.
- Add regressions for concurrent edits/deletion, failed-only crash recovery, scope preservation, malformed scope, concurrent migration, and migration rollback.

### Demo/Screenshot for feature changes and bug fixes -

Before (new regression tests against original runner/executor):
```text
pause/edit during execution: expected enabled=False, observed True
failed-only crash recovery: expected 1 Slack delivery, observed 2
2 failed, 1 passed
```

After:
```text
uv run python -m pytest tests/scheduler \
  gateway/tests/runtime/test_scheduler_hosting.py \
  gateway/tests/runtime/test_scheduler_runners.py \
  tests/infrastructure/test_setup_state.py -q
277 passed in 3.38s

make lint          -> passed
make format-check  -> passed (3079 files)
make typecheck     -> passed (1782 source files)
git diff --check   -> passed
```

### Upgrade consideration

Existing unfinished attempts lack durable delivery scope. Their recovery now records a visible failure rather than guessing destinations. New unrestricted runs still recover normally. See the updated cron documentation for explicit rerun options.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The JSON task store owns the atomic completion update; the runner no longer writes a stale full object. SQLite claim acquisition owns execution scope so every reclaimed attempt inherits the original restriction even when its caller supplies no filter. An unlocked reread would retain a race; reconstructing scope from latest delivery history could use a different execution. Legacy scope is intentionally treated as empty because it cannot be reconstructed reliably. Tests exercise real scheduler functions and persistence with controlled delivery adapters.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Maintainers may modify this branch.

### Pull-request CI evidence

[CI run for this PR](https://github.com/Tracer-Cloud/opensre/actions/runs/34033148062) — all test shards, static checks, typecheck, session-store checks, and [CI Gate](https://github.com/Tracer-Cloud/opensre/actions/runs/34033148062/job/101486459106) passed for `4037912e43604006c43f05bab2d3849cae0371b5`.
