### PR TITLE
fix(scheduler): finalize recovered one-shots and prevent recovery starvation

### DIFF
--- a/infrastructure/scheduling/scheduler/runner.py
+++ b/infrastructure/scheduling/scheduler/runner.py
@@ -144,13 +144,16 @@ def _recover_expired_tasks(
     task_filter: TaskFilter | None = None,
 ) -> None:
     """Resubmit expired scheduled ticks through the normal fenced executor."""
-    for expired in get_expired_claims():
+    eligible_task_ids = _desired_task_ids(task_filter=task_filter)
+    for expired in get_expired_claims(eligible_task_ids=eligible_task_ids):
         task = get_task(expired.task_id)
         if task is None or not task.enabled:
             continue
         if task_filter is not None and not task_filter(task):
             continue
         result = execute_task(task, expired.fire_time, runners)
+        if result:
+            record_task_success(task.id)
         logger.info(
             "Recovered expired task %s fire_time=%s result=%s",
             expired.task_id,

--- a/infrastructure/scheduling/scheduler/storage/run_store.py
+++ b/infrastructure/scheduling/scheduler/storage/run_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -137,20 +137,27 @@ def _decode_target_filter(raw: str) -> frozenset[tuple[Provider, str]] | None:
 
 
 def get_expired_claims(
-    *, limit: int = _EXPIRED_CLAIM_SCAN_LIMIT, db_path: Path | None = None
+    *,
+    limit: int = _EXPIRED_CLAIM_SCAN_LIMIT,
+    db_path: Path | None = None,
+    eligible_task_ids: Collection[str] | None = None,
 ) -> list[ExpiredClaim]:
-    """Return the latest expired running attempts that are eligible for retry."""
+    """Return expired attempts, applying task eligibility before the scan limit."""
+    if eligible_task_ids is not None and not eligible_task_ids:
+        return []
+    task_ids_json = json.dumps(list(eligible_task_ids)) if eligible_task_ids is not None else None
     with database.connection(db_path) as conn:
         now_text = datetime.now(UTC).isoformat()
         rows = conn.execute(
             "SELECT task_id, fire_time FROM task_runs AS current "
             "WHERE current.status = ? AND current.lease_expires_at != '' "
             "AND current.lease_expires_at < ? "
+            "AND (? IS NULL OR current.task_id IN (SELECT value FROM json_each(?))) "
             "AND current.attempt = (SELECT MAX(latest.attempt) FROM task_runs AS latest "
             "WHERE latest.task_id = current.task_id "
             "AND latest.fire_time = current.fire_time) "
             "ORDER BY current.lease_expires_at LIMIT ?",
-            (TaskStatus.RUNNING.value, now_text, limit),
+            (TaskStatus.RUNNING.value, now_text, task_ids_json, task_ids_json, limit),
         ).fetchall()
         return [ExpiredClaim(task_id=str(row[0]), fire_time=str(row[1])) for row in rows]
 

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -119,6 +119,92 @@ def _expire_claim(db_path: Path, task_id: str, fire_time: str) -> None:
 
 @pytest.mark.usefixtures("_tmp_stores")
 class TestExecutor:
+    @pytest.mark.parametrize("delivery_succeeds", [True, False])
+    def test_recovered_one_shot_finalizes_only_after_success(
+        self, tmp_path: Path, delivery_succeeds: bool
+    ) -> None:
+        from infrastructure.scheduling.scheduler.storage import get_task, try_claim
+
+        task = add_task(
+            ScheduledTask(
+                kind=TaskKind.MANUAL_LOOP,
+                cron="0 9 * * *",
+                provider=Provider.SLACK,
+                params={"disable_after_success": "true"},
+            )
+        )
+        assert try_claim(task.id, "old-tick") is not None
+        _expire_claim(tmp_path / "scheduler.db", task.id, "old-tick")
+        adapters = _install_fake_bundle()
+        adapters[Provider.SLACK].result = (
+            (True, "", "message") if delivery_succeeds else (False, "unavailable", "")
+        )
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message", return_value="report"
+        ):
+            _recover_expired_tasks(real_runners())
+        stored = get_task(task.id)
+        assert stored is not None
+        assert stored.enabled is not delivery_succeeds
+        assert (stored.last_run is not None) is delivery_succeeds
+        assert get_runs(task.id)[0].status is (
+            TaskStatus.SUCCESS if delivery_succeeds else TaskStatus.FAILED
+        )
+
+    @pytest.mark.parametrize("ineligible", ["disabled", "missing", "filtered"])
+    def test_recovery_skips_ineligible_claims_before_limiting(
+        self, tmp_path: Path, ineligible: str
+    ) -> None:
+        from infrastructure.scheduling.scheduler.storage import get_task, try_claim
+
+        blocked = ScheduledTask(
+            id="blocked",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.TELEGRAM,
+            enabled=ineligible != "disabled",
+            chat_id="blocked",
+        )
+        if ineligible != "missing":
+            add_task(blocked)
+        task = add_task(
+            ScheduledTask(
+                kind=TaskKind.MANUAL_LOOP,
+                cron="0 9 * * *",
+                provider=Provider.SLACK,
+                chat_id="eligible",
+            )
+        )
+        for index in range(100):
+            assert try_claim(blocked.id, f"old-{index}") is not None
+        assert try_claim(task.id, "eligible-tick") is not None
+        with sqlite3.connect(tmp_path / "scheduler.db") as conn:
+            conn.execute(
+                "UPDATE task_runs SET lease_expires_at = ? WHERE task_id = ?",
+                ("2020-01-01T00:00:00+00:00", blocked.id),
+            )
+            conn.execute(
+                "UPDATE task_runs SET lease_expires_at = ? WHERE task_id = ?",
+                ("2021-01-01T00:00:00+00:00", task.id),
+            )
+        adapters = _install_fake_bundle()
+
+        def accepts_task(candidate: ScheduledTask) -> bool:
+            return candidate.provider is Provider.SLACK
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message", return_value="report"
+        ):
+            _recover_expired_tasks(
+                real_runners(), task_filter=accepts_task if ineligible == "filtered" else None
+            )
+        assert len(adapters[Provider.SLACK].calls) == 1
+        assert not adapters[Provider.TELEGRAM].calls
+        assert get_runs(task.id)[0].status is TaskStatus.SUCCESS
+        assert all(run.status is TaskStatus.RUNNING for run in get_runs(blocked.id, limit=100))
+        stored = get_task(task.id)
+        assert stored is not None and stored.last_run is not None
+
     @pytest.mark.parametrize("mutation", ["pause_and_edit", "delete"])
     def test_completion_preserves_concurrent_task_changes(self, mutation: str) -> None:
         from concurrent.futures import ThreadPoolExecutor

--- a/tests/scheduler/test_run_store.py
+++ b/tests/scheduler/test_run_store.py
@@ -690,3 +690,13 @@ def test_delivery_scope_migration_rolls_back_on_failure(db_path: Path) -> None:
     finally:
         conn.close()
     assert len(get_runs("task", db_path=db_path)) == 1
+
+
+def test_expired_claim_eligibility_handles_empty_and_large_sets(db_path: Path) -> None:
+    _claimed(db_path, "eligible", "tick")
+    _expire_claim(db_path, "eligible", "tick")
+    assert get_expired_claims(db_path=db_path, eligible_task_ids=set()) == []
+    eligible = {f"task-{index}" for index in range(2000)} | {"eligible"}
+    assert get_expired_claims(db_path=db_path, eligible_task_ids=eligible) == [
+        ExpiredClaim(task_id="eligible", fire_time="tick")
+    ]


### PR DESCRIPTION
Fixes #6041
Fixes #6042

**Stacked on #6044.** Merge order: #6044 → #6045. This PR targets `fix/scheduler-p1-state-and-retry-scope`, showing only the P2 changes. After #6044 merges, retarget this PR to main and rerun CI before merging.

#### Describe the changes you have made in this PR -

Recovered tasks currently skip success bookkeeping, leaving one-shot reminders enabled after successful delivery. Recovery also limits its query to 100 claims before checking eligibility, so old claims belonging to disabled, missing, or excluded tasks can permanently hide eligible work.

- Apply the same atomic completion update used by normal scheduled execution after successful recovery. Update last_run and honor disable_after_success without overwriting concurrent user edits. Failed or fenced execution does not receive success bookkeeping.
- Compute eligible task IDs before the recovery query and filter in SQL before LIMIT. Keep the 100-attempt bound and recheck current task eligibility immediately before execution.
- Pass eligibility as one JSON array parameter to avoid SQL variable-count limits for large task sets. An empty eligible set returns no claims; omitted eligibility retains the store API's unfiltered behavior.
- Add regressions covering recovered one-shot success/failure, 100 older ineligible claims (disabled, missing, and host-filtered), recurring last_run bookkeeping, and empty/large eligibility sets.

### Demo/Screenshot for feature changes and bug fixes -

Before (new tests against the original recovery function):
```text
Recovered one-shot: expected enabled=False; observed True
100 disabled/missing/filtered claims: expected eligible delivery; observed zero
4 failed, 1 passed
```

After:
```text
uv run python -m pytest tests/scheduler \
  gateway/tests/runtime/test_scheduler_hosting.py \
  gateway/tests/runtime/test_scheduler_runners.py \
  tests/infrastructure/test_setup_state.py -q
283 passed in 2.75s

make lint          -> passed
make format-check  -> passed (3079 files)
make typecheck     -> passed (1782 source files)
git diff --check   -> passed
```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The runner owns task eligibility and passes eligible IDs into the run store; the store applies that scope before limiting rows. This avoids mutable pagination state while retaining bounded execution per sweep and allows temporarily disabled tasks to recover when enabled later. The runner rechecks each task because it may change after the initial snapshot. Successful recovery reuses record_task_success from #6044, so completion updates the latest persisted definition under its lock. Tests use real claims and task stores with controlled delivery adapters.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Maintainers may modify this branch.

### Pull-request CI evidence

[CI run](https://github.com/Tracer-Cloud/opensre/actions/runs/34035788317): all test shards, static checks, typecheck, session-store checks, and CI Gate passed on `267052c9e90cc54f806f669937b212003cc2c21d`. That CI run validated this same head when the PR targeted main. The PR is now stacked on #6044; repository CI currently only triggers for main-targeted PRs. Rerun CI after retargeting to main following #6044's merge.
