### PR TITLE
fix(scheduler): preserve manual_loop prompt through creation and confirmation

### DIFF
--- a/core/agent_harness/session/pending_offer.py
+++ b/core/agent_harness/session/pending_offer.py
@@ -63,6 +63,7 @@ class PendingScheduleOffer:
     chat_id: str = ""
     skill_name: str = ""
     skill_inputs: dict[str, str] = field(default_factory=dict)
+    prompt: str = ""
 
     def to_slash_command(self) -> str:
         """Literal slash the action driver dispatches without an LLM round-trip."""
@@ -95,6 +96,10 @@ class PendingScheduleOffer:
                     value = self.skill_inputs.get(key, "").strip()
                     if value:
                         args.extend([flag, value])
+        elif self.kind == "manual_loop":
+            prompt_text = self.prompt.strip()
+            if prompt_text:
+                args.extend(["--prompt", prompt_text])
         chat = self.chat_id.strip()
         if chat:
             args.extend(["--chat-id", chat])

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -24,15 +24,18 @@ When you open the interactive shell (`opensre`) and no scheduled tasks exist yet
 ```bash
 # Add a free-form recurring ops digest to Telegram at 09:00 IST on weekdays
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --name "Ops digest" --tz Asia/Kolkata --provider telegram --chat-id <chat_id>
+  --name "Ops digest" --tz Asia/Kolkata --provider telegram --chat-id <chat_id> \
+  --prompt "Check open incidents and summarize production risk"
 
 # Same kind to Slack via incoming webhook (omit --chat-id; webhook is channel-bound)
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --tz Europe/London --provider slack
+  --tz Europe/London --provider slack \
+  --prompt "Check open incidents and summarize production risk"
 
 # Slack bot token: omit --chat-id when SLACK_DEFAULT_CHAT_ID is set
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --tz Europe/London --provider slack
+  --tz Europe/London --provider slack \
+  --prompt "Check open incidents and summarize production risk"
 
 # GitHub PR sweep standup digest → Slack
 opensre cron add --kind github_pr_sweep --cron "0 9 * * 1-5" \
@@ -51,7 +54,8 @@ opensre cron add --kind recurring_skill --skill morning-report \
 
 # Local interactive-shell inbox delivery, useful for debugging
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --name "Local ops digest" --provider interactive_shell
+  --name "Local ops digest" --provider interactive_shell \
+  --prompt "Check open incidents and summarize production risk"
 
 # List configured tasks
 opensre cron list
@@ -84,6 +88,7 @@ Create a new scheduled delivery task.
 | `--branch` | No | Branch filter for `github-ci-health`; cannot be combined with `--pr` |
 | `--pr` | No | Pull-request filter for `github-ci-health`; cannot be combined with `--branch` |
 | `--city` | No | City for `morning-report`; omitted to use its default-location behavior |
+| `--prompt` | Cond. | Required with `--kind manual_loop`; the instruction executed on each run |
 
 ### `opensre cron list`
 
@@ -255,7 +260,7 @@ The lower-level `/cron` slash command forwards to the CLI:
 
 ```
 /cron list
-/cron add --kind manual_loop --cron "0 9 * * *" --provider telegram --chat-id <id>
+/cron add --kind manual_loop --cron "0 9 * * *" --provider telegram --chat-id <id> --prompt "Check open incidents and summarize production risk"
 /cron run <task_id>
 ```
 

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -107,6 +107,13 @@ def cron_command() -> None:
     "--pr", "pr_number", type=click.IntRange(min=1), default=None, help="Optional GitHub PR filter."
 )
 @click.option("--city", type=str, default="", help="Optional city for the morning-report skill.")
+@click.option(
+    "--prompt",
+    type=str,
+    default="",
+    show_default=False,
+    help="Instruction to execute on each run (required for manual_loop).",
+)
 def cron_add(
     name: str,
     kind: str,
@@ -121,6 +128,7 @@ def cron_add(
     branch: str,
     pr_number: int | None,
     city: str,
+    prompt: str,
 ) -> None:
     """Add a new scheduled delivery task."""
     from infrastructure.scheduling.scheduler.types import ScheduledTask
@@ -150,6 +158,18 @@ def cron_add(
         pr_number=pr_number,
     )
 
+    from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+
+    prompt_text = prompt.strip()
+    if task_kind == TaskKind.MANUAL_LOOP:
+        if not prompt_text:
+            raise click.ClickException("--prompt is required when --kind is manual_loop.")
+    elif prompt_text:
+        raise click.ClickException("--prompt is only valid with --kind manual_loop.")
+    params: dict[str, str] = {}
+    if task_kind == TaskKind.MANUAL_LOOP:
+        params[LOOP_PROMPT_PARAM] = prompt_text
+
     task = ScheduledTask(
         name=name.strip(),
         kind=task_kind,
@@ -161,6 +181,7 @@ def cron_add(
         skill_name=pinned_name,
         skill_revision=pinned_revision,
         skill_inputs=skill_inputs,
+        params=params,
     )
 
     from infrastructure.scheduling.scheduler.operation_log import record_scheduler_task_operation

--- a/tests/cli/test_cron_command.py
+++ b/tests/cli/test_cron_command.py
@@ -104,6 +104,8 @@ def test_cron_add_allows_slack_without_chat_id(
             "Europe/Amsterdam",
             "--provider",
             "slack",
+            "--prompt",
+            "Check open incidents and summarize risk.",
         ],
     )
     assert result.exit_code == 0, result.output
@@ -131,6 +133,8 @@ def test_cron_add_persists_loop_name(tmp_path: Path, monkeypatch: pytest.MonkeyP
             "0 8 * * 1-5",
             "--provider",
             "slack",
+            "--prompt",
+            "Check open incidents and summarize risk.",
         ],
     )
 
@@ -332,6 +336,8 @@ def test_cron_add_allows_interactive_shell_without_chat_id(
             "0 8 * * 1-5",
             "--provider",
             "interactive_shell",
+            "--prompt",
+            "Check open incidents and summarize risk.",
         ],
     )
 
@@ -516,3 +522,122 @@ def test_cron_run_failed_only_skips_the_warning(monkeypatch: pytest.MonkeyPatch)
     assert result.exit_code == 0, result.output
     assert "already delivered" not in result.output
     assert calls == [{"task_id": "t1", "only_failed": True}]
+
+
+def test_cron_add_manual_loop_persists_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI-created manual_loop schedules must store the prompt for the scheduler.
+
+    Regression for #6047: cron_add built the ScheduledTask without a prompt,
+    so the scheduler had nothing to execute and returned a missing-prompt
+    warning instead of running the instruction.
+    """
+    from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+    from infrastructure.scheduling.scheduler.storage import task_store as scheduler_store
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+
+    store = tmp_path / "scheduler_tasks.json"
+    monkeypatch.setattr(scheduler_store, "default_task_store_path", lambda: store)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/services/T/B/x")
+
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "manual_loop",
+            "--cron",
+            "0 9 * * 1-5",
+            "--provider",
+            "slack",
+            "--prompt",
+            "Check open incidents and summarize production risk.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    task = list_tasks(store)[0]
+    assert task.params[LOOP_PROMPT_PARAM] == "Check open incidents and summarize production risk."
+
+
+def test_cron_add_manual_loop_executes_stored_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stored prompt must reach the scheduler runner on every run."""
+    from infrastructure.scheduling.scheduler.storage import task_store as scheduler_store
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+    from infrastructure.scheduling.scheduler.tasks import build_message
+
+    store = tmp_path / "scheduler_tasks.json"
+    monkeypatch.setattr(scheduler_store, "default_task_store_path", lambda: store)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/services/T/B/x")
+
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "manual_loop",
+            "--cron",
+            "0 9 * * 1-5",
+            "--provider",
+            "slack",
+            "--prompt",
+            "Check open incidents and summarize production risk.",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    task = list_tasks(store)[0]
+
+    captured: dict[str, object] = {}
+
+    def _fake_agent(payload: dict[str, object]) -> str:
+        captured.update(payload)
+        return "report body"
+
+    from infrastructure.scheduling.scheduler.runners import SchedulerRunners
+
+    runners = SchedulerRunners(agent=_fake_agent)
+    assert build_message(task, runners) == "report body"
+    assert captured["loop_prompt"] == "Check open incidents and summarize production risk."
+
+
+def test_cron_add_manual_loop_requires_prompt() -> None:
+    """A manual_loop without --prompt must not create an unrunnable schedule."""
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "manual_loop",
+            "--cron",
+            "0 9 * * *",
+            "--provider",
+            "interactive_shell",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--prompt is required" in result.output
+
+
+def test_cron_add_rejects_prompt_for_other_kinds() -> None:
+    """--prompt belongs to manual_loop only, like --skill belongs to recurring_skill."""
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "github_pr_sweep",
+            "--cron",
+            "0 9 * * *",
+            "--provider",
+            "interactive_shell",
+            "--prompt",
+            "Check incidents.",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--prompt is only valid" in result.output

--- a/tests/cli/test_cron_slack_destination.py
+++ b/tests/cli/test_cron_slack_destination.py
@@ -29,7 +29,16 @@ def _add(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> object:
     _patch_scheduler_store(tmp_path, monkeypatch)
     return CliRunner().invoke(
         cron_add,
-        ["--kind", "manual_loop", "--cron", "0 8 * * 1-5", "--provider", "slack"],
+        [
+            "--kind",
+            "manual_loop",
+            "--cron",
+            "0 8 * * 1-5",
+            "--provider",
+            "slack",
+            "--prompt",
+            "Check open incidents and summarize risk.",
+        ],
     )
 
 

--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -264,7 +264,11 @@ def test_a_confirmed_schedule_survives_the_literal_slash_dispatcher(
         name = "slash_invoke"
 
     offer = PendingScheduleOffer(
-        kind="manual_loop", cron="0 8 * * 1-5", timezone="UTC", provider="slack"
+        kind="manual_loop",
+        cron="0 8 * * 1-5",
+        timezone="UTC",
+        provider="slack",
+        prompt="Check open incidents and summarize risk.",
     )
 
     # Act
@@ -546,3 +550,100 @@ def test_the_turn_boundary_reaches_the_tool_context_in_production() -> None:
     # Assert
     assert ctx is not None
     assert ctx.history_start == 2, "boundary must exclude rows already in the session"
+
+
+def test_pending_manual_loop_offer_preserves_prompt() -> None:
+    """Regression for #6047: the prompt must survive offer → slash → task.
+
+    The conversational confirmation previously dropped the prompt when
+    converting a pending schedule offer into a slash command, leaving the
+    scheduler with no instruction to execute.
+    """
+    import shlex
+
+    offer = PendingScheduleOffer(
+        kind="manual_loop",
+        cron="0 9 * * 1-5",
+        timezone="UTC",
+        provider="slack",
+        prompt="Check open incidents and summarize production risk.",
+    )
+
+    slash = offer.to_slash_command()
+    assert "--prompt" in slash
+    tokens = shlex.split(slash, posix=True)
+    assert "Check open incidents and summarize production risk." in tokens
+
+
+def test_propose_manual_loop_offer_preserves_prompt_through_confirmation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: propose → slash_preview → cron_add stores the prompt."""
+    from pathlib import Path
+
+    from click.testing import CliRunner
+
+    from core.agent_harness.turns.action_driver import _literal_slash_tool_call
+    from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+    from surfaces.cli.commands.cron import cron_add
+
+    session = InMemorySessionState()
+    session.record(
+        "shell",
+        "curl -s 'wttr.in/Amsterdam?format=3'",
+        ok=True,
+        response_text="Amsterdam: ☀️ +20°C",
+    )
+    session.record(
+        "shell",
+        "curl -s 'https://feeds.bbci.co.uk/news/rss.xml' | head",
+        ok=True,
+        response_text="Some headline",
+    )
+    ctx = ActionToolScope(session=session, console=object())
+    briefing = (
+        "Good morning! Here is your briefing.\n"
+        "Weather — Amsterdam: ☀️ +20°C\n"
+        "Top headlines:\n"
+        "- Some headline"
+    )
+    result = execute_propose_scheduled_delivery_tool(
+        {
+            "kind": "manual_loop",
+            "cron": "0 9 * * 1-5",
+            "timezone": "UTC",
+            "provider": "interactive_shell",
+            "briefing_text": briefing,
+            "prompt": "Check open incidents and summarize production risk.",
+        },
+        ctx,
+    )
+
+    assert result["ok"] is True
+    assert session.pending_schedule_offer is not None
+    assert (
+        session.pending_schedule_offer.prompt
+        == "Check open incidents and summarize production risk."
+    )
+    assert "--prompt" in result["slash_preview"]
+
+    class _SlashTool:
+        name = "slash_invoke"
+
+    call = _literal_slash_tool_call(result["slash_preview"], [_SlashTool()])
+    assert call is not None
+    args = call.input["args"]
+    assert "Check open incidents and summarize production risk." in args
+
+    # The slash args must create a runnable task: prompt stored in params.
+    from infrastructure.scheduling.scheduler.storage import task_store as scheduler_store
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+
+    store: Path = tmp_path / "scheduler_tasks.json"
+    monkeypatch.setattr(scheduler_store, "default_task_store_path", lambda: store)
+    cli_result = CliRunner().invoke(cron_add, args[1:])
+    assert cli_result.exit_code == 0, cli_result.output
+    tasks = list_tasks(store)
+    assert tasks[0].params[LOOP_PROMPT_PARAM] == (
+        "Check open incidents and summarize production risk."
+    )

--- a/tools/interactive_shell/actions/propose_scheduled_delivery.py
+++ b/tools/interactive_shell/actions/propose_scheduled_delivery.py
@@ -108,6 +108,7 @@ def execute_propose_scheduled_delivery_tool(
     provider = str(args.get("provider", "")).strip().lower()
     chat_id = str(args.get("chat_id", "")).strip()
     briefing_text = str(args.get("briefing_text", "") or "").strip()
+    prompt_text = str(args.get("prompt", "") or "").strip()
     skill_name = normalize_skill_name(str(args.get("skill_name", "") or ""))
     owner = str(args.get("owner", "") or "").strip()
     repo = str(args.get("repo", "") or "").strip()
@@ -176,6 +177,19 @@ def execute_propose_scheduled_delivery_tool(
             return blocked
 
     scope_supplied = bool(owner or repo or branch or pr_number)
+    if kind == TaskKind.MANUAL_LOOP.value:
+        if prompt_text and (scope_supplied or city or skill_name):
+            return {
+                "ok": False,
+                "error": (
+                    "owner, repo, branch, pr_number, city, and skill_name are only "
+                    "valid for recurring_skill."
+                ),
+            }
+        if not prompt_text:
+            return {"ok": False, "error": "prompt is required for manual_loop."}
+    elif prompt_text:
+        return {"ok": False, "error": "prompt is only valid for manual_loop."}
     skill_inputs: dict[str, str] = {}
     if skill_name == "morning-report":
         if city:
@@ -220,6 +234,7 @@ def execute_propose_scheduled_delivery_tool(
         chat_id=chat_id,
         skill_name=skill_name if kind == TaskKind.RECURRING_SKILL.value else "",
         skill_inputs=skill_inputs,
+        prompt=prompt_text if kind == TaskKind.MANUAL_LOOP.value else "",
     )
     ctx.session.pending_schedule_offer = offer
     clear_competing_pending_offers(ctx.session, keep_attr="pending_schedule_offer")
@@ -251,6 +266,7 @@ def run_propose_scheduled_delivery(
     timezone: str = "UTC",
     chat_id: str = "",
     briefing_text: str = "",
+    prompt: str = "",
     skill_name: str = "",
     owner: str = "",
     repo: str = "",
@@ -267,6 +283,7 @@ def run_propose_scheduled_delivery(
             "provider": provider,
             "chat_id": chat_id,
             "briefing_text": briefing_text,
+            "prompt": prompt,
             "skill_name": skill_name,
             "owner": owner,
             "repo": repo,
@@ -339,6 +356,13 @@ propose_scheduled_delivery_tool = RegisteredTool(
                     "already produced for the user. Returned in response_text "
                     "ahead of the Want me to: closer so the user never sees an "
                     "offer without the report."
+                ),
+            ),
+            "prompt": string_property(
+                description=(
+                    "Required for manual_loop: the instruction to execute on each "
+                    "scheduled run (e.g. the user request that produced the briefing). "
+                    "Persisted as the scheduled task prompt."
                 ),
             ),
             "skill_name": string_property(


### PR DESCRIPTION
Fixes #6047

#### Describe the changes you have made in this PR -
manual_loop schedules lost their prompt during creation: cron_add built ScheduledTask without LOOP_PROMPT_PARAM, and PendingScheduleOffer dropped the prompt when serializing to /cron add. The scheduler then returned a missing-prompt warning instead of executing.

- surfaces/cli/commands/cron.py: new --prompt option; required for manual_loop, rejected otherwise; stored in params[LOOP_PROMPT_PARAM].
- core/agent_harness/session/pending_offer.py: PendingScheduleOffer gains prompt field; to_slash_command emits --prompt for manual_loop.
- tools/interactive_shell/actions/propose_scheduled_delivery.py: new prompt input (required for manual_loop, rejected otherwise); stored on the offer so yes-confirmation carries it through slash_preview into cron_add.
- docs/cron.mdx: document --prompt and update manual_loop examples.
- Updated existing manual_loop CLI tests to pass --prompt; updated the literal-slash dispatcher test to include a prompt.

### Demo/Screenshot for feature changes and bug fixes -
Focused suites green:
- tests/cli/test_cron_command.py + tests/core/agent_harness/session/test_pending_offer.py: 47 passed (includes 6 new regression tests)
- tests/tools/test_propose_scheduled_delivery_destination.py + tests/scheduler/test_tasks.py + tests/cli/test_cron_slack_destination.py + tests/scheduler/test_executor.py + tests/scheduler/test_runner.py: 67 passed
- make lint: pass; make format-check: pass; make typecheck: 1782 files clean

New regression tests:
- test_cron_add_manual_loop_persists_prompt (CLI stores prompt in params)
- test_cron_add_manual_loop_executes_stored_prompt (stored prompt reaches runners.agent as loop_prompt)
- test_cron_add_manual_loop_requires_prompt / test_cron_add_rejects_prompt_for_other_kinds
- test_pending_manual_loop_offer_preserves_prompt (offer to slash keeps --prompt)
- test_propose_manual_loop_offer_preserves_prompt_through_confirmation (propose to slash_preview to cron_add end-to-end)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The prompt was dropped at two seams: CLI creation never stored it, and offer serialization never emitted it. I followed the #6023 city-precedent: add --prompt to cron_add (stored as LOOP_PROMPT_PARAM, the key tasks.py already reads), add prompt to PendingScheduleOffer (serialized as --prompt), and add prompt to the propose tool so conversational offers populate it. Requiring --prompt for manual_loop (and rejecting elsewhere) mirrors /loops add which already requires a prompt, preventing apparently-valid but unrunnable schedules. Alternatives considered: optional --prompt (less breaking but leaves the Impact bug possible) and reusing briefing_text as the prompt (wrong semantics: result vs instruction). Key pieces: cron_add validation + params, offer.prompt + to_slash_command branch, propose prompt input + offer wiring.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions