### PR TITLE
fix(guardrails): load no rules instead of raising when the rules key is empty

### DIFF
--- a/infrastructure/safety/guardrails/rules.py
+++ b/infrastructure/safety/guardrails/rules.py
@@ -61,8 +61,17 @@ def load_rules(path: Path | None = None) -> list[GuardrailRule]:
         logger.warning("Guardrails config missing 'rules' key at %s", rules_path)
         return []
 
+    entries = raw["rules"]
+    if not isinstance(entries, list):
+        logger.warning(
+            "Guardrails config 'rules' must be a list at %s, got %s; ignoring",
+            rules_path,
+            type(entries).__name__,
+        )
+        return []
+
     rules: list[GuardrailRule] = []
-    for entry in raw["rules"]:
+    for entry in entries:
         if not isinstance(entry, dict):
             continue
         parsed = _parse_rule(entry)

--- a/tests/infrastructure/safety/guardrails/test_rules.py
+++ b/tests/infrastructure/safety/guardrails/test_rules.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
+import pytest
 import yaml
 
 from infrastructure.safety.guardrails.rules import GuardrailAction, load_rules
@@ -25,6 +27,29 @@ class TestLoadRules:
     def test_returns_empty_when_rules_key_missing(self, tmp_path: Path) -> None:
         path = _write_config(tmp_path, {"version": 1})
         assert load_rules(path) == []
+
+    def test_returns_empty_when_rules_key_is_empty(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # "rules:" with every entry commented out parses as None, not a list.
+        path = tmp_path / "guardrails.yml"
+        path.write_text("rules:", encoding="utf-8")
+        with caplog.at_level(logging.WARNING):
+            assert load_rules(path) == []
+        assert "must be a list" in caplog.text
+        assert "NoneType" in caplog.text
+
+    def test_rejects_a_non_list_rules_key(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A scalar already returned [], but only because iterating the string
+        # yielded characters that each failed the per-entry dict check. Assert
+        # the warning so the shape check itself is what is under test.
+        path = _write_config(tmp_path, {"rules": "aws_key"})
+        with caplog.at_level(logging.WARNING):
+            assert load_rules(path) == []
+        assert "must be a list" in caplog.text
+        assert "str" in caplog.text
 
     def test_parses_pattern_rule(self, tmp_path: Path) -> None:
         path = _write_config(


### PR DESCRIPTION
Fixes #6033

#### Describe the changes you have made in this PR -

`load_rules` says it returns an empty list for a missing or malformed config, and it guards the missing-key case. It does not guard the key being present with nothing under it. A `rules:` block with every entry commented out parses as `None`, and `for entry in raw["rules"]` then raises `TypeError`. The `try` only covers `yaml.safe_load`, so nothing catches it.

Commenting out your rules is the obvious way to turn guardrails off for a moment, so this is easy to hit by hand. The exception escapes `load_rules`, which means `get_guardrail_evaluator()` cannot build its singleton, and `opensre health` raises while rendering the guardrails row.

The fix checks the value is a list before iterating it. That also closes a quieter hole beside it: `rules: aws_key` was already returning `[]`, but only because iterating a string yields characters that each fail the per-entry `isinstance(entry, dict)` test. The wrong shape was accepted in silence; it is now rejected explicitly and logged, so a typo in the config says so instead of behaving like an empty rule set.

### Demo/Screenshot for feature changes and bug fixes -

Before:

```
  rules: (empty)             -> TypeError: 'NoneType' object is not iterable
  rules: with only comments  -> TypeError: 'NoneType' object is not iterable
  rules: []                  -> []
```

After:

```
  rules: (empty)             -> []
  rules: with only comments  -> []
  rules: []                  -> []
```

Both new tests fail against `main`. They assert the warning and the rejected type name, so what is under test is the shape check itself rather than a return value the old code reached by a different route:

```
$ git checkout main -- infrastructure/safety/guardrails/rules.py
$ uv run pytest tests/infrastructure/safety/guardrails/test_rules.py -k "is_empty or non_list"
FAILED ...::TestLoadRules::test_returns_empty_when_rules_key_is_empty
FAILED ...::TestLoadRules::test_rejects_a_non_list_rules_key
2 failed, 13 deselected
```

Local checks:

```
$ uv run pytest tests/infrastructure/safety/guardrails/ -q
115 passed
$ uv run ruff check infrastructure/safety/guardrails/rules.py tests/infrastructure/safety/guardrails/test_rules.py
All checks passed!
$ uv run ruff format --check ...
2 files already formatted
$ uv run mypy infrastructure/safety/guardrails/rules.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The function's contract is that a bad config degrades to "no rules" rather than propagating, and the existing guard covers only one of the two ways the `rules` key can be unusable. I validated the shape rather than widening the `try`, because catching `TypeError` there would also swallow a genuine bug inside `_parse_rule` and report it as an empty rule set.

There is one new branch: after confirming `rules` is present, check `isinstance(entries, list)` and return `[]` with a warning naming the type that was found. Everything downstream is unchanged, and the loop now iterates a value proven to be a list.

Edge cases I checked: `rules:` with nothing under it and with only comments (both `None`, both now `[]`), `rules: []` (already correct, still correct), `rules: aws_key` (a string, previously iterated character by character in silence, now rejected and logged), and `rules: {name: x}` (a dict, previously iterated as keys, now rejected). The missing-file, malformed-YAML and missing-key paths are untouched and still covered by the existing tests.

On the tests: asserting only the return value would not have distinguished the new branch from the old accident in the non-list case, since both produce `[]`. Both tests therefore assert the logged warning and the rejected type under `caplog`, which also pins the empty-key case against a future "fix" that merely widened the try/except.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
