### PR TITLE
fix(scheduler): preserve manual_loop prompts through creation confirmation

### DIFF
--- a/core/agent_harness/session/pending_offer.py
+++ b/core/agent_harness/session/pending_offer.py
@@ -61,6 +61,7 @@ class PendingScheduleOffer:
     timezone: str
     provider: str
     chat_id: str = ""
+    prompt: str = ""
     skill_name: str = ""
     skill_inputs: dict[str, str] = field(default_factory=dict)
 
@@ -77,6 +78,10 @@ class PendingScheduleOffer:
             "--provider",
             self.provider,
         ]
+        if self.kind == "manual_loop":
+            prompt = self.prompt.strip()
+            if prompt:
+                args.extend(["--prompt", prompt])
         if self.kind == "recurring_skill":
             skill = self.skill_name.strip()
             if skill:

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -24,14 +24,17 @@ When you open the interactive shell (`opensre`) and no scheduled tasks exist yet
 ```bash
 # Add a free-form recurring ops digest to Telegram at 09:00 IST on weekdays
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --name "Ops digest" --tz Asia/Kolkata --provider telegram --chat-id <chat_id>
+  --name "Ops digest" --prompt "Check open incidents and summarize production risk" \
+  --tz Asia/Kolkata --provider telegram --chat-id <chat_id>
 
 # Same kind to Slack via incoming webhook (omit --chat-id; webhook is channel-bound)
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
+  --prompt "Check open incidents and summarize production risk" \
   --tz Europe/London --provider slack
 
 # Slack bot token: omit --chat-id when SLACK_DEFAULT_CHAT_ID is set
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
+  --prompt "Check open incidents and summarize production risk" \
   --tz Europe/London --provider slack
 
 # GitHub PR sweep standup digest → Slack
@@ -51,7 +54,8 @@ opensre cron add --kind recurring_skill --skill morning-report \
 
 # Local interactive-shell inbox delivery, useful for debugging
 opensre cron add --kind manual_loop --cron "0 9 * * 1-5" \
-  --name "Local ops digest" --provider interactive_shell
+  --name "Local ops digest" --prompt "Check open incidents and summarize production risk" \
+  --provider interactive_shell
 
 # List configured tasks
 opensre cron list
@@ -78,6 +82,7 @@ Create a new scheduled delivery task.
 | `--provider` | Yes | Messaging provider: `telegram`, `slack`, `discord`, `rocketchat`, `interactive_shell` |
 | `--chat-id` | Cond. | Required for telegram/discord/rocketchat. Optional for slack when an incoming webhook or `SLACK_DEFAULT_CHAT_ID` is configured, and not needed for `interactive_shell`. |
 | `--window` | No | Lookback window in hours (default: `24`) |
+| `--prompt` | Cond. | Instruction to execute on every run; required for `manual_loop` and rejected for other kinds |
 | `--skill` | Cond. | Required with `--kind recurring_skill`; names the revision-pinned skill to execute |
 | `--owner` | Cond. | GitHub repository owner; required for the `github-ci-health` recurring skill |
 | `--repo` | Cond. | GitHub repository name; required for the `github-ci-health` recurring skill |
@@ -255,7 +260,7 @@ The lower-level `/cron` slash command forwards to the CLI:
 
 ```
 /cron list
-/cron add --kind manual_loop --cron "0 9 * * *" --provider telegram --chat-id <id>
+/cron add --kind manual_loop --cron "0 9 * * *" --prompt "Check open incidents" --provider telegram --chat-id <id>
 /cron run <task_id>
 ```
 

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from core.agent_harness import pin_recurring_skill, validate_skill_inputs
 from infrastructure.scheduling.scheduler.credentials import requires_explicit_chat_id
+from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
 from infrastructure.scheduling.scheduler.types import Provider, TaskKind, TaskRun, TaskStatus
 from infrastructure.terminal.theme import GLYPH_ERROR, GLYPH_SUCCESS
 from surfaces.cli.commands.scheduling import validate_cron_and_timezone
@@ -93,6 +94,13 @@ def cron_command() -> None:
     help="Lookback window in hours for the report (must be >= 1).",
 )
 @click.option(
+    "--prompt",
+    type=str,
+    default="",
+    show_default=False,
+    help="Instruction to execute on each manual_loop run.",
+)
+@click.option(
     "--skill",
     "skill_name",
     type=str,
@@ -115,6 +123,7 @@ def cron_add(
     provider: str,
     chat_id: str,
     window_hours: int,
+    prompt: str,
     skill_name: str,
     owner: str,
     repo: str,
@@ -130,6 +139,12 @@ def cron_add(
     _validate_chat_id_for_provider(provider, chat_id)
 
     task_kind = TaskKind(kind)
+    normalized_prompt = prompt.strip()
+    if task_kind == TaskKind.MANUAL_LOOP:
+        if not normalized_prompt:
+            raise click.ClickException("--prompt is required when --kind is manual_loop.")
+    elif normalized_prompt:
+        raise click.ClickException("--prompt is only valid with --kind manual_loop.")
     pinned_name = ""
     pinned_revision = ""
     if task_kind == TaskKind.RECURRING_SKILL:
@@ -149,6 +164,7 @@ def cron_add(
         branch=branch,
         pr_number=pr_number,
     )
+    task_params = {LOOP_PROMPT_PARAM: normalized_prompt} if normalized_prompt else {}
 
     task = ScheduledTask(
         name=name.strip(),
@@ -161,6 +177,7 @@ def cron_add(
         skill_name=pinned_name,
         skill_revision=pinned_revision,
         skill_inputs=skill_inputs,
+        params=task_params,
     )
 
     from infrastructure.scheduling.scheduler.operation_log import record_scheduler_task_operation

--- a/tests/cli/test_cron_command.py
+++ b/tests/cli/test_cron_command.py
@@ -29,6 +29,73 @@ def test_cron_add_kind_choices_exclude_sentry_kinds() -> None:
     }
 
 
+def test_cron_add_manual_loop_requires_prompt() -> None:
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "manual_loop",
+            "--cron",
+            "0 9 * * *",
+            "--provider",
+            "interactive_shell",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--prompt is required" in result.output
+
+
+def test_cron_add_rejects_prompt_for_non_manual_loop() -> None:
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "github_pr_sweep",
+            "--cron",
+            "0 9 * * *",
+            "--provider",
+            "interactive_shell",
+            "--prompt",
+            "Check open incidents.",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--prompt is only valid" in result.output
+
+
+def test_cron_add_persists_manual_loop_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+    from infrastructure.scheduling.scheduler.storage import task_store as scheduler_store
+    from infrastructure.scheduling.scheduler.storage.task_store import list_tasks
+
+    store = tmp_path / "scheduler_tasks.json"
+    monkeypatch.setattr(scheduler_store, "default_task_store_path", lambda: store)
+
+    result = CliRunner().invoke(
+        cron_command,
+        [
+            "add",
+            "--kind",
+            "manual_loop",
+            "--cron",
+            "0 9 * * *",
+            "--provider",
+            "interactive_shell",
+            "--prompt",
+            "  Check open incidents.  ",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert list_tasks(store)[0].params == {LOOP_PROMPT_PARAM: "Check open incidents."}
+
+
 def test_cron_add_rejects_non_positive_window() -> None:
     runner = CliRunner()
     result = runner.invoke(
@@ -100,6 +167,8 @@ def test_cron_add_allows_slack_without_chat_id(
             "manual_loop",
             "--cron",
             "0 8 * * 1-5",
+            "--prompt",
+            "Check open incidents.",
             "--tz",
             "Europe/Amsterdam",
             "--provider",
@@ -129,6 +198,8 @@ def test_cron_add_persists_loop_name(tmp_path: Path, monkeypatch: pytest.MonkeyP
             "manual_loop",
             "--cron",
             "0 8 * * 1-5",
+            "--prompt",
+            "Check open incidents.",
             "--provider",
             "slack",
         ],
@@ -297,6 +368,8 @@ def test_cron_add_rejects_github_scope_for_an_unrelated_kind() -> None:
             "manual_loop",
             "--cron",
             "0 8 * * *",
+            "--prompt",
+            "Check open incidents.",
             "--provider",
             "interactive_shell",
             "--owner",
@@ -330,6 +403,8 @@ def test_cron_add_allows_interactive_shell_without_chat_id(
             "manual_loop",
             "--cron",
             "0 8 * * 1-5",
+            "--prompt",
+            "Check open incidents.",
             "--provider",
             "interactive_shell",
         ],
@@ -349,6 +424,8 @@ def test_cron_add_still_requires_chat_id_for_telegram() -> None:
             "manual_loop",
             "--cron",
             "0 8 * * 1-5",
+            "--prompt",
+            "Check open incidents.",
             "--provider",
             "telegram",
         ],

--- a/tests/cli/test_cron_slack_destination.py
+++ b/tests/cli/test_cron_slack_destination.py
@@ -29,7 +29,16 @@ def _add(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> object:
     _patch_scheduler_store(tmp_path, monkeypatch)
     return CliRunner().invoke(
         cron_add,
-        ["--kind", "manual_loop", "--cron", "0 8 * * 1-5", "--provider", "slack"],
+        [
+            "--kind",
+            "manual_loop",
+            "--cron",
+            "0 8 * * 1-5",
+            "--prompt",
+            "Check open incidents.",
+            "--provider",
+            "slack",
+        ],
     )
 
 

--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from core.agent_harness.prompts.memory.conversation import expand_affirmative_follow_up
@@ -111,9 +113,11 @@ def test_pending_offer_to_slash_omits_slack_chat_id() -> None:
         cron="0 8 * * 1-5",
         timezone="Europe/Amsterdam",
         provider="slack",
+        prompt="Check open incidents.",
     )
     assert offer.to_slash_command() == (
-        "/cron add --kind manual_loop --cron '0 8 * * 1-5' --tz Europe/Amsterdam --provider slack"
+        "/cron add --kind manual_loop --cron '0 8 * * 1-5' "
+        "--tz Europe/Amsterdam --provider slack --prompt 'Check open incidents.'"
     )
 
 
@@ -124,6 +128,7 @@ def test_yes_uses_pending_schedule_not_prose() -> None:
         timezone="UTC",
         provider="telegram",
         chat_id="-100123",
+        prompt="Check open incidents.",
     )
     history = [
         (
@@ -135,7 +140,8 @@ def test_yes_uses_pending_schedule_not_prose() -> None:
     expanded = expand_affirmative_follow_up("yes", history, pending_schedule=pending)
     assert expanded == (
         "/cron add --kind manual_loop --cron '0 9 * * 1' "
-        "--tz UTC --provider telegram --chat-id -100123"
+        "--tz UTC --provider telegram --prompt 'Check open incidents.' "
+        "--chat-id -100123"
     )
     assert "1-5" not in expanded
     assert "same channel" not in expanded
@@ -186,6 +192,47 @@ def test_propose_tool_sets_session_pending_offer() -> None:
     assert result["closer"] in result["response_text"]
 
 
+def test_propose_manual_loop_offer_preserves_prompt_through_confirmation() -> None:
+    session = InMemorySessionState()
+    session.record(
+        "shell",
+        "curl -s 'wttr.in/Amsterdam?format=3'",
+        ok=True,
+        response_text="Amsterdam: ☀️ +20°C",
+    )
+    session.record(
+        "shell",
+        "curl -s 'https://feeds.bbci.co.uk/news/rss.xml' | head",
+        ok=True,
+        response_text="Some headline",
+    )
+    ctx = ActionToolScope(session=session, console=object())
+    prompt = "Check open incidents and summarize production risk."
+
+    result = execute_propose_scheduled_delivery_tool(
+        {
+            "kind": "manual_loop",
+            "cron": "0 8 * * 1-5",
+            "timezone": "UTC",
+            "provider": "interactive_shell",
+            "prompt": prompt,
+            "briefing_text": (
+                "Good morning! Weather — Amsterdam: ☀️ +20°C\nTop headlines:\n- Some headline"
+            ),
+        },
+        ctx,
+    )
+
+    assert result["ok"] is True
+    assert session.pending_schedule_offer is not None
+    assert session.pending_schedule_offer.prompt == prompt
+    assert f"--prompt '{prompt}'" in result["slash_preview"]
+    expanded = expand_affirmative_follow_up(
+        "yes", [], pending_schedule=session.pending_schedule_offer
+    )
+    assert f"--prompt '{prompt}'" in expanded
+
+
 def test_propose_alone_without_briefing_work_is_rejected() -> None:
     """User symptom: 'give me a morning report' → only Want me to, no weather."""
     session = InMemorySessionState()
@@ -216,6 +263,7 @@ def test_run_turn_consumes_pending_schedule_on_yes() -> None:
         cron="0 8 * * 1-5",
         timezone="UTC",
         provider="slack",
+        prompt="Check open incidents.",
     )
     seen: list[str] = []
 
@@ -243,7 +291,7 @@ def test_run_turn_consumes_pending_schedule_on_yes() -> None:
 
 
 def test_a_confirmed_schedule_survives_the_literal_slash_dispatcher(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The cron expression must reach the CLI as ONE argument.
 
@@ -258,17 +306,27 @@ def test_a_confirmed_schedule_survives_the_literal_slash_dispatcher(
 
     from core.agent_harness.session.pending_offer import PendingScheduleOffer
     from core.agent_harness.turns.action_driver import _literal_slash_tool_call
+    from infrastructure.scheduling.scheduler.storage import task_store as scheduler_store
     from surfaces.cli.commands.cron import cron_add
 
     class _SlashTool:
         name = "slash_invoke"
 
+    monkeypatch.setattr(
+        scheduler_store,
+        "default_task_store_path",
+        lambda: tmp_path / "scheduler_tasks.json",
+    )
+
     offer = PendingScheduleOffer(
-        kind="manual_loop", cron="0 8 * * 1-5", timezone="UTC", provider="slack"
+        kind="manual_loop",
+        cron="0 8 * * 1-5",
+        timezone="UTC",
+        provider="interactive_shell",
+        prompt="Check open incidents.",
     )
 
     # Act
-    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/services/T/B/x")
     call = _literal_slash_tool_call(offer.to_slash_command(), [_SlashTool()])
 
     # Assert
@@ -321,6 +379,7 @@ def test_slash_tool_rebuild_keeps_cron_expression_for_dispatch() -> None:
         cron="0 8 * * 1-5",
         timezone="Europe/Amsterdam",
         provider="slack",
+        prompt="Check open incidents.",
     )
     call = _literal_slash_tool_call(offer.to_slash_command(), [_SlashTool()])
     assert call is not None
@@ -423,7 +482,11 @@ def test_a_failed_schedule_keeps_the_offer_for_a_second_try() -> None:
 
     session = InMemorySessionState()
     session.pending_schedule_offer = PendingScheduleOffer(
-        kind="manual_loop", cron="0 8 * * 1-5", timezone="UTC", provider="slack"
+        kind="manual_loop",
+        cron="0 8 * * 1-5",
+        timezone="UTC",
+        provider="slack",
+        prompt="Check open incidents.",
     )
 
     def _execute_failing(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
@@ -459,7 +522,11 @@ def test_a_successful_schedule_consumes_the_offer() -> None:
 
     session = InMemorySessionState()
     session.pending_schedule_offer = PendingScheduleOffer(
-        kind="manual_loop", cron="0 8 * * 1-5", timezone="UTC", provider="slack"
+        kind="manual_loop",
+        cron="0 8 * * 1-5",
+        timezone="UTC",
+        provider="slack",
+        prompt="Check open incidents.",
     )
 
     def _execute_ok(_text: str, **_kwargs: object) -> ToolCallingTurnResult:
@@ -513,6 +580,7 @@ def test_a_stale_fetch_from_an_earlier_turn_does_not_unlock_the_offer() -> None:
             "cron": "0 8 * * 1-5",
             "provider": "slack",
             "chat_id": "C0123ABCD",
+            "prompt": "Check open incidents.",
             "briefing_text": "Good morning! Weather — Amsterdam: +20C\nTop headlines:\n- one",
         },
         ctx,

--- a/tools/interactive_shell/actions/propose_scheduled_delivery.py
+++ b/tools/interactive_shell/actions/propose_scheduled_delivery.py
@@ -107,6 +107,7 @@ def execute_propose_scheduled_delivery_tool(
     timezone = str(args.get("timezone", "UTC")).strip() or "UTC"
     provider = str(args.get("provider", "")).strip().lower()
     chat_id = str(args.get("chat_id", "")).strip()
+    prompt = str(args.get("prompt", "") or "").strip()
     briefing_text = str(args.get("briefing_text", "") or "").strip()
     skill_name = normalize_skill_name(str(args.get("skill_name", "") or ""))
     owner = str(args.get("owner", "") or "").strip()
@@ -132,6 +133,11 @@ def execute_propose_scheduled_delivery_tool(
             "ok": False,
             "error": "cron must have exactly 5 fields (minute hour day month day_of_week)",
         }
+    if kind == TaskKind.MANUAL_LOOP.value:
+        if not prompt:
+            return {"ok": False, "error": "prompt is required for manual_loop."}
+    elif prompt:
+        return {"ok": False, "error": "prompt is only valid for manual_loop."}
     # Slack is not unconditionally exempt: it can skip an explicit channel only
     # while a webhook supplies one. Asking the scheduler (same check as
     # `/cron add`) instead of hard-coding the provider keeps the offer from
@@ -218,6 +224,7 @@ def execute_propose_scheduled_delivery_tool(
         timezone=timezone,
         provider=provider,
         chat_id=chat_id,
+        prompt=prompt if kind == TaskKind.MANUAL_LOOP.value else "",
         skill_name=skill_name if kind == TaskKind.RECURRING_SKILL.value else "",
         skill_inputs=skill_inputs,
     )
@@ -250,6 +257,7 @@ def run_propose_scheduled_delivery(
     provider: str,
     timezone: str = "UTC",
     chat_id: str = "",
+    prompt: str = "",
     briefing_text: str = "",
     skill_name: str = "",
     owner: str = "",
@@ -266,6 +274,7 @@ def run_propose_scheduled_delivery(
             "timezone": timezone,
             "provider": provider,
             "chat_id": chat_id,
+            "prompt": prompt,
             "briefing_text": briefing_text,
             "skill_name": skill_name,
             "owner": owner,
@@ -286,7 +295,8 @@ propose_scheduled_delivery_tool = RegisteredTool(
         "canonical Want me to: closer plus response_text (briefing + closer). "
         "PRECONDITION for recurring_skill morning-report and for manual_loop: "
         "weather/news shell_run fetches must already have succeeded in this "
-        "session, and briefing_text must be the composed briefing. This tool "
+        "session, prompt must describe the recurring instruction, and "
+        "briefing_text must be the composed briefing. This tool "
         "schedules nothing and produces no weather — calling it alone leaves "
         "the user with an empty offer. Do NOT call /cron add until the user "
         "confirms; their yes becomes the slash command."
@@ -330,6 +340,12 @@ propose_scheduled_delivery_tool = RegisteredTool(
                 description=(
                     "Target chat/channel. Optional for slack (webhook-bound). "
                     "Required for telegram/discord/rocketchat."
+                ),
+            ),
+            "prompt": string_property(
+                description=(
+                    "Required for manual_loop: the instruction to execute on "
+                    "every scheduled run. Do not provide it for other task kinds."
                 ),
             ),
             "briefing_text": string_property(


### PR DESCRIPTION
 Fixes #6047

  ## Description

  `manual_loop` schedules were being created without the prompt they were supposed to execute. As a result, the scheduler accepted the task but
  later returned a missing-prompt warning instead of running the requested instruction.

  This change fixes prompt handling across both supported creation flows:

  - Adds a required `--prompt` option to `opensre cron add --kind manual_loop`.
  - Persists the prompt using the scheduler’s existing `loop_prompt` parameter.
  - Preserves the prompt in conversational schedule offers.
  - Includes the prompt when a confirmed offer is serialized into `/cron add`.
  - Rejects prompts for task kinds that do not support them.
  - Updates cron documentation and adds regression coverage.

  ## Testing

  - 62 focused tests passed.
  - `make lint`
  - `make format-check`
  - `make typecheck`
\