### PR TITLE
feat(release): sign and notarize the macOS bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,22 +367,69 @@ jobs:
             exit 1
           fi
 
-      - name: Re-sign macOS onedir after post-build mutations
+      - name: Import Developer ID certificate (macOS)
+        if: runner.os == 'macOS' && matrix.pyinstaller_mode == 'onedir'
+        shell: bash
+        env:
+          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # Without the certificate secrets (forks, local dry runs) the build
+          # stays ad-hoc signed; MACOS_SIGN_IDENTITY is then "-".
+          if [ -z "${APPLE_DEVELOPER_ID_P12:-}" ]; then
+            echo "MACOS_SIGN_IDENTITY=-" >> "$GITHUB_ENV"
+            echo "No Developer ID certificate in secrets; the bundle will be ad-hoc signed"
+            exit 0
+          fi
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          P12="$RUNNER_TEMP/developer-id.p12"
+          printf '%s' "$APPLE_DEVELOPER_ID_P12" | base64 --decode > "$P12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$P12" -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" -A \
+            -t cert -f pkcs12 -k "$KEYCHAIN"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$P12"
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -n 1)"
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::The imported certificate is not a Developer ID Application identity" >&2
+            exit 1
+          fi
+          echo "MACOS_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+          echo "MACOS_SIGN_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+          echo "Signing with: $IDENTITY"
+
+      - name: Sign macOS onedir
         if: runner.os == 'macOS' && matrix.pyinstaller_mode == 'onedir'
         shell: bash
         run: |
           set -euo pipefail
           # Replacing/rewriting bundled dylibs (libssl align) invalidates the
-          # adhoc signature PyInstaller applied. Consumer Macs then SIGKILL the
-          # binary on first exec (exit 137, CODESIGNING / Invalid Page) even when
-          # CI runners still let --version through. Sign nested libs first, then
-          # the main binary — ``codesign --deep`` on the directory fails with
+          # signature PyInstaller applied. Consumer Macs then SIGKILL the binary
+          # on first exec (exit 137, CODESIGNING / Invalid Page) even when CI
+          # runners still let --version through. Sign nested libs first, then
+          # the main binary; ``codesign --deep`` on the directory fails with
           # "invalid resource directory" for this PyInstaller layout.
+          #
+          # With a Developer ID identity every Mach-O gets a hardened-runtime,
+          # timestamped signature so the bundle can be notarized; the
+          # entitlements are the exceptions a frozen CPython needs. With "-"
+          # (no certificate) the same steps produce an ad-hoc signature.
           APP_DIR="./dist/opensre"
           APP_BIN="${APP_DIR}/opensre"
           if [ ! -f "$APP_BIN" ]; then
-            echo "No onedir binary at ${APP_BIN}; skip re-sign"
+            echo "No onedir binary at ${APP_BIN}; skip signing"
             exit 0
+          fi
+          SIGN=(codesign --force --sign "$MACOS_SIGN_IDENTITY")
+          if [ "$MACOS_SIGN_IDENTITY" != "-" ]; then
+            SIGN+=(--options runtime --timestamp --entitlements packaging/macos/opensre.entitlements)
           fi
           # Nested libs are independent — parallelize with a small cap, then
           # sign the main binary last (same order as install.sh).
@@ -394,10 +441,11 @@ jobs:
             JOBS=1
           fi
           find "$APP_DIR" -type f \( -name '*.dylib' -o -name '*.so' -o -name '*.so.*' \) -print0 \
-            | xargs -0 -P "$JOBS" -n 1 codesign --force --sign -
-          codesign --force --sign - "$APP_BIN"
+            | xargs -0 -P "$JOBS" -n 1 "${SIGN[@]}"
+          "${SIGN[@]}" "$APP_BIN"
           codesign --verify --strict "$APP_BIN"
-          echo "Re-signed onedir libs + ${APP_BIN} (adhoc) after post-build mutations"
+          codesign -dv "$APP_BIN" 2>&1 | grep -E '^(Authority|Signature|CodeDirectory)' || true
+          echo "Signed onedir libs + ${APP_BIN} with identity: ${MACOS_SIGN_IDENTITY}"
 
       - name: Smoke test binary (Unix)
         if: runner.os != 'Windows'
@@ -480,6 +528,35 @@ jobs:
           }
           & ".\dist\${{ matrix.binary_name }}" -h | Out-Null
           & ".\dist\${{ matrix.binary_name }}" _package-smoke
+
+      - name: Notarize macOS onedir
+        if: runner.os == 'macOS' && matrix.pyinstaller_mode == 'onedir'
+        shell: bash
+        env:
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          if [ "${MACOS_SIGN_IDENTITY:--}" = "-" ]; then
+            echo "Ad-hoc signed bundle; nothing to notarize"
+            exit 0
+          fi
+          if [ -z "${APPLE_NOTARY_KEY_P8:-}" ]; then
+            echo "::error::Developer ID signing is configured but the notary API key secrets are missing" >&2
+            exit 1
+          fi
+          # notarytool takes a zip, dmg or pkg; the release asset stays the
+          # tar.gz packaged below. A folder cannot be stapled, so Gatekeeper
+          # fetches the ticket online the first time the bundle runs on a Mac.
+          KEY="$RUNNER_TEMP/notary-key.p8"
+          printf '%s' "$APPLE_NOTARY_KEY_P8" | base64 --decode > "$KEY"
+          ditto -c -k --keepParent dist/opensre "$RUNNER_TEMP/opensre-notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/opensre-notarize.zip" \
+            --key "$KEY" --key-id "$APPLE_NOTARY_KEY_ID" --issuer "$APPLE_NOTARY_ISSUER_ID" \
+            --wait --timeout 45m
+          rm -f "$KEY" "$RUNNER_TEMP/opensre-notarize.zip"
+          echo "Notarized dist/opensre"
 
       - name: Package binary archive (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,7 +393,7 @@ jobs:
             -t cert -f pkcs12 -k "$KEYCHAIN"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
             -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
-          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
           rm -f "$P12"
           IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
             | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -n 1)"
@@ -402,8 +402,6 @@ jobs:
             exit 1
           fi
           echo "MACOS_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
-          echo "MACOS_SIGN_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
-          echo "Signing with: $IDENTITY"
 
       - name: Sign macOS onedir
         if: runner.os == 'macOS' && matrix.pyinstaller_mode == 'onedir'
@@ -445,7 +443,7 @@ jobs:
           "${SIGN[@]}" "$APP_BIN"
           codesign --verify --strict "$APP_BIN"
           codesign -dv "$APP_BIN" 2>&1 | grep -E '^(Authority|Signature|CodeDirectory)' || true
-          echo "Signed onedir libs + ${APP_BIN} with identity: ${MACOS_SIGN_IDENTITY}"
+          echo "Signed onedir libs + ${APP_BIN}"
 
       - name: Smoke test binary (Unix)
         if: runner.os != 'Windows'

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,6 +87,34 @@ For Railway: ensure the project has Postgres and Redis services and that the Ope
 service has `DATABASE_URI` and `REDIS_URI` set before deploying. Set
 `OPENSRE_DEPLOYMENT_METHOD=railway` for telemetry labeling.
 
+## macOS signing and notarization
+
+The release workflow signs the macOS onedir bundle with a Developer ID
+certificate and notarizes it when these repository secrets exist. Without them
+the bundle is ad-hoc signed, which still builds and runs but makes every Mac
+validate all bundled files on first use (about 15 seconds at install and
+several seconds on the first launch).
+
+| Secret | Value |
+| ------ | ----- |
+| `APPLE_DEVELOPER_ID_P12` | The "Developer ID Application" certificate with its private key, exported from Keychain Access as `.p12`, base64-encoded (`base64 -i cert.p12 \| pbcopy`) |
+| `APPLE_DEVELOPER_ID_P12_PASSWORD` | The password chosen at export |
+| `APPLE_NOTARY_KEY_ID` | Key ID of an App Store Connect API key with the Developer role |
+| `APPLE_NOTARY_ISSUER_ID` | Issuer ID shown on the same API keys page |
+| `APPLE_NOTARY_KEY_P8` | The downloaded `AuthKey_<id>.p8`, base64-encoded |
+
+The identity comes from the certificate, so no team ID secret is needed. The
+hardened-runtime exceptions the frozen interpreter needs live in
+`packaging/macos/opensre.entitlements`. The installer leaves a Developer ID
+signature untouched; it only re-signs ad-hoc bundles.
+
+To check a published build:
+
+```bash
+codesign -dv --verbose=2 ~/.local/bin/.opensre-app/opensre 2>&1 | grep Authority
+xcrun notarytool history --key AuthKey.p8 --key-id <id> --issuer <issuer>
+```
+
 ## Telemetry and privacy
 
 `opensre` ships with two telemetry stacks, both opt-out:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,22 +89,13 @@ service has `DATABASE_URI` and `REDIS_URI` set before deploying. Set
 
 ## macOS signing and notarization
 
-The release workflow signs the macOS onedir bundle with a Developer ID
-certificate and notarizes it when these repository secrets exist. Without them
-the bundle is ad-hoc signed, which still builds and runs but makes every Mac
-validate all bundled files on first use (about 15 seconds at install and
-several seconds on the first launch).
+Release builds sign the macOS onedir bundle with the project's Developer ID
+and notarize it. The credentials live only in the release workflow's GitHub
+Actions secrets. A build without them (a fork, a local dry run) is ad-hoc
+signed instead: it still runs, but every Mac validates all bundled files on
+first use (about 15 seconds at install and several seconds on first launch).
 
-| Secret | Value |
-| ------ | ----- |
-| `APPLE_DEVELOPER_ID_P12` | The "Developer ID Application" certificate with its private key, exported from Keychain Access as `.p12`, base64-encoded (`base64 -i cert.p12 \| pbcopy`) |
-| `APPLE_DEVELOPER_ID_P12_PASSWORD` | The password chosen at export |
-| `APPLE_NOTARY_KEY_ID` | Key ID of an App Store Connect API key with the Developer role |
-| `APPLE_NOTARY_ISSUER_ID` | Issuer ID shown on the same API keys page |
-| `APPLE_NOTARY_KEY_P8` | The downloaded `AuthKey_<id>.p8`, base64-encoded |
-
-The identity comes from the certificate, so no team ID secret is needed. The
-hardened-runtime exceptions the frozen interpreter needs live in
+The hardened-runtime exceptions the frozen interpreter needs live in
 `packaging/macos/opensre.entitlements`. The installer leaves a Developer ID
 signature untouched; it only re-signs ad-hoc bundles.
 
@@ -112,7 +103,6 @@ To check a published build:
 
 ```bash
 codesign -dv --verbose=2 ~/.local/bin/.opensre-app/opensre 2>&1 | grep Authority
-xcrun notarytool history --key AuthKey.p8 --key-id <id> --issuer <issuer>
 ```
 
 ## Telemetry and privacy

--- a/install.sh
+++ b/install.sh
@@ -799,6 +799,10 @@ clear_macos_quarantine() {
   xattr -dr com.apple.quarantine "$target_path" >/dev/null 2>&1 || true
 }
 
+macos_binary_is_developer_id_signed() {
+  codesign -dv "$1" 2>&1 | grep -q 'Authority=Developer ID Application'
+}
+
 resign_macos_onedir_adhoc() {
   local binary_path="$1"
   local bundle_dir
@@ -812,6 +816,11 @@ resign_macos_onedir_adhoc() {
   [ -f "$binary_path" ] || return 0
   bundle_dir="$(cd "$(dirname "$binary_path")" && pwd)"
   clear_macos_quarantine "$bundle_dir"
+  # A Developer ID signed (notarized) bundle keeps its signature: re-signing
+  # ad-hoc would throw away the notarization and the trust that comes with it.
+  if macos_binary_is_developer_id_signed "$binary_path"; then
+    return 0
+  fi
   # Nested libs are independent; parallelize with a small cap so large hosts
   # do not stampede the disk. The main binary stays serial and last.
   jobs="$(sysctl -n hw.ncpu 2>/dev/null || printf '4')"

--- a/packaging/macos/opensre.entitlements
+++ b/packaging/macos/opensre.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Hardened-runtime exceptions a PyInstaller-frozen CPython needs:
+       the interpreter JIT-free but maps writable+executable pages for
+       ctypes/cffi trampolines, loads bundled dylibs that are signed
+       separately, and reads PYTHON*/DYLD* variables set by the launcher. -->
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -669,3 +669,40 @@ def test_resign_macos_onedir_parallelizes_nested_libs() -> None:
     assert 'codesign --force --sign - "$binary_path"' in source
     # Cap avoids disk stampede on large hosts.
     assert 'if [ "$jobs" -gt 4 ]; then' in source
+
+
+@pytest.mark.parametrize(
+    ("authority_line", "expect_resign"),
+    [
+        ("Authority=Developer ID Application: Tracer Cloud (TEAMID1234)", False),
+        ("Signature=adhoc", True),
+    ],
+    ids=["developer-id-kept", "adhoc-resigned"],
+)
+def test_resign_keeps_a_developer_id_signature(
+    tmp_path: Path, authority_line: str, expect_resign: bool
+) -> None:
+    """Re-signing a notarized bundle ad-hoc would discard its trust; only ad-hoc gets re-signed."""
+    bundle = tmp_path / "app"
+    bundle.mkdir()
+    binary = bundle / "opensre"
+    binary.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+    (bundle / "lib.dylib").write_text("", encoding="utf-8")
+    resigned = tmp_path / "resigned"
+
+    result = _run_logging_snippet(
+        f"""
+        uname() {{ printf 'Darwin\\n'; }}
+        xattr() {{ return 0; }}
+        sysctl() {{ printf '2\\n'; }}
+        codesign() {{
+          if [ "$1" = "-dv" ]; then printf '%s\\n' {shlex.quote(authority_line)} >&2; return 0; fi
+          printf '%s\\n' "$*" >> {shlex.quote(str(resigned))}
+        }}
+        export -f codesign uname xattr sysctl
+        resign_macos_onedir_adhoc {shlex.quote(str(binary))}
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert resigned.exists() == expect_resign

--- a/tests/packaging/test_release_manifest.py
+++ b/tests/packaging/test_release_manifest.py
@@ -135,13 +135,32 @@ def test_release_smoke_asserts_onedir_contains_the_baked_index() -> None:
     assert "_package-smoke" in workflow
 
 
-def test_release_workflow_parallelizes_macos_onedir_resign() -> None:
+def test_release_workflow_parallelizes_macos_onedir_signing() -> None:
     """Nested lib signs are independent; main binary stays serial and last."""
     workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
-    assert 'xargs -0 -P "$JOBS" -n 1 codesign --force --sign -' in workflow
-    assert 'codesign --force --sign - "$APP_BIN"' in workflow
+    assert 'xargs -0 -P "$JOBS" -n 1 "${SIGN[@]}"' in workflow
+    assert '"${SIGN[@]}" "$APP_BIN"' in workflow
     assert 'if [ "$JOBS" -gt 4 ]; then' in workflow
+
+
+def test_release_workflow_signs_with_developer_id_and_notarizes_when_configured() -> None:
+    """With the certificate secrets the bundle is hardened-runtime signed and notarized;
+    without them it stays ad-hoc so forks and secret-less runs still build."""
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    entitlements = _REPO_ROOT / "packaging" / "macos" / "opensre.entitlements"
+
+    assert entitlements.is_file()
+    assert 'echo "MACOS_SIGN_IDENTITY=-" >> "$GITHUB_ENV"' in workflow
+    assert (
+        "--options runtime --timestamp --entitlements packaging/macos/opensre.entitlements"
+        in workflow
+    )
+    assert "xcrun notarytool submit" in workflow
+    # Notarization runs before the archive is packaged so the asset carries the signed tree.
+    assert workflow.index("- name: Notarize macOS onedir") < workflow.index(
+        "- name: Package binary archive (Unix)"
+    )
 
 
 def test_release_workflow_does_not_run_on_pull_requests() -> None:


### PR DESCRIPTION
The macOS onedir bundle was only ad-hoc signed, so every Mac validated all
bundled files on first use (about 15 seconds at install, several seconds on
first launch). Release builds are now signed with the project's Developer ID
under the hardened runtime and notarized. Builds without release credentials,
such as forks, keep the previous ad-hoc behaviour unchanged.

- `release.yml`: signing runs through one `codesign` argument list for the
  parallel nested-lib pass and the serial main-binary pass. A release identity
  adds hardened runtime, timestamp, and entitlements. Notarization runs before
  the archive is packaged so the asset carries the signed tree. A folder
  cannot be stapled, so Gatekeeper fetches the ticket online on first run.
- `packaging/macos/opensre.entitlements`: the three hardened-runtime
  exceptions a PyInstaller-frozen CPython needs.
- `install.sh`: the installer keeps a Developer ID signature and only
  re-signs ad-hoc bundles, so it no longer discards notarization.
- `docs/DEVELOPMENT.md`: how to verify a published build.