### PR TITLE
fix(llm): discover Ollama models before switching

### DIFF
--- a/surfaces/cli/wizard/local_llm/ollama.py
+++ b/surfaces/cli/wizard/local_llm/ollama.py
@@ -13,7 +13,14 @@ import httpx
 
 from config.llm_models import DEFAULT_OLLAMA_HOST
 from infrastructure.terminal.theme import DIM, WARNING
-from surfaces.shared.llm_setup.ollama import normalize_model_tag
+from surfaces.shared.llm_setup.ollama import (
+    OllamaModelDiscoveryError,
+    list_available_models,
+    model_is_available,
+)
+from surfaces.shared.llm_setup.ollama import (
+    normalize_model_tag as normalize_model_tag,
+)
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -80,13 +87,10 @@ def wait_for_server(host: str, timeout_s: int = 30) -> bool:
 def is_model_present(model: str, host: str = DEFAULT_OLLAMA_HOST) -> bool:
     """Return True if the model tag is already pulled."""
     try:
-        r = httpx.get(f"{host.rstrip('/')}/api/tags", timeout=5.0)
-        r.raise_for_status()
-        available = [m["name"] for m in r.json().get("models", [])]
-        normalized_model = normalize_model_tag(model)
-        return normalized_model in available
-    except Exception:
+        available_models = list_available_models(host)
+    except OllamaModelDiscoveryError:
         return False
+    return model_is_available(model, available_models)
 
 
 def pull_model(model: str, console: Console, host: str = DEFAULT_OLLAMA_HOST) -> bool:

--- a/surfaces/interactive_shell/command_registry/model/command.py
+++ b/surfaces/interactive_shell/command_registry/model/command.py
@@ -129,10 +129,20 @@ def _interactive_set_provider(console: Console) -> bool | None:
 
         crumb_model = f"{crumb_set}{CRUMB_SEP}{provider_value}"
         while True:
+            if provider.value == "ollama":
+                from surfaces.interactive_shell.command_registry.model.ollama import (
+                    model_menu_choices,
+                )
+
+                reasoning_choices = model_menu_choices(provider, console)
+                if reasoning_choices is None:
+                    break
+            else:
+                reasoning_choices = _reasoning_model_menu_choices(provider)
             reasoning_choice = repl_choose_one(
                 title="reasoning model",
                 breadcrumb=crumb_model,
-                choices=_reasoning_model_menu_choices(provider),
+                choices=reasoning_choices,
             )
             if reasoning_choice is None:
                 break

--- a/surfaces/interactive_shell/command_registry/model/ollama.py
+++ b/surfaces/interactive_shell/command_registry/model/ollama.py
@@ -1,0 +1,74 @@
+"""Ollama-specific model discovery for the interactive model command."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.markup import escape
+
+from config.llm_credentials import resolve_env_credential
+from surfaces.interactive_shell.ui import DIM, ERROR, WARNING
+from surfaces.shared.llm_setup.catalog import ProviderOption
+from surfaces.shared.llm_setup.ollama import (
+    OllamaModelDiscoveryError,
+    list_available_models,
+    model_is_available,
+)
+from surfaces.shared.terminal.components import llm_loader
+
+
+def _available_models(provider: ProviderOption, console: Console) -> tuple[str, ...] | None:
+    host = resolve_env_credential(provider.api_key_env, default=provider.credential_default)
+    try:
+        with llm_loader(console, "Detecting available Ollama models"):
+            return list_available_models(host)
+    except KeyboardInterrupt:
+        console.print(f"[{WARNING}]Ollama model detection cancelled.[/]")
+        return None
+    except OllamaModelDiscoveryError as exc:
+        console.print(f"[{ERROR}]{escape(str(exc))}[/]")
+        console.print(
+            f"[{DIM}]Start Ollama with[/] [bold]ollama serve[/bold][{DIM}], then retry.[/]"
+        )
+        return None
+
+
+def model_menu_choices(
+    provider: ProviderOption,
+    console: Console,
+) -> list[tuple[str, str]] | None:
+    """Build model choices from the configured Ollama instance."""
+    available_models = _available_models(provider, console)
+    if available_models is None:
+        return None
+    if not available_models:
+        console.print(f"[{ERROR}]No Ollama models are available.[/]")
+        console.print(
+            f"[{DIM}]Pull one with[/] [bold]ollama pull <model>[/bold] "
+            f"[{DIM}]or choose another provider.[/]"
+        )
+        return None
+    return [(model, model) for model in available_models]
+
+
+def validate_model_available(
+    provider: ProviderOption,
+    model: str,
+    console: Console,
+) -> bool:
+    """Require the selected model to exist on the configured Ollama instance."""
+    available_models = _available_models(provider, console)
+    if available_models is None:
+        return False
+    if model_is_available(model, available_models):
+        return True
+
+    listed = ", ".join(available_models) or "none"
+    console.print(f"[{ERROR}]Ollama model is not available:[/] {escape(model)}")
+    console.print(f"[{DIM}]available models:[/] {escape(listed)}")
+    console.print(
+        f"[{DIM}]Pull it with[/] [bold]ollama pull {escape(model)}[/bold][{DIM}], then retry.[/]"
+    )
+    return False
+
+
+__all__ = ["model_menu_choices", "validate_model_available"]

--- a/surfaces/interactive_shell/command_registry/model/switching.py
+++ b/surfaces/interactive_shell/command_registry/model/switching.py
@@ -216,6 +216,13 @@ def switch_llm_provider(
             f"[{DIM}]known reasoning models:[/] {escape(_format_supported_models(provider.models))}"
         )
         return False
+    if provider.value == "ollama" and selected_model:
+        from surfaces.interactive_shell.command_registry.model.ollama import (
+            validate_model_available,
+        )
+
+        if not validate_model_available(provider, selected_model, console):
+            return False
 
     selected_toolcall: str | None = None
     if toolcall_model is not None:
@@ -246,12 +253,13 @@ def switch_llm_provider(
     # Be explicit about which slot each model lands in.
     console.print(f"[{HIGHLIGHT}]switched LLM provider:[/] {provider.value}")
     console.print(
-        f"[{HIGHLIGHT}]reasoning model:[/] {selected_model or 'provider default'} "
+        f"[{HIGHLIGHT}]reasoning model:[/] "
+        f"{escape(selected_model) if selected_model else 'provider default'} "
         f"[{DIM}]({provider.model_env})[/]"
     )
     if selected_toolcall:
         console.print(
-            f"[{HIGHLIGHT}]toolcall model:[/] {selected_toolcall} "
+            f"[{HIGHLIGHT}]toolcall model:[/] {escape(selected_toolcall)} "
             f"[{DIM}]({provider.toolcall_model_env})[/]"
         )
     console.print(f"[{DIM}]updated {env_path}[/]")
@@ -300,7 +308,7 @@ def switch_toolcall_model(
     _reset_runtime_llm_caches()
 
     console.print(
-        f"[{HIGHLIGHT}]toolcall model set to:[/] {new_model} "
+        f"[{HIGHLIGHT}]toolcall model set to:[/] {escape(new_model)} "
         f"[{DIM}]({provider.value} · {provider.toolcall_model_env})[/]"
     )
     console.print(f"[{DIM}]updated {env_path}[/]")
@@ -343,12 +351,19 @@ def switch_reasoning_model(
             f"[{DIM}]known reasoning models:[/] {escape(_format_supported_models(provider.models))}"
         )
         return False
+    if provider.value == "ollama":
+        from surfaces.interactive_shell.command_registry.model.ollama import (
+            validate_model_available,
+        )
+
+        if not validate_model_available(provider, new_model, console):
+            return False
 
     env_path = sync_reasoning_model_env(provider=provider, model=new_model)
     _reset_runtime_llm_caches()
 
     console.print(
-        f"[{HIGHLIGHT}]reasoning model set to:[/] {new_model} "
+        f"[{HIGHLIGHT}]reasoning model set to:[/] {escape(new_model)} "
         f"[{DIM}]({provider.value} · {provider.model_env})[/]"
     )
     console.print(f"[{DIM}]updated {env_path}[/]")

--- a/surfaces/shared/llm_setup/ollama.py
+++ b/surfaces/shared/llm_setup/ollama.py
@@ -1,6 +1,16 @@
-"""Ollama model-tag rules shared by validation and the local-LLM wizard."""
+"""Ollama model discovery and tag rules."""
 
 from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+_MODEL_LIST_TIMEOUT_SECONDS = 5.0
+
+
+class OllamaModelDiscoveryError(RuntimeError):
+    """Raised when the configured Ollama host cannot provide its model catalog."""
 
 
 def normalize_model_tag(model: str) -> str:
@@ -8,4 +18,42 @@ def normalize_model_tag(model: str) -> str:
     return model if ":" in model else f"{model}:latest"
 
 
-__all__ = ["normalize_model_tag"]
+def list_available_models(host: str) -> tuple[str, ...]:
+    """Return model names exposed by the configured Ollama host."""
+    try:
+        response = httpx.get(
+            f"{host.rstrip('/')}/api/tags",
+            timeout=_MODEL_LIST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload: Any = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise OllamaModelDiscoveryError(f"Cannot reach Ollama at {host}: {exc}") from exc
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        raise OllamaModelDiscoveryError(f"Ollama at {host} returned an invalid model catalog.")
+
+    names = {
+        str(item.get("name") or item.get("model") or "").strip()
+        for item in payload["models"]
+        if isinstance(item, dict)
+    }
+    return tuple(sorted(name for name in names if name))
+
+
+def model_is_available(model: str, available_models: tuple[str, ...]) -> bool:
+    """Return whether ``model`` resolves to an available Ollama tag."""
+    normalized_available = {normalize_model_tag(candidate) for candidate in available_models}
+    if normalize_model_tag(model) in normalized_available:
+        return True
+    if ":" in model:
+        return False
+    return any(candidate.split(":", maxsplit=1)[0] == model for candidate in available_models)
+
+
+__all__ = [
+    "OllamaModelDiscoveryError",
+    "list_available_models",
+    "model_is_available",
+    "normalize_model_tag",
+]

--- a/surfaces/shared/llm_setup/validation.py
+++ b/surfaces/shared/llm_setup/validation.py
@@ -60,28 +60,17 @@ def _check_ollama(host: str, model: str) -> ValidationResult:
     """Check Ollama server connectivity and verify model responds to inference."""
     import httpx
 
-    tags_url = f"{host.rstrip('/')}/api/tags"
-    try:
-        r = httpx.get(tags_url, timeout=5.0)
-        r.raise_for_status()
-    except Exception as err:
-        return ValidationResult(
-            ok=False,
-            detail=f"Cannot reach Ollama at {host}. Is it running? Try: ollama serve\n({err})",
-        )
-    available = [m["name"] for m in r.json().get("models", [])]
-    from surfaces.shared.llm_setup.ollama import normalize_model_tag
-
-    normalized_model = normalize_model_tag(model)
-    base_name = model.split(":")[0]
-    # An explicit tag must match exactly: asking for llama3.1:8b and silently
-    # accepting llama3.1:latest would validate a different model than the one
-    # that then gets used. Only an untagged request falls back to the base name.
-    asked_for_a_tag = ":" in model
-    matched = normalized_model in available or (
-        not asked_for_a_tag and any(m.split(":")[0] == base_name for m in available)
+    from surfaces.shared.llm_setup.ollama import (
+        OllamaModelDiscoveryError,
+        list_available_models,
+        model_is_available,
     )
-    if not matched:
+
+    try:
+        available = list_available_models(host)
+    except OllamaModelDiscoveryError as exc:
+        return ValidationResult(ok=False, detail=str(exc))
+    if not model_is_available(model, available):
         listed = ", ".join(available) or "none pulled yet"
         return ValidationResult(
             ok=False,

--- a/tests/cli/test_model_persistence_scenarios.py
+++ b/tests/cli/test_model_persistence_scenarios.py
@@ -290,3 +290,20 @@ class TestReplModelPersistence:
         )
         stored = wizard_store.load_local_config(persistence_paths["store"])
         assert stored["targets"]["local"]["model"] == model
+
+    def test_unavailable_ollama_model_does_not_persist(
+        self,
+        persistence_paths: dict[str, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "surfaces.interactive_shell.command_registry.model.ollama.list_available_models",
+            lambda _host: ("llama3.2:latest",),
+        )
+        console, output = _capture()
+
+        dispatch_slash("/model set ollama ghost-model", Session(), console)
+
+        assert "Ollama model is not available: ghost-model" in output.getvalue()
+        assert not persistence_paths["env"].exists()
+        assert not persistence_paths["store"].exists()

--- a/tests/interactive_shell/test_ollama_model_switching.py
+++ b/tests/interactive_shell/test_ollama_model_switching.py
@@ -1,0 +1,55 @@
+"""Tests for Ollama-specific model switching behavior."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from surfaces.interactive_shell.command_registry.model import ollama
+from surfaces.shared.llm_setup.catalog import PROVIDER_BY_VALUE
+
+
+def _capture() -> tuple[Console, io.StringIO]:
+    output = io.StringIO()
+    return Console(file=output, force_terminal=False, highlight=False), output
+
+
+def test_model_menu_choices_come_from_ollama(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ollama,
+        "list_available_models",
+        lambda _host: ("llama3.2:latest", "qwen2.5:7b"),
+    )
+    console, _ = _capture()
+
+    assert ollama.model_menu_choices(PROVIDER_BY_VALUE["ollama"], console) == [
+        ("llama3.2:latest", "llama3.2:latest"),
+        ("qwen2.5:7b", "qwen2.5:7b"),
+    ]
+
+
+def test_unavailable_model_is_rejected(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ollama,
+        "list_available_models",
+        lambda _host: ("llama3.2:latest",),
+    )
+    console, output = _capture()
+
+    assert (
+        ollama.validate_model_available(PROVIDER_BY_VALUE["ollama"], "ghost-model", console)
+        is False
+    )
+    assert "Ollama model is not available: ghost-model" in output.getvalue()
+
+
+def test_model_detection_can_be_cancelled(monkeypatch) -> None:
+    def _cancel(_host: str) -> tuple[str, ...]:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(ollama, "list_available_models", _cancel)
+    console, output = _capture()
+
+    assert ollama.model_menu_choices(PROVIDER_BY_VALUE["ollama"], console) is None
+    assert "Ollama model detection cancelled" in output.getvalue()

--- a/tests/shared/llm_setup/test_ollama.py
+++ b/tests/shared/llm_setup/test_ollama.py
@@ -1,0 +1,37 @@
+"""Tests for Ollama model discovery and tag matching."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import httpx
+
+from surfaces.shared.llm_setup.ollama import list_available_models, model_is_available
+
+
+def test_list_available_models_returns_sorted_unique_names(monkeypatch) -> None:
+    request = httpx.Request("GET", "http://localhost:11434/api/tags")
+    response = httpx.Response(
+        HTTPStatus.OK,
+        json={
+            "models": [
+                {"name": "qwen2.5:7b"},
+                {"model": "llama3.2:latest"},
+                {"name": "qwen2.5:7b"},
+            ]
+        },
+        request=request,
+    )
+    monkeypatch.setattr(httpx, "get", lambda *_args, **_kwargs: response)
+
+    assert list_available_models("http://localhost:11434") == (
+        "llama3.2:latest",
+        "qwen2.5:7b",
+    )
+
+
+def test_model_is_available_requires_the_selected_tag() -> None:
+    available = ("llama3.2:8b", "qwen2.5:latest")
+
+    assert model_is_available("qwen2.5", available) is True
+    assert model_is_available("llama3.2:latest", available) is False


### PR DESCRIPTION
Fixes #5768

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Discover model choices from the configured Ollama host via `GET /api/tags` instead of showing the static provider catalog.
- Reject unavailable Ollama models before changing `.env` or resetting runtime clients.
- Keep model switching for hosted, CLI, and ambient-auth providers unchanged; switching no longer performs an implicit paid completion probe.
- Reuse the Ollama discovery and tag-matching helpers in onboarding validation and the local-model lifecycle.
- Preserve Rich escaping for model identifiers shown by the switching commands.

This is a clean, focused replacement for #6011, whose branch accumulated unrelated `main` merges and whose generic `_validate_selected_model` approach expanded model switching into cross-provider live validation.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```text
$ uv run python -m pytest tests/cli/ tests/interactive_shell/ \
    tests/shared/llm_setup/test_ollama.py \
    tests/shared/llm_setup/test_validation.py -q
2261 passed, 5 skipped

$ uv run python -m pytest \
    tests/interactive_shell/test_ollama_model_switching.py \
    tests/shared/llm_setup/test_ollama.py \
    tests/cli/test_model_persistence_scenarios.py \
    tests/shared/llm_setup/test_validation.py \
    tests/cli/test_local_llm.py \
    tests/cli/test_local_llm_ollama_lifecycle.py -q
76 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is specific to Ollama's locally available model inventory, so the implementation keeps the provider-specific behavior in Ollama-owned modules. A shared helper performs one bounded `/api/tags` request, validates the response shape, normalizes tags, and returns a stable model tuple. The interactive picker consumes that tuple, while direct switching performs the same availability check immediately before persistence. Hosted-provider credential verification remains an explicit authentication concern rather than an implicit side effect of model switching.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and understand how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
