### PR TITLE
fix(evidence): match bare status codes only as whole numbers

### DIFF
--- a/infrastructure/evidence/log_compaction.py
+++ b/infrastructure/evidence/log_compaction.py
@@ -148,14 +148,16 @@ _ERROR_TYPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("DNSResolution", re.compile(r"dns|name\s*resolution|resolve\s*host", re.IGNORECASE)),
     (
         "AuthenticationError",
-        re.compile(r"auth(entication|orization)?\s*(fail|error|denied)|401|403", re.IGNORECASE),
+        re.compile(
+            r"auth(entication|orization)?\s*(fail|error|denied)|\b401\b|\b403\b", re.IGNORECASE
+        ),
     ),
     (
         "OutOfMemory",
         re.compile(r"(out\s*of\s*memory|oom\s*kill|memory\s*(error|exceed|limit))", re.IGNORECASE),
     ),
     ("DiskFull", re.compile(r"(no\s*space|disk\s*full|storage\s*(full|limit))", re.IGNORECASE)),
-    ("RateLimited", re.compile(r"rate\s*limit|throttl|429", re.IGNORECASE)),
+    ("RateLimited", re.compile(r"rate\s*limit|throttl|\b429\b", re.IGNORECASE)),
     (
         "SchemaValidation",
         re.compile(
@@ -174,7 +176,7 @@ _ERROR_TYPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ),
     (
         "ResourceNotFound",
-        re.compile(r"(not\s*found|404|no\s*such\s*(file|key|bucket))", re.IGNORECASE),
+        re.compile(r"(not\s*found|\b404\b|no\s*such\s*(file|key|bucket))", re.IGNORECASE),
     ),
     (
         "SyntaxError",

--- a/tests/tools/test_log_compaction.py
+++ b/tests/tools/test_log_compaction.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from infrastructure.evidence.log_compaction import (
     _classify_error_type,
     _extract_components,
@@ -279,6 +281,40 @@ class TestClassifyErrorType:
 
     def test_unknown(self):
         assert _classify_error_type("Something completely unexpected") == "Unknown"
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Request completed in 1429ms",
+            "Processed 40412 records from the queue",
+            "worker pod-4013 restarted",
+            "Backfill wrote 8404 rows",
+            "checkpoint 24290 committed",
+        ],
+    )
+    def test_status_codes_inside_larger_numbers_are_not_errors(self, message):
+        # The status-code alternatives were unanchored, so `re.search` found
+        # 429 inside 1429 and bucketed an ordinary latency as RateLimited.
+        # build_error_taxonomy feeds the model's error breakdown, so this
+        # invented an error class that was never in the data.
+        assert _classify_error_type(message) == "Unknown"
+
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            ("HTTP 429 Too Many Requests", "RateLimited"),
+            ("returned 429.", "RateLimited"),
+            ("got 401 unauthorized", "AuthenticationError"),
+            ("HTTP/1.1 403 Forbidden", "AuthenticationError"),
+            ("code: 401,", "AuthenticationError"),
+            ("status=404 not found", "ResourceNotFound"),
+            ("[404] missing", "ResourceNotFound"),
+        ],
+    )
+    def test_standalone_status_codes_still_classify(self, message, expected):
+        # The boundaries must not cost us the real ones: a code delimited by a
+        # space, punctuation, a slash or a bracket still has to be recognised.
+        assert _classify_error_type(message) == expected
 
     def test_rate_limit(self):
         assert _classify_error_type("429 Too Many Requests") == "RateLimited"


### PR DESCRIPTION
Fixes #6034

#### Describe the changes you have made in this PR -

`_ERROR_TYPE_PATTERNS` listed `401`, `403`, `404` and `429` as bare alternatives, so `re.search` matched them anywhere inside a longer number. Anchored all four with `\b`.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`):

```
'Request completed in 1429ms'              -> RateLimited
'Processed 40412 records from the queue'   -> ResourceNotFound
'worker pod-4013 restarted'                -> AuthenticationError
'Backfill wrote 8404 rows'                 -> ResourceNotFound
'checkpoint 24290 committed'               -> RateLimited
```

After:

```
--- benign (want Unknown) ---
  'Request completed in 1429ms'            -> Unknown
  'Processed 40412 records from the queue' -> Unknown
  'worker pod-4013 restarted'              -> Unknown
  'Backfill wrote 8404 rows'               -> Unknown
  'checkpoint 24290 committed'             -> Unknown
--- real errors (want a bucket) ---
  'HTTP 429 Too Many Requests'             -> RateLimited
  'got 401 unauthorized'                   -> AuthenticationError
  'status=404 not found'                   -> ResourceNotFound
  'HTTP/1.1 403 Forbidden'                 -> AuthenticationError
  'returned 429.'                          -> RateLimited
  '[404] missing'                          -> ResourceNotFound
  'code: 401,'                             -> AuthenticationError
```

Test run:

```
$ pytest tests/tools/test_log_compaction.py -q
48 passed
```

With the two new test classes in place and `log_compaction.py` reverted: `5 failed, 43 passed`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**The problem.** `_classify_error_type` walks `_ERROR_TYPE_PATTERNS` in order and returns the first label whose regex matches. Three of those regexes carry a bare HTTP status code as an alternative — `...|401|403`, `...|429`, `...|404|...`. `re.search` is substring-based, so `429` matches inside `1429`, `404` inside `8404` and `40412`, `401` inside `4013`. Any log line whose digits happen to contain those three-digit runs is bucketed as an error.

It matters because `build_error_taxonomy` is the error breakdown handed to the model for an incident. A benign duration or record count does not just get mislabelled — it adds a count to an error class that never occurred, so the model reasons about a rate-limit or auth problem that is not in the data.

**Alternatives I considered.**

1. *Drop the bare codes entirely* and rely on the wording alternatives (`rate limit`, `throttl`, `auth failed`). Rejected: plenty of real log lines carry only the code, e.g. `status=404`, and the codes are there deliberately.
2. *Require a prefix* such as `(?:status|code|HTTP)\s*[:=]?\s*404`. Rejected as too narrow — it would miss `[404] missing` and `returned 429.`, both of which are unambiguous to a reader.
3. *Word boundaries* — what I chose. `\b404\b` keeps every delimiter that actually occurs around a status code (space, `=`, `:`, `,`, `.`, `/`, `[`, `]`) because none of those are word characters, while a digit on either side suppresses the match, which is exactly the false-positive case.

**Why this one.** It is the minimal change that separates the two cases on the structural property that distinguishes them — a status code is a whole number, a false positive is a digit run inside a longer one — rather than on a guess about surrounding wording. Nothing else in the module changes, and the ordering of the pattern list is untouched.

**Key components.** Only the three `re.compile` calls change. `_classify_error_type` and `build_error_taxonomy` are not modified.

**Edge cases tested.** Both directions are parametrized in `TestClassifyErrorType`: five benign lines that must be `Unknown` (leading digit, trailing digit, hyphen-prefixed, and codes embedded mid-number), and seven genuine ones that must still classify, covering space, `=`, `:`, `,`, `.`, `/` and `[]` delimiters. I checked the trailing-punctuation cases specifically, since that is what a naive `\s` anchor would have broken.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
