### PR TITLE
fix(aws): do not abort an invocation listing on an unparseable START line

### DIFF
--- a/integrations/aws/lambda_client.py
+++ b/integrations/aws/lambda_client.py
@@ -204,9 +204,16 @@ def get_recent_invocations(
             if "START RequestId:" in message:
                 if current_invocation:
                     invocations.append(current_invocation)
-                request_id = (
-                    message.split("RequestId: ")[1].split()[0] if "RequestId:" in message else None
-                )
+                # The guard tested for "RequestId:" while the split used
+                # "RequestId: ", so it could not prevent the failure it looked
+                # like it was there for. filter_log_events returns the
+                # function's own stdout as well as AWS preamble, so this is
+                # parsing untrusted text; leave the field unset and keep the
+                # rest of the summary, as the Duration and Memory Used parses
+                # below already do.
+                request_id = None
+                with suppress(IndexError, ValueError):
+                    request_id = message.split("RequestId: ")[1].split()[0]
                 current_invocation = {
                     "request_id": request_id,
                     "start_time": timestamp,

--- a/tests/integrations/aws/test_lambda_client.py
+++ b/tests/integrations/aws/test_lambda_client.py
@@ -134,6 +134,40 @@ def test_get_recent_invocations_success(mock_logs_client) -> None:
     assert len(invocation["logs"]) == 4
 
 
+@pytest.mark.parametrize(
+    ("message", "label"),
+    [
+        ("START RequestId:req9 Version: $LATEST\n", "no space after the colon"),
+        ("START RequestId: \n", "label with no value"),
+    ],
+)
+def test_get_recent_invocations_tolerates_unparseable_request_id(
+    mock_logs_client, message, label
+) -> None:
+    """An unparseable START line leaves request_id unset, it does not abort the call.
+
+    filter_log_events returns everything in the log group, the function's own
+    stdout included, so the START parse reads untrusted text. The guard tested
+    for "RequestId:" while the split used "RequestId: ", so neither of these
+    two shapes was caught and the IndexError escaped get_recent_invocations.
+    """
+    mock_logs_client.filter_log_events.return_value = {
+        "events": [
+            {"timestamp": 1000, "message": message},
+            {"timestamp": 1100, "message": "hello world\n"},
+        ]
+    }
+
+    result = get_recent_invocations("test-func")
+
+    assert result["success"] is True, label
+    invocation = result["data"]["invocations"][0]
+    assert invocation["request_id"] is None
+    assert invocation["start_time"] == 1000
+    # the trailing stdout line still lands in this invocation
+    assert invocation["logs"] == [message, "hello world\n"]
+
+
 def test_get_recent_invocations_resource_not_found(mock_logs_client) -> None:
     error_response = {
         "Error": {"Code": "ResourceNotFoundException", "Message": "Log group not found"}

--- a/tests/integrations/aws/test_lambda_client.py
+++ b/tests/integrations/aws/test_lambda_client.py
@@ -144,13 +144,9 @@ def test_get_recent_invocations_success(mock_logs_client) -> None:
 def test_get_recent_invocations_tolerates_unparseable_request_id(
     mock_logs_client, message, label
 ) -> None:
-    """An unparseable START line leaves request_id unset, it does not abort the call.
-
-    filter_log_events returns everything in the log group, the function's own
-    stdout included, so the START parse reads untrusted text. The guard tested
-    for "RequestId:" while the split used "RequestId: ", so neither of these
-    two shapes was caught and the IndexError escaped get_recent_invocations.
-    """
+    """An unparseable START line leaves request_id unset without aborting the call."""
+    # filter_log_events returns everything in the log group, the function's own
+    # stdout included, so the START parse reads untrusted text.
     mock_logs_client.filter_log_events.return_value = {
         "events": [
             {"timestamp": 1000, "message": message},


### PR DESCRIPTION
Fixes #6035

#### Describe the changes you have made in this PR -

Wrapped the `START RequestId:` parse in `suppress(IndexError, ValueError)` with the field defaulting to `None`, matching the `Duration` and `Memory Used` parses a few lines below.

### Demo/Screenshot for feature changes and bug fixes -

Before (on `main`) — both shapes abort the whole call:

```
'START RequestId:req9 Version: $LATEST\n'  -> IndexError: list index out of range
'START RequestId: \n'                      -> IndexError: list index out of range
'START RequestId: ok-1 Version: $LATEST\n' -> OK  request_id='ok-1'
```

After — the field is left unset and the rest of the summary survives:

```
no space after colon   success=True count=1 request_id=None logs_kept=1
label with no value    success=True count=1 request_id=None logs_kept=1
normal                 success=True count=1 request_id='ok-1' logs_kept=1
```

Test run:

```
$ pytest tests/integrations/aws/test_lambda_client.py tests/tools/test_lambda_errors_tool.py tests/tools/test_lambda_invocation_logs_tool.py -q
38 passed
```

With the new test in place and `lambda_client.py` reverted: `2 failed, 13 passed`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**The problem.** The parse was

```python
request_id = (
    message.split("RequestId: ")[1].split()[0] if "RequestId:" in message else None
)
```

The guard tests for `RequestId:` but the split uses `RequestId: ` with a trailing space, so the two do not describe the same condition and the guard cannot prevent the failure it appears to exist for. Two shapes get past it: `START RequestId:req9 …` (no space, so `split` returns one element and `[1]` raises) and `START RequestId: ` (label with no value, so `[1]` is `""` and `"".split()[0]` raises).

`get_recent_invocations` catches only `ClientError`, so the `IndexError` propagates out and the caller loses every invocation, not just the one field. That is reachable from ordinary traffic rather than a malformed AWS response: `filter_log_events` returns every event in `/aws/lambda/<function>`, including whatever the function itself prints, so any application log line beginning `START RequestId:` reaches this parser.

**Alternatives I considered.**

1. *Fix the guard to `"RequestId: " in message`* — makes the two agree and stops the first shape, but `START RequestId: ` with nothing after it still passes the guard and still raises on `.split()[0]`. It fixes one of the two inputs and leaves a guard that looks total but is not.
2. *Parse with a regex, `RequestId:\s*(\S+)`* — this would also succeed on `RequestId:req9` and recover `req9`. Tempting, but it changes what the function extracts rather than only how it fails, and #6035 states the expected behaviour as leaving `request_id` unset. I left it out to keep the change to the defect; worth doing separately if you want the no-space form actually parsed.
3. *`suppress(IndexError, ValueError)`* — what I chose.

**Why this one.** The block already establishes the convention two parses down: `Duration` and `Memory Used` are both wrapped in exactly this, on the same reasoning, that one unreadable field should not cost the whole record. Following it makes the three parses uniform, covers both failing inputs and any third shape, and adds nothing new to the file — `suppress` is already imported.

**Key components.** Only the `request_id` assignment inside the `START RequestId:` branch changes: `request_id = None` up front, then the split inside `with suppress(...)`. No other control flow is touched, and a well-formed START line still yields the same id.

**Edge cases tested.** The new test is parametrized over both failing shapes and asserts the positive outcome, not just the absence of a raise: `success is True`, `request_id is None`, `start_time` still recorded, and the following stdout line still attached to the invocation's logs. `test_get_recent_invocations_success` continues to pin the well-formed path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
