### PR TITLE
feat(cli): show LLM source and tighten first-run sign-in copy

### DIFF
--- a/surfaces/cli/account_ui.py
+++ b/surfaces/cli/account_ui.py
@@ -92,25 +92,18 @@ class AccountLoginPresenter:
     def prompt_sign_in(self, url: str, *, opened: bool) -> None:
         console = self._console
         console.print()
-        console.print("Sign in to OpenSRE with GitHub:")
+        console.print(f"[bold {TEXT}]Sign in to OpenSRE with GitHub[/]")
         console.print()
         if opened:
-            console.print("  1. Your browser will open this link")
+            console.print("  1  Browser opened")
         else:
-            console.print("  1. Open this URL in your browser")
+            console.print("  1  Open this link in your browser")
         _print_url(console, url)
         if opened:
-            console.print(
-                f"     [{SECONDARY}](if it doesn't open, copy that URL into your browser).[/]"
-            )
-        else:
-            console.print(
-                f"     [{SECONDARY}](copy the link, then return here once GitHub is connected).[/]"
-            )
-        console.print("  2. Sign in with GitHub.")
-        console.print("  3. Connect repository and security access.")
+            console.print(f"     [{SECONDARY}]If it did not open, use the link above.[/]")
+        console.print("  2  Sign in and approve repository and security access")
         console.print()
-        console.print(f"  [{SECONDARY}]Waiting for you to approve in the browser…[/]")
+        console.print(f"  [{SECONDARY}]Waiting for browser approval…[/]")
 
     def authorization_received(self) -> None:
         console = self._console

--- a/surfaces/cli/wizard/factory_setup.py
+++ b/surfaces/cli/wizard/factory_setup.py
@@ -27,8 +27,6 @@ def _run_account_signup_step(*, step: int, total_steps: int) -> bool:
 
     presenter = AccountLoginPresenter(console)
     while True:
-        console.print()
-        console.print("An OpenSRE account is required for the interactive shell.")
         try:
             result = login_account(progress=presenter)
         except (EOFError, KeyboardInterrupt):

--- a/surfaces/cli/wizard/summaries.py
+++ b/surfaces/cli/wizard/summaries.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import cast
 
 from rich import box
+from rich.align import Align
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.text import Text
@@ -29,6 +30,7 @@ from infrastructure.terminal.theme import (
 )
 from surfaces.cli.wizard.components import console
 from surfaces.cli.wizard.integration_health import IntegrationHealthResult
+from surfaces.shared.terminal.banner import build_launch_banner
 
 
 def render_header() -> None:
@@ -55,14 +57,32 @@ def render_header() -> None:
 
 
 def render_factory_setup_header() -> None:
-    """Print the first-run setup splash (webapp account → hosted shell)."""
-    _render_splash_header(
-        heading="A few steps and you are in the terminal",
-        steps=(
-            "Sign in or create your OpenSRE account with GitHub.",
-            "OpenSRE activates the hosted model and opens the interactive shell.",
-        ),
+    """Print the shell launch banner followed by the two-step account setup."""
+    console.print()
+    console.print(build_launch_banner(console))
+
+    steps = Text()
+    steps.append("1  ", style=f"bold {BRAND}")
+    steps.append("Sign in with GitHub", style=f"bold {TEXT}")
+    steps.append(" in the OpenSRE webapp.", style=SECONDARY)
+    steps.append("\n")
+    steps.append("2  ", style=f"bold {BRAND}")
+    steps.append("Start the shell", style=f"bold {TEXT}")
+    steps.append(" with your hosted model.", style=SECONDARY)
+    console.print(
+        Align.center(
+            Panel(
+                steps,
+                title="Setup · 2 steps",
+                title_align="left",
+                border_style=DIM,
+                padding=(1, 2),
+                expand=False,
+                box=box.ROUNDED,
+            )
+        )
     )
+    console.print()
 
 
 def _render_splash_header(*, heading: str, steps: tuple[str, ...]) -> None:

--- a/surfaces/interactive_shell/command_registry/model/command.py
+++ b/surfaces/interactive_shell/command_registry/model/command.py
@@ -7,8 +7,8 @@ import os
 from rich.console import Console
 from rich.markup import escape
 
-import surfaces.interactive_shell.command_registry.repl_data as repl_data
 from config.constants.llm import LLM_PROVIDER_ENV
+from surfaces.interactive_shell.command_registry.model.presentation import render_current_models
 from surfaces.interactive_shell.command_registry.model.switching import (
     _provider_allows_custom_models,
     restore_default_model,
@@ -18,7 +18,7 @@ from surfaces.interactive_shell.command_registry.model.switching import (
 )
 from surfaces.interactive_shell.command_registry.types import SlashCommand
 from surfaces.interactive_shell.runtime import Session
-from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING, render_models_table
+from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING
 from surfaces.shared.llm_setup.provider_choices import (
     OTHER_PROVIDER_SELECTION,
     focused_setup_provider_options,
@@ -248,7 +248,7 @@ def _interactive_model_menu(session: Session, console: Console) -> bool:
             return True
         if action == "show":
             repl_section_break(console)
-            render_models_table(console, repl_data.load_llm_settings())
+            render_current_models(console)
             repl_section_break(console)
             continue
         if action == "set":
@@ -325,18 +325,18 @@ def _cmd_model(session: Session, console: Console, args: list[str]) -> bool:
 
         if exclusive_stdin_active(session):
             return _interactive_model_menu(session, console)
-        render_models_table(console, repl_data.load_llm_settings())
+        render_current_models(console)
         return True
 
     sub = (args[0].lower() if args else "show").strip()
 
     if sub == "show":
-        render_models_table(console, repl_data.load_llm_settings())
+        render_current_models(console)
         return True
 
     if sub == "toolcall":
         if len(args) >= 2 and args[1].lower() == "show":
-            render_models_table(console, repl_data.load_llm_settings())
+            render_current_models(console)
             return True
         if len(args) >= 2 and args[1].lower() in ("set", "use", "switch"):
             if len(args) < 3:

--- a/surfaces/interactive_shell/command_registry/model/presentation.py
+++ b/surfaces/interactive_shell/command_registry/model/presentation.py
@@ -1,0 +1,20 @@
+"""Presentation helpers for the effective LLM connection."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+import surfaces.interactive_shell.command_registry.repl_data as repl_data
+from surfaces.interactive_shell.ui import render_models_table
+
+
+def render_current_models(console: Console) -> None:
+    """Render the effective models together with their configuration source."""
+    render_models_table(
+        console,
+        repl_data.load_llm_settings(),
+        repl_data.load_llm_source(),
+    )
+
+
+__all__ = ["render_current_models"]

--- a/surfaces/interactive_shell/command_registry/model/switching.py
+++ b/surfaces/interactive_shell/command_registry/model/switching.py
@@ -7,9 +7,9 @@ import os
 from rich.console import Console
 from rich.markup import escape
 
-import surfaces.interactive_shell.command_registry.repl_data as repl_data
 from config.constants.llm import LLM_PROVIDER_ENV
-from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING, render_models_table
+from surfaces.interactive_shell.command_registry.model.presentation import render_current_models
+from surfaces.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING
 from surfaces.shared.terminal.components.choice_menu import print_valid_choice_list
 
 
@@ -255,7 +255,7 @@ def switch_llm_provider(
             f"[{DIM}]({provider.toolcall_model_env})[/]"
         )
     console.print(f"[{DIM}]updated {env_path}[/]")
-    render_models_table(console, repl_data.load_llm_settings())
+    render_current_models(console)
     return True
 
 
@@ -304,7 +304,7 @@ def switch_toolcall_model(
         f"[{DIM}]({provider.value} · {provider.toolcall_model_env})[/]"
     )
     console.print(f"[{DIM}]updated {env_path}[/]")
-    render_models_table(console, repl_data.load_llm_settings())
+    render_current_models(console)
     return True
 
 
@@ -352,7 +352,7 @@ def switch_reasoning_model(
         f"[{DIM}]({provider.value} · {provider.model_env})[/]"
     )
     console.print(f"[{DIM}]updated {env_path}[/]")
-    render_models_table(console, repl_data.load_llm_settings())
+    render_current_models(console)
     return True
 
 

--- a/surfaces/interactive_shell/command_registry/repl_data.py
+++ b/surfaces/interactive_shell/command_registry/repl_data.py
@@ -50,8 +50,19 @@ def load_llm_settings() -> Any | None:
         return None
 
 
+def load_llm_source() -> str:
+    """Return the user-facing origin of the effective LLM route."""
+    try:
+        from config.account import account_llm_route
+
+        return "OpenSRE webapp" if account_llm_route() is not None else "local configuration"
+    except Exception:
+        return "local configuration"
+
+
 __all__ = [
     "configured_integration_names",
+    "load_llm_source",
     "load_llm_settings",
     "load_verified_integrations",
     "verify_integration",

--- a/surfaces/shared/terminal/tables/tables.py
+++ b/surfaces/shared/terminal/tables/tables.py
@@ -174,7 +174,11 @@ def render_mcp_table(console: Console, results: list[dict[str, str]]) -> None:
     render_table(console, "MCP servers", _INTEGRATION_COLS, [_integration_row(r) for r in rows])
 
 
-def render_models_table(console: Console, settings: Any) -> None:
+def render_models_table(
+    console: Console,
+    settings: Any,
+    source: str = "local configuration",
+) -> None:
     if settings is None:
         repl_print(console, f"[{ERROR}]LLM settings unavailable[/] — check provider env vars.")
         return
@@ -182,7 +186,7 @@ def render_models_table(console: Console, settings: Any) -> None:
     reasoning_model, toolcall_model = resolve_provider_models(settings, provider)
     render_table(
         console,
-        "LLM connection",
+        f"LLM connection · {source}",
         _MODEL_COLS,
         [(provider, reasoning_model, toolcall_model)],
     )

--- a/tests/cli/test_account_command.py
+++ b/tests/cli/test_account_command.py
@@ -285,7 +285,7 @@ def test_logout_revokes_the_file_token_not_an_environment_override(
     assert "OPENSRE_ACCOUNT_TOKEN" in result.detail
 
 
-def test_login_presenter_prints_url_and_numbered_steps() -> None:
+def test_login_presenter_prints_url_and_concise_browser_steps() -> None:
     url = (
         "http://localhost:3000/cli/auth/github"
         "?callback_port=43721&state=login-state&code_challenge=pkce"
@@ -298,12 +298,12 @@ def test_login_presenter_prints_url_and_numbered_steps() -> None:
     presenter.setup_complete()
 
     output = buf.getvalue()
-    assert "Sign in to OpenSRE with GitHub:" in output
-    assert "1. Your browser will open this link" in output
+    assert "Sign in to OpenSRE with GitHub" in output
+    assert "1  Browser opened" in output
     assert url in output
-    assert "2. Sign in with GitHub." in output
-    assert "3. Connect repository and security access." in output
-    assert "Waiting for you to approve in the browser" in output
+    assert "2  Sign in and approve repository and security access" in output
+    assert "3." not in output
+    assert "Waiting for browser approval" in output
     assert "Browser authorization received." in output
     assert "GitHub integration connected." in output
     assert "Hosted model activated." in output

--- a/tests/cli/wizard/test_factory_setup.py
+++ b/tests/cli/wizard/test_factory_setup.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import io
+
+from rich.console import Console
+
 from config.account import AccountRecord
 from surfaces.cli.account_auth import AccountAuthError, AccountLoginResult
-from surfaces.cli.wizard import factory_setup
+from surfaces.cli.wizard import factory_setup, summaries
 from surfaces.shared.account_session import AccountSessionState, AccountStatus
+from surfaces.shared.terminal.banner import banner as banner_module
+from surfaces.shared.terminal.banner.banner_state import LaunchStatus
 
 
 def _signed_out() -> AccountStatus:
@@ -23,6 +29,29 @@ def _record() -> AccountRecord:
         token_expires_at="2026-12-01T10:00:00+00:00",
         llm_model="gpt-5.4-mini",
     )
+
+
+def test_factory_setup_uses_the_shell_banner_with_concise_steps(monkeypatch) -> None:
+    output = io.StringIO()
+    monkeypatch.setattr(
+        banner_module,
+        "load_launch_status",
+        lambda: LaunchStatus(skill_count=4, integration_count=1),
+    )
+    monkeypatch.setattr(
+        summaries,
+        "console",
+        Console(file=output, force_terminal=False, highlight=False, width=100),
+    )
+
+    summaries.render_factory_setup_header()
+
+    rendered = output.getvalue()
+    assert "Welcome to OpenSRE CLI" in rendered
+    assert "Skills (4)" in rendered
+    assert "Setup · 2 steps" in rendered
+    assert "Sign in with GitHub in the OpenSRE webapp" in rendered
+    assert "Start the shell with your hosted model" in rendered
 
 
 def test_run_factory_setup_requires_account_then_returns_success(monkeypatch) -> None:

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -384,10 +384,23 @@ class TestSpecificListCommands:
         console, buf = _capture()
         dispatch_slash("/model show", Session(), console)
         output = buf.getvalue()
+        assert "local configuration" in output
         assert "provider" in output
         assert "reasoning model" in output
         assert "toolcall model" in output
         assert "anthropic" in output
+
+    def test_model_show_identifies_the_opensre_webapp_source(self, monkeypatch: object) -> None:
+        self._patch_llm(monkeypatch)
+        monkeypatch.setattr(
+            "config.account.account_llm_route",
+            lambda: object(),
+        )
+        console, buf = _capture()
+
+        dispatch_slash("/model show", Session(), console)
+
+        assert "OpenSRE webapp" in buf.getvalue()
 
     def test_model_show_displays_ollama_model(self, monkeypatch: object) -> None:
         class _FakeLLM:

--- a/tests/interactive_shell/test_model_credential_entry.py
+++ b/tests/interactive_shell/test_model_credential_entry.py
@@ -69,8 +69,7 @@ def test_pasted_key_is_saved_and_switch_proceeds(monkeypatch: Any) -> None:
     monkeypatch.setattr(service, "configure_api_key_provider", lambda **kw: saves.append(kw))
     monkeypatch.setattr(env_sync, "sync_provider_env", lambda **_: "/tmp/.env")
     monkeypatch.setattr(switching, "_reset_runtime_llm_caches", lambda: None)
-    monkeypatch.setattr(switching, "render_models_table", lambda *_: None)
-    monkeypatch.setattr(switching.repl_data, "load_llm_settings", lambda: {})
+    monkeypatch.setattr(switching, "render_current_models", lambda *_: None)
 
     console = _Console(key="sk-test-123")
     assert switching.switch_llm_provider("openai", console) is True  # type: ignore[arg-type]
@@ -169,8 +168,7 @@ def test_custom_provider_no_model_preserves_configured_model(monkeypatch: Any) -
         env_sync, "sync_provider_env", lambda **kw: synced.append(kw) or "/tmp/.env"
     )
     monkeypatch.setattr(switching, "_reset_runtime_llm_caches", lambda: None)
-    monkeypatch.setattr(switching, "render_models_table", lambda *_: None)
-    monkeypatch.setattr(switching.repl_data, "load_llm_settings", lambda: {})
+    monkeypatch.setattr(switching, "render_current_models", lambda *_: None)
 
     console = _Console()
     assert switching.switch_llm_provider("custom-openai", console) is True  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Show whether the LLM connection comes from the OpenSRE webapp or local config.
- Simplify GitHub first-run sign-in copy and the setup splash.

## Test plan
- [x] CI

## Code Understanding and AI Usage
- [x] Yes, I used AI assistance
- [x] I have reviewed the AI-generated code