### PR TITLE
fix(guardrails): load no rules when the rules key is empty instead of raising TypeError

### DIFF
--- a/infrastructure/safety/guardrails/rules.py
+++ b/infrastructure/safety/guardrails/rules.py
@@ -61,8 +61,19 @@ def load_rules(path: Path | None = None) -> list[GuardrailRule]:
         logger.warning("Guardrails config missing 'rules' key at %s", rules_path)
         return []
 
+    entries = raw["rules"]
+    if entries is None:
+        # A `rules:` key with nothing under it parses as None. Commenting out
+        # every rule is the natural way to disable guardrails for a moment, and
+        # the documented contract for a malformed config is an empty list, so
+        # this loads no rules rather than raising.
+        return []
+    if not isinstance(entries, list):
+        logger.warning("Guardrails config 'rules' is not a list at %s", rules_path)
+        return []
+
     rules: list[GuardrailRule] = []
-    for entry in raw["rules"]:
+    for entry in entries:
         if not isinstance(entry, dict):
             continue
         parsed = _parse_rule(entry)

--- a/tests/infrastructure/safety/guardrails/test_rules.py
+++ b/tests/infrastructure/safety/guardrails/test_rules.py
@@ -157,6 +157,17 @@ class TestLoadRules:
         assert rules[0].description == "Credit cards"
         assert rules[0].replacement == "[CC_REDACTED]"
 
+    def test_returns_empty_when_rules_key_is_empty(self, tmp_path: Path) -> None:
+        """A `rules:` key with nothing under it parses as None, not a list.
+
+        Commenting out every rule is the natural way to disable guardrails, and
+        it used to raise TypeError out of load_rules, which broke the
+        guardrail evaluator singleton and `opensre health`.
+        """
+        path = tmp_path / "guardrails.yml"
+        path.write_text("rules:", encoding="utf-8")
+        assert load_rules(path) == []
+
     def test_multiple_rules(self, tmp_path: Path) -> None:
         path = _write_config(
             tmp_path,


### PR DESCRIPTION
Fixes #6033

#### Describe the changes you have made in this PR -

`load_rules` documents an empty rule list for a missing or malformed config, and already guards the missing-key case. It did not guard a `rules:` key that is present but empty: YAML parses that as `None`, and `for entry in raw["rules"]` raises `TypeError: 'NoneType' object is not iterable`. The `try` only wraps `yaml.safe_load`, so nothing catches it — `get_guardrail_evaluator()` fails to build its singleton and `opensre health` raises while rendering the guardrails row.

Two lines of guard after the existing missing-key check:

- `rules: None` (the empty key) returns `[]` silently. It is the natural way to disable guardrails for a moment — comment out every rule — so it is a valid config, not a malformed one, and does not deserve a warning.
- `rules:` holding something that is not a list (a scalar, a mapping) returns `[]` with the same `logger.warning` the other malformed shapes get.

### Demo/Screenshot for feature changes and bug fixes -

The issue's reproduction, before and after, plus the new test:

```
$ # before (git stash of the fix), the new test on current main:
E   TypeError: 'NoneType' object is not iterable
====================== 1 failed, 13 deselected in 2.02s =======================

$ # after:
====================== 1 passed, 13 deselected in 1.51s =======================

$ uv run python -m pytest tests/infrastructure/safety/guardrails/test_rules.py -q
============================= 14 passed in 5.55s ==============================
```

Lint and format on the touched files:

```
$ ruff check infrastructure/safety/guardrails/rules.py tests/infrastructure/safety/guardrails/test_rules.py
All checks passed!
$ ruff format --check <same>
2 files already formatted
```

(`make lint` / `make format-check` could not run from this checkout — the local `.venv` has no `ruff` module — so ruff was invoked directly on the touched files with the repo's own config.)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is a contract mismatch inside one function. `load_rules` promises callers an empty list for anything it cannot use, and its two existing exits honour that: an unparseable file is caught around `yaml.safe_load`, and a document with no `rules` key returns early. The third shape — the key exists, its value is `None` — fell through both and reached the `for` loop, so a config a user would reasonably write became an exception that propagated two layers up into `opensre health`.

The alternative I considered was widening the `try` to cover the loop as well. I did not, for two reasons. It would swallow genuine errors from `_parse_rule` that today are visible, and it would turn a predictable config shape into an exception path when it is really just "no rules configured". Guarding the value's type keeps the failure classification honest.

That is also why the two new exits differ. `rules: None` is a *valid* way to express "no rules", so it returns quietly. A `rules:` holding a scalar or a mapping is genuinely malformed and warns, matching the existing missing-key branch. Logging both identically would train users to ignore the warning; logging neither would hide a real typo.

`entries` is bound once and the loop iterates that, rather than indexing `raw["rules"]` a second time.

The test drives the exact reproduction from the issue — `path.write_text("rules:")` — rather than constructing `{"rules": None}` through `_write_config`, so it pins the YAML-level behaviour that caused the bug and not just the Python value. Per AGENTS.md I added one test for the bug class rather than one per malformed shape; the non-list branch shares the existing malformed-config path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
