### PR TITLE
fix(installer): stop TrimEnd eating the final e of opensre in the Next steps block

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1187,7 +1187,10 @@ function Install-OpenSre {
 
     Ensure-OpenSreGithubCli
 
-    $exe = $binaryName.TrimEnd(".exe")
+    # Not TrimEnd(".exe"): TrimEnd takes a set of characters, not a suffix, so it
+    # strips the trailing "e" of "opensre" along with the extension and the
+    # Next steps block below tells the user to run "opensr".
+    $exe = [System.IO.Path]::GetFileNameWithoutExtension($binaryName)
     $sep = "────────────────────────────────────────────"
 
     Write-Host ""

--- a/tests/cli/test_install_ps1_progress.py
+++ b/tests/cli/test_install_ps1_progress.py
@@ -174,3 +174,50 @@ def test_install_ps1_dot_sources_when_powershell_available() -> None:
     assert "Unit progress step" in output
     assert "OK Unit progress step" in output
     assert "result-value" in output
+
+
+def test_install_ps1_strips_the_exe_suffix_without_eating_the_name() -> None:
+    """The Next steps block must say `opensre`, not `opensr`.
+
+    `$binaryName.TrimEnd(".exe")` reads as "drop the extension" and is not:
+    TrimEnd takes a *set of characters*, so it also removes the trailing "e"
+    of "opensre". The installer then told the user to run a command that does
+    not exist.
+    """
+    source = INSTALL_PS1.read_text()
+
+    assert '.TrimEnd(".exe")' not in source, (
+        "TrimEnd with a suffix-shaped argument is back; it strips characters, "
+        "not a suffix"
+    )
+    assert "[System.IO.Path]::GetFileNameWithoutExtension($binaryName)" in source
+
+
+def test_install_ps1_next_steps_name_survives_powershell() -> None:
+    """Measured in a real shell, because this bug is a PowerShell semantic."""
+    shell = _powershell()
+    if shell is None:
+        pytest.skip("PowerShell is not installed in this environment.")
+
+    script = textwrap.dedent(
+        """
+        $binaryName = 'opensre.exe'
+        Write-Output ("trimend=" + $binaryName.TrimEnd(".exe"))
+        Write-Output ("fixed=" + [System.IO.Path]::GetFileNameWithoutExtension($binaryName))
+        Write-Output ("bare=" + [System.IO.Path]::GetFileNameWithoutExtension('opensre'))
+        """
+    )
+
+    result = subprocess.run(
+        [shell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = result.stdout
+    # The old expression really does produce the wrong name, on this shell.
+    assert "trimend=opensr\n" in output.replace("\r", "")
+    assert "fixed=opensre" in output
+    # And the replacement is a no-op when the archive ships no .exe suffix.
+    assert "bare=opensre" in output


### PR DESCRIPTION
Fixes #5992

#### Describe the changes you have made in this PR -

`install.ps1:1190` derived the display name for the "Next steps" block with:

```powershell
$exe = $binaryName.TrimEnd(".exe")
```

`TrimEnd` takes a **set of characters**, not a suffix, so `.` `e` `x` are all trimmed from the right — and `opensre.exe` loses its own trailing `e` too. The installer finished correctly and then told the user to run three commands that do not exist.

Replaced with `[System.IO.Path]::GetFileNameWithoutExtension($binaryName)`, which does what the old line looked like it did and is a no-op when the archive ships a binary with no suffix.

The two other `TrimEnd` calls in this file (lines 850 and 856) pass `"\", "/"` — a character set on purpose, trimming path separators. Left alone.

### Demo/Screenshot for feature changes and bug fixes -

Measured in PowerShell 7 on Windows 11, which is where the semantic lives:

```
PS> $binaryName = "opensre.exe"
PS> $binaryName.TrimEnd(".exe")
opensr                                    <- what the installer printed
PS> [System.IO.Path]::GetFileNameWithoutExtension($binaryName)
opensre
PS> [System.IO.Path]::GetFileNameWithoutExtension("opensre")
opensre                                   <- no-op without a suffix
```

Test run:

```
$ uv run python -m pytest tests/cli/test_install_ps1_progress.py -q
1 failed, 11 passed

  the two new tests pass; on main the source-level one fails:
  FAILED test_install_ps1_strips_the_exe_suffix_without_eating_the_name
```

The one remaining failure is `test_install_ps1_dot_sources_when_powershell_available`, and it fails identically on `main` with `install.ps1` reverted — pre-existing on this checkout, nothing to do with this change.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a one-line API misreading, so the fix is one line — but the interesting part is why it survived. `TrimEnd(".exe")` reads as "remove the .exe suffix" to anyone skimming, and it is wrong only for binary names ending in one of `.`, `e` or `x`. `opensre` ends in `e`, so this project is exactly the case where it breaks, and a rename to almost any other name would have hidden it again.

That shaped how I tested it. A string assertion on the *fixed* expression alone would pass even if someone later reintroduced `TrimEnd`, so there are two tests:

1. `test_install_ps1_strips_the_exe_suffix_without_eating_the_name` asserts the old expression is **absent** from the source as well as asserting the new one is present. That is the half that fails on main and the half that catches a regression.
2. `test_install_ps1_next_steps_name_survives_powershell` runs both expressions in a real `pwsh`/`powershell` and asserts `TrimEnd` really does yield `opensr` while the replacement yields `opensre`. A pure-Python test could not have caught this bug in the first place, because the semantic belongs to .NET's `String.TrimEnd`, not to the script's logic. It follows the existing `test_install_ps1_dot_sources_when_powershell_available` pattern and skips when no PowerShell is on PATH.

I considered `-replace '\.exe$', ''` and `$binaryName -replace '\.exe$'`. `GetFileNameWithoutExtension` is better here because it is the framework's own answer to this exact question, it handles a name with no extension without a special case, and it cannot be misread the way the regex form can when someone forgets the `$` anchor.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
