### PR TITLE
fix(evidence): require a bare 401/403/404/429 to be a status code, not part of a number

### DIFF
--- a/infrastructure/evidence/log_compaction.py
+++ b/infrastructure/evidence/log_compaction.py
@@ -141,6 +141,22 @@ def deduplicate_logs(
 # Phase 2 — Structured Error Taxonomy
 # ---------------------------------------------------------------------------
 
+
+def _STATUS(code: int) -> str:
+    """A bare HTTP status code that is not part of a longer number.
+
+    ``re.search("429", "1429ms")`` matches, so latency and counter values were
+    bucketed as rate-limit or auth errors and inflated the taxonomy the model
+    is handed.
+
+    Two exclusions, both about numbers rather than words: an adjacent digit
+    ("1429", "8404", "pod-4013") and a trailing unit letter ("429ms", which is
+    a latency, not a status). A leading letter is deliberately still allowed,
+    so "HTTP404" keeps classifying.
+    """
+    return rf"(?<!\d){code}(?!\d)(?![a-z])"
+
+
 # Broad error-type buckets derived from the message text
 _ERROR_TYPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("ConnectionTimeout", re.compile(r"timeout|timed?\s*out", re.IGNORECASE)),
@@ -148,14 +164,21 @@ _ERROR_TYPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("DNSResolution", re.compile(r"dns|name\s*resolution|resolve\s*host", re.IGNORECASE)),
     (
         "AuthenticationError",
-        re.compile(r"auth(entication|orization)?\s*(fail|error|denied)|401|403", re.IGNORECASE),
+        re.compile(
+            r"auth(entication|orization)?\s*(fail|error|denied)"
+            # A bare status code must not be a run of digits inside a larger
+            # number: 401 in "pod-4013" is not an auth failure. Digit-only
+            # guards rather than , so "401s" and "403 (retrying)" still match.
+            rf"|{_STATUS(401)}|{_STATUS(403)}",
+            re.IGNORECASE,
+        ),
     ),
     (
         "OutOfMemory",
         re.compile(r"(out\s*of\s*memory|oom\s*kill|memory\s*(error|exceed|limit))", re.IGNORECASE),
     ),
     ("DiskFull", re.compile(r"(no\s*space|disk\s*full|storage\s*(full|limit))", re.IGNORECASE)),
-    ("RateLimited", re.compile(r"rate\s*limit|throttl|429", re.IGNORECASE)),
+    ("RateLimited", re.compile(rf"rate\s*limit|throttl|{_STATUS(429)}", re.IGNORECASE)),
     (
         "SchemaValidation",
         re.compile(
@@ -174,7 +197,7 @@ _ERROR_TYPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ),
     (
         "ResourceNotFound",
-        re.compile(r"(not\s*found|404|no\s*such\s*(file|key|bucket))", re.IGNORECASE),
+        re.compile(rf"(not\s*found|{_STATUS(404)}|no\s*such\s*(file|key|bucket))", re.IGNORECASE),
     ),
     (
         "SyntaxError",

--- a/tests/tools/test_log_compaction.py
+++ b/tests/tools/test_log_compaction.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from infrastructure.evidence.log_compaction import (
     _classify_error_type,
     _extract_components,
@@ -288,6 +290,49 @@ class TestClassifyErrorType:
 
     def test_import_error(self):
         assert _classify_error_type("ImportError: No module named 'pandas'") == "ImportError"
+
+
+class TestStatusCodesNeedToBeStatusCodes:
+    """A bare 401/403/404/429 must be the status code, not part of a number.
+
+    ``re.search`` has no boundary, so an ordinary latency or counter value was
+    bucketed as an auth, not-found or rate-limit error. build_error_taxonomy
+    is what the log tools hand the model as the error breakdown for an
+    incident, so this invented an error class that was never in the data and
+    inflated its count.
+    """
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Request completed in 1429ms",
+            "Processed 40412 records from the queue",
+            "worker pod-4013 restarted",
+            "Backfill wrote 8404 rows",
+            "checkpoint 24290 committed",
+            # A latency that happens to be the number itself, not a longer one.
+            "p99 latency 429ms exceeded",
+        ],
+    )
+    def test_a_benign_number_is_not_an_error(self, message: str) -> None:
+        assert _classify_error_type(message) == "Unknown"
+
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            ("HTTP 429 Too Many Requests from upstream", "RateLimited"),
+            ("GET /v1/items returned 404", "ResourceNotFound"),
+            ("auth failed: 401 Unauthorized", "AuthenticationError"),
+            ("403 Forbidden", "AuthenticationError"),
+            ("status=404, retrying", "ResourceNotFound"),
+            ("[429] upstream", "RateLimited"),
+            # A leading letter is allowed on purpose; only digits and a
+            # trailing unit are excluded.
+            ("HTTP404 from origin", "ResourceNotFound"),
+        ],
+    )
+    def test_a_real_status_code_still_classifies(self, message: str, expected: str) -> None:
+        assert _classify_error_type(message) == expected
 
 
 class TestExtractComponents:


### PR DESCRIPTION
Fixes #6034

#### Describe the changes you have made in this PR -

`_classify_error_type` matched the bare codes `401`, `403`, `404` and `429` with no boundary at all, so `re.search` found them inside ordinary numbers. One helper now builds the guard for all four:

```python
def _STATUS(code: int) -> str:
    return rf"(?<!\d){code}(?!\d)(?![a-z])"
```

Two exclusions, both about numbers rather than words:

- **an adjacent digit** — `1429`, `40412`, `pod-4013`, `8404`, `24290`, which is the reported defect;
- **a trailing lowercase letter** — `429ms`. That one is not in the issue's list, but it is the same bug one digit shorter: a p99 latency that happens to be exactly 429ms was still classified `RateLimited` after the digit guard alone.

A *leading* letter is deliberately still allowed, so `HTTP404` keeps classifying. That is why this is not a plain `\b`: `\b404` does not match in `HTTP404`, and losing a real status code to fix a fake one is the wrong trade.

### Demo/Screenshot for feature changes and bug fixes -

The issue's reproduction, plus the contrast set, plus the cases the guard has to be careful about:

```
must be Unknown
  Unknown              Request completed in 1429ms
  Unknown              Processed 40412 records from the queue
  Unknown              worker pod-4013 restarted
  Unknown              Backfill wrote 8404 rows
  Unknown              checkpoint 24290 committed
  Unknown              p99 latency 429ms exceeded

must still classify
  RateLimited          HTTP 429 Too Many Requests from upstream
  ResourceNotFound     GET /v1/items returned 404
  AuthenticationError  auth failed: 401 Unauthorized
  AuthenticationError  403 Forbidden
  ResourceNotFound     status=404, retrying
  RateLimited          [429] upstream
  ResourceNotFound     HTTP404 from origin
```

All thirteen were red-or-wrong before in the six benign cases and are correct now.

```
$ uv run python -m pytest tests/tools/test_log_compaction.py -q
49 passed

$ # the new class, with the fix reverted:
6 failed, 7 passed

$ ruff check infrastructure/evidence/log_compaction.py tests/tools/test_log_compaction.py
All checks passed!
$ ruff format --check <same>
2 files already formatted
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is that a three-digit literal is a terrible way to say "HTTP status code" without saying where it may sit. The question is only what counts as a boundary.

I considered three shapes:

`\b429\b` is the reflex answer and I rejected it. It fixes the reported cases and also kills `HTTP404`, because there is no word boundary between `P` and `4`. That trades a false positive for a false negative in a tool whose output the model reads as evidence, which is the worse direction.

`(?<!\d)429(?!\d)` alone was my first pass, and I kept it until I tested `p99 latency 429ms`. That still classified as `RateLimited`, which is the issue's own complaint with one fewer digit — so the digit guard alone does not actually close the class of bug being reported, only the examples listed.

The shipped form adds `(?![a-z])`. A status code in a log is followed by a space, a comma, a bracket, a colon or end-of-line; a number followed immediately by lowercase letters is a value with a unit. The cost is `404s` (plural) no longer classifying, which I judged acceptable and much rarer than a latency reading.

I put it in one helper rather than editing three regexes because the three had already drifted — `RateLimited` was a flat alternation, `ResourceNotFound` was parenthesised, `AuthenticationError` had two codes — and the next code added would have had to get the guard right a fourth time by hand.

The tests are parametrized in two directions on purpose. Asserting only that the benign strings are `Unknown` would pass if someone deleted the numeric alternatives entirely, which would be a silent loss of real signal; the second parametrization is what stops that. `HTTP404` and `429ms` are in there specifically because they are the two edges the guard is built around, so a future simplification to `\b` fails visibly rather than quietly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
