### PR TITLE
fix(account): drop legacy GitHub tokens on logout

### DIFF
--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -36,6 +36,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "GitHubDeviceCode": "integrations.github.mcp_oauth",
     "GitHubDeviceFlowError": "integrations.github.mcp_oauth",
     "authorize_github_via_device_flow": "integrations.github.mcp_oauth",
+    "disconnect_personal_github": "integrations.github.personal_account",
 }
 
 
@@ -71,6 +72,7 @@ if TYPE_CHECKING:
         GitHubDeviceFlowError,
         authorize_github_via_device_flow,
     )
+    from integrations.github.personal_account import disconnect_personal_github
     from integrations.github.pull_requests import (
         ERR_GITHUB_TOKEN,
         GitHubPullRequestError,
@@ -96,6 +98,7 @@ __all__ = [
     "authenticate_and_configure_github",
     "authorize_github_via_device_flow",
     "build_github_mcp_config",
+    "disconnect_personal_github",
     "format_github_mcp_validation_cli_report",
     "github_creds",
     "github_integration_is_configured",

--- a/integrations/github/personal_account.py
+++ b/integrations/github/personal_account.py
@@ -1,0 +1,21 @@
+"""Remove GitHub credentials created by older OpenSRE account login."""
+
+from __future__ import annotations
+
+from integrations.store import get_integration, remove_integration
+
+_ACCOUNT_AUTH_SOURCE = "opensre_account"
+
+
+def disconnect_personal_github() -> bool:
+    """Remove a GitHub integration tagged as account-managed; leave manual ones."""
+    integration = get_integration("github")
+    instances = integration.get("instances") if integration else None
+    first = instances[0] if isinstance(instances, list) and instances else None
+    tags = first.get("tags") if isinstance(first, dict) else None
+    if not isinstance(tags, dict) or tags.get("auth_source") != _ACCOUNT_AUTH_SOURCE:
+        return False
+    return remove_integration("github")
+
+
+__all__ = ["disconnect_personal_github"]

--- a/surfaces/cli/account_auth.py
+++ b/surfaces/cli/account_auth.py
@@ -374,6 +374,9 @@ def logout_account() -> AccountLogoutResult:
 
     try:
         delete_account_token()
+        from integrations.github import disconnect_personal_github
+
+        disconnect_personal_github()
         delete_account_record()
     except Exception as exc:
         raise AccountAuthError("OpenSRE could not clear all local account data.") from exc

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -348,7 +348,7 @@ COMMANDS: list[SlashCommand] = [
         "/setup",
         "First-run setup: OpenSRE account, hosted model, then the interactive shell.",
         _cmd_setup,
-        usage=("/setup",),
+        usage=("/setup", "/setup --dev"),
     ),
     SlashCommand(
         "/onboard",

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -223,10 +223,11 @@ def _cmd_onboard(session: Session, console: Console, args: list[str]) -> bool:  
 
 def _cmd_setup(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
     if session_terminal(session) is None:
+        cli_cmd = " ".join(["uv run opensre setup", *args]).strip()
         message = (
             "Setup signs in to an OpenSRE account and activates its hosted model. "
             "It cannot run inside a Telegram chat.\n\n"
-            "Run on the server:\n  uv run opensre setup\n\n"
+            f"Run on the server:\n  {cli_cmd}\n\n"
             "Configure integrations separately with `/integrations setup <service>`."
         )
         console.print()

--- a/tests/cli/test_account_command.py
+++ b/tests/cli/test_account_command.py
@@ -213,6 +213,33 @@ def test_account_logout_preserves_manual_github_integration(
     assert store.get_integration("github") is not None
 
 
+def test_account_logout_removes_legacy_account_github_integration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(store, "STORE_PATH", tmp_path / "integrations.json")
+    store.upsert_integration(
+        "github",
+        {
+            "instances": [
+                {
+                    "name": "default",
+                    "tags": {"auth_source": "opensre_account"},
+                    "credentials": {"auth_token": "gho_legacy"},
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(account_auth, "load_account_record", lambda: None)
+    monkeypatch.setattr(account_auth, "stored_account_token", lambda: "")
+    monkeypatch.setattr(account_auth, "delete_account_token", lambda: None)
+    monkeypatch.setattr(account_auth, "delete_account_record", lambda: None)
+
+    result = account_auth.logout_account()
+
+    assert result.remote_revoked is True
+    assert store.get_integration("github") is None
+
+
 def test_logout_revokes_the_file_token_not_an_environment_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -2228,6 +2228,18 @@ class TestCliDelegatedCommands:
 
         assert captured == [["onboard", "local_llm"]]
 
+    def test_headless_setup_keeps_dev_flag_in_fallback_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        monkeypatch.setattr(m, "session_terminal", lambda _session: None)
+        console, buf = _capture()
+        session = Session()
+
+        assert m._cmd_setup(session, console, ["--dev"]) is True
+        assert "uv run opensre setup --dev" in buf.getvalue()
+
 
 def test_alerts_inactive_prints_enable_instructions(monkeypatch: pytest.MonkeyPatch) -> None:
     """The inactive warning must say how to turn the listener on."""

--- a/tools/interactive_shell/shared/slash_catalog.py
+++ b/tools/interactive_shell/shared/slash_catalog.py
@@ -60,11 +60,11 @@ MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         anti_examples=("User asks a docs/how-to question about OpenSRE features",),
     ),
     "/account": _mcp(
-        "Sign in to a personal OpenSRE account with GitHub, inspect the local login, "
+        "Sign in to a personal OpenSRE account, inspect the local login, "
         "or sign out. Signing out closes the interactive shell. Subcommands: login, "
         "status, logout.",
-        "User asks to sign in to OpenSRE with GitHub or create a personal account",
-        "User asks whether they are logged into OpenSRE or which GitHub user is linked",
+        "User asks to sign in to OpenSRE or create a personal account",
+        "User asks whether they are logged into OpenSRE",
         anti_examples=(
             "User asks to log in to an LLM provider (use /auth)",
             "User asks to configure the GitHub integration only (use /integrations)",
@@ -315,9 +315,11 @@ MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         anti_examples=("User asks for the current session status (use /status)",),
     ),
     "/setup": _mcp(
-        "First-run setup: OpenSRE account sign-in, hosted model, then the interactive shell.",
+        "First-run setup: OpenSRE account sign-in, hosted model, then the interactive shell. "
+        "Use --dev to authenticate against a local webapp at http://localhost:3000.",
         "User asks to run first-run setup or factory-style install setup",
         "User just installed OpenSRE and needs to create or sign in to an account",
+        "User is developing the webapp locally and needs opensre setup --dev",
     ),
     "/status": _mcp(
         "Explicit /status command operation: show REPL session status, including "


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Follow-up to #6063. Logout again removes GitHub integrations tagged `auth_source: opensre_account` so an upgrade from GitHub-only signup cannot leave that token authorized after sign-out. Manually configured GitHub integrations are unchanged. Also advertise `/setup --dev` in slash-command usage and catalog copy.

### Demo/Screenshot for feature changes and bug fixes -

`opensre account logout` after an old GitHub-backed signup clears the tagged GitHub store record. A GitHub integration added via `/integrations setup github` remains.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

#6063 stopped provisioning GitHub at signup, which was correct, but it also dropped the logout cleanup for tokens the previous flow had written. Restore that tagged-record disconnect only. Local checks: lint, format-check, typecheck, account logout tests, slash catalog/parity.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions