### PR TITLE
fix(shell): keep the prompt spinner alive for the demo's auto-submitted turn

### DIFF
--- a/core/agent_harness/session/terminal_access.py
+++ b/core/agent_harness/session/terminal_access.py
@@ -103,6 +103,8 @@ def clear_pending_autosubmit(session: Any) -> None:
         terminal.pending_prompt_default = None
     if hasattr(terminal, "pending_prompt_autosubmit"):
         terminal.pending_prompt_autosubmit = False
+    if hasattr(terminal, "pending_prompt_plain_turn"):
+        terminal.pending_prompt_plain_turn = False
 
 
 __all__ = [

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -248,7 +248,9 @@ class PromptBuilder:
         if prefilled and self.session.terminal.pop_pending_autosubmit():
             # Same paint path as Enter: mark so ``render_submitted_prompt`` can
             # label ``/goal`` work turns distinctly from the ``/goal set`` slash.
-            self.session.terminal.last_input_autosubmitted = True
+            # A plain auto prompt is submitted exactly as typed input instead.
+            plain = self.session.terminal.pop_pending_plain_turn()
+            self.session.terminal.last_input_autosubmitted = not plain
             return prefilled
 
         if prefilled:

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -163,7 +163,7 @@ def offer_demo(session: Session, console: Console | None = None, *, force: bool 
         if suggestion is None:
             capture_onboarding_demo_selected(option=_CUSTOM_OPTION, custom=True)
             _record(_CUSTOM_OPTION)
-            session.terminal.set_auto_command(selected)
+            session.terminal.set_auto_prompt(selected)
             return True
         capture_onboarding_demo_selected(option=suggestion.option, custom=False)
         if suggestion.option == OPTION_CI_ANALYTICS:
@@ -209,7 +209,9 @@ def _start_ci_analytics_demo(
             "days. Reading the GitHub Actions history takes about half a minute; the report "
             "appears below when it is ready.[/]"
         )
-    session.terminal.set_auto_command(suggestion.prompt.format(repository=repository))
+    # A plain turn keeps the prompt bar and its spinner visible while the model
+    # and the analysis run; a work-turn autosubmit would suspend them.
+    session.terminal.set_auto_prompt(suggestion.prompt.format(repository=repository))
     return True
 
 

--- a/surfaces/interactive_shell/session/session.py
+++ b/surfaces/interactive_shell/session/session.py
@@ -56,6 +56,7 @@ class Session(SessionCore):
         self.terminal.submitted_turn_count = 0
         self.terminal.pending_prompt_default = None
         self.terminal.pending_prompt_autosubmit = False
+        self.terminal.pending_prompt_plain_turn = False
         self.terminal.last_input_autosubmitted = False
         self.terminal.pending_choice_response = None
         self.terminal.dispatch_active = False

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -103,6 +103,11 @@ class TerminalSession:
     pending_prompt_default: str | None = None
     """When set, the next interactive prompt is pre-filled with this string (then cleared)."""
 
+    pending_prompt_plain_turn: bool = False
+    """When True alongside ``pending_prompt_autosubmit``, the submitted prefill runs
+    as an ordinary typed turn: the prompt bar (and its spinner) stays up and no
+    ``/goal`` work-turn label is painted. Set by :meth:`set_auto_prompt`."""
+
     pending_prompt_autosubmit: bool = False
     """When True alongside ``pending_prompt_default``, the prefilled prompt is
     submitted automatically instead of waiting for the user to press Enter.
@@ -289,6 +294,23 @@ class TerminalSession:
         self.pending_prompt_autosubmit = False
         return value
 
+    def pop_pending_plain_turn(self) -> bool:
+        """Return whether the pending autosubmit is a plain turn, and clear the flag."""
+        value = self.pending_prompt_plain_turn
+        self.pending_prompt_plain_turn = False
+        return value
+
+    def set_auto_prompt(self, text: str) -> None:
+        """Queue *text* to be submitted as an ordinary turn, as if the user typed it.
+
+        Unlike :meth:`set_auto_command`, the controller does not suspend the
+        prompt for the turn, so the pinned-layout spinner keeps showing progress.
+        """
+        self.pending_prompt_default = text
+        self.pending_prompt_autosubmit = True
+        self.pending_prompt_plain_turn = True
+        self.notify_prompt_changed()
+
     def set_auto_command(self, command: str) -> None:
         """Queue a command to run automatically on the next prompt iteration.
 
@@ -300,6 +322,7 @@ class TerminalSession:
         """
         self.pending_prompt_default = command
         self.pending_prompt_autosubmit = True
+        self.pending_prompt_plain_turn = False
         self.notify_prompt_changed()
 
     def notify_prompt_changed(self) -> None:

--- a/surfaces/interactive_shell/ui/input_prompt/refresh.py
+++ b/surfaces/interactive_shell/ui/input_prompt/refresh.py
@@ -41,13 +41,15 @@ def wire_prompt_refresh(
                 # not gate on it here — ``dispatch_active`` is the nest guard.
                 session.terminal.pending_prompt_default = None
                 session.terminal.pop_pending_autosubmit()
-                session.terminal.last_input_autosubmitted = True
+                plain = session.terminal.pop_pending_plain_turn()
+                session.terminal.last_input_autosubmitted = not plain
                 buffer.text = pending
                 try:
                     buffer.validate_and_handle()
                 except Exception:  # noqa: BLE001
                     session.terminal.pending_prompt_default = pending
                     session.terminal.pending_prompt_autosubmit = True
+                    session.terminal.pending_prompt_plain_turn = plain
                     session.terminal.last_input_autosubmitted = False
             elif pt_app.is_running:
                 session.terminal.pending_prompt_default = None

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -96,6 +96,7 @@ def test_analytics_demo_scans_asks_for_the_repository_then_queues_the_analysis(
     repo_choices = [value for value, _label in calls[1]["choices"]]
     assert repo_choices == ["me/mine", "acme/busy", demo_picker.EXAMPLE_REPOSITORY, "custom"]
     assert session.terminal.pending_prompt_autosubmit is True
+    assert session.terminal.pending_prompt_plain_turn is True
     assert "me/mine[v2]" in session.terminal.pending_prompt_default
     assert json.loads(marker.read_text())["option"] == demo_picker.OPTION_CI_ANALYTICS
 
@@ -143,6 +144,7 @@ def test_other_demos_queue_their_prompt_directly(
 
     assert demo_picker.offer_demo(session, None) is True
     assert "Slack" in session.terminal.pending_prompt_default
+    assert session.terminal.pending_prompt_plain_turn is False
 
 
 def test_typed_answer_is_submitted_verbatim(

--- a/tests/interactive_shell/runtime/test_session.py
+++ b/tests/interactive_shell/runtime/test_session.py
@@ -49,6 +49,16 @@ class TestSession:
         assert session.terminal.pending_prompt_autosubmit is True
         assert calls == [True]
 
+    def test_queue_auto_prompt_marks_a_plain_turn_and_auto_command_clears_it(self) -> None:
+        session = Session()
+        session.terminal.set_auto_prompt("analyze acme/app CI reliability")
+        assert session.terminal.pending_prompt_autosubmit is True
+        assert session.terminal.pop_pending_plain_turn() is True
+        assert session.terminal.pending_prompt_plain_turn is False
+        session.terminal.set_auto_prompt("again")
+        session.terminal.set_auto_command("/goal set done")
+        assert session.terminal.pending_prompt_plain_turn is False
+
     def test_take_pending_autosubmit_returns_and_clears(self) -> None:
         session = Session()
         session.terminal.pending_prompt_autosubmit = True


### PR DESCRIPTION
After picking a repository in the CI/CD analytics demo, the pinned layout
showed nothing from "Skill activated" until the analytics tool printed its
first line, often for a minute. An auto-submitted prompt is treated as a
`/goal` work turn, and the controller suspends the prompt bar until that
turn ends. In the pinned layout the spinner lives in that bar, so the
model's thinking phase had no visible progress at all.

- `TerminalSession.set_auto_prompt` queues text to be submitted as an
  ordinary typed turn. The prompt bar stays up, so the "Thinking…",
  "Executing…" and "Invoking tools…" phases keep animating, and the
  misleading "↗ /goal — work turn" label is no longer painted.
  `set_auto_command` is unchanged and still drives loop suggestions and
  interactive setup handoffs.
- `PromptBuilder.read_prompt_text` and the prompt refresh path honour the
  new flag; `Session.clear` and the harness terminal reset clear it.
- The demo picker uses `set_auto_prompt` for the analysis prompt and for
  a typed custom answer.

Verified with a scripted run of `/demo` in the pinned layout at Auto (Low):
between the repository pick and the tool's first output line the terminal
stream now carries 60 "Thinking…" frames plus the "Executing…" and
"Invoking tools…" phases, where before it carried none. Unit tests cover
the new session method and the picker's use of it.