### PR TITLE
fix(ci-analytics): read the whole window past GitHub's 1,000-run listing ceiling

### DIFF
--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -13,12 +13,17 @@ from integrations.github.client import GitHubApiError, GitHubRestClient
 from integrations.github.tools.ci_analytics.models import MergedPullRequest, WorkflowRun
 
 _PER_PAGE = 100
-_MAX_RUN_PAGES_PER_SCOPE = 20
-_MAX_PR_PAGES = 5
+# GitHub stops paging a workflow-run listing at 1,000 rows however far you page,
+# so a window is fetched in time slices that are split until each fits.
+_LIST_CEILING = 1000
+_MAX_RUN_PAGES_PER_SLICE = _LIST_CEILING // _PER_PAGE
+_MIN_SLICE = timedelta(hours=1)
+_SLICE_WORKERS = 6
+_MAX_PR_PAGES = 30
 _MAX_RERUN_WORKERS = 8
 # Each passing re-run costs up to attempt-1 extra requests; bound the total so
 # a very flaky repository cannot turn the demo into minutes of API calls.
-_MAX_ATTEMPT_LOOKUPS = 200
+_MAX_ATTEMPT_LOOKUPS = 500
 _DEFAULT_BRANCH_EVENTS = ("push", "schedule", "workflow_dispatch")
 _PR_EVENT = "pull_request"
 
@@ -51,7 +56,6 @@ def collect_runs(
     if not default_branch:
         raise ValueError(f"GitHub repository {owner}/{repo} has no readable default branch.")
     since = now - timedelta(days=window_days)
-    created = f">={_iso_utc(since)}"
     notices: list[str] = []
     # Each scope is an independent paginated listing; fetching them together
     # keeps the demo well under a minute on busy repositories.
@@ -61,9 +65,10 @@ def collect_runs(
                 _runs,
                 client,
                 root,
-                params={"branch": default_branch, "event": event, "created": created},
+                params={"branch": default_branch, "event": event},
                 scope=f"{default_branch} {event} runs",
                 since=since,
+                until=now,
                 notices=notices,
             )
             for event in _DEFAULT_BRANCH_EVENTS
@@ -72,17 +77,18 @@ def collect_runs(
             _runs,
             client,
             root,
-            params={"event": _PR_EVENT, "created": created},
+            params={"event": _PR_EVENT},
             scope="pull request runs",
             since=since,
+            until=now,
             notices=notices,
         )
         merged_future = pool.submit(_merged_prs, client, root, since=since, notices=notices)
         branch_runs = [run for future in branch_futures for run in future.result()]
+        merged = merged_future.result()
         # Only PR reruns affect failure rate and blocked time; skip extra
         # attempt fetches on default-branch listings.
-        pr_runs = _annotate_reruns(client, root, pr_future.result(), notices=notices)
-        merged = merged_future.result()
+        pr_runs = _annotate_reruns(client, root, pr_future.result(), merged=merged, notices=notices)
     return CollectedRuns(
         default_branch=default_branch,
         branch_runs=branch_runs,
@@ -99,24 +105,77 @@ def _runs(
     params: dict[str, Any],
     scope: str,
     since: datetime,
+    until: datetime,
     notices: list[str],
 ) -> list[WorkflowRun]:
-    rows = client.paginate(
-        f"{root}/actions/runs",
-        params={
-            **params,
-            "status": "completed",
-            "per_page": _PER_PAGE,
-        },
-        collection_key="workflow_runs",
-        max_pages=_MAX_RUN_PAGES_PER_SCOPE,
-    )
-    if len(rows) >= _PER_PAGE * _MAX_RUN_PAGES_PER_SCOPE:
+    """Completed runs created in ``[since, until]``, complete despite the listing ceiling.
+
+    A slice that returns the ceiling is split in half and refetched; a slice
+    at the minimum width that still hits it is reported as a coverage gap.
+    """
+    rows: list[dict[str, Any]] = []
+    truncated: list[tuple[datetime, datetime]] = []
+    pending = [(since, until)]
+    with ThreadPoolExecutor(max_workers=_SLICE_WORKERS) as pool:
+        while pending:
+            fetched = list(pool.map(lambda s: _slice(client, root, params, s), pending))
+            pending = []
+            for (start, end), slice_rows in fetched:
+                if len(slice_rows) < _LIST_CEILING:
+                    rows.extend(slice_rows)
+                elif end - start <= _MIN_SLICE:
+                    rows.extend(slice_rows)
+                    truncated.append((start, end))
+                else:
+                    middle = start + (end - start) / 2
+                    pending.extend([(start, middle), (middle, end)])
+    if truncated:
         notices.append(
-            f"Coverage notice: {scope} limited to the newest {len(rows)} runs in the window."
+            f"Coverage notice: {scope} exceeded GitHub's listing ceiling in "
+            f"{len(truncated)} one-hour {'slice' if len(truncated) == 1 else 'slices'}; "
+            "those hours are partially counted."
         )
-    parsed = [run for run in (parse_run(row) for row in rows) if run is not None]
-    return [run for run in parsed if run.created_at >= since]
+    seen: set[int] = set()
+    parsed: list[WorkflowRun] = []
+    for row in rows:
+        run = parse_run(row)
+        if run is None or run.run_id in seen or run.created_at < since:
+            continue
+        seen.add(run.run_id)
+        parsed.append(run)
+    return parsed
+
+
+def _slice(
+    client: GitHubRestClient,
+    root: str,
+    params: dict[str, Any],
+    window: tuple[datetime, datetime],
+) -> tuple[tuple[datetime, datetime], list[dict[str, Any]]]:
+    """Rows for one time slice, or a ceiling-sized marker when it must be split.
+
+    The first page carries GitHub's ``total_count``; a slice over the ceiling
+    is reported without paging the rest, so splitting costs one request.
+    """
+    start, end = window
+    query = {
+        **params,
+        "status": "completed",
+        "created": f"{_iso_utc(start)}..{_iso_utc(end)}",
+        "per_page": _PER_PAGE,
+    }
+    path = f"{root}/actions/runs"
+    first = client.request("GET", path, params=query)
+    total = first.get("total_count") if isinstance(first, dict) else None
+    first_rows = first.get("workflow_runs") if isinstance(first, dict) else None
+    if isinstance(total, int) and total > _LIST_CEILING and end - start > _MIN_SLICE:
+        return window, [{}] * _LIST_CEILING
+    if isinstance(total, int) and total <= _PER_PAGE and isinstance(first_rows, list):
+        return window, [row for row in first_rows if isinstance(row, dict)]
+    rows = client.paginate(
+        path, params=query, collection_key="workflow_runs", max_pages=_MAX_RUN_PAGES_PER_SLICE
+    )
+    return window, rows
 
 
 def _merged_prs(
@@ -126,40 +185,55 @@ def _merged_prs(
     since: datetime,
     notices: list[str],
 ) -> tuple[MergedPullRequest, ...]:
-    """Merged PRs inside the window, keyed by number and head repository."""
-    rows = client.paginate(
-        f"{root}/pulls",
-        params={
-            "state": "closed",
-            "sort": "updated",
-            "direction": "desc",
-            "per_page": _PER_PAGE,
-        },
-        max_pages=_MAX_PR_PAGES,
-    )
-    if len(rows) >= _PER_PAGE * _MAX_PR_PAGES:
-        notices.append(
-            f"Coverage notice: merged PR detection limited to the {len(rows)} most recently "
-            "updated closed PRs."
-        )
+    """Merged PRs inside the window, keyed by number and head repository.
+
+    Closed PRs come newest-updated first, so paging stops as soon as a page
+    ends before the window; only a window busier than the page cap is flagged.
+    """
     merged: list[MergedPullRequest] = []
-    for row in rows:
-        merged_at = _timestamp(row.get("merged_at"))
-        number = row.get("number")
-        head = row.get("head")
-        if merged_at is None or merged_at < since or not isinstance(number, int) or number <= 0:
-            continue
-        if not isinstance(head, dict):
-            continue
-        ref = str(head.get("ref") or "").strip()
-        repo = head.get("repo")
-        head_repo = str(repo.get("full_name") or "").strip() if isinstance(repo, dict) else ""
-        if not ref:
-            continue
-        merged.append(
-            MergedPullRequest(number=number, branch=ref, head_repo=head_repo, merged_at=merged_at)
+    for page in range(1, _MAX_PR_PAGES + 1):
+        payload = client.request(
+            "GET",
+            f"{root}/pulls",
+            params={
+                "state": "closed",
+                "sort": "updated",
+                "direction": "desc",
+                "per_page": _PER_PAGE,
+                "page": page,
+            },
+        )
+        rows = (
+            [row for row in payload if isinstance(row, dict)] if isinstance(payload, list) else []
+        )
+        if not rows:
+            break
+        merged.extend(pr for pr in (_merged_pr(row, since=since) for row in rows) if pr is not None)
+        oldest_update = _timestamp(rows[-1].get("updated_at"))
+        if len(rows) < _PER_PAGE or (oldest_update is not None and oldest_update < since):
+            break
+    else:
+        notices.append(
+            f"Coverage notice: merged PR detection limited to the {_MAX_PR_PAGES * _PER_PAGE} "
+            "most recently updated closed PRs."
         )
     return tuple(merged)
+
+
+def _merged_pr(row: dict[str, Any], *, since: datetime) -> MergedPullRequest | None:
+    merged_at = _timestamp(row.get("merged_at"))
+    number = row.get("number")
+    head = row.get("head")
+    if merged_at is None or merged_at < since or not isinstance(number, int) or number <= 0:
+        return None
+    if not isinstance(head, dict):
+        return None
+    ref = str(head.get("ref") or "").strip()
+    repo = head.get("repo")
+    head_repo = str(repo.get("full_name") or "").strip() if isinstance(repo, dict) else ""
+    if not ref:
+        return None
+    return MergedPullRequest(number=number, branch=ref, head_repo=head_repo, merged_at=merged_at)
 
 
 def parse_run(row: dict[str, Any]) -> WorkflowRun | None:
@@ -220,22 +294,35 @@ def _annotate_reruns(
     root: str,
     runs: list[WorkflowRun],
     *,
+    merged: tuple[MergedPullRequest, ...],
     notices: list[str],
 ) -> list[WorkflowRun]:
     """Attach earlier-failure times so a later attempt is not assumed to hide a flake.
 
+    Re-runs on merged PRs are checked first because they drive blocked time.
     A re-run whose history could not be read, or fell outside the lookup
     budget, stays a plain success and is reported in a coverage notice rather
     than silently shrinking the failure counts.
     """
-    rerun_count = sum(1 for run in runs if run.succeeded and run.attempt > 1)
-    if not rerun_count:
+    reruns = [run for run in runs if run.succeeded and run.attempt > 1]
+    if not reruns:
         return runs
+    merged_numbers = {pr.number for pr in merged}
+    merged_branches = {(pr.head_repo, pr.branch) for pr in merged}
+
+    def on_merged_pr(run: WorkflowRun) -> bool:
+        if run.pr_numbers:
+            return any(number in merged_numbers for number in run.pr_numbers)
+        return (run.head_repo, run.branch) in merged_branches
+
+    ordered = sorted(reruns, key=lambda run: (not on_merged_pr(run), run.created_at))
     lookups = _AttemptLookups(_MAX_ATTEMPT_LOOKUPS)
-    with ThreadPoolExecutor(max_workers=min(_MAX_RERUN_WORKERS, rerun_count)) as pool:
-        annotated = list(
-            pool.map(lambda run: _with_earlier_failure(client, root, run, lookups), runs)
+    with ThreadPoolExecutor(max_workers=min(_MAX_RERUN_WORKERS, len(ordered))) as pool:
+        results = list(
+            pool.map(lambda run: _with_earlier_failure(client, root, run, lookups), ordered)
         )
+    checked = {run.run_id: result for run, result in zip(ordered, results, strict=True)}
+    annotated = [checked.get(run.run_id, run) for run in runs]
     if lookups.unavailable:
         notices.append(
             f"Coverage notice: attempt history was unavailable for {lookups.unavailable} "

--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -98,6 +98,16 @@ def collect_runs(
     )
 
 
+@dataclass(frozen=True)
+class _Slice:
+    """One time slice of a listing and whether GitHub reported more than the ceiling."""
+
+    start: datetime
+    end: datetime
+    rows: list[dict[str, Any]]
+    over_ceiling: bool
+
+
 def _runs(
     client: GitHubRestClient,
     root: str,
@@ -110,29 +120,30 @@ def _runs(
 ) -> list[WorkflowRun]:
     """Completed runs created in ``[since, until]``, complete despite the listing ceiling.
 
-    A slice that returns the ceiling is split in half and refetched; a slice
-    at the minimum width that still hits it is reported as a coverage gap.
+    A slice GitHub reports as larger than the ceiling is split in half and
+    refetched; a slice at the minimum width that is still over it is kept as
+    far as it goes and reported as a coverage gap.
     """
     rows: list[dict[str, Any]] = []
-    truncated: list[tuple[datetime, datetime]] = []
+    truncated = 0
     pending = [(since, until)]
     with ThreadPoolExecutor(max_workers=_SLICE_WORKERS) as pool:
         while pending:
-            fetched = list(pool.map(lambda s: _slice(client, root, params, s), pending))
+            fetched = list(pool.map(lambda w: _fetch_slice(client, root, params, w), pending))
             pending = []
-            for (start, end), slice_rows in fetched:
-                if len(slice_rows) < _LIST_CEILING:
-                    rows.extend(slice_rows)
-                elif end - start <= _MIN_SLICE:
-                    rows.extend(slice_rows)
-                    truncated.append((start, end))
+            for piece in fetched:
+                if not piece.over_ceiling:
+                    rows.extend(piece.rows)
+                elif piece.end - piece.start <= _MIN_SLICE:
+                    rows.extend(piece.rows)
+                    truncated += 1
                 else:
-                    middle = start + (end - start) / 2
-                    pending.extend([(start, middle), (middle, end)])
+                    middle = piece.start + (piece.end - piece.start) / 2
+                    pending.extend([(piece.start, middle), (middle, piece.end)])
     if truncated:
         notices.append(
             f"Coverage notice: {scope} exceeded GitHub's listing ceiling in "
-            f"{len(truncated)} one-hour {'slice' if len(truncated) == 1 else 'slices'}; "
+            f"{truncated} one-hour {'slice' if truncated == 1 else 'slices'}; "
             "those hours are partially counted."
         )
     seen: set[int] = set()
@@ -146,16 +157,17 @@ def _runs(
     return parsed
 
 
-def _slice(
+def _fetch_slice(
     client: GitHubRestClient,
     root: str,
     params: dict[str, Any],
     window: tuple[datetime, datetime],
-) -> tuple[tuple[datetime, datetime], list[dict[str, Any]]]:
-    """Rows for one time slice, or a ceiling-sized marker when it must be split.
+) -> _Slice:
+    """Fetch one slice; a slice over the ceiling costs one request unless it is the minimum width.
 
-    The first page carries GitHub's ``total_count``; a slice over the ceiling
-    is reported without paging the rest, so splitting costs one request.
+    The first page carries GitHub's ``total_count``. Exactly the ceiling is a
+    complete listing; only a larger total is over it. Without a total the row
+    count is the fallback signal.
     """
     start, end = window
     query = {
@@ -168,14 +180,19 @@ def _slice(
     first = client.request("GET", path, params=query)
     total = first.get("total_count") if isinstance(first, dict) else None
     first_rows = first.get("workflow_runs") if isinstance(first, dict) else None
-    if isinstance(total, int) and total > _LIST_CEILING and end - start > _MIN_SLICE:
-        return window, [{}] * _LIST_CEILING
+    over = total > _LIST_CEILING if isinstance(total, int) else None
+    if over and end - start > _MIN_SLICE:
+        return _Slice(start, end, [], over_ceiling=True)
     if isinstance(total, int) and total <= _PER_PAGE and isinstance(first_rows, list):
-        return window, [row for row in first_rows if isinstance(row, dict)]
+        return _Slice(
+            start, end, [r for r in first_rows if isinstance(r, dict)], over_ceiling=False
+        )
     rows = client.paginate(
         path, params=query, collection_key="workflow_runs", max_pages=_MAX_RUN_PAGES_PER_SLICE
     )
-    return window, rows
+    if over is None:
+        over = len(rows) >= _LIST_CEILING
+    return _Slice(start, end, rows, over_ceiling=over)
 
 
 def _merged_prs(
@@ -299,10 +316,11 @@ def _annotate_reruns(
 ) -> list[WorkflowRun]:
     """Attach earlier-failure times so a later attempt is not assumed to hide a flake.
 
-    Re-runs on merged PRs are checked first because they drive blocked time.
-    A re-run whose history could not be read, or fell outside the lookup
-    budget, stays a plain success and is reported in a coverage notice rather
-    than silently shrinking the failure counts.
+    Re-runs on merged PRs are checked as a first phase, so the shared lookup
+    budget is spent on them before any other re-run competes for it; they are
+    the ones that feed blocked time. A re-run whose history could not be read,
+    or fell outside the budget, stays a plain success and is reported in a
+    coverage notice rather than silently shrinking the failure counts.
     """
     reruns = [run for run in runs if run.succeeded and run.attempt > 1]
     if not reruns:
@@ -315,13 +333,19 @@ def _annotate_reruns(
             return any(number in merged_numbers for number in run.pr_numbers)
         return (run.head_repo, run.branch) in merged_branches
 
-    ordered = sorted(reruns, key=lambda run: (not on_merged_pr(run), run.created_at))
     lookups = _AttemptLookups(_MAX_ATTEMPT_LOOKUPS)
-    with ThreadPoolExecutor(max_workers=min(_MAX_RERUN_WORKERS, len(ordered))) as pool:
-        results = list(
-            pool.map(lambda run: _with_earlier_failure(client, root, run, lookups), ordered)
-        )
-    checked = {run.run_id: result for run, result in zip(ordered, results, strict=True)}
+    checked: dict[int, WorkflowRun] = {}
+    for phase in (
+        [run for run in reruns if on_merged_pr(run)],
+        [run for run in reruns if not on_merged_pr(run)],
+    ):
+        if not phase:
+            continue
+        with ThreadPoolExecutor(max_workers=min(_MAX_RERUN_WORKERS, len(phase))) as pool:
+            results = list(
+                pool.map(lambda run: _with_earlier_failure(client, root, run, lookups), phase)
+            )
+        checked.update({run.run_id: result for run, result in zip(phase, results, strict=True)})
     annotated = [checked.get(run.run_id, run) for run in runs]
     if lookups.unavailable:
         notices.append(

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -9,7 +9,7 @@ transcript — only the one-shot ``Plan complete`` breakdown is.
 
 from __future__ import annotations
 
-from rich.console import Console
+from rich.console import Console, Group
 from rich.text import Text
 
 from core.agent_harness.spi.task_plan import (
@@ -22,6 +22,7 @@ from core.agent_harness.spi.task_plan import (
 )
 from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
+from surfaces.shared.terminal.components.rendering import print_repl_renderable
 
 _STEP_INDENT = "  "
 # Steps shown before the plan collapses; a longer plan folds to a window
@@ -45,32 +46,31 @@ def render_plan_breakdown(console: Console, breakdown: str) -> None:
 
     Checked steps stay primary (warm ``✓`` + body text); nested work notes
     under ``↳`` go dim so the checklist reads apart from tool chatter —
-    the same parent/child split live tool rows already use.
+    the same parent/child split live tool rows already use. The rows go out
+    as one buffered block so they stay left-aligned when the prompt has the
+    terminal in raw mode.
     """
     text = (breakdown or "").rstrip("\n")
     if not text:
         return
+    rows: list[Text] = []
     for raw in text.splitlines():
-        line = Text()
         stripped = raw.lstrip()
         if not stripped:
-            console.print()
+            rows.append(Text(""))
             continue
         if stripped.startswith(_WORK_NOTE_MARKER):
             # Theme DIM as raw truecolor. Rich Style.parse caches ANSI from
             # the first color_system that rendered ``#6E6E6E``; a prior
             # 16-color console then emits bright-black ``[90m`` instead of
             # DIM_ANSI on a truecolor breakdown.
-            console.print(
-                f"{ui_theme.DIM_ANSI}{raw}{ui_theme.ANSI_RESET}",
-                highlight=False,
-                markup=False,
-            )
+            rows.append(Text.from_ansi(f"{ui_theme.DIM_ANSI}{raw}{ui_theme.ANSI_RESET}"))
             continue
+        line = Text()
         # Header (``Plan complete · n/n``) or a checklist step (``  ✓ …``).
         if stripped.startswith("Plan"):
             line.append(raw, style=str(ui_theme.SECONDARY))
-            console.print(line)
+            rows.append(line)
             continue
         # Step row: accent the status glyph, keep the step title as body text.
         indent_len = len(raw) - len(stripped)
@@ -88,7 +88,8 @@ def render_plan_breakdown(console: Console, breakdown: str) -> None:
             line.append(rest, style=str(ui_theme.TEXT))
         else:
             line.append(stripped, style=str(ui_theme.TEXT))
-        console.print(line)
+        rows.append(line)
+    print_repl_renderable(console, Group(*rows))
 
 
 def _overlay_line(text: str, style: str, width: int) -> str:

--- a/surfaces/shared/terminal/components/rendering.py
+++ b/surfaces/shared/terminal/components/rendering.py
@@ -13,7 +13,7 @@ import shutil
 import sys
 from collections.abc import Callable
 from contextvars import ContextVar
-from typing import Any
+from typing import Any, Literal, cast
 
 from rich import box
 from rich.console import Console
@@ -95,11 +95,17 @@ def _write_repl_tty_buffered(
 ) -> None:
     """Render Rich output to a buffer and write it in one TTY-safe stdout call."""
     buf = io.StringIO()
+    # Inherit the caller's color depth so theme colours are not down-converted
+    # on a truecolor terminal (Rich would otherwise re-detect from the env).
     buf_console = Console(
         file=buf,
         force_terminal=True,
         highlight=False,
         width=width,
+        color_system=cast(
+            Literal["auto", "standard", "256", "truecolor", "windows"],
+            console.color_system or "auto",
+        ),
     )
     render_to_buffer(buf_console)
     styled = buf.getvalue()

--- a/surfaces/shared/terminal/components/rendering.py
+++ b/surfaces/shared/terminal/components/rendering.py
@@ -202,6 +202,24 @@ def print_repl_text(console: Console, text: str, *, markup: bool = False) -> Non
     _console_print_prepared(console, text, markup=markup)
 
 
+def print_repl_renderable(console: Console, renderable: Any) -> None:
+    """Print one Rich renderable with CRLF under ``patch_stdout(raw=True)``.
+
+    Same buffered path as :func:`print_repl_text`, for styled multi-row
+    output (``Text``/``Group``) that would otherwise staircase in raw mode.
+    """
+    if console.file is sys.stdout and sys.stdout.isatty() and not _console_is_capturing(console):
+        width = _prepare_tty_for_rich(console)
+        _write_repl_tty_buffered(
+            console=console,
+            width=width,
+            leading_blank=False,
+            render_to_buffer=lambda buf_console: buf_console.print(renderable),
+        )
+        return
+    _console_print_prepared(console, renderable)
+
+
 def repl_print(console: Console, *objects: Any, **kwargs: Any) -> None:
     """Print via Rich after resetting the TTY column (inline-menu safe)."""
     from surfaces.shared.terminal.components.choice_menu import prepare_repl_output_line
@@ -260,6 +278,7 @@ __all__ = [
     "_repl_output_already_prepared",
     "_repl_table_width",
     "print_repl_json",
+    "print_repl_renderable",
     "print_repl_table",
     "print_repl_text",
     "repl_clear_screen",

--- a/tests/interactive_shell/ui/test_rendering.py
+++ b/tests/interactive_shell/ui/test_rendering.py
@@ -15,6 +15,7 @@ from surfaces.interactive_shell.ui.streaming.console import StreamingConsole
 from surfaces.shared.terminal.components.rendering import (
     _repl_write_buffer,
     print_repl_json,
+    print_repl_renderable,
     print_repl_text,
     repl_print,
     repl_table,
@@ -94,6 +95,36 @@ def test_print_repl_text_uses_crlf_so_goal_checklists_do_not_staircase(
     assert "\r\n    [ ] 1. Identify" in joined
     assert "\r\n  → [ ] 2. Run" in joined
     # No bare LF left (would staircase under raw patch_stdout).
+    assert "\n" not in joined.replace("\r\n", "")
+
+
+def test_print_repl_renderable_keeps_truecolor_and_crlf(monkeypatch: pytest.MonkeyPatch) -> None:
+    from rich.console import Group
+    from rich.text import Text
+
+    class _FakeStdout:
+        def __init__(self) -> None:
+            self.writes: list[str] = []
+
+        def write(self, text: str) -> int:
+            self.writes.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+        def isatty(self) -> bool:
+            return True
+
+    fake = _FakeStdout()
+    monkeypatch.setattr("surfaces.shared.terminal.components.rendering.sys.stdout", fake)
+    console = Console(file=fake, force_terminal=True, highlight=False, color_system="truecolor")
+    monkeypatch.setattr(console, "file", fake)
+
+    print_repl_renderable(console, Group(Text("Plan complete"), Text("  ✓ step", style="#6E6E6E")))
+
+    joined = "".join(fake.writes)
+    assert "38;2;110;110;110" in joined
     assert "\n" not in joined.replace("\r\n", "")
 
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -389,7 +389,10 @@ def test_collect_runs_keeps_the_timestamp_cutoff_and_proves_earlier_failures() -
     collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
 
     assert client.run_queries
-    assert all(">=2026-08-08T18:00:00Z" in str(call) for call in client.run_queries)
+    assert all(
+        str(call.get("created", "")).startswith("2026-08-08T18:00:00Z..")
+        for call in client.run_queries
+    )
     assert [run.run_id for run in collected.pr_runs] == [11]
     assert collected.pr_runs[0].retried_to_green is True
     assert collected.pr_runs[0].earlier_failure_started_at is not None
@@ -409,6 +412,41 @@ def test_collect_runs_does_not_treat_a_cancelled_rerun_as_a_flake() -> None:
     collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
 
     assert collected.pr_runs[0].retried_to_green is False
+
+
+def test_collect_runs_splits_the_window_past_the_listing_ceiling() -> None:
+    # Arrange: 1,500 PR runs spread over 30 days; one query can only return 1,000.
+    now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
+    rows = [
+        _payload(index, created_at=_iso(now - timedelta(minutes=28 * index)))
+        for index in range(1, 1501)
+    ]
+    client = _FakeGitHub(repository={"default_branch": "main"}, runs=rows)
+
+    # Act
+    collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
+
+    # Assert: every run is collected exactly once, and no slice needed a gap notice.
+    assert len(collected.pr_runs) == 1500
+    assert len({run.run_id for run in collected.pr_runs}) == 1500
+    assert not any("listing ceiling" in n for n in collected.coverage_notices)
+    assert all(".." in q.get("created", "") for q in client.run_queries)
+
+
+def test_collect_runs_reports_an_hour_that_still_exceeds_the_ceiling() -> None:
+    now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
+    burst = now - timedelta(days=3)
+    rows = [
+        _payload(index, created_at=_iso(burst + timedelta(seconds=index)))
+        for index in range(1, 1201)
+    ]
+    client = _FakeGitHub(repository={"default_branch": "main"}, runs=rows)
+
+    collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
+
+    assert any("listing ceiling" in n for n in collected.coverage_notices)
+    # The capped hour keeps its 1,000 rows; a neighbouring slice may add the rest.
+    assert 1000 <= len(collected.pr_runs) < 1200
 
 
 def test_collect_runs_reports_unavailable_attempt_history_instead_of_hiding_it() -> None:
@@ -489,9 +527,17 @@ class _FakeGitHub:
         self._pulls = pulls or []
         self.run_queries: list[dict[str, Any]] = []
 
-    def request(self, method: str, path: str, **_kwargs: Any) -> dict[str, Any]:
+    def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         if path == "/repos/o/r":
             return self._repository
+        if path == "/repos/o/r/actions/runs":
+            params = kwargs.get("params") or {}
+            self.run_queries.append(params)
+            inside = self._runs_in(params)
+            return {"total_count": len(inside), "workflow_runs": inside[:100]}
+        if path == "/repos/o/r/pulls":
+            page = int((kwargs.get("params") or {}).get("page", 1))
+            return self._pulls[(page - 1) * 100 : page * 100]
         marker = "/actions/runs/"
         if marker in path and "/attempts/" in path:
             rest = path.split(marker, 1)[1]
@@ -502,12 +548,23 @@ class _FakeGitHub:
                 raise GitHubApiError("attempt not found", status_code=404) from exc
         raise AssertionError(f"unexpected {method} {path}")
 
+    def _runs_in(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        """Rows for one listing query: PR event only, inside the created range, newest first."""
+        if params.get("event") != "pull_request":
+            return []
+        start, _, end = str(params.get("created", "")).partition("..")
+        inside = [
+            row
+            for row in self._runs
+            if (not start or row["created_at"] >= start) and (not end or row["created_at"] <= end)
+        ]
+        return sorted(inside, key=lambda row: row["created_at"], reverse=True)
+
     def paginate(self, path: str, *, params: dict[str, Any] | None = None, **_kwargs: Any) -> list:
         if path == "/repos/o/r/actions/runs":
             self.run_queries.append(params or {})
-            if (params or {}).get("event") == "pull_request":
-                return self._runs
-            return []
+            # GitHub returns at most 1,000 rows for one listing.
+            return self._runs_in(params or {})[:1000]
         if path == "/repos/o/r/pulls":
             return self._pulls
         return []

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -433,6 +433,56 @@ def test_collect_runs_splits_the_window_past_the_listing_ceiling() -> None:
     assert all(".." in q.get("created", "") for q in client.run_queries)
 
 
+def test_collect_runs_treats_exactly_the_ceiling_as_complete() -> None:
+    now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
+    rows = [
+        _payload(index, created_at=_iso(now - timedelta(minutes=40 * index)))
+        for index in range(1, 1001)
+    ]
+    client = _FakeGitHub(repository={"default_branch": "main"}, runs=rows)
+
+    collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
+
+    assert len(collected.pr_runs) == 1000
+    assert collected.coverage_notices == []
+    # One listing sufficed: the whole-window query was not split.
+    assert sum(1 for q in client.run_queries if q.get("event") == "pull_request") <= 2
+
+
+def test_rerun_budget_is_spent_on_merged_prs_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    from integrations.github.tools.ci_analytics import collector
+
+    monkeypatch.setattr(collector, "_MAX_ATTEMPT_LOOKUPS", 1)
+    now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
+    # The unmerged re-run is older, so plain ordering would check it first.
+    unmerged = _payload(5, created_at="2026-09-01T09:00:00Z", attempt=2, branch="feat/other")
+    merged = _payload(6, created_at="2026-09-02T09:00:00Z", attempt=2, branch="feat/x")
+    attempts = {
+        (5, 1): _payload(5, created_at=unmerged["created_at"], conclusion="failure", attempt=1),
+        (6, 1): _payload(6, created_at=merged["created_at"], conclusion="failure", attempt=1),
+    }
+    pulls = [
+        {
+            "number": 42,
+            "merged_at": "2026-09-03T09:00:00Z",
+            "updated_at": "2026-09-03T09:00:00Z",
+            "head": {"ref": "feat/x", "repo": {"full_name": "o/r"}},
+        }
+    ]
+    client = _FakeGitHub(
+        repository={"default_branch": "main"},
+        runs=[unmerged, merged],
+        attempts=attempts,
+        pulls=pulls,
+    )
+
+    collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
+
+    by_id = {run.run_id: run for run in collected.pr_runs}
+    assert by_id[6].retried_to_green is True
+    assert by_id[5].retried_to_green is False
+
+
 def test_collect_runs_reports_an_hour_that_still_exceeds_the_ceiling() -> None:
     now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
     burst = now - timedelta(days=3)
@@ -494,12 +544,13 @@ def _payload(
     conclusion: str = "success",
     attempt: int = 1,
     event: str = "pull_request",
+    branch: str = "feat/x",
 ) -> dict[str, Any]:
     return {
         "id": run_id,
         "name": "CI",
         "workflow_id": 1,
-        "head_branch": "feat/x",
+        "head_branch": branch,
         "head_sha": "abc",
         "event": event,
         "conclusion": conclusion,


### PR DESCRIPTION
GitHub's workflow-run listing stops at 1,000 rows however far you page.
On an active repository the "last 30 days" report therefore covered only
the newest few days, with no coverage notice because the cap check was
set at 2,000. On Tracer-Cloud/opensre the demo showed 645 PR runs where
the window holds 5,572, and every KPI derived from it was an undercount.

- `collector.py`: each scope is fetched in time slices. A slice's first
  page carries `total_count`; a slice over the ceiling is split in half
  and refetched without paging the rest, slices run in parallel, and only
  a one-hour slice that still exceeds 1,000 runs is reported as a gap.
  Closed PRs are paged until their update time leaves the window instead
  of stopping at 500. Re-run history lookups check merged-PR re-runs
  first under a budget of 500 requests.
- `task_plan.py` / `rendering.py`: the post-turn plan breakdown is
  written as one buffered block with CRLF line endings through a new
  `print_repl_renderable`, so it stays left-aligned when the prompt has
  the terminal in raw mode.
