### PR TITLE
fix(ci-analytics): give re-run lookup priority only to PRs merged after the run

### DIFF
--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -10,6 +10,7 @@ from typing import Any
 from urllib.parse import quote
 
 from integrations.github.client import GitHubApiError, GitHubRestClient
+from integrations.github.tools.ci_analytics.metrics import on_critical_path
 from integrations.github.tools.ci_analytics.models import MergedPullRequest, WorkflowRun
 
 _PER_PAGE = 100
@@ -325,19 +326,12 @@ def _annotate_reruns(
     reruns = [run for run in runs if run.succeeded and run.attempt > 1]
     if not reruns:
         return runs
-    merged_numbers = {pr.number for pr in merged}
-    merged_branches = {(pr.head_repo, pr.branch) for pr in merged}
-
-    def on_merged_pr(run: WorkflowRun) -> bool:
-        if run.pr_numbers:
-            return any(number in merged_numbers for number in run.pr_numbers)
-        return (run.head_repo, run.branch) in merged_branches
-
+    # Same rule as the blocked-time metric, so priority and critical path agree.
     lookups = _AttemptLookups(_MAX_ATTEMPT_LOOKUPS)
     checked: dict[int, WorkflowRun] = {}
     for phase in (
-        [run for run in reruns if on_merged_pr(run)],
-        [run for run in reruns if not on_merged_pr(run)],
+        [run for run in reruns if on_critical_path(run, merged)],
+        [run for run in reruns if not on_critical_path(run, merged)],
     ):
         if not phase:
             continue

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -110,7 +110,7 @@ def classify_failures(
                         recovery=run,
                         kind=FailureKind.RELIABILITY,
                         delay_minutes=max(0.0, elapsed - normal_minutes.get(workflow_key, 0.0)),
-                        critical_path=_on_critical_path(run, merged_prs),
+                        critical_path=on_critical_path(run, merged_prs),
                     )
                 )
                 continue
@@ -133,7 +133,7 @@ def classify_failures(
                     recovery=recovery,
                     kind=kind,
                     delay_minutes=delay,
-                    critical_path=_on_critical_path(run, merged_prs),
+                    critical_path=on_critical_path(run, merged_prs),
                 )
             )
     return sorted(classified, key=lambda c: c.failure.completed_at)
@@ -219,7 +219,13 @@ def _history_key(run: WorkflowRun) -> tuple[int | str, str, str, int]:
     return (_workflow_key(run), run.head_repo, run.branch, pr_number)
 
 
-def _on_critical_path(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> bool:
+def on_critical_path(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> bool:
+    """True when the run belongs to a PR merged inside the window, after the run was created.
+
+    A PR number is decisive when GitHub attached one; otherwise the head
+    repository and branch must match a PR merged later than the run, so a
+    reused branch name does not inherit an earlier merge.
+    """
     if run.pr_numbers:
         merged_ids = {pr.number for pr in merged}
         return any(number in merged_ids for number in run.pr_numbers)
@@ -231,6 +237,7 @@ def _on_critical_path(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> 
 
 __all__ = [
     "classify_failures",
+    "on_critical_path",
     "compute_report",
     "find_outages",
     "normal_minutes",

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -483,6 +483,48 @@ def test_rerun_budget_is_spent_on_merged_prs_first(monkeypatch: pytest.MonkeyPat
     assert by_id[5].retried_to_green is False
 
 
+def test_rerun_on_a_reused_branch_does_not_take_merged_pr_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from integrations.github.tools.ci_analytics import collector
+
+    monkeypatch.setattr(collector, "_MAX_ATTEMPT_LOOKUPS", 1)
+    now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
+    # feat/x was merged on the 3rd; this re-run on a reused feat/x is from the 5th.
+    reused = _payload(7, created_at="2026-09-05T09:00:00Z", attempt=2, branch="feat/x")
+    genuine = _payload(8, created_at="2026-09-02T09:00:00Z", attempt=2, branch="feat/y")
+    attempts = {
+        (7, 1): _payload(7, created_at=reused["created_at"], conclusion="failure", attempt=1),
+        (8, 1): _payload(8, created_at=genuine["created_at"], conclusion="failure", attempt=1),
+    }
+    pulls = [
+        {
+            "number": 42,
+            "merged_at": "2026-09-03T09:00:00Z",
+            "updated_at": "2026-09-03T09:00:00Z",
+            "head": {"ref": "feat/x", "repo": {"full_name": "o/r"}},
+        },
+        {
+            "number": 43,
+            "merged_at": "2026-09-04T09:00:00Z",
+            "updated_at": "2026-09-04T09:00:00Z",
+            "head": {"ref": "feat/y", "repo": {"full_name": "o/r"}},
+        },
+    ]
+    client = _FakeGitHub(
+        repository={"default_branch": "main"},
+        runs=[reused, genuine],
+        attempts=attempts,
+        pulls=pulls,
+    )
+
+    collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
+
+    by_id = {run.run_id: run for run in collected.pr_runs}
+    assert by_id[8].retried_to_green is True
+    assert by_id[7].retried_to_green is False
+
+
 def test_collect_runs_reports_an_hour_that_still_exceeds_the_ceiling() -> None:
     now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
     burst = now - timedelta(days=3)


### PR DESCRIPTION
Follow-up to #6075. Attempt-history lookups for passing re-runs are
checked in two phases so the shared budget is spent on merged-PR re-runs
first. The phase selector matched a re-run to a merged PR by head
repository and branch alone, without checking that the merge happened
after the run. On a reused branch name an unrelated re-run could take
priority budget away from a genuine merged-PR re-run, understating
CI-caused failures and blocked time under a tight budget.

- `metrics.py`: `on_critical_path` is now the public, documented rule: a
  PR number match when GitHub attached one, otherwise head repository and
  branch must match a PR merged later than the run was created.
- `collector.py`: the priority phase uses that same rule instead of its own
  branch-only lookup, so priority and the blocked-time metric can never
  disagree.
- Test: a re-run on a reused branch merged earlier in the window does not
  take the single available lookup; the genuine merged-PR re-run does.
