### PR TITLE
fix(scheduler): migrate legacy task kinds

### DIFF
--- a/infrastructure/scheduling/scheduler/loop_constants.py
+++ b/infrastructure/scheduling/scheduler/loop_constants.py
@@ -6,6 +6,8 @@ LOOP_CHANNELS_PARAM = "loop_channels"
 LOOP_CREATED_BY_PARAM = "loop_created_by"
 LOOP_DESCRIPTION_PARAM = "loop_description"
 LOOP_GROUP_ID_PARAM = "loop_group_id"
+LOOP_LEGACY_TASK_KIND_PARAM = "opensre_legacy_task_kind"
+LOOP_MIGRATION_NOTICE_PARAM = "opensre_task_migration_notice"
 LOOP_PROMPT_PARAM = "loop_prompt"
 LOOP_SLACK_CHAT_ID_PARAM = "slack_chat_id"
 LOOP_SLUG_PARAM = "loop_slug"
@@ -18,6 +20,8 @@ __all__ = [
     "LOOP_CREATED_BY_PARAM",
     "LOOP_DESCRIPTION_PARAM",
     "LOOP_GROUP_ID_PARAM",
+    "LOOP_LEGACY_TASK_KIND_PARAM",
+    "LOOP_MIGRATION_NOTICE_PARAM",
     "LOOP_PROMPT_PARAM",
     "LOOP_SLACK_CHAT_ID_PARAM",
     "LOOP_SLUG_PARAM",

--- a/infrastructure/scheduling/scheduler/loops.py
+++ b/infrastructure/scheduling/scheduler/loops.py
@@ -21,6 +21,7 @@ from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_CREATED_BY_PARAM,
     LOOP_DESCRIPTION_PARAM,
     LOOP_GROUP_ID_PARAM,
+    LOOP_MIGRATION_NOTICE_PARAM,
     LOOP_PROMPT_PARAM,
     LOOP_SLACK_CHAT_ID_PARAM,
     LOOP_SLUG_PARAM,
@@ -591,7 +592,11 @@ def _summarize_group(
 ) -> LoopSummary:
     representative = sorted(tasks, key=lambda task: (task.created_at, task.id))[0]
     next_runs: list[str] = []
-    schedule_errors: list[str] = []
+    schedule_errors = [
+        notice
+        for task in tasks
+        if (notice := task.params.get(LOOP_MIGRATION_NOTICE_PARAM, "").strip())
+    ]
     for task in tasks:
         try:
             computed_next_run = compute_next_run(task, now)

--- a/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
+++ b/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_LEGACY_TASK_KIND_PARAM,
     LOOP_MIGRATION_NOTICE_PARAM,
@@ -21,10 +23,12 @@ _RETIRED_TASK_KINDS = frozenset(
 )
 
 
-def migrate_legacy_task_entries(entries: list[dict[str, object]]) -> bool:
+def migrate_legacy_task_entries(entries: Iterable[object]) -> bool:
     """Normalize retired task kinds in place before strict model validation."""
     changed = False
     for entry in entries:
+        if not isinstance(entry, dict):
+            continue
         legacy_kind = entry.get("kind")
         if legacy_kind not in _RETIRED_TASK_KINDS:
             continue

--- a/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
+++ b/infrastructure/scheduling/scheduler/storage/legacy_task_migration.py
@@ -1,0 +1,54 @@
+"""Migrate scheduler rows written before retired task kinds were removed."""
+
+from __future__ import annotations
+
+from infrastructure.scheduling.scheduler.loop_constants import (
+    LOOP_LEGACY_TASK_KIND_PARAM,
+    LOOP_MIGRATION_NOTICE_PARAM,
+    LOOP_PROMPT_PARAM,
+)
+from infrastructure.scheduling.scheduler.types import TaskKind
+
+_CUSTOM_INVESTIGATION = "custom_investigation"
+_RETIRED_TASK_KINDS = frozenset(
+    {
+        _CUSTOM_INVESTIGATION,
+        "daily_summary",
+        "weekly_audit",
+        "incident_window_replay",
+        "synthetic_run",
+    }
+)
+
+
+def migrate_legacy_task_entries(entries: list[dict[str, object]]) -> bool:
+    """Normalize retired task kinds in place before strict model validation."""
+    changed = False
+    for entry in entries:
+        legacy_kind = entry.get("kind")
+        if legacy_kind not in _RETIRED_TASK_KINDS:
+            continue
+
+        params = entry.get("params")
+        if not isinstance(params, dict):
+            params = {}
+            entry["params"] = params
+
+        prompt = params.get(LOOP_PROMPT_PARAM)
+        entry["kind"] = TaskKind.MANUAL_LOOP.value
+        changed = True
+        if legacy_kind == _CUSTOM_INVESTIGATION and isinstance(prompt, str) and prompt.strip():
+            continue
+
+        task_id = str(entry.get("id") or "<task-id>")
+        entry["enabled"] = False
+        params[LOOP_LEGACY_TASK_KIND_PARAM] = legacy_kind
+        params[LOOP_MIGRATION_NOTICE_PARAM] = (
+            f"Legacy task kind '{legacy_kind}' depended on the retired investigation scheduler "
+            "and was disabled. Recreate it with 'opensre cron add --kind manual_loop "
+            f"--prompt <instruction> ...', then remove this task with 'opensre cron remove {task_id}'."
+        )
+    return changed
+
+
+__all__ = ["migrate_legacy_task_entries"]

--- a/infrastructure/scheduling/scheduler/storage/task_store.py
+++ b/infrastructure/scheduling/scheduler/storage/task_store.py
@@ -18,6 +18,9 @@ from filelock import FileLock
 from config.constants import OPENSRE_HOME_DIR
 from infrastructure.scheduling.scheduler import reload_signal
 from infrastructure.scheduling.scheduler.storage.database import run_database_path
+from infrastructure.scheduling.scheduler.storage.legacy_task_migration import (
+    migrate_legacy_task_entries,
+)
 from infrastructure.scheduling.scheduler.storage.run_store import delete_runs
 from infrastructure.scheduling.scheduler.types import ScheduledTask
 
@@ -159,6 +162,16 @@ def list_tasks(store_path: Path | None = None) -> list[ScheduledTask]:
     lock = FileLock(_lock_path(path))
     with lock:
         raw = _load_raw(path)
+        if migrate_legacy_task_entries(raw):
+            try:
+                _save_raw(path, raw)
+            except OSError:
+                logger.warning(
+                    "Could not persist migrated legacy scheduler tasks at %s; "
+                    "using the migrated definitions for this process",
+                    path,
+                    exc_info=True,
+                )
     tasks: list[ScheduledTask] = []
     for entry in raw:
         try:

--- a/surfaces/cli/commands/cron.py
+++ b/surfaces/cli/commands/cron.py
@@ -281,6 +281,11 @@ def cron_list() -> None:
         )
 
     _console.print(table)
+    for loop in loops:
+        if loop.schedule_error:
+            _console.print(
+                f"[yellow]Task {loop.id[:12]} requires action:[/yellow] {loop.schedule_error}"
+            )
 
 
 @cron_command.command(name="remove")

--- a/tests/cli/test_cron_command.py
+++ b/tests/cli/test_cron_command.py
@@ -29,6 +29,42 @@ def test_cron_add_kind_choices_exclude_sentry_kinds() -> None:
     }
 
 
+def test_cron_list_surfaces_legacy_task_migration_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from infrastructure.scheduling.scheduler.loops import LoopSummary
+
+    notice = "daily_summary retired; recreate with opensre cron add --kind manual_loop"
+    summary = LoopSummary(
+        id="legacy-daily",
+        task_ids=("legacy-daily",),
+        name="Daily reliability",
+        description="",
+        prompt="",
+        kind=TaskKind.MANUAL_LOOP,
+        cron="0 8 * * 1-5",
+        timezone="UTC",
+        provider=Provider.SLACK,
+        chat_id="C123",
+        channels=("slack",),
+        enabled=False,
+        window_hours=24,
+        last_run=None,
+        next_run=None,
+        schedule_error=notice,
+    )
+    monkeypatch.setattr(
+        "infrastructure.scheduling.scheduler.loops.list_loop_summaries", lambda: [summary]
+    )
+
+    result = CliRunner().invoke(cron_command, ["list"])
+
+    assert result.exit_code == 0
+    output = " ".join(result.output.split())
+    assert "daily_summary retired" in output
+    assert "opensre cron add --kind" in output
+
+
 def test_cron_add_manual_loop_requires_prompt() -> None:
     result = CliRunner().invoke(
         cron_command,

--- a/tests/fixtures/scheduler/pre_5981_tasks.json
+++ b/tests/fixtures/scheduler/pre_5981_tasks.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "existing-loop",
+    "name": "Overnight incidents",
+    "kind": "custom_investigation",
+    "cron": "0 9 * * *",
+    "timezone": "Asia/Kolkata",
+    "provider": "interactive_shell",
+    "chat_id": "local-session",
+    "window_hours": 12,
+    "enabled": true,
+    "params": {
+      "loop_prompt": "Summarize overnight incidents",
+      "loop_channels": "interactive_shell"
+    },
+    "created_at": "2026-08-20T03:30:00+00:00",
+    "last_run": "2026-09-01T03:30:00+00:00",
+    "next_run": "2026-09-02T03:30:00+00:00"
+  },
+  {
+    "id": "legacy-daily",
+    "name": "Daily reliability",
+    "kind": "daily_summary",
+    "cron": "0 8 * * 1-5",
+    "timezone": "UTC",
+    "provider": "slack",
+    "chat_id": "C0123ABCD",
+    "window_hours": 24,
+    "enabled": true,
+    "params": {},
+    "created_at": "2026-08-01T00:00:00+00:00"
+  },
+  {
+    "id": "legacy-weekly",
+    "name": "Weekly alert audit",
+    "kind": "weekly_audit",
+    "cron": "0 9 * * 1",
+    "timezone": "UTC",
+    "provider": "telegram",
+    "chat_id": "-100123",
+    "window_hours": 168,
+    "enabled": false,
+    "params": {},
+    "created_at": "2026-08-01T00:00:00+00:00"
+  },
+  {
+    "id": "legacy-replay",
+    "name": "Incident replay",
+    "kind": "incident_window_replay",
+    "cron": "30 2 * * *",
+    "timezone": "UTC",
+    "provider": "discord",
+    "chat_id": "987654321",
+    "window_hours": 6,
+    "enabled": true,
+    "params": {},
+    "created_at": "2026-08-01T00:00:00+00:00"
+  },
+  {
+    "id": "legacy-synthetic",
+    "name": "Synthetic checks",
+    "kind": "synthetic_run",
+    "cron": "*/15 * * * *",
+    "timezone": "UTC",
+    "provider": "rocketchat",
+    "chat_id": "ops",
+    "window_hours": 1,
+    "enabled": true,
+    "params": {},
+    "created_at": "2026-08-01T00:00:00+00:00"
+  },
+  {
+    "id": "legacy-promptless",
+    "name": "Old custom investigation",
+    "kind": "custom_investigation",
+    "cron": "0 4 * * *",
+    "timezone": "UTC",
+    "provider": "slack",
+    "chat_id": "C999",
+    "window_hours": 24,
+    "enabled": true,
+    "params": {},
+    "created_at": "2026-08-01T00:00:00+00:00"
+  }
+]

--- a/tests/scheduler/test_task_store.py
+++ b/tests/scheduler/test_task_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -547,3 +548,15 @@ class TestLegacyTaskMigration:
         assert summary.enabled is False
         assert "daily_summary" in summary.schedule_error
         assert "opensre cron add --kind manual_loop" in summary.schedule_error
+
+    def test_migration_keeps_loading_valid_tasks_alongside_non_object_entries(
+        self, store_path: Path
+    ) -> None:
+        self._copy_fixture(store_path)
+        entries = json.loads(store_path.read_text(encoding="utf-8"))
+        entries.insert(0, "malformed task row")
+        store_path.write_text(json.dumps(entries), encoding="utf-8")
+
+        tasks = list_tasks(store_path)
+
+        assert any(task.id == "existing-loop" for task in tasks)

--- a/tests/scheduler/test_task_store.py
+++ b/tests/scheduler/test_task_store.py
@@ -468,3 +468,82 @@ class TestStoreSurvivesTornWrites:
         assert list(store_path.parent.glob(f"{store_path.name}.corrupt-*")) == []
         # The original (unreadable) store is untouched -- os.replace never happened.
         assert store_path.read_text(encoding="utf-8") == "not valid json"
+
+
+class TestLegacyTaskMigration:
+    @staticmethod
+    def _copy_fixture(store_path: Path) -> None:
+        fixture = Path(__file__).parents[1] / "fixtures" / "scheduler" / "pre_5981_tasks.json"
+        store_path.write_bytes(fixture.read_bytes())
+
+    def test_pre_5981_prompt_loop_is_migrated_without_losing_its_contract(
+        self, store_path: Path
+    ) -> None:
+        self._copy_fixture(store_path)
+
+        task = get_task("existing-loop", store_path)
+
+        assert task is not None
+        assert task.model_dump(mode="json") == {
+            "id": "existing-loop",
+            "name": "Overnight incidents",
+            "kind": "manual_loop",
+            "cron": "0 9 * * *",
+            "timezone": "Asia/Kolkata",
+            "provider": "interactive_shell",
+            "chat_id": "local-session",
+            "window_hours": 12,
+            "enabled": True,
+            "params": {
+                "loop_prompt": "Summarize overnight incidents",
+                "loop_channels": "interactive_shell",
+            },
+            "skill_name": "",
+            "skill_revision": "",
+            "skill_inputs": {},
+            "created_at": "2026-08-20T03:30:00+00:00",
+            "last_run": "2026-09-01T03:30:00+00:00",
+            "next_run": "2026-09-02T03:30:00+00:00",
+        }
+        persisted = store_path.read_text(encoding="utf-8")
+        assert '"kind": "manual_loop"' in persisted
+        assert '"kind": "custom_investigation"' not in persisted
+
+    @pytest.mark.parametrize(
+        "task_id,legacy_kind",
+        [
+            ("legacy-daily", "daily_summary"),
+            ("legacy-weekly", "weekly_audit"),
+            ("legacy-replay", "incident_window_replay"),
+            ("legacy-synthetic", "synthetic_run"),
+            ("legacy-promptless", "custom_investigation"),
+        ],
+    )
+    def test_retired_tasks_remain_visible_but_cannot_run_silently(
+        self, store_path: Path, task_id: str, legacy_kind: str
+    ) -> None:
+        self._copy_fixture(store_path)
+
+        task = get_task(task_id, store_path)
+
+        assert task is not None
+        assert task.kind is TaskKind.MANUAL_LOOP
+        assert task.enabled is False
+        assert task.params["opensre_legacy_task_kind"] == legacy_kind
+        notice = task.params["opensre_task_migration_notice"]
+        assert legacy_kind in notice
+        assert f"opensre cron remove {task_id}" in notice
+        assert "opensre cron add --kind manual_loop" in notice
+
+    def test_retired_task_notice_is_exposed_in_loop_status(self, store_path: Path) -> None:
+        from infrastructure.scheduling.scheduler.loops import list_loop_summaries
+
+        self._copy_fixture(store_path)
+
+        summary = next(
+            loop for loop in list_loop_summaries(store_path=store_path) if loop.id == "legacy-daily"
+        )
+
+        assert summary.enabled is False
+        assert "daily_summary" in summary.schedule_error
+        assert "opensre cron add --kind manual_loop" in summary.schedule_error


### PR DESCRIPTION
Fixes #6067

#### Describe the changes you have made in this PR -

- migrate persisted `custom_investigation` prompt loops to `manual_loop` before strict task validation while preserving their existing task contract
- keep every other retired scheduler kind visible as a disabled `manual_loop` with its original kind and actionable recreate/remove guidance
- persist migrated scheduler rows atomically when possible and surface migration guidance in loop summaries and `opensre cron list`
- preserve the existing malformed-row behavior by skipping non-mapping entries during migration
- add a realistic pre-#5981 scheduler fixture and focused scheduler/CLI regression coverage

### Demo/Screenshot for feature changes and bug fixes -

```text
$ make lint
All checks passed!
$ make format-check
3107 files already formatted
$ make typecheck
Success: no issues found in 1800 source files
$ uv run python -m pytest tests/scheduler/test_task_store.py tests/cli/test_cron_command.py -q
65 passed in 1.75s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The scheduler store applies a narrow, idempotent compatibility migration to raw JSON rows before Pydantic validation. Prompt-backed legacy loops map directly to `manual_loop`; retired kinds without a safe equivalent are disabled rather than guessed at or dropped, and carry guidance in params so existing summary/list paths expose the required action. Non-mapping entries remain subject to the existing guarded validation path, preserving valid schedules in mixed malformed stores.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
