### PR TITLE
fix(cli): allow ask chat-surface tools

### DIFF
--- a/core/agent_harness/tools/__init__.py
+++ b/core/agent_harness/tools/__init__.py
@@ -11,6 +11,7 @@ role), :mod:`core.agent_harness.runtime` (build and run the agent).
 
 from __future__ import annotations
 
+from core.agent_harness.tools.action_tools import registered_single_turn_tool_names
 from core.agent_harness.tools.tool_context import (
     ActionToolScope,
     action_context_from_agent_context,
@@ -27,4 +28,5 @@ __all__ = [
     "capability_available_from_sources",
     "coerce_gathered_evidence",
     "execute_with_action_context",
+    "registered_single_turn_tool_names",
 ]

--- a/core/agent_harness/tools/action_tools.py
+++ b/core/agent_harness/tools/action_tools.py
@@ -12,6 +12,7 @@ from infrastructure.harness_providers import resolve_surface_tool_map, resolve_s
 from infrastructure.observability.trace.redaction import redact_sensitive
 
 _ACTION_SESSION_SOURCE = "_action_session"
+_SINGLE_TURN_TOOL_SURFACES = (ToolSurface.ACTION, ToolSurface.CHAT)
 
 
 class _IntegrationsSessionView(Protocol):
@@ -57,12 +58,7 @@ def get_action_tools_from_integrations_view(
     """Return action and chat tools available to the single turn agent."""
     sources = _sources_for_view(view, resolved_integrations)
     tools: list[RegisteredTool] = []
-    candidates = {
-        candidate.name: candidate
-        for surface in (ToolSurface.ACTION, ToolSurface.CHAT)
-        for candidate in resolve_surface_tools(surface)
-    }
-    for candidate in candidates.values():
+    for candidate in _registered_single_turn_tools().values():
         try:
             if not candidate.is_available(sources):
                 continue
@@ -73,6 +69,19 @@ def get_action_tools_from_integrations_view(
             ) from exc
         tools.append(candidate)
     return tools
+
+
+def _registered_single_turn_tools() -> dict[str, RegisteredTool]:
+    return {
+        candidate.name: candidate
+        for surface in _SINGLE_TURN_TOOL_SURFACES
+        for candidate in resolve_surface_tools(surface)
+    }
+
+
+def registered_single_turn_tool_names() -> frozenset[str]:
+    """Return every registered tool name the single-turn agent can reach."""
+    return frozenset(_registered_single_turn_tools())
 
 
 def get_action_tool(name: str) -> RegisteredTool | None:
@@ -89,4 +98,5 @@ __all__ = [
     "action_tool_names",
     "get_action_tool",
     "get_action_tools_from_integrations_view",
+    "registered_single_turn_tool_names",
 ]

--- a/surfaces/cli/ask/approval.py
+++ b/surfaces/cli/ask/approval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 from collections.abc import Iterable
 
-from core.agent_harness.tools.action_tools import registered_single_turn_tool_names
+from core.agent_harness.tools import registered_single_turn_tool_names
 from core.tool import (
     BeforeToolCallResult,
     RuntimeTool,

--- a/surfaces/cli/ask/approval.py
+++ b/surfaces/cli/ask/approval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 from collections.abc import Iterable
 
-from core.domain.types.tools import ToolSurface
+from core.agent_harness.tools.action_tools import registered_single_turn_tool_names
 from core.tool import (
     BeforeToolCallResult,
     RuntimeTool,
@@ -13,7 +13,6 @@ from core.tool import (
     ToolExecutionHooks,
     ToolExecutionRequest,
 )
-from infrastructure.harness_providers import resolve_surface_tool_map
 
 _GATED_SIDE_EFFECTS = frozenset({SideEffectLevel.MUTATING, SideEffectLevel.EXTERNAL})
 
@@ -49,10 +48,7 @@ def approval_required(tool: RuntimeTool) -> bool:
 
 def registered_ask_tool_names() -> frozenset[str]:
     """Return every registered tool name the ask action or gather phases can reach."""
-    names: set[str] = set()
-    for surface in (ToolSurface.ACTION,):
-        names.update(resolve_surface_tool_map(surface))
-    return frozenset(names)
+    return registered_single_turn_tool_names()
 
 
 def unknown_allowed_tools(allowed_tools: Iterable[str]) -> tuple[str, ...]:

--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -6,11 +6,16 @@ import threading
 import pytest
 
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+from core.domain.types.tools import ToolSurface
 from core.llm.types import ToolCall
 from core.tool.contracts import RegisteredTool, SideEffectLevel
 from core.tool.execution import ToolExecutionHooks, ToolExecutionRequest
+from infrastructure.harness_providers import resolve_surface_tool_map
 from surfaces.cli.ask import service
+from surfaces.cli.ask.approval import unknown_allowed_tools
 from surfaces.cli.ask.service import AskExitCode, AskSignal, AskStatus
+
+_CHAT_ONLY_TOOL = "query_tempo"
 
 
 def _turn(
@@ -42,6 +47,19 @@ def _risky_request() -> ToolExecutionRequest:
     )
     return ToolExecutionRequest(
         tool_call=ToolCall(id="call-1", name=tool.name, input={}),
+        tool=tool,
+        arguments={},
+        source=tool.source,
+        resolved_integrations={},
+    )
+
+
+def _chat_only_request() -> ToolExecutionRequest:
+    action_tools = resolve_surface_tool_map(ToolSurface.ACTION)
+    tool = resolve_surface_tool_map(ToolSurface.CHAT)[_CHAT_ONLY_TOOL]
+    assert _CHAT_ONLY_TOOL not in action_tools
+    return ToolExecutionRequest(
+        tool_call=ToolCall(id="call-chat", name=tool.name, input={}),
         tool=tool,
         arguments={},
         source=tool.source,
@@ -177,6 +195,37 @@ def test_run_ask_reports_denial_before_agent_failure(monkeypatch) -> None:
     # The denial is actionable: it names the exact flags that unblock the run.
     assert "--allowed-tool shell_run" in outcome.response
     assert "--dangerously-bypass-approvals" in outcome.response
+
+
+def test_chat_only_tool_denial_suggests_valid_authorized_rerun(monkeypatch) -> None:
+    request = _chat_only_request()
+
+    def run_tool(_prompt: str, hooks: ToolExecutionHooks) -> TurnResult:
+        assert hooks.before_tool_call is not None
+        decision = hooks.before_tool_call(request)
+        assert decision is not None
+        if decision.blocked:
+            raise RuntimeError("tool call blocked")
+        assert decision.approved
+        return _turn("trace results")
+
+    monkeypatch.setattr(service, "_run_agent_turn", run_tool)
+
+    denied = service.run_ask("prompt", allowed_tools=(), bypass_approvals=False)
+
+    assert denied.status is AskStatus.APPROVAL_DENIED
+    assert denied.denied_tools == (_CHAT_ONLY_TOOL,)
+    assert f"--allowed-tool {_CHAT_ONLY_TOOL}" in denied.response
+    assert unknown_allowed_tools((_CHAT_ONLY_TOOL, "query_temop")) == ("query_temop",)
+
+    authorized = service.run_ask(
+        "prompt",
+        allowed_tools=(_CHAT_ONLY_TOOL,),
+        bypass_approvals=False,
+    )
+
+    assert authorized.status is AskStatus.SUCCESS
+    assert authorized.response == "trace results"
 
 
 def test_run_ask_maps_hosted_credit_exhaustion_to_nonzero_upgrade_error(

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -208,6 +208,7 @@ TOOLS = frozenset(
         "capability_available_from_sources",
         "coerce_gathered_evidence",
         "execute_with_action_context",
+        "registered_single_turn_tool_names",
     }
 )
 


### PR DESCRIPTION
Fixes #6069

#### Describe the changes you have made in this PR -

- centralize the ACTION + CHAT tool registry union used by the single-turn agent
- derive `opensre ask --allowed-tool` validation from that same executable registry
- preserve exact, fail-closed validation for genuinely unknown tool names
- expose the registry-name helper through the harness public API and pin the API contract
- add a real-registry CHAT-only regression covering denial, suggested rerun, typo rejection, and authorized execution

### Demo/Screenshot for feature changes and bug fixes -

```text
$ make lint
All checks passed!
$ make format-check
3108 files already formatted
$ make typecheck
Success: no issues found in 1801 source files
$ uv run python -m pytest tests/core/agent_harness/test_harness_api.py tests/interactive_shell/test_harness_api_border.py tests/cli/test_ask_service.py tests/cli/test_ask_command.py -q
33 passed in 2.86s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The runtime's ACTION + CHAT surface tuple is now the single source of truth for both executable tool discovery and allowlist-name validation. This avoids duplicating surface selection while preserving exact-name validation. The helper is exported through the intended harness API rather than coupling the CLI surface to an internal leaf module.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
