### PR TITLE
fix(onboarding): render the demo's discovery steps in the transcript idioms

### DIFF
--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any
 
 from rich.console import Group
+from rich.padding import Padding
 from rich.table import Table
 from rich.text import Text
 
@@ -150,7 +151,8 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
     if not report.executions:
         parts.append(Text("No completed workflow runs were found in this window.", style="dim"))
     parts.extend(Text(notice, style="dim") for notice in report.coverage_notices)
-    console.print(Group(*parts))
+    # Hang the block in the shell's two-column reply gutter like agent output.
+    console.print(Padding(Group(*parts), (0, 0, 0, 2)))
 
 
 def headline(report: CiAnalyticsReport) -> str:

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -230,8 +230,10 @@ def analyze_github_ci_reliability(
     now = datetime.now(UTC)
     console = _console(context)
     if console is not None:
+        # Two-column lead matches the shell's reply gutter so the tool's lines
+        # hang with the agent's notes instead of breaking the transcript edge.
         console.print(
-            f"[dim]Reading GitHub Actions history for {escape(f'{repo_owner}/{repo_name}')}, "
+            f"  [dim]Reading GitHub Actions history for {escape(f'{repo_owner}/{repo_name}')}, "
             f"last {window} days…[/dim]"
         )
     started = time.monotonic()
@@ -274,7 +276,7 @@ def analyze_github_ci_reliability(
     rendered = console is not None
     if console is not None:
         read = len(collected.branch_runs) + len(collected.pr_runs)
-        console.print(f"[dim]Read {read} runs in {time.monotonic() - started:.0f}s.[/dim]")
+        console.print(f"  [dim]Read {read} runs in {time.monotonic() - started:.0f}s.[/dim]")
         console.print()
     base = {
         "source": _SOURCE,

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich.markup import escape
+from rich.text import Text
 
 from config.constants.paths import OPENSRE_HOME_DIR
 from infrastructure.analytics.capture import (
@@ -33,12 +34,13 @@ from infrastructure.analytics.capture import (
 from infrastructure.analytics.source import is_test_run
 from infrastructure.terminal.theme import DIM, WARNING
 from integrations.github import resolve_github_token
+from surfaces.interactive_shell.ui.streaming.renderer import render_note_block, reply_gutter
 from surfaces.shared.terminal.components.choice_menu import (
     repl_choose_one,
     repl_tty_interactive,
 )
 from surfaces.shared.terminal.components.loaders import llm_loader
-from tools.system.workspace_git_scan.render import render_snapshot
+from tools.system.workspace_git_scan.render import snapshot_renderable
 from tools.system.workspace_git_scan.scan import RepoActivity, WorkspaceSnapshot, scan_workspace
 
 if TYPE_CHECKING:
@@ -56,6 +58,8 @@ _MENU_EXPLAINER = (
     "Each takes a couple of minutes and I'll use real GitHub repositories on your machine."
 )
 _CUSTOM_LABEL = "Or type your own answer..."
+# Same header the agent's own menus carry, so the demo reads as one conversation.
+_MENU_HEADER = "Ask User"
 _CUSTOM_OPTION = "custom"
 _SKIPPED_OPTION = "skipped"
 _SNAPSHOT_LEAD = "Here's a live snapshot built from your machine:"
@@ -153,6 +157,7 @@ def offer_demo(session: Session, console: Console | None = None, *, force: bool 
             ],
             custom_label=_CUSTOM_LABEL,
             letter_keys=True,
+            header=_MENU_HEADER,
         )
         if _nothing_chosen(selected):
             capture_onboarding_demo_skipped()
@@ -190,24 +195,26 @@ def _start_ci_analytics_demo(
     else:
         snapshot = scan_workspace(home, days=_SCAN_DAYS)
     if console is not None:
+        # Transcript idiom: the lead is an agent note, the chart hangs in the
+        # same gutter, so the demo does not read as a different program.
         console.print()
-        console.print(_SNAPSHOT_LEAD)
-        console.print()
-        render_snapshot(console, snapshot)
+        render_note_block(console, _SNAPSHOT_LEAD)
+        console.print(reply_gutter(snapshot_renderable(snapshot), lead=False))
         console.print()
     if not resolve_github_token(None):
         if console is not None:
-            console.print(f"[{WARNING}]{_TOKEN_MISSING}[/]")
+            console.print(reply_gutter(Text(_TOKEN_MISSING, style=str(WARNING)), lead=False))
         return False
     repository = choose_repository(snapshot)
     if repository is None:
         return False
     if console is not None:
         console.print()
-        console.print(
-            f"[{DIM}]Analyzing the CI/CD reliability of {escape(repository)} for the last {_SCAN_DAYS} "
-            "days. Reading the GitHub Actions history takes about half a minute; the report "
-            "appears below when it is ready.[/]"
+        render_note_block(
+            console,
+            f"Analyzing the CI/CD reliability of {repository} for the last {_SCAN_DAYS} days. "
+            "Reading the GitHub Actions history takes about half a minute; the report "
+            "appears below when it is ready.",
         )
     # A plain turn keeps the prompt bar and its spinner visible while the model
     # and the analysis run; a work-turn autosubmit would suspend them.
@@ -227,6 +234,7 @@ def choose_repository(snapshot: WorkspaceSnapshot) -> str | None:
         choices=choices,
         custom_label=_CUSTOM_LABEL,
         letter_keys=True,
+        header=_MENU_HEADER,
     )
     if _nothing_chosen(selected):
         return None

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -93,6 +93,8 @@ def test_analytics_demo_scans_asks_for_the_repository_then_queues_the_analysis(
     assert "Analyzing the CI/CD reliability of me/mine[v2]" in output
     demo_labels = [label for _value, label in calls[0]["choices"]]
     assert demo_labels[-1] == "Or type your own answer..."
+    assert calls[0]["header"] == "Ask User"
+    assert calls[1]["header"] == "Ask User"
     repo_choices = [value for value, _label in calls[1]["choices"]]
     assert repo_choices == ["me/mine", "acme/busy", demo_picker.EXAMPLE_REPOSITORY, "custom"]
     assert session.terminal.pending_prompt_autosubmit is True

--- a/tools/system/workspace_git_scan/render.py
+++ b/tools/system/workspace_git_scan/render.py
@@ -17,9 +17,14 @@ _SERIES_STYLES = (HIGHLIGHT, BRAND, SECONDARY, WARNING, ERROR)
 _OTHERS_LABEL = "all others"
 
 
+def snapshot_renderable(snapshot: WorkspaceSnapshot) -> Group:
+    """Headline counts and the activity bar chart as one Rich renderable."""
+    return Group(*_headline(snapshot), Text(""), *_bar_chart(snapshot))
+
+
 def render_snapshot(console: Any, snapshot: WorkspaceSnapshot) -> None:
     """Print the headline counts and the activity bar chart to *console*."""
-    console.print(Group(*_headline(snapshot), Text(""), *_bar_chart(snapshot)))
+    console.print(snapshot_renderable(snapshot))
 
 
 def snapshot_text(snapshot: WorkspaceSnapshot) -> str:
@@ -89,4 +94,4 @@ def _label(repo: RepoActivity) -> str:
     return repo.github_repo or repo.name
 
 
-__all__ = ["render_snapshot", "snapshot_text"]
+__all__ = ["render_snapshot", "snapshot_renderable", "snapshot_text"]


### PR DESCRIPTION
The scan lead, chart, token hint, and "Analyzing…" line were printed as plain console output while everything the agent says goes through the reply gutter, so the demo read as a different program from the shell. The lead and the analysis line are now agent notes, the chart and the token hint hang in the same gutter, both pickers carry the Ask User header the agent's menus use, and the analytics tool indents its progress lines and painted report to the same body column.
