### PR TITLE
feat(ci-analytics): measure blocked time per merged PR as expected vs actual green

### DIFF
--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -44,9 +44,12 @@ how much developer time does flaky CI cost us
 
 Only PRs that were merged count toward blocked time, so the number reflects
 delays that sat on the path to a real merge. Workflows that fail and recover in
-parallel on the same commit count once, and a commit whose workflows never all
-passed is left out. The report also shows the total across all PRs when it
-differs, the typical wait per blocked PR, and the longest wait with its PR.
+parallel on the same commit count once, a commit's wait ends when the next
+commit of the same PR is pushed, and a commit whose workflows never all passed
+is left out. A run GitHub attached no PR number to belongs to the PR merged
+from its branch after the run, so a reused branch name does not merge two PRs.
+The report also shows the total across all PRs when it differs, the typical
+wait per blocked PR, and the longest wait with its PR.
 
 ## Limits
 

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -45,11 +45,12 @@ how much developer time does flaky CI cost us
 Only PRs that were merged count toward blocked time, so the number reflects
 delays that sat on the path to a real merge. Workflows that fail and recover in
 parallel on the same commit count once, a commit's wait ends when the next
-commit of the same PR is pushed or the PR merges, a later commit that triggered
-no workflow still ends the previous wait, and a commit whose workflows never
-all passed is left out. A run GitHub attached no PR number to belongs to the PR merged
-from its branch after the run, so a reused branch name does not merge two PRs.
-A run GitHub attached to several PRs belongs to the merged one.
+commit of the same PR is pushed or the PR merges, and a commit whose workflows
+never all passed is left out. A later commit that triggered no workflow is
+invisible; the merge time still bounds the wait. When GitHub omits a PR number,
+the run belongs to the first later merge of that head repository and branch.
+When it attaches several, the run belongs to the merged PR whose lifetime
+contains the run.
 The report also shows the total across all PRs when it differs, the typical
 wait per blocked PR, and the longest wait with its PR.
 

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -45,8 +45,8 @@ how much developer time does flaky CI cost us
 Only PRs that were merged count toward blocked time, so the number reflects
 delays that sat on the path to a real merge. Workflows that fail and recover in
 parallel on the same commit count once, a commit's wait ends when the next
-commit of the same PR is pushed, and a commit whose workflows never all passed
-is left out. A run GitHub attached no PR number to belongs to the PR merged
+commit of the same PR is pushed or the PR merges, and a commit whose workflows
+never all passed is left out. A run GitHub attached no PR number to belongs to the PR merged
 from its branch after the run, so a reused branch name does not merge two PRs.
 The report also shows the total across all PRs when it differs, the typical
 wait per blocked PR, and the longest wait with its PR.

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -45,9 +45,11 @@ how much developer time does flaky CI cost us
 Only PRs that were merged count toward blocked time, so the number reflects
 delays that sat on the path to a real merge. Workflows that fail and recover in
 parallel on the same commit count once, a commit's wait ends when the next
-commit of the same PR is pushed or the PR merges, and a commit whose workflows
-never all passed is left out. A run GitHub attached no PR number to belongs to the PR merged
+commit of the same PR is pushed or the PR merges, a later commit that triggered
+no workflow still ends the previous wait, and a commit whose workflows never
+all passed is left out. A run GitHub attached no PR number to belongs to the PR merged
 from its branch after the run, so a reused branch name does not merge two PRs.
+A run GitHub attached to several PRs belongs to the merged one.
 The report also shows the total across all PRs when it differs, the typical
 wait per blocked PR, and the longest wait with its PR.
 

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -38,13 +38,15 @@ how much developer time does flaky CI cost us
 | PR-triggered failed workflows and failure rate | Pull request runs that failed, including runs that only passed after a re-run |
 | CI reliability failures | Failures where the identical commit passed later, by re-run or a fresh run. CI, not the code, was at fault |
 | Source-code failures | Failures that passed only after the branch moved to a new commit |
-| Developer time blocked by unreliable CI | For CI reliability failures on PRs that were later merged: wall-clock time from the first queued attempt to the eventual pass, minus the workflow's normal duration |
+| Developer time blocked by unreliable CI | Per merged PR: how much later its commits went green than they would have had CI run normally. For each commit with a CI reliability failure, the expected green time is the first queued run plus the slowest workflow's normal duration; the actual green time is when its last workflow passed |
 | Normal duration | Per workflow, the median duration of first-attempt passing runs |
 | Default-branch red time | Hours during which at least one push-triggered workflow on the default branch stayed red, overlaps counted once, with mean time to recovery |
 
 Only PRs that were merged count toward blocked time, so the number reflects
-delays that sat on the path to a real merge. The report also shows the total
-across all PRs when it differs.
+delays that sat on the path to a real merge. Workflows that fail and recover in
+parallel on the same commit count once, and a commit whose workflows never all
+passed is left out. The report also shows the total across all PRs when it
+differs, the typical wait per blocked PR, and the longest wait with its PR.
 
 ## Limits
 

--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
@@ -25,6 +26,8 @@ _MAX_RERUN_WORKERS = 8
 # Each passing re-run costs up to attempt-1 extra requests; bound the total so
 # a very flaky repository cannot turn the demo into minutes of API calls.
 _MAX_ATTEMPT_LOOKUPS = 500
+_MAX_PR_COMMIT_PAGES = 3
+_PR_COMMIT_WORKERS = 6
 _DEFAULT_BRANCH_EVENTS = ("push", "schedule", "workflow_dispatch")
 _PR_EVENT = "pull_request"
 
@@ -90,6 +93,7 @@ def collect_runs(
         # Only PR reruns affect failure rate and blocked time; skip extra
         # attempt fetches on default-branch listings.
         pr_runs = _annotate_reruns(client, root, pr_future.result(), merged=merged, notices=notices)
+    merged = _with_pr_commits(client, root, merged, pr_runs)
     return CollectedRuns(
         default_branch=default_branch,
         branch_runs=branch_runs,
@@ -252,6 +256,68 @@ def _merged_pr(row: dict[str, Any], *, since: datetime) -> MergedPullRequest | N
     if not ref:
         return None
     return MergedPullRequest(number=number, branch=ref, head_repo=head_repo, merged_at=merged_at)
+
+
+def _with_pr_commits(
+    client: GitHubRestClient,
+    root: str,
+    merged: tuple[MergedPullRequest, ...],
+    pr_runs: Sequence[WorkflowRun],
+) -> tuple[MergedPullRequest, ...]:
+    """Attach commit timestamps so a skipped later push still ends a commit's wait."""
+    needed = _merged_needing_commits(merged, pr_runs)
+    if not needed:
+        return merged
+    commits_by_number: dict[int, tuple[tuple[str, datetime], ...]] = {}
+    with ThreadPoolExecutor(max_workers=min(_PR_COMMIT_WORKERS, len(needed))) as pool:
+        fetched = list(pool.map(lambda pr: _pr_commits(client, root, pr.number), needed))
+    for pr, commits in zip(needed, fetched, strict=True):
+        commits_by_number[pr.number] = commits
+    return tuple(replace(pr, commits=commits_by_number.get(pr.number, ())) for pr in merged)
+
+
+def _merged_needing_commits(
+    merged: Sequence[MergedPullRequest], pr_runs: Sequence[WorkflowRun]
+) -> list[MergedPullRequest]:
+    interesting = [run for run in pr_runs if run.failed or run.retried_to_green]
+    if not interesting:
+        return []
+    numbers = {number for run in interesting for number in run.pr_numbers}
+    branches = {(run.head_repo, run.branch) for run in interesting}
+    return [pr for pr in merged if pr.number in numbers or (pr.head_repo, pr.branch) in branches]
+
+
+def _pr_commits(
+    client: GitHubRestClient, root: str, number: int
+) -> tuple[tuple[str, datetime], ...]:
+    try:
+        rows = client.paginate(
+            f"{root}/pulls/{number}/commits",
+            params={"per_page": _PER_PAGE},
+            max_pages=_MAX_PR_COMMIT_PAGES,
+        )
+    except GitHubApiError:
+        return ()
+    parsed: list[tuple[str, datetime]] = []
+    for row in rows:
+        sha = str(row.get("sha") or "").strip()
+        commit = row.get("commit")
+        if not sha or not isinstance(commit, dict):
+            continue
+        when = _commit_timestamp(commit)
+        if when is not None:
+            parsed.append((sha, when))
+    return tuple(parsed)
+
+
+def _commit_timestamp(commit: dict[str, Any]) -> datetime | None:
+    for key in ("committer", "author"):
+        party = commit.get(key)
+        if isinstance(party, dict):
+            when = _timestamp(party.get("date"))
+            if when is not None:
+                return when
+    return None
 
 
 def parse_run(row: dict[str, Any]) -> WorkflowRun | None:

--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
@@ -11,7 +10,7 @@ from typing import Any
 from urllib.parse import quote
 
 from integrations.github.client import GitHubApiError, GitHubRestClient
-from integrations.github.tools.ci_analytics.metrics import on_critical_path
+from integrations.github.tools.ci_analytics.metrics import PullRequestIdentity
 from integrations.github.tools.ci_analytics.models import MergedPullRequest, WorkflowRun
 
 _PER_PAGE = 100
@@ -26,8 +25,6 @@ _MAX_RERUN_WORKERS = 8
 # Each passing re-run costs up to attempt-1 extra requests; bound the total so
 # a very flaky repository cannot turn the demo into minutes of API calls.
 _MAX_ATTEMPT_LOOKUPS = 500
-_MAX_PR_COMMIT_PAGES = 3
-_PR_COMMIT_WORKERS = 6
 _DEFAULT_BRANCH_EVENTS = ("push", "schedule", "workflow_dispatch")
 _PR_EVENT = "pull_request"
 
@@ -93,7 +90,6 @@ def collect_runs(
         # Only PR reruns affect failure rate and blocked time; skip extra
         # attempt fetches on default-branch listings.
         pr_runs = _annotate_reruns(client, root, pr_future.result(), merged=merged, notices=notices)
-    merged = _with_pr_commits(client, root, merged, pr_runs)
     return CollectedRuns(
         default_branch=default_branch,
         branch_runs=branch_runs,
@@ -258,68 +254,6 @@ def _merged_pr(row: dict[str, Any], *, since: datetime) -> MergedPullRequest | N
     return MergedPullRequest(number=number, branch=ref, head_repo=head_repo, merged_at=merged_at)
 
 
-def _with_pr_commits(
-    client: GitHubRestClient,
-    root: str,
-    merged: tuple[MergedPullRequest, ...],
-    pr_runs: Sequence[WorkflowRun],
-) -> tuple[MergedPullRequest, ...]:
-    """Attach commit timestamps so a skipped later push still ends a commit's wait."""
-    needed = _merged_needing_commits(merged, pr_runs)
-    if not needed:
-        return merged
-    commits_by_number: dict[int, tuple[tuple[str, datetime], ...]] = {}
-    with ThreadPoolExecutor(max_workers=min(_PR_COMMIT_WORKERS, len(needed))) as pool:
-        fetched = list(pool.map(lambda pr: _pr_commits(client, root, pr.number), needed))
-    for pr, commits in zip(needed, fetched, strict=True):
-        commits_by_number[pr.number] = commits
-    return tuple(replace(pr, commits=commits_by_number.get(pr.number, ())) for pr in merged)
-
-
-def _merged_needing_commits(
-    merged: Sequence[MergedPullRequest], pr_runs: Sequence[WorkflowRun]
-) -> list[MergedPullRequest]:
-    interesting = [run for run in pr_runs if run.failed or run.retried_to_green]
-    if not interesting:
-        return []
-    numbers = {number for run in interesting for number in run.pr_numbers}
-    branches = {(run.head_repo, run.branch) for run in interesting}
-    return [pr for pr in merged if pr.number in numbers or (pr.head_repo, pr.branch) in branches]
-
-
-def _pr_commits(
-    client: GitHubRestClient, root: str, number: int
-) -> tuple[tuple[str, datetime], ...]:
-    try:
-        rows = client.paginate(
-            f"{root}/pulls/{number}/commits",
-            params={"per_page": _PER_PAGE},
-            max_pages=_MAX_PR_COMMIT_PAGES,
-        )
-    except GitHubApiError:
-        return ()
-    parsed: list[tuple[str, datetime]] = []
-    for row in rows:
-        sha = str(row.get("sha") or "").strip()
-        commit = row.get("commit")
-        if not sha or not isinstance(commit, dict):
-            continue
-        when = _commit_timestamp(commit)
-        if when is not None:
-            parsed.append((sha, when))
-    return tuple(parsed)
-
-
-def _commit_timestamp(commit: dict[str, Any]) -> datetime | None:
-    for key in ("committer", "author"):
-        party = commit.get(key)
-        if isinstance(party, dict):
-            when = _timestamp(party.get("date"))
-            if when is not None:
-                return when
-    return None
-
-
 def parse_run(row: dict[str, Any]) -> WorkflowRun | None:
     """Reduce one REST workflow-run row; rows missing identity or timestamps are dropped."""
     run_id = row.get("id")
@@ -393,11 +327,12 @@ def _annotate_reruns(
     if not reruns:
         return runs
     # Same rule as the blocked-time metric, so priority and critical path agree.
+    identity = PullRequestIdentity(merged)
     lookups = _AttemptLookups(_MAX_ATTEMPT_LOOKUPS)
     checked: dict[int, WorkflowRun] = {}
     for phase in (
-        [run for run in reruns if on_critical_path(run, merged)],
-        [run for run in reruns if not on_critical_path(run, merged)],
+        [run for run in reruns if identity.on_critical_path(run)],
+        [run for run in reruns if not identity.on_critical_path(run)],
     ):
         if not phase:
             continue

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -86,10 +86,10 @@ def pull_request_delays(
     of its workflows first passed. A commit whose workflows never all passed
     is left out. The wait on a commit ends when the developer pushes the next
     commit of the PR or the PR merges, whichever comes first, so a stale
-    commit re-run later adds nothing. A next commit that triggered no PR
-    workflow is invisible here; the merge time still bounds the wait. The
-    delay intervals of a PR's commits are unioned so overlapping workflows
-    and re-runs are counted once.
+    commit re-run later adds nothing. A later commit that triggered no
+    workflow still cuts off the wait when its timestamp is known; otherwise
+    the merge time is the last bound. The delay intervals of a PR's commits
+    are unioned so overlapping workflows and re-runs are counted once.
     """
     identity = _PullRequestIdentity(merged_prs)
     affected: set[tuple[PullRequestKey, str]] = set()
@@ -105,7 +105,9 @@ def pull_request_delays(
     by_commit: dict[tuple[PullRequestKey, str], list[WorkflowRun]] = defaultdict(list)
     for run in pr_runs:
         by_commit[(identity.key(run), run.head_sha)].append(run)
-    next_push = _next_push_times(by_commit)
+    next_push = _next_push_times(
+        by_commit, extra_commits={pr.number: pr.commits for pr in merged_prs if pr.commits}
+    )
     intervals: dict[PullRequestKey, list[tuple[datetime, datetime]]] = defaultdict(list)
     for key, sha in affected:
         interval = _commit_delay(
@@ -173,11 +175,23 @@ def _earliest(*times: datetime | None) -> datetime | None:
 
 def _next_push_times(
     by_commit: dict[tuple[PullRequestKey, str], list[WorkflowRun]],
+    extra_commits: dict[int, Sequence[tuple[str, datetime]]] | None = None,
 ) -> dict[tuple[PullRequestKey, str], datetime]:
-    """For each commit, when the same PR's next commit was first queued."""
+    """For each commit, when the same PR's next commit landed.
+
+    Workflow-run queue times cover commits that triggered CI. ``extra_commits``
+    adds later SHAs that path filters skipped, so those still cut off the wait.
+    """
     queued: dict[PullRequestKey, list[tuple[datetime, str]]] = defaultdict(list)
     for (key, sha), runs in by_commit.items():
         queued[key].append((min(run.created_at for run in runs), sha))
+    extras = extra_commits or {}
+    for key, commits in queued.items():
+        known = {sha for _, sha in commits}
+        for sha, when in extras.get(key[2], ()):
+            if sha not in known:
+                commits.append((when, sha))
+                known.add(sha)
     next_push: dict[tuple[PullRequestKey, str], datetime] = {}
     for key, commits in queued.items():
         commits.sort()
@@ -269,9 +283,10 @@ def classify_failures(
     newer commit a source-code failure, and no later pass leaves it unresolved.
     Every delay subtracts the workflow's normal duration.
     """
+    merged_ids = {pr.number for pr in merged_prs}
     groups: dict[tuple[int | str, str, str, int], list[WorkflowRun]] = defaultdict(list)
     for run in pr_runs:
-        groups[_history_key(run)].append(run)
+        groups[_history_key(run, merged_ids)].append(run)
     classified: list[ClassifiedFailure] = []
     for (workflow_key, _head_repo, _branch, _pr), runs in groups.items():
         ordered = sorted(runs, key=lambda r: r.completed_at)
@@ -389,9 +404,12 @@ def _workflow_key(run: WorkflowRun) -> int | str:
     return run.workflow_id if run.workflow_id else run.workflow
 
 
-def _history_key(run: WorkflowRun) -> tuple[int | str, str, str, int]:
-    pr_number = run.pr_numbers[0] if run.pr_numbers else 0
-    return (_workflow_key(run), run.head_repo, run.branch, pr_number)
+def _history_key(run: WorkflowRun, merged_ids: set[int]) -> tuple[int | str, str, str, int]:
+    if run.pr_numbers:
+        number = next((n for n in run.pr_numbers if n in merged_ids), run.pr_numbers[0])
+    else:
+        number = 0
+    return (_workflow_key(run), run.head_repo, run.branch, number)
 
 
 def on_critical_path(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> bool:

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -82,27 +82,37 @@ def pull_request_delays(
     Only commits with a CI-caused failure count. For such a commit the
     expected green time is the earliest queue time of its runs plus the
     slowest workflow's normal duration ("had CI worked normally, when should
-    this commit have been green?"); the actual green time is when the last of
-    its workflows passed. A commit whose workflows never all passed is left
-    out. The delay intervals of a PR's commits are unioned so overlapping
-    workflows and re-runs are counted once.
+    this commit have been green?"); the actual green time is when the last
+    of its workflows first passed. A commit whose workflows never all passed
+    is left out. The wait on a commit ends when the developer pushes the next
+    commit of the PR, so a stale commit re-run days later adds nothing. The
+    delay intervals of a PR's commits are unioned so overlapping workflows
+    and re-runs are counted once.
+
+    A run GitHub attached no PR number to is assigned to the first PR merged
+    from its head repository and branch after the run was queued, so a reused
+    branch name does not fold two PRs into one.
     """
-    affected: set[tuple[tuple[str, str, int], str]] = set()
-    first_failure: dict[tuple[str, str, int], ClassifiedFailure] = {}
+    identity = _PullRequestIdentity(merged_prs)
+    affected: set[tuple[PullRequestKey, str]] = set()
+    first_failure: dict[PullRequestKey, ClassifiedFailure] = {}
     for item in classified:
         if item.kind is not FailureKind.RELIABILITY:
             continue
-        key = _history_key(item.failure)[1:]
+        key = identity.key(item.failure)
         affected.add((key, item.failure.head_sha))
         earliest = first_failure.get(key)
         if earliest is None or item.failure.created_at < earliest.failure.created_at:
             first_failure[key] = item
-    by_commit: dict[tuple[tuple[str, str, int], str], list[WorkflowRun]] = defaultdict(list)
+    by_commit: dict[tuple[PullRequestKey, str], list[WorkflowRun]] = defaultdict(list)
     for run in pr_runs:
-        by_commit[(_history_key(run)[1:], run.head_sha)].append(run)
-    intervals: dict[tuple[str, str, int], list[tuple[datetime, datetime]]] = defaultdict(list)
+        by_commit[(identity.key(run), run.head_sha)].append(run)
+    next_push = _next_push_times(by_commit)
+    intervals: dict[PullRequestKey, list[tuple[datetime, datetime]]] = defaultdict(list)
     for key, sha in affected:
-        interval = _commit_delay(by_commit.get((key, sha), []), normal_minutes)
+        interval = _commit_delay(
+            by_commit.get((key, sha), []), normal_minutes, until=next_push.get((key, sha))
+        )
         if interval is not None:
             intervals[key].append(interval)
     delays: list[PullRequestDelay] = []
@@ -113,7 +123,7 @@ def pull_request_delays(
             PullRequestDelay(
                 head_repo=head_repo,
                 branch=branch,
-                pr_number=number or _merged_number(item.failure, merged_prs),
+                pr_number=number,
                 critical_path=item.critical_path,
                 delay_minutes=_union_minutes(spans),
                 commits=len(spans),
@@ -123,39 +133,83 @@ def pull_request_delays(
     return sorted(delays, key=lambda d: -d.delay_minutes)
 
 
-def _merged_number(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> int:
-    """PR number of the merge that closed the run's branch, when GitHub attached none."""
-    return next(
-        (
-            pr.number
-            for pr in merged
-            if pr.branch == run.branch
-            and pr.head_repo == run.head_repo
-            and pr.merged_at >= run.created_at
-        ),
-        0,
-    )
+PullRequestKey = tuple[str, str, int]
+"""Head repository, branch, and PR number identifying one pull request."""
+
+
+class _PullRequestIdentity:
+    """Resolve which pull request a run belongs to, using merges when GitHub attached none."""
+
+    def __init__(self, merged: Sequence[MergedPullRequest]) -> None:
+        by_branch: dict[tuple[str, str], list[MergedPullRequest]] = defaultdict(list)
+        for pr in merged:
+            by_branch[(pr.head_repo, pr.branch)].append(pr)
+        for prs in by_branch.values():
+            prs.sort(key=lambda pr: pr.merged_at)
+        self._by_branch = by_branch
+
+    def key(self, run: WorkflowRun) -> PullRequestKey:
+        if run.pr_numbers:
+            return (run.head_repo, run.branch, run.pr_numbers[0])
+        candidates = self._by_branch.get((run.head_repo, run.branch), [])
+        merged = next((pr for pr in candidates if pr.merged_at >= run.created_at), None)
+        return (run.head_repo, run.branch, merged.number if merged else 0)
+
+
+def _next_push_times(
+    by_commit: dict[tuple[PullRequestKey, str], list[WorkflowRun]],
+) -> dict[tuple[PullRequestKey, str], datetime]:
+    """For each commit, when the same PR's next commit was first queued."""
+    queued: dict[PullRequestKey, list[tuple[datetime, str]]] = defaultdict(list)
+    for (key, sha), runs in by_commit.items():
+        queued[key].append((min(run.created_at for run in runs), sha))
+    next_push: dict[tuple[PullRequestKey, str], datetime] = {}
+    for key, commits in queued.items():
+        commits.sort()
+        for (_, sha), (later, _) in zip(commits, commits[1:], strict=False):
+            next_push[(key, sha)] = later
+    return next_push
 
 
 def _commit_delay(
-    runs: Sequence[WorkflowRun], normal_minutes: dict[int | str, float]
+    runs: Sequence[WorkflowRun],
+    normal_minutes: dict[int | str, float],
+    *,
+    until: datetime | None = None,
 ) -> tuple[datetime, datetime] | None:
-    """Expected and actual green times of one commit, or None when it never went green."""
+    """Expected and actual green times of one commit, or None when nobody waited.
+
+    Each workflow's green time is its first passing completion; a later
+    duplicate pass changes nothing. A workflow without a first-attempt
+    baseline is expected to take as long as that first pass took, never as
+    long as a failed attempt. ``until`` is when the PR's next commit was
+    pushed; the wait cannot extend past it because the developer had already
+    moved on.
+    """
     if not runs:
         return None
     by_workflow: dict[int | str, list[WorkflowRun]] = defaultdict(list)
     for run in runs:
         by_workflow[_workflow_key(run)].append(run)
     greens: list[datetime] = []
-    for workflow_runs in by_workflow.values():
-        passed = [run.completed_at for run in workflow_runs if run.succeeded]
-        if not passed:
+    expected_duration = 0.0
+    for workflow_key, workflow_runs in by_workflow.items():
+        first_pass = min(
+            (run for run in workflow_runs if run.succeeded),
+            key=lambda run: run.completed_at,
+            default=None,
+        )
+        if first_pass is None:
             return None
-        greens.append(max(passed))
+        greens.append(first_pass.completed_at)
+        expected_duration = max(
+            expected_duration, normal_minutes.get(workflow_key, first_pass.minutes)
+        )
     queued = min(run.created_at for run in runs)
-    expected_duration = max(normal_minutes.get(_workflow_key(run), run.minutes) for run in runs)
     expected_green = queued + timedelta(minutes=expected_duration)
     actual_green = max(greens)
+    if until is not None:
+        actual_green = min(actual_green, until)
     if actual_green <= expected_green:
         return None
     return expected_green, actual_green

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -87,11 +87,11 @@ def pull_request_delays(
     is left out. The wait on a commit ends when the developer pushes the next
     commit of the PR or the PR merges, whichever comes first, so a stale
     commit re-run later adds nothing. A later commit that triggered no
-    workflow still cuts off the wait when its timestamp is known; otherwise
-    the merge time is the last bound. The delay intervals of a PR's commits
-    are unioned so overlapping workflows and re-runs are counted once.
+    workflow is invisible here; the merge time still bounds the wait. The
+    delay intervals of a PR's commits are unioned so overlapping workflows
+    and re-runs are counted once.
     """
-    identity = _PullRequestIdentity(merged_prs)
+    identity = PullRequestIdentity(merged_prs)
     affected: set[tuple[PullRequestKey, str]] = set()
     first_failure: dict[PullRequestKey, ClassifiedFailure] = {}
     for item in classified:
@@ -105,9 +105,7 @@ def pull_request_delays(
     by_commit: dict[tuple[PullRequestKey, str], list[WorkflowRun]] = defaultdict(list)
     for run in pr_runs:
         by_commit[(identity.key(run), run.head_sha)].append(run)
-    next_push = _next_push_times(
-        by_commit, extra_commits={pr.number: pr.commits for pr in merged_prs if pr.commits}
-    )
+    next_push = _next_push_times(by_commit)
     intervals: dict[PullRequestKey, list[tuple[datetime, datetime]]] = defaultdict(list)
     for key, sha in affected:
         interval = _commit_delay(
@@ -139,12 +137,14 @@ PullRequestKey = tuple[str, str, int]
 """Head repository, branch, and PR number identifying one pull request."""
 
 
-class _PullRequestIdentity:
-    """Resolve which pull request a run belongs to and when that PR merged.
+class PullRequestIdentity:
+    """Which pull request a run belongs to, and whether that PR was merged after the run.
 
-    Of several attached PR numbers the merged one wins; a run with none is
-    assigned to the first PR merged from its head repository and branch
-    after the run was queued.
+    Of several attached PR numbers, the one whose lifetime contains the run
+    wins: merged after the run was queued, earliest merge first. A run with
+    no attached number is assigned to the first PR merged from its head
+    repository and branch after the run, so a reused branch name does not
+    fold two PRs into one.
     """
 
     def __init__(self, merged: Sequence[MergedPullRequest]) -> None:
@@ -157,15 +157,27 @@ class _PullRequestIdentity:
         self._merged_at = {pr.number: pr.merged_at for pr in merged}
 
     def key(self, run: WorkflowRun) -> PullRequestKey:
-        if run.pr_numbers:
-            number = next((n for n in run.pr_numbers if n in self._merged_at), run.pr_numbers[0])
-            return (run.head_repo, run.branch, number)
-        candidates = self._by_branch.get((run.head_repo, run.branch), [])
-        merged = next((pr for pr in candidates if pr.merged_at >= run.created_at), None)
-        return (run.head_repo, run.branch, merged.number if merged else 0)
+        return (run.head_repo, run.branch, self._number(run))
 
     def merged_at(self, key: PullRequestKey) -> datetime | None:
         return self._merged_at.get(key[2])
+
+    def on_critical_path(self, run: WorkflowRun) -> bool:
+        """True when the run's PR was merged inside the window, after the run was queued."""
+        merged_at = self._merged_at.get(self._number(run))
+        return merged_at is not None and merged_at >= run.created_at
+
+    def _number(self, run: WorkflowRun) -> int:
+        if run.pr_numbers:
+            containing = [
+                (self._merged_at[n], n)
+                for n in run.pr_numbers
+                if n in self._merged_at and self._merged_at[n] >= run.created_at
+            ]
+            return min(containing)[1] if containing else run.pr_numbers[0]
+        candidates = self._by_branch.get((run.head_repo, run.branch), [])
+        merged = next((pr for pr in candidates if pr.merged_at >= run.created_at), None)
+        return merged.number if merged else 0
 
 
 def _earliest(*times: datetime | None) -> datetime | None:
@@ -175,23 +187,11 @@ def _earliest(*times: datetime | None) -> datetime | None:
 
 def _next_push_times(
     by_commit: dict[tuple[PullRequestKey, str], list[WorkflowRun]],
-    extra_commits: dict[int, Sequence[tuple[str, datetime]]] | None = None,
 ) -> dict[tuple[PullRequestKey, str], datetime]:
-    """For each commit, when the same PR's next commit landed.
-
-    Workflow-run queue times cover commits that triggered CI. ``extra_commits``
-    adds later SHAs that path filters skipped, so those still cut off the wait.
-    """
+    """For each commit, when the same PR's next commit was first queued."""
     queued: dict[PullRequestKey, list[tuple[datetime, str]]] = defaultdict(list)
     for (key, sha), runs in by_commit.items():
         queued[key].append((min(run.created_at for run in runs), sha))
-    extras = extra_commits or {}
-    for key, commits in queued.items():
-        known = {sha for _, sha in commits}
-        for sha, when in extras.get(key[2], ()):
-            if sha not in known:
-                commits.append((when, sha))
-                known.add(sha)
     next_push: dict[tuple[PullRequestKey, str], datetime] = {}
     for key, commits in queued.items():
         commits.sort()
@@ -283,10 +283,10 @@ def classify_failures(
     newer commit a source-code failure, and no later pass leaves it unresolved.
     Every delay subtracts the workflow's normal duration.
     """
-    merged_ids = {pr.number for pr in merged_prs}
+    identity = PullRequestIdentity(merged_prs)
     groups: dict[tuple[int | str, str, str, int], list[WorkflowRun]] = defaultdict(list)
     for run in pr_runs:
-        groups[_history_key(run, merged_ids)].append(run)
+        groups[_history_key(run, identity)].append(run)
     classified: list[ClassifiedFailure] = []
     for (workflow_key, _head_repo, _branch, _pr), runs in groups.items():
         ordered = sorted(runs, key=lambda r: r.completed_at)
@@ -300,7 +300,7 @@ def classify_failures(
                         recovery=run,
                         kind=FailureKind.RELIABILITY,
                         delay_minutes=max(0.0, elapsed - normal_minutes.get(workflow_key, 0.0)),
-                        critical_path=on_critical_path(run, merged_prs),
+                        critical_path=identity.on_critical_path(run),
                     )
                 )
                 continue
@@ -323,7 +323,7 @@ def classify_failures(
                     recovery=recovery,
                     kind=kind,
                     delay_minutes=delay,
-                    critical_path=on_critical_path(run, merged_prs),
+                    critical_path=identity.on_critical_path(run),
                 )
             )
     return sorted(classified, key=lambda c: c.failure.completed_at)
@@ -404,33 +404,16 @@ def _workflow_key(run: WorkflowRun) -> int | str:
     return run.workflow_id if run.workflow_id else run.workflow
 
 
-def _history_key(run: WorkflowRun, merged_ids: set[int]) -> tuple[int | str, str, str, int]:
-    if run.pr_numbers:
-        number = next((n for n in run.pr_numbers if n in merged_ids), run.pr_numbers[0])
-    else:
-        number = 0
-    return (_workflow_key(run), run.head_repo, run.branch, number)
-
-
-def on_critical_path(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> bool:
-    """True when the run belongs to a PR merged inside the window, after the run was created.
-
-    A PR number is decisive when GitHub attached one; otherwise the head
-    repository and branch must match a PR merged later than the run, so a
-    reused branch name does not inherit an earlier merge.
-    """
-    if run.pr_numbers:
-        merged_ids = {pr.number for pr in merged}
-        return any(number in merged_ids for number in run.pr_numbers)
-    return any(
-        pr.branch == run.branch and pr.head_repo == run.head_repo and pr.merged_at >= run.created_at
-        for pr in merged
-    )
+def _history_key(
+    run: WorkflowRun, identity: PullRequestIdentity
+) -> tuple[int | str, str, str, int]:
+    head_repo, branch, number = identity.key(run)
+    return (_workflow_key(run), head_repo, branch, number)
 
 
 __all__ = [
     "classify_failures",
-    "on_critical_path",
+    "PullRequestIdentity",
     "pull_request_delays",
     "compute_report",
     "find_outages",

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from statistics import median
 
 from integrations.github.tools.ci_analytics.models import (
@@ -13,6 +13,7 @@ from integrations.github.tools.ci_analytics.models import (
     FailureKind,
     MergedPullRequest,
     Outage,
+    PullRequestDelay,
     WorkflowRun,
     WorkflowSummary,
 )
@@ -42,7 +43,7 @@ def compute_report(
     push_runs = [run for run in counted_branch if run.event == PUSH_EVENT]
     outages = find_outages(push_runs)
     closed = [o for o in outages if not o.ongoing]
-    reliability = [c for c in classified if c.kind is FailureKind.RELIABILITY]
+    delays = pull_request_delays(counted_pr, classified, normal_minutes=normal, merged_prs=merged)
     return CiAnalyticsReport(
         owner=owner,
         repo=repo,
@@ -53,11 +54,9 @@ def compute_report(
         pr_executions=len(counted_pr),
         pr_failures=sum(1 for run in counted_pr if run.failed or run.retried_to_green),
         classified=tuple(classified),
-        merged_pr_branches=len(
-            {_history_key(c.failure)[1:] for c in reliability if c.critical_path}
-        ),
-        blocked_minutes=sum(c.delay_minutes for c in reliability if c.critical_path),
-        blocked_minutes_all=sum(c.delay_minutes for c in reliability),
+        merged_pr_branches=sum(1 for d in delays if d.critical_path and d.delay_minutes > 0),
+        blocked_minutes=sum(d.delay_minutes for d in delays if d.critical_path),
+        blocked_minutes_all=sum(d.delay_minutes for d in delays),
         branch_runs=len(push_runs),
         branch_failures=sum(1 for run in push_runs if run.failed),
         red_hours=union_hours(outages, now=now),
@@ -67,7 +66,114 @@ def compute_report(
         ),
         workflows=tuple(summarize_workflows(all_runs, classified, normal)),
         coverage_notices=tuple(coverage_notices),
+        pr_delays=tuple(delays),
     )
+
+
+def pull_request_delays(
+    pr_runs: Sequence[WorkflowRun],
+    classified: Sequence[ClassifiedFailure],
+    *,
+    normal_minutes: dict[int | str, float],
+    merged_prs: Sequence[MergedPullRequest] = (),
+) -> list[PullRequestDelay]:
+    """Per PR: how much later its commits went green than they should have.
+
+    Only commits with a CI-caused failure count. For such a commit the
+    expected green time is the earliest queue time of its runs plus the
+    slowest workflow's normal duration ("had CI worked normally, when should
+    this commit have been green?"); the actual green time is when the last of
+    its workflows passed. A commit whose workflows never all passed is left
+    out. The delay intervals of a PR's commits are unioned so overlapping
+    workflows and re-runs are counted once.
+    """
+    affected: set[tuple[tuple[str, str, int], str]] = set()
+    first_failure: dict[tuple[str, str, int], ClassifiedFailure] = {}
+    for item in classified:
+        if item.kind is not FailureKind.RELIABILITY:
+            continue
+        key = _history_key(item.failure)[1:]
+        affected.add((key, item.failure.head_sha))
+        earliest = first_failure.get(key)
+        if earliest is None or item.failure.created_at < earliest.failure.created_at:
+            first_failure[key] = item
+    by_commit: dict[tuple[tuple[str, str, int], str], list[WorkflowRun]] = defaultdict(list)
+    for run in pr_runs:
+        by_commit[(_history_key(run)[1:], run.head_sha)].append(run)
+    intervals: dict[tuple[str, str, int], list[tuple[datetime, datetime]]] = defaultdict(list)
+    for key, sha in affected:
+        interval = _commit_delay(by_commit.get((key, sha), []), normal_minutes)
+        if interval is not None:
+            intervals[key].append(interval)
+    delays: list[PullRequestDelay] = []
+    for key, item in first_failure.items():
+        spans = intervals.get(key, [])
+        head_repo, branch, number = key
+        delays.append(
+            PullRequestDelay(
+                head_repo=head_repo,
+                branch=branch,
+                pr_number=number or _merged_number(item.failure, merged_prs),
+                critical_path=item.critical_path,
+                delay_minutes=_union_minutes(spans),
+                commits=len(spans),
+                url=item.failure.url,
+            )
+        )
+    return sorted(delays, key=lambda d: -d.delay_minutes)
+
+
+def _merged_number(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> int:
+    """PR number of the merge that closed the run's branch, when GitHub attached none."""
+    return next(
+        (
+            pr.number
+            for pr in merged
+            if pr.branch == run.branch
+            and pr.head_repo == run.head_repo
+            and pr.merged_at >= run.created_at
+        ),
+        0,
+    )
+
+
+def _commit_delay(
+    runs: Sequence[WorkflowRun], normal_minutes: dict[int | str, float]
+) -> tuple[datetime, datetime] | None:
+    """Expected and actual green times of one commit, or None when it never went green."""
+    if not runs:
+        return None
+    by_workflow: dict[int | str, list[WorkflowRun]] = defaultdict(list)
+    for run in runs:
+        by_workflow[_workflow_key(run)].append(run)
+    greens: list[datetime] = []
+    for workflow_runs in by_workflow.values():
+        passed = [run.completed_at for run in workflow_runs if run.succeeded]
+        if not passed:
+            return None
+        greens.append(max(passed))
+    queued = min(run.created_at for run in runs)
+    expected_duration = max(normal_minutes.get(_workflow_key(run), run.minutes) for run in runs)
+    expected_green = queued + timedelta(minutes=expected_duration)
+    actual_green = max(greens)
+    if actual_green <= expected_green:
+        return None
+    return expected_green, actual_green
+
+
+def _union_minutes(spans: Sequence[tuple[datetime, datetime]]) -> float:
+    total = 0.0
+    current: tuple[datetime, datetime] | None = None
+    for start, end in sorted(spans):
+        if current is None or start > current[1]:
+            if current is not None:
+                total += (current[1] - current[0]).total_seconds()
+            current = (start, end)
+        elif end > current[1]:
+            current = (current[0], end)
+    if current is not None:
+        total += (current[1] - current[0]).total_seconds()
+    return total / 60
 
 
 def normal_minutes(runs: Sequence[WorkflowRun]) -> dict[int | str, float]:
@@ -238,6 +344,7 @@ def on_critical_path(run: WorkflowRun, merged: Sequence[MergedPullRequest]) -> b
 __all__ = [
     "classify_failures",
     "on_critical_path",
+    "pull_request_delays",
     "compute_report",
     "find_outages",
     "normal_minutes",

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -85,13 +85,11 @@ def pull_request_delays(
     this commit have been green?"); the actual green time is when the last
     of its workflows first passed. A commit whose workflows never all passed
     is left out. The wait on a commit ends when the developer pushes the next
-    commit of the PR, so a stale commit re-run days later adds nothing. The
+    commit of the PR or the PR merges, whichever comes first, so a stale
+    commit re-run later adds nothing. A next commit that triggered no PR
+    workflow is invisible here; the merge time still bounds the wait. The
     delay intervals of a PR's commits are unioned so overlapping workflows
     and re-runs are counted once.
-
-    A run GitHub attached no PR number to is assigned to the first PR merged
-    from its head repository and branch after the run was queued, so a reused
-    branch name does not fold two PRs into one.
     """
     identity = _PullRequestIdentity(merged_prs)
     affected: set[tuple[PullRequestKey, str]] = set()
@@ -111,7 +109,9 @@ def pull_request_delays(
     intervals: dict[PullRequestKey, list[tuple[datetime, datetime]]] = defaultdict(list)
     for key, sha in affected:
         interval = _commit_delay(
-            by_commit.get((key, sha), []), normal_minutes, until=next_push.get((key, sha))
+            by_commit.get((key, sha), []),
+            normal_minutes,
+            until=_earliest(next_push.get((key, sha)), identity.merged_at(key)),
         )
         if interval is not None:
             intervals[key].append(interval)
@@ -138,7 +138,12 @@ PullRequestKey = tuple[str, str, int]
 
 
 class _PullRequestIdentity:
-    """Resolve which pull request a run belongs to, using merges when GitHub attached none."""
+    """Resolve which pull request a run belongs to and when that PR merged.
+
+    Of several attached PR numbers the merged one wins; a run with none is
+    assigned to the first PR merged from its head repository and branch
+    after the run was queued.
+    """
 
     def __init__(self, merged: Sequence[MergedPullRequest]) -> None:
         by_branch: dict[tuple[str, str], list[MergedPullRequest]] = defaultdict(list)
@@ -147,13 +152,23 @@ class _PullRequestIdentity:
         for prs in by_branch.values():
             prs.sort(key=lambda pr: pr.merged_at)
         self._by_branch = by_branch
+        self._merged_at = {pr.number: pr.merged_at for pr in merged}
 
     def key(self, run: WorkflowRun) -> PullRequestKey:
         if run.pr_numbers:
-            return (run.head_repo, run.branch, run.pr_numbers[0])
+            number = next((n for n in run.pr_numbers if n in self._merged_at), run.pr_numbers[0])
+            return (run.head_repo, run.branch, number)
         candidates = self._by_branch.get((run.head_repo, run.branch), [])
         merged = next((pr for pr in candidates if pr.merged_at >= run.created_at), None)
         return (run.head_repo, run.branch, merged.number if merged else 0)
+
+    def merged_at(self, key: PullRequestKey) -> datetime | None:
+        return self._merged_at.get(key[2])
+
+
+def _earliest(*times: datetime | None) -> datetime | None:
+    known = [time for time in times if time is not None]
+    return min(known) if known else None
 
 
 def _next_push_times(

--- a/integrations/github/tools/ci_analytics/models.py
+++ b/integrations/github/tools/ci_analytics/models.py
@@ -89,6 +89,32 @@ class ClassifiedFailure:
 
 
 @dataclass(frozen=True)
+class PullRequestDelay:
+    """How much later one PR went green than it should have, because CI misbehaved.
+
+    For every commit of the PR that had a CI-caused failure, the expected
+    green time is the first run's queue time plus the slowest workflow's
+    normal duration; the actual green time is when its last workflow passed.
+    Overlapping workflow delays on one commit are counted once.
+    """
+
+    head_repo: str
+    branch: str
+    pr_number: int
+    critical_path: bool
+    delay_minutes: float
+    commits: int
+    """Commits of the PR whose green time was delayed by CI."""
+
+    url: str
+    """The first CI-caused failure on the PR, for the report link."""
+
+    @property
+    def label(self) -> str:
+        return f"PR #{self.pr_number} ({self.branch})" if self.pr_number else self.branch
+
+
+@dataclass(frozen=True)
 class MergedPullRequest:
     """A pull request merged inside the report window, identified beyond branch name."""
 
@@ -143,11 +169,13 @@ class CiAnalyticsReport:
     pr_failures: int
     classified: tuple[ClassifiedFailure, ...]
     merged_pr_branches: int
+    """PRs on the critical path whose green time CI delayed."""
+
     blocked_minutes: float
-    """Developer minutes blocked by unreliable CI on PRs that were later merged."""
+    """Minutes PRs that were later merged waited beyond their expected green time."""
 
     blocked_minutes_all: float
-    """Same delay summed over every PR branch, merged or not."""
+    """Same wait summed over every PR, merged or not."""
 
     branch_runs: int
     """Push-triggered runs on the default branch, the ones that define red time."""
@@ -158,6 +186,7 @@ class CiAnalyticsReport:
     mean_recovery_hours: float | None
     workflows: tuple[WorkflowSummary, ...] = field(default_factory=tuple)
     coverage_notices: tuple[str, ...] = field(default_factory=tuple)
+    pr_delays: tuple[PullRequestDelay, ...] = field(default_factory=tuple)
 
     @property
     def pr_failure_rate(self) -> float | None:
@@ -175,13 +204,15 @@ class CiAnalyticsReport:
         )
 
     @property
+    def blocked_pr_delays(self) -> tuple[PullRequestDelay, ...]:
+        """Critical-path PRs that actually waited, worst first."""
+        delays = [d for d in self.pr_delays if d.critical_path and d.delay_minutes > 0]
+        return tuple(sorted(delays, key=lambda d: -d.delay_minutes))
+
+    @property
     def median_delay_minutes(self) -> float | None:
-        """Typical CI-caused delay, so one long re-run gap does not read as the norm."""
-        delays = sorted(
-            item.delay_minutes
-            for item in self.classified
-            if item.kind is FailureKind.RELIABILITY and item.delay_minutes > 0
-        )
+        """Typical wait per blocked merged PR, so one long outlier does not read as the norm."""
+        delays = sorted(d.delay_minutes for d in self.blocked_pr_delays)
         if not delays:
             return None
         middle = len(delays) // 2
@@ -190,11 +221,9 @@ class CiAnalyticsReport:
         return (delays[middle - 1] + delays[middle]) / 2
 
     @property
-    def longest_delay(self) -> ClassifiedFailure | None:
-        delays = [item for item in self.classified if item.kind is FailureKind.RELIABILITY]
-        if not delays:
-            return None
-        return max(delays, key=lambda item: item.delay_minutes)
+    def longest_delay(self) -> PullRequestDelay | None:
+        blocked = self.blocked_pr_delays
+        return blocked[0] if blocked else None
 
     @property
     def longest_outage(self) -> Outage | None:
@@ -215,6 +244,7 @@ __all__ = [
     "FailureKind",
     "MergedPullRequest",
     "Outage",
+    "PullRequestDelay",
     "WorkflowRun",
     "WorkflowSummary",
 ]

--- a/integrations/github/tools/ci_analytics/models.py
+++ b/integrations/github/tools/ci_analytics/models.py
@@ -124,6 +124,8 @@ class MergedPullRequest:
     """owner/name of the head repository at merge time."""
 
     merged_at: datetime
+    commits: tuple[tuple[str, datetime], ...] = ()
+    """(sha, committed_at) in PR order, when the collector fetched them."""
 
 
 @dataclass(frozen=True)

--- a/integrations/github/tools/ci_analytics/models.py
+++ b/integrations/github/tools/ci_analytics/models.py
@@ -124,8 +124,6 @@ class MergedPullRequest:
     """owner/name of the head repository at merge time."""
 
     merged_at: datetime
-    commits: tuple[tuple[str, datetime], ...] = ()
-    """(sha, committed_at) in PR order, when the collector fetched them."""
 
 
 @dataclass(frozen=True)

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -11,9 +11,9 @@ from rich.text import Text
 
 from integrations.github.tools.ci_analytics.models import (
     CiAnalyticsReport,
-    ClassifiedFailure,
     FailureKind,
     Outage,
+    PullRequestDelay,
 )
 
 _TOP_WORKFLOWS = 5
@@ -89,8 +89,9 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
                     style="bold",
                 ),
                 Text(
-                    "Only PRs that were later merged count, so CI sat on the path to merge. "
-                    "Baseline: each workflow's median first-attempt passing duration.",
+                    "Per pull request: how much later its commits went green than they would "
+                    "have had CI run normally (median first-attempt duration per workflow). "
+                    "Only PRs that were later merged count; overlapping workflows count once.",
                     style="dim",
                 ),
             ]
@@ -107,7 +108,7 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
             )
         longest = report.longest_delay
         if longest is not None and longest.delay_minutes > 0:
-            parts.append(_kpi_line("Longest single delay", _delay(longest)))
+            parts.append(_kpi_line("Longest wait", _delay(longest)))
     if report.branch_runs:
         parts.extend(
             [
@@ -158,10 +159,10 @@ def headline(report: CiAnalyticsReport) -> str:
     if report.blocked_minutes > 0:
         typical = report.median_delay_minutes or 0.0
         longest = report.longest_delay
-        worst = f", the worst {_minutes(longest.delay_minutes)}" if longest else ""
+        worst = f", the longest {_minutes(longest.delay_minutes)}" if longest else ""
         return (
             f"Unreliable CI blocked merged pull requests for {_minutes(report.blocked_minutes)} "
-            f"in the last {report.window_days} days; the typical CI-caused delay was "
+            f"in the last {report.window_days} days; the typical blocked PR waited "
             f"{_minutes(typical)}{worst}."
         )
     if report.red_hours > 0:
@@ -202,19 +203,17 @@ def _blocked_time(report: CiAnalyticsReport) -> list[str]:
         "",
         f"**Developer time blocked by unreliable CI: {_minutes(report.blocked_minutes)}** "
         f"across {report.merged_pr_branches} merged {_plural(report.merged_pr_branches, 'PR')}",
-        "- Counts only PRs that were later merged, so CI was on the path to merge",
-        "- Baseline: each workflow's median first-attempt passing duration; "
-        "the delay is the extra wall-clock time until the same commit passed",
+        "- Per pull request: how much later its commits went green than they would have "
+        "had CI run normally (median first-attempt duration per workflow)",
+        "- Only PRs that were later merged count; overlapping workflows count once",
     ]
     if report.blocked_minutes_all > report.blocked_minutes:
         lines.append(f"- Including PRs not merged yet: {_minutes(report.blocked_minutes_all)}")
     if report.median_delay_minutes is not None:
-        lines.append(
-            f"- Typical delay per CI-caused failure: {_minutes(report.median_delay_minutes)}"
-        )
+        lines.append(f"- Typical wait per blocked PR: {_minutes(report.median_delay_minutes)}")
     longest = report.longest_delay
     if longest is not None and longest.delay_minutes > 0:
-        lines.append(f"- Longest single delay: {_delay(longest)}")
+        lines.append(f"- Longest wait: {_delay(longest)}")
     return lines
 
 
@@ -237,11 +236,9 @@ def _default_branch(report: CiAnalyticsReport) -> list[str]:
     return lines
 
 
-def _delay(item: ClassifiedFailure) -> str:
-    return (
-        f"{_minutes(item.delay_minutes)} on {item.failure.branch} ({item.failure.workflow}) "
-        f"{item.failure.url}".strip()
-    )
+def _delay(item: PullRequestDelay) -> str:
+    commits = f", {item.commits} {_plural(item.commits, 'commit')}" if item.commits > 1 else ""
+    return f"{_minutes(item.delay_minutes)} on {item.label}{commits} {item.url}".strip()
 
 
 def _outage(outage: Outage, *, now: datetime) -> str:

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -102,9 +102,7 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
             )
         if report.median_delay_minutes is not None:
             parts.append(
-                _kpi_line(
-                    "Typical delay per CI-caused failure", _minutes(report.median_delay_minutes)
-                )
+                _kpi_line("Typical wait per blocked PR", _minutes(report.median_delay_minutes))
             )
         longest = report.longest_delay
         if longest is not None and longest.delay_minutes > 0:

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -108,6 +108,15 @@ def _payload(report: CiAnalyticsReport) -> dict[str, Any]:
         "blocked_minutes": round(report.blocked_minutes, 1),
         "blocked_minutes_all": round(report.blocked_minutes_all, 1),
         "merged_pr_branches": report.merged_pr_branches,
+        "blocked_prs": [
+            {
+                "pr_number": d.pr_number,
+                "branch": d.branch,
+                "delay_minutes": round(d.delay_minutes, 1),
+                "commits": d.commits,
+            }
+            for d in report.blocked_pr_delays[:10]
+        ],
         "branch_runs": report.branch_runs,
         "branch_failures": report.branch_failures,
         "red_hours": round(report.red_hours, 2),
@@ -154,7 +163,7 @@ def _payload(report: CiAnalyticsReport) -> dict[str, Any]:
         "executions": "Completed workflow runs counted in the window",
         "pr_failure_rate": "Failed share of PR-triggered runs",
         "reliability_failures": "Failures that passed later on the identical commit",
-        "blocked_minutes": "Developer minutes blocked by CI-caused failures on merged PRs",
+        "blocked_minutes": "Minutes merged PRs waited past their expected green time because of CI",
         "red_hours": "Hours the default branch had at least one red workflow",
         "headline": "One sentence naming the biggest cost, to repeat verbatim",
         "response_text": "The rendered report, or a one-line summary when the shell painted it",

--- a/tests/interactive_shell/shell/test_execution.py
+++ b/tests/interactive_shell/shell/test_execution.py
@@ -15,6 +15,18 @@ from tools.interactive_shell.shell.execution import (
 from tools.interactive_shell.shell.parsing import parse_shell_command
 
 
+def _assert_pid_gone(pid: int, *, timeout_seconds: float = 2.0) -> None:
+    """Wait until *pid* is gone; a single ``kill(pid, 0)`` races a zombie."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return
+        time.sleep(0.05)
+    pytest.fail(f"process {pid} still alive after cancel")
+
+
 def test_execute_shell_command_reports_timeout_argv_mode() -> None:
     started = time.monotonic()
     result = execute_shell_command(
@@ -82,8 +94,7 @@ def test_execute_shell_command_stops_on_cancel_and_reaps_grandchild() -> None:
     assert elapsed < 4
     assert "GRAND:" in result.stdout
     grand_pid = int(result.stdout.strip().split("GRAND:", 1)[1].split()[0])
-    with pytest.raises(OSError):
-        os.kill(grand_pid, 0)
+    _assert_pid_gone(grand_pid)
 
 
 def test_execute_quoted_heredoc_through_shell() -> None:

--- a/tests/tools/interactive_shell/test_subprocess_primitives.py
+++ b/tests/tools/interactive_shell/test_subprocess_primitives.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 import tempfile
 import threading
+import time
 
 import pytest
 
@@ -42,6 +45,39 @@ def test_terminate_child_process_noop_when_exited() -> None:
     proc = subprocess.Popen(["true"])
     proc.wait()
     terminate_child_process(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process-group cancel is POSIX")
+def test_terminate_reaps_grandchild_that_ignores_sigterm() -> None:
+    script = (
+        "import subprocess, sys, time\n"
+        "child = subprocess.Popen(["
+        "sys.executable, '-c',"
+        "'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)'"
+        "])\n"
+        "print(f'GRAND:{child.pid}', flush=True)\n"
+        "time.sleep(60)\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    assert proc.stdout is not None
+    line = proc.stdout.readline()
+    grand_pid = int(line.strip().split("GRAND:", 1)[1])
+    terminate_child_process(proc)
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(grand_pid, 0)
+        except OSError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"grandchild {grand_pid} still alive after terminate")
+    assert proc.poll() is not None
 
 
 def test_watch_subprocess_until_exit_on_cancel() -> None:

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -378,6 +378,47 @@ def test_run_attached_to_several_prs_belongs_to_the_merged_one() -> None:
     assert report.blocked_minutes == 50.0
 
 
+def test_skipped_next_commit_caps_the_wait_before_merge() -> None:
+    # Arrange: commit "a" failed and was re-run a day later. Commit "b" was
+    # pushed at 30 minutes and skipped by path filters, so it has no workflow.
+    # The PR merged a day later.
+    merged = (
+        MergedPullRequest(
+            number=1,
+            branch="feat/x",
+            head_repo="",
+            merged_at=_T0 + timedelta(days=1),
+            commits=(("a", _T0), ("b", _T0 + timedelta(minutes=30))),
+        ),
+    )
+    pr_runs = [
+        _run(
+            1,
+            sha="a",
+            conclusion="success",
+            start_minutes=24 * 60,
+            queued_minutes=24 * 60,
+            attempt=2,
+            earlier_failure_started_at=_T0,
+        ),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=merged,
+        now=_T0 + timedelta(days=2),
+    )
+
+    # Assert: expected green at 10, wait ends at the skipped push at 30, not merge.
+    assert report.blocked_minutes == 20.0
+
+
 def test_stale_rerun_after_the_merge_waits_only_until_the_merge() -> None:
     # Arrange: the failed run was re-run two days after the PR merged at day 1,
     # and no later commit of the PR triggered a workflow.
@@ -717,6 +758,36 @@ def test_rerun_budget_is_spent_on_merged_prs_first(monkeypatch: pytest.MonkeyPat
     assert by_id[5].retried_to_green is False
 
 
+def test_collect_runs_attaches_commit_times_for_merged_prs_with_failures() -> None:
+    now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
+    row = _payload(6, created_at="2026-09-02T09:00:00Z", conclusion="failure", attempt=1)
+    pulls = [
+        {
+            "number": 42,
+            "merged_at": "2026-09-03T09:00:00Z",
+            "updated_at": "2026-09-03T09:00:00Z",
+            "head": {"ref": "feat/x", "repo": {"full_name": "o/r"}},
+        }
+    ]
+    commits = [
+        {"sha": "aaa", "commit": {"committer": {"date": "2026-09-02T09:00:00Z"}}},
+        {"sha": "bbb", "commit": {"committer": {"date": "2026-09-02T09:30:00Z"}}},
+    ]
+    client = _FakeGitHub(
+        repository={"default_branch": "main"},
+        runs=[row],
+        pulls=pulls,
+        pr_commits={42: commits},
+    )
+
+    collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
+
+    assert collected.merged_prs[0].commits == (
+        ("aaa", datetime(2026, 9, 2, 9, 0, tzinfo=UTC)),
+        ("bbb", datetime(2026, 9, 2, 9, 30, tzinfo=UTC)),
+    )
+
+
 def test_rerun_on_a_reused_branch_does_not_take_merged_pr_priority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -847,11 +918,13 @@ class _FakeGitHub:
         runs: list[dict[str, Any]],
         attempts: dict[tuple[int, int], dict[str, Any]] | None = None,
         pulls: list[dict[str, Any]] | None = None,
+        pr_commits: dict[int, list[dict[str, Any]]] | None = None,
     ) -> None:
         self._repository = repository
         self._runs = runs
         self._attempts = attempts or {}
         self._pulls = pulls or []
+        self._pr_commits = pr_commits or {}
         self.run_queries: list[dict[str, Any]] = []
 
     def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
@@ -894,6 +967,9 @@ class _FakeGitHub:
             return self._runs_in(params or {})[:1000]
         if path == "/repos/o/r/pulls":
             return self._pulls
+        if path.startswith("/repos/o/r/pulls/") and path.endswith("/commits"):
+            number = int(path.rsplit("/", 2)[1])
+            return self._pr_commits.get(number, [])
         return []
 
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -226,6 +226,134 @@ def test_parallel_workflows_on_one_commit_count_the_wait_once() -> None:
     assert report.pr_delays[0].pr_number == _merged("feat/x")[0].number
 
 
+def test_stale_commit_rerun_after_next_push_waits_only_until_the_push() -> None:
+    # Arrange: commit "a" failed at 0 and its run was re-run to green a day later,
+    # but the developer had already pushed commit "b" at 30, which passed first time.
+    pr_runs = [
+        _run(
+            1,
+            sha="a",
+            conclusion="success",
+            start_minutes=24 * 60,
+            queued_minutes=24 * 60,
+            attempt=2,
+            earlier_failure_started_at=_T0,
+        ),
+        _run(3, sha="b", conclusion="success", start_minutes=30),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=_merged("feat/x"),
+        now=_T0 + timedelta(days=2),
+    )
+
+    # Assert: expected green at 10, wait ends at the push at 30, not at the re-run.
+    assert report.count(FailureKind.RELIABILITY) == 1
+    assert report.blocked_minutes == 20.0
+
+
+def test_duplicate_pass_on_a_green_commit_does_not_extend_the_wait() -> None:
+    # Arrange: failure at 0, first pass at 50, and the workflow run again at 500.
+    pr_runs = [
+        _run(1, sha="m", conclusion="failure", start_minutes=0),
+        _run(2, sha="m", conclusion="success", start_minutes=50),
+        _run(3, sha="m", conclusion="success", start_minutes=500),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=_merged("feat/x"),
+        now=_T0 + timedelta(days=1),
+    )
+
+    # Assert: green at 60 (first pass), expected at 10.
+    assert report.blocked_minutes == 50.0
+
+
+def test_missing_baseline_uses_the_passing_duration_not_the_failed_one() -> None:
+    # Arrange: the only pass is a re-run, so there is no first-attempt baseline.
+    # The failed attempt ran 120 minutes; the passing re-run took 10.
+    pr_runs = [
+        _run(
+            1,
+            sha="m",
+            conclusion="success",
+            start_minutes=200,
+            queued_minutes=200,
+            duration_minutes=10,
+            attempt=2,
+            earlier_failure_started_at=_T0,
+        ),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=_merged("feat/x"),
+        now=_T0 + timedelta(days=1),
+    )
+
+    # Assert: expected green at 0 + 10, actual at 210.
+    assert report.blocked_minutes == 200.0
+
+
+def test_reused_branch_without_pr_numbers_splits_into_separate_prs() -> None:
+    # Arrange: branch "feat/x" was merged as PR 1 on day 1 and reused for PR 2,
+    # merged on day 3. Each life had one CI-caused failure; GitHub attached no numbers.
+    merged = (
+        MergedPullRequest(
+            number=1, branch="feat/x", head_repo="", merged_at=_T0 + timedelta(days=1)
+        ),
+        MergedPullRequest(
+            number=2, branch="feat/x", head_repo="", merged_at=_T0 + timedelta(days=3)
+        ),
+    )
+    day2 = 2 * 24 * 60
+    pr_runs = [
+        _run(1, sha="a", conclusion="failure", start_minutes=0),
+        _run(2, sha="a", conclusion="success", start_minutes=50),
+        _run(3, sha="b", conclusion="failure", start_minutes=day2),
+        _run(4, sha="b", conclusion="success", start_minutes=day2 + 30),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=merged,
+        now=_T0 + timedelta(days=4),
+    )
+
+    # Assert: two PRs with their own waits, not one bucket of two commits.
+    assert [(d.pr_number, d.delay_minutes, d.commits) for d in report.pr_delays] == [
+        (1, 50.0, 1),
+        (2, 30.0, 1),
+    ]
+    assert report.merged_pr_branches == 2
+
+
 def test_source_code_failures_do_not_add_blocked_time() -> None:
     pr_runs = [
         _run(1, sha="old", conclusion="failure", start_minutes=0),

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -197,6 +197,57 @@ def test_blocked_time_counts_only_merged_pr_branches() -> None:
     assert report.merged_pr_branches == 1
 
 
+def test_parallel_workflows_on_one_commit_count_the_wait_once() -> None:
+    # Arrange: CI and Lint both failed at 0 and both passed after a re-run at 50.
+    pr_runs = [
+        _run(1, workflow="CI", workflow_id=1, sha="m", conclusion="failure", start_minutes=0),
+        _run(2, workflow="CI", workflow_id=1, sha="m", conclusion="success", start_minutes=50),
+        _run(3, workflow="Lint", workflow_id=2, sha="m", conclusion="failure", start_minutes=0),
+        _run(4, workflow="Lint", workflow_id=2, sha="m", conclusion="success", start_minutes=50),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=_merged("feat/x"),
+        now=_T0 + timedelta(days=1),
+    )
+
+    # Assert: expected green at 10 (slowest normal run), actual at 60; not 50 + 50.
+    assert report.count(FailureKind.RELIABILITY) == 2
+    assert report.blocked_minutes == 50.0
+    assert report.merged_pr_branches == 1
+    assert report.pr_delays[0].commits == 1
+    assert report.pr_delays[0].pr_number == _merged("feat/x")[0].number
+
+
+def test_source_code_failures_do_not_add_blocked_time() -> None:
+    pr_runs = [
+        _run(1, sha="old", conclusion="failure", start_minutes=0),
+        _run(2, sha="new", conclusion="success", start_minutes=120),
+    ]
+
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=_merged("feat/x"),
+        now=_T0 + timedelta(days=1),
+    )
+
+    assert report.count(FailureKind.SOURCE) == 1
+    assert report.blocked_minutes == 0.0
+    assert report.pr_delays == ()
+
+
 def test_normal_minutes_uses_median_of_first_attempt_passes_only() -> None:
     runs = [
         _run(1, conclusion="success", duration_minutes=8),
@@ -735,7 +786,7 @@ def test_tool_renders_report_from_collected_runs() -> None:
     assert result["blocked_minutes"] == 40.0
     assert result["headline"] == (
         "Unreliable CI blocked merged pull requests for 40m in the last 7 days; "
-        "the typical CI-caused delay was 40m, the worst 40m."
+        "the typical blocked PR waited 40m, the longest 40m."
     )
     assert "Coverage notice: sample" in result["response_text"]
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -378,29 +378,20 @@ def test_run_attached_to_several_prs_belongs_to_the_merged_one() -> None:
     assert report.blocked_minutes == 50.0
 
 
-def test_skipped_next_commit_caps_the_wait_before_merge() -> None:
-    # Arrange: commit "a" failed and was re-run a day later. Commit "b" was
-    # pushed at 30 minutes and skipped by path filters, so it has no workflow.
-    # The PR merged a day later.
+def test_run_attached_to_two_merged_prs_belongs_to_the_later_lifetime() -> None:
+    # Arrange: GitHub lists PR 1 (merged at 20 min) before PR 2 (merged at day 1).
+    # The run was queued at 30 min, after PR 1 had already merged.
     merged = (
         MergedPullRequest(
-            number=1,
-            branch="feat/x",
-            head_repo="",
-            merged_at=_T0 + timedelta(days=1),
-            commits=(("a", _T0), ("b", _T0 + timedelta(minutes=30))),
+            number=1, branch="feat/x", head_repo="", merged_at=_T0 + timedelta(minutes=20)
+        ),
+        MergedPullRequest(
+            number=2, branch="feat/x", head_repo="", merged_at=_T0 + timedelta(days=1)
         ),
     )
     pr_runs = [
-        _run(
-            1,
-            sha="a",
-            conclusion="success",
-            start_minutes=24 * 60,
-            queued_minutes=24 * 60,
-            attempt=2,
-            earlier_failure_started_at=_T0,
-        ),
+        _run(1, sha="m", conclusion="failure", start_minutes=30, pr_numbers=(1, 2)),
+        _run(2, sha="m", conclusion="success", start_minutes=80, pr_numbers=(1, 2)),
     ]
 
     # Act
@@ -415,8 +406,9 @@ def test_skipped_next_commit_caps_the_wait_before_merge() -> None:
         now=_T0 + timedelta(days=2),
     )
 
-    # Assert: expected green at 10, wait ends at the skipped push at 30, not merge.
-    assert report.blocked_minutes == 20.0
+    # Assert: charged to PR 2, whose lifetime contains the run.
+    assert [(d.pr_number, d.critical_path) for d in report.pr_delays] == [(2, True)]
+    assert report.blocked_minutes == 50.0
 
 
 def test_stale_rerun_after_the_merge_waits_only_until_the_merge() -> None:
@@ -758,36 +750,6 @@ def test_rerun_budget_is_spent_on_merged_prs_first(monkeypatch: pytest.MonkeyPat
     assert by_id[5].retried_to_green is False
 
 
-def test_collect_runs_attaches_commit_times_for_merged_prs_with_failures() -> None:
-    now = datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
-    row = _payload(6, created_at="2026-09-02T09:00:00Z", conclusion="failure", attempt=1)
-    pulls = [
-        {
-            "number": 42,
-            "merged_at": "2026-09-03T09:00:00Z",
-            "updated_at": "2026-09-03T09:00:00Z",
-            "head": {"ref": "feat/x", "repo": {"full_name": "o/r"}},
-        }
-    ]
-    commits = [
-        {"sha": "aaa", "commit": {"committer": {"date": "2026-09-02T09:00:00Z"}}},
-        {"sha": "bbb", "commit": {"committer": {"date": "2026-09-02T09:30:00Z"}}},
-    ]
-    client = _FakeGitHub(
-        repository={"default_branch": "main"},
-        runs=[row],
-        pulls=pulls,
-        pr_commits={42: commits},
-    )
-
-    collected = collect_runs(client, owner="o", repo="r", window_days=30, now=now)
-
-    assert collected.merged_prs[0].commits == (
-        ("aaa", datetime(2026, 9, 2, 9, 0, tzinfo=UTC)),
-        ("bbb", datetime(2026, 9, 2, 9, 30, tzinfo=UTC)),
-    )
-
-
 def test_rerun_on_a_reused_branch_does_not_take_merged_pr_priority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -918,13 +880,11 @@ class _FakeGitHub:
         runs: list[dict[str, Any]],
         attempts: dict[tuple[int, int], dict[str, Any]] | None = None,
         pulls: list[dict[str, Any]] | None = None,
-        pr_commits: dict[int, list[dict[str, Any]]] | None = None,
     ) -> None:
         self._repository = repository
         self._runs = runs
         self._attempts = attempts or {}
         self._pulls = pulls or []
-        self._pr_commits = pr_commits or {}
         self.run_queries: list[dict[str, Any]] = []
 
     def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
@@ -967,9 +927,6 @@ class _FakeGitHub:
             return self._runs_in(params or {})[:1000]
         if path == "/repos/o/r/pulls":
             return self._pulls
-        if path.startswith("/repos/o/r/pulls/") and path.endswith("/commits"):
-            number = int(path.rsplit("/", 2)[1])
-            return self._pr_commits.get(number, [])
         return []
 
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -354,6 +354,61 @@ def test_reused_branch_without_pr_numbers_splits_into_separate_prs() -> None:
     assert report.merged_pr_branches == 2
 
 
+def test_run_attached_to_several_prs_belongs_to_the_merged_one() -> None:
+    # Arrange: GitHub lists PR 7 (never merged) before PR 1 (merged) on both runs.
+    pr_runs = [
+        _run(1, sha="m", conclusion="failure", start_minutes=0, pr_numbers=(7, 1)),
+        _run(2, sha="m", conclusion="success", start_minutes=50, pr_numbers=(7, 1)),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=_merged("feat/x"),
+        now=_T0 + timedelta(days=1),
+    )
+
+    # Assert
+    assert [(d.pr_number, d.critical_path) for d in report.pr_delays] == [(1, True)]
+    assert report.blocked_minutes == 50.0
+
+
+def test_stale_rerun_after_the_merge_waits_only_until_the_merge() -> None:
+    # Arrange: the failed run was re-run two days after the PR merged at day 1,
+    # and no later commit of the PR triggered a workflow.
+    pr_runs = [
+        _run(
+            1,
+            sha="m",
+            conclusion="success",
+            start_minutes=3 * 24 * 60,
+            queued_minutes=3 * 24 * 60,
+            attempt=2,
+            earlier_failure_started_at=_T0,
+        ),
+    ]
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=_merged("feat/x"),
+        now=_T0 + timedelta(days=4),
+    )
+
+    # Assert: expected green at 10 minutes, wait ends at the merge one day in.
+    assert report.blocked_minutes == 24 * 60 - 10
+
+
 def test_source_code_failures_do_not_add_blocked_time() -> None:
     pr_runs = [
         _run(1, sha="old", conclusion="failure", start_minutes=0),

--- a/tools/interactive_shell/subprocess.py
+++ b/tools/interactive_shell/subprocess.py
@@ -46,22 +46,40 @@ def _is_process_group_leader(pid: int) -> bool:
         return False
 
 
-def _signal_child(proc: subprocess.Popen[Any], *, forceful: bool) -> None:
-    """Signal a child, and its descendants when it leads a process group.
+def _process_group_leader_pid(proc: subprocess.Popen[Any]) -> int | None:
+    """Pgid to ``killpg`` when *proc* leads a session, else None.
+
+    Snapshot this before the child exits: ``getpgid`` fails once the
+    leader is reaped, and descendants can outlive it.
+    """
+    pid = proc.pid
+    if not pid or not _is_process_group_leader(pid):
+        return None
+    return pid
+
+
+def _signal_child(
+    proc: subprocess.Popen[Any],
+    *,
+    forceful: bool,
+    group_pid: int | None,
+) -> None:
+    """Signal a child, and its descendants when it led a process group.
 
     Nested ``uv run opensre …`` / ``gh`` children survive a single-pid
     SIGTERM. Group leaders (``start_new_session=True``) are safe to
     ``killpg``; other children stay in the parent's group, so we must
-    not signal that group.
+    not signal that group. ``group_pid`` is snapshotted while the
+    leader is still queryable so a later SIGKILL can reap leftovers
+    after the leader has already exited.
     """
-    if proc.poll() is not None:
-        return
-    pid = getattr(proc, "pid", None)
-    if pid is not None and _is_process_group_leader(pid) and hasattr(os, "killpg"):
+    if group_pid is not None and hasattr(os, "killpg"):
         sig = signal.SIGKILL if forceful else signal.SIGTERM
         with contextlib.suppress(OSError):
-            os.killpg(pid, sig)
+            os.killpg(group_pid, sig)
             return
+    if proc.poll() is not None:
+        return
     with contextlib.suppress(OSError):
         if forceful:
             proc.kill()
@@ -70,14 +88,19 @@ def _signal_child(proc: subprocess.Popen[Any], *, forceful: bool) -> None:
 
 
 def terminate_child_process(proc: subprocess.Popen[Any]) -> None:
-    """Best-effort SIGTERM → wait → SIGKILL → wait without blocking forever."""
-    if proc.poll() is not None:
-        return
-    _signal_child(proc, forceful=False)
-    try:
-        proc.wait(timeout=SIGTERM_GRACE_SECONDS)
-    except subprocess.TimeoutExpired:
-        _signal_child(proc, forceful=True)
+    """SIGTERM the child (and its group), then SIGKILL leftovers.
+
+    Descendants that ignore SIGTERM, or are still starting when the
+    leader exits, outlive a parent-only wait. The second signal still
+    uses the snapshotted pgid so they cannot.
+    """
+    group_pid = _process_group_leader_pid(proc)
+    if proc.poll() is None:
+        _signal_child(proc, forceful=False, group_pid=group_pid)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=SIGTERM_GRACE_SECONDS)
+    _signal_child(proc, forceful=True, group_pid=group_pid)
+    if proc.poll() is None:
         with contextlib.suppress(subprocess.TimeoutExpired):
             proc.wait(timeout=5)
 


### PR DESCRIPTION
The "developer time blocked by unreliable CI" KPI summed delays per workflow failure, so two workflows failing and recovering in parallel on the same commit counted twice. It now follows the intended definition: per merged PR, how much later its commits went green than they would have had CI run normally.

For each commit with a CI-caused failure, expected green = first queued run + slowest workflow's normal duration (median first-attempt pass); actual green = last workflow passed. Intervals are unioned per PR. Commits that never went fully green are left out.

On Tracer-Cloud/opensre over 30 days the figure moves from 124.7d to 47.3d across 60 merged PRs (typical wait 3.4h, longest 5.3d).