### PR TITLE
fix(scheduler): renew leases during long-running executions

### DIFF
--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
+from datetime import UTC, datetime
 
 from infrastructure.scheduling.scheduler.delivery_bundle import resolve_delivery_adapter
 from infrastructure.scheduling.scheduler.delivery_plan import (
@@ -40,6 +41,7 @@ class _ClaimHeartbeat:
 
     def __init__(self, claim: ExecutionClaim) -> None:
         self._claim = claim
+        self._lease_expires_at = claim.lease_expires_at
         self._stop = threading.Event()
         self._lost = threading.Event()
         self._thread = threading.Thread(
@@ -64,8 +66,11 @@ class _ClaimHeartbeat:
     def _run(self) -> None:
         """Renew until asked to stop or until the claim is no longer owned."""
         while not self._stop.wait(claim_heartbeat_interval_seconds()):
+            if datetime.now(UTC) >= self._lease_expires_at:
+                self._mark_lost()
+                return
             try:
-                renewed = renew_claim(self._claim)
+                renewed_until = renew_claim(self._claim)
             except Exception:  # noqa: BLE001
                 logger.warning(
                     "Failed to renew claim for task %s fire_time=%s",
@@ -73,17 +78,24 @@ class _ClaimHeartbeat:
                     self._claim.fire_time,
                     exc_info=True,
                 )
-                continue
-            if not renewed:
-                if self._stop.is_set():
+                if datetime.now(UTC) >= self._lease_expires_at:
+                    self._mark_lost()
                     return
-                self._lost.set()
-                logger.warning(
-                    "Stopping heartbeat after losing claim for task %s fire_time=%s",
-                    self._claim.task_id,
-                    self._claim.fire_time,
-                )
+                continue
+            if renewed_until is None:
+                self._mark_lost()
                 return
+            self._lease_expires_at = renewed_until
+
+    def _mark_lost(self) -> None:
+        if self._stop.is_set():
+            return
+        self._lost.set()
+        logger.warning(
+            "Stopping heartbeat after losing claim for task %s fire_time=%s",
+            self._claim.task_id,
+            self._claim.fire_time,
+        )
 
 
 def execute_task(

--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 
 from infrastructure.scheduling.scheduler.delivery_bundle import resolve_delivery_adapter
 from infrastructure.scheduling.scheduler.delivery_plan import (
@@ -16,7 +17,9 @@ from infrastructure.scheduling.scheduler.operation_log import record_scheduler_e
 from infrastructure.scheduling.scheduler.runners import SchedulerRunners
 from infrastructure.scheduling.scheduler.storage import (
     ExecutionClaim,
+    claim_heartbeat_interval_seconds,
     complete_run,
+    renew_claim,
     try_claim,
 )
 from infrastructure.scheduling.scheduler.tasks import build_message
@@ -28,6 +31,52 @@ from infrastructure.scheduling.scheduler.types import (
 )
 
 logger = logging.getLogger(__name__)
+_CLAIM_HEARTBEAT_JOIN_TIMEOUT_SECONDS = 5.0
+
+
+class _ClaimHeartbeat:
+    """Renew a claimed execution until its executor exits or loses fencing."""
+
+    def __init__(self, claim: ExecutionClaim) -> None:
+        self._claim = claim
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"scheduler-claim-heartbeat-{claim.task_id}",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        """Start renewing the claim in the background."""
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop renewing the claim and wait briefly for the heartbeat to exit."""
+        self._stop.set()
+        self._thread.join(timeout=_CLAIM_HEARTBEAT_JOIN_TIMEOUT_SECONDS)
+
+    def _run(self) -> None:
+        """Renew until asked to stop or until the claim is no longer owned."""
+        while not self._stop.wait(claim_heartbeat_interval_seconds()):
+            try:
+                renewed = renew_claim(self._claim)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to renew claim for task %s fire_time=%s",
+                    self._claim.task_id,
+                    self._claim.fire_time,
+                    exc_info=True,
+                )
+                continue
+            if not renewed:
+                if self._stop.is_set():
+                    return
+                logger.warning(
+                    "Stopping heartbeat after losing claim for task %s fire_time=%s",
+                    self._claim.task_id,
+                    self._claim.fire_time,
+                )
+                return
 
 
 def execute_task(
@@ -68,6 +117,29 @@ def execute_task(
         )
         return False
 
+    heartbeat = _ClaimHeartbeat(claim)
+    heartbeat.start()
+    try:
+        return _execute_claimed_task(
+            claim,
+            task,
+            fire_time,
+            runners,
+            target_filter=target_filter,
+        )
+    finally:
+        heartbeat.stop()
+
+
+def _execute_claimed_task(
+    claim: ExecutionClaim,
+    task: ScheduledTask,
+    fire_time: str,
+    runners: SchedulerRunners,
+    *,
+    target_filter: frozenset[TargetKey] | None,
+) -> bool:
+    """Build and deliver a task while its claim heartbeat is active."""
     logger.info("Executing task %s (kind=%s, fire_time=%s)", task.id, task.kind, fire_time)
     record_scheduler_execution_operation(
         "scheduled_task_execution_started",

--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -67,14 +67,13 @@ class _ClaimHeartbeat:
             try:
                 renewed = renew_claim(self._claim)
             except Exception:  # noqa: BLE001
-                self._lost.set()
                 logger.warning(
                     "Failed to renew claim for task %s fire_time=%s",
                     self._claim.task_id,
                     self._claim.fire_time,
                     exc_info=True,
                 )
-                return
+                continue
             if not renewed:
                 if self._stop.is_set():
                     return

--- a/infrastructure/scheduling/scheduler/storage/__init__.py
+++ b/infrastructure/scheduling/scheduler/storage/__init__.py
@@ -7,12 +7,14 @@ from infrastructure.scheduling.scheduler.storage.database import (
 from infrastructure.scheduling.scheduler.storage.run_store import (
     ExecutionClaim,
     ExpiredClaim,
+    claim_heartbeat_interval_seconds,
     complete_run,
     delete_runs,
     get_expired_claims,
     get_latest_finished_run,
     get_latest_targeted_run,
     get_runs,
+    renew_claim,
     try_claim,
 )
 from infrastructure.scheduling.scheduler.storage.task_store import (
@@ -27,6 +29,7 @@ from infrastructure.scheduling.scheduler.storage.task_store import (
 __all__ = [
     "add_task",
     "complete_run",
+    "claim_heartbeat_interval_seconds",
     "default_run_database_path",
     "default_task_store_path",
     "delete_runs",
@@ -36,6 +39,7 @@ __all__ = [
     "get_latest_finished_run",
     "get_latest_targeted_run",
     "get_runs",
+    "renew_claim",
     "get_task",
     "list_tasks",
     "remove_task",

--- a/infrastructure/scheduling/scheduler/storage/run_store.py
+++ b/infrastructure/scheduling/scheduler/storage/run_store.py
@@ -104,6 +104,33 @@ def try_claim(task_id: str, fire_time: str, db_path: Path | None = None) -> Exec
         return None
 
 
+def claim_heartbeat_interval_seconds() -> float:
+    """Return a renewal interval that leaves two lease intervals of safety."""
+    return _CLAIM_LEASE_SECONDS / 3
+
+
+def renew_claim(claim: ExecutionClaim, db_path: Path | None = None) -> bool:
+    """Extend an active claim lease while its owner token is still fenced in."""
+    now = datetime.now(UTC)
+    lease_text = (now + timedelta(seconds=_CLAIM_LEASE_SECONDS)).isoformat()
+    with database.transaction(db_path) as conn:
+        cursor = conn.execute(
+            "UPDATE task_runs SET lease_expires_at = ? "
+            "WHERE task_id = ? AND fire_time = ? AND attempt = ? "
+            "AND owner_token = ? AND status = ?",
+            (
+                lease_text,
+                claim.task_id,
+                claim.fire_time,
+                claim.attempt,
+                claim.owner_token,
+                TaskStatus.RUNNING.value,
+            ),
+        )
+        renewed = cursor.rowcount == 1
+        return renewed
+
+
 def get_expired_claims(
     *, limit: int = _EXPIRED_CLAIM_SCAN_LIMIT, db_path: Path | None = None
 ) -> list[ExpiredClaim]:

--- a/infrastructure/scheduling/scheduler/storage/run_store.py
+++ b/infrastructure/scheduling/scheduler/storage/run_store.py
@@ -38,6 +38,7 @@ class ExecutionClaim:
     fire_time: str
     attempt: int
     owner_token: str
+    lease_expires_at: datetime
     target_filter: frozenset[tuple[Provider, str]] | None = None
 
 
@@ -108,7 +109,14 @@ def try_claim(
                     json.dumps(sorted(target_filter) if target_filter is not None else None),
                 ),
             )
-            return ExecutionClaim(task_id, fire_time, attempt, owner_token, target_filter)
+            return ExecutionClaim(
+                task_id,
+                fire_time,
+                attempt,
+                owner_token,
+                now + timedelta(seconds=_CLAIM_LEASE_SECONDS),
+                target_filter,
+            )
     except sqlite3.IntegrityError:
         return None
 
@@ -118,17 +126,17 @@ def claim_heartbeat_interval_seconds() -> float:
     return _CLAIM_LEASE_SECONDS / 3
 
 
-def renew_claim(claim: ExecutionClaim, db_path: Path | None = None) -> bool:
-    """Extend an active claim lease while its owner token is still fenced in."""
+def renew_claim(claim: ExecutionClaim, db_path: Path | None = None) -> datetime | None:
+    """Extend an active claim and return its new expiry while still fenced in."""
     now = datetime.now(UTC)
-    lease_text = (now + timedelta(seconds=_CLAIM_LEASE_SECONDS)).isoformat()
+    lease_expires_at = now + timedelta(seconds=_CLAIM_LEASE_SECONDS)
     with database.transaction(db_path) as conn:
         cursor = conn.execute(
             "UPDATE task_runs SET lease_expires_at = ? "
             "WHERE task_id = ? AND fire_time = ? AND attempt = ? "
             "AND owner_token = ? AND status = ?",
             (
-                lease_text,
+                lease_expires_at.isoformat(),
                 claim.task_id,
                 claim.fire_time,
                 claim.attempt,
@@ -136,7 +144,7 @@ def renew_claim(claim: ExecutionClaim, db_path: Path | None = None) -> bool:
                 TaskStatus.RUNNING.value,
             ),
         )
-        return cursor.rowcount == 1
+        return lease_expires_at if cursor.rowcount == 1 else None
 
 
 def _decode_target_filter(raw: str) -> frozenset[tuple[Provider, str]] | None:
@@ -368,5 +376,7 @@ __all__ = [
     "get_latest_finished_run",
     "get_latest_targeted_run",
     "get_runs",
+    "claim_heartbeat_interval_seconds",
+    "renew_claim",
     "try_claim",
 ]

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -34,6 +35,7 @@ from infrastructure.scheduling.scheduler.types import (
     TaskStatus,
 )
 from tests.scheduler._bundle import real_runners
+from tests.utils.polling import wait_until
 
 #: Generous enough to survive a loaded CI shard; a real hang still fails fast.
 _SYNC_TIMEOUT_SECONDS = 15.0
@@ -148,9 +150,9 @@ class TestExecutor:
         renewed_after_expiry = threading.Event()
         real_renew_claim = scheduler_executor.renew_claim
 
-        def _renew_and_signal(claim: Any) -> bool:
+        def _renew_and_signal(claim: Any) -> datetime | None:
             result = real_renew_claim(claim)
-            if result and expiry_forced.is_set():
+            if result is not None and expiry_forced.is_set():
                 renewed_after_expiry.set()
             return result
 
@@ -193,9 +195,9 @@ class TestExecutor:
         adapters = _install_fake_bundle()
         ownership_lost = threading.Event()
 
-        def _claim_is_lost(_claim: Any) -> bool:
+        def _claim_is_lost(_claim: Any) -> datetime | None:
             ownership_lost.set()
-            return False
+            return None
 
         def _build_until_ownership_loss(*_args: object) -> str:
             assert ownership_lost.wait(timeout=_SYNC_TIMEOUT_SECONDS)
@@ -227,13 +229,13 @@ class TestExecutor:
         recovered = threading.Event()
         renewal_attempts = 0
 
-        def _renew_with_transient_error(_claim: Any) -> bool:
+        def _renew_with_transient_error(_claim: Any) -> datetime | None:
             nonlocal renewal_attempts
             renewal_attempts += 1
             if renewal_attempts == 1:
                 raise sqlite3.OperationalError("temporary lock")
             recovered.set()
-            return True
+            return datetime.now(UTC) + timedelta(minutes=30)
 
         def _build_until_recovery(*_args: object) -> str:
             assert recovered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
@@ -257,6 +259,32 @@ class TestExecutor:
 
         assert renewal_attempts >= 2
         assert len(adapters[Provider.SLACK].calls) == 1
+
+    def test_persistent_heartbeat_errors_fence_the_expired_claim(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        claim = scheduler_executor.ExecutionClaim(
+            task_id="test_expiring_heartbeat",
+            fire_time="2026-01-01T09:00",
+            attempt=1,
+            owner_token="owner-token",
+            lease_expires_at=datetime.now(UTC) + timedelta(milliseconds=40),
+        )
+        heartbeat = scheduler_executor._ClaimHeartbeat(claim)
+        monkeypatch.setattr(scheduler_executor, "claim_heartbeat_interval_seconds", lambda: 0.01)
+
+        def _renew_with_persistent_error(_claim: Any) -> datetime | None:
+            raise sqlite3.OperationalError("database unavailable")
+
+        monkeypatch.setattr(scheduler_executor, "renew_claim", _renew_with_persistent_error)
+        heartbeat.start()
+        try:
+            wait_until(heartbeat.lost, timeout=_SYNC_TIMEOUT_SECONDS, interval=0.01)
+        finally:
+            heartbeat.stop()
+
+        assert heartbeat.lost()
 
     @pytest.mark.parametrize("delivery_succeeds", [True, False])
     def test_recovered_one_shot_finalizes_only_after_success(

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 
 import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
+import infrastructure.scheduling.scheduler.executor as scheduler_executor
 from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
 from infrastructure.observability.operations_log import read_operations
 from infrastructure.scheduling.scheduler.executor import execute_task
@@ -73,6 +74,22 @@ class _CrashOnceAdapter:
         return True, "", "recovered-message"
 
 
+class _SlowAdapter:
+    """Holds one delivery open so lease renewal can be observed during delivery."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def deliver(self, _task: ScheduledTask, _message: str) -> tuple[bool, str, str]:
+        self.calls += 1
+        self.started.set()
+        if not self.release.wait(timeout=_SYNC_TIMEOUT_SECONDS):
+            return False, "delivery did not finish", ""
+        return True, "", f"message-{self.calls}"
+
+
 def _install_fake_bundle() -> dict[Provider, _FakeAdapter]:
     """Install a fake adapter for every provider; return them to configure/inspect."""
     adapters = {provider: _FakeAdapter() for provider in _DELIVERY_PROVIDERS}
@@ -119,6 +136,56 @@ def _expire_claim(db_path: Path, task_id: str, fire_time: str) -> None:
 
 @pytest.mark.usefixtures("_tmp_stores")
 class TestExecutor:
+    def test_heartbeat_keeps_a_slow_delivery_from_being_reclaimed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        adapter = _SlowAdapter()
+        _install_bundle({Provider.SLACK: adapter})
+        monkeypatch.setattr(scheduler_executor, "claim_heartbeat_interval_seconds", lambda: 0.01)
+        expiry_forced = threading.Event()
+        renewed_after_expiry = threading.Event()
+        real_renew_claim = scheduler_executor.renew_claim
+
+        def _renew_and_signal(claim: Any) -> bool:
+            result = real_renew_claim(claim)
+            if result and expiry_forced.is_set():
+                renewed_after_expiry.set()
+            return result
+
+        monkeypatch.setattr(scheduler_executor, "renew_claim", _renew_and_signal)
+        task = ScheduledTask(
+            id="test_slow_delivery_heartbeat",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+        fire_time = "2026-01-01T09:00"
+        first_result: list[bool] = []
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
+        ):
+            worker = threading.Thread(
+                target=lambda: first_result.append(execute_task(task, fire_time, real_runners()))
+            )
+            worker.start()
+            assert adapter.started.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+            _expire_claim(tmp_path / "scheduler.db", task.id, fire_time)
+            expiry_forced.set()
+            assert renewed_after_expiry.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+
+            assert execute_task(task, fire_time, real_runners()) is False
+            adapter.release.set()
+            worker.join(timeout=_SYNC_TIMEOUT_SECONDS)
+
+        assert not worker.is_alive()
+        assert first_result == [True]
+        assert adapter.calls == 1
+
     def test_crash_before_build_is_recovered_by_a_new_attempt(self, tmp_path: Path) -> None:
         from infrastructure.scheduling.scheduler.storage.run_store import get_runs, try_claim
 

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -219,6 +219,45 @@ class TestExecutor:
 
         assert adapters[Provider.SLACK].calls == []
 
+    def test_transient_heartbeat_error_does_not_abort_execution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        adapters = _install_fake_bundle()
+        recovered = threading.Event()
+        renewal_attempts = 0
+
+        def _renew_with_transient_error(_claim: Any) -> bool:
+            nonlocal renewal_attempts
+            renewal_attempts += 1
+            if renewal_attempts == 1:
+                raise sqlite3.OperationalError("temporary lock")
+            recovered.set()
+            return True
+
+        def _build_until_recovery(*_args: object) -> str:
+            assert recovered.wait(timeout=_SYNC_TIMEOUT_SECONDS)
+            return "Scheduled report"
+
+        monkeypatch.setattr(scheduler_executor, "claim_heartbeat_interval_seconds", lambda: 0.01)
+        monkeypatch.setattr(scheduler_executor, "renew_claim", _renew_with_transient_error)
+        task = ScheduledTask(
+            id="test_transient_heartbeat",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            side_effect=_build_until_recovery,
+        ):
+            assert execute_task(task, "2026-01-01T09:00", real_runners()) is True
+
+        assert renewal_attempts >= 2
+        assert len(adapters[Provider.SLACK].calls) == 1
+
     @pytest.mark.parametrize("delivery_succeeds", [True, False])
     def test_recovered_one_shot_finalizes_only_after_success(
         self, tmp_path: Path, delivery_succeeds: bool

--- a/tests/scheduler/test_run_store.py
+++ b/tests/scheduler/test_run_store.py
@@ -80,13 +80,13 @@ class TestClaimStore:
 
     def test_claim_can_be_renewed_only_by_its_current_owner(self, db_path: Path) -> None:
         first = _claimed(db_path, "task1", "2026-01-01T09:00")
-        assert renew_claim(first, db_path=db_path)
+        assert renew_claim(first, db_path=db_path) is not None
 
         _expire_claim(db_path, "task1", "2026-01-01T09:00")
         second = _claimed(db_path, "task1", "2026-01-01T09:00")
 
-        assert not renew_claim(first, db_path=db_path)
-        assert renew_claim(second, db_path=db_path)
+        assert renew_claim(first, db_path=db_path) is None
+        assert renew_claim(second, db_path=db_path) is not None
 
     def test_expired_lease_is_abandoned_and_reclaimed(self, db_path: Path) -> None:
         first = try_claim("task1", "2026-01-01T09:00", db_path=db_path)

--- a/tests/scheduler/test_run_store.py
+++ b/tests/scheduler/test_run_store.py
@@ -19,6 +19,7 @@ from infrastructure.scheduling.scheduler.storage.run_store import (
     get_latest_finished_run,
     get_latest_targeted_run,
     get_runs,
+    renew_claim,
     try_claim,
 )
 from infrastructure.scheduling.scheduler.types import DeliveryOutcome, Provider, TaskStatus
@@ -76,6 +77,16 @@ class TestClaimStore:
 
         assert first is not None
         assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is None
+
+    def test_claim_can_be_renewed_only_by_its_current_owner(self, db_path: Path) -> None:
+        first = _claimed(db_path, "task1", "2026-01-01T09:00")
+        assert renew_claim(first, db_path=db_path)
+
+        _expire_claim(db_path, "task1", "2026-01-01T09:00")
+        second = _claimed(db_path, "task1", "2026-01-01T09:00")
+
+        assert not renew_claim(first, db_path=db_path)
+        assert renew_claim(second, db_path=db_path)
 
     def test_expired_lease_is_abandoned_and_reclaimed(self, db_path: Path) -> None:
         first = try_claim("task1", "2026-01-01T09:00", db_path=db_path)


### PR DESCRIPTION
  Fixes #6082

  #### Describe the changes you have made in this PR -

  Long-running scheduled tasks could outlive their fixed 30-
  minute claim lease. The recovery sweep could then reclaim
  the task while the original worker was still delivering,
  causing duplicate external messages.

  This change:

  - Adds owner-token-fenced claim renewal.
  - Runs a heartbeat during message building and delivery.
  - Preserves recovery for genuinely crashed workers.
  - Adds regression coverage for slow deliveries and stale
  claim owners.



  Explain your implementation approach:

  The scheduler now renews an active claim approximately every
  third of the lease duration. Renewal is guarded by the task
  ID, fire time, attempt number, owner token, and running
  status, so a reclaimed worker cannot extend a newer attempt.

  The heartbeat stops when execution completes, fails, is
  interrupted, or loses ownership. If the worker genuinely
  dies, the heartbeat stops with it and the existing recovery
  sweep can reclaim the expired task.

