### PR TITLE
feat(onboarding): CI reliability agent demo schedules a local loop and runs it once

### DIFF
--- a/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
+++ b/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
@@ -25,6 +25,7 @@ WHEN TO USE:
 USE THESE TOOLS:
 - `scan_local_git_workspace`
 - `analyze_github_ci_reliability`
+- `schedule_ci_reliability_loop`
 - `ask_user_choice`
 
 DO NOT USE THIS SKILL FOR:
@@ -83,8 +84,11 @@ headers [3/4] and [4/4] only.
    - `Set up an agent that improves CI/CD reliability over time`
    - `Connect OpenSRE to Slack and hand off DevOps chores for your team`
    - `Exit demo`
-   WAIT for the answer. On the first option, load `github-ci-fix-onboarding`
-   and continue there. On the second, check Slack with the CLI tool
+   WAIT for the answer. On the first option, call
+   `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the
+   analyzed repository, output its `response_text` verbatim, and stop; it
+   schedules a weekday 08:00 local check that delivers to this shell's inbox
+   and never posts anywhere else. On the second, check Slack with the CLI tool
    (`/integrations verify slack`); if it is not configured, run
    `opensre integrations setup slack` through the CLI tool, otherwise say it is
    connected. Then explain in two sentences how to hand off a chore from Slack

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -29,6 +29,7 @@ how much developer time does flaky CI cost us
 2. **Pick.** It offers up to three of your repositories that have CI configured, the ones you contributed to first, plus an open-source example, and asks which one to analyze. Without a GitHub token it stops here and shows the setup command.
 3. **Analyze.** It reads the last 30 days of workflow runs and reports the KPIs below.
 4. **Next step.** It offers to set up the CI reliability agent, connect Slack, or exit.
+   The agent option schedules the check described below without leaving the shell.
 
 ## The KPIs
 
@@ -53,6 +54,21 @@ When it attaches several, the run belongs to the merged PR whose lifetime
 contains the run.
 The report also shows the total across all PRs when it differs, the typical
 wait per blocked PR, and the longest wait with its PR.
+
+## The CI reliability agent
+
+Pick "Set up an agent that improves CI/CD reliability over time" from `/demo`
+to schedule the same analysis as a recurring check. The demo scans your
+machine, asks which repository to watch and when to run (weekdays at 08:00
+local time is the default), creates the loop, runs it once, and shows the
+first report. Every run analyzes the last 7 days.
+
+- Reports land in this shell's inbox: `/loops messages`. The loop never posts
+  to Slack or any chat channel, even when those integrations are configured.
+- Manage it with `/loops list`, `/loops stop <id>`, and `/loops delete <id>`.
+- The loop fires while the shell is open. To run it when the shell is closed,
+  start the scheduler with `opensre cron start` or run the gateway.
+- Running the demo again for the same repository reuses the existing loop.
 
 ## Limits
 

--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -37,6 +37,12 @@ _LAZY_EXPORTS: dict[str, str] = {
     "GitHubDeviceFlowError": "integrations.github.mcp_oauth",
     "authorize_github_via_device_flow": "integrations.github.mcp_oauth",
     "disconnect_personal_github": "integrations.github.personal_account",
+    "DEFAULT_LOOP_TIME": "integrations.github.tools.ci_analytics.loop",
+    "ScheduledLoop": "integrations.github.tools.ci_analytics.loop",
+    "local_timezone": "integrations.github.tools.ci_analytics.loop",
+    "loop_card": "integrations.github.tools.ci_analytics.loop",
+    "report_looks_complete": "integrations.github.tools.ci_analytics.loop",
+    "schedule_ci_reliability_loop": "integrations.github.tools.ci_analytics.loop",
 }
 
 
@@ -80,11 +86,20 @@ if TYPE_CHECKING:
         open_pull_request,
         resolve_repo_scope,
     )
+    from integrations.github.tools.ci_analytics.loop import (
+        DEFAULT_LOOP_TIME,
+        ScheduledLoop,
+        local_timezone,
+        loop_card,
+        report_looks_complete,
+        schedule_ci_reliability_loop,
+    )
 
 
 __all__ = [
     "DEFAULT_GITHUB_MCP_MODE",
     "DEFAULT_GITHUB_MCP_URL",
+    "DEFAULT_LOOP_TIME",
     "ERR_GITHUB_TOKEN",
     "GitHubApiError",
     "GitHubDeviceCode",
@@ -95,6 +110,7 @@ __all__ = [
     "GitHubPullRequestError",
     "GitHubRestClient",
     "PullRequest",
+    "ScheduledLoop",
     "authenticate_and_configure_github",
     "authorize_github_via_device_flow",
     "build_github_mcp_config",
@@ -102,10 +118,14 @@ __all__ = [
     "format_github_mcp_validation_cli_report",
     "github_creds",
     "github_integration_is_configured",
+    "local_timezone",
+    "loop_card",
     "open_pull_request",
     "print_github_mcp_validation_report",
+    "report_looks_complete",
     "resolve_github_token",
     "resolve_repo_scope",
     "saved_github_username",
+    "schedule_ci_reliability_loop",
     "validate_github_mcp_config",
 ]

--- a/integrations/github/tools/ci_analytics/__init__.py
+++ b/integrations/github/tools/ci_analytics/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-TOOL_MODULES = ("tool",)
+TOOL_MODULES = ("tool", "loop_tool")
 
 __all__ = ["TOOL_MODULES"]

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -1,0 +1,136 @@
+"""The recurring CI reliability check: a prompt loop that re-runs the analytics for one repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from config.runtime_metadata.probes import local_tz_name
+from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+from infrastructure.scheduling.scheduler.loops import (
+    ManualLoop,
+    create_manual_loop,
+    loop_channels,
+    loop_time_label,
+)
+from infrastructure.scheduling.scheduler.storage import list_tasks
+from infrastructure.scheduling.scheduler.types import Provider, TaskKind
+
+DEFAULT_LOOP_TIME = "08:00"
+LOOP_WINDOW_DAYS = 7
+_LOCAL_CHANNEL = Provider.INTERACTIVE_SHELL.value
+
+
+@dataclass(frozen=True)
+class ScheduledLoop:
+    """The persisted loop and whether it already existed."""
+
+    loop: ManualLoop
+    reused: bool
+
+    @property
+    def task_id(self) -> str:
+        return self.loop.task.id
+
+
+def loop_name(owner: str, repo: str) -> str:
+    return f"CI reliability check · {owner}/{repo}"
+
+
+def loop_prompt(owner: str, repo: str) -> str:
+    """The report request the loop runs unattended on every tick."""
+    return (
+        f"Scheduled CI/CD reliability report for {owner}/{repo}. First call "
+        f'analyze_github_ci_reliability(owner="{owner}", repo="{repo}", days={LOOP_WINDOW_DAYS}); '
+        "this read-only tool is the only source of the report. The report body is the tool's "
+        "response_text followed by its headline, exactly as returned: do not compute, convert, "
+        "reword, or omit any figure, and never answer without the tool result."
+    )
+
+
+def report_looks_complete(report: str, owner: str, repo: str) -> bool:
+    """True when a delivered report carries the analytics header for ``owner/repo``."""
+    return f"CI/CD reliability for {owner}/{repo}" in report
+
+
+def schedule_ci_reliability_loop(
+    owner: str,
+    repo: str,
+    *,
+    time_text: str = DEFAULT_LOOP_TIME,
+    weekdays: bool = True,
+    timezone: str = "",
+    store_path: Path | None = None,
+) -> ScheduledLoop:
+    """Create the loop for ``owner/repo``, or return the one that already exists.
+
+    Delivery is pinned to this machine's shell inbox so a scheduled report can
+    never post to a chat channel by accident. Raises ``ValueError`` for a time
+    the scheduler cannot parse.
+    """
+    prompt = loop_prompt(owner, repo)
+    existing = next(
+        (
+            task
+            for task in list_tasks(store_path)
+            if task.kind is TaskKind.MANUAL_LOOP and task.params.get(LOOP_PROMPT_PARAM) == prompt
+        ),
+        None,
+    )
+    if existing is not None:
+        loop = ManualLoop(
+            task=existing,
+            channels=loop_channels(existing),
+            next_run=existing.next_run,
+        )
+        return ScheduledLoop(loop=loop, reused=True)
+    created = create_manual_loop(
+        name=loop_name(owner, repo),
+        prompt=prompt,
+        time_text=time_text,
+        timezone=timezone or local_timezone(),
+        weekdays=weekdays,
+        channels=(_LOCAL_CHANNEL,),
+        store_path=store_path,
+    )
+    return ScheduledLoop(loop=created, reused=False)
+
+
+def local_timezone() -> str:
+    """This machine's IANA timezone, or UTC when it cannot be resolved."""
+    name = local_tz_name()
+    try:
+        ZoneInfo(name)
+    except (KeyError, ValueError, OSError):
+        return "UTC"
+    return name
+
+
+def loop_card(scheduled: ScheduledLoop) -> list[str]:
+    """Plain lines describing the loop: schedule, next run, where reports land."""
+    task = scheduled.loop.task
+    verb = "Already scheduled" if scheduled.reused else "Scheduled"
+    when = loop_time_label(task.cron) or task.cron
+    cadence = "weekdays" if task.cron.split()[-1] == "1-5" else "every day"
+    lines = [
+        f"{verb}: {task.name}",
+        f"Runs {cadence} at {when} {task.timezone}; next run {scheduled.loop.next_run or 'pending'}.",
+        "Each report lands in this shell's inbox: /loops messages. "
+        f"Manage it with /loops list, /loops stop {task.id}, /loops delete {task.id}.",
+        "It runs while the shell is open, or under `opensre cron start` when it is not.",
+    ]
+    return lines
+
+
+__all__ = [
+    "DEFAULT_LOOP_TIME",
+    "LOOP_WINDOW_DAYS",
+    "ScheduledLoop",
+    "local_timezone",
+    "loop_card",
+    "loop_name",
+    "loop_prompt",
+    "report_looks_complete",
+    "schedule_ci_reliability_loop",
+]

--- a/integrations/github/tools/ci_analytics/loop_tool.py
+++ b/integrations/github/tools/ci_analytics/loop_tool.py
@@ -1,0 +1,98 @@
+"""Action tool that schedules the recurring CI reliability check for one repository."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.domain.types.tools import ToolSurface
+from core.tool import SideEffectLevel
+from core.tool_framework import tool
+from integrations.github.tools.ci_analytics import loop as ci_loop
+
+TOOL_NAME = "schedule_ci_reliability_loop"
+
+
+@tool(
+    name="schedule_ci_reliability_loop",
+    source="github",
+    display_name="Schedule CI reliability check",
+    description=(
+        "Schedule a recurring CI/CD reliability check for one repository: a local "
+        "prompt loop that re-runs the reliability analytics and delivers the report "
+        "to this shell's inbox. Weekdays at 08:00 local time unless told otherwise. "
+        "Never posts to Slack or any chat channel. Returns the schedule to repeat "
+        "verbatim."
+    ),
+    use_cases=[
+        "Set up an agent that improves CI/CD reliability over time",
+        "Schedule a daily CI reliability report for owner/repo",
+        "Watch our CI reliability every weekday morning",
+    ],
+    anti_examples=[
+        "Analyzing CI reliability once, right now (use analyze_github_ci_reliability)",
+        "Delivering a report to Slack or Telegram (use propose_scheduled_delivery)",
+        "Fixing a failing check (use fix_github_pr_ci)",
+    ],
+    requires=[],
+    outputs={
+        "task_id": "Id of the scheduled loop, for /loops commands",
+        "next_run": "When the loop fires next",
+        "reused": "True when the repository already had this loop",
+        "response_text": "The schedule card, to repeat verbatim",
+    },
+    surfaces=(ToolSurface.ACTION,),
+    side_effect_level=SideEffectLevel.MUTATING,
+    parallel_safe=False,
+    input_schema={
+        "type": "object",
+        "properties": {
+            "owner": {"type": "string", "description": "Repository owner."},
+            "repo": {"type": "string", "description": "Repository name."},
+            "time": {
+                "type": "string",
+                "description": "Local time of day such as 08:00 or 7:30am; default 08:00.",
+            },
+            "weekdays": {
+                "type": "boolean",
+                "description": "Run Monday to Friday only (default true); false runs every day.",
+            },
+        },
+        "required": ["owner", "repo"],
+        "additionalProperties": False,
+    },
+    tags=("safe",),
+)
+def schedule_ci_reliability_loop(
+    owner: str,
+    repo: str,
+    time: str | None = None,
+    weekdays: bool | None = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    owner = owner.strip()
+    repo = repo.strip()
+    if not owner or not repo:
+        return {"ok": False, "error": "owner and repo are required."}
+    try:
+        scheduled = ci_loop.schedule_ci_reliability_loop(
+            owner,
+            repo,
+            time_text=(time or ci_loop.DEFAULT_LOOP_TIME).strip() or ci_loop.DEFAULT_LOOP_TIME,
+            weekdays=True if weekdays is None else weekdays,
+        )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    task = scheduled.loop.task
+    return {
+        "ok": True,
+        "task_id": task.id,
+        "name": task.name,
+        "cron": task.cron,
+        "timezone": task.timezone,
+        "next_run": scheduled.loop.next_run,
+        "reused": scheduled.reused,
+        "response_text": "\n".join(ci_loop.loop_card(scheduled)),
+    }
+
+
+__all__ = ["TOOL_NAME", "schedule_ci_reliability_loop"]

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -61,12 +61,18 @@ def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
 
 
 def _console(context: Any) -> Any:
+    """The terminal to paint on, or None when the caller only reads the result.
+
+    A headless run (scheduled loop, gateway) carries a capture console; painting
+    there would hide the report, so it is returned as text instead.
+    """
     if context is None:
         return None
     try:
-        return action_context_from_agent_context(context).console
+        console = action_context_from_agent_context(context).console
     except RuntimeError:
         return None
+    return console if getattr(console, "is_terminal", False) else None
 
 
 def _failure_message(exc: Exception, *, repository: str) -> str:

--- a/surfaces/interactive_shell/command_registry/loops_cmds.py
+++ b/surfaces/interactive_shell/command_registry/loops_cmds.py
@@ -427,15 +427,9 @@ def _cmd_loops_messages(session: Session, console: Console, args: list[str]) -> 
 
 
 def _run_loop_task_ids_once(console: Console, task_ids: tuple[str, ...]) -> bool:
-    from bootstrap.adapters import scheduler_runners
-    from bootstrap.process import SCHEDULED_COMMAND_PROFILE, configure_process
-    from infrastructure.scheduling.scheduler.runner import run_task_now
+    from surfaces.interactive_shell.runtime.loop_scheduler import run_loop_now
 
-    configure_process(SCHEDULED_COMMAND_PROFILE)
-    failures: list[str] = []
-    for task_id in task_ids:
-        if not run_task_now(task_id, scheduler_runners()):
-            failures.append(task_id)
+    failures = [task_id for task_id in task_ids if not run_loop_now(task_id)]
 
     if failures:
         console.print(

--- a/surfaces/interactive_shell/runtime/loop_scheduler.py
+++ b/surfaces/interactive_shell/runtime/loop_scheduler.py
@@ -50,6 +50,15 @@ def reload_loop_scheduler() -> int:
         return _start_locked()
 
 
+def run_loop_now(task_id: str) -> bool:
+    """Fire one loop task immediately in this process; False when the run failed."""
+    from bootstrap.adapters import scheduler_runners
+    from infrastructure.scheduling.scheduler.runner import run_task_now
+
+    configure_process(SCHEDULED_COMMAND_PROFILE)
+    return run_task_now(task_id, scheduler_runners())
+
+
 def shutdown_loop_scheduler() -> None:
     """Stop the shell-local prompt-loop scheduler."""
     with _scheduler_lock:
@@ -106,6 +115,7 @@ def _shutdown_locked() -> None:
 
 __all__ = [
     "reload_loop_scheduler",
+    "run_loop_now",
     "shutdown_loop_scheduler",
     "start_loop_scheduler",
 ]

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -11,6 +11,10 @@ analysis and the next-step offer. Mid-turn menus cannot open inside an
 auto-submitted turn, so every choice that needs a menu happens before the turn
 starts. Routing of the prompt itself stays with the action agent (no intent
 heuristics — see ``surfaces/interactive_shell/AGENTS.md``).
+
+The CI reliability agent demo is deterministic end to end: the same scan and
+repository picker, a schedule picker, the loop is created and run once, and
+its first report is shown from the shell inbox.
 """
 
 from __future__ import annotations
@@ -22,6 +26,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from rich.markdown import Markdown
 from rich.markup import escape
 from rich.text import Text
 
@@ -32,8 +37,18 @@ from infrastructure.analytics.capture import (
     capture_onboarding_demo_skipped,
 )
 from infrastructure.analytics.source import is_test_run
+from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
+from infrastructure.scheduling.scheduler.loops import parse_loop_time
 from infrastructure.terminal.theme import DIM, WARNING
 from integrations.github import resolve_github_token
+from integrations.github.tools.ci_analytics.loop import (
+    DEFAULT_LOOP_TIME,
+    local_timezone,
+    loop_card,
+    report_looks_complete,
+    schedule_ci_reliability_loop,
+)
+from surfaces.interactive_shell.runtime.loop_scheduler import reload_loop_scheduler, run_loop_now
 from surfaces.interactive_shell.ui.streaming.renderer import render_note_block, reply_gutter
 from surfaces.shared.terminal.components.choice_menu import (
     repl_choose_one,
@@ -71,6 +86,24 @@ _TOKEN_MISSING = (
 )
 _MAX_OWN_REPOSITORIES = 3
 _SCAN_DAYS = 30
+_LOOP_REPOSITORY_TITLE = "Which repository should the agent watch?"
+_LOOP_TIME_TITLE = "When should it run?"
+_LOOP_TIME_CUSTOM_LABEL = "Or type a time like 07:30..."
+_LOOP_WEEKDAYS = "weekdays"
+_LOOP_DAILY = "daily"
+_LOOP_TOKEN_MISSING = (
+    "The agent reads GitHub Actions history on every run, which needs a GitHub token. "
+    "Run `opensre integrations setup github`, then `/demo` to continue."
+)
+_LOOP_FIRST_PASS_FAILED = (
+    "The first pass did not produce the report; the schedule stays in place. "
+    "Retry with `/loops run {task_id}` or check `/cron logs {task_id}`."
+)
+_NEXT_TITLE = "What would you like to do next?"
+_NEXT_SLACK = "slack"
+_NEXT_EXIT = "exit"
+_NEXT_EXIT_LABEL = "Exit demo"
+_DEMO_EXITED = "Demo exited. Run /demo any time to pick another one."
 
 OPTION_CI_ANALYTICS = "ci_analytics"
 OPTION_CI_AGENT = "ci_agent"
@@ -87,8 +120,8 @@ class DemoSuggestion:
     label: str
     """Menu row shown to the user."""
 
-    prompt: str
-    """Canned prompt auto-submitted as the first turn when selected."""
+    prompt: str = ""
+    """Canned prompt auto-submitted as the first turn when selected; empty for deterministic demos."""
 
 
 DEMO_SUGGESTIONS: tuple[DemoSuggestion, ...] = (
@@ -104,10 +137,6 @@ DEMO_SUGGESTIONS: tuple[DemoSuggestion, ...] = (
     DemoSuggestion(
         option=OPTION_CI_AGENT,
         label="Set up an agent that improves CI/CD reliability over time",
-        prompt=(
-            "Onboard me on the CI/CD fixing flow for the current repository, then set up "
-            "a read-only recurring weekday CI health check at 8:00 AM."
-        ),
     ),
     DemoSuggestion(
         option=OPTION_SLACK,
@@ -171,8 +200,9 @@ def offer_demo(session: Session, console: Console | None = None, *, force: bool 
             session.terminal.set_auto_prompt(selected)
             return True
         capture_onboarding_demo_selected(option=suggestion.option, custom=False)
-        if suggestion.option == OPTION_CI_ANALYTICS:
-            started = _start_ci_analytics_demo(session, console, suggestion)
+        starter = _DEMO_STARTERS.get(suggestion.option)
+        if starter is not None:
+            started = starter(session, console, suggestion)
             if started:
                 _record(suggestion.option)
             return started
@@ -184,10 +214,8 @@ def offer_demo(session: Session, console: Console | None = None, *, force: bool 
         return False
 
 
-def _start_ci_analytics_demo(
-    session: Session, console: Console | None, suggestion: DemoSuggestion
-) -> bool:
-    """Scan, let the user pick a repository, then queue the analysis prompt."""
+def _scan_and_show(console: Console | None) -> WorkspaceSnapshot:
+    """Scan the home directory under a spinner and paint the activity chart."""
     home = Path.home()
     if console is not None:
         with llm_loader(console, f"Scanning {escape(str(home))} for git repositories"):
@@ -201,9 +229,21 @@ def _start_ci_analytics_demo(
         render_note_block(console, _SNAPSHOT_LEAD)
         console.print(reply_gutter(snapshot_renderable(snapshot), lead=False))
         console.print()
+    return snapshot
+
+
+def _warn(console: Console | None, text: str) -> None:
+    if console is not None:
+        console.print(reply_gutter(Text(text, style=str(WARNING)), lead=False))
+
+
+def _start_ci_analytics_demo(
+    session: Session, console: Console | None, suggestion: DemoSuggestion
+) -> bool:
+    """Scan, let the user pick a repository, then queue the analysis prompt."""
+    snapshot = _scan_and_show(console)
     if not resolve_github_token(None):
-        if console is not None:
-            console.print(reply_gutter(Text(_TOKEN_MISSING, style=str(WARNING)), lead=False))
+        _warn(console, _TOKEN_MISSING)
         return False
     repository = choose_repository(snapshot)
     if repository is None:
@@ -222,15 +262,113 @@ def _start_ci_analytics_demo(
     return True
 
 
-def choose_repository(snapshot: WorkspaceSnapshot) -> str | None:
-    """Ask which repository to analyze; ``None`` when the user escapes."""
+def _start_ci_agent_demo(
+    session: Session, console: Console | None, _suggestion: DemoSuggestion
+) -> bool:
+    """Scan, pick a repository and a time, schedule the loop, run it once, offer Slack."""
+    snapshot = _scan_and_show(console)
+    if not resolve_github_token(None):
+        _warn(console, _LOOP_TOKEN_MISSING)
+        return False
+    repository = choose_repository(snapshot, title=_LOOP_REPOSITORY_TITLE)
+    if repository is None:
+        return False
+    owner, _, repo = repository.partition("/")
+    if not owner or not repo:
+        _warn(console, f"{repository!r} is not a GitHub repository; use the owner/name form.")
+        return False
+    try:
+        schedule = choose_loop_time()
+        if schedule is None:
+            return False
+        time_text, weekdays = schedule
+        scheduled = schedule_ci_reliability_loop(
+            owner, repo, time_text=time_text, weekdays=weekdays, timezone=local_timezone()
+        )
+    except ValueError as exc:
+        _warn(console, f"Could not schedule the check: {exc}")
+        return False
+    reload_loop_scheduler()
+    if console is not None:
+        headline, *details = loop_card(scheduled)
+        console.print()
+        render_note_block(console, headline)
+        console.print(reply_gutter(Text("\n".join(details)), lead=False))
+        console.print()
+    _record(OPTION_CI_AGENT)
+    _run_first_pass(console, scheduled.task_id, owner=owner, repo=repo)
+    return _offer_after_loop(session, console)
+
+
+def choose_loop_time() -> tuple[str, bool] | None:
+    """Ask when the loop runs: ``(time_text, weekdays)`` or ``None`` when the user escapes."""
+    timezone = local_timezone()
+    selected = repl_choose_one(
+        title=_LOOP_TIME_TITLE,
+        choices=[
+            (_LOOP_WEEKDAYS, f"Weekdays at {DEFAULT_LOOP_TIME} {timezone} (recommended)"),
+            (_LOOP_DAILY, f"Every day at {DEFAULT_LOOP_TIME} {timezone}"),
+            (_CUSTOM_OPTION, _LOOP_TIME_CUSTOM_LABEL),
+        ],
+        custom_label=_LOOP_TIME_CUSTOM_LABEL,
+        letter_keys=True,
+        header=_MENU_HEADER,
+    )
+    if selected is None or selected.strip() in {"", _CUSTOM_OPTION, _LOOP_TIME_CUSTOM_LABEL}:
+        return None
+    if selected == _LOOP_WEEKDAYS:
+        return DEFAULT_LOOP_TIME, True
+    if selected == _LOOP_DAILY:
+        return DEFAULT_LOOP_TIME, False
+    parse_loop_time(selected)
+    return selected.strip(), True
+
+
+def _run_first_pass(console: Console | None, task_id: str, *, owner: str, repo: str) -> None:
+    """Run the loop once now and show the delivered report from the inbox."""
+    if console is not None:
+        with llm_loader(console, "Running the first pass now; about a minute"):
+            delivered = run_loop_now(task_id)
+    else:
+        delivered = run_loop_now(task_id)
+    report = next((m.message for m in get_loop_messages(limit=20) if m.task_id == task_id), "")
+    if not delivered or not report_looks_complete(report, owner, repo):
+        _warn(console, _LOOP_FIRST_PASS_FAILED.format(task_id=task_id))
+        return
+    if console is not None:
+        console.print()
+        render_note_block(console, "The first report, as it will land in /loops messages:")
+        console.print(reply_gutter(Markdown(report), lead=False))
+        console.print()
+
+
+def _offer_after_loop(session: Session, console: Console | None) -> bool:
+    """Offer the Slack demo as the next step; ``True`` when its prompt was queued."""
+    slack = _suggestion_for(OPTION_SLACK)
+    assert slack is not None
+    selected = repl_choose_one(
+        title=_NEXT_TITLE,
+        choices=[(_NEXT_SLACK, slack.label), (_NEXT_EXIT, _NEXT_EXIT_LABEL)],
+        letter_keys=True,
+        header=_MENU_HEADER,
+    )
+    if selected == _NEXT_SLACK:
+        session.terminal.set_auto_command(slack.prompt)
+        return True
+    if console is not None:
+        render_note_block(console, _DEMO_EXITED)
+    return False
+
+
+def choose_repository(snapshot: WorkspaceSnapshot, *, title: str = _REPOSITORY_TITLE) -> str | None:
+    """Ask which repository to use; ``None`` when the user escapes."""
     choices = [
         (repo.github_full_name, _candidate_label(repo)) for repo in suitable_repositories(snapshot)
     ]
     choices.append((EXAMPLE_REPOSITORY, _EXAMPLE_LABEL))
     choices.append((_CUSTOM_OPTION, _CUSTOM_LABEL))
     selected = repl_choose_one(
-        title=_REPOSITORY_TITLE,
+        title=title,
         choices=choices,
         custom_label=_CUSTOM_LABEL,
         letter_keys=True,
@@ -240,6 +378,12 @@ def choose_repository(snapshot: WorkspaceSnapshot) -> str | None:
         return None
     assert selected is not None
     return selected.strip()
+
+
+_DEMO_STARTERS = {
+    OPTION_CI_ANALYTICS: _start_ci_analytics_demo,
+    OPTION_CI_AGENT: _start_ci_agent_demo,
+}
 
 
 def _suggestion_for(option: str) -> DemoSuggestion | None:

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -40,12 +40,12 @@ from infrastructure.analytics.source import is_test_run
 from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
 from infrastructure.scheduling.scheduler.loops import parse_loop_time
 from infrastructure.terminal.theme import DIM, WARNING
-from integrations.github import resolve_github_token
-from integrations.github.tools.ci_analytics.loop import (
+from integrations.github import (
     DEFAULT_LOOP_TIME,
     local_timezone,
     loop_card,
     report_looks_complete,
+    resolve_github_token,
     schedule_ci_reliability_loop,
 )
 from surfaces.interactive_shell.runtime.loop_scheduler import reload_loop_scheduler, run_loop_now

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -196,3 +196,167 @@ def test_force_reopens_the_picker_after_it_was_recorded(
 
     assert demo_picker.offer_demo(session, None) is False
     assert demo_picker.offer_demo(session, None, force=True) is True
+
+
+def _scheduled_stub(owner: str, repo: str) -> object:
+    from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+    from infrastructure.scheduling.scheduler.loops import ManualLoop
+    from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, TaskKind
+    from integrations.github.tools.ci_analytics.loop import ScheduledLoop, loop_name, loop_prompt
+
+    task = ScheduledTask(
+        id="loop1",
+        name=loop_name(owner, repo),
+        kind=TaskKind.MANUAL_LOOP,
+        cron="0 8 * * 1-5",
+        timezone="UTC",
+        provider=Provider.INTERACTIVE_SHELL,
+        window_hours=24,
+        enabled=True,
+        params={LOOP_PROMPT_PARAM: loop_prompt(owner, repo)},
+    )
+    loop = ManualLoop(
+        task=task, channels=(Provider.INTERACTIVE_SHELL,), next_run="2026-09-08 08:00"
+    )
+    return ScheduledLoop(loop=loop, reused=False)
+
+
+def _agent_demo_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[dict[str, object]]:
+    """Fake the scheduler side of the agent demo; returns the schedule calls made."""
+    from infrastructure.scheduling.scheduler.local_delivery import LocalLoopMessage
+
+    _offerable(monkeypatch, tmp_path)
+    calls: list[dict[str, object]] = []
+
+    def schedule(owner: str, repo: str, **kwargs: object) -> object:
+        calls.append({"owner": owner, "repo": repo, **kwargs})
+        return _scheduled_stub(owner, repo)
+
+    def messages(limit: int = 20) -> list[LocalLoopMessage]:
+        return [
+            LocalLoopMessage(
+                message_id="local:1",
+                task_id="loop1",
+                loop_id="loop1",
+                name="CI reliability check",
+                created_at="2026-09-07T18:00:00+00:00",
+                message="**CI/CD reliability for me/mine, last 7 days**",
+                prompt="",
+            )
+        ]
+
+    monkeypatch.setattr(demo_picker, "schedule_ci_reliability_loop", schedule)
+    monkeypatch.setattr(demo_picker, "local_timezone", lambda: "UTC")
+    monkeypatch.setattr(demo_picker, "reload_loop_scheduler", lambda: 1)
+    monkeypatch.setattr(demo_picker, "run_loop_now", lambda _task_id: True)
+    monkeypatch.setattr(demo_picker, "get_loop_messages", messages)
+    return calls
+
+
+def test_agent_demo_schedules_the_loop_runs_it_once_and_shows_the_report(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Arrange: pick the agent demo, the user's repository, weekdays, then exit.
+    calls = _agent_demo_ready(monkeypatch, tmp_path)
+    menus = _answers(monkeypatch, demo_picker.OPTION_CI_AGENT, "me/mine", "weekdays", "exit")
+    session = Session()
+    console, buf = _capture()
+
+    # Act
+    queued = demo_picker.offer_demo(session, console)
+
+    # Assert: loop created for the pick, weekdays at 08:00, card and first report shown.
+    assert queued is False
+    assert calls == [
+        {"owner": "me", "repo": "mine", "time_text": "08:00", "weekdays": True, "timezone": "UTC"}
+    ]
+    titles = [menu["title"] for menu in menus]
+    assert titles == [
+        "Which demo would you like me to run? (Esc to skip)",
+        "Which repository should the agent watch?",
+        "When should it run?",
+        "What would you like to do next?",
+    ]
+    assert all(menu["header"] == "Ask User" for menu in menus)
+    output = buf.getvalue()
+    assert "Scheduled: CI reliability check · me/mine" in output
+    assert "/loops messages" in output
+    assert "CI/CD reliability for me/mine, last 7 days" in output
+    assert "Demo exited" in output
+    assert session.terminal.pending_prompt_autosubmit is False
+
+
+def test_agent_demo_warns_when_the_first_pass_skipped_the_analysis(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Arrange: the loop ran, but the model answered without the analytics header.
+    from infrastructure.scheduling.scheduler.local_delivery import LocalLoopMessage
+
+    _agent_demo_ready(monkeypatch, tmp_path)
+    refusal = LocalLoopMessage(
+        message_id="local:2",
+        task_id="loop1",
+        loop_id="loop1",
+        name="CI reliability check",
+        created_at="2026-09-07T18:00:00+00:00",
+        message="Report unavailable: no report scope was provided.",
+        prompt="",
+    )
+    monkeypatch.setattr(demo_picker, "get_loop_messages", lambda **_kw: [refusal])
+    _answers(monkeypatch, demo_picker.OPTION_CI_AGENT, "me/mine", "weekdays", "exit")
+    session = Session()
+    console, buf = _capture()
+
+    # Act
+    demo_picker.offer_demo(session, console)
+
+    # Assert: the refusal is not shown as the report; the retry command names the loop.
+    output = " ".join(buf.getvalue().split())
+    assert "Report unavailable" not in output
+    assert "/loops run loop1" in output
+
+
+def test_agent_demo_hands_off_to_the_slack_demo_when_chosen(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _agent_demo_ready(monkeypatch, tmp_path)
+    _answers(monkeypatch, demo_picker.OPTION_CI_AGENT, "me/mine", "daily", "slack")
+    session = Session()
+    console, _buf = _capture()
+
+    queued = demo_picker.offer_demo(session, console)
+
+    assert queued is True
+    assert session.terminal.pending_prompt_autosubmit is True
+    assert "Slack" in session.terminal.pending_prompt_default
+
+
+def test_agent_demo_rejects_an_unparseable_custom_time_without_scheduling(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls = _agent_demo_ready(monkeypatch, tmp_path)
+    _answers(monkeypatch, demo_picker.OPTION_CI_AGENT, "me/mine", "half past eight")
+    session = Session()
+    console, buf = _capture()
+
+    queued = demo_picker.offer_demo(session, console)
+
+    assert queued is False
+    assert calls == []
+    assert "Could not schedule the check" in buf.getvalue()
+
+
+def test_agent_demo_stops_with_setup_hint_when_no_github_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls = _agent_demo_ready(monkeypatch, tmp_path)
+    monkeypatch.setattr(demo_picker, "resolve_github_token", lambda _token: "")
+    _answers(monkeypatch, demo_picker.OPTION_CI_AGENT)
+    session = Session()
+    console, buf = _capture()
+
+    queued = demo_picker.offer_demo(session, console)
+
+    assert queued is False
+    assert calls == []
+    assert "opensre integrations setup github" in " ".join(buf.getvalue().split())

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -1,0 +1,108 @@
+"""Tests for the recurring CI reliability check: loop creation and its action tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
+from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+from infrastructure.scheduling.scheduler.storage import list_tasks
+from infrastructure.scheduling.scheduler.types import Provider, TaskKind
+from integrations.github.tools.ci_analytics import loop as ci_loop
+from integrations.github.tools.ci_analytics import loop_tool
+
+
+@pytest.fixture
+def store_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv(OPENSRE_OPERATIONS_LOG_PATH_ENV, str(tmp_path / "operations.jsonl"))
+    return tmp_path / "scheduler_tasks.json"
+
+
+def test_loop_is_a_weekday_manual_loop_delivered_only_to_this_shell(store_path: Path) -> None:
+    # Act
+    scheduled = ci_loop.schedule_ci_reliability_loop(
+        "acme", "app", timezone="UTC", store_path=store_path
+    )
+
+    # Assert: the prompt names the repository, delivery cannot reach a chat channel.
+    task = scheduled.loop.task
+    assert scheduled.reused is False
+    assert task.kind is TaskKind.MANUAL_LOOP
+    assert task.cron == "0 8 * * 1-5"
+    assert task.timezone == "UTC"
+    assert scheduled.loop.channels == (Provider.INTERACTIVE_SHELL,)
+    assert "acme/app" in task.params[LOOP_PROMPT_PARAM]
+    assert "analyze_github_ci_reliability" in task.params[LOOP_PROMPT_PARAM]
+    assert [t.id for t in list_tasks(store_path)] == [task.id]
+
+
+def test_scheduling_the_same_repository_again_reuses_the_loop(store_path: Path) -> None:
+    # Arrange
+    first = ci_loop.schedule_ci_reliability_loop(
+        "acme", "app", timezone="UTC", store_path=store_path
+    )
+
+    # Act: a different time must not create a second loop for the same repository.
+    second = ci_loop.schedule_ci_reliability_loop(
+        "acme", "app", time_text="07:30", weekdays=False, timezone="UTC", store_path=store_path
+    )
+
+    # Assert
+    assert second.reused is True
+    assert second.task_id == first.task_id
+    assert len(list_tasks(store_path)) == 1
+    assert ci_loop.loop_card(second)[0].startswith("Already scheduled")
+
+
+def test_unparseable_time_raises_before_anything_is_stored(store_path: Path) -> None:
+    with pytest.raises(ValueError):
+        ci_loop.schedule_ci_reliability_loop(
+            "acme", "app", time_text="half past eight", timezone="UTC", store_path=store_path
+        )
+    assert list_tasks(store_path) == []
+
+
+def test_tool_returns_the_card_and_reports_a_bad_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange: the tool schedules through the loop module; pin the store to a fake.
+    calls: list[dict[str, object]] = []
+
+    def fake_schedule(owner: str, repo: str, **kwargs: object) -> object:
+        calls.append({"owner": owner, "repo": repo, **kwargs})
+        if kwargs["time_text"] == "noon-ish":
+            raise ValueError("time must look like 08:30")
+        return _scheduled_stub(owner, repo)
+
+    monkeypatch.setattr(ci_loop, "schedule_ci_reliability_loop", fake_schedule)
+
+    # Act
+    ok = loop_tool.schedule_ci_reliability_loop(owner="acme", repo="app")
+    bad = loop_tool.schedule_ci_reliability_loop(owner="acme", repo="app", time="noon-ish")
+
+    # Assert
+    assert ok["ok"] is True
+    assert ok["task_id"] == "task1"
+    assert "/loops messages" in ok["response_text"]
+    assert calls[0]["time_text"] == ci_loop.DEFAULT_LOOP_TIME
+    assert calls[0]["weekdays"] is True
+    assert bad == {"ok": False, "error": "time must look like 08:30"}
+
+
+def _scheduled_stub(owner: str, repo: str) -> ci_loop.ScheduledLoop:
+    from infrastructure.scheduling.scheduler.loops import ManualLoop
+    from infrastructure.scheduling.scheduler.types import ScheduledTask
+
+    task = ScheduledTask(
+        id="task1",
+        name=ci_loop.loop_name(owner, repo),
+        kind=TaskKind.MANUAL_LOOP,
+        cron="0 8 * * 1-5",
+        timezone="UTC",
+        provider=Provider.INTERACTIVE_SHELL,
+        window_hours=24,
+        enabled=True,
+        params={LOOP_PROMPT_PARAM: ci_loop.loop_prompt(owner, repo)},
+    )
+    loop = ManualLoop(task=task, channels=(Provider.INTERACTIVE_SHELL,), next_run="soon")
+    return ci_loop.ScheduledLoop(loop=loop, reused=False)

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1019,7 +1019,7 @@ def test_tool_shows_progress_lines_around_the_painted_report() -> None:
     from core.tool.contracts import AgentToolContext
 
     buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False, width=120)
+    console = Console(file=buf, force_terminal=True, color_system=None, width=120)
     scope = ActionToolScope(session=None, console=console)
     context = AgentToolContext(
         resolved_integrations={}, resources={ACTION_TOOL_CONTEXT_RESOURCE_KEY: scope}

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -938,6 +938,9 @@ _TOOLS_WITHOUT_DELIBERATE_CATCH: frozenset[str] = frozenset(
         # scan_local_git_workspace shells out to git per repository and lets
         # anything unexpected reach the global wrapper.
         "scan_local_git_workspace",
+        # schedule_ci_reliability_loop writes the local task store; only a bad
+        # time is caught, anything else reaches the global wrapper.
+        "schedule_ci_reliability_loop",
         # architecture_* catch only WorkspaceError / ReportPersistenceError for
         # known failure states; unexpected errors escape to the #1476 wrapper.
         "architecture_cleanup_repo",


### PR DESCRIPTION
Onboarding: "Set up an agent that improves CI/CD reliability
over time". Picking it in `/demo` scans the machine, asks which repository
to watch and when to run (weekdays 08:00 local by default), creates a
local prompt loop that re-runs the CI/CD reliability analytics for the
last 7 days, runs the first pass, shows the report as it will land in
`/loops messages`, and offers the Slack demo next. Every step before the
loop is deterministic; no model turn is needed to configure it.

Delivery is pinned to the shell inbox, so the loop cannot post to Slack or
Telegram even when those are configured.

## Changes

- `loop.py`: loop prompt, creation with reuse of an existing loop for the
  same repository, local timezone, schedule card, report completeness check
- `schedule_ci_reliability_loop` action tool; the analytics skill's step 4
  calls it for "Set up an agent…" instead of the CI-fix onboarding
- `run_loop_now` in the shell runtime, shared with `/loops run`
- `analyze_github_ci_reliability` paints only on a real terminal; a
  headless run gets the full markdown back (loop messages were one line)
- Docs section "The CI reliability agent"