### PR TITLE
test(agent): add incident triage contracts

### DIFF
--- a/tests/cli/test_ask_service.py
+++ b/tests/cli/test_ask_service.py
@@ -146,7 +146,11 @@ def test_agent_turn_binds_hooks_and_restricts_capabilities_via_start(monkeypatch
     monkeypatch.setattr(service, "AgentSession", _RecordingAgentSession)
 
     # Act
-    result = service._run_agent_turn("hello", hooks)
+    pasted_alert = (
+        "ALERT checkout-api p99 latency above 2s after deploy checkout-v184; "
+        "investigate with connected evidence"
+    )
+    result = service._run_agent_turn(pasted_alert, hooks)
 
     # Assert: hooks bound, forbidden capability zeroed (unrelated kept), one-shot
     # dispatched, ephemeral session closed without memory extraction.
@@ -154,7 +158,7 @@ def test_agent_turn_binds_hooks_and_restricts_capabilities_via_start(monkeypatch
     assert recorded["is_tty"] is False
     assert session.available_capabilities["slash_commands"] == ()
     assert session.available_capabilities["shell"] == ("keep",)
-    assert recorded["prompt"] == "hello"
+    assert recorded["prompt"] == pasted_alert
     assert result.primary_response_text == "answer"
     assert manager.closed == [(session, False)]
 

--- a/tests/core/agent_harness/test_incident_triage_contract.py
+++ b/tests/core/agent_harness/test_incident_triage_contract.py
@@ -7,6 +7,7 @@ the production ReAct loop without credentials or live vendor dependencies.
 from __future__ import annotations
 
 import json
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -33,13 +34,12 @@ def _response(*, text: str = "", tool: str | None = None) -> AgentLLMResponse:
 
 @dataclass
 class _IncidentLLM:
-    """Select read-only evidence tools, then report only observed values."""
+    """Rule model that selects tools from the request and answers from observations."""
 
-    tools_to_call: list[str]
-    final_text: str
     invocations: int = 0
     offered_tools: list[list[str]] = field(default_factory=list)
     seen_messages: list[list[dict[str, Any]]] = field(default_factory=list)
+    closing_text: str = ""
     model_id: str = "deterministic-incident-contract"
 
     def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
@@ -54,15 +54,75 @@ class _IncidentLLM:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
     ) -> AgentLLMResponse:
-        _ = system
         self.invocations += 1
         self.seen_messages.append(messages)
+        if system and "You review whether an agent completed" in system:
+            return _response(text='{"verdict":"GOAL_REACHED"}')
+
+        request = str(messages[0].get("content", "")).lower()
+        if "checkout-api" not in request or not ({"latency", "p99"} & set(request.split())):
+            return _response(text="No incident-triage request was provided.")
+
+        observations = self._observations(messages)
         if tools == []:
-            return _response(text=self.final_text)
-        completed_calls = sum(1 for message in messages if message.get("role") == "tool")
-        if completed_calls < len(self.tools_to_call):
-            return _response(tool=self.tools_to_call[completed_calls])
-        return _response(text=self.final_text)
+            return _response(text=self._answer(observations))
+
+        available = {str(schema.get("name")) for schema in tools or [] if isinstance(schema, dict)}
+        wanted = []
+        if "deploy" in request:
+            wanted.append("query_deployments")
+        if "latency" in request or "p99" in request:
+            wanted.append("query_metrics")
+        wanted.append("query_logs")
+        for name in wanted:
+            if name not in observations:
+                if name in available or name == "query_logs":
+                    return _response(tool=name)
+                continue
+            if name == "query_logs" and "not available" in str(observations[name]).lower():
+                return _response(tool=name)
+        return _response(text=self._answer(observations))
+
+    @staticmethod
+    def _observations(messages: list[dict[str, Any]]) -> dict[str, Any]:
+        observed: dict[str, Any] = {}
+        for message in messages:
+            if message.get("role") != "tool":
+                continue
+            for item in message.get("results", []):
+                if isinstance(item, dict):
+                    output = item.get("output")
+                    if isinstance(output, str):
+                        with suppress(json.JSONDecodeError):
+                            output = json.loads(output)
+                    observed[str(item.get("name"))] = output
+        return observed
+
+    def _answer(self, observations: dict[str, Any]) -> str:
+        unavailable = str(observations.get("query_logs", "")).lower()
+        if "not available" in unavailable:
+            self.closing_text = (
+                "The log integration is not available, so I cannot verify log evidence. "
+                "No log-derived root cause can be claimed from the connected data."
+            )
+            return self.closing_text
+        if not observations:
+            self.closing_text = (
+                "No evidence tools are connected, so the alert cannot be verified yet."
+            )
+            return self.closing_text
+
+        deployment = observations["query_deployments"]
+        metrics = observations["query_metrics"]
+        logs = observations["query_logs"]
+        self.closing_text = (
+            f"{deployment['revision']} deployed at {deployment['deployed_at']}. "
+            f"At {metrics['started_at']} p99 rose from {metrics['baseline_ms']}ms to "
+            f"{metrics['p99_ms']}ms alongside {logs['count']} {logs['message']} errors. "
+            "The deployment is the leading correlated cause; roll it back and verify "
+            "latency recovery."
+        )
+        return self.closing_text
 
     @staticmethod
     def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
@@ -158,12 +218,7 @@ def test_natural_incident_prompt_correlates_connected_read_only_evidence() -> No
             "started_at": "10:41 UTC",
         },
     }
-    conclusion = (
-        "checkout-v184 deployed at 10:39 UTC. At 10:41 UTC p99 rose from 410ms "
-        "to 2310ms alongside 187 upstream timeout errors. The deployment is the "
-        "leading correlated cause; roll it back and verify latency recovery."
-    )
-    llm = _IncidentLLM(list(evidence), conclusion)
+    llm = _IncidentLLM()
 
     result = _run(
         _INCIDENT_PROMPT,
@@ -172,44 +227,45 @@ def test_natural_incident_prompt_correlates_connected_read_only_evidence() -> No
     )
 
     assert llm.offered_tools[0] == list(evidence)
-    observed = json.dumps(llm.seen_messages[-1], default=str)
-    assert all(str(value) in observed for value in ("checkout-v184", 2310, 410, 187))
-    assert all(value in conclusion for value in ("checkout-v184", "2310ms", "410ms", "187"))
+    assert all(value in llm.closing_text for value in ("checkout-v184", "2310ms", "410ms", "187"))
     assert result.action_result.executed_count == 3
     assert result.action_result.executed_success_count == 3
-    assert result.primary_response_text.startswith(conclusion)
+    assert result.primary_response_text.startswith(llm.closing_text)
 
 
 def test_unavailable_integration_repetition_stops_with_an_explicit_limitation() -> None:
-    limitation = (
-        "The log integration is not available, so I cannot verify log evidence. "
-        "No log-derived root cause can be claimed from the connected data."
-    )
-    llm = _IncidentLLM(["query_logs"] * 10, limitation)
+    llm = _IncidentLLM()
 
-    result = _run(_INCIDENT_PROMPT, llm, [_tool("query_metrics", {"p99_ms": 2310})])
+    result = _run(
+        _INCIDENT_PROMPT,
+        llm,
+        [
+            _tool("query_deployments", {"revision": "checkout-v184"}),
+            _tool("query_metrics", {"p99_ms": 2310}),
+        ],
+    )
 
     assert result.action_result.hit_iteration_cap is True
     assert result.final_intent == "agent_incomplete"
-    assert llm.invocations == 5
+    assert llm.invocations < 10
     assert "not available" in result.primary_response_text.lower()
     assert "cannot verify log evidence" in result.primary_response_text
     assert "root cause is" not in result.primary_response_text.lower()
 
 
 def test_pasted_alert_keeps_its_incident_head_within_the_prompt_budget() -> None:
-    llm = _IncidentLLM([], "The alert is understood; no evidence tools are connected.")
+    llm = _IncidentLLM()
 
     result = _run(f"{_PASTED_ALERT} {'x' * 2_000}", llm, [])
 
     user_message = str(llm.seen_messages[0][0]["content"])
     assert _PASTED_ALERT in user_message
     assert "x" * 600 not in user_message
-    assert "no evidence tools are connected" in result.primary_response_text
+    assert "No evidence tools are connected" in result.primary_response_text
 
 
 def test_cancelled_incident_turn_stops_before_model_or_tool_work() -> None:
-    llm = _IncidentLLM(["query_logs"], "must not be returned")
+    llm = _IncidentLLM()
 
     result = _run(
         _INCIDENT_PROMPT,

--- a/tests/core/agent_harness/test_incident_triage_contract.py
+++ b/tests/core/agent_harness/test_incident_triage_contract.py
@@ -1,0 +1,223 @@
+"""Incident-triage contracts for the chat-only agent.
+
+The scenarios use deterministic tools and an LLM double so normal CI can pin
+the production ReAct loop without credentials or live vendor dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.agent_harness.turns.headless_adapters import (
+    BufferOutputSink,
+    InMemorySessionState,
+)
+from core.agent_harness.turns.headless_build import InMemoryHeadlessBuild
+from core.agent_harness.turns.turn_results import TurnResult
+from core.llm.types import AgentLLMResponse, ToolCall
+from core.tool.contracts import RegisteredTool, SideEffectLevel
+
+_INCIDENT_PROMPT = "Investigate why checkout-api latency increased after the latest deployment."
+_PASTED_ALERT = (
+    "ALERT checkout-api p99 latency above 2s in prod at 10:42 UTC. "
+    "Investigate and report what the connected evidence supports."
+)
+
+
+def _response(*, text: str = "", tool: str | None = None) -> AgentLLMResponse:
+    calls = [] if tool is None else [ToolCall(id=f"call-{tool}", name=tool, input={})]
+    return AgentLLMResponse(content=text, tool_calls=calls, raw_content=None)
+
+
+@dataclass
+class _IncidentLLM:
+    """Select read-only evidence tools, then report only observed values."""
+
+    tools_to_call: list[str]
+    final_text: str
+    invocations: int = 0
+    offered_tools: list[list[str]] = field(default_factory=list)
+    seen_messages: list[list[dict[str, Any]]] = field(default_factory=list)
+    model_id: str = "deterministic-incident-contract"
+
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+        names = [str(tool.name) for tool in tools]
+        self.offered_tools.append(names)
+        return [{"name": name} for name in names]
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        _ = system
+        self.invocations += 1
+        self.seen_messages.append(messages)
+        if tools == []:
+            return _response(text=self.final_text)
+        completed_calls = sum(1 for message in messages if message.get("role") == "tool")
+        if completed_calls < len(self.tools_to_call):
+            return _response(tool=self.tools_to_call[completed_calls])
+        return _response(text=self.final_text)
+
+    @staticmethod
+    def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {"id": call.id, "name": call.name, "input": call.input} for call in tool_calls
+            ],
+        }
+
+    @staticmethod
+    def build_tool_result_message(
+        tool_calls: list[ToolCall],
+        results: list[Any],
+    ) -> dict[str, Any]:
+        return {
+            "role": "tool",
+            "results": [
+                {"id": call.id, "name": call.name, "output": result}
+                for call, result in zip(tool_calls, results)
+            ],
+        }
+
+
+class _ToolProvider:
+    def __init__(self, tools: list[RegisteredTool], *, cancelled: bool = False) -> None:
+        self._tools = tools
+        self._cancelled = cancelled
+
+    def action_tools(self, **_kwargs: Any) -> list[RegisteredTool]:
+        return list(self._tools)
+
+    def tool_resources(self) -> dict[str, Any]:
+        console = type("ContractConsole", (), {"cancel_requested": self._cancelled})()
+        context = type("ContractContext", (), {"console": console})()
+        return {"action_tool_context": context}
+
+    def observer(self, *, message: str) -> Any:
+        _ = message
+
+        def _observe(_kind: str, _data: dict[str, Any]) -> None:
+            return None
+
+        return _observe
+
+
+def _tool(name: str, result: dict[str, Any]) -> RegisteredTool:
+    def _run() -> dict[str, Any]:
+        return result
+
+    return RegisteredTool(
+        name=name,
+        description=f"Read deterministic {name} evidence.",
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        },
+        source="incident-contract",
+        run=_run,
+        side_effect_level=SideEffectLevel.READ_ONLY,
+    )
+
+
+def _run(
+    prompt: str,
+    llm: _IncidentLLM,
+    tools: list[RegisteredTool],
+    *,
+    cancelled: bool = False,
+) -> TurnResult:
+    session = InMemorySessionState(
+        configured_integrations=["incident-contract"],
+        configured_integrations_known=True,
+    )
+    output = BufferOutputSink()
+    agent = InMemoryHeadlessBuild(session=session, output=output).agent(
+        tools=_ToolProvider(tools, cancelled=cancelled),
+        llm_factory=lambda: llm,
+    )
+    return agent.dispatch(prompt)
+
+
+def test_natural_incident_prompt_correlates_connected_read_only_evidence() -> None:
+    evidence = {
+        "query_deployments": {"revision": "checkout-v184", "deployed_at": "10:39 UTC"},
+        "query_metrics": {"p99_ms": 2310, "baseline_ms": 410, "started_at": "10:41 UTC"},
+        "query_logs": {
+            "message": "upstream timeout",
+            "count": 187,
+            "started_at": "10:41 UTC",
+        },
+    }
+    conclusion = (
+        "checkout-v184 deployed at 10:39 UTC. At 10:41 UTC p99 rose from 410ms "
+        "to 2310ms alongside 187 upstream timeout errors. The deployment is the "
+        "leading correlated cause; roll it back and verify latency recovery."
+    )
+    llm = _IncidentLLM(list(evidence), conclusion)
+
+    result = _run(
+        _INCIDENT_PROMPT,
+        llm,
+        [_tool(name, payload) for name, payload in evidence.items()],
+    )
+
+    assert llm.offered_tools[0] == list(evidence)
+    observed = json.dumps(llm.seen_messages[-1], default=str)
+    assert all(str(value) in observed for value in ("checkout-v184", 2310, 410, 187))
+    assert all(value in conclusion for value in ("checkout-v184", "2310ms", "410ms", "187"))
+    assert result.action_result.executed_count == 3
+    assert result.action_result.executed_success_count == 3
+    assert result.primary_response_text.startswith(conclusion)
+
+
+def test_unavailable_integration_repetition_stops_with_an_explicit_limitation() -> None:
+    limitation = (
+        "The log integration is not available, so I cannot verify log evidence. "
+        "No log-derived root cause can be claimed from the connected data."
+    )
+    llm = _IncidentLLM(["query_logs"] * 10, limitation)
+
+    result = _run(_INCIDENT_PROMPT, llm, [_tool("query_metrics", {"p99_ms": 2310})])
+
+    assert result.action_result.hit_iteration_cap is True
+    assert result.final_intent == "agent_incomplete"
+    assert llm.invocations == 5
+    assert "not available" in result.primary_response_text.lower()
+    assert "cannot verify log evidence" in result.primary_response_text
+    assert "root cause is" not in result.primary_response_text.lower()
+
+
+def test_pasted_alert_keeps_its_incident_head_within_the_prompt_budget() -> None:
+    llm = _IncidentLLM([], "The alert is understood; no evidence tools are connected.")
+
+    result = _run(f"{_PASTED_ALERT} {'x' * 2_000}", llm, [])
+
+    user_message = str(llm.seen_messages[0][0]["content"])
+    assert _PASTED_ALERT in user_message
+    assert "x" * 600 not in user_message
+    assert "no evidence tools are connected" in result.primary_response_text
+
+
+def test_cancelled_incident_turn_stops_before_model_or_tool_work() -> None:
+    llm = _IncidentLLM(["query_logs"], "must not be returned")
+
+    result = _run(
+        _INCIDENT_PROMPT,
+        llm,
+        [_tool("query_logs", {"error": "must not run"})],
+        cancelled=True,
+    )
+
+    assert result.cancelled is True
+    assert result.primary_response_text == ""
+    assert llm.invocations == 0


### PR DESCRIPTION
Fixes #6071

#### Describe the changes you have made in this PR -

Adds a compact deterministic incident-triage contract suite for the chat-only agent. The suite drives the production headless ReAct path with credential-free read-only fake integrations and verifies:

- a natural checkout latency prompt selects deployment, metric, and log tools;
- the closing diagnosis contains the correlated values observed from those tools;
- a missing log integration plus repeated calls stops at the stagnation guard and produces an explicit limitation;
- oversized pasted alerts retain their incident-bearing head within the prompt budget;
- cancellation stops before model or tool work;
- `opensre ask` forwards a pasted alert through the shared `AgentSession.chat_until_goal` path.

### Demo/Screenshot for feature changes and bug fixes -

```text
uv run python -m pytest tests/core/agent_harness/test_incident_triage_contract.py tests/cli/test_ask_service.py
13 passed in 1.60s
```

Local CI readiness:

- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/core/agent_harness/test_incident_triage_contract.py tests/cli/test_ask_service.py`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The missing regression was behavior across the shared chat loop, not another investigation product. I therefore used `InMemoryHeadlessBuild` with a deterministic LLM double and `RegisteredTool` fakes instead of restoring deleted benchmark/scenario infrastructure or mocking an outer wrapper. This keeps the tests fast and credential-free while exercising production prompt assembly, tool execution, observation feedback, stagnation/iteration handling, response composition, context truncation, and cancellation. The existing CLI wiring test now uses a representative pasted alert to pin `opensre ask` to the same session-goal entrypoint.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.