### PR TITLE
docs: document investigation-to-chat migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -636,6 +636,10 @@ jobs:
             printf '### PowerShell (Windows)\n\n%spowershell\n$env:OPENSRE_INSTALL_CHANNEL="release"; $env:OPENSRE_VERSION="%s"; irm https://install.opensre.com | iex\n%s\n\n' "$CB" "${TAG_NAME#v}" "$CB"
             printf '### Python\n\n%sbash\npipx install opensre\n%s\n\n' "$CB" "$CB"
           } > RELEASE_NOTES.md
+          {
+            printf '## Upgrade notes\n\n'
+            printf 'Upgrading from v0.1.2026.9.3 or earlier? Read the [investigation-to-chat migration guide](https://www.opensre.com/docs/migration-investigation-to-chat-v0-1-2026-9-4) before changing CLI scripts, Python hosts, HTTP clients, or scheduled tasks.\n\n'
+          } >> RELEASE_NOTES.md
           cat GENERATED_CHANGELOG.md >> RELEASE_NOTES.md
 
       - name: Create GitHub release
@@ -813,6 +817,7 @@ jobs:
           {
             printf '## Main build\n\nRolling binary build from `main`.\n\n'
             printf -- '- Version: `%s`\n- Commit: `%s`\n- Built: %s\n\n' "$VERSION_NAME" "$short_sha" "$built_at"
+            printf '### Upgrade note\n\nUpgrading from v0.1.2026.9.3 or earlier? Read the [investigation-to-chat migration guide](https://www.opensre.com/docs/migration-investigation-to-chat-v0-1-2026-9-4).\n\n'
             printf '### Install\n\nmacOS / Linux:\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash\n%s\n\n' "$CB" "$CB"
             printf 'Equivalent explicit main channel:\n\n%sbash\ncurl -fsSL https://install.opensre.com | bash -s -- --main\n%s\n\n' "$CB" "$CB"
             printf 'Windows:\n\n%spowershell\nirm https://install.opensre.com | iex\n%s\n' "$CB" "$CB"

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -54,9 +54,9 @@ curl -X POST "https://<host>/alerts" \
 Required field: `text`. Optional fields: `alert_name`, `severity`, `source`,
 `received_at`. Request bodies larger than 1 MiB return `413`.
 
-Queued alerts are picked up by the agent's alert inbox — the interactive shell
-surfaces them with `/alerts`, and chat gateways deliver them to the paired
-channel.
+Queued alerts are drained only by the interactive shell when its alert listener
+is enabled; `/alerts` shows that inbox. The gateway web process accepts and
+queues this request but does not currently consume it.
 
 ## Status codes
 

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -13,6 +13,12 @@ Terraform-managed, separately from this repo).
 In production, terminate TLS at a load balancer or reverse proxy in front of
 the application.
 
+The synchronous and asynchronous investigation APIs were removed in
+v0.1.2026.9.4. Existing `/investigate` clients must follow the
+[investigation-to-chat migration guide](/migration-investigation-to-chat-v0-1-2026-9-4);
+`POST /alerts` is intake only and is not a replacement for a report-returning
+endpoint.
+
 ## Authentication
 
 | Routes | Caller | Authentication |

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -230,6 +230,11 @@ not `opensre cron add`. See [Sentry](/sentry#morning-digest-scheduled).
 
 ## Persistence
 
+Tasks created before v0.1.2026.9.4 with an investigation task kind require an
+explicit store migration. Back up the JSON store and follow the
+[scheduler migration table](/migration-investigation-to-chat-v0-1-2026-9-4#scheduler-store-migration)
+before starting the scheduler.
+
 - **Task definitions** are stored in `~/.opensre/scheduler_tasks.json` (JSON + filelock)
 - **Execution history** is stored in `~/.opensre/scheduler.db` (SQLite with WAL mode)
 - **Interactive-shell loop messages** are stored in `~/.opensre/scheduler_loop_messages.jsonl`

--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -79,6 +79,10 @@ curl -X POST http://127.0.0.1:8000/alerts \
   }'
 ```
 
+The gateway acknowledges and queues this request, but does not currently drain
+the alert inbox. Use the interactive shell's alert listener when alerts must be
+triaged in chat; see [`/alerts`](/interactive-shell-commands#alerts).
+
 By default, `/alerts` accepts only loopback callers. To allow remote access, set
 `OPENSRE_ALERT_LISTENER_TOKEN` and send it as a bearer token:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,7 @@
             "group": "First steps",
             "pages": [
               "quickstart",
+              "migrations/investigation-to-chat-v0-1-2026-9-4",
               "interactive-shell-commands",
               "interactive-shell-assistant",
               "goals"
@@ -340,6 +341,26 @@
     {
       "source": "/quickstart-monitoring",
       "destination": "/quickstart"
+    },
+    {
+      "source": "/investigation-overview",
+      "destination": "/migration-investigation-to-chat-v0-1-2026-9-4"
+    },
+    {
+      "source": "/how-investigations-work",
+      "destination": "/migration-investigation-to-chat-v0-1-2026-9-4"
+    },
+    {
+      "source": "/background-investigations",
+      "destination": "/migration-investigation-to-chat-v0-1-2026-9-4"
+    },
+    {
+      "source": "/remote-runtime-investigation",
+      "destination": "/migration-investigation-to-chat-v0-1-2026-9-4"
+    },
+    {
+      "source": "/grafana-log-sink",
+      "destination": "/migration-investigation-to-chat-v0-1-2026-9-4"
     },
     {
       "source": "/environments/codespaces",

--- a/docs/headless-cli.mdx
+++ b/docs/headless-cli.mdx
@@ -9,6 +9,10 @@ turn, prints the response, and exits instead of opening the interactive shell.
 It uses the LLM provider from `opensre onboard` and any tools configured with
 `opensre integrations setup`.
 
+If you previously used `opensre investigate`, its structured output is not
+compatible with `ask`. Follow the
+[v0.1.2026.9.4 migration guide](/migration-investigation-to-chat-v0-1-2026-9-4).
+
 ```bash
 opensre ask "why did checkout latency increase today?"
 ```

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -5,6 +5,10 @@ description: "Slash commands in the OpenSRE interactive shell — usage detail f
 
 Start the shell with `opensre` (needs a real terminal). Type a `/command`, or describe what you want in plain language.
 
+If you are looking for the removed `/investigate`, `/rca`, `/last`, `/save`, or
+`/background` commands, see the
+[v0.1.2026.9.4 migration guide](/migration-investigation-to-chat-v0-1-2026-9-4#cli-and-shell-mapping).
+
 ```bash
 opensre
 /help

--- a/docs/migrations/investigation-to-chat-v0-1-2026-9-4.mdx
+++ b/docs/migrations/investigation-to-chat-v0-1-2026-9-4.mdx
@@ -25,7 +25,7 @@ Use this guide when upgrading from v0.1.2026.9.3 or earlier.
 | Embed the agent in Python | `AgentSession.chat()` | `TurnResult`; inspect `answered`, `cancelled`, and `primary_response_text` |
 | Repeat a free-form prompt | Scheduler kind `manual_loop` or `/loops` | One headless chat turn per schedule |
 | Repeat a supported packaged workflow | Scheduler kind `recurring_skill` | A named, revision-pinned skill with validated inputs |
-| Receive an external alert | `POST /alerts` | Queue acknowledgement only; a shell or chat gateway consumes the inbox |
+| Receive an external alert | `POST /alerts` | Queue acknowledgement only; the interactive shell drains the inbox when its listener is enabled |
 | Start and poll a remote investigation over HTTP | **No replacement** | There is no general HTTP chat/investigation endpoint |
 | Produce a typed RCA, score, tool-call list, or report artifact | **No replacement** | Consume conversational text or build that schema in your own host |
 
@@ -61,7 +61,7 @@ These surfaces are deliberately different:
 
 ### JSON return contract
 
-The old CLI, synchronous HTTP endpoint, and payload runner returned an
+The old CLI, synchronous HTTP endpoint, and investigation API returned an
 investigation object like this:
 
 ```json
@@ -95,12 +95,11 @@ investigation object like this:
 The old API returned a typed `InvestigationResult`:
 
 ```python
-from core.agent_harness import AgentSession
-from tools.investigation.capability import run_investigation_payload
+from core.agent_harness import AgentSession, InvestigationResult
 
-result = AgentSession().investigate(
+result: InvestigationResult = AgentSession().investigate(
     alert_payload,
-    runner=run_investigation_payload,
+    runner=your_investigation_runner,
 )
 print(result.report)
 print(result.root_cause)
@@ -165,11 +164,12 @@ It returns an acknowledgement such as:
 {"queued": true, "queue_depth": 1}
 ```
 
-Run a gateway or interactive shell that consumes the alert inbox. Do not wait
-for an investigation ID or poll `/api/investigations`; neither exists. If an
-HTTP caller needs the answer in its response, embed `AgentSession.chat()` in
-your own authenticated service and define that service's lifecycle, storage,
-cancellation, and response schema.
+Run the interactive shell with its alert listener enabled to drain the inbox.
+The gateway web process exposes the same intake route but does not consume its
+queued alerts. Do not wait for an investigation ID or poll
+`/api/investigations`; neither exists. If an HTTP caller needs the answer in its
+response, embed `AgentSession.chat()` in your own authenticated service and
+define that service's lifecycle, storage, cancellation, and response schema.
 
 ## Scheduler-store migration
 
@@ -188,9 +188,9 @@ cp ~/.opensre/scheduler_tasks.json \
 
 | Old kind | Migration |
 | --- | --- |
-| `daily_summary` | Change to `manual_loop` and set `params.prompt` to the exact daily-summary instruction you want |
-| `weekly_audit` | Change to `manual_loop` and set `params.prompt` to the exact weekly-audit instruction you want |
-| `custom_investigation` | Change to `manual_loop` only when `params.prompt` is non-empty; otherwise recreate it with `opensre cron add --kind manual_loop --prompt ...` |
+| `daily_summary` | Change to `manual_loop` and set `params.loop_prompt` to the exact daily-summary instruction you want |
+| `weekly_audit` | Change to `manual_loop` and set `params.loop_prompt` to the exact weekly-audit instruction you want |
+| `custom_investigation` | Change to `manual_loop` only when `params.loop_prompt` is non-empty; otherwise recreate it with `opensre cron add --kind manual_loop --prompt ...` |
 | `incident_window_replay` | **No replacement**; remove or disable the row |
 | `synthetic_run` | **No replacement**; the synthetic investigation product was removed |
 | `sentry_morning_digest`, `sentry_uptime_watch`, `github_pr_sweep`, `posthog_metric_report`, `work_item_reminder`, `work_item_checkin` | Still recognized; no kind change |
@@ -209,7 +209,7 @@ For example, a migrated task has this shape:
   "window_hours": 24,
   "enabled": true,
   "params": {
-    "prompt": "Summarize alerts, error spikes, and production risk from the last 24 hours."
+    "loop_prompt": "Summarize alerts, error spikes, and production risk from the last 24 hours."
   }
 }
 ```

--- a/docs/migrations/investigation-to-chat-v0-1-2026-9-4.mdx
+++ b/docs/migrations/investigation-to-chat-v0-1-2026-9-4.mdx
@@ -1,0 +1,263 @@
+---
+title: "Investigation to chat migration (v0.1.2026.9.4)"
+slug: "migration-investigation-to-chat-v0-1-2026-9-4"
+description: "Migrate CLI scripts, Python hosts, HTTP clients, and scheduler stores after the structured investigation product was removed."
+---
+
+OpenSRE v0.1.2026.9.4 removed the structured investigation/RCA product. The
+single-agent chat core remains, and it can still inspect connected systems when
+you ask an operational question, but it does not reproduce the old pipeline's
+typed report, polling, artifact, or delivery contracts.
+
+Use this guide when upgrading from v0.1.2026.9.3 or earlier.
+
+<Warning>
+  This is a compatibility break, not a command rename. Do not parse a chat
+  answer as though it were an `InvestigationResult`.
+</Warning>
+
+## Choose the replacement surface
+
+| Need | Current surface | Contract |
+| --- | --- | --- |
+| Investigate one incident interactively | Ask in the `opensre` shell | A conversational answer in the current session |
+| Run one non-interactive turn | `opensre ask "..."` or pipe a prompt to `opensre ask -` | Text, or the `opensre --json ask` envelope |
+| Embed the agent in Python | `AgentSession.chat()` | `TurnResult`; inspect `answered`, `cancelled`, and `primary_response_text` |
+| Repeat a free-form prompt | Scheduler kind `manual_loop` or `/loops` | One headless chat turn per schedule |
+| Repeat a supported packaged workflow | Scheduler kind `recurring_skill` | A named, revision-pinned skill with validated inputs |
+| Receive an external alert | `POST /alerts` | Queue acknowledgement only; a shell or chat gateway consumes the inbox |
+| Start and poll a remote investigation over HTTP | **No replacement** | There is no general HTTP chat/investigation endpoint |
+| Produce a typed RCA, score, tool-call list, or report artifact | **No replacement** | Consume conversational text or build that schema in your own host |
+
+These surfaces are deliberately different:
+
+- **Natural-language chat investigation** is an immediate user turn. The agent
+  chooses relevant tools and answers in the conversation; there is no fixed RCA
+  stage sequence or report schema.
+- **`manual_loop`** stores your prompt and runs it as one unattended chat turn.
+  Use it when the instruction itself defines the recurring job.
+- **`recurring_skill`** runs a supported skill whose body is revision-pinned.
+  Use it when you need a repeatable packaged workflow such as
+  `github-ci-health` or `morning-report`, including its required inputs.
+- **HTTP alert intake** only places an alert in the process-wide inbox. It does
+  not run an investigation, return an answer, create an ID, or persist an RCA.
+
+## CLI and shell mapping
+
+| Before v0.1.2026.9.4 | Now | Compatibility note |
+| --- | --- | --- |
+| `opensre investigate -i alert.json` | `{ printf 'Triage this alert and explain the likely cause:\n'; cat alert.json; } \| opensre ask -` | Free-form response; no structured report fields |
+| `opensre investigate --input-json "$ALERT_JSON"` | `printf 'Triage this alert:\n%s\n' "$ALERT_JSON" \| opensre ask -` | The payload is prompt context, not a typed alert input |
+| `opensre investigate --interactive` | Start `opensre`, then paste the alert with an instruction | Conversational session |
+| `opensre investigate -o rca.json ...` | `opensre --json ask "..." > result.json` | New JSON envelope shown below |
+| `opensre investigate --print-template ...` | **No replacement** | Built-in investigation templates were removed |
+| `opensre investigate --evaluate ...` | **No replacement** | The scoring-rubric judge was removed |
+| `opensre investigate --service ...` | Ask the shell to inspect the service using its configured integration tools | No dedicated remote-ops or RCA contract |
+| `/investigate` | Describe the incident directly in the shell | Natural-language chat turn |
+| `/rca` | Ask for a root-cause analysis in the current conversation | No archived RCA browser or typed record |
+| `/last` | Ask a follow-up in the same session, or use `/resume` for a saved session | No last-investigation object |
+| `/save` | Redirect `opensre ask` output, or save/copy the response in your host | No RCA Markdown/JSON exporter |
+| `/background` | **No background-turn replacement**; use `/loops` for recurrence and `/tasks` only to inspect runtime jobs | No background RCA records or completion notifications |
+
+### JSON return contract
+
+The old CLI, synchronous HTTP endpoint, and payload runner returned an
+investigation object like this:
+
+```json
+{
+  "report": "...",
+  "problem_md": "...",
+  "root_cause": "...",
+  "is_noise": false,
+  "validity_score": 0.91,
+  "tool_calls": []
+}
+```
+
+`opensre --json ask` now returns a process outcome:
+
+```json
+{
+  "status": "success",
+  "response": "...",
+  "denied_tools": [],
+  "error": null
+}
+```
+
+`status` can also be `approval_denied`, `error`, or `cancelled`. When present,
+`error` contains `message` and `suggestion`. There are no `report`,
+`root_cause`, `is_noise`, `validity_score`, or `tool_calls` fields.
+
+## Python migration
+
+The old API returned a typed `InvestigationResult`:
+
+```python
+from core.agent_harness import AgentSession
+from tools.investigation.capability import run_investigation_payload
+
+result = AgentSession().investigate(
+    alert_payload,
+    runner=run_investigation_payload,
+)
+print(result.report)
+print(result.root_cause)
+```
+
+There is no typed investigation replacement. Pass the alert as chat context and
+handle `TurnResult`:
+
+```python
+import json
+
+from bootstrap.process import EMBEDDED_PROFILE, configure_process
+from core.agent_harness import AgentSession
+
+configure_process(EMBEDDED_PROFILE)
+session = AgentSession.start()
+result = session.chat(
+    "Triage this alert and explain the likely cause:\n"
+    + json.dumps(alert_payload)
+)
+
+action_ok = (
+    result.action_result.handled
+    and not result.action_result.has_unhandled_clause
+    and result.action_result.accounting_status == "completed"
+)
+if result.cancelled or not (result.answered or action_ok):
+    raise RuntimeError(result.primary_response_text or "turn failed")
+
+print(result.primary_response_text)
+```
+
+`TurnResult` exposes `final_intent`, `action_result`,
+`assistant_response_text`, `answered`, `cancelled`, and
+`primary_response_text`. It does not expose structured RCA fields. If your host
+requires a stable domain schema, define and validate that schema after the chat
+turn in your application; OpenSRE no longer supplies one.
+
+## HTTP migration
+
+The following routes and capabilities have no HTTP replacement:
+
+- `POST /investigate` (synchronous report)
+- `POST /api/investigations` (asynchronous enqueue and investigation ID)
+- `GET /api/investigations/<id>` (status polling and result lookup)
+- `POST /api/investigations/<id>/cancel`
+- local/S3 report artifacts and report URLs
+- Clerk-organization-scoped investigation records
+
+`POST /alerts` remains an intake endpoint:
+
+```bash
+curl -X POST "https://<host>/alerts" \
+  -H "Authorization: Bearer $OPENSRE_ALERT_LISTENER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"CPU above 90% on checkout-db","source":"grafana"}'
+```
+
+It returns an acknowledgement such as:
+
+```json
+{"queued": true, "queue_depth": 1}
+```
+
+Run a gateway or interactive shell that consumes the alert inbox. Do not wait
+for an investigation ID or poll `/api/investigations`; neither exists. If an
+HTTP caller needs the answer in its response, embed `AgentSession.chat()` in
+your own authenticated service and define that service's lifecycle, storage,
+cancellation, and response schema.
+
+## Scheduler-store migration
+
+Task definitions remain in `~/.opensre/scheduler_tasks.json`, but old
+investigation kinds are not renamed automatically. The loader skips each row
+whose `kind` is no longer recognized, so an old task can disappear from
+`opensre cron list` while its JSON row remains on disk.
+
+Stop every gateway and `opensre cron start` process before editing the store,
+then make a backup:
+
+```bash
+cp ~/.opensre/scheduler_tasks.json \
+  ~/.opensre/scheduler_tasks.pre-v0.1.2026.9.4.json
+```
+
+| Old kind | Migration |
+| --- | --- |
+| `daily_summary` | Change to `manual_loop` and set `params.prompt` to the exact daily-summary instruction you want |
+| `weekly_audit` | Change to `manual_loop` and set `params.prompt` to the exact weekly-audit instruction you want |
+| `custom_investigation` | Change to `manual_loop` only when `params.prompt` is non-empty; otherwise recreate it with `opensre cron add --kind manual_loop --prompt ...` |
+| `incident_window_replay` | **No replacement**; remove or disable the row |
+| `synthetic_run` | **No replacement**; the synthetic investigation product was removed |
+| `sentry_morning_digest`, `sentry_uptime_watch`, `github_pr_sweep`, `posthog_metric_report`, `work_item_reminder`, `work_item_checkin` | Still recognized; no kind change |
+
+For example, a migrated task has this shape:
+
+```json
+{
+  "id": "existing-id",
+  "name": "Morning reliability summary",
+  "kind": "manual_loop",
+  "cron": "0 9 * * 1-5",
+  "timezone": "Asia/Kolkata",
+  "provider": "slack",
+  "chat_id": "C0123ABCD",
+  "window_hours": 24,
+  "enabled": true,
+  "params": {
+    "prompt": "Summarize alerts, error spikes, and production risk from the last 24 hours."
+  }
+}
+```
+
+Restart one scheduler, confirm the rows with `opensre cron list`, and test each
+migrated task with `opensre cron run <task_id>`. The old
+`~/.opensre/scheduler.db` run history may remain on disk, but it does not make a
+skipped task executable.
+
+Session JSONL and long-term memory created before the upgrade remain readable.
+Investigation-only persistence is not migrated: background records under
+`~/.opensre/background/investigations.json`, HTTP investigation records,
+`~/.opensre/investigations/<id>/report.json`, and S3 report artifacts have no
+current reader or import path. Back them up before uninstalling or cleaning the
+OpenSRE home directory.
+
+## Removed integrations and delivery paths
+
+Most data-source and chat integrations stayed available to the chat agent, but
+the following product-specific capabilities did not:
+
+- **Notion** was removed as an integration, including setup, verification, and
+  creation of investigation report pages. There is no replacement.
+- **Hermes investigation mode** and its session-evidence bridge were removed;
+  the remaining Hermes product integration was removed separately in the same
+  release line.
+- **OpenClaw investigation/report delivery** was removed; OpenClaw itself was
+  removed separately in the same release line.
+- **Discord `/investigate`** was removed. Discord chat remains a conversation
+  surface where configured.
+- **Grafana log-sink report publishing** was removed. Grafana remains available
+  as an evidence source for chat turns.
+- Automatic foreground report fan-out was removed for **Slack, Discord,
+  Telegram, Rocket.Chat, Buzz, Twilio SMS, WhatsApp, OpenClaw, and Grafana**.
+- Investigation-triggered **GitLab merge-request write-back** was removed.
+- Background RCA completion delivery was removed for **email/SMTP, Telegram,
+  Rocket.Chat, and Buzz**.
+- Automatic local report rendering/editor output, stored report URLs, and
+  report artifacts were removed.
+
+Messaging providers that still appear in [Scheduled Deliveries](/cron) can
+deliver current scheduled loop or skill output. That does not restore the old
+investigation report renderer or its delivery contract.
+
+## Related current documentation
+
+- [Headless CLI](/headless-cli)
+- [Python API](/python-api)
+- [HTTP API](/api)
+- [Scheduled Deliveries](/cron)
+- [Interactive shell commands](/interactive-shell-commands)

--- a/docs/python-api.mdx
+++ b/docs/python-api.mdx
@@ -10,6 +10,11 @@ want agent responses without invoking the CLI. For network access, use the
 reporting and drive one agent across many turns, see
 [Hosting the Agent](/hosting-the-agent).
 
+`AgentSession.investigate()` and `InvestigationResult` were removed in
+v0.1.2026.9.4. See the
+[investigation-to-chat migration guide](/migration-investigation-to-chat-v0-1-2026-9-4)
+for the old and new return contracts.
+
 ## OpenSRE as a teammate in your daily loop
 
 OpenSRE functions as an autonomous engineering teammate embedded directly into

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,6 +3,12 @@ title: "Quickstart"
 slug: "quickstart"
 ---
 
+<Note>
+  Upgrading from v0.1.2026.9.3 or earlier? Read the
+  [investigation-to-chat migration guide](/migration-investigation-to-chat-v0-1-2026-9-4)
+  before changing CLI scripts, Python hosts, HTTP clients, or scheduled tasks.
+</Note>
+
 <Steps>
   <Step title="Install OpenSRE">
     <Tabs>


### PR DESCRIPTION
Fixes #6070

#### Describe the changes you have made in this PR -

- add a versioned v0.1.2026.9.4 migration guide for CLI, Python, HTTP, scheduler, persistence, integrations, and delivery contracts
- document explicit no-replacement cases and before/after JSON and Python return shapes
- document the exact `loop_prompt` scheduler-store key and clarify that only the interactive shell drains alert intake
- link the guide from quickstart and current command/API references
- redirect deleted investigation documentation URLs to the migration guide
- include the guide in generated stable and rolling-main release notes

### Demo/Screenshot for feature changes and bug fixes -

Documentation/config validation and the focused quickstart suite:

```text
$ uv run python -c 'import json, yaml; json.load(open("docs/docs.json")); yaml.safe_load(open(".github/workflows/release.yml"))'
docs.json and release.yml parse
$ make lint
All checks passed!
$ make format-check
3110 files already formatted
$ make typecheck
Success: no issues found in 1802 source files
$ uv run python -m pytest tests/cli/test_quickstart.py
11 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I compared the pre-removal contracts at v0.1.2026.9.3 with the current CLI, `TurnResult`, HTTP alert-intake, and scheduler implementations. The guide separates semantic replacements from capabilities with no replacement so users do not mistake `ask` or `POST /alerts` for compatible RCA APIs. It documents the persisted `loop_prompt` key and each old scheduler kind, and restores discoverability from deleted documentation URLs through redirects. Release-note generation links the versioned guide for both stable and rolling-main builds.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---