### PR TITLE
feat(scheduler): deterministic CI reliability loop, background service, raw snapshots

### DIFF
--- a/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
+++ b/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
@@ -81,14 +81,15 @@ headers [3/4] and [4/4] only.
 4) Offer what to do next.
    Call `ask_user_choice` with title `What would you like to do next?` and
    these exact options:
-   - `Set up an agent that improves CI/CD reliability over time`
+   - `Set up an agent that reports CI/CD reliability every weekday`
    - `Connect OpenSRE to Slack and hand off DevOps chores for your team`
    - `Exit demo`
    WAIT for the answer. On the first option, call
    `schedule_ci_reliability_loop(owner="<owner>", repo="<repo>")` for the
    analyzed repository, output its `response_text` verbatim, and stop; it
    schedules a weekday 08:00 local check that delivers to this shell's inbox
-   and never posts anywhere else. On the second, check Slack with the CLI tool
+   and never posts anywhere else. Each tick is deterministic (no model turn);
+   `/loops service install` keeps it running when no shell is open. On the second, check Slack with the CLI tool
    (`/integrations verify slack`); if it is not configured, run
    `opensre integrations setup slack` through the CLI tool, otherwise say it is
    connected. Then explain in two sentences how to hand off a chore from Slack

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -57,7 +57,7 @@ wait per blocked PR, and the longest wait with its PR.
 
 ## The CI reliability agent
 
-Pick "Set up an agent that improves CI/CD reliability over time" from `/demo`
+Pick "Set up an agent that reports CI/CD reliability every weekday" from `/demo`
 to schedule the same analysis as a recurring check. The demo scans your
 machine, asks which repository to watch and when to run (weekdays at 08:00
 local time is the default), creates the loop, runs it once, and shows the
@@ -66,8 +66,15 @@ first report. Every run analyzes the last 7 days.
 - Reports land in this shell's inbox: `/loops messages`. The loop never posts
   to Slack or any chat channel, even when those integrations are configured.
 - Manage it with `/loops list`, `/loops stop <id>`, and `/loops delete <id>`.
-- The loop fires while the shell is open. To run it when the shell is closed,
-  start the scheduler with `opensre cron start` or run the gateway.
+- Each run is deterministic: no model turn sits between the schedule and the
+  report, and the raw figures are saved as JSON next to the report path named
+  at the end of every delivery, under `~/.opensre/ci_reliability_reports/`.
+- The loop fires while the shell is open. To keep it running when the shell is
+  closed, pick "Keep it running when this shell is closed" at the end of the
+  demo or run `/loops service install`; it installs a per-user service (launchd
+  on macOS, systemd on Linux) that starts at login. `/loops service remove`
+  deletes it. Windows is not supported yet; run `opensre cron start --service`
+  from Task Scheduler instead.
 - Running the demo again for the same repository reuses the existing loop.
 
 ## Limits

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -134,6 +134,10 @@ that missed it. A run is `failed` only when every destination failed.
 Start the blocking scheduler daemon. Loads all enabled tasks and fires them
 according to their cron schedules. Blocks until `SIGINT` or `SIGTERM`.
 
+To keep it running without a terminal, `/loops service install` in the shell
+registers a per-user service (launchd on macOS, systemd on Linux) that runs
+`opensre cron start --service` at login; `/loops service remove` deletes it.
+
 ## Cron Syntax
 
 Standard 5-field cron expressions:

--- a/infrastructure/scheduling/scheduler/background_service.py
+++ b/infrastructure/scheduling/scheduler/background_service.py
@@ -71,7 +71,11 @@ def install_background_service(
     run: Runner = _run,
     command: Sequence[str] | None = None,
 ) -> BackgroundServiceState:
-    """Install and start the service; raises ``RuntimeError`` when the OS refuses."""
+    """Install and start the service; raises ``RuntimeError`` when the OS refuses.
+
+    A refused activation removes the unit again, so status never reports a
+    service the OS is not running.
+    """
     name = system or platform.system()
     argv = list(command or scheduler_command())
     log_path = _log_path()
@@ -82,14 +86,15 @@ def install_background_service(
         unit.write_bytes(plistlib.dumps(_launchd_definition(argv, log_path)))
         domain = f"gui/{os.getuid()}"
         run(["launchctl", "bootout", f"{domain}/{SERVICE_LABEL}"])
-        _check(run(["launchctl", "bootstrap", domain, str(unit)]), "launchctl bootstrap")
+        _activate(unit, run(["launchctl", "bootstrap", domain, str(unit)]), "launchctl bootstrap")
         return BackgroundServiceState("Darwin", True, True, unit, log_path)
     if name == "Linux":
         unit = _systemd_unit_path(home)
         unit.parent.mkdir(parents=True, exist_ok=True)
         unit.write_text(_systemd_definition(argv, log_path), encoding="utf-8")
-        _check(run(["systemctl", "--user", "daemon-reload"]), "systemctl daemon-reload")
-        _check(
+        _activate(unit, run(["systemctl", "--user", "daemon-reload"]), "systemctl daemon-reload")
+        _activate(
+            unit,
             run(["systemctl", "--user", "enable", "--now", f"{SERVICE_LABEL}.service"]),
             "systemctl enable",
         )
@@ -100,16 +105,27 @@ def install_background_service(
 def remove_background_service(
     *, home: Path | None = None, system: str = "", run: Runner = _run
 ) -> BackgroundServiceState:
-    """Stop and delete the service; a missing service is not an error."""
+    """Stop and delete the service; a missing service is not an error.
+
+    The unit is deleted only once the OS confirms the service is no longer
+    loaded, so a refused stop raises ``RuntimeError`` and leaves the unit for
+    a retry.
+    """
     name = system or platform.system()
     if name == "Darwin":
         unit = _launchd_unit_path(home)
-        run(["launchctl", "bootout", f"gui/{os.getuid()}/{SERVICE_LABEL}"])
+        target = f"gui/{os.getuid()}/{SERVICE_LABEL}"
+        run(["launchctl", "bootout", target])
+        if run(["launchctl", "print", target]).returncode == 0:
+            raise RuntimeError("launchctl bootout failed: the service is still loaded")
         unit.unlink(missing_ok=True)
         return BackgroundServiceState("Darwin", True, False, None, None)
     if name == "Linux":
         unit = _systemd_unit_path(home)
-        run(["systemctl", "--user", "disable", "--now", f"{SERVICE_LABEL}.service"])
+        service = f"{SERVICE_LABEL}.service"
+        run(["systemctl", "--user", "disable", "--now", service])
+        if run(["systemctl", "--user", "is-active", service]).returncode == 0:
+            raise RuntimeError("systemctl disable failed: the service is still active")
         unit.unlink(missing_ok=True)
         run(["systemctl", "--user", "daemon-reload"])
         return BackgroundServiceState("Linux", True, False, None, None)
@@ -144,8 +160,10 @@ def _unsupported(name: str) -> BackgroundServiceState:
     )
 
 
-def _check(result: subprocess.CompletedProcess[str], step: str) -> None:
+def _activate(unit: Path, result: subprocess.CompletedProcess[str], step: str) -> None:
+    """Fail an install step, removing the unit so a half-installed service is not reported."""
     if result.returncode != 0:
+        unit.unlink(missing_ok=True)
         detail = (result.stderr or result.stdout or "").strip()
         raise RuntimeError(f"{step} failed: {detail or f'exit code {result.returncode}'}")
 

--- a/infrastructure/scheduling/scheduler/background_service.py
+++ b/infrastructure/scheduling/scheduler/background_service.py
@@ -1,0 +1,206 @@
+"""Keep the scheduler running when no shell is open: a per-user OS service.
+
+macOS gets a launchd LaunchAgent, Linux a systemd user unit; both run
+``opensre cron start --service`` and restart it when it exits. Other
+platforms are reported as unsupported rather than guessed at.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import plistlib
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from config.constants.paths import OPENSRE_HOME_DIR
+
+SERVICE_LABEL = "com.opensre.scheduler"
+_LOGS_DIRNAME = "logs"
+_COMMAND_TIMEOUT_SECONDS = 30
+
+Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class BackgroundServiceState:
+    """What the OS knows about the scheduler service."""
+
+    platform: str
+    supported: bool
+    installed: bool
+    unit_path: Path | None
+    log_path: Path | None
+    detail: str = ""
+
+    @property
+    def summary(self) -> str:
+        if not self.supported:
+            return f"Background scheduling is not supported on {self.platform}; {self.detail}"
+        if not self.installed:
+            return "No background scheduler service is installed."
+        return f"Background scheduler service installed: {self.unit_path}"
+
+
+def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        capture_output=True,
+        text=True,
+        timeout=_COMMAND_TIMEOUT_SECONDS,
+        check=False,
+    )
+
+
+def scheduler_command() -> list[str]:
+    """The command the service runs; the installed ``opensre`` when present."""
+    executable = shutil.which("opensre")
+    if executable:
+        return [executable, "cron", "start", "--service"]
+    return [sys.executable, "-m", "surfaces.entrypoint", "cron", "start", "--service"]
+
+
+def install_background_service(
+    *,
+    home: Path | None = None,
+    system: str = "",
+    run: Runner = _run,
+    command: Sequence[str] | None = None,
+) -> BackgroundServiceState:
+    """Install and start the service; raises ``RuntimeError`` when the OS refuses."""
+    name = system or platform.system()
+    argv = list(command or scheduler_command())
+    log_path = _log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    if name == "Darwin":
+        unit = _launchd_unit_path(home)
+        unit.parent.mkdir(parents=True, exist_ok=True)
+        unit.write_bytes(plistlib.dumps(_launchd_definition(argv, log_path)))
+        domain = f"gui/{os.getuid()}"
+        run(["launchctl", "bootout", f"{domain}/{SERVICE_LABEL}"])
+        _check(run(["launchctl", "bootstrap", domain, str(unit)]), "launchctl bootstrap")
+        return BackgroundServiceState("Darwin", True, True, unit, log_path)
+    if name == "Linux":
+        unit = _systemd_unit_path(home)
+        unit.parent.mkdir(parents=True, exist_ok=True)
+        unit.write_text(_systemd_definition(argv, log_path), encoding="utf-8")
+        _check(run(["systemctl", "--user", "daemon-reload"]), "systemctl daemon-reload")
+        _check(
+            run(["systemctl", "--user", "enable", "--now", f"{SERVICE_LABEL}.service"]),
+            "systemctl enable",
+        )
+        return BackgroundServiceState("Linux", True, True, unit, log_path)
+    return _unsupported(name)
+
+
+def remove_background_service(
+    *, home: Path | None = None, system: str = "", run: Runner = _run
+) -> BackgroundServiceState:
+    """Stop and delete the service; a missing service is not an error."""
+    name = system or platform.system()
+    if name == "Darwin":
+        unit = _launchd_unit_path(home)
+        run(["launchctl", "bootout", f"gui/{os.getuid()}/{SERVICE_LABEL}"])
+        unit.unlink(missing_ok=True)
+        return BackgroundServiceState("Darwin", True, False, None, None)
+    if name == "Linux":
+        unit = _systemd_unit_path(home)
+        run(["systemctl", "--user", "disable", "--now", f"{SERVICE_LABEL}.service"])
+        unit.unlink(missing_ok=True)
+        run(["systemctl", "--user", "daemon-reload"])
+        return BackgroundServiceState("Linux", True, False, None, None)
+    return _unsupported(name)
+
+
+def background_service_state(
+    *, home: Path | None = None, system: str = ""
+) -> BackgroundServiceState:
+    """Whether the service unit exists on this machine."""
+    name = system or platform.system()
+    if name == "Darwin":
+        unit = _launchd_unit_path(home)
+    elif name == "Linux":
+        unit = _systemd_unit_path(home)
+    else:
+        return _unsupported(name)
+    installed = unit.exists()
+    return BackgroundServiceState(
+        name, True, installed, unit if installed else None, _log_path() if installed else None
+    )
+
+
+def _unsupported(name: str) -> BackgroundServiceState:
+    return BackgroundServiceState(
+        name,
+        False,
+        False,
+        None,
+        None,
+        detail="run `opensre cron start --service` from your own scheduler instead.",
+    )
+
+
+def _check(result: subprocess.CompletedProcess[str], step: str) -> None:
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(f"{step} failed: {detail or f'exit code {result.returncode}'}")
+
+
+def _log_path() -> Path:
+    return OPENSRE_HOME_DIR / _LOGS_DIRNAME / "scheduler.log"
+
+
+def _launchd_unit_path(home: Path | None) -> Path:
+    return (home or Path.home()) / "Library" / "LaunchAgents" / f"{SERVICE_LABEL}.plist"
+
+
+def _systemd_unit_path(home: Path | None) -> Path:
+    return (home or Path.home()) / ".config" / "systemd" / "user" / f"{SERVICE_LABEL}.service"
+
+
+def _launchd_definition(argv: Sequence[str], log_path: Path) -> dict[str, object]:
+    return {
+        "Label": SERVICE_LABEL,
+        "ProgramArguments": list(argv),
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "ProcessType": "Background",
+        "EnvironmentVariables": {"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        "StandardOutPath": str(log_path),
+        "StandardErrorPath": str(log_path),
+    }
+
+
+def _systemd_definition(argv: Sequence[str], log_path: Path) -> str:
+    exec_start = " ".join(_systemd_quote(part) for part in argv)
+    return (
+        "[Unit]\n"
+        "Description=OpenSRE scheduler\n"
+        "After=network-online.target\n\n"
+        "[Service]\n"
+        f"ExecStart={exec_start}\n"
+        "Restart=always\n"
+        "RestartSec=10\n"
+        f"StandardOutput=append:{log_path}\n"
+        f"StandardError=append:{log_path}\n\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+def _systemd_quote(part: str) -> str:
+    return f'"{part}"' if " " in part else part
+
+
+__all__ = [
+    "SERVICE_LABEL",
+    "BackgroundServiceState",
+    "background_service_state",
+    "install_background_service",
+    "remove_background_service",
+    "scheduler_command",
+]

--- a/infrastructure/scheduling/scheduler/loop_constants.py
+++ b/infrastructure/scheduling/scheduler/loop_constants.py
@@ -7,6 +7,12 @@ LOOP_CREATED_BY_PARAM = "loop_created_by"
 LOOP_DESCRIPTION_PARAM = "loop_description"
 LOOP_GROUP_ID_PARAM = "loop_group_id"
 LOOP_PROMPT_PARAM = "loop_prompt"
+LOOP_REPORT_PARAM = "loop_report"
+"""Name of a deterministic report builder that replaces the model turn for this loop."""
+
+LOOP_REPORT_ARGS_PARAM = "loop_report_args"
+"""JSON object of string arguments handed to the report builder."""
+
 LOOP_SLACK_CHAT_ID_PARAM = "slack_chat_id"
 LOOP_SLUG_PARAM = "loop_slug"
 LOOP_SOURCE_PARAM = "loop_source"
@@ -19,6 +25,8 @@ __all__ = [
     "LOOP_DESCRIPTION_PARAM",
     "LOOP_GROUP_ID_PARAM",
     "LOOP_PROMPT_PARAM",
+    "LOOP_REPORT_ARGS_PARAM",
+    "LOOP_REPORT_PARAM",
     "LOOP_SLACK_CHAT_ID_PARAM",
     "LOOP_SLUG_PARAM",
     "LOOP_SOURCE_PARAM",

--- a/infrastructure/scheduling/scheduler/loops.py
+++ b/infrastructure/scheduling/scheduler/loops.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import re
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -22,6 +23,8 @@ from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_DESCRIPTION_PARAM,
     LOOP_GROUP_ID_PARAM,
     LOOP_PROMPT_PARAM,
+    LOOP_REPORT_ARGS_PARAM,
+    LOOP_REPORT_PARAM,
     LOOP_SLACK_CHAT_ID_PARAM,
     LOOP_SLUG_PARAM,
     LOOP_SOURCE_PARAM,
@@ -307,8 +310,15 @@ def create_manual_loop(
     slack_chat_id: str = "",
     window_hours: int = 24,
     store_path: Path | None = None,
+    report: str = "",
+    report_args: Mapping[str, str] | None = None,
 ) -> ManualLoop:
-    """Create an active recurring prompt loop."""
+    """Create an active recurring prompt loop.
+
+    ``report`` names a deterministic report builder the runner uses instead
+    of a model turn; ``prompt`` then documents the loop and is the fallback
+    when the builder is not installed.
+    """
     loop_prompt = prompt.strip()
     if not loop_prompt:
         raise ValueError("prompt is required")
@@ -338,6 +348,9 @@ def create_manual_loop(
     time_label = loop_time_label(cron_expr)
     if time_label:
         params[LOOP_TIME_PARAM] = time_label
+    if report.strip():
+        params[LOOP_REPORT_PARAM] = report.strip()
+        params[LOOP_REPORT_ARGS_PARAM] = json.dumps(dict(report_args or {}), sort_keys=True)
     if telegram_chat_id.strip():
         params[LOOP_TELEGRAM_CHAT_ID_PARAM] = telegram_chat_id.strip()
     if slack_chat_id.strip():

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from config.constants.paths import OPENSRE_HOME_DIR
 from config.runtime_metadata.probes import local_tz_name
 from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
 from infrastructure.scheduling.scheduler.loops import (
@@ -19,6 +23,10 @@ from infrastructure.scheduling.scheduler.types import Provider, TaskKind
 
 DEFAULT_LOOP_TIME = "08:00"
 LOOP_WINDOW_DAYS = 7
+REPORT_NAME = "github_ci_reliability"
+"""Builder name the manual-loop runner maps to :func:`build_report`."""
+
+SNAPSHOT_DIRNAME = "ci_reliability_reports"
 _LOCAL_CHANNEL = Provider.INTERACTIVE_SHELL.value
 
 
@@ -93,8 +101,68 @@ def schedule_ci_reliability_loop(
         weekdays=weekdays,
         channels=(_LOCAL_CHANNEL,),
         store_path=store_path,
+        report=REPORT_NAME,
+        report_args={"owner": owner, "repo": repo, "days": str(LOOP_WINDOW_DAYS)},
     )
     return ScheduledLoop(loop=created, reused=False)
+
+
+def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -> str:
+    """Deterministic loop tick: read GitHub, render the report, keep the raw figures on disk.
+
+    No model is involved, so every delivery carries the analytics header and
+    the numbers can be traced back to the JSON snapshot named at the end.
+    Raises ``RuntimeError`` with a generic message when GitHub cannot be read.
+    """
+    from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
+    from integrations.github.tools.ci_analytics.collector import collect_runs
+    from integrations.github.tools.ci_analytics.metrics import compute_report
+    from integrations.github.tools.ci_analytics.render import headline, render_markdown
+    from integrations.github.tools.ci_analytics.tool import report_payload
+
+    owner = args.get("owner", "").strip()
+    repo = args.get("repo", "").strip()
+    days = int(args.get("days", LOOP_WINDOW_DAYS) or LOOP_WINDOW_DAYS)
+    if not owner or not repo:
+        raise RuntimeError("The CI reliability loop needs owner and repo.")
+    token = resolve_github_token(None)
+    if not token:
+        raise RuntimeError(
+            f"No GitHub token to read {owner}/{repo}; run `opensre integrations setup github`."
+        )
+    now = datetime.now(UTC)
+    try:
+        collected = collect_runs(
+            GitHubRestClient(token), owner=owner, repo=repo, window_days=days, now=now
+        )
+    except (GitHubApiError, ValueError) as exc:
+        raise RuntimeError(f"Could not read the GitHub Actions history of {owner}/{repo}.") from exc
+    report = compute_report(
+        owner=owner,
+        repo=repo,
+        default_branch=collected.default_branch,
+        window_days=days,
+        branch_runs=collected.branch_runs,
+        pr_runs=collected.pr_runs,
+        merged_prs=collected.merged_prs,
+        now=now,
+        coverage_notices=collected.coverage_notices,
+    )
+    snapshot = _write_snapshot(
+        snapshot_dir or OPENSRE_HOME_DIR / SNAPSHOT_DIRNAME,
+        owner,
+        repo,
+        now,
+        {"generated_at": now.isoformat(), "headline": headline(report), **report_payload(report)},
+    )
+    return "\n".join([render_markdown(report), "", headline(report), "", f"Raw data: {snapshot}"])
+
+
+def _write_snapshot(root: Path, owner: str, repo: str, now: datetime, payload: dict) -> Path:
+    target = root / f"{owner}-{repo}" / f"{now:%Y-%m-%dT%H%M%SZ}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+    return target
 
 
 def local_timezone() -> str:
@@ -126,7 +194,10 @@ def loop_card(scheduled: ScheduledLoop) -> list[str]:
 __all__ = [
     "DEFAULT_LOOP_TIME",
     "LOOP_WINDOW_DAYS",
+    "REPORT_NAME",
+    "SNAPSHOT_DIRNAME",
     "ScheduledLoop",
+    "build_report",
     "local_timezone",
     "loop_card",
     "loop_name",

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -11,14 +11,18 @@ from zoneinfo import ZoneInfo
 
 from config.constants.paths import OPENSRE_HOME_DIR
 from config.runtime_metadata.probes import local_tz_name
-from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
+from infrastructure.scheduling.scheduler.loop_constants import (
+    LOOP_PROMPT_PARAM,
+    LOOP_REPORT_ARGS_PARAM,
+    LOOP_REPORT_PARAM,
+)
 from infrastructure.scheduling.scheduler.loops import (
     ManualLoop,
     create_manual_loop,
     loop_channels,
     loop_time_label,
 )
-from infrastructure.scheduling.scheduler.storage import list_tasks
+from infrastructure.scheduling.scheduler.storage import list_tasks, update_task
 from infrastructure.scheduling.scheduler.types import Provider, TaskKind
 
 DEFAULT_LOOP_TIME = "08:00"
@@ -73,11 +77,14 @@ def schedule_ci_reliability_loop(
 ) -> ScheduledLoop:
     """Create the loop for ``owner/repo``, or return the one that already exists.
 
-    Delivery is pinned to this machine's shell inbox so a scheduled report can
-    never post to a chat channel by accident. Raises ``ValueError`` for a time
-    the scheduler cannot parse.
+    A loop saved before the deterministic builder existed is upgraded in
+    place so it stops running as a model turn. Delivery is pinned to this
+    machine's shell inbox so a scheduled report can never post to a chat
+    channel by accident. Raises ``ValueError`` for a time the scheduler
+    cannot parse.
     """
     prompt = loop_prompt(owner, repo)
+    report_args = {"owner": owner, "repo": repo, "days": str(LOOP_WINDOW_DAYS)}
     existing = next(
         (
             task
@@ -87,6 +94,10 @@ def schedule_ci_reliability_loop(
         None,
     )
     if existing is not None:
+        if existing.params.get(LOOP_REPORT_PARAM) != REPORT_NAME:
+            existing.params[LOOP_REPORT_PARAM] = REPORT_NAME
+            existing.params[LOOP_REPORT_ARGS_PARAM] = json.dumps(report_args, sort_keys=True)
+            update_task(existing, store_path)
         loop = ManualLoop(
             task=existing,
             channels=loop_channels(existing),
@@ -102,7 +113,7 @@ def schedule_ci_reliability_loop(
         channels=(_LOCAL_CHANNEL,),
         store_path=store_path,
         report=REPORT_NAME,
-        report_args={"owner": owner, "repo": repo, "days": str(LOOP_WINDOW_DAYS)},
+        report_args=report_args,
     )
     return ScheduledLoop(loop=created, reused=False)
 

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -102,7 +102,8 @@ def _map_evidence(evidence: dict[str, Any], output: dict[str, Any], _input: dict
         )
 
 
-def _payload(report: CiAnalyticsReport) -> dict[str, Any]:
+def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
+    """The report's figures as plain JSON-ready values."""
     return {
         "executions": report.executions,
         "pr_executions": report.pr_executions,
@@ -313,7 +314,7 @@ def analyze_github_ci_reliability(
             "coverage_notices": list(report.coverage_notices),
             "response_text": summary,
         }
-    return {**base, **_payload(report), "response_text": render_markdown(report)}
+    return {**base, **report_payload(report), "response_text": render_markdown(report)}
 
 
 __all__ = ["TOOL_NAME", "analyze_github_ci_reliability"]

--- a/integrations/manual_loop_runner.py
+++ b/integrations/manual_loop_runner.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
+import importlib
+import json
 import logging
+from collections.abc import Callable, Mapping
 
 from core.agent_harness import AgentSession
 from infrastructure.scheduling.scheduler.agent_runner import AgentPayload
+from infrastructure.scheduling.scheduler.loop_constants import (
+    LOOP_REPORT_ARGS_PARAM,
+    LOOP_REPORT_PARAM,
+)
 
 logger = logging.getLogger(__name__)
+
+#: Report builder name -> "module:function" producing the report text from string args.
+REPORT_BUILDERS: dict[str, str] = {
+    "github_ci_reliability": "integrations.github.tools.ci_analytics.loop:build_report",
+}
 
 _MANUAL_LOOP_INSTRUCTIONS = """Scheduled report loop.
 
@@ -34,8 +46,30 @@ def build_manual_loop_prompt(payload: AgentPayload) -> str:
     return f"{_MANUAL_LOOP_INSTRUCTIONS}\nLoop name: {name}\n\nReport request:\n{prompt}"
 
 
+def report_builder(payload: AgentPayload) -> Callable[[Mapping[str, str]], str] | None:
+    """The deterministic builder a loop names, or None when it runs as a model turn."""
+    name = str(payload.get(LOOP_REPORT_PARAM) or "").strip()
+    target = REPORT_BUILDERS.get(name)
+    if target is None:
+        return None
+    module_path, _, attribute = target.partition(":")
+    builder = getattr(importlib.import_module(module_path), attribute)
+    return builder  # type: ignore[no-any-return]
+
+
+def _report_args(payload: AgentPayload) -> dict[str, str]:
+    raw = payload.get(LOOP_REPORT_ARGS_PARAM) or "{}"
+    parsed = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Manual loop report arguments must be a JSON object.")
+    return {str(key): str(value) for key, value in parsed.items()}
+
+
 def run_manual_prompt_loop(payload: AgentPayload) -> str:
-    """Run one headless turn that produces only the requested report body."""
+    """Produce the loop's report: a deterministic builder when it names one, else one model turn."""
+    builder = report_builder(payload)
+    if builder is not None:
+        return builder(_report_args(payload))
     message = build_manual_loop_prompt(payload)
     result = AgentSession.run_headless_turn(
         message,
@@ -48,4 +82,9 @@ def run_manual_prompt_loop(payload: AgentPayload) -> str:
     return report
 
 
-__all__ = ["build_manual_loop_prompt", "run_manual_prompt_loop"]
+__all__ = [
+    "REPORT_BUILDERS",
+    "build_manual_loop_prompt",
+    "report_builder",
+    "run_manual_prompt_loop",
+]

--- a/surfaces/interactive_shell/command_registry/loops_cmds.py
+++ b/surfaces/interactive_shell/command_registry/loops_cmds.py
@@ -32,6 +32,7 @@ _LOOPS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("delete", "remove a loop permanently"),
     ("next", "debug one loop's next fire time"),
     ("messages", "local interactive-shell loop inbox"),
+    ("service", "background scheduler service: status, install, remove"),
 )
 
 _USAGE = (
@@ -44,6 +45,7 @@ _USAGE = (
     "/loops delete LOOP_ID",
     "/loops next LOOP_ID",
     "/loops messages [--limit N]",
+    "/loops service [install|remove]",
 )
 
 
@@ -176,6 +178,7 @@ def _validate_loops_args(args: list[str]) -> str | None:
         "remove",
         "resume",
         "run",
+        "service",
         "start",
         "stop",
     }:
@@ -202,6 +205,8 @@ def _cmd_loops(session: Session, console: Console, args: list[str]) -> bool:
         return _cmd_loops_next(session, console, rest)
     if sub in {"messages", "inbox"}:
         return _cmd_loops_messages(session, console, rest)
+    if sub == "service":
+        return _cmd_loops_service(session, console, rest)
 
     console.print(_loops_usage_error())
     return True
@@ -423,6 +428,33 @@ def _cmd_loops_messages(session: Session, console: Console, args: list[str]) -> 
             escape(_short(message.message)),
         )
     print_repl_table(console, table)
+    return True
+
+
+def _cmd_loops_service(session: Session, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    from infrastructure.scheduling.scheduler.background_service import (
+        background_service_state,
+        install_background_service,
+        remove_background_service,
+    )
+
+    action = args[0].lower() if args else "status"
+    try:
+        if action == "install":
+            state = install_background_service()
+        elif action == "remove":
+            state = remove_background_service()
+        elif action == "status":
+            state = background_service_state()
+        else:
+            console.print(f"[{ERROR}]usage:[/] /loops service [install|remove]")
+            return True
+    except RuntimeError as exc:
+        console.print(f"[{ERROR}]service change failed:[/] {escape(str(exc))}")
+        return True
+    console.print(escape(state.summary))
+    if state.installed and state.log_path is not None:
+        console.print(f"  [{DIM}]log:[/] {escape(str(state.log_path))}")
     return True
 
 

--- a/surfaces/interactive_shell/command_registry/loops_cmds.py
+++ b/surfaces/interactive_shell/command_registry/loops_cmds.py
@@ -86,7 +86,7 @@ def _short(text: str, *, max_chars: int = 120) -> str:
 def _loops_usage_error() -> str:
     return (
         f"[{ERROR}]usage:[/] "
-        "/loops [list|active|all|add|run|stop|start|delete|next|messages]\n"
+        "/loops [list|active|all|add|run|stop|start|delete|next|messages|service]\n"
         f'[{DIM}]example:[/] /loops add --name "Morning ops" --time 08:30 '
         '--prompt "Check open incidents and summarize risk" --run-now'
     )

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -37,6 +37,10 @@ from infrastructure.analytics.capture import (
     capture_onboarding_demo_skipped,
 )
 from infrastructure.analytics.source import is_test_run
+from infrastructure.scheduling.scheduler.background_service import (
+    background_service_state,
+    install_background_service,
+)
 from infrastructure.scheduling.scheduler.local_delivery import get_loop_messages
 from infrastructure.scheduling.scheduler.loops import parse_loop_time
 from infrastructure.terminal.theme import DIM, WARNING
@@ -100,9 +104,17 @@ _LOOP_FIRST_PASS_FAILED = (
     "Retry with `/loops run {task_id}` or check `/cron logs {task_id}`."
 )
 _NEXT_TITLE = "What would you like to do next?"
+_NEXT_SERVICE = "service"
+_NEXT_SERVICE_LABEL = (
+    "Keep it running when this shell is closed (installs a background scheduler service)"
+)
 _NEXT_SLACK = "slack"
 _NEXT_EXIT = "exit"
 _NEXT_EXIT_LABEL = "Exit demo"
+_SERVICE_INSTALLED = (
+    "Background scheduler installed. It starts at login and runs every loop on this machine; "
+    "remove it with /loops service remove."
+)
 _DEMO_EXITED = "Demo exited. Run /demo any time to pick another one."
 
 OPTION_CI_ANALYTICS = "ci_analytics"
@@ -136,7 +148,7 @@ DEMO_SUGGESTIONS: tuple[DemoSuggestion, ...] = (
     ),
     DemoSuggestion(
         option=OPTION_CI_AGENT,
-        label="Set up an agent that improves CI/CD reliability over time",
+        label="Set up an agent that reports CI/CD reliability every weekday",
     ),
     DemoSuggestion(
         option=OPTION_SLACK,
@@ -343,21 +355,37 @@ def _run_first_pass(console: Console | None, task_id: str, *, owner: str, repo: 
 
 
 def _offer_after_loop(session: Session, console: Console | None) -> bool:
-    """Offer the Slack demo as the next step; ``True`` when its prompt was queued."""
+    """Offer the background service and the Slack demo; ``True`` when a prompt was queued."""
     slack = _suggestion_for(OPTION_SLACK)
     assert slack is not None
+    choices = [(_NEXT_SLACK, slack.label), (_NEXT_EXIT, _NEXT_EXIT_LABEL)]
+    service = background_service_state()
+    if service.supported and not service.installed:
+        choices.insert(0, (_NEXT_SERVICE, _NEXT_SERVICE_LABEL))
     selected = repl_choose_one(
-        title=_NEXT_TITLE,
-        choices=[(_NEXT_SLACK, slack.label), (_NEXT_EXIT, _NEXT_EXIT_LABEL)],
-        letter_keys=True,
-        header=_MENU_HEADER,
+        title=_NEXT_TITLE, choices=choices, letter_keys=True, header=_MENU_HEADER
     )
+    if selected == _NEXT_SERVICE:
+        _install_service(console)
+        return _offer_after_loop(session, console)
     if selected == _NEXT_SLACK:
         session.terminal.set_auto_command(slack.prompt)
         return True
     if console is not None:
         render_note_block(console, _DEMO_EXITED)
     return False
+
+
+def _install_service(console: Console | None) -> None:
+    try:
+        state = install_background_service()
+    except RuntimeError as exc:
+        _warn(console, f"Could not install the background scheduler: {exc}")
+        return
+    if console is not None:
+        render_note_block(console, _SERVICE_INSTALLED)
+        console.print(reply_gutter(Text(f"Log: {state.log_path}"), lead=False))
+        console.print()
 
 
 def choose_repository(snapshot: WorkspaceSnapshot, *, title: str = _REPOSITORY_TITLE) -> str | None:

--- a/tests/integrations/test_manual_loop_runner.py
+++ b/tests/integrations/test_manual_loop_runner.py
@@ -1,0 +1,79 @@
+"""Tests for the manual loop runner's deterministic report builders."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+import pytest
+
+from integrations import manual_loop_runner
+from integrations.github.tools.ci_analytics import loop as ci_loop
+
+
+def _no_model_turn(*_args: object, **_kwargs: object) -> object:
+    raise AssertionError("a loop with a report builder must not run a model turn")
+
+
+def test_loop_naming_a_builder_runs_it_instead_of_a_model_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the registry points at the CI reliability builder; fake it.
+    received: list[Mapping[str, str]] = []
+
+    def fake_build_report(args: Mapping[str, str]) -> str:
+        received.append(dict(args))
+        return "**CI/CD reliability for o/r, last 7 days**"
+
+    monkeypatch.setattr(ci_loop, "build_report", fake_build_report)
+    monkeypatch.setattr(manual_loop_runner.AgentSession, "run_headless_turn", _no_model_turn)
+    payload = {
+        "loop_prompt": "fallback prompt",
+        "name": "CI reliability check",
+        "loop_report": "github_ci_reliability",
+        "loop_report_args": json.dumps({"owner": "o", "repo": "r", "days": "7"}),
+    }
+
+    # Act
+    report = manual_loop_runner.run_manual_prompt_loop(payload)
+
+    # Assert
+    assert report.startswith("**CI/CD reliability for o/r")
+    assert received == [{"owner": "o", "repo": "r", "days": "7"}]
+
+
+def test_loop_without_a_builder_still_runs_the_model_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    class _Result:
+        answered = True
+        primary_response_text = "report body"
+
+    def fake_turn(message: str, **_kwargs: object) -> _Result:
+        calls.append(message)
+        return _Result()
+
+    monkeypatch.setattr(manual_loop_runner.AgentSession, "run_headless_turn", fake_turn)
+
+    report = manual_loop_runner.run_manual_prompt_loop(
+        {"loop_prompt": "Summarize stars", "name": "x"}
+    )
+
+    assert report == "report body"
+    assert "Summarize stars" in calls[0]
+
+
+def test_unknown_builder_name_falls_back_to_the_model_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Result:
+        answered = True
+        primary_response_text = "fallback"
+
+    monkeypatch.setattr(
+        manual_loop_runner.AgentSession, "run_headless_turn", lambda *_a, **_k: _Result()
+    )
+
+    report = manual_loop_runner.run_manual_prompt_loop(
+        {"loop_prompt": "p", "name": "x", "loop_report": "not-a-builder"}
+    )
+
+    assert report == "fallback"

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -221,6 +221,15 @@ def _scheduled_stub(owner: str, repo: str) -> object:
     return ScheduledLoop(loop=loop, reused=False)
 
 
+def _service_state_factory(*, installed: bool, supported: bool = True) -> object:
+    from infrastructure.scheduling.scheduler.background_service import BackgroundServiceState
+
+    def state() -> BackgroundServiceState:
+        return BackgroundServiceState("Darwin", supported, installed, None, None)
+
+    return state
+
+
 def _agent_demo_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[dict[str, object]]:
     """Fake the scheduler side of the agent demo; returns the schedule calls made."""
     from infrastructure.scheduling.scheduler.local_delivery import LocalLoopMessage
@@ -246,6 +255,9 @@ def _agent_demo_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[d
         ]
 
     monkeypatch.setattr(demo_picker, "schedule_ci_reliability_loop", schedule)
+    monkeypatch.setattr(
+        demo_picker, "background_service_state", _service_state_factory(installed=True)
+    )
     monkeypatch.setattr(demo_picker, "local_timezone", lambda: "UTC")
     monkeypatch.setattr(demo_picker, "reload_loop_scheduler", lambda: 1)
     monkeypatch.setattr(demo_picker, "run_loop_now", lambda _task_id: True)
@@ -314,6 +326,40 @@ def test_agent_demo_warns_when_the_first_pass_skipped_the_analysis(
     output = " ".join(buf.getvalue().split())
     assert "Report unavailable" not in output
     assert "/loops run loop1" in output
+
+
+def test_agent_demo_offers_the_background_service_and_installs_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Arrange: no service yet; the user picks it, then exits.
+    from infrastructure.scheduling.scheduler.background_service import BackgroundServiceState
+
+    _agent_demo_ready(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        demo_picker, "background_service_state", _service_state_factory(installed=False)
+    )
+    installs: list[bool] = []
+
+    def install() -> BackgroundServiceState:
+        installs.append(True)
+        return BackgroundServiceState("Darwin", True, True, tmp_path / "unit", tmp_path / "log")
+
+    monkeypatch.setattr(demo_picker, "install_background_service", install)
+    menus = _answers(
+        monkeypatch, demo_picker.OPTION_CI_AGENT, "me/mine", "weekdays", "service", "exit"
+    )
+    session = Session()
+    console, buf = _capture()
+
+    # Act
+    demo_picker.offer_demo(session, console)
+
+    # Assert: the service row led the menu, the install ran once, then the menu came back.
+    first_next = [value for value, _label in menus[3]["choices"]]
+    assert first_next[0] == "service"
+    assert installs == [True]
+    assert "Background scheduler installed" in " ".join(buf.getvalue().split())
+    assert menus[4]["title"] == "What would you like to do next?"
 
 
 def test_agent_demo_hands_off_to_the_slack_demo_when_chosen(

--- a/tests/scheduler/test_background_service.py
+++ b/tests/scheduler/test_background_service.py
@@ -1,0 +1,119 @@
+"""Tests for the per-user background scheduler service."""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from infrastructure.scheduling.scheduler import background_service as svc
+
+
+class _Runner:
+    """Records OS commands and answers with a scripted exit code per command name."""
+
+    def __init__(self, failing: str = "") -> None:
+        self.commands: list[list[str]] = []
+        self._failing = failing
+
+    def __call__(self, command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        argv = list(command)
+        self.commands.append(argv)
+        code = 1 if self._failing and self._failing in argv else 0
+        return subprocess.CompletedProcess(argv, code, "", "denied" if code else "")
+
+
+def test_macos_install_writes_a_keepalive_launch_agent_and_bootstraps_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    runner = _Runner()
+
+    # Act
+    state = svc.install_background_service(
+        home=tmp_path,
+        system="Darwin",
+        run=runner,
+        command=["/usr/local/bin/opensre", "cron", "start", "--service"],
+    )
+
+    # Assert: the unit runs the scheduler, restarts it, and the OS was asked to load it.
+    assert state.installed is True
+    assert state.unit_path is not None
+    definition = plistlib.loads(state.unit_path.read_bytes())
+    assert definition["ProgramArguments"] == [
+        "/usr/local/bin/opensre",
+        "cron",
+        "start",
+        "--service",
+    ]
+    assert definition["KeepAlive"] is True
+    assert definition["RunAtLoad"] is True
+    assert [c[:2] for c in runner.commands] == [
+        ["launchctl", "bootout"],
+        ["launchctl", "bootstrap"],
+    ]
+    assert svc.background_service_state(home=tmp_path, system="Darwin").installed is True
+
+
+def test_macos_remove_deletes_the_unit_after_unloading_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    installed = svc.install_background_service(
+        home=tmp_path, system="Darwin", run=_Runner(), command=["x"]
+    )
+    assert installed.unit_path is not None and installed.unit_path.exists()
+
+    state = svc.remove_background_service(home=tmp_path, system="Darwin", run=_Runner())
+
+    assert state.installed is False
+    assert not installed.unit_path.exists()
+
+
+def test_a_refused_bootstrap_raises_instead_of_reporting_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+
+    with pytest.raises(RuntimeError, match="launchctl bootstrap failed: denied"):
+        svc.install_background_service(
+            home=tmp_path, system="Darwin", run=_Runner(failing="bootstrap"), command=["x"]
+        )
+
+
+def test_linux_install_writes_a_systemd_user_unit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    runner = _Runner()
+
+    state = svc.install_background_service(
+        home=tmp_path,
+        system="Linux",
+        run=runner,
+        command=["/usr/bin/opensre", "cron", "start", "--service"],
+    )
+
+    assert state.unit_path is not None
+    unit = state.unit_path.read_text()
+    assert "ExecStart=/usr/bin/opensre cron start --service" in unit
+    assert "Restart=always" in unit
+    assert runner.commands[-1][:4] == ["systemctl", "--user", "enable", "--now"]
+
+
+def test_other_platforms_are_reported_unsupported_without_touching_the_os(tmp_path: Path) -> None:
+    runner = _Runner()
+
+    state = svc.install_background_service(
+        home=tmp_path, system="Windows", run=runner, command=["x"]
+    )
+
+    assert state.supported is False
+    assert state.installed is False
+    assert runner.commands == []
+    assert "not supported on Windows" in state.summary

--- a/tests/scheduler/test_background_service.py
+++ b/tests/scheduler/test_background_service.py
@@ -13,15 +13,19 @@ from infrastructure.scheduling.scheduler import background_service as svc
 
 
 class _Runner:
-    """Records OS commands and answers with a scripted exit code per command name."""
+    """Records OS commands; ``failing`` names a command word that exits 1, ``loaded`` makes
+    the post-removal state check report the service as still running."""
 
-    def __init__(self, failing: str = "") -> None:
+    def __init__(self, failing: str = "", loaded: bool = False) -> None:
         self.commands: list[list[str]] = []
         self._failing = failing
+        self._loaded = loaded
 
     def __call__(self, command: Sequence[str]) -> subprocess.CompletedProcess[str]:
         argv = list(command)
         self.commands.append(argv)
+        if argv[:2] == ["launchctl", "print"] or argv[2:3] == ["is-active"]:
+            return subprocess.CompletedProcess(argv, 0 if self._loaded else 3, "", "")
         code = 1 if self._failing and self._failing in argv else 0
         return subprocess.CompletedProcess(argv, code, "", "denied" if code else "")
 
@@ -84,6 +88,23 @@ def test_a_refused_bootstrap_raises_instead_of_reporting_installed(
         svc.install_background_service(
             home=tmp_path, system="Darwin", run=_Runner(failing="bootstrap"), command=["x"]
         )
+    # The half-written unit is gone, so status does not claim a running service.
+    assert svc.background_service_state(home=tmp_path, system="Darwin").installed is False
+
+
+def test_a_service_the_os_will_not_stop_keeps_its_unit_and_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    installed = svc.install_background_service(
+        home=tmp_path, system="Darwin", run=_Runner(), command=["x"]
+    )
+
+    with pytest.raises(RuntimeError, match="still loaded"):
+        svc.remove_background_service(home=tmp_path, system="Darwin", run=_Runner(loaded=True))
+
+    assert installed.unit_path is not None and installed.unit_path.exists()
+    assert svc.background_service_state(home=tmp_path, system="Darwin").installed is True
 
 
 def test_linux_install_writes_a_systemd_user_unit(

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -106,3 +106,67 @@ def _scheduled_stub(owner: str, repo: str) -> ci_loop.ScheduledLoop:
     )
     loop = ManualLoop(task=task, channels=(Provider.INTERACTIVE_SHELL,), next_run="soon")
     return ci_loop.ScheduledLoop(loop=loop, reused=False)
+
+
+def test_loop_names_the_deterministic_builder_with_its_arguments(store_path: Path) -> None:
+    import json
+
+    from infrastructure.scheduling.scheduler.loop_constants import (
+        LOOP_REPORT_ARGS_PARAM,
+        LOOP_REPORT_PARAM,
+    )
+
+    scheduled = ci_loop.schedule_ci_reliability_loop(
+        "acme", "app", timezone="UTC", store_path=store_path
+    )
+
+    params = scheduled.loop.task.params
+    assert params[LOOP_REPORT_PARAM] == ci_loop.REPORT_NAME
+    assert json.loads(params[LOOP_REPORT_ARGS_PARAM]) == {
+        "owner": "acme",
+        "repo": "app",
+        "days": "7",
+    }
+
+
+def test_build_report_renders_the_analytics_and_keeps_a_json_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange: GitHub answers with no runs; the token is present.
+    import json
+
+    from integrations.github import client as github_client
+    from integrations.github.tools.ci_analytics import collector
+    from integrations.github.tools.ci_analytics.collector import CollectedRuns
+
+    monkeypatch.setattr(github_client, "resolve_github_token", lambda _t: "tok")
+    monkeypatch.setattr(
+        collector,
+        "collect_runs",
+        lambda *_a, **_k: CollectedRuns(
+            default_branch="main", branch_runs=[], pr_runs=[], merged_prs=(), coverage_notices=()
+        ),
+    )
+
+    # Act
+    report = ci_loop.build_report(
+        {"owner": "acme", "repo": "app", "days": "7"}, snapshot_dir=tmp_path
+    )
+
+    # Assert: header, headline, and a traceable snapshot on disk.
+    assert "CI/CD reliability for acme/app, last 7 days" in report
+    assert "Raw data: " in report
+    snapshot = Path(report.rsplit("Raw data: ", 1)[1].strip())
+    assert snapshot.parent == tmp_path / "acme-app"
+    assert json.loads(snapshot.read_text())["executions"] == 0
+
+
+def test_build_report_without_a_token_raises_a_generic_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from integrations.github import client as github_client
+
+    monkeypatch.setattr(github_client, "resolve_github_token", lambda _t: "")
+
+    with pytest.raises(RuntimeError, match="No GitHub token"):
+        ci_loop.build_report({"owner": "acme", "repo": "app"})

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -129,6 +129,38 @@ def test_loop_names_the_deterministic_builder_with_its_arguments(store_path: Pat
     }
 
 
+def test_a_loop_saved_before_the_builder_existed_is_upgraded_in_place(store_path: Path) -> None:
+    # Arrange: a legacy loop with the same prompt but no builder configured.
+    import json
+
+    from infrastructure.scheduling.scheduler.loop_constants import (
+        LOOP_REPORT_ARGS_PARAM,
+        LOOP_REPORT_PARAM,
+    )
+    from infrastructure.scheduling.scheduler.loops import create_manual_loop
+
+    legacy = create_manual_loop(
+        name=ci_loop.loop_name("acme", "app"),
+        prompt=ci_loop.loop_prompt("acme", "app"),
+        cron="0 8 * * 1-5",
+        channels=["interactive_shell"],
+        store_path=store_path,
+    )
+    assert LOOP_REPORT_PARAM not in legacy.task.params
+
+    # Act
+    scheduled = ci_loop.schedule_ci_reliability_loop(
+        "acme", "app", timezone="UTC", store_path=store_path
+    )
+
+    # Assert: same loop, now carrying the builder, persisted in the store.
+    assert scheduled.reused is True
+    assert scheduled.task_id == legacy.task.id
+    stored = next(t for t in list_tasks(store_path) if t.id == legacy.task.id)
+    assert stored.params[LOOP_REPORT_PARAM] == ci_loop.REPORT_NAME
+    assert json.loads(stored.params[LOOP_REPORT_ARGS_PARAM])["repo"] == "app"
+
+
 def test_build_report_renders_the_analytics_and_keeps_a_json_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tools/interactive_shell/shared/slash_catalog.py
+++ b/tools/interactive_shell/shared/slash_catalog.py
@@ -233,13 +233,17 @@ MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "List, create, stop, start, delete, run once, and debug recurring prompt loops, "
         "including next fire time. "
         "Subcommands: list, active, all, add, run <id>, stop <id>, start <id>, delete <id>, "
-        "next <id>, messages. "
-        "Use add with --prompt, --time or --cron, optional --channel, and --run-now.",
+        "next <id>, messages, service [install|remove]. "
+        "Use add with --prompt, --time or --cron, optional --channel, and --run-now. "
+        "service installs, removes, or shows the background scheduler service that keeps "
+        "loops running when no shell is open.",
         "User asks to list active loops or recurring scheduled loops",
         "User asks when configured loops will run next",
         "User asks to set up a manual recurring loop from a prompt",
         "User asks to add a loop and execute it once immediately",
         "User asks to stop, disable, resume, start, delete, or remove a recurring loop",
+        "User asks to keep loops running when the shell is closed, or to install, "
+        "check, or remove the background scheduler service",
         anti_examples=("User wants low-level cron task logs by task id (use /cron)",),
     ),
     "/mcp": _mcp(


### PR DESCRIPTION
Hardens the CI reliability agent demo after comparing it with what Droid
and Claude Code produce for the same request: both generate a launchd
service and a deterministic script. This PR closes those two gaps and
keeps opensre's advantages (60-second setup, baseline-adjusted KPI,
shell-only delivery).

- Deterministic tick: a manual loop may name a report builder; the runner
  uses it instead of a model turn. The CI reliability loop is built this
  way, so a delivery can no longer be a model refusal.
- Raw data: each delivery names a JSON snapshot of its figures under
  `~/.opensre/ci_reliability_reports/`.
- Background service: `/loops service install` registers a per-user
  launchd or systemd unit running `opensre cron start --service`; the demo
  offers it as the first next step when none is installed.
- The demo option now reads "Set up an agent that reports CI/CD
  reliability every weekday".