### PR TITLE
refactor(scheduler): centralize lease renewal and ownership fencing

### DIFF
--- a/infrastructure/scheduling/scheduler/claim_lease.py
+++ b/infrastructure/scheduling/scheduler/claim_lease.py
@@ -47,7 +47,7 @@ class ClaimOwnership:
             return not self._state.lost and self._monotonic() < self._state.confirmed_until
 
 
-class ClaimLeaseManager:
+class ClaimLeaseRenewer:
     """Renew every active process claim from one shared background loop."""
 
     def __init__(
@@ -189,7 +189,7 @@ class ClaimLeaseManager:
                 state.renew_at = min(state.confirmed_until, retry_at)
 
 
-default_claim_lease_manager = ClaimLeaseManager()
+default_claim_lease_renewer = ClaimLeaseRenewer()
 
 
-__all__ = ["ClaimLeaseManager", "ClaimOwnership", "default_claim_lease_manager"]
+__all__ = ["ClaimLeaseRenewer", "ClaimOwnership", "default_claim_lease_renewer"]

--- a/infrastructure/scheduling/scheduler/claim_lease.py
+++ b/infrastructure/scheduling/scheduler/claim_lease.py
@@ -1,0 +1,195 @@
+"""Process-level lease renewal for active scheduler executions."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable, Collection, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from infrastructure.scheduling.scheduler.storage import (
+    ExecutionClaim,
+    claim_renewal_interval_seconds,
+    renew_claims,
+)
+
+logger = logging.getLogger(__name__)
+
+RenewClaims = Callable[[Collection[ExecutionClaim]], Mapping[ExecutionClaim, datetime]]
+
+
+@dataclass(slots=True)
+class _LeaseState:
+    confirmed_until: float
+    renew_at: float
+    lost: bool = False
+
+
+class ClaimOwnership:
+    """Expose whether one execution still owns its confirmed lease."""
+
+    def __init__(
+        self,
+        state: _LeaseState,
+        condition: threading.Condition,
+        monotonic: Callable[[], float],
+    ) -> None:
+        self._state = state
+        self._condition = condition
+        self._monotonic = monotonic
+
+    def valid(self) -> bool:
+        """Return whether storage still confirms an unexpired fenced claim."""
+        with self._condition:
+            return not self._state.lost and self._monotonic() < self._state.confirmed_until
+
+
+class ClaimLeaseManager:
+    """Renew every active process claim from one shared background loop."""
+
+    def __init__(
+        self,
+        *,
+        renew: RenewClaims = renew_claims,
+        renewal_interval_seconds: float | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        utc_now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._renew = renew
+        self._renewal_interval_seconds = (
+            claim_renewal_interval_seconds()
+            if renewal_interval_seconds is None
+            else renewal_interval_seconds
+        )
+        if self._renewal_interval_seconds <= 0:
+            raise ValueError("renewal interval must be positive")
+        self._monotonic = monotonic
+        self._utc_now = utc_now or (lambda: datetime.now(UTC))
+        self._lock = threading.RLock()
+        self._condition = threading.Condition(self._lock)
+        self._active: dict[ExecutionClaim, _LeaseState] = {}
+        self._thread: threading.Thread | None = None
+
+    @contextmanager
+    def hold(self, claim: ExecutionClaim) -> Iterator[ClaimOwnership]:
+        """Register an active claim and release it when execution exits."""
+        confirmed_until = self._deadline_for(claim.lease_expires_at)
+        state = _LeaseState(
+            confirmed_until=confirmed_until,
+            renew_at=min(
+                confirmed_until,
+                self._monotonic() + self._renewal_interval_seconds,
+            ),
+        )
+        ownership = ClaimOwnership(state, self._condition, self._monotonic)
+        with self._condition:
+            if claim in self._active:
+                raise RuntimeError("claim is already registered")
+            self._active[claim] = state
+            self._ensure_thread_locked()
+            self._condition.notify_all()
+        try:
+            yield ownership
+        finally:
+            with self._condition:
+                state.lost = True
+                self._active.pop(claim, None)
+                self._condition.notify_all()
+
+    def _deadline_for(self, lease_expires_at: datetime) -> float:
+        remaining = max(0.0, (lease_expires_at - self._utc_now()).total_seconds())
+        return self._monotonic() + remaining
+
+    def _ensure_thread_locked(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name="scheduler-claim-renewal",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                if not self._active:
+                    self._thread = None
+                    return
+                live_states = [state for state in self._active.values() if not state.lost]
+                if not live_states:
+                    self._condition.wait()
+                    continue
+                wake_at = min(min(state.renew_at, state.confirmed_until) for state in live_states)
+                delay = min(
+                    self._renewal_interval_seconds,
+                    max(0.0, wake_at - self._monotonic()),
+                )
+                self._condition.wait(timeout=delay)
+                claims = self._claims_for_renewal_locked()
+            if not claims:
+                continue
+            try:
+                renewed = self._renew(claims)
+            except Exception:  # noqa: BLE001
+                logger.warning("Failed to renew scheduler execution claims", exc_info=True)
+                with self._condition:
+                    self._schedule_retry_locked(claims)
+                continue
+            with self._condition:
+                for claim in claims:
+                    state = self._active.get(claim)
+                    if state is None:
+                        continue
+                    lease_expires_at = renewed.get(claim)
+                    if lease_expires_at is None:
+                        state.lost = True
+                        logger.warning(
+                            "Lost scheduler claim for task %s fire_time=%s attempt=%d",
+                            claim.task_id,
+                            claim.fire_time,
+                            claim.attempt,
+                        )
+                    else:
+                        state.confirmed_until = self._deadline_for(lease_expires_at)
+                        state.renew_at = min(
+                            state.confirmed_until,
+                            self._monotonic() + self._renewal_interval_seconds,
+                        )
+
+    def _claims_for_renewal_locked(self) -> tuple[ExecutionClaim, ...]:
+        now = self._monotonic()
+        live: list[ExecutionClaim] = []
+        renewal_due = False
+        for claim, state in self._active.items():
+            if state.lost:
+                continue
+            if now >= state.confirmed_until:
+                state.lost = True
+                logger.warning(
+                    "Scheduler claim expired without confirmed renewal for task %s "
+                    "fire_time=%s attempt=%d",
+                    claim.task_id,
+                    claim.fire_time,
+                    claim.attempt,
+                )
+                continue
+            live.append(claim)
+            renewal_due = renewal_due or now >= state.renew_at
+        return tuple(live) if renewal_due else ()
+
+    def _schedule_retry_locked(self, claims: Collection[ExecutionClaim]) -> None:
+        retry_at = self._monotonic() + self._renewal_interval_seconds
+        for claim in claims:
+            state = self._active.get(claim)
+            if state is not None and not state.lost:
+                state.renew_at = min(state.confirmed_until, retry_at)
+
+
+default_claim_lease_manager = ClaimLeaseManager()
+
+
+__all__ = ["ClaimLeaseManager", "ClaimOwnership", "default_claim_lease_manager"]

--- a/infrastructure/scheduling/scheduler/claim_lease.py
+++ b/infrastructure/scheduling/scheduler/claim_lease.py
@@ -100,8 +100,10 @@ class ClaimLeaseRenewer:
                 self._condition.notify_all()
 
     def _deadline_for(self, lease_expires_at: datetime) -> float:
+        # Sample monotonic first so a pause between clocks cannot extend ownership.
+        monotonic_now = self._monotonic()
         remaining = max(0.0, (lease_expires_at - self._utc_now()).total_seconds())
-        return self._monotonic() + remaining
+        return monotonic_now + remaining
 
     def _ensure_thread_locked(self) -> None:
         if self._thread is not None and self._thread.is_alive():

--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 
 from infrastructure.scheduling.scheduler.claim_lease import (
     ClaimOwnership,
-    default_claim_lease_manager,
+    default_claim_lease_renewer,
 )
 from infrastructure.scheduling.scheduler.delivery_bundle import resolve_delivery_adapter
 from infrastructure.scheduling.scheduler.delivery_plan import (
@@ -73,7 +73,7 @@ def execute_task(
         )
         return False
 
-    with default_claim_lease_manager.hold(claim) as ownership:
+    with default_claim_lease_renewer.hold(claim) as ownership:
         return _execute_claimed_task(claim, ownership, task, fire_time, runners)
 
 

--- a/infrastructure/scheduling/scheduler/executor.py
+++ b/infrastructure/scheduling/scheduler/executor.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
+from infrastructure.scheduling.scheduler.claim_lease import (
+    ClaimOwnership,
+    default_claim_lease_manager,
+)
 from infrastructure.scheduling.scheduler.delivery_bundle import resolve_delivery_adapter
 from infrastructure.scheduling.scheduler.delivery_plan import (
     DeliveryTarget,
@@ -68,6 +73,18 @@ def execute_task(
         )
         return False
 
+    with default_claim_lease_manager.hold(claim) as ownership:
+        return _execute_claimed_task(claim, ownership, task, fire_time, runners)
+
+
+def _execute_claimed_task(
+    claim: ExecutionClaim,
+    ownership: ClaimOwnership,
+    task: ScheduledTask,
+    fire_time: str,
+    runners: SchedulerRunners,
+) -> bool:
+    """Build and deliver a task while its fenced lease remains valid."""
     logger.info("Executing task %s (kind=%s, fire_time=%s)", task.id, task.kind, fire_time)
     record_scheduler_execution_operation(
         "scheduled_task_execution_started",
@@ -104,6 +121,14 @@ def execute_task(
         )
         return False
 
+    if not ownership.valid():
+        logger.warning(
+            "Skipping delivery after losing scheduler claim for task %s fire_time=%s",
+            task.id,
+            fire_time,
+        )
+        return False
+
     # Quiet ticks (e.g. uptime watch with no transitions) skip delivery.
     if not message.strip():
         if not complete_run(
@@ -126,7 +151,19 @@ def execute_task(
         return True
 
     # Fan out to every destination the task resolves to, concurrently.
-    result = _deliver_all(task, message, target_filter=claim.target_filter)
+    result = _deliver_all(
+        task,
+        message,
+        target_filter=claim.target_filter,
+        can_deliver=ownership.valid,
+    )
+    if not ownership.valid():
+        logger.warning(
+            "Discarding delivery result after losing scheduler claim for task %s fire_time=%s",
+            task.id,
+            fire_time,
+        )
+        return False
     message_id = result.message_id()
     error = result.error()
 
@@ -203,8 +240,14 @@ def _record_work_item_reminder_delivery(task: ScheduledTask) -> None:
         )
 
 
-def _deliver_single(target: DeliveryTarget, message: str) -> tuple[bool, str, str]:
+def _deliver_single(
+    target: DeliveryTarget,
+    message: str,
+    can_deliver: Callable[[], bool] | None = None,
+) -> tuple[bool, str, str]:
     """Deliver one message to one destination via its installed adapter."""
+    if can_deliver is not None and not can_deliver():
+        return False, "scheduler claim ownership lost", ""
     adapter = resolve_delivery_adapter(target.provider)
     if adapter is None:
         return False, f"Unsupported provider: {target.provider}", ""
@@ -212,11 +255,19 @@ def _deliver_single(target: DeliveryTarget, message: str) -> tuple[bool, str, st
 
 
 def _deliver_all(
-    task: ScheduledTask, message: str, *, target_filter: frozenset[TargetKey] | None = None
+    task: ScheduledTask,
+    message: str,
+    *,
+    target_filter: frozenset[TargetKey] | None = None,
+    can_deliver: Callable[[], bool] | None = None,
 ) -> FanOutResult:
     """Resolve ``task``'s destinations once and deliver to all of them at once."""
     plan = resolve_delivery_plan(task, only=target_filter)
-    return deliver_plan(plan, message, _deliver_single)
+    return deliver_plan(
+        plan,
+        message,
+        lambda target, content: _deliver_single(target, content, can_deliver),
+    )
 
 
 def _target_outcome_summary(result: FanOutResult) -> tuple[str, ...]:

--- a/infrastructure/scheduling/scheduler/storage/__init__.py
+++ b/infrastructure/scheduling/scheduler/storage/__init__.py
@@ -7,12 +7,14 @@ from infrastructure.scheduling.scheduler.storage.database import (
 from infrastructure.scheduling.scheduler.storage.run_store import (
     ExecutionClaim,
     ExpiredClaim,
+    claim_renewal_interval_seconds,
     complete_run,
     delete_runs,
     get_expired_claims,
     get_latest_finished_run,
     get_latest_targeted_run,
     get_runs,
+    renew_claims,
     try_claim,
 )
 from infrastructure.scheduling.scheduler.storage.task_store import (
@@ -27,6 +29,7 @@ from infrastructure.scheduling.scheduler.storage.task_store import (
 
 __all__ = [
     "add_task",
+    "claim_renewal_interval_seconds",
     "complete_run",
     "default_run_database_path",
     "default_task_store_path",
@@ -41,6 +44,7 @@ __all__ = [
     "list_tasks",
     "record_task_success",
     "remove_task",
+    "renew_claims",
     "run_database_path",
     "try_claim",
     "update_task",

--- a/infrastructure/scheduling/scheduler/storage/run_store.py
+++ b/infrastructure/scheduling/scheduler/storage/run_store.py
@@ -38,6 +38,7 @@ class ExecutionClaim:
     fire_time: str
     attempt: int
     owner_token: str
+    lease_expires_at: datetime
     target_filter: frozenset[tuple[Provider, str]] | None = None
 
 
@@ -108,9 +109,54 @@ def try_claim(
                     json.dumps(sorted(target_filter) if target_filter is not None else None),
                 ),
             )
-            return ExecutionClaim(task_id, fire_time, attempt, owner_token, target_filter)
+            return ExecutionClaim(
+                task_id,
+                fire_time,
+                attempt,
+                owner_token,
+                now + timedelta(seconds=_CLAIM_LEASE_SECONDS),
+                target_filter,
+            )
     except sqlite3.IntegrityError:
         return None
+
+
+def claim_renewal_interval_seconds() -> float:
+    """Return a renewal interval that leaves two intervals of lease safety."""
+    return _CLAIM_LEASE_SECONDS / 3
+
+
+def renew_claims(
+    claims: Collection[ExecutionClaim],
+    db_path: Path | None = None,
+) -> dict[ExecutionClaim, datetime]:
+    """Renew live fenced claims together and return their confirmed expiries."""
+    if not claims:
+        return {}
+    renewed: dict[ExecutionClaim, datetime] = {}
+    with database.transaction(db_path, immediate=True) as conn:
+        now = datetime.now(UTC)
+        now_text = now.isoformat()
+        lease_expires_at = now + timedelta(seconds=_CLAIM_LEASE_SECONDS)
+        lease_text = lease_expires_at.isoformat()
+        for claim in claims:
+            cursor = conn.execute(
+                "UPDATE task_runs SET lease_expires_at = ? "
+                "WHERE task_id = ? AND fire_time = ? AND attempt = ? "
+                "AND owner_token = ? AND status = ? AND lease_expires_at >= ?",
+                (
+                    lease_text,
+                    claim.task_id,
+                    claim.fire_time,
+                    claim.attempt,
+                    claim.owner_token,
+                    TaskStatus.RUNNING.value,
+                    now_text,
+                ),
+            )
+            if cursor.rowcount == 1:
+                renewed[claim] = lease_expires_at
+    return renewed
 
 
 def _decode_target_filter(raw: str) -> frozenset[tuple[Provider, str]] | None:
@@ -177,13 +223,13 @@ def complete_run(
     ``targets`` is stored in the order it is given, which is the order the run
     planned its destinations in — not the order they finished.
     """
-    with database.transaction(db_path) as conn:
+    with database.transaction(db_path, immediate=True) as conn:
         now = datetime.now(UTC).isoformat()
         cursor = conn.execute(
             "UPDATE task_runs SET finished_at = ?, status = ?, "
             "posted_message_id = ?, error = ?, provider = ?, targets = ? "
             "WHERE task_id = ? AND fire_time = ? AND attempt = ? "
-            "AND owner_token = ? AND status = ?",
+            "AND owner_token = ? AND status = ? AND lease_expires_at >= ?",
             (
                 now,
                 status.value,
@@ -196,6 +242,7 @@ def complete_run(
                 claim.attempt,
                 claim.owner_token,
                 TaskStatus.RUNNING.value,
+                now,
             ),
         )
         completed = cursor.rowcount == 1
@@ -334,6 +381,7 @@ def delete_runs(task_id: str, db_path: Path | None = None) -> int:
 
 
 __all__ = [
+    "claim_renewal_interval_seconds",
     "complete_run",
     "delete_runs",
     "ExpiredClaim",
@@ -342,5 +390,6 @@ __all__ = [
     "get_latest_finished_run",
     "get_latest_targeted_run",
     "get_runs",
+    "renew_claims",
     "try_claim",
 ]

--- a/tests/scheduler/test_claim_lease.py
+++ b/tests/scheduler/test_claim_lease.py
@@ -32,6 +32,26 @@ def _wait_until(predicate: Callable[[], bool], timeout: float = _SYNC_TIMEOUT_SE
     return False
 
 
+def test_clock_sampling_pause_does_not_extend_ownership() -> None:
+    claim = _claim("clock-pause", expires_in=10)
+    elapsed = 0.0
+
+    def utc_now() -> datetime:
+        nonlocal elapsed
+        sampled = claim.lease_expires_at - timedelta(seconds=10)
+        # Model descheduling after sampling UTC but before returning to the caller.
+        elapsed = 20.0
+        return sampled
+
+    renewer = ClaimLeaseRenewer(
+        monotonic=lambda: elapsed,
+        utc_now=utc_now,
+        renewal_interval_seconds=60,
+    )
+    with renewer.hold(claim) as ownership:
+        assert not ownership.valid()
+
+
 def test_concurrent_claims_are_renewed_in_one_batch() -> None:
     first = _claim("first")
     second = _claim("second")

--- a/tests/scheduler/test_claim_lease.py
+++ b/tests/scheduler/test_claim_lease.py
@@ -6,7 +6,7 @@ import threading
 from collections.abc import Callable, Collection, Mapping
 from datetime import UTC, datetime, timedelta
 
-from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseRenewer
 from infrastructure.scheduling.scheduler.storage import ExecutionClaim
 
 _SYNC_TIMEOUT_SECONDS = 5.0
@@ -47,8 +47,8 @@ def test_concurrent_claims_are_renewed_in_one_batch() -> None:
         expiry = datetime.now(UTC) + timedelta(seconds=1)
         return dict.fromkeys(batch, expiry)
 
-    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.05)
-    with manager.hold(first) as first_ownership, manager.hold(second) as second_ownership:
+    renewer = ClaimLeaseRenewer(renew=renew, renewal_interval_seconds=0.05)
+    with renewer.hold(first) as first_ownership, renewer.hold(second) as second_ownership:
         assert renewed.wait(_SYNC_TIMEOUT_SECONDS)
         assert _wait_until(lambda: len(batches) >= 1)
         assert set(batches[0]) == {first, second}
@@ -68,8 +68,8 @@ def test_fenced_renewal_loses_only_the_rejected_claim() -> None:
         expiry = datetime.now(UTC) + timedelta(seconds=1)
         return {claim: expiry for claim in claims if claim == retained}
 
-    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
-    with manager.hold(rejected) as rejected_ownership, manager.hold(retained) as retained_ownership:
+    renewer = ClaimLeaseRenewer(renew=renew, renewal_interval_seconds=0.01)
+    with renewer.hold(rejected) as rejected_ownership, renewer.hold(retained) as retained_ownership:
         assert renewed.wait(_SYNC_TIMEOUT_SECONDS)
         assert _wait_until(lambda: not rejected_ownership.valid())
         assert retained_ownership.valid()
@@ -91,8 +91,8 @@ def test_transient_renewal_error_recovers_before_confirmed_deadline() -> None:
         expiry = datetime.now(UTC) + timedelta(seconds=1)
         return dict.fromkeys(claims, expiry)
 
-    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
-    with manager.hold(claim) as ownership:
+    renewer = ClaimLeaseRenewer(renew=renew, renewal_interval_seconds=0.01)
+    with renewer.hold(claim) as ownership:
         assert recovered.wait(_SYNC_TIMEOUT_SECONDS)
         assert attempts >= 2
         assert ownership.valid()
@@ -108,8 +108,8 @@ def test_persistent_renewal_error_expires_the_local_ownership() -> None:
         attempted.set()
         raise RuntimeError("database unavailable")
 
-    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
-    with manager.hold(claim) as ownership:
+    renewer = ClaimLeaseRenewer(renew=renew, renewal_interval_seconds=0.01)
+    with renewer.hold(claim) as ownership:
         assert attempted.wait(_SYNC_TIMEOUT_SECONDS)
         assert _wait_until(lambda: not ownership.valid())
 
@@ -125,8 +125,8 @@ def test_renewal_loop_stops_after_the_last_claim_exits() -> None:
         expiry = datetime.now(UTC) + timedelta(seconds=1)
         return dict.fromkeys(claims, expiry)
 
-    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
-    with manager.hold(claim):
+    renewer = ClaimLeaseRenewer(renew=renew, renewal_interval_seconds=0.01)
+    with renewer.hold(claim):
         assert renewed.wait(_SYNC_TIMEOUT_SECONDS)
 
-    assert _wait_until(lambda: manager._thread is None)  # noqa: SLF001
+    assert _wait_until(lambda: renewer._thread is None)  # noqa: SLF001

--- a/tests/scheduler/test_claim_lease.py
+++ b/tests/scheduler/test_claim_lease.py
@@ -1,0 +1,132 @@
+"""Tests for process-level scheduler claim renewal."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Collection, Mapping
+from datetime import UTC, datetime, timedelta
+
+from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+from infrastructure.scheduling.scheduler.storage import ExecutionClaim
+
+_SYNC_TIMEOUT_SECONDS = 5.0
+
+
+def _claim(task_id: str, *, expires_in: float = 1.0) -> ExecutionClaim:
+    return ExecutionClaim(
+        task_id=task_id,
+        fire_time="2026-01-01T09:00Z",
+        attempt=1,
+        owner_token=f"owner-{task_id}",
+        lease_expires_at=datetime.now(UTC) + timedelta(seconds=expires_in),
+    )
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = _SYNC_TIMEOUT_SECONDS) -> bool:
+    done = threading.Event()
+    deadline = datetime.now(UTC) + timedelta(seconds=timeout)
+    while datetime.now(UTC) < deadline:
+        if predicate():
+            return True
+        done.wait(0.005)
+    return False
+
+
+def test_concurrent_claims_are_renewed_in_one_batch() -> None:
+    first = _claim("first")
+    second = _claim("second")
+    batches: list[tuple[ExecutionClaim, ...]] = []
+    renewed = threading.Event()
+
+    def renew(
+        claims: Collection[ExecutionClaim],
+    ) -> Mapping[ExecutionClaim, datetime]:
+        batch = tuple(claims)
+        batches.append(batch)
+        renewed.set()
+        expiry = datetime.now(UTC) + timedelta(seconds=1)
+        return dict.fromkeys(batch, expiry)
+
+    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.05)
+    with manager.hold(first) as first_ownership, manager.hold(second) as second_ownership:
+        assert renewed.wait(_SYNC_TIMEOUT_SECONDS)
+        assert _wait_until(lambda: len(batches) >= 1)
+        assert set(batches[0]) == {first, second}
+        assert first_ownership.valid()
+        assert second_ownership.valid()
+
+
+def test_fenced_renewal_loses_only_the_rejected_claim() -> None:
+    rejected = _claim("rejected")
+    retained = _claim("retained")
+    renewed = threading.Event()
+
+    def renew(
+        claims: Collection[ExecutionClaim],
+    ) -> Mapping[ExecutionClaim, datetime]:
+        renewed.set()
+        expiry = datetime.now(UTC) + timedelta(seconds=1)
+        return {claim: expiry for claim in claims if claim == retained}
+
+    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
+    with manager.hold(rejected) as rejected_ownership, manager.hold(retained) as retained_ownership:
+        assert renewed.wait(_SYNC_TIMEOUT_SECONDS)
+        assert _wait_until(lambda: not rejected_ownership.valid())
+        assert retained_ownership.valid()
+
+
+def test_transient_renewal_error_recovers_before_confirmed_deadline() -> None:
+    claim = _claim("transient")
+    attempts = 0
+    recovered = threading.Event()
+
+    def renew(
+        claims: Collection[ExecutionClaim],
+    ) -> Mapping[ExecutionClaim, datetime]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary database failure")
+        recovered.set()
+        expiry = datetime.now(UTC) + timedelta(seconds=1)
+        return dict.fromkeys(claims, expiry)
+
+    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
+    with manager.hold(claim) as ownership:
+        assert recovered.wait(_SYNC_TIMEOUT_SECONDS)
+        assert attempts >= 2
+        assert ownership.valid()
+
+
+def test_persistent_renewal_error_expires_the_local_ownership() -> None:
+    claim = _claim("persistent", expires_in=0.08)
+    attempted = threading.Event()
+
+    def renew(
+        _claims: Collection[ExecutionClaim],
+    ) -> Mapping[ExecutionClaim, datetime]:
+        attempted.set()
+        raise RuntimeError("database unavailable")
+
+    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
+    with manager.hold(claim) as ownership:
+        assert attempted.wait(_SYNC_TIMEOUT_SECONDS)
+        assert _wait_until(lambda: not ownership.valid())
+
+
+def test_renewal_loop_stops_after_the_last_claim_exits() -> None:
+    claim = _claim("cleanup")
+    renewed = threading.Event()
+
+    def renew(
+        claims: Collection[ExecutionClaim],
+    ) -> Mapping[ExecutionClaim, datetime]:
+        renewed.set()
+        expiry = datetime.now(UTC) + timedelta(seconds=1)
+        return dict.fromkeys(claims, expiry)
+
+    manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.01)
+    with manager.hold(claim):
+        assert renewed.wait(_SYNC_TIMEOUT_SECONDS)
+
+    assert _wait_until(lambda: manager._thread is None)  # noqa: SLF001

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -137,7 +137,7 @@ class TestExecutor:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseRenewer
 
         monkeypatch.setattr(run_store, "_CLAIM_LEASE_SECONDS", 0.1)
         renewed = threading.Event()
@@ -149,8 +149,8 @@ class TestExecutor:
                 renewed.set()
             return result
 
-        manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.02)
-        monkeypatch.setattr(scheduler_executor, "default_claim_lease_manager", manager)
+        renewer = ClaimLeaseRenewer(renew=renew, renewal_interval_seconds=0.02)
+        monkeypatch.setattr(scheduler_executor, "default_claim_lease_renewer", renewer)
         adapters = _install_fake_bundle()
         task = ScheduledTask(
             id="test_slow_execution_renewal",
@@ -192,7 +192,7 @@ class TestExecutor:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseRenewer
 
         monkeypatch.setattr(run_store, "_CLAIM_LEASE_SECONDS", 0.08)
         attempted = threading.Event()
@@ -201,8 +201,8 @@ class TestExecutor:
             attempted.set()
             raise sqlite3.OperationalError("database unavailable")
 
-        manager = ClaimLeaseManager(renew=unavailable, renewal_interval_seconds=0.01)
-        monkeypatch.setattr(scheduler_executor, "default_claim_lease_manager", manager)
+        renewer = ClaimLeaseRenewer(renew=unavailable, renewal_interval_seconds=0.01)
+        monkeypatch.setattr(scheduler_executor, "default_claim_lease_renewer", renewer)
         adapters = _install_fake_bundle()
         task = ScheduledTask(
             id="test_persistent_renewal_failure",
@@ -229,15 +229,15 @@ class TestExecutor:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseRenewer
 
         monkeypatch.setattr(run_store, "_CLAIM_LEASE_SECONDS", 0.2)
 
         def unavailable(_claims: Any) -> Any:
             raise sqlite3.OperationalError("database unavailable")
 
-        manager = ClaimLeaseManager(renew=unavailable, renewal_interval_seconds=0.01)
-        monkeypatch.setattr(scheduler_executor, "default_claim_lease_manager", manager)
+        renewer = ClaimLeaseRenewer(renew=unavailable, renewal_interval_seconds=0.01)
+        monkeypatch.setattr(scheduler_executor, "default_claim_lease_renewer", renewer)
         adapter = _SlowFailingAdapter()
         _install_bundle({Provider.SLACK: adapter, Provider.TELEGRAM: adapter})
         task = ScheduledTask(

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -18,6 +18,8 @@ from unittest.mock import patch
 import pytest
 
 import infrastructure.scheduling.scheduler.delivery_bundle as delivery_bundle
+import infrastructure.scheduling.scheduler.executor as scheduler_executor
+import infrastructure.scheduling.scheduler.storage.run_store as run_store
 from config.constants import OPENSRE_OPERATIONS_LOG_PATH_ENV
 from infrastructure.observability.operations_log import read_operations
 from infrastructure.scheduling.scheduler.executor import execute_task
@@ -73,6 +75,18 @@ class _CrashOnceAdapter:
         return True, "", "recovered-message"
 
 
+class _SlowFailingAdapter:
+    """Outlive a short lease and expose retries attempted after ownership loss."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def deliver(self, _task: ScheduledTask, _message: str) -> tuple[bool, str, str]:
+        self.calls += 1
+        threading.Event().wait(0.25)
+        return False, "temporary delivery failure", ""
+
+
 def _install_fake_bundle() -> dict[Provider, _FakeAdapter]:
     """Install a fake adapter for every provider; return them to configure/inspect."""
     adapters = {provider: _FakeAdapter() for provider in _DELIVERY_PROVIDERS}
@@ -119,6 +133,136 @@ def _expire_claim(db_path: Path, task_id: str, fire_time: str) -> None:
 
 @pytest.mark.usefixtures("_tmp_stores")
 class TestExecutor:
+    def test_shared_lease_renewal_prevents_recovery_of_a_slow_execution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+
+        monkeypatch.setattr(run_store, "_CLAIM_LEASE_SECONDS", 0.1)
+        renewed = threading.Event()
+        real_renew = run_store.renew_claims
+
+        def renew(claims: Any) -> Any:
+            result = real_renew(claims)
+            if result:
+                renewed.set()
+            return result
+
+        manager = ClaimLeaseManager(renew=renew, renewal_interval_seconds=0.02)
+        monkeypatch.setattr(scheduler_executor, "default_claim_lease_manager", manager)
+        adapters = _install_fake_bundle()
+        task = ScheduledTask(
+            id="test_slow_execution_renewal",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+        fire_time = "2026-01-01T09:00Z"
+        building = threading.Event()
+        release = threading.Event()
+        first_result: list[bool] = []
+
+        def build_slowly(*_args: object) -> str:
+            building.set()
+            assert release.wait(_SYNC_TIMEOUT_SECONDS)
+            return "Scheduled report"
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            side_effect=build_slowly,
+        ):
+            worker = threading.Thread(
+                target=lambda: first_result.append(execute_task(task, fire_time, real_runners()))
+            )
+            worker.start()
+            assert building.wait(_SYNC_TIMEOUT_SECONDS)
+            assert renewed.wait(_SYNC_TIMEOUT_SECONDS)
+            threading.Event().wait(0.12)
+            assert execute_task(task, fire_time, real_runners()) is False
+            release.set()
+            worker.join(_SYNC_TIMEOUT_SECONDS)
+
+        assert not worker.is_alive()
+        assert first_result == [True]
+        assert len(adapters[Provider.SLACK].calls) == 1
+
+    def test_persistent_renewal_errors_stop_delivery_at_the_confirmed_deadline(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+
+        monkeypatch.setattr(run_store, "_CLAIM_LEASE_SECONDS", 0.08)
+        attempted = threading.Event()
+
+        def unavailable(_claims: Any) -> Any:
+            attempted.set()
+            raise sqlite3.OperationalError("database unavailable")
+
+        manager = ClaimLeaseManager(renew=unavailable, renewal_interval_seconds=0.01)
+        monkeypatch.setattr(scheduler_executor, "default_claim_lease_manager", manager)
+        adapters = _install_fake_bundle()
+        task = ScheduledTask(
+            id="test_persistent_renewal_failure",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.SLACK,
+            chat_id="C123",
+        )
+
+        def build_past_expiry(*_args: object) -> str:
+            assert attempted.wait(_SYNC_TIMEOUT_SECONDS)
+            threading.Event().wait(0.12)
+            return "Scheduled report"
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            side_effect=build_past_expiry,
+        ):
+            assert execute_task(task, "2026-01-01T09:00Z", real_runners()) is False
+
+        assert adapters[Provider.SLACK].calls == []
+
+    def test_ownership_loss_stops_delivery_retries(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from infrastructure.scheduling.scheduler.claim_lease import ClaimLeaseManager
+
+        monkeypatch.setattr(run_store, "_CLAIM_LEASE_SECONDS", 0.2)
+
+        def unavailable(_claims: Any) -> Any:
+            raise sqlite3.OperationalError("database unavailable")
+
+        manager = ClaimLeaseManager(renew=unavailable, renewal_interval_seconds=0.01)
+        monkeypatch.setattr(scheduler_executor, "default_claim_lease_manager", manager)
+        adapter = _SlowFailingAdapter()
+        _install_bundle({Provider.SLACK: adapter, Provider.TELEGRAM: adapter})
+        task = ScheduledTask(
+            id="test_lost_delivery_retry",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.INTERACTIVE_SHELL,
+            params={
+                "delivery_targets": json.dumps(
+                    [
+                        {"provider": "slack", "chat_id": "C123"},
+                        {"provider": "telegram", "chat_id": "456"},
+                    ]
+                )
+            },
+        )
+
+        with patch(
+            "infrastructure.scheduling.scheduler.executor.build_message",
+            return_value="Scheduled report",
+        ):
+            assert execute_task(task, "2026-01-01T09:00Z", real_runners()) is False
+
+        assert adapter.calls == 2
+
     @pytest.mark.parametrize("delivery_succeeds", [True, False])
     def test_recovered_one_shot_finalizes_only_after_success(
         self, tmp_path: Path, delivery_succeeds: bool

--- a/tests/scheduler/test_run_store.py
+++ b/tests/scheduler/test_run_store.py
@@ -19,6 +19,7 @@ from infrastructure.scheduling.scheduler.storage.run_store import (
     get_latest_finished_run,
     get_latest_targeted_run,
     get_runs,
+    renew_claims,
     try_claim,
 )
 from infrastructure.scheduling.scheduler.types import DeliveryOutcome, Provider, TaskStatus
@@ -122,6 +123,34 @@ class TestClaimStore:
             status=TaskStatus.SUCCESS,
             db_path=db_path,
         )
+
+    def test_active_claims_are_renewed_in_one_transaction(self, db_path: Path) -> None:
+        first = _claimed(db_path, "task1", "2026-01-01T09:00")
+        second = _claimed(db_path, "task2", "2026-01-01T09:00")
+
+        renewed = renew_claims((first, second), db_path=db_path)
+
+        assert set(renewed) == {first, second}
+        assert renewed[first] > first.lease_expires_at
+        assert renewed[second] > second.lease_expires_at
+
+    def test_renewal_rejects_an_expired_claim_before_recovery(self, db_path: Path) -> None:
+        claim = _claimed(db_path, "task1", "2026-01-01T09:00")
+        _expire_claim(db_path, claim.task_id, claim.fire_time)
+
+        assert renew_claims((claim,), db_path=db_path) == {}
+        assert not complete_run(claim, status=TaskStatus.SUCCESS, db_path=db_path)
+        assert get_runs(claim.task_id, db_path=db_path)[0].status is TaskStatus.RUNNING
+
+    def test_batch_renewal_excludes_a_reclaimed_owner(self, db_path: Path) -> None:
+        stale = _claimed(db_path, "task1", "2026-01-01T09:00")
+        _expire_claim(db_path, stale.task_id, stale.fire_time)
+        current = _claimed(db_path, stale.task_id, stale.fire_time)
+
+        renewed = renew_claims((stale, current), db_path=db_path)
+
+        assert stale not in renewed
+        assert current in renewed
 
     def test_different_fire_times_both_succeed(self, db_path: Path) -> None:
         assert try_claim("task1", "2026-01-01T09:00", db_path=db_path) is not None


### PR DESCRIPTION
Fixes #6087

Related to #6082. This is the process-level batched lease-renewal alternative to #6083.

#### Describe the changes you have made in this PR -

- add one process-level `ClaimLeaseRenewer` that registers every locally active claim and renews due claims in a shared batch
- track each claim's last storage-confirmed lease deadline using a monotonic clock
- sample monotonic time before UTC so a pause between clock readings cannot extend ownership
- retry transient renewal errors only inside that confirmed safety window and fail closed at expiry
- fence renewal and completion by task, fire time, attempt, owner token, running status, and an unexpired lease
- check ownership before delivery, before every fan-out retry, and before persisting delivery results
- stop the renewal loop automatically after the final active claim exits

This keeps the existing durable recovery sweep for genuinely abandoned work while removing one heartbeat thread per execution.

### Demo/Screenshot for feature changes and bug fixes -

Local scheduler validation:

```text
$ uv run python -m pytest tests/scheduler -n 4 -q
270 passed

$ make test-scope
89 passed

$ uv run python -m pytest tests/quality/test_no_umbrella_names.py -q
38 passed

$ make lint
All checks passed!

$ make format-check
3115 files already formatted

$ make typecheck
Success: no issues found in 1804 source files
```

The regression suite covers concurrent claims sharing a renewal batch, slow execution surviving its original lease, fenced stale owners, transient and persistent renewal failures, recovery after expiry, fan-out retry fencing, renewal-loop cleanup, and a deterministic clock-sampling pause. The new clock-pause regression fails on the previous head and passes with the conservative deadline conversion.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The existing lease remains the durable crash-recovery authority. A local renewer owns only process liveness: executions register their claims, one daemon renewal loop batches active claims, and each registration receives a lightweight ownership guard.

A successful renewal moves the local monotonic deadline to the new storage-confirmed expiry. A definitive fenced result invalidates that claim immediately. Storage exceptions schedule another attempt but never extend the local deadline, so persistent failures eventually stop new external sends.

Alternatives considered:

- per-execution heartbeat threads: simpler locally, but thread and renewal work scale with concurrent executions
- renewal from the recovery sweep: cannot distinguish a slow live owner from a crashed owner
- a fixed longer lease: delays recovery and still fails for sufficiently slow executions
- a durable delivery outbox: valuable follow-up for provider-side send/ack ambiguity, but intentionally outside this ownership-focused change

Key components:

- `ClaimLeaseRenewer`: shared claim registry, renewal scheduling, batching, and lifecycle
- `ClaimOwnership`: claim-scoped validity check used by execution and delivery
- `renew_claims`: one immediate SQLite transaction containing fenced renewals
- `complete_run`: now also rejects completion after lease expiry

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
