### PR TITLE
docs: give the Quickstart install step a real anchor

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -4,7 +4,7 @@ slug: "quickstart"
 ---
 
 <Steps>
-  <Step title="Install OpenSRE">
+  <Step title="Install OpenSRE" id="install-opensre">
     <Tabs>
       <Tab title="macOS / Linux">
         Choose one install method. The one-line installer tracks the latest stable build from `main`.


### PR DESCRIPTION
Fixes #6090

#### Describe the changes you have made in this PR -

- Set `id="install-opensre"` on the Quickstart's install `<Step>` so the anchor the Showcase card already links to actually exists.

The Showcase page's "Jump to the GIFs" card points at `/quickstart#install-opensre`. That anchor was never there. Mintlify builds heading anchors from Markdown headings only, and neither `<Step>` nor `<Tab>` titles generate one, so the card dropped readers at the top of the Quickstart — the same place the "Full quickstart" card next to it already goes. The two cards behaved identically.

`<Step>` takes an `id` prop for anchor linking, so this sets it instead of restructuring the tabs.

### Demo/Screenshot for feature changes and bug fixes -

Verified against a local `mint dev` build of `docs/`.

Before, the rendered Quickstart exposed only these ids:

```
id="troubleshooting"
id="uninstall"
id="windows"          <- auto-generated tab ids
id="windows-2"
id="windows-3"
```

After:

```
$ curl -s localhost:3111/quickstart | grep -o 'id="install-opensre"'
id="install-opensre"
```

It renders on the install step container, so the card lands on the install section:

```html
<div id="install-opensre" role="listitem" class="step group/step step-container ...">
```

The card's `href="/quickstart#install-opensre"` is unchanged and still present in the rendered output.

`uv run pytest tests/cli/test_install_matrix.py tests/interactive_shell/references/test_docs_reference.py -q` — 46 passed, 1 skipped.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The broken anchor turned up while working on #5989, which had used the same `#install-opensre` link in the supported-platforms table. Checking the rendered page showed the anchor did not exist, so that PR switched to the `environments/*#1-install` anchors instead and this one fixes the underlying gap.

I considered two alternatives. Adding a Markdown heading inside the step would generate an anchor, but it duplicates the step title on screen. Putting the anchor inside a `<Tab>` does not work at all, because Mintlify hides inactive tab content, so the anchor is unreachable for whichever platform is not selected. The `id` prop is documented for exactly this and leaves the tabbed layout alone.

The other option was deleting the card, since it currently duplicates its neighbour. Giving it a working target seemed better than removing a link someone deliberately added, but happy to drop it instead if you would rather.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
