### PR TITLE
fix(scheduler): pass fire times directly to scheduled callbacks

### DIFF
--- a/infrastructure/scheduling/scheduler/apscheduler_executor.py
+++ b/infrastructure/scheduling/scheduler/apscheduler_executor.py
@@ -1,0 +1,88 @@
+"""APScheduler executor that passes each scheduled fire time to the job."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, cast
+
+from apscheduler.executors.base import run_job
+from apscheduler.executors.pool import ThreadPoolExecutor
+
+
+@dataclass(frozen=True)
+class _ScheduledJobInvocation:
+    """Expose one APScheduler run time through the job callable."""
+
+    job: Any
+    scheduled_run_time: datetime
+
+    @property
+    def id(self) -> str:
+        return cast(str, self.job.id)
+
+    @property
+    def func(self) -> Any:
+        def invoke(*args: Any, **kwargs: Any) -> Any:
+            return self.job.func(
+                *args,
+                scheduled_run_time=self.scheduled_run_time,
+                **kwargs,
+            )
+
+        return invoke
+
+    @property
+    def args(self) -> tuple[Any, ...]:
+        return cast(tuple[Any, ...], self.job.args)
+
+    @property
+    def kwargs(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self.job.kwargs)
+
+    @property
+    def misfire_grace_time(self) -> int | None:
+        return cast(int | None, self.job.misfire_grace_time)
+
+
+def _run_job_with_scheduled_time(
+    job: Any,
+    jobstore_alias: str,
+    run_times: list[datetime],
+    logger_name: str,
+) -> list[Any]:
+    """Run each submitted time with its own callback argument."""
+    events: list[Any] = []
+    for scheduled_run_time in run_times:
+        invocation = _ScheduledJobInvocation(job, scheduled_run_time)
+        events.extend(run_job(invocation, jobstore_alias, [scheduled_run_time], logger_name))
+    return events
+
+
+class ScheduledThreadPoolExecutor(ThreadPoolExecutor):
+    """Run scheduler jobs with their exact APScheduler fire time attached."""
+
+    def _do_submit_job(self, job: Any, run_times: list[datetime]) -> None:
+        def callback(future: Future[list[Any]]) -> None:
+            exc, traceback = (
+                future.exception_info()
+                if hasattr(future, "exception_info")
+                else (future.exception(), getattr(future.exception(), "__traceback__", None))
+            )
+            if exc:
+                self._run_job_error(job.id, exc, traceback)
+            else:
+                self._run_job_success(job.id, future.result())
+
+        future = self._pool.submit(
+            _run_job_with_scheduled_time,
+            job,
+            job._jobstore_alias,
+            run_times,
+            self._logger.name,
+        )
+        future.add_done_callback(callback)
+
+
+__all__ = ["ScheduledThreadPoolExecutor"]

--- a/infrastructure/scheduling/scheduler/apscheduler_executor.py
+++ b/infrastructure/scheduling/scheduler/apscheduler_executor.py
@@ -3,47 +3,20 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
-from dataclasses import dataclass
+from copy import copy
 from datetime import datetime
-from typing import Any, cast
+from functools import partial
+from typing import Any
 
 from apscheduler.executors.base import run_job
 from apscheduler.executors.pool import ThreadPoolExecutor
 
 
-@dataclass(frozen=True)
-class _ScheduledJobInvocation:
-    """Expose one APScheduler run time through the job callable."""
-
-    job: Any
-    scheduled_run_time: datetime
-
-    @property
-    def id(self) -> str:
-        return cast(str, self.job.id)
-
-    @property
-    def func(self) -> Any:
-        def invoke(*args: Any, **kwargs: Any) -> Any:
-            return self.job.func(
-                *args,
-                scheduled_run_time=self.scheduled_run_time,
-                **kwargs,
-            )
-
-        return invoke
-
-    @property
-    def args(self) -> tuple[Any, ...]:
-        return cast(tuple[Any, ...], self.job.args)
-
-    @property
-    def kwargs(self) -> dict[str, Any]:
-        return cast(dict[str, Any], self.job.kwargs)
-
-    @property
-    def misfire_grace_time(self) -> int | None:
-        return cast(int | None, self.job.misfire_grace_time)
+def _job_for_run_time(job: Any, scheduled_run_time: datetime) -> Any:
+    """Bind one fire time to a shallow copy of an APScheduler job."""
+    invocation = copy(job)
+    invocation.func = partial(job.func, scheduled_run_time=scheduled_run_time)
+    return invocation
 
 
 def _run_job_with_scheduled_time(
@@ -55,7 +28,7 @@ def _run_job_with_scheduled_time(
     """Run each submitted time with its own callback argument."""
     events: list[Any] = []
     for scheduled_run_time in run_times:
-        invocation = _ScheduledJobInvocation(job, scheduled_run_time)
+        invocation = _job_for_run_time(job, scheduled_run_time)
         events.extend(run_job(invocation, jobstore_alias, [scheduled_run_time], logger_name))
     return events
 

--- a/infrastructure/scheduling/scheduler/runner.py
+++ b/infrastructure/scheduling/scheduler/runner.py
@@ -1,9 +1,9 @@
 """APScheduler-backed blocking runner for scheduled tasks.
 
 Loads all enabled tasks from the store, creates CronTrigger jobs, and
-blocks until SIGINT/SIGTERM. Fire times for dedup come from
-``JobSubmissionEvent.scheduled_run_times[0]`` (UTC, minute precision),
-not wall-clock time inside the callback.
+blocks until SIGINT/SIGTERM. Fire times for dedup are passed directly from the
+APScheduler executor to each callback (UTC, minute precision), not recovered
+from listener timing or wall-clock time inside the callback.
 """
 
 from __future__ import annotations
@@ -39,9 +39,6 @@ from infrastructure.scheduling.scheduler.types import Provider, ScheduledTask, T
 logger = logging.getLogger(__name__)
 TaskFilter = Callable[[ScheduledTask], bool]
 
-# Populated by EVENT_JOB_SUBMITTED before each job runs (job_id -> fire_time).
-_pending_fire_times: dict[str, str] = {}
-_pending_fire_times_lock = threading.Lock()
 _RECOVERY_JOB_ID = "scheduler-claim-recovery"
 _RECOVERY_INTERVAL_SECONDS = 60
 
@@ -80,38 +77,23 @@ def compute_next_run(task: ScheduledTask, now: datetime | None = None) -> str | 
     return _next_run_from_trigger(_make_trigger(task), now)
 
 
-def _compute_fire_time(scheduled_run_time: Any) -> str:
+def _compute_fire_time(scheduled_run_time: datetime) -> str:
     """Compute a stable, UTC-normalized fire_time string.
 
     Always converts to UTC so DST transitions don't produce ambiguous keys.
     """
-    if scheduled_run_time is not None:
-        utc_time: datetime = scheduled_run_time.astimezone(UTC)
-        return utc_time.strftime("%Y-%m-%dT%H:%MZ")
-    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%MZ")
+    utc_time: datetime = scheduled_run_time.astimezone(UTC)
+    return utc_time.strftime("%Y-%m-%dT%H:%MZ")
 
 
-def _on_job_submitted(event: Any) -> None:
-    """Capture the intended fire time for this tick before the job callback runs."""
-    run_times = getattr(event, "scheduled_run_times", None)
-    if run_times:
-        fire_time = _compute_fire_time(run_times[0])
-    else:
-        fire_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%MZ")
-    with _pending_fire_times_lock:
-        _pending_fire_times[event.job_id] = fire_time
-
-
-def _scheduled_job(task_id: str, runners: SchedulerRunners) -> None:
+def _scheduled_job(
+    task_id: str,
+    runners: SchedulerRunners,
+    *,
+    scheduled_run_time: datetime,
+) -> None:
     """Job callback invoked by APScheduler on each cron tick."""
-    with _pending_fire_times_lock:
-        fire_time = _pending_fire_times.pop(task_id, None)
-    if fire_time is None:
-        logger.warning(
-            "No scheduled fire_time for task %s; using UTC now (listener may have missed)",
-            task_id,
-        )
-        fire_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%MZ")
+    fire_time = _compute_fire_time(scheduled_run_time)
 
     task = get_task(task_id)
     if task is None:
@@ -142,8 +124,10 @@ def _recover_expired_tasks(
     runners: SchedulerRunners,
     *,
     task_filter: TaskFilter | None = None,
+    scheduled_run_time: datetime | None = None,
 ) -> None:
     """Resubmit expired scheduled ticks through the normal fenced executor."""
+    _ = scheduled_run_time
     eligible_task_ids = _desired_task_ids(task_filter=task_filter)
     for expired in get_expired_claims(eligible_task_ids=eligible_task_ids):
         task = get_task(expired.task_id)
@@ -190,14 +174,8 @@ def _register_jobs(
     runners: SchedulerRunners,
     *,
     task_filter: TaskFilter | None = None,
-    add_listener: bool = True,
 ) -> int:
     """Register all enabled tasks on *scheduler*; invalid tasks are logged and skipped."""
-    if add_listener:
-        from apscheduler.events import EVENT_JOB_SUBMITTED
-
-        scheduler.add_listener(_on_job_submitted, EVENT_JOB_SUBMITTED)
-
     enabled_count = 0
     for task in list_tasks():
         if not task.enabled:
@@ -263,7 +241,6 @@ def resync_scheduler_jobs(
         scheduler,
         runners,
         task_filter=task_filter,
-        add_listener=False,
     )
     desired_ids = _desired_task_ids(task_filter=task_filter)
     for job_id in existing_ids - desired_ids - {_RECOVERY_JOB_ID}:
@@ -328,7 +305,11 @@ def start_background_scheduler(
     """
     from apscheduler.schedulers.background import BackgroundScheduler
 
-    scheduler = BackgroundScheduler()
+    from infrastructure.scheduling.scheduler.apscheduler_executor import (
+        ScheduledThreadPoolExecutor,
+    )
+
+    scheduler = BackgroundScheduler(executors={"default": ScheduledThreadPoolExecutor()})
     enabled_count = _register_jobs(scheduler, runners, task_filter=task_filter)
     if enabled_count == 0:
         record_scheduler_service_operation("scheduler_idle", task_count=0)
@@ -370,7 +351,11 @@ def start_scheduler(runners: SchedulerRunners, *, idle_when_empty: bool = False)
     """
     from apscheduler.schedulers.blocking import BlockingScheduler
 
-    scheduler = BlockingScheduler()
+    from infrastructure.scheduling.scheduler.apscheduler_executor import (
+        ScheduledThreadPoolExecutor,
+    )
+
+    scheduler = BlockingScheduler(executors={"default": ScheduledThreadPoolExecutor()})
     enabled_count = _register_jobs(scheduler, runners)
     if enabled_count == 0 and not idle_when_empty:
         logger.warning("No enabled tasks found. Scheduler has nothing to run.")

--- a/infrastructure/scheduling/scheduler/runner.py
+++ b/infrastructure/scheduling/scheduler/runner.py
@@ -90,9 +90,11 @@ def _scheduled_job(
     task_id: str,
     runners: SchedulerRunners,
     *,
-    scheduled_run_time: datetime,
+    scheduled_run_time: datetime | None = None,
 ) -> None:
     """Job callback invoked by APScheduler on each cron tick."""
+    if scheduled_run_time is None:
+        raise RuntimeError("scheduled_run_time must be supplied by the scheduler executor")
     fire_time = _compute_fire_time(scheduled_run_time)
 
     task = get_task(task_id)

--- a/tests/scheduler/test_apscheduler_executor.py
+++ b/tests/scheduler/test_apscheduler_executor.py
@@ -1,0 +1,50 @@
+"""Tests for the scheduler's APScheduler executor adapter."""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from infrastructure.scheduling.scheduler.apscheduler_executor import (
+    ScheduledThreadPoolExecutor,
+)
+
+
+class _FakeScheduler:
+    def _create_lock(self) -> threading.RLock:
+        return threading.RLock()
+
+    def _dispatch_event(self, _event: object) -> None:
+        return None
+
+
+def test_worker_receives_exact_fire_time_without_submission_listener() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    observed: list[datetime] = []
+    scheduled_run_time = datetime(2026, 1, 15, 9, 0, tzinfo=UTC)
+
+    def callback(*, scheduled_run_time: datetime) -> None:
+        observed.append(scheduled_run_time)
+        started.set()
+        assert release.wait(5)
+
+    job = SimpleNamespace(
+        id="task-1",
+        max_instances=1,
+        misfire_grace_time=None,
+        func=callback,
+        args=(),
+        kwargs={},
+        _jobstore_alias="default",
+    )
+    executor = ScheduledThreadPoolExecutor(max_workers=1)
+    executor.start(_FakeScheduler(), "default")
+    try:
+        executor.submit_job(job, [scheduled_run_time])
+        assert started.wait(5)
+        assert observed == [scheduled_run_time]
+    finally:
+        release.set()
+        executor.shutdown(wait=True)

--- a/tests/scheduler/test_apscheduler_executor.py
+++ b/tests/scheduler/test_apscheduler_executor.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import threading
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+
+from apscheduler.events import EVENT_JOB_EXECUTED, EVENT_JOB_MISSED, JobEvent
 
 from infrastructure.scheduling.scheduler.apscheduler_executor import (
     ScheduledThreadPoolExecutor,
@@ -12,39 +14,47 @@ from infrastructure.scheduling.scheduler.apscheduler_executor import (
 
 
 class _FakeScheduler:
+    def __init__(self) -> None:
+        self.event_codes: list[int] = []
+
     def _create_lock(self) -> threading.RLock:
         return threading.RLock()
 
-    def _dispatch_event(self, _event: object) -> None:
-        return None
+    def _dispatch_event(self, event: JobEvent) -> None:
+        self.event_codes.append(event.code)
 
 
-def test_worker_receives_exact_fire_time_without_submission_listener() -> None:
+def test_worker_receives_each_eligible_fire_time_without_submission_listener() -> None:
     started = threading.Event()
     release = threading.Event()
     observed: list[datetime] = []
-    scheduled_run_time = datetime(2026, 1, 15, 9, 0, tzinfo=UTC)
+    now = datetime.now(UTC)
+    run_times = [now - timedelta(minutes=5), now - timedelta(seconds=1), now]
 
     def callback(*, scheduled_run_time: datetime) -> None:
         observed.append(scheduled_run_time)
-        started.set()
-        assert release.wait(5)
+        if len(observed) == 1:
+            started.set()
+            assert release.wait(5)
 
+    scheduler = _FakeScheduler()
     job = SimpleNamespace(
         id="task-1",
         max_instances=1,
-        misfire_grace_time=None,
+        misfire_grace_time=60,
         func=callback,
         args=(),
         kwargs={},
         _jobstore_alias="default",
     )
     executor = ScheduledThreadPoolExecutor(max_workers=1)
-    executor.start(_FakeScheduler(), "default")
+    executor.start(scheduler, "default")
     try:
-        executor.submit_job(job, [scheduled_run_time])
+        executor.submit_job(job, run_times)
         assert started.wait(5)
-        assert observed == [scheduled_run_time]
     finally:
         release.set()
         executor.shutdown(wait=True)
+
+    assert observed == run_times[1:]
+    assert scheduler.event_codes == [EVENT_JOB_MISSED, EVENT_JOB_EXECUTED, EVENT_JOB_EXECUTED]

--- a/tests/scheduler/test_executor.py
+++ b/tests/scheduler/test_executor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -235,7 +236,12 @@ class TestExecutor:
             ),
             ThreadPoolExecutor(max_workers=1) as pool,
         ):
-            future = pool.submit(_scheduled_job, task.id, real_runners())
+            future = pool.submit(
+                _scheduled_job,
+                task.id,
+                real_runners(),
+                scheduled_run_time=datetime(2026, 1, 15, 9, 0, tzinfo=UTC),
+            )
             try:
                 assert started.wait(_SYNC_TIMEOUT_SECONDS)
                 if mutation == "delete":

--- a/tests/scheduler/test_runner.py
+++ b/tests/scheduler/test_runner.py
@@ -10,9 +10,8 @@ from infrastructure.scheduling.scheduler.loop_constants import LOOP_PROMPT_PARAM
 from infrastructure.scheduling.scheduler.runner import (
     _compute_fire_time,
     _make_trigger,
-    _on_job_submitted,
-    _pending_fire_times,
     _register_jobs,
+    _scheduled_job,
     compute_next_run,
     refresh_background_scheduler,
     resync_scheduler_jobs,
@@ -81,20 +80,6 @@ class TestMakeTrigger:
         assert trigger is not None
 
 
-class TestOnJobSubmitted:
-    def test_stores_fire_time_from_scheduled_run_times(self) -> None:
-        from datetime import UTC, datetime
-        from types import SimpleNamespace
-
-        _pending_fire_times.clear()
-        event = SimpleNamespace(
-            job_id="task-1",
-            scheduled_run_times=[datetime(2026, 1, 15, 9, 0, tzinfo=UTC)],
-        )
-        _on_job_submitted(event)
-        assert _pending_fire_times["task-1"] == "2026-01-15T09:00Z"
-
-
 class TestComputeFireTime:
     def test_with_utc_datetime(self) -> None:
         from datetime import UTC, datetime
@@ -113,10 +98,35 @@ class TestComputeFireTime:
         # 14:30 IST = 09:00 UTC
         assert result == "2026-01-15T09:00Z"
 
-    def test_with_none_falls_back_to_utc_now(self) -> None:
-        result = _compute_fire_time(None)
-        assert result.endswith("Z")
-        assert "T" in result
+    def test_scheduled_job_uses_callback_fire_time(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        task = ScheduledTask(
+            id="task-1",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="0 9 * * *",
+            provider=Provider.SLACK,
+        )
+        observed: list[str] = []
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.runner.get_task",
+            lambda _task_id: task,
+        )
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.runner.execute_task",
+            lambda _task, fire_time, _runners: observed.append(fire_time) or False,
+        )
+
+        _scheduled_job(
+            task.id,
+            real_runners(),
+            scheduled_run_time=datetime(2026, 1, 15, 9, 0, tzinfo=UTC),
+        )
+
+        assert observed == ["2026-01-15T09:00Z"]
 
 
 class TestComputeNextRun:
@@ -147,9 +157,6 @@ class TestRegisterJobs:
         class _FakeScheduler:
             def __init__(self) -> None:
                 self.job_ids: list[str] = []
-
-            def add_listener(self, *_args: object) -> None:
-                return None
 
             def add_job(self, *args: object, **kwargs: object) -> None:
                 _ = args
@@ -202,9 +209,6 @@ class TestRegisterJobs:
         class _FakeScheduler:
             def __init__(self) -> None:
                 self.jobs: dict[str, _FakeJob] = {"stale": _FakeJob("stale")}
-
-            def add_listener(self, *_args: object) -> None:
-                return None
 
             def add_job(self, *args: object, **kwargs: object) -> None:
                 _ = args
@@ -398,6 +402,9 @@ class TestStartSchedulerIdle:
         started: list[bool] = []
 
         class _FakeScheduler:
+            def __init__(self, **_kwargs: object) -> None:
+                pass
+
             def start(self) -> None:
                 started.append(True)  # no-op instead of blocking forever
 

--- a/tests/scheduler/test_runner.py
+++ b/tests/scheduler/test_runner.py
@@ -128,6 +128,10 @@ class TestComputeFireTime:
 
         assert observed == ["2026-01-15T09:00Z"]
 
+    def test_scheduled_job_rejects_missing_fire_time(self) -> None:
+        with pytest.raises(RuntimeError, match="scheduled_run_time"):
+            _scheduled_job("task-1", real_runners())
+
 
 class TestComputeNextRun:
     def test_returns_next_utc_fire_time(self) -> None:
@@ -146,6 +150,79 @@ class TestComputeNextRun:
 
 
 class TestRegisterJobs:
+    def test_real_scheduler_registers_and_passes_fire_time(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+        from threading import Event
+
+        from apscheduler.schedulers.background import BackgroundScheduler
+        from apscheduler.triggers.date import DateTrigger
+
+        from infrastructure.scheduling.scheduler.apscheduler_executor import (
+            ScheduledThreadPoolExecutor,
+        )
+
+        task = ScheduledTask(
+            id="real-scheduler-task",
+            kind=TaskKind.MANUAL_LOOP,
+            cron="* * * * *",
+            provider=Provider.TELEGRAM,
+        )
+        scheduled_run_time = datetime.now(UTC) + timedelta(seconds=2)
+        observed_fire_times: list[str] = []
+        execution_finished = Event()
+
+        def _make_date_trigger(_task: ScheduledTask) -> DateTrigger:
+            return DateTrigger(run_date=scheduled_run_time)
+
+        def _execute_task(
+            _task: ScheduledTask,
+            fire_time: str,
+            _runners: object,
+        ) -> bool:
+            observed_fire_times.append(fire_time)
+            execution_finished.set()
+            return False
+
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.runner.list_tasks",
+            lambda: [task],
+        )
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.runner.get_task",
+            lambda _task_id: task,
+        )
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.runner._make_trigger",
+            _make_date_trigger,
+        )
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.runner.update_task",
+            lambda _task: None,
+        )
+        monkeypatch.setattr(
+            "infrastructure.scheduling.scheduler.runner.execute_task",
+            _execute_task,
+        )
+
+        scheduler = BackgroundScheduler(
+            executors={"default": ScheduledThreadPoolExecutor(max_workers=1)}
+        )
+        started = False
+        try:
+            assert _register_jobs(scheduler, real_runners()) == 1
+            scheduler.start()
+            started = True
+            assert execution_finished.wait(10)
+        finally:
+            if started:
+                scheduler.shutdown(wait=True)
+
+        expected_fire_time = scheduled_run_time.strftime("%Y-%m-%dT%H:%MZ")
+        assert observed_fire_times == [expected_fire_time]
+
     def test_applies_task_filter(
         self,
         tmp_path,


### PR DESCRIPTION
Fixes #6092

  ## Summary

  - Remove the `EVENT_JOB_SUBMITTED` fire-time mailbox.
  - Pass each APScheduler `scheduled_run_time` directly through the scheduler executor.
  - Eliminate the wall-clock fallback in scheduled callbacks.
  - Preserve the correct fire time for misfired and coalesced runs.
  - Add deterministic regression coverage for worker-before-listener execution.

  This complements the concurrency work in #6024. Its bounded executor can use
  `ScheduledThreadPoolExecutor(max_workers=limit)`.

  ## Testing

  - `uv run pytest tests/scheduler/test_runner.py tests/scheduler/test_executor.py tests/scheduler/test_apscheduler_executor.py -q`
    - 58 passed
  - `make lint`
  - `make format-check`
  - `make typecheck`

