### PR TITLE
docs: add supported platforms table

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -6,9 +6,10 @@ slug: "quickstart"
 ## Supported platforms
 
 OpenSRE publishes native release bundles for the platforms below. The public
-installer selects the matching bundle automatically. Windows ARM64 is not
-supported in the default release because the required `cryptography` wheel is
-not available for that target.
+installer selects the matching bundle automatically. Windows ARM64 has no native
+default-release bundle because the required `cryptography` wheel is unavailable
+for that target; the Windows installer falls back to the x64 bundle under
+emulation.
 
 | Platform | Public install command | Release bundle | Verification |
 | --- | --- | --- | --- |
@@ -17,9 +18,9 @@ not available for that target.
 | macOS Apple Silicon | `curl -fsSL https://install.opensre.com \| bash` | `darwin-arm64` `.tar.gz` | Post-publish installer canary |
 | macOS Intel | `curl -fsSL https://install.opensre.com \| bash` | `darwin-x64` `.tar.gz` | Release build smoke test |
 | Windows x64 | `irm https://install.opensre.com \| iex` | `windows-x64` `.zip` | Post-publish installer canary |
-| Windows ARM64 | — | — | Not supported |
+| Windows ARM64 | `irm https://install.opensre.com \| iex` | `windows-x64` `.zip` via emulation | Native bundle not supported |
 
-For a local editable development install on any of these platforms, follow
+For local editable development installation instructions, follow
 [SETUP.md](https://github.com/Tracer-Cloud/opensre/blob/main/SETUP.md).
 
 <Steps>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,6 +3,25 @@ title: "Quickstart"
 slug: "quickstart"
 ---
 
+## Supported platforms
+
+OpenSRE publishes native release bundles for the platforms below. The public
+installer selects the matching bundle automatically. Windows ARM64 is not
+supported in the default release because the required `cryptography` wheel is
+not available for that target.
+
+| Platform | Public install command | Release bundle | Verification |
+| --- | --- | --- | --- |
+| Linux x86_64 | `curl -fsSL https://install.opensre.com \| bash` | `linux-x64` `.tar.gz` | Post-publish installer canary |
+| Linux ARM64 | `curl -fsSL https://install.opensre.com \| bash` | `linux-arm64` `.tar.gz` | Release build smoke test |
+| macOS Apple Silicon | `curl -fsSL https://install.opensre.com \| bash` | `darwin-arm64` `.tar.gz` | Post-publish installer canary |
+| macOS Intel | `curl -fsSL https://install.opensre.com \| bash` | `darwin-x64` `.tar.gz` | Release build smoke test |
+| Windows x64 | `irm https://install.opensre.com \| iex` | `windows-x64` `.zip` | Post-publish installer canary |
+| Windows ARM64 | — | — | Not supported |
+
+For a local editable development install on any of these platforms, follow
+[SETUP.md](https://github.com/Tracer-Cloud/opensre/blob/main/SETUP.md).
+
 <Steps>
   <Step title="Install OpenSRE">
     <Tabs>


### PR DESCRIPTION
## Summary

Adds a supported-platforms table to the Quickstart documentation.

The table makes the current release coverage clear for Linux, macOS, and Windows, including:

- public installer commands
- published release bundle targets
- post-publish canary or release-build verification coverage
- the current Windows ARM64 limitation

It also links contributors to `SETUP.md` for editable development installs.

Closes #5396