### PR TITLE
fix(onboarding): deterministic CI/CD loop suggestion, bottom-up blocked time, single answer line

### DIFF
--- a/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
+++ b/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
@@ -50,6 +50,10 @@ HARD RULES:
   not fall back to a different data source.
 - Decision points use `ask_user_choice` with the exact option texts below.
   End the turn after calling it; the answer arrives as the next user message.
+- Ask each question once. When the answer arrives, continue with the next
+  step immediately: do not reload this skill, do not restate the options, and
+  never ask what the answer or the request "means". A repository name in the
+  request or in the answer is the repository; go straight to step 3.
 
 Steps, in order (headers are mandatory, see the labeling rules below).
 When the request already names the repository (the startup demo does the scan

--- a/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
+++ b/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
@@ -9,6 +9,11 @@ description: >-
   performance", "how reliable is our CI", "what does flaky CI cost us". Not for
   listing currently failing checks (github-ci-health). Multi-step; load before
   acting.
+tools:
+  - scan_local_git_workspace
+  - analyze_github_ci_reliability
+  - schedule_ci_reliability_loop
+  - ask_user_choice
 ---
 ══════════════════════════════════════════════════════════
 CI/CD ANALYTICS DEMO SKILL — interactive-shell action agent:

--- a/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
+++ b/core/agent_harness/prompts/skills/cicd_analytics_demo/SKILL.md
@@ -13,6 +13,7 @@ tools:
   - scan_local_git_workspace
   - analyze_github_ci_reliability
   - schedule_ci_reliability_loop
+  - cli_exec
   - ask_user_choice
 ---
 ══════════════════════════════════════════════════════════
@@ -31,6 +32,7 @@ USE THESE TOOLS:
 - `scan_local_git_workspace`
 - `analyze_github_ci_reliability`
 - `schedule_ci_reliability_loop`
+- `cli_exec`
 - `ask_user_choice`
 
 DO NOT USE THIS SKILL FOR:
@@ -42,9 +44,10 @@ DO NOT USE THIS SKILL FOR:
 HARD RULES:
 - Every number in the reply comes from a tool result. Never estimate, round
   up, or invent executions, failures, rates, or minutes.
-- Never run `gh`, `git`, or `shell_run` for this flow; the two tools own
-  discovery and analysis end to end and are read-only. The whole demo is
-  read-only: no Slack messages, no pushes, no issue writes.
+- Never run `gh`, `git`, or `shell_run` for this flow; the scan and
+  analysis tools own discovery and analysis end to end and are read-only.
+  The analysis itself is read-only: no Slack messages, no pushes, no
+  issue writes. Use `cli_exec` only for the Slack continuation in step 4.
 - The scan tool draws the workspace chart in the shell itself. Do not repeat
   the chart or the repository list as text; add one sentence at most.
 - `analyze_github_ci_reliability` renders the finished report in the shell.
@@ -98,10 +101,10 @@ headers [3/4] and [4/4] only.
    analyzed repository, output its `response_text` verbatim, and stop; it
    schedules a weekday 08:00 local check that delivers to this shell's inbox
    and never posts anywhere else. Each tick is deterministic (no model turn);
-   `/loops service install` keeps it running when no shell is open. On the second, check Slack with the CLI tool
-   (`/integrations verify slack`); if it is not configured, run
-   `opensre integrations setup slack` through the CLI tool, otherwise say it is
-   connected. Then explain in two sentences how to hand off a chore from Slack
+   `/loops service install` keeps it running when no shell is open. On the second, call
+   `cli_exec` with payload `integrations verify slack`; if Slack is not
+   configured, call `cli_exec` with payload `integrations setup slack`,
+   otherwise say it is connected. Then explain in two sentences how to hand off a chore from Slack
    (mention OpenSRE in a channel or DM it). Never post, reply, or send anything
    to Slack in this demo. On `Exit demo`, reply with one line and stop.
 

--- a/core/agent_harness/prompts/skills/github_ci_health/SKILL.md
+++ b/core/agent_harness/prompts/skills/github_ci_health/SKILL.md
@@ -39,3 +39,12 @@ When offering this report as a recurring task interactively, use kind
 `recurring_skill` and skill name `github-ci-health`. Pass the exact `owner` and
 `repo`, plus at most one of `branch` or `pr_number`, to
 `propose_scheduled_delivery` so confirmation preserves the repository scope.
+
+Interactively, the repository comes from the request; when it names none,
+call `scan_local_git_workspace` and ask with `ask_user_choice`. Never run
+`cli_exec` (`opensre health`, `opensre integrations …`), `shell_run`, or
+`github_cli` to discover the repository, the token, or the environment: they
+print unrelated integration state and are not part of this skill. To show
+the checks failing right now during an interactive turn, use
+`summarize_github_pr_status`; this skill's own report is produced by the
+scheduled runner only.

--- a/core/agent_harness/prompts/skills/loader.py
+++ b/core/agent_harness/prompts/skills/loader.py
@@ -56,6 +56,8 @@ class ActionSkill:
     description: str
     path: Path
     recurring: str | None = None
+    tools: tuple[str, ...] = ()
+    """Tool names the skill's flow uses; an answer turn inside the skill offers only these."""
 
 
 def skills_dir() -> Path:
@@ -134,6 +136,12 @@ def _string_field(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def _string_list_field(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
 def _derive_description(body: str) -> str:
     """Best-effort one-liner when frontmatter has no description."""
     lines = [ln.strip() for ln in body.splitlines()]
@@ -200,6 +208,7 @@ def _load_action_skill(skill_path: Path) -> ActionSkill | None:
         description=description,
         path=skill_path,
         recurring=recurring,
+        tools=_string_list_field(frontmatter.get("tools")),
     )
 
 

--- a/core/agent_harness/session/memory_extraction.py
+++ b/core/agent_harness/session/memory_extraction.py
@@ -108,8 +108,10 @@ Extract ONLY durable knowledge worth keeping across future sessions:
 - lessons learned from real incidents or investigations the user confirmed
 
 Do NOT extract: transient session state, one-off command outputs, secrets,
-credentials, or anything already captured by an existing memory (unless it
-needs updating — then reuse the existing name exactly).
+credentials, scheduled loops or tasks created in this session, demo or
+onboarding outcomes, the status of work just done (the shell already shows
+it and it goes stale), or anything already captured by an existing memory
+(unless it needs updating — then reuse the existing name exactly).
 
 User-authored statements are the source of truth. Do NOT store infrastructure
 facts or investigation learnings that appear only in assistant/tool output.

--- a/core/agent_harness/session/session_core.py
+++ b/core/agent_harness/session/session_core.py
@@ -157,6 +157,12 @@ class SessionCore:
     """Ask-User clarification rounds asked this workload; caps repeated batches.
     Reset on a genuine user turn."""
 
+    active_skill: str | None = None
+    """Skill loaded by ``skill_view`` in the current flow; cleared on a genuine user turn."""
+
+    active_skill_tools: tuple[str, ...] = ()
+    """The active skill's declared tools; an answer turn inside the flow offers only these."""
+
     task_plan: TaskPlan | None = None
     """Live execution checklist for the current workload, rendered above the
     prompt and persisted so it survives transcript compaction."""

--- a/core/agent_harness/task_plan/prompt.py
+++ b/core/agent_harness/task_plan/prompt.py
@@ -12,8 +12,9 @@ from core.agent_harness.task_plan.progress import format_task_plan_plain
 
 ASK_USER_ANSWERED_GUIDANCE = (
     "ASK USER JUST ANSWERED (this turn). Continue — do not sit idle. "
-    "If this is the FIRST round and the answers open new discriminating "
-    "questions, call ask_user_choice for ONE more scoped round. If two rounds "
+    "The answer settles the question it belongs to: do not re-ask it, do not ask "
+    "what it means, and do not open another round unless the work is impossible "
+    "without one more fixed choice. If two rounds "
     "are already answered (see the Q&A above), do NOT ask again — write the "
     "plan now with your best reading of the answers. Two rounds is the hard "
     "maximum.\n"
@@ -38,9 +39,10 @@ ASK_USER_ANSWERED_GUIDANCE = (
 
 ASK_USER_ANSWERED_PLAN_ONLY_GUIDANCE = (
     "ASK USER JUST ANSWERED (this turn). This request is plan-only — answering "
-    "does not authorize execution. If this is the FIRST round and the answers "
-    "open new discriminating questions, call ask_user_choice for ONE more "
-    "scoped round. If two rounds are already answered, do NOT ask again. "
+    "does not authorize execution. The answer settles the question it belongs "
+    "to: do not re-ask it or ask what it means; open another round only when the "
+    "plan is impossible without one more fixed choice. If two rounds are already "
+    "answered, do NOT ask again. "
     "Then update_plan with every step pending and STOP. Put the rationale in "
     "explanation=... "
     "If this is a diagnosis: Facts; What the signature tells us (what each "

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -45,6 +45,7 @@ from core.agent_harness.turns.action_dedup import (
     coerce_fingerprint_quiet,
     with_duplicate_action_call_guard,
 )
+from core.agent_harness.turns.action_menu_end import with_menu_turn_end
 from core.agent_harness.turns.conversation_recording import record_conversation_turn
 from core.agent_harness.turns.display_text import (
     cap_for_display,
@@ -902,7 +903,9 @@ def _run_action_turn(
             turn_snapshot=turn_snapshot,
             resolved_integrations=resolved_integrations,
             llm_factory=args.llm_factory,
-            tool_hooks=with_duplicate_action_call_guard(args.tool_hooks),
+            tool_hooks=with_menu_turn_end(
+                with_duplicate_action_call_guard(args.tool_hooks), session
+            ),
             tool_resources=tool_resources,
             observer=observer,
         )

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -60,6 +60,7 @@ from core.agent_harness.turns.goal_review import (
     tap_executed_tool_names,
     task_plan_blocks_conclusion,
 )
+from core.agent_harness.turns.skill_scope import scope_tools_to_active_skill
 from core.agent_harness.turns.turn_plan import TurnPlan
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
@@ -876,10 +877,14 @@ def _run_action_turn(
     resolved_integrations = _turn_resolved_integrations(session, turn_plan)
     history_start = len(session.history)
 
-    agent_tools = args.tools.action_tools(
-        confirm_fn=args.confirm_fn,
-        is_tty=args.is_tty,
-        resolved_integrations=resolved_integrations,
+    agent_tools = scope_tools_to_active_skill(
+        args.tools.action_tools(
+            confirm_fn=args.confirm_fn,
+            is_tty=args.is_tty,
+            resolved_integrations=resolved_integrations,
+        ),
+        session,
+        message,
     )
     tool_resources_provider = getattr(args.tools, "tool_resources", None)
     tool_resources = tool_resources_provider() if callable(tool_resources_provider) else {}

--- a/core/agent_harness/turns/action_menu_end.py
+++ b/core/agent_harness/turns/action_menu_end.py
@@ -1,0 +1,54 @@
+"""End the action turn as soon as a user-choice menu is queued.
+
+``ask_user_choice`` queues the picker for after the turn; the loop must not
+take another model step in between, or the model sees no answer, decides
+the choice is "still missing", and asks again. A hook, not an instruction:
+the tool result is marked ``terminate`` whenever a choice is pending.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from core.tool.execution import (
+    ToolExecutionHooks,
+    ToolExecutionPatch,
+    ToolExecutionRequest,
+    ToolExecutionResult,
+)
+
+_CHOICE_TOOL_NAMES = frozenset({"ask_user_choice"})
+
+
+def with_menu_turn_end(
+    base: ToolExecutionHooks | None,
+    session: Any,
+) -> ToolExecutionHooks:
+    """Wrap ``base`` so a queued user-choice menu terminates the tool loop."""
+    base_before = base.before_tool_call if base is not None else None
+    base_after = base.after_tool_call if base is not None else None
+    base_update = base.on_tool_update if base is not None else None
+    base_batch = base.before_tool_batch if base is not None else None
+
+    def after(
+        request: ToolExecutionRequest, result: ToolExecutionResult
+    ) -> ToolExecutionPatch | None:
+        patch = base_after(request, result) if base_after is not None else None
+        if request.tool_call.name not in _CHOICE_TOOL_NAMES or result.is_error:
+            return patch
+        if getattr(session, "pending_user_choice", None) is None:
+            return patch
+        if patch is None:
+            return ToolExecutionPatch(terminate=True)
+        return replace(patch, terminate=True)
+
+    return ToolExecutionHooks(
+        before_tool_call=base_before,
+        after_tool_call=after,
+        on_tool_update=base_update,
+        before_tool_batch=base_batch,
+    )
+
+
+__all__ = ["with_menu_turn_end"]

--- a/core/agent_harness/turns/skill_scope.py
+++ b/core/agent_harness/turns/skill_scope.py
@@ -1,0 +1,41 @@
+"""Keep an answer turn inside the skill that asked the question.
+
+When a skill loaded by ``skill_view`` declares its tools, the turn that
+carries the user's menu answer offers only those tools plus the harness's
+own. Without this the planner sees every tool again and can wander into an
+unrelated skill on the strength of one word in the answer. A genuine new user
+turn clears the scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.session.pending_choice import parse_ask_user_answers
+
+_ALWAYS_OFFERED = frozenset(
+    {
+        "ask_user_choice",
+        "update_plan",
+        "skill_view",
+        "memory_remember",
+        "memory_recall",
+        "task_cancel",
+    }
+)
+
+
+def scope_tools_to_active_skill(tools: list[Any], session: Any, message: str) -> list[Any]:
+    """Filter ``tools`` for an answer turn inside a skill; reset the scope otherwise."""
+    declared = tuple(getattr(session, "active_skill_tools", ()) or ())
+    if not parse_ask_user_answers(message):
+        session.active_skill = None
+        session.active_skill_tools = ()
+        return tools
+    if not declared:
+        return tools
+    allowed = set(declared) | _ALWAYS_OFFERED
+    return [tool for tool in tools if getattr(tool, "name", None) in allowed]
+
+
+__all__ = ["scope_tools_to_active_skill"]

--- a/core/domain/memory/index.py
+++ b/core/domain/memory/index.py
@@ -16,8 +16,9 @@ _INDEX_HEADER = (
     "\n"
 )
 
-DEFAULT_PROMPT_INDEX_CHARS = 8_000
-_MAX_PROMPT_ENTRIES = 50
+DEFAULT_PROMPT_INDEX_CHARS = 3_000
+"""Per-turn budget for injected memory: durable facts, not a second transcript."""
+_MAX_PROMPT_ENTRIES = 15
 _MAX_BODY_CHARS_PER_ENTRY = 600
 
 

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -39,7 +39,8 @@ how much developer time does flaky CI cost us
 | PR-triggered failed workflows and failure rate | Pull request runs that failed, including runs that only passed after a re-run |
 | CI reliability failures | Failures where the identical commit passed later, by re-run or a fresh run. CI, not the code, was at fault |
 | Source-code failures | Failures that passed only after the branch moved to a new commit |
-| Developer time blocked by unreliable CI | Per merged PR: how much later its commits went green than they would have had CI run normally. For each commit with a CI reliability failure, the expected green time is the first queued run plus the slowest workflow's normal duration; the actual green time is when its last workflow passed |
+| Developer downtime from unreliable CI | The working-hours part of the wait below, attributed to each PR's author, with the heaviest-hit developers in hours per week |
+| Wall-clock wait on merged PRs | Per merged PR: how much later its commits went green than they would have had CI run normally. For each commit with a CI reliability failure, the expected green time is the first queued run plus the slowest workflow's normal duration; the actual green time is when its last workflow passed |
 | Normal duration | Per workflow, the median duration of first-attempt passing runs |
 | Default-branch red time | Hours during which at least one push-triggered workflow on the default branch stayed red, overlaps counted once, with mean time to recovery |
 
@@ -52,10 +53,18 @@ invisible; the merge time still bounds the wait. When GitHub omits a PR number,
 the run belongs to the first later merge of that head repository and branch.
 When it attaches several, the run belongs to the merged PR whose lifetime
 contains the run.
+
+Developer downtime is the part of each wait that falls inside working hours:
+Monday to Friday, 09:00 to 18:00 in this machine's timezone, printed with the
+figure. A re-run that happened over a weekend adds wall-clock wait but no
+downtime. Each blocked PR is attributed to its author, so the report can say
+how many hours a week the heaviest-hit developers lost.
+
 The report shows how the total adds up: a table of the most blocked PRs with
-when each should have been green, when it actually was, and how long it
-waited, then the sum across all blocked PRs and the typical wait. The total
-across PRs not merged yet is shown when it differs.
+their author, when each should have been green, when it actually was, and the
+working-hours and wall-clock wait, then the sum across all blocked PRs and
+developers and the typical wait. The wall-clock total across PRs not merged
+yet is shown when it differs.
 
 ## The CI reliability agent
 

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -60,10 +60,13 @@ figure. A re-run that happened over a weekend adds wall-clock wait but no
 downtime. Each blocked PR is attributed to its author, so the report can say
 how many hours a week the heaviest-hit developers lost.
 
-The report shows how the total adds up: a table of the most blocked PRs with
-their author, when each should have been green, when it actually was, and the
-working-hours and wall-clock wait, then the sum across all blocked PRs and
-developers and the typical wait. The wall-clock total across PRs not merged
+The report shows the calculation, not only its result. It states the formula
+(expected green = first run queued + normal duration; blocked = actually green
+minus expected green, in working hours), then a table of the most blocked PRs
+with their author, queue time, normal duration, expected and actual green
+times, and the working-hours and wall-clock wait, then the sum across all
+blocked PRs, the division by the developers affected, the per-week figure,
+and the heaviest-hit developers. The wall-clock total across PRs not merged
 yet is shown when it differs.
 
 ## The CI reliability agent

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -52,8 +52,10 @@ invisible; the merge time still bounds the wait. When GitHub omits a PR number,
 the run belongs to the first later merge of that head repository and branch.
 When it attaches several, the run belongs to the merged PR whose lifetime
 contains the run.
-The report also shows the total across all PRs when it differs, the typical
-wait per blocked PR, and the longest wait with its PR.
+The report shows how the total adds up: a table of the most blocked PRs with
+when each should have been green, when it actually was, and how long it
+waited, then the sum across all blocked PRs and the typical wait. The total
+across PRs not merged yet is shown when it differs.
 
 ## The CI reliability agent
 

--- a/docs/cicd-analytics-demo.mdx
+++ b/docs/cicd-analytics-demo.mdx
@@ -25,11 +25,22 @@ how much developer time does flaky CI cost us
 
 ## What happens
 
-1. **Scan.** OpenSRE finds git repositories under your home directory, counts commits in the last 30 days (total and yours) and uncommitted files, notes which have GitHub Actions workflows, and draws the activity chart. Clones of the same repository are folded into one row.
-2. **Pick.** It offers up to three of your repositories that have CI configured, the ones you contributed to first, plus an open-source example, and asks which one to analyze. Without a GitHub token it stops here and shows the setup command.
-3. **Analyze.** It reads the last 30 days of workflow runs and reports the KPIs below.
-4. **Next step.** It offers to set up the CI reliability agent, connect Slack, or exit.
-   The agent option schedules the check described below without leaving the shell.
+Every step runs in the shell itself; no model turn is involved until you hand
+off to Slack.
+
+1. **Scan.** It scans your home directory for git checkouts and paints a bar
+   chart of the last 30 days of commits, your own contributions first.
+2. **Pick a repository.** A menu lists your checkouts that have GitHub Actions
+   workflows, then the open-source example, then a row to type your own.
+3. **Analyze.** It reads the repository's Actions history for the last 30 days
+   under a spinner and paints the report, ending with the one-sentence headline.
+4. **Next step.** A menu offers the CI reliability agent (it schedules the
+   check for the repository you just analyzed, no second repository question),
+   the Slack hand-off, or exit.
+
+Typing a request such as `analyze owner/repo CI/CD performance for the last
+30 days` runs the same analysis through the agent's `cicd-analytics-demo`
+skill.
 
 ## The KPIs
 

--- a/docs/cron.mdx
+++ b/docs/cron.mdx
@@ -17,7 +17,7 @@ delivery, and keep task metadata in the work-item store.
 
 ## Suggested loops on first launch
 
-When you open the interactive shell (`opensre`) and no scheduled tasks exist yet, a picker offers three starter loops: a CI/CD check (weekdays 8:00 AM), a task-management sweep of your open issues and PRs (weekdays 9:00 AM), and a daily brief (weekdays 9:00 AM). Picking one runs the loop once so you can see the output, then offers to schedule it — confirm with a plain "yes". Press Escape to skip; the picker returns on the next launch until you configure a task.
+When you open the interactive shell (`opensre`) and no scheduled tasks exist yet, a picker offers three starter loops: a CI/CD reliability report (weekdays 8:00 AM), a task-management sweep of your open issues and PRs (weekdays 9:00 AM), and a daily brief (weekdays 9:00 AM). The CI/CD loop asks which repository to watch and when, schedules it, and shows the first report; see [CI/CD analytics demo](/cicd-analytics-demo). The other two run once so you can see the output, then offer to schedule — confirm with a plain "yes". Press Escape to skip; the picker returns on the next launch until you configure a task.
 
 ## Quick Start
 

--- a/infrastructure/scheduling/scheduler/background_service.py
+++ b/infrastructure/scheduling/scheduler/background_service.py
@@ -13,6 +13,7 @@ import plistlib
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,6 +23,8 @@ from config.constants.paths import OPENSRE_HOME_DIR
 SERVICE_LABEL = "com.opensre.scheduler"
 _LOGS_DIRNAME = "logs"
 _COMMAND_TIMEOUT_SECONDS = 30
+_UNLOAD_WAIT_SECONDS = 15.0
+_UNLOAD_POLL_SECONDS = 0.5
 
 Runner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
 
@@ -70,6 +73,7 @@ def install_background_service(
     system: str = "",
     run: Runner = _run,
     command: Sequence[str] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> BackgroundServiceState:
     """Install and start the service; raises ``RuntimeError`` when the OS refuses.
 
@@ -85,7 +89,16 @@ def install_background_service(
         unit.parent.mkdir(parents=True, exist_ok=True)
         unit.write_bytes(plistlib.dumps(_launchd_definition(argv, log_path)))
         domain = f"gui/{os.getuid()}"
-        run(["launchctl", "bootout", f"{domain}/{SERVICE_LABEL}"])
+        target = f"{domain}/{SERVICE_LABEL}"
+        run(["launchctl", "bootout", target])
+        # bootout only starts the teardown; bootstrapping the same label while
+        # the old process is still exiting fails with "5: Input/output error".
+        if not _wait_until_unloaded(run, ["launchctl", "print", target], sleep=sleep):
+            unit.unlink(missing_ok=True)
+            raise RuntimeError(
+                "launchctl bootstrap skipped: the previous scheduler service is still "
+                "stopping; try again in a few seconds"
+            )
         _activate(unit, run(["launchctl", "bootstrap", domain, str(unit)]), "launchctl bootstrap")
         return BackgroundServiceState("Darwin", True, True, unit, log_path)
     if name == "Linux":
@@ -103,7 +116,11 @@ def install_background_service(
 
 
 def remove_background_service(
-    *, home: Path | None = None, system: str = "", run: Runner = _run
+    *,
+    home: Path | None = None,
+    system: str = "",
+    run: Runner = _run,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> BackgroundServiceState:
     """Stop and delete the service; a missing service is not an error.
 
@@ -116,7 +133,7 @@ def remove_background_service(
         unit = _launchd_unit_path(home)
         target = f"gui/{os.getuid()}/{SERVICE_LABEL}"
         run(["launchctl", "bootout", target])
-        if run(["launchctl", "print", target]).returncode == 0:
+        if not _wait_until_unloaded(run, ["launchctl", "print", target], sleep=sleep):
             raise RuntimeError("launchctl bootout failed: the service is still loaded")
         unit.unlink(missing_ok=True)
         return BackgroundServiceState("Darwin", True, False, None, None)
@@ -158,6 +175,18 @@ def _unsupported(name: str) -> BackgroundServiceState:
         None,
         detail="run `opensre cron start --service` from your own scheduler instead.",
     )
+
+
+def _wait_until_unloaded(
+    run: Runner, query: Sequence[str], *, sleep: Callable[[float], None]
+) -> bool:
+    """Poll ``query`` (a service status command) until it reports no service, or give up."""
+    deadline = time.monotonic() + _UNLOAD_WAIT_SECONDS
+    while run(query).returncode == 0:
+        if time.monotonic() >= deadline:
+            return False
+        sleep(_UNLOAD_POLL_SECONDS)
+    return True
 
 
 def _activate(unit: Path, result: subprocess.CompletedProcess[str], step: str) -> None:

--- a/integrations/github/__init__.py
+++ b/integrations/github/__init__.py
@@ -37,6 +37,10 @@ _LAZY_EXPORTS: dict[str, str] = {
     "GitHubDeviceFlowError": "integrations.github.mcp_oauth",
     "authorize_github_via_device_flow": "integrations.github.mcp_oauth",
     "disconnect_personal_github": "integrations.github.personal_account",
+    "Analysis": "integrations.github.tools.ci_analytics.analysis",
+    "analyze_repository": "integrations.github.tools.ci_analytics.analysis",
+    "ci_report_headline": "integrations.github.tools.ci_analytics.render",
+    "render_ci_report": "integrations.github.tools.ci_analytics.render",
     "DEFAULT_LOOP_TIME": "integrations.github.tools.ci_analytics.loop",
     "ScheduledLoop": "integrations.github.tools.ci_analytics.loop",
     "local_timezone": "integrations.github.tools.ci_analytics.loop",
@@ -86,6 +90,7 @@ if TYPE_CHECKING:
         open_pull_request,
         resolve_repo_scope,
     )
+    from integrations.github.tools.ci_analytics.analysis import Analysis, analyze_repository
     from integrations.github.tools.ci_analytics.loop import (
         DEFAULT_LOOP_TIME,
         ScheduledLoop,
@@ -94,11 +99,13 @@ if TYPE_CHECKING:
         report_looks_complete,
         schedule_ci_reliability_loop,
     )
+    from integrations.github.tools.ci_analytics.render import ci_report_headline, render_ci_report
 
 
 __all__ = [
     "DEFAULT_GITHUB_MCP_MODE",
     "DEFAULT_GITHUB_MCP_URL",
+    "Analysis",
     "DEFAULT_LOOP_TIME",
     "ERR_GITHUB_TOKEN",
     "GitHubApiError",
@@ -111,9 +118,11 @@ __all__ = [
     "GitHubRestClient",
     "PullRequest",
     "ScheduledLoop",
+    "analyze_repository",
     "authenticate_and_configure_github",
     "authorize_github_via_device_flow",
     "build_github_mcp_config",
+    "ci_report_headline",
     "disconnect_personal_github",
     "format_github_mcp_validation_cli_report",
     "github_creds",
@@ -122,6 +131,7 @@ __all__ = [
     "loop_card",
     "open_pull_request",
     "print_github_mcp_validation_report",
+    "render_ci_report",
     "report_looks_complete",
     "resolve_github_token",
     "resolve_repo_scope",

--- a/integrations/github/tools/ci_analytics/analysis.py
+++ b/integrations/github/tools/ci_analytics/analysis.py
@@ -1,0 +1,58 @@
+"""One repository's CI reliability report: read GitHub, then compute the KPIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from integrations.github.client import GitHubRestClient
+from integrations.github.tools.ci_analytics.collector import collect_runs
+from integrations.github.tools.ci_analytics.metrics import compute_report
+from integrations.github.tools.ci_analytics.models import CiAnalyticsReport
+from integrations.github.tools.ci_analytics.working_hours import WorkingHours, local_working_hours
+
+DEFAULT_WINDOW_DAYS = 30
+
+
+@dataclass(frozen=True)
+class Analysis:
+    """The computed report plus how much history it was built from."""
+
+    report: CiAnalyticsReport
+    runs_read: int
+
+
+def analyze_repository(
+    owner: str,
+    repo: str,
+    *,
+    token: str,
+    days: int = DEFAULT_WINDOW_DAYS,
+    working_hours: WorkingHours | None = None,
+    now: datetime | None = None,
+) -> Analysis:
+    """Read the window's Actions history and compute the report.
+
+    Raises ``GitHubApiError`` or ``ValueError`` when GitHub cannot be read;
+    callers decide how to word that for their surface.
+    """
+    at = now or datetime.now(UTC)
+    collected = collect_runs(
+        GitHubRestClient(token), owner=owner, repo=repo, window_days=days, now=at
+    )
+    report = compute_report(
+        owner=owner,
+        repo=repo,
+        default_branch=collected.default_branch,
+        window_days=days,
+        branch_runs=collected.branch_runs,
+        pr_runs=collected.pr_runs,
+        merged_prs=collected.merged_prs,
+        now=at,
+        coverage_notices=collected.coverage_notices,
+        working_hours=working_hours or local_working_hours(),
+    )
+    return Analysis(report=report, runs_read=len(collected.branch_runs) + len(collected.pr_runs))
+
+
+__all__ = ["DEFAULT_WINDOW_DAYS", "Analysis", "analyze_repository"]

--- a/integrations/github/tools/ci_analytics/collector.py
+++ b/integrations/github/tools/ci_analytics/collector.py
@@ -251,7 +251,11 @@ def _merged_pr(row: dict[str, Any], *, since: datetime) -> MergedPullRequest | N
     head_repo = str(repo.get("full_name") or "").strip() if isinstance(repo, dict) else ""
     if not ref:
         return None
-    return MergedPullRequest(number=number, branch=ref, head_repo=head_repo, merged_at=merged_at)
+    user = row.get("user")
+    author = str(user.get("login") or "").strip() if isinstance(user, dict) else ""
+    return MergedPullRequest(
+        number=number, branch=ref, head_repo=head_repo, merged_at=merged_at, author=author
+    )
 
 
 def parse_run(row: dict[str, Any]) -> WorkflowRun | None:

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -7,10 +7,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from config.constants.paths import OPENSRE_HOME_DIR
-from config.runtime_metadata.probes import local_tz_name
 from infrastructure.scheduling.scheduler.loop_constants import (
     LOOP_PROMPT_PARAM,
     LOOP_REPORT_ARGS_PARAM,
@@ -24,6 +22,10 @@ from infrastructure.scheduling.scheduler.loops import (
 )
 from infrastructure.scheduling.scheduler.storage import list_tasks, update_task
 from infrastructure.scheduling.scheduler.types import Provider, TaskKind
+from integrations.github.tools.ci_analytics.working_hours import (
+    local_timezone,
+    local_working_hours,
+)
 
 DEFAULT_LOOP_TIME = "08:00"
 LOOP_WINDOW_DAYS = 7
@@ -158,6 +160,7 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
         merged_prs=collected.merged_prs,
         now=now,
         coverage_notices=collected.coverage_notices,
+        working_hours=local_working_hours(),
     )
     snapshot = _write_snapshot(
         snapshot_dir or OPENSRE_HOME_DIR / SNAPSHOT_DIRNAME,
@@ -174,16 +177,6 @@ def _write_snapshot(root: Path, owner: str, repo: str, now: datetime, payload: d
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
     return target
-
-
-def local_timezone() -> str:
-    """This machine's IANA timezone, or UTC when it cannot be resolved."""
-    name = local_tz_name()
-    try:
-        ZoneInfo(name)
-    except (KeyError, ValueError, OSError):
-        return "UTC"
-    return name
 
 
 def loop_card(scheduled: ScheduledLoop) -> list[str]:

--- a/integrations/github/tools/ci_analytics/loop.py
+++ b/integrations/github/tools/ci_analytics/loop.py
@@ -127,9 +127,8 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
     the numbers can be traced back to the JSON snapshot named at the end.
     Raises ``RuntimeError`` with a generic message when GitHub cannot be read.
     """
-    from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
-    from integrations.github.tools.ci_analytics.collector import collect_runs
-    from integrations.github.tools.ci_analytics.metrics import compute_report
+    from integrations.github.client import GitHubApiError, resolve_github_token
+    from integrations.github.tools.ci_analytics.analysis import analyze_repository
     from integrations.github.tools.ci_analytics.render import headline, render_markdown
     from integrations.github.tools.ci_analytics.tool import report_payload
 
@@ -145,23 +144,12 @@ def build_report(args: Mapping[str, str], *, snapshot_dir: Path | None = None) -
         )
     now = datetime.now(UTC)
     try:
-        collected = collect_runs(
-            GitHubRestClient(token), owner=owner, repo=repo, window_days=days, now=now
+        analysis = analyze_repository(
+            owner, repo, token=token, days=days, working_hours=local_working_hours(), now=now
         )
     except (GitHubApiError, ValueError) as exc:
         raise RuntimeError(f"Could not read the GitHub Actions history of {owner}/{repo}.") from exc
-    report = compute_report(
-        owner=owner,
-        repo=repo,
-        default_branch=collected.default_branch,
-        window_days=days,
-        branch_runs=collected.branch_runs,
-        pr_runs=collected.pr_runs,
-        merged_prs=collected.merged_prs,
-        now=now,
-        coverage_notices=collected.coverage_notices,
-        working_hours=local_working_hours(),
-    )
+    report = analysis.report
     snapshot = _write_snapshot(
         snapshot_dir or OPENSRE_HOME_DIR / SNAPSHOT_DIRNAME,
         owner,

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -17,6 +17,7 @@ from integrations.github.tools.ci_analytics.models import (
     WorkflowRun,
     WorkflowSummary,
 )
+from integrations.github.tools.ci_analytics.working_hours import WorkingHours
 
 PUSH_EVENT = "push"
 
@@ -32,8 +33,14 @@ def compute_report(
     merged_prs: Iterable[MergedPullRequest],
     now: datetime,
     coverage_notices: Iterable[str] = (),
+    working_hours: WorkingHours | None = None,
 ) -> CiAnalyticsReport:
-    """Reduce default-branch and PR runs to the KPIs the report shows."""
+    """Reduce default-branch and PR runs to the KPIs the report shows.
+
+    ``working_hours`` decides which part of each wait counts as developer
+    downtime; the default is 09:00 to 18:00 UTC on weekdays.
+    """
+    hours = working_hours or WorkingHours()
     counted_branch = [run for run in branch_runs if run.failed or run.succeeded]
     counted_pr = [run for run in pr_runs if run.failed or run.succeeded]
     all_runs = [*counted_branch, *counted_pr]
@@ -43,7 +50,9 @@ def compute_report(
     push_runs = [run for run in counted_branch if run.event == PUSH_EVENT]
     outages = find_outages(push_runs)
     closed = [o for o in outages if not o.ongoing]
-    delays = pull_request_delays(counted_pr, classified, normal_minutes=normal, merged_prs=merged)
+    delays = pull_request_delays(
+        counted_pr, classified, normal_minutes=normal, merged_prs=merged, working_hours=hours
+    )
     return CiAnalyticsReport(
         owner=owner,
         repo=repo,
@@ -57,6 +66,8 @@ def compute_report(
         merged_pr_branches=sum(1 for d in delays if d.critical_path and d.delay_minutes > 0),
         blocked_minutes=sum(d.delay_minutes for d in delays if d.critical_path),
         blocked_minutes_all=sum(d.delay_minutes for d in delays),
+        blocked_working_minutes=sum(d.working_minutes for d in delays if d.critical_path),
+        working_hours_label=hours.label,
         branch_runs=len(push_runs),
         branch_failures=sum(1 for run in push_runs if run.failed),
         red_hours=union_hours(outages, now=now),
@@ -76,6 +87,7 @@ def pull_request_delays(
     *,
     normal_minutes: dict[int | str, float],
     merged_prs: Sequence[MergedPullRequest] = (),
+    working_hours: WorkingHours | None = None,
 ) -> list[PullRequestDelay]:
     """Per PR: how much later its commits went green than they should have.
 
@@ -92,6 +104,7 @@ def pull_request_delays(
     and re-runs are counted once.
     """
     identity = PullRequestIdentity(merged_prs)
+    hours = working_hours or WorkingHours()
     affected: set[tuple[PullRequestKey, str]] = set()
     first_failure: dict[PullRequestKey, ClassifiedFailure] = {}
     for item in classified:
@@ -117,7 +130,7 @@ def pull_request_delays(
             intervals[key].append(interval)
     delays: list[PullRequestDelay] = []
     for key, item in first_failure.items():
-        spans = intervals.get(key, [])
+        spans = _union_spans(intervals.get(key, []))
         head_repo, branch, number = key
         delays.append(
             PullRequestDelay(
@@ -125,11 +138,13 @@ def pull_request_delays(
                 branch=branch,
                 pr_number=number,
                 critical_path=item.critical_path,
-                delay_minutes=_union_minutes(spans),
-                commits=len(spans),
+                delay_minutes=sum((end - start).total_seconds() / 60 for start, end in spans),
+                commits=len(intervals.get(key, [])),
                 url=item.failure.url,
                 expected_green=min(start for start, _ in spans) if spans else None,
                 actual_green=max(end for _, end in spans) if spans else None,
+                author=identity.author(key),
+                working_minutes=sum(hours.minutes(start, end) for start, end in spans),
             )
         )
     return sorted(delays, key=lambda d: -d.delay_minutes)
@@ -157,12 +172,16 @@ class PullRequestIdentity:
             prs.sort(key=lambda pr: pr.merged_at)
         self._by_branch = by_branch
         self._merged_at = {pr.number: pr.merged_at for pr in merged}
+        self._author = {pr.number: pr.author for pr in merged}
 
     def key(self, run: WorkflowRun) -> PullRequestKey:
         return (run.head_repo, run.branch, self._number(run))
 
     def merged_at(self, key: PullRequestKey) -> datetime | None:
         return self._merged_at.get(key[2])
+
+    def author(self, key: PullRequestKey) -> str:
+        return self._author.get(key[2], "")
 
     def on_critical_path(self, run: WorkflowRun) -> bool:
         """True when the run's PR was merged inside the window, after the run was queued."""
@@ -246,19 +265,17 @@ def _commit_delay(
     return expected_green, actual_green
 
 
-def _union_minutes(spans: Sequence[tuple[datetime, datetime]]) -> float:
-    total = 0.0
-    current: tuple[datetime, datetime] | None = None
+def _union_spans(
+    spans: Sequence[tuple[datetime, datetime]],
+) -> list[tuple[datetime, datetime]]:
+    """Merge overlapping intervals so a wait is counted once."""
+    merged: list[tuple[datetime, datetime]] = []
     for start, end in sorted(spans):
-        if current is None or start > current[1]:
-            if current is not None:
-                total += (current[1] - current[0]).total_seconds()
-            current = (start, end)
-        elif end > current[1]:
-            current = (current[0], end)
-    if current is not None:
-        total += (current[1] - current[0]).total_seconds()
-    return total / 60
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
 
 
 def normal_minutes(runs: Sequence[WorkflowRun]) -> dict[int | str, float]:

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -10,6 +10,7 @@ from statistics import median
 from integrations.github.tools.ci_analytics.models import (
     CiAnalyticsReport,
     ClassifiedFailure,
+    CommitWait,
     FailureKind,
     MergedPullRequest,
     Outage,
@@ -119,18 +120,20 @@ def pull_request_delays(
     for run in pr_runs:
         by_commit[(identity.key(run), run.head_sha)].append(run)
     next_push = _next_push_times(by_commit)
-    intervals: dict[PullRequestKey, list[tuple[datetime, datetime]]] = defaultdict(list)
+    waits: dict[PullRequestKey, list[CommitWait]] = defaultdict(list)
     for key, sha in affected:
-        interval = _commit_delay(
+        wait = _commit_delay(
             by_commit.get((key, sha), []),
             normal_minutes,
             until=_earliest(next_push.get((key, sha)), identity.merged_at(key)),
         )
-        if interval is not None:
-            intervals[key].append(interval)
+        if wait is not None:
+            waits[key].append(wait)
     delays: list[PullRequestDelay] = []
     for key, item in first_failure.items():
-        spans = _union_spans(intervals.get(key, []))
+        commit_waits = sorted(waits.get(key, []), key=lambda w: w.queued)
+        spans = _union_spans([(w.expected_green, w.actual_green) for w in commit_waits])
+        first = commit_waits[0] if commit_waits else None
         head_repo, branch, number = key
         delays.append(
             PullRequestDelay(
@@ -139,12 +142,14 @@ def pull_request_delays(
                 pr_number=number,
                 critical_path=item.critical_path,
                 delay_minutes=sum((end - start).total_seconds() / 60 for start, end in spans),
-                commits=len(intervals.get(key, [])),
+                commits=len(commit_waits),
                 url=item.failure.url,
                 expected_green=min(start for start, _ in spans) if spans else None,
                 actual_green=max(end for _, end in spans) if spans else None,
                 author=identity.author(key),
                 working_minutes=sum(hours.minutes(start, end) for start, end in spans),
+                first_queued=first.queued if first else None,
+                normal_minutes=first.normal_minutes if first else 0.0,
             )
         )
     return sorted(delays, key=lambda d: -d.delay_minutes)
@@ -226,7 +231,7 @@ def _commit_delay(
     normal_minutes: dict[int | str, float],
     *,
     until: datetime | None = None,
-) -> tuple[datetime, datetime] | None:
+) -> CommitWait | None:
     """Expected and actual green times of one commit, or None when nobody waited.
 
     Each workflow's green time is its first passing completion; a later
@@ -262,7 +267,12 @@ def _commit_delay(
         actual_green = min(actual_green, until)
     if actual_green <= expected_green:
         return None
-    return expected_green, actual_green
+    return CommitWait(
+        queued=queued,
+        normal_minutes=expected_duration,
+        expected_green=expected_green,
+        actual_green=actual_green,
+    )
 
 
 def _union_spans(

--- a/integrations/github/tools/ci_analytics/metrics.py
+++ b/integrations/github/tools/ci_analytics/metrics.py
@@ -128,6 +128,8 @@ def pull_request_delays(
                 delay_minutes=_union_minutes(spans),
                 commits=len(spans),
                 url=item.failure.url,
+                expected_green=min(start for start, _ in spans) if spans else None,
+                actual_green=max(end for _, end in spans) if spans else None,
             )
         )
     return sorted(delays, key=lambda d: -d.delay_minutes)

--- a/integrations/github/tools/ci_analytics/models.py
+++ b/integrations/github/tools/ci_analytics/models.py
@@ -89,6 +89,23 @@ class ClassifiedFailure:
 
 
 @dataclass(frozen=True)
+class CommitWait:
+    """One commit's wait: the inputs and the two timestamps the subtraction uses."""
+
+    queued: datetime
+    """When the commit's first run was queued."""
+
+    normal_minutes: float
+    """Normal duration of the slowest workflow on the commit."""
+
+    expected_green: datetime
+    """``queued`` plus ``normal_minutes``: when the commit should have been green."""
+
+    actual_green: datetime
+    """When its last workflow first passed, or the next push or merge if earlier."""
+
+
+@dataclass(frozen=True)
 class PullRequestDelay:
     """How much later one PR went green than it should have, because CI misbehaved.
 
@@ -120,6 +137,12 @@ class PullRequestDelay:
 
     working_minutes: float = 0.0
     """The part of ``delay_minutes`` inside the report's working hours."""
+
+    first_queued: datetime | None = None
+    """When the first delayed commit's first run was queued."""
+
+    normal_minutes: float = 0.0
+    """Normal duration added to ``first_queued`` to get ``expected_green``."""
 
     @property
     def label(self) -> str:
@@ -310,6 +333,7 @@ __all__ = [
     "SUCCESS_CONCLUSION",
     "CiAnalyticsReport",
     "ClassifiedFailure",
+    "CommitWait",
     "DeveloperWait",
     "FailureKind",
     "MergedPullRequest",

--- a/integrations/github/tools/ci_analytics/models.py
+++ b/integrations/github/tools/ci_analytics/models.py
@@ -115,9 +115,30 @@ class PullRequestDelay:
     actual_green: datetime | None = None
     """When the last delayed commit actually went green, or the wait was cut off."""
 
+    author: str = ""
+    """GitHub login of the PR author, the developer who waited."""
+
+    working_minutes: float = 0.0
+    """The part of ``delay_minutes`` inside the report's working hours."""
+
     @property
     def label(self) -> str:
         return f"PR #{self.pr_number} ({self.branch})" if self.pr_number else self.branch
+
+
+@dataclass(frozen=True)
+class DeveloperWait:
+    """One developer's downtime from unreliable CI over the report window."""
+
+    login: str
+    pull_requests: int
+    working_minutes: float
+    wall_minutes: float
+    window_days: int
+
+    @property
+    def working_minutes_per_week(self) -> float:
+        return self.working_minutes / (self.window_days / 7) if self.window_days else 0.0
 
 
 @dataclass(frozen=True)
@@ -130,6 +151,8 @@ class MergedPullRequest:
     """owner/name of the head repository at merge time."""
 
     merged_at: datetime
+    author: str = ""
+    """GitHub login of the PR author."""
 
 
 @dataclass(frozen=True)
@@ -193,6 +216,11 @@ class CiAnalyticsReport:
     workflows: tuple[WorkflowSummary, ...] = field(default_factory=tuple)
     coverage_notices: tuple[str, ...] = field(default_factory=tuple)
     pr_delays: tuple[PullRequestDelay, ...] = field(default_factory=tuple)
+    blocked_working_minutes: float = 0.0
+    """The part of ``blocked_minutes`` inside working hours: developer downtime."""
+
+    working_hours_label: str = ""
+    """The working window the downtime figure assumes, for the report."""
 
     @property
     def pr_failure_rate(self) -> float | None:
@@ -211,20 +239,45 @@ class CiAnalyticsReport:
 
     @property
     def blocked_pr_delays(self) -> tuple[PullRequestDelay, ...]:
-        """Critical-path PRs that actually waited, worst first."""
+        """Critical-path PRs that actually waited, worst working-hours wait first."""
         delays = [d for d in self.pr_delays if d.critical_path and d.delay_minutes > 0]
-        return tuple(sorted(delays, key=lambda d: -d.delay_minutes))
+        return tuple(sorted(delays, key=lambda d: (-d.working_minutes, -d.delay_minutes)))
+
+    @property
+    def developer_waits(self) -> tuple[DeveloperWait, ...]:
+        """Blocked merged PRs grouped by author, heaviest working-hours wait first."""
+        totals: dict[str, list[float]] = {}
+        for delay in self.blocked_pr_delays:
+            login = delay.author or "unknown"
+            entry = totals.setdefault(login, [0, 0.0, 0.0])
+            entry[0] += 1
+            entry[1] += delay.working_minutes
+            entry[2] += delay.delay_minutes
+        waits = [
+            DeveloperWait(
+                login=login,
+                pull_requests=int(prs),
+                working_minutes=working,
+                wall_minutes=wall,
+                window_days=self.window_days,
+            )
+            for login, (prs, working, wall) in totals.items()
+        ]
+        return tuple(sorted(waits, key=lambda w: (-w.working_minutes, -w.wall_minutes)))
+
+    @property
+    def developers_affected(self) -> int:
+        return sum(1 for wait in self.developer_waits if wait.working_minutes > 0)
+
+    @property
+    def median_working_minutes(self) -> float | None:
+        """Typical working-hours wait per blocked merged PR."""
+        return _median([d.working_minutes for d in self.blocked_pr_delays if d.working_minutes > 0])
 
     @property
     def median_delay_minutes(self) -> float | None:
-        """Typical wait per blocked merged PR, so one long outlier does not read as the norm."""
-        delays = sorted(d.delay_minutes for d in self.blocked_pr_delays)
-        if not delays:
-            return None
-        middle = len(delays) // 2
-        if len(delays) % 2:
-            return delays[middle]
-        return (delays[middle - 1] + delays[middle]) / 2
+        """Typical wall-clock wait per blocked merged PR."""
+        return _median([d.delay_minutes for d in self.blocked_pr_delays])
 
     @property
     def longest_delay(self) -> PullRequestDelay | None:
@@ -242,11 +295,22 @@ class CiAnalyticsReport:
         return tuple(o for o in self.outages if o.ongoing)
 
 
+def _median(values: list[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2
+
+
 __all__ = [
     "FAILED_CONCLUSIONS",
     "SUCCESS_CONCLUSION",
     "CiAnalyticsReport",
     "ClassifiedFailure",
+    "DeveloperWait",
     "FailureKind",
     "MergedPullRequest",
     "Outage",

--- a/integrations/github/tools/ci_analytics/models.py
+++ b/integrations/github/tools/ci_analytics/models.py
@@ -109,6 +109,12 @@ class PullRequestDelay:
     url: str
     """The first CI-caused failure on the PR, for the report link."""
 
+    expected_green: datetime | None = None
+    """When the first delayed commit should have been green had CI run normally."""
+
+    actual_green: datetime | None = None
+    """When the last delayed commit actually went green, or the wait was cut off."""
+
     @property
     def label(self) -> str:
         return f"PR #{self.pr_number} ({self.branch})" if self.pr_number else self.branch

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -20,7 +20,6 @@ from integrations.github.tools.ci_analytics.models import (
 _TOP_WORKFLOWS = 5
 _TOP_BLOCKED_PRS = 5
 _TOP_DEVELOPERS = 3
-_BRANCH_WIDTH = 30
 _METHOD_LINES = (
     "For each merged PR whose CI failed and later passed on the same commit:",
     "  expected green = first run queued + normal duration "

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -19,7 +19,12 @@ from integrations.github.tools.ci_analytics.models import (
 
 _TOP_WORKFLOWS = 5
 _TOP_BLOCKED_PRS = 5
-_BRANCH_WIDTH = 36
+_TOP_DEVELOPERS = 3
+_BRANCH_WIDTH = 30
+_ASSUMPTIONS = (
+    "normal duration is each workflow's median first-attempt pass; a wait ends at the "
+    "next push or the merge; parallel workflows count once"
+)
 
 
 def render_markdown(report: CiAnalyticsReport) -> str:
@@ -85,24 +90,20 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
                 ),
                 _kpi_line("Not recovered in the window", str(report.count(FailureKind.UNRESOLVED))),
                 Text(""),
-                Text(
-                    f"Developer time blocked by unreliable CI: {_minutes(report.blocked_minutes)} "
-                    f"across {report.merged_pr_branches} merged "
-                    f"{_plural(report.merged_pr_branches, 'PR')}",
-                    style="bold",
-                ),
-                Text(
-                    "Per pull request: how much later its commits went green than they would "
-                    "have had CI run normally (median first-attempt duration per workflow). "
-                    "Only PRs that were later merged count; overlapping workflows count once.",
-                    style="dim",
-                ),
+                Text(_downtime_headline(report), style="bold"),
+                Text(_downtime_basis(report), style="dim"),
             ]
         )
         if report.blocked_minutes_all > report.blocked_minutes:
             parts.append(
-                _kpi_line("Including PRs not merged yet", _minutes(report.blocked_minutes_all))
+                _kpi_line(
+                    "Including PRs not merged yet",
+                    f"{_minutes(report.blocked_minutes_all)} wall clock",
+                )
             )
+        heaviest = _heaviest_developers(report)
+        if heaviest:
+            parts.append(_kpi_line("Heaviest hit", heaviest))
         blocked = report.blocked_pr_delays
         if blocked:
             parts.extend([Text(""), Text("How it adds up, worst first", style="bold")])
@@ -154,41 +155,82 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
     console.print(Padding(Group(*parts), (0, 0, 0, 2)))
 
 
+def _working(minutes: float) -> str:
+    """Working time in hours, never calendar days: 215h, not 8.9d."""
+    return f"{minutes:.0f}m" if minutes < 60 else f"{minutes / 60:.1f}h"
+
+
+def _downtime_headline(report: CiAnalyticsReport) -> str:
+    developers = report.developers_affected
+    return (
+        f"Developer downtime from unreliable CI: {_working(report.blocked_working_minutes)} "
+        f"of working time across {developers} {_plural(developers, 'developer')}"
+    )
+
+
+def _downtime_basis(report: CiAnalyticsReport) -> str:
+    return (
+        f"{_minutes(report.blocked_minutes)} of wall-clock wait across "
+        f"{report.merged_pr_branches} merged {_plural(report.merged_pr_branches, 'PR')}: how much "
+        "later each PR's commits went green than they would have had CI run normally. "
+        f"Assumptions: working hours {report.working_hours_label}; {_ASSUMPTIONS}."
+    )
+
+
+def _heaviest_developers(report: CiAnalyticsReport) -> str:
+    waits = [w for w in report.developer_waits if w.working_minutes > 0][:_TOP_DEVELOPERS]
+    return " · ".join(
+        f"{w.login} {_working(w.working_minutes_per_week)}/week over {w.pull_requests} "
+        f"{_plural(w.pull_requests, 'PR')}"
+        for w in waits
+    )
+
+
 def _blocked_table(blocked: tuple[PullRequestDelay, ...]) -> Table:
     table = Table(show_edge=False, pad_edge=False, box=None, header_style="dim")
     for column, justify in (
         ("PR", "left"),
+        ("Author", "left"),
         ("Branch", "left"),
         ("Expected green (UTC)", "left"),
         ("Actually green (UTC)", "left"),
-        ("Waited", "right"),
+        ("Working wait", "right"),
+        ("Wall clock", "right"),
     ):
         table.add_column(column, justify=justify)  # type: ignore[arg-type]
     for item in blocked[:_TOP_BLOCKED_PRS]:
-        table.add_row(
-            f"#{item.pr_number}" if item.pr_number else "-",
-            _shorten(item.branch, _BRANCH_WIDTH),
-            _stamp(item.expected_green),
-            _stamp(item.actual_green),
-            _minutes(item.delay_minutes),
-        )
+        table.add_row(*_blocked_row(item))
     return table
 
 
+def _blocked_row(item: PullRequestDelay) -> tuple[str, ...]:
+    return (
+        f"#{item.pr_number}" if item.pr_number else "-",
+        item.author or "-",
+        _shorten(item.branch, _BRANCH_WIDTH),
+        _stamp(item.expected_green),
+        _stamp(item.actual_green),
+        _working(item.working_minutes),
+        _minutes(item.delay_minutes),
+    )
+
+
 def _blocked_sum_lines(report: CiAnalyticsReport) -> list[str]:
-    """The bottom-up total: every blocked PR's wait, summed."""
+    """The bottom-up total: every blocked PR's working-hours wait, summed."""
     blocked = report.blocked_pr_delays
     lines = []
     rest = blocked[_TOP_BLOCKED_PRS:]
     if rest:
         lines.append(
             f"and {len(rest)} more {_plural(len(rest), 'PR')} waiting "
-            f"{_minutes(sum(item.delay_minutes for item in rest))} between them"
+            f"{_working(sum(item.working_minutes for item in rest))} of working time between them"
         )
-    typical = _minutes(report.median_delay_minutes or 0.0)
+    typical = _working(report.median_working_minutes or 0.0)
+    developers = report.developers_affected
     lines.append(
-        f"Sum of waits: {_minutes(report.blocked_minutes)} across {len(blocked)} merged "
-        f"{_plural(len(blocked), 'PR')}; the typical blocked PR waited {typical}"
+        f"Sum of working-hour waits: {_working(report.blocked_working_minutes)} across "
+        f"{developers} {_plural(developers, 'developer')} and {len(blocked)} merged "
+        f"{_plural(len(blocked), 'PR')}; the typical blocked PR cost {typical} of working time"
     )
     return lines
 
@@ -203,14 +245,21 @@ def _shorten(text: str, width: int) -> str:
 
 def headline(report: CiAnalyticsReport) -> str:
     """One deterministic sentence naming the biggest cost, for the agent to repeat verbatim."""
+    if report.blocked_working_minutes > 0:
+        heaviest = report.developer_waits[0]
+        developers = report.developers_affected
+        return (
+            f"Unreliable CI cost {developers} {_plural(developers, 'developer')} "
+            f"{_working(report.blocked_working_minutes)} of working time in the last "
+            f"{report.window_days} days, up to {_working(heaviest.working_minutes_per_week)} a "
+            f"week for the worst hit; {_minutes(report.blocked_minutes)} of wall-clock wait "
+            f"across {report.merged_pr_branches} merged {_plural(report.merged_pr_branches, 'PR')}."
+        )
     if report.blocked_minutes > 0:
-        typical = report.median_delay_minutes or 0.0
-        longest = report.longest_delay
-        worst = f", the longest {_minutes(longest.delay_minutes)}" if longest else ""
         return (
             f"Unreliable CI blocked merged pull requests for {_minutes(report.blocked_minutes)} "
-            f"in the last {report.window_days} days; the typical blocked PR waited "
-            f"{_minutes(typical)}{worst}."
+            f"of wall-clock time in the last {report.window_days} days, all of it outside "
+            f"working hours ({report.working_hours_label})."
         )
     if report.red_hours > 0:
         return (
@@ -248,25 +297,26 @@ def _classification(report: CiAnalyticsReport) -> list[str]:
 def _blocked_time(report: CiAnalyticsReport) -> list[str]:
     lines = [
         "",
-        f"**Developer time blocked by unreliable CI: {_minutes(report.blocked_minutes)}** "
-        f"across {report.merged_pr_branches} merged {_plural(report.merged_pr_branches, 'PR')}",
-        "- Per pull request: how much later its commits went green than they would have "
-        "had CI run normally (median first-attempt duration per workflow)",
-        "- Only PRs that were later merged count; overlapping workflows count once",
+        f"**{_downtime_headline(report)}**",
+        f"- {_downtime_basis(report)}",
     ]
     if report.blocked_minutes_all > report.blocked_minutes:
-        lines.append(f"- Including PRs not merged yet: {_minutes(report.blocked_minutes_all)}")
+        lines.append(
+            f"- Including PRs not merged yet: {_minutes(report.blocked_minutes_all)} wall clock"
+        )
+    heaviest = _heaviest_developers(report)
+    if heaviest:
+        lines.append(f"- Heaviest hit: {heaviest}")
     blocked = report.blocked_pr_delays
     if blocked:
         lines.extend(["", "How it adds up, worst first:"])
-        lines.append("| PR | Branch | Expected green (UTC) | Actually green (UTC) | Waited |")
-        lines.append("| --- | --- | --- | --- | ---: |")
+        lines.append(
+            "| PR | Author | Branch | Expected green (UTC) | Actually green (UTC) | "
+            "Working wait | Wall clock |"
+        )
+        lines.append("| --- | --- | --- | --- | --- | ---: | ---: |")
         for item in blocked[:_TOP_BLOCKED_PRS]:
-            lines.append(
-                f"| {f'#{item.pr_number}' if item.pr_number else '-'} | "
-                f"{_shorten(item.branch, _BRANCH_WIDTH)} | {_stamp(item.expected_green)} | "
-                f"{_stamp(item.actual_green)} | {_minutes(item.delay_minutes)} |"
-            )
+            lines.append("| " + " | ".join(_blocked_row(item)) + " |")
         lines.extend(f"- {line}" for line in _blocked_sum_lines(report))
     return lines
 

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -18,6 +18,8 @@ from integrations.github.tools.ci_analytics.models import (
 )
 
 _TOP_WORKFLOWS = 5
+_TOP_BLOCKED_PRS = 5
+_BRANCH_WIDTH = 36
 
 
 def render_markdown(report: CiAnalyticsReport) -> str:
@@ -101,13 +103,11 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
             parts.append(
                 _kpi_line("Including PRs not merged yet", _minutes(report.blocked_minutes_all))
             )
-        if report.median_delay_minutes is not None:
-            parts.append(
-                _kpi_line("Typical wait per blocked PR", _minutes(report.median_delay_minutes))
-            )
-        longest = report.longest_delay
-        if longest is not None and longest.delay_minutes > 0:
-            parts.append(_kpi_line("Longest wait", _delay(longest)))
+        blocked = report.blocked_pr_delays
+        if blocked:
+            parts.extend([Text(""), Text("How it adds up, worst first", style="bold")])
+            parts.append(_blocked_table(blocked))
+            parts.extend(Text(line, style="dim") for line in _blocked_sum_lines(report))
     if report.branch_runs:
         parts.extend(
             [
@@ -152,6 +152,53 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
     parts.extend(Text(notice, style="dim") for notice in report.coverage_notices)
     # Hang the block in the shell's two-column reply gutter like agent output.
     console.print(Padding(Group(*parts), (0, 0, 0, 2)))
+
+
+def _blocked_table(blocked: tuple[PullRequestDelay, ...]) -> Table:
+    table = Table(show_edge=False, pad_edge=False, box=None, header_style="dim")
+    for column, justify in (
+        ("PR", "left"),
+        ("Branch", "left"),
+        ("Expected green", "left"),
+        ("Actually green", "left"),
+        ("Waited", "right"),
+    ):
+        table.add_column(column, justify=justify)  # type: ignore[arg-type]
+    for item in blocked[:_TOP_BLOCKED_PRS]:
+        table.add_row(
+            f"#{item.pr_number}" if item.pr_number else "-",
+            _shorten(item.branch, _BRANCH_WIDTH),
+            _stamp(item.expected_green),
+            _stamp(item.actual_green),
+            _minutes(item.delay_minutes),
+        )
+    return table
+
+
+def _blocked_sum_lines(report: CiAnalyticsReport) -> list[str]:
+    """The bottom-up total: every blocked PR's wait, summed."""
+    blocked = report.blocked_pr_delays
+    lines = []
+    rest = blocked[_TOP_BLOCKED_PRS:]
+    if rest:
+        lines.append(
+            f"and {len(rest)} more {_plural(len(rest), 'PR')} waiting "
+            f"{_minutes(sum(item.delay_minutes for item in rest))} between them"
+        )
+    typical = _minutes(report.median_delay_minutes or 0.0)
+    lines.append(
+        f"Sum of waits: {_minutes(report.blocked_minutes)} across {len(blocked)} merged "
+        f"{_plural(len(blocked), 'PR')}; the typical blocked PR waited {typical}"
+    )
+    return lines
+
+
+def _stamp(when: datetime | None) -> str:
+    return when.strftime("%b %d %H:%M") if when else "-"
+
+
+def _shorten(text: str, width: int) -> str:
+    return text if len(text) <= width else text[: width - 1] + "…"
 
 
 def headline(report: CiAnalyticsReport) -> str:
@@ -209,11 +256,18 @@ def _blocked_time(report: CiAnalyticsReport) -> list[str]:
     ]
     if report.blocked_minutes_all > report.blocked_minutes:
         lines.append(f"- Including PRs not merged yet: {_minutes(report.blocked_minutes_all)}")
-    if report.median_delay_minutes is not None:
-        lines.append(f"- Typical wait per blocked PR: {_minutes(report.median_delay_minutes)}")
-    longest = report.longest_delay
-    if longest is not None and longest.delay_minutes > 0:
-        lines.append(f"- Longest wait: {_delay(longest)}")
+    blocked = report.blocked_pr_delays
+    if blocked:
+        lines.extend(["", "How it adds up, worst first:"])
+        lines.append("| PR | Branch | Expected green | Actually green | Waited |")
+        lines.append("| --- | --- | --- | --- | ---: |")
+        for item in blocked[:_TOP_BLOCKED_PRS]:
+            lines.append(
+                f"| {f'#{item.pr_number}' if item.pr_number else '-'} | "
+                f"{_shorten(item.branch, _BRANCH_WIDTH)} | {_stamp(item.expected_green)} | "
+                f"{_stamp(item.actual_green)} | {_minutes(item.delay_minutes)} |"
+            )
+        lines.extend(f"- {line}" for line in _blocked_sum_lines(report))
     return lines
 
 
@@ -234,11 +288,6 @@ def _default_branch(report: CiAnalyticsReport) -> list[str]:
     for outage in report.ongoing_outages:
         lines.append(f"- **Still red now:** {_outage(outage, now=report.generated_at)}")
     return lines
-
-
-def _delay(item: PullRequestDelay) -> str:
-    commits = f", {item.commits} {_plural(item.commits, 'commit')}" if item.commits > 1 else ""
-    return f"{_minutes(item.delay_minutes)} on {item.label}{commits} {item.url}".strip()
 
 
 def _outage(outage: Outage, *, now: datetime) -> str:

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -159,8 +159,8 @@ def _blocked_table(blocked: tuple[PullRequestDelay, ...]) -> Table:
     for column, justify in (
         ("PR", "left"),
         ("Branch", "left"),
-        ("Expected green", "left"),
-        ("Actually green", "left"),
+        ("Expected green (UTC)", "left"),
+        ("Actually green (UTC)", "left"),
         ("Waited", "right"),
     ):
         table.add_column(column, justify=justify)  # type: ignore[arg-type]
@@ -259,7 +259,7 @@ def _blocked_time(report: CiAnalyticsReport) -> list[str]:
     blocked = report.blocked_pr_delays
     if blocked:
         lines.extend(["", "How it adds up, worst first:"])
-        lines.append("| PR | Branch | Expected green | Actually green | Waited |")
+        lines.append("| PR | Branch | Expected green (UTC) | Actually green (UTC) | Waited |")
         lines.append("| --- | --- | --- | --- | ---: |")
         for item in blocked[:_TOP_BLOCKED_PRS]:
             lines.append(

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -21,9 +21,13 @@ _TOP_WORKFLOWS = 5
 _TOP_BLOCKED_PRS = 5
 _TOP_DEVELOPERS = 3
 _BRANCH_WIDTH = 30
-_ASSUMPTIONS = (
-    "normal duration is each workflow's median first-attempt pass; a wait ends at the "
-    "next push or the merge; parallel workflows count once"
+_METHOD_LINES = (
+    "For each merged PR whose CI failed and later passed on the same commit:",
+    "  expected green = first run queued + normal duration "
+    "(median first-attempt pass of the slowest workflow)",
+    "  actually green = last workflow's first pass, or the next push / merge if earlier",
+    "  blocked        = actually green - expected green, counted in working hours ({hours}); "
+    "parallel workflows count once",
 )
 
 
@@ -91,9 +95,14 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
                 _kpi_line("Not recovered in the window", str(report.count(FailureKind.UNRESOLVED))),
                 Text(""),
                 Text(_downtime_headline(report), style="bold"),
-                Text(_downtime_basis(report), style="dim"),
             ]
         )
+        parts.extend(Text(line, style="dim") for line in _method_lines(report))
+        blocked = report.blocked_pr_delays
+        if blocked:
+            parts.append(Text(""))
+            parts.append(_blocked_table(blocked))
+            parts.extend(Text(line) for line in _roll_up_lines(report))
         if report.blocked_minutes_all > report.blocked_minutes:
             parts.append(
                 _kpi_line(
@@ -101,14 +110,6 @@ def render_report(console: Any, report: CiAnalyticsReport) -> None:
                     f"{_minutes(report.blocked_minutes_all)} wall clock",
                 )
             )
-        heaviest = _heaviest_developers(report)
-        if heaviest:
-            parts.append(_kpi_line("Heaviest hit", heaviest))
-        blocked = report.blocked_pr_delays
-        if blocked:
-            parts.extend([Text(""), Text("How it adds up, worst first", style="bold")])
-            parts.append(_blocked_table(blocked))
-            parts.extend(Text(line, style="dim") for line in _blocked_sum_lines(report))
     if report.branch_runs:
         parts.extend(
             [
@@ -163,27 +164,14 @@ def _working(minutes: float) -> str:
 def _downtime_headline(report: CiAnalyticsReport) -> str:
     developers = report.developers_affected
     return (
-        f"Developer downtime from unreliable CI: {_working(report.blocked_working_minutes)} "
-        f"of working time across {developers} {_plural(developers, 'developer')}"
+        f"Developer Blocked Time, estimated bottom-up: "
+        f"{_working(report.blocked_working_minutes)} of working time across {developers} "
+        f"{_plural(developers, 'developer')}"
     )
 
 
-def _downtime_basis(report: CiAnalyticsReport) -> str:
-    return (
-        f"{_minutes(report.blocked_minutes)} of wall-clock wait across "
-        f"{report.merged_pr_branches} merged {_plural(report.merged_pr_branches, 'PR')}: how much "
-        "later each PR's commits went green than they would have had CI run normally. "
-        f"Assumptions: working hours {report.working_hours_label}; {_ASSUMPTIONS}."
-    )
-
-
-def _heaviest_developers(report: CiAnalyticsReport) -> str:
-    waits = [w for w in report.developer_waits if w.working_minutes > 0][:_TOP_DEVELOPERS]
-    return " · ".join(
-        f"{w.login} {_working(w.working_minutes_per_week)}/week over {w.pull_requests} "
-        f"{_plural(w.pull_requests, 'PR')}"
-        for w in waits
-    )
+def _method_lines(report: CiAnalyticsReport) -> list[str]:
+    return [line.format(hours=report.working_hours_label) for line in _METHOD_LINES]
 
 
 def _blocked_table(blocked: tuple[PullRequestDelay, ...]) -> Table:
@@ -191,10 +179,11 @@ def _blocked_table(blocked: tuple[PullRequestDelay, ...]) -> Table:
     for column, justify in (
         ("PR", "left"),
         ("Author", "left"),
-        ("Branch", "left"),
-        ("Expected green (UTC)", "left"),
-        ("Actually green (UTC)", "left"),
-        ("Working wait", "right"),
+        ("Queued (UTC)", "left"),
+        ("+ normal", "right"),
+        ("= expected green", "left"),
+        ("Actually green", "left"),
+        ("Blocked, working", "right"),
         ("Wall clock", "right"),
     ):
         table.add_column(column, justify=justify)  # type: ignore[arg-type]
@@ -207,7 +196,8 @@ def _blocked_row(item: PullRequestDelay) -> tuple[str, ...]:
     return (
         f"#{item.pr_number}" if item.pr_number else "-",
         item.author or "-",
-        _shorten(item.branch, _BRANCH_WIDTH),
+        _stamp(item.first_queued),
+        _minutes(item.normal_minutes),
         _stamp(item.expected_green),
         _stamp(item.actual_green),
         _working(item.working_minutes),
@@ -215,24 +205,43 @@ def _blocked_row(item: PullRequestDelay) -> tuple[str, ...]:
     )
 
 
-def _blocked_sum_lines(report: CiAnalyticsReport) -> list[str]:
-    """The bottom-up total: every blocked PR's working-hours wait, summed."""
+def _roll_up_lines(report: CiAnalyticsReport) -> list[str]:
+    """The sum and the per-developer division, written as arithmetic."""
     blocked = report.blocked_pr_delays
-    lines = []
+    developers = report.developers_affected
+    weeks = report.window_days / 7
+    lines: list[str] = []
     rest = blocked[_TOP_BLOCKED_PRS:]
     if rest:
         lines.append(
-            f"and {len(rest)} more {_plural(len(rest), 'PR')} waiting "
-            f"{_working(sum(item.working_minutes for item in rest))} of working time between them"
+            f"+ {len(rest)} more {_plural(len(rest), 'PR')}: "
+            f"{_working(sum(item.working_minutes for item in rest))} of working time"
         )
-    typical = _working(report.median_working_minutes or 0.0)
-    developers = report.developers_affected
     lines.append(
-        f"Sum of working-hour waits: {_working(report.blocked_working_minutes)} across "
-        f"{developers} {_plural(developers, 'developer')} and {len(blocked)} merged "
-        f"{_plural(len(blocked), 'PR')}; the typical blocked PR cost {typical} of working time"
+        f"Σ blocked = {_working(report.blocked_working_minutes)} of working time across "
+        f"{len(blocked)} merged {_plural(len(blocked), 'PR')} "
+        f"({_minutes(report.blocked_minutes)} wall clock)"
     )
+    if developers:
+        each = report.blocked_working_minutes / developers
+        lines.append(
+            f"÷ {developers} {_plural(developers, 'developer')} = {_working(each)} each in "
+            f"{report.window_days} days, about {_working(each / weeks)} per developer per week; "
+            f"typical blocked PR {_working(report.median_working_minutes or 0.0)}"
+        )
+    heaviest = _heaviest_developers(report)
+    if heaviest:
+        lines.append(f"Heaviest hit: {heaviest}")
     return lines
+
+
+def _heaviest_developers(report: CiAnalyticsReport) -> str:
+    waits = [w for w in report.developer_waits if w.working_minutes > 0][:_TOP_DEVELOPERS]
+    return " · ".join(
+        f"{w.login} {_working(w.working_minutes_per_week)}/week over {w.pull_requests} "
+        f"{_plural(w.pull_requests, 'PR')}"
+        for w in waits
+    )
 
 
 def _stamp(when: datetime | None) -> str:
@@ -295,29 +304,23 @@ def _classification(report: CiAnalyticsReport) -> list[str]:
 
 
 def _blocked_time(report: CiAnalyticsReport) -> list[str]:
-    lines = [
-        "",
-        f"**{_downtime_headline(report)}**",
-        f"- {_downtime_basis(report)}",
-    ]
+    lines = ["", f"**{_downtime_headline(report)}**"]
+    lines.extend(f"- {line.strip()}" for line in _method_lines(report))
+    blocked = report.blocked_pr_delays
+    if blocked:
+        lines.append("")
+        lines.append(
+            "| PR | Author | Queued (UTC) | + normal | = expected green | Actually green | "
+            "Blocked, working | Wall clock |"
+        )
+        lines.append("| --- | --- | --- | ---: | --- | --- | ---: | ---: |")
+        for item in blocked[:_TOP_BLOCKED_PRS]:
+            lines.append("| " + " | ".join(_blocked_row(item)) + " |")
+        lines.extend(f"- {line}" for line in _roll_up_lines(report))
     if report.blocked_minutes_all > report.blocked_minutes:
         lines.append(
             f"- Including PRs not merged yet: {_minutes(report.blocked_minutes_all)} wall clock"
         )
-    heaviest = _heaviest_developers(report)
-    if heaviest:
-        lines.append(f"- Heaviest hit: {heaviest}")
-    blocked = report.blocked_pr_delays
-    if blocked:
-        lines.extend(["", "How it adds up, worst first:"])
-        lines.append(
-            "| PR | Author | Branch | Expected green (UTC) | Actually green (UTC) | "
-            "Working wait | Wall clock |"
-        )
-        lines.append("| --- | --- | --- | --- | --- | ---: | ---: |")
-        for item in blocked[:_TOP_BLOCKED_PRS]:
-            lines.append("| " + " | ".join(_blocked_row(item)) + " |")
-        lines.extend(f"- {line}" for line in _blocked_sum_lines(report))
     return lines
 
 

--- a/integrations/github/tools/ci_analytics/render.py
+++ b/integrations/github/tools/ci_analytics/render.py
@@ -247,10 +247,6 @@ def _stamp(when: datetime | None) -> str:
     return when.strftime("%b %d %H:%M") if when else "-"
 
 
-def _shorten(text: str, width: int) -> str:
-    return text if len(text) <= width else text[: width - 1] + "…"
-
-
 def headline(report: CiAnalyticsReport) -> str:
     """One deterministic sentence naming the biggest cost, for the agent to repeat verbatim."""
     if report.blocked_working_minutes > 0:
@@ -371,6 +367,16 @@ def _plural(count: int, noun: str) -> str:
     return noun if count == 1 else f"{noun}s"
 
 
-__all__ = ["format_minutes", "headline", "render_markdown", "render_report"]
+render_ci_report = render_report
+ci_report_headline = headline
+
+__all__ = [
+    "ci_report_headline",
+    "render_ci_report",
+    "format_minutes",
+    "headline",
+    "render_markdown",
+    "render_report",
+]
 
 format_minutes = _minutes

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -31,6 +31,7 @@ from integrations.github.tools.ci_analytics.render import (
     render_markdown,
     render_report,
 )
+from integrations.github.tools.ci_analytics.working_hours import local_working_hours
 
 TOOL_NAME = "analyze_github_ci_reliability"
 _SOURCE = "github"
@@ -115,11 +116,25 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
         "blocked_minutes": round(report.blocked_minutes, 1),
         "blocked_minutes_all": round(report.blocked_minutes_all, 1),
         "merged_pr_branches": report.merged_pr_branches,
+        "blocked_working_minutes": round(report.blocked_working_minutes, 1),
+        "working_hours": report.working_hours_label,
+        "developers_affected": report.developers_affected,
+        "developers": [
+            {
+                "login": w.login,
+                "pull_requests": w.pull_requests,
+                "working_minutes": round(w.working_minutes, 1),
+                "working_minutes_per_week": round(w.working_minutes_per_week, 1),
+            }
+            for w in report.developer_waits[:10]
+        ],
         "blocked_prs": [
             {
                 "pr_number": d.pr_number,
+                "author": d.author,
                 "branch": d.branch,
                 "delay_minutes": round(d.delay_minutes, 1),
+                "working_minutes": round(d.working_minutes, 1),
                 "commits": d.commits,
             }
             for d in report.blocked_pr_delays[:10]
@@ -170,7 +185,8 @@ def report_payload(report: CiAnalyticsReport) -> dict[str, Any]:
         "executions": "Completed workflow runs counted in the window",
         "pr_failure_rate": "Failed share of PR-triggered runs",
         "reliability_failures": "Failures that passed later on the identical commit",
-        "blocked_minutes": "Minutes merged PRs waited past their expected green time because of CI",
+        "blocked_minutes": "Wall-clock minutes merged PRs waited past their expected green time",
+        "blocked_working_minutes": "The part of that wait inside working hours: developer downtime",
         "red_hours": "Hours the default branch had at least one red workflow",
         "headline": "One sentence naming the biggest cost, to repeat verbatim",
         "response_text": "The rendered report, or a one-line summary when the shell painted it",
@@ -282,12 +298,14 @@ def analyze_github_ci_reliability(
         merged_prs=collected.merged_prs,
         now=now,
         coverage_notices=collected.coverage_notices,
+        working_hours=local_working_hours(),
     )
     summary = (
         f"{repo_owner}/{repo_name}: {report.executions} runs in {window} days, "
         f"{report.pr_failures} of {report.pr_executions} PR runs failed, "
         f"{report.count(FailureKind.RELIABILITY)} CI-caused, "
-        f"{format_minutes(report.blocked_minutes)} of developer time blocked on merged PRs."
+        f"{format_minutes(report.blocked_working_minutes)} of developer downtime "
+        f"({format_minutes(report.blocked_minutes)} wall clock) on merged PRs."
     )
     rendered = console is not None
     if console is not None:

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -251,7 +251,8 @@ def analyze_github_ci_reliability(
             "owner/repo is required unless the workspace origin identifies a GitHub repository.",
             response_text="I need a GitHub repository (owner/repo) to analyze.",
         )
-    if not resolve_github_token(github_token):
+    token = resolve_github_token(github_token)
+    if not token:
         message = (
             f"A GitHub token is required to read the Actions history of {repo_owner}/{repo_name}. "
             "Run `opensre integrations setup github` and try again."
@@ -268,9 +269,7 @@ def analyze_github_ci_reliability(
         )
     started = time.monotonic()
     try:
-        analysis = analyze_repository(
-            repo_owner, repo_name, token=github_token, days=window, now=now
-        )
+        analysis = analyze_repository(repo_owner, repo_name, token=token, days=window, now=now)
     except (GitHubApiError, ValueError) as exc:
         report_run_error(
             exc,

--- a/integrations/github/tools/ci_analytics/tool.py
+++ b/integrations/github/tools/ci_analytics/tool.py
@@ -15,15 +15,14 @@ from core.domain.types.tools import ToolSurface
 from core.tool import SideEffectLevel, report_run_error
 from core.tool_framework import tool
 from core.tool_framework.utils import tool_unavailable
-from integrations.github.client import GitHubApiError, GitHubRestClient, resolve_github_token
+from integrations.github.client import GitHubApiError, resolve_github_token
 from integrations.github.helpers import (
     GITHUB_INJECTED_PARAMS,
     github_creds,
     github_source_available,
 )
 from integrations.github.repo_scope import detect_git_remote_repo_scope
-from integrations.github.tools.ci_analytics.collector import collect_runs
-from integrations.github.tools.ci_analytics.metrics import compute_report
+from integrations.github.tools.ci_analytics.analysis import analyze_repository
 from integrations.github.tools.ci_analytics.models import CiAnalyticsReport, FailureKind
 from integrations.github.tools.ci_analytics.render import (
     format_minutes,
@@ -31,7 +30,6 @@ from integrations.github.tools.ci_analytics.render import (
     render_markdown,
     render_report,
 )
-from integrations.github.tools.ci_analytics.working_hours import local_working_hours
 
 TOOL_NAME = "analyze_github_ci_reliability"
 _SOURCE = "github"
@@ -270,12 +268,8 @@ def analyze_github_ci_reliability(
         )
     started = time.monotonic()
     try:
-        collected = collect_runs(
-            GitHubRestClient(github_token),
-            owner=repo_owner,
-            repo=repo_name,
-            window_days=window,
-            now=now,
+        analysis = analyze_repository(
+            repo_owner, repo_name, token=github_token, days=window, now=now
         )
     except (GitHubApiError, ValueError) as exc:
         report_run_error(
@@ -288,18 +282,7 @@ def analyze_github_ci_reliability(
         )
         message = _failure_message(exc, repository=f"{repo_owner}/{repo_name}")
         return tool_unavailable(_SOURCE, message, response_text=message)
-    report = compute_report(
-        owner=repo_owner,
-        repo=repo_name,
-        default_branch=collected.default_branch,
-        window_days=window,
-        branch_runs=collected.branch_runs,
-        pr_runs=collected.pr_runs,
-        merged_prs=collected.merged_prs,
-        now=now,
-        coverage_notices=collected.coverage_notices,
-        working_hours=local_working_hours(),
-    )
+    report = analysis.report
     summary = (
         f"{repo_owner}/{repo_name}: {report.executions} runs in {window} days, "
         f"{report.pr_failures} of {report.pr_executions} PR runs failed, "
@@ -309,15 +292,16 @@ def analyze_github_ci_reliability(
     )
     rendered = console is not None
     if console is not None:
-        read = len(collected.branch_runs) + len(collected.pr_runs)
-        console.print(f"  [dim]Read {read} runs in {time.monotonic() - started:.0f}s.[/dim]")
+        console.print(
+            f"  [dim]Read {analysis.runs_read} runs in {time.monotonic() - started:.0f}s.[/dim]"
+        )
         console.print()
     base = {
         "source": _SOURCE,
         "success": True,
         "owner": repo_owner,
         "repo": repo_name,
-        "default_branch": collected.default_branch,
+        "default_branch": report.default_branch,
         "window_days": window,
         "summary": summary,
         "headline": headline(report),

--- a/integrations/github/tools/ci_analytics/working_hours.py
+++ b/integrations/github/tools/ci_analytics/working_hours.py
@@ -1,0 +1,65 @@
+"""Working hours: the part of a wall-clock wait a developer actually sat through."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from config.runtime_metadata.probes import local_tz_name
+
+_WEEKDAY_COUNT = 5
+
+
+@dataclass(frozen=True)
+class WorkingHours:
+    """A weekday working window in one timezone; the default is 09:00 to 18:00 UTC."""
+
+    timezone: str = "UTC"
+    start_hour: int = 9
+    end_hour: int = 18
+    weekdays_only: bool = True
+
+    @property
+    def label(self) -> str:
+        days = "Mon-Fri" if self.weekdays_only else "every day"
+        return f"{days} {self.start_hour:02d}:00-{self.end_hour:02d}:00 {self.timezone}"
+
+    def minutes(self, start: datetime, end: datetime) -> float:
+        """Minutes of ``[start, end)`` that fall inside the working window."""
+        if end <= start:
+            return 0.0
+        zone = ZoneInfo(self.timezone)
+        cursor = start.astimezone(zone)
+        finish = end.astimezone(zone)
+        total = 0.0
+        while cursor < finish:
+            day_start = cursor.replace(hour=self.start_hour, minute=0, second=0, microsecond=0)
+            day_end = cursor.replace(hour=self.end_hour, minute=0, second=0, microsecond=0)
+            next_day = (cursor + timedelta(days=1)).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            if not self.weekdays_only or cursor.weekday() < _WEEKDAY_COUNT:
+                window_start = max(cursor, day_start)
+                window_end = min(finish, day_end)
+                if window_end > window_start:
+                    total += (window_end - window_start).total_seconds() / 60
+            cursor = next_day
+        return total
+
+
+def local_timezone() -> str:
+    """This machine's IANA timezone, or UTC when it cannot be resolved."""
+    name = local_tz_name()
+    try:
+        ZoneInfo(name)
+    except (KeyError, ValueError, OSError):
+        return "UTC"
+    return name
+
+
+def local_working_hours() -> WorkingHours:
+    return WorkingHours(timezone=local_timezone())
+
+
+__all__ = ["WorkingHours", "local_timezone", "local_working_hours"]

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -76,7 +76,10 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         return True
 
     render_choice_selection(console, items[0].title, picked_one)
-    session.terminal.set_auto_command(picked_one)
+    # The answer travels with its question, as the batched wizard's does: a bare
+    # label such as "owner/repo (757 commits, CI configured)" reads to the
+    # planner like a fresh request and gets re-asked or re-routed.
+    session.terminal.set_auto_command(format_ask_user_answers(items, (picked_one,)))
     session.terminal.awaiting_handoff_answer = True
     return True
 

--- a/surfaces/interactive_shell/runtime/core/prompt_builder.py
+++ b/surfaces/interactive_shell/runtime/core/prompt_builder.py
@@ -116,8 +116,8 @@ class PromptBuilder:
         )
         install_session_key_bindings(self.pt_session, output_kb)
 
-    def _rerender_banner_if_idle(self) -> None:
-        """Clear the viewport and reprint the launch banner at the new width.
+    def _rerender_banner_if_idle(self) -> bool:
+        """Clear the viewport and reprint the launch banner at the new width; True when done.
 
         The banner is static scrollback laid out for the width it was printed
         at; a resize reflows it into sliced / wrapped garbage. While nothing
@@ -128,7 +128,7 @@ class PromptBuilder:
         No startup spin here — SIGWINCH must stay instant.
         """
         if self.session.terminal.submitted_turn_count > 0 or self.pt_app is None:
-            return
+            return False
         repl_clear_screen()
         drain_stale_cpr_bytes()
         console = Console(
@@ -138,6 +138,7 @@ class PromptBuilder:
             legacy_windows=False,
         )
         render_launch_banner(console, session=self.session, animate=False)
+        return True
 
     def _expand_collapsed_output(self, text: str) -> None:
         """Suspend the prompt and expand the next folded tool result (Ctrl+O).

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -312,6 +312,13 @@ def _start_ci_agent_demo(
     return _offer_after_loop(session, console)
 
 
+def start_ci_agent_demo(session: Session, console: Console | None) -> bool:
+    """Run the CI reliability agent demo on its own, e.g. from another picker."""
+    suggestion = _suggestion_for(OPTION_CI_AGENT)
+    assert suggestion is not None
+    return _start_ci_agent_demo(session, console, suggestion)
+
+
 def choose_loop_time() -> tuple[str, bool] | None:
     """Ask when the loop runs: ``(time_text, weekdays)`` or ``None`` when the user escapes."""
     timezone = local_timezone()
@@ -465,6 +472,7 @@ __all__ = [
     "demo_already_offered",
     "marker_path",
     "offer_demo",
+    "start_ci_agent_demo",
     "should_offer_demo",
     "suitable_repositories",
 ]

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -42,6 +42,7 @@ from infrastructure.scheduling.scheduler.loops import parse_loop_time
 from infrastructure.terminal.theme import DIM, WARNING
 from integrations.github import (
     DEFAULT_LOOP_TIME,
+    Analysis,
     GitHubApiError,
     analyze_repository,
     ci_report_headline,
@@ -279,14 +280,15 @@ def _start_ci_analytics_demo(
 def _analyze_and_show(console: Console | None, owner: str, repo: str, token: str) -> bool:
     """Read GitHub under a spinner, paint the report and the headline; False on failure."""
     label = f"Reading the GitHub Actions history of {owner}/{repo}, last {_SCAN_DAYS} days"
-    try:
-        if console is not None:
-            with llm_loader(console, label):
-                analysis = analyze_repository(owner, repo, token=token, days=_SCAN_DAYS)
-        else:
-            analysis = analyze_repository(owner, repo, token=token, days=_SCAN_DAYS)
-    except (GitHubApiError, ValueError):
-        logger.warning("Demo analysis failed for %s/%s.", owner, repo, exc_info=True)
+    analysis = None
+    # The failure is handled inside the spinner: a GitHub error must not be
+    # re-raised through the loader's context manager.
+    if console is not None:
+        with llm_loader(console, label):
+            analysis = _analyze_or_none(owner, repo, token)
+    else:
+        analysis = _analyze_or_none(owner, repo, token)
+    if analysis is None:
         _warn(console, _ANALYSIS_FAILED.format(repository=f"{owner}/{repo}"))
         return False
     if console is not None:
@@ -297,6 +299,14 @@ def _analyze_and_show(console: Console | None, owner: str, repo: str, token: str
         render_note_block(console, ci_report_headline(analysis.report))
         console.print()
     return True
+
+
+def _analyze_or_none(owner: str, repo: str, token: str) -> Analysis | None:
+    try:
+        return analyze_repository(owner, repo, token=token, days=_SCAN_DAYS)
+    except (GitHubApiError, ValueError):
+        logger.warning("Demo analysis failed for %s/%s.", owner, repo, exc_info=True)
+        return None
 
 
 def _offer_after_analysis(session: Session, console: Console | None, repository: str) -> bool:

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -4,17 +4,13 @@ On the first interactive launch the shell asks which demo to run before the
 prompt takes stdin. A marker file records the choice so the picker shows once;
 ``/demo`` reopens it on demand.
 
-The CI/CD analytics demo runs its discovery steps here, deterministically:
-the workspace scan paints the activity chart, a second picker asks which
-repository to analyze, and only then is a canned prompt auto-submitted for the
-analysis and the next-step offer. Mid-turn menus cannot open inside an
-auto-submitted turn, so every choice that needs a menu happens before the turn
-starts. Routing of the prompt itself stays with the action agent (no intent
-heuristics — see ``surfaces/interactive_shell/AGENTS.md``).
-
-The CI reliability agent demo is deterministic end to end: the same scan and
-repository picker, a schedule picker, the loop is created and run once, and
-its first report is shown from the shell inbox.
+Both demos run deterministically, with no model turn: the workspace scan
+paints the activity chart, a picker asks which repository, the analysis (or
+the loop's first pass) runs under a spinner, the report is painted, and a
+final picker offers the next step. Only the Slack hand-off submits a prompt
+to the action agent; its routing stays with the agent (no intent heuristics,
+see ``surfaces/interactive_shell/AGENTS.md``). The ``cicd-analytics-demo``
+skill remains the path for typed requests.
 """
 
 from __future__ import annotations
@@ -46,8 +42,12 @@ from infrastructure.scheduling.scheduler.loops import parse_loop_time
 from infrastructure.terminal.theme import DIM, WARNING
 from integrations.github import (
     DEFAULT_LOOP_TIME,
+    GitHubApiError,
+    analyze_repository,
+    ci_report_headline,
     local_timezone,
     loop_card,
+    render_ci_report,
     report_looks_complete,
     resolve_github_token,
     schedule_ci_reliability_loop,
@@ -104,6 +104,11 @@ _LOOP_FIRST_PASS_FAILED = (
     "Retry with `/loops run {task_id}` or check `/cron logs {task_id}`."
 )
 _NEXT_TITLE = "What would you like to do next?"
+_NEXT_AGENT = "agent"
+_ANALYSIS_FAILED = (
+    "Could not read the GitHub Actions history of {repository}. Check the token with "
+    "`opensre integrations setup github`, then `/demo` to try again."
+)
 _NEXT_SERVICE = "service"
 _NEXT_SERVICE_LABEL = (
     "Keep it running when this shell is closed (installs a background scheduler service)"
@@ -140,11 +145,6 @@ DEMO_SUGGESTIONS: tuple[DemoSuggestion, ...] = (
     DemoSuggestion(
         option=OPTION_CI_ANALYTICS,
         label="Explore a repo and analyze its CI/CD performance (recommended)",
-        prompt=(
-            "Analyze the CI/CD reliability of {repository} for the last 30 days as the "
-            "CI/CD analytics demo: show the KPIs and the developer time blocked by "
-            "unreliable CI, then offer what to do next."
-        ),
     ),
     DemoSuggestion(
         option=OPTION_CI_AGENT,
@@ -250,39 +250,98 @@ def _warn(console: Console | None, text: str) -> None:
 
 
 def _start_ci_analytics_demo(
-    session: Session, console: Console | None, suggestion: DemoSuggestion
+    session: Session, console: Console | None, _suggestion: DemoSuggestion
 ) -> bool:
-    """Scan, let the user pick a repository, then queue the analysis prompt."""
+    """Scan, pick a repository, analyze it, show the report, then offer the next step.
+
+    Every step is deterministic. The report and the headline come from the
+    analytics pipeline directly, and the next-step menu is this picker's, so
+    no model turn can improvise a different plan on the way.
+    """
     snapshot = _scan_and_show(console)
-    if not resolve_github_token(None):
+    token = resolve_github_token(None)
+    if not token:
         _warn(console, _TOKEN_MISSING)
         return False
     repository = choose_repository(snapshot)
     if repository is None:
         return False
+    owner, _, repo = repository.partition("/")
+    if not owner or not repo:
+        _warn(console, f"{repository!r} is not a GitHub repository; use the owner/name form.")
+        return False
+    _record(OPTION_CI_ANALYTICS)
+    if not _analyze_and_show(console, owner, repo, token):
+        return False
+    return _offer_after_analysis(session, console, repository)
+
+
+def _analyze_and_show(console: Console | None, owner: str, repo: str, token: str) -> bool:
+    """Read GitHub under a spinner, paint the report and the headline; False on failure."""
+    label = f"Reading the GitHub Actions history of {owner}/{repo}, last {_SCAN_DAYS} days"
+    try:
+        if console is not None:
+            with llm_loader(console, label):
+                analysis = analyze_repository(owner, repo, token=token, days=_SCAN_DAYS)
+        else:
+            analysis = analyze_repository(owner, repo, token=token, days=_SCAN_DAYS)
+    except (GitHubApiError, ValueError):
+        logger.warning("Demo analysis failed for %s/%s.", owner, repo, exc_info=True)
+        _warn(console, _ANALYSIS_FAILED.format(repository=f"{owner}/{repo}"))
+        return False
     if console is not None:
         console.print()
-        render_note_block(
-            console,
-            f"Analyzing the CI/CD reliability of {repository} for the last {_SCAN_DAYS} days. "
-            "Reading the GitHub Actions history takes about half a minute; the report "
-            "appears below when it is ready.",
-        )
-    # A plain turn keeps the prompt bar and its spinner visible while the model
-    # and the analysis run; a work-turn autosubmit would suspend them.
-    session.terminal.set_auto_prompt(suggestion.prompt.format(repository=repository))
+        render_note_block(console, f"Read {analysis.runs_read} runs. Here is the report:")
+        render_ci_report(console, analysis.report)
+        console.print()
+        render_note_block(console, ci_report_headline(analysis.report))
+        console.print()
     return True
 
 
+def _offer_after_analysis(session: Session, console: Console | None, repository: str) -> bool:
+    """The demo's step 4: schedule the agent, hand off to Slack, or exit."""
+    agent = _suggestion_for(OPTION_CI_AGENT)
+    slack = _suggestion_for(OPTION_SLACK)
+    assert agent is not None and slack is not None
+    selected = repl_choose_one(
+        title=_NEXT_TITLE,
+        choices=[
+            (_NEXT_AGENT, agent.label),
+            (_NEXT_SLACK, slack.label),
+            (_NEXT_EXIT, _NEXT_EXIT_LABEL),
+        ],
+        letter_keys=True,
+        header=_MENU_HEADER,
+    )
+    if selected == _NEXT_AGENT:
+        return _start_ci_agent_demo(session, console, agent, repository=repository)
+    if selected == _NEXT_SLACK:
+        session.terminal.set_auto_command(slack.prompt)
+        return True
+    if console is not None:
+        render_note_block(console, _DEMO_EXITED)
+    return False
+
+
 def _start_ci_agent_demo(
-    session: Session, console: Console | None, _suggestion: DemoSuggestion
+    session: Session,
+    console: Console | None,
+    _suggestion: DemoSuggestion,
+    *,
+    repository: str | None = None,
 ) -> bool:
-    """Scan, pick a repository and a time, schedule the loop, run it once, offer Slack."""
-    snapshot = _scan_and_show(console)
-    if not resolve_github_token(None):
-        _warn(console, _LOOP_TOKEN_MISSING)
-        return False
-    repository = choose_repository(snapshot, title=_LOOP_REPOSITORY_TITLE)
+    """Scan, pick a repository and a time, schedule the loop, run it once, offer Slack.
+
+    ``repository`` skips the scan and the repository menu when the analytics
+    demo already settled it.
+    """
+    if repository is None:
+        snapshot = _scan_and_show(console)
+        if not resolve_github_token(None):
+            _warn(console, _LOOP_TOKEN_MISSING)
+            return False
+        repository = choose_repository(snapshot, title=_LOOP_REPOSITORY_TITLE)
     if repository is None:
         return False
     owner, _, repo = repository.partition("/")

--- a/surfaces/interactive_shell/runtime/startup/loop_suggestions.py
+++ b/surfaces/interactive_shell/runtime/startup/loop_suggestions.py
@@ -2,10 +2,11 @@
 
 When the interactive shell starts and no scheduled tasks ("loops") are
 configured on this machine, offer three suggested recurring loops in an inline
-dropdown. Picking one auto-submits a canned prompt as the first turn; the
-action agent then drives the matching bundled skill or tool guidance
-(``github-ci-fix``, GitHub tools, ``morning-report``) through a first demo pass
-and the existing ``propose_scheduled_delivery`` → ``/cron add`` confirmation flow. Escape skips
+dropdown. The CI/CD loop runs the deterministic CI reliability agent demo
+(scan, repository, schedule, first pass) without a model turn. The other two
+auto-submit a canned prompt as the first turn; the action agent then drives
+the matching bundled skill through a first demo pass and the existing
+``propose_scheduled_delivery`` → ``/cron add`` confirmation flow. Escape skips
 into the normal prompt for this launch — nothing is persisted, so the picker
 returns on the next launch while zero loops exist.
 
@@ -27,6 +28,7 @@ from infrastructure.analytics.capture import (
 )
 from infrastructure.analytics.source import is_test_run
 from infrastructure.terminal.theme import DIM
+from surfaces.interactive_shell.runtime.startup.demo_picker import start_ci_agent_demo
 from surfaces.shared.terminal.components.choice_menu import (
     repl_choose_one,
     repl_tty_interactive,
@@ -61,19 +63,15 @@ class LoopSuggestion:
     label: str
     """Menu row shown to the user (name + cadence + one-line pitch)."""
 
-    prompt: str
-    """Canned prompt auto-submitted as the first turn when selected."""
+    prompt: str = ""
+    """Canned prompt auto-submitted as the first turn when selected; empty when the
+    suggestion runs deterministically."""
 
 
 LOOP_SUGGESTIONS: tuple[LoopSuggestion, ...] = (
     LoopSuggestion(
         option=OPTION_CI_CD,
-        label="CI/CD loop — weekdays 8:00 AM · watch pipelines, surface failing checks",
-        prompt=(
-            "Report failing CI checks on the current repository's pull requests, "
-            "with links and an interactive repair handoff, then set this up as a "
-            "read-only recurring weekday check at 8:00 AM."
-        ),
+        label="CI/CD loop — weekdays 8:00 AM · CI reliability report for a repository you pick",
     ),
     LoopSuggestion(
         option=OPTION_TASK_MANAGEMENT,
@@ -130,6 +128,9 @@ def offer_loop_suggestions(session: Session, console: Console | None = None) -> 
             return
         suggestion = _SUGGESTIONS_BY_OPTION[selected]
         capture_loop_suggestion_selected(option=suggestion.option)
+        if suggestion.option == OPTION_CI_CD:
+            start_ci_agent_demo(session, console)
+            return
         # Prefill + auto-submit: the prompt echoes the command itself, so no
         # extra announcement print here (it would show the text twice).
         session.terminal.set_auto_command(suggestion.prompt)

--- a/surfaces/interactive_shell/ui/handoff_questions.py
+++ b/surfaces/interactive_shell/ui/handoff_questions.py
@@ -21,28 +21,30 @@ def _display_safe(text: str) -> str:
 
 
 def render_choice_selection(console: Console, title: str, answer: str) -> None:
-    """Persist selected choice(s) as an Ask User card after the picker closes.
+    """Persist the pick after the menu closes, as an answer line rather than a repeated question.
 
-    Must not use the plan-step ``✓`` glyph — that makes a single pick look like
-    another ``Plan complete`` row. Same hierarchy as :func:`render_ask_user_qa`:
-    accent header, bold question, brand answer(s). Leading blank separates the
-    card from Plan complete / reply text above.
+    The menu itself is erased, so this is the transcript's only record of the
+    choice. It must read as "answered", not as the question asked again: no
+    header, the question dim on one line with a single answer after it, and a
+    multi-select listed underneath. Must not use the plan-step ``✓`` glyph.
+    Leading blank separates it from Plan complete / reply text above.
     """
     console.print()
-    console.print(Text("Ask User", style=f"bold {ui_theme.HIGHLIGHT}"))
-    console.print()
-    qline = Text()
-    qline.append("  1.  ", style=str(ui_theme.DIM))
-    qline.append(_display_safe(title.strip()), style=f"bold {ui_theme.TEXT}")
-    console.print(qline)
-    # Multi-select arrives as one option per line; keep every line indented
-    # under the question so the set reads as one block.
-    for line in _display_safe(answer.strip()).splitlines():
-        if not line.strip():
-            continue
+    question = _display_safe(title.strip())
+    answers = [line for line in _display_safe(answer.strip()).splitlines() if line.strip()]
+    line = Text()
+    line.append("  ↳ ", style=str(ui_theme.DIM))
+    line.append(question, style=str(ui_theme.DIM))
+    if len(answers) == 1:
+        line.append("  ", style=str(ui_theme.DIM))
+        line.append(answers[0], style=str(ui_theme.BRAND))
+        console.print(line)
+        return
+    console.print(line)
+    for item in answers:
         aline = Text()
         aline.append("      ", style=str(ui_theme.DIM))
-        aline.append(line, style=str(ui_theme.BRAND))
+        aline.append(item, style=str(ui_theme.BRAND))
         console.print(aline)
 
 

--- a/surfaces/interactive_shell/ui/input_prompt/rendering.py
+++ b/surfaces/interactive_shell/ui/input_prompt/rendering.py
@@ -95,8 +95,11 @@ def render_submitted_prompt(console: Console, session: Session, text: str) -> No
     if is_handoff_answer and autosubmitted:
         # A fixed picker choice already has a compact persistent result. Do not
         # manufacture a second user turn in scrollback; only mark the synthetic
-        # answer so a no-op model acknowledgement can be omitted as well.
-        session.terminal.pending_choice_response = stripped
+        # answer (the label alone, not the question it travels with) so a no-op
+        # model acknowledgement can be omitted as well.
+        session.terminal.pending_choice_response = (
+            ask_user_pairs[0][1] if len(ask_user_pairs) == 1 else stripped
+        )
         return
     if autosubmitted:
         # Keep this shorter than the condition — the ``[N] ❯`` line carries the

--- a/surfaces/interactive_shell/ui/input_prompt/resize.py
+++ b/surfaces/interactive_shell/ui/input_prompt/resize.py
@@ -11,9 +11,14 @@ terminal under the launch banner). That tall Screen scrolls the banner away,
 and ``last_height`` sticks so later paints stay hollow.
 
 Partial ``erase`` on SIGWINCH cannot keep scrollback chrome and the live
-region aligned — soft-wrap and reflow leave Auto/composer ghosts. On resize the
-host therefore clears the viewport, reprints the static banner, and redraws the
-prompt from a clean cursor position.
+region aligned — soft-wrap and reflow leave Auto/composer ghosts. While the
+screen holds only the banner, the host therefore clears the viewport, reprints
+the static banner, and redraws the prompt from a clean cursor position.
+
+Once a turn is on screen the transcript above must survive, so the host
+erases the live region from its top row before redrawing. Forgetting the
+previous frame without erasing it left a copy behind per resize signal, and a
+window drag sends several, stacking status, plan, and composer down the screen.
 """
 
 from __future__ import annotations
@@ -64,14 +69,15 @@ def _size_changed(previous: Size | None, current: Size) -> bool:
 def install_shrink_resize_guard(
     app: Application[Any],
     *,
-    rerender_banner: Callable[[], None] | None = None,
+    rerender_banner: Callable[[], bool] | None = None,
 ) -> None:
     """Install height + resize chrome guards for banner-safe layout.
 
     ``rerender_banner`` clears the viewport and reprints the static launch
-    banner at the new size. When provided, resize skips prompt-toolkit's
-    partial erase (which stacks Auto/composer ghosts) and redraws the live
-    region from the cursor below the fresh banner.
+    banner at the new size, returning True when it did so. Then resize skips
+    prompt-toolkit's partial erase (which stacks Auto/composer ghosts) and
+    redraws the live region from the cursor below the fresh banner. When it
+    returns False, a turn is on screen and the live region is erased in place.
     """
     output = app.output
     renderer = app.renderer
@@ -100,17 +106,20 @@ def install_shrink_resize_guard(
     def _on_resize() -> None:
         output.disable_autowrap()
         renderer._min_available_height = 0
-        renderer._last_screen = None
-        if rerender_banner is not None:
+        if rerender_banner is not None and rerender_banner():
             # Full chrome reset: clear + static banner, then redraw the live
             # region only. Do not call original erase — it leaves ghosts.
-            rerender_banner()
+            renderer._last_screen = None
             renderer.reset(leave_alternate_screen=False)
             app._request_absolute_cursor_position()
             app._redraw()
             output.disable_autowrap()
             return
+        # A turn is on screen: prompt-toolkit's own path erases the live region
+        # from its top row (autowrap is off, so the row count is exact), then
+        # re-queries the cursor and redraws in place.
         original_on_resize()
+        output.disable_autowrap()
 
     renderer.report_absolute_cursor_row = report_absolute_cursor_row  # type: ignore[method-assign]
     renderer.render = _render  # type: ignore[method-assign, assignment]

--- a/surfaces/interactive_shell/ui/streaming/console.py
+++ b/surfaces/interactive_shell/ui/streaming/console.py
@@ -10,6 +10,7 @@ from rich.console import Console, RenderableType, ThemeContext
 from rich.file_proxy import FileProxy
 from rich.status import Status
 from rich.style import StyleType
+from rich.text import Text
 from rich.theme import Theme
 
 
@@ -19,6 +20,21 @@ class _PromptSpinner(Protocol):
 
     def stop(self) -> None:
         """Stop the prompt spinner."""
+
+
+_ROW_SAFE_KWARGS = frozenset({"width"})
+
+
+def _renders_as_rows(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+    """One renderable printed with default options: safe to route through the buffered path."""
+    return len(args) == 1 and set(kwargs) <= _ROW_SAFE_KWARGS
+
+
+def _as_renderable(args: tuple[Any, ...]) -> Any:
+    renderable = args[0]
+    if isinstance(renderable, str):
+        return Text.from_markup(renderable)
+    return renderable
 
 
 class StreamingConsole(Console):
@@ -64,7 +80,13 @@ class StreamingConsole(Console):
         return self._cancel_event
 
     def print(self, *args: Any, **kwargs: Any) -> None:
-        """Reset the TTY column before each print when not streaming."""
+        """Print with the TTY column reset and CRLF row endings when not streaming.
+
+        Tool output (a chart, a report) is rendered to a buffer and written in
+        one call with ``\\r\\n`` rows: under the pinned prompt's raw stdout
+        patching, row-by-row ``\\n`` output makes the status bar repaint one
+        line lower per row, stacking stale copies of itself down the screen.
+        """
         if self._output is not None:
             self._output.print(*args, **kwargs)
             return
@@ -76,6 +98,7 @@ class StreamingConsole(Console):
             from surfaces.shared.terminal.components.rendering import (
                 _repl_output_already_prepared,
                 _repl_table_width,
+                print_repl_renderable,
             )
 
             if not args and not kwargs:
@@ -84,6 +107,9 @@ class StreamingConsole(Console):
                 prepare_repl_output_line()
             if sys.stdout.isatty() and "width" not in kwargs:
                 kwargs["width"] = _repl_table_width(self)
+            if _renders_as_rows(args, kwargs) and self.file is sys.stdout and sys.stdout.isatty():
+                print_repl_renderable(self, _as_renderable(args))
+                return
         super().print(*args, **kwargs)
 
     def use_theme(self, theme: Theme, *, inherit: bool = True) -> ThemeContext:

--- a/surfaces/interactive_shell/ui/task_plan.py
+++ b/surfaces/interactive_shell/ui/task_plan.py
@@ -9,8 +9,7 @@ transcript — only the one-shot ``Plan complete`` breakdown is.
 
 from __future__ import annotations
 
-from rich.console import Console, Group
-from rich.text import Text
+from rich.console import Console
 
 from core.agent_harness.spi.task_plan import (
     PLAN_STATUS_GLYPH,
@@ -22,7 +21,7 @@ from core.agent_harness.spi.task_plan import (
 )
 from infrastructure.terminal import theme as ui_theme
 from surfaces.interactive_shell.ui.input_prompt.layout import clip_prompt_text, prompt_line_width
-from surfaces.shared.terminal.components.rendering import print_repl_renderable
+from surfaces.shared.terminal.components.rendering import print_repl_text
 
 _STEP_INDENT = "  "
 # Steps shown before the plan collapses; a longer plan folds to a window
@@ -53,43 +52,39 @@ def render_plan_breakdown(console: Console, breakdown: str) -> None:
     text = (breakdown or "").rstrip("\n")
     if not text:
         return
-    rows: list[Text] = []
-    for raw in text.splitlines():
-        stripped = raw.lstrip()
-        if not stripped:
-            rows.append(Text(""))
-            continue
-        if stripped.startswith(_WORK_NOTE_MARKER):
-            # Theme DIM as raw truecolor. Rich Style.parse caches ANSI from
-            # the first color_system that rendered ``#6E6E6E``; a prior
-            # 16-color console then emits bright-black ``[90m`` instead of
-            # DIM_ANSI on a truecolor breakdown.
-            rows.append(Text.from_ansi(f"{ui_theme.DIM_ANSI}{raw}{ui_theme.ANSI_RESET}"))
-            continue
-        line = Text()
-        # Header (``Plan complete · n/n``) or a checklist step (``  ✓ …``).
-        if stripped.startswith("Plan"):
-            line.append(raw, style=str(ui_theme.SECONDARY))
-            rows.append(line)
-            continue
-        # Step row: accent the status glyph, keep the step title as body text.
-        indent_len = len(raw) - len(stripped)
-        if indent_len:
-            line.append(raw[:indent_len])
-        glyph, _, rest = stripped.partition(" ")
-        if glyph in PLAN_STATUS_GLYPH.values() and rest:
-            glyph_style = (
-                str(ui_theme.HIGHLIGHT)
-                if glyph == PLAN_STATUS_GLYPH[PlanStepStatus.COMPLETED]
-                else str(ui_theme.TEXT)
-            )
-            line.append(glyph, style=glyph_style)
-            line.append(" ")
-            line.append(rest, style=str(ui_theme.TEXT))
-        else:
-            line.append(stripped, style=str(ui_theme.TEXT))
-        rows.append(line)
-    print_repl_renderable(console, Group(*rows))
+    # Palette ANSI, not Rich Style. Style.parse caches the first color_system
+    # that rendered ``#6E6E6E``; a 16-color console on the same worker then
+    # re-emits work notes as bright-black ``[90m`` instead of DIM_ANSI.
+    print_repl_text(
+        console,
+        "\n".join(_breakdown_row_ansi(raw) for raw in text.splitlines()),
+        markup=False,
+    )
+
+
+def _breakdown_row_ansi(raw: str) -> str:
+    """One breakdown row in theme ANSI (header, checklist step, or work note)."""
+    stripped = raw.lstrip()
+    if not stripped:
+        return ""
+    if stripped.startswith(_WORK_NOTE_MARKER):
+        return f"{ui_theme.DIM_ANSI}{raw}{ui_theme.ANSI_RESET}"
+    if stripped.startswith("Plan"):
+        return f"{ui_theme.SECONDARY_ANSI}{raw}{ui_theme.ANSI_RESET}"
+    indent_len = len(raw) - len(stripped)
+    indent = raw[:indent_len]
+    glyph, _, rest = stripped.partition(" ")
+    if glyph in PLAN_STATUS_GLYPH.values() and rest:
+        glyph_ansi = (
+            ui_theme.HIGHLIGHT_ANSI
+            if glyph == PLAN_STATUS_GLYPH[PlanStepStatus.COMPLETED]
+            else ui_theme.TEXT_ANSI
+        )
+        return (
+            f"{indent}{glyph_ansi}{glyph}{ui_theme.ANSI_RESET} "
+            f"{ui_theme.TEXT_ANSI}{rest}{ui_theme.ANSI_RESET}"
+        )
+    return f"{indent}{ui_theme.TEXT_ANSI}{stripped}{ui_theme.ANSI_RESET}"
 
 
 def _overlay_line(text: str, style: str, width: int) -> str:

--- a/tests/core/agent/orchestration/test_menu_turn_end.py
+++ b/tests/core/agent/orchestration/test_menu_turn_end.py
@@ -1,0 +1,56 @@
+"""A queued user-choice menu must end the tool loop, so the model cannot re-ask."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.turns.action_menu_end import with_menu_turn_end
+from core.llm.types import ToolCall
+from core.tool.execution import ToolExecutionHooks, ToolExecutionPatch, ToolExecutionResult
+
+
+def _request(name: str) -> Any:
+    call = ToolCall(id=f"call-{name}", name=name, input={"title": "Which repository?"})
+    return type("Request", (), {"tool_call": call, "arguments": call.input})()
+
+
+def _session(pending: object) -> Any:
+    return type("Session", (), {"pending_user_choice": pending})()
+
+
+def test_queued_menu_terminates_the_loop() -> None:
+    hooks = with_menu_turn_end(None, _session(pending=object()))
+
+    patch = hooks.after_tool_call(
+        _request("ask_user_choice"), ToolExecutionResult(content="queued")
+    )
+
+    assert patch is not None and patch.terminate is True
+
+
+def test_unavailable_menu_or_other_tools_do_not_terminate() -> None:
+    no_menu = with_menu_turn_end(None, _session(pending=None))
+    other = with_menu_turn_end(None, _session(pending=object()))
+
+    assert (
+        no_menu.after_tool_call(_request("ask_user_choice"), ToolExecutionResult(content=""))
+        is None
+    )
+    assert other.after_tool_call(_request("shell_run"), ToolExecutionResult(content="")) is None
+
+
+def test_base_hook_patch_is_kept_and_marked_terminate() -> None:
+    seen: list[str] = []
+
+    def base_after(request: Any, _result: ToolExecutionResult) -> ToolExecutionPatch:
+        seen.append(request.tool_call.name)
+        return ToolExecutionPatch(content="rewritten")
+
+    hooks = with_menu_turn_end(ToolExecutionHooks(after_tool_call=base_after), _session(object()))
+
+    patch = hooks.after_tool_call(
+        _request("ask_user_choice"), ToolExecutionResult(content="queued")
+    )
+
+    assert seen == ["ask_user_choice"]
+    assert patch is not None and patch.content == "rewritten" and patch.terminate is True

--- a/tests/core/agent/orchestration/test_skill_scope.py
+++ b/tests/core/agent/orchestration/test_skill_scope.py
@@ -1,0 +1,67 @@
+"""An answer turn inside a skill offers only the skill's tools; a new request clears the scope."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
+from core.agent_harness.turns.skill_scope import scope_tools_to_active_skill
+
+
+def _tool(name: str) -> Any:
+    return type("Tool", (), {"name": name})()
+
+
+def _session(tools: tuple[str, ...]) -> Any:
+    return type(
+        "Session", (), {"active_skill": "cicd-analytics-demo", "active_skill_tools": tools}
+    )()
+
+
+_ANSWER = format_ask_user_answers(
+    (AskUserQuestion(label="", title="Which repository should I analyze?", options=("a",)),),
+    ("Tracer-Cloud/opensre (757 commits, CI configured)",),
+)
+_ALL = [
+    _tool(n)
+    for n in (
+        "scan_local_git_workspace",
+        "analyze_github_ci_reliability",
+        "cli_exec",
+        "github_cli",
+        "ask_user_choice",
+        "update_plan",
+    )
+]
+
+
+def test_answer_turn_inside_a_skill_drops_tools_the_skill_did_not_declare() -> None:
+    session = _session(
+        ("scan_local_git_workspace", "analyze_github_ci_reliability", "ask_user_choice")
+    )
+
+    scoped = scope_tools_to_active_skill(_ALL, session, _ANSWER)
+
+    assert [t.name for t in scoped] == [
+        "scan_local_git_workspace",
+        "analyze_github_ci_reliability",
+        "ask_user_choice",
+        "update_plan",
+    ]
+    assert session.active_skill == "cicd-analytics-demo"
+
+
+def test_a_genuine_user_turn_clears_the_scope_and_keeps_every_tool() -> None:
+    session = _session(("scan_local_git_workspace",))
+
+    scoped = scope_tools_to_active_skill(_ALL, session, "check the health of my integrations")
+
+    assert scoped == _ALL
+    assert session.active_skill is None
+    assert session.active_skill_tools == ()
+
+
+def test_a_skill_without_declared_tools_leaves_the_answer_turn_unscoped() -> None:
+    session = _session(())
+
+    assert scope_tools_to_active_skill(_ALL, session, _ANSWER) == _ALL

--- a/tests/core/agent_harness/session/test_session_characterization.py
+++ b/tests/core/agent_harness/session/test_session_characterization.py
@@ -26,6 +26,8 @@ _CORE_FIELDS = (
     "pending_schedule_offer",
     "pending_user_choice",
     "ask_user_rounds",
+    "active_skill",
+    "active_skill_tools",
     "task_plan",
     "task_plan_work",
     "task_plan_work_step_texts",

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -417,5 +417,6 @@ def test_analytics_demo_skill_declares_its_tools() -> None:
         "scan_local_git_workspace",
         "analyze_github_ci_reliability",
         "schedule_ci_reliability_loop",
+        "cli_exec",
         "ask_user_choice",
     )

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -406,3 +406,16 @@ def test_agent_demo_stops_with_setup_hint_when_no_github_token(
     assert queued is False
     assert calls == []
     assert "opensre integrations setup github" in " ".join(buf.getvalue().split())
+
+
+def test_analytics_demo_skill_declares_its_tools() -> None:
+    from core.agent_harness.prompts.skills.loader import list_action_skills
+
+    skill = next(s for s in list_action_skills() if s.name == "cicd-analytics-demo")
+
+    assert skill.tools == (
+        "scan_local_git_workspace",
+        "analyze_github_ci_reliability",
+        "schedule_ci_reliability_loop",
+        "ask_user_choice",
+    )

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -73,34 +73,128 @@ def _answers(monkeypatch: pytest.MonkeyPatch, *values: str | None) -> list[dict]
     return calls
 
 
-def test_analytics_demo_scans_asks_for_the_repository_then_queues_the_analysis(
+def _analysis_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[tuple[str, str]]:
+    """Fake the GitHub read; returns the (owner, repo) pairs analyzed."""
+    from datetime import UTC, datetime
+
+    from integrations.github.tools.ci_analytics.analysis import Analysis
+    from integrations.github.tools.ci_analytics.metrics import compute_report
+
+    _offerable(monkeypatch, tmp_path)
+    analyzed: list[tuple[str, str]] = []
+
+    def analyze(owner: str, repo: str, **_kw: object) -> Analysis:
+        analyzed.append((owner, repo))
+        report = compute_report(
+            owner=owner,
+            repo=repo,
+            default_branch="main",
+            window_days=30,
+            branch_runs=[],
+            pr_runs=[],
+            merged_prs=(),
+            now=datetime(2026, 9, 8, 12, 0, tzinfo=UTC),
+        )
+        return Analysis(report=report, runs_read=0)
+
+    monkeypatch.setattr(demo_picker, "analyze_repository", analyze)
+    return analyzed
+
+
+def test_analytics_demo_scans_asks_analyzes_and_offers_the_next_step_without_a_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    # Arrange
+    # Arrange: pick the analytics demo, a repository, then exit at the final menu.
     marker = _offerable(monkeypatch, tmp_path)
-    calls = _answers(monkeypatch, demo_picker.OPTION_CI_ANALYTICS, "me/mine[v2]")
+    analyzed = _analysis_ready(monkeypatch, tmp_path)
+    calls = _answers(monkeypatch, demo_picker.OPTION_CI_ANALYTICS, "me/mine", "exit")
     session = Session()
     console, buf = _capture()
 
     # Act
     queued = demo_picker.offer_demo(session, console)
 
-    # Assert: chart painted, own repositories with CI first, example last, prompt names the pick.
-    assert queued is True
+    # Assert: chart, menus, report, headline, and the demo's own next-step menu; no prompt.
+    assert queued is False
+    assert analyzed == [("me", "mine")]
     output = buf.getvalue()
     assert "live snapshot built from your machine" in output
     assert "Activity (commits, last 30 days)" in output
-    assert "Analyzing the CI/CD reliability of me/mine[v2]" in output
-    demo_labels = [label for _value, label in calls[0]["choices"]]
-    assert demo_labels[-1] == "Or type your own answer..."
-    assert calls[0]["header"] == "Ask User"
-    assert calls[1]["header"] == "Ask User"
+    assert "CI/CD reliability for me/mine, last 30 days" in output
+    assert "No CI failures were found in the last 30 days." in output
+    assert [c["title"] for c in calls] == [
+        "Which demo would you like me to run? (Esc to skip)",
+        "Which repository should I analyze?",
+        "What would you like to do next?",
+    ]
+    assert all(c["header"] == "Ask User" for c in calls)
     repo_choices = [value for value, _label in calls[1]["choices"]]
     assert repo_choices == ["me/mine", "acme/busy", demo_picker.EXAMPLE_REPOSITORY, "custom"]
-    assert session.terminal.pending_prompt_autosubmit is True
-    assert session.terminal.pending_prompt_plain_turn is True
-    assert "me/mine[v2]" in session.terminal.pending_prompt_default
+    next_values = [value for value, _label in calls[2]["choices"]]
+    assert next_values == ["agent", "slack", "exit"]
+    assert session.terminal.pending_prompt_autosubmit is False
     assert json.loads(marker.read_text())["option"] == demo_picker.OPTION_CI_ANALYTICS
+
+
+def test_analytics_demo_chains_into_the_agent_demo_without_asking_the_repository_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    schedule_calls = _agent_demo_ready(monkeypatch, tmp_path)
+    _analysis_ready(monkeypatch, tmp_path)
+    calls = _answers(
+        monkeypatch, demo_picker.OPTION_CI_ANALYTICS, "me/mine", "agent", "weekdays", "exit"
+    )
+    session = Session()
+    console, _buf = _capture()
+
+    demo_picker.offer_demo(session, console)
+
+    titles = [c["title"] for c in calls]
+    assert titles == [
+        "Which demo would you like me to run? (Esc to skip)",
+        "Which repository should I analyze?",
+        "What would you like to do next?",
+        "When should it run?",
+        "What would you like to do next?",
+    ]
+    assert schedule_calls[0]["owner"] == "me" and schedule_calls[0]["repo"] == "mine"
+
+
+def test_analytics_demo_hands_off_to_slack_when_chosen(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _analysis_ready(monkeypatch, tmp_path)
+    _answers(monkeypatch, demo_picker.OPTION_CI_ANALYTICS, "me/mine", "slack")
+    session = Session()
+    console, _buf = _capture()
+
+    queued = demo_picker.offer_demo(session, console)
+
+    assert queued is True
+    assert "Slack" in session.terminal.pending_prompt_default
+
+
+def test_analytics_demo_reports_a_failed_read_without_a_traceback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from integrations.github import GitHubApiError
+
+    _offerable(monkeypatch, tmp_path)
+
+    def failing(*_a: object, **_k: object) -> object:
+        raise GitHubApiError("boom", status_code=401)
+
+    monkeypatch.setattr(demo_picker, "analyze_repository", failing)
+    _answers(monkeypatch, demo_picker.OPTION_CI_ANALYTICS, "me/mine")
+    session = Session()
+    console, buf = _capture()
+
+    queued = demo_picker.offer_demo(session, console)
+
+    assert queued is False
+    text = " ".join(buf.getvalue().split())
+    assert "Could not read the GitHub Actions history of me/mine" in text
+    assert "boom" not in text
 
 
 def test_analytics_demo_stops_with_setup_hint_when_no_github_token(

--- a/tests/interactive_shell/runtime/test_loop_suggestions.py
+++ b/tests/interactive_shell/runtime/test_loop_suggestions.py
@@ -59,19 +59,27 @@ def test_selection_queues_the_canned_prompt(monkeypatch: pytest.MonkeyPatch) -> 
     assert "morning report" in session.terminal.pending_prompt_default
 
 
-def test_ci_suggestion_is_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ci_suggestion_runs_the_deterministic_agent_demo_without_a_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the CI/CD row must not hand a model a prompt it cannot fulfil.
     _offerable(monkeypatch)
     monkeypatch.setattr(
         loop_suggestions, "repl_choose_one", lambda **_kw: loop_suggestions.OPTION_CI_CD
     )
+    started: list[object] = []
+    monkeypatch.setattr(
+        loop_suggestions, "start_ci_agent_demo", lambda session, _console: started.append(session)
+    )
     session = Session()
 
+    # Act
     loop_suggestions.offer_loop_suggestions(session, None)
 
-    prompt = session.terminal.pending_prompt_default
-    assert "read-only" in prompt
-    assert "repair handoff" in prompt
-    assert "fix any failing checks" not in prompt
+    # Assert
+    assert started == [session]
+    assert session.terminal.pending_prompt_autosubmit is False
+    assert not session.terminal.pending_prompt_default
 
 
 def test_skip_queues_nothing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/interactive_shell/session/test_session_facets.py
+++ b/tests/interactive_shell/session/test_session_facets.py
@@ -22,7 +22,7 @@ from surfaces.interactive_shell.session.session import Session
 # plus the session-goal trio (session_goal, pending_integration_setup_offer,
 # offered_upgrade_ctas), and the host-owned task-plan work log
 # (task_plan_work, task_plan_work_step_texts, task_plan_breakdown_emitted).
-_CORE_FIELD_COUNT = 29
+_CORE_FIELD_COUNT = 31
 _FACET_FIELDS = ("alerts", "terminal")
 
 

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -54,8 +54,10 @@ def test_selection_is_auto_submitted_as_next_user_message(
     assert session.terminal.pending_prompt_default == "Commit the changes"
     assert session.terminal.pending_prompt_autosubmit is True
     output = buf.getvalue()
-    # Ask User card — not a plan-step ``✓`` (that glued picks into Plan complete).
-    assert "Ask User" in output
+    # Single-pick recap is one answered line — not an Ask User card and not a
+    # plan-step ``✓`` (that glued picks into Plan complete).
+    assert "Ask User" not in output
+    assert "↳" in output
     assert "✓" not in output
     assert _CHOICE.title in output
     assert "Commit the changes" in output

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -51,7 +51,10 @@ def test_selection_is_auto_submitted_as_next_user_message(
 
     assert _handler(session, console) is True
     assert session.pending_user_choice is None
-    assert session.terminal.pending_prompt_default == "Commit the changes"
+    # The question travels with the answer so the next turn cannot be re-routed.
+    assert session.terminal.pending_prompt_default == format_ask_user_answers(
+        _CHOICE.items(), ("Commit the changes",)
+    )
     assert session.terminal.pending_prompt_autosubmit is True
     output = buf.getvalue()
     # Single-pick recap is one answered line — not an Ask User card and not a
@@ -204,7 +207,9 @@ def test_single_choice_types_custom_in_place(
     choices = seen["choices"]
     assert isinstance(choices, list)
     assert (CUSTOM_OPTION, CUSTOM_OPTION) in choices
-    assert session.terminal.pending_prompt_default == "typed by hand"
+    assert session.terminal.pending_prompt_default == format_ask_user_answers(
+        _CHOICE.items(), ("typed by hand",)
+    )
     assert session.terminal.pending_prompt_autosubmit is True
 
 

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -140,6 +140,27 @@ def test_auto_submitted_single_choice_is_not_echoed_as_a_user_turn() -> None:
     assert session.terminal.pending_choice_response == "Blue-green"
 
 
+def test_single_answer_with_its_question_marks_only_the_label_as_the_choice() -> None:
+    # Arrange: a single-menu answer arrives as "1. question\nlabel", auto-submitted.
+    from core.agent_harness.session.pending_choice import AskUserQuestion, format_ask_user_answers
+    from surfaces.interactive_shell.session import Session
+    from surfaces.interactive_shell.ui.input_prompt.rendering import render_submitted_prompt
+
+    session = Session()
+    session.terminal.awaiting_handoff_answer = True
+    session.terminal.last_input_autosubmitted = True
+    question = AskUserQuestion(label="", title="Which repository should I analyze?", options=("a",))
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, highlight=False, width=80)
+
+    # Act
+    render_submitted_prompt(console, session, format_ask_user_answers((question,), ("acme/app",)))
+
+    # Assert: no second user row, and the acknowledgement filter sees the label alone.
+    assert buffer.getvalue() == ""
+    assert session.terminal.pending_choice_response == "acme/app"
+
+
 def test_choice_selection_strips_terminal_controls() -> None:
     buffer = io.StringIO()
     console = Console(file=buffer, force_terminal=False, highlight=False, width=80)

--- a/tests/interactive_shell/ui/test_handoff_questions.py
+++ b/tests/interactive_shell/ui/test_handoff_questions.py
@@ -149,11 +149,12 @@ def test_choice_selection_strips_terminal_controls() -> None:
     output = buffer.getvalue()
     assert "\x1b" not in output
     assert "\x07" not in output
-    assert "Ask User" in output
-    assert "Deploy?" in output
-    assert "Canary" in output
+    # One answered line, not the question asked again under a new header.
+    assert "Ask User" not in output
+    assert "Deploy?" in output and "Canary" in output
+    assert output.strip().count("\n") == 0
     assert "✓" not in output
-    # Section gap above the card so it does not join Plan complete.
+    # Section gap above the line so it does not join Plan complete.
     assert output.startswith("\n")
 
 
@@ -166,10 +167,9 @@ def test_multi_select_choice_indents_every_selected_line() -> None:
     # Act
     render_choice_selection(console, "Select Complex Demos", answer)
 
-    # Assert: Ask User card — question, then every option indented under it.
+    # Assert: the question once, then every option indented under it.
     lines = [line.rstrip() for line in buffer.getvalue().splitlines() if line.strip()]
-    assert lines[0] == "Ask User"
-    assert "1.  Select Complex Demos" in lines[1] or lines[1].endswith("Select Complex Demos")
+    assert lines[0].endswith("Select Complex Demos")
     for label in ("Audit the architecture", "Find failing PRs", "Remediate alerts"):
         assert any(label in line and line.startswith(" ") for line in lines)
         assert label not in lines
@@ -188,7 +188,7 @@ def test_choice_selection_is_not_a_plan_step() -> None:
     )
 
     output = buffer.getvalue()
-    assert "Ask User" in output
+    assert "Ask User" not in output
     assert "Choose a Demo" in output
     assert "Explore a repo" in output
     assert "✓ Choose a Demo" not in output

--- a/tests/interactive_shell/ui/test_prompt_resize.py
+++ b/tests/interactive_shell/ui/test_prompt_resize.py
@@ -118,8 +118,9 @@ def test_resize_with_banner_hook_skips_partial_erase_and_redraws() -> None:
 
     banner_calls: list[int] = []
 
-    def _rerender() -> None:
+    def _rerender() -> bool:
         banner_calls.append(1)
+        return True
 
     install_shrink_resize_guard(app, rerender_banner=_rerender)
     app._on_resize()
@@ -131,6 +132,34 @@ def test_resize_with_banner_hook_skips_partial_erase_and_redraws() -> None:
     app._redraw.assert_called_once()
     assert renderer._min_available_height == 0
     assert renderer._last_screen is None
+
+
+def test_resize_during_a_turn_erases_the_live_region_instead_of_forgetting_it() -> None:
+    """Reset without erase left one stale frame per resize signal, stacking down the screen."""
+    terminal = io.StringIO()
+    output = Vt100_Output(
+        terminal,
+        get_size=lambda: Size(rows=30, columns=80),
+        term="xterm-256color",
+        enable_cpr=False,
+    )
+    app: Any = MagicMock()
+    app.output = output
+    renderer = MagicMock()
+    renderer._last_screen = _Screen(height=6)
+    renderer.reset = MagicMock()
+    app.renderer = renderer
+    original_on_resize = MagicMock()
+    app._on_resize = original_on_resize
+    app._redraw = MagicMock()
+
+    install_shrink_resize_guard(app, rerender_banner=lambda: False)
+    app._on_resize()
+
+    # prompt-toolkit's own resize path erases from the top row and redraws.
+    original_on_resize.assert_called_once()
+    renderer.reset.assert_not_called()
+    app._redraw.assert_not_called()
 
 
 def test_shrink_resize_guard_disables_autowrap_after_render() -> None:

--- a/tests/interactive_shell/ui/test_task_plan.py
+++ b/tests/interactive_shell/ui/test_task_plan.py
@@ -245,7 +245,10 @@ def test_plan_breakdown_dims_work_notes_and_accents_checked_steps() -> None:
 
     ui_theme.set_active_theme("amber")
     # A 16-color render of theme DIM must not pin work notes to bright-black.
-    Style.parse(str(ui_theme.DIM))._make_ansi_codes(ColorSystem.STANDARD)
+    # Rich stores the first color_system on the cached Style; reset it so this
+    # poison does not leak to later tests in the same process.
+    dim_style = Style.parse(str(ui_theme.DIM))
+    dim_style._make_ansi_codes(ColorSystem.STANDARD)
     breakdown = (
         "Plan complete · 2/2\n"
         "  ✓ Confirm repository\n"
@@ -262,8 +265,12 @@ def test_plan_breakdown_dims_work_notes_and_accents_checked_steps() -> None:
         no_color=False,
         width=80,
     )
-    render_plan_breakdown(console, breakdown)
-    out = buf.getvalue()
+    try:
+        render_plan_breakdown(console, breakdown)
+        out = buf.getvalue()
+    finally:
+        dim_style._ansi = None
+        Style.parse.cache_clear()
     plain = _strip_ansi(out)
     assert "Plan complete · 2/2" in plain
     assert "✓ Confirm repository" in plain

--- a/tests/scheduler/test_background_service.py
+++ b/tests/scheduler/test_background_service.py
@@ -13,19 +13,22 @@ from infrastructure.scheduling.scheduler import background_service as svc
 
 
 class _Runner:
-    """Records OS commands; ``failing`` names a command word that exits 1, ``loaded`` makes
-    the post-removal state check report the service as still running."""
+    """Records OS commands; ``failing`` names a command word that exits 1, ``loaded_for``
+    is how many status checks still report the service as loaded (``-1`` = forever)."""
 
-    def __init__(self, failing: str = "", loaded: bool = False) -> None:
+    def __init__(self, failing: str = "", loaded_for: int = 0) -> None:
         self.commands: list[list[str]] = []
         self._failing = failing
-        self._loaded = loaded
+        self._loaded_for = loaded_for
 
     def __call__(self, command: Sequence[str]) -> subprocess.CompletedProcess[str]:
         argv = list(command)
         self.commands.append(argv)
         if argv[:2] == ["launchctl", "print"] or argv[2:3] == ["is-active"]:
-            return subprocess.CompletedProcess(argv, 0 if self._loaded else 3, "", "")
+            loaded = self._loaded_for != 0
+            if self._loaded_for > 0:
+                self._loaded_for -= 1
+            return subprocess.CompletedProcess(argv, 0 if loaded else 3, "", "")
         code = 1 if self._failing and self._failing in argv else 0
         return subprocess.CompletedProcess(argv, code, "", "denied" if code else "")
 
@@ -59,6 +62,7 @@ def test_macos_install_writes_a_keepalive_launch_agent_and_bootstraps_it(
     assert definition["RunAtLoad"] is True
     assert [c[:2] for c in runner.commands] == [
         ["launchctl", "bootout"],
+        ["launchctl", "print"],
         ["launchctl", "bootstrap"],
     ]
     assert svc.background_service_state(home=tmp_path, system="Darwin").installed is True
@@ -101,10 +105,49 @@ def test_a_service_the_os_will_not_stop_keeps_its_unit_and_raises(
     )
 
     with pytest.raises(RuntimeError, match="still loaded"):
-        svc.remove_background_service(home=tmp_path, system="Darwin", run=_Runner(loaded=True))
+        svc.remove_background_service(
+            home=tmp_path, system="Darwin", run=_Runner(loaded_for=-1), sleep=lambda _s: None
+        )
 
     assert installed.unit_path is not None and installed.unit_path.exists()
     assert svc.background_service_state(home=tmp_path, system="Darwin").installed is True
+
+
+def test_reinstall_waits_for_the_old_service_to_unload_before_bootstrapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange: the previous service is still tearing down for two status checks.
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    runner = _Runner(loaded_for=2)
+    naps: list[float] = []
+
+    # Act
+    state = svc.install_background_service(
+        home=tmp_path, system="Darwin", run=runner, command=["x"], sleep=naps.append
+    )
+
+    # Assert: bootstrap ran only after the status check reported the service gone.
+    assert state.installed is True
+    names = [c[:2] for c in runner.commands]
+    assert names.index(["launchctl", "bootstrap"]) > names.index(["launchctl", "print"])
+    assert len(naps) == 2
+
+
+def test_reinstall_gives_up_when_the_old_service_never_unloads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    monkeypatch.setattr(svc, "_UNLOAD_WAIT_SECONDS", 0.0)
+
+    with pytest.raises(RuntimeError, match="still stopping"):
+        svc.install_background_service(
+            home=tmp_path,
+            system="Darwin",
+            run=_Runner(loaded_for=-1),
+            command=["x"],
+            sleep=lambda _s: None,
+        )
+    assert svc.background_service_state(home=tmp_path, system="Darwin").installed is False
 
 
 def test_linux_install_writes_a_systemd_user_unit(

--- a/tests/tools/test_ci_reliability_loop.py
+++ b/tests/tools/test_ci_reliability_loop.py
@@ -168,12 +168,12 @@ def test_build_report_renders_the_analytics_and_keeps_a_json_snapshot(
     import json
 
     from integrations.github import client as github_client
-    from integrations.github.tools.ci_analytics import collector
+    from integrations.github.tools.ci_analytics import analysis
     from integrations.github.tools.ci_analytics.collector import CollectedRuns
 
     monkeypatch.setattr(github_client, "resolve_github_token", lambda _t: "tok")
     monkeypatch.setattr(
-        collector,
+        analysis,
         "collect_runs",
         lambda *_a, **_k: CollectedRuns(
             default_branch="main", branch_runs=[], pr_runs=[], merged_prs=(), coverage_notices=()

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1105,7 +1105,9 @@ def test_tool_renders_report_from_collected_runs() -> None:
     )
     with (
         patch("integrations.github.tools.ci_analytics.tool.resolve_github_token", return_value="t"),
-        patch("integrations.github.tools.ci_analytics.analysis.collect_runs", return_value=collected),
+        patch(
+            "integrations.github.tools.ci_analytics.analysis.collect_runs", return_value=collected
+        ),
     ):
         result = analyze_github_ci_reliability(owner="o", repo="r", days=7)
 
@@ -1146,7 +1148,9 @@ def test_tool_shows_progress_lines_around_the_painted_report() -> None:
 
     with (
         patch("integrations.github.tools.ci_analytics.tool.resolve_github_token", return_value="t"),
-        patch("integrations.github.tools.ci_analytics.analysis.collect_runs", return_value=collected),
+        patch(
+            "integrations.github.tools.ci_analytics.analysis.collect_runs", return_value=collected
+        ),
     ):
         result = analyze_github_ci_reliability(owner="o", repo="r[1]", days=7, context=context)
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1080,7 +1080,7 @@ def test_tool_failure_text_never_carries_exception_detail() -> None:
     with (
         patch("integrations.github.tools.ci_analytics.tool.resolve_github_token", return_value="t"),
         patch(
-            "integrations.github.tools.ci_analytics.tool.collect_runs",
+            "integrations.github.tools.ci_analytics.analysis.collect_runs",
             side_effect=GitHubApiError(secret_detail, status_code=403),
         ),
     ):
@@ -1105,7 +1105,7 @@ def test_tool_renders_report_from_collected_runs() -> None:
     )
     with (
         patch("integrations.github.tools.ci_analytics.tool.resolve_github_token", return_value="t"),
-        patch("integrations.github.tools.ci_analytics.tool.collect_runs", return_value=collected),
+        patch("integrations.github.tools.ci_analytics.analysis.collect_runs", return_value=collected),
     ):
         result = analyze_github_ci_reliability(owner="o", repo="r", days=7)
 
@@ -1146,7 +1146,7 @@ def test_tool_shows_progress_lines_around_the_painted_report() -> None:
 
     with (
         patch("integrations.github.tools.ci_analytics.tool.resolve_github_token", return_value="t"),
-        patch("integrations.github.tools.ci_analytics.tool.collect_runs", return_value=collected),
+        patch("integrations.github.tools.ci_analytics.analysis.collect_runs", return_value=collected),
     ):
         result = analyze_github_ci_reliability(owner="o", repo="r[1]", days=7, context=context)
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -442,6 +442,110 @@ def test_stale_rerun_after_the_merge_waits_only_until_the_merge() -> None:
     assert report.blocked_minutes == 24 * 60 - 10
 
 
+def test_working_hours_count_only_the_part_of_a_wait_a_developer_sat_through() -> None:
+    # Arrange: CI failed Friday 16:00 UTC and was re-run to green Monday 11:00 UTC.
+    # _T0 is Tuesday 09:00; Friday 16:00 is +3 days +7 hours.
+    friday_1600 = 3 * 24 * 60 + 7 * 60
+    monday_1100 = friday_1600 + 2 * 24 * 60 + 19 * 60
+    pr_runs = [
+        _run(
+            1,
+            sha="m",
+            conclusion="success",
+            start_minutes=monday_1100,
+            queued_minutes=monday_1100 - friday_1600,
+            attempt=2,
+            earlier_failure_started_at=_T0 + timedelta(minutes=friday_1600),
+        ),
+    ]
+    merged = (
+        MergedPullRequest(
+            number=1,
+            branch="feat/x",
+            head_repo="",
+            merged_at=_T0 + timedelta(days=7),
+            author="alice",
+        ),
+    )
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=30,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=merged,
+        now=_T0 + timedelta(days=8),
+    )
+
+    # Assert: expected green Friday 16:10; wall clock to Monday 11:10 is 67h, working
+    # hours (Mon-Fri 09-18 UTC) are Friday 16:10-18:00 plus Monday 09:00-11:10 = 4h.
+    delay = report.blocked_pr_delays[0]
+    assert round(delay.delay_minutes) == 67 * 60
+    assert round(delay.working_minutes) == 240
+    assert delay.author == "alice"
+    assert report.blocked_working_minutes == delay.working_minutes
+    assert "Mon-Fri 09:00-18:00 UTC" in report.working_hours_label
+
+
+def test_developer_waits_group_blocked_prs_by_author() -> None:
+    # Arrange: alice waited on two PRs, bob on one, all inside working hours.
+    merged = tuple(
+        MergedPullRequest(
+            number=n, branch=f"feat/{n}", head_repo="", merged_at=_T0 + timedelta(days=1), author=a
+        )
+        for n, a in ((1, "alice"), (2, "alice"), (3, "bob"))
+    )
+    pr_runs = []
+    for n in (1, 2, 3):
+        pr_runs.append(_run(n * 10, branch=f"feat/{n}", sha=f"s{n}", conclusion="failure"))
+        pr_runs.append(
+            _run(
+                n * 10 + 1, branch=f"feat/{n}", sha=f"s{n}", conclusion="success", start_minutes=50
+            )
+        )
+
+    # Act
+    report = compute_report(
+        owner="o",
+        repo="r",
+        default_branch="main",
+        window_days=7,
+        branch_runs=[],
+        pr_runs=pr_runs,
+        merged_prs=merged,
+        now=_T0 + timedelta(days=2),
+    )
+
+    # Assert: 50 minutes per PR; alice 100, bob 50; per week over a 7-day window.
+    waits = report.developer_waits
+    assert [(w.login, w.pull_requests, w.working_minutes) for w in waits] == [
+        ("alice", 2, 100.0),
+        ("bob", 1, 50.0),
+    ]
+    assert waits[0].working_minutes_per_week == 100.0
+    assert report.developers_affected == 2
+    assert "Heaviest hit: alice 1.7h/week over 2 PRs" in render_markdown(report)
+
+
+def test_merged_pr_row_keeps_the_author_login() -> None:
+    from integrations.github.tools.ci_analytics.collector import _merged_pr
+
+    row = {
+        "number": 7,
+        "merged_at": "2026-09-02T09:00:00Z",
+        "updated_at": "2026-09-02T09:00:00Z",
+        "head": {"ref": "feat/x", "repo": {"full_name": "o/r"}},
+        "user": {"login": "alice"},
+    }
+
+    parsed = _merged_pr(row, since=_T0 - timedelta(days=30))
+
+    assert parsed is not None and parsed.author == "alice"
+
+
 def test_source_code_failures_do_not_add_blocked_time() -> None:
     pr_runs = [
         _run(1, sha="old", conclusion="failure", start_minutes=0),
@@ -951,7 +1055,7 @@ def test_render_shows_the_kpi_block_and_classification() -> None:
     assert "GitHub Actions executions: **3**" in text
     assert "Raw PR workflow failure rate: **50.0%**" in text
     assert "CI reliability failures, passed later on the same commit: **1**" in text
-    assert "Developer time blocked by unreliable CI: 40m" in text
+    assert "Developer downtime from unreliable CI: 40m of working time across 1 developer" in text
     assert "| CI | 3 | 1 | 1 | 10m |" in text
 
 
@@ -1001,8 +1105,8 @@ def test_tool_renders_report_from_collected_runs() -> None:
     assert result["reliability_failures"] == 1
     assert result["blocked_minutes"] == 40.0
     assert result["headline"] == (
-        "Unreliable CI blocked merged pull requests for 40m in the last 7 days; "
-        "the typical blocked PR waited 40m, the longest 40m."
+        "Unreliable CI cost 1 developer 40m of working time in the last 7 days, up to 40m a "
+        "week for the worst hit; 40m of wall-clock wait across 1 merged PR."
     )
     assert "Coverage notice: sample" in result["response_text"]
 

--- a/tests/tools/test_github_ci_analytics.py
+++ b/tests/tools/test_github_ci_analytics.py
@@ -1055,7 +1055,15 @@ def test_render_shows_the_kpi_block_and_classification() -> None:
     assert "GitHub Actions executions: **3**" in text
     assert "Raw PR workflow failure rate: **50.0%**" in text
     assert "CI reliability failures, passed later on the same commit: **1**" in text
-    assert "Developer downtime from unreliable CI: 40m of working time across 1 developer" in text
+    assert (
+        "Developer Blocked Time, estimated bottom-up: 40m of working time across 1 developer"
+        in text
+    )
+    # The calculation is shown, not just its result: inputs, formula, sum, division.
+    assert "expected green = first run queued + normal duration" in text
+    assert "| + normal | = expected green |" in text
+    assert "Σ blocked = 40m of working time across 1 merged PR" in text
+    assert "÷ 1 developer = 40m each in 30 days" in text
     assert "| CI | 3 | 1 | 1 | 10m |" in text
 
 

--- a/tests/tools/test_telemetry.py
+++ b/tests/tools/test_telemetry.py
@@ -308,7 +308,7 @@ def _github_star_history_case() -> ToolFailureCase:
 def _github_ci_analytics_case() -> ToolFailureCase:
     def patch(mp: pytest.MonkeyPatch) -> None:
         from integrations.github.client import GitHubApiError
-        from integrations.github.tools.ci_analytics import tool as mod
+        from integrations.github.tools.ci_analytics import analysis as mod
 
         mp.setattr(mod, "collect_runs", MagicMock(side_effect=GitHubApiError("boom")))
 

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -46,9 +46,9 @@ _FALLBACK_INSTRUCTION = (
 _QUEUED_INSTRUCTION = (
     "The selection menu opens after this turn ends. End the turn now without a "
     "user-facing sentence; do NOT repeat the options as text or ask the user to "
-    "type a number. The user's selection arrives as the next user message (the "
-    "chosen option label, verbatim). After selection, continue the original work "
-    "and do not merely repeat or acknowledge the chosen label."
+    "type a number. The user's selection arrives as the next user message as the "
+    "question followed by the chosen option label, verbatim. After selection, "
+    "continue the original work and do not merely repeat or acknowledge the label."
 )
 _QUEUED_BATCH_INSTRUCTION = (
     "The Ask User menu opens after this turn ends. Before it, say in one or two "

--- a/tools/interactive_shell/actions/cli_command.py
+++ b/tools/interactive_shell/actions/cli_command.py
@@ -31,16 +31,18 @@ def run_cli_command(*, payload: str, context: Any) -> dict[str, Any]:
 cli_exec_tool = RegisteredTool(
     name="cli_exec",
     description=(
-        "Run an `opensre` CLI subcommand payload (without the leading `opensre ` prefix). "
-        "Prefer allowed operational families such as health/status/list/show/integrations/"
-        "synthetic checks; avoid unrelated or dangerous payloads."
+        "Run an `opensre` CLI subcommand the user asked for (payload without the leading "
+        "`opensre ` prefix), such as integrations/status/list/show/synthetic checks. "
+        "Not a discovery tool: never run it to find a repository, a token, or configured "
+        "integrations for a skill, and never run `health` unless the user asked for a "
+        "health check; it prints every integration on the machine."
     ),
     input_schema=object_schema(
         properties={
             "payload": string_property(
                 description=(
                     "CLI payload passed to `opensre` without the leading command prefix "
-                    "(for example: `integrations list`, `health`, `synthetic run ...`). "
+                    "(for example: `integrations list`, `synthetic run ...`). "
                     "Must not start with `opensre `."
                 ),
                 min_length=1,

--- a/tools/interactive_shell/actions/skill_view.py
+++ b/tools/interactive_shell/actions/skill_view.py
@@ -13,7 +13,6 @@ from tools.interactive_shell.action_names import ActionToolName
 
 
 def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
-    _ = ctx
     name = str(args.get("name", "")).strip()
     if not name:
         available = [skill.name for skill in list_action_skills()]
@@ -32,6 +31,12 @@ def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[
             "available": available,
         }
     slug = name.replace("_", "-").lower()
+    skill = next((item for item in list_action_skills() if item.name == slug), None)
+    # The flow is now inside this skill: the next answer turn offers only its tools.
+    session = getattr(ctx, "session", None)
+    if session is not None:
+        session.active_skill = slug
+        session.active_skill_tools = tuple(getattr(skill, "tools", ()) or ())
     # ``summary`` is what the user sees; ``content`` is for the model only.
     # Without it the generic formatter prints the whole skill body on screen.
     return {


### PR DESCRIPTION
Addresses the review of the onboarding demos: the demo ran `opensre
health`, seemed to ask the same question twice, and the blocked-time KPI
was a single total rather than a bottom-up calculation.

- **No more `opensre health`.** The first-launch loop picker's CI/CD row
  auto-submitted a prompt into `github-ci-health`, a skill that only works
  under the scheduled runner; with nothing legitimate to call, the model ran
  `opensre health` and printed 61 missing integrations on a fresh machine.
  The row now runs the deterministic CI reliability agent demo (scan,
  repository, schedule, first pass) with no model turn. The `cli_exec` tool
  no longer advertises `health` as its preferred payload, and the skill
  states how to find the repository interactively.
- **Bottom-up blocked time.** The report shows "How it adds up, worst
  first": the five most blocked merged PRs with when each should have been
  green, when it actually was, and how long it waited, then the remainder
  and the sum with the typical wait. `PullRequestDelay` carries the expected
  and actual green times.
- **One answer line.** After a menu the shell printed the question again
  under an "Ask User" header, which read as asking twice. It is now a single
  dim question with the answer after it.
- The analytics skill asks each question once, continues with the answer,
  and never asks what a request means.