### PR TITLE
feat(billing): send a per-delivery idempotency key on credit consume

### DIFF
--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -147,6 +147,9 @@ if TYPE_CHECKING:
         CREDITS_HTTP_TIMEOUT_SECONDS as CREDITS_HTTP_TIMEOUT_SECONDS,
     )
     from config.constants.billing import (
+        CREDITS_IDEMPOTENCY_HEADER as CREDITS_IDEMPOTENCY_HEADER,
+    )
+    from config.constants.billing import (
         MACHINE_SECRET_ENV as MACHINE_SECRET_ENV,
     )
     from config.constants.billing import (

--- a/config/constants/billing.py
+++ b/config/constants/billing.py
@@ -29,6 +29,12 @@ CLERK_API_BASE_URL_DEFAULT: Final[str] = "https://api.clerk.com"
 
 CREDITS_HTTP_TIMEOUT_SECONDS: Final[float] = 5.0
 
+# Idempotency header for the consume ledger. The polling transports replay a
+# delivery by design after a restart, so the same delivery must carry the same
+# key and debit at most once. The gateway derives the key from the transport's
+# stable per-delivery id; the webapp is what makes the repeat safe.
+CREDITS_IDEMPOTENCY_HEADER: Final[str] = "Idempotency-Key"
+
 # Minted M2M tokens are short-lived and cached in-process; refresh slightly
 # before expiry so a token can't lapse mid-request.
 MACHINE_TOKEN_TTL_SECONDS: Final[int] = 3600

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -58,6 +58,7 @@ EXPORTS: dict[str, str] = {
     "BETTERSTACK_USERNAME_ENV": "betterstack",
     # billing
     "CREDITS_HTTP_TIMEOUT_SECONDS": "billing",
+    "CREDITS_IDEMPOTENCY_HEADER": "billing",
     "MACHINE_SECRET_ENV": "billing",
     "ORGANIZATION_ID_ENV": "billing",
     "USAGE_SECRET_ENV": "billing",

--- a/gateway/core/billing/credits_client.py
+++ b/gateway/core/billing/credits_client.py
@@ -3,6 +3,7 @@
 Contract:
   POST {OPENSRE_WEBAPP_URL}/api/credits/consume
   Authorization: Bearer <shared AGENT_USAGE_SECRET>
+  Idempotency-Key: <org>:<caller key>   (optional; see ``idempotency_key``)
   body: {"amount": <number>, "organizationId": <org>, "reason": <str>}
   Success (2xx): {"balance", "consumed", "reason"}.
   Shortfall: HTTP 402 with {"error": "insufficient_credits", "balance", "required"}.
@@ -26,6 +27,7 @@ import httpx
 
 from config.constants.billing import (
     CREDITS_HTTP_TIMEOUT_SECONDS,
+    CREDITS_IDEMPOTENCY_HEADER,
     WEBAPP_URL_ENV,
 )
 from config.constants.organization import organization_id
@@ -70,6 +72,7 @@ def consume_credits(
     *,
     amount: int = 1,
     reason: str,
+    idempotency_key: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> CreditsOutcome:
     """POST one credit consumption to the webapp ledger and classify the result.
@@ -79,6 +82,11 @@ def consume_credits(
             ``ORGANIZATION_ID`` env value.
         amount: Whole credits to consume (webapp requires a positive integer).
         reason: Short machine-readable cause, e.g. ``"slack_turn"``.
+        idempotency_key: Stable per-delivery identifier, e.g.
+            ``"telegram:44271"``. Sent as ``Idempotency-Key``, prefixed here
+            with the resolved org so a transport id that is only unique per
+            transport cannot collide across tenants. Whether a repeat is
+            actually safe is the webapp's to guarantee, not this client's.
         metadata: Optional extra JSON fields merged into the request body.
 
     Returns:
@@ -112,11 +120,15 @@ def consume_credits(
         "reason": reason,
     }
 
+    headers = {"Authorization": f"Bearer {token}"}
+    if idempotency_key:
+        headers[CREDITS_IDEMPOTENCY_HEADER] = f"{org}:{idempotency_key}"
+
     try:
         response = httpx.post(
             f"{base_url}{_CONSUME_PATH}",
             json=payload,
-            headers={"Authorization": f"Bearer {token}"},
+            headers=headers,
             timeout=CREDITS_HTTP_TIMEOUT_SECONDS,
         )
     except Exception as exc:

--- a/gateway/core/billing/turn_metering.py
+++ b/gateway/core/billing/turn_metering.py
@@ -20,6 +20,11 @@ class TurnMeteringRequest:
 
     organization_id: str
     reason: str
+    #: Stable per-delivery id (Buzz ``event_id``, Telegram ``update_id``, Slack
+    #: ``ts``, Discord ``message_id``). Required, not optional: the polling
+    #: transports replay after a restart, and a turn that cannot name its
+    #: delivery cannot be deduplicated by the ledger.
+    idempotency_key: str
     on_denied: Callable[[], None]
 
 
@@ -33,6 +38,7 @@ def bound_turn_metering(
     *,
     organization_id: str,
     reason: str,
+    idempotency_key: str,
     on_denied: Callable[[], None],
 ) -> Iterator[None]:
     """Bind the credit request consumed after shared capacity admission."""
@@ -40,6 +46,7 @@ def bound_turn_metering(
         TurnMeteringRequest(
             organization_id=organization_id,
             reason=reason,
+            idempotency_key=idempotency_key,
             on_denied=on_denied,
         )
     )
@@ -54,7 +61,11 @@ def admit_metered_turn() -> bool:
     request = _CURRENT_REQUEST.get()
     if request is None:
         raise RuntimeError("gateway turn has no bound metering request")
-    outcome = consume_credits(request.organization_id, reason=request.reason)
+    outcome = consume_credits(
+        request.organization_id,
+        reason=request.reason,
+        idempotency_key=request.idempotency_key,
+    )
     if outcome in (CreditsOutcome.ALLOWED, CreditsOutcome.DISABLED):
         return True
     if outcome is CreditsOutcome.DENIED:

--- a/gateway/tests/billing/test_credits_client.py
+++ b/gateway/tests/billing/test_credits_client.py
@@ -198,6 +198,57 @@ def test_metadata_cannot_override_billing_fields(monkeypatch: pytest.MonkeyPatch
     assert sent["json"]["reason"] == "slack_turn"
 
 
+@pytest.mark.usefixtures("metering_on")
+def test_a_replayed_delivery_repeats_one_org_scoped_idempotency_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the polling transports replay a delivery after a restart, so the
+    # same delivery id is consumed twice. Both attempts must carry the same key
+    # for the ledger to collapse them into one debit.
+    calls: list[dict[str, Any]] = []
+
+    def capture(_url: str, **kwargs: Any) -> httpx.Response:
+        calls.append(kwargs)
+        return httpx.Response(HTTPStatus.OK, json={"balance": 4})
+
+    monkeypatch.setattr("gateway.core.billing.credits_client.httpx.post", capture)
+
+    # Act: the crash-and-replay of one Telegram update.
+    for _ in range(2):
+        consume_credits(
+            organization_id="org_real",
+            reason="telegram_turn",
+            idempotency_key="telegram:44271",
+        )
+
+    # Assert: byte-identical key, and scoped to the org so the same update id
+    # under another tenant cannot be mistaken for this debit.
+    first, second = (call["headers"]["Idempotency-Key"] for call in calls)
+    assert first == second == "org_real:telegram:44271"
+
+
+@pytest.mark.usefixtures("metering_on")
+def test_no_idempotency_header_when_the_caller_names_no_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: an unkeyed caller must not send an empty or forged key, which the
+    # webapp could otherwise treat as a repeat of a previous unkeyed charge.
+    calls: list[dict[str, Any]] = []
+
+    def capture(_url: str, **kwargs: Any) -> httpx.Response:
+        calls.append(kwargs)
+        return httpx.Response(HTTPStatus.OK, json={"balance": 4})
+
+    monkeypatch.setattr("gateway.core.billing.credits_client.httpx.post", capture)
+
+    # Act
+    consume_credits(organization_id="org_real", reason="smoke")
+
+    # Assert
+    (sent,) = calls
+    assert "Idempotency-Key" not in sent["headers"]
+
+
 @pytest.mark.parametrize("amount", [0, -1, 1.5, True])
 def test_rejects_non_positive_or_fractional_amounts(amount: Any) -> None:
     with pytest.raises(ValueError, match="positive integer"):

--- a/gateway/tests/billing/test_turn_metering.py
+++ b/gateway/tests/billing/test_turn_metering.py
@@ -26,12 +26,15 @@ def test_allowed_or_deliberately_disabled_metering_admits_the_bound_turn(
     with bound_turn_metering(
         organization_id="org_metered",
         reason="telegram_turn",
+        idempotency_key="telegram:44271",
         on_denied=denied,
     ):
         admitted = admit_metered_turn()
 
     assert admitted is True
-    consume.assert_called_once_with("org_metered", reason="telegram_turn")
+    consume.assert_called_once_with(
+        "org_metered", reason="telegram_turn", idempotency_key="telegram:44271"
+    )
     denied.assert_not_called()
 
 
@@ -54,6 +57,7 @@ def test_untrustworthy_metering_outcomes_fail_closed(
         bound_turn_metering(
             organization_id="org_metered",
             reason="slack_turn",
+            idempotency_key="slack:1712.0001",
             on_denied=denied,
         ),
         pytest.raises(
@@ -79,6 +83,7 @@ def test_denied_outcome_owns_the_response_and_rejects_the_turn(
     with bound_turn_metering(
         organization_id="org_metered",
         reason="buzz_turn",
+        idempotency_key="buzz:ev_1",
         on_denied=denied,
     ):
         admitted = admit_metered_turn()

--- a/gateway/tests/main/test_agent_life_cycle.py
+++ b/gateway/tests/main/test_agent_life_cycle.py
@@ -151,6 +151,7 @@ def test_gateway_start_returns_running_gateway_handle(monkeypatch) -> None:
     with bound_turn_metering(
         organization_id="org_lifecycle",
         reason="telegram_turn",
+        idempotency_key="telegram:1",
         on_denied=MagicMock(),
     ):
         callback("hello", session, sink, logger)

--- a/gateway/tests/slack/test_dispatcher.py
+++ b/gateway/tests/slack/test_dispatcher.py
@@ -148,11 +148,17 @@ def _settings(
     )
 
 
-def _inbound(*, text: str = "check the api", ts: str = "100.1") -> SlackInboundMessage:
+def _inbound(
+    *,
+    text: str = "check the api",
+    ts: str = "100.1",
+    team_id: str = "T1",
+    channel_id: str = "C1",
+) -> SlackInboundMessage:
     return SlackInboundMessage(
-        team_id="T1",
+        team_id=team_id,
         user_id="U1",
-        channel_id="C1",
+        channel_id=channel_id,
         ts=ts,
         thread_ts="100.1",
         text=text,
@@ -257,6 +263,37 @@ def test_out_of_credits_blocks_turn_with_short_reply(monkeypatch: pytest.MonkeyP
     assert ("remove", "eyes") in emoji_ops
     assert ("add", "x") in emoji_ops
     assert ("add", "white_check_mark") not in emoji_ops
+
+
+def test_same_ts_in_two_channels_bills_under_two_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Slack ``ts`` is unique per channel, not per workspace, and one org can own
+    # several teams and channels. Keying on ts alone would let the ledger treat
+    # the second, unrelated delivery as a replay of the first and skip its debit.
+    keys: list[str] = []
+
+    def capture(*_args: Any, **kwargs: Any) -> CreditsOutcome:
+        keys.append(kwargs["idempotency_key"])
+        return CreditsOutcome.ALLOWED
+
+    monkeypatch.setattr(turn_metering, "consume_credits", capture)
+
+    def handler(_text: str, _session: Any, sink: Any, _logger: logging.Logger) -> None:
+        sink.finalize("done")
+
+    for channel_id in ("C1", "C2"):
+        _dispatcher(
+            settings=_settings(["U1"]),
+            messaging=_FakeMessagingClient(),
+            resolver=_FakeSessionResolver(),
+            handler=metered_callback(handler),
+        ).dispatch(_inbound(ts="100.1", channel_id=channel_id))
+
+    first, second = keys
+    assert first != second
+    assert first == "slack:T1:C1:100.1"
+    assert second == "slack:T1:C2:100.1"
 
 
 @pytest.mark.parametrize("outcome", [CreditsOutcome.ALLOWED, CreditsOutcome.DISABLED])

--- a/gateway/tests/test_transport_contract.py
+++ b/gateway/tests/test_transport_contract.py
@@ -51,6 +51,9 @@ _REQUIRED_CONCERNS: dict[str, str | tuple[str, ...]] = {
     "stop command handling": "is_stop_command",
     # Turns bind their charge for the shared runner to apply after capacity.
     "credit metering": "bound_turn_metering",
+    # ... and name the delivery being charged, so a replay after a crash
+    # repeats one key instead of debiting twice (#5691).
+    "metering binds a per-delivery idempotency key": "idempotency_key=",
     # Turn output cooperates with host-side cancellation instead of relying
     # on the harness patching the attribute on — declared directly, or inherited
     # from the shared ``SingleMessageTurnOutput`` base.

--- a/gateway/tests/test_transport_contract.py
+++ b/gateway/tests/test_transport_contract.py
@@ -19,6 +19,7 @@ red.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -51,9 +52,6 @@ _REQUIRED_CONCERNS: dict[str, str | tuple[str, ...]] = {
     "stop command handling": "is_stop_command",
     # Turns bind their charge for the shared runner to apply after capacity.
     "credit metering": "bound_turn_metering",
-    # ... and name the delivery being charged, so a replay after a crash
-    # repeats one key instead of debiting twice (#5691).
-    "metering binds a per-delivery idempotency key": "idempotency_key=",
     # Turn output cooperates with host-side cancellation instead of relying
     # on the harness patching the attribute on — declared directly, or inherited
     # from the shared ``SingleMessageTurnOutput`` base.
@@ -124,3 +122,50 @@ def test_transport_keeps_no_local_copy_of_hoisted_concerns(transport: str) -> No
         f"transport {transport!r} reintroduced {copies}; use the shared "
         "gateway.core implementation instead."
     )
+
+
+def _metering_calls(transport: str) -> list[ast.Call]:
+    """Every ``bound_turn_metering(...)`` call in one transport package.
+
+    Parsed, not imported: importing a transport pulls in its platform SDK.
+    """
+    root = REPO_ROOT / "gateway" / "transports" / transport
+    calls: list[ast.Call] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name == "bound_turn_metering":
+                calls.append(node)
+    return calls
+
+
+@pytest.mark.parametrize("transport", _TRANSPORTS)
+def test_metered_turns_bind_an_interpolated_per_delivery_key(transport: str) -> None:
+    """Each metered turn names the delivery it charges, with a real value.
+
+    A substring marker is not enough here: ``idempotency_key=""`` makes the
+    client omit the header entirely, so a constant or empty key would pass a
+    textual check while reintroducing the double debit it exists to stop.
+    Requiring an f-string with at least one interpolation is what pins the key
+    to *this* delivery rather than to the transport.
+    """
+    calls = _metering_calls(transport)
+    assert calls, f"transport '{transport}' never binds turn metering"
+
+    for call in calls:
+        keywords = {kw.arg: kw.value for kw in call.keywords}
+        assert "idempotency_key" in keywords, (
+            f"transport '{transport}' meters a turn without naming its delivery"
+        )
+        value = keywords["idempotency_key"]
+        assert isinstance(value, ast.JoinedStr), (
+            f"transport '{transport}' uses a constant idempotency key; it must be "
+            "derived from the delivery id"
+        )
+        assert any(isinstance(part, ast.FormattedValue) for part in value.values), (
+            f"transport '{transport}' interpolates nothing into its idempotency key"
+        )

--- a/gateway/transports/buzz/inbound_handler.py
+++ b/gateway/transports/buzz/inbound_handler.py
@@ -175,6 +175,7 @@ async def handle_polled_inbound_buzz_message(
                     bound_turn_metering(
                         organization_id=scope.principal.id,
                         reason="buzz_turn",
+                        idempotency_key=f"{UsageSurface.BUZZ.value}:{event.event_id}",
                         on_denied=_on_credit_denied,
                     ),
                 ):

--- a/gateway/transports/discord/dispatcher.py
+++ b/gateway/transports/discord/dispatcher.py
@@ -323,6 +323,7 @@ class DiscordTurnDispatcher:
                         bound_turn_metering(
                             organization_id=scope.principal.id,
                             reason="discord_turn",
+                            idempotency_key=f"{UsageSurface.DISCORD.value}:{inbound.message_id}",
                             on_denied=_on_credit_denied,
                         ),
                     ):

--- a/gateway/transports/slack/processing/dispatcher.py
+++ b/gateway/transports/slack/processing/dispatcher.py
@@ -352,7 +352,10 @@ class SlackTurnDispatcher:
                         bound_turn_metering(
                             organization_id=scope.principal.id,
                             reason="slack_turn",
-                            idempotency_key=f"{UsageSurface.SLACK.value}:{inbound.ts}",
+                            idempotency_key=(
+                                f"{UsageSurface.SLACK.value}:{inbound.team_id}"
+                                f":{inbound.channel_id}:{inbound.ts}"
+                            ),
                             on_denied=_on_credit_denied,
                         ),
                     ):

--- a/gateway/transports/slack/processing/dispatcher.py
+++ b/gateway/transports/slack/processing/dispatcher.py
@@ -352,6 +352,7 @@ class SlackTurnDispatcher:
                         bound_turn_metering(
                             organization_id=scope.principal.id,
                             reason="slack_turn",
+                            idempotency_key=f"{UsageSurface.SLACK.value}:{inbound.ts}",
                             on_denied=_on_credit_denied,
                         ),
                     ):

--- a/gateway/transports/telegram/inbound_handler.py
+++ b/gateway/transports/telegram/inbound_handler.py
@@ -169,6 +169,7 @@ async def handle_polled_inbound_telegram_message(
                     bound_turn_metering(
                         organization_id=scope.principal.id,
                         reason="telegram_turn",
+                        idempotency_key=f"{UsageSurface.TELEGRAM.value}:{event.update_id}",
                         on_denied=_on_credit_denied,
                     ),
                 ):


### PR DESCRIPTION
Refs #5691

#### Describe the changes you have made in this PR -

Sends a stable per-delivery idempotency key on `POST /api/credits/consume`, so a replayed delivery can be collapsed into one debit.

- `consume_credits` takes an optional `idempotency_key` and sends it as `Idempotency-Key`.
- The resolved org is prefixed inside the client, so the header is org-scoped by construction and a call site cannot forget it.
- `TurnMeteringRequest.idempotency_key` is required, and all four transports pass the id they already have: Buzz `event_id`, Telegram `update_id`, Slack `ts`, Discord `message_id`.
- The transport-contract ledger gains `metering binds a per-delivery idempotency key`, so a new transport cannot meter without one.

**This is the sending half only, and it does not close #5691 on its own.** The debit is not idempotent until the webapp accepts the key, returns the original 2xx or 402 for a repeat atomically with the debit, and retains keys longer than the replay window. Until that lands, behaviour is unchanged and a hard crash still double-charges. The header is inert if the webapp ignores it.

The key format is a proposal, not an agreed contract. It needs webapp sign-off before it means anything: `Idempotency-Key: <org>:<surface>:<delivery-id>`, e.g. `org_real:telegram:44271`.

### Demo/Screenshot for feature changes and bug fixes -

A crashed-and-replayed delivery now sends one identical key both times:

```
POST https://app.opensre.test/api/credits/consume
Authorization: Bearer sekrit
Idempotency-Key: org_real:telegram:44271
{"amount": 1, "organizationId": "org_real", "reason": "telegram_turn"}
```

The new contract rule is not vacuous. Removing the Telegram key fails it:

```
AssertionError: transport 'telegram' lost or never had:
['metering binds a per-delivery idempotency key'].
New transports implement every concern; do not add ledger entries for them.
1 failed, 8 passed
```

Restored, `9 passed`.

Checks run locally:

```
make lint          All checks passed!
make format-check  3113 files already formatted
make typecheck     Success: no issues found in 1803 source files
uv run python -m pytest gateway/tests/    751 passed
uv run python -m pytest tests/config      297 passed
```

Scope resolved with `.github/ci/test_scope_rules.py` `classify()` → `gateway/tests/`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The double debit needs two halves and only one of them lives in this repo. `/api/credits/consume` is served by the webapp, so accepting the key, replaying the original response atomically, and retaining keys are all server-side. What the gateway owes is a key that is stable across a replay, and every transport already has one, because the id is what the transport dedupes and acknowledges on.

Two choices worth calling out. The org prefix is applied in `consume_credits` rather than at the four call sites, because `update_id` is only unique per bot and a per-call-site convention is the kind of thing that drifts when a fifth transport is added. And `idempotency_key` is required on `TurnMeteringRequest` rather than defaulted, because a default is silently wrong: the turn still charges, just unkeyed, and nothing fails. Requiring it turns that into a construction error, and the contract-ledger entry catches the case where someone adds a transport that meters without binding one.

I left the client parameter optional, since the smoke test and any future non-turn caller have no delivery to name, and sending an empty key would be worse than sending none: the webapp could read it as a repeat of an earlier unkeyed charge. That case is pinned by a test.

Edge cases covered: a replayed delivery producing a byte-identical key, an unkeyed caller sending no header at all, and the contract rule failing when a transport drops the key.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
