### PR TITLE
fix(shell): make session goals legible: credit plan steps, pause on stall with options

### DIFF
--- a/core/agent_harness/session/pending_choice.py
+++ b/core/agent_harness/session/pending_choice.py
@@ -14,7 +14,7 @@ and no "Reply with 1, 2, or 3" free-text parsing.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 _ANSWER_HEADER = re.compile(r"^(\d+)\.\s+(.+)$")
 
@@ -51,6 +51,9 @@ class PendingUserChoice:
 
     multi_select: bool = False
     """Multi-select for the single-question path (ignored when ``questions`` is set)."""
+
+    commands: dict[str, str] = field(default_factory=dict)
+    """Option label -> slash command the shell runs instead of answering the model."""
 
     def items(self) -> tuple[AskUserQuestion, ...]:
         """Questions to render: ``questions`` when set, otherwise one from title/options."""

--- a/core/agent_harness/session_goal/evaluate.py
+++ b/core/agent_harness/session_goal/evaluate.py
@@ -45,6 +45,7 @@ from core.agent_harness.session_goal.goal import (
     apply_session_goal_progress,
     attach_session_goal,
 )
+from core.agent_harness.session_goal.plan_credit import credit_completed_plan_steps
 from core.agent_harness.session_goal.progress import is_session_goal_progress_text
 from core.agent_harness.turns.cohort_identity import (
     goal_needs_cohort_identity,
@@ -221,6 +222,7 @@ def evaluate_session_goal(
             current = stored
     completed_before = current.completed
     current = apply_session_goal_progress(current, text)
+    current = credit_completed_plan_steps(current, session)
 
     claimed = reply_claims_session_goal_achieved(text)
     evidence = turn_has_session_goal_evidence(result)

--- a/core/agent_harness/session_goal/goal.py
+++ b/core/agent_harness/session_goal/goal.py
@@ -153,6 +153,9 @@ class SessionGoal:
     # ``session_goal:achieved`` tag without tool evidence (product rule for the
     # slash path — agent-attached goals still require tools).
     host_owned: bool = False
+    # ``turns_used`` when ``completed`` last grew. Stall detection compares
+    # against this so a later plateau still pauses after two idle turns.
+    last_progress_turns_used: int = 0
 
     def with_status(self, status: str) -> SessionGoal:
         return replace(self, status=status)
@@ -161,6 +164,10 @@ class SessionGoal:
         return replace(self, turns_used=self.turns_used + 1)
 
     def with_completed(self, completed: frozenset[int]) -> SessionGoal:
+        if completed == self.completed:
+            return self
+        if completed - self.completed:
+            return replace(self, completed=completed, last_progress_turns_used=self.turns_used)
         return replace(self, completed=completed)
 
     def with_finding(self, finding: str) -> SessionGoal:
@@ -273,19 +280,33 @@ def attach_session_goal(session: Any, goal: SessionGoal) -> SessionGoal:
     Fresh active goals get a start stamp (duration / token delta) unless the
     caller already set ``started_at`` (e.g. restore from payload). Leading
     shell prompt chrome in ``condition`` is stripped so a pasted ``[n] ❯``
-    line never becomes the durable goal text.
+    line never becomes the durable goal text. A new goal identity drops the
+    session task plan so completed steps from earlier work cannot credit it.
     """
+    previous = getattr(session, "session_goal", None)
+    new_identity = goal.started_at is None or (
+        isinstance(previous, SessionGoal) and previous.started_at != goal.started_at
+    )
     cleaned = strip_shell_prompt_chrome(goal.condition)
     if cleaned != goal.condition:
         goal = replace(goal, condition=cleaned)
     if goal.started_at is None and goal.status == SessionGoalStatus.ACTIVE:
         goal = mark_session_goal_started(goal, session=session)
     session.session_goal = goal
+    if new_identity:
+        _discard_session_task_plan(session)
     return goal
 
 
 def clear_session_goal(session: Any) -> None:
     session.session_goal = None
+    _discard_session_task_plan(session)
+
+
+def _discard_session_task_plan(session: Any) -> None:
+    """Drop the live plan so a later goal cannot inherit completed steps."""
+    if hasattr(session, "task_plan"):
+        session.task_plan = None
 
 
 def session_goal_elapsed_seconds(

--- a/core/agent_harness/session_goal/goal.py
+++ b/core/agent_harness/session_goal/goal.py
@@ -59,6 +59,7 @@ class SessionGoalReason:
     WAITING_TOOL_EVIDENCE = "waiting for an achieved signal with tool evidence"
     WAITING_USER_CHOICE = "waiting for user choice"
     PAUSED_USER_CHOICE = "paused — waiting for your choice"
+    PAUSED_NO_PROGRESS = "paused — no checklist progress after 2 turns"
     # Distinct from PAUSED_USER_CHOICE: user ran ``/goal pause`` (status=paused).
     PAUSED_BY_USER = "paused by you"
     BUDGET_EXHAUSTED = "session-goal turn budget exhausted"

--- a/core/agent_harness/session_goal/persist.py
+++ b/core/agent_harness/session_goal/persist.py
@@ -29,6 +29,7 @@ def session_goal_to_payload(goal: SessionGoal) -> dict[str, Any]:
         "token_baseline_input": int(goal.token_baseline_input),
         "token_baseline_output": int(goal.token_baseline_output),
         "host_owned": bool(goal.host_owned),
+        "last_progress_turns_used": int(goal.last_progress_turns_used),
     }
     if goal.started_at is not None:
         payload["started_at"] = float(goal.started_at)
@@ -86,6 +87,10 @@ def session_goal_from_payload(payload: Any) -> SessionGoal | None:
     except (TypeError, ValueError):
         token_in, token_out = 0, 0
     host_owned = bool(payload.get("host_owned", False))
+    try:
+        last_progress_turns_used = max(0, int(payload.get("last_progress_turns_used", 0) or 0))
+    except (TypeError, ValueError):
+        last_progress_turns_used = 0
     return SessionGoal(
         condition=condition.strip(),
         max_outer_turns=max_outer,
@@ -99,6 +104,7 @@ def session_goal_from_payload(payload: Any) -> SessionGoal | None:
         token_baseline_input=token_in,
         token_baseline_output=token_out,
         host_owned=host_owned,
+        last_progress_turns_used=last_progress_turns_used,
     )
 
 

--- a/core/agent_harness/session_goal/persist.py
+++ b/core/agent_harness/session_goal/persist.py
@@ -87,10 +87,7 @@ def session_goal_from_payload(payload: Any) -> SessionGoal | None:
     except (TypeError, ValueError):
         token_in, token_out = 0, 0
     host_owned = bool(payload.get("host_owned", False))
-    try:
-        last_progress_turns_used = max(0, int(payload.get("last_progress_turns_used", 0) or 0))
-    except (TypeError, ValueError):
-        last_progress_turns_used = 0
+    last_progress_turns_used = _restore_last_progress_turns_used(payload, turns_used)
     return SessionGoal(
         condition=condition.strip(),
         max_outer_turns=max_outer,
@@ -106,6 +103,19 @@ def session_goal_from_payload(payload: Any) -> SessionGoal | None:
         host_owned=host_owned,
         last_progress_turns_used=last_progress_turns_used,
     )
+
+
+def _restore_last_progress_turns_used(payload: dict[str, Any], turns_used: int) -> int:
+    """Stall watermark, or ``turns_used`` when the key is missing or unreadable."""
+    if "last_progress_turns_used" not in payload:
+        return turns_used
+    raw = payload.get("last_progress_turns_used")
+    if raw is None:
+        return turns_used
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return turns_used
 
 
 def session_goal_state_snapshot(session: Any) -> dict[str, Any]:

--- a/core/agent_harness/session_goal/plan_credit.py
+++ b/core/agent_harness/session_goal/plan_credit.py
@@ -1,0 +1,58 @@
+"""Credit the goal checklist from the turn's plan.
+
+The action turn tracks its own plan with ``update_plan``; a session goal's
+checklist usually lists the same steps. Without this the plan shows every
+step done while the checklist never gets a tick and the outer loop repeats
+the work until its budget runs out.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from core.agent_harness.session_goal.goal import SessionGoal
+from core.agent_harness.task_plan.plan import PlanStepStatus, TaskPlan
+
+_NOISE = re.compile(r"[^a-z0-9 ]+")
+_ARTICLES = frozenset({"a", "an", "the"})
+_MIN_MATCH_CHARS = 12
+
+
+def _normalize(text: str) -> str:
+    words = _NOISE.sub(" ", text.casefold()).split()
+    return " ".join(word for word in words if word not in _ARTICLES)
+
+
+def _matches(item: str, step: str) -> bool:
+    if not item or not step:
+        return False
+    if item == step:
+        return True
+    shorter, longer = sorted((item, step), key=len)
+    return len(shorter) >= _MIN_MATCH_CHARS and shorter in longer
+
+
+def credit_completed_plan_steps(goal: SessionGoal, session: Any) -> SessionGoal:
+    """Mark checklist items done when a completed plan step says the same thing."""
+    plan = getattr(session, "task_plan", None)
+    if not goal.checklist or not isinstance(plan, TaskPlan):
+        return goal
+    done_steps = [
+        _normalize(step.step) for step in plan.steps if step.status is PlanStepStatus.COMPLETED
+    ]
+    if not done_steps:
+        return goal
+    credited = set(goal.completed)
+    for index, item in enumerate(goal.checklist):
+        if index in credited:
+            continue
+        normalized = _normalize(item)
+        if any(_matches(normalized, step) for step in done_steps):
+            credited.add(index)
+    if credited == set(goal.completed):
+        return goal
+    return goal.with_completed(frozenset(credited))
+
+
+__all__ = ["credit_completed_plan_steps"]

--- a/core/agent_harness/session_goal/run_until.py
+++ b/core/agent_harness/session_goal/run_until.py
@@ -11,7 +11,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any
 
-from core.agent_harness.session.terminal_access import clear_pending_autosubmit
+from core.agent_harness.session.pending_choice import PendingUserChoice
+from core.agent_harness.session.terminal_access import clear_pending_autosubmit, set_auto_command
 from core.agent_harness.session_goal.continuation import continuation_prompt
 from core.agent_harness.session_goal.evaluate import (
     default_evaluate_session_goal,
@@ -118,6 +119,41 @@ def _announce_working(
     return working
 
 
+_NO_PROGRESS_TURNS = 2
+STALL_MENU_TITLE = "The goal made no checklist progress in 2 turns. How should I continue?"
+STALL_OPTION_MORE = "Keep going for one more turn"
+STALL_OPTION_STOP = "Stop here; the work above is enough"
+STALL_COMMANDS = {STALL_OPTION_MORE: "/goal resume", STALL_OPTION_STOP: "/goal clear"}
+
+
+def goal_has_stalled(goal: SessionGoal) -> bool:
+    """True when a checklist goal has used two turns without completing any item."""
+    return bool(goal.checklist) and not goal.completed and goal.turns_used >= _NO_PROGRESS_TURNS
+
+
+def pause_for_no_progress(
+    session: Any, active: SessionGoal, on_progress: ProgressFn | None
+) -> SessionGoal:
+    """Pause a stalled goal and open a menu with the ways forward.
+
+    Two full turns with nothing ticked off means repeating the same steps to
+    the budget; instead the shell asks: one more turn, stop, or typed guidance
+    (the custom row), which reaches the model as an ordinary answer.
+    """
+    paused = active.with_status(SessionGoalStatus.PAUSED).with_reason(
+        SessionGoalReason.PAUSED_NO_PROGRESS
+    )
+    paused = _paint(session, paused, on_progress, rederive=False)
+    _clear_host_autosubmit(session)
+    session.pending_user_choice = PendingUserChoice(
+        title=STALL_MENU_TITLE,
+        options=(STALL_OPTION_MORE, STALL_OPTION_STOP),
+        commands=dict(STALL_COMMANDS),
+    )
+    set_auto_command(session, "/choose")
+    return paused
+
+
 def _clear_host_autosubmit(session: Any) -> None:
     """Drop any queued shell autosubmit when the session goal stops continuing."""
     clear_pending_autosubmit(session)
@@ -179,6 +215,10 @@ def _finish_outer_turn(
         active = active.with_status(SessionGoalStatus.BUDGET_EXHAUSTED)
         active = _paint(session, active, on_progress)
         _clear_host_autosubmit(session)
+        return active, last, True
+
+    if goal_has_stalled(active):
+        active = pause_for_no_progress(session, active, on_progress)
         return active, last, True
 
     # Still active under budget: skip paint here — ``_announce_working`` owns

--- a/core/agent_harness/session_goal/run_until.py
+++ b/core/agent_harness/session_goal/run_until.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 from core.agent_harness.session.pending_choice import PendingUserChoice
-from core.agent_harness.session.terminal_access import clear_pending_autosubmit, set_auto_command
+from core.agent_harness.session.terminal_access import (
+    clear_pending_autosubmit,
+    session_terminal,
+    set_auto_command,
+)
 from core.agent_harness.session_goal.continuation import continuation_prompt
 from core.agent_harness.session_goal.evaluate import (
     default_evaluate_session_goal,
@@ -127,24 +131,29 @@ STALL_COMMANDS = {STALL_OPTION_MORE: "/goal resume", STALL_OPTION_STOP: "/goal c
 
 
 def goal_has_stalled(goal: SessionGoal) -> bool:
-    """True when a checklist goal has used two turns without completing any item."""
-    return bool(goal.checklist) and not goal.completed and goal.turns_used >= _NO_PROGRESS_TURNS
+    """True when a checklist goal has gone two turns without a new tick."""
+    if not goal.checklist or goal.checklist_complete:
+        return False
+    return goal.turns_used - goal.last_progress_turns_used >= _NO_PROGRESS_TURNS
 
 
 def pause_for_no_progress(
     session: Any, active: SessionGoal, on_progress: ProgressFn | None
 ) -> SessionGoal:
-    """Pause a stalled goal and open a menu with the ways forward.
+    """Pause a stalled goal; the shell also opens a menu with the ways forward.
 
-    Two full turns with nothing ticked off means repeating the same steps to
-    the budget; instead the shell asks: one more turn, stop, or typed guidance
-    (the custom row), which reaches the model as an ordinary answer.
+    Two full turns without a new tick means repeating the same steps to the
+    budget. The interactive shell asks: one more turn, stop, or typed guidance
+    (the custom row). Headless hosts have no ``/choose`` handler, so they only
+    pause and return.
     """
     paused = active.with_status(SessionGoalStatus.PAUSED).with_reason(
         SessionGoalReason.PAUSED_NO_PROGRESS
     )
     paused = _paint(session, paused, on_progress, rederive=False)
     _clear_host_autosubmit(session)
+    if session_terminal(session) is None:
+        return paused
     session.pending_user_choice = PendingUserChoice(
         title=STALL_MENU_TITLE,
         options=(STALL_OPTION_MORE, STALL_OPTION_STOP),

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -211,6 +211,14 @@ def _stash_collapsed_tool_output(session: SessionState, text: str | None) -> Non
         terminal.collapsed_tool_output = text
 
 
+def _preferred_tool_response_texts(result: Any) -> str:
+    texts = [
+        preferred_tool_response_text(tool_result)
+        for _tool_call, tool_result in _generic_tool_results(result)
+    ]
+    return "\n\n".join(text for text in texts if text)
+
+
 def _has_preferred_tool_response_text(result: Any) -> bool:
     return any(
         bool(preferred_tool_response_text(tool_result))
@@ -714,6 +722,11 @@ def _compose_response(
     if already_inline and terminal is not None:
         terminal.inline_tool_results = False
         display_generic = ""
+    if prefer_tool_response_text and not display_final and not display_generic:
+        # A tool that ships its own reply text (a schedule card, a report
+        # summary) is the closing when the model's is dropped for it; otherwise
+        # the turn ends with nothing visible after the call list.
+        display_final = _preferred_tool_response_texts(result)
     is_json = looks_like_json(generic_text)
     body, markers = split_output_truncation_markers(display_generic)
     truncated = bool(markers)

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -12,6 +12,7 @@ as the next user message so the agent receives the decision verbatim.
 from __future__ import annotations
 
 from rich.console import Console
+from rich.markup import escape
 
 from core.agent_harness.spi.handoff import format_ask_user_answers
 from infrastructure.terminal import theme as ui_theme
@@ -75,6 +76,14 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         session.terminal.awaiting_handoff_answer = False
         return True
 
+    command = pending.commands.get(picked_one) or (picked_one if picked_one.startswith("/") else "")
+    if command:
+        # A mapped option, or a slash command typed into the custom row, is a
+        # command the shell runs, not an answer for the model.
+        console.print(f"[{ui_theme.DIM}]Running {escape(command)}.[/]")
+        session.terminal.awaiting_handoff_answer = False
+        session.terminal.set_auto_command(command)
+        return True
     render_choice_selection(console, items[0].title, picked_one)
     # The answer travels with its question, as the batched wizard's does: a bare
     # label such as "owner/repo (757 commits, CI configured)" reads to the

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -36,7 +36,13 @@ def goal_paint_text(goal: SessionGoal, session: Session) -> str:
     Every outer turn used to reprint condition, reason, and the whole
     checklist; with nothing ticked off, that read as the same screen four times.
     """
-    signature = (goal.status, goal.completed, len(goal.checklist), goal.condition)
+    signature = (
+        goal.status,
+        goal.completed,
+        len(goal.checklist),
+        goal.condition,
+        goal.started_at,
+    )
     terminal = session.terminal
     if terminal.goal_paint_signature == signature and goal.status == "active":
         return format_session_goal_status_line(goal, session=session)

--- a/surfaces/interactive_shell/runtime/shell_turn_execution.py
+++ b/surfaces/interactive_shell/runtime/shell_turn_execution.py
@@ -17,6 +17,7 @@ from core.agent_harness import (
 from core.agent_harness.spi.session_goal import (
     SessionGoal,
     format_session_goal_progress,
+    format_session_goal_status_line,
 )
 from core.tool import ToolExecutionHooks
 from infrastructure.turn_host.turn_output import TurnOutput
@@ -27,6 +28,20 @@ from surfaces.interactive_shell.runtime.shell_agent import shell_agent_build_con
 from surfaces.interactive_shell.session import Session
 from surfaces.interactive_shell.telemetry import PromptRecorder
 from surfaces.shared.terminal.components.rendering import print_repl_text
+
+
+def goal_paint_text(goal: SessionGoal, session: Session) -> str:
+    """The full goal block when something changed, else one status line.
+
+    Every outer turn used to reprint condition, reason, and the whole
+    checklist; with nothing ticked off, that read as the same screen four times.
+    """
+    signature = (goal.status, goal.completed, len(goal.checklist), goal.condition)
+    terminal = session.terminal
+    if terminal.goal_paint_signature == signature and goal.status == "active":
+        return format_session_goal_status_line(goal, session=session)
+    terminal.goal_paint_signature = signature
+    return format_session_goal_progress(goal, session=session)
 
 
 def execute_shell_turn(
@@ -63,7 +78,7 @@ def execute_shell_turn(
         )
 
     def _on_progress(goal: SessionGoal) -> None:
-        rendered = format_session_goal_progress(goal, session=session)
+        rendered = goal_paint_text(goal, session)
         if rendered:
             # Checklist uses ``[x]`` / ``[ ]`` — Rich markup must stay off.
             # CRLF under patch_stdout(raw=True) so rows do not staircase.

--- a/surfaces/interactive_shell/session/terminal_session.py
+++ b/surfaces/interactive_shell/session/terminal_session.py
@@ -132,6 +132,8 @@ class TerminalSession:
     submitted prompt is painted so the answer uses the brand colour."""
 
     pending_choice_response: str | None = None
+    goal_paint_signature: tuple[object, ...] | None = None
+    """What the last session-goal block showed; unchanged goals repaint as one line."""
     """Selected label while its synthetic answer turn awaits a response.
 
     The response composer consumes the label to hide a pure acknowledgement

--- a/surfaces/interactive_shell/ui/action_rendering.py
+++ b/surfaces/interactive_shell/ui/action_rendering.py
@@ -373,6 +373,7 @@ class ActionRenderObserver:
         self.message = message
         self.planned_count = 0
         self._pending_skill_calls: dict[str, str] = {}
+        self._last_skill_header: str = ""
         self._pending_result_tools: set[str] = set()
 
     def __call__(self, kind: str, data: dict[str, Any]) -> None:
@@ -515,6 +516,7 @@ class ActionRenderObserver:
         raw_name = str(args.get("name", "")).strip() if isinstance(args, dict) else ""
         slug = strip_terminal_controls(raw_name.replace("_", "-").lower()) or "skill"
         self._pending_skill_calls[str(data.get("id") or "")] = slug
+        self._last_skill_header = slug
         # ``Text`` renders the (model-supplied) skill name literally — never
         # through Rich markup.
         line = Text()
@@ -564,11 +566,16 @@ class ActionRenderObserver:
         The next block (another call, a note, or the ``Ω`` reply) opens with
         its own blank line — do not add one here or the gap doubles.
         """
-        if self._pending_skill_calls.pop(str(data.get("id") or ""), None) is None:
+        slug = self._pending_skill_calls.pop(str(data.get("id") or ""), None)
+        if slug is None:
             return
         output = data.get("output")
         activated = isinstance(output, dict) and bool(output.get("ok"))
-        label = "Skill activated" if activated else "Skill failed to load"
+        # Several skills loading in one batch print their headers first and
+        # their results after; name the skill whenever the line would land
+        # under another skill's header.
+        subject = "Skill" if slug == self._last_skill_header else slug
+        label = f"{subject} activated" if activated else f"{subject} failed to load"
         self.console.print(Text(f"  ↳ {label}", style=DIM))
 
 

--- a/tests/core/agent/orchestration/test_quiet_shell_display.py
+++ b/tests/core/agent/orchestration/test_quiet_shell_display.py
@@ -531,3 +531,20 @@ def test_plan_snapshots_are_stripped_from_the_reply() -> None:
     assert "Repository: /Users/x/opensre" in shown
     assert "Plan ·" not in shown
     assert "✓ Inspect path" not in shown
+
+
+def test_tool_reply_text_is_shown_when_the_model_closing_is_dropped_for_it() -> None:
+    # Arrange: the observer already nested results inline and the tool carries
+    # its own reply (a schedule card); the model's closing is dropped for it.
+    card = "Scheduled: CI reliability check · o/r\nRuns weekdays at 08:00 UTC."
+    call = ToolCall(id="1", name="schedule_ci_reliability_loop", input={"owner": "o", "repo": "r"})
+    result = _Result(tool_results=[(call, _ToolResult(_payload(card)))], final_text="Done.")
+    session = _Session()
+    session.terminal.inline_tool_results = True  # type: ignore[attr-defined]
+
+    # Act
+    _response_text, display_chunks, _use_final_text = _compose_response(result, session, _counts(1))
+
+    # Assert: the card is the visible closing, not an empty turn.
+    shown = "\n".join(display_chunks)
+    assert "Scheduled: CI reliability check" in shown

--- a/tests/core/agent_harness/session_goal/test_persist.py
+++ b/tests/core/agent_harness/session_goal/test_persist.py
@@ -17,6 +17,7 @@ from core.agent_harness.session_goal.persist import (
     session_goal_state_snapshot,
     session_goal_to_payload,
 )
+from core.agent_harness.session_goal.run_until import goal_has_stalled
 
 
 def test_session_goal_round_trips_through_payload() -> None:
@@ -48,6 +49,23 @@ def test_paused_session_goal_round_trips_through_payload() -> None:
     assert restored == goal
     assert restored is not None
     assert restored.status == SessionGoalStatus.PAUSED
+
+
+def test_legacy_payload_starts_the_stall_clock_at_restored_turns() -> None:
+    restored = session_goal_from_payload(
+        {
+            "condition": "finish checklist",
+            "max_outer_turns": 5,
+            "status": SessionGoalStatus.ACTIVE,
+            "turns_used": 3,
+            "checklist": ["a", "b", "c"],
+            "completed": [0],
+        }
+    )
+
+    assert restored is not None
+    assert restored.last_progress_turns_used == 3
+    assert goal_has_stalled(restored) is False
 
 
 def test_session_goal_state_snapshot_includes_cta_and_pending() -> None:

--- a/tests/core/agent_harness/session_goal/test_persist.py
+++ b/tests/core/agent_harness/session_goal/test_persist.py
@@ -28,6 +28,7 @@ def test_session_goal_round_trips_through_payload() -> None:
         step_count=3,
         checklist=("a", "b", "c"),
         completed=frozenset({0}),
+        last_progress_turns_used=2,
         last_reason="checklist 1/3 done — next: b",
     )
     restored = session_goal_from_payload(session_goal_to_payload(goal))

--- a/tests/core/agent_harness/session_goal/test_plan_credit.py
+++ b/tests/core/agent_harness/session_goal/test_plan_credit.py
@@ -1,0 +1,84 @@
+"""The goal checklist is credited from completed plan steps, and a stalled goal pauses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.agent_harness.session_goal.goal import SessionGoal
+from core.agent_harness.session_goal.plan_credit import credit_completed_plan_steps
+from core.agent_harness.session_goal.run_until import (
+    STALL_OPTION_MORE,
+    STALL_OPTION_STOP,
+    goal_has_stalled,
+    pause_for_no_progress,
+)
+from core.agent_harness.task_plan.plan import PlanStep, PlanStepStatus, TaskPlan
+
+
+def _goal(*items: str, turns_used: int = 0, completed: frozenset[int] = frozenset()) -> SessionGoal:
+    return SessionGoal(
+        condition="Report failing CI checks, then set up a recurring check",
+        checklist=tuple(items),
+        completed=completed,
+        turns_used=turns_used,
+        max_outer_turns=6,
+    )
+
+
+def _session_with_plan(*steps: tuple[str, PlanStepStatus]) -> Any:
+    plan = TaskPlan(steps=tuple(PlanStep(step=text, status=status) for text, status in steps))
+    return type("Session", (), {"task_plan": plan})()
+
+
+def test_completed_plan_steps_tick_the_matching_checklist_items() -> None:
+    # Arrange: the plan lists the checklist's steps, two of them done.
+    goal = _goal(
+        "Summarize failing PR checks with links",
+        "Create an interactive repair handoff",
+        "Set a weekday 8:00 AM read-only recurring check",
+    )
+    session = _session_with_plan(
+        ("Summarize failing PR checks with links", PlanStepStatus.COMPLETED),
+        ("Create an interactive repair handoff", PlanStepStatus.COMPLETED),
+        ("Set weekday 8:00 AM recurring check", PlanStepStatus.IN_PROGRESS),
+    )
+
+    # Act
+    credited = credit_completed_plan_steps(goal, session)
+
+    # Assert: exact and near matches count, the unfinished step does not.
+    assert credited.completed == frozenset({0, 1})
+
+
+def test_goal_without_a_plan_or_checklist_is_untouched() -> None:
+    goal = _goal("Summarize failing PR checks with links")
+    assert credit_completed_plan_steps(goal, type("S", (), {})()) is goal
+    assert credit_completed_plan_steps(_goal(), _session_with_plan()) == _goal()
+
+
+def test_goal_stalls_after_two_turns_without_a_tick_and_not_otherwise() -> None:
+    assert goal_has_stalled(_goal("a", "b", turns_used=2)) is True
+    assert goal_has_stalled(_goal("a", "b", turns_used=1)) is False
+    assert goal_has_stalled(_goal("a", "b", turns_used=3, completed=frozenset({0}))) is False
+    assert goal_has_stalled(_goal(turns_used=4)) is False
+
+
+def test_a_stalled_goal_pauses_and_offers_the_ways_forward_as_a_menu() -> None:
+    # Arrange: a shell-like session that records what the pause queues.
+    from surfaces.interactive_shell.session import Session
+
+    session = Session()
+    painted: list[SessionGoal] = []
+
+    # Act
+    paused = pause_for_no_progress(session, _goal("a", "b", turns_used=2), painted.append)
+
+    # Assert: paused with a plain reason, menu queued, its options run goal commands.
+    assert paused.status == "paused"
+    assert "no checklist progress" in paused.last_reason
+    assert painted and painted[-1].status == "paused"
+    choice = session.pending_user_choice
+    assert choice is not None
+    assert choice.options == (STALL_OPTION_MORE, STALL_OPTION_STOP)
+    assert choice.commands == {STALL_OPTION_MORE: "/goal resume", STALL_OPTION_STOP: "/goal clear"}
+    assert session.terminal.pending_prompt_default == "/choose"

--- a/tests/core/agent_harness/session_goal/test_plan_credit.py
+++ b/tests/core/agent_harness/session_goal/test_plan_credit.py
@@ -15,12 +15,18 @@ from core.agent_harness.session_goal.run_until import (
 from core.agent_harness.task_plan.plan import PlanStep, PlanStepStatus, TaskPlan
 
 
-def _goal(*items: str, turns_used: int = 0, completed: frozenset[int] = frozenset()) -> SessionGoal:
+def _goal(
+    *items: str,
+    turns_used: int = 0,
+    completed: frozenset[int] = frozenset(),
+    last_progress_turns_used: int = 0,
+) -> SessionGoal:
     return SessionGoal(
         condition="Report failing CI checks, then set up a recurring check",
         checklist=tuple(items),
         completed=completed,
         turns_used=turns_used,
+        last_progress_turns_used=last_progress_turns_used,
         max_outer_turns=6,
     )
 
@@ -56,11 +62,40 @@ def test_goal_without_a_plan_or_checklist_is_untouched() -> None:
     assert credit_completed_plan_steps(_goal(), _session_with_plan()) == _goal()
 
 
-def test_goal_stalls_after_two_turns_without_a_tick_and_not_otherwise() -> None:
+def test_goal_stalls_after_two_turns_without_a_new_tick() -> None:
     assert goal_has_stalled(_goal("a", "b", turns_used=2)) is True
     assert goal_has_stalled(_goal("a", "b", turns_used=1)) is False
-    assert goal_has_stalled(_goal("a", "b", turns_used=3, completed=frozenset({0}))) is False
+    assert (
+        goal_has_stalled(
+            _goal(
+                "a",
+                "b",
+                turns_used=3,
+                completed=frozenset({0}),
+                last_progress_turns_used=1,
+            )
+        )
+        is True
+    )
+    assert (
+        goal_has_stalled(
+            _goal(
+                "a",
+                "b",
+                turns_used=3,
+                completed=frozenset({0}),
+                last_progress_turns_used=3,
+            )
+        )
+        is False
+    )
     assert goal_has_stalled(_goal(turns_used=4)) is False
+
+
+def test_a_new_tick_records_the_turn_so_later_plateaus_can_stall() -> None:
+    progressed = _goal("a", "b", turns_used=1).with_completed(frozenset({0}))
+    assert progressed.last_progress_turns_used == 1
+    assert goal_has_stalled(progressed) is False
 
 
 def test_a_stalled_goal_pauses_and_offers_the_ways_forward_as_a_menu() -> None:
@@ -82,3 +117,43 @@ def test_a_stalled_goal_pauses_and_offers_the_ways_forward_as_a_menu() -> None:
     assert choice.options == (STALL_OPTION_MORE, STALL_OPTION_STOP)
     assert choice.commands == {STALL_OPTION_MORE: "/goal resume", STALL_OPTION_STOP: "/goal clear"}
     assert session.terminal.pending_prompt_default == "/choose"
+
+
+def test_headless_stall_pauses_without_a_choose_menu() -> None:
+    from core.agent_harness.session import InMemorySessionStore, SessionCore
+
+    session = SessionCore(store=InMemorySessionStore())
+    painted: list[SessionGoal] = []
+
+    paused = pause_for_no_progress(session, _goal("a", "b", turns_used=2), painted.append)
+
+    assert paused.status == "paused"
+    assert painted and painted[-1].status == "paused"
+    assert session.pending_user_choice is None
+
+
+def test_replacing_or_clearing_a_goal_drops_the_prior_plan() -> None:
+    from core.agent_harness.session import InMemorySessionStore, SessionCore
+    from core.agent_harness.session_goal.goal import attach_session_goal, clear_session_goal
+
+    session = SessionCore(store=InMemorySessionStore())
+    first = attach_session_goal(session, _goal("Summarize failing PR checks with links"))
+    leftover = TaskPlan(
+        steps=(
+            PlanStep(
+                step="Summarize failing PR checks with links",
+                status=PlanStepStatus.COMPLETED,
+            ),
+        )
+    )
+    session.task_plan = leftover
+    attach_session_goal(session, first)
+    assert session.task_plan is leftover
+
+    clear_session_goal(session)
+    assert session.task_plan is None
+
+    session.task_plan = leftover
+    attach_session_goal(session, _goal("Summarize failing PR checks with links"))
+    assert session.task_plan is None
+    assert credit_completed_plan_steps(session.session_goal, session).completed == frozenset()

--- a/tests/interactive_shell/runtime/test_goal_paint.py
+++ b/tests/interactive_shell/runtime/test_goal_paint.py
@@ -1,0 +1,42 @@
+"""An unchanged session goal repaints as one line, not the whole block again."""
+
+from __future__ import annotations
+
+from core.agent_harness.session_goal.goal import SessionGoal
+from surfaces.interactive_shell.runtime.shell_turn_execution import goal_paint_text
+from surfaces.interactive_shell.session import Session
+
+
+def _goal(**overrides: object) -> SessionGoal:
+    base: dict[str, object] = {
+        "condition": "Report failing CI checks, then set up a recurring check",
+        "checklist": ("Summarize failing PR checks", "Set a recurring check"),
+        "max_outer_turns": 6,
+        "turns_used": 1,
+        "status": "active",
+    }
+    base.update(overrides)
+    return SessionGoal(**base)  # type: ignore[arg-type]
+
+
+def test_same_goal_paints_the_block_once_then_one_status_line() -> None:
+    session = Session()
+    first = goal_paint_text(_goal(), session)
+    second = goal_paint_text(_goal(turns_used=2), session)
+
+    assert "Checklist:" in first
+    assert "Checklist:" not in second
+    assert second.count("\n") == 0
+
+
+def test_progress_or_status_change_paints_the_full_block_again() -> None:
+    session = Session()
+    goal_paint_text(_goal(), session)
+
+    ticked = goal_paint_text(_goal(turns_used=2, completed=frozenset({0})), session)
+    paused = goal_paint_text(
+        _goal(turns_used=3, completed=frozenset({0}), status="paused"), session
+    )
+
+    assert "[x] 1." in ticked
+    assert "Checklist:" in paused

--- a/tests/interactive_shell/runtime/test_goal_paint.py
+++ b/tests/interactive_shell/runtime/test_goal_paint.py
@@ -40,3 +40,12 @@ def test_progress_or_status_change_paints_the_full_block_again() -> None:
 
     assert "[x] 1." in ticked
     assert "Checklist:" in paused
+
+
+def test_a_new_goal_with_the_same_shape_paints_the_full_block() -> None:
+    session = Session()
+    goal_paint_text(_goal(started_at=1.0), session)
+
+    painted = goal_paint_text(_goal(started_at=2.0), session)
+
+    assert "Checklist:" in painted

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -186,6 +186,45 @@ def test_batch_custom_option_is_captured_inline_and_auto_submitted(
     )
 
 
+def test_slash_command_typed_into_the_menu_runs_as_a_command_not_an_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange: the user types a slash command into the custom row.
+    session = Session()
+    session.pending_user_choice = _CHOICE
+    console, buf = _console()
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(choice_prompt, "repl_choose_one", lambda **_kw: "/loops messages")
+
+    # Act
+    assert _handler(session, console) is True
+
+    # Assert: the menu closes, the command runs, nothing is handed to the model as an answer.
+    assert session.terminal.pending_prompt_default == "/loops messages"
+    assert session.terminal.awaiting_handoff_answer is False
+    assert "Running /loops messages" in buf.getvalue()
+
+
+def test_option_mapped_to_a_command_runs_that_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    from core.agent_harness.session.pending_choice import PendingUserChoice
+
+    session = Session()
+    session.pending_user_choice = PendingUserChoice(
+        title="How should I continue?",
+        options=("Keep going", "Stop here"),
+        commands={"Stop here": "/goal clear"},
+    )
+    console, buf = _console()
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(choice_prompt, "repl_choose_one", lambda **_kw: "Stop here")
+
+    assert _handler(session, console) is True
+
+    assert session.terminal.pending_prompt_default == "/goal clear"
+    assert session.terminal.awaiting_handoff_answer is False
+    assert "Running /goal clear" in buf.getvalue()
+
+
 def test_single_choice_types_custom_in_place(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/interactive_shell/ui/test_action_rendering.py
+++ b/tests/interactive_shell/ui/test_action_rendering.py
@@ -158,6 +158,28 @@ def test_skill_view_renders_activation_event() -> None:
     assert buffer.getvalue() == "\nSkill install-code-review\n  ↳ Skill activated\n"
 
 
+def test_two_skills_in_one_batch_name_the_skill_on_each_activation_line() -> None:
+    """Headers print first, results after; the first skill's line must say which skill."""
+    observer, buffer = _skill_observer()
+    for call_id, name in (("t1", "github_ci_health"), ("t2", "github_ci_fix_onboarding")):
+        observer("tool_start", {"id": call_id, "name": "skill_view", "input": {"name": name}})
+    for call_id, name in (("t1", "github-ci-health"), ("t2", "github-ci-fix-onboarding")):
+        observer(
+            "tool_end",
+            {
+                "id": call_id,
+                "name": "skill_view",
+                "input": {"name": name},
+                "output": {"ok": True, "name": name, "content": "<body>"},
+            },
+        )
+
+    assert buffer.getvalue() == (
+        "\nSkill github-ci-health\n\nSkill github-ci-fix-onboarding\n"
+        "  ↳ github-ci-health activated\n  ↳ Skill activated\n"
+    )
+
+
 def test_skill_view_renders_bold_green_skill_label() -> None:
     console = Mock(spec=Console)
     observer = ActionRenderObserver(session=Session(), console=console, message="run code review")


### PR DESCRIPTION
A typed request with two parts ("report failing checks, then set up a
recurring check") runs as a session goal. In practice the goal's checklist
never got a tick while the per-turn plan showed every step done, so the
loop repeated the same work for six turns, reprinted the full goal block
each time, and ended "budget exhausted". Along the way a slash command
typed into an open menu was taken as the answer.

- **Checklist credit from the plan.** Completed `update_plan` steps mark
  matching checklist items done (normalized text match), so a goal whose
  steps the plan completed closes instead of repeating them.
- **Stall pause with options.** Two turns without a tick pause the goal and
  open a menu: keep going one more turn (`/goal resume`), stop here
  (`/goal clear`), or type guidance. Menu options can now carry a slash
  command the shell runs directly (`PendingUserChoice.commands`).
- **One-line repaint.** An unchanged active goal prints one status line;
  the full block returns when a tick, a pause, or the end changes it.
- **Menus and commands.** A slash command typed into the custom row runs as
  a command rather than being handed to the model as the chosen option.