### PR TITLE
fix(shell): open the shell on a configured provider without an account

### DIFF
--- a/config/account.py
+++ b/config/account.py
@@ -200,6 +200,11 @@ def ignore_account_llm_route() -> None:
     os.environ[OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV] = "1"
 
 
+def restore_account_llm_route() -> None:
+    """Re-enable the hosted route after a login replaces the rejected session."""
+    os.environ.pop(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, None)
+
+
 def account_llm_route() -> AccountLLMRoute | None:
     """Return the hosted OpenAI route only when account metadata and token exist.
 
@@ -224,6 +229,7 @@ __all__ = [
     "AccountLLMRoute",
     "account_llm_route",
     "ignore_account_llm_route",
+    "restore_account_llm_route",
     "account_metadata_path",
     "delete_account_record",
     "delete_account_token",

--- a/config/account.py
+++ b/config/account.py
@@ -20,6 +20,7 @@ from config.constants.account import (
     OPENSRE_ACCOUNT_TOKEN_ENV,
     OPENSRE_APP_URL_DEFAULT,
     OPENSRE_APP_URL_ENV,
+    OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV,
 )
 from config.constants.paths import host_home
 from config.secrets.store import (
@@ -194,8 +195,21 @@ def delete_account_token() -> None:
     delete_secret(OPENSRE_ACCOUNT_TOKEN_ENV)
 
 
+def ignore_account_llm_route() -> None:
+    """Drop the hosted route for this process; the user chose their own model."""
+    os.environ[OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV] = "1"
+
+
 def account_llm_route() -> AccountLLMRoute | None:
-    """Return the hosted OpenAI route only when account metadata and token exist."""
+    """Return the hosted OpenAI route only when account metadata and token exist.
+
+    A session the webapp rejected or could not validate still leaves its record
+    and token on disk, so the route outlives the sign-in it came from. Callers
+    that let the user pick a local provider instead first call
+    :func:`ignore_account_llm_route`.
+    """
+    if os.getenv(OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV, "").strip():
+        return None
     record = load_account_record()
     if record is None or record.llm_provider != "openai" or not resolve_account_token():
         return None
@@ -209,6 +223,7 @@ __all__ = [
     "AccountRecord",
     "AccountLLMRoute",
     "account_llm_route",
+    "ignore_account_llm_route",
     "account_metadata_path",
     "delete_account_record",
     "delete_account_token",

--- a/config/constants/__init__.py
+++ b/config/constants/__init__.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
     from config.constants.account import (
         OPENSRE_APP_URL_ENV as OPENSRE_APP_URL_ENV,
     )
+    from config.constants.account import (
+        OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV as OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV,
+    )
     from config.constants.alertmanager import (
         ALERTMANAGER_BEARER_TOKEN_ENV as ALERTMANAGER_BEARER_TOKEN_ENV,
     )

--- a/config/constants/account.py
+++ b/config/constants/account.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 OPENSRE_ACCOUNT_FILENAME = "account.json"
 OPENSRE_ACCOUNT_METADATA_PATH_ENV = "OPENSRE_ACCOUNT_METADATA_PATH"
 OPENSRE_ACCOUNT_TOKEN_ENV = "OPENSRE_ACCOUNT_TOKEN"
+#: Set for this process when the user chooses their own model over a stored
+#: hosted route, so an expired or unreachable session cannot silently win.
+OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV = "OPENSRE_IGNORE_ACCOUNT_ROUTE"
 OPENSRE_ACCOUNT_LLM_BASE_PATH = "/api/llm/v1"
 OPENSRE_ACCOUNT_LOGIN_PATH = "/cli/auth/start"
 OPENSRE_ACCOUNT_LOGIN_SUCCESS_PATH = "/cli/auth/success"
@@ -25,6 +28,7 @@ __all__ = [
     "OPENSRE_ACCOUNT_EXCHANGE_PATH",
     "OPENSRE_ACCOUNT_HTTP_TIMEOUT_SECONDS",
     "OPENSRE_ACCOUNT_TOKEN_ENV",
+    "OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV",
     "OPENSRE_ACCOUNT_SESSION_PATH",
     "OPENSRE_ACCOUNT_USAGE_PATH",
     "OPENSRE_APP_URL_DEFAULT",

--- a/config/constants/exports.py
+++ b/config/constants/exports.py
@@ -19,6 +19,7 @@ EXPORTS: dict[str, str] = {
     "OPENSRE_APP_URL_DEFAULT": "account",
     "OPENSRE_APP_URL_DEV": "account",
     "OPENSRE_APP_URL_ENV": "account",
+    "OPENSRE_IGNORE_ACCOUNT_ROUTE_ENV": "account",
     # analytics
     "ANALYTICS_DISABLED_ENV": "analytics",
     "ANALYTICS_EVENT_SCHEMA_VERSION": "analytics",

--- a/config/llm_settings.py
+++ b/config/llm_settings.py
@@ -98,6 +98,7 @@ __all__ = (
     "get_configured_llm_provider",
     "get_llm_provider_api_key_env",
     "has_credentials_for_active_llm_provider",
+    "has_user_configured_llm_provider",
     "llm_provider_error_context",
     "resolve_llm_settings",
     "resolve_llm_settings_verbose",
@@ -486,4 +487,20 @@ def has_credentials_for_active_llm_provider() -> bool:
     """Return prompt-safe auth availability for the configured LLM provider."""
     settings = resolve_llm_settings()
     auth_status = credential_status(settings.provider)
+    return auth_status.configured and not auth_status.stale
+
+
+def has_user_configured_llm_provider() -> bool:
+    """Return whether the user picked their own LLM provider and it has credentials.
+
+    "Own" means ``LLM_PROVIDER`` is set explicitly, in the environment or the
+    persisted ``.env`` the wizard writes. The built-in default provider does not
+    count, so a fresh install reports False and callers cannot mistake it for a
+    deliberate choice.
+    """
+    bootstrap_opensre_env(override=False)
+    provider = os.getenv(LLM_PROVIDER_ENV, "").strip().lower()
+    if not provider:
+        return False
+    auth_status = credential_status(provider)
     return auth_status.configured and not auth_status.stale

--- a/config/llm_settings.py
+++ b/config/llm_settings.py
@@ -499,8 +499,14 @@ def has_user_configured_llm_provider() -> bool:
     deliberate choice.
     """
     bootstrap_opensre_env(override=False)
-    provider = os.getenv(LLM_PROVIDER_ENV, "").strip().lower()
-    if not provider:
+    if not os.getenv(LLM_PROVIDER_ENV, "").strip():
         return False
-    auth_status = credential_status(provider)
+    try:
+        settings = resolve_llm_settings()
+    except Exception:
+        # Credentials alone do not make a provider usable: azure-openai needs an
+        # endpoint, vertex-ai a project. Resolving here keeps callers from
+        # offering a route that fails on the first turn.
+        return False
+    auth_status = credential_status(settings.provider)
     return auth_status.configured and not auth_status.stale

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -60,8 +60,9 @@ description: "Common questions about OpenSRE."
 
   <Accordion title="What happens when I run opensre with no arguments?">
     Running `opensre` validates your OpenSRE account, then starts the interactive
-    shell. You can exit and stay signed out, but an inactive account cannot enter
-    the shell. Once signed in, you can describe issues in plain language. Slash
+    shell. Without an account you can still enter the shell on your own model, as
+    long as you configured a provider first (`opensre onboard local_llm` for a
+    local Ollama model). Once signed in, you can describe issues in plain language. Slash
     commands such as `/help`, `/status`, and `/verify datadog` are documented in
     [Shell commands](/interactive-shell-commands).
   </Accordion>

--- a/docs/install-local.mdx
+++ b/docs/install-local.mdx
@@ -69,7 +69,7 @@ When developing the webapp locally on port 3000, use:
 opensre setup --dev
 ```
 
-To remain signed out, cancel setup or choose **Exit and stay signed out** when `opensre` shows the account gate. Other CLI commands remain available; the interactive shell does not.
+To remain signed out, cancel setup or choose **Exit and stay signed out** when `opensre` shows the account gate. Other CLI commands remain available. The shell itself opens signed out only when you configured your own provider, which the gate then offers as **Continue with my own model**.
 
 ## 3. Open the shell
 

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -10,7 +10,7 @@ This page gets the `opensre` command onto your laptop or server, then walks you 
 After install, you have:
 
 - The `opensre` CLI on your PATH
-- An account-gated interactive shell when you run `opensre` with no arguments
+- An account-gated interactive shell when you run `opensre` with no arguments, or a signed-out shell on your own model once you configure a provider
 - A short webapp sign-in that also activates the OpenSRE-hosted model
 
 No sudo required on macOS/Linux in the usual case — the installer puts the binary somewhere writable (often `~/.local/bin`) and tells you if you need a PATH tweak.
@@ -106,6 +106,7 @@ Full walkthrough with GIFs: [Quickstart](/quickstart).
 
 - **Command not found** — open a new terminal, or add the bin directory the installer printed to your PATH
 - **The shell keeps asking you to sign in** — run `opensre account status`; expired, revoked, incomplete, or unreachable sessions do not open the shell
+- **You want a local model instead of the hosted one** — run `opensre onboard local_llm`, then `opensre account logout`; the sign-in screen then offers "Continue with my own model"
 - **Docker / `make` missing** — see [Quickstart troubleshooting](/quickstart#troubleshooting)
 
 Need deploy options beyond a laptop binary? See [Deployment](/deployment).

--- a/docs/interactive-shell-commands.mdx
+++ b/docs/interactive-shell-commands.mdx
@@ -566,7 +566,7 @@ MCP-capable integrations only (subset of the full integration catalog).
 
 <Accordion title="/model">
 
-Show the active hosted model. An authenticated interactive shell is account-managed, so local provider/model changes are locked until sign-out; signing out closes the shell.
+Show the active hosted model. An authenticated interactive shell is account-managed, so local provider/model changes are locked until sign-out. To run your own model, configure a provider first (`opensre onboard local_llm` for Ollama), then sign out. `/account logout` keeps the shell open on that provider, and the startup sign-in screen offers "Continue with my own model".
 
 ```text
 /model show
@@ -826,7 +826,7 @@ These spawn `opensre …` subprocesses. Output is captured into the REPL buffer 
 /account logout
 ```
 
-Sign in to a personal OpenSRE account, inspect the local login, open the credits and top-up page (`/account usage`, opens your browser; from a chat it replies with the link), or sign out. Same as `opensre account`. The browser opens the OpenSRE sign-up page, where you can use email or any enabled sign-in provider. The shell starts only for an `active` account state. `/account logout` revokes the saved session, invalidates the hosted-model route, and closes the shell before another turn. If `OPENSRE_ACCOUNT_TOKEN` is set in the environment, it overrides the token saved by login until you unset it.
+Sign in to a personal OpenSRE account, inspect the local login, open the credits and top-up page (`/account usage`, opens your browser; from a chat it replies with the link), or sign out. Same as `opensre account`. The browser opens the OpenSRE sign-up page, where you can use email or any enabled sign-in provider. The shell starts only for an `active` account state. `/account logout` revokes the saved session and invalidates the hosted-model route. The shell then closes, unless you configured your own LLM provider, in which case it stays open on that provider. If `OPENSRE_ACCOUNT_TOKEN` is set in the environment, it overrides the token saved by login until you unset it.
 
 </Accordion>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -85,7 +85,7 @@ slug: "quickstart"
   <Step title="Ask your first question">
     Choose either path — both use the same local `opensre` binary:
 
-    **Interactive prompt shell** — start OpenSRE with no arguments (TTY). The shell opens only after the webapp validates your account; choosing **Exit and stay signed out** leaves account-independent CLI commands available:
+    **Interactive prompt shell** — start OpenSRE with no arguments (TTY). The shell opens after the webapp validates your account, or on your own configured provider via **Continue with my own model**; choosing **Exit and stay signed out** leaves account-independent CLI commands available:
 
     ```bash
     opensre
@@ -147,4 +147,4 @@ opensre uninstall --yes
 - **Docker is not running**: Start Docker Desktop, OrbStack, or Colima before running setup.
 - **`make` is missing**: Install it via your package manager (`brew install make` on macOS, `choco install make` on Windows).
 - **The shell does not open after login**: Run `opensre account status`. The webapp must be reachable and the stored account token and metadata must both be valid.
-- **You want to stay signed out**: Choose **Exit and stay signed out** at startup. Commands such as `opensre account`, `opensre doctor`, and `opensre integrations` remain available, but the interactive shell stays closed.
+- **You want to stay signed out**: Choose **Exit and stay signed out** at startup. Commands such as `opensre account`, `opensre doctor`, and `opensre integrations` remain available, and the shell stays closed unless you configured your own provider and pick **Continue with my own model**.

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -258,8 +258,14 @@ def _cmd_account(session: Session, console: Console, args: list[str]) -> bool:  
     )
     if subcommand == "logout" and session_terminal(session) is not None:
         from config.account import account_llm_route
+        from config.llm_settings import has_user_configured_llm_provider
 
         if account_llm_route() is None:
+            # Logging out to reach a local model is the documented route off the
+            # hosted lock, so keep the shell open when the user has a provider.
+            if has_user_configured_llm_provider():
+                console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
+                return handled
             console.print(f"[{DIM}]Signed out. Closing the interactive shell.[/]")
             return False
     return handled

--- a/surfaces/interactive_shell/command_registry/cli_parity.py
+++ b/surfaces/interactive_shell/command_registry/cli_parity.py
@@ -256,6 +256,14 @@ def _cmd_account(session: Session, console: Console, args: list[str]) -> bool:  
     handled = run_cli_command(
         console, ["account", *cli_args], capture_output=capture_output, session=session
     )
+    if subcommand == "login" and handled:
+        from config.account import restore_account_llm_route
+        from surfaces.shared.account_session import account_status
+
+        if account_status().authenticated:
+            # A signed-in shell is hosted-routed again, even if the user entered
+            # it earlier by choosing their own model.
+            restore_account_llm_route()
     if subcommand == "logout" and session_terminal(session) is not None:
         from config.account import account_llm_route
         from config.llm_settings import has_user_configured_llm_provider

--- a/surfaces/interactive_shell/command_registry/model/switching.py
+++ b/surfaces/interactive_shell/command_registry/model/switching.py
@@ -16,6 +16,7 @@ from surfaces.shared.terminal.components.choice_menu import print_valid_choice_l
 def _account_model_change_is_locked(console: Console) -> bool:
     """Explain and enforce the hosted model lock for signed-in accounts."""
     from config.account import account_llm_route
+    from config.llm_settings import has_user_configured_llm_provider
 
     route = account_llm_route()
     if route is None:
@@ -28,6 +29,13 @@ def _account_model_change_is_locked(console: Console) -> bool:
         f"[{DIM}]Run[/] [bold]opensre account logout[/bold] "
         f"[{DIM}]before configuring a different provider or model.[/]"
     )
+    if not has_user_configured_llm_provider():
+        # Logging out with no provider of your own leaves no way back into the
+        # shell, so name the command that configures one first.
+        console.print(
+            f"[{DIM}]Set one up first with[/] [bold]opensre onboard local_llm[/bold] "
+            f"[{DIM}]for a local Ollama model.[/]"
+        )
     return True
 
 

--- a/surfaces/interactive_shell/runtime/startup/account_gate.py
+++ b/surfaces/interactive_shell/runtime/startup/account_gate.py
@@ -20,6 +20,13 @@ def account_is_signed_in() -> bool:
     return account_status().authenticated
 
 
+def own_llm_provider_configured() -> bool:
+    """Return whether a user-selected LLM provider can serve the shell signed out."""
+    from config.llm_settings import has_user_configured_llm_provider
+
+    return has_user_configured_llm_provider()
+
+
 def account_login(*, console: Console | None = None) -> bool:
     """Run the canonical webapp login command and verify its resulting session."""
     from infrastructure.terminal.theme import ERROR
@@ -60,11 +67,13 @@ def pass_sign_in_gate(console: Console) -> bool:
         console,
         is_signed_in=account_is_signed_in,
         login=_login,
+        has_own_provider=own_llm_provider_configured,
     )
 
 
 __all__ = [
     "account_is_signed_in",
     "account_login",
+    "own_llm_provider_configured",
     "pass_sign_in_gate",
 ]

--- a/surfaces/interactive_shell/runtime/startup/account_gate.py
+++ b/surfaces/interactive_shell/runtime/startup/account_gate.py
@@ -27,6 +27,13 @@ def own_llm_provider_configured() -> bool:
     return has_user_configured_llm_provider()
 
 
+def use_own_llm_provider() -> None:
+    """Drop a stored hosted route so the user's own provider serves this shell."""
+    from config.account import ignore_account_llm_route
+
+    ignore_account_llm_route()
+
+
 def account_login(*, console: Console | None = None) -> bool:
     """Run the canonical webapp login command and verify its resulting session."""
     from infrastructure.terminal.theme import ERROR
@@ -68,6 +75,7 @@ def pass_sign_in_gate(console: Console) -> bool:
         is_signed_in=account_is_signed_in,
         login=_login,
         has_own_provider=own_llm_provider_configured,
+        on_own_provider=use_own_llm_provider,
     )
 
 
@@ -76,4 +84,5 @@ __all__ = [
     "account_login",
     "own_llm_provider_configured",
     "pass_sign_in_gate",
+    "use_own_llm_provider",
 ]

--- a/surfaces/interactive_shell/runtime/startup/account_gate.py
+++ b/surfaces/interactive_shell/runtime/startup/account_gate.py
@@ -54,7 +54,13 @@ def account_login(*, console: Console | None = None) -> bool:
         if console is not None:
             console.print(f"[{ERROR}]OpenSRE account sign-in did not complete.[/]")
         return False
-    return account_is_signed_in()
+    if not account_is_signed_in():
+        return False
+    # This login supersedes any earlier own-model choice in this process.
+    from config.account import restore_account_llm_route
+
+    restore_account_llm_route()
+    return True
 
 
 def pass_sign_in_gate(console: Console) -> bool:

--- a/surfaces/interactive_shell/ui/sign_in.py
+++ b/surfaces/interactive_shell/ui/sign_in.py
@@ -81,6 +81,7 @@ def run_sign_in_gate(
     is_signed_in: Callable[[], bool],
     login: Callable[[], bool],
     has_own_provider: Callable[[], bool] = lambda: False,
+    on_own_provider: Callable[[], None] = lambda: None,
 ) -> bool:
     """Gate the REPL behind sign-in; return ``True`` to proceed, ``False`` to exit.
 
@@ -88,8 +89,10 @@ def run_sign_in_gate(
     screen and loops the menu. A user who configured their own LLM provider is
     offered a third choice that enters the shell signed out, which is the only
     way to run a local model: an account session pins the shell to the hosted
-    route. On non-interactive stdin the gate fails closed and prints the command
-    that can establish an account.
+    route. Picking it calls ``on_own_provider``, which drops any stored hosted
+    route so a rejected or unvalidated session cannot override the choice. On
+    non-interactive stdin the gate fails closed and prints the command that can
+    establish an account.
     """
     if is_signed_in():
         return True
@@ -108,6 +111,7 @@ def run_sign_in_gate(
                 return True
             continue  # login failed — offer the choice again
         if choice is SignInChoice.OWN_MODEL:
+            on_own_provider()
             console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
             return True
         return False  # Exit or Esc

--- a/surfaces/interactive_shell/ui/sign_in.py
+++ b/surfaces/interactive_shell/ui/sign_in.py
@@ -24,9 +24,14 @@ from surfaces.shared.terminal.components.choice_menu import repl_choose_one, rep
 
 
 class SignInChoice(enum.StrEnum):
-    """The two actions offered on the forced sign-in screen."""
+    """The actions offered on the forced sign-in screen.
+
+    ``OWN_MODEL`` is offered only when the user already configured their own
+    provider, so a fresh install still sees the two-way sign-in choice.
+    """
 
     LOGIN = "Sign in or create account"
+    OWN_MODEL = "Continue with my own model"
     EXIT = "Exit and stay signed out"
 
 
@@ -52,22 +57,22 @@ def render_sign_in_screen(console: Console) -> None:
     console.print(screen)
 
 
-def prompt_login_or_exit() -> SignInChoice | None:
-    """Show the Login/Exit menu; return the choice, or ``None`` on Esc.
+def prompt_login_or_exit(*, offer_own_model: bool = False) -> SignInChoice | None:
+    """Show the sign-in menu; return the choice, or ``None`` on Esc.
 
     The sign-in prompt is already printed by ``render_sign_in_screen`` above the
     menu, so the menu itself carries no title (avoids repeating the prompt).
     """
+    offered = [SignInChoice.LOGIN]
+    if offer_own_model:
+        offered.append(SignInChoice.OWN_MODEL)
+    offered.append(SignInChoice.EXIT)
     picked = repl_choose_one(
         title="",
-        choices=[(SignInChoice.LOGIN, SignInChoice.LOGIN), (SignInChoice.EXIT, SignInChoice.EXIT)],
+        choices=[(choice, choice) for choice in offered],
         numbered=False,
     )
-    if picked == SignInChoice.LOGIN:
-        return SignInChoice.LOGIN
-    if picked == SignInChoice.EXIT:
-        return SignInChoice.EXIT
-    return None
+    return next((choice for choice in offered if picked == choice), None)
 
 
 def run_sign_in_gate(
@@ -75,12 +80,16 @@ def run_sign_in_gate(
     *,
     is_signed_in: Callable[[], bool],
     login: Callable[[], bool],
+    has_own_provider: Callable[[], bool] = lambda: False,
 ) -> bool:
     """Gate the REPL behind sign-in; return ``True`` to proceed, ``False`` to exit.
 
     Returns immediately when already signed in. Otherwise renders the sign-in
-    screen and loops the sign-in/stay-signed-out menu. On non-interactive stdin
-    the gate fails closed and prints the command that can establish an account.
+    screen and loops the menu. A user who configured their own LLM provider is
+    offered a third choice that enters the shell signed out, which is the only
+    way to run a local model: an account session pins the shell to the hosted
+    route. On non-interactive stdin the gate fails closed and prints the command
+    that can establish an account.
     """
     if is_signed_in():
         return True
@@ -91,12 +100,16 @@ def run_sign_in_gate(
         console.print("Run [bold]opensre account login[/bold] from an interactive terminal.")
         return False
     render_sign_in_screen(console)
+    offer_own_model = has_own_provider()
     while True:
-        choice = prompt_login_or_exit()
+        choice = prompt_login_or_exit(offer_own_model=offer_own_model)
         if choice is SignInChoice.LOGIN:
             if login():
                 return True
             continue  # login failed — offer the choice again
+        if choice is SignInChoice.OWN_MODEL:
+            console.print(f"[{DIM}]Signed out. Using your configured LLM provider.[/]")
+            return True
         return False  # Exit or Esc
 
 

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -166,7 +166,12 @@ def test_ignoring_the_account_route_survives_a_stored_session(
 ) -> None:
     # A rejected or unreachable login keeps its record and token on disk, so the
     # hosted route outlives the sign-in. Choosing a local model must win.
-    from config.account import AccountRecord, account_llm_route, ignore_account_llm_route
+    from config.account import (
+        AccountRecord,
+        account_llm_route,
+        ignore_account_llm_route,
+        restore_account_llm_route,
+    )
 
     record = AccountRecord(
         user_id="u1",
@@ -188,3 +193,9 @@ def test_ignoring_the_account_route_survives_a_stored_session(
     ignore_account_llm_route()
 
     assert account_llm_route() is None
+
+    # A later successful login replaces the rejected session, so the hosted
+    # route has to come back; otherwise the shell stays local until restart.
+    restore_account_llm_route()
+
+    assert account_llm_route() is not None

--- a/tests/config/test_llm_auth.py
+++ b/tests/config/test_llm_auth.py
@@ -159,3 +159,32 @@ def test_resolve_for_request_stales_when_credential_is_genuinely_absent(
     record = resolve_provider_auth_record("deepseek")
     assert record["stale"] == "true"
     assert record["verified"] == "false"
+
+
+def test_ignoring_the_account_route_survives_a_stored_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A rejected or unreachable login keeps its record and token on disk, so the
+    # hosted route outlives the sign-in. Choosing a local model must win.
+    from config.account import AccountRecord, account_llm_route, ignore_account_llm_route
+
+    record = AccountRecord(
+        user_id="u1",
+        email="dev@example.com",
+        app_url="https://app.opensre.com",
+        llm_provider="openai",
+        llm_model="gpt-5.4-mini",
+        organization_id="org1",
+        signed_in_at="2026-09-08T00:00:00Z",
+        token_expires_at="2026-12-08T00:00:00Z",
+    )
+    monkeypatch.setattr("config.account.load_account_record", lambda: record)
+    monkeypatch.setattr("config.account.resolve_account_token", lambda: "token")
+    # setenv (not delenv) so monkeypatch removes the flag this test sets below.
+    monkeypatch.setenv("OPENSRE_IGNORE_ACCOUNT_ROUTE", "")
+
+    assert account_llm_route() is not None
+
+    ignore_account_llm_route()
+
+    assert account_llm_route() is None

--- a/tests/config/test_llm_settings.py
+++ b/tests/config/test_llm_settings.py
@@ -431,3 +431,13 @@ def test_user_configured_provider_ignores_the_built_in_default(monkeypatch) -> N
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
 
     assert has_user_configured_llm_provider() is True
+
+
+def test_user_configured_provider_rejects_settings_that_cannot_resolve(monkeypatch) -> None:
+    # An API key is not enough for azure-openai: without an endpoint every turn
+    # fails, so this must not read as a provider the shell can run on.
+    monkeypatch.setenv("LLM_PROVIDER", "azure-openai")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "sk-not-a-real-key")
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+
+    assert has_user_configured_llm_provider() is False

--- a/tests/config/test_llm_settings.py
+++ b/tests/config/test_llm_settings.py
@@ -10,6 +10,7 @@ from config.llm_settings import (
     LLMSettings,
     describe_llm_resolution,
     has_credentials_for_active_llm_provider,
+    has_user_configured_llm_provider,
     llm_provider_error_context,
     resolve_llm_settings,
     resolve_llm_settings_verbose,
@@ -418,3 +419,15 @@ def test_llm_provider_error_context_never_raises(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "not-a-real-provider")
 
     assert llm_provider_error_context() == ""
+
+
+def test_user_configured_provider_ignores_the_built_in_default(monkeypatch) -> None:
+    # An unset LLM_PROVIDER still resolves to a default provider; that is not a
+    # choice the user made, and the shell's sign-in gate must not read it as one.
+    monkeypatch.setenv("LLM_PROVIDER", "")
+
+    assert has_user_configured_llm_provider() is False
+
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+
+    assert has_user_configured_llm_provider() is True

--- a/tests/interactive_shell/runtime/test_account_gate.py
+++ b/tests/interactive_shell/runtime/test_account_gate.py
@@ -88,12 +88,36 @@ def test_pass_sign_in_gate_allows_only_valid_account(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen", lambda _console: None
     )
+    monkeypatch.setattr(account_gate, "own_llm_provider_configured", lambda: False)
     monkeypatch.setattr(
         "surfaces.interactive_shell.ui.sign_in.prompt_login_or_exit",
-        lambda: SignInChoice.EXIT,
+        lambda **_kwargs: SignInChoice.EXIT,
     )
 
     assert account_gate.pass_sign_in_gate(_console()) is False
+
+
+def test_pass_sign_in_gate_offers_the_configured_provider_instead_of_an_account(
+    monkeypatch: Any,
+) -> None:
+    # Pins the seam: without it the shell never offers the signed-out local-model path.
+    monkeypatch.setattr(account_gate, "is_test_run", lambda: False)
+    monkeypatch.setattr(account_gate, "account_is_signed_in", lambda: False)
+    monkeypatch.setattr(account_gate, "own_llm_provider_configured", lambda: True)
+    monkeypatch.setattr("surfaces.interactive_shell.ui.sign_in.repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(
+        "surfaces.interactive_shell.ui.sign_in.render_sign_in_screen", lambda _console: None
+    )
+    offered: list[bool] = []
+
+    def _prompt(*, offer_own_model: bool) -> SignInChoice:
+        offered.append(offer_own_model)
+        return SignInChoice.OWN_MODEL
+
+    monkeypatch.setattr("surfaces.interactive_shell.ui.sign_in.prompt_login_or_exit", _prompt)
+
+    assert account_gate.pass_sign_in_gate(_console()) is True
+    assert offered == [True]
 
 
 def test_run_repl_stops_before_runtime_when_sign_in_is_declined(monkeypatch: Any) -> None:

--- a/tests/interactive_shell/test_commands.py
+++ b/tests/interactive_shell/test_commands.py
@@ -113,10 +113,26 @@ class TestDispatchSlash:
 
         monkeypatch.setattr(m, "run_cli_command", lambda *_args, **_kwargs: True)
         monkeypatch.setattr("config.account.account_llm_route", lambda: None)
+        monkeypatch.setattr("config.llm_settings.has_user_configured_llm_provider", lambda: False)
         console, output = _capture()
 
         assert dispatch_slash("/account logout", Session(), console) is False
         assert "Closing the interactive shell" in output.getvalue()
+
+    def test_account_logout_keeps_the_shell_on_a_configured_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # /model sends users here to reach a local model; closing the shell would
+        # leave that instruction with nowhere to land.
+        from surfaces.interactive_shell.command_registry import cli_parity as m
+
+        monkeypatch.setattr(m, "run_cli_command", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr("config.account.account_llm_route", lambda: None)
+        monkeypatch.setattr("config.llm_settings.has_user_configured_llm_provider", lambda: True)
+        console, output = _capture()
+
+        assert dispatch_slash("/account logout", Session(), console) is True
+        assert "Closing the interactive shell" not in output.getvalue()
 
     def test_help_lists_all_commands(self) -> None:
         session = Session()

--- a/tests/interactive_shell/ui/test_sign_in.py
+++ b/tests/interactive_shell/ui/test_sign_in.py
@@ -77,7 +77,7 @@ def test_gate_logs_in_then_proceeds(monkeypatch) -> None:
     login_calls: list[bool] = []
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
-    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda: SignInChoice.LOGIN)
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.LOGIN)
     console, _ = _console()
 
     def _login() -> bool:
@@ -93,7 +93,7 @@ def test_gate_logs_in_then_proceeds(monkeypatch) -> None:
 def test_gate_exit_declines(monkeypatch) -> None:
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
-    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda: SignInChoice.EXIT)
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.EXIT)
     console, _ = _console()
 
     result = run_sign_in_gate(console, is_signed_in=lambda: False, login=lambda: False)
@@ -110,9 +110,43 @@ def test_gate_retries_after_a_failed_login_then_exits(monkeypatch) -> None:
     choices = iter([SignInChoice.LOGIN, SignInChoice.EXIT])
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
-    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda: next(choices))
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: next(choices))
     console, _ = _console()
 
     result = run_sign_in_gate(console, is_signed_in=lambda: False, login=lambda: False)
 
     assert result is False
+
+
+def test_gate_enters_the_shell_on_a_configured_provider_without_signing_in(monkeypatch) -> None:
+    # The only path to a local model: an account session pins the shell to the hosted route.
+    monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
+    monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.OWN_MODEL)
+    console, _ = _console()
+
+    result = run_sign_in_gate(
+        console,
+        is_signed_in=lambda: False,
+        login=lambda: False,
+        has_own_provider=lambda: True,
+    )
+
+    assert result is True
+
+
+def test_menu_hides_the_own_model_row_without_a_configured_provider(monkeypatch) -> None:
+    # A fresh install keeps the two-way gate: no provider means no way past sign-in.
+    offered: list[list[str]] = []
+
+    def _choose(*, choices: list[tuple[str, str]], **_kwargs: object) -> None:
+        offered.append([value for value, _label in choices])
+        return None
+
+    monkeypatch.setattr(sign_in, "repl_choose_one", _choose)
+
+    sign_in.prompt_login_or_exit(offer_own_model=False)
+    sign_in.prompt_login_or_exit(offer_own_model=True)
+
+    assert offered[0] == [SignInChoice.LOGIN, SignInChoice.EXIT]
+    assert SignInChoice.OWN_MODEL in offered[1]

--- a/tests/interactive_shell/ui/test_sign_in.py
+++ b/tests/interactive_shell/ui/test_sign_in.py
@@ -120,19 +120,27 @@ def test_gate_retries_after_a_failed_login_then_exits(monkeypatch) -> None:
 
 def test_gate_enters_the_shell_on_a_configured_provider_without_signing_in(monkeypatch) -> None:
     # The only path to a local model: an account session pins the shell to the hosted route.
+    # A rejected or unreachable session leaves that route on disk, so picking the
+    # local model must drop it or the shell keeps calling the hosted proxy.
+    dropped: list[bool] = []
     monkeypatch.setattr(sign_in, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(sign_in, "render_sign_in_screen", lambda _c: None)
     monkeypatch.setattr(sign_in, "prompt_login_or_exit", lambda **_kwargs: SignInChoice.OWN_MODEL)
     console, _ = _console()
+
+    def _on_own_provider() -> None:
+        dropped.append(True)
 
     result = run_sign_in_gate(
         console,
         is_signed_in=lambda: False,
         login=lambda: False,
         has_own_provider=lambda: True,
+        on_own_provider=_on_own_provider,
     )
 
     assert result is True
+    assert dropped == [True]
 
 
 def test_menu_hides_the_own_model_row_without_a_configured_provider(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #6112

#### Describe the changes you have made in this PR -

Running a local model was unreachable from the shell. The shell requires an account, a signed-in shell is pinned to the hosted OpenAI route, and the `/model` lock tells you to sign out. Signing out then closed the shell, so the instruction had nowhere to land.

Two changes close the loop, both conditioned on the user having already configured their own provider:

- The startup gate offers a third choice, "Continue with my own model", which enters the shell signed out.
- `/account logout` keeps the shell open instead of closing it.

`has_user_configured_llm_provider()` backs both. It requires `LLM_PROVIDER` to be set explicitly plus resolvable credentials. The built-in default provider does not count, so a fresh install has no provider, still sees the same two-way sign-in choice, and cannot slip past the gate only to fail on its first turn.

The `/model` lock message now names `opensre onboard local_llm` when there is no provider to fall back to, and the docs that said signing out closes the shell are updated.

**Worth a maintainer's opinion before merge:** anyone who already has an API key in their environment now has a way past the sign-in screen. The gate sits directly on hosted credits, so that tradeoff is a product call rather than mine. Happy to narrow the condition to local providers only, or to drop the startup half and keep just the logout fix, if you prefer.

### Demo/Screenshot for feature changes and bug fixes -

Real binary driven under a pty with an isolated `OPENSRE_HOME`.

No provider configured, unchanged from today:

```text
Sign in or create an OpenSRE account to use the interactive shell.
  ❯ Sign in or create account
    Exit and stay signed out
  ↑↓ Navigate • Enter Select • Esc cancel
```

With `LLM_PROVIDER=ollama`:

```text
Sign in or create an OpenSRE account to use the interactive shell.
  ❯ Sign in or create account
    Continue with my own model
    Exit and stay signed out
  ↑↓ Navigate • Enter Select • Esc cancel
```

Checks:

```text
make lint          All checks passed!
make format-check  3119 files already formatted
make typecheck     Success: no issues found in 1807 source files
uv run pytest tests/interactive_shell tests/config tests/shared tests/cli/wizard tests/quality -q
                   2334 passed, 1 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug is a collision between two workstreams rather than one broken function: the mandatory account gate (#5920) and the hosted-model lock added alongside credit exhaustion (#5958) each make sense alone, and together they leave no route to a local model. Saptarshi's Ollama discovery fix (#6011) merged the day before he reported this on Discord, so the picker works; you just cannot reach it.

I considered letting the gate pass silently whenever a provider is configured. I rejected that because it removes the sign-in screen for a whole class of users without them choosing it, and the forced screen is deliberate. Making it an explicit third row keeps the screen, keeps the exposure, and only opens the door for someone who already did the setup work.

The predicate deliberately reads `LLM_PROVIDER` rather than `get_configured_llm_provider()`, which falls back to a default provider when unset. Using the resolved value would show the extra row on a machine with nothing configured, which trades one dead end for a worse one.

I extended the check to `/account logout` after tracing what a signed-out shell touches. Without it the loop is still closed from inside the shell: `/model` sends you to log out, and logging out ejects you.

Tests cover the two failure modes that matter: the row appears and enters the shell when a provider exists, and it is absent when one does not. `has_user_configured_llm_provider` has one test pinning that the default provider does not count.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
