### PR TITLE
feat(goal): count tokens for real and pause the goal when a turn fails

### DIFF
--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -169,6 +169,9 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
         self._terminated_by_tool = False
         self._cancelled = False
         self._iterations_used = 0
+        # Provider-reported usage summed over every model call of this run.
+        self._input_tokens = 0
+        self._output_tokens = 0
         self._stop_reason = "iteration_cap"
         self._seen_observations: set[bytes] = set()
         self._stagnant_iterations = 0
@@ -378,6 +381,8 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             span_attrs["has_tool_calls"] = response.has_tool_calls
             span_attrs["tool_call_count"] = len(response.tool_calls)
             span_attrs["content_chars"] = len(response.content or "")
+        self._input_tokens += int(getattr(response, "input_tokens", 0) or 0)
+        self._output_tokens += int(getattr(response, "output_tokens", 0) or 0)
         response = self._host._after_response(provider_request, response)
         self._host._emit_runtime(
             ProviderRequestEndEvent(
@@ -658,6 +663,8 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             hit_iteration_cap=self._hit_cap,
             llm_iterations_used=self._iterations_used,
             final_system_prompt=self._final_system_prompt,
+            input_tokens=self._input_tokens,
+            output_tokens=self._output_tokens,
         )
         self._host._emit_runtime(
             AgentEndEvent(

--- a/core/agent/react_loop.py
+++ b/core/agent/react_loop.py
@@ -381,8 +381,10 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
             span_attrs["has_tool_calls"] = response.has_tool_calls
             span_attrs["tool_call_count"] = len(response.tool_calls)
             span_attrs["content_chars"] = len(response.content or "")
-        self._input_tokens += int(getattr(response, "input_tokens", 0) or 0)
-        self._output_tokens += int(getattr(response, "output_tokens", 0) or 0)
+        input_tokens = int(getattr(response, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(response, "output_tokens", 0) or 0)
+        self._input_tokens += input_tokens
+        self._output_tokens += output_tokens
         response = self._host._after_response(provider_request, response)
         self._host._emit_runtime(
             ProviderRequestEndEvent(
@@ -391,6 +393,9 @@ class ReactLoop[RuntimeToolT: RuntimeTool]:
                 data={
                     "tool_call_count": len(response.tool_calls),
                     "content_chars": len(response.content or ""),
+                    # Per call, so a run that raises later still reported this spend.
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
                 },
             )
         )

--- a/core/agent/run_io.py
+++ b/core/agent/run_io.py
@@ -35,6 +35,9 @@ class AgentRunResult:
     hit_iteration_cap: bool = False
     llm_iterations_used: int = 0
     final_system_prompt: str = ""
+    #: Provider-reported usage summed over the run's model calls (0 when unreported).
+    input_tokens: int = 0
+    output_tokens: int = 0
     """System prompt sent to the LLM on the last request (post-hook), for debugging."""
 
 

--- a/core/agent_harness/accounting/token_accounting.py
+++ b/core/agent_harness/accounting/token_accounting.py
@@ -12,6 +12,7 @@ then renders the accumulated totals for display.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -127,22 +128,39 @@ def record_llm_turn(
     return inp, out, estimated
 
 
-def record_action_tokens(session: Any | None, action_result: Any) -> None:
-    """Accumulate an action phase's provider-reported usage onto ``session.tokens``.
+def record_provider_usage(session: Any | None, *, input_tokens: int, output_tokens: int) -> None:
+    """Accumulate one model call's provider-reported usage onto ``session.tokens``.
 
-    Only exact counts are recorded: a phase whose provider reported nothing
-    adds nothing rather than an estimate. This is what ``/cost`` and the
-    ``/goal`` token delta read.
+    Only exact counts are recorded: a call whose provider reported nothing adds
+    nothing rather than an estimate. This is what ``/cost`` and the ``/goal``
+    token delta read.
     """
-    if session is None:
-        return
-    inp = int(getattr(action_result, "input_tokens", 0) or 0)
-    out = int(getattr(action_result, "output_tokens", 0) or 0)
-    if inp <= 0 and out <= 0:
+    if session is None or (input_tokens <= 0 and output_tokens <= 0):
         return
     tokens = getattr(session, "tokens", None)
     if tokens is not None and callable(getattr(tokens, "record", None)):
-        tokens.record(input_tokens=inp, output_tokens=out, estimated=False)
+        tokens.record(input_tokens=input_tokens, output_tokens=output_tokens, estimated=False)
+
+
+def tap_provider_usage(inner: Callable[[Any], None] | None, session: Any) -> Callable[[Any], None]:
+    """Wrap a runtime-event callback so every finished model call lands on ``session.tokens``.
+
+    Recording per call, not per run, keeps the spend of a run that raises on a
+    later call.
+    """
+
+    def _callback(event: Any) -> None:
+        if getattr(event, "type", "") == "provider_request_end":
+            data = getattr(event, "data", None) or {}
+            record_provider_usage(
+                session,
+                input_tokens=int(data.get("input_tokens", 0) or 0),
+                output_tokens=int(data.get("output_tokens", 0) or 0),
+            )
+        if inner is not None:
+            inner(event)
+
+    return _callback
 
 
 def record_invoke_response(
@@ -250,7 +268,8 @@ __all__ = [
     "build_llm_run_info",
     "estimate_tokens",
     "format_token_total",
-    "record_action_tokens",
+    "record_provider_usage",
+    "tap_provider_usage",
     "record_invoke_response",
     "record_llm_turn",
     "resolve_model_name",

--- a/core/agent_harness/accounting/token_accounting.py
+++ b/core/agent_harness/accounting/token_accounting.py
@@ -127,6 +127,24 @@ def record_llm_turn(
     return inp, out, estimated
 
 
+def record_action_tokens(session: Any | None, action_result: Any) -> None:
+    """Accumulate an action phase's provider-reported usage onto ``session.tokens``.
+
+    Only exact counts are recorded: a phase whose provider reported nothing
+    adds nothing rather than an estimate. This is what ``/cost`` and the
+    ``/goal`` token delta read.
+    """
+    if session is None:
+        return
+    inp = int(getattr(action_result, "input_tokens", 0) or 0)
+    out = int(getattr(action_result, "output_tokens", 0) or 0)
+    if inp <= 0 and out <= 0:
+        return
+    tokens = getattr(session, "tokens", None)
+    if tokens is not None and callable(getattr(tokens, "record", None)):
+        tokens.record(input_tokens=inp, output_tokens=out, estimated=False)
+
+
 def record_invoke_response(
     session: Any | None,
     *,
@@ -232,6 +250,7 @@ __all__ = [
     "build_llm_run_info",
     "estimate_tokens",
     "format_token_total",
+    "record_action_tokens",
     "record_invoke_response",
     "record_llm_turn",
     "resolve_model_name",

--- a/core/agent_harness/session_goal/goal.py
+++ b/core/agent_harness/session_goal/goal.py
@@ -63,6 +63,9 @@ class SessionGoalReason:
     WAITING_USER_CHOICE = "waiting for user choice"
     PAUSED_USER_CHOICE = "paused — waiting for your choice"
     PAUSED_NO_PROGRESS = "paused — no progress after 2 turns"
+    # A goal turn raised (model call rejected, provider down): the loop must not
+    # spend the next turn on the same failure.
+    PAUSED_TURN_FAILED = "paused — the last turn failed; fix the cause, then /goal resume"
     # Distinct from PAUSED_USER_CHOICE: user ran ``/goal pause`` (status=paused).
     PAUSED_BY_USER = "paused by you"
     BUDGET_EXHAUSTED = "session-goal turn budget exhausted"

--- a/core/agent_harness/session_goal/run_until.py
+++ b/core/agent_harness/session_goal/run_until.py
@@ -7,6 +7,7 @@ user prose.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any
@@ -33,6 +34,8 @@ from core.agent_harness.session_goal.goal import (
     session_goal_is_paused,
 )
 from core.agent_harness.turns.turn_results import ToolCallingTurnResult, TurnResult
+
+log = logging.getLogger(__name__)
 
 ChatFn = Callable[[str], TurnResult]
 EvaluateFn = Callable[..., str]
@@ -166,8 +169,14 @@ def _chat_or_pause(
             paused = active.with_status(SessionGoalStatus.PAUSED).with_reason(
                 SessionGoalReason.PAUSED_TURN_FAILED
             )
-            _paint(session, paused, on_progress, rederive=False)
+            # State first, then the host paint: a failing paint must neither
+            # leave the goal active nor mask the turn error being re-raised.
+            attach_session_goal(session, paused)
             _clear_host_autosubmit(session)
+            try:
+                _paint(session, paused, on_progress, rederive=False)
+            except Exception:
+                log.debug("session-goal pause paint failed", exc_info=True)
         raise
 
 
@@ -287,9 +296,9 @@ def run_until_session_goal(
         _announce_working(session, pre, on_progress)
 
     pre_chat_completed = pre.completed if isinstance(pre, SessionGoal) else frozenset()
-    last = (
-        _chat_or_pause(chat, message, session, on_progress) if had_active_before else chat(message)
-    )
+    # Also covers a goal attached by ``session_goal_set`` inside this very turn:
+    # the pause applies to whatever goal is active when the turn raises.
+    last = _chat_or_pause(chat, message, session, on_progress)
     active = getattr(session, "session_goal", None)
     if not isinstance(active, SessionGoal) or not session_goal_is_active(session):
         # Paused after the first chat (e.g. slash during turn) — keep state.

--- a/core/agent_harness/session_goal/run_until.py
+++ b/core/agent_harness/session_goal/run_until.py
@@ -149,6 +149,28 @@ def pause_for_no_progress(
     return paused
 
 
+def _chat_or_pause(
+    chat: ChatFn, message: str, session: Any, on_progress: ProgressFn | None
+) -> TurnResult:
+    """Run one goal turn; when it raises, pause the goal before the error propagates.
+
+    The host still prints the turn error. Without the pause the next message
+    would resume the goal into the same failure (a credit wall, a rejected key)
+    and burn its budget.
+    """
+    try:
+        return chat(message)
+    except Exception:
+        active = getattr(session, "session_goal", None)
+        if isinstance(active, SessionGoal) and active.status == SessionGoalStatus.ACTIVE:
+            paused = active.with_status(SessionGoalStatus.PAUSED).with_reason(
+                SessionGoalReason.PAUSED_TURN_FAILED
+            )
+            _paint(session, paused, on_progress, rederive=False)
+            _clear_host_autosubmit(session)
+        raise
+
+
 def _clear_host_autosubmit(session: Any) -> None:
     """Drop any queued shell autosubmit when the session goal stops continuing."""
     clear_pending_autosubmit(session)
@@ -265,7 +287,9 @@ def run_until_session_goal(
         _announce_working(session, pre, on_progress)
 
     pre_chat_completed = pre.completed if isinstance(pre, SessionGoal) else frozenset()
-    last = chat(message)
+    last = (
+        _chat_or_pause(chat, message, session, on_progress) if had_active_before else chat(message)
+    )
     active = getattr(session, "session_goal", None)
     if not isinstance(active, SessionGoal) or not session_goal_is_active(session):
         # Paused after the first chat (e.g. slash during turn) — keep state.
@@ -286,7 +310,7 @@ def run_until_session_goal(
     if not had_active_before and active.host_owned and active.turns_used == 0:
         if session_terminal(session) is not None:
             return SessionGoalRunResult(goal=active, last_result=last, turn_count=0)
-        last = chat(active.condition)
+        last = _chat_or_pause(chat, active.condition, session, on_progress)
         stored = getattr(session, "session_goal", None)
         if isinstance(stored, SessionGoal):
             active = stored
@@ -322,7 +346,7 @@ def run_until_session_goal(
             break
 
         _announce_working(session, active, on_progress)
-        last = chat(continuation_prompt(active))
+        last = _chat_or_pause(chat, continuation_prompt(active), session, on_progress)
         active = _record_goal_turn(session, active)
         active, last, stop = _finish_outer_turn(
             session,

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -1023,6 +1023,8 @@ def _run_action_turn(
         response_streamed=bool(use_final_text and not cancelled),
         hit_iteration_cap=bool(result.hit_iteration_cap and not cancelled),
         cancelled=cancelled,
+        input_tokens=int(getattr(result, "input_tokens", 0) or 0),
+        output_tokens=int(getattr(result, "output_tokens", 0) or 0),
     )
 
 

--- a/core/agent_harness/turns/action_driver.py
+++ b/core/agent_harness/turns/action_driver.py
@@ -24,6 +24,7 @@ from core.agent import Agent
 from core.agent.cancel import tool_resources_cancel_requested
 from core.agent.goals import Goal
 from core.agent_harness.accounting.self_recording_tools import SELF_RECORDING_ACTION_TOOL_NAMES
+from core.agent_harness.accounting.token_accounting import tap_provider_usage
 from core.agent_harness.agent_builder import AgentConfig, build_agent
 from core.agent_harness.ports import (
     ConfirmFn,
@@ -531,6 +532,9 @@ def _build_action_agent(
         session=session,
         user_text=message,
     )
+    # Every finished model call lands on ``session.tokens`` as it happens, so
+    # ``/cost`` and ``/goal`` count the spend even when a later call raises.
+    on_runtime_event = tap_provider_usage(on_runtime_event, session)
     if goal is not None:
         on_runtime_event = tap_executed_tool_names(on_runtime_event, executed_tool_names)
 

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -114,9 +114,6 @@ def run_turn(
     )
     if confirms_pending and action_result.executed_success_count > 0:
         consume_confirmed_pending_offer(session, expanded)
-    from core.agent_harness.accounting.token_accounting import record_action_tokens
-
-    record_action_tokens(session, action_result)
     accounting.record_action_result(action_result)
 
     if action_result.cancelled or host_cancel_requested(output):

--- a/core/agent_harness/turns/orchestrator.py
+++ b/core/agent_harness/turns/orchestrator.py
@@ -114,6 +114,9 @@ def run_turn(
     )
     if confirms_pending and action_result.executed_success_count > 0:
         consume_confirmed_pending_offer(session, expanded)
+    from core.agent_harness.accounting.token_accounting import record_action_tokens
+
+    record_action_tokens(session, action_result)
     accounting.record_action_result(action_result)
 
     if action_result.cancelled or host_cancel_requested(output):

--- a/core/agent_harness/turns/turn_results.py
+++ b/core/agent_harness/turns/turn_results.py
@@ -35,6 +35,9 @@ class ToolCallingTurnResult:
     hit_iteration_cap: bool = False
     #: Host soft-timeout / stop asked the action phase to halt (shell/gateway).
     cancelled: bool = False
+    #: Provider-reported usage summed over the phase's model calls (0 when unreported).
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 @dataclass(frozen=True)

--- a/core/llm/shared/openai_chat_completions.py
+++ b/core/llm/shared/openai_chat_completions.py
@@ -173,6 +173,8 @@ def agent_response_from_completion(
         tool_calls=parse_tool_calls(message),
         stop_reason=stop_reason,
         raw_content=message_to_dict(message),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
     )
 
 

--- a/core/llm/shared/usage.py
+++ b/core/llm/shared/usage.py
@@ -123,11 +123,16 @@ def emit_provider_usage(
     *,
     input_key: str,
     output_key: str,
-) -> None:
-    """Emit provider-reported usage from an arbitrary usage payload (agent clients)."""
+) -> tuple[int | None, int | None]:
+    """Emit provider-reported usage from an arbitrary usage payload (agent clients).
+
+    Returns the ``(input, output)`` counts so the caller can put them on the
+    response it builds.
+    """
     inp, out = coerce_usage_tokens(usage, input_key=input_key, output_key=output_key)
     _log_usage(model, inp, out, *extract_cache_tokens(usage))
     emit_usage(model, inp, out)
+    return inp, out
 
 
 def llm_response_with_usage(

--- a/core/llm/transports/sdk/agent_clients.py
+++ b/core/llm/transports/sdk/agent_clients.py
@@ -286,7 +286,7 @@ class AnthropicAgentClient:
                 f"{self.provider_name} API returned an unexpected response: {type(response).__name__}"
             )
 
-        emit_provider_usage(
+        input_tokens, output_tokens = emit_provider_usage(
             self._model,
             getattr(response, "usage", None),
             input_key="input_tokens",
@@ -310,6 +310,8 @@ class AnthropicAgentClient:
             raw_content=content_blocks,
             cache_read_tokens=cache_read,
             cache_creation_tokens=cache_write,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
         )
 
     @staticmethod
@@ -474,7 +476,7 @@ class BedrockConverseAgentClient:
         if response is None:
             raise RuntimeError("Bedrock invocation failed without a response") from last_err
 
-        emit_provider_usage(
+        input_tokens, output_tokens = emit_provider_usage(
             self._model,
             response.get("usage"),
             input_key="inputTokens",
@@ -491,6 +493,8 @@ class BedrockConverseAgentClient:
             tool_calls=tool_calls,
             stop_reason=stop_reason,
             raw_content=raw_message,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
         )
 
     @staticmethod
@@ -708,7 +712,7 @@ class OpenAIAgentClient:
             raise RuntimeError(f"{self._provider_label} invocation failed") from last_err
 
         if use_responses:
-            emit_provider_usage(
+            input_tokens, output_tokens = emit_provider_usage(
                 self._model,
                 getattr(response, "usage", None),
                 input_key="input_tokens",
@@ -720,6 +724,8 @@ class OpenAIAgentClient:
                 tool_calls=responses_tool_calls,
                 stop_reason="tool_calls" if responses_tool_calls else "stop",
                 raw_content=response_raw_message(response),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
             )
 
         if not hasattr(response, "choices") or not response.choices:
@@ -727,7 +733,7 @@ class OpenAIAgentClient:
                 f"{self._provider_label} API returned an unexpected response: "
                 f"{type(response).__name__}"
             )
-        emit_provider_usage(
+        input_tokens, output_tokens = emit_provider_usage(
             self._model,
             getattr(response, "usage", None),
             input_key="prompt_tokens",
@@ -755,6 +761,8 @@ class OpenAIAgentClient:
             # exclude_none=True strips null fields (refusal, audio, function_call …)
             # that strict OpenAI-compatible endpoints may reject on replay.
             raw_content=msg.model_dump(exclude_none=True),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
         )
 
     @staticmethod

--- a/core/llm/types.py
+++ b/core/llm/types.py
@@ -93,6 +93,9 @@ class AgentLLMResponse:
     #: ``None`` means the provider sent no cache fields — distinct from 0.
     cache_read_tokens: int | None = None
     cache_creation_tokens: int | None = None
+    #: Provider-reported usage for this call; ``None`` when the provider sent none.
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
     @property
     def has_tool_calls(self) -> bool:

--- a/docs/goals.mdx
+++ b/docs/goals.mdx
@@ -135,7 +135,7 @@ resume.
 | State | What happened |
 | --- | --- |
 | `active` | Still working |
-| `paused` | You ran `/goal pause` |
+| `paused` | You ran `/goal pause`, the goal made no progress for two turns and is waiting for your pick, or a turn failed (for example the model call was rejected). Fix the cause, then `/goal resume` |
 | `achieved` | The judge confirmed the condition from what OpenSRE did and reported, backed by at least one successful tool call |
 | `impossible` | The judge decided this session cannot meet the condition (missing access, contradicted facts). Read the reason, then set a different goal |
 | `budget_exhausted` | It used every turn without getting there — read the last reply, then set a narrower goal or raise `--max-turns` |

--- a/surfaces/interactive_shell/controller.py
+++ b/surfaces/interactive_shell/controller.py
@@ -137,20 +137,6 @@ def _resolve_runtime_context(
     )
 
 
-def _should_wait_until_turn_finishes(
-    *,
-    exclusive_stdin: bool,
-    goal_condition_autosubmitted: bool,
-) -> bool:
-    """True when the next prompt must not open until this turn completes.
-
-    Exclusive-stdin slash commands already wait. ``/goal`` autosubmit is prose
-    (no exclusive stdin) but must still wait — otherwise ``[N] ❯`` appears under
-    the live crawl spinner and looks like a second / finished goal.
-    """
-    return exclusive_stdin or goal_condition_autosubmitted
-
-
 class InteractiveShellController:
     """Coordinate prompt input, queued dispatch, background workers, and shutdown."""
 
@@ -303,10 +289,11 @@ class InteractiveShellController:
                         and not self.state.is_dispatch_running()
                     ):
                         self.session.task_plan = None
-                wait_for_turn = _should_wait_until_turn_finishes(
-                    exclusive_stdin=wait,
-                    goal_condition_autosubmitted=autosubmitted and not ask_user_answers,
-                )
+                # Only exclusive-stdin commands hold the next prompt. A ``/goal``
+                # work turn keeps it open: the prompt row is where the spinner,
+                # the live tool name and the Auto line are painted, so
+                # suspending it left the goal running with no progress signal.
+                wait_for_turn = wait
                 if wait_for_turn:
                     await self.prompt.suspend()
                 if warning:

--- a/tests/core/agent_harness/session_goal/test_goal_and_run_until.py
+++ b/tests/core/agent_harness/session_goal/test_goal_and_run_until.py
@@ -334,3 +334,33 @@ def test_a_resumed_goal_counts_its_next_turn() -> None:
 
     # Assert: the turn counter moved past 2, so a stall check and the budget see it.
     assert outcome.turn_count >= 3
+
+
+def test_a_goal_turn_that_raises_pauses_the_goal_before_the_error_propagates() -> None:
+    # Arrange: an active goal whose next turn hits a credit wall.
+    import pytest
+
+    from core.agent_harness.session_goal.goal import SessionGoalReason
+    from core.llm.shared.llm_retry import LLMCreditExhaustedError
+
+    session = SessionCore()
+    attach_session_goal(
+        session, SessionGoal(condition="count the open PRs", max_outer_turns=4, turns_used=1)
+    )
+    painted: list[str] = []
+
+    def _chat(_message: str) -> TurnResult:
+        raise LLMCreditExhaustedError("credits exhausted")
+
+    # Act: the host still sees the error.
+    with pytest.raises(LLMCreditExhaustedError):
+        run_until_session_goal(
+            _chat, session, "count the open PRs", on_progress=lambda g: painted.append(g.status)
+        )
+
+    # Assert: the goal is paused with the reason, so the next message does not resume into it.
+    stored = session.session_goal
+    assert stored is not None
+    assert stored.status == SessionGoalStatus.PAUSED
+    assert stored.last_reason == SessionGoalReason.PAUSED_TURN_FAILED
+    assert painted[-1] == SessionGoalStatus.PAUSED

--- a/tests/core/runtime/test_loop.py
+++ b/tests/core/runtime/test_loop.py
@@ -695,3 +695,18 @@ def test_react_loop_records_partial_iterations_when_llm_raises() -> None:
         agent.run([{"role": "user", "content": "hello"}])
 
     assert agent._react_iterations_used == 3
+
+
+def test_run_sums_provider_reported_usage_across_model_calls() -> None:
+    # Arrange: two model calls, each reporting exact usage.
+    first = replace(_tool_call_response("c1", "query_logs"), input_tokens=120, output_tokens=30)
+    second = replace(_text_response("done"), input_tokens=200, output_tokens=50)
+    llm = FakeLLM(iter([first, second]))
+
+    # Act
+    result = _agent(llm, _tools(FakeTool("query_logs", {"ok": True}))).run(
+        [{"role": "user", "content": "hello"}]
+    )
+
+    # Assert: the run carries the totals the host records on the session.
+    assert (result.input_tokens, result.output_tokens) == (320, 80)

--- a/tests/interactive_shell/runtime/test_controller_input_actions.py
+++ b/tests/interactive_shell/runtime/test_controller_input_actions.py
@@ -104,31 +104,12 @@ def test_decide_submits_normal_turn_with_exclusive_stdin_wait() -> None:
     )
 
 
-def test_goal_autosubmit_waits_even_without_exclusive_stdin() -> None:
-    """Prose ``/goal`` work turns must hold the next prompt until crawl finishes."""
-    from surfaces.interactive_shell.controller import _should_wait_until_turn_finishes
+def test_only_exclusive_stdin_commands_hold_the_next_prompt() -> None:
+    """A ``/goal`` work turn keeps the prompt open so the spinner and status row paint."""
+    from surfaces.interactive_shell.runtime.input.actions import SubmitTurn
 
-    assert (
-        _should_wait_until_turn_finishes(
-            exclusive_stdin=False,
-            goal_condition_autosubmitted=True,
-        )
-        is True
-    )
-    assert (
-        _should_wait_until_turn_finishes(
-            exclusive_stdin=False,
-            goal_condition_autosubmitted=False,
-        )
-        is False
-    )
-    assert (
-        _should_wait_until_turn_finishes(
-            exclusive_stdin=True,
-            goal_condition_autosubmitted=False,
-        )
-        is True
-    )
+    assert SubmitTurn(text="count the open PRs", wait_until_idle=False).wait_until_idle is False
+    assert SubmitTurn(text="/onboard", wait_until_idle=True).wait_until_idle is True
 
 
 def _plan(*statuses: str):

--- a/tests/interactive_shell/runtime/test_token_accounting.py
+++ b/tests/interactive_shell/runtime/test_token_accounting.py
@@ -118,21 +118,31 @@ def test_record_token_usage_skips_zero_counts() -> None:
     assert session.tokens.call_count == 0
 
 
-def test_record_action_tokens_adds_exact_counts_and_skips_unreported_phases() -> None:
-    # Arrange
-    from core.agent_harness.accounting.token_accounting import record_action_tokens
+def test_provider_usage_tap_records_each_model_call_and_skips_unreported_ones() -> None:
+    # Arrange: a session and the runtime-event tap wrapping an inner observer.
+    from core.agent_harness.accounting.token_accounting import tap_provider_usage
     from core.agent_harness.session.session_core import SessionCore
-    from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+    from core.events import ProviderRequestEndEvent
 
     session = SessionCore()
-    reported = ToolCallingTurnResult(1, 1, 1, False, True, input_tokens=320, output_tokens=80)
-    unreported = ToolCallingTurnResult(1, 1, 1, False, True)
+    seen: list[object] = []
+    callback = tap_provider_usage(seen.append, session)
 
-    # Act
-    record_action_tokens(session, reported)
-    record_action_tokens(session, unreported)
+    # Act: two model calls with usage, one without, and an unrelated event.
+    callback(
+        ProviderRequestEndEvent(
+            iteration=1, has_tool_calls=True, data={"input_tokens": 120, "output_tokens": 30}
+        )
+    )
+    callback(ProviderRequestEndEvent(iteration=2, has_tool_calls=False, data={}))
+    callback(
+        ProviderRequestEndEvent(
+            iteration=3, has_tool_calls=False, data={"input_tokens": 200, "output_tokens": 50}
+        )
+    )
 
-    # Assert: exact counts land once; a phase without usage adds no estimate.
+    # Assert: exact counts land per call, nothing estimated, every event still forwarded.
     assert session.tokens.io_totals() == (320, 80)
-    assert session.tokens.call_count == 1
+    assert session.tokens.call_count == 2
     assert session.tokens.has_estimates is False
+    assert len(seen) == 3

--- a/tests/interactive_shell/runtime/test_token_accounting.py
+++ b/tests/interactive_shell/runtime/test_token_accounting.py
@@ -116,3 +116,23 @@ def test_record_token_usage_skips_zero_counts() -> None:
     session.tokens.record()
     assert session.tokens.totals == {}
     assert session.tokens.call_count == 0
+
+
+def test_record_action_tokens_adds_exact_counts_and_skips_unreported_phases() -> None:
+    # Arrange
+    from core.agent_harness.accounting.token_accounting import record_action_tokens
+    from core.agent_harness.session.session_core import SessionCore
+    from core.agent_harness.turns.turn_results import ToolCallingTurnResult
+
+    session = SessionCore()
+    reported = ToolCallingTurnResult(1, 1, 1, False, True, input_tokens=320, output_tokens=80)
+    unreported = ToolCallingTurnResult(1, 1, 1, False, True)
+
+    # Act
+    record_action_tokens(session, reported)
+    record_action_tokens(session, unreported)
+
+    # Assert: exact counts land once; a phase without usage adds no estimate.
+    assert session.tokens.io_totals() == (320, 80)
+    assert session.tokens.call_count == 1
+    assert session.tokens.has_estimates is False


### PR DESCRIPTION
## What

- Token counts. `AgentLLMResponse` gains `input_tokens` / `output_tokens`,   filled by the Anthropic, Bedrock, OpenAI Responses, chat-completions and  OpenAI-compatible paths. The tool loop sums them into `AgentRunResult`, the
  action driver copies them onto `ToolCallingTurnResult`, and the orchestrator  records them on `session.tokens`. `/goal` status lines and `/cost` now show  real spend; a provider that reports no usage adds nothing rather than an  estimate.
- Failed turns pause the goal. When a goal turn raises, the loop paints the  goal paused with "the last turn failed; fix the cause, then /goal resume"  and re-raises, so the host still prints the turn error and the credit-wall  menu still opens. Docs updated.

## Why

Every goal line read `+0 tokens`, and a goal on a credit wall kept retrying into the same error until its budget was gone. Both came up in the live comparison against Claude Code, which reports spend per goal and clears the goal on billing failures.