### PR TITLE
fix(ci): drop stale github-ci-fix-onboarding references; fix morning-report ordering test

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -49,8 +49,7 @@ Slack setup.
 ## Related workflows
 
 - Fixing a failing check. Use `github-ci-fix`.
-- Setting up the local CI fix loop or prerequisites. Use
-  `github-ci-fix-onboarding`.
+- Setting up a recurring CI fix loop. Use `cicd-reliability-agent`.
 - Listing the checks that are failing right now. Use `github-ci-health`.
 
 ## Workflow rules

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/a_local_analysis/SKILL.md
@@ -49,7 +49,8 @@ Slack setup.
 ## Related workflows
 
 - Fixing a failing check. Use `github-ci-fix`.
-- Setting up a recurring CI fix loop. Use `cicd-reliability-agent`.
+- Scheduling a recurring CI/CD reliability check with inbox reports. Use
+  `cicd-reliability-agent`.
 - Listing the checks that are failing right now. Use `github-ci-health`.
 
 ## Workflow rules

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md
@@ -43,7 +43,6 @@ the shell inbox.
 - A one-shot CI/CD performance report. Use `cicd-analytics-demo`.
 - Listing checks that are failing right now. Use `github-ci-health`.
 - Fixing a failing check. Use `github-ci-fix`.
-- First-time CI-fix setup. Use `github-ci-fix-onboarding`.
 
 ## Workflow rules
 

--- a/docs/github-ci-fix.mdx
+++ b/docs/github-ci-fix.mdx
@@ -48,11 +48,10 @@ OpenSRE uses the configured coding-agent backend through `CODING_AGENT=auto` by 
 | --- | --- |
 | `fix_github_pr_ci` | Inspect failing Actions checks, apply a fix, commit, and push to the existing PR head branch or a fresh branch repair worktree |
 
-Related skills: `github-ci-fix`, `github-ci-fix-onboarding`.
+Related skill: `github-ci-fix`.
 
-Say "onboard me on the CI/CD flow" to load `github-ci-fix-onboarding` and walk
-from zero to a green CI run on a real pull request. First-run `/demo`
-recommends CI/CD analytics, not this onboarding flow.
+Run `/demo` in the interactive shell for the guided CI/CD onboarding menu; its
+recommended first option is CI/CD analytics.
 
 ### Use it
 

--- a/surfaces/cli/commands/package_smoke.py
+++ b/surfaces/cli/commands/package_smoke.py
@@ -30,7 +30,6 @@ _REQUIRED_ACTION_SKILL_NAMES = frozenset(
         # builds bundle and discover skills/<package>/<child>/SKILL.md.
         "cicd-analytics-demo",
         "github-ci-fix",
-        "github-ci-fix-onboarding",
         "github-security-fix",
         "morning-report",
         "onboarding-cicd-fix",

--- a/tests/core/agent/orchestration/test_action_prompt.py
+++ b/tests/core/agent/orchestration/test_action_prompt.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from config.constants.skills import ONBOARDING_SKILL_NAME
 from core.agent_harness.prompts import (
     build_action_system_prompt,
     connected_integrations_block,
@@ -264,15 +265,15 @@ def test_skill_matches_take_priority_over_generic_docs_answer() -> None:
     cached_load_skills_block.cache_clear()
 
     index = load_skills_index()
-    body = load_skill_body("github-ci-fix-onboarding")
+    body = load_skill_body(ONBOARDING_SKILL_NAME)
     prompt = build_action_system_prompt(_ctx())
 
     assert "Skill matches outrank a generic docs/how-to answer" in index
     assert '"onboard me"' in index
-    assert "Can you onboard me on the CI/CD flow?" in body
+    assert "owns the onboarding question" in body
     # Skills index still rides the assembled prompt after the markdown base.
     assert SKILLS_HEADER in prompt
-    assert "github-ci-fix-onboarding" in prompt
+    assert ONBOARDING_SKILL_NAME in prompt
     cached_load_skills_block.cache_clear()
 
 

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -52,7 +52,6 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
     assert len(names) == len(set(names))
     assert ONBOARDING_SKILL_NAME in loader.load_skills_index()
     assert loader.load_skill_body("github-ci-fix")
-    assert loader.load_skill_body("github-ci-fix-onboarding")
 
 
 def test_capability_and_demo_prompts_load_master_instead_of_defining_another_menu() -> None:

--- a/tests/core/agent_harness/session/test_pending_offer.py
+++ b/tests/core/agent_harness/session/test_pending_offer.py
@@ -456,9 +456,8 @@ def test_the_skill_forbids_offering_before_the_work() -> None:
     # Arrange
     from core.agent_harness.prompts.skills.loader import skills_dir
 
-    body = " ".join(
-        (skills_dir() / "morning_report" / "SKILL.md").read_text(encoding="utf-8").lower().split()
-    )
+    raw = (skills_dir() / "morning_report" / "SKILL.md").read_text(encoding="utf-8")
+    body = " ".join(raw.replace("`", "").lower().split())
 
     # Assert
     assert "never call propose_scheduled_delivery as the first or only tool" in body


### PR DESCRIPTION
Fixes main CI after 7cab011fb removed the duplicate `github-ci-fix-onboarding` skill.

#### Describe the changes you have made in this PR -

`main` is red on `package-preflight`, `test (cli-runtime-3)`, `test (tools-runtime-3)`, `session-store-locked`, and `Interactive Shell Live`. Two independent root causes, both fixed here; the removed skill stays removed.

**1. Stale references to the removed `github-ci-fix-onboarding` skill**
- `surfaces/cli/commands/package_smoke.py` — drop it from `_REQUIRED_ACTION_SKILL_NAMES` (this is what failed `package-preflight`).
- `tests/core/agent/prompts/test_skills_demo.py` — drop the `load_skill_body("github-ci-fix-onboarding")` assertion.
- `tests/core/agent/orchestration/test_action_prompt.py::test_skill_matches_take_priority_over_generic_docs_answer` — point at `ONBOARDING_SKILL_NAME` (`onboarding-cicd-fix`), which is the skill that now owns onboarding.
- `onboarding_cicd_fix/a_local_analysis/SKILL.md`, `onboarding_cicd_fix/b_local_scheduled_loops/SKILL.md` — remove the "Related workflows" bullets pointing at the deleted skill; local analysis now points setup at `cicd-reliability-agent`.
- `docs/github-ci-fix.mdx` — drop the "say 'onboard me…'" paragraph; point readers at `/demo`.

**2. `test_the_skill_forbids_offering_before_the_work` (pre-existing, from #6124)**
#6124 rewrote `morning-report` and wrapped `propose_scheduled_delivery` in backticks, so the plain-phrase assertion stopped matching. The test now strips markdown backticks before normalising; the ordering rule in the skill is unchanged.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest -q tests/core/agent/prompts/test_skills_demo.py tests/core/agent/orchestration/test_action_prompt.py \
    tests/core/agent_harness/session/test_pending_offer.py tests/cli/test_package_smoke.py tests/interactive_shell/ui/test_action_rendering.py
88 passed in 8.18s

$ uv run pytest -q -n 4 tests/core/agent tests/core/agent_harness tests/cli/test_package_smoke.py tests/quality
858 passed, 1 xfailed in 12.37s

$ make lint && make format-check && make typecheck
All checks passed!
3140 files already formatted
Success: no issues found in 1817 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Pulled the failing job logs for the two most recent `main` runs, grepped the tree for every remaining reference to the removed skill name, and removed or repointed each one. The alternative — restoring the skill file — was rejected because the removal was intentional (duplicate of the `onboarding-cicd-fix` master skill). For the morning-report test, the alternative was removing the backticks from the skill; stripping them in the test keeps the skill's markdown and still pins the ordering rule.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
