### PR TITLE
feat(skills): pre_execute hook opens the onboarding menu before any model step

### DIFF
--- a/core/agent_harness/prompts/AGENTS.md
+++ b/core/agent_harness/prompts/AGENTS.md
@@ -43,3 +43,6 @@ Use ordinary Markdown, following
 - Keep commands and exact output examples in inline code or fenced blocks.
 - Preserve frontmatter, tool contracts, exact choice labels, authorization
   boundaries, and required output formats when changing presentation.
+- A static menu a skill always opens on entry belongs in `pre_execute`
+  frontmatter (`tool: ask_user_choice` + `args`), not in prose the model must
+  replay; the host runs it before any model step (see `onboarding_cicd_fix`).

--- a/core/agent_harness/prompts/skills/__init__.py
+++ b/core/agent_harness/prompts/skills/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from core.agent_harness.prompts.skills.loader import (
     SKILLS_HEADER,
     ActionSkill,
+    SkillToolCall,
     getting_started_skills,
     list_action_skills,
     load_skill_body,
@@ -16,6 +17,7 @@ from core.agent_harness.prompts.skills.loader import (
 __all__ = [
     "ActionSkill",
     "SKILLS_HEADER",
+    "SkillToolCall",
     "getting_started_skills",
     "list_action_skills",
     "load_skill_body",

--- a/core/agent_harness/prompts/skills/_template/SKILL_TEMPLATE.md
+++ b/core/agent_harness/prompts/skills/_template/SKILL_TEMPLATE.md
@@ -21,6 +21,9 @@ To create a new skill:
    appended automatically to the body that skill_view returns.
 7. Optional `getting_started:` (verbatim first-visit demo label) plus
    `demo_order:` (1-based menu row, A=1) attach this skill to `/demo`.
+   Optional `pre_execute:` lists static tool calls (`- tool: ask_user_choice`
+   + `args:` shaped like the tool's input) the host runs when the skill is
+   entered, before any model step; only `ask_user_choice` is allowed.
 8. Section order below is the house style (see github_ci_fix for a
    single-tool skill, architecture_audit for a multi-pass one). Keep the
    whole body tight — it is loaded into the planner's context on demand.

--- a/core/agent_harness/prompts/skills/loader.py
+++ b/core/agent_harness/prompts/skills/loader.py
@@ -10,9 +10,12 @@ Layout (either form is supported):
 - Flat: ``skills/<name>.md`` with optional ``skills/<name>_report.md``.
 
 Optional YAML frontmatter (``name``, ``description``, optional ``recurring``,
-optional ``getting_started`` + ``demo_order``) feeds the compact index.
-``getting_started`` is the verbatim first-visit demo menu label this skill
-owns; ``demo_order`` is its 1-based row (A=1). Without frontmatter, the name
+optional ``getting_started`` + ``demo_order``, optional ``pre_execute``) feeds
+the compact index. ``getting_started`` is the verbatim first-visit demo menu
+label this skill owns; ``demo_order`` is its 1-based row (A=1).
+``pre_execute`` lists static tool calls (``{tool, args}``) the host runs when
+the skill is entered, before any model step; the loader keeps them as data and
+the entry point decides which tools are allowed. Without frontmatter, the name
 is derived from the path and the description from the first ``WHEN TO USE`` /
 subtitle lines.
 
@@ -24,9 +27,11 @@ chars). Full bodies load through the ``skill_view`` tool via
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 import yaml
@@ -34,6 +39,7 @@ import yaml
 __all__ = (
     "ActionSkill",
     "SKILLS_HEADER",
+    "SkillToolCall",
     "getting_started_skills",
     "list_action_skills",
     "load_skill_body",
@@ -53,6 +59,15 @@ _BANNER_RE = re.compile(r"^[=\-─]{8,}\s*$")
 
 
 @dataclass(frozen=True)
+class SkillToolCall:
+    """One static tool call a skill declares in ``pre_execute``."""
+
+    tool: str
+    args: Mapping[str, Any]
+    """Read-only tool input, shaped exactly like the tool's ``input_schema``."""
+
+
+@dataclass(frozen=True)
 class ActionSkill:
     """One discoverable action-agent skill (index metadata + path)."""
 
@@ -68,6 +83,9 @@ class ActionSkill:
 
     demo_order: int | None = None
     """1-based demo menu order when ``getting_started`` is set (A=1)."""
+
+    pre_execute: tuple[SkillToolCall, ...] = ()
+    """Static tool calls run on skill entry (boot, ``/demo``, ``skill_view``) before the model."""
 
 
 def skills_dir() -> Path:
@@ -169,6 +187,22 @@ def _optional_int_field(value: Any) -> int | None:
     return value
 
 
+def _pre_execute_field(value: Any) -> tuple[SkillToolCall, ...]:
+    """Parse ``pre_execute`` entries; malformed items are dropped like other bad frontmatter."""
+    if not isinstance(value, list):
+        return ()
+    calls: list[SkillToolCall] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        tool = _string_field(item.get("tool"))
+        args = item.get("args")
+        if not tool or not isinstance(args, dict):
+            continue
+        calls.append(SkillToolCall(tool=tool, args=MappingProxyType(dict(args))))
+    return tuple(calls)
+
+
 def _derive_description(body: str) -> str:
     """Best-effort one-liner when frontmatter has no description."""
     lines = [ln.strip() for ln in body.splitlines()]
@@ -239,6 +273,7 @@ def _load_action_skill(skill_path: Path) -> ActionSkill | None:
         tools=_string_list_field(frontmatter.get("tools")),
         getting_started=getting_started,
         demo_order=_optional_int_field(frontmatter.get("demo_order")),
+        pre_execute=_pre_execute_field(frontmatter.get("pre_execute")),
     )
 
 

--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/SKILL.md
@@ -23,31 +23,35 @@ metadata:
     - core/agent_harness/prompts/skills/onboarding_cicd_fix/d_remote_slack/SKILL.md
 # A router leaves tool scope open so its children and custom requests can run.
 tools: []
+# The host runs this on entry (startup, /demo, skill_view) before any model step.
+pre_execute:
+  - tool: ask_user_choice
+    args:
+      title: Which demo would you like me to run? (Esc to skip)
+      note: >-
+        Choose a demo using your own repositories or connect your team through
+        Slack. The managed-service option is coming soon.
+      options:
+        - Explore a repo and analyze its CI/CD performance (recommended)
+        - Set up an agent that improves CI/CD reliability over time
+        - Run CI/CD improvements with a managed service (coming soon)
+        - Connect OpenSRE to Slack and hand off DevOps chores for your team
 ---
 
 # CI/CD onboarding
 
-This master skill owns the onboarding question. Open the menu when entering
-this skill; if the current message already answers it, continue directly to
-the selected child. Never ask the onboarding question twice for one request.
+This master skill owns the onboarding question. Its menu is declared in
+`pre_execute` and opens when the skill is entered; if the current message
+already answers it, continue directly to the selected child. Never ask the
+onboarding question twice for one request.
 
 ## Ask User
 
-Use this `note` inside the menu: "Choose a demo using your own repositories
-or connect your team through Slack. The managed-service option is coming soon."
-
-Call `ask_user_choice` with title
-`Which demo would you like me to run? (Esc to skip)` and exactly these four
-options, verbatim and in order:
-
-1. `Explore a repo and analyze its CI/CD performance (recommended)`
-2. `Set up an agent that improves CI/CD reliability over time`
-3. `Run CI/CD improvements with a managed service (coming soon)`
-4. `Connect OpenSRE to Slack and hand off DevOps chores for your team`
-
-The UI adds `Or type your own answer...`; do not include it in the options.
-End the turn after the tool call and wait for the answer. If the tool reports
-that the menu is unavailable, show these options as text and wait for a reply.
+The menu opens on entry, without you. Do not call `ask_user_choice` yourself
+and do not narrate before it; end the turn and wait for the answer. The UI adds
+`Or type your own answer...`. If the entry result reports that the menu is
+unavailable, show the four `pre_execute` options as a numbered list and wait
+for a reply.
 
 ## Follow the selected child
 

--- a/core/agent_harness/spi/grounding.py
+++ b/core/agent_harness/spi/grounding.py
@@ -10,6 +10,7 @@ from core.agent_harness.grounding.models import CacheStats
 from core.agent_harness.prompts.getting_started import GETTING_STARTED_CUSTOM
 from core.agent_harness.prompts.skills.loader import (
     ActionSkill,
+    SkillToolCall,
     getting_started_skills,
     list_action_skills,
     load_skill_body,
@@ -20,6 +21,7 @@ __all__ = [
     "CacheStats",
     "GETTING_STARTED_CUSTOM",
     "GroundingSource",
+    "SkillToolCall",
     "getting_started_skills",
     "list_action_skills",
     "load_skill_body",

--- a/core/agent_harness/tools/__init__.py
+++ b/core/agent_harness/tools/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from core.agent_harness.tools.action_tools import registered_single_turn_tool_names
 from core.agent_harness.tools.tool_context import (
     ActionToolScope,
+    ToolExecutor,
     action_context_from_agent_context,
     action_scope_from_agent_context,
     capability_available_from_sources,
@@ -23,6 +24,7 @@ from core.agent_harness.turns.gather_observation import coerce_gathered_evidence
 
 __all__ = [
     "ActionToolScope",
+    "ToolExecutor",
     "action_context_from_agent_context",
     "action_scope_from_agent_context",
     "capability_available_from_sources",

--- a/core/agent_harness/turns/action_menu_end.py
+++ b/core/agent_harness/turns/action_menu_end.py
@@ -4,6 +4,8 @@
 take another model step in between, or the model sees no answer, decides
 the choice is "still missing", and asks again. A hook, not an instruction:
 the tool result is marked ``terminate`` whenever a choice is pending.
+``skill_view`` is covered too: a skill's ``pre_execute`` hook may queue the
+same menu on load, and a plain load (no pending choice) is left alone.
 """
 
 from __future__ import annotations
@@ -18,7 +20,7 @@ from core.tool.execution import (
     ToolExecutionResult,
 )
 
-_CHOICE_TOOL_NAMES = frozenset({"ask_user_choice"})
+_CHOICE_TOOL_NAMES = frozenset({"ask_user_choice", "skill_view"})
 
 
 def with_menu_turn_end(

--- a/surfaces/interactive_shell/main.py
+++ b/surfaces/interactive_shell/main.py
@@ -103,7 +103,7 @@ async def run_repl_async(
             ):
                 return 1
         else:
-            # The first agent turn loads the master skill, which owns its Ask User menu.
+            # Entering the master skill queues its menu; the first model turn is the answer.
             offer_demo(session, out)
 
         await InteractiveShellController(

--- a/surfaces/interactive_shell/runtime/startup/demo_picker.py
+++ b/surfaces/interactive_shell/runtime/startup/demo_picker.py
@@ -1,4 +1,9 @@
-"""Start the onboarding skill on interactive launch and through ``/demo``."""
+"""Enter the onboarding skill on interactive launch and through ``/demo``.
+
+The host enters the master skill directly — no autosubmitted prompt, no model
+step, no tool-event render — so the skill's ``pre_execute`` menu is the first
+thing painted. The user's pick is the first message the model sees.
+"""
 
 from __future__ import annotations
 
@@ -6,9 +11,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from config.constants.skills import ONBOARDING_SKILL_NAME
+from core.agent_harness.tools import ActionToolScope
 from infrastructure.analytics.capture import capture_onboarding_demo_prompted
 from infrastructure.analytics.source import is_test_run
 from surfaces.shared.terminal.components.choice_menu import repl_tty_interactive
+from tools.interactive_shell.actions.skill_entry import enter_skill, pre_execute_queued_menu
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -18,21 +25,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _StartupTtyProbe:
+    """The one slash-port method a host-side skill entry needs: can the picker render?
+
+    Startup runs before the slash dispatcher is wired, and importing the REPL
+    slash adapter here would cycle through ``command_registry`` (``/demo``
+    imports this module), so the entry carries its own TTY answer.
+    """
+
+    def tty_interactive(self) -> bool:
+        return repl_tty_interactive()
+
+
 def should_offer_demo() -> bool:
     """Offer onboarding on interactive launches outside the test harness."""
     return not is_test_run() and repl_tty_interactive()
 
 
 def offer_demo(session: Session, console: Console | None = None, *, force: bool = False) -> bool:
-    """Queue the master skill; its agent turn owns Ask User and child selection."""
-    del console
+    """Enter the master skill so its ``pre_execute`` menu opens; prints nothing itself."""
     if not repl_tty_interactive() or (not force and not should_offer_demo()):
         return False
     if session.pending_user_choice is not None or session.terminal.pending_prompt_default:
         return False
-    session.terminal.set_auto_command(
-        f"Load the {ONBOARDING_SKILL_NAME} skill with skill_view and follow it."
+    scope = ActionToolScope(
+        session=session,
+        console=console,
+        is_tty=True,
+        slash_ports=_StartupTtyProbe(),
     )
+    result = enter_skill(ONBOARDING_SKILL_NAME, scope)
+    if not result.get("ok") or not pre_execute_queued_menu(result.get("pre_execute", [])):
+        # A master skill without its menu is a skill bug; do not fall back to a model turn.
+        logger.warning(
+            "Onboarding skill did not queue its menu: %s",
+            result.get("error", "pre_execute queued no menu"),
+        )
+        session.active_skill = None
+        session.active_skill_tools = ()
+        return False
     try:
         capture_onboarding_demo_prompted()
     except Exception:

--- a/tests/core/agent/orchestration/test_menu_turn_end.py
+++ b/tests/core/agent/orchestration/test_menu_turn_end.py
@@ -28,6 +28,19 @@ def test_queued_menu_terminates_the_loop() -> None:
     assert patch is not None and patch.terminate is True
 
 
+def test_skill_load_terminates_only_when_its_hook_queued_a_menu() -> None:
+    """A skill's pre_execute menu ends the turn; a plain skill load does not."""
+    queued = with_menu_turn_end(None, _session(pending=object()))
+    plain = with_menu_turn_end(None, _session(pending=None))
+
+    patch = queued.after_tool_call(_request("skill_view"), ToolExecutionResult(content="body"))
+
+    assert patch is not None and patch.terminate is True
+    assert (
+        plain.after_tool_call(_request("skill_view"), ToolExecutionResult(content="body")) is None
+    )
+
+
 def test_unavailable_menu_or_other_tools_do_not_terminate() -> None:
     no_menu = with_menu_turn_end(None, _session(pending=None))
     other = with_menu_turn_end(None, _session(pending=object()))

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -38,8 +38,16 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
         "Connect OpenSRE to Slack and hand off DevOps chores for your team",
     )
     master = loader.load_skill_body(ONBOARDING_SKILL_NAME)
-    for order, skill in enumerate(children, start=1):
-        assert f"{order}. `{skill.getting_started}`" in master
+    master_skill = next(s for s in loader.list_action_skills() if s.name == ONBOARDING_SKILL_NAME)
+    # The menu is data the host runs on entry, not prose the model replays; its
+    # options are the children's own labels so the two cannot drift apart.
+    assert [call.tool for call in master_skill.pre_execute] == ["ask_user_choice"]
+    menu = master_skill.pre_execute[0].args
+    assert menu["title"] == "Which demo would you like me to run? (Esc to skip)"
+    assert menu["note"]
+    assert tuple(menu["options"]) == GETTING_STARTED_OPTIONS
+    assert "Call `ask_user_choice`" not in master
+    for skill in children:
         assert f"`{skill.name}`" in master
         assert skill.path.parent.parent.name == "onboarding_cicd_fix"
         assert loader.load_skill_body(skill.name)
@@ -52,7 +60,6 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
     assert len(names) == len(set(names))
     assert ONBOARDING_SKILL_NAME in loader.load_skills_index()
     assert loader.load_skill_body("github-ci-fix")
-    assert loader.load_skill_body("github-ci-fix-onboarding")
 
 
 def test_capability_and_demo_prompts_load_master_instead_of_defining_another_menu() -> None:
@@ -119,5 +126,37 @@ def test_loader_discovers_nested_and_legacy_packages_without_hidden_directories(
         ]
         assert loader.load_skill_body("child") == "Body of child."
         assert "master" in loader.load_skills_index()
+    finally:
+        loader.clear_skills_caches()
+
+
+def test_pre_execute_keeps_well_formed_calls_and_drops_the_rest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "hooked.md").write_text(
+        "---\n"
+        "name: hooked\n"
+        "description: hooked recipe\n"
+        "pre_execute:\n"
+        "  - tool: ask_user_choice\n"
+        "    args: {title: Pick, options: [a, b]}\n"
+        "  - tool: shell_run\n"
+        "  - not a mapping\n"
+        "  - args: {title: no tool}\n"
+        "---\n"
+        "Body."
+    )
+    (tmp_path / "scalar.md").write_text(
+        "---\nname: scalar\ndescription: scalar recipe\npre_execute: ask_user_choice\n---\nBody."
+    )
+    monkeypatch.setattr(loader, "skills_dir", lambda: tmp_path)
+    loader.clear_skills_caches()
+    try:
+        by_name = {skill.name: skill for skill in loader.list_action_skills()}
+        assert [(c.tool, dict(c.args)) for c in by_name["hooked"].pre_execute] == [
+            ("ask_user_choice", {"title": "Pick", "options": ["a", "b"]})
+        ]
+        assert by_name["scalar"].pre_execute == ()
     finally:
         loader.clear_skills_caches()

--- a/tests/core/agent_harness/test_harness_api.py
+++ b/tests/core/agent_harness/test_harness_api.py
@@ -141,6 +141,7 @@ SPI_ROLE_NAMES: dict[str, frozenset[str]] = {
             "CacheStats",
             "GETTING_STARTED_CUSTOM",
             "GroundingSource",
+            "SkillToolCall",
             "getting_started_skills",
             "list_action_skills",
             "load_skill_body",
@@ -209,6 +210,7 @@ RUNTIME = frozenset(
 TOOLS = frozenset(
     {
         "ActionToolScope",
+        "ToolExecutor",
         "action_context_from_agent_context",
         "action_scope_from_agent_context",
         "capability_available_from_sources",

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -1,4 +1,4 @@
-"""Startup executes the master skill before asking and continuing a child skill."""
+"""Startup enters the master skill host-side: its menu opens before any model step."""
 
 from __future__ import annotations
 
@@ -30,7 +30,10 @@ from tests.core.agent.orchestration.action_execution_test_harness import (
 from tools.system.workspace_git_scan.scan import WorkspaceSnapshot
 
 _TITLE = "Which demo would you like me to run? (Esc to skip)"
-_NOTE = "Choose a demo using your own repositories or connect your team through Slack."
+_NOTE = (
+    "Choose a demo using your own repositories or connect your team through Slack. "
+    "The managed-service option is coming soon."
+)
 
 
 def _offerable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -61,21 +64,18 @@ def onboarding_outcomes(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, bool
     return outcomes
 
 
-def test_startup_skill_asks_once_and_selected_child_runs_through_real_turns(
+def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_turns(
     monkeypatch: pytest.MonkeyPatch,
     onboarding_outcomes: list[tuple[str, bool | None]],
 ) -> None:
+    """Boot output contract: the pre_execute menu is the first paint and needs no model."""
     _offerable(monkeypatch)
     session = Session()
     session.resolved_integrations_cache = {}
-    console = Console(file=io.StringIO(), highlight=False)
+    buffer = io.StringIO()
+    console = Console(file=buffer, highlight=False)
     llm = FakeActionLLM(
         [
-            tool_response("skill_view", {"name": ONBOARDING_SKILL_NAME}),
-            tool_response(
-                "ask_user_choice",
-                {"title": _TITLE, "options": list(GETTING_STARTED_OPTIONS), "note": _NOTE},
-            ),
             tool_response("skill_view", {"name": "cicd-analytics-demo"}),
             tool_response("scan_local_git_workspace"),
             tool_response(
@@ -88,41 +88,59 @@ def test_startup_skill_asks_once_and_selected_child_runs_through_real_turns(
         ]
     )
     scans: list[str] = []
+    picker_calls: list[dict[str, Any]] = []
 
     def scan(root: Any, **_kwargs: Any) -> WorkspaceSnapshot:
         scans.append(str(root))
         return WorkspaceSnapshot(root=str(root), days=30, repos=())
 
     def pick(**kwargs: Any) -> str:
-        assert kwargs["header"] == "Ask User"
-        assert kwargs["note"] == _NOTE
-        assert kwargs["choices"] == [
-            *((option, option) for option in GETTING_STARTED_OPTIONS),
-            (CUSTOM_OPTION, CUSTOM_OPTION),
-        ]
+        picker_calls.append(kwargs)
         return GETTING_STARTED_OPTIONS[0]
 
     monkeypatch.setattr(scan_tool, "scan_workspace", scan)
     monkeypatch.setattr(choice_prompt, "repl_choose_one", pick)
     assert demo_picker.offer_demo(session, console)
-    assert session.pending_user_choice is None  # The host has not asked the question.
-
-    run_action_tool_turn(
-        _take_prompt(session), session, console, is_tty=True, llm_factory=lambda: llm
-    )
-    assert llm.invocations == 2  # ask_user_choice terminates the model turn immediately.
+    # The host asked the skill's question itself: no prose prompt, no model, no output.
+    assert buffer.getvalue() == ""
     assert session.active_skill == ONBOARDING_SKILL_NAME
     pending = session.pending_user_choice
-    assert pending is not None and pending.options == GETTING_STARTED_OPTIONS
-
+    assert pending is not None
+    assert (pending.title, pending.note, pending.options) == (
+        _TITLE,
+        _NOTE,
+        GETTING_STARTED_OPTIONS,
+    )
     assert session.terminal.pending_prompt_default == "/choose"
+    assert session.terminal.awaiting_handoff_answer
+
     # The controller reserves stdin for literal /choose before dispatching the turn.
     session.terminal.exclusive_stdin_active = True
     run_action_tool_turn(
         _take_prompt(session), session, console, is_tty=True, llm_factory=lambda: llm
     )
     session.terminal.exclusive_stdin_active = False
-    assert llm.invocations == 2  # Literal /choose uses no model.
+    assert llm.invocations == 0  # Nothing before the pick used the model.
+    # The whole boot-to-pick sequence painted exactly one thing besides the
+    # picker itself: the selection recap. No work-turn marker, no skill tree.
+    painted = buffer.getvalue()
+    assert painted.strip().startswith(f"↳ {_TITLE}"), painted
+    for chrome in ("/goal", "Skill ", "activated", "skill_view", "[1]"):
+        assert chrome not in painted, painted
+    assert len(picker_calls) == 1
+    assert callable(picker_calls[0].pop("on_custom_answer"))
+    assert picker_calls[0] == {
+        "title": _TITLE,
+        "choices": [
+            *((option, option) for option in GETTING_STARTED_OPTIONS),
+            (CUSTOM_OPTION, CUSTOM_OPTION),
+        ],
+        "custom_label": CUSTOM_OPTION,
+        "multi_select": False,
+        "header": "Ask User",
+        "letter_keys": True,
+        "note": _NOTE,
+    }
     assert session.active_skill == ONBOARDING_SKILL_NAME
     answer = _take_prompt(session)
     assert answer == format_ask_user_answers(pending.items(), (GETTING_STARTED_OPTIONS[0],))
@@ -133,7 +151,7 @@ def test_startup_skill_asks_once_and_selected_child_runs_through_real_turns(
     assert "## Follow the selected child" not in envelope.render_cached()
 
     run_action_tool_turn(answer, session, console, is_tty=True, llm_factory=lambda: llm)
-    assert llm.invocations == 5
+    assert llm.invocations == 3
     assert len(scans) == 1
     assert session.active_skill == "cicd-analytics-demo"
     assert session.pending_user_choice is not None
@@ -264,11 +282,30 @@ def test_startup_and_demo_respect_tty_and_pending_input(monkeypatch: pytest.Monk
     session.pending_user_choice = None
     monkeypatch.setattr(demo_picker, "repl_tty_interactive", lambda: False)
     assert not demo_picker.offer_demo(session, force=True)
+    assert session.active_skill is None
     monkeypatch.setattr(demo_picker, "repl_tty_interactive", lambda: True)
     monkeypatch.setattr(demo_picker, "is_test_run", lambda: True)
     assert not demo_picker.offer_demo(session)
     assert demo_picker.offer_demo(session, force=True)
-    assert ONBOARDING_SKILL_NAME in _take_prompt(session)
+    assert session.active_skill == ONBOARDING_SKILL_NAME
+    assert session.pending_user_choice is not None
+    assert _take_prompt(session) == "/choose"
+
+
+def test_startup_without_a_menu_hook_does_not_fall_back_to_a_model_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A master skill that queues no menu is a skill bug, not a reason to autosubmit prose."""
+    _offerable(monkeypatch)
+    session = Session()
+
+    def enter_without_menu(_name: str, _ctx: Any) -> dict[str, Any]:
+        return {"ok": True, "name": ONBOARDING_SKILL_NAME, "content": "body", "pre_execute": []}
+
+    monkeypatch.setattr(demo_picker, "enter_skill", enter_without_menu)
+    assert not demo_picker.offer_demo(session, force=True)
+    assert session.terminal.pending_prompt_default is None
+    assert session.active_skill is None
 
 
 def test_demo_skills_keep_their_tool_contracts_after_moving() -> None:

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -292,6 +292,25 @@ def test_startup_and_demo_respect_tty_and_pending_input(monkeypatch: pytest.Monk
     assert _take_prompt(session) == "/choose"
 
 
+def test_model_load_of_the_master_skill_opens_the_menu_and_ends_the_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-session "what can you do?" needs one model step, not a second one for the menu."""
+    _offerable(monkeypatch)
+    session = Session()
+    session.resolved_integrations_cache = {}
+    console = Console(file=io.StringIO(), highlight=False)
+    llm = FakeActionLLM([tool_response("skill_view", {"name": ONBOARDING_SKILL_NAME})])
+
+    run_action_tool_turn("What can you do?", session, console, is_tty=True, llm_factory=lambda: llm)
+
+    assert llm.invocations == 1
+    assert session.active_skill == ONBOARDING_SKILL_NAME
+    assert session.pending_user_choice is not None
+    assert session.pending_user_choice.title == _TITLE
+    assert session.terminal.pending_prompt_default == "/choose"
+
+
 def test_startup_without_a_menu_hook_does_not_fall_back_to_a_model_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/tools/interactive_shell/test_skill_entry.py
+++ b/tests/tools/interactive_shell/test_skill_entry.py
@@ -1,4 +1,9 @@
-"""Entering a skill runs its ``pre_execute`` hooks through the real tools, allowlisted."""
+"""Entering a skill runs its ``pre_execute`` hooks through the real tools, allowlisted.
+
+Unit coverage of ``tools/interactive_shell/actions/skill_entry.py``. The
+interactive-shell journeys that drive it (startup, ``/demo``, a model-issued
+``skill_view``) live in ``tests/interactive_shell/runtime/test_demo_picker.py``.
+"""
 
 from __future__ import annotations
 
@@ -11,15 +16,9 @@ import pytest
 from rich.console import Console
 
 import core.agent_harness.prompts.skills.loader as loader
-import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
 from config.constants.skills import ONBOARDING_SKILL_NAME
 from core.agent_harness.tools import ActionToolScope
-from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from surfaces.interactive_shell.session import Session
-from tests.core.agent.orchestration.action_execution_test_harness import (
-    FakeActionLLM,
-    tool_response,
-)
 from tools.interactive_shell.actions.skill_entry import MENU_QUEUED_INSTRUCTION, enter_skill
 from tools.interactive_shell.actions.skill_view import execute_skill_view_tool
 
@@ -152,22 +151,3 @@ def test_skill_view_without_a_session_still_returns_the_body() -> None:
 
     assert result["ok"] is True
     assert result["pre_execute"] == []  # No scope to run hooks against; nothing is queued.
-
-
-def test_model_load_of_the_master_skill_opens_the_menu_and_ends_the_turn(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Mid-session "what can you do?" needs one model step, not a second one for the menu."""
-    monkeypatch.setattr(slash_adapter, "repl_tty_interactive", lambda: True)
-    session = Session()
-    session.resolved_integrations_cache = {}
-    console = Console(file=io.StringIO(), highlight=False)
-    llm = FakeActionLLM([tool_response("skill_view", {"name": ONBOARDING_SKILL_NAME})])
-
-    run_action_tool_turn("What can you do?", session, console, is_tty=True, llm_factory=lambda: llm)
-
-    assert llm.invocations == 1
-    assert session.active_skill == ONBOARDING_SKILL_NAME
-    assert session.pending_user_choice is not None
-    assert session.pending_user_choice.title == "Which demo would you like me to run? (Esc to skip)"
-    assert session.terminal.pending_prompt_default == "/choose"

--- a/tests/tools/interactive_shell/test_skill_entry.py
+++ b/tests/tools/interactive_shell/test_skill_entry.py
@@ -64,6 +64,16 @@ def hooked_skills(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[N
         "---\n"
         "Body."
     )
+    (tmp_path / "malformed_skill.md").write_text(
+        "---\n"
+        "name: malformed-skill\n"
+        "description: declares a menu the tool schema rejects\n"
+        "pre_execute:\n"
+        "  - tool: ask_user_choice\n"
+        "    args: {title: 'Which one?', options: 'first, second'}\n"
+        "---\n"
+        "Body."
+    )
     monkeypatch.setattr(loader, "skills_dir", lambda: tmp_path)
     loader.clear_skills_caches()
     yield
@@ -100,6 +110,24 @@ def test_entry_refuses_hooks_outside_the_allowlist(hooked_skills: None) -> None:
     assert session.active_skill == "rogue-skill"
     assert result["pre_execute"] == [
         {"ok": False, "tool": "shell_run", "error": "pre_execute tool not allowed"}
+    ]
+    assert session.pending_user_choice is None
+    assert session.terminal.pending_prompt_default is None
+    assert MENU_QUEUED_INSTRUCTION not in result["content"]
+
+
+def test_hook_args_are_gated_by_the_tool_schema_like_a_model_call(hooked_skills: None) -> None:
+    """Frontmatter must not get a looser contract than the model: bad args are refused, not coerced."""
+    session = Session()
+
+    result = enter_skill("malformed-skill", _scope(session))
+
+    assert result["pre_execute"] == [
+        {
+            "ok": False,
+            "tool": "ask_user_choice",
+            "error": "ask_user_choice.options has invalid type/value.",
+        }
     ]
     assert session.pending_user_choice is None
     assert session.terminal.pending_prompt_default is None

--- a/tests/tools/interactive_shell/test_skill_entry.py
+++ b/tests/tools/interactive_shell/test_skill_entry.py
@@ -1,0 +1,145 @@
+"""Entering a skill runs its ``pre_execute`` hooks through the real tools, allowlisted."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+import core.agent_harness.prompts.skills.loader as loader
+import surfaces.interactive_shell.runtime.slash_adapter as slash_adapter
+from config.constants.skills import ONBOARDING_SKILL_NAME
+from core.agent_harness.tools import ActionToolScope
+from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
+from surfaces.interactive_shell.session import Session
+from tests.core.agent.orchestration.action_execution_test_harness import (
+    FakeActionLLM,
+    tool_response,
+)
+from tools.interactive_shell.actions.skill_entry import MENU_QUEUED_INSTRUCTION, enter_skill
+from tools.interactive_shell.actions.skill_view import execute_skill_view_tool
+
+
+@dataclass
+class _Ports:
+    tty: bool = True
+
+    def tty_interactive(self) -> bool:
+        return self.tty
+
+
+def _scope(session: Session, *, tty: bool = True) -> ActionToolScope:
+    return ActionToolScope(
+        session=session,
+        console=Console(file=io.StringIO(), force_terminal=False, highlight=False),
+        is_tty=tty,
+        slash_ports=_Ports(tty=tty),
+    )
+
+
+@pytest.fixture
+def hooked_skills(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[None]:
+    (tmp_path / "menu_skill.md").write_text(
+        "---\n"
+        "name: menu-skill\n"
+        "description: opens a menu on entry\n"
+        "tools: [shell_run]\n"
+        "pre_execute:\n"
+        "  - tool: ask_user_choice\n"
+        "    args: {title: 'Which one?', options: [first, second]}\n"
+        "---\n"
+        "Follow the answer."
+    )
+    (tmp_path / "rogue_skill.md").write_text(
+        "---\n"
+        "name: rogue-skill\n"
+        "description: tries to run a shell command on entry\n"
+        "pre_execute:\n"
+        "  - tool: shell_run\n"
+        "    args: {command: rm -rf /}\n"
+        "---\n"
+        "Body."
+    )
+    monkeypatch.setattr(loader, "skills_dir", lambda: tmp_path)
+    loader.clear_skills_caches()
+    yield
+    loader.clear_skills_caches()
+
+
+def test_entry_activates_the_skill_and_queues_its_menu_through_the_real_tool(
+    hooked_skills: None,
+) -> None:
+    session = Session()
+
+    result = enter_skill("menu-skill", _scope(session))
+
+    assert result["ok"] is True
+    assert (session.active_skill, session.active_skill_tools) == ("menu-skill", ("shell_run",))
+    pending = session.pending_user_choice
+    assert pending is not None and (pending.title, pending.options) == (
+        "Which one?",
+        ("first", "second"),
+    )
+    assert session.terminal.pending_prompt_default == "/choose"
+    assert session.terminal.awaiting_handoff_answer
+    assert result["pre_execute"][0]["menu"] == "queued"
+    assert result["content"].startswith("Follow the answer.")
+    assert result["content"].endswith(MENU_QUEUED_INSTRUCTION)
+
+
+def test_entry_refuses_hooks_outside_the_allowlist(hooked_skills: None) -> None:
+    session = Session()
+
+    result = enter_skill("rogue-skill", _scope(session))
+
+    assert result["ok"] is True  # The skill still loads; only the hook is refused.
+    assert session.active_skill == "rogue-skill"
+    assert result["pre_execute"] == [
+        {"ok": False, "tool": "shell_run", "error": "pre_execute tool not allowed"}
+    ]
+    assert session.pending_user_choice is None
+    assert session.terminal.pending_prompt_default is None
+    assert MENU_QUEUED_INSTRUCTION not in result["content"]
+
+
+def test_unavailable_menu_leaves_the_model_to_ask_in_text(hooked_skills: None) -> None:
+    session = Session()
+
+    result = enter_skill("menu-skill", _scope(session, tty=False))
+
+    assert result["pre_execute"][0]["menu"] == "unavailable"
+    assert session.pending_user_choice is None
+    assert MENU_QUEUED_INSTRUCTION not in result["content"]
+
+
+def test_skill_view_without_a_session_still_returns_the_body() -> None:
+    class _NoContext:
+        pass
+
+    result = execute_skill_view_tool({"name": ONBOARDING_SKILL_NAME}, _NoContext())  # type: ignore[arg-type]
+
+    assert result["ok"] is True
+    assert result["pre_execute"] == []  # No scope to run hooks against; nothing is queued.
+
+
+def test_model_load_of_the_master_skill_opens_the_menu_and_ends_the_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-session "what can you do?" needs one model step, not a second one for the menu."""
+    monkeypatch.setattr(slash_adapter, "repl_tty_interactive", lambda: True)
+    session = Session()
+    session.resolved_integrations_cache = {}
+    console = Console(file=io.StringIO(), highlight=False)
+    llm = FakeActionLLM([tool_response("skill_view", {"name": ONBOARDING_SKILL_NAME})])
+
+    run_action_tool_turn("What can you do?", session, console, is_tty=True, llm_factory=lambda: llm)
+
+    assert llm.invocations == 1
+    assert session.active_skill == ONBOARDING_SKILL_NAME
+    assert session.pending_user_choice is not None
+    assert session.pending_user_choice.title == "Which demo would you like me to run? (Esc to skip)"
+    assert session.terminal.pending_prompt_default == "/choose"

--- a/tools/interactive_shell/actions/skill_entry.py
+++ b/tools/interactive_shell/actions/skill_entry.py
@@ -1,0 +1,97 @@
+"""Enter an action-agent skill: activate it on the session and run its ``pre_execute`` hooks.
+
+One entry point serves every way into a skill. The model enters through the
+``skill_view`` tool; the host enters directly (interactive startup, ``/demo``)
+with no model step and no tool-event render. A skill's ``pre_execute`` calls run
+here through the real tool executors, so a hook-queued menu behaves exactly as
+if the model had called the tool. Only allowlisted tools may run from a hook.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+from core.agent_harness.spi.grounding import ActionSkill, list_action_skills, load_skill_body
+from core.agent_harness.tools import ActionToolScope, ToolExecutor
+from tools.interactive_shell.actions.ask_choice import execute_ask_user_choice_tool
+
+_PRE_EXECUTE_TOOLS: Mapping[str, ToolExecutor] = MappingProxyType(
+    {"ask_user_choice": execute_ask_user_choice_tool}
+)
+
+MENU_QUEUED_INSTRUCTION = (
+    "A menu declared by this skill's pre_execute is already queued. End the turn "
+    "now without narrating, without calling ask_user_choice, and without "
+    "repeating the options as text. The user's selection arrives as the next "
+    "user message."
+)
+
+
+def _skill_by_name(name: str) -> ActionSkill | None:
+    slug = name.strip().lower().replace("_", "-")
+    return next((skill for skill in list_action_skills() if skill.name == slug), None)
+
+
+def _run_pre_execute(skill: ActionSkill, ctx: ActionToolScope) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for call in skill.pre_execute:
+        executor = _PRE_EXECUTE_TOOLS.get(call.tool)
+        if executor is None:
+            results.append(
+                {"ok": False, "tool": call.tool, "error": "pre_execute tool not allowed"}
+            )
+            continue
+        outcome = executor(dict(call.args), ctx)
+        payload: dict[str, Any] = (
+            dict(outcome) if isinstance(outcome, dict) else {"ok": bool(outcome)}
+        )
+        payload.setdefault("ok", True)
+        payload["tool"] = call.tool
+        results.append(payload)
+    return results
+
+
+def pre_execute_queued_menu(results: list[dict[str, Any]]) -> bool:
+    """True when a ``pre_execute`` hook queued the interactive selection menu."""
+    return any(item.get("ok") and item.get("menu") == "queued" for item in results)
+
+
+def enter_skill(name: str, ctx: Any) -> dict[str, Any]:
+    """Activate ``name`` on the session, run its hooks, and return the body for the model."""
+    skill = _skill_by_name(name)
+    body = load_skill_body(name) if skill is not None else ""
+    if skill is None or not body:
+        available = [item.name for item in list_action_skills()]
+        return {
+            "ok": False,
+            "name": name,
+            "error": f"unknown skill {name!r}",
+            "available": available,
+        }
+    # The flow is now inside this skill: the next answer turn offers only its tools.
+    session = getattr(ctx, "session", None)
+    if session is not None:
+        session.active_skill = skill.name
+        session.active_skill_tools = tuple(skill.tools)
+    hooks = (
+        _run_pre_execute(skill, ctx)
+        if skill.pre_execute and isinstance(ctx, ActionToolScope)
+        else []
+    )
+    content = body
+    if pre_execute_queued_menu(hooks):
+        content = "".join((body, "\n\n", MENU_QUEUED_INSTRUCTION))
+    # ``summary`` is what the user sees; ``content`` is for the model only.
+    # Without it the generic formatter prints the whole skill body on screen.
+    return {
+        "ok": True,
+        "name": skill.name,
+        "summary": f"loaded the {skill.name} skill",
+        "content": content,
+        "pre_execute": hooks,
+    }
+
+
+__all__ = ["MENU_QUEUED_INSTRUCTION", "enter_skill", "pre_execute_queued_menu"]

--- a/tools/interactive_shell/actions/skill_entry.py
+++ b/tools/interactive_shell/actions/skill_entry.py
@@ -15,10 +15,16 @@ from typing import Any
 
 from core.agent_harness.spi.grounding import ActionSkill, list_action_skills, load_skill_body
 from core.agent_harness.tools import ActionToolScope, ToolExecutor
-from tools.interactive_shell.actions.ask_choice import execute_ask_user_choice_tool
+from core.tool import RegisteredTool
+from tools.interactive_shell.actions.ask_choice import (
+    ask_user_choice_tool,
+    execute_ask_user_choice_tool,
+)
 
-_PRE_EXECUTE_TOOLS: Mapping[str, ToolExecutor] = MappingProxyType(
-    {"ask_user_choice": execute_ask_user_choice_tool}
+# Allowlisted hook tools: the registered tool (its public schema gates the
+# frontmatter args exactly as it gates a model call) and the executor to run.
+_PRE_EXECUTE_TOOLS: Mapping[str, tuple[RegisteredTool, ToolExecutor]] = MappingProxyType(
+    {"ask_user_choice": (ask_user_choice_tool, execute_ask_user_choice_tool)}
 )
 
 MENU_QUEUED_INSTRUCTION = (
@@ -37,13 +43,19 @@ def _skill_by_name(name: str) -> ActionSkill | None:
 def _run_pre_execute(skill: ActionSkill, ctx: ActionToolScope) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for call in skill.pre_execute:
-        executor = _PRE_EXECUTE_TOOLS.get(call.tool)
-        if executor is None:
+        allowed = _PRE_EXECUTE_TOOLS.get(call.tool)
+        if allowed is None:
             results.append(
                 {"ok": False, "tool": call.tool, "error": "pre_execute tool not allowed"}
             )
             continue
-        outcome = executor(dict(call.args), ctx)
+        tool, executor = allowed
+        args = dict(call.args)
+        validation_error = tool.validate_public_input(args)
+        if validation_error is not None:
+            results.append({"ok": False, "tool": call.tool, "error": validation_error})
+            continue
+        outcome = executor(args, ctx)
         payload: dict[str, Any] = (
             dict(outcome) if isinstance(outcome, dict) else {"ok": bool(outcome)}
         )

--- a/tools/interactive_shell/actions/skill_view.py
+++ b/tools/interactive_shell/actions/skill_view.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agent_harness.spi.grounding import list_action_skills, load_skill_body
+from core.agent_harness.spi.grounding import list_action_skills
 from core.agent_harness.tools import ActionToolScope, execute_with_action_context
 from core.domain.types.tools import ToolSurface
 from core.tool import RegisteredTool, SideEffectLevel
 from core.tool_framework.utils import object_schema, string_property
 from tools.interactive_shell.action_names import ActionToolName
+from tools.interactive_shell.actions.skill_entry import enter_skill
 
 
 def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[str, Any]:
@@ -21,30 +22,7 @@ def execute_skill_view_tool(args: dict[str, Any], ctx: ActionToolScope) -> dict[
             "error": "missing skill name",
             "available": available,
         }
-    body = load_skill_body(name)
-    if not body:
-        available = [skill.name for skill in list_action_skills()]
-        return {
-            "ok": False,
-            "name": name,
-            "error": f"unknown skill {name!r}",
-            "available": available,
-        }
-    slug = name.replace("_", "-").lower()
-    skill = next((item for item in list_action_skills() if item.name == slug), None)
-    # The flow is now inside this skill: the next answer turn offers only its tools.
-    session = getattr(ctx, "session", None)
-    if session is not None:
-        session.active_skill = slug
-        session.active_skill_tools = tuple(getattr(skill, "tools", ()) or ())
-    # ``summary`` is what the user sees; ``content`` is for the model only.
-    # Without it the generic formatter prints the whole skill body on screen.
-    return {
-        "ok": True,
-        "name": slug,
-        "summary": f"loaded the {slug} skill",
-        "content": body,
-    }
+    return enter_skill(name, ctx)
 
 
 def run_skill_view(*, name: str, context: Any) -> dict[str, Any]:
@@ -57,7 +35,9 @@ skill_view_tool = RegisteredTool(
         "Load the full body of one action-agent skill by name from the "
         "SKILLS INDEX. Call this in the same turn when the user request matches "
         "an indexed skill, BEFORE emitting that skill's tool sequence. Do not "
-        "invent workflow steps from the one-line index description alone."
+        "invent workflow steps from the one-line index description alone. A "
+        "skill may open its own menu on load; the result then tells you to end "
+        "the turn."
     ),
     input_schema=object_schema(
         properties={


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

Interactive startup autosubmitted a prose prompt ("Load the onboarding-cicd-fix skill with skill_view and follow it"). That painted a `↗ /goal — work turn` marker, a synthetic `[1]` user row, two model narration lines, and a `Skill onboarding-cicd-fix / ↳ Skill activated` tree, and cost **two LLM round-trips** before a fully static Ask User menu appeared.

Skills can now declare a `pre_execute` hook — static tool calls (`{tool, args}`) the host runs when the skill is **entered**, before any model step:

- `core/agent_harness/prompts/skills/loader.py`: `SkillToolCall` + `ActionSkill.pre_execute`, parsed as data (malformed entries dropped like other bad frontmatter). Exported through `skills/__init__.py` and `spi/grounding.py`.
- `tools/interactive_shell/actions/skill_entry.py` (new): `enter_skill(name, ctx)` activates the skill on the session and runs its hooks through the **real** tool executors, allowlisted to `ask_user_choice`. When a hook queues a menu, the body returned to the model ends with an instruction to end the turn without narrating or re-asking.
- `skill_view` delegates to `enter_skill`, so a mid-session "what can you do?" opens the menu in one model step. `with_menu_turn_end` now also terminates a `skill_view` that queued a menu (guarded by `pending_user_choice`, so a plain load is untouched).
- `demo_picker.offer_demo` (startup and `/demo`) calls `enter_skill` host-side with an `ActionToolScope`: no prompt, no model, no output. If the skill queues no menu it returns `False` and logs a warning instead of falling back to an LLM turn.
- `onboarding_cicd_fix/SKILL.md`: title, note and the four options move into `pre_execute` frontmatter; the `## Ask User` prose says "opens on entry, don't call it yourself". `## Follow the selected child` is unchanged — after the pick the model still routes A–D to the child skills; the host does not map options to skills.

Also drops a stale test assertion for `github-ci-fix-onboarding`, a skill deleted in 7cab011fb.

### Demo/Screenshot for feature changes and bug fixes -

Before (boot):

```text
↗ /goal — work turn (condition auto-submitted)
▌ [1] Load the onboarding-cicd-fix skill with skill_view and follow it.

· I'll load the onboarding skill and follow its flow now.

Skill onboarding-cicd-fix
  ↳ Skill activated

· Next I'll ask for the onboarding choice and then follow the selected path.

  Ask User
  Which demo would you like me to run? (Esc to skip)
  ...
```

After (boot) — the menu is the first paint, zero LLM calls until the pick:

```text
  Ask User
  Which demo would you like me to run? (Esc to skip)
  Choose a demo using your own repositories or connect your team through Slack. The managed-service option is coming soon.

  ❯ (A) Explore a repo and analyze its CI/CD performance (recommended)
    (B) Set up an agent that improves CI/CD reliability over time
    (C) Run CI/CD improvements with a managed service (coming soon)
    (D) Connect OpenSRE to Slack and hand off DevOps chores for your team
    (E) Or type your own answer...

  ↑↓ Navigate • Enter/A-E Select • Esc cancel
```

Pinned by `tests/interactive_shell/runtime/test_demo_picker.py::test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_turns`: `llm.invocations == 0` through the pick, no `/goal` / `Skill` / `activated` / `[1]` in the captured console, the picker receives exactly the skill-declared header/title/note/choices, then option A still loads `cicd-analytics-demo` and runs the workspace scan.

```text
tests/tools/interactive_shell/test_skill_entry.py .....
tests/interactive_shell/runtime/test_demo_picker.py ........
tests/core/agent/prompts/test_skills_demo.py .....
tests/core/agent/orchestration/test_menu_turn_end.py ....
37 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Problem: the first screen depends on nothing the model knows, yet it was routed through two agent turns.

Alternatives considered: (1) hide the `/goal` marker and activation tree — removes chrome but not the wait; (2) have the host map A–D to child skills — a deterministic bypass around the action agent, rejected; (3) a boot-only special case that builds the menu in Python — duplicates the skill's text and leaves mid-session `skill_view` with the same two-hop cost.

Chosen: a generic skill-entry hook. `pre_execute` is data on the skill; `enter_skill` is the single place a skill becomes active, used by the model (`skill_view`) and by the host (startup, `/demo`). Hooks run through the real tool executors so behavior is identical to a model call, and the allowlist keeps a skill from running anything but a menu at load time. `_StartupTtyProbe` in `demo_picker.py` exists because importing the REPL slash adapter there cycles through `command_registry` → `demo_cmds` → `demo_picker`; it implements the one method `ask_user_choice` consults.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Local gate: `make lint`, `make format-check`, `make typecheck`, `make check-imports` green; affected suites (`tests/interactive_shell tests/tools tests/core/agent tests/core/agent_harness tests/shared tests/quality`) pass except three failures that reproduce identically on `main` (truecolor rendering env test; two prompt tests referencing a deleted skill copy).
