### PR TITLE
fix(scheduler): preserve PATH in systemd background service definitio…

### DIFF
--- a/infrastructure/scheduling/scheduler/background_service.py
+++ b/infrastructure/scheduling/scheduler/background_service.py
@@ -195,12 +195,14 @@ def _launchd_definition(argv: Sequence[str], log_path: Path) -> dict[str, object
 
 def _systemd_definition(argv: Sequence[str], log_path: Path) -> str:
     exec_start = " ".join(_systemd_quote(part) for part in argv)
+    path_env = os.environ.get("PATH", "/usr/bin:/bin")
     return (
         "[Unit]\n"
         "Description=OpenSRE scheduler\n"
         "After=network-online.target\n\n"
         "[Service]\n"
         f"ExecStart={exec_start}\n"
+        f'Environment="PATH={path_env}"\n'
         "Restart=always\n"
         "RestartSec=10\n"
         f"StandardOutput=append:{log_path}\n"

--- a/infrastructure/scheduling/scheduler/background_service.py
+++ b/infrastructure/scheduling/scheduler/background_service.py
@@ -196,19 +196,35 @@ def _launchd_definition(argv: Sequence[str], log_path: Path) -> dict[str, object
 def _systemd_definition(argv: Sequence[str], log_path: Path) -> str:
     exec_start = " ".join(_systemd_quote(part) for part in argv)
     path_env = os.environ.get("PATH", "/usr/bin:/bin")
+    escaped_path = _systemd_escape_env(path_env)
     return (
         "[Unit]\n"
         "Description=OpenSRE scheduler\n"
         "After=network-online.target\n\n"
         "[Service]\n"
         f"ExecStart={exec_start}\n"
-        f'Environment="PATH={path_env}"\n'
+        f'Environment="PATH={escaped_path}"\n'
         "Restart=always\n"
         "RestartSec=10\n"
         f"StandardOutput=append:{log_path}\n"
         f"StandardError=append:{log_path}\n\n"
         "[Install]\n"
         "WantedBy=default.target\n"
+    )
+
+
+def _systemd_escape_env(value: str) -> str:
+    """Escape an environment variable value for systemd unit file syntax.
+
+    In systemd unit syntax, values inside double quotes support C-style
+    escapes: backslashes must be doubled, double quotes escaped with a
+    backslash, and newlines encoded as '\\n'.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
     )
 
 

--- a/tests/scheduler/test_background_service.py
+++ b/tests/scheduler/test_background_service.py
@@ -129,6 +129,25 @@ def test_linux_install_writes_a_systemd_user_unit(
     assert runner.commands[-1][:4] == ["systemctl", "--user", "enable", "--now"]
 
 
+def test_linux_install_escapes_systemd_special_characters_in_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    monkeypatch.setenv("PATH", r'/usr/bin:/bin with "quotes":/path\with\backslash')
+    runner = _Runner()
+
+    state = svc.install_background_service(
+        home=tmp_path,
+        system="Linux",
+        run=runner,
+        command=["/usr/bin/opensre", "cron", "start", "--service"],
+    )
+
+    assert state.unit_path is not None
+    unit = state.unit_path.read_text()
+    assert r'Environment="PATH=/usr/bin:/bin with \"quotes\":/path\\with\\backslash"' in unit
+
+
 def test_other_platforms_are_reported_unsupported_without_touching_the_os(tmp_path: Path) -> None:
     runner = _Runner()
 

--- a/tests/scheduler/test_background_service.py
+++ b/tests/scheduler/test_background_service.py
@@ -111,6 +111,7 @@ def test_linux_install_writes_a_systemd_user_unit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(svc, "OPENSRE_HOME_DIR", tmp_path / ".opensre")
+    monkeypatch.setenv("PATH", "/custom/bin:/usr/bin")
     runner = _Runner()
 
     state = svc.install_background_service(
@@ -123,6 +124,7 @@ def test_linux_install_writes_a_systemd_user_unit(
     assert state.unit_path is not None
     unit = state.unit_path.read_text()
     assert "ExecStart=/usr/bin/opensre cron start --service" in unit
+    assert 'Environment="PATH=/custom/bin:/usr/bin"' in unit
     assert "Restart=always" in unit
     assert runner.commands[-1][:4] == ["systemctl", "--user", "enable", "--now"]
 


### PR DESCRIPTION
Fixes #6131

#### Describe the changes you have made in this PR -
- In `infrastructure/scheduling/scheduler/background_service.py`, updated `_systemd_definition()` to include `Environment="PATH=..."` in the `[Service]` block, using `os.environ.get("PATH", "/usr/bin:/bin")`.
- In `tests/scheduler/test_background_service.py`, updated `test_linux_install_writes_a_systemd_user_unit` to assert the generated systemd unit contains `Environment="PATH=..."`.

#### Demo/Screenshot for feature changes and bug fixes -
<img width="1500" height="717" alt="image" src="https://github.com/user-attachments/assets/fbdf2f8e-1925-409d-94b4-4f755def39e6" />
<img width="1355" height="161" alt="image" src="https://github.com/user-attachments/assets/2005b9af-df29-4d30-a31c-a7a63f925cd7" />
<img width="1372" height="706" alt="image" src="https://github.com/user-attachments/assets/bae72ec0-9dd0-40a1-a8bc-6162c59ba592" />

```text
=== Background Service Unit Test Verification ===
PASS: test_linux_install (Systemd unit generated with Environment='PATH=...')
PASS: test_macos_install (Launchd plist generated with EnvironmentVariables)

=== Import and Cycle Check ===
No import cycles found across 1937 first-party modules (8 roots).
No forbidden direct import edges found (module baseline: 0, nested baseline: 0).
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The macOS `_launchd_definition()` already propagates `PATH` via `EnvironmentVariables`, but the Linux `_systemd_definition()` was omitting it. Since systemd user services default to the minimal `/usr/bin:/bin`, the scheduler's background daemon couldn't locate binaries installed in `~/.local/bin` or in user virtualenvs. Adding `Environment="PATH=..."` to `_systemd_definition()` brings Linux systemd in line with macOS launchd behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions