### PR TITLE
refactor(llm-cli): share output parsing

### DIFF
--- a/integrations/llm_cli/antigravity_cli.py
+++ b/integrations/llm_cli/antigravity_cli.py
@@ -53,6 +53,7 @@ from integrations.llm_cli.constants import (
 from integrations.llm_cli.constants import (
     MIN_EXEC_TIMEOUT_SEC as _MIN_EXEC_TIMEOUT_SEC,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
 from integrations.llm_cli.subprocess_env import build_cli_subprocess_env
@@ -277,13 +278,7 @@ class AntigravityCLIAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/claude_code.py
+++ b/integrations/llm_cli/claude_code.py
@@ -56,6 +56,7 @@ from integrations.llm_cli.env_overrides import (
     ANTHROPIC_CLI_ENV_KEYS,
     nonempty_env_values,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part
 from integrations.llm_cli.subprocess_env import build_cli_subprocess_env
@@ -336,13 +337,7 @@ class ClaudeCodeAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/codex.py
+++ b/integrations/llm_cli/codex.py
@@ -25,6 +25,7 @@ from integrations.llm_cli.env_overrides import (
     OPENAI_PLATFORM_ENV_KEYS,
     nonempty_env_values,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
 
@@ -234,13 +235,7 @@ class CodexAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/copilot.py
+++ b/integrations/llm_cli/copilot.py
@@ -66,6 +66,7 @@ from integrations.llm_cli.env_overrides import (
     COPILOT_CLI_ENV_KEYS,
     nonempty_env_values,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part
 
@@ -320,13 +321,7 @@ class CopilotAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/cursor.py
+++ b/integrations/llm_cli/cursor.py
@@ -16,6 +16,7 @@ from integrations.llm_cli.binary_resolver import (
 from integrations.llm_cli.binary_resolver import resolve_cli_binary
 from integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
 from integrations.llm_cli.env_overrides import CURSOR_CLI_ENV_KEYS, nonempty_env_values
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 
 _CURSOR_VERSION_RE = re.compile(r"(\d{4}\.\d{2}\.\d{2}-[a-zA-Z0-9]+|\d+\.\d+\.\d+)")
@@ -202,15 +203,14 @@ class CursorAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            if returncode == 0:
-                raise RuntimeError("Cursor Agent CLI returned empty output.")
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        empty_output_error = "Cursor Agent CLI returned empty output." if returncode == 0 else None
+        return require_nonempty_output(
+            stdout,
+            stderr,
+            returncode,
+            self.explain_failure,
+            empty_output_error=empty_output_error,
+        )
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/gemini_cli.py
+++ b/integrations/llm_cli/gemini_cli.py
@@ -38,6 +38,7 @@ from integrations.llm_cli.constants import (
 from integrations.llm_cli.constants import (
     MIN_EXEC_TIMEOUT_SEC as _MIN_EXEC_TIMEOUT_SEC,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part
 from integrations.llm_cli.subprocess_env import build_cli_subprocess_env
@@ -259,12 +260,7 @@ class GeminiCLIAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        text = (stdout or "").strip()
-        if not text:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
+        text = require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
         try:
             payload = json.loads(text)
         except json.JSONDecodeError:

--- a/integrations/llm_cli/grok_cli.py
+++ b/integrations/llm_cli/grok_cli.py
@@ -61,6 +61,7 @@ from integrations.llm_cli.env_overrides import (
     XAI_CLI_ENV_KEYS,
     nonempty_env_values,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part
 from integrations.llm_cli.timeout_utils import resolve_timeout_from_env
@@ -301,13 +302,7 @@ class GrokCLIAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/kimi.py
+++ b/integrations/llm_cli/kimi.py
@@ -19,6 +19,7 @@ from integrations.llm_cli.binary_resolver import (
 )
 from integrations.llm_cli.binary_resolver import resolve_cli_binary
 from integrations.llm_cli.constants import DEFAULT_EXEC_TIMEOUT_SEC
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part, semver_to_tuple
 
@@ -268,13 +269,7 @@ class KimiAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/opencode.py
+++ b/integrations/llm_cli/opencode.py
@@ -27,6 +27,7 @@ from integrations.llm_cli.env_overrides import (
     HTTP_LLM_PROVIDER_ENV_KEYS,
     nonempty_env_values,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part
 
@@ -219,13 +220,7 @@ class OpenCodeAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/integrations/llm_cli/output.py
+++ b/integrations/llm_cli/output.py
@@ -1,0 +1,24 @@
+"""Shared output validation for non-interactive LLM CLI adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def require_nonempty_output(
+    stdout: str,
+    stderr: str,
+    returncode: int,
+    explain_failure: Callable[..., str],
+    *,
+    empty_output_error: str | None = None,
+) -> str:
+    """Return stripped CLI output or raise the adapter's descriptive error."""
+    result = (stdout or "").strip()
+    if result:
+        return result
+
+    message = empty_output_error or (
+        f"{explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)} (empty output)"
+    )
+    raise RuntimeError(message)

--- a/integrations/llm_cli/pi_cli.py
+++ b/integrations/llm_cli/pi_cli.py
@@ -60,6 +60,7 @@ from integrations.llm_cli.env_overrides import (
     PI_PROVIDER_ENV_KEYS,
     nonempty_env_values,
 )
+from integrations.llm_cli.output import require_nonempty_output
 from integrations.llm_cli.probe_utils import run_version_probe
 from integrations.llm_cli.semver_utils import parse_semver_three_part
 
@@ -250,13 +251,7 @@ class PiAdapter:
         )
 
     def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
-        result = (stdout or "").strip()
-        if not result:
-            raise RuntimeError(
-                self.explain_failure(stdout=stdout, stderr=stderr, returncode=returncode)
-                + " (empty output)"
-            )
-        return result
+        return require_nonempty_output(stdout, stderr, returncode, self.explain_failure)
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
         from integrations.llm_cli.failure_explain import explain_cli_failure

--- a/tests/integrations/llm_cli/test_output.py
+++ b/tests/integrations/llm_cli/test_output.py
@@ -1,0 +1,16 @@
+"""Tests for shared CLI output validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations.llm_cli.output import require_nonempty_output
+
+
+def _failure_detail(*, stdout: str, stderr: str, returncode: int) -> str:
+    return f"exit {returncode}: {stderr or stdout}"
+
+
+def test_require_nonempty_output_preserves_adapter_failure_detail() -> None:
+    with pytest.raises(RuntimeError, match=r"exit 1: unavailable \(empty output\)"):
+        require_nonempty_output("", "unavailable", 1, _failure_detail)


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

- Centralize the shared trim-and-reject-empty behavior used by all ten LLM CLI adapters.
- Preserve each adapter's existing failure explanation; Cursor keeps its distinct zero-exit empty-output message and Gemini keeps its JSON-envelope parsing.
- Add a focused regression test for the shared error path.

### Demo/Screenshot for feature changes and bug fixes -

```
uv run python -m pytest tests/integrations/llm_cli
347 passed, 1 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The adapters all strip stdout and attach their own `explain_failure` result when it is empty. A small shared helper now owns that invariant and accepts the adapter failure callback. This removes duplicated parser bodies while retaining provider-specific behavior. Cursor supplies its existing special successful-exit message, and Gemini validates output before retaining its existing JSON parsing. The alternative of changing the adapter protocol or normalizing all provider failure messages would add coupling and risk behavior changes, so the helper keeps the current boundary.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how the code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
