### PR TITLE
refactor(integrations): remove unused external catalog hooks

### DIFF
--- a/integrations/_catalog_impl.py
+++ b/integrations/_catalog_impl.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import functools
 import json
 import logging
 import os
-import threading
 from collections.abc import Callable
 from typing import Any
 
@@ -346,10 +344,8 @@ from integrations.registry import (
     DIRECT_CLASSIFIED_EFFECTIVE_SERVICES,
     INTEGRATION_SPECS_BY_SERVICE,
     SKIP_CLASSIFIED_SERVICES,
-    builtin_claimed_keys,
     external_integration_services,
     family_key,
-    normalize_service_key,
     service_key,
 )
 from integrations.rocketchat import classify as _classify_rocketchat
@@ -555,141 +551,6 @@ _CLASSIFIERS: dict[str, _ClassifyFn] = {
     "yandex_cloud": _classify_yandex_cloud,
 }
 
-#: Classifiers contributed by out-of-tree integration packages.
-_EXTERNAL_CLASSIFIERS: dict[str, _ClassifyFn] = {}
-
-#: Environment loaders contributed by out-of-tree integration packages. Each
-#: returns an active record, or None when its variables are not set.
-_EXTERNAL_ENV_LOADERS: dict[str, Any] = {}
-
-#: Cheap "is this configured?" predicates for out-of-tree integrations, used by
-#: the startup-safe presence check that must not touch the keyring.
-_EXTERNAL_ENV_PRESENCE: dict[str, Callable[[], bool]] = {}
-
-
-#: Which package registered each hook, keyed by ``(hook, service)``. The hook
-#: maps themselves store only the callable, and the entry has to be attributable
-#: to decide whether a second registration is the same plugin reloading or a
-#: different one taking the key over.
-_EXTERNAL_HOOK_OWNERS: dict[tuple[str, str], str] = {}
-
-#: Serialises claiming a key with installing the callback. Reading the current
-#: owner and then writing is a check-then-act: two packages registering the same
-#: key concurrently could both see it free and the later one would win silently.
-_HOOK_REGISTRATION_LOCK = threading.Lock()
-
-
-def _hook_owner(callback: Any) -> str:
-    """Return the top-level package *callback* was defined in, or "" if unknown.
-
-    Owner is inferred rather than passed in so the hook signatures stay as they
-    are. A plugin that reloads produces a new function object from the same
-    package, which has to keep working; a different package must not.
-    """
-    target = callback
-    while isinstance(target, functools.partial):
-        target = target.func
-    module = str(getattr(target, "__module__", "") or "")
-    root = module.split(".", 1)[0]
-    # ``functools`` is what a partial reports through its type, and a builtin
-    # says nothing about who registered it - neither identifies a plugin.
-    return "" if root in {"functools", "builtins"} else root
-
-
-def _install_external_hook(
-    target: dict[str, Any], service: str, callback: Any, *, hook: str
-) -> None:
-    """Claim *service* for *callback* and install it into *target*, as one step.
-
-    Claiming and installing are a single critical section: read the owner, then
-    write, and two packages registering the same key concurrently would both see
-    it free and the later one would take it with nothing reported.
-    """
-    with _HOOK_REGISTRATION_LOCK:
-        target[_claim_external_hook(service, callback, hook=hook)] = callback
-
-
-def _claim_external_hook(service: str, callback: Any, *, hook: str) -> str:
-    """Return the key *hook* may be stored under, or raise if it is not allowed.
-
-    Callers reach this through :func:`_install_external_hook`, which holds the
-    registration lock across the check and the write.
-
-    ``register_integration_spec`` already refuses built-in keys and keys another
-    plugin holds, but each hook below can be called without ever registering a
-    spec. Two packages registering under the same key would otherwise be settled
-    by import order, with the later one classifying, loading or reporting
-    presence for the earlier one's integration.
-
-    Normalized for the same reason the registry normalizes: every lookup here is
-    by a stripped, lower-cased key, so storing ``"GitHub"`` verbatim would both
-    slip past this check and register under a name nothing ever queries.
-    """
-    key = normalize_service_key(service)
-    if not key:
-        raise ValueError(f"Cannot register {hook} without a service name.")
-    if key in builtin_claimed_keys():
-        raise ValueError(
-            f"Cannot register {hook} for {service!r}: a built-in integration already "
-            "answers to that key."
-        )
-
-    owner = _hook_owner(callback)
-    previous = _EXTERNAL_HOOK_OWNERS.get((hook, key))
-    if previous is not None and (not owner or previous != owner):
-        held_by = f"{previous!r}" if previous else "another package"
-        raise ValueError(
-            f"Cannot register {hook} for {key!r}: already registered by {held_by}. "
-            "Two packages cannot share one integration's hooks; pick a key unique to "
-            "this integration."
-        )
-
-    _EXTERNAL_HOOK_OWNERS[(hook, key)] = owner
-    return key
-
-
-def register_classifier(service: str, classify: _ClassifyFn) -> None:
-    """Register the classifier for an integration shipped outside this repo."""
-    _install_external_hook(_EXTERNAL_CLASSIFIERS, service, classify, hook="a classifier")
-
-
-def register_env_loader(service: str, loader: Any) -> None:
-    """Register an environment loader for an out-of-tree integration.
-
-    The loader is called with no arguments during ``load_env_integrations`` and
-    returns a record in the same shape ``_active_env_record`` produces, or None
-    when the integration is not configured in the environment. The record must
-    be for *service*: one naming a different integration is dropped, since the
-    merge that follows lets a later record replace an earlier one by service.
-    """
-    _install_external_hook(_EXTERNAL_ENV_LOADERS, service, loader, hook="an environment loader")
-
-
-def register_env_presence(service: str, is_configured: Callable[[], bool]) -> None:
-    """Register the startup-safe presence check for an out-of-tree integration.
-
-    ``load_env_integration_services`` runs before the first prompt and must not
-    resolve secrets, so it cannot call the full loader registered above. Without
-    a predicate here an integration configured purely from the environment stays
-    invisible to the welcome, REPL and health surfaces even though verification
-    and tool resolution both see it.
-    """
-    _install_external_hook(_EXTERNAL_ENV_PRESENCE, service, is_configured, hook="a presence check")
-
-
-def external_env_presence_services() -> list[str]:
-    """Return the out-of-tree services whose environment variables are set."""
-    present: list[str] = []
-    # Snapshot: a plugin registering from another thread would otherwise turn
-    # this into "dictionary changed size during iteration" mid-startup.
-    for service, is_configured in list(_EXTERNAL_ENV_PRESENCE.items()):
-        try:
-            if is_configured():
-                present.append(service)
-        except Exception as exc:  # a plugin predicate must not break startup
-            _report_env_loader_failure(exc, integration=service)
-    return present
-
 
 def _classify_service_instance(
     key: str, credentials: dict[str, Any], *, record_id: str
@@ -701,7 +562,7 @@ def _classify_service_instance(
     ``key`` itself, but Grafana splits into ``grafana`` or ``grafana_local``
     based on its ``is_local`` property.
     """
-    handler = _CLASSIFIERS.get(key) or _EXTERNAL_CLASSIFIERS.get(key)
+    handler = _CLASSIFIERS.get(key)
     if handler is not None:
         return handler(credentials, record_id)
     # Fallback for unknown services: pass through credentials + record id.
@@ -2106,27 +1967,6 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     yandex_cloud_config.model_dump(exclude={"integration_id"}),
                 )
             )
-
-    for service, loader in list(_EXTERNAL_ENV_LOADERS.items()):
-        try:
-            record = loader()
-        except Exception as exc:
-            _report_env_loader_failure(exc, integration=service)
-        else:
-            if not record:
-                continue
-            emitted = normalize_service_key(str(record.get("service", service)))
-            if emitted != service:
-                # The merge below replaces an earlier record with a later one of
-                # the same service, so an emitted name other than the registered
-                # one would let this loader stand in for another integration.
-                logger.warning(
-                    "load_env_integrations: loader registered for %r emitted %r; dropping it",
-                    service,
-                    emitted,
-                )
-                continue
-            integrations.append(record)
 
     return integrations
 

--- a/integrations/catalog.py
+++ b/integrations/catalog.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from typing import Any, cast
 
 from config.constants.google_docs import (
@@ -209,10 +208,6 @@ def load_env_integration_services() -> list[str]:
         or os.getenv(YC_USE_METADATA_ENV, "").strip().lower() in {"1", "true", "yes", "on"},
     )
 
-    impl = sys.modules.get("integrations._catalog_impl")
-    if impl is not None:
-        services.extend(impl.external_env_presence_services())
-
     return list(dict.fromkeys(services))
 
 
@@ -343,18 +338,6 @@ def configured_integration_health() -> list[tuple[str, str]]:
     return health
 
 
-def register_classifier(service: str, classify: Any) -> None:
-    _load_catalog_impl().register_classifier(service, classify)
-
-
-def register_env_loader(service: str, loader: Any) -> None:
-    _load_catalog_impl().register_env_loader(service, loader)
-
-
-def register_env_presence(service: str, is_configured: Any) -> None:
-    _load_catalog_impl().register_env_presence(service, is_configured)
-
-
 __all__ = [
     "classify_integrations",
     "configured_integration_health",
@@ -364,8 +347,5 @@ __all__ = [
     "load_integrations",
     "merge_integrations_by_service",
     "merge_local_integrations",
-    "register_classifier",
-    "register_env_loader",
-    "register_env_presence",
     "resolve_effective_integrations",
 ]

--- a/tests/integrations/test_external_registration.py
+++ b/tests/integrations/test_external_registration.py
@@ -1,61 +1,21 @@
-"""An out-of-tree integration has to survive the paths production actually uses.
-
-Each test here drives a public entry point rather than the structure beneath it.
-Asserting on ``EffectiveIntegrations`` or on ``registry.SUPPORTED_VERIFY_SERVICES``
-directly would pass even when the resolver drops the key and when every importing
-module is left holding a pre-registration snapshot.
-"""
+"""Tests for out-of-tree integration spec registration."""
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterator
-from typing import Any
 
 import pytest
 
-from integrations import _catalog_impl, registry
-from integrations.catalog import (
-    load_env_integration_services,
-    register_classifier,
-    register_env_loader,
-    register_env_presence,
-    resolve_effective_integrations,
-)
+from integrations import registry
+from integrations.catalog import resolve_effective_integrations
 from integrations.registry import IntegrationSpec, register_integration_spec
 
 SERVICE = "acme_external"
-ENV_VAR = "ACME_EXTERNAL_API_KEY"
-
-
-def _classify(credentials: dict[str, Any], record_id: str) -> tuple[Any | None, str | None]:
-    return {"configured": True, "source": "local env"}, SERVICE
-
-
-def _env_record() -> dict[str, Any] | None:
-    if not os.getenv(ENV_VAR):
-        return None
-    return {
-        "service": SERVICE,
-        "status": "active",
-        "source": "local env",
-        "config": {"api_key": os.environ[ENV_VAR]},
-    }
-
-
-def _is_configured() -> bool:
-    return bool(os.getenv(ENV_VAR))
 
 
 @pytest.fixture
-def registered_integration(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
-    """Register an external integration and remove it again afterwards.
-
-    Registration mutates module-level tables, so leaking one would change the
-    service lists every other test in the suite asserts against.
-    """
-    monkeypatch.setenv(ENV_VAR, "secret-value")
-
+def registered_integration() -> Iterator[str]:
+    """Register an external spec and remove it after the test."""
     register_integration_spec(
         IntegrationSpec(
             service=SERVICE,
@@ -64,9 +24,6 @@ def registered_integration(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
             direct_effective=True,
         )
     )
-    register_classifier(SERVICE, _classify)
-    register_env_loader(SERVICE, _env_record)
-    register_env_presence(SERVICE, _is_configured)
 
     yield SERVICE
 
@@ -74,17 +31,6 @@ def registered_integration(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
         spec for spec in registry._EXTERNAL_SPECS if spec.service != SERVICE
     ]
     registry._rebuild_registry()
-    _forget_hooks(SERVICE)
-
-
-def _forget_hooks(service: str) -> None:
-    """Drop every hook registered for *service*, ownership record included."""
-    _catalog_impl._EXTERNAL_CLASSIFIERS.pop(service, None)
-    _catalog_impl._EXTERNAL_ENV_LOADERS.pop(service, None)
-    _catalog_impl._EXTERNAL_ENV_PRESENCE.pop(service, None)
-    for hook, key in list(_catalog_impl._EXTERNAL_HOOK_OWNERS):
-        if key == service:
-            del _catalog_impl._EXTERNAL_HOOK_OWNERS[hook, key]
 
 
 def test_registration_reaches_a_module_that_imported_the_tables_earlier(
@@ -108,41 +54,20 @@ def test_registration_reaches_a_second_hand_re_export(registered_integration: st
 
 
 def test_external_service_survives_effective_resolution(registered_integration: str) -> None:
-    """The resolver filters unknown keys before validating, so it must know this one."""
+    """The resolver preserves records for services registered at runtime."""
     effective = resolve_effective_integrations(
         store_integrations=[],
-        env_integrations=[_env_record() or {}],
+        env_integrations=[
+            {
+                "service": registered_integration,
+                "status": "active",
+                "source": "local env",
+                "config": {"api_key": "test"},
+            }
+        ],
     )
 
     assert registered_integration in effective
-
-
-def test_external_service_is_visible_to_the_startup_presence_check(
-    registered_integration: str,
-) -> None:
-    """The pre-prompt check is a separate list from the full environment loader."""
-    assert registered_integration in load_env_integration_services()
-
-
-def test_presence_check_stays_quiet_when_the_integration_is_unconfigured(
-    registered_integration: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv(ENV_VAR, raising=False)
-
-    assert registered_integration not in load_env_integration_services()
-
-
-def test_a_failing_presence_predicate_does_not_break_startup(
-    registered_integration: str,
-) -> None:
-    """A plugin bug must degrade to "not configured", never to a failed launch."""
-
-    def _explode() -> bool:
-        raise RuntimeError("plugin is broken")
-
-    _catalog_impl._EXTERNAL_ENV_PRESENCE[registered_integration] = _explode
-
-    assert registered_integration not in load_env_integration_services()
 
 
 def test_built_in_integrations_are_unaffected(registered_integration: str) -> None:
@@ -285,44 +210,6 @@ def test_re_registering_the_same_service_still_replaces_it(first_plugin: str) ->
     assert [spec.service for spec in registry._EXTERNAL_SPECS].count(first_plugin) == 1
 
 
-@pytest.mark.parametrize(
-    ("hook", "register"),
-    [
-        ("classifier", lambda: register_classifier("github", _classify)),
-        ("env loader", lambda: register_env_loader("github", _env_record)),
-        ("presence check", lambda: register_env_presence("github", _is_configured)),
-    ],
-)
-def test_a_hook_cannot_attach_to_a_built_in_service(hook: str, register: Any) -> None:
-    """Each hook can be called without a spec, so each needs the same gate."""
-    with pytest.raises(ValueError, match="built-in integration"):
-        register()
-
-
-def test_an_env_loader_cannot_emit_another_integrations_record(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The merge replaces by service, so an impostor record would outrank the real one."""
-    monkeypatch.setenv("GITHUB_MCP_URL", "https://real.example")
-
-    def _impostor() -> dict[str, Any]:
-        return {
-            "service": "github",
-            "status": "active",
-            "source": "local env",
-            "config": {"url": "https://impostor.example"},
-        }
-
-    register_env_loader("acme_impostor", _impostor)
-    try:
-        github = [r for r in _catalog_impl.load_env_integrations() if r.get("service") == "github"]
-    finally:
-        _forget_hooks("acme_impostor")
-
-    assert len(github) == 1
-    assert "impostor" not in str(github[0].get("config"))
-
-
 def test_the_cli_command_offers_a_registered_integration(
     registered_with_setup_handler: list[str],
 ) -> None:
@@ -397,157 +284,3 @@ def test_a_rebuilt_table_never_drops_a_surviving_key() -> None:
 
     assert all(observed), "a surviving key disappeared while the table was rebuilt"
     assert watched == {"keep": "keep", "added": "added"}
-
-
-def _make_plugin_module(name: str) -> Any:
-    """Return a throwaway module standing in for a separately installed plugin.
-
-    Ownership is inferred from where the callback was defined, so two plugins
-    have to come from two modules for the check to mean anything.
-    """
-    import sys
-    import types
-
-    module = types.ModuleType(name)
-    exec(  # noqa: S102 - building a stand-in plugin module is the point
-        "def classify(credentials, record_id):\n"
-        "    return None, None\n"
-        "def load():\n"
-        "    return None\n"
-        "def present():\n"
-        "    return True\n",
-        module.__dict__,
-    )
-    sys.modules[name] = module
-    return module
-
-
-@pytest.fixture
-def two_plugin_modules() -> Iterator[tuple[Any, Any]]:
-    import sys
-
-    alpha = _make_plugin_module("plugin_alpha_stub")
-    beta = _make_plugin_module("plugin_beta_stub")
-
-    yield alpha, beta
-
-    _forget_hooks("shared_hook_key")
-    sys.modules.pop("plugin_alpha_stub", None)
-    sys.modules.pop("plugin_beta_stub", None)
-
-
-@pytest.mark.parametrize(
-    ("hook", "attribute", "register"),
-    [
-        ("classifier", "classify", register_classifier),
-        ("env loader", "load", register_env_loader),
-        ("presence check", "present", register_env_presence),
-    ],
-)
-def test_a_second_plugin_cannot_take_over_a_hook(
-    two_plugin_modules: tuple[Any, Any], hook: str, attribute: str, register: Any
-) -> None:
-    """Assignment into the hook map was last-write-wins, settled by import order."""
-    alpha, beta = two_plugin_modules
-
-    register("shared_hook_key", getattr(alpha, attribute))
-
-    with pytest.raises(ValueError, match="already registered by"):
-        register("shared_hook_key", getattr(beta, attribute))
-
-
-def test_the_owning_plugin_can_re_register_its_own_hook(
-    two_plugin_modules: tuple[Any, Any],
-) -> None:
-    """A reload hands back a new function object from the same package."""
-    alpha, _beta = two_plugin_modules
-
-    register_classifier("shared_hook_key", alpha.classify)
-    exec(  # noqa: S102 - stands in for the module being reloaded
-        "def classify(credentials, record_id):\n    return None, None\n", alpha.__dict__
-    )
-    register_classifier("shared_hook_key", alpha.classify)
-
-    assert _catalog_impl._EXTERNAL_CLASSIFIERS["shared_hook_key"] is alpha.classify
-
-
-def test_an_unattributable_hook_cannot_overwrite_an_existing_one() -> None:
-    """A callable with no package of its own identifies nobody, so it may not replace."""
-    register_env_loader("unattributable_key", dict)
-    try:
-        with pytest.raises(ValueError, match="already registered by"):
-            register_env_loader("unattributable_key", list)
-    finally:
-        _forget_hooks("unattributable_key")
-
-
-def test_only_one_package_wins_a_contested_hook_key() -> None:
-    """Claiming and installing must be one step.
-
-    Reading the owner and then writing lets every concurrent caller see the key
-    free, so the last writer takes it and the others never learn they lost.
-    """
-    import threading
-
-    modules = [_make_plugin_module(f"contender_{index}_stub") for index in range(8)]
-    won: list[str] = []
-    refused: list[str] = []
-    barrier = threading.Barrier(len(modules))
-
-    def claim(module: Any) -> None:
-        barrier.wait()
-        try:
-            register_classifier("contested_key", module.classify)
-            won.append(module.__name__)
-        except ValueError:
-            refused.append(module.__name__)
-
-    threads = [threading.Thread(target=claim, args=(module,)) for module in modules]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
-
-    try:
-        assert len(won) == 1, f"expected a single winner, got {won}"
-        assert len(refused) == len(modules) - 1
-        owner = _catalog_impl._EXTERNAL_HOOK_OWNERS["a classifier", "contested_key"]
-        assert owner == won[0]
-    finally:
-        import sys
-
-        _forget_hooks("contested_key")
-        for module in modules:
-            sys.modules.pop(module.__name__, None)
-
-
-def test_the_presence_sweep_survives_a_registration_from_another_thread() -> None:
-    """``load_env_integration_services`` iterates the hook map during startup."""
-    import sys
-    import threading
-
-    module = _make_plugin_module("sweeper_stub")
-    crashes: list[str] = []
-    stop = threading.Event()
-
-    def scan() -> None:
-        while not stop.is_set():
-            try:
-                load_env_integration_services()
-            except RuntimeError as exc:  # "dictionary changed size during iteration"
-                crashes.append(str(exc))
-
-    scanner = threading.Thread(target=scan)
-    scanner.start()
-    registered = [f"sweep_target_{index}" for index in range(200)]
-    try:
-        for service in registered:
-            register_env_presence(service, module.present)
-    finally:
-        stop.set()
-        scanner.join()
-        for service in registered:
-            _forget_hooks(service)
-        sys.modules.pop("sweeper_stub", None)
-
-    assert not crashes


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
- Removed unused out-of-tree classifier, environment-loader, and presence-hook registration APIs.
- Kept external integration-spec registration and its effective-resolution coverage.
- Deleted hook-only tests and simplified the catalog facade.

### Demo/Screenshot for feature changes and bug fixes -
Terminal validation:
```text
28 passed in 1.83s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
No in-repository or documented extension registers these hooks. I removed the unused dynamic callback system rather than preserving a compatibility layer, while retaining the supported external integration-spec registry path. The focused test keeps the resolver contract for a runtime-registered integration.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Validation run:
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/integrations/`
- `uv run python -m pytest tests/integrations/test_external_registration.py -q`
