### PR TITLE
fix(shell): startup demo menu offers a skip row and no free-text row

### DIFF
--- a/core/agent_harness/prompts/skills/onboarding_cicd_fix/SKILL.md
+++ b/core/agent_harness/prompts/skills/onboarding_cicd_fix/SKILL.md
@@ -37,6 +37,7 @@ pre_execute:
         - Run CI/CD improvements with a managed service (coming soon)
         - Connect OpenSRE to Slack and hand off DevOps chores for your team
         - Skip the demo and open the shell
+      allow_custom: false
 ---
 
 # CI/CD onboarding
@@ -49,8 +50,7 @@ onboarding question twice for one request.
 ## Ask User
 
 The menu opens on entry, without you. Do not call `ask_user_choice` yourself
-and do not narrate before it; end the turn and wait for the answer. The UI adds
-`Or type your own answer...`. If the entry result reports that the menu is
+and do not narrate before it; end the turn and wait for the answer. The menu has no free-text row: the last option opens the plain shell. If the entry result reports that the menu is
 unavailable, show the `pre_execute` options as a numbered list and wait for a
 reply. The last option, skipping the demo, is handled by the shell and never
 reaches you.

--- a/core/agent_harness/session/pending_choice.py
+++ b/core/agent_harness/session/pending_choice.py
@@ -58,6 +58,9 @@ class PendingUserChoice:
     commands: dict[str, str] = field(default_factory=dict)
     """Option label -> slash command the shell runs instead of answering the model."""
 
+    custom_answer: bool = True
+    """Offer the free-text row under the options (single-question path)."""
+
     def items(self) -> tuple[AskUserQuestion, ...]:
         """Questions to render: ``questions`` when set, otherwise one from title/options."""
         if self.questions:

--- a/surfaces/interactive_shell/command_registry/choice_prompt.py
+++ b/surfaces/interactive_shell/command_registry/choice_prompt.py
@@ -76,7 +76,9 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
         return True
 
     option_choices = [(option, option) for option in items[0].options]
-    option_choices.append((CUSTOM_OPTION, CUSTOM_OPTION))
+    custom_label = CUSTOM_OPTION if pending.custom_answer else None
+    if custom_label is not None:
+        option_choices.append((custom_label, custom_label))
     custom_answer = False
 
     def mark_custom_answer() -> None:
@@ -87,7 +89,7 @@ def _cmd_choose(session: Session, console: Console, args: list[str]) -> bool:
     picked_one = repl_choose_one(
         title=items[0].title,
         choices=option_choices,
-        custom_label=CUSTOM_OPTION,
+        custom_label=custom_label,
         multi_select=items[0].multi_select,
         header="Ask User",
         letter_keys=True,

--- a/tests/core/agent/prompts/test_skills_demo.py
+++ b/tests/core/agent/prompts/test_skills_demo.py
@@ -56,7 +56,8 @@ def test_master_menu_matches_four_unique_children_and_preserves_specialists() ->
         "scan_local_git_workspace",
         "analyze_github_ci_reliability",
     ]
-    assert GETTING_STARTED_CUSTOM in master
+    assert menu["allow_custom"] is False
+    assert GETTING_STARTED_CUSTOM not in master
     assert "not implemented yet" in loader.load_skill_body("remote-managed-service")
     discovered = [
         loader._load_action_skill(path) for path in loader._iter_skill_paths(loader.skills_dir())

--- a/tests/interactive_shell/runtime/test_demo_picker.py
+++ b/tests/interactive_shell/runtime/test_demo_picker.py
@@ -21,7 +21,6 @@ from core.agent_harness.session.pending_choice import PendingUserChoice, format_
 from core.agent_harness.turns.turn_snapshot import TurnSnapshot
 from surfaces.interactive_shell.runtime.action_turn import run_action_tool_turn
 from surfaces.interactive_shell.session import Session
-from surfaces.interactive_shell.ui.ask_user import CUSTOM_OPTION
 from surfaces.shared.terminal.components import choice_menu, cpr_stdin
 from tests.core.agent.orchestration.action_execution_test_harness import (
     FakeActionLLM,
@@ -127,9 +126,8 @@ def test_boot_paints_only_the_skill_menu_then_selected_child_runs_through_real_t
         "choices": [
             *((option, option) for option in GETTING_STARTED_OPTIONS),
             (SKIP_DEMO_OPTION, SKIP_DEMO_OPTION),
-            (CUSTOM_OPTION, CUSTOM_OPTION),
         ],
-        "custom_label": CUSTOM_OPTION,
+        "custom_label": None,
         "multi_select": False,
         "header": "Ask User",
         "letter_keys": True,

--- a/tests/interactive_shell/test_choice_prompt.py
+++ b/tests/interactive_shell/test_choice_prompt.py
@@ -290,3 +290,31 @@ def test_non_tty_batch_prints_every_question(monkeypatch: pytest.MonkeyPatch) ->
         assert question.title in output
         for option in question.options:
             assert option in output
+
+
+def test_single_choice_without_custom_row_when_the_menu_disallows_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The startup demo menu declares allow_custom false: options only."""
+    # Arrange
+    session = Session()
+    session.pending_user_choice = PendingUserChoice(
+        title="Which demo?", options=("A", "B"), custom_answer=False
+    )
+    console, _buf = _console()
+    seen: dict[str, object] = {}
+
+    def _pick(**kwargs: object) -> str:
+        seen["custom_label"] = kwargs.get("custom_label")
+        seen["choices"] = kwargs["choices"]
+        return "A"
+
+    monkeypatch.setattr(choice_prompt, "repl_tty_interactive", lambda: True)
+    monkeypatch.setattr(choice_prompt, "repl_choose_one", _pick)
+
+    # Act
+    assert _handler(session, console) is True
+
+    # Assert
+    assert seen["custom_label"] is None
+    assert (CUSTOM_OPTION, CUSTOM_OPTION) not in seen["choices"]  # type: ignore[operator]

--- a/tools/interactive_shell/actions/ask_choice.py
+++ b/tools/interactive_shell/actions/ask_choice.py
@@ -225,6 +225,7 @@ def execute_ask_user_choice_tool(args: dict[str, Any], ctx: ActionToolScope) -> 
             options=tuple(options),
             multi_select=multi_select,
             note=strip_terminal_controls(str(args.get("note", ""))).strip(),
+            custom_answer=_parse_bool(args.get("allow_custom"), default=True),
         )
         queued = _QUEUED_INSTRUCTION
         summary = f"selection menu queued: {title}"
@@ -343,6 +344,14 @@ ask_user_choice_tool = RegisteredTool(
                     "For a single title/options decision: when true, the shell "
                     "shows checkboxes and the user may toggle several options. "
                     "Ignored when questions is set (use per-question multi_select)."
+                ),
+            },
+            "allow_custom": {
+                "type": "boolean",
+                "description": (
+                    "For a single title/options decision: when false, the menu has "
+                    "no free-text row and the user must pick one of the options. "
+                    "Default true."
                 ),
             },
         },


### PR DESCRIPTION
The startup onboarding menu had no way to just open the shell: Esc printed
"Selection cancelled" and a typed answer such as "open interactive shell"
went to the model as a demo answer and did nothing useful. The
"Or type your own answer..." row also invited that.

- The menu ends with `Skip the demo and open the shell`. The shell handles
  that row itself: no model turn, the onboarding skill is left, and the
  prompt reads "Demo skipped — type a request, or /demo to come back to it."
- `ask_user_choice` accepts an optional `allow_custom` boolean. The master
  onboarding skill declares `allow_custom: false` in its `pre_execute`
  menu, so the picker shows only the five rows (A–E). Every other menu
  keeps the free-text row.
- The "↗ /goal — work turn" marker above a submitted prompt now prints
  only while a goal is active. It used to appear above `/demo` because the
  queued startup picker also sets the autosubmit flag.