### PR TITLE
fix(runbooks): allow trusted historical SHA URLs

### DIFF
--- a/integrations/github/runbooks/revisions.py
+++ b/integrations/github/runbooks/revisions.py
@@ -1,0 +1,55 @@
+"""GitHub revision-boundary checks for trusted runbook sources."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from urllib.parse import quote
+
+import httpx
+
+from config.constants.github import GITHUB_API_BASE_URL
+
+_GITHUB_API_VERSION = "2022-11-28"
+_COMPARISON_TIMEOUT_SECONDS = 15.0
+_REACHABLE_STATUSES = frozenset({"behind", "identical"})
+
+
+class GitHubRevisionComparisonError(RuntimeError):
+    """Raised when GitHub cannot verify a runbook revision's ancestry."""
+
+
+def is_github_revision_reachable(
+    *,
+    owner: str,
+    repo: str,
+    trusted_revision: str,
+    candidate_revision: str,
+    auth_token: str,
+) -> bool:
+    """Return whether ``candidate_revision`` is in ``trusted_revision``'s history."""
+    if not auth_token:
+        raise GitHubRevisionComparisonError("GitHub authentication is unavailable.")
+    repository = f"{quote(owner, safe='')}/{quote(repo, safe='')}"
+    comparison = f"{quote(trusted_revision, safe='')}...{quote(candidate_revision, safe='')}"
+    url = f"{GITHUB_API_BASE_URL}/repos/{repository}/compare/{comparison}"
+    try:
+        response = httpx.get(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {auth_token}",
+                "X-GitHub-Api-Version": _GITHUB_API_VERSION,
+            },
+            timeout=_COMPARISON_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        raise GitHubRevisionComparisonError("GitHub comparison request failed.") from exc
+    if response.status_code != HTTPStatus.OK:
+        raise GitHubRevisionComparisonError("GitHub comparison request was rejected.")
+    try:
+        status = str(response.json().get("status") or "").lower()
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise GitHubRevisionComparisonError(
+            "GitHub returned an invalid comparison result."
+        ) from exc
+    return status in _REACHABLE_STATUSES

--- a/integrations/github/runbooks/source.py
+++ b/integrations/github/runbooks/source.py
@@ -174,9 +174,6 @@ class GitHubRunbookSource:
         if candidate_parts[: len(configured_ref_parts)] == configured_ref_parts:
             revision = self._source.ref
             path_parts = candidate_parts[len(configured_ref_parts) :]
-        elif candidate_parts and _FULL_SHA_RE.fullmatch(candidate_parts[0]):
-            revision = candidate_parts[0]
-            path_parts = candidate_parts[1:]
         else:
             return None
         path = _safe_markdown_path("/".join(path_parts))

--- a/integrations/github/runbooks/source.py
+++ b/integrations/github/runbooks/source.py
@@ -17,6 +17,10 @@ from core.domain.runbooks import (
 )
 from integrations.github.helpers import github_creds, github_source_available
 from integrations.github.runbooks.manifest import ManifestError, parse_manifest
+from integrations.github.runbooks.revisions import (
+    GitHubRevisionComparisonError,
+    is_github_revision_reachable,
+)
 from integrations.github.tools.commits import list_github_commits
 from integrations.github.tools.file_contents import get_github_file_contents
 
@@ -140,6 +144,41 @@ class GitHubRunbookSource:
             raise RunbookRetrievalError("GitHub returned content from an unexpected revision.")
         return content, uri, resolved_revision
 
+    def _verify_revision_boundary(self, revision: str) -> None:
+        if not _FULL_SHA_RE.fullmatch(revision):
+            return
+        if (
+            _FULL_SHA_RE.fullmatch(self._source.ref)
+            and revision.lower() == self._source.ref.lower()
+        ):
+            return
+        trusted_revision = self._resolve_revision(self._source.ref, verify_access=True)
+        if revision.lower() == trusted_revision:
+            return
+        try:
+            reachable = is_github_revision_reachable(
+                owner=self._owner,
+                repo=self._repo,
+                trusted_revision=trusted_revision,
+                candidate_revision=revision.lower(),
+                auth_token=str(
+                    self._github.get("github_token") or self._github.get("auth_token") or ""
+                ),
+            )
+        except GitHubRevisionComparisonError as exc:
+            logger.warning(
+                "GitHub runbook revision comparison failed for %s",
+                self._source.name,
+                exc_info=True,
+            )
+            raise RunbookRetrievalError(
+                "GitHub could not verify the requested runbook revision."
+            ) from exc
+        if not reachable:
+            raise RunbookRetrievalError(
+                "The requested runbook revision is not reachable from the configured ref."
+            )
+
     def verify(self) -> tuple[bool, str]:
         """Verify repository access and the manifest when one is configured."""
         if self._source.manifest:
@@ -174,6 +213,9 @@ class GitHubRunbookSource:
         if candidate_parts[: len(configured_ref_parts)] == configured_ref_parts:
             revision = self._source.ref
             path_parts = candidate_parts[len(configured_ref_parts) :]
+        elif candidate_parts and _FULL_SHA_RE.fullmatch(candidate_parts[0]):
+            revision = candidate_parts[0]
+            path_parts = candidate_parts[1:]
         else:
             return None
         path = _safe_markdown_path("/".join(path_parts))
@@ -215,6 +257,7 @@ class GitHubRunbookSource:
         if path is None:
             raise RunbookRetrievalError("Runbook reference contains an unsafe document path.")
         revision = reference.requested_revision or self._source.ref
+        self._verify_revision_boundary(revision)
         content, _resource_uri, resolved_revision = self._fetch_file(path, revision)
         truncated = len(content) > RUNBOOK_CONTENT_MAX_CHARS
         bounded = content[:RUNBOOK_CONTENT_MAX_CHARS]

--- a/tests/integrations/github/runbooks/test_revisions.py
+++ b/tests/integrations/github/runbooks/test_revisions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from integrations.github.runbooks.revisions import (
+    GitHubRevisionComparisonError,
+    is_github_revision_reachable,
+)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    (("identical", True), ("behind", True), ("ahead", False), ("diverged", False)),
+)
+def test_revision_reachability_uses_comparison_status(status: str, expected: bool) -> None:
+    response = httpx.Response(
+        HTTPStatus.OK,
+        json={"status": status},
+        request=httpx.Request("GET", "https://api.github.com"),
+    )
+
+    with patch("integrations.github.runbooks.revisions.httpx.get", return_value=response):
+        reachable = is_github_revision_reachable(
+            owner="acme",
+            repo="operations",
+            trusted_revision="b" * 40,
+            candidate_revision="a" * 40,
+            auth_token="secret",
+        )
+
+    assert reachable is expected
+
+
+def test_revision_reachability_fails_closed_without_authentication() -> None:
+    with pytest.raises(GitHubRevisionComparisonError, match="authentication is unavailable"):
+        is_github_revision_reachable(
+            owner="acme",
+            repo="operations",
+            trusted_revision="b" * 40,
+            candidate_revision="a" * 40,
+            auth_token="",
+        )
+
+
+def test_revision_reachability_fails_closed_when_comparison_is_rejected() -> None:
+    response = httpx.Response(
+        HTTPStatus.NOT_FOUND,
+        request=httpx.Request("GET", "https://api.github.com"),
+    )
+
+    with (
+        patch("integrations.github.runbooks.revisions.httpx.get", return_value=response),
+        pytest.raises(GitHubRevisionComparisonError, match="comparison request was rejected"),
+    ):
+        is_github_revision_reachable(
+            owner="acme",
+            repo="operations",
+            trusted_revision="b" * 40,
+            candidate_revision="a" * 40,
+            auth_token="secret",
+        )

--- a/tests/integrations/github/runbooks/test_source.py
+++ b/tests/integrations/github/runbooks/test_source.py
@@ -67,10 +67,36 @@ def test_resolve_reference_accepts_only_configured_repository_and_ref() -> None:
     )
     assert (
         source.resolve_reference(
+            f"https://github.com/acme/operations/blob/{'a' * 40}/runbooks/checkout.md"
+        )
+        is None
+    )
+    assert (
+        source.resolve_reference(
             "https://github.com/acme/operations/blob/main/runbooks/%00checkout.md"
         )
         is None
     )
+
+
+def test_resolve_reference_accepts_a_url_at_an_explicitly_pinned_sha() -> None:
+    revision = "a" * 40
+    source = GitHubRunbookSource(
+        RunbookSourceConfig(
+            name="pinned-runbook",
+            provider="github",
+            repository="acme/operations",
+            ref=revision,
+        ),
+        _GITHUB,
+    )
+
+    reference = source.resolve_reference(
+        f"https://github.com/acme/operations/blob/{revision}/runbooks/checkout.md"
+    )
+
+    assert reference is not None
+    assert reference.requested_revision == revision
 
 
 def test_catalog_revision_pins_document_fetch() -> None:

--- a/tests/integrations/github/runbooks/test_source.py
+++ b/tests/integrations/github/runbooks/test_source.py
@@ -65,12 +65,11 @@ def test_resolve_reference_accepts_only_configured_repository_and_ref() -> None:
         source.resolve_reference("https://github.com/acme/operations/blob/dev/runbooks/checkout.md")
         is None
     )
-    assert (
-        source.resolve_reference(
-            f"https://github.com/acme/operations/blob/{'a' * 40}/runbooks/checkout.md"
-        )
-        is None
+    sha_reference = source.resolve_reference(
+        f"https://github.com/acme/operations/blob/{'a' * 40}/runbooks/checkout.md"
     )
+    assert sha_reference is not None
+    assert sha_reference.requested_revision == "a" * 40
     assert (
         source.resolve_reference(
             "https://github.com/acme/operations/blob/main/runbooks/%00checkout.md"
@@ -97,6 +96,67 @@ def test_resolve_reference_accepts_a_url_at_an_explicitly_pinned_sha() -> None:
 
     assert reference is not None
     assert reference.requested_revision == revision
+
+
+def test_fetch_document_rejects_sha_outside_configured_ref_history() -> None:
+    candidate_revision = "a" * 40
+    trusted_revision = "b" * 40
+    source = GitHubRunbookSource(_SOURCE, _GITHUB)
+    reference = source.resolve_reference(
+        f"https://github.com/acme/operations/blob/{candidate_revision}/runbooks/checkout.md"
+    )
+
+    assert reference is not None
+    with (
+        patch(
+            "integrations.github.runbooks.source.list_github_commits",
+            return_value=_commits_payload(trusted_revision),
+        ),
+        patch(
+            "integrations.github.runbooks.source.is_github_revision_reachable",
+            return_value=False,
+        ) as reachable,
+        pytest.raises(RunbookRetrievalError, match="not reachable from the configured ref"),
+    ):
+        source.fetch_document(reference)
+
+    reachable.assert_called_once_with(
+        owner="acme",
+        repo="operations",
+        trusted_revision=trusted_revision,
+        candidate_revision=candidate_revision,
+        auth_token="secret",
+    )
+
+
+def test_fetch_document_accepts_sha_in_configured_ref_history() -> None:
+    candidate_revision = "a" * 40
+    trusted_revision = "b" * 40
+    source = GitHubRunbookSource(_SOURCE, _GITHUB)
+    reference = source.resolve_reference(
+        f"https://github.com/acme/operations/blob/{candidate_revision}/runbooks/checkout.md"
+    )
+
+    assert reference is not None
+    with (
+        patch(
+            "integrations.github.runbooks.source.list_github_commits",
+            return_value=_commits_payload(trusted_revision),
+        ),
+        patch(
+            "integrations.github.runbooks.source.is_github_revision_reachable",
+            return_value=True,
+        ),
+        patch(
+            "integrations.github.runbooks.source.get_github_file_contents",
+            return_value=_file_payload(
+                "runbooks/checkout.md", "# Checkout", sha=candidate_revision
+            ),
+        ),
+    ):
+        document = source.fetch_document(reference)
+
+    assert document.resolved_revision == candidate_revision
 
 
 def test_catalog_revision_pins_document_fetch() -> None:


### PR DESCRIPTION
Fixes #6142

#### Describe the changes you have made in this PR -

Explicit GitHub blob URLs can now use immutable commit SHAs when—and only when—the SHA is in the configured source ref's history. This keeps OpenSRE's own provenance URLs reusable while refusing unmerged or diverged branch commits.

Added regression coverage for:
- accepting SHA URLs that are identical to or behind the configured ref;
- rejecting SHA URLs ahead of or diverged from that ref;
- failing closed when GitHub cannot authenticate or complete the comparison.

### Demo/Screenshot for feature changes and bug fixes -

```
uv run python -m pytest tests/integrations/github/runbooks
16 passed
make lint
All checks passed!
make format-check
3183 files already formatted
make typecheck
Success: no issues found in 1839 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

A source ref establishes a trusted Git history boundary. For a SHA-form URL, OpenSRE first resolves the configured ref to an immutable commit, then compares that commit with the requested SHA through GitHub's comparison API. GitHub reports `identical` when both commits match and `behind` when the requested SHA is an ancestor; only those states are accepted. `ahead` and `diverged` reject unmerged side-branch content. The checked SHA is then used for retrieval, preserving immutable provenance.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions