### PR TITLE
fix(ci): serialize installer-canary tracking updates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,7 +13,7 @@ Internal notes for repository automation under `.github/workflows/`. Not publish
 | [`celebrate-merged-pr.yml`](celebrate-merged-pr.yml) | Post-merge celebration comment |
 | [`good-first-issue-assign.yml`](good-first-issue-assign.yml) | Auto-assign good first issues |
 | [`release.yml`](release.yml) | Release builds and artifacts |
-| [`installer-canary.yml`](installer-canary.yml) | Post-publish canaries for the public install paths (CDN, GitHub release resolution, PowerShell, Homebrew) on Linux/macOS/Windows |
+| [`installer-canary.yml`](installer-canary.yml) | Queued post-publish canaries for the public install paths (CDN, GitHub release resolution, PowerShell, Homebrew) on Linux/macOS/Windows; cycles are globally serialized because they share one failure-tracking issue |
 
 See [CI.md](../../CI.md) for local parity commands before push.
 

--- a/.github/workflows/installer-canary.yml
+++ b/.github/workflows/installer-canary.yml
@@ -23,6 +23,14 @@ permissions:
   contents: read
   issues: write
 
+# All triggers report through the same ``installer-canary-failure`` issue. Queue
+# complete cycles globally so an older successful run cannot close a newer
+# failure, and retain every report rather than dropping a pending release check.
+concurrency:
+  group: installer-canary-tracking-issue
+  cancel-in-progress: false
+  queue: max
+
 env:
   OPENSRE_LIVE_INSTALL: "1"
   OPENSRE_LIVE_INSTALL_TAG: ${{ github.event.client_payload.tag || inputs.tag || '' }}


### PR DESCRIPTION
  Fixes #6152

  ## Summary

  The installer canary’s release, scheduled, and manual triggers all update the
  same `installer-canary-failure` issue. Concurrent runs could create duplicate
  issues or let an older successful run close a newer failure.

  - Add a workflow-level global concurrency group.
  - Queue all pending canary cycles (`queue: max`) rather than dropping release
    checks or cancelling a running cycle.
  - Document why the canary is globally serialized.

   Implementation approach: use one global workflow-level concurrency group because
  all trigger types and release tags update the same shared tracking issue. A
  tag-specific group would not prevent cross-tag issue-state races.